### PR TITLE
feat: copyright confirmation for text assignment (#108)

### DIFF
--- a/backend/app/routes/classroom_texts.py
+++ b/backend/app/routes/classroom_texts.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 class ClassroomTextAssignRequest(BaseModel):
     text_id: str
+    copyright_confirmed: bool = False
 
 
 class ClassroomTextResponse(BaseModel):
@@ -52,6 +53,10 @@ def assign_text_to_classroom(
     """Assign a platform story (text) to a classroom."""
     classroom = _get_classroom_or_404(classroom_id, db)
     _require_owner_or_admin(classroom, current_user, db)
+
+    # Require copyright confirmation
+    if not payload.copyright_confirmed:
+        raise HTTPException(status_code=422, detail="copyright_confirmed must be true")
 
     # Validate that the story exists
     try:

--- a/backend/tests/test_copyright.py
+++ b/backend/tests/test_copyright.py
@@ -1,0 +1,200 @@
+"""
+Tests for copyright confirmation gate on classroom text assignment.
+
+Covers:
+- POST /api/classrooms/{id}/texts without copyright_confirmed → 422
+- POST /api/classrooms/{id}/texts with copyright_confirmed=false → 422
+- POST /api/classrooms/{id}/texts with copyright_confirmed=true → 201
+
+Run with:
+    cd backend
+    python -m pytest tests/test_copyright.py -v
+"""
+
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, UserRole
+from app.models.school import School
+
+
+# ---------------------------------------------------------------------------
+# Test database setup (SQLite in-memory with StaticPool)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        session.add(Role(**role_data))
+    session.commit()
+
+
+def _seed_school(session) -> int:
+    school = School(name="Copyright Test School")
+    session.add(school)
+    session.commit()
+    session.refresh(school)
+    return school.id
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+_test_school_id: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    global _test_school_id
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    _test_school_id = _seed_school(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def school_id():
+    return _test_school_id
+
+
+def _auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register_and_login(client) -> str:
+    unique = uuid.uuid4().hex[:8]
+    email = f"teacher_{unique}@example.com"
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": "SecurePass123!",
+        "name": f"Teacher {unique}",
+    })
+    assert resp.status_code == 201
+    return resp.json()["access_token"]
+
+
+def _create_classroom(client, token: str, school_id: int) -> int:
+    resp = client.post(
+        "/api/classrooms",
+        json={"name": f"班級_{uuid.uuid4().hex[:6]}", "school_id": school_id},
+        headers=_auth_header(token),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# Use story id "1" which is known to exist in the fixture YAML data
+TEXT_ID = "1"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCopyrightConfirmation:
+    """POST /api/classrooms/{id}/texts copyright gate."""
+
+    @pytest.fixture(scope="class")
+    def setup(self, client, school_id):
+        token = _register_and_login(client)
+        classroom_id = _create_classroom(client, token, school_id)
+        return {"token": token, "classroom_id": classroom_id}
+
+    def test_missing_copyright_confirmed_returns_422(self, client, setup):
+        """Omitting copyright_confirmed (defaults to false) must return 422."""
+        resp = client.post(
+            f"/api/classrooms/{setup['classroom_id']}/texts",
+            json={"text_id": TEXT_ID},
+            headers=_auth_header(setup["token"]),
+        )
+        assert resp.status_code == 422
+        assert "copyright_confirmed" in resp.json().get("detail", "").lower()
+
+    def test_copyright_confirmed_false_returns_422(self, client, setup):
+        """Explicitly sending copyright_confirmed=false must return 422."""
+        resp = client.post(
+            f"/api/classrooms/{setup['classroom_id']}/texts",
+            json={"text_id": TEXT_ID, "copyright_confirmed": False},
+            headers=_auth_header(setup["token"]),
+        )
+        assert resp.status_code == 422
+        assert "copyright_confirmed" in resp.json().get("detail", "").lower()
+
+    def test_copyright_confirmed_true_succeeds(self, client, setup):
+        """Sending copyright_confirmed=true must succeed with 201."""
+        resp = client.post(
+            f"/api/classrooms/{setup['classroom_id']}/texts",
+            json={"text_id": TEXT_ID, "copyright_confirmed": True},
+            headers=_auth_header(setup["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["text_id"] == TEXT_ID
+        assert "title" in data
+        assert "assigned_at" in data

--- a/frontend/src/pages/teacher/TextManagementTab.tsx
+++ b/frontend/src/pages/teacher/TextManagementTab.tsx
@@ -29,6 +29,8 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
   // Assign flow
   const [showAssignSelector, setShowAssignSelector] = useState(false);
   const [assigningTextId, setAssigningTextId] = useState<string | null>(null);
+  const [copyrightConfirmed, setCopyrightConfirmed] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(false);
 
   // Unassign flow
   const [confirmUnassignId, setConfirmUnassignId] = useState<string | null>(null);
@@ -82,14 +84,20 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
 
   const handleOpenAssignSelector = () => {
     setShowAssignSelector(true);
+    setCopyrightConfirmed(false);
     loadStories();
   };
 
+  const handleCloseAssignSelector = () => {
+    setShowAssignSelector(false);
+    setCopyrightConfirmed(false);
+  };
+
   const handleAssign = async (textId: string) => {
-    if (!token) return;
+    if (!token || !copyrightConfirmed) return;
     setAssigningTextId(textId);
     try {
-      const newItem = await assignText(token, classroomId, textId);
+      const newItem = await assignText(token, classroomId, textId, true);
       setAssignedTexts((prev) => [...prev, newItem]);
     } catch (err) {
       if (err instanceof TeacherApiError) {
@@ -201,12 +209,49 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
           <div className="flex items-center justify-between mb-3">
             <h4 className="text-sm font-bold text-gray-900">選擇課文指派</h4>
             <button
-              onClick={() => setShowAssignSelector(false)}
+              onClick={handleCloseAssignSelector}
               className="text-sm text-gray-500 hover:text-gray-700 cursor-pointer"
             >
               關閉
             </button>
           </div>
+
+          {/* Copyright confirmation */}
+          <div className="mb-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={copyrightConfirmed}
+                onChange={(e) => setCopyrightConfirmed(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-gray-300 text-accent cursor-pointer shrink-0"
+              />
+              <span className="text-xs text-amber-900 leading-relaxed">
+                我確認本教材的使用符合著作權規範
+              </span>
+            </label>
+            <div className="mt-1.5 ml-6 flex items-center gap-1 relative">
+              <button
+                type="button"
+                onMouseEnter={() => setShowTooltip(true)}
+                onMouseLeave={() => setShowTooltip(false)}
+                onFocus={() => setShowTooltip(true)}
+                onBlur={() => setShowTooltip(false)}
+                className="text-xs text-amber-700 underline cursor-pointer hover:text-amber-900 flex items-center gap-0.5"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                著作權說明
+              </button>
+              {showTooltip && (
+                <div className="absolute bottom-full left-0 mb-1 w-64 p-2.5 bg-gray-800 text-white text-xs rounded-lg shadow-lg z-10 leading-relaxed">
+                  依據著作權法第46條，學校教師在教學目的下得合理使用已公開發表之著作。請確認您使用的教材符合合理使用原則，或已取得著作權人授權。
+                  <div className="absolute top-full left-3 border-4 border-transparent border-t-gray-800" />
+                </div>
+              )}
+            </div>
+          </div>
+
           {isLoadingStories ? (
             <div className="flex items-center gap-2 py-4">
               <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
@@ -228,7 +273,8 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
                   </div>
                   <button
                     onClick={() => handleAssign(story.id)}
-                    disabled={assigningTextId === story.id}
+                    disabled={assigningTextId === story.id || !copyrightConfirmed}
+                    title={!copyrightConfirmed ? '請先確認著作權聲明' : undefined}
                     className="px-3 py-1 rounded-md bg-accent hover:bg-accent-hover text-white text-xs font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
                   >
                     {assigningTextId === story.id ? '指派中...' : '指派'}

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -112,13 +112,14 @@ export async function assignText(
   token: string,
   classroomId: number,
   textId: string,
+  copyrightConfirmed: boolean = false,
 ): Promise<ClassroomTextItem> {
   const res = await fetch(
     `${API_BASE}/api/classrooms/${classroomId}/texts`,
     {
       method: 'POST',
       headers: authHeaders(token),
-      body: JSON.stringify({ text_id: textId }),
+      body: JSON.stringify({ text_id: textId, copyright_confirmed: copyrightConfirmed }),
     },
   );
   return handleResponse<ClassroomTextItem>(res);


### PR DESCRIPTION
## Summary

- **Backend**: Added `copyright_confirmed: bool = False` to `ClassroomTextAssignRequest`. `POST /api/classrooms/{id}/texts` now returns 422 with message `"copyright_confirmed must be true"` if the field is missing or false.
- **Frontend**: Added a copyright confirmation checkbox in the assign selector panel. The assign buttons are disabled until the checkbox is checked. A tooltip explains the educational fair-use provision (著作權法第46條).
- **Tests**: `backend/tests/test_copyright.py` — 3 tests covering missing field → 422, `false` → 422, `true` → 201.

## Test plan

- [ ] Run `python -m pytest tests/test_copyright.py -v` — all 3 pass
- [ ] Open teacher dashboard → classroom → 課文管理 tab
- [ ] Click 指派課文 — confirm checkbox appears with amber background
- [ ] Try clicking 指派 without checking checkbox — button should be disabled (greyed out)
- [ ] Hover 著作權說明 — tooltip with fair-use text should appear
- [ ] Check the checkbox → 指派 buttons become active
- [ ] Assign a text — succeeds as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)