### PR TITLE
fix: report section 2 logic + full reading intro + exit ticket distractors (#168 #170 #172)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -300,15 +300,15 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
       </Section>
 
       {/* ============ 環節二：錄音內容與智能分析 ============ */}
-      <Section number={2} title="錄音內容與智能分析" disabled={!readingAttempt}>
-        {readingAttempt ? (
+      <Section number={2} title="錄音內容與智能分析" disabled={!readingAttempt && !fullReadingResult}>
+        {(readingAttempt || fullReadingResult) ? (
           <div className="space-y-4">
             {/* Transcription text */}
-            {readingAttempt.transcription && (
+            {(readingAttempt?.transcription || fullReadingResult?.transcript) && (
               <div>
                 <p className="text-xs text-gray-500 font-bold mb-2">語音轉文字</p>
                 <div className="bg-slate-50 rounded-2xl p-4 text-sm text-gray-700 leading-relaxed">
-                  {readingAttempt.transcription}
+                  {readingAttempt?.transcription ?? fullReadingResult?.transcript}
                 </div>
               </div>
             )}

--- a/frontend/src/components/reading-steps/ExitTicket.tsx
+++ b/frontend/src/components/reading-steps/ExitTicket.tsx
@@ -28,15 +28,17 @@ const shuffle = <T,>(arr: T[]): T[] => {
   return a;
 };
 
+const COMMON_PARTICLES = new Set(['的', '了', '在', '是', '有', '和', '與', '也', '都', '就', '把', '被', '讓', '給', '從', '到', '著', '過', '嗎', '呢', '吧', '啊', '嗎']);
+
 /** Generate up to 3 multiple-choice questions from wrong + missing tokens */
 const generateQuestions = (wrongTokens: WrongToken[], missingChars: string[], storyContent: string[]): Question[] => {
   if (wrongTokens.length === 0 && missingChars.length === 0) return [];
 
-  // Collect unique characters from the story for distractors
+  // Collect unique characters from the story for distractors, excluding common particles
   const storyChars = new Set<string>();
   for (const paragraph of storyContent) {
     for (const ch of paragraph) {
-      if (/[\u4e00-\u9fff]/.test(ch)) storyChars.add(ch);
+      if (/[\u4e00-\u9fff]/.test(ch) && !COMMON_PARTICLES.has(ch)) storyChars.add(ch);
     }
   }
 

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -326,6 +326,9 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {/* Instructions */}
           {!result && !isSessionActive && !isPreparing && (
             <div className="bg-white border border-gray-200 rounded-2xl p-4">
+              <p className="text-base font-bold text-gray-800 leading-relaxed mb-2">
+                你剛才一段一段練習過了，現在試著從頭到尾讀完整篇文章，不要中斷！
+              </p>
               <p className="text-base text-gray-600 leading-relaxed">
                 請從頭到尾朗讀整篇課文。讀完後按「完成朗讀」送出。
               </p>


### PR DESCRIPTION
## Summary

- **#168 / #173** `AssessmentReport.tsx`: Section 2 (錄音內容與智能分析) was incorrectly disabled when `readingAttempt` is null even if `fullReadingResult` exists. Fixed disabled condition to `!readingAttempt && !fullReadingResult`. Inner content now renders when either exists, with transcript falling back to `fullReadingResult.transcript` when `readingAttempt.transcription` is unavailable.
- **#170** `FullReading.tsx`: Added a brief explanation subtitle at the top of the instructions panel — "你剛才一段一段練習過了，現在試著從頭到尾讀完整篇文章，不要中斷！" — to help students understand why they need to read again.
- **#172** `ExitTicket.tsx`: Added `COMMON_PARTICLES` set (的/了/在/是/有/和 etc.) and filtered those characters from the `storyChars` distractor pool in `generateQuestions`, so common function words never appear as misleading answer choices.

## Test plan

- [ ] Navigate to AssessmentReport with a session that has `fullReadingResult` but no `readingAttempt` — Section 2 should be enabled and show `fullReadingResult.transcript`
- [ ] Navigate to AssessmentReport with a session that has neither — Section 2 should remain disabled ("尚未完成朗讀練習")
- [ ] Navigate to AssessmentReport with a session that has both — Section 2 shows `readingAttempt.transcription` (original behaviour)
- [ ] On FullReading step (before starting), verify the new subtitle "你剛才一段一段練習過了..." appears above the existing instruction text
- [ ] Complete a reading session that produces wrong/missing tokens, open the Exit Ticket, and verify none of the answer options are common particles like 的、了、在、是

## Files changed

- `frontend/src/components/reading-steps/AssessmentReport.tsx`
- `frontend/src/components/reading-steps/FullReading.tsx`
- `frontend/src/components/reading-steps/ExitTicket.tsx`

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>