### PR TITLE
fix: translate English UI labels to zh-TW (#199)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Reading Tutor — Taiwan</title>
+    <title>AI 朗讀助教 — 國語文閱讀學習平台</title>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
       @font-face {

--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -267,7 +267,7 @@ const StepperNav: React.FC<StepperNavProps> = ({
       {/* User avatar */}
       <div className="ml-3 flex items-center gap-1 pl-3 border-l border-gray-200">
         <div className="w-6 h-6 rounded-full bg-gray-200"></div>
-        <span className="text-[10px] text-gray-500 hidden sm:block">Lv.12</span>
+        <span className="text-[10px] text-gray-500 hidden sm:block">等級 12</span>
       </div>
     </nav>
   );

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -123,7 +123,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-accent-bg-subtle text-accent-hover border border-accent-bg-subtle uppercase tracking-widest">
                   {CATEGORY_LABEL[story.category] ?? story.category}
                 </span>
-                <span className="text-[10px] text-gray-400">Lv.{story.level}</span>
+                <span className="text-[10px] text-gray-400">難度 {story.level}</span>
               </div>
               <h1 className={`text-2xl font-black text-gray-900 leading-[3rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                 {processZhuyin(story.title)}

--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -52,7 +52,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
       const fullStory = await fetchStory(story.id);
       onStartReading(fullStory);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load story');
+      setError(err instanceof Error ? err.message : '無法載入課文');
     } finally {
       setLoadingStoryId(null);
     }
@@ -115,7 +115,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
                 : 'bg-white text-gray-600 border border-gray-200 hover:border-accent'
             }`}
           >
-            G{grade}
+            {grade}年級
           </button>
         ))}
       </div>
@@ -175,7 +175,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({ onStartReading, limit }) =>
                 {/* Grade badge */}
                 {story.grade && (
                   <div className="absolute top-2 right-2 bg-accent text-white text-xs font-bold px-2 py-1 rounded">
-                    G{story.grade}
+                    {story.grade}年級
                   </div>
                 )}
                 {/* Loading overlay */}


### PR DESCRIPTION
## Summary
將前端殘留英文 UI 標籤翻譯為臺灣繁體中文，確保目標用戶（國小生+老師）看到全中文介面。

## Changes
| 檔案 | 修改 |
|------|------|
| `frontend/index.html` | title: "AI Reading Tutor — Taiwan" → "AI 朗讀助教 — 國語文閱讀學習平台" |
| `frontend/src/pages/student/StoryLibrary.tsx` | "Failed to load story" → "無法載入課文"、"G{grade}" → "{grade}年級" |
| `frontend/src/components/reading-steps/Intro.tsx` | "Lv.{level}" → "難度 {level}" |
| `frontend/src/components/StepperNav.tsx` | "Lv.12" → "等級 12" |

## Test plan
- [ ] 瀏覽器 tab 顯示中文標題
- [ ] 年級篩選按鈕顯示「X年級」
- [ ] 課文卡片角標顯示「X年級」
- [ ] 簡介頁顯示「難度 X」
- [ ] 載入失敗時顯示中文錯誤訊息

Closes #199

🤖 Generated with [Claude Code](https://claude.ai/code)