### PR TITLE
fix: add empty state for Step 6 report page (#137)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -140,6 +140,24 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
 
   const { readingAttempt, comprehensionResult, vocabResult, fullReadingResult } = session;
 
+  // Empty state: session exists but no learning data completed yet
+  const hasNoData = !readingAttempt && !comprehensionResult && !vocabResult && !fullReadingResult;
+  if (hasNoData) {
+    return (
+      <div className="max-w-4xl mx-auto flex flex-col items-center justify-center gap-6 py-24 text-center">
+        <span className="text-6xl">📖</span>
+        <h2 className="text-2xl font-bold text-gray-900">還沒有完成朗讀練習喔！</h2>
+        <p className="text-gray-500">請先完成「逐段朗讀」或「全文朗讀」，才能查看學習報告。</p>
+        <button
+          onClick={onRetry}
+          className="bg-accent hover:bg-accent-hover text-white px-8 py-3 rounded-xl font-bold transition-all"
+        >
+          回到課文
+        </button>
+      </div>
+    );
+  }
+
   // Compute overall score
   const scores: number[] = [];
   if (readingAttempt) scores.push(readingAttempt.accuracy);


### PR DESCRIPTION
## Summary
- Step 6 報告頁在沒有任何學習數據時顯示友善的空狀態提示
- 避免直接跳到報告頁時出現完全空白頁面

## Root Cause
`session` 物件存在（選了課文就會建立），但四個 result 欄位（readingAttempt, comprehensionResult, vocabResult, fullReadingResult）全部為 null。原本只檢查 `!session`，沒有處理「session 有但沒數據」的情況。

## Fix
在 destructure session 欄位後加入 `hasNoData` 檢查，若四個 result 都為 null，顯示：
- 📖 圖示
- 「還沒有完成朗讀練習喔！」
- 「請先完成逐段朗讀或全文朗讀」提示
- 「回到課文」按鈕

Closes #137

## Test plan
- [ ] 選擇課文後直接跳到 Step 6 → 應顯示空狀態提示
- [ ] 完成朗讀後到 Step 6 → 應顯示完整報告
- [ ] 「回到課文」按鈕可正常導回

🤖 Generated with [Claude Code](https://claude.ai/code)