### PR TITLE
feat: 3-level comprehension scoring after Socratic dialogue (#243)

### DIFF
--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 from sqlalchemy import String, Integer, Float, Boolean, Text, ForeignKey, DateTime, func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -23,6 +22,12 @@ class LearningSession(Base):
     vocab_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     full_reading_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     ai_analysis: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    # 3-level comprehension scoring (Issue #243)
+    comprehension_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    literal_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    inferential_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    evaluative_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    comprehension_feedback: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -12,6 +12,7 @@ from ..models.school import ClassroomStudent
 from ..models.session import LearningSession, DialogueTurn
 from ..models.user import User
 from ..schemas.session import (
+    ComprehensionScoreResponse,
     SessionCreateRequest,
     SessionDetailResponse,
     SessionListResponse,
@@ -19,7 +20,7 @@ from ..schemas.session import (
     SessionSummaryResponse,
     SessionUpdateRequest,
 )
-from ..services.ai_service import generate_reading_analysis, generate_socratic_question
+from ..services.ai_service import evaluate_comprehension, generate_reading_analysis, generate_socratic_question
 from ..services.socratic_agent import socratic_agent
 
 router = APIRouter(tags=["learning"])
@@ -568,4 +569,99 @@ def get_dialogue_history(
         story_slug=session.story_slug,
         turns=[DialogueTurnResponse.model_validate(t) for t in turns],
         total=len(turns),
+    )
+
+
+# ── Comprehension Scoring (Issue #243) ────────────────────────────────────────
+
+
+class ComprehensionScoreRequest(BaseModel):
+    story_title: str
+    story_text: str = Field(..., max_length=10000)
+    dialogue_turns: list[ConversationTurn] = Field(..., min_length=1)
+
+
+@router.post(
+    "/learning/sessions/{session_id}/comprehension-score",
+    response_model=ComprehensionScoreResponse,
+    dependencies=[Depends(ai_limit_5_per_min)],
+)
+async def score_comprehension(
+    session_id: int,
+    payload: ComprehensionScoreRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Score a student's comprehension across 3 levels after Socratic dialogue.
+
+    Rate limited: 5 requests per minute per user/IP.
+
+    If scores already exist for this session (cached), returns them without
+    re-calling Gemini. Otherwise calls Gemini to evaluate and caches in DB.
+    """
+    session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.student_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not your session")
+
+    # Return cached scores if they exist
+    if session.comprehension_score is not None:
+        feedback = {}
+        if session.comprehension_feedback:
+            try:
+                feedback = json.loads(session.comprehension_feedback)
+            except (json.JSONDecodeError, TypeError):
+                feedback = {}
+        return ComprehensionScoreResponse(
+            comprehension_score=session.comprehension_score,
+            literal_score=session.literal_score or 0,
+            inferential_score=session.inferential_score or 0,
+            evaluative_score=session.evaluative_score or 0,
+            feedback=feedback,
+        )
+
+    # Build story context
+    story_context = {
+        "title": payload.story_title,
+        "summary": payload.story_text[:500],  # Use first 500 chars as summary
+    }
+
+    # Build dialogue turns list
+    dialogue_turns = [t.model_dump() for t in payload.dialogue_turns]
+
+    try:
+        result = await evaluate_comprehension(
+            dialogue_turns=dialogue_turns,
+            story_context=story_context,
+        )
+    except Exception as e:
+        logger.error("Comprehension scoring error: %s", e)
+        raise HTTPException(status_code=503, detail="AI service unavailable")
+
+    # Cache scores in DB
+    session.comprehension_score = result["comprehension_score"]
+    session.literal_score = result["literal_score"]
+    session.inferential_score = result["inferential_score"]
+    session.evaluative_score = result["evaluative_score"]
+    session.comprehension_feedback = json.dumps(result.get("feedback", {}), ensure_ascii=False)
+    db.commit()
+    db.refresh(session)
+
+    logger.info(
+        "Scored comprehension for session %d: overall=%.1f, literal=%.1f, "
+        "inferential=%.1f, evaluative=%.1f",
+        session_id,
+        result["comprehension_score"],
+        result["literal_score"],
+        result["inferential_score"],
+        result["evaluative_score"],
+    )
+
+    return ComprehensionScoreResponse(
+        comprehension_score=result["comprehension_score"],
+        literal_score=result["literal_score"],
+        inferential_score=result["inferential_score"],
+        evaluative_score=result["evaluative_score"],
+        feedback=result.get("feedback", {}),
     )

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -39,6 +39,12 @@ class SessionDetailResponse(SessionSummaryResponse):
     comprehension_result: dict[str, Any] | None
     vocab_result: dict[str, Any] | None
     full_reading_result: dict[str, Any] | None
+    # 3-level comprehension scoring (Issue #243)
+    comprehension_score: float | None = None
+    literal_score: float | None = None
+    inferential_score: float | None = None
+    evaluative_score: float | None = None
+    comprehension_feedback: str | None = None
 
 
 class SessionListResponse(BaseModel):
@@ -58,3 +64,11 @@ class SessionStatusResponse(BaseModel):
     completed_at: datetime | None
 
     model_config = {"from_attributes": True}
+
+
+class ComprehensionScoreResponse(BaseModel):
+    comprehension_score: float = Field(..., ge=0, le=100)
+    literal_score: float = Field(..., ge=0, le=100)
+    inferential_score: float = Field(..., ge=0, le=100)
+    evaluative_score: float = Field(..., ge=0, le=100)
+    feedback: dict[str, str] = Field(default_factory=dict)

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -289,6 +289,122 @@ async def generate_reading_analysis(session_data: dict) -> dict:
     )
 
 
+COMPREHENSION_SCORE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "comprehension_score": {
+            "type": "number",
+            "description": "Overall comprehension score 0-100",
+        },
+        "literal_score": {
+            "type": "number",
+            "description": "字面理解 score 0-100",
+        },
+        "inferential_score": {
+            "type": "number",
+            "description": "推論理解 score 0-100",
+        },
+        "evaluative_score": {
+            "type": "number",
+            "description": "評鑑理解 score 0-100",
+        },
+        "feedback": {
+            "type": "object",
+            "properties": {
+                "literal": {
+                    "type": "string",
+                    "description": "字面理解評語 (Traditional Chinese)",
+                },
+                "inferential": {
+                    "type": "string",
+                    "description": "推論理解評語 (Traditional Chinese)",
+                },
+                "evaluative": {
+                    "type": "string",
+                    "description": "評鑑理解評語 (Traditional Chinese)",
+                },
+                "overall": {
+                    "type": "string",
+                    "description": "整體評語 (Traditional Chinese)",
+                },
+            },
+            "required": ["literal", "inferential", "evaluative", "overall"],
+        },
+    },
+    "required": [
+        "comprehension_score",
+        "literal_score",
+        "inferential_score",
+        "evaluative_score",
+        "feedback",
+    ],
+}
+
+
+async def evaluate_comprehension(
+    dialogue_turns: list[dict],
+    story_context: dict,
+) -> dict:
+    """Evaluate student comprehension across 3 levels based on Socratic dialogue.
+
+    Args:
+        dialogue_turns: List of {"role": "ai"|"student", "text": str} dicts.
+        story_context: {"title": str, "summary": str} with story metadata.
+
+    Returns:
+        Dict with comprehension_score, literal_score, inferential_score,
+        evaluative_score, and feedback dict.
+    """
+    formatted_dialogue = "\n".join(
+        f"{'AI老師' if t['role'] == 'ai' else '學生'}: {t['text']}"
+        for t in dialogue_turns
+    )
+
+    system_prompt = f"""{TUTOR_PERSONA}
+你是國語文理解力評量專家。請根據以下蘇格拉底對話記錄，評估學生的三層次理解力。
+
+課文：{story_context['title']}
+課文內容摘要：{story_context['summary']}
+
+對話記錄：
+{formatted_dialogue}
+
+評分標準（0-100）：
+- literal_score（字面理解）：學生能否正確回答課文中明確提到的事實、人物、地點、事件？
+- inferential_score（推論理解）：學生能否推測因果關係、角色動機、或隱含的意義？
+- evaluative_score（評鑑理解）：學生能否連結自身經驗、提出觀點、或評論課文主題？
+
+評分規則：
+- 如果對話中沒有涉及某個層次的問題，給予 50 分（中間值）
+- 學生回答正確且詳細 → 80-100 分
+- 學生回答正確但簡略 → 60-79 分
+- 學生回答部分正確 → 40-59 分
+- 學生回答錯誤或敷衍 → 0-39 分
+- comprehension_score 是三個分數的加權平均（字面 30% + 推論 40% + 評鑑 30%）
+- 必須使用臺灣繁體中文（zh-TW）撰寫評語"""
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[genai_types.Part(text="請根據以上對話記錄評估學生的理解力。")],
+        )
+    ]
+
+    result = await generate_structured_response(
+        system_prompt=system_prompt,
+        contents=contents,
+        response_schema=COMPREHENSION_SCORE_SCHEMA,
+        max_tokens=1024,
+        temperature=0.3,
+    )
+
+    # Clamp scores to 0-100 range
+    for key in ("comprehension_score", "literal_score", "inferential_score", "evaluative_score"):
+        val = result.get(key, 50)
+        result[key] = max(0, min(100, float(val)))
+
+    return result
+
 async def generate_exit_ticket(text: str) -> list[dict]:
     """
     Generate exit-ticket questions for a story text.

--- a/backend/tests/test_comprehension_score.py
+++ b/backend/tests/test_comprehension_score.py
@@ -1,0 +1,389 @@
+"""
+Tests for the 3-level comprehension scoring API (Issue #243).
+
+Covers:
+- POST /api/learning/sessions/{id}/comprehension-score
+  - Success with mock Gemini response
+  - Cached scores returned without re-calling Gemini
+  - 404 for invalid session
+  - 403 for other user's session
+  - 401 for unauthenticated requests
+  - Score ranges are valid (0-100)
+  - All 3 sub-scores present
+  - 503 on Gemini failure
+
+Run with:
+    cd backend && python -m pytest tests/test_comprehension_score.py -v
+"""
+
+import sys
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+
+# ---------------------------------------------------------------------------
+# Test database setup (SQLite in-memory with StaticPool)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    """Create all tables once, seed roles, override get_db, and clean up at end."""
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiters():
+    """Reset all rate limiters before each test."""
+    from app.auth.rate_limiter import ai_rate_limiter, general_rate_limiter
+    from app.routes.auth import rate_limiter
+    ai_rate_limiter.reset()
+    general_rate_limiter.reset()
+    rate_limiter.reset()
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_user(client, suffix: str | None = None) -> dict:
+    """Register a user and return {email, password, token, name}."""
+    unique = suffix or uuid.uuid4().hex[:8]
+    email = f"comp_score_{unique}@example.com"
+    password = "SecurePass123!"
+    name = f"CompScore User {unique}"
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": name,
+    })
+    assert resp.status_code == 201, resp.text
+    return {
+        "email": email,
+        "password": password,
+        "name": name,
+        "token": resp.json()["access_token"],
+    }
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="module")
+def user_a(client):
+    return _register_user(client, "comp_a")
+
+
+@pytest.fixture(scope="module")
+def user_b(client):
+    return _register_user(client, "comp_b")
+
+
+# Mock Gemini response for comprehension scoring
+MOCK_GEMINI_SCORE = {
+    "comprehension_score": 75.0,
+    "literal_score": 85.0,
+    "inferential_score": 70.0,
+    "evaluative_score": 65.0,
+    "feedback": {
+        "literal": "你能正確回答課文的基本事實，表示你有仔細閱讀。",
+        "inferential": "推論能力不錯，但可以更深入思考角色的動機。",
+        "evaluative": "你的觀點很有趣，但可以多連結自己的經驗。",
+        "overall": "整體理解力不錯！繼續加油。",
+    },
+}
+
+SCORE_REQUEST_BODY = {
+    "story_title": "玉山",
+    "story_text": "玉山是東北亞第一高峰，海拔約3952公尺。",
+    "dialogue_turns": [
+        {"role": "ai", "text": "這篇課文提到玉山的稱號是什麼？"},
+        {"role": "student", "text": "東北亞第一高峰"},
+        {"role": "ai", "text": "為什麼玉山會被稱為東北亞第一高峰？"},
+        {"role": "student", "text": "因為它的海拔最高，有3952公尺"},
+        {"role": "ai", "text": "如果你有機會爬玉山，你會怎麼準備？"},
+        {"role": "student", "text": "我會帶很多水和食物，穿保暖的衣服"},
+    ],
+}
+
+
+def _create_session(client, token: str, slug: str = "comp-test") -> int:
+    resp = client.post(
+        "/api/learning/sessions",
+        json={"story_slug": slug},
+        headers=auth_header(token),
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+# ===========================================================================
+# POST /api/learning/sessions/{id}/comprehension-score
+# ===========================================================================
+
+
+class TestComprehensionScore:
+    @patch("app.routes.learning.evaluate_comprehension", new_callable=AsyncMock)
+    def test_score_returns_200_with_valid_data(self, mock_eval, client, user_a):
+        mock_eval.return_value = MOCK_GEMINI_SCORE
+        session_id = _create_session(client, user_a["token"], "score-200")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["comprehension_score"] == 75.0
+        assert data["literal_score"] == 85.0
+        assert data["inferential_score"] == 70.0
+        assert data["evaluative_score"] == 65.0
+        assert "feedback" in data
+        assert data["feedback"]["literal"] is not None
+        assert data["feedback"]["overall"] is not None
+
+    @patch("app.routes.learning.evaluate_comprehension", new_callable=AsyncMock)
+    def test_all_three_subscores_present(self, mock_eval, client, user_a):
+        mock_eval.return_value = MOCK_GEMINI_SCORE
+        session_id = _create_session(client, user_a["token"], "subscores")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        data = resp.json()
+        assert "literal_score" in data
+        assert "inferential_score" in data
+        assert "evaluative_score" in data
+
+    @patch("app.routes.learning.evaluate_comprehension", new_callable=AsyncMock)
+    def test_scores_in_valid_range(self, mock_eval, client, user_a):
+        mock_eval.return_value = MOCK_GEMINI_SCORE
+        session_id = _create_session(client, user_a["token"], "range")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        data = resp.json()
+        for key in ("comprehension_score", "literal_score", "inferential_score", "evaluative_score"):
+            assert 0 <= data[key] <= 100, f"{key}={data[key]} out of range"
+
+    @patch("app.routes.learning.evaluate_comprehension", new_callable=AsyncMock)
+    def test_cached_scores_returned_without_recalling_gemini(self, mock_eval, client, user_a):
+        mock_eval.return_value = MOCK_GEMINI_SCORE
+        session_id = _create_session(client, user_a["token"], "cache-test")
+
+        # First call — should call Gemini
+        resp1 = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp1.status_code == 200
+        assert mock_eval.call_count == 1
+
+        # Second call — should return cached, NOT call Gemini again
+        resp2 = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp2.status_code == 200
+        assert mock_eval.call_count == 1  # Still 1, not 2
+
+        # Verify same scores returned
+        assert resp1.json()["comprehension_score"] == resp2.json()["comprehension_score"]
+
+    def test_not_found_returns_404(self, client, user_a):
+        resp = client.post(
+            "/api/learning/sessions/999999/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Session not found"
+
+    def test_other_users_session_returns_403(self, client, user_a, user_b):
+        session_id = _create_session(client, user_b["token"], "owned-by-b")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Not your session"
+
+    def test_requires_auth(self, client):
+        resp = client.post(
+            "/api/learning/sessions/1/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_token_returns_401(self, client):
+        resp = client.post(
+            "/api/learning/sessions/1/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header("invalid.jwt.token"),
+        )
+        assert resp.status_code == 401
+
+    @patch("app.routes.learning.evaluate_comprehension", new_callable=AsyncMock)
+    def test_gemini_failure_returns_503(self, mock_eval, client, user_a):
+        mock_eval.side_effect = RuntimeError("AI service error")
+        session_id = _create_session(client, user_a["token"], "gemini-fail")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 503
+        assert "unavailable" in resp.json()["detail"].lower()
+
+    def test_empty_dialogue_returns_422(self, client, user_a):
+        session_id = _create_session(client, user_a["token"], "empty-dialogue")
+        body = {
+            "story_title": "Test",
+            "story_text": "Test story text.",
+            "dialogue_turns": [],
+        }
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=body,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 422
+
+    def test_missing_story_title_returns_422(self, client, user_a):
+        session_id = _create_session(client, user_a["token"], "missing-title")
+        body = {
+            "story_text": "Test story text.",
+            "dialogue_turns": [{"role": "ai", "text": "Question?"}],
+        }
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=body,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 422
+
+    @patch("app.routes.learning.evaluate_comprehension", new_callable=AsyncMock)
+    def test_scores_persisted_in_session_detail(self, mock_eval, client, user_a):
+        """Verify that comprehension scores appear in the session detail response."""
+        mock_eval.return_value = MOCK_GEMINI_SCORE
+        session_id = _create_session(client, user_a["token"], "persist-check")
+
+        # Score the session
+        client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+
+        # Fetch session detail
+        resp = client.get(
+            f"/api/learning/sessions/{session_id}",
+            headers=auth_header(user_a["token"]),
+        )
+        data = resp.json()
+        assert data["comprehension_score"] == 75.0
+        assert data["literal_score"] == 85.0
+        assert data["inferential_score"] == 70.0
+        assert data["evaluative_score"] == 65.0
+
+    @patch("app.routes.learning.evaluate_comprehension", new_callable=AsyncMock)
+    def test_feedback_structure(self, mock_eval, client, user_a):
+        mock_eval.return_value = MOCK_GEMINI_SCORE
+        session_id = _create_session(client, user_a["token"], "feedback-struct")
+
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/comprehension-score",
+            json=SCORE_REQUEST_BODY,
+            headers=auth_header(user_a["token"]),
+        )
+        feedback = resp.json()["feedback"]
+        assert "literal" in feedback
+        assert "inferential" in feedback
+        assert "evaluative" in feedback
+        assert "overall" in feedback

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -2,8 +2,10 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { LearningSession } from '../../types';
 import type { Story } from '../../types';
+import type { ComprehensionScoreResult } from '../../services/api';
 import DiffDisplay from '../ui/DiffDisplay';
 import CelebrationOverlay from '../ui/CelebrationOverlay';
+import ComprehensionScoreCard from './ComprehensionScoreCard';
 import { CPM_VERY_FAST, CPM_FAST, CPM_MEDIUM, CPM_SLOW } from '../../utils/personaConfig';
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
 import { parseReadingBenchmark, getBenchmarkFeedback } from '../../utils/fluencyAnalyzer';
@@ -52,6 +54,8 @@ interface AssessmentReportProps {
   story?: Story | null;
   onRetry: () => void;
   onGoToVocab?: () => void;
+  comprehensionScores?: ComprehensionScoreResult | null;
+  comprehensionScoresLoading?: boolean;
 }
 
 // CPM thresholds aligned with backend persona.py (Issue #54)
@@ -150,7 +154,7 @@ const Section: React.FC<{
   );
 };
 
-const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab }) => {
+const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab, comprehensionScores, comprehensionScoresLoading }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
 
   // Track lesson completion when a valid report is viewed.
@@ -569,8 +573,27 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
         )}
       </Section>
 
-      {/* ============ 環節六：AI 詳細分析 ============ */}
-      <Section number={6} title="AI 詳細分析" defaultOpen={false} disabled={!readingAttempt && !fullReadingResult}>
+      {/* ============ 環節六：課文理解力評估 (Issue #243) ============ */}
+      <Section number={6} title="課文理解力評估" defaultOpen={true} disabled={!comprehensionScores && !comprehensionScoresLoading}>
+        {comprehensionScores || comprehensionScoresLoading ? (
+          <ComprehensionScoreCard
+            comprehensionScore={comprehensionScores?.comprehension_score ?? 0}
+            literalScore={comprehensionScores?.literal_score ?? 0}
+            inferentialScore={comprehensionScores?.inferential_score ?? 0}
+            evaluativeScore={comprehensionScores?.evaluative_score ?? 0}
+            feedback={comprehensionScores?.feedback ?? null}
+            loading={comprehensionScoresLoading}
+          />
+        ) : (
+          <div className="p-6 bg-gray-50 rounded-2xl text-center">
+            <p className="text-sm text-gray-400 font-bold">尚未完成課文理解對話</p>
+            <p className="text-xs text-gray-300 mt-1">完成蘇格拉底式對話後，系統將評估你的三層次理解力</p>
+          </div>
+        )}
+      </Section>
+
+      {/* ============ 環節七：AI 詳細分析 (Issue #241) ============ */}
+      <Section number={7} title="AI 詳細分析" defaultOpen={false} disabled={!readingAttempt && !fullReadingResult}>
         {(readingAttempt || fullReadingResult) ? (
           <AIAnalysisSection
             storyTitle={story?.title ?? ''}

--- a/frontend/src/components/reading-steps/ComprehensionScoreCard.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionScoreCard.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import type { ComprehensionScoreFeedback } from '../../services/api';
+
+interface ComprehensionScoreCardProps {
+  comprehensionScore: number;
+  literalScore: number;
+  inferentialScore: number;
+  evaluativeScore: number;
+  feedback: ComprehensionScoreFeedback | null;
+  loading?: boolean;
+}
+
+const levelConfig = [
+  {
+    key: 'literal' as const,
+    label: '字面理解',
+    description: '回答課文中明確提到的事實',
+    color: 'bg-blue-500',
+    bgLight: 'bg-blue-50',
+    textColor: 'text-blue-700',
+    borderColor: 'border-blue-200',
+  },
+  {
+    key: 'inferential' as const,
+    label: '推論理解',
+    description: '推測因果關係與隱含意義',
+    color: 'bg-violet-500',
+    bgLight: 'bg-violet-50',
+    textColor: 'text-violet-700',
+    borderColor: 'border-violet-200',
+  },
+  {
+    key: 'evaluative' as const,
+    label: '評鑑理解',
+    description: '連結經驗、提出觀點與評論',
+    color: 'bg-amber-500',
+    bgLight: 'bg-amber-50',
+    textColor: 'text-amber-700',
+    borderColor: 'border-amber-200',
+  },
+];
+
+const getScoreLevel = (score: number) => {
+  if (score >= 80) return { label: '優秀', textColor: 'text-emerald-600' };
+  if (score >= 60) return { label: '良好', textColor: 'text-blue-600' };
+  if (score >= 40) return { label: '加油', textColor: 'text-amber-600' };
+  return { label: '待加強', textColor: 'text-red-500' };
+};
+
+const ComprehensionScoreCard: React.FC<ComprehensionScoreCardProps> = ({
+  comprehensionScore,
+  literalScore,
+  inferentialScore,
+  evaluativeScore,
+  feedback,
+  loading = false,
+}) => {
+  if (loading) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 animate-pulse">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-16 h-16 rounded-full bg-gray-200" />
+          <div className="space-y-2">
+            <div className="h-4 w-32 bg-gray-200 rounded" />
+            <div className="h-3 w-48 bg-gray-200 rounded" />
+          </div>
+        </div>
+        <div className="space-y-4">
+          {[1, 2, 3].map(i => (
+            <div key={i} className="h-12 bg-gray-100 rounded-xl" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const scores = {
+    literal: literalScore,
+    inferential: inferentialScore,
+    evaluative: evaluativeScore,
+  };
+
+  const overallLevel = getScoreLevel(comprehensionScore);
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white overflow-hidden">
+      {/* Header with overall score */}
+      <div className="bg-gradient-to-r from-accent/5 to-violet-50 px-6 py-5 border-b border-slate-100">
+        <div className="flex items-center gap-4">
+          {/* Score circle */}
+          <div className="relative w-16 h-16 shrink-0">
+            <svg className="w-16 h-16 -rotate-90" viewBox="0 0 64 64">
+              <circle
+                cx="32" cy="32" r="28"
+                fill="none"
+                stroke="#e2e8f0"
+                strokeWidth="4"
+              />
+              <circle
+                cx="32" cy="32" r="28"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="4"
+                strokeDasharray={`${(comprehensionScore / 100) * 175.93} 175.93`}
+                strokeLinecap="round"
+                className="text-accent transition-all duration-1000"
+              />
+            </svg>
+            <div className="absolute inset-0 flex items-center justify-center">
+              <span className="text-lg font-black text-gray-900">{Math.round(comprehensionScore)}</span>
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-bold text-gray-900">課文理解力評估</h3>
+            <p className={`text-sm font-bold ${overallLevel.textColor}`}>
+              {overallLevel.label}
+            </p>
+            {feedback?.overall && (
+              <p className="text-xs text-gray-500 mt-1">{feedback.overall}</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 3 level scores */}
+      <div className="p-6 space-y-4">
+        {levelConfig.map(level => {
+          const score = scores[level.key];
+          const scoreLevel = getScoreLevel(score);
+          const feedbackText = feedback?.[level.key];
+
+          return (
+            <div key={level.key} className={`rounded-xl border ${level.borderColor} ${level.bgLight} p-4`}>
+              <div className="flex items-center justify-between mb-2">
+                <div>
+                  <span className={`text-sm font-bold ${level.textColor}`}>{level.label}</span>
+                  <span className="text-xs text-gray-400 ml-2">{level.description}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className={`text-xs font-bold ${scoreLevel.textColor}`}>{scoreLevel.label}</span>
+                  <span className="text-lg font-black text-gray-900">{Math.round(score)}</span>
+                </div>
+              </div>
+
+              {/* Progress bar */}
+              <div className="w-full bg-white/60 rounded-full h-2 mb-2">
+                <div
+                  className={`${level.color} h-2 rounded-full transition-all duration-700`}
+                  style={{ width: `${Math.min(100, score)}%` }}
+                />
+              </div>
+
+              {/* Feedback text */}
+              {feedbackText && (
+                <p className="text-xs text-gray-600 mt-2 leading-relaxed">{feedbackText}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ComprehensionScoreCard;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -283,6 +283,48 @@ export interface ChatResponse {
   referenced_paragraph: number | null;
 }
 
+// --- Comprehension Scoring API (Issue #243) ---
+
+export interface ComprehensionScoreFeedback {
+  literal: string;
+  inferential: string;
+  evaluative: string;
+  overall: string;
+}
+
+export interface ComprehensionScoreResult {
+  comprehension_score: number;
+  literal_score: number;
+  inferential_score: number;
+  evaluative_score: number;
+  feedback: ComprehensionScoreFeedback;
+}
+
+export async function getComprehensionScore(
+  token: string,
+  sessionId: number,
+  payload: {
+    storyTitle: string;
+    storyText: string;
+    dialogueTurns: ConversationTurn[];
+  },
+): Promise<ComprehensionScoreResult> {
+  const res = await fetch(`${API_BASE}/api/learning/sessions/${sessionId}/comprehension-score`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      story_title: payload.storyTitle,
+      story_text: payload.storyText,
+      dialogue_turns: payload.dialogueTurns,
+    }),
+  });
+  if (!res.ok) throw new Error(`getComprehensionScore failed: ${res.status}`);
+  return res.json();
+}
+
 export async function sendComprehensionChat(payload: {
   sessionId: string;
   storyTitle: string;


### PR DESCRIPTION
## Summary
- Add comprehension scoring columns to LearningSession (literal, inferential, evaluative)
- Add `POST /api/learning/sessions/{id}/comprehension-score` endpoint
- Add `evaluate_comprehension()` in ai_service.py with Gemini
- Add `ComprehensionScoreCard` component with progress bars for 3 levels
- Integrated into AssessmentReport
- 13 new backend tests

## Test plan
- [x] Backend tests pass (13 new tests)
- [x] TypeScript compiles
- [ ] Manual: complete Socratic dialogue, verify scores appear in report

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)