### PR TITLE
feat: 學生錄音資料隱私政策 — 存儲/留存/刪除規範 (Fixes #265)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from .routes import stories, learning, users, auth, classrooms, schools, organiz
 from .routes.classroom_texts import router as classroom_texts_router
 from .routes.teacher import router as teacher_router
 from .routes.assignments import router as assignments_router
+from .routes.privacy import router as privacy_router
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ app.include_router(roles.router, prefix="/api")
 app.include_router(classroom_texts_router, prefix="/api", tags=["classroom-texts"])
 app.include_router(teacher_router, prefix="/api", tags=["teacher"])
 app.include_router(assignments_router, prefix="/api", tags=["assignments"])
+app.include_router(privacy_router, prefix="/api", tags=["privacy"])
 
 
 def seed_default_data():

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -27,6 +27,7 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     email_verified: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     last_login_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    privacy_accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routes/organizations.py
+++ b/backend/app/routes/organizations.py
@@ -54,7 +54,6 @@ def _org_to_response(org: Organization, school_count: int) -> OrganizationRespon
         is_active=org.is_active,
         created_at=org.created_at,
         school_count=school_count,
-        teacher_limit=org.teacher_limit,
         description=org.description,
         tax_id=org.tax_id,
         contact_email=org.contact_email,

--- a/backend/app/routes/privacy.py
+++ b/backend/app/routes/privacy.py
@@ -1,0 +1,154 @@
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..auth.dependencies import get_current_user
+from ..database import get_db
+from ..models.user import User
+
+router = APIRouter(prefix="/privacy", tags=["privacy"])
+
+# Policy version — bump this whenever the policy text changes
+POLICY_VERSION = "1.0.0"
+POLICY_EFFECTIVE_DATE = "2026-01-01"
+
+
+@router.get("/policy")
+def get_privacy_policy():
+    """Return the current privacy policy as structured JSON.
+
+    This endpoint is public and does not require authentication.
+    """
+    return {
+        "version": POLICY_VERSION,
+        "effective_date": POLICY_EFFECTIVE_DATE,
+        "language": "zh-TW",
+        "platform_name": "LingoLeap 朗朗國語文閱讀學習平台",
+        "sections": {
+            "data_collection": {
+                "title": "一、資料蒐集範圍",
+                "content": (
+                    "本平台依據個人資料保護法及相關法規，蒐集下列使用者資料："
+                    "\n\n"
+                    "（一）帳號資料：電子郵件地址、使用者名稱、姓名。\n"
+                    "（二）學習記錄：課文學習進度、朗讀評估結果（文字形式）、"
+                    "生字練習紀錄、課文理解作答。\n"
+                    "（三）裝置資訊：瀏覽器類型、作業系統版本（用於相容性分析）。\n\n"
+                    "本平台不蒐集下列資料：\n"
+                    "（一）語音錄音檔案（詳見第二條）。\n"
+                    "（二）精確地理位置資訊。\n"
+                    "（三）生物特徵辨識資料。"
+                ),
+            },
+            "audio_data": {
+                "title": "二、錄音資料處理方式",
+                "content": (
+                    "本平台使用瀏覽器內建之 Web Speech API 進行語音辨識。"
+                    "\n\n"
+                    "重要說明：\n"
+                    "（一）語音辨識完全在使用者的裝置端（瀏覽器）執行，"
+                    "語音錄音原始檔案不會上傳至本平台伺服器。\n"
+                    "（二）僅有語音辨識後產生的文字結果（逐字稿）會傳送至本平台"
+                    "後端，用於評估朗讀正確度並提供學習回饋。\n"
+                    "（三）Web Speech API 之語音處理規則依您使用的瀏覽器及作業系統"
+                    "而定，建議參閱各瀏覽器廠商（如 Google Chrome、Apple Safari）"
+                    "之隱私政策，以了解其語音資料處理方式。\n"
+                    "（四）本平台不會錄製、儲存或重播任何語音錄音原始資料。"
+                ),
+            },
+            "data_retention": {
+                "title": "三、資料保留期限",
+                "content": (
+                    "（一）帳號資料：於帳號存續期間保留。帳號停用後，"
+                    "資料將於三十（30）個日曆日內刪除。\n"
+                    "（二）學習記錄：於帳號存續期間保留，供教師查閱及教學分析使用。"
+                    "學生畢業或離校後，記錄將保留至學年度結束，"
+                    "之後由所屬學校管理員決定是否保留或刪除。\n"
+                    "（三）系統日誌：最長保留九十（90）個日曆日，"
+                    "用於系統安全及故障排除。\n"
+                    "（四）備份資料：備份複本最長保留三十（30）個日曆日後自動清除。"
+                ),
+            },
+            "data_deletion": {
+                "title": "四、刪除權利",
+                "content": (
+                    "依據個人資料保護法第三條，您享有下列權利：\n\n"
+                    "（一）查詢或請求閱覽個人資料。\n"
+                    "（二）請求製給複製本。\n"
+                    "（三）請求補充或更正個人資料。\n"
+                    "（四）請求停止蒐集、處理或利用個人資料。\n"
+                    "（五）請求刪除個人資料。\n\n"
+                    "行使上述權利，請透過學校管理員或聯絡本平台客服信箱提出申請。"
+                    "本平台將於收到申請後十五（15）個工作日內回覆並處理。\n\n"
+                    "注意事項：部分資料受法令要求須留存一定期間（如教育記錄），"
+                    "在法定期間內無法刪除，本平台將說明理由。"
+                ),
+            },
+            "children_privacy": {
+                "title": "五、兒童隱私保護",
+                "content": (
+                    "本平台服務對象包含未滿十八歲之兒童及青少年（主要為國小高年級"
+                    "至國中學生），因此特別重視兒童隱私保護。\n\n"
+                    "（一）帳號申請：學生帳號由學校管理員或教師代為建立，"
+                    "不開放學生自行公開註冊。\n"
+                    "（二）監護人同意：學校在建立學生帳號前，應依相關法規取得"
+                    "學生家長或法定監護人之同意。\n"
+                    "（三）資料最小化：本平台僅蒐集提供教學服務所必要之最少資料，"
+                    "不蒐集與學習無關之個人資訊。\n"
+                    "（四）廣告限制：本平台不對兒童使用者投放行為廣告，"
+                    "不將兒童資料提供予第三方廣告商。\n"
+                    "（五）公開限制：學生的學習記錄僅限教師及授權之學校管理員查閱，"
+                    "不對外公開。"
+                ),
+            },
+            "contact": {
+                "title": "六、聯絡方式",
+                "content": (
+                    "如對本隱私政策有任何疑問，或欲行使個人資料相關權利，"
+                    "請透過以下方式聯絡我們：\n\n"
+                    "服務信箱：support@lingoleap.edu.tw\n"
+                    "服務時間：週一至週五 09:00–18:00（國定假日除外）\n\n"
+                    "本隱私政策得視法規變動或業務需要適時修訂，"
+                    "修訂後將公告於本頁面，並以顯著方式通知使用者。"
+                ),
+            },
+        },
+        "last_updated": POLICY_EFFECTIVE_DATE,
+    }
+
+
+@router.post("/accept")
+def accept_privacy_policy(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Record that the current user has accepted the privacy policy.
+
+    Stores the acceptance timestamp in the user record.
+    Idempotent — calling multiple times is safe.
+    """
+    current_user.privacy_accepted_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(current_user)
+    return {
+        "message": "Privacy policy accepted",
+        "accepted_at": current_user.privacy_accepted_at.isoformat(),
+        "policy_version": POLICY_VERSION,
+    }
+
+
+@router.get("/consent-status")
+def get_consent_status(
+    current_user: User = Depends(get_current_user),
+):
+    """Return whether the current user has accepted the privacy policy."""
+    return {
+        "has_accepted": current_user.privacy_accepted_at is not None,
+        "accepted_at": (
+            current_user.privacy_accepted_at.isoformat()
+            if current_user.privacy_accepted_at
+            else None
+        ),
+        "current_policy_version": POLICY_VERSION,
+    }

--- a/backend/tests/test_privacy_api.py
+++ b/backend/tests/test_privacy_api.py
@@ -1,0 +1,199 @@
+"""
+Tests for privacy policy endpoints.
+
+Covers:
+- GET  /api/privacy/policy       — public, returns structured policy JSON
+- POST /api/privacy/accept       — requires auth, records acceptance timestamp
+- GET  /api/privacy/consent-status — requires auth, reports acceptance state
+
+Uses SQLite in-memory DB to avoid any external dependency.
+
+Run with:
+    cd /path/to/backend
+    python -m pytest tests/test_privacy_api.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, UserRole
+from app.models.school import School
+from app.models.organization import Organization
+from app.auth.password import hash_password
+from app.models.user import User
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite test DB setup
+# ---------------------------------------------------------------------------
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+
+    # Seed roles
+    student_role = Role(name="student", display_name="學生", scope_level="school")
+    db.add(student_role)
+    db.flush()
+
+    # Seed test user
+    user = User(
+        email="student_priv@test.com",
+        password_hash=hash_password("test12345"),
+        name="隱私測試生",
+        is_active=True,
+    )
+    db.add(user)
+    db.flush()
+    db.add(UserRole(user_id=user.id, role_id=student_role.id, scope_type="platform"))
+    db.commit()
+    db.close()
+
+    yield
+
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(scope="module")
+def auth_token(client):
+    resp = client.post("/api/auth/login", json={"email": "student_priv@test.com", "password": "test12345"})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+@pytest.fixture(scope="module")
+def auth_headers(auth_token):
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/privacy/policy  (public)
+# ---------------------------------------------------------------------------
+
+class TestGetPrivacyPolicy:
+    def test_returns_200_without_auth(self, client):
+        resp = client.get("/api/privacy/policy")
+        assert resp.status_code == 200
+
+    def test_response_has_required_top_level_fields(self, client):
+        resp = client.get("/api/privacy/policy")
+        data = resp.json()
+        assert "version" in data
+        assert "effective_date" in data
+        assert "language" in data
+        assert "sections" in data
+        assert data["language"] == "zh-TW"
+
+    def test_all_required_sections_present(self, client):
+        resp = client.get("/api/privacy/policy")
+        sections = resp.json()["sections"]
+        required = {"data_collection", "audio_data", "data_retention", "data_deletion", "children_privacy"}
+        assert required.issubset(sections.keys())
+
+    def test_audio_data_section_mentions_web_speech_api(self, client):
+        resp = client.get("/api/privacy/policy")
+        audio_content = resp.json()["sections"]["audio_data"]["content"]
+        assert "Web Speech API" in audio_content
+
+    def test_audio_data_section_clarifies_no_server_upload(self, client):
+        resp = client.get("/api/privacy/policy")
+        audio_content = resp.json()["sections"]["audio_data"]["content"]
+        # Key claim: audio files are NOT uploaded to the server
+        assert "不會上傳" in audio_content or "不上傳" in audio_content
+
+    def test_each_section_has_title_and_content(self, client):
+        resp = client.get("/api/privacy/policy")
+        for key, section in resp.json()["sections"].items():
+            assert "title" in section, f"Section '{key}' missing title"
+            assert "content" in section, f"Section '{key}' missing content"
+            assert len(section["content"]) > 20, f"Section '{key}' content too short"
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /api/privacy/accept  (auth required)
+# ---------------------------------------------------------------------------
+
+class TestAcceptPrivacyPolicy:
+    def test_requires_auth(self, client):
+        resp = client.post("/api/privacy/accept")
+        assert resp.status_code == 401
+
+    def test_accept_returns_200_with_accepted_at(self, client, auth_headers):
+        resp = client.post("/api/privacy/accept", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "accepted_at" in data
+        assert data["accepted_at"] is not None
+        assert "policy_version" in data
+
+    def test_accept_is_idempotent(self, client, auth_headers):
+        """Calling accept multiple times should not fail."""
+        resp1 = client.post("/api/privacy/accept", headers=auth_headers)
+        resp2 = client.post("/api/privacy/accept", headers=auth_headers)
+        assert resp1.status_code == 200
+        assert resp2.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /api/privacy/consent-status  (auth required)
+# ---------------------------------------------------------------------------
+
+class TestConsentStatus:
+    def test_requires_auth(self, client):
+        resp = client.get("/api/privacy/consent-status")
+        assert resp.status_code == 401
+
+    def test_after_accept_has_accepted_is_true(self, client, auth_headers):
+        # Ensure accepted first
+        client.post("/api/privacy/accept", headers=auth_headers)
+        resp = client.get("/api/privacy/consent-status", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["has_accepted"] is True
+        assert data["accepted_at"] is not None
+
+    def test_consent_status_includes_policy_version(self, client, auth_headers):
+        resp = client.get("/api/privacy/consent-status", headers=auth_headers)
+        assert "current_policy_version" in resp.json()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import FullReadingPage from './pages/learning/FullReadingPage';
 import ReportPage from './pages/learning/ReportPage';
 import JoinClassroomPage from './pages/JoinClassroomPage';
 import MyAssignments from './pages/student/MyAssignments';
+import PrivacyPolicy from './pages/PrivacyPolicy';
 
 /** Redirect authenticated users away from auth pages. */
 const PublicOnlyRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -313,6 +314,16 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       </header>
 
       <main className="flex-1 flex flex-col overflow-hidden">{children}</main>
+
+      {/* Footer */}
+      <footer className="shrink-0 bg-white border-t border-gray-100 flex items-center justify-center py-1.5 px-4">
+        <button
+          onClick={() => navigate('/privacy')}
+          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          隱私政策
+        </button>
+      </footer>
     </div>
   );
 };
@@ -462,6 +473,9 @@ const App: React.FC = () => {
             {/* Default: redirect to intro */}
             <Route index element={<Navigate to="intro" replace />} />
           </Route>
+
+          {/* Privacy policy — public, no auth required */}
+          <Route path="/privacy" element={<PrivacyPolicy />} />
 
           {/* Catch-all: redirect to home */}
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/pages/PrivacyPolicy.tsx
+++ b/frontend/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface PolicySection {
+  title: string;
+  content: string;
+}
+
+interface PrivacyPolicyData {
+  version: string;
+  effective_date: string;
+  platform_name: string;
+  sections: Record<string, PolicySection>;
+  last_updated: string;
+}
+
+const SECTION_ORDER = [
+  'data_collection',
+  'audio_data',
+  'data_retention',
+  'data_deletion',
+  'children_privacy',
+  'contact',
+];
+
+/** Renders newline characters in policy content as paragraph breaks. */
+const PolicyContent: React.FC<{ text: string }> = ({ text }) => {
+  const paragraphs = text.split('\n\n');
+  return (
+    <div className="space-y-3">
+      {paragraphs.map((para, i) => {
+        const lines = para.split('\n');
+        return (
+          <p key={i} className="text-gray-700 leading-relaxed text-sm whitespace-pre-line">
+            {lines.join('\n')}
+          </p>
+        );
+      })}
+    </div>
+  );
+};
+
+const PrivacyPolicy: React.FC = () => {
+  const navigate = useNavigate();
+  const [policy, setPolicy] = useState<PrivacyPolicyData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const apiBase = import.meta.env.VITE_API_URL ?? '';
+    fetch(`${apiBase}/api/privacy/policy`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<PrivacyPolicyData>;
+      })
+      .then((data) => {
+        setPolicy(data);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError('無法載入隱私政策，請稍後再試。');
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-amber-50">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-8 h-8 border-3 border-amber-500 border-t-transparent rounded-full animate-spin" />
+          <span className="text-sm text-gray-500">載入隱私政策中...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !policy) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-amber-50 p-6">
+        <div className="bg-white rounded-xl shadow p-8 max-w-md text-center">
+          <p className="text-red-500 mb-4">{error ?? '發生未知錯誤'}</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            返回
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-amber-50 py-10 px-4">
+      <div className="max-w-3xl mx-auto">
+        {/* Header card */}
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8 mb-6">
+          <div className="flex items-center gap-3 mb-4">
+            <button
+              onClick={() => navigate(-1)}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+              aria-label="返回"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+            </button>
+            <h1 className="text-2xl font-bold text-gray-900">隱私政策</h1>
+          </div>
+          <p className="text-sm text-gray-500">
+            平台：{policy.platform_name}
+          </p>
+          <p className="text-sm text-gray-500 mt-1">
+            版本 {policy.version}．生效日期：{policy.effective_date}
+          </p>
+
+          {/* Audio data highlight box */}
+          <div className="mt-5 bg-blue-50 border border-blue-200 rounded-xl p-4">
+            <div className="flex items-start gap-3">
+              <svg
+                className="w-5 h-5 text-blue-500 shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 110 20A10 10 0 0112 2z"
+                />
+              </svg>
+              <div>
+                <p className="text-sm font-semibold text-blue-800 mb-1">關於錄音資料</p>
+                <p className="text-sm text-blue-700">
+                  本平台使用瀏覽器 Web Speech API 進行語音辨識。
+                  <strong>語音錄音原始檔案不會上傳至伺服器</strong>，僅有辨識後的文字結果會傳送至後端。
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Policy sections */}
+        <div className="space-y-4">
+          {SECTION_ORDER.filter((key) => key in policy.sections).map((key) => {
+            const section = policy.sections[key];
+            return (
+              <section
+                key={key}
+                className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6"
+              >
+                <h2 className="text-base font-bold text-gray-900 mb-3">{section.title}</h2>
+                <PolicyContent text={section.content} />
+              </section>
+            );
+          })}
+        </div>
+
+        {/* Footer note */}
+        <p className="text-center text-xs text-gray-400 mt-8">
+          最後更新：{policy.last_updated}．如有疑問請透過頁面內聯絡方式與我們聯繫。
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;


### PR DESCRIPTION
Fixes #265

## Summary

- **Backend**: New `GET /api/privacy/policy` public endpoint returns structured privacy policy in zh-TW JSON; `POST /api/privacy/accept` and `GET /api/privacy/consent-status` (auth required) to track user consent
- **Model**: Add `privacy_accepted_at` (nullable `DateTime`) column to `User` model — no migration needed on existing DBs (column is nullable/additive)
- **Frontend**: New `PrivacyPolicy` page at `/privacy` (public route, no auth required); blue callout box prominently clarifies audio is NOT uploaded to server
- **Footer**: "隱私政策" link added to `AppShell` footer visible to all authenticated users
- **Bug fix**: Fix pre-existing `SyntaxError` (duplicate keyword arg `teacher_limit`) in `organizations.py` that was blocking all tests

## Key facts stated in the policy

- Audio is processed via browser Web Speech API — raw audio files are never uploaded to the server
- Only text transcription results are sent to backend
- Student accounts created by school admins/teachers only
- Data retention: 30 days after account deactivation; system logs 90 days

## Test plan

- [x] `pytest tests/test_privacy_api.py -v` — 12/12 tests pass
- [x] `tsc --noEmit` — TypeScript passes with 0 errors
- [x] `vite build` — Production build succeeds
- [ ] Visit `/privacy` in PR Preview — verify page loads, all 6 sections display, blue audio callout visible
- [ ] Check footer "隱私政策" link navigates to `/privacy`
- [ ] `curl /api/privacy/policy` returns 200 without auth token

## DB Schema Note

`privacy_accepted_at` is a **nullable** column added to the `users` table. On Cloud SQL (PostgreSQL), `ALTER TABLE users ADD COLUMN privacy_accepted_at TIMESTAMPTZ` is safe and backward-compatible. SQLAlchemy will emit this on first startup if using `create_all` (dev), or it can be applied manually on production. No Alembic migration file included — please confirm if you want one created separately.

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>