### PR TITLE
feat: star rating after completing all learning steps (Fixes #222)

### DIFF
--- a/frontend/src/components/gamification/StarCelebration.tsx
+++ b/frontend/src/components/gamification/StarCelebration.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import StarRating from './StarRating';
+
+export interface StarCelebrationProps {
+  /** 1–3 stars based on performance */
+  stars: 1 | 2 | 3;
+  /** Reading accuracy percentage (0–100). Used for display. */
+  readingAccuracy: number | null;
+  /** Comprehension score percentage (0–100). Used for display. */
+  comprehensionScore: number | null;
+}
+
+const STAR_CONFIG: Record<
+  1 | 2 | 3,
+  { label: string; bg: string; border: string; badge: string; badgeText: string; emoji: string }
+> = {
+  1: {
+    label: '完成學習！繼續加油！',
+    bg: 'from-blue-50 to-indigo-50',
+    border: 'border-blue-200',
+    badge: 'bg-blue-100 text-blue-700',
+    badgeText: '參與獎',
+    emoji: '👏',
+  },
+  2: {
+    label: '表現很棒！',
+    bg: 'from-amber-50 to-yellow-50',
+    border: 'border-amber-200',
+    badge: 'bg-amber-100 text-amber-700',
+    badgeText: '優秀獎',
+    emoji: '🎉',
+  },
+  3: {
+    label: '太厲害了！完美表現！',
+    bg: 'from-yellow-50 to-orange-50',
+    border: 'border-yellow-300',
+    badge: 'bg-yellow-100 text-yellow-700',
+    badgeText: '滿分獎',
+    emoji: '🏆',
+  },
+};
+
+/**
+ * Full star-rating card displayed at the top of AssessmentReport.
+ * Shows 1–3 stars with a warm, encouraging message for elementary students.
+ */
+const StarCelebration: React.FC<StarCelebrationProps> = ({
+  stars,
+  readingAccuracy,
+  comprehensionScore,
+}) => {
+  const cfg = STAR_CONFIG[stars];
+
+  // Build sub-label from available scores
+  const parts: string[] = [];
+  if (readingAccuracy !== null) parts.push(`朗讀準確度 ${readingAccuracy}%`);
+  if (comprehensionScore !== null) parts.push(`理解力 ${comprehensionScore}%`);
+  const subLabel = parts.length > 0 ? parts.join('　｜　') : undefined;
+
+  return (
+    <div
+      className={`rounded-3xl border-2 ${cfg.border} bg-gradient-to-br ${cfg.bg} p-8 flex flex-col items-center gap-4 shadow-sm`}
+    >
+      {/* Badge */}
+      <div className="flex items-center gap-2">
+        <span className="text-2xl">{cfg.emoji}</span>
+        <span className={`text-sm font-black px-3 py-1 rounded-full ${cfg.badge}`}>
+          {cfg.badgeText}
+        </span>
+        <span className="text-2xl">{cfg.emoji}</span>
+      </div>
+
+      {/* Animated star row */}
+      <StarRating
+        stars={stars}
+        label={cfg.label}
+        subLabel={subLabel}
+        animationDelay={200}
+      />
+
+      {/* Scoring criteria hint */}
+      <div className="mt-1 flex gap-3 text-xs text-gray-400">
+        <span className={stars >= 1 ? 'text-gray-500 font-bold' : ''}>
+          ★ 完成學習
+        </span>
+        <span className={stars >= 2 ? 'text-amber-600 font-bold' : ''}>
+          ★★ 準確度 ≥ 70%
+        </span>
+        <span className={stars >= 3 ? 'text-yellow-600 font-bold' : ''}>
+          ★★★ 準確度 ≥ 90%
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default StarCelebration;

--- a/frontend/src/components/gamification/StarRating.tsx
+++ b/frontend/src/components/gamification/StarRating.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+
+export interface StarRatingProps {
+  /** Number of stars earned: 1, 2, or 3 */
+  stars: 1 | 2 | 3;
+  /** Label shown below the stars */
+  label: string;
+  /** Optional sub-label (e.g. score breakdown) */
+  subLabel?: string;
+  /** Delay (ms) before animation starts */
+  animationDelay?: number;
+}
+
+/**
+ * Displays 1–3 animated stars with kid-friendly styling.
+ * Stars appear one by one with a pop animation.
+ */
+const StarRating: React.FC<StarRatingProps> = ({
+  stars,
+  label,
+  subLabel,
+  animationDelay = 300,
+}) => {
+  const [visibleStars, setVisibleStars] = useState(0);
+  const [labelVisible, setLabelVisible] = useState(false);
+
+  useEffect(() => {
+    // Reveal each star with a staggered delay
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    for (let i = 1; i <= 3; i++) {
+      timers.push(
+        setTimeout(() => {
+          setVisibleStars(v => Math.max(v, i));
+        }, animationDelay + (i - 1) * 250),
+      );
+    }
+    timers.push(
+      setTimeout(() => setLabelVisible(true), animationDelay + 3 * 250 + 100),
+    );
+    return () => timers.forEach(clearTimeout);
+  }, [animationDelay, stars]);
+
+  const starColors: Record<number, { filled: string; glow: string }> = {
+    1: { filled: '#f59e0b', glow: 'rgba(245,158,11,0.45)' },
+    2: { filled: '#f59e0b', glow: 'rgba(245,158,11,0.45)' },
+    3: { filled: '#fbbf24', glow: 'rgba(251,191,36,0.55)' },
+  };
+
+  const { filled, glow } = starColors[stars];
+
+  return (
+    <>
+      <style>{`
+        @keyframes star-appear {
+          0%   { transform: scale(0) rotate(-20deg); opacity: 0; }
+          55%  { transform: scale(1.35) rotate(8deg);  opacity: 1; }
+          75%  { transform: scale(0.9) rotate(-4deg); opacity: 1; }
+          100% { transform: scale(1) rotate(0deg);    opacity: 1; }
+        }
+        @keyframes star-idle-pulse {
+          0%, 100% { filter: drop-shadow(0 0 6px ${glow}); }
+          50%       { filter: drop-shadow(0 0 14px ${glow}); }
+        }
+        @keyframes label-rise {
+          0%   { opacity: 0; transform: translateY(10px); }
+          100% { opacity: 1; transform: translateY(0); }
+        }
+        .star-appear {
+          animation: star-appear 0.45s cubic-bezier(0.34,1.56,0.64,1) forwards,
+                     star-idle-pulse 2.5s ease-in-out 0.8s infinite;
+        }
+        .label-rise {
+          animation: label-rise 0.4s ease forwards;
+        }
+      `}</style>
+
+      <div className="flex flex-col items-center gap-3 select-none">
+        {/* Stars row */}
+        <div className="flex items-end gap-2">
+          {[1, 2, 3].map(i => {
+            const isFilled = i <= stars;
+            const isVisible = i <= visibleStars;
+            // Middle star (2nd) is slightly larger for visual drama
+            const sizeClass = i === 2 ? 'text-[3.5rem]' : 'text-[2.75rem]';
+            return (
+              <span
+                key={i}
+                className={`${sizeClass} leading-none`}
+                style={{
+                  opacity: 0,
+                  color: isFilled ? filled : '#d1d5db',
+                  ...(isVisible
+                    ? {
+                        animationName: 'star-appear, star-idle-pulse',
+                        animationDuration: `0.45s, 2.5s`,
+                        animationTimingFunction:
+                          'cubic-bezier(0.34,1.56,0.64,1), ease-in-out',
+                        animationDelay: `0s, 0.8s`,
+                        animationFillMode: 'forwards, none',
+                        animationIterationCount: '1, infinite',
+                        filter: isFilled
+                          ? `drop-shadow(0 0 8px ${glow})`
+                          : 'none',
+                      }
+                    : {}),
+                }}
+              >
+                {isFilled ? '★' : '☆'}
+              </span>
+            );
+          })}
+        </div>
+
+        {/* Label */}
+        {labelVisible && (
+          <div className="label-rise text-center">
+            <p className="text-xl font-black text-gray-800 tracking-wide">
+              {label}
+            </p>
+            {subLabel && (
+              <p className="text-sm text-gray-500 mt-0.5">{subLabel}</p>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default StarRating;

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -12,6 +12,8 @@ import { parseReadingBenchmark, getBenchmarkFeedback } from '../../utils/fluency
 import ExitTicket from './ExitTicket';
 import { trackLearningEvent } from '../../utils/analytics';
 import AIAnalysisSection from './AIAnalysisSection';
+import StarCelebration from '../gamification/StarCelebration';
+import { calcStarRating } from '../../utils/starRatingCalc';
 
 /**
  * A wrapper around ResponsiveContainer that only renders the chart
@@ -262,9 +264,38 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
   // Practice suggestions
   const suggestions = readingAttempt ? generateSuggestions(wrongTokens, accuracy, cpm) : [];
 
+  // --- Star rating calculation (Issue #222) ---
+  // Best available reading accuracy: prefer full reading match rate, fall back to per-segment accuracy
+  const bestReadingAccuracy =
+    fullMatchPct !== null ? fullMatchPct : readingAttempt ? accuracy : null;
+
+  // Comprehension score: use AI-evaluated score if available, else derive from dialogue result
+  const comprehensionPct = comprehensionScores
+    ? Math.round(comprehensionScores.comprehension_score)
+    : comprehensionResult
+    ? Math.round(
+        (comprehensionResult.understoodCount /
+          Math.max(comprehensionResult.requiredCount, 1)) *
+          100,
+      )
+    : null;
+
+  const starCount = calcStarRating({
+    readingAccuracy: bestReadingAccuracy,
+    comprehensionScore: comprehensionPct,
+  });
+
   return (
     <div className="max-w-4xl mx-auto space-y-6 animate-fadeIn">
       <CelebrationOverlay score={overallScore} />
+
+      {/* ============ 星星評級 Star Rating (Issue #222) ============ */}
+      <StarCelebration
+        stars={starCount}
+        readingAccuracy={bestReadingAccuracy}
+        comprehensionScore={comprehensionPct}
+      />
+
       {/* Header */}
       <div className="text-center">
         <div className="inline-block bg-green-100 text-green-700 px-4 py-1 rounded-full text-sm font-bold mb-4">

--- a/frontend/src/utils/starRatingCalc.ts
+++ b/frontend/src/utils/starRatingCalc.ts
@@ -1,0 +1,42 @@
+/**
+ * Calculate star rating (1–3) based on reading and comprehension performance.
+ *
+ * Scoring rules:
+ *   1 star  — completed at least one learning step (participation)
+ *   2 stars — reading accuracy >= 70% AND comprehension adequate (>= 50%)
+ *   3 stars — reading accuracy >= 90% AND comprehension excellent (>= 80%)
+ *
+ * If comprehension data is unavailable, reading accuracy alone determines the grade.
+ */
+export function calcStarRating(params: {
+  /** Reading accuracy 0–100 (from readingAttempt or fullReadingResult) */
+  readingAccuracy: number | null;
+  /** Comprehension score 0–100 (from comprehensionScores.comprehension_score) */
+  comprehensionScore: number | null;
+}): 1 | 2 | 3 {
+  const { readingAccuracy, comprehensionScore } = params;
+
+  // No reading data at all → 1 star (participation)
+  if (readingAccuracy === null) return 1;
+
+  const hasComprehension = comprehensionScore !== null;
+
+  // 3 stars: reading >= 90% AND (no comprehension data OR comprehension >= 80%)
+  if (
+    readingAccuracy >= 90 &&
+    (!hasComprehension || (comprehensionScore as number) >= 80)
+  ) {
+    return 3;
+  }
+
+  // 2 stars: reading >= 70% AND (no comprehension data OR comprehension >= 50%)
+  if (
+    readingAccuracy >= 70 &&
+    (!hasComprehension || (comprehensionScore as number) >= 50)
+  ) {
+    return 2;
+  }
+
+  // 1 star: participated
+  return 1;
+}


### PR DESCRIPTION
Fixes #222

## Summary

- Add `StarRating` component — 1–3 stars animate in one-by-one with a pop + glow effect designed for elementary school students
- Add `StarCelebration` card — wraps `StarRating` with a warm badge (參與獎/優秀獎/滿分獎), emoji, and score breakdown sub-label
- Add `calcStarRating` utility — pure function, easy to unit-test
- Integrate at the **top** of `AssessmentReport` (Step 6) so students see their stars immediately upon reaching the report

## Scoring logic

| Stars | Condition |
|-------|-----------|
| ★     | Completed at least one learning step (participation) |
| ★★    | Reading accuracy ≥ 70% AND comprehension ≥ 50% (if available) |
| ★★★   | Reading accuracy ≥ 90% AND comprehension ≥ 80% (if available) |

Reading accuracy = full-reading match rate if available, else per-segment accuracy.
Comprehension = AI comprehension_score if available, else dialogue understood/required ratio.

## No backend changes

All data is derived from the existing `LearningSession` and `ComprehensionScoreResult` passed as props — no new API endpoints or DB columns needed.

## Test plan

1. Open PR Preview URL (posted by CI as PR comment)
2. Log in and open any story
3. Complete all 6 learning steps (or skip to AssessmentReport)
4. Verify stars appear at the top of the report page with animation
5. Confirm scoring:
   - Low accuracy → 1 star
   - ~70–89% accuracy → 2 stars
   - ≥90% accuracy → 3 stars
6. Check on mobile viewport (stars should be centered and readable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)