### PR TITLE
feat: unify AI tutor persona constants (#54)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -5,6 +5,7 @@ import type { Story } from '../../types';
 import DiffDisplay from '../ui/DiffDisplay';
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
 import { parseReadingBenchmark, getBenchmarkFeedback } from '../../utils/fluencyAnalyzer';
+import { CPM_VERY_FAST, CPM_FAST, CPM_MEDIUM, CPM_SLOW } from '../../utils/personaConfig';
 import ExitTicket from './ExitTicket';
 
 /**
@@ -51,24 +52,24 @@ interface AssessmentReportProps {
 
 // Research-based CPM thresholds for 國小高年級～國中生
 const getCpmFeedback = (cpm: number) => {
-  if (cpm >= 180) return { text: '非常流利！你讀得又快又準！', level: 'very-fast' };
-  if (cpm >= 130) return { text: '流利度很好，繼續保持！', level: 'fast' };
-  if (cpm >= 90) return { text: '速度適中，每天練習會越來越快！', level: 'medium' };
-  if (cpm >= 50) return { text: '慢慢來沒關係，多練習就會進步！', level: 'slow' };
+  if (cpm >= CPM_VERY_FAST) return { text: '非常流利！你讀得又快又準！', level: 'very-fast' };
+  if (cpm >= CPM_FAST) return { text: '流利度很好，繼續保持！', level: 'fast' };
+  if (cpm >= CPM_MEDIUM) return { text: '速度適中，每天練習會越來越快！', level: 'medium' };
+  if (cpm >= CPM_SLOW) return { text: '慢慢來沒關係，多練習就會進步！', level: 'slow' };
   return { text: '不要急，一個字一個字慢慢讀就好！', level: 'very-slow' };
 };
 
 const speedSegments = [
-  { label: '慢', threshold: 50, color: 'bg-red-400' },
-  { label: '適中', threshold: 90, color: 'bg-amber-400' },
-  { label: '快', threshold: 130, color: 'bg-green-400' },
-  { label: '很快', threshold: 180, color: 'bg-emerald-400' },
+  { label: '慢', threshold: CPM_SLOW, color: 'bg-red-400' },
+  { label: '適中', threshold: CPM_MEDIUM, color: 'bg-amber-400' },
+  { label: '快', threshold: CPM_FAST, color: 'bg-green-400' },
+  { label: '很快', threshold: CPM_VERY_FAST, color: 'bg-emerald-400' },
 ];
 
 const getCurrentSegment = (cpm: number) => {
-  if (cpm < 50) return 0;
-  if (cpm < 90) return 1;
-  if (cpm < 130) return 2;
+  if (cpm < CPM_SLOW) return 0;
+  if (cpm < CPM_MEDIUM) return 1;
+  if (cpm < CPM_FAST) return 2;
   return 3;
 };
 

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -7,6 +7,7 @@ import DiffDisplay from '../ui/DiffDisplay';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
 import { useIsMobile } from '../../hooks/useIsMobile';
+import { READING_EXCELLENT, READING_PASS } from '../../utils/personaConfig';
 
 /* ------------------------------------------------------------------ */
 /*  Canned response pools — randomly selected to avoid repetition     */
@@ -26,8 +27,8 @@ const TIER2_POOL = [
   '很好！下一段。',
   '不錯不錯！下一段。',
   '加油，繼續下一段！',
-  '好的，繼續下一段！',
-  '唸得可以喔！下一段。',
+  '很好！繼續加油！',
+  '讀得不錯喔！下一段。',
 ];
 
 const TIER3_POOL = [
@@ -287,8 +288,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     // Step 3: Determine tier
     const isLastLine = lineIdx >= story.content.length - 1;
     let tier: 1 | 2 | 3;
-    if (matchRate >= 0.8) tier = 1;
-    else if (matchRate >= 0.6) tier = 2;
+    if (matchRate >= READING_EXCELLENT) tier = 1;
+    else if (matchRate >= READING_PASS) tier = 2;
     else tier = 3;
 
     const shouldAdvance = tier <= 2 && !isLastLine;

--- a/frontend/src/utils/fluencyAnalyzer.ts
+++ b/frontend/src/utils/fluencyAnalyzer.ts
@@ -6,6 +6,7 @@ import type { DiffToken } from '../types';
 import { diffCharacters } from './textDiff';
 import { correctHomophones } from './pinyin';
 import { normalizeForComparison, cleanChineseText } from './textDiff';
+import { FULLREADING_CPM_PASS, FULLREADING_ACCURACY_PASS } from './personaConfig';
 
 export interface FluencyThresholds {
   cpmPass: number;
@@ -13,8 +14,8 @@ export interface FluencyThresholds {
 }
 
 export const DEFAULT_THRESHOLDS: FluencyThresholds = {
-  cpmPass: 120,
-  accuracyPass: 0.80,
+  cpmPass: FULLREADING_CPM_PASS,
+  accuracyPass: FULLREADING_ACCURACY_PASS,
 };
 
 export interface ErrorBreakdown {

--- a/frontend/src/utils/personaConfig.ts
+++ b/frontend/src/utils/personaConfig.ts
@@ -1,0 +1,19 @@
+/**
+ * Frontend persona config — aligned with backend/app/services/persona.py
+ * Issue #54: Unified "warm but firm" AI tutor personality
+ */
+
+// Reading thresholds (LiveTutor per-line)
+export const READING_EXCELLENT = 0.80;  // >=80%: very good
+export const READING_PASS = 0.60;       // >=60%: pass
+// <60%: retry
+
+// FullReading fluency thresholds
+export const FULLREADING_CPM_PASS = 120;
+export const FULLREADING_ACCURACY_PASS = 0.80;
+
+// AssessmentReport CPM tiers
+export const CPM_VERY_FAST = 180;
+export const CPM_FAST = 130;
+export const CPM_MEDIUM = 90;
+export const CPM_SLOW = 50;


### PR DESCRIPTION
## Summary
- Add `personaConfig.ts` as single source of truth for reading/CPM thresholds
- Replace hardcoded magic numbers (`0.8`, `0.6`, `180`, `130`, `90`, `50`) across LiveTutor, fluencyAnalyzer, AssessmentReport with named constants
- Improve TIER2_POOL message warmth ("好的，繼續下一段！" → "很好！繼續加油！")
- Aligned with `backend/app/services/persona.py` Thresholds class

Closes #54

## Changes (4 files, +39/-17)
| File | Change |
|------|--------|
| `frontend/src/utils/personaConfig.ts` | **NEW** — unified persona thresholds |
| `frontend/src/components/reading-steps/LiveTutor.tsx` | Import constants + fix TIER2 tone |
| `frontend/src/utils/fluencyAnalyzer.ts` | Import constants |
| `frontend/src/components/reading-steps/AssessmentReport.tsx` | Import CPM constants |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vite build` — success
- [ ] LiveTutor: verify TIER2 feedback shows warmer messages at 60-80% accuracy
- [ ] AssessmentReport: verify CPM tier labels still display correctly
- [ ] FullReading: verify pass/fail thresholds unchanged (120 CPM / 80% accuracy)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)