### PR TITLE
fix: pin bcrypt<4.1 for passlib compatibility (#82)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,7 @@ alembic>=1.13
 google-cloud-storage>=2.14
 pyyaml>=6.0
 passlib[bcrypt]>=1.7
+bcrypt>=4.0,<4.1
 python-jose[cryptography]>=3.3
 python-multipart>=0.0.9
 email-validator>=2.0


### PR DESCRIPTION
## Summary
- Pin `bcrypt>=4.0,<4.1` in requirements.txt
- passlib's `CryptContext.hash()` breaks with bcrypt 4.1+ (removed `__about__` module causes `ValueError`)
- This fixes the 500 errors on all auth endpoints after #82 merge

## Context
PR #179 introduced the auth system. After deploying to staging, all auth endpoints returned 500 due to bcrypt 4.1 being installed (passlib incompatibility). This is a known issue: https://github.com/pyca/bcrypt/issues/684

## Test plan
- [ ] Staging deploy succeeds
- [ ] `POST /api/auth/register` returns 200 (not 500)
- [ ] `POST /api/auth/login` returns 401 for bad creds (not 500)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)