### PR TITLE
fix: Gemini JSON truncation causing 503 on AI Analysis (#241) and Comprehension Scoring (#243)

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -284,47 +284,47 @@ async def generate_reading_analysis(session_data: dict) -> dict:
         system_prompt=system_prompt,
         contents=contents,
         response_schema=response_schema,
-        max_tokens=1024,
+        max_tokens=2048,
         temperature=0.7,
     )
 
 
 COMPREHENSION_SCORE_SCHEMA = {
-    "type": "object",
+    "type": "OBJECT",
     "properties": {
         "comprehension_score": {
-            "type": "number",
+            "type": "NUMBER",
             "description": "Overall comprehension score 0-100",
         },
         "literal_score": {
-            "type": "number",
+            "type": "NUMBER",
             "description": "字面理解 score 0-100",
         },
         "inferential_score": {
-            "type": "number",
+            "type": "NUMBER",
             "description": "推論理解 score 0-100",
         },
         "evaluative_score": {
-            "type": "number",
+            "type": "NUMBER",
             "description": "評鑑理解 score 0-100",
         },
         "feedback": {
-            "type": "object",
+            "type": "OBJECT",
             "properties": {
                 "literal": {
-                    "type": "string",
+                    "type": "STRING",
                     "description": "字面理解評語 (Traditional Chinese)",
                 },
                 "inferential": {
-                    "type": "string",
+                    "type": "STRING",
                     "description": "推論理解評語 (Traditional Chinese)",
                 },
                 "evaluative": {
-                    "type": "string",
+                    "type": "STRING",
                     "description": "評鑑理解評語 (Traditional Chinese)",
                 },
                 "overall": {
-                    "type": "string",
+                    "type": "STRING",
                     "description": "整體評語 (Traditional Chinese)",
                 },
             },
@@ -394,7 +394,7 @@ async def evaluate_comprehension(
         system_prompt=system_prompt,
         contents=contents,
         response_schema=COMPREHENSION_SCORE_SCHEMA,
-        max_tokens=1024,
+        max_tokens=2048,
         temperature=0.3,
     )
 


### PR DESCRIPTION
## Root Cause

`COMPREHENSION_SCORE_SCHEMA` in `backend/app/services/ai_service.py` used **lowercase** JSON Schema type strings (`"object"`, `"string"`, `"number"`). The Vertex AI Gemini SDK requires **uppercase** type strings (`"OBJECT"`, `"STRING"`, `"NUMBER"`) to activate constrained JSON generation mode.

With lowercase types, Gemini produced **unconstrained** output that was frequently truncated mid-string. The truncated JSON then failed `json.loads()` with errors exactly matching the staging logs:

```
Unterminated string starting at: line 2 column 23 (char 24)
Expecting property name enclosed in double quotes: line 3 column 23 (char 55)
```

All 3 retries failed → `raise last_error` → HTTP 503.

## Changes

**`backend/app/services/ai_service.py`**

1. `COMPREHENSION_SCORE_SCHEMA`: changed all type strings from lowercase to uppercase (`OBJECT`, `NUMBER`, `STRING`) to match Vertex AI SDK requirements — fixes #243
2. `generate_reading_analysis()`: raised `max_tokens` from `1024` → `2048` to give headroom for 5-field Chinese text output — fixes #241
3. `evaluate_comprehension()`: raised `max_tokens` from `1024` → `2048` to handle the nested `feedback` object with 4 Chinese feedback strings

## Evidence

- Staging error logs: `Gemini API failed after 3 attempts: Unterminated string` — truncated JSON from unconstrained generation
- `generate_reading_analysis()` schema already used uppercase correctly (worked); `COMPREHENSION_SCORE_SCHEMA` was inconsistent (broken)
- 27/27 tests pass locally: `test_ai_analysis.py` + `test_comprehension_score.py`

## Test Plan

- [ ] Merge to staging and trigger a full reading session to Step 6 (AssessmentReport) — verify no 503 on AI Analysis
- [ ] Complete a Socratic dialogue session and trigger comprehension scoring — verify scores return correctly
- [ ] Check staging logs for absence of `Gemini API failed after 3 attempts` errors

Closes #241
Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)