### PR TITLE
feat: analytics API + Recharts dashboard (#21, #22)

### DIFF
--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -16,7 +16,7 @@ from ..auth.dependencies import get_current_user
 from ..database import get_db
 from ..dependencies.tenant import _check_classroom_access
 from ..models.school import Classroom, ClassroomStudent, ClassroomText
-from ..models.session import LearningSession
+from ..models.session import CharacterError, LearningSession
 from ..models.user import User
 from ..services.lesson_loader import get_lesson_by_id
 from .classrooms import _get_classroom_or_404, _require_owner_or_admin
@@ -56,6 +56,9 @@ class ClassroomStatsResponse(BaseModel):
     total_sessions: int
     active_students: int
     inactive_students: int
+    avg_accuracy: float | None
+    completion_rate: float
+    avg_session_duration_minutes: float | None
 
     model_config = {"from_attributes": True}
 
@@ -67,6 +70,25 @@ class StudentSessionResponse(BaseModel):
     completed_at: datetime | None
     overall_score: float | None
     status: str
+
+    model_config = {"from_attributes": True}
+
+
+class ErrorVocabItem(BaseModel):
+    character: str
+    error_type: str
+    count: int
+    student_count: int
+
+    model_config = {"from_attributes": True}
+
+
+class TimeStatsResponse(BaseModel):
+    total_hours: float
+    avg_minutes_per_session: float | None
+    study_days: int
+    sessions_this_week: int
+    sessions_last_week: int
 
     model_config = {"from_attributes": True}
 
@@ -215,6 +237,9 @@ def get_classroom_stats(
             total_sessions=0,
             active_students=0,
             inactive_students=0,
+            avg_accuracy=None,
+            completion_rate=0.0,
+            avg_session_duration_minutes=None,
         )
 
     # Count total sessions for these students
@@ -237,11 +262,189 @@ def get_classroom_stats(
     )
     active_students = len(active_student_ids)
 
+    # Average accuracy from completed sessions' overall_score
+    avg_accuracy = (
+        db.query(func.avg(LearningSession.overall_score))
+        .filter(
+            LearningSession.student_id.in_(student_ids),
+            LearningSession.status == "completed",
+            LearningSession.overall_score.isnot(None),
+        )
+        .scalar()
+    )
+
+    # Completion rate = completed / total
+    completed_count = (
+        db.query(func.count(LearningSession.id))
+        .filter(
+            LearningSession.student_id.in_(student_ids),
+            LearningSession.status == "completed",
+        )
+        .scalar()
+    )
+    completion_rate = (completed_count / total_sessions) if total_sessions else 0.0
+
+    # Average session duration (completed sessions with both timestamps)
+    completed_sessions = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.student_id.in_(student_ids),
+            LearningSession.status == "completed",
+            LearningSession.started_at.isnot(None),
+            LearningSession.completed_at.isnot(None),
+        )
+        .all()
+    )
+    avg_duration = None
+    if completed_sessions:
+        durations = []
+        for s in completed_sessions:
+            delta = (s.completed_at - s.started_at).total_seconds() / 60.0
+            if delta > 0:
+                durations.append(delta)
+        if durations:
+            avg_duration = round(sum(durations) / len(durations), 1)
+
     return ClassroomStatsResponse(
         total_students=total_students,
         total_sessions=total_sessions,
         active_students=active_students,
         inactive_students=total_students - active_students,
+        avg_accuracy=round(avg_accuracy, 1) if avg_accuracy is not None else None,
+        completion_rate=round(completion_rate, 2),
+        avg_session_duration_minutes=avg_duration,
+    )
+
+
+@router.get(
+    "/teacher/classrooms/{classroom_id}/error-vocab",
+    response_model=list[ErrorVocabItem],
+)
+def get_classroom_error_vocab(
+    classroom_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get top 20 most frequent character errors for a classroom."""
+    classroom = _check_classroom_access(current_user, classroom_id, db)
+
+    student_ids = [
+        row[0]
+        for row in db.query(ClassroomStudent.student_id)
+        .filter(ClassroomStudent.classroom_id == classroom_id)
+        .all()
+    ]
+
+    if not student_ids:
+        return []
+
+    # Query CharacterError joined through LearningSession, filtered by classroom students
+    rows = (
+        db.query(
+            CharacterError.character,
+            CharacterError.error_type,
+            func.count(CharacterError.id).label("count"),
+            func.count(func.distinct(LearningSession.student_id)).label("student_count"),
+        )
+        .join(LearningSession, CharacterError.session_id == LearningSession.id)
+        .filter(LearningSession.student_id.in_(student_ids))
+        .group_by(CharacterError.character, CharacterError.error_type)
+        .order_by(func.count(CharacterError.id).desc())
+        .limit(20)
+        .all()
+    )
+
+    return [
+        ErrorVocabItem(
+            character=row.character,
+            error_type=row.error_type,
+            count=row.count,
+            student_count=row.student_count,
+        )
+        for row in rows
+    ]
+
+
+@router.get(
+    "/teacher/classrooms/{classroom_id}/time-stats",
+    response_model=TimeStatsResponse,
+)
+def get_classroom_time_stats(
+    classroom_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get learning time statistics for a classroom."""
+    classroom = _check_classroom_access(current_user, classroom_id, db)
+
+    student_ids = [
+        row[0]
+        for row in db.query(ClassroomStudent.student_id)
+        .filter(ClassroomStudent.classroom_id == classroom_id)
+        .all()
+    ]
+
+    if not student_ids:
+        return TimeStatsResponse(
+            total_hours=0.0,
+            avg_minutes_per_session=None,
+            study_days=0,
+            sessions_this_week=0,
+            sessions_last_week=0,
+        )
+
+    # All sessions for classroom students
+    sessions = (
+        db.query(LearningSession)
+        .filter(LearningSession.student_id.in_(student_ids))
+        .all()
+    )
+
+    # Total hours and average duration from sessions with both timestamps
+    total_minutes = 0.0
+    duration_count = 0
+    for s in sessions:
+        if s.started_at and s.completed_at:
+            delta = (s.completed_at - s.started_at).total_seconds() / 60.0
+            if delta > 0:
+                total_minutes += delta
+                duration_count += 1
+
+    total_hours = round(total_minutes / 60.0, 1)
+    avg_minutes = round(total_minutes / duration_count, 1) if duration_count else None
+
+    # Distinct study days
+    study_days = len({s.started_at.date() for s in sessions if s.started_at})
+
+    # Sessions this week and last week
+    now = datetime.now(timezone.utc)
+    # Monday of this week
+    this_monday = (now - timedelta(days=now.weekday())).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    last_monday = this_monday - timedelta(days=7)
+
+    def _make_aware(dt: datetime) -> datetime:
+        """Ensure datetime is timezone-aware (handles SQLite naive datetimes)."""
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt
+
+    sessions_this_week = sum(
+        1 for s in sessions if s.started_at and _make_aware(s.started_at) >= this_monday
+    )
+    sessions_last_week = sum(
+        1
+        for s in sessions
+        if s.started_at and last_monday <= _make_aware(s.started_at) < this_monday
+    )
+
+    return TimeStatsResponse(
+        total_hours=total_hours,
+        avg_minutes_per_session=avg_minutes,
+        study_days=study_days,
+        sessions_this_week=sessions_this_week,
+        sessions_last_week=sessions_last_week,
     )
 
 

--- a/backend/tests/test_teacher_analytics.py
+++ b/backend/tests/test_teacher_analytics.py
@@ -1,0 +1,573 @@
+"""
+Tests for teacher analytics API endpoints.
+
+Covers:
+- GET /api/teacher/classrooms/{id}/stats   (enhanced with avg_accuracy, completion_rate, duration)
+- GET /api/teacher/classrooms/{id}/error-vocab  (character error frequency)
+- GET /api/teacher/classrooms/{id}/time-stats   (learning time statistics)
+
+Uses SQLite in-memory DB to avoid any external dependency.
+
+Run with:
+    cd backend && python -m pytest tests/test_teacher_analytics.py -v
+"""
+
+import sys
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, UserRole
+from app.models.school import School
+from app.models.session import CharacterError, LearningSession
+
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        session.add(Role(**role_data))
+    session.commit()
+
+
+def _seed_school(session) -> int:
+    school = School(name="Analytics Test School")
+    session.add(school)
+    session.commit()
+    session.refresh(school)
+    return school.id
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# Module-level state
+_test_school_id: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    global _test_school_id
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    _test_school_id = _seed_school(session)
+    session.close()
+
+    from app.routes.auth import rate_limiter
+    rate_limiter.reset()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def school_id():
+    return _test_school_id
+
+
+def _register_user(client, suffix: str) -> dict:
+    unique = uuid.uuid4().hex[:8]
+    email = f"{suffix}_{unique}@example.com"
+    password = "SecurePass123!"
+    name = f"{suffix.title()} {unique}"
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": name,
+    })
+    assert resp.status_code == 201
+    token = resp.json()["access_token"]
+    me_resp = client.get("/api/users/me", headers=_auth(token))
+    user_id = me_resp.json()["id"]
+    return {"email": email, "name": name, "token": token, "user_id": user_id}
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_admin(user_id: int):
+    db = TestingSessionLocal()
+    role = db.query(Role).filter(Role.name == "system_admin").first()
+    user_role = UserRole(
+        user_id=user_id,
+        role_id=role.id,
+        scope_type="platform",
+        scope_id=None,
+    )
+    db.add(user_role)
+    db.commit()
+    db.close()
+
+
+@pytest.fixture(scope="module")
+def teacher(client):
+    return _register_user(client, "analytics_teacher")
+
+
+@pytest.fixture(scope="module")
+def other_teacher(client):
+    return _register_user(client, "analytics_other")
+
+
+@pytest.fixture(scope="module")
+def student1(client):
+    return _register_user(client, "analytics_stu1")
+
+
+@pytest.fixture(scope="module")
+def student2(client):
+    return _register_user(client, "analytics_stu2")
+
+
+@pytest.fixture(scope="module")
+def admin_user(client):
+    user = _register_user(client, "analytics_admin")
+    _make_admin(user["user_id"])
+    return user
+
+
+def _create_classroom_with_students(client, teacher, students, school_id, name="Test Class"):
+    """Helper to create a classroom and enroll students."""
+    resp = client.post(
+        "/api/classrooms",
+        json={"name": name, "school_id": school_id},
+        headers=_auth(teacher["token"]),
+    )
+    assert resp.status_code == 201
+    classroom_id = resp.json()["id"]
+
+    for student in students:
+        client.post(
+            f"/api/classrooms/{classroom_id}/students",
+            json={"student_id": student["user_id"]},
+            headers=_auth(teacher["token"]),
+        )
+
+    return classroom_id
+
+
+# ===========================================================================
+# Enhanced stats endpoint
+# ===========================================================================
+
+
+class TestEnhancedClassroomStats:
+    def test_returns_new_fields(self, client, teacher, student1, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1], school_id, "Enhanced Stats Class"
+        )
+
+        # Create a completed session with score
+        db = TestingSessionLocal()
+        session = LearningSession(
+            student_id=student1["user_id"],
+            story_slug="1",
+            status="completed",
+            overall_score=85.0,
+            started_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            completed_at=datetime.now(timezone.utc),
+        )
+        db.add(session)
+        db.commit()
+        db.close()
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/stats",
+            headers=_auth(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Check all new fields exist
+        assert "avg_accuracy" in data
+        assert "completion_rate" in data
+        assert "avg_session_duration_minutes" in data
+
+    def test_avg_accuracy_computed(self, client, teacher, student1, student2, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1, student2], school_id, "Accuracy Stats Class"
+        )
+
+        db = TestingSessionLocal()
+        # Two completed sessions with different scores
+        db.add(LearningSession(
+            student_id=student1["user_id"],
+            story_slug="1",
+            status="completed",
+            overall_score=80.0,
+            started_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            completed_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        ))
+        db.add(LearningSession(
+            student_id=student2["user_id"],
+            story_slug="2",
+            status="completed",
+            overall_score=60.0,
+            started_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            completed_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        ))
+        db.commit()
+        db.close()
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/stats",
+            headers=_auth(teacher["token"]),
+        )
+        data = resp.json()
+        assert data["avg_accuracy"] is not None
+        # avg of 80 and 60 = 70 (approximately, other sessions may exist)
+        assert isinstance(data["avg_accuracy"], (int, float))
+
+    def test_completion_rate_computed(self, client, teacher, student1, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1], school_id, "Completion Rate Class"
+        )
+
+        db = TestingSessionLocal()
+        # One completed, one in_progress
+        db.add(LearningSession(
+            student_id=student1["user_id"],
+            story_slug="1",
+            status="completed",
+            overall_score=90.0,
+            started_at=datetime.now(timezone.utc) - timedelta(hours=2),
+            completed_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        ))
+        db.add(LearningSession(
+            student_id=student1["user_id"],
+            story_slug="2",
+            status="in_progress",
+            started_at=datetime.now(timezone.utc) - timedelta(minutes=30),
+        ))
+        db.commit()
+        db.close()
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/stats",
+            headers=_auth(teacher["token"]),
+        )
+        data = resp.json()
+        assert data["completion_rate"] > 0
+        assert data["completion_rate"] <= 1.0
+
+    def test_empty_classroom_returns_defaults(self, client, teacher, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [], school_id, "Empty Analytics Class"
+        )
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/stats",
+            headers=_auth(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_students"] == 0
+        assert data["total_sessions"] == 0
+        assert data["avg_accuracy"] is None
+        assert data["completion_rate"] == 0.0
+        assert data["avg_session_duration_minutes"] is None
+
+
+# ===========================================================================
+# Error vocabulary endpoint
+# ===========================================================================
+
+
+class TestErrorVocabEndpoint:
+    def test_returns_200(self, client, teacher, student1, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1], school_id, "ErrorVocab Class"
+        )
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/error-vocab",
+            headers=_auth(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_returns_seeded_errors(self, client, teacher, student1, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1], school_id, "ErrorVocab Seeded"
+        )
+
+        db = TestingSessionLocal()
+        session = LearningSession(
+            student_id=student1["user_id"],
+            story_slug="1",
+            status="completed",
+            started_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            completed_at=datetime.now(timezone.utc),
+        )
+        db.add(session)
+        db.flush()
+
+        # Add character errors
+        db.add(CharacterError(session_id=session.id, character="的", error_type="substitution"))
+        db.add(CharacterError(session_id=session.id, character="的", error_type="substitution"))
+        db.add(CharacterError(session_id=session.id, character="是", error_type="omission"))
+        db.commit()
+        db.close()
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/error-vocab",
+            headers=_auth(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) >= 1
+
+        # Check structure
+        first = data[0]
+        assert "character" in first
+        assert "error_type" in first
+        assert "count" in first
+        assert "student_count" in first
+
+    def test_ordered_by_count_desc(self, client, teacher, student1, student2, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1, student2], school_id, "ErrorVocab Ordered"
+        )
+
+        db = TestingSessionLocal()
+        s1 = LearningSession(
+            student_id=student1["user_id"], story_slug="1", status="completed",
+            started_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            completed_at=datetime.now(timezone.utc),
+        )
+        s2 = LearningSession(
+            student_id=student2["user_id"], story_slug="1", status="completed",
+            started_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            completed_at=datetime.now(timezone.utc),
+        )
+        db.add_all([s1, s2])
+        db.flush()
+
+        # "了" appears 3 times, "我" appears 1 time
+        db.add(CharacterError(session_id=s1.id, character="了", error_type="substitution"))
+        db.add(CharacterError(session_id=s1.id, character="了", error_type="substitution"))
+        db.add(CharacterError(session_id=s2.id, character="了", error_type="substitution"))
+        db.add(CharacterError(session_id=s1.id, character="我", error_type="omission"))
+        db.commit()
+        db.close()
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/error-vocab",
+            headers=_auth(teacher["token"]),
+        )
+        data = resp.json()
+        # First item should have the highest count
+        if len(data) >= 2:
+            assert data[0]["count"] >= data[1]["count"]
+
+    def test_empty_classroom_returns_empty(self, client, teacher, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [], school_id, "ErrorVocab Empty"
+        )
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/error-vocab",
+            headers=_auth(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_returns_401_without_auth(self, client, teacher, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [], school_id, "ErrorVocab Auth"
+        )
+
+        resp = client.get(f"/api/teacher/classrooms/{classroom_id}/error-vocab")
+        assert resp.status_code == 401
+
+    def test_returns_403_for_non_owner(self, client, teacher, other_teacher, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [], school_id, "ErrorVocab Forbidden"
+        )
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/error-vocab",
+            headers=_auth(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+
+# ===========================================================================
+# Time stats endpoint
+# ===========================================================================
+
+
+class TestTimeStatsEndpoint:
+    def test_returns_200(self, client, teacher, student1, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1], school_id, "TimeStats Class"
+        )
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/time-stats",
+            headers=_auth(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "total_hours" in data
+        assert "avg_minutes_per_session" in data
+        assert "study_days" in data
+        assert "sessions_this_week" in data
+        assert "sessions_last_week" in data
+
+    def test_computes_from_sessions(self, client, teacher, student1, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1], school_id, "TimeStats Compute"
+        )
+
+        now = datetime.now(timezone.utc)
+        db = TestingSessionLocal()
+        # Two sessions, each 30 minutes
+        db.add(LearningSession(
+            student_id=student1["user_id"],
+            story_slug="1",
+            status="completed",
+            started_at=now - timedelta(hours=2),
+            completed_at=now - timedelta(hours=1, minutes=30),
+        ))
+        db.add(LearningSession(
+            student_id=student1["user_id"],
+            story_slug="2",
+            status="completed",
+            started_at=now - timedelta(hours=1),
+            completed_at=now - timedelta(minutes=30),
+        ))
+        db.commit()
+        db.close()
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/time-stats",
+            headers=_auth(teacher["token"]),
+        )
+        data = resp.json()
+        assert data["total_hours"] >= 0
+        assert data["avg_minutes_per_session"] is not None
+        assert data["avg_minutes_per_session"] > 0
+        assert data["study_days"] >= 1
+
+    def test_empty_classroom_returns_defaults(self, client, teacher, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [], school_id, "TimeStats Empty"
+        )
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/time-stats",
+            headers=_auth(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_hours"] == 0.0
+        assert data["avg_minutes_per_session"] is None
+        assert data["study_days"] == 0
+        assert data["sessions_this_week"] == 0
+        assert data["sessions_last_week"] == 0
+
+    def test_returns_401_without_auth(self, client, teacher, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [], school_id, "TimeStats Auth"
+        )
+
+        resp = client.get(f"/api/teacher/classrooms/{classroom_id}/time-stats")
+        assert resp.status_code == 401
+
+    def test_returns_403_for_non_owner(self, client, teacher, other_teacher, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [], school_id, "TimeStats Forbidden"
+        )
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/time-stats",
+            headers=_auth(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+    def test_sessions_this_week_counted(self, client, teacher, student1, school_id):
+        classroom_id = _create_classroom_with_students(
+            client, teacher, [student1], school_id, "TimeStats Week"
+        )
+
+        now = datetime.now(timezone.utc)
+        db = TestingSessionLocal()
+        # Session today (should be in "this week")
+        db.add(LearningSession(
+            student_id=student1["user_id"],
+            story_slug="1",
+            status="completed",
+            started_at=now - timedelta(hours=1),
+            completed_at=now,
+        ))
+        db.commit()
+        db.close()
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/time-stats",
+            headers=_auth(teacher["token"]),
+        )
+        data = resp.json()
+        assert data["sessions_this_week"] >= 1

--- a/frontend/src/pages/teacher/ClassroomAnalytics.tsx
+++ b/frontend/src/pages/teacher/ClassroomAnalytics.tsx
@@ -1,0 +1,322 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  getClassroomStats,
+  getClassroomProgress,
+  getStudentSessions,
+  getErrorVocab,
+  getTimeStats,
+  ClassroomStats,
+  StudentProgress,
+  StudentSession,
+  ErrorVocabItem,
+  TimeStats,
+  TeacherApiError,
+} from '../../services/teacherApi';
+
+interface ClassroomAnalyticsProps {
+  classroomId: number;
+}
+
+// Color palette for multi-student lines
+const LINE_COLORS = [
+  '#6366f1', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6',
+  '#ec4899', '#14b8a6', '#f97316', '#06b6d4', '#84cc16',
+];
+
+interface AccuracyDataPoint {
+  date: string;
+  [studentName: string]: string | number | null;
+}
+
+const ClassroomAnalytics: React.FC<ClassroomAnalyticsProps> = ({ classroomId }) => {
+  const { token } = useAuth();
+  const [stats, setStats] = useState<ClassroomStats | null>(null);
+  const [errorVocab, setErrorVocab] = useState<ErrorVocabItem[]>([]);
+  const [timeStats, setTimeStats] = useState<TimeStats | null>(null);
+  const [accuracyData, setAccuracyData] = useState<AccuracyDataPoint[]>([]);
+  const [studentNames, setStudentNames] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const loadData = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      // Fetch all data in parallel
+      const [statsData, errorData, timeData, progressData] = await Promise.all([
+        getClassroomStats(token, classroomId),
+        getErrorVocab(token, classroomId),
+        getTimeStats(token, classroomId),
+        getClassroomProgress(token, classroomId),
+      ]);
+
+      setStats(statsData);
+      setErrorVocab(errorData);
+      setTimeStats(timeData);
+
+      // Build accuracy trend data from per-student sessions
+      await buildAccuracyTrend(progressData);
+    } catch (err) {
+      if (err instanceof TeacherApiError) {
+        setError(err.message);
+      } else {
+        setError('無法載入分析資料');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, classroomId]);
+
+  const buildAccuracyTrend = async (progressData: StudentProgress[]) => {
+    if (!token || progressData.length === 0) {
+      setAccuracyData([]);
+      setStudentNames([]);
+      return;
+    }
+
+    // Fetch sessions for up to 10 students (avoid too many requests)
+    const studentsToShow = progressData
+      .filter((s) => s.total_sessions > 0)
+      .slice(0, 10);
+
+    if (studentsToShow.length === 0) {
+      setAccuracyData([]);
+      setStudentNames([]);
+      return;
+    }
+
+    const sessionsMap: Record<string, StudentSession[]> = {};
+    const names: string[] = [];
+
+    await Promise.all(
+      studentsToShow.map(async (student) => {
+        try {
+          const sessions = await getStudentSessions(token, student.student_id);
+          const completedWithScore = sessions.filter(
+            (s) => s.status === 'completed' && s.overall_score !== null,
+          );
+          if (completedWithScore.length > 0) {
+            sessionsMap[student.student_name] = completedWithScore;
+            names.push(student.student_name);
+          }
+        } catch {
+          // Skip students we can't load
+        }
+      }),
+    );
+
+    setStudentNames(names);
+
+    // Build time-series: collect all unique dates, then map scores
+    const dateScoreMap: Record<string, Record<string, number>> = {};
+
+    for (const [name, sessions] of Object.entries(sessionsMap)) {
+      for (const sess of sessions) {
+        const date = new Date(sess.started_at).toLocaleDateString('zh-TW', {
+          month: 'short',
+          day: 'numeric',
+        });
+        if (!dateScoreMap[date]) dateScoreMap[date] = {};
+        dateScoreMap[date][name] = Math.round(sess.overall_score!);
+      }
+    }
+
+    // Sort by date
+    const sortedDates = Object.keys(dateScoreMap).sort((a, b) => {
+      // Parse zh-TW short date for sorting
+      return a.localeCompare(b, 'zh-TW');
+    });
+
+    const chartData: AccuracyDataPoint[] = sortedDates.map((date) => {
+      const point: AccuracyDataPoint = { date };
+      for (const name of names) {
+        point[name] = dateScoreMap[date][name] ?? null;
+      }
+      return point;
+    });
+
+    setAccuracyData(chartData);
+  };
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  if (isLoading) {
+    return (
+      <div className="p-5 space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-32 bg-gray-100 animate-pulse rounded-lg" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-5">
+        <div className="text-center py-6 bg-red-50 rounded-lg border border-red-200">
+          <p className="text-red-700 text-sm">{error}</p>
+          <button
+            onClick={loadData}
+            className="mt-2 text-sm text-red-600 underline hover:text-red-800 cursor-pointer"
+          >
+            重試
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-5 space-y-6">
+      {/* Overview cards */}
+      {stats && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <StatCard
+            label="活躍學生"
+            value={`${stats.active_students} / ${stats.total_students}`}
+            sub="位"
+          />
+          <StatCard
+            label="平均正確率"
+            value={stats.avg_accuracy !== null ? `${stats.avg_accuracy}%` : '-'}
+          />
+          <StatCard
+            label="完成率"
+            value={`${Math.round(stats.completion_rate * 100)}%`}
+          />
+          <StatCard
+            label="平均學習時長"
+            value={
+              stats.avg_session_duration_minutes !== null
+                ? `${stats.avg_session_duration_minutes}`
+                : '-'
+            }
+            sub="分鐘"
+          />
+        </div>
+      )}
+
+      {/* Time stats row */}
+      {timeStats && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <StatCard label="總學習時數" value={`${timeStats.total_hours}`} sub="小時" />
+          <StatCard label="學習天數" value={`${timeStats.study_days}`} sub="天" />
+          <StatCard label="本週練習" value={`${timeStats.sessions_this_week}`} sub="次" />
+          <StatCard label="上週練習" value={`${timeStats.sessions_last_week}`} sub="次" />
+        </div>
+      )}
+
+      {/* Accuracy trend chart */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-sm font-semibold text-gray-700 mb-3">成績趨勢</h3>
+        {accuracyData.length > 0 ? (
+          <ResponsiveContainer width="100%" height={280}>
+            <LineChart data={accuracyData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <XAxis dataKey="date" tick={{ fontSize: 12 }} />
+              <YAxis domain={[0, 100]} tick={{ fontSize: 12 }} />
+              <Tooltip />
+              <Legend />
+              {studentNames.map((name, idx) => (
+                <Line
+                  key={name}
+                  type="monotone"
+                  dataKey={name}
+                  stroke={LINE_COLORS[idx % LINE_COLORS.length]}
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                  connectNulls
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="text-center py-8 text-gray-400 text-sm">
+            尚無已完成的學習記錄
+          </div>
+        )}
+      </div>
+
+      {/* Error vocabulary bar chart */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-sm font-semibold text-gray-700 mb-3">
+          常見錯字排行（前 10）
+        </h3>
+        {errorVocab.length > 0 ? (
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart
+              data={errorVocab.slice(0, 10)}
+              layout="vertical"
+              margin={{ left: 30 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <XAxis type="number" tick={{ fontSize: 12 }} />
+              <YAxis
+                type="category"
+                dataKey="character"
+                tick={{ fontSize: 14 }}
+                width={40}
+              />
+              <Tooltip
+                formatter={(value: number, name: string) => {
+                  if (name === 'count') return [value, '錯誤次數'];
+                  if (name === 'student_count') return [value, '學生人數'];
+                  return [value, name];
+                }}
+              />
+              <Bar dataKey="count" fill="#ef4444" name="count" radius={[0, 4, 4, 0]} />
+              <Bar
+                dataKey="student_count"
+                fill="#f59e0b"
+                name="student_count"
+                radius={[0, 4, 4, 0]}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="text-center py-8 text-gray-400 text-sm">
+            尚無錯字記錄
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="bg-gray-50 rounded-lg p-4 text-center">
+      <p className="text-xs text-gray-500 mb-1">{label}</p>
+      <p className="text-xl font-bold text-gray-900">
+        {value}
+        {sub && <span className="text-xs font-normal text-gray-500 ml-0.5">{sub}</span>}
+      </p>
+    </div>
+  );
+}
+
+export default ClassroomAnalytics;

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -13,11 +13,13 @@ import StudentProgressTab from './StudentProgressTab';
 import TextManagementTab from './TextManagementTab';
 import StudentListTab from './StudentListTab';
 import AssignmentTab from './AssignmentTab';
+import ClassroomAnalytics from './ClassroomAnalytics';
 
-type TabKey = 'progress' | 'texts' | 'assignments' | 'students';
+type TabKey = 'progress' | 'texts' | 'assignments' | 'students' | 'analytics';
 
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'progress', label: '學生進度' },
+  { key: 'analytics', label: '學習分析' },
   { key: 'texts', label: '課文管理' },
   { key: 'assignments', label: '作業管理' },
   { key: 'students', label: '學生名單' },
@@ -367,6 +369,10 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
           {/* Tab content */}
           {activeTab === 'progress' && (
             <StudentProgressTab classroomId={classroomId} />
+          )}
+
+          {activeTab === 'analytics' && (
+            <ClassroomAnalytics classroomId={classroomId} />
           )}
 
           {activeTab === 'texts' && (

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -56,6 +56,31 @@ async function handleResponse<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+export interface ClassroomStats {
+  total_students: number;
+  total_sessions: number;
+  active_students: number;
+  inactive_students: number;
+  avg_accuracy: number | null;
+  completion_rate: number;
+  avg_session_duration_minutes: number | null;
+}
+
+export interface ErrorVocabItem {
+  character: string;
+  error_type: string;
+  count: number;
+  student_count: number;
+}
+
+export interface TimeStats {
+  total_hours: number;
+  avg_minutes_per_session: number | null;
+  study_days: number;
+  sessions_this_week: number;
+  sessions_last_week: number;
+}
+
 // --- API functions ---
 
 /** Get student progress for a classroom. */
@@ -152,4 +177,40 @@ export async function exportClassroomReport(token: string, classroomId: number):
   });
   if (!res.ok) throw new TeacherApiError('Export failed', res.status);
   return res.blob();
+}
+
+/** Get classroom aggregate statistics. */
+export async function getClassroomStats(
+  token: string,
+  classroomId: number,
+): Promise<ClassroomStats> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/classrooms/${classroomId}/stats`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return handleResponse<ClassroomStats>(res);
+}
+
+/** Get top error vocabulary for a classroom. */
+export async function getErrorVocab(
+  token: string,
+  classroomId: number,
+): Promise<ErrorVocabItem[]> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/classrooms/${classroomId}/error-vocab`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return handleResponse<ErrorVocabItem[]>(res);
+}
+
+/** Get learning time statistics for a classroom. */
+export async function getTimeStats(
+  token: string,
+  classroomId: number,
+): Promise<TimeStats> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/classrooms/${classroomId}/time-stats`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return handleResponse<TimeStats>(res);
 }


### PR DESCRIPTION
## Summary
- Enhanced class stats with `avg_accuracy`, `completion_rate`, `avg_session_duration_minutes`
- New error vocabulary frequency endpoint (`GET /api/teacher/classrooms/{id}/error-vocab`)
- New learning time stats endpoint (`GET /api/teacher/classrooms/{id}/time-stats`)
- New `ClassroomAnalytics.tsx` with Recharts LineChart (accuracy trend) + BarChart (error vocab)
- Added 學習分析 tab to ClassroomDetail
- 16 new backend tests, 785 total passing

## Test plan
- [x] 785 backend tests pass
- [x] Frontend TypeScript compiles
- [ ] Manual: teacher classroom → 學習分析 tab → verify charts

Closes #21, Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)