### PR TITLE
fix: make FullReading listening transcript text readable

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -341,7 +341,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {isSessionActive && streamingTranscript && (
             <div className="flex flex-col gap-1">
               <span className="text-[9px] font-bold text-accent-light uppercase animate-pulse">LISTENING...</span>
-              <div className="bg-accent/20 border border-accent/30 rounded-xl px-3 py-2.5 text-base text-accent-bg-subtle leading-relaxed">
+              <div className="bg-accent/20 border border-accent/30 rounded-xl px-3 py-2.5 text-base text-gray-800 leading-relaxed">
                 {streamingTranscript}
               </div>
             </div>
@@ -350,7 +350,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {isSessionActive && !streamingTranscript && (
             <div className="flex flex-col gap-1">
               <span className="text-[9px] font-bold text-green-500 uppercase animate-pulse">LISTENING</span>
-              <div className="bg-green-900/20 border border-green-700/30 rounded-xl px-3 py-2.5 text-base text-green-300 leading-relaxed">
+              <div className="bg-green-900/20 border border-green-700/30 rounded-xl px-3 py-2.5 text-base text-gray-600 leading-relaxed">
                 請朗讀左側課文，從頭到尾…
               </div>
             </div>


### PR DESCRIPTION
## Summary
Fixed nearly invisible text color in FullReading listening transcript display.

## Changes
- Line 344: Changed `text-accent-bg-subtle` to `text-gray-800` for live transcript
- Line 353: Changed `text-green-300` to `text-gray-600` for placeholder text

## Problem
Text was using light colors (indigo-100, green-300) on light backgrounds, making it nearly impossible to read.

## Test plan
- [ ] Open FullReading step
- [ ] Click "開始朗讀"
- [ ] Verify placeholder text "請朗讀左側課文，從頭到尾…" is clearly readable
- [ ] Start speaking and verify live transcript text is clearly readable (dark gray on light indigo background)

🤖 Generated with [Claude Code](https://claude.ai/code)