### PR TITLE
feat: voice input for ComprehensionChat dialogue (Fixes #217)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@types/dom-speech-recognition": "^0.0.7",
         "@types/node": "^22.14.0",
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.0",
@@ -1394,6 +1395,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-speech-recognition": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/dom-speech-recognition/-/dom-speech-recognition-0.0.7.tgz",
+      "integrity": "sha512-NjiUoJbBlKhyufNsMZLSp+pbPNtPAFnR738RCJvtZy/HVQ2TZjmqpMyaeOSMXgxdfZM60nt8QGbtfmQrJAH2sw==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
+    "@types/dom-speech-recognition": "^0.0.7",
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.0",

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -6,6 +6,7 @@ import ZhuyinToggle from '../ui/ZhuyinToggle';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { getEncouragementMessage } from '../../utils/encouragement';
 import { useAuth } from '../../contexts/AuthContext';
+import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 
 interface ComprehensionChatProps {
   story: Story;
@@ -50,6 +51,19 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   const [requiredCount, setRequiredCount] = useState(3);
   const [isSessionComplete, setIsSessionComplete] = useState(false);
   const [highlightedParagraph, setHighlightedParagraph] = useState<number | null>(null);
+
+  // Speech recognition for voice input (Issue #217)
+  const {
+    status: speechStatus,
+    isSupported: speechSupported,
+    errorMessage: speechError,
+    startListening,
+    stopListening,
+  } = useSpeechRecognition('zh-TW', (finalText) => {
+    setInputText(prev => prev ? `${prev} ${finalText}` : finalText);
+  });
+
+  const isListening = speechStatus === 'listening';
 
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -420,28 +434,56 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
           </button>
         </div>
       ) : (
-        <div className="flex gap-2 items-end">
-          <textarea
-            ref={inputRef}
-            value={inputText}
-            onChange={e => setInputText(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="輸入你的回答……（Enter 送出）"
-            rows={2}
-            disabled={isLoading || isSessionComplete}
-            className="flex-1 bg-white border border-gray-200 rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none disabled:opacity-50"
-          />
-          <button
-            onClick={handleSubmit}
-            disabled={!inputText.trim() || isLoading || isSessionComplete}
-            className="flex-shrink-0 w-11 h-11 rounded-xl bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-                d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-            </svg>
-          </button>
-        </div>
+        <>
+          {/* Speech error hint */}
+          {speechError && (
+            <p className="text-xs text-red-500 mb-1.5 px-1">{speechError}</p>
+          )}
+          <div className="flex gap-2 items-end">
+            <textarea
+              ref={inputRef}
+              value={inputText}
+              onChange={e => setInputText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={isListening ? '正在聆聽……' : '輸入你的回答……（Enter 送出）'}
+              rows={2}
+              disabled={isLoading || isSessionComplete}
+              className={`flex-1 bg-white border rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none resize-none disabled:opacity-50 transition-colors ${
+                isListening ? 'border-red-400 focus:border-red-500' : 'border-gray-200 focus:border-accent'
+              }`}
+            />
+            {/* Mic button — shown only when Speech API is supported */}
+            {speechSupported && (
+              <button
+                type="button"
+                onClick={isListening ? stopListening : startListening}
+                disabled={isLoading || isSessionComplete}
+                title={isListening ? '停止錄音' : '語音輸入'}
+                aria-label={isListening ? '停止錄音' : '語音輸入'}
+                className={`flex-shrink-0 w-11 h-11 rounded-xl flex items-center justify-center transition-all active:scale-95 disabled:opacity-40 ${
+                  isListening
+                    ? 'bg-red-500 hover:bg-red-600 text-white animate-pulse-mic'
+                    : 'bg-gray-100 hover:bg-gray-200 text-gray-600'
+                }`}
+              >
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+                  <path d="M19 10v2a7 7 0 0 1-14 0v-2H3v2a9 9 0 0 0 8 8.94V23h2v-2.06A9 9 0 0 0 21 12v-2h-2z" />
+                </svg>
+              </button>
+            )}
+            <button
+              onClick={handleSubmit}
+              disabled={!inputText.trim() || isLoading || isSessionComplete}
+              className="flex-shrink-0 w-11 h-11 rounded-xl bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+                  d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+              </svg>
+            </button>
+          </div>
+        </>
       )}
     </div>
   );
@@ -620,6 +662,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         .custom-scrollbar::-webkit-scrollbar-thumb:hover { background: #9ca3af; }
         @keyframes fade-in { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: translateY(0); } }
         .animate-fade-in { animation: fade-in 0.3s ease-out forwards; }
+        @keyframes pulse-mic { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.75; transform: scale(0.92); } }
+        .animate-pulse-mic { animation: pulse-mic 1s ease-in-out infinite; }
       `}</style>
     </div>
   );

--- a/frontend/src/hooks/useSpeechRecognition.ts
+++ b/frontend/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,159 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+
+export type SpeechRecognitionStatus = 'idle' | 'listening' | 'error' | 'unsupported';
+
+export interface SpeechRecognitionState {
+  status: SpeechRecognitionStatus;
+  transcript: string;
+  errorMessage: string;
+  isSupported: boolean;
+}
+
+export interface SpeechRecognitionActions {
+  startListening: () => void;
+  stopListening: () => void;
+  clearTranscript: () => void;
+}
+
+function getSpeechRecognitionConstructor(): typeof SpeechRecognition | null {
+  if (typeof window === 'undefined') return null;
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition ?? null;
+}
+
+export function useSpeechRecognition(
+  lang = 'zh-TW',
+  onTranscript?: (text: string) => void,
+): SpeechRecognitionState & SpeechRecognitionActions {
+  const SpeechRecognitionCtor = getSpeechRecognitionConstructor();
+  const isSupported = SpeechRecognitionCtor !== null;
+
+  const [status, setStatus] = useState<SpeechRecognitionStatus>(
+    isSupported ? 'idle' : 'unsupported',
+  );
+  const [transcript, setTranscript] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const onTranscriptRef = useRef(onTranscript);
+
+  // Keep callback ref up to date without re-running effects
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  }, [onTranscript]);
+
+  const stopListening = useCallback(() => {
+    if (recognitionRef.current) {
+      recognitionRef.current.stop();
+      recognitionRef.current = null;
+    }
+    setStatus(prev => (prev === 'listening' ? 'idle' : prev));
+  }, []);
+
+  const startListening = useCallback(() => {
+    if (!SpeechRecognitionCtor) {
+      setStatus('unsupported');
+      return;
+    }
+
+    // Stop any in-progress session first
+    if (recognitionRef.current) {
+      recognitionRef.current.stop();
+      recognitionRef.current = null;
+    }
+
+    setErrorMessage('');
+    setTranscript('');
+
+    const recognition = new SpeechRecognitionCtor();
+    recognition.lang = lang;
+    recognition.interimResults = true;
+    recognition.continuous = false;
+    recognition.maxAlternatives = 1;
+
+    recognitionRef.current = recognition;
+
+    recognition.onstart = () => {
+      setStatus('listening');
+    };
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      let interim = '';
+      let final = '';
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          final += result[0].transcript;
+        } else {
+          interim += result[0].transcript;
+        }
+      }
+      const combined = final || interim;
+      setTranscript(combined);
+      if (final && onTranscriptRef.current) {
+        onTranscriptRef.current(final);
+      }
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      recognitionRef.current = null;
+      switch (event.error) {
+        case 'not-allowed':
+          setErrorMessage('麥克風權限被拒絕，請在瀏覽器設定中允許麥克風存取。');
+          break;
+        case 'no-speech':
+          setErrorMessage('沒有偵測到語音，請再試一次。');
+          break;
+        case 'network':
+          setErrorMessage('網路連線問題，請確認網路後再試。');
+          break;
+        case 'audio-capture':
+          setErrorMessage('找不到麥克風裝置，請確認麥克風已連接。');
+          break;
+        default:
+          setErrorMessage('語音識別發生錯誤，請再試一次。');
+      }
+      setStatus('error');
+    };
+
+    recognition.onend = () => {
+      recognitionRef.current = null;
+      setStatus(prev => (prev === 'listening' ? 'idle' : prev));
+    };
+
+    try {
+      recognition.start();
+    } catch {
+      recognitionRef.current = null;
+      setErrorMessage('無法啟動語音識別，請重試。');
+      setStatus('error');
+    }
+  }, [SpeechRecognitionCtor, lang]);
+
+  const clearTranscript = useCallback(() => {
+    setTranscript('');
+    setErrorMessage('');
+    if (status === 'error') {
+      setStatus('idle');
+    }
+  }, [status]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (recognitionRef.current) {
+        recognitionRef.current.stop();
+        recognitionRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    status,
+    transcript,
+    errorMessage,
+    isSupported,
+    startListening,
+    stopListening,
+    clearTranscript,
+  };
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,7 +12,8 @@
     "skipLibCheck": true,
     "types": [
       "node",
-      "vite/client"
+      "vite/client",
+      "dom-speech-recognition"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,


### PR DESCRIPTION
Fixes #217

## Summary

- Add `useSpeechRecognition` hook wrapping the Web Speech API with zh-TW language recognition
- Microphone button appears in the ComprehensionChat input area (hidden when API is unsupported)
- Pulsing red animation while recording; clicking again stops recognition
- Final transcript appends to existing text input so students can combine voice + typing
- Error messages in Traditional Chinese for all failure modes (permission denied, no-speech, network, audio-capture)
- Added `@types/dom-speech-recognition` dev dependency for proper TypeScript types in tsconfig

## Files Changed

- `frontend/src/hooks/useSpeechRecognition.ts` — new hook (Web Speech API wrapper)
- `frontend/src/components/reading-steps/ComprehensionChat.tsx` — mic button + hook integration
- `frontend/tsconfig.json` — added `dom-speech-recognition` type reference
- `frontend/package.json` / `package-lock.json` — dev dependency added

## Test Plan

- [ ] Open ComprehensionChat on a Chrome-based browser
- [ ] Verify microphone button appears to the left of the send button
- [ ] Click the mic button — browser should prompt for microphone permission
- [ ] Speak in Chinese — transcribed text should appear in the input field
- [ ] Click mic button again to stop recording
- [ ] Submit the transcribed text with Enter or the send button
- [ ] Verify the mic button is hidden on browsers that do not support Web Speech API (e.g. Firefox with flag disabled)
- [ ] Verify graceful error message when microphone permission is denied