### PR TITLE
feat: LCS-based text diff algorithm with error highlighting (#80)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -1,6 +1,7 @@
 
 import React, { useRef, useState, useEffect } from 'react';
 import { LearningSession } from '../../types';
+import DiffDisplay from '../ui/DiffDisplay';
 import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
 
 /**
@@ -87,6 +88,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, onRetry })
   }
 
   const { readingAttempt, comprehensionResult, vocabResult, fullReadingResult } = session;
+  const [expandedLine, setExpandedLine] = useState<number | null>(null);
 
   // Compute overall score from available steps
   const scores: number[] = [];
@@ -327,6 +329,68 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, onRetry })
           )}
         </div>
       </div>
+
+      {/* 逐段朗讀分析 (diff breakdown) */}
+      {readingAttempt?.lineBreakdown && readingAttempt.lineBreakdown.length > 0 && (
+        <div className="bg-white rounded-3xl border border-slate-200 shadow-sm overflow-hidden">
+          <div className="p-6 border-b border-slate-100">
+            <h3 className="text-lg font-bold">逐段朗讀分析</h3>
+            <p className="text-sm text-gray-500 mt-1">
+              點擊每一段可展開查看逐字比對結果
+            </p>
+          </div>
+          <div className="divide-y divide-slate-100">
+            {readingAttempt.lineBreakdown.map((line, idx) => {
+              const pct = Math.round(line.matchRate * 100);
+              const isExpanded = expandedLine === idx;
+              return (
+                <div key={idx}>
+                  <button
+                    onClick={() => setExpandedLine(isExpanded ? null : idx)}
+                    className="w-full px-6 py-4 flex items-center gap-4 hover:bg-slate-50 transition-colors text-left"
+                  >
+                    <span className="text-xs font-bold text-gray-400 w-8 shrink-0">
+                      #{idx + 1}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-gray-700 truncate">
+                        {line.transcript || '（未朗讀）'}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0">
+                      <span className={`text-sm font-bold ${
+                        pct >= 80 ? 'text-emerald-600' : pct >= 60 ? 'text-amber-600' : 'text-red-500'
+                      }`}>
+                        {pct}%
+                      </span>
+                      <span className="text-xs text-gray-400">
+                        {line.cpm} 字/分
+                      </span>
+                      <svg
+                        className={`w-4 h-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+                      </svg>
+                    </div>
+                  </button>
+                  {isExpanded && line.diffTokens && (
+                    <div className="px-6 pb-4 pt-1">
+                      <DiffDisplay tokens={line.diffTokens} showLegend />
+                      <div className="flex gap-4 mt-3 text-xs text-gray-400">
+                        <span>正確: {line.diffTokens.filter(t => t.type === 'correct').length} 字</span>
+                        <span>讀錯: {line.diffTokens.filter(t => t.type === 'wrong').length} 字</span>
+                        <span>漏讀: {line.diffTokens.filter(t => t.type === 'missing').length} 字</span>
+                        <span>多讀: {line.diffTokens.filter(t => t.type === 'extra').length} 字</span>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* CTA */}
       <div className="bg-gradient-to-r from-accent to-violet-600 rounded-3xl p-8 text-white flex flex-col md:flex-row items-center justify-between gap-6 shadow-xl">

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -1,46 +1,11 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Story, FullReadingResult } from '../../types';
+import { Story, FullReadingResult, DiffToken } from '../../types';
 import { correctHomophones } from '../../utils/pinyin';
+import { diffCharacters, normalizeForComparison, cleanChineseText } from '../../utils/textDiff';
+import DiffDisplay from '../ui/DiffDisplay';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
 import { useIsMobile } from '../../hooks/useIsMobile';
-
-/* ---- Text helpers (same normalisation as LiveTutor) ---- */
-
-const cleanChineseText = (text: string) => {
-  if (!text) return '';
-  return text
-    .replace(/([\u4e00-\u9fa5！，。？：；（）])\s+([\u4e00-\u9fa5！，。？：；（）])/g, '$1$2')
-    .replace(/([\u4e00-\u9fa5])\s+([\u4e00-\u9fa5])/g, '$1$2')
-    .trim();
-};
-
-const CHINESE_DIGITS = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九'];
-const intToChinese = (num: number): string => {
-  if (num === 0) return '零';
-  let n = num; let result = '';
-  if (n >= 100_000_000) { result += intToChinese(Math.floor(n / 100_000_000)) + '億'; n %= 100_000_000; if (n > 0 && n < 10_000_000) result += '零'; }
-  if (n >= 10_000) { result += intToChinese(Math.floor(n / 10_000)) + '萬'; n %= 10_000; if (n > 0 && n < 1_000) result += '零'; }
-  if (n >= 1_000) { result += CHINESE_DIGITS[Math.floor(n / 1_000)] + '千'; n %= 1_000; if (n > 0 && n < 100) result += '零'; }
-  if (n >= 100) { result += CHINESE_DIGITS[Math.floor(n / 100)] + '百'; n %= 100; if (n > 0 && n < 10) result += '零'; }
-  if (n >= 10) { const tens = Math.floor(n / 10); if (tens > 1 || result.length > 0) result += CHINESE_DIGITS[tens]; result += '十'; n %= 10; }
-  if (n > 0) result += CHINESE_DIGITS[n];
-  return result;
-};
-const normalizeNumbers = (text: string) => text.replace(/\d+/g, m => intToChinese(parseInt(m, 10)));
-const normalizeForComparison = (text: string) =>
-  normalizeNumbers(cleanChineseText(text)).replace(/[「」『』，。！？：；、\s]/g, '');
-
-const computeMatchRate = (spokenRaw: string, targetRaw: string): number => {
-  const spoken = normalizeForComparison(spokenRaw);
-  const target = normalizeForComparison(targetRaw);
-  if (!target || !spoken) return 0;
-  const freq: Record<string, number> = {};
-  for (const ch of spoken) freq[ch] = (freq[ch] || 0) + 1;
-  let matched = 0;
-  for (const ch of target) { if (freq[ch] && freq[ch] > 0) { matched++; freq[ch]--; } }
-  return matched / target.length;
-};
 
 /* ------------------------------------------------------------------ */
 
@@ -60,7 +25,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
   const [isTtsPaused, setIsTtsPaused]           = useState(false);
   const [streamingTranscript, setStreamingTranscript] = useState('');
   const [micError, setMicError]                 = useState('');
-  const [result, setResult]                     = useState<{ matchRate: number; feedback: string } | null>(null);
+  const [result, setResult]                     = useState<{ matchRate: number; feedback: string; diffTokens: DiffToken[] } | null>(null);
   const [zhuyinEnabled, setZhuyinEnabled]       = useState(true);
   const [zhuyinReady, setZhuyinReady]           = useState(false);
 
@@ -262,14 +227,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
     const targetNorm = normalizeForComparison(fullText);
     const corrected = correctHomophones(cleanChineseText(transcript), targetNorm);
-    const matchRate = computeMatchRate(corrected, fullText);
+    const diffResult = diffCharacters(corrected, fullText, { useHomophone: true });
 
     const feedback =
-      matchRate >= 0.80 ? '太流利了！全文朗讀表現非常棒！' :
-      matchRate >= 0.60 ? '唸得不錯，過關！繼續練習會更好！' :
+      diffResult.matchRate >= 0.80 ? '太流利了！全文朗讀表現非常棒！' :
+      diffResult.matchRate >= 0.60 ? '唸得不錯，過關！繼續練習會更好！' :
       '再練習一次，你一定可以更流利！';
 
-    setResult({ matchRate, feedback });
+    setResult({ matchRate: diffResult.matchRate, feedback, diffTokens: diffResult.tokens });
     setStreamingTranscript(cleanChineseText(transcript));
   }, [fullText, stopSession]);
 
@@ -403,6 +368,13 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
                 <div className="bg-white border border-gray-200 rounded-xl px-3 py-2.5">
                   <p className="text-[10px] text-gray-500 mb-1 uppercase tracking-widest">你說的</p>
                   <p className="text-xs text-gray-600 leading-relaxed line-clamp-6">{streamingTranscript}</p>
+                </div>
+              )}
+
+              {result.diffTokens && result.diffTokens.length > 0 && (
+                <div className="bg-white border border-gray-200 rounded-xl px-3 py-2.5">
+                  <p className="text-[10px] text-gray-500 mb-2 uppercase tracking-widest">逐字比對</p>
+                  <DiffDisplay tokens={result.diffTokens} showLegend />
                 </div>
               )}
             </div>

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -1,7 +1,9 @@
 
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Story, ReadingAttempt, LiveMessage } from '../../types';
+import { Story, ReadingAttempt, LiveMessage, DiffToken } from '../../types';
 import { correctHomophones } from '../../utils/pinyin';
+import { diffCharacters, normalizeForComparison, cleanChineseText } from '../../utils/textDiff';
+import DiffDisplay from '../ui/DiffDisplay';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
 import { useIsMobile } from '../../hooks/useIsMobile';
@@ -96,103 +98,6 @@ const extractPracticeChars = (results: LineResult[], content: string[]): string[
 };
 
 /* ------------------------------------------------------------------ */
-/*  Text processing helpers                                           */
-/* ------------------------------------------------------------------ */
-
-const cleanChineseText = (text: string) => {
-  if (!text) return '';
-  return text
-    .replace(/([\u4e00-\u9fa5！，。？：；（）])\s+([\u4e00-\u9fa5！，。？：；（）])/g, '$1$2')
-    .replace(/([\u4e00-\u9fa5])\s+([\u4e00-\u9fa5])/g, '$1$2')
-    .trim();
-};
-
-/* ---- Arabic numeral → Chinese numeral conversion ---- */
-
-const CHINESE_DIGITS = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九'];
-
-/**
- * Convert an integer to Chinese numeral string.
- * e.g. 4000 → "四千",  12 → "十二",  305 → "三百零五"
- */
-const intToChinese = (num: number): string => {
-  if (num === 0) return '零';
-  let n = num;
-  let result = '';
-
-  // 億
-  if (n >= 100_000_000) {
-    result += intToChinese(Math.floor(n / 100_000_000)) + '億';
-    n %= 100_000_000;
-    if (n > 0 && n < 10_000_000) result += '零';
-  }
-  // 萬
-  if (n >= 10_000) {
-    result += intToChinese(Math.floor(n / 10_000)) + '萬';
-    n %= 10_000;
-    if (n > 0 && n < 1_000) result += '零';
-  }
-  // 千
-  if (n >= 1_000) {
-    result += CHINESE_DIGITS[Math.floor(n / 1_000)] + '千';
-    n %= 1_000;
-    if (n > 0 && n < 100) result += '零';
-  }
-  // 百
-  if (n >= 100) {
-    result += CHINESE_DIGITS[Math.floor(n / 100)] + '百';
-    n %= 100;
-    if (n > 0 && n < 10) result += '零';
-  }
-  // 十
-  if (n >= 10) {
-    const tens = Math.floor(n / 10);
-    // Skip leading 一 only for 10-19 at the top level (十二, not 一十二)
-    if (tens > 1 || result.length > 0) {
-      result += CHINESE_DIGITS[tens];
-    }
-    result += '十';
-    n %= 10;
-  }
-  // 個位
-  if (n > 0) {
-    result += CHINESE_DIGITS[n];
-  }
-  return result;
-};
-
-/** Replace all Arabic numeral sequences in text with Chinese equivalents. */
-const normalizeNumbers = (text: string): string =>
-  text.replace(/\d+/g, (m) => intToChinese(parseInt(m, 10)));
-
-const normalizeForComparison = (text: string) =>
-  normalizeNumbers(cleanChineseText(text)).replace(/[「」『』，。！？：；、\s]/g, '');
-
-/**
- * Compute character-frequency match rate between spoken (after homophone
- * correction) and target text.  Returns 0–1.
- */
-const computeMatchRate = (spokenRaw: string, targetRaw: string): number => {
-  const spoken = normalizeForComparison(spokenRaw);
-  const target = normalizeForComparison(targetRaw);
-  if (!target) return 0;
-  if (!spoken) return 0;
-
-  const spokenFreq: Record<string, number> = {};
-  for (const ch of spoken) spokenFreq[ch] = (spokenFreq[ch] || 0) + 1;
-
-  let matched = 0;
-  for (const ch of target) {
-    if (spokenFreq[ch] && spokenFreq[ch] > 0) {
-      matched++;
-      spokenFreq[ch]--;
-    }
-  }
-
-  return matched / target.length;
-};
-
-/* ------------------------------------------------------------------ */
 /*  Per-line result tracking                                          */
 /* ------------------------------------------------------------------ */
 
@@ -202,6 +107,7 @@ interface LineResult {
   cpm: number;
   durationMs: number;
   transcript: string;
+  diffTokens: DiffToken[];
 }
 
 /* ------------------------------------------------------------------ */
@@ -237,6 +143,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const [zhuyinReady, setZhuyinReady] = useState(false);
   const [isTtsSpeaking, setIsTtsSpeaking] = useState(false);
   const [isTtsPaused, setIsTtsPaused] = useState(false);
+  const [lastDiffTokens, setLastDiffTokens] = useState<DiffToken[] | null>(null);
 
   const isAdvancingRef = useRef(false);
   const isDraggingRef = useRef(false);
@@ -373,8 +280,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     const targetForAlignment = normalizeForComparison(targetText);
     const corrected = correctHomophones(cleaned, targetForAlignment);
 
-    // Step 2: Match rate
-    const matchRate = computeMatchRate(corrected, targetText);
+    // Step 2: Diff analysis (LCS-based, replaces bag-of-words)
+    const diffResult = diffCharacters(corrected, targetText, { useHomophone: true });
+    const matchRate = diffResult.matchRate;
 
     // Step 3: Determine tier
     const isLastLine = lineIdx >= story.content.length - 1;
@@ -413,7 +321,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     const cpm = Math.round((targetChars / durationSec) * 60);
 
     // Step 7: Record line result
-    const result: LineResult = { lineIndex: lineIdx, matchRate, cpm, durationMs, transcript: cleaned };
+    const result: LineResult = { lineIndex: lineIdx, matchRate, cpm, durationMs, transcript: cleaned, diffTokens: diffResult.tokens };
+    setLastDiffTokens(diffResult.tokens);
     setLineResults(prev => [...prev, result]);
 
     // Step 8: Debug logging
@@ -460,6 +369,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           storyId: story.id, accuracy: Math.round(avgMatchRate * 100), fluency: overallCpm,
           cpm: overallCpm, mispronouncedWords: extractPracticeChars(allResults, story.content),
           transcription: allResults.map(r => r.transcript).join(' '), timestamp: Date.now(),
+          lineBreakdown: allResults.map(r => ({
+            lineIndex: r.lineIndex, matchRate: r.matchRate, cpm: r.cpm,
+            transcript: r.transcript, diffTokens: r.diffTokens,
+          })),
         });
       }, 2000);
     }
@@ -586,6 +499,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       rawSttRef.current = '';
       accumulatedTranscriptRef.current = '';
       setStreamingUserInput('');
+      setLastDiffTokens(null);
       sentenceStartTimeRef.current = Date.now();
       // Immediately restart — onend will also try but catch silently
       if (isSessionActiveRef.current) {
@@ -683,6 +597,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       storyId: story.id, accuracy: Math.round(avgMatchRate * 100), fluency: overallCpm,
       cpm: overallCpm, mispronouncedWords: extractPracticeChars(lineResults, story.content),
       transcription: lineResults.map(r => r.transcript).join(' '), timestamp: Date.now(),
+      lineBreakdown: lineResults.map(r => ({
+        lineIndex: r.lineIndex, matchRate: r.matchRate, cpm: r.cpm,
+        transcript: r.transcript, diffTokens: r.diffTokens,
+      })),
     });
   };
 
@@ -813,6 +731,17 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               </span>
               <div className={`px-4 py-3 rounded-2xl text-lg bg-accent/60 text-gray-800 rounded-tr-none max-w-[90%] border border-accent/30 leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
                 {processZhuyin(streamingUserInput)}
+              </div>
+            </div>
+          )}
+
+          {lastDiffTokens && !isAdvancing && !streamingUserInput && (
+            <div className="flex flex-col items-start">
+              <span className="text-[9px] font-bold text-gray-400 mb-0.5 uppercase">
+                DIFF
+              </span>
+              <div className="px-4 py-3 rounded-2xl bg-white border border-gray-200 rounded-tl-none max-w-[95%]">
+                <DiffDisplay tokens={lastDiffTokens} showLegend className="text-base" />
               </div>
             </div>
           )}

--- a/frontend/src/components/ui/DiffDisplay.tsx
+++ b/frontend/src/components/ui/DiffDisplay.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { DiffToken } from '../../types';
+
+interface DiffDisplayProps {
+  tokens: DiffToken[];
+  showLegend?: boolean;
+  className?: string;
+}
+
+/**
+ * Renders character-level diff tokens with color-coded highlighting.
+ *
+ * Rendering rules:
+ * - correct → normal text (inherit color)
+ * - wrong   → red background + white text, tooltip shows expected char
+ * - missing → gray background + dashed underline (shows target char that was skipped)
+ * - extra   → orange background + strikethrough (shows char that shouldn't be there)
+ */
+const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, className = '' }) => {
+  if (!tokens || tokens.length === 0) return null;
+
+  return (
+    <div className={className}>
+      <div className="flex flex-wrap leading-relaxed text-lg">
+        {tokens.map((token, idx) => {
+          switch (token.type) {
+            case 'correct':
+              return (
+                <span key={idx} className="text-gray-900">
+                  {token.char}
+                </span>
+              );
+            case 'wrong':
+              return (
+                <span
+                  key={idx}
+                  className="bg-error text-white rounded-sm px-0.5 mx-px cursor-help relative group"
+                  title={`應該是「${token.expected}」`}
+                >
+                  {token.char}
+                  {token.expected && (
+                    <span className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                      應該是「{token.expected}」
+                    </span>
+                  )}
+                </span>
+              );
+            case 'missing':
+              return (
+                <span
+                  key={idx}
+                  className="bg-gray-200 text-gray-400 border-b-2 border-dashed border-gray-400 rounded-sm px-0.5 mx-px"
+                  title="漏讀"
+                >
+                  {token.char}
+                </span>
+              );
+            case 'extra':
+              return (
+                <span
+                  key={idx}
+                  className="bg-warning/30 text-warning line-through rounded-sm px-0.5 mx-px"
+                  title="多讀"
+                >
+                  {token.char}
+                </span>
+              );
+            default:
+              return <span key={idx}>{token.char}</span>;
+          }
+        })}
+      </div>
+
+      {showLegend && (
+        <div className="flex flex-wrap gap-3 mt-3 text-xs text-gray-500">
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded-sm bg-gray-900 inline-block" />
+            正確
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded-sm bg-error inline-block" />
+            讀錯
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded-sm bg-gray-200 border border-dashed border-gray-400 inline-block" />
+            漏讀
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-3 rounded-sm bg-warning/30 inline-block" />
+            多讀
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DiffDisplay;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -46,6 +46,23 @@ export interface ReadingAttempt {
   mispronouncedWords: string[];
   transcription: string;
   timestamp: number;
+  lineBreakdown?: LineBreakdown[];
+}
+
+export type DiffType = 'correct' | 'wrong' | 'missing' | 'extra';
+
+export interface DiffToken {
+  char: string;
+  type: DiffType;
+  expected?: string;
+}
+
+export interface LineBreakdown {
+  lineIndex: number;
+  matchRate: number;
+  cpm: number;
+  transcript: string;
+  diffTokens: DiffToken[];
 }
 
 export interface ComprehensionResult {

--- a/frontend/src/utils/textDiff.ts
+++ b/frontend/src/utils/textDiff.ts
@@ -1,0 +1,216 @@
+/**
+ * LCS-based character diff for comparing spoken text against target text.
+ * Used by LiveTutor and FullReading to show exactly which characters
+ * the student read correctly, incorrectly, missed, or added.
+ */
+import { isHomophone } from './pinyin';
+
+export type DiffType = 'correct' | 'wrong' | 'missing' | 'extra';
+
+export interface DiffToken {
+  char: string;
+  type: DiffType;
+  expected?: string; // For 'wrong' type: what character was expected
+}
+
+export interface DiffResult {
+  tokens: DiffToken[];
+  matchRate: number;      // 0-1, based on correct/target ratio
+  correctCount: number;
+  wrongCount: number;
+  missingCount: number;
+  extraCount: number;
+}
+
+/* ---- Text normalization (shared with LiveTutor/FullReading) ---- */
+
+export const cleanChineseText = (text: string) => {
+  if (!text) return '';
+  return text
+    .replace(/([\u4e00-\u9fa5！，。？：；（）])\s+([\u4e00-\u9fa5！，。？：；（）])/g, '$1$2')
+    .replace(/([\u4e00-\u9fa5])\s+([\u4e00-\u9fa5])/g, '$1$2')
+    .trim();
+};
+
+const CHINESE_DIGITS = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九'];
+
+const intToChinese = (num: number): string => {
+  if (num === 0) return '零';
+  let n = num;
+  let result = '';
+  if (n >= 100_000_000) { result += intToChinese(Math.floor(n / 100_000_000)) + '億'; n %= 100_000_000; if (n > 0 && n < 10_000_000) result += '零'; }
+  if (n >= 10_000) { result += intToChinese(Math.floor(n / 10_000)) + '萬'; n %= 10_000; if (n > 0 && n < 1_000) result += '零'; }
+  if (n >= 1_000) { result += CHINESE_DIGITS[Math.floor(n / 1_000)] + '千'; n %= 1_000; if (n > 0 && n < 100) result += '零'; }
+  if (n >= 100) { result += CHINESE_DIGITS[Math.floor(n / 100)] + '百'; n %= 100; if (n > 0 && n < 10) result += '零'; }
+  if (n >= 10) { const tens = Math.floor(n / 10); if (tens > 1 || result.length > 0) result += CHINESE_DIGITS[tens]; result += '十'; n %= 10; }
+  if (n > 0) result += CHINESE_DIGITS[n];
+  return result;
+};
+
+const normalizeNumbers = (text: string) => text.replace(/\d+/g, m => intToChinese(parseInt(m, 10)));
+
+export const normalizeForComparison = (text: string) =>
+  normalizeNumbers(cleanChineseText(text)).replace(/[「」『』，。！？：；、\s]/g, '');
+
+/**
+ * LCS-based diff: compare spoken text against target text, producing
+ * a token array showing correct/wrong/missing/extra characters.
+ *
+ * Algorithm:
+ * 1. Build LCS DP table between spoken and target characters
+ * 2. Backtrack to produce alignment
+ * 3. Classify each position:
+ *    - Both match (or homophone match) → correct
+ *    - Both present but different → wrong (substitution)
+ *    - Target char skipped → missing (deletion from target)
+ *    - Spoken char extra → extra (insertion not in target)
+ *
+ * matchRate = correctCount / target.length
+ */
+export function diffCharacters(
+  spoken: string,
+  target: string,
+  options?: { useHomophone?: boolean }
+): DiffResult {
+  const useHomophone = options?.useHomophone ?? false;
+  const s = Array.from(normalizeForComparison(spoken));
+  const t = Array.from(normalizeForComparison(target));
+  const sLen = s.length;
+  const tLen = t.length;
+
+  if (tLen === 0) {
+    return {
+      tokens: s.map(ch => ({ char: ch, type: 'extra' as DiffType })),
+      matchRate: 0,
+      correctCount: 0,
+      wrongCount: 0,
+      missingCount: 0,
+      extraCount: sLen,
+    };
+  }
+
+  if (sLen === 0) {
+    return {
+      tokens: t.map(ch => ({ char: ch, type: 'missing' as DiffType })),
+      matchRate: 0,
+      correctCount: 0,
+      wrongCount: 0,
+      missingCount: tLen,
+      extraCount: 0,
+    };
+  }
+
+  // Step 1: Build LCS DP table
+  // dp[i][j] = length of LCS of s[0..i-1] and t[0..j-1]
+  const dp: number[][] = Array.from({ length: sLen + 1 }, () => Array(tLen + 1).fill(0));
+
+  const isMatch = (a: string, b: string): boolean => {
+    if (a === b) return true;
+    if (useHomophone) return isHomophone(a, b);
+    return false;
+  };
+
+  for (let i = 1; i <= sLen; i++) {
+    for (let j = 1; j <= tLen; j++) {
+      if (isMatch(s[i - 1], t[j - 1])) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  // Step 2: Backtrack to produce diff tokens
+  const tokens: DiffToken[] = [];
+  let i = sLen;
+  let j = tLen;
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && isMatch(s[i - 1], t[j - 1])) {
+      // Match — correct (use the target char for display consistency)
+      tokens.push({ char: t[j - 1], type: 'correct' });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      // Target char not in spoken — missing
+      tokens.push({ char: t[j - 1], type: 'missing' });
+      j--;
+    } else {
+      // Spoken char not in target — extra
+      tokens.push({ char: s[i - 1], type: 'extra' });
+      i--;
+    }
+  }
+
+  tokens.reverse();
+
+  // Step 3: Post-process — merge adjacent missing+extra into wrong (substitution)
+  // This handles the case where a student said one char instead of another
+  const merged: DiffToken[] = [];
+  let idx = 0;
+  while (idx < tokens.length) {
+    if (
+      idx + 1 < tokens.length &&
+      tokens[idx].type === 'extra' &&
+      tokens[idx + 1].type === 'missing'
+    ) {
+      // extra followed by missing = substitution (wrong)
+      merged.push({
+        char: tokens[idx].char,
+        type: 'wrong',
+        expected: tokens[idx + 1].char,
+      });
+      idx += 2;
+    } else if (
+      idx + 1 < tokens.length &&
+      tokens[idx].type === 'missing' &&
+      tokens[idx + 1].type === 'extra'
+    ) {
+      // missing followed by extra = substitution (wrong)
+      merged.push({
+        char: tokens[idx + 1].char,
+        type: 'wrong',
+        expected: tokens[idx].char,
+      });
+      idx += 2;
+    } else {
+      merged.push(tokens[idx]);
+      idx++;
+    }
+  }
+
+  // Step 4: Compute stats
+  let correctCount = 0;
+  let wrongCount = 0;
+  let missingCount = 0;
+  let extraCount = 0;
+
+  for (const token of merged) {
+    switch (token.type) {
+      case 'correct': correctCount++; break;
+      case 'wrong': wrongCount++; break;
+      case 'missing': missingCount++; break;
+      case 'extra': extraCount++; break;
+    }
+  }
+
+  const matchRate = tLen > 0 ? correctCount / tLen : 0;
+
+  return {
+    tokens: merged,
+    matchRate,
+    correctCount,
+    wrongCount,
+    missingCount,
+    extraCount,
+  };
+}
+
+/**
+ * Backward-compatible replacement for the old bag-of-words computeMatchRate.
+ * Now uses LCS-based ordering for more accurate results.
+ */
+export function computeMatchRate(spoken: string, target: string): number {
+  const result = diffCharacters(spoken, target, { useHomophone: true });
+  return result.matchRate;
+}


### PR DESCRIPTION
## Summary

- **New `textDiff.ts`**: LCS-based `diffCharacters()` replaces bag-of-words `computeMatchRate()` — produces per-character `correct/wrong/missing/extra` tokens with ordered comparison
- **New `DiffDisplay.tsx`**: Color-coded UI component (red=wrong with tooltip, gray dashed=missing, orange strikethrough=extra, legend)
- **Refactored LiveTutor + FullReading**: Removed ~125 lines of duplicated helpers, now import from shared `textDiff` module; show `DiffDisplay` after each evaluation
- **Updated AssessmentReport**: Expandable "逐段朗讀分析" section with per-line diff breakdown and character stats

Closes #80

## Files Changed

| File | Change |
|------|--------|
| `frontend/src/utils/textDiff.ts` | **New** — LCS diff algorithm + backward-compatible `computeMatchRate` |
| `frontend/src/components/ui/DiffDisplay.tsx` | **New** — Diff token rendering component |
| `frontend/src/types.ts` | +`DiffToken`, +`LineBreakdown`, +`lineBreakdown?` on `ReadingAttempt` |
| `frontend/src/components/reading-steps/LiveTutor.tsx` | Replace local helpers → import textDiff; add diff display + lineBreakdown |
| `frontend/src/components/reading-steps/FullReading.tsx` | Replace local helpers → import textDiff; add diff display in result |
| `frontend/src/components/reading-steps/AssessmentReport.tsx` | Add expandable per-line diff breakdown section |

## Test plan

- [ ] `npx tsc --noEmit` — zero errors ✅
- [ ] `npx vite build` — success ✅
- [ ] LiveTutor: 完成一段朗讀後，chat 區顯示逐字 diff（紅/灰/橘色標記）
- [ ] FullReading: 完成全文朗讀後，結果區顯示「逐字比對」diff
- [ ] AssessmentReport: 展開每段可看到 DiffDisplay + 正確/讀錯/漏讀/多讀 統計
- [ ] 「老虎跑了」vs「了老虎跑」不再 100%（舊 bag-of-words 的 bug）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)