### PR TITLE
refactor: extract theme color constants via CSS variables (#72)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,7 +56,7 @@ const App: React.FC = () => {
       <header className="bg-white border-b border-gray-200 h-12 flex items-center justify-between px-4 shrink-0">
         {/* Logo */}
         <div className="flex items-center gap-2 cursor-pointer shrink-0" onClick={() => setView(AppView.HOME)}>
-          <div className="bg-indigo-600 w-6 h-6 rounded flex items-center justify-center">
+          <div className="bg-accent w-6 h-6 rounded flex items-center justify-center">
             <span className="text-white font-bold text-xs">L</span>
           </div>
           <span className="text-sm font-bold text-gray-800 hidden sm:block">AI Reading Tutor</span>
@@ -69,7 +69,7 @@ const App: React.FC = () => {
             onClick={() => setView(AppView.HOME)}
             className={`px-2 py-1 rounded transition-colors ${
               view === AppView.HOME
-                ? 'bg-indigo-600 text-white'
+                ? 'bg-accent text-white'
                 : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
             }`}
           >
@@ -95,14 +95,14 @@ const App: React.FC = () => {
                   onClick={() => !isDisabled && setView(targetView)}
                   className={`flex items-center gap-1 px-2 py-1 rounded transition-colors ${
                     isActive
-                      ? 'bg-indigo-600 text-white'
+                      ? 'bg-accent text-white'
                       : isDisabled
                       ? 'text-gray-400 cursor-not-allowed'
                       : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
                   }`}
                 >
                   <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 ${
-                    isActive ? 'bg-white text-indigo-600' : isDisabled ? 'bg-gray-300 text-gray-400' : 'bg-gray-200 text-gray-900'
+                    isActive ? 'bg-white text-accent' : isDisabled ? 'bg-gray-300 text-gray-400' : 'bg-gray-200 text-gray-900'
                   }`}>
                     {step}
                   </span>
@@ -130,7 +130,7 @@ const App: React.FC = () => {
             <p className="text-gray-600 max-w-md">準備好開始今天的朗讀挑戰了嗎？</p>
             <button 
               onClick={() => setView(AppView.LIBRARY)}
-              className="bg-indigo-600 hover:bg-indigo-500 text-white px-10 py-4 rounded-xl font-bold shadow-2xl transition-all"
+              className="bg-accent hover:bg-accent-hover text-white px-10 py-4 rounded-xl font-bold shadow-2xl transition-all"
             >
               進入圖書館
             </button>
@@ -215,12 +215,12 @@ const App: React.FC = () => {
                   onChange={e => setWriteInput(e.target.value.slice(-1))}
                   placeholder="輸入一個字"
                   maxLength={1}
-                  className="w-24 h-12 text-center text-2xl bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:border-indigo-500"
+                  className="w-24 h-12 text-center text-2xl bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:border-accent"
                 />
                 <button
                   onClick={() => { if (writeInput) setWritingChar(writeInput); }}
                   disabled={!writeInput}
-                  className="px-6 h-12 bg-indigo-600 hover:bg-indigo-500 disabled:bg-gray-300 disabled:text-gray-400 text-white rounded-lg font-bold transition-all"
+                  className="px-6 h-12 bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white rounded-lg font-bold transition-all"
                 >
                   開始
                 </button>

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -102,7 +102,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ attempt, onRetry })
                </PieChart>
              </SafeResponsiveContainer>
              <div className="absolute inset-0 flex flex-col items-center justify-center">
-                <span className="text-4xl font-black text-indigo-600">{attempt.accuracy}%</span>
+                <span className="text-4xl font-black text-accent">{attempt.accuracy}%</span>
                 <span className="text-xs text-gray-600 font-bold uppercase tracking-widest">準確度</span>
              </div>
           </div>
@@ -131,12 +131,12 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ attempt, onRetry })
               </BarChart>
             </SafeResponsiveContainer>
           </div>
-          <div className="mt-4 p-4 bg-indigo-50 rounded-2xl border border-indigo-100">
-            <h4 className="text-sm font-bold text-indigo-800 mb-2 flex items-center gap-2">
+          <div className="mt-4 p-4 bg-accent-bg rounded-2xl border border-accent-bg-subtle">
+            <h4 className="text-sm font-bold text-accent-hover mb-2 flex items-center gap-2">
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" /></svg>
               朗讀分析
             </h4>
-            <p className="text-sm text-indigo-900/80 leading-relaxed">
+            <p className="text-sm text-accent-hover/80 leading-relaxed">
               你的朗讀速度是每分鐘 {attempt.cpm} 個字。{cpmDescription}
               字詞準確度達到 {attempt.accuracy}%，繼續保持！
             </p>
@@ -144,15 +144,15 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ attempt, onRetry })
         </div>
       </div>
 
-      <div className="bg-gradient-to-r from-indigo-600 to-violet-600 rounded-3xl p-8 text-white flex flex-col md:flex-row items-center justify-between gap-6 shadow-xl">
+      <div className="bg-gradient-to-r from-accent to-violet-600 rounded-3xl p-8 text-white flex flex-col md:flex-row items-center justify-between gap-6 shadow-xl">
         <div>
           <h3 className="text-2xl font-bold">準備好讀下一個故事了嗎？</h3>
-          <p className="text-indigo-100">每天進步一點點，你就會變成閱讀小達人！</p>
+          <p className="text-accent-bg-subtle">每天進步一點點，你就會變成閱讀小達人！</p>
         </div>
         <div className="flex gap-4">
           <button 
             onClick={onRetry}
-            className="bg-white text-indigo-600 px-8 py-3 rounded-xl font-bold hover:shadow-lg transition-all"
+            className="bg-white text-accent px-8 py-3 rounded-xl font-bold hover:shadow-lg transition-all"
           >
             回圖書館
           </button>

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -261,7 +261,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       <div className="flex-1 flex flex-col bg-amber-50 min-w-0">
         {/* Tab bar */}
         <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
-          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-indigo-500 border-x border-gray-200 text-xs text-gray-800 gap-2">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
             {story.filename}
           </div>
           <div className="flex-1" />
@@ -298,14 +298,14 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       {/* Resizable divider */}
       <div
         onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-indigo-500 cursor-col-resize transition-colors"
+        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
       />
 
       {/* RIGHT: AI Tutor chat panel */}
       <div className="flex-shrink-0 bg-white flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
         {/* Panel header */}
         <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
-          <span className="text-[10px] font-black text-indigo-400 uppercase tracking-widest">
+          <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">
             AI Tutor
           </span>
           <div className="flex-1" />
@@ -325,12 +325,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
           {/* Intro message */}
           <div className="flex gap-2.5 pt-1">
-            <div className="flex-shrink-0 w-7 h-7 rounded-full bg-indigo-600 flex items-center justify-center">
+            <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
               <span className="text-white text-[10px] font-bold">AI</span>
             </div>
             <div className="flex-1">
-              <div className="bg-indigo-50 border border-indigo-200 rounded-2xl rounded-tl-sm px-4 py-3">
-                <p className={`text-lg text-indigo-900 leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+              <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3">
+                <p className={`text-lg text-accent-hover leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
                   {processZhuyin(`你剛才讀完了《${story.title}》，做得很棒！我想問你幾個關於課文的問題，幫助你更深入理解。準備好了嗎？`)}
                 </p>
               </div>
@@ -357,7 +357,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             return (
               <div key={i} className={`flex gap-2.5 ${turn.role === 'student' ? 'flex-row-reverse' : ''}`}>
                 {turn.role === 'ai' ? (
-                  <div className="flex-shrink-0 w-7 h-7 rounded-full bg-indigo-600 flex items-center justify-center">
+                  <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
                     <span className="text-white text-[10px] font-bold">AI</span>
                   </div>
                 ) : (
@@ -372,8 +372,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                   <div className={[
                     'rounded-2xl px-4 py-3',
                     turn.role === 'ai'
-                      ? 'bg-indigo-50 border border-indigo-200 rounded-tl-sm text-indigo-900'
-                      : 'bg-indigo-600 rounded-tr-sm text-white',
+                      ? 'bg-accent-bg border border-accent-bg-subtle rounded-tl-sm text-accent-hover'
+                      : 'bg-accent rounded-tr-sm text-white',
                   ].join(' ')}>
                     <p className={`text-lg leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
                   </div>
@@ -385,13 +385,13 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
           {/* Loading indicator */}
           {isLoading && (
             <div className="flex gap-2.5">
-              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-indigo-600 flex items-center justify-center">
+              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
                 <span className="text-white text-[10px] font-bold">AI</span>
               </div>
-              <div className="bg-indigo-50 border border-indigo-200 rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5">
-                <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce [animation-delay:0ms]" />
-                <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce [animation-delay:150ms]" />
-                <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full animate-bounce [animation-delay:300ms]" />
+              <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5">
+                <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:0ms]" />
+                <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:150ms]" />
+                <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:300ms]" />
               </div>
             </div>
           )}
@@ -450,12 +450,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 placeholder="輸入你的回答……（Enter 送出）"
                 rows={2}
                 disabled={isLoading || isSessionComplete}
-                className="flex-1 bg-white border border-gray-200 rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:border-indigo-500 resize-none disabled:opacity-50"
+                className="flex-1 bg-white border border-gray-200 rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none disabled:opacity-50"
               />
               <button
                 onClick={handleSubmit}
                 disabled={!inputText.trim() || isLoading || isSessionComplete}
-                className="flex-shrink-0 w-10 h-10 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
+                className="flex-shrink-0 w-10 h-10 rounded-xl bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -273,7 +273,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       <div className="flex-1 flex flex-col bg-amber-50 min-w-0">
         {/* Tab bar */}
         <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
-          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-indigo-500 border-x border-gray-200 text-xs text-gray-800">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800">
             {story.filename}
           </div>
           <div className="flex-1" />
@@ -309,7 +309,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       {/* Resizable divider */}
       <div
         onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-indigo-500 cursor-col-resize transition-colors"
+        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
       />
 
       {/* RIGHT: Recording panel */}
@@ -319,7 +319,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       >
         {/* Header */}
         <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4">
-          <span className="text-[10px] font-black text-indigo-400 uppercase tracking-widest">全文朗讀</span>
+          <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">全文朗讀</span>
         </div>
 
         {/* Content */}
@@ -340,8 +340,8 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {/* Live transcript */}
           {isSessionActive && streamingTranscript && (
             <div className="flex flex-col gap-1">
-              <span className="text-[9px] font-bold text-indigo-400 uppercase animate-pulse">LISTENING...</span>
-              <div className="bg-indigo-600/20 border border-indigo-500/30 rounded-xl px-3 py-2.5 text-base text-indigo-200 leading-relaxed">
+              <span className="text-[9px] font-bold text-accent-light uppercase animate-pulse">LISTENING...</span>
+              <div className="bg-accent/20 border border-accent/30 rounded-xl px-3 py-2.5 text-base text-accent-bg-subtle leading-relaxed">
                 {streamingTranscript}
               </div>
             </div>
@@ -471,7 +471,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
               </button>
               <button
                 onClick={startSession}
-                className="flex-1 py-3 rounded-xl text-base font-bold bg-indigo-600 hover:bg-indigo-500 text-white transition-all flex items-center justify-center gap-1.5 active:scale-95"
+                className="flex-1 py-3 rounded-xl text-base font-bold bg-accent hover:bg-accent-hover text-white transition-all flex items-center justify-center gap-1.5 active:scale-95"
               >
                 <div className="w-2.5 h-2.5 bg-white rounded-full" />
                 開始朗讀

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -102,7 +102,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
         <span className="text-gray-300 text-xs">›</span>
         <span className="text-xs text-gray-600">{story.title}</span>
         <span className="text-gray-300 text-xs">›</span>
-        <span className="text-xs text-indigo-400 font-bold">簡介</span>
+        <span className="text-xs text-accent-light font-bold">簡介</span>
         <div className="flex-1" />
         <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
       </div>
@@ -120,7 +120,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
             />
             <div className="flex flex-col gap-2">
               <div className="flex items-center gap-2">
-                <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-indigo-100 text-indigo-700 border border-indigo-300 uppercase tracking-widest">
+                <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-accent-bg-subtle text-accent-hover border border-accent-bg-subtle uppercase tracking-widest">
                   {CATEGORY_LABEL[story.category] ?? story.category}
                 </span>
                 <span className="text-[10px] text-gray-400">Lv.{story.level}</span>
@@ -140,10 +140,10 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
           {story.intro ? (
             <div className="bg-white border border-gray-200 rounded-2xl p-6 space-y-4">
               <div className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-4 h-4 text-accent-light" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
-                <span className="text-xs font-bold text-indigo-400 uppercase tracking-widest">課文簡介</span>
+                <span className="text-xs font-bold text-accent-light uppercase tracking-widest">課文簡介</span>
               </div>
               <p className={`text-gray-900 text-xl leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                 {processZhuyin(story.intro.background)}
@@ -197,7 +197,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
             stopSpeaking();
             onStartReading();
           }}
-          className="px-8 py-3 rounded-xl font-bold text-base bg-indigo-600 hover:bg-indigo-500 text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
+          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
         >
           開始逐段朗讀
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -687,7 +687,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       {/* CENTER: Editor */}
       <div className="flex-1 flex flex-col bg-amber-50">
         <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2">
-          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-indigo-500 border-x border-gray-200 text-xs text-gray-800 gap-2">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
             {processZhuyin(story.filename)}
           </div>
           <div className="flex-1" />
@@ -702,7 +702,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 ref={idx === currentLineIndex ? activeLineRef : null}
                 className={`transition-all duration-700 rounded-2xl p-8 border ${
                   idx === currentLineIndex
-                    ? 'bg-indigo-500/5 border-indigo-500/40 shadow-[0_0_40px_rgba(99,102,241,0.1)] scale-[1.03]'
+                    ? 'bg-accent/5 border-accent/40 shadow-[0_0_40px_rgba(99,102,241,0.1)] scale-[1.03]'
                     : 'opacity-40 border-transparent'
                 }`}
               >
@@ -734,13 +734,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       {/* Resizable divider */}
       <div
         onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-indigo-500 cursor-col-resize transition-colors"
+        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
       />
 
       {/* RIGHT: Interaction panel */}
       <div className="flex-shrink-0 bg-amber-50 flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
         <div className="h-9 flex-shrink-0 bg-white border-b border-gray-200 flex items-center px-4">
-          <span className="text-[10px] font-black text-indigo-400 uppercase tracking-widest">
+          <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">
             Live Feedback
           </span>
         </div>
@@ -760,7 +760,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                   zhuyinActive ? 'tracking-[0.3em]' : ''
                 } ${
                   m.role === 'user'
-                    ? 'bg-indigo-600 text-white rounded-tr-none'
+                    ? 'bg-accent text-white rounded-tr-none'
                     : 'bg-gray-100 text-gray-800 border border-gray-200 rounded-tl-none'
                 }`}
               >
@@ -782,10 +782,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
           {streamingUserInput && (
             <div className="flex flex-col items-end">
-              <span className="text-[9px] font-bold text-indigo-500 mb-0.5 uppercase animate-pulse">
+              <span className="text-[9px] font-bold text-accent mb-0.5 uppercase animate-pulse">
                 LISTENING...
               </span>
-              <div className={`px-4 py-3 rounded-2xl text-lg bg-indigo-600/60 text-indigo-100 rounded-tr-none max-w-[90%] border border-indigo-500/30 leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+              <div className={`px-4 py-3 rounded-2xl text-lg bg-accent/60 text-accent-bg-subtle rounded-tr-none max-w-[90%] border border-accent/30 leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
                 {processZhuyin(streamingUserInput)}
               </div>
             </div>
@@ -793,10 +793,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
           {isAdvancing && (
             <div className="flex flex-col items-start">
-              <span className="text-[9px] font-bold text-indigo-500 mb-0.5 uppercase animate-pulse">
+              <span className="text-[9px] font-bold text-accent mb-0.5 uppercase animate-pulse">
                 NEXT...
               </span>
-              <div className={`px-4 py-3 rounded-2xl text-lg bg-gray-100 text-indigo-300 border border-indigo-900/30 rounded-tl-none leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+              <div className={`px-4 py-3 rounded-2xl text-lg bg-gray-100 text-accent-light border border-accent-hover/30 rounded-tl-none leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
                 {processZhuyin('正在前往下一段...')}
               </div>
             </div>
@@ -805,7 +805,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
         {/* Controls */}
         <div className="flex-shrink-0 p-3 bg-white border-t border-gray-200 space-y-2">
-          <div className={`min-h-[3rem] p-2 rounded-lg bg-black/40 border border-gray-200 text-base text-indigo-300 overflow-hidden leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+          <div className={`min-h-[3rem] p-2 rounded-lg bg-black/40 border border-gray-200 text-base text-accent-light overflow-hidden leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
             {streamingUserInput ? processZhuyin(streamingUserInput) : (
               <span className="text-gray-800 italic">
                 {processZhuyin(isPreparing ? '正在準備語音辨識...' : isSessionActive ? '正在聆聽您的朗讀...' : '點擊「開始朗讀」開始')}
@@ -900,7 +900,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                   className={`flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 transition-all shadow active:scale-95 ${
                     isAdvancing
                       ? 'bg-gray-300 text-gray-400 cursor-not-allowed opacity-50'
-                      : 'bg-indigo-600 hover:bg-indigo-500 text-white'
+                      : 'bg-accent hover:bg-accent-hover text-white'
                   }`}
                 >
                   <div className="w-2.5 h-2.5 bg-white rounded-full" />

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -115,7 +115,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     >
       {/* Tab bar — VS Code style */}
       <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
-        <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-indigo-500 border-x border-gray-200 text-xs text-gray-800 gap-2">
+        <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
           {story.filename} — 生字練習
         </div>
         <div className="flex-1" />
@@ -157,7 +157,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                         ? 'bg-emerald-50 border-emerald-700/50 text-emerald-800'
                         : isSuggested
                           ? 'bg-amber-900/30 border-amber-600/60 text-amber-200 ring-1 ring-amber-500/30 hover:bg-amber-900/50'
-                          : 'bg-white border-gray-200 text-gray-800 hover:bg-gray-100 hover:border-indigo-500/40',
+                          : 'bg-white border-gray-200 text-gray-800 hover:bg-gray-100 hover:border-accent/40',
                     ].join(' ')}
                   >
                     <span className={`text-3xl font-bold leading-[2.8] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}>
@@ -220,7 +220,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
         </button>
         <button
           onClick={onFinish}
-          className="px-8 py-3 rounded-xl font-bold text-base bg-indigo-600 hover:bg-indigo-500 text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
+          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
         >
           {practicedChars.size > 0 ? '完成，查看報告' : '跳過，查看報告'}
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -356,7 +356,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
   if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center bg-[#0d1117]">
-        <div className="w-8 h-8 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+        <div className="w-8 h-8 border-4 border-accent border-t-transparent rounded-full animate-spin" />
       </div>
     );
   }
@@ -368,7 +368,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
         {onBack && (
           <button
             onClick={onBack}
-            className="text-indigo-400 hover:text-indigo-300 font-bold"
+            className="text-accent-light hover:text-accent-light font-bold"
           >
             返回
           </button>
@@ -397,7 +397,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
         {isComplete && onComplete && (
           <button
             onClick={onComplete}
-            className="text-indigo-400 hover:text-indigo-300 text-sm font-bold"
+            className="text-accent-light hover:text-accent-light text-sm font-bold"
           >
             完成 →
           </button>
@@ -515,7 +515,7 @@ function CtrlBtn({ icon, label, active, glow, disabled, onClick }: {
         'flex flex-col items-center gap-1 px-5 py-2.5 rounded-xl transition-all',
         disabled ? 'opacity-30 cursor-not-allowed' : 'hover:bg-slate-800 active:scale-95',
         glow ? 'ring-2 ring-yellow-400/70 bg-slate-800/50' : '',
-        active ? 'text-indigo-400' : 'text-slate-400',
+        active ? 'text-accent-light' : 'text-slate-400',
       ].join(' ')}
     >
       <span className="text-2xl leading-none">{icon}</span>

--- a/frontend/src/components/ui/ZhuyinToggle.tsx
+++ b/frontend/src/components/ui/ZhuyinToggle.tsx
@@ -10,7 +10,7 @@ export default function ZhuyinToggle({ enabled, ready, onToggle }: ZhuyinToggleP
       onClick={onToggle}
       className={`px-2.5 py-1 rounded text-xs transition-colors ${
         enabled && ready
-          ? 'bg-indigo-600/80 text-white hover:bg-indigo-500'
+          ? 'bg-accent/80 text-white hover:bg-accent-hover'
           : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
       }`}
       title={enabled ? '隱藏注音' : '顯示注音'}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    /* Brand / Accent */
+    --color-accent: 99 102 241;       /* indigo-600 */
+    --color-accent-hover: 79 70 229;  /* indigo-700 */
+    --color-accent-light: 129 140 248; /* indigo-400 */
+    --color-accent-bg: 238 242 255;   /* indigo-50 */
+    --color-accent-bg-subtle: 224 231 255; /* indigo-100 */
+
+    /* Status */
+    --color-success: 16 185 129;      /* emerald-500 */
+    --color-warning: 245 158 11;      /* amber-500 */
+    --color-error: 239 68 68;         /* red-500 */
+  }
+}

--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -38,8 +38,8 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
           onClick={() => setSelectedGrade(null)}
           className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
             selectedGrade === null
-              ? 'bg-indigo-600 text-white'
-              : 'bg-white text-gray-600 border border-gray-200 hover:border-indigo-500'
+              ? 'bg-accent text-white'
+              : 'bg-white text-gray-600 border border-gray-200 hover:border-accent'
           }`}
         >
           全部
@@ -50,8 +50,8 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
             onClick={() => setSelectedGrade(grade)}
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${
               selectedGrade === grade
-                ? 'bg-indigo-600 text-white'
-                : 'bg-white text-gray-600 border border-gray-200 hover:border-indigo-500'
+                ? 'bg-accent text-white'
+                : 'bg-white text-gray-600 border border-gray-200 hover:border-accent'
             }`}
           >
             G{grade}
@@ -64,7 +64,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
         {stories.map((story) => (
           <div
             key={story.id}
-            className="bg-white rounded-xl overflow-hidden border border-gray-200 hover:border-indigo-500 transition-all cursor-pointer group shadow-sm"
+            className="bg-white rounded-xl overflow-hidden border border-gray-200 hover:border-accent transition-all cursor-pointer group shadow-sm"
             onClick={() => onStartReading(story)}
           >
             <div className="h-40 overflow-hidden relative">
@@ -75,7 +75,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
               />
               {/* Grade badge */}
               {story.grade && (
-                <div className="absolute top-2 right-2 bg-indigo-600 text-white text-xs font-bold px-2 py-1 rounded">
+                <div className="absolute top-2 right-2 bg-accent text-white text-xs font-bold px-2 py-1 rounded">
                   G{story.grade}
                 </div>
               )}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,7 +5,20 @@ export default {
     './src/**/*.{ts,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        accent: {
+          DEFAULT: 'rgb(var(--color-accent) / <alpha-value>)',
+          hover: 'rgb(var(--color-accent-hover) / <alpha-value>)',
+          light: 'rgb(var(--color-accent-light) / <alpha-value>)',
+          bg: 'rgb(var(--color-accent-bg) / <alpha-value>)',
+          'bg-subtle': 'rgb(var(--color-accent-bg-subtle) / <alpha-value>)',
+        },
+        success: 'rgb(var(--color-success) / <alpha-value>)',
+        warning: 'rgb(var(--color-warning) / <alpha-value>)',
+        error: 'rgb(var(--color-error) / <alpha-value>)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- 新增 CSS variables 定義品牌色 + 狀態色（`index.css`）
- Tailwind config 加入語意化色彩別名：`accent`, `accent-hover`, `accent-light`, `accent-bg`, `accent-bg-subtle`
- 10 個檔案的 65 處 `indigo-*` 全部替換為 `accent-*`
- 未來改設計只需改 CSS variables，不用動元件

## Before / After
```
// Before — 硬編碼
bg-indigo-600 hover:bg-indigo-500 text-indigo-400

// After — 語意化
bg-accent hover:bg-accent-hover text-accent-light
```

## Test plan
- [x] `npm run build` passed (742 modules, 0 errors)
- [x] `grep -r "indigo" frontend/src/` = 0 code references (only CSS comments)
- [ ] 視覺檢查：所有頁面顏色不變

Closes #72

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)