### PR TITLE
feat: 全站配色從 dark theme 改為 light theme（適合國小生）(Fixes #61)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,15 +51,15 @@ const App: React.FC = () => {
   };
 
   return (
-    <div className="h-screen flex flex-col bg-[#0d1117] text-slate-300 font-sans overflow-hidden">
+    <div className="h-screen flex flex-col bg-amber-50 text-gray-900 font-sans overflow-hidden">
       {/* Header */}
-      <header className="bg-[#161b22] border-b border-[#30363d] h-12 flex items-center justify-between px-4 shrink-0">
+      <header className="bg-white border-b border-gray-200 h-12 flex items-center justify-between px-4 shrink-0">
         {/* Logo */}
         <div className="flex items-center gap-2 cursor-pointer shrink-0" onClick={() => setView(AppView.HOME)}>
           <div className="bg-indigo-600 w-6 h-6 rounded flex items-center justify-center">
             <span className="text-white font-bold text-xs">L</span>
           </div>
-          <span className="text-sm font-bold text-slate-200 hidden sm:block">AI Reading Tutor</span>
+          <span className="text-sm font-bold text-gray-800 hidden sm:block">AI Reading Tutor</span>
         </div>
 
         {/* Step Navigation (upper right) */}
@@ -70,13 +70,13 @@ const App: React.FC = () => {
             className={`px-2 py-1 rounded transition-colors ${
               view === AppView.HOME
                 ? 'bg-indigo-600 text-white'
-                : 'text-slate-400 hover:text-white hover:bg-[#21262d]'
+                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
             }`}
           >
             首頁
           </button>
 
-          <span className="text-slate-700 select-none">·</span>
+          <span className="text-gray-300 select-none">·</span>
 
           {/* Steps 1–6 */}
           {([
@@ -97,28 +97,28 @@ const App: React.FC = () => {
                     isActive
                       ? 'bg-indigo-600 text-white'
                       : isDisabled
-                      ? 'text-slate-700 cursor-not-allowed'
-                      : 'text-slate-400 hover:text-white hover:bg-[#21262d]'
+                      ? 'text-gray-400 cursor-not-allowed'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
                   }`}
                 >
                   <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 ${
-                    isActive ? 'bg-white text-indigo-600' : isDisabled ? 'bg-slate-800 text-slate-600' : 'bg-slate-700 text-slate-300'
+                    isActive ? 'bg-white text-indigo-600' : isDisabled ? 'bg-gray-300 text-gray-400' : 'bg-gray-200 text-gray-900'
                   }`}>
                     {step}
                   </span>
                   <span className="hidden md:block">{label}</span>
                 </button>
                 {i < arr.length - 1 && (
-                  <span className="text-slate-700 select-none">·</span>
+                  <span className="text-gray-300 select-none">·</span>
                 )}
               </React.Fragment>
             );
           })}
 
           {/* User avatar */}
-          <div className="ml-3 flex items-center gap-1 pl-3 border-l border-[#30363d]">
-            <div className="w-6 h-6 rounded-full bg-slate-700"></div>
-            <span className="text-[10px] text-slate-500 hidden sm:block">Lv.12</span>
+          <div className="ml-3 flex items-center gap-1 pl-3 border-l border-gray-200">
+            <div className="w-6 h-6 rounded-full bg-gray-200"></div>
+            <span className="text-[10px] text-gray-500 hidden sm:block">Lv.12</span>
           </div>
         </nav>
       </header>
@@ -126,8 +126,8 @@ const App: React.FC = () => {
       <main className="flex-1 flex flex-col overflow-hidden">
         {view === AppView.HOME && (
           <div className="flex-1 flex flex-col items-center justify-center p-8 text-center space-y-6">
-            <h1 className="text-5xl font-black text-white">AI 朗讀助教</h1>
-            <p className="text-slate-400 max-w-md">準備好開始今天的朗讀挑戰了嗎？</p>
+            <h1 className="text-5xl font-black text-gray-900">AI 朗讀助教</h1>
+            <p className="text-gray-600 max-w-md">準備好開始今天的朗讀挑戰了嗎？</p>
             <button 
               onClick={() => setView(AppView.LIBRARY)}
               className="bg-indigo-600 hover:bg-indigo-500 text-white px-10 py-4 rounded-xl font-bold shadow-2xl transition-all"
@@ -206,8 +206,8 @@ const App: React.FC = () => {
             />
           ) : (
             <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8">
-              <h2 className="text-2xl font-bold text-white">寫字練習</h2>
-              <p className="text-slate-400 text-sm">輸入一個中文字，開始練習寫字</p>
+              <h2 className="text-2xl font-bold text-gray-900">寫字練習</h2>
+              <p className="text-gray-600 text-sm">輸入一個中文字，開始練習寫字</p>
               <div className="flex gap-3 items-center">
                 <input
                   type="text"
@@ -215,12 +215,12 @@ const App: React.FC = () => {
                   onChange={e => setWriteInput(e.target.value.slice(-1))}
                   placeholder="輸入一個字"
                   maxLength={1}
-                  className="w-24 h-12 text-center text-2xl bg-[#161b22] border border-[#30363d] rounded-lg text-white focus:outline-none focus:border-indigo-500"
+                  className="w-24 h-12 text-center text-2xl bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:border-indigo-500"
                 />
                 <button
                   onClick={() => { if (writeInput) setWritingChar(writeInput); }}
                   disabled={!writeInput}
-                  className="px-6 h-12 bg-indigo-600 hover:bg-indigo-500 disabled:bg-slate-800 disabled:text-slate-600 text-white rounded-lg font-bold transition-all"
+                  className="px-6 h-12 bg-indigo-600 hover:bg-indigo-500 disabled:bg-gray-300 disabled:text-gray-400 text-white rounded-lg font-bold transition-all"
                 >
                   開始
                 </button>
@@ -230,7 +230,7 @@ const App: React.FC = () => {
                   <button
                     key={ch}
                     onClick={() => setWritingChar(ch)}
-                    className="w-12 h-12 bg-[#21262d] hover:bg-[#30363d] text-white text-xl rounded-lg border border-[#30363d] transition-colors"
+                    className="w-12 h-12 bg-gray-100 hover:bg-gray-200 text-gray-900 text-xl rounded-lg border border-gray-200 transition-colors"
                   >
                     {ch}
                   </button>

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -79,7 +79,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ attempt, onRetry })
           恭喜完成練習！
         </div>
         <h2 className="text-4xl font-bold mb-2">好棒！你今天又進步了。</h2>
-        <p className="text-slate-500">讓我們看看這次朗讀的分析數據吧。</p>
+        <p className="text-gray-500">讓我們看看這次朗讀的分析數據吧。</p>
       </div>
 
       <div className="grid md:grid-cols-2 gap-8">
@@ -103,18 +103,18 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ attempt, onRetry })
              </SafeResponsiveContainer>
              <div className="absolute inset-0 flex flex-col items-center justify-center">
                 <span className="text-4xl font-black text-indigo-600">{attempt.accuracy}%</span>
-                <span className="text-xs text-slate-400 font-bold uppercase tracking-widest">準確度</span>
+                <span className="text-xs text-gray-600 font-bold uppercase tracking-widest">準確度</span>
              </div>
           </div>
           <div className="mt-8 grid grid-cols-2 gap-4 w-full">
-            <div className="bg-slate-50 p-4 rounded-2xl text-center">
-              <p className="text-xs text-slate-400 font-bold mb-1">朗讀速度</p>
-              <p className="text-xl font-bold text-slate-800">{attempt.cpm}</p>
-              <p className="text-[10px] text-slate-400">字/分鐘</p>
+            <div className="bg-gray-50 p-4 rounded-2xl text-center">
+              <p className="text-xs text-gray-600 font-bold mb-1">朗讀速度</p>
+              <p className="text-xl font-bold text-gray-800">{attempt.cpm}</p>
+              <p className="text-[10px] text-gray-600">字/分鐘</p>
             </div>
-            <div className="bg-slate-50 p-4 rounded-2xl text-center">
-              <p className="text-xs text-slate-400 font-bold mb-1">準確度</p>
-              <p className="text-xl font-bold text-slate-800">{attempt.accuracy}%</p>
+            <div className="bg-gray-50 p-4 rounded-2xl text-center">
+              <p className="text-xs text-gray-600 font-bold mb-1">準確度</p>
+              <p className="text-xl font-bold text-gray-800">{attempt.accuracy}%</p>
             </div>
           </div>
         </div>

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -248,7 +248,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
   return (
     <div
-      className="flex flex-1 h-full bg-[#0d1117] overflow-hidden"
+      className="flex flex-1 h-full bg-amber-50 overflow-hidden"
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
@@ -257,10 +257,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     >
 
       {/* LEFT: Story text panel */}
-      <div className="flex-1 flex flex-col bg-[#0d1117] min-w-0">
+      <div className="flex-1 flex flex-col bg-amber-50 min-w-0">
         {/* Tab bar */}
-        <div className="h-9 bg-[#161b22] border-b border-[#30363d] flex items-center px-2 gap-2 shrink-0">
-          <div className="h-full px-4 flex items-center bg-[#0d1117] border-t-2 border-indigo-500 border-x border-[#30363d] text-xs text-slate-200 gap-2">
+        <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-indigo-500 border-x border-gray-200 text-xs text-gray-800 gap-2">
             {story.filename}
           </div>
           <div className="flex-1" />
@@ -269,7 +269,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             className={`px-2.5 py-1 rounded text-xs transition-colors ${
               zhuyinEnabled && zhuyinReady
                 ? 'bg-indigo-600/80 text-white hover:bg-indigo-500'
-                : 'bg-[#30363d] text-slate-400 hover:bg-[#3d444d]'
+                : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
             }`}
           >
             注音 {zhuyinEnabled ? 'ON' : 'OFF'}
@@ -286,10 +286,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 className={`rounded-2xl p-6 border transition-all ${
                   highlightedParagraph === idx
                     ? 'border-amber-500/60 bg-amber-900/10 shadow-[0_0_15px_rgba(245,158,11,0.1)]'
-                    : 'border-transparent hover:border-[#30363d] hover:bg-[#161b22]/40'
+                    : 'border-transparent hover:border-gray-200 hover:bg-white/40'
                 }`}
               >
-                <p className={`text-2xl lg:text-3xl text-slate-300 leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                <p className={`text-2xl lg:text-3xl text-gray-900 leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}
                 </p>
               </div>
@@ -298,7 +298,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         </div>
 
         {/* Status bar */}
-        <div className="h-7 bg-[#161b22] border-t border-[#30363d] flex items-center px-4 text-[10px] text-slate-500 uppercase shrink-0">
+        <div className="h-7 bg-white border-t border-gray-200 flex items-center px-4 text-[10px] text-gray-500 uppercase shrink-0">
           <span>共 {story.content.length} 段 · {story.title}</span>
         </div>
       </div>
@@ -306,30 +306,30 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       {/* Resizable divider */}
       <div
         onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-[#30363d] hover:bg-indigo-500 cursor-col-resize transition-colors"
+        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-indigo-500 cursor-col-resize transition-colors"
       />
 
       {/* RIGHT: AI Tutor chat panel */}
-      <div className="flex-shrink-0 bg-[#0d1117] flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
+      <div className="flex-shrink-0 bg-white flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
         {/* Panel header */}
-        <div className="h-9 shrink-0 bg-[#161b22] border-b border-[#30363d] flex items-center px-4 gap-3">
+        <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
           <span className="text-[10px] font-black text-indigo-400 uppercase tracking-widest">
             AI Tutor
           </span>
           <div className="flex-1" />
-          <span className="text-[10px] text-slate-600">
+          <span className="text-[10px] text-gray-600">
             {understoodCount} / {requiredCount} 理解
           </span>
           <button
             onClick={onFinish}
-            className="text-[10px] text-slate-600 hover:text-slate-400 transition-colors"
+            className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors"
           >
             跳過
           </button>
         </div>
 
         {/* Chat messages */}
-        <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-black/10">
+        <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-gray-50">
 
           {/* Intro message */}
           <div className="flex gap-2.5 pt-1">
@@ -337,8 +337,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               <span className="text-white text-[10px] font-bold">AI</span>
             </div>
             <div className="flex-1">
-              <div className="bg-[#161b22] border border-[#30363d] rounded-2xl rounded-tl-sm px-4 py-3">
-                <p className={`text-lg text-slate-300 leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+              <div className="bg-indigo-50 border border-indigo-200 rounded-2xl rounded-tl-sm px-4 py-3">
+                <p className={`text-lg text-indigo-900 leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
                   {processZhuyin(`你剛才讀完了《${story.title}》，做得很棒！我想問你幾個關於課文的問題，幫助你更深入理解。準備好了嗎？`)}
                 </p>
               </div>
@@ -352,8 +352,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               return (
                 <div key={i} className={`mx-10 rounded-xl px-3.5 py-2 text-sm border ${
                   turn.understood
-                    ? 'bg-emerald-900/20 border-emerald-700/40 text-emerald-300'
-                    : 'bg-amber-900/20 border-amber-700/40 text-amber-300'
+                    ? 'bg-emerald-50 border-emerald-300 text-emerald-800'
+                    : 'bg-amber-50 border-amber-300 text-amber-800'
                 }`}>
                   <span className="mr-1.5">{turn.understood ? '✓' : '💡'}</span>
                   {processZhuyin(turn.text)}
@@ -369,8 +369,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                     <span className="text-white text-[10px] font-bold">AI</span>
                   </div>
                 ) : (
-                  <div className="flex-shrink-0 w-7 h-7 rounded-full bg-slate-700 flex items-center justify-center">
-                    <svg className="w-3.5 h-3.5 text-slate-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <div className="flex-shrink-0 w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center">
+                    <svg className="w-3.5 h-3.5 text-gray-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
                         d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                     </svg>
@@ -380,7 +380,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                   <div className={[
                     'rounded-2xl px-4 py-3',
                     turn.role === 'ai'
-                      ? 'bg-[#161b22] border border-[#30363d] rounded-tl-sm text-slate-300'
+                      ? 'bg-indigo-50 border border-indigo-200 rounded-tl-sm text-indigo-900'
                       : 'bg-indigo-600 rounded-tr-sm text-white',
                   ].join(' ')}>
                     <p className={`text-lg leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
@@ -396,10 +396,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               <div className="flex-shrink-0 w-7 h-7 rounded-full bg-indigo-600 flex items-center justify-center">
                 <span className="text-white text-[10px] font-bold">AI</span>
               </div>
-              <div className="bg-[#161b22] border border-[#30363d] rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5">
-                <span className="w-1.5 h-1.5 bg-slate-500 rounded-full animate-bounce [animation-delay:0ms]" />
-                <span className="w-1.5 h-1.5 bg-slate-500 rounded-full animate-bounce [animation-delay:150ms]" />
-                <span className="w-1.5 h-1.5 bg-slate-500 rounded-full animate-bounce [animation-delay:300ms]" />
+              <div className="bg-indigo-50 border border-indigo-200 rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5">
+                <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce [animation-delay:0ms]" />
+                <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce [animation-delay:150ms]" />
+                <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce [animation-delay:300ms]" />
               </div>
             </div>
           )}
@@ -419,9 +419,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
           {/* Completion message */}
           {isSessionComplete && !isLoading && (
-            <div className="bg-emerald-900/30 border border-emerald-700/40 rounded-2xl p-4 text-center">
-              <p className="text-emerald-300 font-bold text-sm">太棒了！你展現了很好的理解力！</p>
-              <p className="text-emerald-400/70 text-xs mt-1">你對課文的理解很好，繼續下一步吧！</p>
+            <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center">
+              <p className="text-emerald-800 font-bold text-sm">太棒了！你展現了很好的理解力！</p>
+              <p className="text-emerald-700 text-xs mt-1">你對課文的理解很好，繼續下一步吧！</p>
             </div>
           )}
 
@@ -429,12 +429,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         </div>
 
         {/* Bottom: input or proceed button */}
-        <div className="shrink-0 bg-[#161b22] border-t border-[#30363d] p-3">
+        <div className="shrink-0 bg-white border-t border-gray-200 p-3">
           {isSessionComplete ? (
             <div className="flex items-center justify-between gap-2">
               <button
                 onClick={onBack}
-                className="px-3 py-3 rounded-xl text-base text-slate-500 hover:text-slate-300 transition-colors"
+                className="px-3 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors"
               >
                 ← 回到朗讀
               </button>
@@ -458,12 +458,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 placeholder="輸入你的回答……（Enter 送出）"
                 rows={2}
                 disabled={isLoading || isSessionComplete}
-                className="flex-1 bg-[#0d1117] border border-[#30363d] rounded-xl px-3 py-2 text-base text-slate-200 placeholder-slate-600 focus:outline-none focus:border-indigo-500 resize-none disabled:opacity-50"
+                className="flex-1 bg-white border border-gray-200 rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:border-indigo-500 resize-none disabled:opacity-50"
               />
               <button
                 onClick={handleSubmit}
                 disabled={!inputText.trim() || isLoading || isSessionComplete}
-                className="flex-shrink-0 w-10 h-10 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:bg-slate-800 disabled:text-slate-600 text-white flex items-center justify-center transition-all active:scale-95"
+                className="flex-shrink-0 w-10 h-10 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
@@ -478,8 +478,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       <style>{`
         .custom-scrollbar::-webkit-scrollbar { width: 5px; }
         .custom-scrollbar::-webkit-scrollbar-track { background: transparent; }
-        .custom-scrollbar::-webkit-scrollbar-thumb { background: #30363d; border-radius: 10px; }
-        .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: #4b5563; }
+        .custom-scrollbar::-webkit-scrollbar-thumb { background: #d1d5db; border-radius: 10px; }
+        .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: #9ca3af; }
       `}</style>
     </div>
   );

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -261,7 +261,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
   return (
     <div
-      className="flex flex-1 h-full bg-[#0d1117] overflow-hidden"
+      className="flex flex-1 h-full bg-amber-50 overflow-hidden"
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
@@ -269,10 +269,10 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       }}
     >
       {/* LEFT: Full story text */}
-      <div className="flex-1 flex flex-col bg-[#0d1117] min-w-0">
+      <div className="flex-1 flex flex-col bg-amber-50 min-w-0">
         {/* Tab bar */}
-        <div className="h-9 bg-[#161b22] border-b border-[#30363d] flex items-center px-2 gap-2 shrink-0">
-          <div className="h-full px-4 flex items-center bg-[#0d1117] border-t-2 border-indigo-500 border-x border-[#30363d] text-xs text-slate-200">
+        <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-indigo-500 border-x border-gray-200 text-xs text-gray-800">
             {story.filename}
           </div>
           <div className="flex-1" />
@@ -281,7 +281,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
             className={`px-2.5 py-1 rounded text-xs transition-colors ${
               zhuyinEnabled && zhuyinReady
                 ? 'bg-indigo-600/80 text-white hover:bg-indigo-500'
-                : 'bg-[#30363d] text-slate-400 hover:bg-[#3d444d]'
+                : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
             }`}
           >
             注音 {zhuyinEnabled ? 'ON' : 'OFF'}
@@ -294,9 +294,9 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
             {story.content.map((line, idx) => (
               <div
                 key={idx}
-                className="rounded-2xl p-6 border border-transparent hover:border-[#30363d] hover:bg-[#161b22]/30 transition-all"
+                className="rounded-2xl p-6 border border-transparent hover:border-gray-200 hover:bg-white/30 transition-all"
               >
-                <p className={`text-2xl lg:text-3xl text-slate-200 leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                <p className={`text-2xl lg:text-3xl text-gray-800 leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}
                 </p>
               </div>
@@ -305,10 +305,10 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
         </div>
 
         {/* Status bar */}
-        <div className="h-7 bg-[#161b22] border-t border-[#30363d] flex items-center px-4 text-[10px] text-slate-500 uppercase shrink-0">
+        <div className="h-7 bg-white border-t border-gray-200 flex items-center px-4 text-[10px] text-gray-500 uppercase shrink-0">
           <span>共 {story.content.length} 段 · {story.title}</span>
           <div className="flex-1" />
-          <span className={isSessionActive ? 'text-green-500 font-bold' : isPreparing ? 'text-yellow-500 font-bold' : 'text-slate-700'}>
+          <span className={isSessionActive ? 'text-green-500 font-bold' : isPreparing ? 'text-yellow-500 font-bold' : 'text-gray-300'}>
             {isSessionActive ? '• LISTENING' : isPreparing ? '• PREPARING' : '• IDLE'}
           </span>
         </div>
@@ -317,29 +317,29 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       {/* Resizable divider */}
       <div
         onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-[#30363d] hover:bg-indigo-500 cursor-col-resize transition-colors"
+        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-indigo-500 cursor-col-resize transition-colors"
       />
 
       {/* RIGHT: Recording panel */}
       <div
-        className="flex-shrink-0 bg-[#0d1117] flex flex-col h-full min-h-0"
+        className="flex-shrink-0 bg-amber-50 flex flex-col h-full min-h-0"
         style={{ width: rightPanelWidth }}
       >
         {/* Header */}
-        <div className="h-9 shrink-0 bg-[#161b22] border-b border-[#30363d] flex items-center px-4">
+        <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4">
           <span className="text-[10px] font-black text-indigo-400 uppercase tracking-widest">全文朗讀</span>
         </div>
 
         {/* Content */}
-        <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4 custom-scrollbar bg-black/10">
+        <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-4 custom-scrollbar bg-gray-50">
 
           {/* Instructions */}
           {!result && !isSessionActive && !isPreparing && (
-            <div className="bg-[#161b22] border border-[#30363d] rounded-2xl p-4">
-              <p className="text-xs text-slate-400 leading-relaxed">
+            <div className="bg-white border border-gray-200 rounded-2xl p-4">
+              <p className="text-xs text-gray-600 leading-relaxed">
                 請從頭到尾朗讀整篇課文。讀完後按「完成朗讀」送出。
               </p>
-              <p className="text-[10px] text-slate-600 mt-2">
+              <p className="text-[10px] text-gray-400 mt-2">
                 標準比逐段朗讀寬鬆，放輕鬆自然地讀吧！
               </p>
             </div>
@@ -369,25 +369,25 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
             <div className="space-y-4">
               <div className="flex flex-col items-center gap-3 py-4">
                 <div className={`w-24 h-24 rounded-full flex items-center justify-center border-4 ${
-                  percent >= 75 ? 'border-emerald-500 text-emerald-300'
-                  : percent >= 55 ? 'border-amber-500 text-amber-300'
+                  percent >= 75 ? 'border-emerald-500 text-emerald-800'
+                  : percent >= 55 ? 'border-amber-500 text-amber-800'
                   : 'border-red-500/60 text-red-300'
                 }`}>
                   <span className="text-2xl font-black">{percent}%</span>
                 </div>
                 <p className={`text-sm font-bold text-center ${
-                  percent >= 75 ? 'text-emerald-300'
-                  : percent >= 55 ? 'text-amber-300'
-                  : 'text-slate-400'
+                  percent >= 75 ? 'text-emerald-800'
+                  : percent >= 55 ? 'text-amber-800'
+                  : 'text-gray-600'
                 }`}>
                   {result.feedback}
                 </p>
               </div>
 
               {streamingTranscript && (
-                <div className="bg-[#161b22] border border-[#30363d] rounded-xl px-3 py-2.5">
-                  <p className="text-[10px] text-slate-500 mb-1 uppercase tracking-widest">你說的</p>
-                  <p className="text-xs text-slate-400 leading-relaxed line-clamp-6">{streamingTranscript}</p>
+                <div className="bg-white border border-gray-200 rounded-xl px-3 py-2.5">
+                  <p className="text-[10px] text-gray-500 mb-1 uppercase tracking-widest">你說的</p>
+                  <p className="text-xs text-gray-600 leading-relaxed line-clamp-6">{streamingTranscript}</p>
                 </div>
               )}
             </div>
@@ -395,14 +395,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
         </div>
 
         {/* Controls */}
-        <div className="shrink-0 p-3 bg-[#161b22] border-t border-[#30363d] space-y-2">
+        <div className="shrink-0 p-3 bg-white border-t border-gray-200 space-y-2">
           {micError && <div className="text-[10px] text-rose-400 px-1 pb-1">{micError}</div>}
 
           {result ? (
             <div className="space-y-2">
               <button
                 onClick={() => { setResult(null); setStreamingTranscript(''); }}
-                className="w-full py-3 rounded-xl text-base font-bold bg-slate-700 hover:bg-slate-600 text-slate-200 transition-all active:scale-95"
+                className="w-full py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all active:scale-95"
               >
                 再試一次
               </button>
@@ -417,7 +417,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
               </button>
             </div>
           ) : isPreparing ? (
-            <button disabled className="w-full py-3 rounded-xl text-base font-bold bg-slate-800 text-slate-500 cursor-wait flex items-center justify-center gap-2">
+            <button disabled className="w-full py-3 rounded-xl text-base font-bold bg-gray-300 text-gray-500 cursor-wait flex items-center justify-center gap-2">
               <div className="w-3 h-3 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
               準備中...
             </button>
@@ -428,7 +428,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
               className={`w-full py-3 rounded-xl text-base font-bold transition-all flex items-center justify-center gap-2 ${
                 streamingTranscript
                   ? 'bg-emerald-600 hover:bg-emerald-500 text-white active:scale-95'
-                  : 'bg-slate-800 text-slate-600 cursor-not-allowed'
+                  : 'bg-gray-300 text-gray-400 cursor-not-allowed'
               }`}
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -458,7 +458,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
               {/* 停止 */}
               <button
                 onClick={stopTts}
-                className="flex-1 py-3 rounded-xl text-base font-bold bg-slate-700 hover:bg-slate-600 text-slate-200 transition-all flex items-center justify-center gap-1.5 active:scale-95"
+                className="flex-1 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all flex items-center justify-center gap-1.5 active:scale-95"
               >
                 <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 10h6v4H9z" />
@@ -470,7 +470,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
             <div className="flex gap-2">
               <button
                 onClick={speakFullStory}
-                className="flex-1 py-3 rounded-xl text-base font-bold bg-slate-700 hover:bg-slate-600 text-slate-200 transition-all flex items-center justify-center gap-1.5 active:scale-95"
+                className="flex-1 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all flex items-center justify-center gap-1.5 active:scale-95"
               >
                 <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
@@ -489,7 +489,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
           <button
             onClick={onBack}
-            className="w-full py-1.5 rounded-lg text-xs text-slate-600 hover:text-slate-400 transition-colors"
+            className="w-full py-1.5 rounded-lg text-xs text-gray-400 hover:text-gray-600 transition-colors"
           >
             ← 返回生字練習
           </button>

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -80,7 +80,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
 
   return (
     <div
-      className="flex-1 flex flex-col bg-[#0d1117] overflow-hidden"
+      className="flex-1 flex flex-col bg-amber-50 overflow-hidden"
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
@@ -88,19 +88,19 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
       }}
     >
       {/* Top bar */}
-      <div className="h-9 bg-[#161b22] border-b border-[#30363d] flex items-center px-4 gap-3">
+      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
         <button
           onClick={onBack}
-          className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-300 transition-colors"
+          className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-900 transition-colors"
         >
           <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7" />
           </svg>
           圖書館
         </button>
-        <span className="text-slate-700 text-xs">›</span>
-        <span className="text-xs text-slate-400">{story.title}</span>
-        <span className="text-slate-700 text-xs">›</span>
+        <span className="text-gray-300 text-xs">›</span>
+        <span className="text-xs text-gray-600">{story.title}</span>
+        <span className="text-gray-300 text-xs">›</span>
         <span className="text-xs text-indigo-400 font-bold">簡介</span>
         <div className="flex-1" />
         <button
@@ -108,7 +108,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
           className={`px-2.5 py-1 rounded text-xs transition-colors ${
             zhuyinEnabled && zhuyinReady
               ? 'bg-indigo-600/80 text-white hover:bg-indigo-500'
-              : 'bg-[#30363d] text-slate-400 hover:bg-[#3d444d]'
+              : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
           }`}
         >
           注音 {zhuyinEnabled ? 'ON' : 'OFF'}
@@ -124,20 +124,20 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
             <img
               src={story.thumbnail}
               alt={story.title}
-              className="w-32 h-24 object-cover rounded-xl border border-[#30363d] flex-shrink-0"
+              className="w-32 h-24 object-cover rounded-xl border border-gray-200 flex-shrink-0"
             />
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
-                <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-indigo-900/60 text-indigo-300 border border-indigo-700/40 uppercase tracking-widest">
+                <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-indigo-100 text-indigo-700 border border-indigo-300 uppercase tracking-widest">
                   {CATEGORY_LABEL[story.category] ?? story.category}
                 </span>
-                <span className="text-[10px] text-slate-600">Lv.{story.level}</span>
+                <span className="text-[10px] text-gray-400">Lv.{story.level}</span>
               </div>
-              <h1 className={`text-2xl font-black text-white leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+              <h1 className={`text-2xl font-black text-gray-900 leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                 {processZhuyin(story.title)}
               </h1>
               {story.intro && (
-                <p className={`text-base leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''} text-slate-400`}>
+                <p className={`text-base leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''} text-gray-600`}>
                   {processZhuyin(story.intro.author)}
                 </p>
               )}
@@ -146,14 +146,14 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
 
           {/* Background section */}
           {story.intro ? (
-            <div className="bg-[#161b22] border border-[#30363d] rounded-2xl p-6 space-y-4">
+            <div className="bg-white border border-gray-200 rounded-2xl p-6 space-y-4">
               <div className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <span className="text-xs font-bold text-indigo-400 uppercase tracking-widest">課文簡介</span>
               </div>
-              <p className={`text-slate-300 text-xl leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+              <p className={`text-gray-900 text-xl leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                 {processZhuyin(story.intro.background)}
               </p>
 
@@ -162,7 +162,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 {isSpeaking ? (
                   <button
                     onClick={stopSpeaking}
-                    className="flex items-center gap-2 px-4 py-3 rounded-xl text-base font-bold bg-amber-800/50 text-amber-300 border border-amber-700/40 transition-all"
+                    className="flex items-center gap-2 px-4 py-3 rounded-xl text-base font-bold bg-amber-800/50 text-amber-800 border border-amber-300 transition-all"
                   >
                     <svg className="w-4 h-4 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -173,7 +173,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 ) : (
                   <button
                     onClick={speakIntro}
-                    className="flex items-center gap-2 px-4 py-3 rounded-xl text-base font-bold bg-slate-700 hover:bg-slate-600 text-slate-200 border border-[#30363d] transition-all active:scale-95"
+                    className="flex items-center gap-2 px-4 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 border border-gray-200 transition-all active:scale-95"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
@@ -184,7 +184,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
               </div>
             </div>
           ) : (
-            <div className="bg-[#161b22] border border-[#30363d] rounded-2xl p-6 text-slate-500 text-sm">
+            <div className="bg-white border border-gray-200 rounded-2xl p-6 text-gray-500 text-sm">
               這篇課文目前沒有簡介資料。
             </div>
           )}
@@ -193,10 +193,10 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
       </div>
 
       {/* Bottom action */}
-      <div className="flex-shrink-0 bg-[#161b22] border-t border-[#30363d] px-6 py-4 flex items-center justify-between">
+      <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
         <button
           onClick={onBack}
-          className="px-4 py-3 rounded-xl text-base text-slate-500 hover:text-slate-300 transition-colors"
+          className="px-4 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors"
         >
           返回圖書館
         </button>

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -676,7 +676,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   return (
     <div
-      className="flex flex-1 h-full bg-[#0d1117] overflow-hidden"
+      className="flex flex-1 h-full bg-amber-50 overflow-hidden"
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
@@ -684,9 +684,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       }}
     >
       {/* CENTER: Editor */}
-      <div className="flex-1 flex flex-col bg-[#0d1117]">
-        <div className="h-9 bg-[#161b22] border-b border-[#30363d] flex items-center px-2 gap-2">
-          <div className="h-full px-4 flex items-center bg-[#0d1117] border-t-2 border-indigo-500 border-x border-[#30363d] text-xs text-slate-200 gap-2">
+      <div className="flex-1 flex flex-col bg-amber-50">
+        <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-indigo-500 border-x border-gray-200 text-xs text-gray-800 gap-2">
             {processZhuyin(story.filename)}
           </div>
           <div className="flex-1" />
@@ -695,7 +695,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
             className={`px-2.5 py-1 rounded text-xs transition-colors ${
               zhuyinEnabled && zhuyinReady
                 ? 'bg-indigo-600/80 text-white hover:bg-indigo-500'
-                : 'bg-[#30363d] text-slate-400 hover:bg-[#3d444d]'
+                : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
             }`}
             title={zhuyinEnabled ? '隱藏注音' : '顯示注音'}
           >
@@ -717,7 +717,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               >
                 <p
                   className={`text-2xl lg:text-3xl leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
-                    idx === currentLineIndex ? 'text-white font-bold' : 'text-slate-400'
+                    idx === currentLineIndex ? 'text-gray-900 font-bold' : 'text-gray-600'
                   }`}
                 >
                   {zhuyinLines ? zhuyinLines[idx] : line}
@@ -727,13 +727,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           </div>
         </div>
 
-        <div className="h-7 bg-[#161b22] border-t border-[#30363d] flex items-center px-4 justify-between text-[10px] text-slate-500 uppercase">
+        <div className="h-7 bg-white border-t border-gray-200 flex items-center px-4 justify-between text-[10px] text-gray-500 uppercase">
           <div className="flex gap-4">
             <span>段 {currentLineIndex + 1} / {story.content.length}</span>
             <span>UTF-8</span>
           </div>
           <div className="flex gap-3">
-            <span className={isSessionActive ? 'text-green-500 font-bold' : isPreparing ? 'text-yellow-500 font-bold' : 'text-slate-700'}>
+            <span className={isSessionActive ? 'text-green-500 font-bold' : isPreparing ? 'text-yellow-500 font-bold' : 'text-gray-300'}>
               {isSessionActive ? '• LISTENING' : isPreparing ? '• PREPARING' : '• IDLE'}
             </span>
           </div>
@@ -743,12 +743,12 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       {/* Resizable divider */}
       <div
         onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-[#30363d] hover:bg-indigo-500 cursor-col-resize transition-colors"
+        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-indigo-500 cursor-col-resize transition-colors"
       />
 
       {/* RIGHT: Interaction panel */}
-      <div className="flex-shrink-0 bg-[#0d1117] flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
-        <div className="h-9 flex-shrink-0 bg-[#161b22] border-b border-[#30363d] flex items-center px-4">
+      <div className="flex-shrink-0 bg-amber-50 flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
+        <div className="h-9 flex-shrink-0 bg-white border-b border-gray-200 flex items-center px-4">
           <span className="text-[10px] font-black text-indigo-400 uppercase tracking-widest">
             Live Feedback
           </span>
@@ -757,11 +757,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         {/* Chat area */}
         <div
           ref={scrollRef}
-          className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-black/10"
+          className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-gray-50"
         >
           {messages.map(m => (
             <div key={m.id} className={`flex flex-col ${m.role === 'user' ? 'items-end' : 'items-start'}`}>
-              <span className="text-[9px] font-bold text-slate-700 mb-0.5 uppercase">
+              <span className="text-[9px] font-bold text-gray-300 mb-0.5 uppercase">
                 {m.role === 'user' ? 'STUDENT' : 'TUTOR'}
               </span>
               <div
@@ -770,7 +770,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 } ${
                   m.role === 'user'
                     ? 'bg-indigo-600 text-white rounded-tr-none'
-                    : 'bg-[#21262d] text-slate-200 border border-[#30363d] rounded-tl-none'
+                    : 'bg-gray-100 text-gray-800 border border-gray-200 rounded-tl-none'
                 }`}
               >
                 {processZhuyin(m.text)}
@@ -805,7 +805,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               <span className="text-[9px] font-bold text-indigo-500 mb-0.5 uppercase animate-pulse">
                 NEXT...
               </span>
-              <div className={`px-4 py-3 rounded-2xl text-lg bg-[#21262d] text-indigo-300 border border-indigo-900/30 rounded-tl-none leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+              <div className={`px-4 py-3 rounded-2xl text-lg bg-gray-100 text-indigo-300 border border-indigo-900/30 rounded-tl-none leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
                 {processZhuyin('正在前往下一段...')}
               </div>
             </div>
@@ -813,10 +813,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         </div>
 
         {/* Controls */}
-        <div className="flex-shrink-0 p-3 bg-[#161b22] border-t border-[#30363d] space-y-2">
-          <div className={`min-h-[3rem] p-2 rounded-lg bg-black/40 border border-[#30363d] text-base text-indigo-300 overflow-hidden leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+        <div className="flex-shrink-0 p-3 bg-white border-t border-gray-200 space-y-2">
+          <div className={`min-h-[3rem] p-2 rounded-lg bg-black/40 border border-gray-200 text-base text-indigo-300 overflow-hidden leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
             {streamingUserInput ? processZhuyin(streamingUserInput) : (
-              <span className="text-slate-800 italic">
+              <span className="text-gray-800 italic">
                 {processZhuyin(isPreparing ? '正在準備語音辨識...' : isSessionActive ? '正在聆聽您的朗讀...' : '點擊「開始朗讀」開始')}
               </span>
             )}
@@ -830,7 +830,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 {/* 系統朗讀 disabled while mic is initializing */}
                 <button
                   disabled
-                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-slate-900 text-slate-700 cursor-not-allowed"
+                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-300 text-gray-300 cursor-not-allowed"
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
@@ -839,7 +839,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 </button>
                 <button
                   disabled
-                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-slate-800 text-slate-400 cursor-wait"
+                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-300 text-gray-600 cursor-wait"
                 >
                   <div className="w-3 h-3 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
                   {processZhuyin('準備中...')}
@@ -851,7 +851,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 disabled={isAdvancing || !streamingUserInput}
                 className={`flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 transition-all shadow active:scale-95 ${
                   isAdvancing || !streamingUserInput
-                    ? 'bg-slate-800 text-slate-600 cursor-not-allowed opacity-50'
+                    ? 'bg-gray-300 text-gray-400 cursor-not-allowed opacity-50'
                     : 'bg-emerald-600 hover:bg-emerald-500 text-white'
                 }`}
               >
@@ -882,7 +882,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 {/* 停止 */}
                 <button
                   onClick={stopTts}
-                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-slate-700 hover:bg-slate-600 text-slate-200 transition-all shadow active:scale-95"
+                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all shadow active:scale-95"
                 >
                   <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 10h6v4H9z" />
@@ -895,7 +895,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 {/* 系統朗讀 */}
                 <button
                   onClick={speakCurrentParagraph}
-                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-slate-700 hover:bg-slate-600 text-slate-200 transition-all shadow active:scale-95"
+                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all shadow active:scale-95"
                 >
                   <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
@@ -908,7 +908,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                   disabled={isAdvancing}
                   className={`flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 transition-all shadow active:scale-95 ${
                     isAdvancing
-                      ? 'bg-slate-800 text-slate-600 cursor-not-allowed opacity-50'
+                      ? 'bg-gray-300 text-gray-400 cursor-not-allowed opacity-50'
                       : 'bg-indigo-600 hover:bg-indigo-500 text-white'
                   }`}
                 >
@@ -926,12 +926,12 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 setCurrentLineIndex(prev => Math.max(0, prev - 1));
               }}
               disabled={currentLineIndex === 0}
-              className={`flex-1 py-3 rounded-lg text-base font-bold border border-[#30363d] leading-[2.6] ${
+              className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${
                 zhuyinActive ? 'tracking-[0.2em]' : ''
               } ${
                 currentLineIndex === 0
-                  ? 'bg-slate-900 text-slate-700 cursor-not-allowed'
-                  : 'bg-slate-800 hover:bg-slate-700 text-slate-400'
+                  ? 'bg-gray-300 text-gray-300 cursor-not-allowed'
+                  : 'bg-gray-300 hover:bg-gray-200 text-gray-600'
               }`}
             >
               {processZhuyin('上一段')}
@@ -945,7 +945,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                   handleFinish();
                 }
               }}
-              className={`flex-1 py-3 bg-slate-800 hover:bg-slate-700 text-slate-400 rounded-lg text-base font-bold border border-[#30363d] leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}
+              className={`flex-1 py-3 bg-gray-300 hover:bg-gray-200 text-gray-600 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}
             >
               {processZhuyin(currentLineIndex === story.content.length - 1 ? '觀看總結報告' : '下一段')}
             </button>
@@ -954,7 +954,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           {isSessionActive && (
             <button
               onClick={stopSession}
-              className={`w-full py-1.5 rounded-lg text-base font-bold text-slate-600 hover:text-slate-400 transition-colors leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}
+              className={`w-full py-1.5 rounded-lg text-base font-bold text-gray-400 hover:text-gray-600 transition-colors leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}
             >
               {processZhuyin('停止朗讀')}
             </button>

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -105,7 +105,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
   return (
     <div
-      className="flex-1 flex flex-col bg-[#0d1117] overflow-hidden"
+      className="flex-1 flex flex-col bg-amber-50 overflow-hidden"
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
@@ -113,12 +113,12 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
       }}
     >
       {/* Tab bar — VS Code style */}
-      <div className="h-9 bg-[#161b22] border-b border-[#30363d] flex items-center px-2 gap-2 shrink-0">
-        <div className="h-full px-4 flex items-center bg-[#0d1117] border-t-2 border-indigo-500 border-x border-[#30363d] text-xs text-slate-200 gap-2">
+      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
+        <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-indigo-500 border-x border-gray-200 text-xs text-gray-800 gap-2">
           {story.filename} — 生字練習
         </div>
         <div className="flex-1" />
-        <span className="text-[10px] text-slate-500">
+        <span className="text-[10px] text-gray-500">
           已練習 {practicedChars.size} / {displayChars.length} 字
         </span>
         <button
@@ -126,7 +126,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           className={`px-2.5 py-1 rounded text-xs transition-colors ${
             zhuyinEnabled && zhuyinReady
               ? 'bg-indigo-600/80 text-white hover:bg-indigo-500'
-              : 'bg-[#30363d] text-slate-400 hover:bg-[#3d444d]'
+              : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
           }`}
         >
           注音 {zhuyinEnabled ? 'ON' : 'OFF'}
@@ -139,8 +139,8 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
           {/* Header */}
           <div>
-            <h2 className="text-xl font-black text-white mb-1">生字練習</h2>
-            <p className="text-sm text-slate-400">
+            <h2 className="text-xl font-black text-gray-900 mb-1">生字練習</h2>
+            <p className="text-sm text-gray-600">
               {needPracticeSet.size > 0
                 ? `朗讀時漏掉了以下 ${Math.min(needPracticeSet.size, 12)} 個字，點一點來練習筆順吧！`
                 : '讀得很棒！沒有漏字。想再練習這篇的字嗎？'}
@@ -149,7 +149,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
           {/* Character grid */}
           {displayChars.length === 0 ? (
-            <div className="text-slate-600 text-sm py-8 text-center">這篇課文的漢字沒有筆順資料</div>
+            <div className="text-gray-400 text-sm py-8 text-center">這篇課文的漢字沒有筆順資料</div>
           ) : (
             <div className="grid grid-cols-4 sm:grid-cols-6 gap-3">
               {displayChars.map(ch => {
@@ -162,10 +162,10 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                     className={[
                       `relative flex flex-col items-center justify-center ${zhuyinActive ? 'aspect-[3/6]' : 'aspect-square'} rounded-2xl border transition-all active:scale-95`,
                       isPracticed
-                        ? 'bg-emerald-900/30 border-emerald-700/50 text-emerald-300'
+                        ? 'bg-emerald-50 border-emerald-700/50 text-emerald-800'
                         : isSuggested
                           ? 'bg-amber-900/30 border-amber-600/60 text-amber-200 ring-1 ring-amber-500/30 hover:bg-amber-900/50'
-                          : 'bg-[#161b22] border-[#30363d] text-slate-200 hover:bg-[#21262d] hover:border-indigo-500/40',
+                          : 'bg-white border-gray-200 text-gray-800 hover:bg-gray-100 hover:border-indigo-500/40',
                     ].join(' ')}
                   >
                     <span className={`text-3xl font-bold leading-[2.8] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}>
@@ -197,7 +197,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
           {/* Legend */}
           {needPracticeSet.size > 0 && (
-            <div className="flex items-center gap-4 text-[10px] text-slate-600">
+            <div className="flex items-center gap-4 text-[10px] text-gray-400">
               <div className="flex items-center gap-1.5">
                 <span className="w-2.5 h-2.5 bg-amber-500 rounded-full" />
                 建議練習
@@ -211,18 +211,18 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
           {/* Completion message */}
           {allDone && (
-            <div className="bg-emerald-900/30 border border-emerald-700/40 rounded-2xl p-4 text-center">
-              <p className="text-emerald-300 font-bold">太棒了！所有生字都練習完了！</p>
+            <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center">
+              <p className="text-emerald-800 font-bold">太棒了！所有生字都練習完了！</p>
             </div>
           )}
         </div>
       </div>
 
       {/* Bottom actions */}
-      <div className="flex-shrink-0 bg-[#161b22] border-t border-[#30363d] px-6 py-4 flex items-center justify-between">
+      <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
         <button
           onClick={onBack}
-          className="px-4 py-3 rounded-xl text-base text-slate-400 hover:text-slate-200 transition-colors"
+          className="px-4 py-3 rounded-xl text-base text-gray-600 hover:text-gray-800 transition-colors"
         >
           回到朗讀
         </button>

--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -25,8 +25,8 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
     <div className="space-y-6">
       {/* Header with lesson count */}
       <div className="text-center">
-        <h2 className="text-2xl font-bold text-white mb-2">選擇讀本</h2>
-        <p className="text-slate-400 text-sm">
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">選擇讀本</h2>
+        <p className="text-gray-600 text-sm">
           共 {allLessons.length} 篇文章
           {selectedGrade && ` · 第 ${selectedGrade} 年級`}
         </p>
@@ -39,7 +39,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
             selectedGrade === null
               ? 'bg-indigo-600 text-white'
-              : 'bg-[#161b22] text-slate-400 border border-[#30363d] hover:border-indigo-500'
+              : 'bg-white text-gray-600 border border-gray-200 hover:border-indigo-500'
           }`}
         >
           全部
@@ -51,7 +51,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
               selectedGrade === grade
                 ? 'bg-indigo-600 text-white'
-                : 'bg-[#161b22] text-slate-400 border border-[#30363d] hover:border-indigo-500'
+                : 'bg-white text-gray-600 border border-gray-200 hover:border-indigo-500'
             }`}
           >
             G{grade}
@@ -64,7 +64,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
         {stories.map((story) => (
           <div
             key={story.id}
-            className="bg-[#161b22] rounded-xl overflow-hidden border border-[#30363d] hover:border-indigo-500 transition-all cursor-pointer group"
+            className="bg-white rounded-xl overflow-hidden border border-gray-200 hover:border-indigo-500 transition-all cursor-pointer group shadow-sm"
             onClick={() => onStartReading(story)}
           >
             <div className="h-40 overflow-hidden relative">
@@ -81,8 +81,8 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
               )}
             </div>
             <div className="p-4">
-              <h4 className="text-white font-bold mb-1">{story.title}</h4>
-              <div className="text-[10px] text-slate-500 font-mono">{story.filename}</div>
+              <h4 className="text-gray-900 font-bold mb-1">{story.title}</h4>
+              <div className="text-[10px] text-gray-500 font-mono">{story.filename}</div>
             </div>
           </div>
         ))}
@@ -90,7 +90,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
 
       {/* Empty state */}
       {stories.length === 0 && (
-        <div className="text-center py-12 text-slate-400">
+        <div className="text-center py-12 text-gray-600">
           <p>沒有找到符合條件的讀本</p>
         </div>
       )}


### PR DESCRIPTION
Fixes #61

## Summary

完整將前端從 GitHub dark theme 配色改為溫暖明亮的 light theme，提升國小學生學習平台的可讀性和學習氛圍。

## 配色變更

| 原配色 | 新配色 | 用途 |
|--------|--------|------|
| `bg-[#0d1117]` | `bg-amber-50` | 主背景（溫暖淺色） |
| `bg-[#161b22]` | `bg-white` | 卡片/面板（加 shadow-sm） |
| `border-[#30363d]` | `border-gray-200` | 邊框 |
| `text-slate-300` | `text-gray-900` | 主文字 |
| `text-slate-400` | `text-gray-600` | 次要文字 |
| `hover:bg-[#21262d]` | `hover:bg-gray-100` | Hover 狀態 |
| AI 訊息深色背景 | `bg-indigo-50` + `text-indigo-900` | AI 對話框 |
| 回饋訊息深色半透明 | `bg-emerald-50` / `bg-amber-50` | 理解/未理解提示 |

## 保留不變

- ✅ Indigo-600 accent 色（按鈕、活動狀態）
- ✅ WCAG AA 對比度標準

## 影響檔案

- `App.tsx` — 主框架、header、步驟導航
- `StoryLibrary.tsx` — 讀本選擇頁
- `Intro.tsx` — 簡介頁
- `LiveTutor.tsx` — 逐段朗讀
- `ComprehensionChat.tsx` — 課文理解對話
- `VocabPractice.tsx` — 生字練習
- `FullReading.tsx` — 全文朗讀
- `AssessmentReport.tsx` — 學習報告

## Test plan

1. 開啟 PR Preview URL
2. 測試所有 6 個學習步驟頁面
3. 驗證：
   - 背景為暖色淺色系（非深色）
   - 文字清晰可讀（無對比度問題）
   - 卡片/面板為白底
   - Hover 狀態正常
   - Indigo accent 色保留
   - AI 對話框樣式正確

## Screenshots

（將於 PR Preview 部署後補充）
