### PR TITLE
feat: student assignment flow with auto-submit (Fixes #24)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -506,3 +506,101 @@ def start_assignment(
         text_id=assignment.text_id,
         status="in_progress",
     )
+
+
+@router.post(
+    "/assignments/{assignment_id}/submit",
+    response_model=StudentAssignmentResponse,
+)
+def submit_assignment(
+    assignment_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Mark an assignment as submitted after the student completes the learning flow.
+
+    Idempotent: if already submitted/graded, returns the current state without error.
+    Optionally pulls the accuracy score from the linked LearningSession.
+
+    TODO: Send Email notification to teacher when student submits (future implementation).
+    """
+    assignment = db.query(Assignment).filter(Assignment.id == assignment_id).first()
+    if assignment is None:
+        raise HTTPException(status_code=404, detail="Assignment not found")
+
+    submission = (
+        db.query(AssignmentSubmission)
+        .filter(
+            AssignmentSubmission.assignment_id == assignment_id,
+            AssignmentSubmission.student_id == current_user.id,
+        )
+        .first()
+    )
+    if submission is None:
+        raise HTTPException(
+            status_code=403, detail="You are not enrolled in this assignment"
+        )
+
+    # Idempotent: already submitted/graded, just return current state
+    if submission.status in ("submitted", "graded"):
+        classroom = (
+            db.query(Classroom).filter(Classroom.id == assignment.classroom_id).first()
+        )
+        story_title = _resolve_story_title(assignment.story_id) or assignment.story_id
+        return StudentAssignmentResponse(
+            assignment_id=assignment.id,
+            story_id=assignment.story_id,
+            story_title=story_title,
+            title=assignment.title,
+            description=assignment.description,
+            assignment_type=assignment.assignment_type,
+            due_date=assignment.due_date,
+            classroom_name=classroom.name if classroom else "Unknown",
+            status=submission.status,
+            submitted_at=submission.submitted_at,
+            score=submission.score,
+        )
+
+    # Pull score from linked LearningSession if available
+    score: float | None = None
+    if submission.session_id is not None:
+        learning_session = (
+            db.query(LearningSession)
+            .filter(LearningSession.id == submission.session_id)
+            .first()
+        )
+        if learning_session and learning_session.overall_score is not None:
+            score = float(learning_session.overall_score)
+
+    from datetime import timezone
+    submission.status = "submitted"
+    submission.submitted_at = datetime.now(tz=timezone.utc)
+    if score is not None:
+        submission.score = score
+
+    db.commit()
+    db.refresh(submission)
+
+    classroom = (
+        db.query(Classroom).filter(Classroom.id == assignment.classroom_id).first()
+    )
+    story_title = _resolve_story_title(assignment.story_id) or assignment.story_id
+
+    logger.info(
+        "Student %d submitted assignment %d (score=%s)",
+        current_user.id, assignment_id, score,
+    )
+
+    return StudentAssignmentResponse(
+        assignment_id=assignment.id,
+        story_id=assignment.story_id,
+        story_title=story_title,
+        title=assignment.title,
+        description=assignment.description,
+        assignment_type=assignment.assignment_type,
+        due_date=assignment.due_date,
+        classroom_name=classroom.name if classroom else "Unknown",
+        status=submission.status,
+        submitted_at=submission.submitted_at,
+        score=submission.score,
+    )

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -9,6 +9,7 @@ import {
   FullReadingResult,
 } from '../types';
 import { fetchStory, saveActiveSession, clearActiveSession } from '../services/api';
+import { submitAssignment } from '../services/assignmentApi';
 import { useAuth } from '../contexts/AuthContext';
 import { useLearningNav } from '../contexts/LearningNavContext';
 
@@ -240,10 +241,23 @@ const LearningLayout: React.FC = () => {
     navigate('/library');
   }, [navigate, clearPersistedSession]);
 
-  /** Called when a session is fully completed (report viewed). */
+  /** Called when a session is fully completed (report viewed). Auto-submits if assignment active. */
   const handleSessionComplete = useCallback(() => {
     clearPersistedSession();
-  }, [clearPersistedSession]);
+
+    // Auto-submit assignment if this session was started from an assignment.
+    const assignmentIdStr = sessionStorage.getItem('activeAssignmentId');
+    if (assignmentIdStr && token) {
+      const assignmentId = parseInt(assignmentIdStr, 10);
+      if (!isNaN(assignmentId)) {
+        sessionStorage.removeItem('activeAssignmentId');
+        // Fire-and-forget: best-effort auto-submit; errors are silent to avoid disrupting the report view.
+        submitAssignment(token, assignmentId).catch((err) => {
+          console.warn('[LearningLayout] Auto-submit assignment failed:', err);
+        });
+      }
+    }
+  }, [clearPersistedSession, token]);
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/student/MyAssignments.tsx
+++ b/frontend/src/pages/student/MyAssignments.tsx
@@ -63,6 +63,8 @@ const MyAssignments: React.FC = () => {
     setStartingId(assignmentId);
     try {
       const result = await startAssignment(token, assignmentId);
+      // Store assignment ID in sessionStorage so LearningLayout can auto-submit on completion.
+      sessionStorage.setItem('activeAssignmentId', String(assignmentId));
       // story_id is set for YAML texts; text_id for DB texts
       const textKey = result.story_id ?? String(result.text_id);
       navigate(`/learn/${textKey}/intro`);
@@ -135,7 +137,12 @@ const MyAssignments: React.FC = () => {
     if (a.status === 'in_progress') {
       return (
         <button
-          onClick={() => navigate(`/learn/${a.story_id ?? a.text_id}/intro`)}
+          onClick={() => {
+            // Restore assignment ID so LearningLayout can auto-submit on completion.
+            sessionStorage.setItem('activeAssignmentId', String(a.assignment_id));
+            // story_id is set for YAML texts; text_id for DB texts
+            navigate(`/learn/${a.story_id ?? a.text_id}/intro`);
+          }}
           className="px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-xs font-medium transition-colors cursor-pointer shrink-0"
         >
           繼續

--- a/frontend/src/services/assignmentApi.ts
+++ b/frontend/src/services/assignmentApi.ts
@@ -219,3 +219,22 @@ export async function startAssignment(
   );
   return handleResponse<StartAssignmentResponse>(res);
 }
+
+/**
+ * Submit a completed assignment. Call this when the student reaches the report page.
+ * Idempotent: safe to call even if already submitted.
+ * TODO: Backend will send Email notification to teacher on submission (future implementation).
+ */
+export async function submitAssignment(
+  token: string,
+  assignmentId: number,
+): Promise<StudentAssignmentResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/assignments/${assignmentId}/submit`,
+    {
+      method: 'POST',
+      headers: authHeaders(token),
+    },
+  );
+  return handleResponse<StudentAssignmentResponse>(res);
+}


### PR DESCRIPTION
Fixes #24

## Summary

The student assignment page (`MyAssignments.tsx`) and API service were already built from the #143 backend merge. This PR adds the missing auto-submit bridge:

- **Backend**: New `POST /api/assignments/{id}/submit` endpoint — marks submission as `submitted`, pulls `overall_score` from the linked `LearningSession`, idempotent (safe to call if already submitted). Includes `TODO` comment for future Email notification.
- **Frontend `assignmentApi.ts`**: New `submitAssignment()` function.
- **Frontend `LearningLayout.tsx`**: `handleSessionComplete` (called when student reaches the report page) now auto-submits the active assignment. Uses `sessionStorage.activeAssignmentId` set when the student clicks "開始作業" or "繼續".
- **Frontend `MyAssignments.tsx`**: "繼續" button also restores `activeAssignmentId` in sessionStorage so resuming an in-progress assignment also triggers auto-submit on completion.

## What was already working (no changes needed)

- `MyAssignments.tsx` — list with filter tabs (pending/completed/all), status badges, overdue indicator, action buttons
- `assignmentApi.ts` — `getMyAssignments()`, `startAssignment()`
- Backend CRUD endpoints for assignments and submissions
- Navigation from assignment list into learning flow

## Test plan

1. Log in as a student who has a pending assignment
2. Go to "作業" tab — should see the assignment with "待完成" badge and "開始作業" button
3. Click "開始作業" — should navigate into the learning flow for that story
4. Complete all 6 learning steps through to the Report page
5. Return to "作業" tab — the assignment should now show "已提交" status
6. For an in-progress assignment: click "繼續", complete the flow, verify auto-submit also works