### PR TITLE
feat: WCAG 2.1 AA accessibility audit (Fixes #258)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,8 +46,8 @@ const PublicOnlyRoute: React.FC<{ children: React.ReactNode }> = ({ children }) 
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-amber-50">
-        <div className="flex flex-col items-center gap-3">
-          <div className="w-8 h-8 border-3 border-accent border-t-transparent rounded-full animate-spin" />
+        <div className="flex flex-col items-center gap-3" role="status" aria-label="載入中，請稍候">
+          <div className="w-8 h-8 border-3 border-accent border-t-transparent rounded-full animate-spin" aria-hidden="true" />
           <span className="text-sm text-gray-400">載入中...</span>
         </div>
       </div>
@@ -69,8 +69,8 @@ const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) =
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-amber-50">
-        <div className="flex flex-col items-center gap-3">
-          <div className="w-8 h-8 border-3 border-accent border-t-transparent rounded-full animate-spin" />
+        <div className="flex flex-col items-center gap-3" role="status" aria-label="載入中，請稍候">
+          <div className="w-8 h-8 border-3 border-accent border-t-transparent rounded-full animate-spin" aria-hidden="true" />
           <span className="text-sm text-gray-400">載入中...</span>
         </div>
       </div>
@@ -93,8 +93,9 @@ const HomePage: React.FC = () => {
       <h1 className="text-5xl font-black text-gray-900">AI 朗讀助教</h1>
       <p className="text-gray-600 max-w-md">準備好開始今天的朗讀挑戰了嗎？</p>
       <button
+        type="button"
         onClick={() => navigate('/library')}
-        className="bg-accent hover:bg-accent-hover text-white px-10 py-4 rounded-xl font-bold shadow-2xl transition-all"
+        className="bg-accent hover:bg-accent-hover text-white px-10 py-4 rounded-xl font-bold shadow-2xl transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
       >
         進入圖書館
       </button>
@@ -141,32 +142,43 @@ const WritePage: React.FC = () => {
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8">
       <h2 className="text-2xl font-bold text-gray-900">寫字練習</h2>
-      <p className="text-gray-600 text-sm">輸入一個中文字，開始練習寫字</p>
+      <p className="text-gray-600 text-sm" id="write-hint">輸入一個中文字，開始練習寫字</p>
       <div className="flex gap-3 items-center">
+        <label htmlFor="write-input" className="sr-only">輸入一個中文字</label>
         <input
+          id="write-input"
           type="text"
           value={writeInput}
           onChange={(e) => setWriteInput(e.target.value.slice(-1))}
           placeholder="輸入一個字"
           maxLength={1}
-          className="w-24 h-12 text-center text-2xl bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:border-accent"
+          aria-describedby="write-hint"
+          className="w-24 h-12 text-center text-2xl bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
         />
         <button
+          type="button"
           onClick={() => {
             if (writeInput) setWritingChar(writeInput);
           }}
           disabled={!writeInput}
-          className="px-6 h-12 bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white rounded-lg font-bold transition-all"
+          aria-disabled={!writeInput}
+          className="px-6 h-12 bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white rounded-lg font-bold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
         >
           開始
         </button>
       </div>
-      <div className="flex gap-2 flex-wrap justify-center max-w-md">
+      <div
+        className="flex gap-2 flex-wrap justify-center max-w-md"
+        role="group"
+        aria-label="常用練習字"
+      >
         {['你', '好', '我', '大', '小', '中', '人', '天', '學', '是'].map((ch) => (
           <button
             key={ch}
+            type="button"
             onClick={() => setWritingChar(ch)}
-            className="w-12 h-12 bg-gray-100 hover:bg-gray-200 text-gray-900 text-xl rounded-lg border border-gray-200 transition-colors"
+            aria-label={`練習「${ch}」字`}
+            className="w-12 h-12 bg-gray-100 hover:bg-gray-200 text-gray-900 text-xl rounded-lg border border-gray-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
           >
             {ch}
           </button>
@@ -277,18 +289,32 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   return (
     <div className="h-screen flex flex-col bg-amber-50 text-gray-900 font-sans overflow-hidden">
+      {/* Skip-to-content link — visually hidden until focused (WCAG 2.4.1) */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-accent focus:text-white focus:rounded focus:font-medium focus:text-sm focus:shadow-lg"
+      >
+        跳至主要內容
+      </a>
+
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 h-12 flex items-center justify-between px-4 shrink-0">
-        {/* Logo */}
-        <div
-          className="flex items-center gap-2 cursor-pointer shrink-0"
+      <header
+        role="banner"
+        aria-label="應用程式標頭"
+        className="bg-white border-b border-gray-200 h-12 flex items-center justify-between px-4 shrink-0"
+      >
+        {/* Logo — keyboard-accessible home link */}
+        <button
+          type="button"
+          className="flex items-center gap-2 shrink-0 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
           onClick={() => navigate('/')}
+          aria-label="LingoLeap 首頁"
         >
-          <div className="bg-accent w-6 h-6 rounded flex items-center justify-center">
+          <div className="bg-accent w-6 h-6 rounded flex items-center justify-center" aria-hidden="true">
             <span className="text-white font-bold text-xs">L</span>
           </div>
           <span className="text-sm font-bold text-gray-800 hidden sm:block">AI Reading Tutor</span>
-        </div>
+        </button>
 
         {![AppView.ADMIN_DASHBOARD, AppView.TEACHER_DASHBOARD, AppView.CLASSROOM_DETAIL, AppView.MY_ASSIGNMENTS, AppView.MY_VOCABULARY, AppView.LEARNING_HISTORY, AppView.DIALOGUE_HISTORY, AppView.STUDENT_PROGRESS].includes(currentView) && (
           <StepperNav
@@ -300,12 +326,22 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
         )}
 
         {/* Nav links + User info + Logout */}
-        <div className="flex items-center gap-3 shrink-0">
+        <nav
+          role="navigation"
+          aria-label="主要導覽"
+          className="flex items-center gap-3 shrink-0"
+        >
           {hasRole(user, 'teacher', 'system_admin', 'principal', 'director') && (
             <>
               <button
+                type="button"
                 onClick={() => navigate('/teacher')}
-                className={`text-xs font-medium transition-colors cursor-pointer ${
+                aria-current={
+                  currentView === AppView.TEACHER_DASHBOARD || currentView === AppView.CLASSROOM_DETAIL
+                    ? 'page'
+                    : undefined
+                }
+                className={`text-xs font-medium transition-colors cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                   currentView === AppView.TEACHER_DASHBOARD ||
                   currentView === AppView.CLASSROOM_DETAIL
                     ? 'text-accent'
@@ -322,8 +358,10 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           {!hasRole(user, 'teacher', 'system_admin', 'principal', 'director', 'org_owner', 'org_admin') && (
             <>
               <button
+                type="button"
                 onClick={() => navigate('/assignments')}
-                className={`text-xs font-medium transition-colors cursor-pointer ${
+                aria-current={currentView === AppView.MY_ASSIGNMENTS ? 'page' : undefined}
+                className={`text-xs font-medium transition-colors cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                   currentView === AppView.MY_ASSIGNMENTS
                     ? 'text-accent'
                     : 'text-gray-500 hover:text-gray-700'
@@ -332,8 +370,10 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
                 作業
               </button>
               <button
+                type="button"
                 onClick={() => navigate('/vocabulary')}
-                className={`text-xs font-medium transition-colors cursor-pointer ${
+                aria-current={currentView === AppView.MY_VOCABULARY ? 'page' : undefined}
+                className={`text-xs font-medium transition-colors cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                   currentView === AppView.MY_VOCABULARY
                     ? 'text-accent'
                     : 'text-gray-500 hover:text-gray-700'
@@ -342,8 +382,14 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
                 我的生字
               </button>
               <button
+                type="button"
                 onClick={() => navigate('/history')}
-                className={`text-xs font-medium transition-colors cursor-pointer ${
+                aria-current={
+                  currentView === AppView.LEARNING_HISTORY || currentView === AppView.DIALOGUE_HISTORY
+                    ? 'page'
+                    : undefined
+                }
+                className={`text-xs font-medium transition-colors cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                   currentView === AppView.LEARNING_HISTORY || currentView === AppView.DIALOGUE_HISTORY
                     ? 'text-accent'
                     : 'text-gray-500 hover:text-gray-700'
@@ -362,8 +408,9 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
                 學習進度
               </button>
               <button
+                type="button"
                 onClick={() => navigate('/join')}
-                className="text-xs font-medium transition-colors cursor-pointer text-gray-500 hover:text-gray-700"
+                className="text-xs font-medium transition-colors cursor-pointer text-gray-500 hover:text-gray-700 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
               >
                 加入班級
               </button>
@@ -371,8 +418,10 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           )}
           {hasRole(user, 'system_admin', 'org_owner', 'org_admin') && (
             <button
+              type="button"
               onClick={() => navigate('/admin')}
-              className={`text-xs font-medium transition-colors cursor-pointer ${
+              aria-current={currentView === AppView.ADMIN_DASHBOARD ? 'page' : undefined}
+              className={`text-xs font-medium transition-colors cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                 currentView === AppView.ADMIN_DASHBOARD
                   ? 'text-accent'
                   : 'text-gray-500 hover:text-gray-700'
@@ -381,20 +430,31 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
               系統管理
             </button>
           )}
-          <div className="w-px h-4 bg-gray-200" />
+          <div className="w-px h-4 bg-gray-200" aria-hidden="true" />
           {user && (
-            <span className="text-xs text-gray-500 hidden sm:block">{user.name}</span>
+            <span className="text-xs text-gray-500 hidden sm:block" aria-label={`已登入為 ${user.name}`}>
+              {user.name}
+            </span>
           )}
           <button
+            type="button"
             onClick={logout}
-            className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+            className="text-xs text-gray-400 hover:text-gray-600 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
           >
             登出
           </button>
-        </div>
+        </nav>
       </header>
 
-      <main className="flex-1 flex flex-col overflow-hidden">{children}</main>
+      <main
+        id="main-content"
+        role="main"
+        aria-label="主要內容"
+        className="flex-1 flex flex-col overflow-hidden"
+        tabIndex={-1}
+      >
+        {children}
+      </main>
 
       {/* Onboarding overlay for first-time students */}
       <OnboardingWrapper />
@@ -403,10 +463,15 @@ const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <FeedbackButton />
 
       {/* Footer */}
-      <footer className="shrink-0 bg-white border-t border-gray-100 flex items-center justify-center py-1.5 px-4">
+      <footer
+        role="contentinfo"
+        aria-label="頁尾"
+        className="shrink-0 bg-white border-t border-gray-100 flex items-center justify-center py-1.5 px-4"
+      >
         <button
+          type="button"
           onClick={() => navigate('/privacy')}
-          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+          className="text-xs text-gray-400 hover:text-gray-600 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
         >
           隱私政策
         </button>

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -307,8 +307,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   const renderChatMessages = () => (
     <>
       {/* Intro message */}
-      <div className="flex gap-2.5 pt-1">
-        <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
+      <div className="flex gap-2.5 pt-1" role="log" aria-label="AI 助教開場白">
+        <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center" aria-hidden="true">
           <span className="text-white text-[10px] font-bold">AI</span>
         </div>
         <div className="flex-1">
@@ -320,67 +320,76 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         </div>
       </div>
 
-      {/* Conversation turns */}
-      {conversation.map((turn, i) => {
-        // Feedback message
-        if (turn.role === 'feedback') {
+      {/* Conversation turns — live region so screen readers announce new messages */}
+      <div aria-live="polite" aria-atomic="false" aria-relevant="additions">
+        {conversation.map((turn, i) => {
+          // Feedback message
+          if (turn.role === 'feedback') {
+            return (
+              <div key={i} className="mx-10 space-y-1.5 mt-5">
+                {/* Encouragement badge shown above hint when student answered incorrectly */}
+                {!turn.understood && turn.encouragement && (
+                  <div className="animate-fade-in flex items-center gap-1.5 text-amber-700 text-xs font-semibold">
+                    <span aria-hidden="true">✨</span>
+                    <span>{processZhuyin(turn.encouragement)}</span>
+                  </div>
+                )}
+                <div
+                  role="status"
+                  aria-label={turn.understood ? '回答正確' : '提示'}
+                  className={`rounded-xl px-3.5 py-2 text-sm border ${
+                    turn.understood
+                      ? 'bg-emerald-50 border-emerald-300 text-emerald-800'
+                      : 'bg-amber-50 border-amber-300 text-amber-800'
+                  }`}
+                >
+                  <span className="mr-1.5" aria-hidden="true">{turn.understood ? '✓' : '💡'}</span>
+                  {processZhuyin(turn.text)}
+                </div>
+              </div>
+            );
+          }
+
+          // AI or student message
           return (
-            <div key={i} className="mx-10 space-y-1.5">
-              {/* Encouragement badge shown above hint when student answered incorrectly */}
-              {!turn.understood && turn.encouragement && (
-                <div className="animate-fade-in flex items-center gap-1.5 text-amber-700 text-xs font-semibold">
-                  <span>✨</span>
-                  <span>{processZhuyin(turn.encouragement)}</span>
+            <div key={i} className={`flex gap-2.5 mt-5 ${turn.role === 'student' ? 'flex-row-reverse' : ''}`}>
+              {turn.role === 'ai' ? (
+                <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center" aria-hidden="true">
+                  <span className="text-white text-[10px] font-bold">AI</span>
+                </div>
+              ) : (
+                <div className="flex-shrink-0 w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center" aria-hidden="true">
+                  <svg className="w-3.5 h-3.5 text-gray-900" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+                      d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                  </svg>
                 </div>
               )}
-              <div className={`rounded-xl px-3.5 py-2 text-sm border ${
-                turn.understood
-                  ? 'bg-emerald-50 border-emerald-300 text-emerald-800'
-                  : 'bg-amber-50 border-amber-300 text-amber-800'
-              }`}>
-                <span className="mr-1.5">{turn.understood ? '✓' : '💡'}</span>
-                {processZhuyin(turn.text)}
+              <div className={`max-w-[85%] flex flex-col ${turn.role === 'student' ? 'items-end' : ''}`}>
+                <div
+                  className={[
+                    'rounded-2xl px-4 py-3',
+                    turn.role === 'ai'
+                      ? 'bg-accent-bg border border-accent-bg-subtle rounded-tl-sm text-accent-hover'
+                      : 'bg-accent rounded-tr-sm text-white',
+                  ].join(' ')}
+                  aria-label={turn.role === 'ai' ? 'AI 助教' : '你的回答'}
+                >
+                  <p className={`text-lg leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
+                </div>
               </div>
             </div>
           );
-        }
-
-        // AI or student message
-        return (
-          <div key={i} className={`flex gap-2.5 ${turn.role === 'student' ? 'flex-row-reverse' : ''}`}>
-            {turn.role === 'ai' ? (
-              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
-                <span className="text-white text-[10px] font-bold">AI</span>
-              </div>
-            ) : (
-              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center">
-                <svg className="w-3.5 h-3.5 text-gray-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                </svg>
-              </div>
-            )}
-            <div className={`max-w-[85%] flex flex-col ${turn.role === 'student' ? 'items-end' : ''}`}>
-              <div className={[
-                'rounded-2xl px-4 py-3',
-                turn.role === 'ai'
-                  ? 'bg-accent-bg border border-accent-bg-subtle rounded-tl-sm text-accent-hover'
-                  : 'bg-accent rounded-tr-sm text-white',
-              ].join(' ')}>
-                <p className={`text-lg leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
-              </div>
-            </div>
-          </div>
-        );
-      })}
+        })}
+      </div>
 
       {/* Loading indicator */}
       {isLoading && (
-        <div className="flex gap-2.5">
-          <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
+        <div className="flex gap-2.5 mt-5" role="status" aria-label="AI 助教正在思考中">
+          <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center" aria-hidden="true">
             <span className="text-white text-[10px] font-bold">AI</span>
           </div>
-          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5">
+          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5" aria-hidden="true">
             <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:0ms]" />
             <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:150ms]" />
             <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:300ms]" />
@@ -390,11 +399,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
       {/* Error */}
       {error && (
-        <div className="bg-red-900/30 border border-red-700/40 rounded-xl px-3.5 py-2.5 text-sm text-red-600">
+        <div role="alert" className="bg-red-900/30 border border-red-700/40 rounded-xl px-3.5 py-2.5 text-sm text-red-600 mt-5">
           {error}
           <button
+            type="button"
             onClick={handleRetry}
-            className="ml-2 underline hover:no-underline"
+            className="ml-2 underline hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-1 rounded"
           >
             重試
           </button>
@@ -403,7 +413,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
       {/* Completion message */}
       {isSessionComplete && !isLoading && (
-        <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center">
+        <div role="status" aria-live="polite" className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center mt-5">
           <p className="text-emerald-800 font-bold text-sm">太棒了！你展現了很好的理解力！</p>
           <p className="text-emerald-700 text-xs mt-1">你對課文的理解很好，繼續下一步吧！</p>
         </div>
@@ -418,17 +428,19 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       {isSessionComplete ? (
         <div className="flex items-center justify-between gap-2">
           <button
+            type="button"
             onClick={onBack}
-            className="px-3 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors"
+            className="px-3 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
           >
             ← 回到朗讀
           </button>
           <button
+            type="button"
             onClick={() => onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length })}
-            className="flex-1 py-3 rounded-xl font-bold text-base bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2"
+            className="flex-1 py-3 rounded-xl font-bold text-base bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1"
           >
             繼續，生字練習
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
             </svg>
           </button>
@@ -440,7 +452,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             <p className="text-xs text-red-500 mb-1.5 px-1">{speechError}</p>
           )}
           <div className="flex gap-2 items-end">
+            <label htmlFor="comprehension-input" className="sr-only">輸入你對課文的回答</label>
             <textarea
+              id="comprehension-input"
               ref={inputRef}
               value={inputText}
               onChange={e => setInputText(e.target.value)}
@@ -448,7 +462,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               placeholder={isListening ? '正在聆聽……' : '輸入你的回答……（Enter 送出）'}
               rows={2}
               disabled={isLoading || isSessionComplete}
-              className={`flex-1 bg-white border rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none resize-none disabled:opacity-50 transition-colors ${
+              aria-disabled={isLoading || isSessionComplete}
+              aria-label="輸入你對課文的回答，按 Enter 送出"
+              className={`flex-1 bg-white border rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 resize-none disabled:opacity-50 transition-colors ${
                 isListening ? 'border-red-400 focus:border-red-500' : 'border-gray-200 focus:border-accent'
               }`}
             />
@@ -460,24 +476,27 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 disabled={isLoading || isSessionComplete}
                 title={isListening ? '停止錄音' : '語音輸入'}
                 aria-label={isListening ? '停止錄音' : '語音輸入'}
-                className={`flex-shrink-0 w-11 h-11 rounded-xl flex items-center justify-center transition-all active:scale-95 disabled:opacity-40 ${
+                className={`flex-shrink-0 w-11 h-11 rounded-xl flex items-center justify-center transition-all active:scale-95 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                   isListening
                     ? 'bg-red-500 hover:bg-red-600 text-white animate-pulse-mic'
                     : 'bg-gray-100 hover:bg-gray-200 text-gray-600'
                 }`}
               >
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
                   <path d="M19 10v2a7 7 0 0 1-14 0v-2H3v2a9 9 0 0 0 8 8.94V23h2v-2.06A9 9 0 0 0 21 12v-2h-2z" />
                 </svg>
               </button>
             )}
             <button
+              type="button"
               onClick={handleSubmit}
               disabled={!inputText.trim() || isLoading || isSessionComplete}
-              className="flex-shrink-0 w-11 h-11 rounded-xl bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
+              aria-disabled={!inputText.trim() || isLoading || isSessionComplete}
+              aria-label="送出回答"
+              className="flex-shrink-0 w-11 h-11 rounded-xl bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
                   d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
               </svg>
@@ -501,10 +520,19 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         /* MOBILE: Tab-based layout */
         <>
           {/* Tab bar */}
-          <div className="flex bg-white border-b border-gray-200 shrink-0">
+          <div
+            role="tablist"
+            aria-label="課文與對話切換"
+            className="flex bg-white border-b border-gray-200 shrink-0"
+          >
             <button
+              type="button"
+              role="tab"
+              id="tab-story"
+              aria-controls="tabpanel-story"
+              aria-selected={activeTab === 'story'}
               onClick={() => setActiveTab('story')}
-              className={`flex-1 py-2 text-sm font-bold transition-colors ${
+              className={`flex-1 py-2 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
                 activeTab === 'story'
                   ? 'text-accent border-b-2 border-accent'
                   : 'text-gray-500 hover:text-gray-700'
@@ -513,8 +541,13 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               課文
             </button>
             <button
+              type="button"
+              role="tab"
+              id="tab-chat"
+              aria-controls="tabpanel-chat"
+              aria-selected={activeTab === 'chat'}
               onClick={() => setActiveTab('chat')}
-              className={`flex-1 py-2 text-sm font-bold transition-colors ${
+              className={`flex-1 py-2 text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
                 activeTab === 'chat'
                   ? 'text-accent border-b-2 border-accent'
                   : 'text-gray-500 hover:text-gray-700'
@@ -529,7 +562,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
           {activeTab === 'story' ? (
             /* Story panel - full height */
-            <div className="flex-1 flex flex-col bg-amber-50 min-h-0">
+            <div
+              id="tabpanel-story"
+              role="tabpanel"
+              aria-labelledby="tab-story"
+              className="flex-1 flex flex-col bg-amber-50 min-h-0"
+            >
               <div className="flex-1 p-4 overflow-y-auto custom-scrollbar">
                 <div className="max-w-3xl mx-auto space-y-12">
                   {story.content.map((line, idx) => (
@@ -552,17 +590,31 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             </div>
           ) : (
             /* Chat panel - full height with input */
-            <div className="flex-1 flex flex-col min-h-0">
+            <div
+              id="tabpanel-chat"
+              role="tabpanel"
+              aria-labelledby="tab-chat"
+              className="flex-1 flex flex-col min-h-0"
+            >
               {/* Panel header with progress */}
               <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
                 <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">
                   AI Tutor
                 </span>
                 <div className="flex-1" />
-                <span className="text-[10px] text-gray-600">
+                <span
+                  className="text-[10px] text-gray-600"
+                  aria-label={`已理解 ${understoodCount} 題，共需 ${requiredCount} 題`}
+                  aria-live="polite"
+                >
                   {understoodCount} / {requiredCount} 理解
                 </span>
-                <button onClick={() => onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length })} className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors">
+                <button
+                  type="button"
+                  onClick={() => onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length })}
+                  aria-label="跳過課文理解，繼續下一步"
+                  className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 rounded"
+                >
                   跳過
                 </button>
               </div>
@@ -622,6 +674,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
           <div
             onMouseDown={onDividerMouseDown}
             onTouchStart={onDividerTouchStart}
+            role="separator"
+            aria-label="拖曳調整面板寬度"
+            aria-orientation="vertical"
             className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
           />
 

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -89,23 +89,25 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
       }}
     >
       {/* Top bar */}
-      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
+      <nav aria-label="麵包屑導覽" className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
         <button
+          type="button"
           onClick={onBack}
-          className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-900 transition-colors"
+          aria-label="返回圖書館"
+          className="flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 rounded"
         >
-          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7" />
           </svg>
           圖書館
         </button>
-        <span className="text-gray-300 text-xs">›</span>
+        <span className="text-gray-300 text-xs" aria-hidden="true">›</span>
         <span className="text-xs text-gray-600">{story.title}</span>
-        <span className="text-gray-300 text-xs">›</span>
-        <span className="text-xs text-accent-light font-bold">簡介</span>
+        <span className="text-gray-300 text-xs" aria-hidden="true">›</span>
+        <span className="text-xs text-accent-light font-bold" aria-current="page">簡介</span>
         <div className="flex-1" />
         <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
-      </div>
+      </nav>
 
       {/* Main content */}
       <div className="flex-1 overflow-y-auto">
@@ -115,7 +117,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
           <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 items-start">
             <img
               src={story.thumbnail}
-              alt={story.title}
+              alt={`《${story.title}》課文封面圖`}
               className="w-32 h-24 object-cover rounded-xl border border-gray-200 flex-shrink-0"
             />
             <div className="flex flex-col gap-2">
@@ -129,7 +131,10 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 {processZhuyin(story.title)}
               </h1>
               {story.intro && (
-                <p className={`text-base leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''} text-gray-600`}>
+                <p
+                  className={`text-base leading-[2.6] ${zhuyinActive ? 'tracking-[0.3em]' : ''} text-gray-600`}
+                  aria-label={`作者：${story.intro.author}`}
+                >
                   {processZhuyin(story.intro.author)}
                 </p>
               )}
@@ -153,10 +158,13 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
               <div className="pt-2">
                 {isSpeaking ? (
                   <button
+                    type="button"
                     onClick={stopSpeaking}
-                    className="flex items-center gap-2 px-4 py-3 rounded-xl text-base font-bold bg-amber-800/50 text-amber-800 border border-amber-300 transition-all"
+                    aria-label="停止朗讀課文簡介"
+                    aria-pressed={true}
+                    className="flex items-center gap-2 px-4 py-3 rounded-xl text-base font-bold bg-amber-800/50 text-amber-800 border border-amber-300 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1"
                   >
-                    <svg className="w-4 h-4 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 10h6v4H9z" />
                     </svg>
@@ -164,10 +172,13 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                   </button>
                 ) : (
                   <button
+                    type="button"
                     onClick={speakIntro}
-                    className="flex items-center gap-2 px-4 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 border border-gray-200 transition-all active:scale-95"
+                    aria-label="朗讀課文簡介"
+                    aria-pressed={false}
+                    className="flex items-center gap-2 px-4 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 border border-gray-200 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
                   >
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
                     </svg>
                     朗讀簡介
@@ -187,20 +198,22 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
       {/* Bottom action */}
       <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
         <button
+          type="button"
           onClick={onBack}
-          className="px-4 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors"
+          className="px-4 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
         >
           返回圖書館
         </button>
         <button
+          type="button"
           onClick={() => {
             stopSpeaking();
             onStartReading();
           }}
-          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
+          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
         >
           開始逐段朗讀
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
           </svg>
         </button>

--- a/frontend/src/components/ui/DiffDisplay.tsx
+++ b/frontend/src/components/ui/DiffDisplay.tsx
@@ -15,13 +15,22 @@ interface DiffDisplayProps {
  * - wrong   → red background + white text, tooltip shows expected char
  * - missing → gray background + dashed underline (shows target char that was skipped)
  * - extra   → orange background + strikethrough (shows char that shouldn't be there)
+ *
+ * Accessibility:
+ * - Each non-correct token carries an aria-label describing the error type
+ * - The container has role="group" with a descriptive label
+ * - The legend uses role="list" for structured screen reader output
  */
 const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, className = '' }) => {
   if (!tokens || tokens.length === 0) return null;
 
   return (
     <div className={className}>
-      <div className="flex flex-wrap leading-relaxed text-lg">
+      <div
+        className="flex flex-wrap leading-relaxed text-lg"
+        role="group"
+        aria-label="朗讀差異對比結果"
+      >
         {tokens.map((token, idx) => {
           switch (token.type) {
             case 'correct':
@@ -36,10 +45,15 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, c
                   key={idx}
                   className="bg-error text-white rounded-sm px-0.5 mx-px cursor-help relative group"
                   title={`應該是「${token.expected}」`}
+                  aria-label={`讀錯：讀成「${token.char}」，應該是「${token.expected ?? ''}」`}
+                  role="mark"
                 >
                   {token.char}
                   {token.expected && (
-                    <span className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                    <span
+                      className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10"
+                      aria-hidden="true"
+                    >
                       應該是「{token.expected}」
                     </span>
                   )}
@@ -51,6 +65,8 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, c
                   key={idx}
                   className="bg-gray-200 text-gray-400 border-b-2 border-dashed border-gray-400 rounded-sm px-0.5 mx-px"
                   title="漏讀"
+                  aria-label={`漏讀：「${token.char}」沒有讀出來`}
+                  role="mark"
                 >
                   {token.char}
                 </span>
@@ -61,6 +77,8 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, c
                   key={idx}
                   className="bg-warning/30 text-warning line-through rounded-sm px-0.5 mx-px"
                   title="多讀"
+                  aria-label={`多讀：多讀了「${token.char}」`}
+                  role="mark"
                 >
                   {token.char}
                 </span>
@@ -72,21 +90,25 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, c
       </div>
 
       {showLegend && (
-        <div className="flex flex-wrap gap-3 mt-3 text-xs text-gray-500">
-          <span className="flex items-center gap-1">
-            <span className="w-3 h-3 rounded-sm bg-gray-900 inline-block" />
+        <div
+          className="flex flex-wrap gap-3 mt-3 text-xs text-gray-500"
+          role="list"
+          aria-label="差異標記說明"
+        >
+          <span className="flex items-center gap-1" role="listitem">
+            <span className="w-3 h-3 rounded-sm bg-gray-900 inline-block" aria-hidden="true" />
             正確
           </span>
-          <span className="flex items-center gap-1">
-            <span className="w-3 h-3 rounded-sm bg-error inline-block" />
+          <span className="flex items-center gap-1" role="listitem">
+            <span className="w-3 h-3 rounded-sm bg-error inline-block" aria-hidden="true" />
             讀錯
           </span>
-          <span className="flex items-center gap-1">
-            <span className="w-3 h-3 rounded-sm bg-gray-200 border border-dashed border-gray-400 inline-block" />
+          <span className="flex items-center gap-1" role="listitem">
+            <span className="w-3 h-3 rounded-sm bg-gray-200 border border-dashed border-gray-400 inline-block" aria-hidden="true" />
             漏讀
           </span>
-          <span className="flex items-center gap-1">
-            <span className="w-3 h-3 rounded-sm bg-warning/30 inline-block" />
+          <span className="flex items-center gap-1" role="listitem">
+            <span className="w-3 h-3 rounded-sm bg-warning/30 inline-block" aria-hidden="true" />
             多讀
           </span>
         </div>

--- a/frontend/src/components/ui/FontSizeControl.tsx
+++ b/frontend/src/components/ui/FontSizeControl.tsx
@@ -46,14 +46,21 @@ export default function FontSizeControl({ onChange }: FontSizeControlProps) {
   }, [level, onChange]);
 
   return (
-    <div className="flex items-center gap-1">
-      <span className="text-[10px] text-gray-400 select-none mr-0.5">字</span>
+    <div
+      className="flex items-center gap-1"
+      role="group"
+      aria-label="調整字體大小"
+    >
+      <span className="text-[10px] text-gray-400 select-none mr-0.5" aria-hidden="true">字</span>
       {LEVELS.map((l) => (
         <button
           key={l}
+          type="button"
           onClick={() => setLevel(l)}
           title={`字體大小：${LABELS[l]}`}
-          className={`w-6 h-6 rounded text-xs font-bold transition-colors ${
+          aria-label={`字體大小：${LABELS[l]}`}
+          aria-pressed={level === l}
+          className={`w-6 h-6 rounded text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
             level === l
               ? 'bg-accent text-white'
               : 'bg-gray-200 text-gray-600 hover:bg-gray-300'

--- a/frontend/src/components/ui/ZhuyinToggle.tsx
+++ b/frontend/src/components/ui/ZhuyinToggle.tsx
@@ -5,17 +5,23 @@ interface ZhuyinToggleProps {
 }
 
 export default function ZhuyinToggle({ enabled, ready, onToggle }: ZhuyinToggleProps) {
+  const isOn = enabled && ready;
+  const label = isOn ? '隱藏注音符號' : '顯示注音符號';
+
   return (
     <button
+      type="button"
       onClick={onToggle}
-      className={`px-2.5 py-1 rounded text-xs transition-colors ${
-        enabled && ready
+      aria-pressed={isOn}
+      aria-label={label}
+      title={label}
+      className={`px-2.5 py-1 rounded text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
+        isOn
           ? 'bg-accent/80 text-white hover:bg-accent-hover'
           : 'bg-gray-200 text-gray-600 hover:bg-gray-300'
       }`}
-      title={enabled ? '隱藏注音' : '顯示注音'}
     >
-      注音 {enabled ? 'ON' : 'OFF'}
+      注音 {isOn ? 'ON' : 'OFF'}
     </button>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -23,4 +23,65 @@
   textarea {
     @apply text-gray-900 bg-white;
   }
+
+  /* ------------------------------------------------------------------ */
+  /* WCAG 2.1 AA: Global focus-visible styles (keyboard navigation)      */
+  /* ------------------------------------------------------------------ */
+
+  /*
+   * Remove the browser default outline only when using a pointer device.
+   * When navigating by keyboard, :focus-visible is used instead.
+   * This satisfies WCAG 2.4.7 (Focus Visible).
+   */
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  /*
+   * High-visibility focus ring for keyboard navigation.
+   * Uses the accent color with a 2px offset so it is never obscured
+   * by the element's own background.
+   */
+  :focus-visible {
+    outline: 2px solid rgb(var(--color-accent));
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  /* Skip-to-content helper — visually hidden by default */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+
+  /* Reveal when focused (keyboard-only) */
+  .focus\:not-sr-only:focus {
+    position: absolute;
+    width: auto;
+    height: auto;
+    padding: inherit;
+    margin: inherit;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+  }
+
+  /* Reduce motion for users who prefer it (WCAG 2.3.3) */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 }

--- a/frontend/src/utils/accessibility.ts
+++ b/frontend/src/utils/accessibility.ts
@@ -1,0 +1,196 @@
+/**
+ * Accessibility utilities for WCAG 2.1 AA compliance.
+ *
+ * Covers:
+ * - Focus trap for modals and overlays
+ * - Live region announcements for dynamic content
+ * - Focus management helpers
+ * - Keyboard navigation utilities
+ */
+// No React import needed — all utilities are DOM-level
+
+// -----------------------------------------------------------------------
+// Live region announcer
+// -----------------------------------------------------------------------
+
+let announcePoliteEl: HTMLElement | null = null;
+let announceAssertiveEl: HTMLElement | null = null;
+
+function getAnnounceEl(politeness: 'polite' | 'assertive'): HTMLElement {
+  if (politeness === 'assertive') {
+    if (!announceAssertiveEl) {
+      announceAssertiveEl = document.createElement('div');
+      announceAssertiveEl.setAttribute('aria-live', 'assertive');
+      announceAssertiveEl.setAttribute('aria-atomic', 'true');
+      announceAssertiveEl.setAttribute('role', 'status');
+      Object.assign(announceAssertiveEl.style, {
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: '0',
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0,0,0,0)',
+        whiteSpace: 'nowrap',
+        border: '0',
+      });
+      document.body.appendChild(announceAssertiveEl);
+    }
+    return announceAssertiveEl;
+  }
+
+  if (!announcePoliteEl) {
+    announcePoliteEl = document.createElement('div');
+    announcePoliteEl.setAttribute('aria-live', 'polite');
+    announcePoliteEl.setAttribute('aria-atomic', 'true');
+    announcePoliteEl.setAttribute('role', 'status');
+    Object.assign(announcePoliteEl.style, {
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+      padding: '0',
+      margin: '-1px',
+      overflow: 'hidden',
+      clip: 'rect(0,0,0,0)',
+      whiteSpace: 'nowrap',
+      border: '0',
+    });
+    document.body.appendChild(announcePoliteEl);
+  }
+  return announcePoliteEl;
+}
+
+/**
+ * Announce a message to screen readers.
+ *
+ * @param message  Text to announce
+ * @param politeness  'polite' (default) waits for user idle; 'assertive' interrupts immediately
+ */
+export function announce(message: string, politeness: 'polite' | 'assertive' = 'polite'): void {
+  if (!message) return;
+  const el = getAnnounceEl(politeness);
+  // Clear then set — forces re-announcement even if message is the same
+  el.textContent = '';
+  // Use rAF to ensure DOM update triggers announcement
+  requestAnimationFrame(() => {
+    el.textContent = message;
+  });
+}
+
+// -----------------------------------------------------------------------
+// Focus trap
+// -----------------------------------------------------------------------
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  'details > summary',
+].join(', ');
+
+/**
+ * Returns all focusable elements within a container.
+ */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+    (el) => !el.hasAttribute('hidden') && getComputedStyle(el).display !== 'none'
+  );
+}
+
+/**
+ * Creates a keyboard event handler that traps focus within a container.
+ * Returns a cleanup function.
+ *
+ * Usage:
+ *   const cleanup = trapFocus(modalRef.current);
+ *   // on unmount:
+ *   cleanup();
+ */
+export function trapFocus(container: HTMLElement): () => void {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== 'Tab') return;
+    const focusable = getFocusableElements(container);
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  container.addEventListener('keydown', handleKeyDown);
+  return () => container.removeEventListener('keydown', handleKeyDown);
+}
+
+// -----------------------------------------------------------------------
+// Focus management
+// -----------------------------------------------------------------------
+
+/**
+ * Moves focus to the first focusable element inside a container.
+ */
+export function focusFirst(container: HTMLElement): void {
+  const focusable = getFocusableElements(container);
+  if (focusable.length > 0) {
+    focusable[0].focus();
+  }
+}
+
+/**
+ * Saves the currently focused element and returns a function to restore focus.
+ *
+ * Useful for modals: save focus before opening, restore when closing.
+ */
+export function saveFocus(): () => void {
+  const saved = document.activeElement as HTMLElement | null;
+  return () => {
+    if (saved && typeof saved.focus === 'function') {
+      saved.focus();
+    }
+  };
+}
+
+// -----------------------------------------------------------------------
+// Keyboard helpers
+// -----------------------------------------------------------------------
+
+/**
+ * Returns true if the event is an activation key (Enter or Space).
+ * Useful for making non-button elements keyboard-accessible.
+ */
+export function isActivationKey(e: globalThis.KeyboardEvent): boolean {
+  return e.key === 'Enter' || e.key === ' ';
+}
+
+/**
+ * Returns true if the event is a dismissal key (Escape).
+ */
+export function isDismissKey(e: globalThis.KeyboardEvent): boolean {
+  return e.key === 'Escape';
+}
+
+// -----------------------------------------------------------------------
+// ID generator for aria-labelledby / aria-describedby
+// -----------------------------------------------------------------------
+
+let idCounter = 0;
+
+/**
+ * Generates a unique ID for use in ARIA attributes.
+ */
+export function generateAriaId(prefix = 'aria'): string {
+  return `${prefix}-${++idCounter}`;
+}


### PR DESCRIPTION
Fixes #258

## Summary

- **新增** `frontend/src/utils/accessibility.ts` — 可重用的 A11y 工具函式（focus trap、aria live region announcer、focus management、keyboard helpers）
- **AppShell (App.tsx)** — skip-to-content 跳轉連結、正確的 ARIA landmark roles（`banner`/`main`/`navigation`/`contentinfo`）、`aria-current="page"` 在導覽按鈕、focus-visible ring、loading spinner 加 `role=status`
- **index.css** — 全域 `focus-visible` 樣式、`sr-only` / `focus:not-sr-only` 工具類、`prefers-reduced-motion` media query
- **ZhuyinToggle** — `aria-pressed`、`aria-label`、`type=button`、focus-visible ring
- **FontSizeControl** — `role=group`、每個按鈕加 `aria-pressed`、`type=button`、`aria-label`
- **DiffDisplay** — `role=group` on container、每個錯誤 token 加 `role=mark` + `aria-label`（「讀錯：讀成『X』，應該是『Y』」）、legend 加 `role=list`
- **ComprehensionChat** — mobile tab bar 加 `role=tablist/tab/tabpanel`、對話訊息加 `aria-live="polite"` region、錯誤加 `role=alert`、loading/完成加 `role=status`、輸入框加 `aria-label` + `aria-disabled`、進度計數加 `aria-live`、送出按鈕加 `aria-label`
- **Intro** — breadcrumb nav 加 `aria-current="page"`、圖片 alt 文字改善、TTS 按鈕加 `aria-pressed`、裝飾性 SVG 加 `aria-hidden`

## Test plan

- [ ] 開啟 Preview URL，按 Tab 鍵時第一個聚焦元素應為「跳至主要內容」連結（僅鍵盤導覽時可見）
- [ ] 所有互動元素（按鈕、輸入框、連結）在 Tab 鍵移動時都能看到清晰的 focus ring（indigo 色 2px outline）
- [ ] 使用螢幕閱讀器（VoiceOver / NVDA）確認：
  - 導覽按鈕念出「已選取」狀態（`aria-current`）
  - 注音切換按鈕念出「已開啟/已關閉」（`aria-pressed`）
  - ComprehensionChat 新訊息出現時自動朗讀
  - DiffDisplay 中的錯誤字念出錯誤類型（讀錯/漏讀/多讀）
- [ ] 在 `prefers-reduced-motion: reduce` 環境下，動畫應被禁用（animate-spin、animate-bounce 縮短至 0.01ms）