### PR TITLE
release: reduce line-height from 5rem to 3.5rem

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -281,7 +281,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                     : 'border-transparent hover:border-gray-200 hover:bg-white/40'
                 }`}
               >
-                <p className={`text-2xl lg:text-3xl text-gray-900 leading-[5rem] lg:leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                <p className={`text-2xl lg:text-3xl text-gray-900 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}
                 </p>
               </div>

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -288,7 +288,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
                 key={idx}
                 className="rounded-2xl px-6 py-12 border-b border-gray-200 last:border-b-0 hover:bg-white/30 transition-all"
               >
-                <p className={`text-2xl lg:text-3xl text-gray-800 leading-[5rem] lg:leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                <p className={`text-2xl lg:text-3xl text-gray-800 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}
                 </p>
               </div>

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -125,7 +125,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 </span>
                 <span className="text-[10px] text-gray-400">Lv.{story.level}</span>
               </div>
-              <h1 className={`text-2xl font-black text-gray-900 leading-[4rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+              <h1 className={`text-2xl font-black text-gray-900 leading-[3rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                 {processZhuyin(story.title)}
               </h1>
               {story.intro && (
@@ -145,7 +145,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 </svg>
                 <span className="text-xs font-bold text-accent-light uppercase tracking-widest">課文簡介</span>
               </div>
-              <p className={`text-gray-900 text-xl leading-[4rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+              <p className={`text-gray-900 text-xl leading-[3rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                 {processZhuyin(story.intro.background)}
               </p>
 

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -707,7 +707,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 }`}
               >
                 <p
-                  className={`text-2xl lg:text-3xl leading-[5rem] lg:leading-[5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
+                  className={`text-2xl lg:text-3xl leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
                     idx === currentLineIndex ? 'text-gray-900 font-bold' : 'text-gray-600'
                   }`}
                 >

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -160,7 +160,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                           : 'bg-white border-gray-200 text-gray-800 hover:bg-gray-100 hover:border-accent/40',
                     ].join(' ')}
                   >
-                    <span className={`text-3xl font-bold leading-[5rem] lg:leading-[5rem] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}>
+                    <span className={`text-3xl font-bold leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}>
                     {processZhuyin(ch)}
                   </span>
 


### PR DESCRIPTION
## Production Release

Reduces line-height from 5rem (80px) to 3.5rem (56px) for better readability per user feedback.

### Changes
- Fix #126: reduce line-height to 3.5rem per user feedback

### Files Modified
- `LiveTutor.tsx`: `leading-[5rem]` → `leading-[3.5rem]`
- `ComprehensionChat.tsx`: `leading-[5rem]` → `leading-[3.5rem]`
- `FullReading.tsx`: `leading-[5rem]` → `leading-[3.5rem]`
- `VocabPractice.tsx`: `leading-[5rem]` → `leading-[3.5rem]`
- `Intro.tsx`: `leading-[4rem]` → `leading-[3rem]`

### Rationale
5rem spacing was too much for Chinese text with zhuyin annotations. 3.5rem provides better visual rhythm.