### PR TITLE
feat: add Alembic migration for manually-added columns (Related to #288)

### DIFF
--- a/backend/alembic/versions/k1l2m3n4o5p6_add_user_onboarding_and_org_teacher_limit.py
+++ b/backend/alembic/versions/k1l2m3n4o5p6_add_user_onboarding_and_org_teacher_limit.py
@@ -1,0 +1,89 @@
+"""add user onboarding/auth columns and org teacher_limit
+
+Covers manually ALTER TABLE'd columns that were missing from migration chain:
+- users.onboarding_completed
+- users.password_reset_token (+ index)
+- users.password_reset_expires
+- users.email_verification_token
+- users.terms_accepted_at
+- users.terms_version
+- users.privacy_accepted_at
+- organizations.teacher_limit
+
+Uses IF NOT EXISTS in raw SQL so the migration is safe on staging (columns
+already exist) and correct on fresh databases (columns don't exist yet).
+
+Revision ID: k1l2m3n4o5p6
+Revises: j0k1l2m3n4o5
+Create Date: 2026-03-09 14:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'k1l2m3n4o5p6'
+down_revision: Union[str, None] = 'j0k1l2m3n4o5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- users table: onboarding + auth columns ---
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS "
+        "onboarding_completed BOOLEAN NOT NULL DEFAULT false"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS "
+        "password_reset_token VARCHAR(64)"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS "
+        "password_reset_expires TIMESTAMPTZ"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS "
+        "email_verification_token VARCHAR(64)"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS "
+        "terms_accepted_at TIMESTAMPTZ"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS "
+        "terms_version VARCHAR(20)"
+    )
+    op.execute(
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS "
+        "privacy_accepted_at TIMESTAMPTZ"
+    )
+
+    # Index on password_reset_token (CREATE INDEX IF NOT EXISTS is supported in PG 9.5+)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_users_password_reset_token "
+        "ON users (password_reset_token)"
+    )
+
+    # --- organizations table: teacher_limit ---
+    op.execute(
+        "ALTER TABLE organizations ADD COLUMN IF NOT EXISTS "
+        "teacher_limit INTEGER"
+    )
+
+
+def downgrade() -> None:
+    # Drop index first, then columns
+    op.execute("DROP INDEX IF EXISTS ix_users_password_reset_token")
+
+    op.drop_column('organizations', 'teacher_limit')
+
+    op.drop_column('users', 'privacy_accepted_at')
+    op.drop_column('users', 'terms_version')
+    op.drop_column('users', 'terms_accepted_at')
+    op.drop_column('users', 'email_verification_token')
+    op.drop_column('users', 'password_reset_expires')
+    op.drop_column('users', 'password_reset_token')
+    op.drop_column('users', 'onboarding_completed')


### PR DESCRIPTION
## Summary

- Adds migration `k1l2m3n4o5p6` (down_revision: `j0k1l2m3n4o5`) to capture 8 columns that were applied via manual `ALTER TABLE` on staging but were absent from the Alembic migration chain
- **users table** (7 columns): `onboarding_completed`, `password_reset_token` (+ index `ix_users_password_reset_token`), `password_reset_expires`, `email_verification_token`, `terms_accepted_at`, `terms_version`, `privacy_accepted_at`
- **organizations table** (1 column): `teacher_limit`
- Uses `IF NOT EXISTS` raw SQL so the migration is **idempotent on staging** (columns already exist from manual ALTER) and **correct on fresh databases** (e.g., production)

## Why IF NOT EXISTS

Standard `op.add_column()` would fail on staging because the columns already exist. Raw SQL with `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` makes this migration safe to run in both states without requiring a manual `alembic stamp`.

## Test plan

- [ ] CI passes (no import errors, migration file is syntactically valid)
- [ ] On a fresh DB: `alembic upgrade head` applies all columns without error
- [ ] On staging DB: migration runs without error (IF NOT EXISTS skips existing columns)
- [ ] `alembic downgrade -1` removes all 8 columns and the index cleanly

Related to #288