### PR TITLE
feat: paragraph-by-paragraph progressive reading unlock (Fixes #85)

### DIFF
--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -10,6 +10,7 @@ import FontSizeControl, { useFontSize } from '../ui/FontSizeControl';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { READING_EXCELLENT, READING_PASS } from '../../utils/personaConfig';
 import RecordingButton from '../recording/RecordingButton';
+import ParagraphProgress, { ParagraphStatus } from './ParagraphProgress';
 
 /* ------------------------------------------------------------------ */
 /*  Canned response pools — randomly selected to avoid repetition     */
@@ -123,6 +124,10 @@ interface LiveTutorProps {
   onPanelWidthChange: (w: number) => void;
   onFinish: (attempt: ReadingAttempt) => void;
   onCancel: () => void;
+  /** Called each time a paragraph is completed (unlocked). Receives the index of the completed paragraph. */
+  onParagraphComplete?: (completedParagraphIndex: number) => void;
+  /** Initial set of completed paragraph indices (for session resume). */
+  initialCompletedParagraphs?: Set<number>;
 }
 
 const LiveTutor: React.FC<LiveTutorProps> = ({
@@ -131,6 +136,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   onPanelWidthChange,
   onFinish,
   onCancel,
+  onParagraphComplete,
+  initialCompletedParagraphs,
 }) => {
   const isMobile = useIsMobile();
   const { px: fontSizePx } = useFontSize();
@@ -149,6 +156,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const [isTtsPaused, setIsTtsPaused] = useState(false);
   const [lastDiffTokens, setLastDiffTokens] = useState<DiffToken[] | null>(null);
   const [showRecorder, setShowRecorder] = useState(false);
+
+  // Progressive unlock state — track which paragraphs have been passed (>= READING_PASS)
+  const [completedParagraphs, setCompletedParagraphs] = useState<Set<number>>(
+    initialCompletedParagraphs ?? new Set<number>()
+  );
+  // Celebration animation: shows briefly when a new paragraph is unlocked
+  const [celebratingIndex, setCelebratingIndex] = useState<number | null>(null);
 
   const isAdvancingRef = useRef(false);
   const isDraggingRef = useRef(false);
@@ -217,20 +231,26 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     }
   }, [story.content, zhuyinActive]);
 
-  /** Compute completed/current/locked status for each paragraph */
-  const lineStatuses = useMemo(() => {
-    const bestByLine = new Map<number, number>();
-    for (const r of lineResults) {
-      const prev = bestByLine.get(r.lineIndex) ?? 0;
-      if (r.matchRate > prev) bestByLine.set(r.lineIndex, r.matchRate);
-    }
+  /** Compute completed/current/locked status for each paragraph.
+   *  A paragraph is 'completed' only if it passed the READING_PASS threshold.
+   *  Paragraphs beyond the current unlocked index are 'locked'. */
+  const lineStatuses = useMemo<ParagraphStatus[]>(() => {
     return story.content.map((_, idx) => {
+      if (completedParagraphs.has(idx)) return 'completed';
       if (idx === currentLineIndex) return 'current';
-      if (idx < currentLineIndex) return 'completed';
-      if (bestByLine.has(idx) && (bestByLine.get(idx)! >= READING_PASS)) return 'completed';
       return 'locked';
     });
-  }, [story.content, lineResults, currentLineIndex]);
+  }, [story.content, completedParagraphs, currentLineIndex]);
+
+  /** Highest paragraph index that is unlocked (either completed or currently active). */
+  const maxUnlockedIndex = useMemo(() => {
+    // All completed paragraphs + current one
+    let max = currentLineIndex;
+    for (const idx of completedParagraphs) {
+      if (idx > max) max = idx;
+    }
+    return max;
+  }, [completedParagraphs, currentLineIndex]);
 
   /* ---- resizable right panel ---- */
   useEffect(() => {
@@ -369,13 +389,35 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       isAdvancingRef.current = true;
       setIsAdvancing(true);
       stopSession(); // stop mic so student sees [系統朗讀][開始朗讀] for the next paragraph
+
+      // Mark this paragraph as completed and notify parent
+      const nextIdx = lineIdx + 1;
+      setCompletedParagraphs(prev => {
+        const updated = new Set(prev);
+        updated.add(lineIdx);
+        return updated;
+      });
+      onParagraphComplete?.(lineIdx);
+
+      // Celebration animation for unlocking next paragraph
+      setCelebratingIndex(nextIdx);
+      setTimeout(() => setCelebratingIndex(null), 2000);
+
       setTimeout(() => {
-        setCurrentLineIndex(prev => prev + 1);
+        setCurrentLineIndex(nextIdx);
         isAdvancingRef.current = false;
         setIsAdvancing(false);
       }, 1500);
     } else if (shouldFinish) {
       stopSession();
+      // Mark final paragraph as completed
+      setCompletedParagraphs(prev => {
+        const updated = new Set(prev);
+        updated.add(lineIdx);
+        return updated;
+      });
+      onParagraphComplete?.(lineIdx);
+
       setTimeout(() => {
         const allResults = [...lineResults, result];
         const avgMatchRate = allResults.reduce((s, r) => s + r.matchRate, 0) / allResults.length;
@@ -648,71 +690,86 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         </div>
 
         {/* Paragraph progress bar */}
-        <div className="px-6 py-2 bg-white border-b border-gray-100">
-          <div className="flex items-center gap-3 max-w-3xl mx-auto">
-            <span className="text-xs text-gray-400 shrink-0 font-medium">進度</span>
-            <div className="flex flex-1 gap-1 h-2">
-              {story.content.map((_, idx) => (
-                <div
-                  key={idx}
-                  className={`flex-1 rounded-full transition-all duration-500 ${
-                    lineStatuses[idx] === 'completed'
-                      ? 'bg-emerald-500'
-                      : lineStatuses[idx] === 'current'
-                      ? 'bg-accent'
-                      : 'bg-gray-200'
-                  }`}
-                />
-              ))}
-            </div>
-            <span className="text-xs text-gray-400 shrink-0 tabular-nums">
-              {currentLineIndex + 1} / {story.content.length}
-            </span>
-          </div>
-        </div>
+        <ParagraphProgress
+          statuses={lineStatuses}
+          currentIndex={currentLineIndex}
+          onSelectParagraph={(idx) => {
+            // Only allow navigating to completed or current paragraphs (not locked)
+            if (lineStatuses[idx] === 'locked') return;
+            stopSession();
+            setCurrentLineIndex(idx);
+          }}
+        />
 
         <div className={`flex-1 ${isMobile ? 'p-4' : 'p-8 lg:p-16'} overflow-y-auto custom-scrollbar`}>
           <div className="max-w-3xl mx-auto space-y-20">
-            {story.content.map((line, idx) => (
-              <div
-                key={idx}
-                ref={idx === currentLineIndex ? activeLineRef : null}
-                className={`transition-all duration-700 rounded-2xl px-8 py-12 border ${
-                  idx === currentLineIndex
-                    ? 'bg-accent/5 border-accent/40 shadow-[0_0_40px_rgba(99,102,241,0.1)] scale-[1.03]'
-                    : lineStatuses[idx] === 'completed'
-                      ? 'opacity-60 bg-emerald-50/50 border-emerald-200/50'
-                      : 'opacity-30 border-transparent'
-                }`}
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  {lineStatuses[idx] === 'completed' && (
-                    <span className="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center shrink-0">
-                      <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
-                      </svg>
-                    </span>
-                  )}
-                  {lineStatuses[idx] === 'current' && (
-                    <span className="w-5 h-5 rounded-full bg-accent flex items-center justify-center shrink-0">
-                      <span className="w-2 h-2 bg-white rounded-full animate-pulse" />
-                    </span>
-                  )}
-                  {lineStatuses[idx] === 'locked' && (
-                    <span className="w-5 h-5 rounded-full border-2 border-gray-300 shrink-0" />
-                  )}
-                  <span className="text-xs text-gray-400 font-bold">第 {idx + 1} 段</span>
-                </div>
-                <p
-                  className={`leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
-                    idx === currentLineIndex ? 'text-gray-900 font-bold' : 'text-gray-600'
+            {story.content.map((line, idx) => {
+              const isCelebrating = celebratingIndex === idx;
+              const status = lineStatuses[idx];
+              return (
+                <div
+                  key={idx}
+                  ref={idx === currentLineIndex ? activeLineRef : null}
+                  className={`transition-all duration-700 rounded-2xl px-8 py-12 border ${
+                    isCelebrating
+                      ? 'bg-emerald-50 border-emerald-400 shadow-[0_0_40px_rgba(16,185,129,0.25)] scale-[1.04]'
+                      : status === 'current'
+                        ? 'bg-accent/5 border-accent/40 shadow-[0_0_40px_rgba(99,102,241,0.1)] scale-[1.03]'
+                        : status === 'completed'
+                          ? 'opacity-60 bg-emerald-50/50 border-emerald-200/50'
+                          : 'opacity-20 border-transparent'
                   }`}
-                  style={{ fontSize: fontSizePx }}
                 >
-                  {zhuyinLines ? zhuyinLines[idx] : line}
-                </p>
-              </div>
-            ))}
+                  <div className="flex items-center gap-2 mb-2">
+                    {/* Status indicator */}
+                    {status === 'completed' && (
+                      <span className="w-5 h-5 rounded-full bg-emerald-500 flex items-center justify-center shrink-0">
+                        <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
+                        </svg>
+                      </span>
+                    )}
+                    {status === 'current' && (
+                      <span className="w-5 h-5 rounded-full bg-accent flex items-center justify-center shrink-0">
+                        <span className="w-2 h-2 bg-white rounded-full animate-pulse" />
+                      </span>
+                    )}
+                    {status === 'locked' && (
+                      /* Lock icon for locked paragraphs */
+                      <span className="w-5 h-5 rounded-full border-2 border-gray-300 flex items-center justify-center shrink-0">
+                        <svg className="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                        </svg>
+                      </span>
+                    )}
+                    <span className="text-xs text-gray-400 font-bold">第 {idx + 1} 段</span>
+                    {/* Celebration label */}
+                    {isCelebrating && (
+                      <span className="ml-auto text-xs font-bold text-emerald-600 animate-bounce">
+                        解鎖了！
+                      </span>
+                    )}
+                    {/* Locked hint */}
+                    {status === 'locked' && (
+                      <span className="ml-auto text-[10px] text-gray-400">完成前一段後解鎖</span>
+                    )}
+                  </div>
+                  <p
+                    className={`leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
+                      status === 'current' ? 'text-gray-900 font-bold' : 'text-gray-600'
+                    }`}
+                    style={{ fontSize: fontSizePx }}
+                  >
+                    {/* Show blurred text for locked paragraphs */}
+                    {status === 'locked' ? (
+                      <span className="blur-sm select-none">{zhuyinLines ? zhuyinLines[idx] : line}</span>
+                    ) : (
+                      zhuyinLines ? zhuyinLines[idx] : line
+                    )}
+                  </p>
+                </div>
+              );
+            })}
           </div>
         </div>
 
@@ -958,10 +1015,14 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           </div>
 
           <div className="flex gap-2">
+            {/* 上一段 — only navigate back to completed or current paragraphs */}
             <button
               onClick={() => {
-                stopSession();
-                setCurrentLineIndex(prev => Math.max(0, prev - 1));
+                const prevIdx = currentLineIndex - 1;
+                if (prevIdx >= 0 && (lineStatuses[prevIdx] === 'completed' || lineStatuses[prevIdx] === 'current')) {
+                  stopSession();
+                  setCurrentLineIndex(prevIdx);
+                }
               }}
               disabled={currentLineIndex === 0}
               className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${
@@ -974,19 +1035,52 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
             >
               {processZhuyin('上一段')}
             </button>
-            <button
-              onClick={() => {
-                if (currentLineIndex < story.content.length - 1) {
-                  stopSession();
-                  setCurrentLineIndex(prev => prev + 1);
-                } else {
-                  handleFinish();
-                }
-              }}
-              className={`flex-1 py-3 bg-gray-300 hover:bg-gray-200 text-gray-600 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}
-            >
-              {processZhuyin(currentLineIndex === story.content.length - 1 ? '觀看總結報告' : '下一段')}
-            </button>
+
+            {/* 下一段 / 觀看總結報告 — gated by paragraph completion */}
+            {(() => {
+              const isLastLine = currentLineIndex === story.content.length - 1;
+              const allDone = completedParagraphs.size === story.content.length;
+              const nextUnlocked = !isLastLine && maxUnlockedIndex > currentLineIndex;
+
+              if (isLastLine) {
+                // Last paragraph: only show finish button when all paragraphs are done
+                return (
+                  <button
+                    onClick={handleFinish}
+                    disabled={!allDone}
+                    title={!allDone ? '完成所有段落後才能查看報告' : undefined}
+                    className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''} ${
+                      allDone
+                        ? 'bg-emerald-600 hover:bg-emerald-500 text-white'
+                        : 'bg-gray-300 text-gray-300 cursor-not-allowed'
+                    }`}
+                  >
+                    {processZhuyin('觀看總結報告')}
+                  </button>
+                );
+              }
+
+              // Non-last paragraph: next paragraph is unlocked only if current is completed
+              return (
+                <button
+                  onClick={() => {
+                    if (nextUnlocked) {
+                      stopSession();
+                      setCurrentLineIndex(prev => prev + 1);
+                    }
+                  }}
+                  disabled={!nextUnlocked}
+                  title={!nextUnlocked ? '請先完成此段朗讀（正確率需達 60%）' : undefined}
+                  className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''} ${
+                    nextUnlocked
+                      ? 'bg-gray-300 hover:bg-gray-200 text-gray-600'
+                      : 'bg-gray-300 text-gray-300 cursor-not-allowed'
+                  }`}
+                >
+                  {processZhuyin('下一段')}
+                </button>
+              );
+            })()}
           </div>
 
           {isSessionActive && (

--- a/frontend/src/components/reading-steps/ParagraphProgress.tsx
+++ b/frontend/src/components/reading-steps/ParagraphProgress.tsx
@@ -1,0 +1,74 @@
+/**
+ * ParagraphProgress — visual progress bar showing paragraph states.
+ * Displays each paragraph as a segment: locked / current / completed.
+ * Used inside LiveTutor to give students a quick overview.
+ */
+
+import React from 'react';
+
+export type ParagraphStatus = 'locked' | 'current' | 'completed';
+
+interface ParagraphProgressProps {
+  statuses: ParagraphStatus[];
+  currentIndex: number;
+  onSelectParagraph?: (idx: number) => void;
+}
+
+const ParagraphProgress: React.FC<ParagraphProgressProps> = ({
+  statuses,
+  currentIndex,
+  onSelectParagraph,
+}) => {
+  const total = statuses.length;
+  const completedCount = statuses.filter((s) => s === 'completed').length;
+
+  return (
+    <div className="px-6 py-2 bg-white border-b border-gray-100">
+      <div className="flex items-center gap-3 max-w-3xl mx-auto">
+        <span className="text-xs text-gray-400 shrink-0 font-medium">進度</span>
+
+        {/* Segment bar */}
+        <div className="flex flex-1 gap-1 h-2">
+          {statuses.map((status, idx) => (
+            <button
+              key={idx}
+              title={
+                status === 'completed'
+                  ? `第 ${idx + 1} 段（完成）`
+                  : status === 'current'
+                    ? `第 ${idx + 1} 段（目前）`
+                    : `第 ${idx + 1} 段（未解鎖）`
+              }
+              disabled={status === 'locked' || !onSelectParagraph}
+              onClick={() => onSelectParagraph?.(idx)}
+              className={`flex-1 rounded-full transition-all duration-500 focus:outline-none ${
+                status === 'completed'
+                  ? 'bg-emerald-500 hover:bg-emerald-400 cursor-pointer'
+                  : status === 'current'
+                    ? 'bg-accent animate-pulse'
+                    : 'bg-gray-200 cursor-not-allowed'
+              }`}
+              style={{ minWidth: 0 }}
+            />
+          ))}
+        </div>
+
+        {/* Counter */}
+        <span className="text-xs text-gray-400 shrink-0 tabular-nums">
+          {completedCount === total
+            ? `全部完成`
+            : `${currentIndex + 1} / ${total}`}
+        </span>
+      </div>
+
+      {/* Unlock hint: shown when all paragraphs done */}
+      {completedCount === total && (
+        <p className="text-center text-xs text-emerald-600 font-bold mt-1 animate-bounce">
+          所有段落完成！可以進行全文朗讀了
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ParagraphProgress;

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -38,6 +38,10 @@ export interface LearningContext {
   emptyAttempt: ReadingAttempt;
   /** DB LearningSession integer ID — set after the session is created in the DB (Issue #242) */
   dbSessionId: number | null;
+  /** Set of paragraph indices completed during LiveTutor (progressive unlock, Issue #85). */
+  completedParagraphsSet: Set<number>;
+  /** Notify layout that a paragraph was completed (Issue #85). */
+  handleParagraphComplete: (paragraphIndex: number) => void;
 }
 
 /**
@@ -73,6 +77,8 @@ const LearningLayout: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   /** DB LearningSession integer ID — created when the user starts the intro (Issue #242) */
   const [dbSessionId, setDbSessionId] = useState<number | null>(null);
+  /** Progressive paragraph unlock tracking (Issue #85). */
+  const [completedParagraphsSet, setCompletedParagraphsSet] = useState<Set<number>>(new Set());
 
   /** Persist current step to localStorage for session resume. */
   const persistStep = useCallback(
@@ -245,6 +251,23 @@ const LearningLayout: React.FC = () => {
     clearPersistedSession();
   }, [clearPersistedSession]);
 
+  /** Mark a paragraph as completed in both local state and session (Issue #85). */
+  const handleParagraphComplete = useCallback((paragraphIndex: number) => {
+    setCompletedParagraphsSet((prev) => {
+      if (prev.has(paragraphIndex)) return prev;
+      const updated = new Set(prev);
+      updated.add(paragraphIndex);
+      return updated;
+    });
+    setSession((prev) => {
+      if (!prev) return prev;
+      const existing = new Set(prev.completedParagraphs ?? []);
+      if (existing.has(paragraphIndex)) return prev;
+      existing.add(paragraphIndex);
+      return { ...prev, completedParagraphs: Array.from(existing) };
+    });
+  }, []);
+
   if (isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center">
@@ -287,6 +310,8 @@ const LearningLayout: React.FC = () => {
     handleSessionComplete,
     emptyAttempt: EMPTY_ATTEMPT,
     dbSessionId,
+    completedParagraphsSet,
+    handleParagraphComplete,
   };
 
   return <Outlet context={ctx} />;

--- a/frontend/src/pages/learning/FullReadingPage.tsx
+++ b/frontend/src/pages/learning/FullReadingPage.tsx
@@ -5,11 +5,64 @@ import { useLearningContext } from '../../layouts/LearningLayout';
 
 const FullReadingPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
-  const { selectedStory, rightPanelWidth, setRightPanelWidth, handleFinishFullReading } =
-    useLearningContext();
+  const {
+    selectedStory,
+    rightPanelWidth,
+    setRightPanelWidth,
+    handleFinishFullReading,
+    completedParagraphsSet,
+  } = useLearningContext();
   const navigate = useNavigate();
 
   if (!selectedStory) return null;
+
+  const totalParagraphs = selectedStory.content.length;
+  const allParagraphsDone = completedParagraphsSet.size >= totalParagraphs;
+
+  // Gate: require all paragraphs completed before accessing full reading (Issue #85)
+  if (!allParagraphsDone) {
+    const remaining = totalParagraphs - completedParagraphsSet.size;
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 bg-amber-50">
+        <div className="text-center max-w-md space-y-4">
+          {/* Lock icon */}
+          <div className="w-20 h-20 rounded-full bg-gray-100 border-2 border-gray-300 flex items-center justify-center mx-auto">
+            <svg className="w-10 h-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+          </div>
+
+          <h2 className="text-2xl font-bold text-gray-800">全文朗讀尚未解鎖</h2>
+          <p className="text-gray-600 leading-relaxed">
+            請先完成逐段朗讀練習，才能進行全文朗讀。
+          </p>
+          <p className="text-sm text-gray-500">
+            目前完成：{completedParagraphsSet.size} / {totalParagraphs} 段
+            {remaining > 0 && `，還需完成 ${remaining} 段`}
+          </p>
+
+          {/* Progress visual */}
+          <div className="flex gap-1.5 h-2.5 justify-center max-w-xs mx-auto">
+            {Array.from({ length: totalParagraphs }, (_, idx) => (
+              <div
+                key={idx}
+                className={`flex-1 rounded-full transition-all ${
+                  completedParagraphsSet.has(idx) ? 'bg-emerald-500' : 'bg-gray-200'
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+
+        <button
+          onClick={() => navigate(`/learn/${storyId}/tutor`)}
+          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white transition-all shadow active:scale-95"
+        >
+          返回逐段練習
+        </button>
+      </div>
+    );
+  }
 
   return (
     <FullReading

--- a/frontend/src/pages/learning/TutorPage.tsx
+++ b/frontend/src/pages/learning/TutorPage.tsx
@@ -4,8 +4,14 @@ import LiveTutor from '../../components/reading-steps/LiveTutor';
 import { useLearningContext } from '../../layouts/LearningLayout';
 
 const TutorPage: React.FC = () => {
-  const { selectedStory, rightPanelWidth, setRightPanelWidth, handleFinishReading } =
-    useLearningContext();
+  const {
+    selectedStory,
+    rightPanelWidth,
+    setRightPanelWidth,
+    handleFinishReading,
+    completedParagraphsSet,
+    handleParagraphComplete,
+  } = useLearningContext();
   const navigate = useNavigate();
 
   if (!selectedStory) return null;
@@ -17,6 +23,8 @@ const TutorPage: React.FC = () => {
       onPanelWidthChange={setRightPanelWidth}
       onFinish={handleFinishReading}
       onCancel={() => navigate('/library')}
+      onParagraphComplete={handleParagraphComplete}
+      initialCompletedParagraphs={completedParagraphsSet}
     />
   );
 };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -103,6 +103,8 @@ export interface LearningSession {
   comprehensionResult: ComprehensionResult | null;
   vocabResult: VocabResult | null;
   fullReadingResult: FullReadingResult | null;
+  /** Paragraph indices (0-based) completed during LiveTutor (progressive unlock). */
+  completedParagraphs?: number[];
 }
 
 export interface LiveMessage {


### PR DESCRIPTION
Fixes #85

## Summary

- Students see only paragraph 1 on first entry to LiveTutor; each paragraph unlocks only after the current one reaches >= 60% accuracy
- New `ParagraphProgress` component: clickable segment bar showing locked / current / completed states with visual indicators
- Locked paragraphs display blurred text + lock icon with hint "完成前一段後解鎖"
- Celebration micro-animation (green glow + "解鎖了！" badge) fires for 2 seconds when a new paragraph is unlocked
- "下一段" button is disabled until the current paragraph passes the threshold; "觀看總結報告" disabled until ALL paragraphs are done
- `FullReadingPage` shows a locked screen (lock icon + progress mini-bar + link back to tutor) when not all paragraphs are completed
- Paragraph completion state is tracked in `LearningContext.completedParagraphsSet` and persisted in `LearningSession.completedParagraphs` (frontend state only, no backend changes)

## Files Changed

- `frontend/src/components/reading-steps/ParagraphProgress.tsx` — new component (74 lines)
- `frontend/src/components/reading-steps/LiveTutor.tsx` — unlock logic, celebration animation, locked paragraph rendering
- `frontend/src/layouts/LearningLayout.tsx` — `completedParagraphsSet` state + `handleParagraphComplete` callback in context
- `frontend/src/pages/learning/TutorPage.tsx` — pass new props to LiveTutor
- `frontend/src/pages/learning/FullReadingPage.tsx` — gate behind all-paragraphs-complete check
- `frontend/src/types.ts` — add `completedParagraphs?: number[]` to `LearningSession`

## Test Plan

- [ ] Open a story in LiveTutor — only paragraph 1 should be active, rest blurred/locked
- [ ] Read paragraph 1 poorly (< 60%) — "下一段" should remain disabled, paragraph stays current
- [ ] Read paragraph 1 well (>= 60%) — auto-advances to paragraph 2, celebration animation appears, progress bar segment turns green
- [ ] Navigate back to completed paragraph 1 via progress bar — should work
- [ ] Try clicking a locked segment in the progress bar — should do nothing
- [ ] After completing all paragraphs, "觀看總結報告" should become active
- [ ] Navigate to full-reading step before completing all paragraphs — should see locked screen with progress bar
- [ ] Complete all paragraphs, navigate to full-reading — should show normally