### PR TITLE
fix: increase paragraph spacing in FullReading for better readability (Fixes #100)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -282,11 +282,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
         {/* All paragraphs */}
         <div className="flex-1 p-8 lg:p-16 overflow-y-auto custom-scrollbar">
-          <div className="max-w-3xl mx-auto space-y-10">
+          <div className="max-w-3xl mx-auto space-y-20">
             {story.content.map((line, idx) => (
               <div
                 key={idx}
-                className="rounded-2xl p-6 mb-2 border border-transparent hover:border-gray-200 hover:bg-white/30 transition-all"
+                className="rounded-2xl p-6 pb-8 border-b border-gray-200 last:border-b-0 hover:bg-white/30 transition-all"
               >
                 <p className={`text-2xl lg:text-3xl text-gray-800 leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}


### PR DESCRIPTION
Fixes #100

## Summary
- Increase paragraph spacing from 40px to 80px (`space-y-10` → `space-y-20`)
- Add subtle bottom border divider between paragraphs
- Remove hover border since permanent divider is now present
- Use `last:border-b-0` to remove final border

## Visual Changes
- Much larger gap between paragraphs (2x increase)
- Thin gray line separator for clearer visual boundaries
- Cleaner hover state (only background change, no border)

## Test Plan
1. Open PR Preview URL
2. Navigate to FullReading step (第五關)
3. Verify paragraphs have large spacing (80px gap)
4. Verify subtle gray line between paragraphs
5. Verify last paragraph has no bottom border