### PR TITLE
fix: add lg:leading-[5rem] to override lg:text-3xl built-in line-height

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -281,7 +281,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                     : 'border-transparent hover:border-gray-200 hover:bg-white/40'
                 }`}
               >
-                <p className={`text-2xl lg:text-3xl text-gray-900 leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                <p className={`text-2xl lg:text-3xl text-gray-900 leading-[5rem] lg:leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}
                 </p>
               </div>

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -288,7 +288,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
                 key={idx}
                 className="rounded-2xl px-6 py-12 border-b border-gray-200 last:border-b-0 hover:bg-white/30 transition-all"
               >
-                <p className={`text-2xl lg:text-3xl text-gray-800 leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                <p className={`text-2xl lg:text-3xl text-gray-800 leading-[5rem] lg:leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}
                 </p>
               </div>

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -707,7 +707,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 }`}
               >
                 <p
-                  className={`text-2xl lg:text-3xl leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
+                  className={`text-2xl lg:text-3xl leading-[5rem] lg:leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
                     idx === currentLineIndex ? 'text-gray-900 font-bold' : 'text-gray-600'
                   }`}
                 >

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -160,7 +160,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                           : 'bg-white border-gray-200 text-gray-800 hover:bg-gray-100 hover:border-accent/40',
                     ].join(' ')}
                   >
-                    <span className={`text-3xl font-bold leading-[5rem] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}>
+                    <span className={`text-3xl font-bold leading-[5rem] lg:leading-[5rem] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}>
                     {processZhuyin(ch)}
                   </span>
 


### PR DESCRIPTION
## Summary

Fixes line-height override issue at the `lg` breakpoint where Tailwind's `lg:text-3xl` resets line-height to 2.25rem, overriding our custom `leading-[5rem]`.

## Changes

Added `lg:leading-[5rem]` alongside `leading-[5rem]` in 4 files:
- **LiveTutor.tsx** - Story paragraph text
- **ComprehensionChat.tsx** - Story paragraph text
- **FullReading.tsx** - Story paragraph text  
- **VocabPractice.tsx** - Character grid item text

## Technical Details

Tailwind's responsive text utilities like `lg:text-3xl` set **both** font-size **and** line-height. At the `lg:` breakpoint:
- `lg:text-3xl` sets: `font-size: 1.875rem` + `line-height: 2.25rem`
- This overwrites our base `leading-[5rem]`
- Solution: Explicitly re-declare `lg:leading-[5rem]` to win specificity

## Test Plan

1. Deploy preview
2. Open any reading step (LiveTutor/ComprehensionChat/FullReading/VocabPractice)
3. Resize window to `lg` breakpoint (1024px+)
4. Verify zhuyin annotations do NOT overlap with text below
5. Verify line-height remains consistent at all breakpoints