### PR TITLE
fix: increase paragraph vertical padding across all reading steps

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -270,12 +270,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
         {/* Story content — all paragraphs visible for reference */}
         <div className="flex-1 p-8 lg:p-16 overflow-y-auto custom-scrollbar">
-          <div className="max-w-3xl mx-auto space-y-10">
+          <div className="max-w-3xl mx-auto space-y-20">
             {story.content.map((line, idx) => (
               <div
                 key={idx}
                 ref={el => { paragraphRefs.current[idx] = el; }}
-                className={`rounded-2xl p-6 border transition-all ${
+                className={`rounded-2xl px-6 py-12 border transition-all ${
                   highlightedParagraph === idx
                     ? 'border-amber-500/60 bg-amber-900/10 shadow-[0_0_15px_rgba(245,158,11,0.1)]'
                     : 'border-transparent hover:border-gray-200 hover:bg-white/40'

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -286,7 +286,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
             {story.content.map((line, idx) => (
               <div
                 key={idx}
-                className="rounded-2xl p-6 pb-8 border-b border-gray-200 last:border-b-0 hover:bg-white/30 transition-all"
+                className="rounded-2xl px-6 py-12 border-b border-gray-200 last:border-b-0 hover:bg-white/30 transition-all"
               >
                 <p className={`text-2xl lg:text-3xl text-gray-800 leading-[2.8] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -695,12 +695,12 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         </div>
 
         <div className="flex-1 p-8 lg:p-16 overflow-y-auto custom-scrollbar">
-          <div className="max-w-3xl mx-auto space-y-10">
+          <div className="max-w-3xl mx-auto space-y-20">
             {story.content.map((line, idx) => (
               <div
                 key={idx}
                 ref={idx === currentLineIndex ? activeLineRef : null}
-                className={`transition-all duration-700 rounded-2xl p-8 border ${
+                className={`transition-all duration-700 rounded-2xl px-8 py-12 border ${
                   idx === currentLineIndex
                     ? 'bg-accent/5 border-accent/40 shadow-[0_0_40px_rgba(99,102,241,0.1)] scale-[1.03]'
                     : 'opacity-40 border-transparent'


### PR DESCRIPTION
## Summary
Increased vertical padding and spacing in paragraph cards across all reading steps for better readability.

## Changes
- **FullReading**: `p-6 pb-8` → `px-6 py-12`
- **ComprehensionChat**: `p-6` → `px-6 py-12`, `space-y-10` → `space-y-20`
- **LiveTutor**: `p-8` → `px-8 py-12`, `space-y-10` → `space-y-20`

## Test plan
- [ ] Verify paragraph spacing in FullReading step
- [ ] Verify paragraph spacing in ComprehensionChat step
- [ ] Verify paragraph spacing in LiveTutor step
- [ ] Check mobile/desktop responsive behavior

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)