### PR TITLE
fix: correct StepperNav step order (#198)

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -21,8 +21,8 @@ interface StepDef {
 const steps: StepDef[] = [
   { step: 1, label: '簡介',    view: AppView.INTRO,         needsStory: true  },
   { step: 2, label: '逐段朗讀', view: AppView.TUTOR,         needsStory: true  },
-  { step: 3, label: '生字練習', view: AppView.VOCAB,         needsStory: true  },
-  { step: 4, label: '課文理解', view: AppView.COMPREHENSION, needsStory: true  },
+  { step: 3, label: '課文理解', view: AppView.COMPREHENSION, needsStory: true  },
+  { step: 4, label: '生字練習', view: AppView.VOCAB,         needsStory: true  },
   { step: 5, label: '全文朗讀', view: AppView.FULL_READING,  needsStory: true  },
   { step: 6, label: '報告',    view: AppView.REPORT,        needsStory: false },
 ];


### PR DESCRIPTION
## Summary
- StepperNav 顯示步驟 3=生字練習、4=課文理解，但實際 App.tsx 流程是 3=課文理解、4=生字練習
- 交換 StepperNav 中步驟 3 和 4 的 label 與 view，對齊 PRD 定義的實際流程

## Changes
- `frontend/src/components/StepperNav.tsx`: 交換步驟 3/4 的定義

## Test plan
- [ ] StepperNav 步驟 3 顯示「課文理解」
- [ ] StepperNav 步驟 4 顯示「生字練習」
- [ ] 點擊步驟 3 進入課文理解頁
- [ ] 點擊步驟 4 進入生字練習頁

Closes #198

🤖 Generated with [Claude Code](https://claude.ai/code)