### PR TITLE
fix: use async Cloud Build with polling to avoid log streaming permission issue (Fixes #35)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,11 +46,37 @@ jobs:
       - name: Build & push backend image
         run: |
           VERSION="v0.$(date +%Y%m%d%H%M)"
-          gcloud builds submit \
+          BUILD_ID=$(gcloud builds submit \
             --tag "${{ env.REGISTRY }}/backend:${VERSION}" \
             --tag "${{ env.REGISTRY }}/backend:latest" \
             --project ${{ env.PROJECT_ID }} \
-            ./backend
+            --async \
+            ./backend \
+            --format='value(id)')
+          echo "Backend build started: $BUILD_ID"
+
+          # Poll for build completion
+          for i in {1..60}; do
+            STATUS=$(gcloud builds describe $BUILD_ID --project ${{ env.PROJECT_ID }} --format='value(status)')
+            echo "Attempt $i/60: Build status = $STATUS"
+
+            if [ "$STATUS" = "SUCCESS" ]; then
+              echo "Backend build completed successfully"
+              break
+            elif [ "$STATUS" = "FAILURE" ] || [ "$STATUS" = "TIMEOUT" ] || [ "$STATUS" = "CANCELLED" ]; then
+              echo "Backend build failed with status: $STATUS"
+              gcloud builds log $BUILD_ID --project ${{ env.PROJECT_ID }}
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          if [ "$STATUS" != "SUCCESS" ]; then
+            echo "Backend build timed out after 10 minutes"
+            exit 1
+          fi
+
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Deploy backend to Cloud Run
@@ -98,11 +124,37 @@ jobs:
       - name: Build & push frontend image
         run: |
           VERSION="v0.$(date +%Y%m%d%H%M)"
-          gcloud builds submit \
+          BUILD_ID=$(gcloud builds submit \
             --tag "${{ env.REGISTRY }}/frontend:${VERSION}" \
             --tag "${{ env.REGISTRY }}/frontend:latest" \
             --project ${{ env.PROJECT_ID }} \
-            ./frontend
+            --async \
+            ./frontend \
+            --format='value(id)')
+          echo "Frontend build started: $BUILD_ID"
+
+          # Poll for build completion
+          for i in {1..60}; do
+            STATUS=$(gcloud builds describe $BUILD_ID --project ${{ env.PROJECT_ID }} --format='value(status)')
+            echo "Attempt $i/60: Build status = $STATUS"
+
+            if [ "$STATUS" = "SUCCESS" ]; then
+              echo "Frontend build completed successfully"
+              break
+            elif [ "$STATUS" = "FAILURE" ] || [ "$STATUS" = "TIMEOUT" ] || [ "$STATUS" = "CANCELLED" ]; then
+              echo "Frontend build failed with status: $STATUS"
+              gcloud builds log $BUILD_ID --project ${{ env.PROJECT_ID }}
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          if [ "$STATUS" != "SUCCESS" ]; then
+            echo "Frontend build timed out after 10 minutes"
+            exit 1
+          fi
+
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Deploy frontend to Cloud Run


### PR DESCRIPTION
Fixes #35

## Summary

修復 Production deploy workflow (`deploy.yml`) 因 Cloud Build log streaming 權限不足導致 CI 失敗的問題。

採用 **方案 B**（從 Issue 中選擇）：使用 `gcloud builds submit --async` 並輪詢 build 狀態，完全避開 log streaming 權限需求。

## Changes

修改 `.github/workflows/deploy.yml` 的兩個 build 步驟：

### Backend build (line 46-54)
- 加入 `--async` flag 和 `--format='value(id)'` 取得 BUILD_ID
- 使用 `gcloud builds describe` 每 10 秒輪詢狀態
- 最多等待 10 分鐘 (60 次 × 10 秒)
- Build 失敗時顯示 log 並 exit 1

### Frontend build (line 98-106)
- 同樣的 async + polling 邏輯
- 保持與 backend 一致的錯誤處理

## Why this approach

**優點**：
- ✅ 不需修改 service account IAM 權限
- ✅ Build 執行不受影響（只是換一種等待方式）
- ✅ 失敗時依然能顯示 log (`gcloud builds log`)
- ✅ 10 分鐘 timeout 足夠（歷史 build 都在 3-5 分鐘內完成）

**替代方案（未採用）**：
- ❌ 方案 A（加 `roles/cloudbuild.builds.viewer` 權限）— 改動 IAM 風險較高，且治標不治本

## Test plan

1. ✅ Syntax check: `yamllint .github/workflows/deploy.yml` (local)
2. ⏳ 等待 PR merge 後觀察下一次 production deploy
3. ⏳ 驗證 CI log 中能看到 "Build started: xxx" 和輪詢過程
4. ⏳ 驗證 build 成功後能正常 deploy

## Risk assessment

**Low risk**:
- 只改變 build 等待方式，不改變 build 本身
- Polling logic 有 timeout 保護
- 失敗處理與原本相同（exit 1）

## Related

- Previous failure: [Run #22260489291](https://github.com/Youngger9765/chinese-literacy-platform/actions/runs/22260489291)
- 錯誤訊息: "This tool can only stream logs if you are Viewer/Owner of the project"