### PR TITLE
feat: CSV 學生名單批量匯入 (Fixes #83)

### DIFF
--- a/backend/app/routes/classrooms.py
+++ b/backend/app/routes/classrooms.py
@@ -1,8 +1,11 @@
+import csv
+import io
 import logging
 import secrets
 import string
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from fastapi.responses import StreamingResponse
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
@@ -23,6 +26,7 @@ from ..schemas.classroom import (
     ClassroomStudentAddRequest,
     ClassroomUpdateRequest,
     CreatedStudentInfo,
+    CsvUploadResponse,
     StudentInClassroomResponse,
     StudentSearchRequest,
     StudentSearchResult,
@@ -211,6 +215,33 @@ def list_my_classrooms(
     return ClassroomListResponse(
         items=[_classroom_to_response(c, db) for c in items],
         total=total,
+    )
+
+
+@router.get("/classrooms/csv-template")
+def download_csv_template(
+    current_user: User = Depends(get_current_user),
+):
+    """Return a sample CSV template for batch student import.
+
+    IMPORTANT: This route MUST appear before /classrooms/{classroom_id} so that
+    FastAPI does not try to parse 'csv-template' as an integer classroom_id.
+
+    The template contains a header row and two example rows.
+    Encoded as UTF-8 with BOM so Excel opens it correctly.
+    """
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["name", "seat_number"])
+    writer.writerow(["王小明", "01"])
+    writer.writerow(["李小美", "02"])
+    csv_content = output.getvalue()
+    output.close()
+
+    return StreamingResponse(
+        iter([csv_content.encode("utf-8-sig")]),
+        media_type="text/csv; charset=UTF-8",
+        headers={"Content-Disposition": 'attachment; filename="student-import-template.csv"'},
     )
 
 
@@ -591,3 +622,224 @@ def search_students_for_classroom(
         StudentSearchResult(id=u.id, name=u.name, email=u.email)
         for u in results
     ]
+
+
+# ── CSV Upload ───────────────────────────────────────────────────────────────
+
+_CSV_MAX_FILE_BYTES = 1_000_000  # 1 MB
+_CSV_MAX_STUDENTS = 100
+
+# Recognised header aliases (case-insensitive) for the two columns
+_NAME_HEADERS = {"name", "姓名", "student_name", "學生姓名"}
+_SEAT_HEADERS = {"seat_number", "seat", "座號", "no", "number", "編號"}
+
+
+def _parse_csv_rows(content: str) -> list[tuple[str, str, str | None]]:
+    """Parse CSV content into (name, seat_number, error) tuples.
+
+    Returns a list of tuples:
+      - (name, seat_number, None) for valid rows
+      - ("", "", error_msg)       for invalid rows
+    If the first row looks like a header, it is skipped.
+    """
+    reader = csv.reader(io.StringIO(content))
+    rows = list(reader)
+    if not rows:
+        return []
+
+    # Detect header row: if first row contains recognised header keywords
+    first = [cell.strip().lower() for cell in rows[0]]
+    has_header = any(cell in _NAME_HEADERS or cell in _SEAT_HEADERS for cell in first)
+    data_rows = rows[1:] if has_header else rows
+
+    results: list[tuple[str, str, str | None]] = []
+    for idx, row in enumerate(data_rows, start=2 if has_header else 1):
+        # Skip entirely blank lines
+        if all(cell.strip() == "" for cell in row):
+            continue
+
+        if len(row) < 2:
+            results.append(("", "", f"第 {idx} 行：欄位數不足（需要 姓名, 座號）"))
+            continue
+
+        name = row[0].strip()
+        seat_number = row[1].strip()
+
+        if not name:
+            results.append(("", seat_number, f"第 {idx} 行：姓名不能為空"))
+            continue
+
+        if not seat_number:
+            results.append((name, "", f"第 {idx} 行：座號不能為空"))
+            continue
+
+        results.append((name, seat_number, None))
+
+    return results
+
+
+@router.post(
+    "/classrooms/{classroom_id}/students/upload-csv",
+    status_code=201,
+    response_model=CsvUploadResponse,
+)
+async def upload_csv_students(
+    classroom_id: int,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Batch-create student accounts from an uploaded CSV file.
+
+    CSV format (header row optional):
+        name,seat_number
+
+    Rules:
+    - Max file size: 1 MB
+    - Max students per upload: 100
+    - Rows with invalid data are skipped and reported in errors[]
+    - Duplicate seat numbers (same classroom join_code) are skipped
+
+    Returns created_count, skipped_count, errors[], created[].
+    """
+    classroom = _get_classroom_or_404(classroom_id, db)
+    _require_owner_or_admin(classroom, current_user, db)
+
+    if not classroom.join_code:
+        raise HTTPException(
+            status_code=400,
+            detail="Classroom has no join code; cannot generate student usernames",
+        )
+
+    # ── 1. Read and size-check the file ──────────────────────────────────────
+    raw_bytes = await file.read()
+
+    if len(raw_bytes) == 0:
+        raise HTTPException(status_code=422, detail="上傳的 CSV 檔案是空的")
+
+    if len(raw_bytes) > _CSV_MAX_FILE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"檔案過大（最大 {_CSV_MAX_FILE_BYTES // 1_000_000} MB）",
+        )
+
+    # Decode: try utf-8-sig first (strips BOM), fall back to utf-8
+    try:
+        content = raw_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        try:
+            content = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            raise HTTPException(status_code=422, detail="檔案編碼不支援，請使用 UTF-8")
+
+    # ── 2. Parse rows ─────────────────────────────────────────────────────────
+    parsed = _parse_csv_rows(content)
+
+    valid_rows = [(name, seat) for name, seat, err in parsed if err is None]
+    invalid_rows = [(name, seat, err) for name, seat, err in parsed if err is not None]
+
+    if len(valid_rows) > _CSV_MAX_STUDENTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"一次最多可匯入 {_CSV_MAX_STUDENTS} 位學生（本次 CSV 含 {len(valid_rows)} 筆有效資料）",
+        )
+
+    # ── 3. Batch-create students (same logic as JSON batch endpoint) ──────────
+    student_role = db.query(Role).filter(Role.name == "student").first()
+
+    created: list[CreatedStudentInfo] = []
+    errors: list[BatchStudentError] = []
+
+    # Carry forward parse errors as skipped entries
+    for _name, _seat, err_msg in invalid_rows:
+        errors.append(BatchStudentError(
+            name=_name or "(未知)",
+            seat_number=_seat or "(未知)",
+            error=err_msg or "格式錯誤",
+        ))
+
+    for name, seat_number in valid_rows:
+        try:
+            savepoint = db.begin_nested()
+            username = f"{classroom.join_code}{seat_number}"
+            email = f"{username.lower()}@student.lingoleap.local"
+
+            existing_user = db.query(User).filter(User.email == email).first()
+            if existing_user:
+                savepoint.rollback()
+                errors.append(BatchStudentError(
+                    name=name,
+                    seat_number=seat_number,
+                    error=f"座號 {seat_number} 已存在（帳號 {username} 重複）",
+                ))
+                continue
+
+            password = "".join(
+                secrets.choice(string.ascii_uppercase + string.digits) for _ in range(8)
+            )
+            user = User(
+                email=email,
+                username=username.upper(),
+                password_hash=hash_password(password),
+                name=name,
+                is_active=True,
+            )
+            db.add(user)
+            db.flush()
+
+            profile = StudentProfile(
+                user_id=user.id,
+                school_id=classroom.school_id,
+                student_number=username.upper(),
+                password_changed=False,
+            )
+            db.add(profile)
+
+            if student_role:
+                user_role = UserRole(
+                    user_id=user.id,
+                    role_id=student_role.id,
+                    scope_type="school",
+                    scope_id=str(classroom.school_id),
+                    granted_by=current_user.id,
+                )
+                db.add(user_role)
+
+            cs = ClassroomStudent(
+                classroom_id=classroom_id,
+                student_id=user.id,
+            )
+            db.add(cs)
+            db.flush()
+
+            created.append(CreatedStudentInfo(
+                name=name,
+                seat_number=seat_number,
+                username=username,
+                password=password,
+                user_id=user.id,
+            ))
+        except Exception as exc:
+            savepoint.rollback()
+            logger.error(
+                "CSV upload: error creating student %s (seat %s): %s",
+                name, seat_number, exc,
+            )
+            errors.append(BatchStudentError(
+                name=name,
+                seat_number=seat_number,
+                error=str(exc),
+            ))
+
+    db.commit()
+    skipped_count = len(errors)
+    logger.info(
+        "CSV upload: created %d, skipped %d for classroom %d (by user %d)",
+        len(created), skipped_count, classroom_id, current_user.id,
+    )
+    return CsvUploadResponse(
+        created_count=len(created),
+        skipped_count=skipped_count,
+        errors=errors,
+        created=created,
+    )

--- a/backend/app/routes/organizations.py
+++ b/backend/app/routes/organizations.py
@@ -54,7 +54,6 @@ def _org_to_response(org: Organization, school_count: int) -> OrganizationRespon
         is_active=org.is_active,
         created_at=org.created_at,
         school_count=school_count,
-        teacher_limit=org.teacher_limit,
         description=org.description,
         tax_id=org.tax_id,
         contact_email=org.contact_email,

--- a/backend/app/schemas/classroom.py
+++ b/backend/app/schemas/classroom.py
@@ -100,3 +100,13 @@ class StudentSearchResult(BaseModel):
     email: str
 
     model_config = {"from_attributes": True}
+
+
+# ── CSV Upload ───────────────────────────────────────────────────────────────
+
+
+class CsvUploadResponse(BaseModel):
+    created_count: int
+    skipped_count: int
+    errors: list[BatchStudentError]
+    created: list[CreatedStudentInfo]

--- a/backend/tests/test_csv_upload.py
+++ b/backend/tests/test_csv_upload.py
@@ -1,0 +1,551 @@
+"""
+Tests for CSV student import API endpoints.
+
+Covers:
+- GET  /api/classrooms/csv-template           (download CSV template)
+- POST /api/classrooms/{id}/students/upload-csv  (upload CSV to create students)
+
+Uses SQLite in-memory DB to avoid any external dependency.
+
+Run with:
+    cd /path/to/chinese-literacy-platform-issue-83/backend
+    python -m pytest tests/test_csv_upload.py -v
+"""
+
+import io
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, UserRole
+from app.models.school import School
+
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        session.add(Role(**role_data))
+    session.commit()
+
+
+def _seed_school(session) -> int:
+    school = School(name="CSV Test School")
+    session.add(school)
+    session.commit()
+    session.refresh(school)
+    return school.id
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+_test_school_id: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    global _test_school_id
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    _test_school_id = _seed_school(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def school_id():
+    return _test_school_id
+
+
+def _register_user(client, suffix: str) -> dict:
+    unique = uuid.uuid4().hex[:8]
+    email = f"{suffix}_{unique}@example.com"
+    password = "SecurePass123!"
+    name = f"{suffix.title()} {unique}"
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": name,
+    })
+    assert resp.status_code == 201
+    token = resp.json()["access_token"]
+    me_resp = client.get("/api/users/me", headers=auth_header(token))
+    user_id = me_resp.json()["id"]
+    return {"email": email, "name": name, "token": token, "user_id": user_id}
+
+
+def _make_admin(user_data: dict) -> dict:
+    db = TestingSessionLocal()
+    role = db.query(Role).filter(Role.name == "system_admin").first()
+    user_role = UserRole(
+        user_id=user_data["user_id"],
+        role_id=role.id,
+        scope_type="platform",
+        scope_id=None,
+    )
+    db.add(user_role)
+    db.commit()
+    db.close()
+    return user_data
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def make_csv_bytes(content: str) -> bytes:
+    """Helper to create CSV file bytes for upload."""
+    return content.encode("utf-8")
+
+
+@pytest.fixture(scope="module")
+def teacher(client):
+    return _register_user(client, "csv_teacher")
+
+
+@pytest.fixture(scope="module")
+def other_teacher(client):
+    return _register_user(client, "csv_other_teacher")
+
+
+@pytest.fixture(scope="module")
+def admin_user(client):
+    user = _register_user(client, "csv_admin")
+    return _make_admin(user)
+
+
+@pytest.fixture(scope="module")
+def classroom(client, teacher, school_id):
+    """Create a classroom for CSV upload tests."""
+    resp = client.post(
+        "/api/classrooms",
+        json={"name": "CSV Upload Classroom", "school_id": school_id},
+        headers=auth_header(teacher["token"]),
+    )
+    assert resp.status_code == 201
+    return resp.json()
+
+
+# ===========================================================================
+# GET /api/classrooms/csv-template
+# ===========================================================================
+
+
+class TestCsvTemplateDownload:
+    """Tests for the CSV template download endpoint."""
+
+    def test_download_template_success(self, client, teacher):
+        resp = client.get(
+            "/api/classrooms/csv-template",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        assert "text/csv" in resp.headers["content-type"]
+        assert "attachment" in resp.headers.get("content-disposition", "")
+
+    def test_template_has_header_row(self, client, teacher):
+        resp = client.get(
+            "/api/classrooms/csv-template",
+            headers=auth_header(teacher["token"]),
+        )
+        content = resp.content.decode("utf-8-sig")  # Handle BOM
+        lines = [line for line in content.strip().split("\n") if line.strip()]
+        assert len(lines) >= 1
+        header = lines[0].lower()
+        # Should contain name and seat_number columns
+        assert "name" in header or "姓名" in header
+        assert "seat" in header or "座號" in header
+
+    def test_template_has_example_rows(self, client, teacher):
+        resp = client.get(
+            "/api/classrooms/csv-template",
+            headers=auth_header(teacher["token"]),
+        )
+        content = resp.content.decode("utf-8-sig")
+        lines = [line for line in content.strip().split("\n") if line.strip()]
+        # Should have at least header + 1 example row
+        assert len(lines) >= 2
+
+    def test_template_requires_auth(self, client):
+        resp = client.get("/api/classrooms/csv-template")
+        assert resp.status_code == 401
+
+
+# ===========================================================================
+# POST /api/classrooms/{id}/students/upload-csv
+# ===========================================================================
+
+
+class TestCsvUpload:
+    """Tests for the CSV student upload endpoint."""
+
+    def test_upload_valid_csv_without_header(self, client, teacher, classroom):
+        classroom_id = classroom["id"]
+        csv_content = "王小明,01\n李小華,02\n陳大文,03\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("students.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["created_count"] >= 3
+        assert data["skipped_count"] == 0
+        assert len(data["errors"]) == 0
+
+    def test_upload_valid_csv_with_header(self, client, teacher, school_id):
+        # Create a fresh classroom for this test to avoid enrollment conflicts
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV Header Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        csv_content = "name,seat_number\n林小美,01\n黃大偉,02\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("students.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["created_count"] == 2
+        assert data["skipped_count"] == 0
+
+    def test_upload_returns_correct_structure(self, client, teacher, school_id):
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV Structure Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        csv_content = "測試學生,10\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("students.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        # Must have all required fields
+        assert "created_count" in data
+        assert "skipped_count" in data
+        assert "errors" in data
+        assert "created" in data
+        # Check created student info
+        assert len(data["created"]) == 1
+        student = data["created"][0]
+        assert "name" in student
+        assert "seat_number" in student
+        assert "username" in student
+        assert "password" in student
+        assert "user_id" in student
+
+    def test_upload_skips_duplicate_seat_numbers(self, client, teacher, school_id):
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV Dupe Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        # First upload
+        csv1 = "初次學生,01\n"
+        client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv1), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+
+        # Second upload with same seat number
+        csv2 = "重複學生,01\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv2), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["created_count"] == 0
+        assert data["skipped_count"] == 1
+        assert len(data["errors"]) == 1
+
+    def test_upload_partial_success(self, client, teacher, school_id):
+        """Valid rows succeed even when some rows fail."""
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV Partial Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        # Upload: first student good, second has empty name
+        csv_content = "有效學生,01\n,02\n另一有效,03\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["created_count"] == 2
+        assert data["skipped_count"] == 1
+        assert len(data["errors"]) == 1
+
+    def test_upload_requires_auth(self, client, classroom):
+        classroom_id = classroom["id"]
+        csv_content = "測試,01\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv_content), "text/csv")},
+        )
+        assert resp.status_code == 401
+
+    def test_upload_403_for_other_teacher(self, client, teacher, other_teacher, classroom):
+        classroom_id = classroom["id"]
+        csv_content = "測試,99\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+    def test_upload_404_nonexistent_classroom(self, client, teacher):
+        csv_content = "測試,01\n"
+        resp = client.post(
+            "/api/classrooms/99999/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 404
+
+    def test_upload_empty_file_returns_422(self, client, teacher, classroom):
+        classroom_id = classroom["id"]
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", b"", "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 422
+
+    def test_upload_respects_100_student_limit(self, client, teacher, school_id):
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV Limit Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        # Generate 101 student rows
+        rows = "\n".join(f"學生{i},{i:03d}" for i in range(1, 102))
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(rows), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 422
+        assert "100" in resp.json()["detail"]
+
+    def test_upload_admin_allowed(self, client, teacher, admin_user, school_id):
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV Admin Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        csv_content = "管理員建立,01\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(admin_user["token"]),
+        )
+        assert resp.status_code == 201
+        assert resp.json()["created_count"] == 1
+
+    def test_upload_csv_with_bom(self, client, teacher, school_id):
+        """Excel-exported CSV files often have a UTF-8 BOM."""
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV BOM Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        # Simulate Excel UTF-8 BOM CSV
+        csv_content_with_bom = "\ufeffname,seat_number\n蔡小英,01\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", csv_content_with_bom.encode("utf-8-sig"), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        assert resp.json()["created_count"] == 1
+
+    def test_upload_strips_whitespace_from_fields(self, client, teacher, school_id):
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV Whitespace Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        csv_content = "  空格學生  ,  05  \n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["created_count"] == 1
+        assert data["created"][0]["name"] == "空格學生"
+        assert data["created"][0]["seat_number"] == "05"
+
+    def test_upload_file_too_large_returns_413(self, client, teacher, classroom):
+        """Files exceeding 1MB should be rejected."""
+        classroom_id = classroom["id"]
+        # Generate > 1MB of CSV content
+        large_content = ("學生姓名很長的名字,001\n" * 60000).encode("utf-8")
+        assert len(large_content) > 1_000_000
+
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("large.csv", large_content, "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 413
+
+    def test_upload_wrong_column_count_rows_are_skipped(self, client, teacher, school_id):
+        """Rows with wrong number of columns should be reported as errors."""
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV ColCount Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        # Row 1: valid, Row 2: only 1 column, Row 3: valid
+        csv_content = "正確學生,01\n只有一欄\n另一正確,03\n"
+        resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("s.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["created_count"] == 2
+        assert data["skipped_count"] == 1
+
+
+# ===========================================================================
+# Integration: Full CSV import flow
+# ===========================================================================
+
+
+class TestCsvFullFlow:
+    def test_download_template_then_upload(self, client, teacher, school_id):
+        """Verify that template format matches what upload endpoint accepts."""
+        # 1. Download template
+        template_resp = client.get(
+            "/api/classrooms/csv-template",
+            headers=auth_header(teacher["token"]),
+        )
+        assert template_resp.status_code == 200
+
+        # 2. Create classroom
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "CSV Full Flow", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        classroom_id = cr.json()["id"]
+
+        # 3. Upload a valid CSV matching template format
+        csv_content = "name,seat_number\n王大明,01\n李小美,02\n張三,03\n"
+        upload_resp = client.post(
+            f"/api/classrooms/{classroom_id}/students/upload-csv",
+            files={"file": ("students.csv", make_csv_bytes(csv_content), "text/csv")},
+            headers=auth_header(teacher["token"]),
+        )
+        assert upload_resp.status_code == 201
+        data = upload_resp.json()
+        assert data["created_count"] == 3
+        assert data["skipped_count"] == 0
+
+        # 4. Verify students appear in classroom detail
+        detail_resp = client.get(
+            f"/api/classrooms/{classroom_id}",
+            headers=auth_header(teacher["token"]),
+        )
+        assert detail_resp.json()["student_count"] == 3

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -380,6 +380,7 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
           {activeTab === 'students' && (
             <StudentListTab
               classroom={classroom}
+              token={token}
               studentIdInput={studentIdInput}
               setStudentIdInput={setStudentIdInput}
               isAddingStudent={isAddingStudent}
@@ -390,6 +391,7 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
               onRemoveStudent={handleRemoveStudent}
               setRemovingStudentId={setRemovingStudentId}
               formatDate={formatDate}
+              onStudentsImported={loadClassroom}
             />
           )}
         </div>

--- a/frontend/src/pages/teacher/CsvUploadModal.tsx
+++ b/frontend/src/pages/teacher/CsvUploadModal.tsx
@@ -1,0 +1,344 @@
+import React, { useRef, useState } from 'react';
+import {
+  downloadCsvTemplate,
+  uploadCsvStudents,
+  type CsvUploadResult,
+} from '../../services/classroomApi';
+
+interface CsvUploadModalProps {
+  token: string;
+  classroomId: number;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+type UploadPhase = 'select' | 'preview' | 'result';
+
+interface ParsedRow {
+  name: string;
+  seat_number: string;
+}
+
+const MAX_PREVIEW_ROWS = 5;
+
+function parseCsvPreview(text: string): ParsedRow[] {
+  const lines = text.split(/\r?\n/).filter((l) => l.trim());
+  if (lines.length === 0) return [];
+
+  // Detect header
+  const firstLower = lines[0].toLowerCase();
+  const hasHeader = firstLower.includes('name') || firstLower.includes('姓名') || firstLower.includes('seat');
+  const dataLines = hasHeader ? lines.slice(1) : lines;
+
+  return dataLines.slice(0, MAX_PREVIEW_ROWS).map((line) => {
+    const parts = line.split(',');
+    return {
+      name: (parts[0] ?? '').trim(),
+      seat_number: (parts[1] ?? '').trim(),
+    };
+  });
+}
+
+const CsvUploadModal: React.FC<CsvUploadModalProps> = ({
+  token,
+  classroomId,
+  onClose,
+  onSuccess,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [phase, setPhase] = useState<UploadPhase>('select');
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewRows, setPreviewRows] = useState<ParsedRow[]>([]);
+  const [totalRows, setTotalRows] = useState(0);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadResult, setUploadResult] = useState<CsvUploadResult | null>(null);
+  const [error, setError] = useState('');
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError('');
+    setSelectedFile(file);
+
+    // Parse preview
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      const text = evt.target?.result as string;
+      const preview = parseCsvPreview(text);
+      // Count total data rows
+      const lines = text.split(/\r?\n/).filter((l) => l.trim());
+      const firstLower = lines[0]?.toLowerCase() ?? '';
+      const hasHeader = firstLower.includes('name') || firstLower.includes('姓名') || firstLower.includes('seat');
+      setTotalRows(hasHeader ? lines.length - 1 : lines.length);
+      setPreviewRows(preview);
+      setPhase('preview');
+    };
+    reader.readAsText(file, 'utf-8');
+  };
+
+  const handleUpload = async () => {
+    if (!selectedFile) return;
+    setIsUploading(true);
+    setError('');
+    try {
+      const result = await uploadCsvStudents(token, classroomId, selectedFile);
+      setUploadResult(result);
+      setPhase('result');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '上傳失敗，請重試';
+      setError(msg);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleReset = () => {
+    setPhase('select');
+    setSelectedFile(null);
+    setPreviewRows([]);
+    setTotalRows(0);
+    setUploadResult(null);
+    setError('');
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleDone = () => {
+    if (uploadResult && uploadResult.created_count > 0) {
+      onSuccess();
+    }
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg mx-4 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+          <h2 className="text-base font-bold text-gray-900">匯入 CSV 學生名單</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+            aria-label="關閉"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-5 space-y-4">
+          {/* Phase: select */}
+          {phase === 'select' && (
+            <>
+              <p className="text-sm text-gray-600">
+                上傳包含學生姓名和座號的 CSV 檔案，系統將自動建立帳號並加入班級。
+              </p>
+
+              {/* Format guide */}
+              <div className="bg-gray-50 rounded-lg px-4 py-3 text-xs text-gray-600 space-y-1">
+                <p className="font-medium text-gray-700">CSV 格式：</p>
+                <p className="font-mono">name,seat_number</p>
+                <p className="font-mono text-gray-500">王小明,01</p>
+                <p className="font-mono text-gray-500">李小美,02</p>
+                <p className="mt-2 text-gray-500">表頭行為可選，最多 100 位學生，檔案上限 1 MB</p>
+              </div>
+
+              {/* Template download */}
+              <button
+                onClick={() => downloadCsvTemplate(token)}
+                className="text-sm text-accent hover:text-accent-hover underline underline-offset-2 transition-colors cursor-pointer"
+              >
+                下載範本 CSV
+              </button>
+
+              {/* File input */}
+              <div>
+                <label
+                  htmlFor="csv-file-input"
+                  className="block w-full cursor-pointer border-2 border-dashed border-gray-300 hover:border-accent rounded-xl p-6 text-center transition-colors"
+                >
+                  <svg className="mx-auto w-8 h-8 text-gray-400 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                  </svg>
+                  <p className="text-sm font-medium text-gray-700">點擊或拖曳 CSV 檔案至此</p>
+                  <p className="text-xs text-gray-400 mt-1">支援 .csv 格式，UTF-8 或 UTF-8 BOM 編碼</p>
+                </label>
+                <input
+                  id="csv-file-input"
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".csv,text/csv"
+                  className="sr-only"
+                  onChange={handleFileChange}
+                />
+              </div>
+
+              {error && <p className="text-sm text-red-600">{error}</p>}
+            </>
+          )}
+
+          {/* Phase: preview */}
+          {phase === 'preview' && selectedFile && (
+            <>
+              <div className="flex items-center gap-2 text-sm text-gray-700">
+                <svg className="w-4 h-4 text-emerald-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <span>
+                  <span className="font-medium">{selectedFile.name}</span>
+                  {' '}— 共 <span className="font-medium text-accent">{totalRows}</span> 位學生
+                </span>
+              </div>
+
+              {previewRows.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-gray-500 mb-2">
+                    預覽（前 {Math.min(previewRows.length, MAX_PREVIEW_ROWS)} 筆）：
+                  </p>
+                  <div className="border border-gray-200 rounded-lg overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="bg-gray-50 text-left">
+                          <th className="px-3 py-2 text-xs font-medium text-gray-500">姓名</th>
+                          <th className="px-3 py-2 text-xs font-medium text-gray-500">座號</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {previewRows.map((row, i) => (
+                          <tr key={i}>
+                            <td className="px-3 py-2 text-gray-900">{row.name || <span className="text-red-400 italic">空白</span>}</td>
+                            <td className="px-3 py-2 text-gray-600">{row.seat_number || <span className="text-red-400 italic">空白</span>}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                    {totalRows > MAX_PREVIEW_ROWS && (
+                      <p className="px-3 py-2 text-xs text-gray-400 border-t border-gray-100">
+                        ...以及其餘 {totalRows - MAX_PREVIEW_ROWS} 位學生
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {error && <p className="text-sm text-red-600">{error}</p>}
+            </>
+          )}
+
+          {/* Phase: result */}
+          {phase === 'result' && uploadResult && (
+            <div className="space-y-3">
+              {/* Summary */}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="bg-emerald-50 border border-emerald-200 rounded-lg px-4 py-3 text-center">
+                  <p className="text-2xl font-bold text-emerald-700">{uploadResult.created_count}</p>
+                  <p className="text-xs text-emerald-600 mt-0.5">成功建立</p>
+                </div>
+                <div className={`border rounded-lg px-4 py-3 text-center ${uploadResult.skipped_count > 0 ? 'bg-amber-50 border-amber-200' : 'bg-gray-50 border-gray-200'}`}>
+                  <p className={`text-2xl font-bold ${uploadResult.skipped_count > 0 ? 'text-amber-700' : 'text-gray-500'}`}>
+                    {uploadResult.skipped_count}
+                  </p>
+                  <p className={`text-xs mt-0.5 ${uploadResult.skipped_count > 0 ? 'text-amber-600' : 'text-gray-400'}`}>跳過</p>
+                </div>
+              </div>
+
+              {/* Credentials table */}
+              {uploadResult.created.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-gray-500 mb-2">帳號資訊（請妥善保存）：</p>
+                  <div className="border border-gray-200 rounded-lg overflow-hidden max-h-48 overflow-y-auto">
+                    <table className="w-full text-xs">
+                      <thead className="bg-gray-50 sticky top-0">
+                        <tr>
+                          <th className="px-3 py-2 text-left font-medium text-gray-500">姓名</th>
+                          <th className="px-3 py-2 text-left font-medium text-gray-500">帳號</th>
+                          <th className="px-3 py-2 text-left font-medium text-gray-500">密碼</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {uploadResult.created.map((s, i) => (
+                          <tr key={i}>
+                            <td className="px-3 py-2 text-gray-900">{s.name}</td>
+                            <td className="px-3 py-2 font-mono text-gray-700">{s.username}</td>
+                            <td className="px-3 py-2 font-mono text-gray-700">{s.password}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {/* Errors */}
+              {uploadResult.errors.length > 0 && (
+                <div>
+                  <p className="text-xs font-medium text-amber-700 mb-1">
+                    跳過的項目（{uploadResult.errors.length} 筆）：
+                  </p>
+                  <ul className="space-y-1 max-h-32 overflow-y-auto">
+                    {uploadResult.errors.map((e, i) => (
+                      <li key={i} className="text-xs text-amber-800 bg-amber-50 border border-amber-100 rounded px-3 py-1.5">
+                        {e.name ? `${e.name}（座號 ${e.seat_number}）：` : ''}{e.error}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer buttons */}
+        <div className="px-6 py-4 border-t border-gray-100 flex gap-3 justify-end">
+          {phase === 'select' && (
+            <button
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
+            >
+              取消
+            </button>
+          )}
+
+          {phase === 'preview' && (
+            <>
+              <button
+                onClick={handleReset}
+                className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
+              >
+                重新選擇
+              </button>
+              <button
+                onClick={handleUpload}
+                disabled={isUploading || totalRows === 0}
+                className="bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white px-5 py-2 rounded-lg font-medium text-sm transition-colors cursor-pointer"
+              >
+                {isUploading ? '匯入中...' : `確認匯入 ${totalRows} 位學生`}
+              </button>
+            </>
+          )}
+
+          {phase === 'result' && (
+            <>
+              {uploadResult && uploadResult.created_count === 0 && (
+                <button
+                  onClick={handleReset}
+                  className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
+                >
+                  重試
+                </button>
+              )}
+              <button
+                onClick={handleDone}
+                className="bg-accent hover:bg-accent-hover text-white px-5 py-2 rounded-lg font-medium text-sm transition-colors cursor-pointer"
+              >
+                完成
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CsvUploadModal;

--- a/frontend/src/pages/teacher/StudentListTab.tsx
+++ b/frontend/src/pages/teacher/StudentListTab.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { ClassroomDetailResponse, StudentInClassroomResponse } from '../../services/classroomApi';
+import CsvUploadModal from './CsvUploadModal';
 
 interface StudentListTabProps {
   classroom: ClassroomDetailResponse;
+  token: string;
   studentIdInput: string;
   setStudentIdInput: (v: string) => void;
   isAddingStudent: boolean;
@@ -13,10 +15,12 @@ interface StudentListTabProps {
   onRemoveStudent: (s: StudentInClassroomResponse) => void;
   setRemovingStudentId: (id: number | null) => void;
   formatDate: (d: string) => string;
+  onStudentsImported: () => void;
 }
 
 const StudentListTab: React.FC<StudentListTabProps> = ({
   classroom,
+  token,
   studentIdInput,
   setStudentIdInput,
   isAddingStudent,
@@ -27,75 +31,102 @@ const StudentListTab: React.FC<StudentListTabProps> = ({
   onRemoveStudent,
   setRemovingStudentId,
   formatDate,
-}) => (
-  <>
-    {/* Add student form */}
-    <div className="p-5 border-b border-gray-100">
-      <form onSubmit={onAddStudent} className="flex gap-3 items-end">
-        <div className="flex-1">
-          <label htmlFor="add-student-id" className="block text-sm font-medium text-gray-700 mb-1">
-            新增學生
-          </label>
-          <input
-            id="add-student-id"
-            type="text"
-            value={studentIdInput}
-            onChange={(e) => {
-              setStudentIdInput(e.target.value);
-              setAddStudentError('');
-            }}
-            placeholder="輸入學生編號"
-            className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-          />
-        </div>
-        <button
-          type="submit"
-          disabled={isAddingStudent || !studentIdInput.trim()}
-          className="h-10 bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white px-4 rounded-lg font-medium text-sm transition-colors shrink-0"
-        >
-          {isAddingStudent ? '新增中...' : '新增'}
-        </button>
-      </form>
-      <p className="text-xs text-gray-400 mt-1">學生可在個人資料頁面查看自己的編號</p>
-      {addStudentError && (
-        <p className="text-red-600 text-sm mt-2">{addStudentError}</p>
-      )}
-    </div>
+  onStudentsImported,
+}) => {
+  const [showCsvModal, setShowCsvModal] = useState(false);
 
-    {classroom.students.length === 0 ? (
-      <div className="p-8 text-center">
-        <div className="inline-flex items-center justify-center w-12 h-12 bg-accent-bg rounded-xl mb-3">
-          <svg className="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
-          </svg>
+  return (
+    <>
+      {/* CSV upload modal */}
+      {showCsvModal && (
+        <CsvUploadModal
+          token={token}
+          classroomId={classroom.id}
+          onClose={() => setShowCsvModal(false)}
+          onSuccess={() => {
+            setShowCsvModal(false);
+            onStudentsImported();
+          }}
+        />
+      )}
+
+      {/* Add student form */}
+      <div className="p-5 border-b border-gray-100">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-sm font-medium text-gray-700">新增學生</span>
+          <button
+            onClick={() => setShowCsvModal(true)}
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-accent hover:text-accent-hover border border-accent/30 hover:border-accent/60 bg-accent-bg hover:bg-accent/10 px-3 py-1.5 rounded-lg transition-colors cursor-pointer"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M9 19l3 3m0 0l3-3m-3 3V10" />
+            </svg>
+            匯入 CSV
+          </button>
         </div>
-        <p className="text-sm font-medium text-gray-700 mb-1">尚無學生</p>
-        <p className="text-xs text-gray-500">使用上方表單新增學生至班級</p>
-      </div>
-    ) : (
-      <div className="divide-y divide-gray-100">
-        {classroom.students.map((s) => (
-          <div key={s.id} className="px-5 py-3 flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-gray-900">{s.name}</p>
-              <p className="text-xs text-gray-500">{s.email}</p>
-            </div>
-            <div className="flex items-center gap-3">
-              <span className="text-xs text-gray-400 hidden sm:inline">{formatDate(s.enrolled_at)}</span>
-              {removingStudentId === s.id ? (
-                <div className="flex gap-2">
-                  <button onClick={() => onRemoveStudent(s)} className="text-xs text-red-600 font-medium hover:text-red-800 transition-colors cursor-pointer">確認移除</button>
-                  <button onClick={() => setRemovingStudentId(null)} className="text-xs text-gray-500 hover:text-gray-700 transition-colors cursor-pointer">取消</button>
-                </div>
-              ) : (
-                <button onClick={() => onRemoveStudent(s)} className="text-xs text-gray-400 hover:text-red-600 transition-colors cursor-pointer">移除</button>
-              )}
-            </div>
+        <form onSubmit={onAddStudent} className="flex gap-3 items-end">
+          <div className="flex-1">
+            <input
+              id="add-student-id"
+              type="text"
+              value={studentIdInput}
+              onChange={(e) => {
+                setStudentIdInput(e.target.value);
+                setAddStudentError('');
+              }}
+              placeholder="輸入學生編號"
+              className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+            />
           </div>
-        ))}
+          <button
+            type="submit"
+            disabled={isAddingStudent || !studentIdInput.trim()}
+            className="h-10 bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white px-4 rounded-lg font-medium text-sm transition-colors shrink-0"
+          >
+            {isAddingStudent ? '新增中...' : '新增'}
+          </button>
+        </form>
+        <p className="text-xs text-gray-400 mt-1">學生可在個人資料頁面查看自己的編號</p>
+        {addStudentError && (
+          <p className="text-red-600 text-sm mt-2">{addStudentError}</p>
+        )}
       </div>
-    )}
-  </>
-);
+
+      {classroom.students.length === 0 ? (
+        <div className="p-8 text-center">
+          <div className="inline-flex items-center justify-center w-12 h-12 bg-accent-bg rounded-xl mb-3">
+            <svg className="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </div>
+          <p className="text-sm font-medium text-gray-700 mb-1">尚無學生</p>
+          <p className="text-xs text-gray-500">使用上方表單新增學生，或點擊「匯入 CSV」批量匯入</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-gray-100">
+          {classroom.students.map((s) => (
+            <div key={s.id} className="px-5 py-3 flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-900">{s.name}</p>
+                <p className="text-xs text-gray-500">{s.email}</p>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-gray-400 hidden sm:inline">{formatDate(s.enrolled_at)}</span>
+                {removingStudentId === s.id ? (
+                  <div className="flex gap-2">
+                    <button onClick={() => onRemoveStudent(s)} className="text-xs text-red-600 font-medium hover:text-red-800 transition-colors cursor-pointer">確認移除</button>
+                    <button onClick={() => setRemovingStudentId(null)} className="text-xs text-gray-500 hover:text-gray-700 transition-colors cursor-pointer">取消</button>
+                  </div>
+                ) : (
+                  <button onClick={() => onRemoveStudent(s)} className="text-xs text-gray-400 hover:text-red-600 transition-colors cursor-pointer">移除</button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+};
 
 export default StudentListTab;

--- a/frontend/src/services/classroomApi.ts
+++ b/frontend/src/services/classroomApi.ts
@@ -242,3 +242,58 @@ export async function batchCreateStudents(
   );
   return handleResponse<BatchCreateResult>(res);
 }
+
+// --- CSV Upload ---
+
+export interface CsvUploadError {
+  name: string;
+  seat_number: string;
+  error: string;
+}
+
+export interface CsvUploadResult {
+  created_count: number;
+  skipped_count: number;
+  errors: CsvUploadError[];
+  created: {
+    name: string;
+    seat_number: string;
+    username: string;
+    password: string;
+    user_id: number;
+  }[];
+}
+
+export async function uploadCsvStudents(
+  token: string,
+  classroomId: number,
+  file: File,
+): Promise<CsvUploadResult> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch(
+    `${API_BASE}/api/classrooms/${classroomId}/students/upload-csv`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    },
+  );
+  return handleResponse<CsvUploadResult>(res);
+}
+
+export function downloadCsvTemplate(token: string): void {
+  const url = `${API_BASE}/api/classrooms/csv-template`;
+  fetch(url, { headers: { Authorization: `Bearer ${token}` } })
+    .then((res) => res.blob())
+    .then((blob) => {
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = blobUrl;
+      a.download = 'student-import-template.csv';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(blobUrl);
+    });
+}


### PR DESCRIPTION
Fixes #83

## Summary

- **Backend** — 2 new endpoints in `classrooms.py`:
  - `GET /api/classrooms/csv-template` — UTF-8 BOM CSV template download (auth required, placed before `{classroom_id}` route to avoid routing conflict)
  - `POST /api/classrooms/{id}/students/upload-csv` — multipart file upload, reuses existing batch-create logic
- **Frontend** — new `CsvUploadModal` component with 3-phase UX: file select → preview → result; "匯入 CSV" button added to `StudentListTab`
- **Tests** — `backend/tests/test_csv_upload.py` with 20 test cases (TDD: written before implementation)
- **Bug fix** — removed duplicate `teacher_limit` kwarg in `organizations.py` that caused a SyntaxError

## Key design decisions

| Decision | Reason |
|----------|--------|
| Route order: `/classrooms/csv-template` before `/classrooms/{classroom_id}` | FastAPI routes match in order; prevents "csv-template" being parsed as int |
| Reuse batch-create logic | Consistency with existing JSON batch endpoint; same join_code + seat_number username scheme |
| Auto-detect header row | Recognises `name`/`seat_number`/`姓名`/`座號` — teacher does not need to strip the header |
| BOM-tolerant decoding | Excel exports CSVs with UTF-8 BOM; `utf-8-sig` codec strips it automatically |
| Partial success | Valid rows succeed even when other rows fail; errors reported per-row |

## Test plan

1. Open the PR Preview URL (posted by CI as a comment)
2. Log in as a teacher account
3. Navigate to any classroom > "學生名單" tab
4. Click "下載範本" — verify a CSV file downloads with `name,seat_number` header and 2 example rows
5. Click "匯入 CSV"
6. Upload the downloaded template (or a custom CSV)
7. Verify preview shows the first 5 rows before submitting
8. Click "確認匯入" — verify the result screen shows created_count and the credentials table
9. Close the modal — verify new students appear in the student list
10. Upload the same CSV again — verify skipped_count = same number and errors list is populated

## Files changed

| File | Change |
|------|--------|
| `backend/app/routes/classrooms.py` | Add `_parse_csv_rows`, `download_csv_template`, `upload_csv_students` |
| `backend/app/schemas/classroom.py` | Add `CsvUploadResponse` schema |
| `backend/app/routes/organizations.py` | Fix duplicate `teacher_limit` kwarg (SyntaxError) |
| `backend/tests/test_csv_upload.py` | 20 new TDD tests |
| `frontend/src/services/classroomApi.ts` | Add `uploadCsvStudents`, `downloadCsvTemplate`, response types |
| `frontend/src/pages/teacher/CsvUploadModal.tsx` | New modal component (3-phase UX) |
| `frontend/src/pages/teacher/StudentListTab.tsx` | Add "匯入 CSV" button + modal wiring |
| `frontend/src/pages/teacher/ClassroomDetail.tsx` | Pass `token` and `onStudentsImported` to `StudentListTab` |