### PR TITLE
fix: filter 0/empty reading values to avoid 422 errors (Fixes #48)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -116,9 +116,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         storyText,
         studentAnswer: null,
         // Pass reading results from LiveTutor (Issue #17)
-        mispronouncedWords: attempt.mispronouncedWords,
-        accuracy: attempt.accuracy,
-        cpm: attempt.cpm,
+        // Filter out 0/empty values to avoid backend validation errors (Issue #48)
+        mispronouncedWords: attempt.mispronouncedWords?.length ? attempt.mispronouncedWords : undefined,
+        accuracy: attempt.accuracy || undefined,
+        cpm: attempt.cpm || undefined,
       });
       setConversation([{ role: 'ai', text: result.question }]);
       applyServerState(result);


### PR DESCRIPTION
Fixes #48

## Summary
When user skips LiveTutor step, `EMPTY_ATTEMPT` contains `cpm: 0, accuracy: 0` which violates backend schema `cpm: Field(None, gt=0)`, causing 422 errors.

## Changes
**File**: `frontend/src/components/reading-steps/ComprehensionChat.tsx` (lines 119-122)

Changed from passing raw values:
```typescript
mispronouncedWords: attempt.mispronouncedWords,
accuracy: attempt.accuracy,
cpm: attempt.cpm,
```

To filtering 0/empty values:
```typescript
mispronouncedWords: attempt.mispronouncedWords?.length ? attempt.mispronouncedWords : undefined,
accuracy: attempt.accuracy || undefined,
cpm: attempt.cpm || undefined,
```

## How It Works
- When values are `0` or empty → convert to `undefined`
- `undefined` properties are omitted from JSON payload
- Backend receives `null` (allowed by schema) instead of `0` (rejected)

## Test Plan
1. Deploy PR preview
2. Navigate to story → skip LiveTutor → go directly to ComprehensionChat
3. Verify no 422 errors in network tab
4. Verify AI responds with first question
5. Test normal flow (with LiveTutor) to ensure reading data still passes correctly