### PR TITLE
feat: add student audio recording with playback (Fixes #77)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -6,6 +6,7 @@ import DiffDisplay from '../ui/DiffDisplay';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
 import { useIsMobile } from '../../hooks/useIsMobile';
+import { useAudioRecorder } from '../../hooks/useAudioRecorder';
 
 /* ------------------------------------------------------------------ */
 
@@ -40,6 +41,9 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
   const zhuyinActive = zhuyinReady && zhuyinEnabled;
   const fullText = useMemo(() => story.content.join(''), [story.content]);
+
+  /* ---- Audio recorder (for student playback review) ---- */
+  const audioRecorder = useAudioRecorder(120);
 
   /* ---- Zhuyin ---- */
   useEffect(() => {
@@ -213,6 +217,10 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
     accumulatedTranscriptRef.current = '';
     setStreamingTranscript('');
     recognition.start();
+    // Also start audio recording so student can replay
+    audioRecorder.startRecording().catch(() => {
+      // Recording is best-effort; STT continues even if recorder fails
+    });
   };
 
   const stopSession = useCallback(() => {
@@ -222,7 +230,8 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
     currentTranscriptRef.current = '';
     accumulatedTranscriptRef.current = '';
     setStreamingTranscript('');
-  }, []);
+    audioRecorder.stopRecording();
+  }, [audioRecorder]);
 
   /* ---- Submit & evaluate ---- */
   const submitReading = useCallback(() => {
@@ -390,6 +399,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
                   <DiffDisplay tokens={result.diffTokens} showLegend />
                 </div>
               )}
+
+              {/* Audio playback — let student re-listen to their reading */}
+              {audioRecorder.audioUrl && (
+                <div className="bg-white border border-gray-200 rounded-xl px-3 py-2.5">
+                  <p className="text-[10px] text-gray-500 mb-2 uppercase tracking-widest">重聽錄音</p>
+                  <audio src={audioRecorder.audioUrl} controls className="w-full h-9" aria-label="播放您的朗讀錄音" />
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -401,7 +418,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {result ? (
             <div className="space-y-2">
               <button
-                onClick={() => { setResult(null); setStreamingTranscript(''); }}
+                onClick={() => { setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); }}
                 className="w-full py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all active:scale-95"
               >
                 再試一次

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -9,6 +9,7 @@ import ZhuyinToggle from '../ui/ZhuyinToggle';
 import FontSizeControl, { useFontSize } from '../ui/FontSizeControl';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { READING_EXCELLENT, READING_PASS } from '../../utils/personaConfig';
+import RecordingButton from '../recording/RecordingButton';
 
 /* ------------------------------------------------------------------ */
 /*  Canned response pools — randomly selected to avoid repetition     */
@@ -147,6 +148,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const [isTtsSpeaking, setIsTtsSpeaking] = useState(false);
   const [isTtsPaused, setIsTtsPaused] = useState(false);
   const [lastDiffTokens, setLastDiffTokens] = useState<DiffToken[] | null>(null);
+  const [showRecorder, setShowRecorder] = useState(false);
 
   const isAdvancingRef = useRef(false);
   const isDraggingRef = useRef(false);
@@ -925,6 +927,33 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                   {processZhuyin(isAdvancing ? '請稍候...' : '開始朗讀')}
                 </button>
               </>
+            )}
+          </div>
+
+          {/* Optional recording for student self-review */}
+          <div className="border-t border-gray-100 pt-2">
+            <button
+              onClick={() => setShowRecorder(prev => !prev)}
+              className="w-full flex items-center justify-between px-2 py-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+              aria-expanded={showRecorder}
+            >
+              <span className="flex items-center gap-1">
+                <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 1a4 4 0 0 1 4 4v6a4 4 0 0 1-8 0V5a4 4 0 0 1 4-4zm0 2a2 2 0 0 0-2 2v6a2 2 0 0 0 4 0V5a2 2 0 0 0-2-2zm7 8a1 1 0 0 1 1 1 8 8 0 0 1-7 7.938V21h2a1 1 0 0 1 0 2H9a1 1 0 0 1 0-2h2v-1.062A8 8 0 0 1 4 12a1 1 0 0 1 2 0 6 6 0 0 0 12 0 1 1 0 0 1 1-1z" />
+                </svg>
+                錄音重聽（選用）
+              </span>
+              <svg
+                className={`w-3.5 h-3.5 transition-transform ${showRecorder ? 'rotate-180' : ''}`}
+                fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            {showRecorder && (
+              <div className="pt-2 pb-1">
+                <RecordingButton maxDurationSeconds={60} label="錄下這段朗讀，完成後可重聽" />
+              </div>
             )}
           </div>
 

--- a/frontend/src/components/recording/RecordingButton.tsx
+++ b/frontend/src/components/recording/RecordingButton.tsx
@@ -1,0 +1,195 @@
+import React, { useRef } from 'react';
+import { useAudioRecorder } from '../../hooks/useAudioRecorder';
+
+interface RecordingButtonProps {
+  /** Maximum recording time in seconds. Default: 120 */
+  maxDurationSeconds?: number;
+  /** Called when a recording is completed (status transitions to 'stopped') */
+  onRecordingComplete?: (blob: Blob, url: string) => void;
+  /** Optional label shown above the controls */
+  label?: string;
+  disabled?: boolean;
+}
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60).toString().padStart(2, '0');
+  const s = (seconds % 60).toString().padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+const RecordingButton: React.FC<RecordingButtonProps> = ({
+  maxDurationSeconds = 120,
+  onRecordingComplete,
+  label,
+  disabled = false,
+}) => {
+  const {
+    status,
+    audioUrl,
+    audioBlob,
+    errorMessage,
+    elapsedSeconds,
+    remainingSeconds,
+    startRecording,
+    stopRecording,
+    clearRecording,
+  } = useAudioRecorder(maxDurationSeconds);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  // Notify parent when recording completes
+  const prevStatusRef = useRef(status);
+  React.useEffect(() => {
+    if (prevStatusRef.current !== 'stopped' && status === 'stopped' && audioBlob && audioUrl) {
+      onRecordingComplete?.(audioBlob, audioUrl);
+    }
+    prevStatusRef.current = status;
+  }, [status, audioBlob, audioUrl, onRecordingComplete]);
+
+  const isIdle = status === 'idle';
+  const isRequesting = status === 'requesting';
+  const isRecording = status === 'recording';
+  const isStopped = status === 'stopped';
+  const isError = status === 'error';
+
+  const urgentCountdown = remainingSeconds <= 10 && isRecording;
+  const warningCountdown = remainingSeconds <= 30 && remainingSeconds > 10 && isRecording;
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      {label && (
+        <p className="text-sm font-medium text-gray-600">{label}</p>
+      )}
+
+      {/* Main control row */}
+      <div className="flex items-center gap-3 flex-wrap justify-center">
+
+        {/* Start / Stop button */}
+        {(isIdle || isError) && (
+          <button
+            onClick={startRecording}
+            disabled={disabled || isRequesting}
+            className="flex items-center gap-2 px-4 py-2 rounded-full bg-red-500 hover:bg-red-600 active:bg-red-700 text-white font-semibold text-sm shadow transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="開始錄音"
+          >
+            {/* Mic icon */}
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 1a4 4 0 0 1 4 4v6a4 4 0 0 1-8 0V5a4 4 0 0 1 4-4zm0 2a2 2 0 0 0-2 2v6a2 2 0 0 0 4 0V5a2 2 0 0 0-2-2zm7 8a1 1 0 0 1 1 1 8 8 0 0 1-7 7.938V21h2a1 1 0 0 1 0 2H9a1 1 0 0 1 0-2h2v-1.062A8 8 0 0 1 4 12a1 1 0 0 1 2 0 6 6 0 0 0 12 0 1 1 0 0 1 1-1z" />
+            </svg>
+            開始錄音
+          </button>
+        )}
+
+        {isRequesting && (
+          <button
+            disabled
+            className="flex items-center gap-2 px-4 py-2 rounded-full bg-gray-400 text-white font-semibold text-sm shadow cursor-not-allowed"
+          >
+            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+            </svg>
+            等待授權...
+          </button>
+        )}
+
+        {isRecording && (
+          <button
+            onClick={stopRecording}
+            className="flex items-center gap-2 px-4 py-2 rounded-full bg-gray-700 hover:bg-gray-800 active:bg-gray-900 text-white font-semibold text-sm shadow transition-colors"
+            aria-label="停止錄音"
+          >
+            {/* Stop icon */}
+            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+              <rect x="4" y="4" width="16" height="16" rx="2" />
+            </svg>
+            停止錄音
+          </button>
+        )}
+
+        {/* Recording status indicator */}
+        {isRecording && (
+          <div className="flex items-center gap-2">
+            {/* Pulsing red dot */}
+            <span className="relative flex h-3 w-3">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500" />
+            </span>
+            <span
+              className={`text-sm font-mono font-semibold tabular-nums ${
+                urgentCountdown ? 'text-red-600' : warningCountdown ? 'text-orange-500' : 'text-gray-700'
+              }`}
+            >
+              {formatTime(elapsedSeconds)}
+            </span>
+          </div>
+        )}
+
+        {/* Countdown warning when recording */}
+        {(urgentCountdown || warningCountdown) && (
+          <span
+            className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+              urgentCountdown
+                ? 'bg-red-100 text-red-700'
+                : 'bg-orange-100 text-orange-700'
+            }`}
+          >
+            剩餘 {formatTime(remainingSeconds)}
+          </span>
+        )}
+      </div>
+
+      {/* Playback section */}
+      {isStopped && audioUrl && (
+        <div className="flex flex-col items-center gap-2 w-full max-w-xs">
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <svg className="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" />
+            </svg>
+            <span>錄音完成（{formatTime(elapsedSeconds)}）</span>
+          </div>
+
+          {/* Native audio player */}
+          <audio
+            ref={audioRef}
+            src={audioUrl}
+            controls
+            className="w-full h-9"
+            aria-label="播放錄音"
+          />
+
+          {/* Re-record button */}
+          <button
+            onClick={clearRecording}
+            disabled={disabled}
+            className="text-xs text-gray-500 hover:text-red-500 underline transition-colors disabled:opacity-50"
+          >
+            重新錄音
+          </button>
+        </div>
+      )}
+
+      {/* Error message */}
+      {isError && errorMessage && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 bg-red-50 border border-red-200 rounded-lg px-3 py-2 text-sm text-red-700 max-w-xs"
+        >
+          <svg className="w-4 h-4 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" />
+          </svg>
+          <span>{errorMessage}</span>
+        </div>
+      )}
+
+      {/* First-time permission hint */}
+      {isRequesting && (
+        <p className="text-xs text-gray-500 max-w-xs text-center">
+          請在瀏覽器彈出視窗中允許麥克風存取。
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default RecordingButton;

--- a/frontend/src/hooks/useAudioRecorder.ts
+++ b/frontend/src/hooks/useAudioRecorder.ts
@@ -1,0 +1,189 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+export type RecorderStatus = 'idle' | 'requesting' | 'recording' | 'stopped' | 'error';
+
+export interface AudioRecorderState {
+  status: RecorderStatus;
+  audioUrl: string | null;
+  audioBlob: Blob | null;
+  errorMessage: string;
+  elapsedSeconds: number;
+  remainingSeconds: number;
+}
+
+export interface AudioRecorderActions {
+  startRecording: () => Promise<void>;
+  stopRecording: () => void;
+  clearRecording: () => void;
+}
+
+const MAX_DURATION_SECONDS = 120; // 2-minute limit
+
+function getSupportedMimeType(): string {
+  const types = [
+    'audio/webm;codecs=opus',
+    'audio/webm',
+    'audio/ogg;codecs=opus',
+    'audio/mp4',
+  ];
+  for (const type of types) {
+    if (MediaRecorder.isTypeSupported(type)) return type;
+  }
+  return '';
+}
+
+export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): AudioRecorderState & AudioRecorderActions {
+  const [status, setStatus] = useState<RecorderStatus>('idle');
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [audioBlob, setAudioBlob] = useState<Blob | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startTimeRef = useRef<number>(0);
+
+  const stopTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const releaseStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach(t => t.stop());
+      streamRef.current = null;
+    }
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+      mediaRecorderRef.current.stop();
+    }
+    stopTimer();
+  }, [stopTimer]);
+
+  const startRecording = useCallback(async () => {
+    // Reset previous state
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+    }
+    setAudioUrl(null);
+    setAudioBlob(null);
+    setErrorMessage('');
+    setElapsedSeconds(0);
+    chunksRef.current = [];
+
+    setStatus('requesting');
+
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err: unknown) {
+      const domErr = err as DOMException;
+      if (domErr?.name === 'NotAllowedError' || domErr?.name === 'PermissionDeniedError') {
+        setErrorMessage('麥克風權限被拒絕，請在瀏覽器設定中允許麥克風存取。');
+      } else if (domErr?.name === 'NotFoundError') {
+        setErrorMessage('找不到麥克風裝置，請確認麥克風已連接。');
+      } else {
+        setErrorMessage('無法存取麥克風，請確認裝置設定。');
+      }
+      setStatus('error');
+      return;
+    }
+
+    streamRef.current = stream;
+
+    const mimeType = getSupportedMimeType();
+    let recorder: MediaRecorder;
+    try {
+      recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+    } catch {
+      setErrorMessage('您的瀏覽器不支援錄音功能，請使用 Chrome 或 Safari。');
+      setStatus('error');
+      releaseStream();
+      return;
+    }
+
+    mediaRecorderRef.current = recorder;
+
+    recorder.ondataavailable = (e: BlobEvent) => {
+      if (e.data && e.data.size > 0) {
+        chunksRef.current.push(e.data);
+      }
+    };
+
+    recorder.onstop = () => {
+      stopTimer();
+      releaseStream();
+      const blob = new Blob(chunksRef.current, {
+        type: recorder.mimeType || 'audio/webm',
+      });
+      const url = URL.createObjectURL(blob);
+      setAudioBlob(blob);
+      setAudioUrl(url);
+      setStatus('stopped');
+    };
+
+    recorder.onerror = () => {
+      stopTimer();
+      releaseStream();
+      setErrorMessage('錄音過程中發生錯誤，請重試。');
+      setStatus('error');
+    };
+
+    recorder.start(250); // collect data every 250ms
+    startTimeRef.current = Date.now();
+    setStatus('recording');
+
+    // Countdown timer
+    timerRef.current = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
+      setElapsedSeconds(elapsed);
+      if (elapsed >= maxDurationSeconds) {
+        stopRecording();
+      }
+    }, 500);
+  }, [audioUrl, maxDurationSeconds, stopRecording, stopTimer, releaseStream]);
+
+  const clearRecording = useCallback(() => {
+    stopRecording();
+    if (audioUrl) {
+      URL.revokeObjectURL(audioUrl);
+    }
+    setAudioUrl(null);
+    setAudioBlob(null);
+    setErrorMessage('');
+    setElapsedSeconds(0);
+    setStatus('idle');
+  }, [audioUrl, stopRecording]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      stopTimer();
+      releaseStream();
+      if (audioUrl) {
+        URL.revokeObjectURL(audioUrl);
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const remainingSeconds = Math.max(0, maxDurationSeconds - elapsedSeconds);
+
+  return {
+    status,
+    audioUrl,
+    audioBlob,
+    errorMessage,
+    elapsedSeconds,
+    remainingSeconds,
+    startRecording,
+    stopRecording,
+    clearRecording,
+  };
+}


### PR DESCRIPTION
Fixes #77

## Summary

- Add `useAudioRecorder` custom hook wrapping the MediaRecorder API with Chrome/Safari support (webm/opus with mp4 fallback), microphone permission error handling, and a configurable recording time limit with countdown
- Add `RecordingButton` reusable component featuring: pulsing red dot status indicator during recording, elapsed time display, countdown warnings at 30s and 10s, native `<audio>` playback after recording stops, and a re-record button
- Integrate into **FullReading**: recording auto-starts alongside the STT session; after submitting, an audio player appears in the result panel so students can replay their full reading
- Integrate into **LiveTutor**: optional collapsible recorder section in the controls panel so students can record and re-listen to individual paragraphs

## New Files

- `frontend/src/hooks/useAudioRecorder.ts`
- `frontend/src/components/recording/RecordingButton.tsx`

## Technical Notes

- No backend upload (Azure Speech SDK deferred per #76) — recording is local playback only
- `MediaRecorder.isTypeSupported()` used for format detection: prefers webm/opus (Chrome), falls back to mp4 (Safari)
- `URL.createObjectURL` / `URL.revokeObjectURL` used to avoid memory leaks
- Both new files are under 300 lines per project rules

## Test Plan

- [ ] Open the app and navigate to the FullReading step
- [ ] Click "開始朗讀" — verify recording starts alongside STT (pulsing red dot visible)
- [ ] Read aloud and click "完成朗讀" — verify result panel shows audio player
- [ ] Play back the audio and confirm your voice is heard
- [ ] Click "再試一次" — verify recording clears
- [ ] Navigate to LiveTutor step, expand "錄音重聽（選用）"
- [ ] Click "開始錄音", record, stop — verify playback works
- [ ] Test on Chrome and Safari (school tablets)
- [ ] Test microphone permission denial — verify error message shown