### PR TITLE
feat: 教師協同教學 — 多教師共管一班 (Fixes #244)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,7 @@
 from .base import Base  # noqa: F401
 from .user import User, Role, UserRole, StudentProfile  # noqa: F401
 from .organization import Organization  # noqa: F401
-from .school import School, Classroom, ClassroomStudent, ClassroomText  # noqa: F401
+from .school import School, Classroom, ClassroomStudent, ClassroomText, ClassroomTeacher  # noqa: F401
 from .text import Text, VisibilityLevel, TextStatus  # noqa: F401
 from .session import LearningSession, CharacterError, ErrorCorrection, DialogueTurn  # noqa: F401
 from .assignment import Assignment, AssignmentSubmission  # noqa: F401

--- a/backend/app/models/school.py
+++ b/backend/app/models/school.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from sqlalchemy import (
     String,
@@ -12,6 +13,9 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .base import Base
+
+# Valid roles for ClassroomTeacher junction table
+ClassroomTeacherRole = Literal["primary", "assistant"]
 
 
 class School(Base):
@@ -60,9 +64,12 @@ class Classroom(Base):
 
     # Relationships
     school: Mapped["School"] = relationship("School", back_populates="classrooms")
-    teacher: Mapped["User"] = relationship("User")
+    teacher: Mapped["User"] = relationship("User", foreign_keys="[Classroom.teacher_id]")
     classroom_students: Mapped[list["ClassroomStudent"]] = relationship(
         "ClassroomStudent", back_populates="classroom"
+    )
+    classroom_teachers: Mapped[list["ClassroomTeacher"]] = relationship(
+        "ClassroomTeacher", back_populates="classroom", cascade="all, delete-orphan"
     )
 
 
@@ -80,6 +87,35 @@ class ClassroomStudent(Base):
     # Relationships
     classroom: Mapped["Classroom"] = relationship("Classroom", back_populates="classroom_students")
     student: Mapped["User"] = relationship("User")
+
+
+class ClassroomTeacher(Base):
+    """Junction table: many teachers per classroom.
+
+    The primary teacher (owner) is always the one stored in Classroom.teacher_id.
+    This table tracks additional co-teachers with role='primary' (owner) or 'assistant'.
+    On classroom creation the owner is automatically inserted with role='primary'.
+    """
+
+    __tablename__ = "classroom_teachers"
+    __table_args__ = (UniqueConstraint("classroom_id", "teacher_id"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    classroom_id: Mapped[int] = mapped_column(
+        ForeignKey("classrooms.id", ondelete="CASCADE"), nullable=False
+    )
+    teacher_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    # "primary" = owner (Classroom.teacher_id), "assistant" = co-teacher
+    role: Mapped[str] = mapped_column(String(20), nullable=False, default="assistant")
+    invited_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    invited_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    # Relationships
+    classroom: Mapped["Classroom"] = relationship("Classroom", back_populates="classroom_teachers")
+    teacher: Mapped["User"] = relationship("User", foreign_keys=[teacher_id])
+    inviter: Mapped["User | None"] = relationship("User", foreign_keys=[invited_by])
 
 
 class ClassroomText(Base):

--- a/backend/app/routes/classrooms.py
+++ b/backend/app/routes/classrooms.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from ..auth.dependencies import get_current_user
 from ..auth.password import hash_password
 from ..database import get_db
-from ..models.school import Classroom, ClassroomStudent, School
+from ..models.school import Classroom, ClassroomStudent, ClassroomTeacher, School
 from ..models.user import Role, StudentProfile, User, UserRole
 from ..schemas.classroom import (
     BatchStudentCreateRequest,
@@ -68,10 +68,47 @@ def _get_classroom_or_404(classroom_id: int, db: Session) -> Classroom:
 
 
 def _require_owner_or_admin(classroom: Classroom, current_user: User, db: Session) -> None:
-    """Allow classroom teacher OR system/org admin. Raise 403 otherwise."""
+    """Allow classroom teacher (primary) OR system/org admin. Raise 403 otherwise.
+
+    For co-teachers (assistants) use _require_member_or_admin which also allows assistants.
+    """
     if classroom.teacher_id == current_user.id:
         return
     # Check if user has admin role
+    admin_role = (
+        db.query(UserRole)
+        .join(Role)
+        .filter(
+            UserRole.user_id == current_user.id,
+            UserRole.is_active == True,
+            Role.name.in_(["system_admin", "org_admin"]),
+        )
+        .first()
+    )
+    if admin_role:
+        return
+    raise HTTPException(status_code=403, detail="Not your classroom")
+
+
+def _require_member_or_admin(classroom: Classroom, current_user: User, db: Session) -> None:
+    """Allow classroom owner, co-teachers (assistants), or system/org admins.
+
+    Used for read-only endpoints like viewing student progress.
+    """
+    if classroom.teacher_id == current_user.id:
+        return
+    # Check co-teacher membership
+    ct = (
+        db.query(ClassroomTeacher)
+        .filter(
+            ClassroomTeacher.classroom_id == classroom.id,
+            ClassroomTeacher.teacher_id == current_user.id,
+        )
+        .first()
+    )
+    if ct:
+        return
+    # Check admin role
     admin_role = (
         db.query(UserRole)
         .join(Role)
@@ -192,6 +229,16 @@ def create_classroom(
         join_code=join_code,
     )
     db.add(classroom)
+    db.flush()  # Get classroom.id before adding junction row
+
+    # Auto-insert primary teacher into classroom_teachers junction table
+    primary_ct = ClassroomTeacher(
+        classroom_id=classroom.id,
+        teacher_id=effective_teacher_id,
+        role="primary",
+        invited_by=current_user.id,
+    )
+    db.add(primary_ct)
     db.commit()
     db.refresh(classroom)
     logger.info(
@@ -208,8 +255,19 @@ def list_my_classrooms(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List classrooms owned by the current teacher."""
-    query = db.query(Classroom).filter(Classroom.teacher_id == current_user.id)
+    """List classrooms where the current teacher is owner or co-teacher."""
+    # Classrooms where user is co-teacher (via classroom_teachers)
+    co_teacher_classroom_ids = (
+        db.query(ClassroomTeacher.classroom_id)
+        .filter(ClassroomTeacher.teacher_id == current_user.id)
+        .scalar_subquery()
+    )
+    query = db.query(Classroom).filter(
+        or_(
+            Classroom.teacher_id == current_user.id,
+            Classroom.id.in_(co_teacher_classroom_ids),
+        )
+    )
     total = query.count()
     items = query.order_by(Classroom.created_at.desc()).offset(offset).limit(limit).all()
     return ClassroomListResponse(
@@ -251,9 +309,9 @@ def get_classroom_detail(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Get classroom detail including student list. Only the classroom's teacher can access."""
+    """Get classroom detail including student list. Owner, co-teachers, and admins can access."""
     classroom = _get_classroom_or_404(classroom_id, db)
-    _require_owner_or_admin(classroom, current_user, db)
+    _require_member_or_admin(classroom, current_user, db)
     return _classroom_to_detail_response(classroom)
 
 
@@ -372,9 +430,9 @@ def list_classroom_students(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List all students enrolled in a classroom. Only the classroom's teacher can access."""
+    """List all students enrolled in a classroom. Owner, co-teachers, and admins can access."""
     classroom = _get_classroom_or_404(classroom_id, db)
-    _require_owner_or_admin(classroom, current_user, db)
+    _require_member_or_admin(classroom, current_user, db)
 
     return [
         StudentInClassroomResponse(


### PR DESCRIPTION
Fixes #244

## Summary

- 新增 `ClassroomTeacher` 關聯表（`classroom_teachers`），支援一個班級由多位教師共同管理
- 建立 `role` 欄位區分「主教師（primary）」與「協同教師（assistant）」，並記錄 `invited_by` 追蹤邀請者
- 建立教室時自動將建立者寫入 `classroom_teachers`（role=primary），保持向後相容
- 新增 `_require_member_or_admin` helper，協同教師可讀取班級資料（學生清單、進度）
- `GET /classrooms` 現在同時列出教師身為 owner 和 co-teacher 的班級

## Changed Files

- `backend/app/models/school.py` — 新增 `ClassroomTeacher` model + `Classroom.classroom_teachers` relationship
- `backend/app/models/__init__.py` — 匯出 `ClassroomTeacher`
- `backend/app/routes/classrooms.py` — 新增 `_require_member_or_admin`、`_is_admin` helpers；調整 classroom 列表查詢；建立時自動插入 primary teacher

## Test Plan

- [ ] 建立新班級 → 確認 `classroom_teachers` 自動有一筆 role=primary 的記錄
- [ ] 以協同教師身份呼叫 `GET /classrooms/{id}` → 應可成功（200）
- [ ] 以協同教師身份呼叫 `GET /classrooms/{id}/students` → 應可成功（200）
- [ ] 以非成員教師呼叫上述 endpoint → 應回 403
- [ ] `GET /classrooms` → 協同教師應能看到該班級出現在清單中
- [ ] 協同教師呼叫需 owner 權限的 endpoint（如 PATCH、DELETE student）→ 應回 403

## Notes

此 PR 只含後端模型與 API 邏輯，不含 DB migration 檔案（migration 需另外由維護者確認後產生）。