### PR TITLE
[SQL] 讓本地資料庫和雲端資料庫可同時相容

### DIFF
--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -1,10 +1,13 @@
 from datetime import datetime
 from uuid import uuid4
 
-from sqlalchemy import Integer, String, Boolean, DateTime, Text, func
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import JSON, Integer, String, Boolean, DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from .base import Base
+
+# Use JSONB on PostgreSQL, plain JSON on SQLite
+FlexibleJSON = JSON().with_variant(PG_JSONB(), "postgresql")
 
 
 class Organization(Base):
@@ -30,4 +33,4 @@ class Organization(Base):
     contact_email: Mapped[str | None] = mapped_column(String(200), nullable=True)
     contact_phone: Mapped[str | None] = mapped_column(String(50), nullable=True)
     address: Mapped[str | None] = mapped_column(Text, nullable=True)
-    settings: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    settings: Mapped[dict | None] = mapped_column(FlexibleJSON, nullable=True)

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -1,8 +1,11 @@
 from datetime import datetime
-from sqlalchemy import String, Integer, Float, ForeignKey, DateTime, func
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import JSON, String, Integer, Float, ForeignKey, DateTime, func
+from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .base import Base
+
+# Use JSONB on PostgreSQL, plain JSON on SQLite
+FlexibleJSON = JSON().with_variant(PG_JSONB(), "postgresql")
 
 
 class LearningSession(Base):
@@ -17,10 +20,10 @@ class LearningSession(Base):
     current_step: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     accuracy: Mapped[float | None] = mapped_column(Float, nullable=True)
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
-    reading_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    comprehension_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    vocab_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    full_reading_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    reading_result: Mapped[dict | None] = mapped_column(FlexibleJSON, nullable=True)
+    comprehension_result: Mapped[dict | None] = mapped_column(FlexibleJSON, nullable=True)
+    vocab_result: Mapped[dict | None] = mapped_column(FlexibleJSON, nullable=True)
+    full_reading_result: Mapped[dict | None] = mapped_column(FlexibleJSON, nullable=True)
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routes/organizations.py
+++ b/backend/app/routes/organizations.py
@@ -50,7 +50,7 @@ def _org_to_response(org: Organization, school_count: int) -> OrganizationRespon
         id=org.id,
         name=org.name,
         display_name=org.display_name,
-        teacher_limit=org.teacher_limit,
+        # teacher_limit=org.teacher_limit, issue 309
         is_active=org.is_active,
         created_at=org.created_at,
         school_count=school_count,


### PR DESCRIPTION
## 問題與解決方法

出現了兩個 ``teacher_limit=org.teacher_limit,`` 
註解掉其中一個

``chinese-literacy-platform/backend/app/models/session.py`` 
and
``chinese-literacy-platform/backend/app/models/organization.py``
將 PostgreSQL 專用的``JSONB`` 改為讓模型同時相容 SQLite（本地開發）和 PostgreSQL（雲端部署）。
