### PR TITLE
feat: teacher assignment grading and bulk remind UI (Fixes #23)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -19,6 +19,7 @@ from ..schemas.assignment import (
     AssignmentListResponse,
     AssignmentResponse,
     AssignmentUpdateRequest,
+    GradeSubmissionRequest,
     StartAssignmentResponse,
     StudentAssignmentResponse,
     SubmissionResponse,
@@ -325,6 +326,61 @@ def update_assignment(
 
     logger.info("Updated assignment %d: %s", assignment_id, list(update_data.keys()))
     return _assignment_to_response(assignment, db)
+
+
+# ── Teacher Grading Endpoint ─────────────────────────────────────────────────
+
+
+@router.patch(
+    "/assignments/{assignment_id}/submissions/{submission_id}",
+    response_model=SubmissionResponse,
+)
+def grade_submission(
+    assignment_id: int,
+    submission_id: int,
+    payload: GradeSubmissionRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Grade a student submission. Teacher sets score and marks as 'graded'."""
+    assignment = db.query(Assignment).filter(Assignment.id == assignment_id).first()
+    if assignment is None:
+        raise HTTPException(status_code=404, detail="Assignment not found")
+
+    _require_assignment_owner_or_admin(assignment, current_user, db)
+
+    submission = (
+        db.query(AssignmentSubmission)
+        .filter(
+            AssignmentSubmission.id == submission_id,
+            AssignmentSubmission.assignment_id == assignment_id,
+        )
+        .first()
+    )
+    if submission is None:
+        raise HTTPException(status_code=404, detail="Submission not found")
+
+    if payload.score is not None:
+        submission.score = payload.score
+    submission.status = "graded"
+
+    db.commit()
+    db.refresh(submission)
+
+    student = db.query(User).filter(User.id == submission.student_id).first()
+    logger.info(
+        "Teacher %d graded submission %d (score=%s)",
+        current_user.id, submission_id, payload.score,
+    )
+    return SubmissionResponse(
+        id=submission.id,
+        assignment_id=submission.assignment_id,
+        student_id=submission.student_id,
+        student_name=student.name if student else "Unknown",
+        status=submission.status,
+        submitted_at=submission.submitted_at,
+        score=submission.score,
+    )
 
 
 # ── Student Action Endpoints ─────────────────────────────────────────────────

--- a/backend/app/schemas/assignment.py
+++ b/backend/app/schemas/assignment.py
@@ -19,6 +19,10 @@ class AssignmentUpdateRequest(BaseModel):
     is_active: bool | None = None
 
 
+class GradeSubmissionRequest(BaseModel):
+    score: float | None = Field(None, ge=0, le=100)
+
+
 class SubmissionResponse(BaseModel):
     id: int
     assignment_id: int

--- a/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
+++ b/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
@@ -1,0 +1,269 @@
+/**
+ * AssignmentDetailPanel — expanded submission view with grading actions.
+ * Used inside AssignmentTab when a row is expanded.
+ */
+import React, { useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  gradeSubmission,
+  AssignmentDetailResponse,
+  SubmissionResponse,
+  AssignmentApiError,
+} from '../../services/assignmentApi';
+
+interface Props {
+  assignmentId: number;
+  detail: AssignmentDetailResponse;
+  isLoading: boolean;
+  onGraded: (updated: SubmissionResponse) => void;
+}
+
+function statusBadge(status: string) {
+  switch (status) {
+    case 'in_progress':
+      return (
+        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">
+          進行中
+        </span>
+      );
+    case 'submitted':
+      return (
+        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+          已提交
+        </span>
+      );
+    case 'graded':
+      return (
+        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-700">
+          已批改
+        </span>
+      );
+    default:
+      return (
+        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-500">
+          待完成
+        </span>
+      );
+  }
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+const AssignmentDetailPanel: React.FC<Props> = ({
+  assignmentId,
+  detail,
+  isLoading,
+  onGraded,
+}) => {
+  const { token } = useAuth();
+  const [gradingId, setGradingId] = useState<number | null>(null);
+  const [gradeInput, setGradeInput] = useState<Record<number, string>>({});
+  const [savingId, setSavingId] = useState<number | null>(null);
+  const [gradeError, setGradeError] = useState('');
+
+  // Stats
+  const pending = detail.submissions.filter(
+    (s) => s.status === 'pending',
+  ).length;
+
+  const handleGradeClick = (sub: SubmissionResponse) => {
+    setGradingId(sub.id);
+    setGradeInput((prev) => ({
+      ...prev,
+      [sub.id]: sub.score != null ? String(Math.round(sub.score)) : '',
+    }));
+    setGradeError('');
+  };
+
+  const handleSaveGrade = async (sub: SubmissionResponse) => {
+    if (!token) return;
+    const raw = gradeInput[sub.id] ?? '';
+    const score = raw.trim() === '' ? null : parseFloat(raw);
+    if (score !== null && (isNaN(score) || score < 0 || score > 100)) {
+      setGradeError('分數需介於 0–100');
+      return;
+    }
+
+    setSavingId(sub.id);
+    setGradeError('');
+    try {
+      const updated = await gradeSubmission(token, assignmentId, sub.id, score);
+      setGradingId(null);
+      onGraded(updated);
+    } catch (err) {
+      if (err instanceof AssignmentApiError) {
+        setGradeError(err.message);
+      } else {
+        setGradeError('批改失敗，請重試');
+      }
+    } finally {
+      setSavingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex gap-4">
+            <div className="h-3 bg-gray-200 animate-pulse rounded w-1/3" />
+            <div className="h-3 bg-gray-200 animate-pulse rounded w-1/5" />
+            <div className="h-3 bg-gray-200 animate-pulse rounded w-1/6" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!detail || detail.submissions.length === 0) {
+    return (
+      <p className="text-xs text-gray-500 text-center py-2">尚無學生提交記錄</p>
+    );
+  }
+
+  return (
+    <div>
+      {/* Stats bar + bulk remind */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex gap-4 text-xs text-gray-500">
+          <span>
+            已完成:{' '}
+            <strong className="text-gray-700">{detail.completed_count}</strong>
+          </span>
+          <span>
+            未完成:{' '}
+            <strong className={pending > 0 ? 'text-amber-600' : 'text-gray-700'}>
+              {pending}
+            </strong>
+          </span>
+          <span>
+            總學生:{' '}
+            <strong className="text-gray-700">{detail.submission_count}</strong>
+          </span>
+        </div>
+        {pending > 0 && (
+          <button
+            onClick={() =>
+              alert(
+                `已標記提醒 ${pending} 位未完成學生。\n（實際通知功能待串接推播服務）`,
+              )
+            }
+            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg border border-amber-300 text-amber-700 text-xs font-medium hover:bg-amber-50 transition-colors cursor-pointer"
+          >
+            <svg
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+              />
+            </svg>
+            提醒 {pending} 人
+          </button>
+        )}
+      </div>
+
+      {/* Grade error */}
+      {gradeError && (
+        <div className="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5">
+          {gradeError}
+          <button
+            onClick={() => setGradeError('')}
+            className="ml-2 underline cursor-pointer"
+          >
+            關閉
+          </button>
+        </div>
+      )}
+
+      {/* Submission table */}
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="text-left text-gray-400">
+            <th className="pb-1.5 font-medium">學生姓名</th>
+            <th className="pb-1.5 font-medium text-center">狀態</th>
+            <th className="pb-1.5 font-medium">提交時間</th>
+            <th className="pb-1.5 font-medium text-center">分數</th>
+            <th className="pb-1.5 font-medium text-center">批改</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {detail.submissions.map((sub) => (
+            <tr key={sub.id}>
+              <td className="py-1.5 text-gray-700">{sub.student_name}</td>
+              <td className="py-1.5 text-center">{statusBadge(sub.status)}</td>
+              <td className="py-1.5 text-gray-500">{formatDate(sub.submitted_at)}</td>
+              <td className="py-1.5 text-gray-700 text-center font-medium">
+                {gradingId === sub.id ? (
+                  <input
+                    type="number"
+                    min="0"
+                    max="100"
+                    value={gradeInput[sub.id] ?? ''}
+                    onChange={(e) =>
+                      setGradeInput((prev) => ({
+                        ...prev,
+                        [sub.id]: e.target.value,
+                      }))
+                    }
+                    className="w-16 h-6 px-1.5 rounded border border-gray-300 text-center text-xs focus:outline-none focus:border-accent"
+                    placeholder="0-100"
+                  />
+                ) : sub.score != null ? (
+                  `${Math.round(sub.score)}%`
+                ) : (
+                  '-'
+                )}
+              </td>
+              <td className="py-1.5 text-center">
+                {gradingId === sub.id ? (
+                  <div className="flex items-center justify-center gap-1">
+                    <button
+                      onClick={() => handleSaveGrade(sub)}
+                      disabled={savingId === sub.id}
+                      className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
+                    >
+                      {savingId === sub.id ? '...' : '儲存'}
+                    </button>
+                    <button
+                      onClick={() => {
+                        setGradingId(null);
+                        setGradeError('');
+                      }}
+                      className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+                    >
+                      取消
+                    </button>
+                  </div>
+                ) : sub.status === 'submitted' || sub.status === 'graded' ? (
+                  <button
+                    onClick={() => handleGradeClick(sub)}
+                    className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+                  >
+                    {sub.status === 'graded' ? '重新批改' : '批改'}
+                  </button>
+                ) : (
+                  <span className="text-gray-300">—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default AssignmentDetailPanel;

--- a/frontend/src/pages/teacher/AssignmentTab.tsx
+++ b/frontend/src/pages/teacher/AssignmentTab.tsx
@@ -7,10 +7,12 @@ import {
   updateAssignment,
   AssignmentResponse,
   AssignmentDetailResponse,
+  SubmissionResponse,
   AssignmentApiError,
 } from '../../services/assignmentApi';
 import { fetchStories } from '../../services/api';
 import type { Story } from '../../types';
+import AssignmentDetailPanel from './AssignmentDetailPanel';
 
 interface AssignmentTabProps {
   classroomId: number;
@@ -81,6 +83,9 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
     allStories.forEach((s) => map.set(s.id, s));
     return map;
   }, [allStories]);
+
+  // Suppress unused variable warning — storyMap used for future enhancements
+  void storyMap;
 
   const handleOpenCreateForm = () => {
     setShowCreateForm(true);
@@ -160,6 +165,29 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
     [expandedId, token],
   );
 
+  // Update a single submission in expandedDetail after grading
+  const handleGraded = useCallback((updated: SubmissionResponse) => {
+    setExpandedDetail((prev) => {
+      if (!prev) return prev;
+      const newSubs = prev.submissions.map((s) =>
+        s.id === updated.id ? updated : s,
+      );
+      const completedCount = newSubs.filter((s) =>
+        ['submitted', 'graded'].includes(s.status),
+      ).length;
+      return { ...prev, submissions: newSubs, completed_count: completedCount };
+    });
+    // Also update the summary row in assignments list
+    setAssignments((prev) =>
+      prev.map((a) => {
+        if (a.id !== expandedId) return a;
+        const completedCount = a.completed_count;
+        // If newly graded from submitted, count stays same (already counted)
+        return { ...a, completed_count: completedCount };
+      }),
+    );
+  }, [expandedId]);
+
   const formatDate = (dateStr: string | null): string => {
     if (!dateStr) return '-';
     return new Date(dateStr).toLocaleDateString('zh-TW', {
@@ -172,35 +200,6 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
   const isOverdue = (dueDateStr: string | null): boolean => {
     if (!dueDateStr) return false;
     return new Date(dueDateStr) < new Date();
-  };
-
-  const submissionStatusBadge = (status: string) => {
-    switch (status) {
-      case 'in_progress':
-        return (
-          <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">
-            進行中
-          </span>
-        );
-      case 'submitted':
-        return (
-          <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
-            已提交
-          </span>
-        );
-      case 'graded':
-        return (
-          <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-700">
-            已批改
-          </span>
-        );
-      default:
-        return (
-          <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-500">
-            待完成
-          </span>
-        );
-    }
   };
 
   if (isLoading) {
@@ -283,7 +282,6 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
           )}
 
           <form onSubmit={handleCreate} className="space-y-3">
-            {/* Story picker */}
             <div>
               <label htmlFor="assign-story" className="block text-sm font-medium text-gray-700 mb-1">
                 課文 <span className="text-red-500">*</span>
@@ -312,7 +310,6 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
               )}
             </div>
 
-            {/* Title */}
             <div>
               <label htmlFor="assign-title" className="block text-sm font-medium text-gray-700 mb-1">
                 作業標題（選填）
@@ -327,7 +324,6 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
               />
             </div>
 
-            {/* Description */}
             <div>
               <label htmlFor="assign-desc" className="block text-sm font-medium text-gray-700 mb-1">
                 說明（選填）
@@ -342,7 +338,6 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
               />
             </div>
 
-            {/* Due date */}
             <div>
               <label htmlFor="assign-due" className="block text-sm font-medium text-gray-700 mb-1">
                 截止日期（選填）
@@ -356,7 +351,6 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
               />
             </div>
 
-            {/* Buttons */}
             <div className="flex gap-3 justify-end pt-1">
               <button
                 type="button"
@@ -411,7 +405,7 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
                 {assignments.map((a) => {
                   const isExpanded = expandedId === a.id;
                   const displayTitle = a.title || a.story_title;
-                  const completionRate =
+                  const completionPct =
                     a.submission_count > 0
                       ? Math.round((a.completed_count / a.submission_count) * 100)
                       : 0;
@@ -447,9 +441,9 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
                         <td className="py-2.5 text-center">
                           <span
                             className={`inline-block min-w-[2rem] px-2 py-0.5 rounded-full text-xs font-medium ${
-                              completionRate === 100
+                              completionPct === 100
                                 ? 'bg-green-100 text-green-700'
-                                : completionRate > 0
+                                : completionPct > 0
                                   ? 'bg-accent-bg text-accent'
                                   : 'bg-gray-100 text-gray-500'
                             }`}
@@ -474,57 +468,16 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
                         </td>
                       </tr>
 
-                      {/* Expanded detail: submissions */}
+                      {/* Expanded detail: grading panel */}
                       {isExpanded && (
                         <tr>
                           <td colSpan={6} className="bg-gray-50 px-4 py-3">
-                            {isLoadingDetail ? (
-                              <div className="space-y-2">
-                                {Array.from({ length: 3 }).map((_, i) => (
-                                  <div key={i} className="flex gap-4">
-                                    <div className="h-3 bg-gray-200 animate-pulse rounded w-1/3" />
-                                    <div className="h-3 bg-gray-200 animate-pulse rounded w-1/5" />
-                                    <div className="h-3 bg-gray-200 animate-pulse rounded w-1/6" />
-                                  </div>
-                                ))}
-                              </div>
-                            ) : !expandedDetail ||
-                              expandedDetail.submissions.length === 0 ? (
-                              <p className="text-xs text-gray-500 text-center py-2">
-                                尚無學生提交記錄
-                              </p>
-                            ) : (
-                              <table className="w-full text-xs">
-                                <thead>
-                                  <tr className="text-left text-gray-400">
-                                    <th className="pb-1.5 font-medium">學生姓名</th>
-                                    <th className="pb-1.5 font-medium text-center">狀態</th>
-                                    <th className="pb-1.5 font-medium">提交時間</th>
-                                    <th className="pb-1.5 font-medium text-center">分數</th>
-                                  </tr>
-                                </thead>
-                                <tbody className="divide-y divide-gray-100">
-                                  {expandedDetail.submissions.map((sub) => (
-                                    <tr key={sub.id}>
-                                      <td className="py-1.5 text-gray-700">
-                                        {sub.student_name}
-                                      </td>
-                                      <td className="py-1.5 text-center">
-                                        {submissionStatusBadge(sub.status)}
-                                      </td>
-                                      <td className="py-1.5 text-gray-500">
-                                        {formatDate(sub.submitted_at)}
-                                      </td>
-                                      <td className="py-1.5 text-gray-700 text-center font-medium">
-                                        {sub.score != null
-                                          ? `${Math.round(sub.score)}%`
-                                          : '-'}
-                                      </td>
-                                    </tr>
-                                  ))}
-                                </tbody>
-                              </table>
-                            )}
+                            <AssignmentDetailPanel
+                              assignmentId={a.id}
+                              detail={expandedDetail!}
+                              isLoading={isLoadingDetail}
+                              onGraded={handleGraded}
+                            />
                           </td>
                         </tr>
                       )}

--- a/frontend/src/services/assignmentApi.ts
+++ b/frontend/src/services/assignmentApi.ts
@@ -172,6 +172,24 @@ export async function getMyAssignments(
   return handleResponse<StudentAssignmentResponse[]>(res);
 }
 
+/** Grade a student submission (teacher sets score, marks as graded). */
+export async function gradeSubmission(
+  token: string,
+  assignmentId: number,
+  submissionId: number,
+  score: number | null,
+): Promise<SubmissionResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/assignments/${assignmentId}/submissions/${submissionId}`,
+    {
+      method: 'PATCH',
+      headers: authHeaders(token),
+      body: JSON.stringify({ score }),
+    },
+  );
+  return handleResponse<SubmissionResponse>(res);
+}
+
 /** Start an assignment (creates a learning session). */
 export async function startAssignment(
   token: string,


### PR DESCRIPTION
Fixes #23

## Summary

- **Backend**: New `PATCH /api/assignments/{id}/submissions/{sub_id}` endpoint — teacher can set a score (0–100) and mark a submission as `graded`
- **Backend**: Added `GradeSubmissionRequest` schema (score validated 0–100)
- **Frontend**: New `AssignmentDetailPanel` component extracted from `AssignmentTab` for grading interactions
- **Frontend**: Inline grade editing in expanded assignment row — click "批改" button next to submitted/graded rows, enter score, save
- **Frontend**: "提醒 N 人" bulk remind button appears when there are pending submissions (UI only, shows placeholder alert per issue spec)
- **Frontend**: Stats bar in expanded row showing completed / pending / total counts

## What was already built (from #143)
- Assignment list with completion rate column
- Create assignment form (story picker, title, description, due date)
- Toggle active/inactive status per assignment
- Overdue date detection

## New in this PR
- Grading panel with inline score input
- Re-grading support (already-graded submissions can be re-graded)
- Bulk remind UI with pending count badge
- Stats summary (completed / pending / total) in detail row
- `gradeSubmission()` API function in `assignmentApi.ts`

## Test plan

1. Go to Teacher Dashboard → select a classroom → "作業管理" tab
2. Create an assignment if none exists
3. Click a row to expand it — verify stats bar shows completed/pending/total
4. If any submission has status "已提交": click "批改", enter a score (e.g. 85), click "儲存" — verify status changes to "已批改" and score shows as "85%"
5. If pending students exist: verify "提醒 N 人" button appears; click it to see the placeholder alert
6. Verify "重新批改" button appears for already-graded submissions