### PR TITLE
feat: 改善生字練習 UX (Related to #220)

### DIFF
--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -21,7 +21,6 @@ enum Step {
   PRACTICE_1,
   PRACTICE_2,
   PRACTICE_3,
-  TOGGLE_OUTLINE,
   PRACTICE_NO_OUTLINE,
   COMPLETE,
 }
@@ -108,23 +107,29 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
     renderStrokes(ctx, getOffCanvas(), state);
   }, [getOffCanvas]);
 
-  /* ---- Load character data ---- */
-  useEffect(() => {
-    setLoading(true);
-    setError('');
+  /* ---- Shared state reset (used by both initial load and retry) ---- */
+  const resetState = useCallback((nStrokes: number) => {
     setStep(Step.ANIMATION);
     setMode('idle');
     setPracticeLeft(4);
     setShowOutline(true);
     setToast('');
-    isAutoLoopingRef.current = false;
-    pendingAutoStartRef.current = false;
     r.current = {
       completedStrokes: 0, animStroke: -1, animProgress: 0,
       hintStroke: -1, hintProgress: 0, correctPaths: [], activeBrush: [],
     };
-    m.current.mistakes = [];
+    m.current.showOutline = true;
+    m.current.mistakes = new Array(nStrokes).fill(0);
     m.current.quizStroke = 0;
+  }, []);
+
+  /* ---- Load character data ---- */
+  useEffect(() => {
+    setLoading(true);
+    setError('');
+    resetState(0);
+    isAutoLoopingRef.current = false;
+    pendingAutoStartRef.current = false;
 
     loadCharacterStrokeData(character).then(d => {
       if (d) {
@@ -142,7 +147,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
       cancelAnimationFrame(hintFrameRef.current);
       clearTimeout(loopTimerRef.current);
     };
-  }, [character]);
+  }, [character, resetState]);
 
   /* ---- Re-render when declarative state changes ---- */
   useEffect(() => {
@@ -207,41 +212,15 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
     animFrameRef.current = requestAnimationFrame(tick);
   }, [doRender]);
 
-  const stopAnimation = useCallback(() => {
-    cancelAnimationFrame(animFrameRef.current);
-    const d = m.current.data;
-    r.current.animStroke = -1;
-    r.current.animProgress = 0;
-    if (d) r.current.completedStrokes = d.nStrokes;
-    doRender();
-    setMode('idle');
-    if (m.current.step === Step.ANIMATION) setStep(Step.PRACTICE_1);
-  }, [doRender]);
-
-  const resetAndLoop = useCallback((d: CharacterStrokeData) => {
+  const handleRetry = useCallback(() => {
+    if (!data) return;
     cancelAnimationFrame(animFrameRef.current);
     cancelAnimationFrame(hintFrameRef.current);
     clearTimeout(loopTimerRef.current);
-    setStep(Step.ANIMATION);
-    setMode('idle');
-    setPracticeLeft(4);
-    setShowOutline(true);
-    setToast('');
-    r.current = {
-      completedStrokes: 0, animStroke: -1, animProgress: 0,
-      hintStroke: -1, hintProgress: 0, correctPaths: [], activeBrush: [],
-    };
-    m.current.showOutline = true;
-    m.current.mistakes = new Array(d.nStrokes).fill(0);
-    m.current.quizStroke = 0;
+    resetState(data.nStrokes);
     isAutoLoopingRef.current = true;
     startAnimation();
-  }, [startAnimation]);
-
-  const handleRetry = useCallback(() => {
-    if (!data) return;
-    resetAndLoop(data);
-  }, [data, resetAndLoop]);
+  }, [data, resetState, startAnimation]);
 
   /* ---- Auto-start animation loop when data first loads ---- */
   useEffect(() => {
@@ -274,6 +253,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
   const handleBeginPractice = useCallback(() => {
     isAutoLoopingRef.current = false;
     cancelAnimationFrame(animFrameRef.current);
+    clearTimeout(loopTimerRef.current);
     r.current.animStroke = -1;
     r.current.animProgress = 0;
     setStep(Step.PRACTICE_1);
@@ -327,7 +307,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
           const newLeft = pl - 1;
           setPracticeLeft(newLeft);
           if (s === Step.PRACTICE_3) {
-            // Auto-skip TOGGLE_OUTLINE — jump straight to no-outline practice
+            // Auto-advance to no-outline practice
             m.current.showOutline = false;
             setShowOutline(false);
             setStep(Step.PRACTICE_NO_OUTLINE);
@@ -471,10 +451,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
             }`}
           />
         </div>
-      )}
-
-      {isComplete && (
-        <div className="text-emerald-400 font-bold text-sm">練習完成！</div>
       )}
 
       {/* Canvas */}


### PR DESCRIPTION
## 變更摘要

### (1) 筆順動畫自動循環播放
- 進入 `WriteCharacter` 後動畫立即自動播放並無限循環
- 以大型「開始練習」按鈕取代原本小圖示按鈕，學生主動點擊後停止循環並進入書寫

### (2) 移除練習控制列，自動推進每輪練習
- 移除 筆順/寫字/邊框 控制列，避免多餘手動操作
- 每輪書寫完成後，畫布自動清空並立即開始下一輪
- PRACTICE_3 完成後自動關閉邊框提示，直接進入無邊框練習（跳過 TOGGLE_OUTLINE 步驟）

### (3) 明顯的完成覆蓋層
- 四輪練習全部完成後，在畫布上疊加慶祝畫面（大字 + 字符 + 完成按鈕）
- 新增「再練一次」按鈕可重置流程並自動播放筆順動畫

## 修改檔案
- `frontend/src/components/stroke-order/WriteCharacter.tsx`

Related to #220
