### PR TITLE
feat: pass reading results to Socratic dialogue (#17)

### DIFF
--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -84,6 +84,10 @@ class ComprehensionChatRequest(BaseModel):
     story_title: str
     story_text: str
     student_answer: str | None = Field(None, max_length=500)  # None = start session
+    # Optional reading results from LiveTutor (Issue #17)
+    mispronounced_words: list[str] | None = None
+    accuracy: float | None = Field(None, ge=0, le=100)
+    cpm: float | None = Field(None, gt=0)
 
 
 class ComprehensionChatResponse(BaseModel):
@@ -109,6 +113,9 @@ async def comprehension_chat(payload: ComprehensionChatRequest):
                 session_id=payload.session_id,
                 story_title=payload.story_title,
                 story_text=payload.story_text,
+                mispronounced_words=payload.mispronounced_words,
+                accuracy=payload.accuracy,
+                cpm=payload.cpm,
             )
         else:
             result = await socratic_agent.process_answer(

--- a/backend/app/services/socratic_agent.py
+++ b/backend/app/services/socratic_agent.py
@@ -25,6 +25,10 @@ class SessionState:
     total_attempts: int = 0
     current_phase: str = "factual"  # factual -> inferential -> evaluative
     created_at: float = field(default_factory=time.time)
+    # Optional reading results from LiveTutor (Issue #17)
+    mispronounced_words: list[str] | None = None
+    accuracy: float | None = None
+    cpm: float | None = None
 
 
 class SessionStore:
@@ -126,13 +130,26 @@ class SocraticAgent:
         numbered_text = "\n".join(
             f"[第{i}段] {p}" for i, p in enumerate(paragraphs) if p.strip()
         )
+
+        # Build reading info section if data is available (Issue #17)
+        reading_info = ""
+        if state.mispronounced_words or state.accuracy is not None or state.cpm is not None:
+            reading_info = "\n學生朗讀資訊：\n"
+            if state.accuracy is not None:
+                reading_info += f"- 正確率：{state.accuracy:.1f}%\n"
+            if state.cpm is not None:
+                reading_info += f"- 語速：{state.cpm:.0f} 字/分鐘\n"
+            if state.mispronounced_words:
+                reading_info += f"- 讀錯的字：{', '.join(state.mispronounced_words)}\n"
+            reading_info += "→ 提問時可以特別關注這些字相關的段落和內容\n"
+
         return f"""你是一位溫暖、鼓勵學生的繁體中文閱讀助教，擅長用蘇格拉底式問答引導學生深入理解課文。
 
 課文標題：{state.story_title}
 
 課文內容（每段前標有段落索引）：
 {numbered_text}
-
+{reading_info}
 你的任務：
 1. 評估學生的回答是否展現了對問題的理解
 2. 給予簡短、溫暖的回饋（1-2句）
@@ -178,13 +195,22 @@ class SocraticAgent:
 - 問題長度：15-40 個字"""
 
     async def start_session(
-        self, session_id: str, story_title: str, story_text: str
+        self,
+        session_id: str,
+        story_title: str,
+        story_text: str,
+        mispronounced_words: list[str] | None = None,
+        accuracy: float | None = None,
+        cpm: float | None = None,
     ) -> AgentResponse:
         """Start a new session — generate the first question."""
         state = SessionState(
             session_id=session_id,
             story_title=story_title,
             story_text=story_text,
+            mispronounced_words=mispronounced_words,
+            accuracy=accuracy,
+            cpm=cpm,
         )
 
         system_prompt = self._build_system_prompt(state)

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -115,6 +115,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         storyTitle: story.title,
         storyText,
         studentAnswer: null,
+        // Pass reading results from LiveTutor (Issue #17)
+        mispronouncedWords: attempt.mispronouncedWords,
+        accuracy: attempt.accuracy,
+        cpm: attempt.cpm,
       });
       setConversation([{ role: 'ai', text: result.question }]);
       applyServerState(result);
@@ -124,7 +128,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       setIsLoading(false);
       setTimeout(() => inputRef.current?.focus(), 100);
     }
-  }, [story.content, story.title, sessionId, applyServerState]);
+  }, [story.content, story.title, sessionId, attempt, applyServerState]);
 
   // Resizable right panel
   useEffect(() => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -78,6 +78,9 @@ export async function sendComprehensionChat(payload: {
   storyTitle: string;
   storyText: string;
   studentAnswer: string | null;
+  mispronouncedWords?: string[];
+  accuracy?: number;
+  cpm?: number;
 }): Promise<ChatResponse> {
   const res = await fetch(`${API_BASE}/api/comprehension/chat`, {
     method: 'POST',
@@ -87,6 +90,9 @@ export async function sendComprehensionChat(payload: {
       story_title: payload.storyTitle,
       story_text: payload.storyText,
       student_answer: payload.studentAnswer,
+      mispronounced_words: payload.mispronouncedWords,
+      accuracy: payload.accuracy,
+      cpm: payload.cpm,
     }),
   });
   if (!res.ok) throw new Error(`sendComprehensionChat failed: ${res.status}`);


### PR DESCRIPTION
## Summary
- LiveTutor 朗讀結果（讀錯的字、正確率、語速）現在會傳給蘇格拉底對話 agent
- AI 提問時可以參考學生朗讀時讀錯的字，聚焦相關段落
- 所有欄位 optional，向後相容

## Changes (4 files, +46 lines)
- `backend/app/routes/learning.py` — API 加 `mispronounced_words`, `accuracy`, `cpm` 可選欄位（含範圍驗證）
- `backend/app/services/socratic_agent.py` — SessionState + prompt 加朗讀資訊
- `frontend/src/components/reading-steps/ComprehensionChat.tsx` — session 開始時傳 attempt 資料
- `frontend/src/services/api.ts` — sendComprehensionChat 加可選欄位

## Test plan
- [x] Python syntax check passed
- [x] Frontend `vite build` passed (683 modules, 0 errors)
- [x] curl test: without reading data → 200, normal question
- [x] curl test: with reading data → 200, question focuses on relevant content
- [x] curl test: wrong answer → `understood: false`, feedback references paragraph
- [x] Code review passed (global-code-reviewer)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)