### PR TITLE
feat: 聽寫練習模組 (Fixes #96)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import IntroPage from './pages/learning/IntroPage';
 import TutorPage from './pages/learning/TutorPage';
 import ComprehensionPage from './pages/learning/ComprehensionPage';
 import VocabPage from './pages/learning/VocabPage';
+import DictationPage from './pages/learning/DictationPage';
 import FullReadingPage from './pages/learning/FullReadingPage';
 import ReportPage from './pages/learning/ReportPage';
 import JoinClassroomPage from './pages/JoinClassroomPage';
@@ -245,6 +246,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       case AppView.TUTOR:
       case AppView.COMPREHENSION:
       case AppView.VOCAB:
+      case AppView.DICTATION:
       case AppView.FULL_READING:
       case AppView.REPORT: {
         const match = window.location.pathname.match(/\/learn\/([^/]+)/);
@@ -255,6 +257,7 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
             [AppView.TUTOR]: 'tutor',
             [AppView.COMPREHENSION]: 'comprehension',
             [AppView.VOCAB]: 'vocab',
+            [AppView.DICTATION]: 'dictation',
             [AppView.FULL_READING]: 'full-reading',
             [AppView.REPORT]: 'report',
           };
@@ -595,6 +598,7 @@ const App: React.FC = () => {
             <Route path="tutor" element={<TutorPage />} />
             <Route path="comprehension" element={<ComprehensionPage />} />
             <Route path="vocab" element={<VocabPage />} />
+            <Route path="dictation" element={<DictationPage />} />
             <Route path="full-reading" element={<FullReadingPage />} />
             <Route path="report" element={<ReportPage />} />
             {/* Default: redirect to intro */}

--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -23,8 +23,9 @@ const steps: StepDef[] = [
   { step: 2, label: '逐段朗讀', view: AppView.TUTOR,         needsStory: true  },
   { step: 3, label: '課文理解', view: AppView.COMPREHENSION, needsStory: true  },
   { step: 4, label: '生字練習', view: AppView.VOCAB,         needsStory: true  },
-  { step: 5, label: '全文朗讀', view: AppView.FULL_READING,  needsStory: true  },
-  { step: 6, label: '報告',    view: AppView.REPORT,        needsStory: false },
+  { step: 5, label: '聽寫練習', view: AppView.DICTATION,     needsStory: true  },
+  { step: 6, label: '全文朗讀', view: AppView.FULL_READING,  needsStory: true  },
+  { step: 7, label: '報告',    view: AppView.REPORT,        needsStory: false },
 ];
 
 function getStepStatus(
@@ -43,6 +44,7 @@ function getStepStatus(
       case AppView.INTRO:          return session.introCompleted;
       case AppView.TUTOR:          return session.readingAttempt !== null;
       case AppView.VOCAB:          return session.vocabResult !== null;
+      case AppView.DICTATION:      return session.dictationResult !== null;
       case AppView.COMPREHENSION:  return session.comprehensionResult !== null;
       case AppView.FULL_READING:   return session.fullReadingResult !== null;
       case AppView.REPORT:         return false; // destination step, never "completed"
@@ -67,6 +69,10 @@ function getMiniSummary(stepDef: StepDef, session: LearningSession | null): stri
     case AppView.COMPREHENSION: {
       const c = session.comprehensionResult;
       return c ? `${c.understoodCount}/${c.requiredCount} \u984C` : null;
+    }
+    case AppView.DICTATION: {
+      const d = session.dictationResult;
+      return d ? `${d.correctCount}/${d.totalWords} \u5C0D` : null;
     }
     case AppView.FULL_READING: {
       const f = session.fullReadingResult;

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -183,7 +183,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
     );
   }
 
-  const { readingAttempt, comprehensionResult, vocabResult, fullReadingResult } = session;
+  const { readingAttempt, comprehensionResult, vocabResult, dictationResult, fullReadingResult } = session;
 
   // Empty state: session exists but no learning data completed yet
   const hasNoData = !readingAttempt && !comprehensionResult && !vocabResult && !fullReadingResult;
@@ -208,6 +208,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
   if (readingAttempt) scores.push(readingAttempt.accuracy);
   if (comprehensionResult) scores.push(Math.round((comprehensionResult.understoodCount / Math.max(comprehensionResult.requiredCount, 1)) * 100));
   if (vocabResult) scores.push(vocabResult.totalChars > 0 ? Math.round((vocabResult.practicedChars.length / vocabResult.totalChars) * 100) : 100);
+  if (dictationResult) scores.push(dictationResult.totalWords > 0 ? Math.round((dictationResult.correctCount / dictationResult.totalWords) * 100) : 0);
   if (fullReadingResult) scores.push(Math.round(fullReadingResult.matchRate * 100));
   const overallScore = scores.length > 0 ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : null;
 
@@ -642,8 +643,8 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
         )}
       </Section>
 
-      {/* ============ 補充資訊：生字練習 + 課文理解 ============ */}
-      {(vocabResult || comprehensionResult) && (
+      {/* ============ 補充資訊：生字練習 + 聽寫練習 + 課文理解 ============ */}
+      {(vocabResult || dictationResult || comprehensionResult) && (
         <div className="space-y-4">
           <h3 className="text-sm font-bold text-gray-400 uppercase tracking-wider">其他學習成果</h3>
 
@@ -677,10 +678,55 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
               )}
             </div>
 
+            {/* 聽寫練習 */}
+            {dictationResult && (
+              <div className="rounded-2xl border p-5 bg-white border-slate-200 shadow-sm">
+                <div className="flex items-center gap-2 mb-3">
+                  <span className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-black bg-accent text-white">5</span>
+                  <h4 className="text-sm font-bold text-gray-900">聽寫練習</h4>
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 bg-gray-200 rounded-full h-2">
+                      <div
+                        className="bg-emerald-500 h-2 rounded-full transition-all"
+                        style={{ width: dictationResult.totalWords > 0 ? `${Math.round((dictationResult.correctCount / dictationResult.totalWords) * 100)}%` : '0%' }}
+                      />
+                    </div>
+                    <span className="text-xs font-bold text-gray-600">{dictationResult.correctCount}/{dictationResult.totalWords}</span>
+                  </div>
+                  <div className="flex gap-3 text-xs text-gray-500">
+                    <span className="text-emerald-600 font-medium">正確 {dictationResult.correctCount}</span>
+                    {dictationResult.incorrectCount > 0 && (
+                      <span className="text-red-500 font-medium">錯誤 {dictationResult.incorrectCount}</span>
+                    )}
+                    {dictationResult.skippedCount > 0 && (
+                      <span className="text-gray-400">跳過 {dictationResult.skippedCount}</span>
+                    )}
+                  </div>
+                  {dictationResult.results.some(r => !r.isCorrect && !r.skipped) && (
+                    <div className="mt-2 space-y-1">
+                      <p className="text-[10px] text-gray-400 font-medium uppercase tracking-wide">答錯的詞語</p>
+                      {dictationResult.results
+                        .filter(r => !r.isCorrect && !r.skipped)
+                        .map((r, i) => (
+                          <div key={i} className="flex items-center gap-2 text-xs">
+                            <span className="font-bold text-gray-900">{r.word}</span>
+                            <span className="text-gray-400">你答：</span>
+                            <span className="text-red-500">{r.studentAnswer || '（空白）'}</span>
+                          </div>
+                        ))
+                      }
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
             {/* 課文理解 */}
             <div className={`rounded-2xl border p-5 ${comprehensionResult ? 'bg-white border-slate-200 shadow-sm' : 'bg-gray-50 border-dashed border-gray-300'}`}>
               <div className="flex items-center gap-2 mb-3">
-                <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-black ${comprehensionResult ? 'bg-accent text-white' : 'bg-gray-200 text-gray-400'}`}>4</span>
+                <span className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-black ${comprehensionResult ? 'bg-accent text-white' : 'bg-gray-200 text-gray-400'}`}>3</span>
                 <h4 className={`text-sm font-bold ${comprehensionResult ? 'text-gray-900' : 'text-gray-400'}`}>課文理解</h4>
                 {comprehensionResult?.isComplete && (
                   <span className="ml-auto bg-emerald-100 text-emerald-700 text-[10px] font-bold px-2 py-0.5 rounded-full">已完成</span>

--- a/frontend/src/components/reading-steps/DictationPractice.tsx
+++ b/frontend/src/components/reading-steps/DictationPractice.tsx
@@ -1,0 +1,409 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { Story } from '../../types';
+
+export interface DictationResult {
+  totalWords: number;
+  correctCount: number;
+  incorrectCount: number;
+  skippedCount: number;
+  results: WordResult[];
+}
+
+interface WordResult {
+  word: string;
+  studentAnswer: string;
+  isCorrect: boolean;
+  skipped: boolean;
+}
+
+interface DictationPracticeProps {
+  story: Story;
+  onFinish: (result: DictationResult) => void;
+  onBack: () => void;
+}
+
+type Phase = 'intro' | 'practice' | 'results';
+
+/**
+ * Extract vocabulary words from a story.
+ * Prefers the story's vocabulary list; falls back to extracting individual
+ * Chinese characters from the story content (up to 10).
+ */
+function extractDictationWords(story: Story): string[] {
+  if (story.vocabulary && story.vocabulary.length > 0) {
+    return story.vocabulary.map((v) => v.word).slice(0, 15);
+  }
+
+  // Fallback: extract unique Chinese characters from content
+  const seen = new Set<string>();
+  const chars: string[] = [];
+  for (const line of story.content) {
+    for (const ch of line) {
+      if (/[\u4e00-\u9fa5]/.test(ch) && !seen.has(ch)) {
+        seen.add(ch);
+        chars.push(ch);
+        if (chars.length >= 10) break;
+      }
+    }
+    if (chars.length >= 10) break;
+  }
+  return chars;
+}
+
+/**
+ * Use Web Speech API SpeechSynthesis to speak text in zh-TW.
+ * Returns a Promise that resolves when speech ends (or rejects on error).
+ */
+function speakText(text: string, rate = 0.85): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!window.speechSynthesis) {
+      reject(new Error('SpeechSynthesis not supported'));
+      return;
+    }
+    window.speechSynthesis.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = 'zh-TW';
+    utterance.rate = rate;
+    utterance.pitch = 1.0;
+
+    // Prefer a zh-TW voice if available
+    const voices = window.speechSynthesis.getVoices();
+    const twVoice =
+      voices.find((v) => v.lang === 'zh-TW') ||
+      voices.find((v) => v.lang.startsWith('zh'));
+    if (twVoice) utterance.voice = twVoice;
+
+    utterance.onend = () => resolve();
+    utterance.onerror = (e) => reject(new Error(e.error));
+    window.speechSynthesis.speak(utterance);
+  });
+}
+
+// ---- Sub-components ----
+
+const ProgressBar: React.FC<{ current: number; total: number }> = ({ current, total }) => (
+  <div className="w-full bg-gray-200 rounded-full h-1.5 mb-4">
+    <div
+      className="bg-accent h-1.5 rounded-full transition-all duration-500"
+      style={{ width: `${(current / total) * 100}%` }}
+    />
+  </div>
+);
+
+const SpeakerIcon: React.FC<{ animate: boolean }> = ({ animate }) => (
+  <svg
+    className={`w-8 h-8 text-accent ${animate ? 'animate-pulse' : ''}`}
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 24 24"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15.536 8.464a5 5 0 010 7.072M12 6v12m0 0l-3-3m3 3l3-3M6.343 9.657a8 8 0 000 4.686"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M9 9v6l-3-1.5V10.5L9 9z"
+    />
+  </svg>
+);
+
+// ---- Main component ----
+
+const DictationPractice: React.FC<DictationPracticeProps> = ({ story, onFinish, onBack }) => {
+  const words = React.useMemo(() => extractDictationWords(story), [story]);
+
+  const [phase, setPhase] = useState<Phase>('intro');
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answer, setAnswer] = useState('');
+  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [wordResults, setWordResults] = useState<WordResult[]>([]);
+  const [ttsSupported, setTtsSupported] = useState(true);
+  const [voicesLoaded, setVoicesLoaded] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Load voices asynchronously (Chrome loads voices after a slight delay)
+  useEffect(() => {
+    const loadVoices = () => {
+      window.speechSynthesis.getVoices();
+      setVoicesLoaded(true);
+    };
+    if (window.speechSynthesis) {
+      if (window.speechSynthesis.getVoices().length > 0) {
+        setVoicesLoaded(true);
+      } else {
+        window.speechSynthesis.addEventListener('voiceschanged', loadVoices, { once: true });
+      }
+    } else {
+      setTtsSupported(false);
+    }
+    return () => {
+      window.speechSynthesis?.removeEventListener('voiceschanged', loadVoices);
+    };
+  }, []);
+
+  // Focus input when entering practice phase or moving to next word
+  useEffect(() => {
+    if (phase === 'practice') {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [phase, currentIndex]);
+
+  const playCurrentWord = useCallback(async () => {
+    if (!ttsSupported || isSpeaking) return;
+    const word = words[currentIndex];
+    if (!word) return;
+    setIsSpeaking(true);
+    try {
+      await speakText(word);
+    } catch {
+      // TTS failed silently — student can use replay button
+    } finally {
+      setIsSpeaking(false);
+    }
+  }, [words, currentIndex, isSpeaking, ttsSupported]);
+
+  // Auto-play when entering a new word
+  useEffect(() => {
+    if (phase === 'practice' && voicesLoaded) {
+      playCurrentWord();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, currentIndex, voicesLoaded]);
+
+  const handleStartPractice = () => {
+    setPhase('practice');
+    setCurrentIndex(0);
+    setAnswer('');
+    setWordResults([]);
+  };
+
+  const submitAnswer = useCallback(
+    (skipped = false) => {
+      const word = words[currentIndex];
+      const trimmed = answer.trim();
+      const isCorrect = !skipped && trimmed === word;
+
+      const result: WordResult = {
+        word,
+        studentAnswer: skipped ? '' : trimmed,
+        isCorrect,
+        skipped,
+      };
+
+      const updatedResults = [...wordResults, result];
+      setWordResults(updatedResults);
+
+      if (currentIndex + 1 >= words.length) {
+        // Done — show results
+        window.speechSynthesis?.cancel();
+        const correct = updatedResults.filter((r) => r.isCorrect).length;
+        const skippedCount = updatedResults.filter((r) => r.skipped).length;
+        const incorrect = updatedResults.length - correct - skippedCount;
+        onFinish({
+          totalWords: words.length,
+          correctCount: correct,
+          incorrectCount: incorrect,
+          skippedCount,
+          results: updatedResults,
+        });
+        setPhase('results');
+      } else {
+        setCurrentIndex((i) => i + 1);
+        setAnswer('');
+      }
+    },
+    [words, currentIndex, answer, wordResults, onFinish],
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') submitAnswer();
+  };
+
+  // ---- Phase: intro ----
+  if (phase === 'intro') {
+    return (
+      <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden">
+        {/* Tab bar */}
+        <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
+            {story.filename} — 聽寫練習
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 flex flex-col items-center justify-center px-6 py-8 gap-8 max-w-lg mx-auto w-full">
+          <div className="text-center space-y-4">
+            <div className="w-20 h-20 rounded-full bg-accent/10 flex items-center justify-center mx-auto">
+              <svg className="w-10 h-10 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                  d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 016 0v6a3 3 0 01-3 3z" />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-black text-gray-900">聽寫練習</h2>
+            <p className="text-gray-600 text-sm leading-relaxed">
+              系統會播放詞語的讀音，請聽完後在輸入框中寫出正確的字詞。
+              <br />
+              共 <span className="font-bold text-accent">{words.length}</span> 個詞語。
+            </p>
+          </div>
+
+          <div className="bg-white rounded-2xl border border-gray-200 p-5 w-full space-y-3">
+            <p className="text-xs font-bold text-gray-500 uppercase tracking-wide">練習說明</p>
+            <ul className="space-y-2 text-sm text-gray-700">
+              <li className="flex items-start gap-2">
+                <span className="w-5 h-5 rounded-full bg-accent/10 text-accent text-xs flex items-center justify-center shrink-0 mt-0.5 font-bold">1</span>
+                聆聽系統播放的詞語音頻
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-5 h-5 rounded-full bg-accent/10 text-accent text-xs flex items-center justify-center shrink-0 mt-0.5 font-bold">2</span>
+                在輸入框中輸入你聽到的詞語
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-5 h-5 rounded-full bg-accent/10 text-accent text-xs flex items-center justify-center shrink-0 mt-0.5 font-bold">3</span>
+                按「確認」或 Enter 提交答案
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-5 h-5 rounded-full bg-accent/10 text-accent text-xs flex items-center justify-center shrink-0 mt-0.5 font-bold">4</span>
+                可以重播音頻，也可以選擇跳過
+              </li>
+            </ul>
+          </div>
+
+          {!ttsSupported && (
+            <div className="bg-amber-100 border border-amber-300 rounded-xl px-4 py-3 text-sm text-amber-800 text-center">
+              目前瀏覽器不支援語音播放，請嘗試使用 Chrome 或 Safari。
+            </div>
+          )}
+        </div>
+
+        {/* Bottom actions */}
+        <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
+          <button
+            onClick={onBack}
+            className="px-4 py-3 rounded-xl text-base text-gray-600 hover:text-gray-800 transition-colors"
+          >
+            返回
+          </button>
+          <button
+            onClick={handleStartPractice}
+            className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
+          >
+            開始聽寫
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ---- Phase: practice ----
+  if (phase === 'practice') {
+    const currentWord = words[currentIndex];
+    const progressText = `${currentIndex + 1} / ${words.length}`;
+
+    return (
+      <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden">
+        {/* Tab bar */}
+        <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
+            {story.filename} — 聽寫練習
+          </div>
+          <div className="flex-1" />
+          <span className="text-[10px] text-gray-500 pr-2">{progressText}</span>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 flex flex-col items-center justify-center px-6 py-8 gap-6 max-w-lg mx-auto w-full">
+          {/* Progress */}
+          <div className="w-full">
+            <ProgressBar current={currentIndex + 1} total={words.length} />
+            <p className="text-xs text-gray-500 text-center">{progressText}</p>
+          </div>
+
+          {/* Speaker card */}
+          <div className="bg-white rounded-3xl border border-gray-200 shadow-sm p-8 w-full flex flex-col items-center gap-6">
+            <p className="text-sm text-gray-500 font-medium">請聆聽並寫出詞語</p>
+
+            {/* Speaker button */}
+            <button
+              onClick={playCurrentWord}
+              disabled={isSpeaking || !ttsSupported}
+              className={`w-24 h-24 rounded-full flex flex-col items-center justify-center gap-2 transition-all
+                ${isSpeaking
+                  ? 'bg-accent/10 border-2 border-accent scale-110'
+                  : 'bg-gray-50 border-2 border-gray-200 hover:border-accent hover:bg-accent/5 active:scale-95'
+                }
+              `}
+              title="重播音頻"
+            >
+              <SpeakerIcon animate={isSpeaking} />
+              <span className="text-xs text-gray-500">{isSpeaking ? '播放中...' : '點我播放'}</span>
+            </button>
+
+            {/* Answer input */}
+            <div className="w-full space-y-3">
+              <label className="block text-xs text-gray-500 font-medium text-center">
+                輸入你聽到的詞語
+              </label>
+              <input
+                ref={inputRef}
+                type="text"
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="在此輸入..."
+                className="w-full text-center text-2xl font-bold py-4 px-4 rounded-xl border-2 border-gray-200 focus:border-accent focus:outline-none bg-white text-gray-900 placeholder-gray-300 transition-colors"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="none"
+                spellCheck={false}
+              />
+            </div>
+          </div>
+
+          {/* Character count hint */}
+          {answer.length > 0 && (
+            <p className="text-xs text-gray-400">
+              已輸入 {answer.length} 個字
+            </p>
+          )}
+        </div>
+
+        {/* Bottom actions */}
+        <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between gap-3">
+          <button
+            onClick={() => submitAnswer(true)}
+            className="px-4 py-3 rounded-xl text-sm text-gray-500 hover:text-gray-700 border border-gray-200 hover:border-gray-300 transition-colors"
+          >
+            跳過
+          </button>
+          <button
+            onClick={() => submitAnswer(false)}
+            disabled={!answer.trim()}
+            className="flex-1 px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover disabled:bg-gray-200 disabled:text-gray-400 text-white shadow-lg transition-all active:scale-95"
+          >
+            {currentIndex + 1 >= words.length ? '完成' : '下一題'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ---- Phase: results (summary shown internally, then onFinish is called) ----
+  // This phase is reached only momentarily; the parent navigates away via onFinish.
+  // We show a brief "loading" state while onFinish fires.
+  return (
+    <div className="flex-1 flex items-center justify-center bg-amber-50">
+      <div className="w-8 h-8 border-4 border-accent border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+};
+
+export default DictationPractice;

--- a/frontend/src/hooks/useAppView.ts
+++ b/frontend/src/hooks/useAppView.ts
@@ -26,6 +26,7 @@ export function useAppView(): AppView {
     if (pathname.endsWith('/tutor')) return AppView.TUTOR;
     if (pathname.endsWith('/comprehension')) return AppView.COMPREHENSION;
     if (pathname.endsWith('/vocab')) return AppView.VOCAB;
+    if (pathname.endsWith('/dictation')) return AppView.DICTATION;
     if (pathname.endsWith('/full-reading')) return AppView.FULL_READING;
     if (pathname.endsWith('/report')) return AppView.REPORT;
   }

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -6,6 +6,7 @@ import {
   LearningSession,
   ComprehensionResult,
   VocabResult,
+  DictationResult,
   FullReadingResult,
 } from '../types';
 import { fetchStory, saveActiveSession, clearActiveSession } from '../services/api';
@@ -33,6 +34,7 @@ export interface LearningContext {
   handleFinishReading: (attempt: ReadingAttempt) => void;
   handleFinishComprehension: (result: ComprehensionResult) => void;
   handleFinishVocab: (result: VocabResult) => void;
+  handleFinishDictation: (result: DictationResult) => void;
   handleFinishFullReading: (result: FullReadingResult) => void;
   handleRetry: () => void;
   handleSessionComplete: () => void;
@@ -53,8 +55,9 @@ const STEP_PATH_TO_NUMBER: Record<string, number> = {
   tutor: 2,
   comprehension: 3,
   vocab: 4,
-  'full-reading': 5,
-  report: 6,
+  dictation: 5,
+  'full-reading': 6,
+  report: 7,
 };
 
 /**
@@ -141,6 +144,7 @@ const LearningLayout: React.FC = () => {
             readingAttempt: null,
             comprehensionResult: null,
             vocabResult: null,
+            dictationResult: null,
             fullReadingResult: null,
           };
         });
@@ -173,6 +177,7 @@ const LearningLayout: React.FC = () => {
           readingAttempt: null,
           comprehensionResult: null,
           vocabResult: null,
+          dictationResult: null,
           fullReadingResult: null,
         };
       }
@@ -224,6 +229,15 @@ const LearningLayout: React.FC = () => {
   const handleFinishVocab = useCallback(
     (result: VocabResult) => {
       setSession((prev) => (prev ? { ...prev, vocabResult: result } : null));
+      persistStep(STEP_PATH_TO_NUMBER['dictation']);
+      navigate(`/learn/${storyId}/dictation`);
+    },
+    [storyId, navigate, persistStep],
+  );
+
+  const handleFinishDictation = useCallback(
+    (result: DictationResult) => {
+      setSession((prev) => (prev ? { ...prev, dictationResult: result } : null));
       persistStep(STEP_PATH_TO_NUMBER['full-reading']);
       navigate(`/learn/${storyId}/full-reading`);
     },
@@ -319,6 +333,7 @@ const LearningLayout: React.FC = () => {
     handleFinishReading,
     handleFinishComprehension,
     handleFinishVocab,
+    handleFinishDictation,
     handleFinishFullReading,
     handleRetry,
     handleSessionComplete,

--- a/frontend/src/pages/learning/DictationPage.tsx
+++ b/frontend/src/pages/learning/DictationPage.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import DictationPractice from '../../components/reading-steps/DictationPractice';
+import { useLearningContext } from '../../layouts/LearningLayout';
+
+const DictationPage: React.FC = () => {
+  const { storyId } = useParams<{ storyId: string }>();
+  const { selectedStory, handleFinishDictation } = useLearningContext();
+  const navigate = useNavigate();
+
+  if (!selectedStory) return null;
+
+  return (
+    <DictationPractice
+      story={selectedStory}
+      onFinish={handleFinishDictation}
+      onBack={() => navigate(`/learn/${storyId}/vocab`)}
+    />
+  );
+};
+
+export default DictationPage;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,6 +6,7 @@ export enum AppView {
   TUTOR = 'TUTOR',
   COMPREHENSION = 'COMPREHENSION',
   VOCAB = 'VOCAB',
+  DICTATION = 'DICTATION',
   FULL_READING = 'FULL_READING',
   REPORT = 'REPORT',
   WRITE = 'WRITE',
@@ -85,6 +86,21 @@ export interface VocabResult {
   totalChars: number;
 }
 
+export interface DictationWordResult {
+  word: string;
+  studentAnswer: string;
+  isCorrect: boolean;
+  skipped: boolean;
+}
+
+export interface DictationResult {
+  totalWords: number;
+  correctCount: number;
+  incorrectCount: number;
+  skippedCount: number;
+  results: DictationWordResult[];
+}
+
 export interface FullReadingResult {
   matchRate: number;
   feedback: string;
@@ -102,6 +118,7 @@ export interface LearningSession {
   readingAttempt: ReadingAttempt | null;
   comprehensionResult: ComprehensionResult | null;
   vocabResult: VocabResult | null;
+  dictationResult: DictationResult | null;
   fullReadingResult: FullReadingResult | null;
   /** Paragraph indices (0-based) completed during LiveTutor (progressive unlock). */
   completedParagraphs?: number[];


### PR DESCRIPTION
Fixes #96

## Summary

- New `DictationPractice` component at `frontend/src/components/reading-steps/DictationPractice.tsx`
- Inserts as **Step 5** between 生字練習 (vocab) and 全文朗讀 in the learning flow
- Uses **Web Speech API SpeechSynthesis** with `zh-TW` voice for audio playback
- Vocab words sourced from `story.vocabulary`; falls back to first 10 unique CJK characters from story content
- Student types answer, submits with button or Enter key; can replay audio or skip
- Tracks correct / incorrect / skipped counts per word
- Results shown in AssessmentReport with wrong-word detail list

## Files changed

| File | Change |
|------|--------|
| `frontend/src/components/reading-steps/DictationPractice.tsx` | New component |
| `frontend/src/pages/learning/DictationPage.tsx` | New page wrapper |
| `frontend/src/types.ts` | Added `DICTATION` AppView, `DictationResult`, `DictationWordResult` types; added `dictationResult` to `LearningSession` |
| `frontend/src/layouts/LearningLayout.tsx` | Added `handleFinishDictation`, updated route flow vocab -> dictation -> full-reading |
| `frontend/src/App.tsx` | Added `/dictation` route, stepper navigation for DICTATION view |
| `frontend/src/components/StepperNav.tsx` | Added step 5 "聽寫練習" with correct/total mini-summary |
| `frontend/src/hooks/useAppView.ts` | Map `/dictation` URL to `AppView.DICTATION` |
| `frontend/src/components/reading-steps/AssessmentReport.tsx` | Show dictation results card with wrong-word list |

## Test plan

1. Open a story in the learning flow and complete vocab practice
2. The flow now navigates to `/learn/:storyId/dictation` (Step 5)
3. Intro screen explains the exercise; click "開始聽寫"
4. Each word auto-plays via SpeechSynthesis (zh-TW); click speaker button to replay
5. Type the heard word and press Enter or "下一題" — or skip with "跳過"
6. After all words, flow navigates to full-reading
7. In the report, a "聽寫練習" card shows correct/total with wrong-word list
8. StepperNav shows step 5 "聽寫練習" with mini-summary after completion