### PR TITLE
fix: increase header nav font size for readability (#130)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -88,7 +88,7 @@ const App: React.FC = () => {
 
         {/* Step Navigation (upper right) */}
         {isMobile ? (
-          <nav className="flex items-center gap-1 text-[11px] font-medium relative">
+          <nav className="flex items-center gap-1 text-xs font-medium relative">
             {/* Compact step circles */}
             {steps.map(({ step, view: targetView, needsStory }) => {
               const isActive = view === targetView;
@@ -97,7 +97,7 @@ const App: React.FC = () => {
                 <button
                   key={targetView}
                   onClick={() => { if (!isDisabled) { setView(targetView); setMobileNavOpen(false); } }}
-                  className={`w-5 h-5 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 transition-colors ${
+                  className={`w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 transition-colors ${
                     isActive ? 'bg-accent text-white' : isDisabled ? 'bg-gray-200 text-gray-400' : 'bg-gray-200 text-gray-600'
                   }`}
                 >
@@ -143,7 +143,7 @@ const App: React.FC = () => {
                           : 'text-gray-700 hover:bg-gray-50'
                         }`}
                       >
-                        <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 ${
+                        <span className={`w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 ${
                           isActive ? 'bg-accent text-white' : isDisabled ? 'bg-gray-200 text-gray-400' : 'bg-gray-200 text-gray-700'
                         }`}>
                           {step}
@@ -162,7 +162,7 @@ const App: React.FC = () => {
             </div>
           </nav>
         ) : (
-          <nav className="flex items-center gap-1 text-[11px] font-medium">
+          <nav className="flex items-center gap-1 text-sm font-medium">
             {/* 首頁 */}
             <button
               onClick={() => setView(AppView.HOME)}
@@ -193,7 +193,7 @@ const App: React.FC = () => {
                         : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
                     }`}
                   >
-                    <span className={`w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-bold shrink-0 ${
+                    <span className={`w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 ${
                       isActive ? 'bg-white text-accent' : isDisabled ? 'bg-gray-300 text-gray-400' : 'bg-gray-200 text-gray-900'
                     }`}>
                       {step}


### PR DESCRIPTION
## Summary
- Header 導航列文字從 11px 增大到 14px (desktop) / 12px (mobile)
- 步驟圓圈數字從 9px 增大到 10px，圓圈從 w-4 h-4 增大到 w-5 h-5
- 提升可讀性，不影響排版

## Changes
| Element | Before | After |
|---------|--------|-------|
| Desktop nav text | `text-[11px]` (11px) | `text-sm` (14px) |
| Mobile nav text | `text-[11px]` (11px) | `text-xs` (12px) |
| Step circle number | `text-[9px]` (9px) | `text-[10px]` (10px) |
| Step circle size | `w-4 h-4` | `w-5 h-5` |

Closes #130

## Test plan
- [ ] Desktop: 確認導航列文字清晰可讀
- [ ] Mobile: 確認圓圈數字和下拉選單文字可讀
- [ ] 確認排版沒有跑掉

🤖 Generated with [Claude Code](https://claude.ai/code)