### PR TITLE
feat: AI detailed reading analysis for step 6 report (#241)

### DIFF
--- a/backend/alembic/versions/i9j0k1l2m3n4_add_ai_analysis_to_learning_sessions.py
+++ b/backend/alembic/versions/i9j0k1l2m3n4_add_ai_analysis_to_learning_sessions.py
@@ -1,0 +1,28 @@
+"""add ai_analysis column to learning_sessions
+
+Revision ID: i9j0k1l2m3n4
+Revises: h8i9j0k1l2m3
+Create Date: 2026-03-09 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'i9j0k1l2m3n4'
+down_revision: Union[str, None] = 'h8i9j0k1l2m3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'learning_sessions',
+        sa.Column('ai_analysis', sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('learning_sessions', 'ai_analysis')

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from sqlalchemy import String, Integer, Float, Boolean, ForeignKey, DateTime, func
+
+from sqlalchemy import String, Integer, Float, Boolean, Text, ForeignKey, DateTime, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .base import Base
@@ -21,6 +22,7 @@ class LearningSession(Base):
     comprehension_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     vocab_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     full_reading_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    ai_analysis: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -18,7 +19,7 @@ from ..schemas.session import (
     SessionSummaryResponse,
     SessionUpdateRequest,
 )
-from ..services.ai_service import generate_socratic_question
+from ..services.ai_service import generate_reading_analysis, generate_socratic_question
 from ..services.socratic_agent import socratic_agent
 
 router = APIRouter(tags=["learning"])
@@ -166,6 +167,116 @@ def update_session(
     db.refresh(session)
     logger.info("Updated learning session %d: %s", session_id, list(update_data.keys()))
     return session
+
+
+# ── Step 6: AI Reading Analysis ─────────────────────────────────────────────
+
+
+class AIAnalysisRequest(BaseModel):
+    story_title: str = Field(..., max_length=200)
+    accuracy: float = Field(..., ge=0, le=100)
+    cpm: float = Field(..., ge=0)
+    error_chars: list[str] = Field(default_factory=list)
+    total_characters: int = Field(..., ge=0)
+
+
+class AIAnalysisResponse(BaseModel):
+    analysis_summary: str
+    strengths: list[str]
+    areas_for_improvement: list[str]
+    practice_suggestions: list[str]
+    encouragement_message: str
+
+
+@router.post(
+    "/learning/sessions/{session_id}/ai-analysis",
+    response_model=AIAnalysisResponse,
+    dependencies=[Depends(ai_limit_5_per_min)],
+)
+async def get_ai_analysis(
+    session_id: int,
+    payload: AIAnalysisRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Generate AI reading diagnosis and improvement suggestions.
+
+    If the session already has a cached analysis, returns it immediately
+    without calling Gemini again. Otherwise calls Gemini and caches the
+    result in the session's ai_analysis column.
+
+    Rate limited: 5 requests per minute per user/IP.
+    """
+    session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.student_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not your session")
+
+    # Return cached result if available
+    if session.ai_analysis:
+        try:
+            cached = json.loads(session.ai_analysis)
+            return AIAnalysisResponse(**cached)
+        except (json.JSONDecodeError, TypeError):
+            # Corrupted cache — regenerate
+            logger.warning("Corrupted ai_analysis cache for session %d, regenerating", session_id)
+
+    # Call Gemini
+    try:
+        analysis = await generate_reading_analysis({
+            "story_title": payload.story_title,
+            "accuracy": payload.accuracy,
+            "cpm": payload.cpm,
+            "error_chars": payload.error_chars,
+            "total_characters": payload.total_characters,
+        })
+    except TimeoutError:
+        raise HTTPException(status_code=503, detail="AI service timeout")
+    except Exception as e:
+        logger.error("AI analysis generation failed for session %d: %s", session_id, e)
+        raise HTTPException(status_code=503, detail="AI service unavailable")
+
+    # Cache the result
+    session.ai_analysis = json.dumps(analysis, ensure_ascii=False)
+    db.commit()
+
+    logger.info("Generated AI analysis for session %d", session_id)
+    return AIAnalysisResponse(**analysis)
+
+
+@router.post(
+    "/learning/ai-analysis",
+    response_model=AIAnalysisResponse,
+    dependencies=[Depends(ai_limit_5_per_min)],
+)
+async def get_ai_analysis_standalone(
+    payload: AIAnalysisRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Generate AI reading diagnosis without requiring a backend session.
+
+    This endpoint is for the frontend learning flow which manages sessions
+    in-memory. No caching — analysis is generated fresh each call.
+
+    Rate limited: 5 requests per minute per user/IP.
+    """
+    try:
+        analysis = await generate_reading_analysis({
+            "story_title": payload.story_title,
+            "accuracy": payload.accuracy,
+            "cpm": payload.cpm,
+            "error_chars": payload.error_chars,
+            "total_characters": payload.total_characters,
+        })
+    except TimeoutError:
+        raise HTTPException(status_code=503, detail="AI service timeout")
+    except Exception as e:
+        logger.error("Standalone AI analysis generation failed: %s", e)
+        raise HTTPException(status_code=503, detail="AI service unavailable")
+
+    logger.info("Generated standalone AI analysis for user %d", current_user.id)
+    return AIAnalysisResponse(**analysis)
 
 
 # ── Step 3: Socratic Comprehension Q&A ──────────────────────────────────────

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -193,6 +193,102 @@ async def generate_socratic_question(
     return response.text.strip()
 
 
+async def generate_reading_analysis(session_data: dict) -> dict:
+    """Generate personalised reading diagnosis and improvement suggestions.
+
+    Uses Gemini to analyse student reading performance and return
+    structured feedback including strengths, areas for improvement,
+    practice suggestions, and encouragement.
+
+    Args:
+        session_data: Dict with keys: story_title, accuracy, cpm,
+                      error_chars (list[str]), total_characters.
+
+    Returns:
+        Dict with keys: analysis_summary, strengths, areas_for_improvement,
+                        practice_suggestions, encouragement_message.
+    """
+    story_title = session_data.get("story_title", "未知課文")
+    accuracy = session_data.get("accuracy", 0)
+    cpm = session_data.get("cpm", 0)
+    error_chars = session_data.get("error_chars", [])
+    total_characters = session_data.get("total_characters", 0)
+
+    error_chars_str = "、".join(error_chars) if error_chars else "無"
+
+    system_prompt = (
+        f"{TUTOR_PERSONA}\n\n"
+        "你同時也是一位國小國語文教學專家。請根據以下學生朗讀數據，"
+        "提供詳細的診斷分析和改善建議。\n\n"
+        "回覆規則：\n"
+        "- 必須使用臺灣繁體中文（zh-TW），嚴禁大陸用語\n"
+        "- 語氣溫暖、鼓勵，適合國小高年級至國中生\n"
+        "- 分析要具體，根據數據給出針對性建議\n"
+        "- 每項建議都要可執行"
+    )
+
+    user_prompt = (
+        f"學生朗讀資料：\n"
+        f"- 課文：{story_title}\n"
+        f"- 正確率：{accuracy}%\n"
+        f"- 朗讀速度：{cpm} 字/分鐘\n"
+        f"- 錯誤字：{error_chars_str}\n"
+        f"- 總字數：{total_characters}\n\n"
+        "請根據以上資料進行分析。"
+    )
+
+    response_schema = {
+        "type": "OBJECT",
+        "properties": {
+            "analysis_summary": {
+                "type": "STRING",
+                "description": "整體分析摘要（2-3句話）",
+            },
+            "strengths": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": "學生的優點（1-3項）",
+            },
+            "areas_for_improvement": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": "待改善的地方（1-3項）",
+            },
+            "practice_suggestions": {
+                "type": "ARRAY",
+                "items": {"type": "STRING"},
+                "description": "具體練習建議（2-4項）",
+            },
+            "encouragement_message": {
+                "type": "STRING",
+                "description": "鼓勵語（1句話）",
+            },
+        },
+        "required": [
+            "analysis_summary",
+            "strengths",
+            "areas_for_improvement",
+            "practice_suggestions",
+            "encouragement_message",
+        ],
+    }
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[genai_types.Part(text=user_prompt)],
+        )
+    ]
+
+    return await generate_structured_response(
+        system_prompt=system_prompt,
+        contents=contents,
+        response_schema=response_schema,
+        max_tokens=1024,
+        temperature=0.7,
+    )
+
+
 async def generate_exit_ticket(text: str) -> list[dict]:
     """
     Generate exit-ticket questions for a story text.

--- a/backend/tests/test_ai_analysis.py
+++ b/backend/tests/test_ai_analysis.py
@@ -1,0 +1,374 @@
+"""
+Tests for AI reading analysis endpoints.
+
+Covers:
+- POST /api/learning/sessions/{id}/ai-analysis  (session-based with caching)
+- POST /api/learning/ai-analysis                 (standalone)
+- 404 for invalid session
+- 403 for other user's session
+- Cached analysis returned without re-calling Gemini
+- Response schema validation
+
+Uses SQLite in-memory DB. Mocks the Gemini AI call.
+"""
+
+import json
+import sys
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MOCK_ANALYSIS = {
+    "analysis_summary": "你的朗讀表現整體不錯，正確率達 85%，速度適中。",
+    "strengths": ["發音清晰", "語速穩定"],
+    "areas_for_improvement": ["注意多音字的讀法"],
+    "practice_suggestions": [
+        "每天朗讀 10 分鐘",
+        "針對錯字反覆練習",
+        "試著用更有感情的語調朗讀",
+    ],
+    "encouragement_message": "你已經很棒了，繼續加油！",
+}
+
+ANALYSIS_PAYLOAD = {
+    "story_title": "玉山之美",
+    "accuracy": 85.0,
+    "cpm": 120.0,
+    "error_chars": ["山", "雪"],
+    "total_characters": 200,
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    """Reset AI rate limiter before each test to avoid 429s."""
+    from app.auth.rate_limiter import ai_rate_limiter
+    ai_rate_limiter.reset()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_user(client, suffix: str | None = None) -> dict:
+    unique = suffix or uuid.uuid4().hex[:8]
+    email = f"ai_user_{unique}@example.com"
+    password = "SecurePass123!"
+    name = f"AI User {unique}"
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": name,
+    })
+    assert resp.status_code == 201, resp.text
+    return {
+        "email": email,
+        "password": password,
+        "name": name,
+        "token": resp.json()["access_token"],
+    }
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="module")
+def user_a(client):
+    return _register_user(client, "ai_a")
+
+
+@pytest.fixture(scope="module")
+def user_b(client):
+    return _register_user(client, "ai_b")
+
+
+def _create_session(client, token: str, slug: str = "ai-test") -> int:
+    resp = client.post(
+        "/api/learning/sessions",
+        json={"story_slug": slug},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+# ===========================================================================
+# POST /api/learning/sessions/{id}/ai-analysis — Session-based
+# ===========================================================================
+
+
+class TestSessionBasedAIAnalysis:
+    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    def test_returns_analysis_for_valid_session(self, mock_gen, client, user_a):
+        mock_gen.return_value = MOCK_ANALYSIS
+        session_id = _create_session(client, user_a["token"], "analysis-valid")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["analysis_summary"] == MOCK_ANALYSIS["analysis_summary"]
+        assert data["strengths"] == MOCK_ANALYSIS["strengths"]
+        assert data["areas_for_improvement"] == MOCK_ANALYSIS["areas_for_improvement"]
+        assert data["practice_suggestions"] == MOCK_ANALYSIS["practice_suggestions"]
+        assert data["encouragement_message"] == MOCK_ANALYSIS["encouragement_message"]
+        mock_gen.assert_called_once()
+
+    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    def test_cached_analysis_returned_without_calling_gemini(self, mock_gen, client, user_a):
+        mock_gen.return_value = MOCK_ANALYSIS
+        session_id = _create_session(client, user_a["token"], "analysis-cache")
+
+        # First call — generates and caches
+        resp1 = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp1.status_code == 200
+        assert mock_gen.call_count == 1
+
+        # Second call — should return cached, no additional Gemini call
+        resp2 = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp2.status_code == 200
+        assert resp2.json() == resp1.json()
+        # Still only 1 call — the second hit the cache
+        assert mock_gen.call_count == 1
+
+    def test_404_for_invalid_session(self, client, user_a):
+        resp = client.post(
+            "/api/learning/sessions/999999/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Session not found"
+
+    def test_403_for_other_users_session(self, client, user_a, user_b):
+        session_id = _create_session(client, user_b["token"], "analysis-forbidden")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Not your session"
+
+    def test_401_without_auth(self, client):
+        resp = client.post(
+            "/api/learning/sessions/1/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+        )
+        assert resp.status_code == 401
+
+    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    def test_response_schema(self, mock_gen, client, user_a):
+        mock_gen.return_value = MOCK_ANALYSIS
+        session_id = _create_session(client, user_a["token"], "analysis-schema")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        data = resp.json()
+        # Verify all required fields exist and have correct types
+        assert isinstance(data["analysis_summary"], str)
+        assert isinstance(data["strengths"], list)
+        assert isinstance(data["areas_for_improvement"], list)
+        assert isinstance(data["practice_suggestions"], list)
+        assert isinstance(data["encouragement_message"], str)
+        assert len(data["strengths"]) > 0
+        assert len(data["practice_suggestions"]) > 0
+
+    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    def test_503_when_gemini_fails(self, mock_gen, client, user_a):
+        mock_gen.side_effect = RuntimeError("Gemini connection error")
+        session_id = _create_session(client, user_a["token"], "analysis-503")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 503
+        assert "AI service" in resp.json()["detail"]
+
+    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    def test_503_on_timeout(self, mock_gen, client, user_a):
+        mock_gen.side_effect = TimeoutError("AI response timeout (30s)")
+        session_id = _create_session(client, user_a["token"], "analysis-timeout")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 503
+        assert "timeout" in resp.json()["detail"].lower()
+
+
+# ===========================================================================
+# POST /api/learning/ai-analysis — Standalone
+# ===========================================================================
+
+
+class TestStandaloneAIAnalysis:
+    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    def test_standalone_returns_analysis(self, mock_gen, client, user_a):
+        mock_gen.return_value = MOCK_ANALYSIS
+
+        resp = client.post(
+            "/api/learning/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["analysis_summary"] == MOCK_ANALYSIS["analysis_summary"]
+        assert data["strengths"] == MOCK_ANALYSIS["strengths"]
+        mock_gen.assert_called_once()
+
+    def test_standalone_401_without_auth(self, client):
+        resp = client.post(
+            "/api/learning/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+        )
+        assert resp.status_code == 401
+
+    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    def test_standalone_503_when_gemini_fails(self, mock_gen, client, user_a):
+        mock_gen.side_effect = RuntimeError("Gemini unavailable")
+
+        resp = client.post(
+            "/api/learning/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 503
+
+    def test_standalone_422_invalid_accuracy(self, client, user_a):
+        bad_payload = {**ANALYSIS_PAYLOAD, "accuracy": 150.0}
+        resp = client.post(
+            "/api/learning/ai-analysis",
+            json=bad_payload,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 422
+
+    def test_standalone_422_missing_required_field(self, client, user_a):
+        incomplete = {"accuracy": 85.0}
+        resp = client.post(
+            "/api/learning/ai-analysis",
+            json=incomplete,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 422
+
+    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    def test_standalone_response_schema(self, mock_gen, client, user_a):
+        mock_gen.return_value = MOCK_ANALYSIS
+
+        resp = client.post(
+            "/api/learning/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(user_a["token"]),
+        )
+        data = resp.json()
+        expected_keys = {
+            "analysis_summary", "strengths", "areas_for_improvement",
+            "practice_suggestions", "encouragement_message",
+        }
+        assert set(data.keys()) == expected_keys

--- a/frontend/src/components/reading-steps/AIAnalysisSection.tsx
+++ b/frontend/src/components/reading-steps/AIAnalysisSection.tsx
@@ -1,0 +1,173 @@
+import React, { useState, useCallback } from 'react';
+import { getAIAnalysis, AIAnalysisResponse } from '../../services/api';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface AIAnalysisSectionProps {
+  storyTitle: string;
+  accuracy: number;
+  cpm: number;
+  errorChars: string[];
+  totalCharacters: number;
+}
+
+const AIAnalysisSection: React.FC<AIAnalysisSectionProps> = ({
+  storyTitle,
+  accuracy,
+  cpm,
+  errorChars,
+  totalCharacters,
+}) => {
+  const { token } = useAuth();
+  const [analysis, setAnalysis] = useState<AIAnalysisResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAnalysis = useCallback(async () => {
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getAIAnalysis(token, {
+        storyTitle,
+        accuracy,
+        cpm,
+        errorChars,
+        totalCharacters,
+      });
+      setAnalysis(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'AI 分析失敗');
+    } finally {
+      setLoading(false);
+    }
+  }, [token, storyTitle, accuracy, cpm, errorChars, totalCharacters]);
+
+  // Not logged in
+  if (!token) {
+    return (
+      <div className="p-6 bg-gray-50 rounded-2xl text-center">
+        <p className="text-sm text-gray-400">請先登入以使用 AI 分析功能</p>
+      </div>
+    );
+  }
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 gap-3">
+        <div className="w-8 h-8 border-3 border-accent border-t-transparent rounded-full animate-spin" />
+        <p className="text-sm text-gray-500">小語老師正在分析你的朗讀表現...</p>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="p-6 bg-red-50 rounded-2xl text-center space-y-3">
+        <p className="text-sm text-red-600 font-bold">無法產生 AI 分析</p>
+        <p className="text-xs text-red-400">{error}</p>
+        <button
+          onClick={fetchAnalysis}
+          className="text-sm text-accent hover:text-accent-hover font-bold"
+        >
+          重試
+        </button>
+      </div>
+    );
+  }
+
+  // Initial state — show generate button
+  if (!analysis) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 gap-4">
+        <p className="text-sm text-gray-500">點擊下方按鈕，讓小語老師幫你分析朗讀表現</p>
+        <button
+          onClick={fetchAnalysis}
+          className="inline-flex items-center gap-2 bg-accent hover:bg-accent-hover text-white px-6 py-3 rounded-xl font-bold transition-all shadow-md hover:shadow-lg"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+          </svg>
+          產生 AI 分析
+        </button>
+      </div>
+    );
+  }
+
+  // Render analysis results
+  return (
+    <div className="space-y-5">
+      {/* Summary card */}
+      <div className="bg-accent/5 rounded-2xl p-5">
+        <p className="text-sm text-gray-700 leading-relaxed">{analysis.analysis_summary}</p>
+      </div>
+
+      {/* Strengths */}
+      {analysis.strengths.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 font-bold mb-2">你的優點</p>
+          <div className="flex flex-wrap gap-2">
+            {analysis.strengths.map((s, idx) => (
+              <span
+                key={idx}
+                className="inline-flex items-center gap-1 bg-emerald-50 border border-emerald-200 text-emerald-700 text-sm font-medium px-3 py-1.5 rounded-lg"
+              >
+                <svg className="w-4 h-4 text-emerald-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                </svg>
+                {s}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Areas for improvement */}
+      {analysis.areas_for_improvement.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 font-bold mb-2">可以加強的地方</p>
+          <div className="flex flex-wrap gap-2">
+            {analysis.areas_for_improvement.map((item, idx) => (
+              <span
+                key={idx}
+                className="inline-flex items-center gap-1 bg-amber-50 border border-amber-200 text-amber-700 text-sm font-medium px-3 py-1.5 rounded-lg"
+              >
+                <svg className="w-4 h-4 text-amber-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                </svg>
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Practice suggestions */}
+      {analysis.practice_suggestions.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 font-bold mb-2">練習建議</p>
+          <div className="space-y-2">
+            {analysis.practice_suggestions.map((suggestion, idx) => (
+              <div key={idx} className="flex items-start gap-3 p-3 bg-slate-50 rounded-xl">
+                <span className="w-6 h-6 rounded-full bg-accent/10 text-accent text-xs font-black flex items-center justify-center shrink-0">
+                  {idx + 1}
+                </span>
+                <p className="text-sm text-gray-700">{suggestion}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Encouragement */}
+      {analysis.encouragement_message && (
+        <div className="bg-gradient-to-r from-accent/10 to-violet-100 rounded-2xl p-5 text-center">
+          <p className="text-base font-bold text-accent">{analysis.encouragement_message}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AIAnalysisSection;

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -1,5 +1,5 @@
 
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { LearningSession } from '../../types';
 import type { Story } from '../../types';
 import DiffDisplay from '../ui/DiffDisplay';
@@ -9,6 +9,7 @@ import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
 import { parseReadingBenchmark, getBenchmarkFeedback } from '../../utils/fluencyAnalyzer';
 import ExitTicket from './ExitTicket';
 import { trackLearningEvent } from '../../utils/analytics';
+import AIAnalysisSection from './AIAnalysisSection';
 
 /**
  * A wrapper around ResponsiveContainer that only renders the chart
@@ -568,13 +569,23 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
         )}
       </Section>
 
-      {/* ============ 環節六：AI 詳細分析 (placeholder) ============ */}
-      <Section number={6} title="AI 詳細分析" defaultOpen={false} disabled>
-        <div className="p-6 bg-gray-50 rounded-2xl text-center">
-          <span className="text-4xl mb-3 block">🤖</span>
-          <p className="text-sm text-gray-400 font-bold">AI 詳細分析</p>
-          <p className="text-xs text-gray-300 mt-1">即將推出 — 系統將分析錯誤根源並提供個別化學習建議</p>
-        </div>
+      {/* ============ 環節六：AI 詳細分析 ============ */}
+      <Section number={6} title="AI 詳細分析" defaultOpen={false} disabled={!readingAttempt && !fullReadingResult}>
+        {(readingAttempt || fullReadingResult) ? (
+          <AIAnalysisSection
+            storyTitle={story?.title ?? ''}
+            accuracy={accuracy}
+            cpm={fullReadingResult?.cpm ?? cpm}
+            errorChars={wrongTokens.map(t => t.expected)}
+            totalCharacters={
+              fullReadingResult?.errorBreakdown
+                ? (fullReadingResult.errorBreakdown.correct + fullReadingResult.errorBreakdown.wrong + fullReadingResult.errorBreakdown.missing + fullReadingResult.errorBreakdown.extra)
+                : (readingAttempt?.lineBreakdown?.reduce((sum, l) => sum + (l.diffTokens?.length ?? 0), 0) ?? 0)
+            }
+          />
+        ) : (
+          <p className="text-sm text-gray-400 text-center py-4">完成朗讀練習後可使用 AI 分析</p>
+        )}
       </Section>
 
       {/* ============ 補充資訊：生字練習 + 課文理解 ============ */}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -221,6 +221,55 @@ export async function askComprehensionQuestion(payload: {
   return res.json();
 }
 
+// --- AI Reading Analysis API (Issue #241: Gemini reading diagnosis) ---
+
+export interface AIAnalysisResponse {
+  analysis_summary: string;
+  strengths: string[];
+  areas_for_improvement: string[];
+  practice_suggestions: string[];
+  encouragement_message: string;
+}
+
+/**
+ * Fetch AI reading analysis. Uses session-based endpoint when sessionId is
+ * available (with server-side caching), otherwise the standalone endpoint.
+ */
+export async function getAIAnalysis(
+  token: string,
+  payload: {
+    storyTitle: string;
+    accuracy: number;
+    cpm: number;
+    errorChars: string[];
+    totalCharacters: number;
+  },
+  sessionId?: number,
+): Promise<AIAnalysisResponse> {
+  const url = sessionId
+    ? `${API_BASE}/api/learning/sessions/${sessionId}/ai-analysis`
+    : `${API_BASE}/api/learning/ai-analysis`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      story_title: payload.storyTitle,
+      accuracy: payload.accuracy,
+      cpm: payload.cpm,
+      error_chars: payload.errorChars,
+      total_characters: payload.totalCharacters,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ detail: 'Unknown error' }));
+    throw new Error(body.detail || `AI analysis failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 // --- New Comprehension Chat API (Issue #1: answer evaluation) ---
 
 export interface ChatResponse {


### PR DESCRIPTION
## Summary
- Add \`generate_reading_analysis()\` to \`ai_service.py\` using \`gemini-2.5-flash\` (us-central1), structured JSON output, max_output_tokens=1024
- Add \`POST /api/learning/sessions/{id}/ai-analysis\` endpoint with server-side Gemini result caching
- Add standalone \`POST /api/learning/ai-analysis\` endpoint for frontend-managed sessions (rate-limited 5/min)
- Add \`ai_analysis TEXT NULL\` column to \`learning_sessions\` + Alembic migration (\`i9j0k1l2m3n4\`)
- Add \`AIAnalysisSection.tsx\` component (on-demand fetch with loading/error/retry states)
- Wire \`AIAnalysisSection\` into \`AssessmentReport\` section 6 (replaces placeholder)
- 14 TDD tests covering: caching, 401/403/404/503, timeout, schema validation

## Test plan
- [ ] Backend: 14 new tests pass (\`pytest tests/test_ai_analysis.py\`)
- [ ] Full test suite: 799 tests pass
- [ ] Frontend: section 6 "AI 詳細分析" button appears after reading attempt
- [ ] Frontend: clicking "產生 AI 分析" calls Gemini and shows structured feedback
- [ ] Frontend: error state shows retry button if API unavailable

Fixes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)