### PR TITLE
feat: 卡點偵測 + 個別化學習建議 (Fixes #91)

### DIFF
--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -24,6 +24,7 @@ from ..schemas.session import (
 )
 from ..services.ai_service import evaluate_comprehension, generate_reading_analysis, generate_socratic_question
 from ..services.socratic_agent import socratic_agent
+from ..services.stuck_detection_service import build_recommendations, detect_stuck_points
 
 router = APIRouter(tags=["learning"])
 logger = logging.getLogger(__name__)
@@ -902,3 +903,99 @@ def mark_error_corrected(
         student_id, payload.character, payload.correction_type,
     )
     return correction
+
+
+# ── Stuck-Point Detection (Issue #91) ─────────────────────────────────────────
+
+
+class StoryStuckItem(BaseModel):
+    story_slug: str
+    attempt_count: int
+    best_accuracy: float
+    last_attempt: str
+
+
+class CharacterStuckItem(BaseModel):
+    character: str
+    error_count: int
+    last_error_date: str | None
+
+
+class StuckPointsResponse(BaseModel):
+    story_stuck: list[StoryStuckItem]
+    character_stuck: list[CharacterStuckItem]
+    is_declining: bool
+    accuracy_trend: list[float]
+
+
+class RecommendationItem(BaseModel):
+    type: str
+    title: str
+    description: str
+    action: str
+
+
+class RecommendationsResponse(BaseModel):
+    recommendations: list[RecommendationItem]
+    total: int
+
+
+@router.get(
+    "/learning/students/{student_id}/stuck-points",
+    response_model=StuckPointsResponse,
+)
+def get_stuck_points(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Detect learning stuck-points for a student.
+
+    Accessible by the student themselves or their teacher.
+
+    Returns:
+    - story_stuck: stories attempted 3+ times without ≥5% accuracy improvement
+    - character_stuck: characters with 3+ errors across sessions (last 30 days)
+    - is_declining: True if last 3 sessions show strictly declining accuracy
+    - accuracy_trend: list of accuracy values (oldest → newest, last 10 sessions)
+    """
+    _verify_student_access(student_id, current_user, db)
+    data = detect_stuck_points(student_id, db)
+    logger.info(
+        "Stuck-point detection for student %d: %d story stuck, %d char stuck, declining=%s",
+        student_id,
+        len(data["story_stuck"]),
+        len(data["character_stuck"]),
+        data["is_declining"],
+    )
+    return StuckPointsResponse(**data)
+
+
+@router.get(
+    "/learning/students/{student_id}/recommendations",
+    response_model=RecommendationsResponse,
+)
+def get_recommendations(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return personalised learning recommendations for a student.
+
+    Accessible by the student themselves or their teacher.
+
+    Rule-based recommendations derived from stuck-point analysis.
+    No AI call — always fast and always available.
+    """
+    _verify_student_access(student_id, current_user, db)
+    stuck_data = detect_stuck_points(student_id, db)
+    recs = build_recommendations(stuck_data)
+    logger.info(
+        "Generated %d recommendations for student %d",
+        len(recs),
+        student_id,
+    )
+    return RecommendationsResponse(
+        recommendations=[RecommendationItem(**r) for r in recs],
+        total=len(recs),
+    )

--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -27,6 +27,7 @@ from ..schemas.teacher_instruction import (
 )
 from ..models.user import User
 from ..services.lesson_loader import get_lesson_by_id
+from ..services.stuck_detection_service import build_recommendations, detect_stuck_points
 from .classrooms import _get_classroom_or_404, _require_owner_or_admin
 
 router = APIRouter(tags=["teacher"])
@@ -1234,3 +1235,83 @@ def delete_instruction(
     db.refresh(instruction)
     logger.info("Soft-deleted instruction %d (teacher %d)", instruction_id, current_user.id)
     return instruction
+
+
+# ── Classroom Stuck-Point Overview (Issue #91) ────────────────────────────────
+
+
+class StudentStuckSummary(BaseModel):
+    student_id: int
+    student_name: str
+    story_stuck_count: int
+    character_stuck_count: int
+    is_declining: bool
+    top_stuck_characters: list[str]
+    top_recommendations: list[str]
+
+
+class ClassroomStuckResponse(BaseModel):
+    students: list[StudentStuckSummary]
+    total_stuck: int
+
+
+@router.get(
+    "/teacher/classrooms/{classroom_id}/stuck-overview",
+    response_model=ClassroomStuckResponse,
+)
+def get_classroom_stuck_overview(
+    classroom_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return a stuck-point overview for all students in a classroom.
+
+    Only teachers with access to the classroom can call this.
+    Returns students who have at least one stuck-point indicator.
+    """
+    _check_classroom_access(current_user, classroom_id, db)
+
+    enrollments = (
+        db.query(ClassroomStudent)
+        .filter(ClassroomStudent.classroom_id == classroom_id)
+        .all()
+    )
+
+    summaries: list[StudentStuckSummary] = []
+    for enrollment in enrollments:
+        student = enrollment.student
+        stuck_data = detect_stuck_points(student.id, db)
+
+        has_stuck = (
+            bool(stuck_data["story_stuck"])
+            or bool(stuck_data["character_stuck"])
+            or stuck_data["is_declining"]
+        )
+        if not has_stuck:
+            continue
+
+        recs = build_recommendations(stuck_data)
+        top_rec_titles = [r["title"] for r in recs if r["type"] != "encouragement"][:2]
+        top_chars = [c["character"] for c in stuck_data["character_stuck"][:3]]
+
+        summaries.append(
+            StudentStuckSummary(
+                student_id=student.id,
+                student_name=student.name,
+                story_stuck_count=len(stuck_data["story_stuck"]),
+                character_stuck_count=len(stuck_data["character_stuck"]),
+                is_declining=stuck_data["is_declining"],
+                top_stuck_characters=top_chars,
+                top_recommendations=top_rec_titles,
+            )
+        )
+
+    logger.info(
+        "Stuck overview for classroom %d: %d students with stuck points",
+        classroom_id,
+        len(summaries),
+    )
+    return ClassroomStuckResponse(
+        students=summaries,
+        total_stuck=len(summaries),
+    )


### PR DESCRIPTION
Fixes #91

## Summary

- Add `GET /learning/students/{student_id}/stuck-points` — detects stories attempted 3+ times without ≥5% accuracy improvement, characters with 3+ errors in last 30 days, and declining accuracy trend across last 3 sessions
- Add `GET /learning/students/{student_id}/recommendations` — rule-based personalized suggestions derived from stuck-point analysis (no AI call, always fast)
- Add `GET /teacher/classrooms/{classroom_id}/stuck-overview` — classroom-wide stuck-point dashboard for teachers, listing students with at least one stuck indicator

Both student endpoints respect the existing `_verify_student_access` guard (student themselves or their teacher). The teacher endpoint uses `_check_classroom_access`.

Logic delegated to `stuck_detection_service.detect_stuck_points` and `build_recommendations`.

## Test plan

- [ ] Call `GET /learning/students/{id}/stuck-points` as the student — expect `story_stuck`, `character_stuck`, `is_declining`, `accuracy_trend` fields
- [ ] Call the same endpoint as the student's teacher — should succeed (200)
- [ ] Call as an unrelated user — expect 403
- [ ] Call `GET /learning/students/{id}/recommendations` — expect a list of `RecommendationItem` objects with `type`, `title`, `description`, `action`
- [ ] Call `GET /teacher/classrooms/{id}/stuck-overview` as the classroom teacher — expect `students` list and `total_stuck` count
- [ ] Call stuck-overview as a non-owner — expect 403
- [ ] Student with no sessions → all arrays empty, `is_declining: false`