### PR TITLE
fix: reduce chat bubble line-height

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -325,7 +325,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             </div>
             <div className="flex-1">
               <div className="bg-[#161b22] border border-[#30363d] rounded-2xl rounded-tl-sm px-4 py-3">
-                <p className={`text-lg text-slate-300 leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+                <p className={`text-lg text-slate-300 leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
                   {processZhuyin(`你剛才讀完了《${story.title}》，做得很棒！我想問你幾個關於課文的問題，幫助你更深入理解。準備好了嗎？`)}
                 </p>
               </div>
@@ -370,7 +370,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                       ? 'bg-[#161b22] border border-[#30363d] rounded-tl-sm text-slate-300'
                       : 'bg-indigo-600 rounded-tr-sm text-white',
                   ].join(' ')}>
-                    <p className={`text-lg leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
+                    <p className={`text-lg leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- Chat bubble line-height reduced from `leading-[2.6]` to `leading-[1.8]`
- Affects intro message and all AI/student conversation bubbles
- Zhuyin still has enough space, but no longer excessive vertical gaps