### PR TITLE
feat: RWD responsive design for mobile/tablet (#125)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,15 @@
 
 import React, { useState } from 'react';
 import { AppView, Story, ReadingAttempt } from './types';
+import { useIsMobile } from './hooks/useIsMobile';
+import StoryLibrary from './pages/student/StoryLibrary';
+import Intro from './components/reading-steps/Intro';
+import LiveTutor from './components/reading-steps/LiveTutor';
+import VocabPractice from './components/reading-steps/VocabPractice';
+import ComprehensionChat from './components/reading-steps/ComprehensionChat';
+import FullReading from './components/reading-steps/FullReading';
+import AssessmentReport from './components/reading-steps/AssessmentReport';
+import WriteCharacter from './components/stroke-order/WriteCharacter';
 
 const EMPTY_ATTEMPT: ReadingAttempt = {
   storyId: '',
@@ -11,14 +20,6 @@ const EMPTY_ATTEMPT: ReadingAttempt = {
   transcription: '',
   timestamp: 0,
 };
-import StoryLibrary from './pages/student/StoryLibrary';
-import Intro from './components/reading-steps/Intro';
-import LiveTutor from './components/reading-steps/LiveTutor';
-import VocabPractice from './components/reading-steps/VocabPractice';
-import ComprehensionChat from './components/reading-steps/ComprehensionChat';
-import FullReading from './components/reading-steps/FullReading';
-import AssessmentReport from './components/reading-steps/AssessmentReport';
-import WriteCharacter from './components/stroke-order/WriteCharacter';
 
 const App: React.FC = () => {
   const [view, setView] = useState<AppView>(AppView.HOME);
@@ -27,6 +28,8 @@ const App: React.FC = () => {
   const [writingChar, setWritingChar] = useState('');
   const [writeInput, setWriteInput] = useState('');
   const [rightPanelWidth, setRightPanelWidth] = useState(320);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const isMobile = useIsMobile();
 
   const handleSelectStory = (story: Story) => {
     setSelectedStory(story);
@@ -50,6 +53,15 @@ const App: React.FC = () => {
     setView(AppView.REPORT);
   };
 
+  const steps = [
+    { step: 1, label: '簡介',    view: AppView.INTRO,         needsStory: true  },
+    { step: 2, label: '逐段朗讀', view: AppView.TUTOR,         needsStory: true  },
+    { step: 3, label: '生字練習', view: AppView.VOCAB,         needsStory: true  },
+    { step: 4, label: '課文理解', view: AppView.COMPREHENSION, needsStory: true  },
+    { step: 5, label: '全文朗讀', view: AppView.FULL_READING,  needsStory: true  },
+    { step: 6, label: '報告',    view: AppView.REPORT,        needsStory: false },
+  ] as const;
+
   return (
     <div className="h-screen flex flex-col bg-amber-50 text-gray-900 font-sans overflow-hidden">
       {/* Header */}
@@ -63,64 +75,133 @@ const App: React.FC = () => {
         </div>
 
         {/* Step Navigation (upper right) */}
-        <nav className="flex items-center gap-1 text-[11px] font-medium">
-          {/* 首頁 */}
-          <button
-            onClick={() => setView(AppView.HOME)}
-            className={`px-2 py-1 rounded transition-colors ${
-              view === AppView.HOME
-                ? 'bg-accent text-white'
-                : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
-            }`}
-          >
-            首頁
-          </button>
-
-          <span className="text-gray-300 select-none">·</span>
-
-          {/* Steps 1–6 */}
-          {([
-            { step: 1, label: '簡介',    view: AppView.INTRO,         needsStory: true  },
-            { step: 2, label: '逐段朗讀', view: AppView.TUTOR,         needsStory: true  },
-            { step: 3, label: '生字練習', view: AppView.VOCAB,         needsStory: true  },
-            { step: 4, label: '課文理解', view: AppView.COMPREHENSION, needsStory: true  },
-            { step: 5, label: '全文朗讀', view: AppView.FULL_READING,  needsStory: true  },
-            { step: 6, label: '報告',    view: AppView.REPORT,        needsStory: false },
-          ] as const).map(({ step, label, view: targetView, needsStory }, i, arr) => {
-            const isActive = view === targetView;
-            const isDisabled = needsStory && !selectedStory;
-            return (
-              <React.Fragment key={targetView}>
+        {isMobile ? (
+          <nav className="flex items-center gap-1 text-[11px] font-medium relative">
+            {/* Compact step circles */}
+            {steps.map(({ step, view: targetView, needsStory }) => {
+              const isActive = view === targetView;
+              const isDisabled = needsStory && !selectedStory;
+              return (
                 <button
-                  onClick={() => !isDisabled && setView(targetView)}
-                  className={`flex items-center gap-1 px-2 py-1 rounded transition-colors ${
-                    isActive
-                      ? 'bg-accent text-white'
-                      : isDisabled
-                      ? 'text-gray-400 cursor-not-allowed'
-                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  key={targetView}
+                  onClick={() => { if (!isDisabled) { setView(targetView); setMobileNavOpen(false); } }}
+                  className={`w-5 h-5 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 transition-colors ${
+                    isActive ? 'bg-accent text-white' : isDisabled ? 'bg-gray-200 text-gray-400' : 'bg-gray-200 text-gray-600'
                   }`}
                 >
-                  <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 ${
-                    isActive ? 'bg-white text-accent' : isDisabled ? 'bg-gray-300 text-gray-400' : 'bg-gray-200 text-gray-900'
-                  }`}>
-                    {step}
-                  </span>
-                  <span className="hidden md:block">{label}</span>
+                  {step}
                 </button>
-                {i < arr.length - 1 && (
-                  <span className="text-gray-300 select-none">·</span>
-                )}
-              </React.Fragment>
-            );
-          })}
+              );
+            })}
 
-          {/* User avatar */}
-          <div className="ml-3 flex items-center gap-1 pl-3 border-l border-gray-200">
-            <div className="w-6 h-6 rounded-full bg-gray-200"></div>
-            <span className="text-[10px] text-gray-500 hidden sm:block">Lv.12</span>
-          </div>
-        </nav>
+            {/* Hamburger */}
+            <button
+              onClick={() => setMobileNavOpen(!mobileNavOpen)}
+              className="ml-1 p-1 rounded hover:bg-gray-100 transition-colors"
+            >
+              <svg className="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+
+            {/* Dropdown */}
+            {mobileNavOpen && (
+              <>
+                <div className="fixed inset-0 z-40" onClick={() => setMobileNavOpen(false)} />
+                <div className="absolute right-0 top-full mt-1 z-50 bg-white border border-gray-200 rounded-xl shadow-lg py-1 min-w-[160px]">
+                  <button
+                    onClick={() => { setView(AppView.HOME); setMobileNavOpen(false); }}
+                    className={`w-full text-left px-3 py-2 text-xs flex items-center gap-2 ${
+                      view === AppView.HOME ? 'bg-accent/10 text-accent font-bold' : 'text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    首頁
+                  </button>
+                  {steps.map(({ step, label, view: targetView, needsStory }) => {
+                    const isActive = view === targetView;
+                    const isDisabled = needsStory && !selectedStory;
+                    return (
+                      <button
+                        key={targetView}
+                        onClick={() => { if (!isDisabled) { setView(targetView); setMobileNavOpen(false); } }}
+                        disabled={isDisabled}
+                        className={`w-full text-left px-3 py-2 text-xs flex items-center gap-2 ${
+                          isActive ? 'bg-accent/10 text-accent font-bold'
+                          : isDisabled ? 'text-gray-300 cursor-not-allowed'
+                          : 'text-gray-700 hover:bg-gray-50'
+                        }`}
+                      >
+                        <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 ${
+                          isActive ? 'bg-accent text-white' : isDisabled ? 'bg-gray-200 text-gray-400' : 'bg-gray-200 text-gray-700'
+                        }`}>
+                          {step}
+                        </span>
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+
+            {/* Avatar */}
+            <div className="ml-2 flex items-center gap-1 pl-2 border-l border-gray-200">
+              <div className="w-6 h-6 rounded-full bg-gray-200"></div>
+            </div>
+          </nav>
+        ) : (
+          <nav className="flex items-center gap-1 text-[11px] font-medium">
+            {/* 首頁 */}
+            <button
+              onClick={() => setView(AppView.HOME)}
+              className={`px-2 py-1 rounded transition-colors ${
+                view === AppView.HOME
+                  ? 'bg-accent text-white'
+                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+              }`}
+            >
+              首頁
+            </button>
+
+            <span className="text-gray-300 select-none">·</span>
+
+            {/* Steps 1–6 */}
+            {steps.map(({ step, label, view: targetView, needsStory }, i, arr) => {
+              const isActive = view === targetView;
+              const isDisabled = needsStory && !selectedStory;
+              return (
+                <React.Fragment key={targetView}>
+                  <button
+                    onClick={() => !isDisabled && setView(targetView)}
+                    className={`flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+                      isActive
+                        ? 'bg-accent text-white'
+                        : isDisabled
+                        ? 'text-gray-400 cursor-not-allowed'
+                        : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                    }`}
+                  >
+                    <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 ${
+                      isActive ? 'bg-white text-accent' : isDisabled ? 'bg-gray-300 text-gray-400' : 'bg-gray-200 text-gray-900'
+                    }`}>
+                      {step}
+                    </span>
+                    <span className="hidden md:block">{label}</span>
+                  </button>
+                  {i < arr.length - 1 && (
+                    <span className="text-gray-300 select-none">·</span>
+                  )}
+                </React.Fragment>
+              );
+            })}
+
+            {/* User avatar */}
+            <div className="ml-3 flex items-center gap-1 pl-3 border-l border-gray-200">
+              <div className="w-6 h-6 rounded-full bg-gray-200"></div>
+              <span className="text-[10px] text-gray-500 hidden sm:block">Lv.12</span>
+            </div>
+          </nav>
+        )}
       </header>
 
       <main className="flex-1 flex flex-col overflow-hidden">

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -3,6 +3,7 @@ import { Story, ReadingAttempt } from '../../types';
 import { sendComprehensionChat, ChatResponse, SessionExpiredError } from '../../services/api';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
+import { useIsMobile } from '../../hooks/useIsMobile';
 
 interface ComprehensionChatProps {
   story: Story;
@@ -32,6 +33,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [zhuyinEnabled, setZhuyinEnabled] = useState(true);
   const [zhuyinReady, setZhuyinReady] = useState(false);
+
+  // Mobile responsive
+  const isMobile = useIsMobile();
+  const [activeTab, setActiveTab] = useState<'story' | 'chat'>('chat');
 
   // Server-driven session state
   const [sessionId] = useState(() => crypto.randomUUID());
@@ -93,6 +98,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     // Highlight referenced paragraph on wrong answer
     if (result.understood === false && result.referenced_paragraph != null) {
       setHighlightedParagraph(result.referenced_paragraph - 1);
+      // On mobile, auto-switch to story tab when highlighting
+      if (isMobile) {
+        setActiveTab('story');
+      }
       // Auto-scroll to highlighted paragraph
       setTimeout(() => {
         paragraphRefs.current[result.referenced_paragraph! - 1]?.scrollIntoView({
@@ -103,7 +112,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     } else {
       setHighlightedParagraph(null);
     }
-  }, []);
+  }, [isMobile]);
 
   // Fetch the first question from the server (no student answer)
   const fetchFirstQuestion = useCallback(async () => {
@@ -132,31 +141,49 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     }
   }, [story.content, story.title, sessionId, attempt, applyServerState]);
 
-  // Resizable right panel
+  // Resizable right panel (mouse + touch)
   useEffect(() => {
     const onMouseMove = (e: MouseEvent) => {
       if (!isDraggingRef.current) return;
       const delta = dragStartXRef.current - e.clientX;
       onPanelWidthChange(Math.max(240, Math.min(600, dragStartWidthRef.current + delta)));
     };
-    const onMouseUp = () => {
+    const onTouchMove = (e: TouchEvent) => {
+      if (!isDraggingRef.current || !e.touches.length) return;
+      const delta = dragStartXRef.current - e.touches[0].clientX;
+      onPanelWidthChange(Math.max(240, Math.min(600, dragStartWidthRef.current + delta)));
+    };
+    const onEnd = () => {
       isDraggingRef.current = false;
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
     };
     window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('mouseup', onEnd);
+    window.addEventListener('touchmove', onTouchMove);
+    window.addEventListener('touchend', onEnd);
     return () => {
       window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('mouseup', onEnd);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onEnd);
     };
-  }, []);
+  }, [onPanelWidthChange]);
 
   const onDividerMouseDown = (e: React.MouseEvent) => {
     isDraggingRef.current = true;
     dragStartXRef.current = e.clientX;
     dragStartWidthRef.current = rightPanelWidth;
     document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    e.preventDefault();
+  };
+
+  const onDividerTouchStart = (e: React.TouchEvent) => {
+    if (!e.touches.length) return;
+    isDraggingRef.current = true;
+    dragStartXRef.current = e.touches[0].clientX;
+    dragStartWidthRef.current = rightPanelWidth;
     document.body.style.userSelect = 'none';
     e.preventDefault();
   };
@@ -247,225 +274,320 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     }
   };
 
+  // Extract chat content to reuse in both mobile and desktop layouts
+  const renderChatMessages = () => (
+    <>
+      {/* Intro message */}
+      <div className="flex gap-2.5 pt-1">
+        <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
+          <span className="text-white text-[10px] font-bold">AI</span>
+        </div>
+        <div className="flex-1">
+          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3">
+            <p className={`text-lg text-accent-hover leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
+              {processZhuyin(`你剛才讀完了《${story.title}》，做得很棒！讓我們來聊聊課文的內容吧。`)}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Conversation turns */}
+      {conversation.map((turn, i) => {
+        // Feedback message
+        if (turn.role === 'feedback') {
+          return (
+            <div key={i} className={`mx-10 rounded-xl px-3.5 py-2 text-sm border ${
+              turn.understood
+                ? 'bg-emerald-50 border-emerald-300 text-emerald-800'
+                : 'bg-amber-50 border-amber-300 text-amber-800'
+            }`}>
+              <span className="mr-1.5">{turn.understood ? '✓' : '💡'}</span>
+              {processZhuyin(turn.text)}
+            </div>
+          );
+        }
+
+        // AI or student message
+        return (
+          <div key={i} className={`flex gap-2.5 ${turn.role === 'student' ? 'flex-row-reverse' : ''}`}>
+            {turn.role === 'ai' ? (
+              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
+                <span className="text-white text-[10px] font-bold">AI</span>
+              </div>
+            ) : (
+              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center">
+                <svg className="w-3.5 h-3.5 text-gray-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                </svg>
+              </div>
+            )}
+            <div className={`max-w-[85%] flex flex-col ${turn.role === 'student' ? 'items-end' : ''}`}>
+              <div className={[
+                'rounded-2xl px-4 py-3',
+                turn.role === 'ai'
+                  ? 'bg-accent-bg border border-accent-bg-subtle rounded-tl-sm text-accent-hover'
+                  : 'bg-accent rounded-tr-sm text-white',
+              ].join(' ')}>
+                <p className={`text-lg leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Loading indicator */}
+      {isLoading && (
+        <div className="flex gap-2.5">
+          <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
+            <span className="text-white text-[10px] font-bold">AI</span>
+          </div>
+          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5">
+            <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:0ms]" />
+            <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:150ms]" />
+            <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:300ms]" />
+          </div>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="bg-red-900/30 border border-red-700/40 rounded-xl px-3.5 py-2.5 text-sm text-red-600">
+          {error}
+          <button
+            onClick={handleRetry}
+            className="ml-2 underline hover:no-underline"
+          >
+            重試
+          </button>
+        </div>
+      )}
+
+      {/* Completion message */}
+      {isSessionComplete && !isLoading && (
+        <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center">
+          <p className="text-emerald-800 font-bold text-sm">太棒了！你展現了很好的理解力！</p>
+          <p className="text-emerald-700 text-xs mt-1">你對課文的理解很好，繼續下一步吧！</p>
+        </div>
+      )}
+
+      <div ref={chatEndRef} />
+    </>
+  );
+
+  const renderInputArea = () => (
+    <div className="shrink-0 bg-white border-t border-gray-200 p-3">
+      {isSessionComplete ? (
+        <div className="flex items-center justify-between gap-2">
+          <button
+            onClick={onBack}
+            className="px-3 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors"
+          >
+            ← 回到朗讀
+          </button>
+          <button
+            onClick={onFinish}
+            className="flex-1 py-3 rounded-xl font-bold text-base bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2"
+          >
+            繼續，生字練習
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <div className="flex gap-2 items-end">
+          <textarea
+            ref={inputRef}
+            value={inputText}
+            onChange={e => setInputText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="輸入你的回答……（Enter 送出）"
+            rows={2}
+            disabled={isLoading || isSessionComplete}
+            className="flex-1 bg-white border border-gray-200 rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none disabled:opacity-50"
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={!inputText.trim() || isLoading || isSessionComplete}
+            className="flex-shrink-0 w-11 h-11 rounded-xl bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+                d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+
   return (
     <div
-      className="flex flex-1 h-full bg-amber-50 overflow-hidden"
+      className={`flex ${isMobile ? 'flex-col' : 'flex-row'} flex-1 h-full bg-amber-50 overflow-hidden`}
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
           : "'Iansui', 'Noto Sans TC', sans-serif",
       }}
     >
-
-      {/* LEFT: Story text panel */}
-      <div className="flex-1 flex flex-col bg-amber-50 min-w-0">
-        {/* Tab bar */}
-        <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
-          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
-            {story.filename}
-          </div>
-          <div className="flex-1" />
-          <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
-        </div>
-
-        {/* Story content — all paragraphs visible for reference */}
-        <div className="flex-1 p-8 lg:p-16 overflow-y-auto custom-scrollbar">
-          <div className="max-w-3xl mx-auto space-y-20">
-            {story.content.map((line, idx) => (
-              <div
-                key={idx}
-                ref={el => { paragraphRefs.current[idx] = el; }}
-                className={`rounded-2xl px-6 py-12 border transition-all ${
-                  highlightedParagraph === idx
-                    ? 'border-amber-500/60 bg-amber-900/10 shadow-[0_0_15px_rgba(245,158,11,0.1)]'
-                    : 'border-transparent hover:border-gray-200 hover:bg-white/40'
-                }`}
-              >
-                <p className={`text-2xl lg:text-3xl text-gray-900 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
-                  {zhuyinLines ? zhuyinLines[idx] : line}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Status bar */}
-        <div className="h-7 bg-white border-t border-gray-200 flex items-center px-4 text-[10px] text-gray-500 uppercase shrink-0">
-          <span>共 {story.content.length} 段 · {story.title}</span>
-        </div>
-      </div>
-
-      {/* Resizable divider */}
-      <div
-        onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
-      />
-
-      {/* RIGHT: AI Tutor chat panel */}
-      <div className="flex-shrink-0 bg-white flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
-        {/* Panel header */}
-        <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
-          <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">
-            AI Tutor
-          </span>
-          <div className="flex-1" />
-          <span className="text-[10px] text-gray-600">
-            {understoodCount} / {requiredCount} 理解
-          </span>
-          <button
-            onClick={onFinish}
-            className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors"
-          >
-            跳過
-          </button>
-        </div>
-
-        {/* Chat messages */}
-        <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-gray-50">
-
-          {/* Intro message */}
-          <div className="flex gap-2.5 pt-1">
-            <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
-              <span className="text-white text-[10px] font-bold">AI</span>
-            </div>
-            <div className="flex-1">
-              <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3">
-                <p className={`text-lg text-accent-hover leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
-                  {processZhuyin(`你剛才讀完了《${story.title}》，做得很棒！讓我們來聊聊課文的內容吧。`)}
-                </p>
-              </div>
+      {isMobile ? (
+        /* MOBILE: Tab-based layout */
+        <>
+          {/* Tab bar */}
+          <div className="flex bg-white border-b border-gray-200 shrink-0">
+            <button
+              onClick={() => setActiveTab('story')}
+              className={`flex-1 py-2 text-sm font-bold transition-colors ${
+                activeTab === 'story'
+                  ? 'text-accent border-b-2 border-accent'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              課文
+            </button>
+            <button
+              onClick={() => setActiveTab('chat')}
+              className={`flex-1 py-2 text-sm font-bold transition-colors ${
+                activeTab === 'chat'
+                  ? 'text-accent border-b-2 border-accent'
+                  : 'text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              AI 對話
+            </button>
+            <div className="flex items-center px-2">
+              <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
             </div>
           </div>
 
-          {/* Conversation turns */}
-          {conversation.map((turn, i) => {
-            // Feedback message
-            if (turn.role === 'feedback') {
-              return (
-                <div key={i} className={`mx-10 rounded-xl px-3.5 py-2 text-sm border ${
-                  turn.understood
-                    ? 'bg-emerald-50 border-emerald-300 text-emerald-800'
-                    : 'bg-amber-50 border-amber-300 text-amber-800'
-                }`}>
-                  <span className="mr-1.5">{turn.understood ? '✓' : '💡'}</span>
-                  {processZhuyin(turn.text)}
-                </div>
-              );
-            }
-
-            // AI or student message
-            return (
-              <div key={i} className={`flex gap-2.5 ${turn.role === 'student' ? 'flex-row-reverse' : ''}`}>
-                {turn.role === 'ai' ? (
-                  <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
-                    <span className="text-white text-[10px] font-bold">AI</span>
-                  </div>
-                ) : (
-                  <div className="flex-shrink-0 w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center">
-                    <svg className="w-3.5 h-3.5 text-gray-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-                        d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                    </svg>
-                  </div>
-                )}
-                <div className={`max-w-[85%] flex flex-col ${turn.role === 'student' ? 'items-end' : ''}`}>
-                  <div className={[
-                    'rounded-2xl px-4 py-3',
-                    turn.role === 'ai'
-                      ? 'bg-accent-bg border border-accent-bg-subtle rounded-tl-sm text-accent-hover'
-                      : 'bg-accent rounded-tr-sm text-white',
-                  ].join(' ')}>
-                    <p className={`text-lg leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
-                  </div>
+          {activeTab === 'story' ? (
+            /* Story panel - full height */
+            <div className="flex-1 flex flex-col bg-amber-50 min-h-0">
+              <div className="flex-1 p-4 overflow-y-auto custom-scrollbar">
+                <div className="max-w-3xl mx-auto space-y-12">
+                  {story.content.map((line, idx) => (
+                    <div
+                      key={idx}
+                      ref={el => { paragraphRefs.current[idx] = el; }}
+                      className={`rounded-2xl px-4 py-8 border transition-all ${
+                        highlightedParagraph === idx
+                          ? 'border-amber-500/60 bg-amber-900/10 shadow-[0_0_15px_rgba(245,158,11,0.1)]'
+                          : 'border-transparent hover:border-gray-200 hover:bg-white/40'
+                      }`}
+                    >
+                      <p className={`text-xl text-gray-900 leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                        {zhuyinLines ? zhuyinLines[idx] : line}
+                      </p>
+                    </div>
+                  ))}
                 </div>
               </div>
-            );
-          })}
-
-          {/* Loading indicator */}
-          {isLoading && (
-            <div className="flex gap-2.5">
-              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
-                <span className="text-white text-[10px] font-bold">AI</span>
-              </div>
-              <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5">
-                <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:0ms]" />
-                <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:150ms]" />
-                <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:300ms]" />
-              </div>
-            </div>
-          )}
-
-          {/* Error */}
-          {error && (
-            <div className="bg-red-900/30 border border-red-700/40 rounded-xl px-3.5 py-2.5 text-sm text-red-600">
-              {error}
-              <button
-                onClick={handleRetry}
-                className="ml-2 underline hover:no-underline"
-              >
-                重試
-              </button>
-            </div>
-          )}
-
-          {/* Completion message */}
-          {isSessionComplete && !isLoading && (
-            <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center">
-              <p className="text-emerald-800 font-bold text-sm">太棒了！你展現了很好的理解力！</p>
-              <p className="text-emerald-700 text-xs mt-1">你對課文的理解很好，繼續下一步吧！</p>
-            </div>
-          )}
-
-          <div ref={chatEndRef} />
-        </div>
-
-        {/* Bottom: input or proceed button */}
-        <div className="shrink-0 bg-white border-t border-gray-200 p-3">
-          {isSessionComplete ? (
-            <div className="flex items-center justify-between gap-2">
-              <button
-                onClick={onBack}
-                className="px-3 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors"
-              >
-                ← 回到朗讀
-              </button>
-              <button
-                onClick={onFinish}
-                className="flex-1 py-3 rounded-xl font-bold text-base bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2"
-              >
-                繼續，生字練習
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-                </svg>
-              </button>
             </div>
           ) : (
-            <div className="flex gap-2 items-end">
-              <textarea
-                ref={inputRef}
-                value={inputText}
-                onChange={e => setInputText(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="輸入你的回答……（Enter 送出）"
-                rows={2}
-                disabled={isLoading || isSessionComplete}
-                className="flex-1 bg-white border border-gray-200 rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none disabled:opacity-50"
-              />
-              <button
-                onClick={handleSubmit}
-                disabled={!inputText.trim() || isLoading || isSessionComplete}
-                className="flex-shrink-0 w-10 h-10 rounded-xl bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-                    d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-                </svg>
-              </button>
+            /* Chat panel - full height with input */
+            <div className="flex-1 flex flex-col min-h-0">
+              {/* Panel header with progress */}
+              <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
+                <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">
+                  AI Tutor
+                </span>
+                <div className="flex-1" />
+                <span className="text-[10px] text-gray-600">
+                  {understoodCount} / {requiredCount} 理解
+                </span>
+                <button onClick={onFinish} className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors">
+                  跳過
+                </button>
+              </div>
+
+              {/* Chat messages */}
+              <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-gray-50">
+                {renderChatMessages()}
+              </div>
+
+              {/* Input area */}
+              {renderInputArea()}
             </div>
           )}
-        </div>
-      </div>
+        </>
+      ) : (
+        /* DESKTOP: Current dual-panel layout */
+        <>
+          {/* LEFT: Story text panel */}
+          <div className="flex-1 flex flex-col bg-amber-50 min-w-0">
+            {/* Tab bar */}
+            <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
+              <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
+                {story.filename}
+              </div>
+              <div className="flex-1" />
+              <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
+            </div>
+
+            {/* Story content — all paragraphs visible for reference */}
+            <div className="flex-1 p-8 lg:p-16 overflow-y-auto custom-scrollbar">
+              <div className="max-w-3xl mx-auto space-y-20">
+                {story.content.map((line, idx) => (
+                  <div
+                    key={idx}
+                    ref={el => { paragraphRefs.current[idx] = el; }}
+                    className={`rounded-2xl px-6 py-12 border transition-all ${
+                      highlightedParagraph === idx
+                        ? 'border-amber-500/60 bg-amber-900/10 shadow-[0_0_15px_rgba(245,158,11,0.1)]'
+                        : 'border-transparent hover:border-gray-200 hover:bg-white/40'
+                    }`}
+                  >
+                    <p className={`text-2xl lg:text-3xl text-gray-900 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                      {zhuyinLines ? zhuyinLines[idx] : line}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Status bar */}
+            <div className="h-7 bg-white border-t border-gray-200 flex items-center px-4 text-[10px] text-gray-500 uppercase shrink-0">
+              <span>共 {story.content.length} 段 · {story.title}</span>
+            </div>
+          </div>
+
+          {/* Resizable divider */}
+          <div
+            onMouseDown={onDividerMouseDown}
+            onTouchStart={onDividerTouchStart}
+            className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
+          />
+
+          {/* RIGHT: AI Tutor chat panel */}
+          <div className="flex-shrink-0 bg-white flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
+            {/* Panel header */}
+            <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
+              <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">
+                AI Tutor
+              </span>
+              <div className="flex-1" />
+              <span className="text-[10px] text-gray-600">
+                {understoodCount} / {requiredCount} 理解
+              </span>
+              <button
+                onClick={onFinish}
+                className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors"
+              >
+                跳過
+              </button>
+            </div>
+
+            {/* Chat messages */}
+            <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-gray-50">
+              {renderChatMessages()}
+            </div>
+
+            {/* Input area */}
+            {renderInputArea()}
+          </div>
+        </>
+      )}
 
       <style>{`
         .custom-scrollbar::-webkit-scrollbar { width: 5px; }

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -3,6 +3,7 @@ import { Story } from '../../types';
 import { correctHomophones } from '../../utils/pinyin';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
+import { useIsMobile } from '../../hooks/useIsMobile';
 
 /* ---- Text helpers (same normalisation as LiveTutor) ---- */
 
@@ -52,6 +53,7 @@ interface FullReadingProps {
 }
 
 const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPanelWidthChange, onFinish, onBack }) => {
+  const isMobile = useIsMobile();
   const [isPreparing, setIsPreparing]           = useState(false);
   const [isSessionActive, setIsSessionActive]   = useState(false);
   const [isTtsSpeaking, setIsTtsSpeaking]       = useState(false);
@@ -104,11 +106,24 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
     };
+    const onTouchMove = (e: TouchEvent) => {
+      if (!isDraggingRef.current) return;
+      const delta = dragStartXRef.current - e.touches[0].clientX;
+      onPanelWidthChange(Math.max(240, Math.min(600, dragStartWidthRef.current + delta)));
+    };
+    const onTouchEnd = () => {
+      isDraggingRef.current = false;
+      document.body.style.userSelect = '';
+    };
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('touchmove', onTouchMove);
+    window.addEventListener('touchend', onTouchEnd);
     return () => {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
     };
   }, []);
 
@@ -262,7 +277,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
   return (
     <div
-      className="flex flex-1 h-full bg-amber-50 overflow-hidden"
+      className={`flex ${isMobile ? 'flex-col' : 'flex-row'} flex-1 h-full bg-amber-50 overflow-hidden`}
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
@@ -270,7 +285,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       }}
     >
       {/* LEFT: Full story text */}
-      <div className="flex-1 flex flex-col bg-amber-50 min-w-0">
+      <div className={`flex flex-col bg-amber-50 min-w-0 ${isMobile ? 'h-[60vh]' : 'flex-1'}`}>
         {/* Tab bar */}
         <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
           <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800">
@@ -281,14 +296,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
         </div>
 
         {/* All paragraphs */}
-        <div className="flex-1 p-8 lg:p-16 overflow-y-auto custom-scrollbar">
+        <div className={`flex-1 ${isMobile ? 'p-4' : 'p-8 lg:p-16'} overflow-y-auto custom-scrollbar`}>
           <div className="max-w-3xl mx-auto space-y-20">
             {story.content.map((line, idx) => (
               <div
                 key={idx}
                 className="rounded-2xl px-6 py-12 border-b border-gray-200 last:border-b-0 hover:bg-white/30 transition-all"
               >
-                <p className={`text-2xl lg:text-3xl text-gray-800 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                <p className={`${isMobile ? 'text-xl' : 'text-2xl lg:text-3xl'} text-gray-800 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}
                 </p>
               </div>
@@ -306,16 +321,24 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
         </div>
       </div>
 
-      {/* Resizable divider */}
-      <div
-        onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
-      />
+      {/* Resizable divider - hidden on mobile */}
+      {!isMobile && (
+        <div
+          onMouseDown={onDividerMouseDown}
+          onTouchStart={(e) => {
+            isDraggingRef.current = true;
+            dragStartXRef.current = e.touches[0].clientX;
+            dragStartWidthRef.current = rightPanelWidth;
+            document.body.style.userSelect = 'none';
+          }}
+          className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
+        />
+      )}
 
       {/* RIGHT: Recording panel */}
       <div
-        className="flex-shrink-0 bg-amber-50 flex flex-col h-full min-h-0"
-        style={{ width: rightPanelWidth }}
+        className={`bg-amber-50 flex flex-col min-h-0 ${isMobile ? 'flex-1' : 'flex-shrink-0 h-full'}`}
+        style={isMobile ? undefined : { width: rightPanelWidth }}
       >
         {/* Header */}
         <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4">

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -112,7 +112,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
         <div className="max-w-3xl mx-auto px-6 py-10 space-y-8">
 
           {/* Hero: thumbnail + title */}
-          <div className="flex gap-6 items-start">
+          <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 items-start">
             <img
               src={story.thumbnail}
               alt={story.title}

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -4,6 +4,7 @@ import { Story, ReadingAttempt, LiveMessage } from '../../types';
 import { correctHomophones } from '../../utils/pinyin';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
+import { useIsMobile } from '../../hooks/useIsMobile';
 
 /* ------------------------------------------------------------------ */
 /*  Canned response pools — randomly selected to avoid repetition     */
@@ -222,6 +223,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   onFinish,
   onCancel,
 }) => {
+  const isMobile = useIsMobile();
   const [currentLineIndex, setCurrentLineIndex] = useState(0);
   const [isPreparing, setIsPreparing] = useState(false);          // STT initializing
   const [isSessionActive, setIsSessionActive] = useState(false);  // mic actively recording
@@ -315,11 +317,24 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
     };
+    const onTouchMove = (e: TouchEvent) => {
+      if (!isDraggingRef.current) return;
+      const delta = dragStartXRef.current - e.touches[0].clientX;
+      onPanelWidthChange(Math.max(240, Math.min(600, dragStartWidthRef.current + delta)));
+    };
+    const onTouchEnd = () => {
+      isDraggingRef.current = false;
+      document.body.style.userSelect = '';
+    };
     window.addEventListener('mousemove', onMouseMove);
     window.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('touchmove', onTouchMove);
+    window.addEventListener('touchend', onTouchEnd);
     return () => {
       window.removeEventListener('mousemove', onMouseMove);
       window.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('touchmove', onTouchMove);
+      window.removeEventListener('touchend', onTouchEnd);
     };
   }, []);
 
@@ -677,15 +692,15 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   return (
     <div
-      className="flex flex-1 h-full bg-amber-50 overflow-hidden"
+      className={`flex ${isMobile ? 'flex-col' : 'flex-row'} flex-1 h-full bg-amber-50 overflow-hidden`}
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
           : "'Iansui', 'Noto Sans TC', sans-serif",
       }}
     >
-      {/* CENTER: Editor */}
-      <div className="flex-1 flex flex-col bg-amber-50">
+      {/* CENTER: Editor - story text panel */}
+      <div className={`flex flex-col bg-amber-50 ${isMobile ? 'h-[60vh]' : 'flex-1'}`}>
         <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2">
           <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
             {processZhuyin(story.filename)}
@@ -694,7 +709,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
         </div>
 
-        <div className="flex-1 p-8 lg:p-16 overflow-y-auto custom-scrollbar">
+        <div className={`flex-1 ${isMobile ? 'p-4' : 'p-8 lg:p-16'} overflow-y-auto custom-scrollbar`}>
           <div className="max-w-3xl mx-auto space-y-20">
             {story.content.map((line, idx) => (
               <div
@@ -707,7 +722,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 }`}
               >
                 <p
-                  className={`text-2xl lg:text-3xl leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
+                  className={`${isMobile ? 'text-xl' : 'text-2xl lg:text-3xl'} leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
                     idx === currentLineIndex ? 'text-gray-900 font-bold' : 'text-gray-600'
                   }`}
                 >
@@ -731,14 +746,25 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         </div>
       </div>
 
-      {/* Resizable divider */}
-      <div
-        onMouseDown={onDividerMouseDown}
-        className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
-      />
+      {/* Resizable divider - hidden on mobile */}
+      {!isMobile && (
+        <div
+          onMouseDown={onDividerMouseDown}
+          onTouchStart={(e) => {
+            isDraggingRef.current = true;
+            dragStartXRef.current = e.touches[0].clientX;
+            dragStartWidthRef.current = rightPanelWidth;
+            document.body.style.userSelect = 'none';
+          }}
+          className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
+        />
+      )}
 
       {/* RIGHT: Interaction panel */}
-      <div className="flex-shrink-0 bg-amber-50 flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
+      <div
+        className={`bg-amber-50 flex flex-col min-h-0 ${isMobile ? 'flex-1' : 'flex-shrink-0 h-full'}`}
+        style={isMobile ? undefined : { width: rightPanelWidth }}
+      >
         <div className="h-9 flex-shrink-0 bg-white border-b border-gray-200 flex items-center px-4">
           <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">
             Live Feedback

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -143,7 +143,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           {displayChars.length === 0 ? (
             <div className="text-gray-400 text-sm py-8 text-center">這篇課文的漢字沒有筆順資料</div>
           ) : (
-            <div className="grid grid-cols-4 sm:grid-cols-6 gap-3">
+            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
               {displayChars.map(ch => {
                 const isSuggested = needPracticeSet.has(ch);
                 const isPracticed = practicedChars.has(ch);

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export function useIsMobile(breakpoint = 768): boolean {
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < breakpoint : false
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler);
+    setIsMobile(mql.matches);
+    return () => mql.removeEventListener('change', handler);
+  }, [breakpoint]);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

Closes #125

- Add `useIsMobile()` hook (768px breakpoint via `matchMedia`)
- **Header**: compact step circles + hamburger dropdown on mobile (<768px)
- **LiveTutor / FullReading**: vertical stack (60vh story / flex-1 panel), divider hidden on mobile
- **ComprehensionChat**: tab-based layout ("課文" / "AI 對話"), auto-switches to story tab when AI highlights paragraph
- **VocabPractice**: 3-col grid on mobile (was 4-col)
- **Intro**: hero stacks vertically on mobile
- Touch handlers added for divider on tablet (>=768px)
- Submit button fixed to 44px (w-11 h-11) for touch target compliance
- Desktop layout: **zero changes**

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/hooks/useIsMobile.ts` | New — shared responsive hook |
| `frontend/src/App.tsx` | Mobile header nav + hamburger |
| `LiveTutor.tsx` | Mobile vertical stack |
| `ComprehensionChat.tsx` | Mobile tab layout + submit fix |
| `FullReading.tsx` | Mobile vertical stack |
| `VocabPractice.tsx` | Grid: `grid-cols-3 sm:4 md:6` |
| `Intro.tsx` | Hero: `flex-col sm:flex-row` |

## Test plan

- [ ] Chrome DevTools 375px (iPhone SE): header compact, all steps usable, no horizontal scroll
- [ ] Chrome DevTools 768px (iPad): desktop layout with divider
- [ ] Chrome DevTools 1024px+: no visual regression
- [ ] LiveTutor mobile: story top, feedback bottom
- [ ] ComprehensionChat mobile: tabs switch, auto-switch on wrong answer
- [ ] FullReading mobile: story top, recording bottom
- [ ] VocabPractice mobile: 3-col grid
- [ ] Intro mobile: hero stacks vertically

🤖 Generated with [Claude Code](https://claude.ai/code)