### PR TITLE
Feature/ 215 [UI/UX] AI 指令區與閱讀內容產生注意力混淆

### DIFF
--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -754,7 +754,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 LISTENING
               </span>
               <div className={`px-4 py-3 rounded-2xl text-lg bg-green-900/30 text-green-200 border border-green-700/30 rounded-tl-none leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
-                {processZhuyin('請朗讀上方的段落')}
+                {processZhuyin(`請閱讀左側文章的第${currentLineIndex + 1}段：${story.content[currentLineIndex].slice(0, 5)}...`)}
               </div>
             </div>
           )}


### PR DESCRIPTION
## 修復內容
將在 [frontend/src/components/reading-steps/LiveTutor.tsx](https://github.com/Youngger9765/chinese-literacy-platform/blob/ebd751a887f0354f4b035fedfa39c59adff7ab09/frontend/src/components/reading-steps/LiveTutor.tsx) 
原本：
```JavaScript
{processZhuyin('請朗讀上方的段落')}
```
修改成：
```JavaScript
{processZhuyin(`請閱讀左側文章的第${currentLineIndex + 1}段：${story.content[currentLineIndex].slice(0, 5)}...`)}
```