### PR TITLE
fix: stepper completion + section 2 whitespace fallback (#167 #173)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,13 @@ const App: React.FC = () => {
   };
 
   const handleStartReading = () => {
-    setSession(prev => prev ? { ...prev, introCompleted: true } : null);
+    setSession(prev => {
+      if (prev) return { ...prev, introCompleted: true };
+      if (selectedStory) {
+        return { storyId: selectedStory.id, startedAt: Date.now(), introCompleted: true, readingAttempt: null, comprehensionResult: null, vocabResult: null, fullReadingResult: null };
+      }
+      return null;
+    });
     setView(AppView.TUTOR);
   };
 
@@ -159,7 +165,7 @@ const App: React.FC = () => {
 
         {view === AppView.REPORT && (
           <div className="p-8 max-w-4xl mx-auto w-full">
-             <AssessmentReport session={session} story={selectedStory} onRetry={() => { setView(AppView.LIBRARY); setSession(null); setLastAttempt(null); }} onGoToVocab={() => setView(AppView.VOCAB)} />
+             <AssessmentReport session={session} story={selectedStory} onRetry={() => { setView(AppView.LIBRARY); setSession(null); setLastAttempt(null); setSelectedStory(null); }} onGoToVocab={() => setView(AppView.VOCAB)} />
           </div>
         )}
 

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -324,11 +324,11 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
         {(readingAttempt || fullReadingResult) ? (
           <div className="space-y-4">
             {/* Transcription text */}
-            {(readingAttempt?.transcription || fullReadingResult?.transcript) && (
+            {((readingAttempt?.transcription ?? '').trim() || (fullReadingResult?.transcript ?? '').trim()) && (
               <div>
                 <p className="text-xs text-gray-500 font-bold mb-2">語音轉文字</p>
                 <div className="bg-slate-50 rounded-2xl p-4 text-sm text-gray-700 leading-relaxed">
-                  {readingAttempt?.transcription ?? fullReadingResult?.transcript}
+                  {(readingAttempt?.transcription ?? '').trim() || (fullReadingResult?.transcript ?? '').trim()}
                 </div>
               </div>
             )}
@@ -358,8 +358,8 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
               </div>
             )}
 
-            {/* Fallback: readingAttempt exists but no transcription or lineBreakdown data */}
-            {!readingAttempt?.transcription && !fullReadingResult?.transcript && lineBreakdown.length === 0 && (
+            {/* Fallback: readingAttempt exists but no meaningful transcription or lineBreakdown data */}
+            {!(readingAttempt?.transcription ?? '').trim() && !(fullReadingResult?.transcript ?? '').trim() && lineBreakdown.length === 0 && (
               <p className="text-sm text-gray-400 text-center py-4">語音辨識資料不足，準確度過低時建議重新朗讀</p>
             )}
           </div>


### PR DESCRIPTION
## Summary
Combined fix for two staging bugs:

### Fix 1: Stepper not showing completion (#167)
- `handleStartReading`: when `session` is null (after retry), rebuild from `selectedStory` instead of returning null
- `onRetry`: also reset `selectedStory` so stepper steps return to disabled state

### Fix 2: Section 2 still blank at 0% accuracy (#173)  
- LiveTutor joins empty transcripts with spaces → `'   '` (truthy, not empty)
- Added `.trim()` to all transcription checks so whitespace-only = "no data"
- Fallback message now correctly shows: "語音辨識資料不足，準確度過低時建議重新朗讀"

## Changes
- `App.tsx` — defensive null handling in `handleStartReading`, `setSelectedStory(null)` in `onRetry`
- `AssessmentReport.tsx` — `.trim()` on transcription checks (lines 327, 362)

## Test plan
- [ ] Complete steps → stepper shows green ✓ + summaries
- [ ] Click retry on report → go back to library → stepper resets to disabled
- [ ] Re-select story → complete steps → ✓ shows again
- [ ] Read with ~0% accuracy → Section 2 shows fallback message (not blank)

Closes #167 #173

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)