### PR TITLE
feat: add paragraph progress bar to LiveTutor (Related to #218)

### DIFF
--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -642,6 +642,30 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
         </div>
 
+        {/* Paragraph progress bar */}
+        <div className="px-6 py-2 bg-white border-b border-gray-100">
+          <div className="flex items-center gap-3 max-w-3xl mx-auto">
+            <span className="text-xs text-gray-400 shrink-0 font-medium">進度</span>
+            <div className="flex flex-1 gap-1 h-2">
+              {story.content.map((_, idx) => (
+                <div
+                  key={idx}
+                  className={`flex-1 rounded-full transition-all duration-500 ${
+                    lineStatuses[idx] === 'completed'
+                      ? 'bg-emerald-500'
+                      : lineStatuses[idx] === 'current'
+                      ? 'bg-accent'
+                      : 'bg-gray-200'
+                  }`}
+                />
+              ))}
+            </div>
+            <span className="text-xs text-gray-400 shrink-0 tabular-nums">
+              {currentLineIndex + 1} / {story.content.length}
+            </span>
+          </div>
+        </div>
+
         <div className={`flex-1 ${isMobile ? 'p-4' : 'p-8 lg:p-16'} overflow-y-auto custom-scrollbar`}>
           <div className="max-w-3xl mx-auto space-y-20">
             {story.content.map((line, idx) => (


### PR DESCRIPTION
## 變更說明

在 LiveTutor 逐段朗讀步驟中，於 ZhuyinToggle 欄位下方新增段落進度條。

## 修改內容

- **檔案**: `frontend/src/components/reading-steps/LiveTutor.tsx`
- **新增**: 24 行 JSX（段落進度條）

## 測試方式

1. 進入任一課文
2. 開啟「逐段朗讀」步驟
3. 確認標題列下方出現進度條
4. 完成各段後確認色塊正確更新

Related to #218