### PR TITLE
fix: collapsible report + better exit ticket distractors (#169 #172)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -106,25 +106,46 @@ const generateSuggestions = (
   return suggestions.slice(0, 4);
 };
 
-/** Section wrapper component for consistent styling */
+/** Section wrapper component for consistent styling, with optional collapse support */
 const Section: React.FC<{
   number: number;
   title: string;
   children: React.ReactNode;
   disabled?: boolean;
-}> = ({ number, title, children, disabled }) => (
-  <div className={`rounded-3xl border overflow-hidden ${disabled ? 'bg-gray-50 border-dashed border-gray-300' : 'bg-white border-slate-200 shadow-sm'}`}>
-    <div className={`px-6 py-4 border-b flex items-center gap-3 ${disabled ? 'border-gray-200' : 'border-slate-100'}`}>
-      <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-black shrink-0 ${disabled ? 'bg-gray-200 text-gray-400' : 'bg-accent text-white'}`}>
-        {number}
-      </span>
-      <h3 className={`text-lg font-bold ${disabled ? 'text-gray-400' : 'text-gray-900'}`}>{title}</h3>
+  defaultOpen?: boolean;
+}> = ({ number, title, children, disabled, defaultOpen = true }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const canToggle = !disabled;
+
+  return (
+    <div className={`rounded-3xl border overflow-hidden ${disabled ? 'bg-gray-50 border-dashed border-gray-300' : 'bg-white border-slate-200 shadow-sm'}`}>
+      <div
+        className={`px-6 py-4 flex items-center gap-3 ${disabled ? 'border-gray-200' : 'border-slate-100'} ${open ? 'border-b' : ''} ${canToggle ? 'cursor-pointer select-none hover:bg-slate-50 transition-colors' : ''}`}
+        onClick={canToggle ? () => setOpen(o => !o) : undefined}
+        role={canToggle ? 'button' : undefined}
+        aria-expanded={canToggle ? open : undefined}
+      >
+        <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-black shrink-0 ${disabled ? 'bg-gray-200 text-gray-400' : 'bg-accent text-white'}`}>
+          {number}
+        </span>
+        <h3 className={`text-lg font-bold flex-1 ${disabled ? 'text-gray-400' : 'text-gray-900'}`}>{title}</h3>
+        {canToggle && (
+          <svg
+            className={`w-5 h-5 text-gray-400 transition-transform shrink-0 ${open ? 'rotate-180' : ''}`}
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        )}
+      </div>
+      {open && (
+        <div className="p-6">
+          {children}
+        </div>
+      )}
     </div>
-    <div className="p-6">
-      {children}
-    </div>
-  </div>
-);
+  );
+};
 
 const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
@@ -242,7 +263,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
       </div>
 
       {/* ============ 環節一：朗讀結果總覽 ============ */}
-      <Section number={1} title="朗讀結果總覽" disabled={!readingAttempt && !fullReadingResult}>
+      <Section number={1} title="朗讀結果總覽" defaultOpen={true} disabled={!readingAttempt && !fullReadingResult}>
         {readingAttempt || fullReadingResult ? (
           <div className="space-y-4">
             {/* 3 KPI Cards */}
@@ -320,7 +341,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
       </Section>
 
       {/* ============ 環節二：錄音內容與智能分析 ============ */}
-      <Section number={2} title="錄音內容與智能分析" disabled={!readingAttempt && !fullReadingResult}>
+      <Section number={2} title="錄音內容與智能分析" defaultOpen={false} disabled={!readingAttempt && !fullReadingResult}>
         {(readingAttempt || fullReadingResult) ? (
           <div className="space-y-4">
             {/* Transcription text */}
@@ -369,7 +390,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
       </Section>
 
       {/* ============ 環節三：逐句分析對比 ============ */}
-      <Section number={3} title="逐句分析對比" disabled={lineBreakdown.length === 0}>
+      <Section number={3} title="逐句分析對比" defaultOpen={false} disabled={lineBreakdown.length === 0}>
         {lineBreakdown.length > 0 ? (
           <div className="-mx-6 -mb-6">
             <p className="text-xs text-gray-500 px-6 mb-3">
@@ -437,7 +458,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
       </Section>
 
       {/* ============ 環節四：錯字詞練習清單 ============ */}
-      <Section number={4} title="錯字詞練習清單" disabled={wrongTokens.length === 0 && missingChars.length === 0}>
+      <Section number={4} title="錯字詞練習清單" defaultOpen={true} disabled={wrongTokens.length === 0 && missingChars.length === 0}>
         {wrongTokens.length > 0 || missingChars.length > 0 ? (
           <div className="space-y-4">
             {wrongTokens.length > 0 && (
@@ -513,7 +534,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
       </Section>
 
       {/* ============ 環節五：練習建議 ============ */}
-      <Section number={5} title="練習建議" disabled={!readingAttempt}>
+      <Section number={5} title="練習建議" defaultOpen={false} disabled={!readingAttempt}>
         {suggestions.length > 0 ? (
           <div className="space-y-3">
             {suggestions.map((s, idx) => (
@@ -532,7 +553,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
       </Section>
 
       {/* ============ 環節六：AI 詳細分析 (placeholder) ============ */}
-      <Section number={6} title="AI 詳細分析" disabled>
+      <Section number={6} title="AI 詳細分析" defaultOpen={false} disabled>
         <div className="p-6 bg-gray-50 rounded-2xl text-center">
           <span className="text-4xl mb-3 block">🤖</span>
           <p className="text-sm text-gray-400 font-bold">AI 詳細分析</p>

--- a/frontend/src/components/reading-steps/ExitTicket.tsx
+++ b/frontend/src/components/reading-steps/ExitTicket.tsx
@@ -30,6 +30,129 @@ const shuffle = <T,>(arr: T[]): T[] => {
 
 const COMMON_PARTICLES = new Set(['的', '了', '在', '是', '有', '和', '與', '也', '都', '就', '把', '被', '讓', '給', '從', '到', '著', '過', '嗎', '呢', '吧', '啊', '嗎']);
 
+/**
+ * Map of commonly confused Chinese characters (形近字 / 音近字).
+ * When generating distractors, use these as priority options before falling back to story chars.
+ */
+const CONFUSABLE_CHARS: Record<string, string[]> = {
+  // 形近字 (visually similar)
+  '己': ['已', '巳'],
+  '已': ['己', '巳'],
+  '巳': ['己', '已'],
+  '未': ['末', '木'],
+  '末': ['未', '木'],
+  '大': ['太', '犬', '天'],
+  '太': ['大', '犬', '天'],
+  '犬': ['大', '太'],
+  '日': ['目', '曰'],
+  '目': ['日', '曰'],
+  '人': ['入', '八'],
+  '入': ['人', '八'],
+  '土': ['士', '王'],
+  '士': ['土', '王'],
+  '干': ['千', '于', '幹'],
+  '千': ['干', '于'],
+  '天': ['夫', '大', '太'],
+  '夫': ['天', '大'],
+  '刀': ['力', '刃'],
+  '力': ['刀', '刃'],
+  '田': ['由', '甲', '申'],
+  '由': ['田', '甲', '申'],
+  '甲': ['田', '由', '申'],
+  '白': ['自', '百', '臼'],
+  '自': ['白', '百'],
+  '百': ['白', '自'],
+  '午': ['牛', '干'],
+  '牛': ['午', '干'],
+  '折': ['拆', '析'],
+  '拆': ['折', '析'],
+  '買': ['賣', '貿'],
+  '賣': ['買', '貿'],
+  '同': ['回', '向'],
+  '回': ['同', '向'],
+  '代': ['伐', '從'],
+  '伐': ['代', '從'],
+  // 形近字 - 三點水系列
+  '晴': ['睛', '情', '清', '請', '精', '青'],
+  '睛': ['晴', '情', '清', '青'],
+  '情': ['晴', '睛', '清', '請'],
+  '清': ['晴', '睛', '情', '請', '青'],
+  '請': ['情', '清', '晴'],
+  '精': ['晴', '清', '青'],
+  '青': ['晴', '清', '精'],
+  // 音近字 (phonetically similar)
+  '在': ['再', '載', '栽'],
+  '再': ['在', '載', '栽'],
+  '的': ['得', '地', '底'],
+  '得': ['的', '地', '底'],
+  '地': ['的', '得', '底'],
+  '做': ['作', '坐', '座'],
+  '作': ['做', '坐', '座'],
+  '坐': ['做', '作', '座'],
+  '座': ['做', '作', '坐'],
+  '他': ['她', '它', '祂'],
+  '她': ['他', '它'],
+  '它': ['他', '她'],
+  '像': ['象', '向', '相'],
+  '象': ['像', '向', '相'],
+  '向': ['像', '象', '鄉'],
+  '那': ['哪', '娜', '拿'],
+  '哪': ['那', '娜'],
+  '只': ['指', '紙', '隻', '支'],
+  '指': ['只', '紙', '隻'],
+  '紙': ['只', '指', '隻'],
+  '隻': ['只', '指', '紙'],
+  '園': ['圓', '源', '緣', '員', '遠'],
+  '圓': ['園', '員', '遠'],
+  '員': ['園', '圓', '遠'],
+  '源': ['園', '緣', '遠'],
+  '緣': ['源', '園', '員'],
+  '生': ['聲', '勝', '省', '升'],
+  '聲': ['生', '勝', '省'],
+  '勝': ['生', '聲', '省'],
+  '省': ['生', '聲', '勝'],
+  '式': ['試', '是', '事', '市'],
+  '試': ['式', '是', '事'],
+  '是': ['式', '試', '事'],
+  '事': ['式', '試', '是'],
+  '市': ['式', '試', '是'],
+  '練': ['煉', '鍊', '連'],
+  '煉': ['練', '鍊', '連'],
+  '鍊': ['練', '煉', '連'],
+  '問': ['聞', '文', '閒'],
+  '聞': ['問', '文', '閒'],
+  '花': ['化', '華', '樺'],
+  '化': ['花', '華'],
+  '心': ['新', '辛', '欣'],
+  '想': ['相', '向', '象'],
+  '相': ['想', '象', '向'],
+  '原': ['園', '圓', '員', '源'],
+  '看': ['著', '觀', '視'],
+  '說': ['話', '語', '悅'],
+  '話': ['說', '語', '悅'],
+  '走': ['足', '奔', '跑'],
+  '跑': ['走', '足', '奔'],
+  '來': ['回', '去', '到'],
+  '去': ['來', '回', '到'],
+  '開': ['關', '閉', '闊'],
+  '關': ['開', '閉', '闊'],
+  '高': ['告', '稿', '膏'],
+  '好': ['壞', '妙', '姐'],
+  '年': ['午', '牛', '幸'],
+  '月': ['目', '日', '用'],
+  '山': ['出', '止', '丘'],
+  '水': ['木', '永', '氷'],
+  '木': ['水', '本', '末'],
+  '本': ['木', '末', '未'],
+  '手': ['毛', '才', '扌'],
+  '上': ['土', '止', '卡'],
+  '下': ['上', '卡', '不'],
+  '中': ['申', '由', '串'],
+  '口': ['日', '目', '回'],
+  '子': ['字', '孑', '孓'],
+  '字': ['子', '守', '宇'],
+};
+
 /** Generate up to 3 multiple-choice questions from wrong + missing tokens */
 const generateQuestions = (wrongTokens: WrongToken[], missingChars: string[], storyContent: string[]): Question[] => {
   if (wrongTokens.length === 0 && missingChars.length === 0) return [];
@@ -44,52 +167,62 @@ const generateQuestions = (wrongTokens: WrongToken[], missingChars: string[], st
 
   const questions: Question[] = [];
 
+  /**
+   * Build a distractor list for a given correct answer.
+   * Priority: 1) CONFUSABLE_CHARS map, 2) other wrongTokens, 3) storyChars, 4) random CJK fallback
+   */
+  const buildDistractors = (correctAnswer: string, exclude: Set<string>): string[] => {
+    const chosen: string[] = [];
+    const seen = new Set<string>([correctAnswer, ...exclude]);
+
+    // Priority 1: confusable chars (form-similar / sound-similar)
+    const confusables = CONFUSABLE_CHARS[correctAnswer] ?? [];
+    for (const c of shuffle(confusables)) {
+      if (!seen.has(c) && chosen.length < 3) { seen.add(c); chosen.push(c); }
+    }
+
+    // Priority 2: other wrong tokens' expected chars
+    for (const t of wrongTokens) {
+      if (!seen.has(t.expected) && chosen.length < 3) { seen.add(t.expected); chosen.push(t.expected); }
+    }
+
+    // Priority 3: story chars
+    for (const c of shuffle([...storyChars])) {
+      if (!seen.has(c) && chosen.length < 3) { seen.add(c); chosen.push(c); }
+    }
+
+    // Priority 4: random CJK fallback
+    while (chosen.length < 3) {
+      const fallback = String.fromCharCode(0x4e00 + Math.floor(Math.random() * 200));
+      if (!seen.has(fallback)) { seen.add(fallback); chosen.push(fallback); }
+    }
+
+    return chosen.slice(0, 3);
+  };
+
   // Questions from wrong tokens: "你讀成了 X，正確的字應該是？"
   for (const token of shuffle(wrongTokens)) {
     if (questions.length >= 3) break;
-    const distractorPool = new Set<string>();
-    for (const t of wrongTokens) {
-      if (t.expected !== token.expected) distractorPool.add(t.expected);
-    }
-    for (const ch of storyChars) {
-      if (ch !== token.expected && ch !== token.char) distractorPool.add(ch);
-    }
-    const distractors = shuffle([...distractorPool]).slice(0, 3);
-    while (distractors.length < 3) {
-      const fallback = String.fromCharCode(0x4e00 + Math.floor(Math.random() * 200));
-      if (fallback !== token.expected && !distractors.includes(fallback)) {
-        distractors.push(fallback);
-      }
-    }
+    const distractors = buildDistractors(token.expected, new Set([token.char]));
     questions.push({
       prompt: `你讀成了「${token.char}」，正確的字應該是？`,
       correctAnswer: token.expected,
-      options: shuffle([token.expected, ...distractors.slice(0, 3)]),
+      options: shuffle([token.expected, ...distractors]),
     });
   }
 
-  // Fill remaining slots with missing chars: "這個字怎麼唸？"
+  // Fill remaining slots with missing chars: "你漏讀了一個字，是下面哪一個？"
   const usedChars = new Set(questions.map(q => q.correctAnswer));
   for (const ch of shuffle(missingChars)) {
     if (questions.length >= 3) break;
     if (usedChars.has(ch)) continue;
     usedChars.add(ch);
 
-    const distractorPool = new Set<string>();
-    for (const sc of storyChars) {
-      if (sc !== ch) distractorPool.add(sc);
-    }
-    const distractors = shuffle([...distractorPool]).slice(0, 3);
-    while (distractors.length < 3) {
-      const fallback = String.fromCharCode(0x4e00 + Math.floor(Math.random() * 200));
-      if (fallback !== ch && !distractors.includes(fallback)) {
-        distractors.push(fallback);
-      }
-    }
+    const distractors = buildDistractors(ch, new Set());
     questions.push({
       prompt: `你漏讀了一個字，是下面哪一個？`,
       correctAnswer: ch,
-      options: shuffle([ch, ...distractors.slice(0, 3)]),
+      options: shuffle([ch, ...distractors]),
     });
   }
 


### PR DESCRIPTION
## Summary

- **#169 Report UX**: `Section` component in `AssessmentReport.tsx` is now collapsible
  - Sections 1 (朗讀結果總覽) and 4 (錯字詞練習清單) open by default
  - Sections 2, 3, 5, 6 collapsed by default — reduces page length for elementary students
  - Chevron icon rotates to indicate expand/collapse state
  - Disabled sections remain non-interactive (no toggle)
- **#172 Exit Ticket distractors**: `ExitTicket.tsx` now uses form-similar / sound-similar chars as priority distractors
  - Added `CONFUSABLE_CHARS` map (~50+ common pairs: 己/已/巳, 未/末, 晴/睛/情/清, 在/再, 做/作/坐/座, etc.)
  - Distractor priority: confusables > other wrong tokens > story chars > random CJK fallback

## Test plan

- [ ] Open the Report page after completing a reading session
- [ ] Verify sections 1 and 4 are open by default; sections 2, 3, 5, 6 are collapsed
- [ ] Click section headers to toggle expand/collapse; verify chevron rotates
- [ ] Verify disabled sections (6, and any unavailable) cannot be toggled
- [ ] Complete a reading session with errors, go to Report → Exit Ticket
- [ ] Verify distractors are visually or phonetically similar to the correct answer
- [ ] Verify correct answer is always one of the 4 options
- [ ] Run `cd frontend && npx tsc --noEmit` — 0 errors
- [ ] Run `cd frontend && npx vite build` — build succeeds

## Files changed

- `frontend/src/components/reading-steps/AssessmentReport.tsx` — collapsible Section component with defaultOpen prop
- `frontend/src/components/reading-steps/ExitTicket.tsx` — CONFUSABLE_CHARS map + priority distractor logic