### PR TITLE
fix: restore session when null in handleStartReading + reset story on retry (#167)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,23 @@ const App: React.FC = () => {
   };
 
   const handleStartReading = () => {
-    setSession(prev => prev ? { ...prev, introCompleted: true } : null);
+    setSession(prev => {
+      if (prev) return { ...prev, introCompleted: true };
+      // Defensive: session can be null if user navigated via stepper after onRetry
+      // without re-selecting a story. Re-initialize from selectedStory.
+      if (selectedStory) {
+        return {
+          storyId: selectedStory.id,
+          startedAt: Date.now(),
+          introCompleted: true,
+          readingAttempt: null,
+          comprehensionResult: null,
+          vocabResult: null,
+          fullReadingResult: null,
+        };
+      }
+      return null;
+    });
     setView(AppView.TUTOR);
   };
 
@@ -159,7 +175,7 @@ const App: React.FC = () => {
 
         {view === AppView.REPORT && (
           <div className="p-8 max-w-4xl mx-auto w-full">
-             <AssessmentReport session={session} story={selectedStory} onRetry={() => { setView(AppView.LIBRARY); setSession(null); setLastAttempt(null); }} onGoToVocab={() => setView(AppView.VOCAB)} />
+             <AssessmentReport session={session} story={selectedStory} onRetry={() => { setView(AppView.LIBRARY); setSession(null); setLastAttempt(null); setSelectedStory(null); }} onGoToVocab={() => setView(AppView.VOCAB)} />
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Fixes two defensive edge cases in `App.tsx` for Issue #167 (stepper completion states):

- **`handleStartReading` null-session guard**: When `session` is `null` (happens if user navigates to the Intro step via stepper after clicking Retry, without re-selecting a story), the old `prev => prev ? ... : null` guard silently kept session as null. Now it creates a fresh session from `selectedStory` so completion tracking works correctly.

- **`onRetry` resets `selectedStory`**: Previously `onRetry` reset `session` and `lastAttempt` but NOT `selectedStory`. This left the stepper steps in an "idle" (clickable) state even though session was null, allowing users to navigate to step views without a valid session. Now `selectedStory` is also reset to `null`, making all steps disabled after retry until a new story is selected.

## Root Cause

After `onRetry`:
- `session = null`
- `selectedStory` = still the previous story (NOT reset)
- Stepper shows steps 1-5 as `idle` (clickable via `needsStory=true && selectedStory!=null`)
- User could click Step 1 in stepper → navigate to INTRO view
- Clicking "開始逐段朗讀" → `handleStartReading` runs `prev => prev ? ... : null`
- Since `prev = null` → returns `null` → session stays null
- ALL steps remain `idle` with no completion indicators

## Investigation Notes

Thorough testing confirmed that in the **normal flow** (select story → click "開始逐段朗讀"), the stepper completion states work correctly. The `getStepStatus` logic and CSS rendering are both correct. The edge case only occurs after the `onRetry` path.

Evidence screenshots (local + staging):
- BEFORE: Home page with all steps gray (correct initial state)
- AFTER Step 1: Green ✓ on Step 1 "簡介", Step 2 active (blue)
- AFTER all steps: All 5 steps show green ✓ + mini-summaries (85% · 120 CPM, 3/5 字, 4/5 題, 92%)

## Test plan

- [ ] Normal flow: select story → click "開始逐段朗讀" → Step 1 shows green ✓ in stepper
- [ ] After completing all steps and clicking Retry → all stepper steps become disabled (gray, cursor-not-allowed)
- [ ] After Retry → select new story from library → fresh session starts, completion tracking works

🤖 Generated with [Claude Code](https://claude.com/claude-code)