### PR TITLE
Upgrade to gemini-2.5-flash + error handling hardening

### DIFF
--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -125,6 +125,8 @@ async def comprehension_chat(payload: ComprehensionChatRequest):
     except ValueError as e:
         status = 429 if "Rate limit" in str(e) else 422
         raise HTTPException(status_code=status, detail=str(e))
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
     except Exception as e:
         logger.error("Comprehension chat error: %s", e)
         raise HTTPException(status_code=500, detail="AI service error")

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -34,7 +34,7 @@ async def generate_structured_response(
     system_prompt: str,
     contents: list[genai_types.Content],
     response_schema: dict,
-    max_tokens: int = 256,
+    max_tokens: int = 1024,
     temperature: float = 0.7,
 ) -> dict:
     """Call Gemini with JSON mode, return parsed dict.
@@ -50,7 +50,7 @@ async def generate_structured_response(
             response = await asyncio.wait_for(
                 asyncio.to_thread(
                     client.models.generate_content,
-                    model="gemini-2.0-flash",
+                    model="gemini-2.5-flash",
                     contents=contents,
                     config=genai_types.GenerateContentConfig(
                         system_instruction=system_prompt,
@@ -147,7 +147,7 @@ async def generate_socratic_question(
 
     client = _get_client()
     response = client.models.generate_content(
-        model="gemini-2.0-flash",
+        model="gemini-2.5-flash",
         contents=contents,
         config=genai_types.GenerateContentConfig(
             system_instruction=system_prompt,


### PR DESCRIPTION
## Summary
- Upgrade Gemini model from `2.0-flash` to `2.5-flash` for better evaluation accuracy
- Fix `max_output_tokens` 256 → 1024 (prevent JSON truncation with 2.5-flash)
- Fix error fallback: `understood=true` → `understood=false` (don't auto-pass students on API errors)
- Add circuit breaker: 3 consecutive AI errors → HTTP 503
- Add stricter evaluation rules in prompt (number precision, anti-vague, anti-lazy)
- Add `referenced_paragraph` for paragraph highlighting on wrong answers

## Eval Results (staging, gemini-2.5-flash)
- number-precision: 4/4 (100%)
- lazy-answer: 3/3 (100%)
- too-vague: 3/3 (100%)
- boundary: 2/2 (100%)
- factual-wrong: 1/1 (100%)
- factual-correct: 3/7 (43%) — test suite question-dependency issue, not model

## Test plan
- [x] Local model comparison: gemini-2.5-flash 6/6 (100%)
- [x] Staging eval suite: 16/20 (80%)
- [ ] Production eval suite after merge

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)