### PR TITLE
Release: FullReading text color fix

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -341,7 +341,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {isSessionActive && streamingTranscript && (
             <div className="flex flex-col gap-1">
               <span className="text-[9px] font-bold text-accent-light uppercase animate-pulse">LISTENING...</span>
-              <div className="bg-accent/20 border border-accent/30 rounded-xl px-3 py-2.5 text-base text-accent-bg-subtle leading-relaxed">
+              <div className="bg-accent/20 border border-accent/30 rounded-xl px-3 py-2.5 text-base text-gray-800 leading-relaxed">
                 {streamingTranscript}
               </div>
             </div>
@@ -350,7 +350,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {isSessionActive && !streamingTranscript && (
             <div className="flex flex-col gap-1">
               <span className="text-[9px] font-bold text-green-500 uppercase animate-pulse">LISTENING</span>
-              <div className="bg-green-900/20 border border-green-700/30 rounded-xl px-3 py-2.5 text-base text-green-300 leading-relaxed">
+              <div className="bg-green-900/20 border border-green-700/30 rounded-xl px-3 py-2.5 text-base text-gray-600 leading-relaxed">
                 請朗讀左側課文，從頭到尾…
               </div>
             </div>


### PR DESCRIPTION
## Production Release

Deploying text color readability fix for FullReading listening transcript.

## PR Included
- #104: Fix FullReading listening transcript text color

## Changes
- Fixed nearly invisible text in listening transcript (light text on light background)
- Changed to dark gray text for clear contrast

🤖 Generated with [Claude Code](https://claude.ai/code)