### PR TITLE
feat: teacher individualized instructions for AI Socratic dialogue (Fixes #90)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,3 +8,4 @@ from .assignment import Assignment, AssignmentSubmission  # noqa: F401
 from .points_log import OrganizationPointsLog  # noqa: F401
 from .feedback import Feedback  # noqa: F401
 from .student_tag import StudentTag  # noqa: F401
+from .teacher_instruction import TeacherInstruction  # noqa: F401

--- a/backend/app/models/teacher_instruction.py
+++ b/backend/app/models/teacher_instruction.py
@@ -1,0 +1,25 @@
+"""
+Teacher special instructions for individualized learning.
+
+Allows teachers to set per-student instructional notes that are
+injected into the AI Socratic dialogue system prompt.
+"""
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class TeacherInstruction(Base):
+    __tablename__ = "teacher_instructions"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    teacher_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    student_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    classroom_id = Column(Integer, ForeignKey("classrooms.id"), nullable=False)
+    instruction_type = Column(String(50), default="general")  # general, reading, comprehension, vocabulary
+    content = Column(Text, nullable=False)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -9,6 +9,7 @@ from ..auth.rate_limiter import ai_limit_10_per_min, ai_limit_5_per_min
 from ..database import get_db
 from ..models.school import ClassroomStudent
 from ..models.session import LearningSession, DialogueTurn
+from ..models.teacher_instruction import TeacherInstruction
 from ..models.user import User
 from ..schemas.session import (
     SessionCreateRequest,
@@ -280,6 +281,21 @@ async def comprehension_chat(
     """
     try:
         if payload.student_answer is None:
+            # Fetch active teacher instructions for this student (Issue #90)
+            teacher_instructions_content: list[str] = []
+            try:
+                instructions = (
+                    db.query(TeacherInstruction)
+                    .filter(
+                        TeacherInstruction.student_id == current_user.id,
+                        TeacherInstruction.is_active == True,  # noqa: E712
+                    )
+                    .all()
+                )
+                teacher_instructions_content = [i.content for i in instructions]
+            except Exception as e:
+                logger.warning("Failed to fetch teacher instructions: %s", e)
+
             result = await socratic_agent.start_session(
                 session_id=payload.session_id,
                 story_title=payload.story_title,
@@ -287,6 +303,7 @@ async def comprehension_chat(
                 mispronounced_words=payload.mispronounced_words,
                 accuracy=payload.accuracy,
                 cpm=payload.cpm,
+                teacher_instructions=teacher_instructions_content or None,
             )
         else:
             result = await socratic_agent.process_answer(

--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -18,6 +18,13 @@ from ..dependencies.tenant import _check_classroom_access
 from ..models.school import Classroom, ClassroomStudent, ClassroomText
 from ..models.session import CharacterError, LearningSession
 from ..models.student_tag import StudentTag
+from ..models.teacher_instruction import TeacherInstruction
+from ..schemas.teacher_instruction import (
+    VALID_INSTRUCTION_TYPES,
+    InstructionCreate,
+    InstructionResponse,
+    InstructionUpdate,
+)
 from ..models.user import User
 from ..services.lesson_loader import get_lesson_by_id
 from .classrooms import _get_classroom_or_404, _require_owner_or_admin
@@ -1064,3 +1071,166 @@ def get_classroom_heatmap(
         stories=stories,
         scores=score_entries,
     )
+
+
+# ── Teacher Instructions (Individualized) ────────────────────────────────────
+
+
+@router.post(
+    "/teacher/students/{student_id}/instructions",
+    status_code=201,
+    response_model=InstructionResponse,
+)
+def create_student_instruction(
+    student_id: int,
+    payload: InstructionCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a special instruction for a student. Teacher must own the classroom."""
+    # Validate instruction_type
+    if payload.instruction_type not in VALID_INSTRUCTION_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid instruction_type. Must be one of: {', '.join(sorted(VALID_INSTRUCTION_TYPES))}",
+        )
+
+    # Verify teacher owns the classroom
+    classroom = _get_classroom_or_404(payload.classroom_id, db)
+    _require_owner_or_admin(classroom, current_user, db)
+
+    # Verify student is enrolled in this classroom
+    enrollment = (
+        db.query(ClassroomStudent)
+        .filter(
+            ClassroomStudent.classroom_id == payload.classroom_id,
+            ClassroomStudent.student_id == student_id,
+        )
+        .first()
+    )
+    if not enrollment:
+        raise HTTPException(
+            status_code=404,
+            detail="Student not found in this classroom",
+        )
+
+    instruction = TeacherInstruction(
+        teacher_id=current_user.id,
+        student_id=student_id,
+        classroom_id=payload.classroom_id,
+        instruction_type=payload.instruction_type,
+        content=payload.content,
+    )
+    db.add(instruction)
+    db.commit()
+    db.refresh(instruction)
+
+    logger.info(
+        "Created instruction %d for student %d in classroom %d (teacher %d)",
+        instruction.id, student_id, payload.classroom_id, current_user.id,
+    )
+    return instruction
+
+
+@router.get(
+    "/teacher/students/{student_id}/instructions",
+    response_model=list[InstructionResponse],
+)
+def list_student_instructions(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """List active instructions for a student. Teacher must own a classroom containing this student."""
+    # Verify teacher owns a classroom containing this student
+    enrollment = (
+        db.query(ClassroomStudent)
+        .join(Classroom, ClassroomStudent.classroom_id == Classroom.id)
+        .filter(
+            ClassroomStudent.student_id == student_id,
+            Classroom.teacher_id == current_user.id,
+        )
+        .first()
+    )
+    if not enrollment:
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to view this student's instructions",
+        )
+
+    instructions = (
+        db.query(TeacherInstruction)
+        .filter(
+            TeacherInstruction.student_id == student_id,
+            TeacherInstruction.teacher_id == current_user.id,
+            TeacherInstruction.is_active == True,  # noqa: E712
+        )
+        .order_by(TeacherInstruction.created_at.desc())
+        .all()
+    )
+    return instructions
+
+
+@router.patch(
+    "/teacher/instructions/{instruction_id}",
+    response_model=InstructionResponse,
+)
+def update_instruction(
+    instruction_id: int,
+    payload: InstructionUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update an instruction. Only the teacher who created it can update."""
+    instruction = (
+        db.query(TeacherInstruction)
+        .filter(TeacherInstruction.id == instruction_id)
+        .first()
+    )
+    if not instruction:
+        raise HTTPException(status_code=404, detail="Instruction not found")
+    if instruction.teacher_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not your instruction")
+
+    # Validate instruction_type if provided
+    if payload.instruction_type is not None and payload.instruction_type not in VALID_INSTRUCTION_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid instruction_type. Must be one of: {', '.join(sorted(VALID_INSTRUCTION_TYPES))}",
+        )
+
+    update_data = payload.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(instruction, field, value)
+
+    db.commit()
+    db.refresh(instruction)
+    logger.info("Updated instruction %d: %s", instruction_id, list(update_data.keys()))
+    return instruction
+
+
+@router.delete(
+    "/teacher/instructions/{instruction_id}",
+    response_model=InstructionResponse,
+)
+def delete_instruction(
+    instruction_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Soft-delete an instruction (set is_active=False). Only the teacher who created it can delete."""
+    instruction = (
+        db.query(TeacherInstruction)
+        .filter(TeacherInstruction.id == instruction_id)
+        .first()
+    )
+    if not instruction:
+        raise HTTPException(status_code=404, detail="Instruction not found")
+    if instruction.teacher_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not your instruction")
+
+    instruction.is_active = False
+    db.commit()
+    db.refresh(instruction)
+    logger.info("Soft-deleted instruction %d (teacher %d)", instruction_id, current_user.id)
+    return instruction

--- a/backend/app/schemas/teacher_instruction.py
+++ b/backend/app/schemas/teacher_instruction.py
@@ -1,0 +1,33 @@
+"""Pydantic schemas for teacher instruction CRUD."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+# Valid instruction types
+VALID_INSTRUCTION_TYPES = {"general", "reading", "comprehension", "vocabulary"}
+
+
+class InstructionCreate(BaseModel):
+    classroom_id: int
+    instruction_type: str = "general"
+    content: str = Field(..., min_length=1, max_length=500)
+
+
+class InstructionUpdate(BaseModel):
+    content: str | None = Field(None, min_length=1, max_length=500)
+    instruction_type: str | None = None
+    is_active: bool | None = None
+
+
+class InstructionResponse(BaseModel):
+    id: int
+    teacher_id: int
+    student_id: int
+    classroom_id: int
+    instruction_type: str
+    content: str
+    is_active: bool
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/socratic_agent.py
+++ b/backend/app/services/socratic_agent.py
@@ -31,6 +31,8 @@ class SessionState:
     mispronounced_words: list[str] | None = None
     accuracy: float | None = None
     cpm: float | None = None
+    # Teacher special instructions for individualized learning (Issue #90)
+    teacher_instructions: list[str] | None = None
 
 
 class SessionStore:
@@ -134,6 +136,14 @@ class SocraticAgent:
             f"[第{i}段] {p}" for i, p in enumerate(paragraphs, 1) if p.strip()
         )
 
+        # Build teacher instructions section if available (Issue #90)
+        teacher_instructions_section = ""
+        if state.teacher_instructions:
+            teacher_instructions_section = "\n教師特別指示：\n"
+            for instr in state.teacher_instructions:
+                teacher_instructions_section += f"- {instr}\n"
+            teacher_instructions_section += "→ 請根據以上指示調整你的教學方式\n"
+
         # Build reading info section if data is available (Issue #17)
         reading_info = ""
         if state.mispronounced_words or state.accuracy is not None or state.cpm is not None:
@@ -153,7 +163,7 @@ class SocraticAgent:
 
 課文內容（每段前標有段落索引）：
 {numbered_text}
-{reading_info}
+{reading_info}{teacher_instructions_section}
 你的任務：
 1. 評估學生的回答是否展現了對問題的理解
 2. 給予簡短、溫暖的回饋（1-2句）
@@ -208,6 +218,7 @@ class SocraticAgent:
         mispronounced_words: list[str] | None = None,
         accuracy: float | None = None,
         cpm: float | None = None,
+        teacher_instructions: list[str] | None = None,
     ) -> AgentResponse:
         """Start a new session — generate the first question."""
         state = SessionState(
@@ -217,6 +228,7 @@ class SocraticAgent:
             mispronounced_words=mispronounced_words,
             accuracy=accuracy,
             cpm=cpm,
+            teacher_instructions=teacher_instructions,
         )
 
         system_prompt = self._build_system_prompt(state)

--- a/backend/tests/test_teacher_instructions.py
+++ b/backend/tests/test_teacher_instructions.py
@@ -1,0 +1,630 @@
+"""
+Tests for teacher special instructions API (Issue #90).
+
+Covers:
+- POST /api/teacher/students/{student_id}/instructions  (create)
+- GET  /api/teacher/students/{student_id}/instructions   (list active)
+- PATCH /api/teacher/instructions/{instruction_id}       (update)
+- DELETE /api/teacher/instructions/{instruction_id}      (soft delete)
+- Authorization checks (teacher must own classroom)
+- Instruction type validation
+- Integration with Socratic agent (verify instructions in system prompt)
+
+Run with:
+    cd backend && python -m pytest tests/test_teacher_instructions.py -v
+"""
+
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, UserRole
+from app.models.school import School
+
+
+# ---------------------------------------------------------------------------
+# Test database setup (SQLite in-memory with StaticPool)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        session.add(Role(**role_data))
+    session.commit()
+
+
+def _seed_school(session) -> int:
+    school = School(name="Instruction Test School")
+    session.add(school)
+    session.commit()
+    session.refresh(school)
+    return school.id
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+_test_school_id: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    global _test_school_id
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    _test_school_id = _seed_school(session)
+    session.close()
+
+    from app.routes.auth import rate_limiter
+    rate_limiter.reset()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def school_id():
+    return _test_school_id
+
+
+def _register_user(client, suffix: str) -> dict:
+    unique = uuid.uuid4().hex[:8]
+    email = f"{suffix}_{unique}@example.com"
+    password = "SecurePass123!"
+    name = f"{suffix.title()} {unique}"
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": name,
+    })
+    assert resp.status_code == 201
+    token = resp.json()["access_token"]
+    me_resp = client.get("/api/users/me", headers=auth_header(token))
+    user_id = me_resp.json()["id"]
+    return {"email": email, "name": name, "token": token, "user_id": user_id}
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_admin(user_id: int):
+    db = TestingSessionLocal()
+    role = db.query(Role).filter(Role.name == "system_admin").first()
+    user_role = UserRole(
+        user_id=user_id,
+        role_id=role.id,
+        scope_type="platform",
+        scope_id=None,
+    )
+    db.add(user_role)
+    db.commit()
+    db.close()
+
+
+@pytest.fixture(scope="module")
+def teacher(client):
+    return _register_user(client, "instr_teacher")
+
+
+@pytest.fixture(scope="module")
+def other_teacher(client):
+    return _register_user(client, "instr_other")
+
+
+@pytest.fixture(scope="module")
+def student1(client):
+    return _register_user(client, "instr_stu1")
+
+
+@pytest.fixture(scope="module")
+def student2(client):
+    return _register_user(client, "instr_stu2")
+
+
+@pytest.fixture(scope="module")
+def admin_user(client):
+    user = _register_user(client, "instr_admin")
+    _make_admin(user["user_id"])
+    return user
+
+
+@pytest.fixture(scope="module")
+def classroom_with_student(client, teacher, student1, school_id):
+    """Create a classroom with student1 enrolled, owned by teacher."""
+    create_resp = client.post(
+        "/api/classrooms",
+        json={"name": "Instruction Test Class", "school_id": school_id},
+        headers=auth_header(teacher["token"]),
+    )
+    assert create_resp.status_code == 201
+    classroom_id = create_resp.json()["id"]
+
+    # Add student
+    add_resp = client.post(
+        f"/api/classrooms/{classroom_id}/students",
+        json={"student_id": student1["user_id"]},
+        headers=auth_header(teacher["token"]),
+    )
+    assert add_resp.status_code == 201
+
+    return classroom_id
+
+
+# ===========================================================================
+# POST /api/teacher/students/{student_id}/instructions — Create instruction
+# ===========================================================================
+
+
+class TestCreateInstruction:
+    def test_create_instruction_happy_path(self, client, teacher, student1, classroom_with_student):
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "This student needs extra encouragement",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["teacher_id"] == teacher["user_id"]
+        assert data["student_id"] == student1["user_id"]
+        assert data["classroom_id"] == classroom_with_student
+        assert data["instruction_type"] == "general"
+        assert data["content"] == "This student needs extra encouragement"
+        assert data["is_active"] is True
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_create_instruction_with_reading_type(self, client, teacher, student1, classroom_with_student):
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "reading",
+                "content": "Please slow down reading pace for this student",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        assert resp.json()["instruction_type"] == "reading"
+
+    def test_create_instruction_with_comprehension_type(self, client, teacher, student1, classroom_with_student):
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "comprehension",
+                "content": "Focus on inference questions",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        assert resp.json()["instruction_type"] == "comprehension"
+
+    def test_create_instruction_with_vocabulary_type(self, client, teacher, student1, classroom_with_student):
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "vocabulary",
+                "content": "Extra focus on stroke order practice",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 201
+        assert resp.json()["instruction_type"] == "vocabulary"
+
+    def test_teacher_must_own_classroom(self, client, other_teacher, student1, classroom_with_student):
+        """other_teacher does not own the classroom -> 403."""
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Some instruction",
+            },
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+    def test_student_must_be_in_classroom(self, client, teacher, student2, classroom_with_student):
+        """student2 is not enrolled in the classroom -> 404."""
+        resp = client.post(
+            f"/api/teacher/students/{student2['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Some instruction",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 404
+
+    def test_invalid_instruction_type(self, client, teacher, student1, classroom_with_student):
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "invalid_type",
+                "content": "Some instruction",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 422
+
+    def test_content_max_length_500(self, client, teacher, student1, classroom_with_student):
+        """Content exceeding 500 characters should be rejected."""
+        long_content = "x" * 501
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": long_content,
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 422
+
+    def test_empty_content_rejected(self, client, teacher, student1, classroom_with_student):
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 422
+
+    def test_requires_auth(self, client, student1, classroom_with_student):
+        resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Some instruction",
+            },
+        )
+        assert resp.status_code == 401
+
+
+# ===========================================================================
+# GET /api/teacher/students/{student_id}/instructions — List instructions
+# ===========================================================================
+
+
+class TestListInstructions:
+    def test_list_active_instructions(self, client, teacher, student1):
+        resp = client.get(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        # Should have the instructions created in TestCreateInstruction
+        assert len(data) >= 1
+        # All returned instructions should be active
+        for item in data:
+            assert item["is_active"] is True
+
+    def test_other_teacher_cannot_list(self, client, other_teacher, student1):
+        resp = client.get(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client, student1):
+        resp = client.get(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+        )
+        assert resp.status_code == 401
+
+
+# ===========================================================================
+# PATCH /api/teacher/instructions/{id} — Update instruction
+# ===========================================================================
+
+
+class TestUpdateInstruction:
+    def test_update_content(self, client, teacher, student1, classroom_with_student):
+        # Create a fresh instruction
+        create_resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Original content",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert create_resp.status_code == 201
+        instruction_id = create_resp.json()["id"]
+
+        # Update it
+        resp = client.patch(
+            f"/api/teacher/instructions/{instruction_id}",
+            json={"content": "Updated content"},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["content"] == "Updated content"
+
+    def test_update_instruction_type(self, client, teacher, student1, classroom_with_student):
+        create_resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Type change test",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        instruction_id = create_resp.json()["id"]
+
+        resp = client.patch(
+            f"/api/teacher/instructions/{instruction_id}",
+            json={"instruction_type": "reading"},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["instruction_type"] == "reading"
+
+    def test_update_invalid_type_rejected(self, client, teacher, student1, classroom_with_student):
+        create_resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Invalid type update test",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        instruction_id = create_resp.json()["id"]
+
+        resp = client.patch(
+            f"/api/teacher/instructions/{instruction_id}",
+            json={"instruction_type": "nonexistent"},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 422
+
+    def test_other_teacher_cannot_update(self, client, teacher, other_teacher, student1, classroom_with_student):
+        create_resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Auth test",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        instruction_id = create_resp.json()["id"]
+
+        resp = client.patch(
+            f"/api/teacher/instructions/{instruction_id}",
+            json={"content": "Hacked"},
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+    def test_update_nonexistent_instruction(self, client, teacher):
+        resp = client.patch(
+            "/api/teacher/instructions/99999",
+            json={"content": "Does not exist"},
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, client):
+        resp = client.patch(
+            "/api/teacher/instructions/1",
+            json={"content": "Unauthenticated"},
+        )
+        assert resp.status_code == 401
+
+
+# ===========================================================================
+# DELETE /api/teacher/instructions/{id} — Soft delete
+# ===========================================================================
+
+
+class TestDeleteInstruction:
+    def test_soft_delete(self, client, teacher, student1, classroom_with_student):
+        # Create instruction
+        create_resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Will be deleted",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        instruction_id = create_resp.json()["id"]
+
+        # Delete it
+        resp = client.delete(
+            f"/api/teacher/instructions/{instruction_id}",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["is_active"] is False
+
+    def test_deleted_instructions_not_in_list(self, client, teacher, student1, classroom_with_student):
+        # Create a fresh instruction
+        create_resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Will be soft deleted and hidden",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        instruction_id = create_resp.json()["id"]
+
+        # Delete it
+        client.delete(
+            f"/api/teacher/instructions/{instruction_id}",
+            headers=auth_header(teacher["token"]),
+        )
+
+        # List should not contain the deleted instruction
+        resp = client.get(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            headers=auth_header(teacher["token"]),
+        )
+        data = resp.json()
+        ids = [item["id"] for item in data]
+        assert instruction_id not in ids
+
+    def test_other_teacher_cannot_delete(self, client, teacher, other_teacher, student1, classroom_with_student):
+        create_resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Not yours to delete",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        instruction_id = create_resp.json()["id"]
+
+        resp = client.delete(
+            f"/api/teacher/instructions/{instruction_id}",
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+    def test_delete_nonexistent_instruction(self, client, teacher):
+        resp = client.delete(
+            "/api/teacher/instructions/99999",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 404
+
+    def test_requires_auth(self, client):
+        resp = client.delete("/api/teacher/instructions/1")
+        assert resp.status_code == 401
+
+
+# ===========================================================================
+# Integration: Socratic Agent receives teacher instructions
+# ===========================================================================
+
+
+class TestSocraticAgentIntegration:
+    def test_instructions_included_in_system_prompt(self):
+        """Verify teacher instructions are injected into the system prompt."""
+        from app.services.socratic_agent import SocraticAgent, SessionState
+
+        agent = SocraticAgent()
+        state = SessionState(
+            session_id="test-session",
+            story_title="Test Story",
+            story_text="This is paragraph one.\nThis is paragraph two.",
+            teacher_instructions=["Read slowly for this student", "Focus on comprehension questions"],
+        )
+
+        prompt = agent._build_system_prompt(state)
+        assert "Read slowly for this student" in prompt
+        assert "Focus on comprehension questions" in prompt
+        assert "please adjust" in prompt.lower() or "adjust" in prompt.lower() or "根據以上指示調整" in prompt
+
+    def test_no_instructions_section_when_none(self):
+        """System prompt should not contain teacher instructions section when none given."""
+        from app.services.socratic_agent import SocraticAgent, SessionState
+
+        agent = SocraticAgent()
+        state = SessionState(
+            session_id="test-session-2",
+            story_title="Test Story",
+            story_text="Content here.",
+            teacher_instructions=None,
+        )
+
+        prompt = agent._build_system_prompt(state)
+        assert "teacher instructions" not in prompt.lower() or "教師特別指示" not in prompt
+
+    def test_empty_instructions_list_no_section(self):
+        """System prompt should not contain instructions section for empty list."""
+        from app.services.socratic_agent import SocraticAgent, SessionState
+
+        agent = SocraticAgent()
+        state = SessionState(
+            session_id="test-session-3",
+            story_title="Test Story",
+            story_text="Content here.",
+            teacher_instructions=[],
+        )
+
+        prompt = agent._build_system_prompt(state)
+        assert "教師特別指示" not in prompt

--- a/frontend/src/pages/teacher/StudentProgressTab.tsx
+++ b/frontend/src/pages/teacher/StudentProgressTab.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import {
   getClassroomProgress,
   getStudentSessions,
+  getStudentInstructions,
   exportClassroomReport,
   addStudentTag,
   removeStudentTag,
@@ -23,6 +24,7 @@ import {
   LearningCurvePoint,
   TeacherApiError,
 } from '../../services/teacherApi';
+import TeacherInstructionPanel from './TeacherInstructionPanel';
 
 interface StudentProgressTabProps {
   classroomId: number;
@@ -250,6 +252,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   const [sessions, setSessions] = useState<StudentSession[]>([]);
   const sessionCache = useRef<Record<number, StudentSession[]>>({});
 
+  // Instruction panel state
+  const [instructionTarget, setInstructionTarget] = useState<{ id: number; name: string } | null>(null);
+  const [instructionCounts, setInstructionCounts] = useState<Record<number, number>>({});
+
   // Tag management state
   const [tagManagerStudent, setTagManagerStudent] = useState<StudentProgress | null>(null);
 
@@ -286,6 +292,30 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   useEffect(() => {
     loadProgress();
   }, [loadProgress]);
+
+
+  // Load instruction counts for each student
+  const loadInstructionCounts = useCallback(async (students: StudentProgress[]) => {
+    if (!token || students.length === 0) return;
+    const counts: Record<number, number> = {};
+    await Promise.all(
+      students.map(async (s) => {
+        try {
+          const instructions = await getStudentInstructions(token, s.student_id);
+          counts[s.student_id] = instructions.length;
+        } catch {
+          counts[s.student_id] = 0;
+        }
+      }),
+    );
+    setInstructionCounts(counts);
+  }, [token]);
+
+  useEffect(() => {
+    if (progress.length > 0) {
+      loadInstructionCounts(progress);
+    }
+  }, [progress, loadInstructionCounts]);
 
   const handleExport = useCallback(async () => {
     if (!token) return;
@@ -486,6 +516,7 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
               <th className="pb-2 font-medium">最近練習日期</th>
               <th className="pb-2 font-medium">最近練習課文</th>
               <th className="pb-2 font-medium text-center">練習次數</th>
+              <th className="pb-2 font-medium text-center w-10">指示</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">
@@ -546,10 +577,29 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                         {s.total_sessions}
                       </span>
                     </td>
+                    <td className="py-2.5 text-center">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setInstructionTarget({ id: s.student_id, name: s.student_name });
+                        }}
+                        className="relative inline-flex items-center justify-center p-1.5 rounded-lg hover:bg-amber-50 transition-colors group"
+                        title="AI 教學指示"
+                      >
+                        <svg className="w-4 h-4 text-gray-400 group-hover:text-amber-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                        </svg>
+                        {(instructionCounts[s.student_id] ?? 0) > 0 && (
+                          <span className="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center w-3.5 h-3.5 text-[9px] font-bold text-white bg-amber-500 rounded-full">
+                            {instructionCounts[s.student_id]}
+                          </span>
+                        )}
+                      </button>
+                    </td>
                   </tr>
                   {isExpanded && (
                     <tr>
-                      <td colSpan={5} className="bg-gray-50 px-4 py-3 space-y-4">
+                      <td colSpan={6} className="bg-gray-50 px-4 py-3 space-y-4">
                         {/* Learning curve chart */}
                         {isLoadingCurve ? (
                           <div className="h-40 bg-gray-200 animate-pulse rounded" />
@@ -641,6 +691,20 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
           </tbody>
         </table>
       </div>
+
+      {/* Teacher Instruction Panel Modal */}
+      {instructionTarget && (
+        <TeacherInstructionPanel
+          studentId={instructionTarget.id}
+          studentName={instructionTarget.name}
+          classroomId={classroomId}
+          onClose={() => {
+            setInstructionTarget(null);
+            // Refresh instruction counts when panel closes
+            loadInstructionCounts(progress);
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/teacher/TeacherInstructionPanel.tsx
+++ b/frontend/src/pages/teacher/TeacherInstructionPanel.tsx
@@ -1,0 +1,338 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  getStudentInstructions,
+  createStudentInstruction,
+  updateInstruction,
+  deleteInstruction,
+  TeacherInstruction,
+  TeacherApiError,
+} from '../../services/teacherApi';
+
+interface TeacherInstructionPanelProps {
+  studentId: number;
+  studentName: string;
+  classroomId: number;
+  onClose: () => void;
+}
+
+const INSTRUCTION_TYPES = [
+  { value: 'general', label: '一般', color: 'bg-gray-100 text-gray-700' },
+  { value: 'reading', label: '朗讀', color: 'bg-blue-100 text-blue-700' },
+  { value: 'comprehension', label: '理解', color: 'bg-purple-100 text-purple-700' },
+  { value: 'vocabulary', label: '生字', color: 'bg-green-100 text-green-700' },
+];
+
+function getTypeConfig(type: string) {
+  return INSTRUCTION_TYPES.find((t) => t.value === type) ?? INSTRUCTION_TYPES[0];
+}
+
+const TeacherInstructionPanel: React.FC<TeacherInstructionPanelProps> = ({
+  studentId,
+  studentName,
+  classroomId,
+  onClose,
+}) => {
+  const { token } = useAuth();
+  const [instructions, setInstructions] = useState<TeacherInstruction[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  // New instruction form state
+  const [newContent, setNewContent] = useState('');
+  const [newType, setNewType] = useState('general');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Edit state
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editContent, setEditContent] = useState('');
+  const [editType, setEditType] = useState('general');
+
+  const loadInstructions = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const data = await getStudentInstructions(token, studentId);
+      setInstructions(data);
+    } catch (err) {
+      if (err instanceof TeacherApiError) {
+        setError(err.message);
+      } else {
+        setError('Failed to load instructions');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, studentId]);
+
+  useEffect(() => {
+    loadInstructions();
+  }, [loadInstructions]);
+
+  const handleCreate = useCallback(async () => {
+    if (!token || !newContent.trim()) return;
+    setIsSubmitting(true);
+    setError('');
+    try {
+      await createStudentInstruction(token, studentId, {
+        classroom_id: classroomId,
+        instruction_type: newType,
+        content: newContent.trim(),
+      });
+      setNewContent('');
+      setNewType('general');
+      await loadInstructions();
+    } catch (err) {
+      if (err instanceof TeacherApiError) {
+        setError(err.message);
+      } else {
+        setError('Failed to create instruction');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [token, studentId, classroomId, newContent, newType, loadInstructions]);
+
+  const handleUpdate = useCallback(
+    async (id: number) => {
+      if (!token || !editContent.trim()) return;
+      setError('');
+      try {
+        await updateInstruction(token, id, {
+          content: editContent.trim(),
+          instruction_type: editType,
+        });
+        setEditingId(null);
+        await loadInstructions();
+      } catch (err) {
+        if (err instanceof TeacherApiError) {
+          setError(err.message);
+        } else {
+          setError('Failed to update instruction');
+        }
+      }
+    },
+    [token, editContent, editType, loadInstructions],
+  );
+
+  const handleDelete = useCallback(
+    async (id: number) => {
+      if (!token) return;
+      setError('');
+      try {
+        await deleteInstruction(token, id);
+        await loadInstructions();
+      } catch (err) {
+        if (err instanceof TeacherApiError) {
+          setError(err.message);
+        } else {
+          setError('Failed to delete instruction');
+        }
+      }
+    },
+    [token, loadInstructions],
+  );
+
+  const startEditing = (instr: TeacherInstruction) => {
+    setEditingId(instr.id);
+    setEditContent(instr.content);
+    setEditType(instr.instruction_type);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+          <div>
+            <h3 className="text-base font-semibold text-gray-900">
+              {studentName} - AI 教學指示
+            </h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              設定特別指示，AI 對話時會依照指示調整教學方式
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          {error && (
+            <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+              {error}
+            </div>
+          )}
+
+          {/* New instruction form */}
+          <div className="space-y-2">
+            <div className="flex gap-2">
+              <select
+                value={newType}
+                onChange={(e) => setNewType(e.target.value)}
+                className="px-2.5 py-1.5 text-sm border border-gray-200 rounded-lg bg-white focus:ring-2 focus:ring-accent/30 focus:border-accent outline-none"
+              >
+                {INSTRUCTION_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+              <div className="flex-1 relative">
+                <textarea
+                  value={newContent}
+                  onChange={(e) => setNewContent(e.target.value)}
+                  placeholder="輸入教學指示，例如：這個學生有閱讀障礙，請放慢速度..."
+                  maxLength={500}
+                  rows={2}
+                  className="w-full px-3 py-1.5 text-sm border border-gray-200 rounded-lg resize-none focus:ring-2 focus:ring-accent/30 focus:border-accent outline-none"
+                />
+                <span className="absolute bottom-1.5 right-2 text-[10px] text-gray-300">
+                  {newContent.length}/500
+                </span>
+              </div>
+            </div>
+            <div className="flex justify-end">
+              <button
+                onClick={handleCreate}
+                disabled={isSubmitting || !newContent.trim()}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-accent text-white hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                {isSubmitting ? '新增中...' : '新增指示'}
+              </button>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <hr className="border-gray-100" />
+
+          {/* Instruction list */}
+          {isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 2 }).map((_, i) => (
+                <div key={i} className="h-16 bg-gray-100 animate-pulse rounded-lg" />
+              ))}
+            </div>
+          ) : instructions.length === 0 ? (
+            <div className="text-center py-6">
+              <svg className="w-10 h-10 text-gray-300 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z" />
+              </svg>
+              <p className="text-sm text-gray-500">尚無教學指示</p>
+              <p className="text-xs text-gray-400 mt-0.5">新增指示後，AI 對話時會自動套用</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {instructions.map((instr) => {
+                const typeConfig = getTypeConfig(instr.instruction_type);
+                const isEditing = editingId === instr.id;
+
+                return (
+                  <div
+                    key={instr.id}
+                    className="border border-gray-100 rounded-lg p-3 hover:border-gray-200 transition-colors"
+                  >
+                    {isEditing ? (
+                      <div className="space-y-2">
+                        <div className="flex gap-2">
+                          <select
+                            value={editType}
+                            onChange={(e) => setEditType(e.target.value)}
+                            className="px-2 py-1 text-sm border border-gray-200 rounded-lg bg-white focus:ring-2 focus:ring-accent/30 outline-none"
+                          >
+                            {INSTRUCTION_TYPES.map((t) => (
+                              <option key={t.value} value={t.value}>
+                                {t.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <textarea
+                          value={editContent}
+                          onChange={(e) => setEditContent(e.target.value)}
+                          maxLength={500}
+                          rows={2}
+                          className="w-full px-3 py-1.5 text-sm border border-gray-200 rounded-lg resize-none focus:ring-2 focus:ring-accent/30 outline-none"
+                        />
+                        <div className="flex gap-2 justify-end">
+                          <button
+                            onClick={() => setEditingId(null)}
+                            className="px-2.5 py-1 text-xs font-medium rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
+                          >
+                            取消
+                          </button>
+                          <button
+                            onClick={() => handleUpdate(instr.id)}
+                            disabled={!editContent.trim()}
+                            className="px-2.5 py-1 text-xs font-medium rounded-lg bg-accent text-white hover:bg-accent/90 disabled:opacity-50 transition-colors"
+                          >
+                            儲存
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div>
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="flex-1">
+                            <span
+                              className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${typeConfig.color} mb-1.5`}
+                            >
+                              {typeConfig.label}
+                            </span>
+                            <p className="text-sm text-gray-700 leading-relaxed">
+                              {instr.content}
+                            </p>
+                          </div>
+                          <div className="flex gap-1 shrink-0">
+                            <button
+                              onClick={() => startEditing(instr)}
+                              className="p-1 rounded hover:bg-gray-100 transition-colors"
+                              title="Edit"
+                            >
+                              <svg className="w-3.5 h-3.5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                              </svg>
+                            </button>
+                            <button
+                              onClick={() => handleDelete(instr.id)}
+                              className="p-1 rounded hover:bg-red-50 transition-colors"
+                              title="Delete"
+                            >
+                              <svg className="w-3.5 h-3.5 text-gray-400 hover:text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                              </svg>
+                            </button>
+                          </div>
+                        </div>
+                        <p className="text-[10px] text-gray-300 mt-1.5">
+                          {new Date(instr.created_at).toLocaleDateString('zh-TW', {
+                            year: 'numeric',
+                            month: 'short',
+                            day: 'numeric',
+                          })}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TeacherInstructionPanel;

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -364,3 +364,89 @@ export async function getStudentLearningCurve(
   );
   return handleResponse<LearningCurveData>(res);
 }
+
+// --- Teacher Instructions (Individualized) ---
+
+export interface TeacherInstruction {
+  id: number;
+  teacher_id: number;
+  student_id: number;
+  classroom_id: number;
+  instruction_type: string;
+  content: string;
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface InstructionCreateData {
+  classroom_id: number;
+  instruction_type: string;
+  content: string;
+}
+
+export interface InstructionUpdateData {
+  content?: string;
+  instruction_type?: string;
+  is_active?: boolean;
+}
+
+/** Create a special instruction for a student. */
+export async function createStudentInstruction(
+  token: string,
+  studentId: number,
+  data: InstructionCreateData,
+): Promise<TeacherInstruction> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/students/${studentId}/instructions`,
+    {
+      method: 'POST',
+      headers: authHeaders(token),
+      body: JSON.stringify(data),
+    },
+  );
+  return handleResponse<TeacherInstruction>(res);
+}
+
+/** Get active instructions for a student. */
+export async function getStudentInstructions(
+  token: string,
+  studentId: number,
+): Promise<TeacherInstruction[]> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/students/${studentId}/instructions`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return handleResponse<TeacherInstruction[]>(res);
+}
+
+/** Update an instruction. */
+export async function updateInstruction(
+  token: string,
+  instructionId: number,
+  data: InstructionUpdateData,
+): Promise<TeacherInstruction> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/instructions/${instructionId}`,
+    {
+      method: 'PATCH',
+      headers: authHeaders(token),
+      body: JSON.stringify(data),
+    },
+  );
+  return handleResponse<TeacherInstruction>(res);
+}
+
+/** Soft-delete an instruction. */
+export async function deleteInstruction(
+  token: string,
+  instructionId: number,
+): Promise<TeacherInstruction> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/instructions/${instructionId}`,
+    {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  return handleResponse<TeacherInstruction>(res);
+}


### PR DESCRIPTION
Fixes #90

## Summary

- Add `TeacherInstruction` SQLAlchemy model (`teacher_instructions` table) with soft-delete support
- Add Pydantic schemas: `InstructionCreate`, `InstructionUpdate`, `InstructionResponse`
- Add 4 CRUD endpoints under `/api/teacher/`:
  - `POST /teacher/students/{id}/instructions` — create instruction (teacher must own classroom)
  - `GET /teacher/students/{id}/instructions` — list active instructions
  - `PATCH /teacher/instructions/{id}` — update content/type (owner only)
  - `DELETE /teacher/instructions/{id}` — soft-delete (owner only)
- Inject active teacher instructions into `SocraticAgent` system prompt at session start
- Add `TeacherInstructionPanel` React modal component (CRUD UI with type badges: 一般/朗讀/理解/生字)
- Add instruction count badge to `StudentProgressTab` with inline panel trigger button
- Extend `teacherApi.ts` with `TeacherInstruction` types and 4 API helper functions

## Authorization model

- Create: teacher must own the classroom AND student must be enrolled
- List: teacher must own at least one classroom containing the student
- Update/Delete: only the teacher who created the instruction

## Test plan

- [ ] 27 unit/integration tests: `cd backend && python -m pytest tests/test_teacher_instructions.py -v`
- [ ] Teacher opens instruction panel from StudentProgressTab via lightbulb icon
- [ ] Teacher can create, edit, and delete instructions per student
- [ ] Badge count updates after panel closes
- [ ] When student starts Socratic session, active instructions appear in AI system prompt
- [ ] Instruction from teacher A not visible to teacher B

🤖 Generated with [Claude Code](https://claude.com/claude-code)