### PR TITLE
fix: change Vertex AI region from asia-east1 to us-central1 (Fixes #32)

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -17,7 +17,7 @@ from ..config import settings
 
 def _get_client() -> genai.Client:
     """Return a Gemini client via Vertex AI (uses Cloud Run service account)."""
-    return genai.Client(vertexai=True, project="lingoleap-dev", location="asia-east1")
+    return genai.Client(vertexai=True, project="lingoleap-dev", location="us-central1")
 
 
 async def generate_socratic_question(


### PR DESCRIPTION
Fixes #32

## Summary
- Changed Vertex AI client location from `asia-east1` to `us-central1`
- The `gemini-2.0-flash` model is not available in `asia-east1`, causing 500 errors

## Changes
- `backend/app/services/ai_service.py`: Updated `_get_client()` to use `us-central1`

## Test plan
- Deploy to preview environment
- Test `/api/comprehension/question` endpoint
- Verify no 500 errors when calling Gemini API