### PR TITLE
feat: error word list → vocab practice navigation (#81)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -289,7 +289,7 @@ const App: React.FC = () => {
 
         {view === AppView.REPORT && (
           <div className="p-8 max-w-4xl mx-auto w-full">
-             <AssessmentReport session={session} story={selectedStory} onRetry={() => { setView(AppView.LIBRARY); setSession(null); setLastAttempt(null); }} />
+             <AssessmentReport session={session} story={selectedStory} onRetry={() => { setView(AppView.LIBRARY); setSession(null); setLastAttempt(null); }} onGoToVocab={() => setView(AppView.VOCAB)} />
           </div>
         )}
 

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -47,6 +47,7 @@ interface AssessmentReportProps {
   session: LearningSession | null;
   story?: Story | null;
   onRetry: () => void;
+  onGoToVocab?: () => void;
 }
 
 // Research-based CPM thresholds for 國小高年級～國中生
@@ -124,7 +125,7 @@ const Section: React.FC<{
   </div>
 );
 
-const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry }) => {
+const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
 
   if (!session) {
@@ -482,6 +483,18 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
                   )}
                 </div>
               </div>
+            )}
+
+            {onGoToVocab && (
+              <button
+                onClick={onGoToVocab}
+                className="w-full mt-2 flex items-center justify-center gap-2 py-3 bg-accent/10 hover:bg-accent/20 text-accent font-bold text-sm rounded-xl transition-colors"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                </svg>
+                去生字練習
+              </button>
             )}
           </div>
         ) : (


### PR DESCRIPTION
## Summary

- 報告頁環節四「錯字詞練習清單」新增 **「去生字練習」** 按鈕
- 學生看到讀錯/漏讀的字後，可直接跳到 Step 3 (VocabPractice) 進行針對性練習
- 按鈕僅在有錯字時顯示

## Changes

- `AssessmentReport.tsx`: 新增 `onGoToVocab` optional prop + 按鈕 UI
- `App.tsx`: 傳入 `onGoToVocab={() => setView(AppView.VOCAB)}`

## Issue #81 scope (Demo 2)

| 需求 | 狀態 |
|------|------|
| 自動彙整讀錯字詞 | ✅ 已有 |
| 🔊 發音按鈕 | ✅ 已有 |
| 點擊→進入生字學習模組 | ✅ **本 PR** |
| 跨次累積統計 | ⏳ Demo 3 (需後端 DB) |
| 已掌握 vs 仍需練習 | ⏳ Demo 3 (需後端 DB) |

## Test plan

- [ ] 完成朗讀（有錯字）→ 報告頁環節四出現「去生字練習」按鈕
- [ ] 點擊按鈕 → 跳到 Step 3 VocabPractice，顯示需要練習的生字
- [ ] 無錯字時不顯示按鈕（只顯示「恭喜！沒有讀錯的字詞！」）

Closes #81

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)