### PR TITLE
docs: restrict RDP/SSH firewall rules and update gcp-windows-vm skill (Fixes #134)

### DIFF
--- a/.claude/skills/gcp-windows-vm.md
+++ b/.claude/skills/gcp-windows-vm.md
@@ -54,7 +54,30 @@ Use **Microsoft Remote Desktop** (Mac App Store) or GCP Console browser RDP.
 
 ## Firewall
 
-- Rule `allow-rdp`: TCP 3389 open from `0.0.0.0/0` (all IPs)
+RDP and SSH access is restricted for security. The following rules are in place:
+
+| Rule | Protocol/Port | Source | Purpose |
+|------|--------------|--------|---------|
+| `default-allow-rdp` | TCP 3389 | `150.117.242.93/32` | RDP access for authorized IP only |
+| `default-allow-ssh` | TCP 22 | `35.235.240.0/20` | SSH via GCP IAP only |
+
+**Important**: The old `allow-rdp` rule (which allowed `0.0.0.0/0`) was deleted on 2026-02-24 as a security fix (#134).
+
+If your IP changes, update the RDP rule with your new IP:
+
+```bash
+gcloud config configurations activate lingoleap
+
+# Update RDP rule with new IP (replace YOUR_IP with your current public IP)
+gcloud compute firewall-rules update default-allow-rdp \
+  --source-ranges="YOUR_IP/32" \
+  --project lingoleap-dev
+
+# Check your current public IP
+curl -s ifconfig.me
+```
+
+**Never set source-ranges to `0.0.0.0/0` — open RDP is scanned 24/7 by brute-force bots.**
 
 ## Cost Estimate
 


### PR DESCRIPTION
Fixes #134

## Summary

- Deleted redundant `allow-rdp` custom firewall rule (was open to `0.0.0.0/0`)
- Restricted `default-allow-rdp` to authorized IP only (`150.117.242.93/32`)
- Restricted `default-allow-ssh` to GCP IAP range only (`35.235.240.0/20`)
- Updated `.claude/skills/gcp-windows-vm.md` to document new firewall configuration with IP-change instructions

## Security Context

Open RDP (`0.0.0.0/0`) is a critical attack vector — automated bots scan port 3389 24/7 for brute-force attempts. This change eliminates that exposure.

## GCP Firewall Changes Applied

These are infrastructure changes applied directly to GCP (not code changes):

| Rule | Before | After |
|------|--------|-------|
| `allow-rdp` | `0.0.0.0/0` | DELETED |
| `default-allow-rdp` | `0.0.0.0/0` | `150.117.242.93/32` |
| `default-allow-ssh` | `0.0.0.0/0` | `35.235.240.0/20` |

## Test Plan

- Verify firewall rules in GCP Console or via `gcloud compute firewall-rules list --project lingoleap-dev`
- Confirm `allow-rdp` no longer exists
- Confirm `default-allow-rdp` source is `150.117.242.93/32`
- Confirm `default-allow-ssh` source is `35.235.240.0/20`
- Verify RDP connection still works from authorized IP `150.117.242.93`