### PR TITLE
feat: 朗讀流暢度分析引擎 — correct-chars CPM + compound pass (#78)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -4,6 +4,7 @@ import { LearningSession } from '../../types';
 import type { Story } from '../../types';
 import DiffDisplay from '../ui/DiffDisplay';
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
+import { parseReadingBenchmark, getBenchmarkFeedback } from '../../utils/fluencyAnalyzer';
 
 /**
  * A wrapper around ResponsiveContainer that only renders the chart
@@ -245,7 +246,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
               {/* 語速 CPM */}
               <div className="text-center p-4 bg-slate-50 rounded-2xl flex flex-col items-center justify-center">
                 <span className="text-3xl font-black text-gray-900">{cpm}</span>
-                <span className="text-xs text-gray-500 font-bold">字/分鐘</span>
+                <span className="text-xs text-gray-500 font-bold">正確字數/分鐘</span>
                 <div className="flex gap-0.5 mt-2 w-full max-w-[120px]">
                   {speedSegments.map((seg, idx) => (
                     <div key={idx} className={`flex-1 h-1.5 rounded-sm ${idx === currentSegment ? seg.color : 'bg-gray-200'}`} />
@@ -266,6 +267,9 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
                       <span className="text-lg font-black">{fullMatchPct}%</span>
                     </div>
                     <p className="text-xs text-gray-500 font-bold mt-1">全文匹配</p>
+                    {fullReadingResult?.cpm != null && (
+                      <p className="text-[10px] text-gray-400 mt-0.5">{fullReadingResult.cpm} 正確字數/分鐘</p>
+                    )}
                   </>
                 ) : (
                   <>
@@ -280,6 +284,14 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
             {readingAttempt && (
               <p className="text-sm text-gray-600 text-center">{getCpmFeedback(cpm).text}</p>
             )}
+            {story?.readingBenchmark && (() => {
+              const levels = parseReadingBenchmark(story.readingBenchmark.levels);
+              const benchCpm = fullReadingResult?.cpm ?? cpm;
+              const benchFeedback = getBenchmarkFeedback(benchCpm, levels);
+              return benchFeedback ? (
+                <p className="text-xs text-gray-400 text-center mt-1">課本標準：{benchFeedback}</p>
+              ) : null;
+            })()}
           </div>
         ) : (
           <p className="text-sm text-gray-400 text-center py-4">尚未完成朗讀練習</p>
@@ -382,6 +394,14 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
               <div className="border-t border-slate-200 px-6 py-4">
                 <p className="text-xs text-gray-500 font-bold mb-2">全文朗讀比對</p>
                 <DiffDisplay tokens={fullReadingResult.diffTokens} showLegend />
+                {fullReadingResult.errorBreakdown && (
+                  <div className="flex gap-4 mt-3 text-xs text-gray-400">
+                    <span>正確: {fullReadingResult.errorBreakdown.correct} 字</span>
+                    <span>讀錯: {fullReadingResult.errorBreakdown.wrong} 字</span>
+                    <span>漏讀: {fullReadingResult.errorBreakdown.missing} 字</span>
+                    <span>多讀: {fullReadingResult.errorBreakdown.extra} 字</span>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Story, FullReadingResult, DiffToken } from '../../types';
-import { correctHomophones } from '../../utils/pinyin';
-import { diffCharacters, normalizeForComparison, cleanChineseText } from '../../utils/textDiff';
+import { cleanChineseText } from '../../utils/textDiff';
+import { analyzeFluency } from '../../utils/fluencyAnalyzer';
 import DiffDisplay from '../ui/DiffDisplay';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
@@ -25,7 +25,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
   const [isTtsPaused, setIsTtsPaused]           = useState(false);
   const [streamingTranscript, setStreamingTranscript] = useState('');
   const [micError, setMicError]                 = useState('');
-  const [result, setResult]                     = useState<{ matchRate: number; feedback: string; diffTokens: DiffToken[] } | null>(null);
+  const [result, setResult]                     = useState<{ matchRate: number; feedback: string; diffTokens: DiffToken[]; cpm: number; durationMs: number; errorBreakdown: { correct: number; wrong: number; missing: number; extra: number } } | null>(null);
   const [zhuyinEnabled, setZhuyinEnabled]       = useState(true);
   const [zhuyinReady, setZhuyinReady]           = useState(false);
 
@@ -36,6 +36,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
   const isDraggingRef             = useRef(false);
   const dragStartXRef             = useRef(0);
   const dragStartWidthRef         = useRef(0);
+  const startTimeRef              = useRef<number>(0);
 
   const zhuyinActive = zhuyinReady && zhuyinEnabled;
   const fullText = useMemo(() => story.content.join(''), [story.content]);
@@ -173,7 +174,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
     recognition.onstart = () => {
       setIsPreparing(false);
-      if (!isSessionActiveRef.current) { isSessionActiveRef.current = true; setIsSessionActive(true); }
+      if (!isSessionActiveRef.current) {
+        startTimeRef.current = Date.now();
+        isSessionActiveRef.current = true;
+        setIsSessionActive(true);
+      }
     };
 
     recognition.onresult = (event: any) => {
@@ -222,19 +227,24 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
   /* ---- Submit & evaluate ---- */
   const submitReading = useCallback(() => {
     const transcript = currentTranscriptRef.current;
+    const durationMs = Date.now() - startTimeRef.current;
     stopSession();
     if (!transcript.trim()) { setMicError('未偵測到語音，請再試一次。'); return; }
 
-    const targetNorm = normalizeForComparison(fullText);
-    const corrected = correctHomophones(cleanChineseText(transcript), targetNorm);
-    const diffResult = diffCharacters(corrected, fullText, { useHomophone: true });
+    const fluency = analyzeFluency({
+      spoken: cleanChineseText(transcript),
+      target: fullText,
+      durationMs,
+    });
 
-    const feedback =
-      diffResult.matchRate >= 0.80 ? '太流利了！全文朗讀表現非常棒！' :
-      diffResult.matchRate >= 0.60 ? '唸得不錯，過關！繼續練習會更好！' :
-      '再練習一次，你一定可以更流利！';
-
-    setResult({ matchRate: diffResult.matchRate, feedback, diffTokens: diffResult.tokens });
+    setResult({
+      matchRate: fluency.accuracy,
+      feedback: fluency.feedback,
+      diffTokens: fluency.diffTokens,
+      cpm: fluency.cpm,
+      durationMs: fluency.durationMs,
+      errorBreakdown: fluency.errorBreakdown,
+    });
     setStreamingTranscript(cleanChineseText(transcript));
   }, [fullText, stopSession]);
 
@@ -394,7 +404,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
                 再試一次
               </button>
               <button
-                onClick={() => onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript })}
+                onClick={() => onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript, cpm: result.cpm, durationMs: result.durationMs, errorBreakdown: result.errorBreakdown })}
                 className="w-full py-3 rounded-xl text-base font-bold bg-emerald-600 hover:bg-emerald-500 text-white transition-all flex items-center justify-center gap-2 active:scale-95"
               >
                 查看報告

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -315,10 +315,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       setStreak(newStreak);
     }
 
-    // Step 6: CPM
-    const targetChars = normalizeForComparison(targetText).length;
+    // Step 6: CPM (only count correctly-read characters)
     const durationSec = Math.max(durationMs / 1000, 0.5);
-    const cpm = Math.round((targetChars / durationSec) * 60);
+    const cpm = Math.round((diffResult.correctCount / durationSec) * 60);
 
     // Step 7: Record line result
     const result: LineResult = { lineIndex: lineIdx, matchRate, cpm, durationMs, transcript: cleaned, diffTokens: diffResult.tokens };
@@ -360,11 +359,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       setTimeout(() => {
         const allResults = [...lineResults, result];
         const avgMatchRate = allResults.reduce((s, r) => s + r.matchRate, 0) / allResults.length;
-        const totalChars = allResults.reduce(
-          (s, r) => s + normalizeForComparison(story.content[r.lineIndex] || '').length, 0
+        const totalCorrectChars = allResults.reduce(
+          (s, r) => s + r.diffTokens.filter(t => t.type === 'correct').length, 0
         );
         const totalDurationSec = allResults.reduce((s, r) => s + r.durationMs, 0) / 1000;
-        const overallCpm = totalDurationSec > 0 ? Math.round((totalChars / totalDurationSec) * 60) : 0;
+        const overallCpm = totalDurationSec > 0 ? Math.round((totalCorrectChars / totalDurationSec) * 60) : 0;
         onFinish({
           storyId: story.id, accuracy: Math.round(avgMatchRate * 100), fluency: overallCpm,
           cpm: overallCpm, mispronouncedWords: extractPracticeChars(allResults, story.content),
@@ -588,11 +587,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     const avgMatchRate =
       lineResults.length > 0
         ? lineResults.reduce((s, r) => s + r.matchRate, 0) / lineResults.length : 0;
-    const totalChars = lineResults.reduce(
-      (s, r) => s + normalizeForComparison(story.content[r.lineIndex] || '').length, 0
+    const totalCorrectChars = lineResults.reduce(
+      (s, r) => s + r.diffTokens.filter(t => t.type === 'correct').length, 0
     );
     const totalDurationSec = lineResults.reduce((s, r) => s + r.durationMs, 0) / 1000;
-    const overallCpm = totalDurationSec > 0 ? Math.round((totalChars / totalDurationSec) * 60) : 0;
+    const overallCpm = totalDurationSec > 0 ? Math.round((totalCorrectChars / totalDurationSec) * 60) : 0;
     onFinish({
       storyId: story.id, accuracy: Math.round(avgMatchRate * 100), fluency: overallCpm,
       cpm: overallCpm, mispronouncedWords: extractPracticeChars(lineResults, story.content),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -47,7 +47,7 @@ interface ApiStoryDetail extends ApiStoryListItem {
   vocabulary: ApiVocabItem[] | null;
   fill_in_blank: unknown;
   multiple_choice: unknown;
-  reading_benchmark: unknown;
+  reading_benchmark: { levels: { threshold: string; feedback: string }[] } | null;
   text_type: string;
   source_file: string;
 }
@@ -90,6 +90,7 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     readingStrategy: detail.reading_strategy ?? undefined,
     vocabulary: detail.vocabulary ?? undefined,
     charCount: detail.char_count,
+    readingBenchmark: detail.reading_benchmark ?? undefined,
   };
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -36,6 +36,7 @@ export interface Story {
   readingStrategy?: string;     // for future Intro enhancement
   vocabulary?: VocabItem[];     // for future VocabPractice enhancement
   charCount?: number;           // for reading benchmark
+  readingBenchmark?: { levels: { threshold: string; feedback: string }[] };
 }
 
 export interface ReadingAttempt {
@@ -80,6 +81,9 @@ export interface VocabResult {
 export interface FullReadingResult {
   matchRate: number;
   feedback: string;
+  cpm?: number;
+  durationMs?: number;
+  errorBreakdown?: { correct: number; wrong: number; missing: number; extra: number };
   diffTokens?: DiffToken[];
   transcript?: string;
 }

--- a/frontend/src/utils/fluencyAnalyzer.ts
+++ b/frontend/src/utils/fluencyAnalyzer.ts
@@ -1,0 +1,164 @@
+/**
+ * Unified fluency analysis engine.
+ * Centralizes CPM calculation, pass/fail determination, and feedback messages.
+ */
+import type { DiffToken } from '../types';
+import { diffCharacters } from './textDiff';
+import { correctHomophones } from './pinyin';
+import { normalizeForComparison, cleanChineseText } from './textDiff';
+
+export interface FluencyThresholds {
+  cpmPass: number;
+  accuracyPass: number;
+}
+
+export const DEFAULT_THRESHOLDS: FluencyThresholds = {
+  cpmPass: 120,
+  accuracyPass: 0.80,
+};
+
+export interface ErrorBreakdown {
+  correct: number;
+  wrong: number;
+  missing: number;
+  extra: number;
+}
+
+export interface FluencyResult {
+  accuracy: number;
+  cpm: number;
+  correctCount: number;
+  durationMs: number;
+  passed: boolean;
+  speedPassed: boolean;
+  accuracyPassed: boolean;
+  errorBreakdown: ErrorBreakdown;
+  diffTokens: DiffToken[];
+  thresholds: FluencyThresholds;
+  feedback: string;
+}
+
+export interface BenchmarkLevel {
+  minCpm: number;
+  maxCpm: number;
+  feedback: string;
+}
+
+function generateFeedback(speedPassed: boolean, accuracyPassed: boolean): string {
+  if (speedPassed && accuracyPassed)
+    return '太棒了！速度和準確度都過關了！';
+  if (accuracyPassed && !speedPassed)
+    return '讀得很準確！速度再練快一點就完美了。';
+  if (speedPassed && !accuracyPassed)
+    return '速度很好！不過有些字要再練一練，讀慢一點沒關係。';
+  return '沒關係，多練幾次就會進步！先把每一段練熟，再挑戰全文。';
+}
+
+export function analyzeFluency(input: {
+  spoken: string;
+  target: string;
+  durationMs: number;
+  thresholds?: FluencyThresholds;
+}): FluencyResult {
+  const thresholds = input.thresholds ?? DEFAULT_THRESHOLDS;
+  const targetNorm = normalizeForComparison(input.target);
+  const cleaned = cleanChineseText(input.spoken);
+  const corrected = correctHomophones(cleaned, targetNorm);
+  const diffResult = diffCharacters(corrected, input.target, { useHomophone: true });
+
+  const durationSec = Math.max(input.durationMs / 1000, 0.5);
+  const cpm = Math.round((diffResult.correctCount / durationSec) * 60);
+
+  const accuracyPassed = diffResult.matchRate >= thresholds.accuracyPass;
+  const speedPassed = cpm >= thresholds.cpmPass;
+  const passed = accuracyPassed && speedPassed;
+
+  const errorBreakdown: ErrorBreakdown = {
+    correct: diffResult.correctCount,
+    wrong: diffResult.wrongCount,
+    missing: diffResult.missingCount,
+    extra: diffResult.extraCount,
+  };
+
+  return {
+    accuracy: diffResult.matchRate,
+    cpm,
+    correctCount: diffResult.correctCount,
+    durationMs: input.durationMs,
+    passed,
+    speedPassed,
+    accuracyPassed,
+    errorBreakdown,
+    diffTokens: diffResult.tokens,
+    thresholds,
+    feedback: generateFeedback(speedPassed, accuracyPassed),
+  };
+}
+
+/**
+ * Parse reading benchmark levels from OCR strings.
+ * Supports:
+ *   - CPM format (字): "□＜190字", "□ 191~220字", "□＞221字"
+ *   - Full-width tilde ～ (U+FF5E) and half-width ~ both supported
+ *   - Inconsistent spacing after □ (trimmed)
+ *   - Returns empty array for 秒 format (Grade 8, only 4 lessons — deferred)
+ */
+export function parseReadingBenchmark(
+  levels: { threshold: string; feedback: string }[]
+): BenchmarkLevel[] {
+  const result: BenchmarkLevel[] = [];
+
+  for (const level of levels) {
+    const raw = level.threshold.replace(/□\s*/, '').trim();
+
+    // Skip 秒-based benchmarks (Grade 8 文言文)
+    if (raw.includes('秒')) return [];
+
+    // Range: 191~220字 or 191～220字
+    const rangeMatch = raw.match(/(\d+)\s*[~～]\s*(\d+)\s*字/);
+    if (rangeMatch) {
+      result.push({
+        minCpm: parseInt(rangeMatch[1], 10),
+        maxCpm: parseInt(rangeMatch[2], 10),
+        feedback: level.feedback,
+      });
+      continue;
+    }
+
+    // Less than: ＜190字
+    const ltMatch = raw.match(/[＜<]\s*(\d+)\s*字/);
+    if (ltMatch) {
+      result.push({
+        minCpm: 0,
+        maxCpm: parseInt(ltMatch[1], 10) - 1,
+        feedback: level.feedback,
+      });
+      continue;
+    }
+
+    // Greater than: ＞221字
+    const gtMatch = raw.match(/[＞>]\s*(\d+)\s*字/);
+    if (gtMatch) {
+      result.push({
+        minCpm: parseInt(gtMatch[1], 10),
+        maxCpm: Infinity,
+        feedback: level.feedback,
+      });
+      continue;
+    }
+  }
+
+  return result;
+}
+
+export function getBenchmarkFeedback(
+  cpm: number,
+  levels: BenchmarkLevel[]
+): string | null {
+  for (const level of levels) {
+    if (cpm >= level.minCpm && cpm <= level.maxCpm) {
+      return level.feedback;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- **新增** `fluencyAnalyzer.ts` — 統一流暢度分析引擎（CPM / 達標判定 / 回饋訊息）
- **核心公式改變**: `CPM = correctChars / duration`（只算讀對的字，天然懲罰不準確）
- **複合達標**: 速度 AND 準確率都要過門檻（120 CPM + 80% 正確率）
- **FullReading**: 加計時 + `analyzeFluency()` 整合，傳出 CPM / errorBreakdown
- **LiveTutor**: 3 處 CPM 公式替換為 `correctCount` 計算
- **AssessmentReport**: 標示「正確字數/分鐘」+ 全文 CPM + 課本 benchmark 回饋 + 錯誤分類統計
- **Types**: `FullReadingResult` 擴充 `cpm`, `durationMs`, `errorBreakdown`；`Story` 加 `readingBenchmark`

## Changes

| File | Change |
|------|--------|
| `frontend/src/utils/fluencyAnalyzer.ts` | **NEW** — analyzeFluency, parseReadingBenchmark, getBenchmarkFeedback |
| `frontend/src/types.ts` | Extend Story + FullReadingResult |
| `frontend/src/services/api.ts` | Type + map reading_benchmark |
| `frontend/src/components/reading-steps/FullReading.tsx` | Add timing + use analyzeFluency |
| `frontend/src/components/reading-steps/LiveTutor.tsx` | Fix 3 CPM formula sites |
| `frontend/src/components/reading-steps/AssessmentReport.tsx` | CPM label + benchmark + error breakdown |

## Test plan

- [ ] `npx tsc --noEmit` passes (verified locally ✓)
- [ ] `npx vite build` succeeds (verified locally ✓)
- [ ] FullReading result panel shows encouragement only (no CPM number)
- [ ] AssessmentReport Step 5 card shows「正確字數/分鐘」+ error stats
- [ ] LiveTutor CPM uses correctCount at all 3 sites
- [ ] Lessons with `reading_benchmark` show「課本標準」feedback in report

Closes #78

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)