### PR TITLE
feat: improve vocab practice UX with animations and progress (Fixes #220)

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -21,6 +21,119 @@ type Phase = 'grid' | 'practice' | 'pronunciation';
 
 type PracticeMode = 'stroke' | 'pronunciation';
 
+/* ================================================================ */
+/*  Progress bar                                                     */
+/* ================================================================ */
+
+interface ProgressBarProps {
+  done: number;
+  total: number;
+}
+
+function ProgressBar({ done, total }: ProgressBarProps) {
+  if (total === 0) return null;
+  const pct = Math.round((done / total) * 100);
+  return (
+    <div className="w-full px-6 py-2 bg-white border-b border-gray-100">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex justify-between items-center mb-1">
+          <span className="text-[10px] font-medium text-gray-500">練習進度</span>
+          <span className="text-[10px] font-bold text-gray-700">{done} / {total} 字</span>
+        </div>
+        <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-emerald-500 rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ================================================================ */
+/*  Completion celebration                                           */
+/* ================================================================ */
+
+interface CompletionBannerProps {
+  count: number;
+  onFinish: () => void;
+}
+
+function CompletionBanner({ count, onFinish }: CompletionBannerProps) {
+  return (
+    <div className="animate-slide-up bg-gradient-to-br from-emerald-50 to-teal-50 border-2 border-emerald-300 rounded-2xl p-6 text-center space-y-3 shadow-lg">
+      <div className="flex justify-center gap-2 text-3xl select-none animate-pop">
+        <span>🌟</span><span>🎉</span><span>🌟</span>
+      </div>
+      <h3 className="text-2xl font-black text-emerald-800">全部完成！</h3>
+      <p className="text-emerald-700 text-sm">
+        你練習了 <span className="font-bold text-emerald-900">{count}</span> 個生字，太厲害了！
+      </p>
+      <button
+        onClick={onFinish}
+        className="w-full max-w-xs mx-auto mt-2 px-8 py-3.5 rounded-2xl font-bold text-base bg-emerald-600 hover:bg-emerald-500 text-white shadow-lg transition-all active:scale-95 flex items-center justify-center gap-2"
+      >
+        查看學習報告
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
+/* ================================================================ */
+/*  Character card                                                   */
+/* ================================================================ */
+
+interface CharCardProps {
+  label: string;
+  isSuggested: boolean;
+  isPracticed: boolean;
+  animDelay: number;
+  onClick: () => void;
+}
+
+function CharCard({ label, isSuggested, isPracticed, animDelay, onClick }: CharCardProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={[
+        'relative flex flex-col items-center justify-center aspect-square rounded-2xl border transition-all duration-200 active:scale-90 animate-card-in',
+        isPracticed
+          ? 'bg-emerald-50 border-emerald-400/70 text-emerald-800 shadow-sm'
+          : isSuggested
+            ? 'bg-amber-50 border-amber-500/60 text-amber-800 ring-1 ring-amber-400/30 hover:bg-amber-100 hover:border-amber-500 shadow-md hover:shadow-lg hover:-translate-y-0.5'
+            : 'bg-white border-gray-200 text-gray-800 hover:bg-gray-50 hover:border-accent/40 hover:shadow-md hover:-translate-y-0.5',
+      ].join(' ')}
+      style={{ animationDelay: `${animDelay}ms`, opacity: 0 }}
+    >
+      <span className="text-3xl font-bold leading-none py-2">{label}</span>
+
+      {isSuggested && !isPracticed && (
+        <span className="absolute -top-1.5 -right-1.5 w-3.5 h-3.5 bg-amber-500 rounded-full border-2 border-white shadow-sm" />
+      )}
+
+      {isPracticed && (
+        <span className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-emerald-500 rounded-full flex items-center justify-center border-2 border-white shadow-sm animate-pop">
+          <svg className="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+          </svg>
+        </span>
+      )}
+
+      <span className="text-[9px] mt-1 opacity-50 font-medium">
+        {isPracticed ? '已完成' : '點我練習'}
+      </span>
+    </button>
+  );
+}
+
+/* ================================================================ */
+/*  Main component                                                   */
+/* ================================================================ */
+
 const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish, onBack }) => {
   const [phase, setPhase] = useState<Phase>('grid');
   const [practicingChar, setPracticingChar] = useState('');
@@ -32,6 +145,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   /** Character whose radical panel is currently open */
   const [radicalChar, setRadicalChar] = useState<string | null>(null);
   const [selectedChar, setSelectedChar] = useState<string | null>(null);
+  const [justCompleted, setJustCompleted] = useState('');
 
   const zhuyinActive = zhuyinReady && zhuyinEnabled;
 
@@ -51,29 +165,18 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     }
   }, [zhuyinActive]);
 
-  /** Characters from low-match-rate paragraphs (suggested practice) */
   const needPracticeSet = useMemo(
     () => new Set(attempt.mispronouncedWords),
     [attempt.mispronouncedWords],
   );
 
-  /**
-   * Build display character list:
-   * - If there are missed characters (mispronouncedWords): show ONLY those.
-   *   Don't mix in unrelated story characters — every card shown is a real miss.
-   * - If none missed (perfect reading): show optional story characters so the
-   *   student can still choose to practice.
-   * All characters are filtered to those with available stroke data.
-   */
   const displayChars = useMemo(() => {
     const suggested = attempt.mispronouncedWords.filter(hasStrokeData);
 
     if (suggested.length > 0) {
-      // Show only the chars the student actually missed
       return suggested.slice(0, 12);
     }
 
-    // No misses — optional story characters for extra practice
     const seen = new Set<string>();
     const optional: string[] = [];
     for (const line of story.content) {
@@ -90,10 +193,13 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   const handlePractice = (ch: string, mode: PracticeMode = 'stroke') => {
     setPracticingChar(ch);
     setPhase(mode === 'stroke' ? 'practice' : 'pronunciation');
+    setJustCompleted('');
   };
 
   const handlePracticeComplete = () => {
-    setPracticedChars(prev => new Set(prev).add(practicingChar));
+    const ch = practicingChar;
+    setPracticedChars(prev => new Set(prev).add(ch));
+    setJustCompleted(ch);
     setPhase('grid');
   };
 
@@ -173,7 +279,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           : "'Iansui', 'Noto Sans TC', sans-serif",
       }}
     >
-      {/* Tab bar — VS Code style */}
+      {/* Tab bar */}
       <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
         <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
           {story.filename} — 生字練習
@@ -187,14 +293,17 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
         <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
       </div>
 
+      {/* Progress bar */}
+      <ProgressBar done={practicedChars.size} total={displayChars.length} />
+
       {/* Main content */}
-      <div className="flex-1 overflow-y-auto px-6 py-8">
+      <div className="flex-1 overflow-y-auto px-6 py-6">
         <div className="max-w-2xl mx-auto space-y-6">
 
           {/* Header */}
           <div>
             <h2 className="text-xl font-black text-gray-900 mb-1">生字練習</h2>
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-gray-500">
               {attempt.timestamp === 0
                 ? '還沒有朗讀紀錄，以下是這篇課文的生字，選一個模式開始練習吧！'
                 : needPracticeSet.size > 0
@@ -237,6 +346,16 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
             </button>
           </div>
 
+          {/* Just-completed flash */}
+          {justCompleted && (
+            <div className="flex items-center gap-2 px-4 py-2.5 bg-emerald-50 border border-emerald-200 rounded-xl text-sm text-emerald-700 animate-slide-up-fast">
+              <svg className="w-4 h-4 text-emerald-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+              </svg>
+              <span>「<strong>{justCompleted}</strong>」練習完成！繼續加油！</span>
+            </div>
+          )}
+
           {/* Character grid */}
           {currentChars.length === 0 ? (
             <div className="text-gray-400 text-sm py-8 text-center">
@@ -246,7 +365,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
             </div>
           ) : (
             <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
-              {currentChars.map(ch => {
+              {currentChars.map((ch, idx) => {
                 const isSuggested = needPracticeSet.has(ch);
                 const isPracticed = currentPracticedSet.has(ch);
                 const hasRadical = activeTab === 'stroke' && getDecomposition(ch) !== null;
@@ -260,7 +379,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                       }}
                       onDoubleClick={() => handlePractice(ch, activeTab)}
                       className={[
-                        `relative flex flex-col items-center justify-center w-full ${zhuyinActive ? 'aspect-[3/6]' : 'aspect-square'} rounded-2xl border transition-all active:scale-95`,
+                        `relative flex flex-col items-center justify-center w-full ${zhuyinActive ? 'aspect-[3/6]' : 'aspect-square'} rounded-2xl border transition-all active:scale-95 animate-card-in`,
                         isSelected
                           ? 'ring-2 ring-indigo-500 ring-offset-1'
                           : '',
@@ -270,6 +389,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                             ? 'bg-amber-900/30 border-amber-600/60 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-900/50'
                             : 'bg-white border-gray-200 text-gray-800 hover:bg-gray-100 hover:border-accent/40',
                       ].join(' ')}
+                      style={{ animationDelay: `${idx * 40}ms`, opacity: 0 }}
                     >
                       <span className={`text-3xl font-bold leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}>
                         {processZhuyin(ch)}
@@ -282,7 +402,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
                       {/* Done checkmark */}
                       {isPracticed && (
-                        <span className="absolute -top-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full flex items-center justify-center border-2 border-[#0d1117]">
+                        <span className="absolute -top-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full flex items-center justify-center border-2 border-[#0d1117] animate-pop">
                           <svg className="w-2.5 h-2.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
                           </svg>
@@ -412,9 +532,10 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           )}
 
           {allDone && (
-            <div className="bg-blue-50 border border-blue-300 rounded-2xl p-4 text-center">
-              <p className="text-blue-800 font-bold">筆順和發音都練習完了，真厲害！</p>
-            </div>
+            <CompletionBanner
+              count={practicedChars.size}
+              onFinish={() => onFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
+            />
           )}
         </div>
       </div>
@@ -423,7 +544,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
       <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
         <button
           onClick={onBack}
-          className="px-4 py-3 rounded-xl text-base text-gray-600 hover:text-gray-800 transition-colors"
+          className="px-4 py-3 rounded-xl text-base text-gray-500 hover:text-gray-800 transition-colors"
         >
           回到朗讀
         </button>
@@ -433,7 +554,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
         >
           {practicedChars.size > 0 || pronouncedChars.size > 0 ? '完成，查看報告' : '跳過，查看報告'}
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
         </button>
       </div>

--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -25,6 +25,158 @@ enum Step {
   COMPLETE,
 }
 
+/* ================================================================ */
+/*  Confetti decoration for completion screen                        */
+/* ================================================================ */
+
+function ConfettiParticles() {
+  const pieces = [
+    { color: 'bg-yellow-400', anim: 'animate-confetti-drop-1', left: '20%', shape: 'rounded-sm w-3 h-3' },
+    { color: 'bg-pink-400',   anim: 'animate-confetti-drop-2', left: '50%', shape: 'rounded-full w-2.5 h-2.5' },
+    { color: 'bg-sky-400',    anim: 'animate-confetti-drop-3', left: '75%', shape: 'rounded-sm w-2 h-3' },
+    { color: 'bg-emerald-400',anim: 'animate-confetti-drop-1', left: '35%', shape: 'rounded-full w-2 h-2' },
+    { color: 'bg-violet-400', anim: 'animate-confetti-drop-2', left: '65%', shape: 'rounded-sm w-3 h-2' },
+    { color: 'bg-orange-400', anim: 'animate-confetti-drop-3', left: '85%', shape: 'rounded-full w-2.5 h-2.5' },
+  ];
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-xl">
+      {pieces.map((p, i) => (
+        <div
+          key={i}
+          className={`absolute top-4 ${p.color} ${p.anim} ${p.shape} opacity-0`}
+          style={{ left: p.left }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/* ================================================================ */
+/*  Practice progress dots                                           */
+/* ================================================================ */
+
+interface ProgressDotsProps {
+  step: Step;
+  practiceLeft: number;
+}
+
+function ProgressDots({ step, practiceLeft }: ProgressDotsProps) {
+  if (step === Step.ANIMATION || step === Step.COMPLETE) return null;
+
+  // 3 bordered rounds + 1 no-outline round = 4 total
+  const dots = [
+    { label: '1', filled: practiceLeft < 4, isNoOutline: false },
+    { label: '2', filled: practiceLeft < 3, isNoOutline: false },
+    { label: '3', filled: practiceLeft < 2, isNoOutline: false },
+    { label: '無框', filled: practiceLeft < 1, isNoOutline: true },
+  ];
+
+  return (
+    <div className="flex items-center gap-2">
+      {dots.map((dot, i) => (
+        <React.Fragment key={i}>
+          {i === 3 && (
+            <div className="w-4 h-px bg-slate-600" />
+          )}
+          <div className="flex flex-col items-center gap-0.5">
+            <div
+              className={`flex items-center justify-center rounded-full border-2 transition-all duration-300 ${
+                dot.isNoOutline ? 'w-7 h-7' : 'w-6 h-6'
+              } ${
+                dot.filled
+                  ? dot.isNoOutline
+                    ? 'border-violet-500 bg-violet-500'
+                    : 'border-orange-500 bg-orange-500'
+                  : 'border-slate-600 bg-transparent'
+              }`}
+            >
+              {dot.filled && (
+                <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </div>
+            <span className={`text-[9px] ${dot.filled ? 'text-orange-400' : 'text-slate-600'}`}>
+              {dot.label}
+            </span>
+          </div>
+        </React.Fragment>
+      ))}
+    </div>
+  );
+}
+
+/* ================================================================ */
+/*  Step guidance banner                                             */
+/* ================================================================ */
+
+interface StepGuidanceProps {
+  step: Step;
+  mode: string;
+  nStrokes: number;
+  completedStrokes: number;
+}
+
+function StepGuidance({ step, mode, nStrokes, completedStrokes }: StepGuidanceProps) {
+  if (step === Step.COMPLETE) return null;
+
+  let icon = '';
+  let text = '';
+  let subtext = '';
+  let colorClass = 'text-slate-400 border-slate-700';
+
+  if (step === Step.ANIMATION) {
+    icon = '👀';
+    text = '觀看筆順動畫';
+    subtext = '準備好了就按「開始練習」';
+    colorClass = 'text-sky-300 border-sky-900 bg-sky-950/40';
+  } else if (mode === 'quizzing') {
+    const remaining = nStrokes - completedStrokes;
+    const isNoOutline = step === Step.PRACTICE_NO_OUTLINE;
+    icon = isNoOutline ? '🧠' : '✏️';
+    text = isNoOutline ? '不看框線，憑記憶寫' : '跟著筆順，一筆一筆寫';
+    subtext = remaining > 0 ? `還有 ${remaining} 筆` : '最後一筆了！';
+    colorClass = isNoOutline
+      ? 'text-violet-300 border-violet-900 bg-violet-950/40'
+      : 'text-emerald-300 border-emerald-900 bg-emerald-950/40';
+  } else if (mode === 'idle' && step !== Step.ANIMATION) {
+    icon = '✅';
+    text = '這一輪寫完了！';
+    colorClass = 'text-emerald-300 border-emerald-900 bg-emerald-950/40';
+  }
+
+  if (!text) return null;
+
+  return (
+    <div className={`flex items-center gap-2 px-4 py-2 rounded-xl border text-sm animate-slide-up-fast ${colorClass}`}>
+      <span>{icon}</span>
+      <span className="font-medium">{text}</span>
+      {subtext && <span className="opacity-60 text-xs">{subtext}</span>}
+    </div>
+  );
+}
+
+/* ================================================================ */
+/*  Toast notification                                               */
+/* ================================================================ */
+
+function Toast({ message, type }: { message: string; type: 'success' | 'error' | 'info' }) {
+  const colors = {
+    success: 'bg-emerald-600 text-white',
+    error: 'bg-red-600 text-white',
+    info: 'bg-slate-700 text-white',
+  };
+  return (
+    <div className={`fixed bottom-8 left-1/2 -translate-x-1/2 px-6 py-3 rounded-2xl shadow-2xl text-sm font-bold z-50 animate-toast-in whitespace-nowrap ${colors[type]}`}>
+      {message}
+    </div>
+  );
+}
+
+/* ================================================================ */
+/*  Main component                                                   */
+/* ================================================================ */
+
 const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, onBack }) => {
   /* ---- React state (drives UI controls) ---- */
   const [data, setData] = useState<CharacterStrokeData | null>(null);
@@ -34,7 +186,10 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
   const [mode, setMode] = useState<'idle' | 'animating' | 'quizzing'>('idle');
   const [practiceLeft, setPracticeLeft] = useState(4);
   const [toast, setToast] = useState('');
+  const [toastType, setToastType] = useState<'success' | 'error' | 'info'>('success');
   const [showOutline, setShowOutline] = useState(true);
+  const [canvasShake, setCanvasShake] = useState(false);
+  const [completedStrokesUI, setCompletedStrokesUI] = useState(0);
 
   /* ---- Refs for imperative canvas rendering ---- */
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -76,6 +231,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
   const isAutoLoopingRef = useRef(false);
   const pendingAutoStartRef = useRef(false);
   const loopTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const shakeTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   /* ---- Off-screen canvas (created once, reused) ---- */
   const getOffCanvas = useCallback(() => {
@@ -114,6 +270,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
     setPracticeLeft(4);
     setShowOutline(true);
     setToast('');
+    setCompletedStrokesUI(0);
     r.current = {
       completedStrokes: 0, animStroke: -1, animProgress: 0,
       hintStroke: -1, hintProgress: 0, correctPaths: [], activeBrush: [],
@@ -146,6 +303,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
       cancelAnimationFrame(animFrameRef.current);
       cancelAnimationFrame(hintFrameRef.current);
       clearTimeout(loopTimerRef.current);
+      clearTimeout(shakeTimerRef.current);
     };
   }, [character, resetState]);
 
@@ -160,6 +318,26 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
     const t = setTimeout(() => setToast(''), 3500);
     return () => clearTimeout(t);
   }, [toast]);
+
+  /* ---- Trigger shake animation ---- */
+  const triggerShake = useCallback(() => {
+    setCanvasShake(false);
+    clearTimeout(shakeTimerRef.current);
+    // Use rAF to allow React to clear the class first
+    requestAnimationFrame(() => {
+      setCanvasShake(true);
+      shakeTimerRef.current = setTimeout(() => setCanvasShake(false), 450);
+    });
+  }, []);
+
+  const showToast = useCallback((msg: string, type: 'success' | 'error' | 'info' = 'success') => {
+    setToast('');
+    // slight delay to re-trigger animation
+    requestAnimationFrame(() => {
+      setToast(msg);
+      setToastType(type);
+    });
+  }, []);
 
   /* ================================================================ */
   /*  Animation                                                        */
@@ -247,6 +425,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
     r.current.hintStroke = -1;
     m.current.mistakes = new Array(d.nStrokes).fill(0);
     m.current.quizStroke = 0;
+    setCompletedStrokesUI(0);
     doRender();
   }, [doRender]);
 
@@ -296,6 +475,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
       r.current.correctPaths = [...r.current.correctPaths, points];
       m.current.quizStroke = stroke + 1;
       r.current.completedStrokes = stroke + 1;
+      setCompletedStrokesUI(stroke + 1);
       doRender();
 
       if (stroke + 1 >= d.nStrokes) {
@@ -311,29 +491,30 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
             m.current.showOutline = false;
             setShowOutline(false);
             setStep(Step.PRACTICE_NO_OUTLINE);
-            setToast('👏 很棒！現在試著不看邊框，憑記憶寫一次！');
+            showToast('👏 很棒！現在試著不看邊框，憑記憶寫一次！', 'info');
             startQuiz();
           } else {
             const nextStep = (s + 1) as Step;
             setStep(nextStep);
-            setToast(`恭喜筆畫正確！讓我們再練習 ${newLeft} 次哦！`);
+            showToast(`恭喜筆畫正確！讓我們再練習 ${newLeft} 次哦！`, 'success');
             startQuiz();
           }
         } else if (s === Step.PRACTICE_NO_OUTLINE) {
           setPracticeLeft(pl - 1);
           setStep(Step.COMPLETE);
-          setToast('恭喜筆畫正確！寫字練習完成！');
+          showToast('恭喜筆畫正確！寫字練習完成！', 'success');
         } else {
-          setToast('恭喜筆畫正確！');
+          showToast('恭喜筆畫正確！', 'success');
         }
       }
     } else {
       m.current.mistakes[stroke] = (m.current.mistakes[stroke] || 0) + 1;
+      triggerShake();
       if (m.current.mistakes[stroke] >= HINT_THRESHOLD) {
         showHint();
       }
     }
-  }, [doRender, showHint, startQuiz]);
+  }, [doRender, showHint, startQuiz, triggerShake, showToast]);
 
   /* ================================================================ */
   /*  Pointer events (drawing)                                         */
@@ -377,10 +558,11 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
   }, [doRender, handleStrokeDrawn]);
 
   /* ================================================================ */
-  /*  Button logic                                                     */
+  /*  Derived values                                                   */
   /* ================================================================ */
 
   const isComplete = step === Step.COMPLETE;
+  const nStrokes = data?.nStrokes ?? 0;
 
   /* ================================================================ */
   /*  JSX                                                              */
@@ -417,65 +599,78 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
         {onBack && (
           <button
             onClick={onBack}
-            className="text-slate-400 hover:text-white transition-colors"
+            className="text-slate-400 hover:text-white transition-colors p-1"
+            aria-label="返回"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
           </button>
         )}
-        <h2 className="text-2xl font-bold text-white flex-1 text-center">
-          寫一寫：{character}
-        </h2>
+        <div className="flex-1 text-center">
+          <h2 className="text-2xl font-bold text-white">
+            寫一寫：<span className="text-accent-light">{character}</span>
+          </h2>
+          {nStrokes > 0 && (
+            <p className="text-xs text-slate-500 mt-0.5">共 {nStrokes} 筆</p>
+          )}
+        </div>
+        {/* Spacer to balance back button */}
+        {onBack && <div className="w-8" />}
       </div>
 
-      {/* Practice progress indicators */}
-      {step !== Step.ANIMATION && !isComplete && (
-        <div className="flex gap-1.5 items-center">
-          {[4, 3, 2].map(n => (
+      {/* Progress dots */}
+      <ProgressDots step={step} practiceLeft={practiceLeft} />
+
+      {/* Stroke progress bar (during quiz) */}
+      {mode === 'quizzing' && nStrokes > 0 && (
+        <div className="w-full max-w-lg">
+          <div className="flex justify-between text-[10px] text-slate-500 mb-1">
+            <span>筆畫進度</span>
+            <span>{completedStrokesUI} / {nStrokes}</span>
+          </div>
+          <div className="h-1.5 bg-slate-800 rounded-full overflow-hidden">
             <div
-              key={n}
-              className={`w-5 h-5 rounded-full border-2 transition-all ${
-                practiceLeft >= n
-                  ? 'border-slate-500 bg-transparent'
-                  : 'border-orange-500 bg-orange-500'
-              }`}
+              className="h-full bg-emerald-500 rounded-full transition-all duration-300"
+              style={{ width: `${(completedStrokesUI / nStrokes) * 100}%` }}
             />
-          ))}
-          <div className="w-3" />
-          <div
-            className={`w-5 h-5 rounded-full border-2 transition-all ${
-              practiceLeft >= 1
-                ? 'border-slate-500 bg-transparent'
-                : 'border-orange-500 bg-orange-500'
-            }`}
-          />
+          </div>
         </div>
       )}
 
       {/* Canvas */}
-      <div className="relative w-full max-w-lg aspect-square">
+      <div
+        className={`relative w-full max-w-lg aspect-square ${canvasShake ? 'animate-shake' : ''}`}
+      >
+        {/* Completion overlay */}
         {isComplete && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center bg-[#0d1117]/95 rounded-xl z-10 gap-5 p-6">
-            <div className="text-6xl">🎉</div>
-            <p className="text-5xl font-black text-white">{character}</p>
-            <p className="text-xl font-bold text-emerald-400">練習完成！</p>
-            {onComplete && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-[#0d1117]/95 rounded-xl z-10 gap-4 p-6 animate-fade-in">
+            <ConfettiParticles />
+            <div className="animate-star-burst text-6xl select-none">🎉</div>
+            <p className="text-6xl font-black text-white animate-pop">{character}</p>
+            <div className="flex flex-col items-center gap-1">
+              <p className="text-xl font-bold text-emerald-400">練習完成！</p>
+              <p className="text-xs text-slate-400">很棒，{nStrokes} 筆全部正確</p>
+            </div>
+            <div className="flex flex-col gap-2 w-full max-w-xs mt-2">
+              {onComplete && (
+                <button
+                  onClick={onComplete}
+                  className="w-full px-8 py-3.5 bg-emerald-500 hover:bg-emerald-400 text-white font-bold rounded-2xl shadow-lg transition-all active:scale-95 text-base"
+                >
+                  完成，回到練習清單
+                </button>
+              )}
               <button
-                onClick={onComplete}
-                className="mt-2 px-8 py-3 bg-emerald-500 hover:bg-emerald-400 text-white font-bold rounded-xl shadow-lg transition-all active:scale-95 text-base"
+                onClick={handleRetry}
+                className="w-full px-6 py-2.5 text-slate-400 hover:text-white border border-slate-700 hover:border-slate-500 rounded-2xl transition-all text-sm"
               >
-                完成，回到練習清單
+                再練一次
               </button>
-            )}
-            <button
-              onClick={handleRetry}
-              className="px-6 py-2 text-slate-400 hover:text-white border border-slate-600 hover:border-slate-400 rounded-xl transition-all text-sm"
-            >
-              再練一次
-            </button>
+            </div>
           </div>
         )}
+
         <canvas
           ref={canvasRef}
           width={CANVAS_SIZE}
@@ -489,7 +684,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
         />
       </div>
 
-      {/* Controls */}
+      {/* Begin practice button (animation phase) */}
       {step === Step.ANIMATION && (
         <button
           onClick={handleBeginPractice}
@@ -500,27 +695,17 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
       )}
 
       {/* Step guidance */}
-      <StepGuidance mode={mode} />
+      <StepGuidance
+        step={step}
+        mode={mode}
+        nStrokes={nStrokes}
+        completedStrokes={completedStrokesUI}
+      />
 
       {/* Toast */}
-      {toast && (
-        <div className="fixed bottom-8 left-1/2 -translate-x-1/2 px-6 py-3 bg-emerald-600 text-white rounded-xl shadow-2xl text-sm font-bold z-50 animate-bounce">
-          {toast}
-        </div>
-      )}
+      {toast && <Toast message={toast} type={toastType} />}
     </div>
   );
 };
-
-/* ---- Sub-components ---- */
-
-function StepGuidance({ mode }: { mode: string }) {
-  let text = '';
-  if (mode === 'animating') text = '觀看筆順動畫，按「開始練習」開始書寫';
-  else if (mode === 'quizzing') text = '請在格子裡寫出每一筆';
-  return text ? (
-    <p className="text-xs text-slate-500 text-center max-w-xs">{text}</p>
-  ) : null;
-}
 
 export default WriteCharacter;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -18,6 +18,72 @@ export default {
         warning: 'rgb(var(--color-warning) / <alpha-value>)',
         error: 'rgb(var(--color-error) / <alpha-value>)',
       },
+      keyframes: {
+        shake: {
+          '0%, 100%': { transform: 'translateX(0)' },
+          '15%': { transform: 'translateX(-6px)' },
+          '30%': { transform: 'translateX(6px)' },
+          '45%': { transform: 'translateX(-4px)' },
+          '60%': { transform: 'translateX(4px)' },
+          '75%': { transform: 'translateX(-2px)' },
+          '90%': { transform: 'translateX(2px)' },
+        },
+        pop: {
+          '0%': { transform: 'scale(0.6)', opacity: '0' },
+          '60%': { transform: 'scale(1.1)', opacity: '1' },
+          '100%': { transform: 'scale(1)', opacity: '1' },
+        },
+        'slide-up': {
+          '0%': { transform: 'translateY(20px)', opacity: '0' },
+          '100%': { transform: 'translateY(0)', opacity: '1' },
+        },
+        'slide-up-fade': {
+          '0%': { transform: 'translateY(12px)', opacity: '0' },
+          '100%': { transform: 'translateY(0)', opacity: '1' },
+        },
+        'card-in': {
+          '0%': { transform: 'scale(0.85) translateY(8px)', opacity: '0' },
+          '100%': { transform: 'scale(1) translateY(0)', opacity: '1' },
+        },
+        'fade-in': {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        'toast-in': {
+          '0%': { transform: 'translate(-50%, 20px)', opacity: '0' },
+          '100%': { transform: 'translate(-50%, 0)', opacity: '1' },
+        },
+        'confetti-drop-1': {
+          '0%':   { transform: 'translate(0, -10px) rotate(0deg)',   opacity: '1' },
+          '100%': { transform: 'translate(-30px, 80px) rotate(240deg)', opacity: '0' },
+        },
+        'confetti-drop-2': {
+          '0%':   { transform: 'translate(0, -10px) rotate(0deg)',   opacity: '1' },
+          '100%': { transform: 'translate(25px, 90px) rotate(-180deg)', opacity: '0' },
+        },
+        'confetti-drop-3': {
+          '0%':   { transform: 'translate(0, -10px) rotate(0deg)',   opacity: '1' },
+          '100%': { transform: 'translate(40px, 70px) rotate(300deg)', opacity: '0' },
+        },
+        'star-burst': {
+          '0%':   { transform: 'scale(0) rotate(0deg)',   opacity: '1' },
+          '50%':  { transform: 'scale(1.4) rotate(180deg)', opacity: '1' },
+          '100%': { transform: 'scale(1) rotate(360deg)', opacity: '1' },
+        },
+      },
+      animation: {
+        shake: 'shake 0.45s ease-in-out',
+        pop: 'pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1)',
+        'slide-up': 'slide-up 0.4s ease-out',
+        'slide-up-fast': 'slide-up-fade 0.25s ease-out',
+        'card-in': 'card-in 0.3s ease-out forwards',
+        'fade-in': 'fade-in 0.3s ease-out',
+        'toast-in': 'toast-in 0.3s ease-out',
+        'confetti-drop-1': 'confetti-drop-1 1s ease-in 0.1s forwards',
+        'confetti-drop-2': 'confetti-drop-2 1.1s ease-in 0.2s forwards',
+        'confetti-drop-3': 'confetti-drop-3 0.9s ease-in 0s forwards',
+        'star-burst': 'star-burst 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Fixes #220

## Summary

- **Shake animation** for incorrect strokes — immediate tactile feedback when a stroke is wrong
- **Confetti + star-burst** on character completion screen — celebration via CSS-only Tailwind animations
- **Stroke progress bar** (completed / total strokes) visible during writing quiz
- **Labeled ProgressDots** — 4 steps (1, 2, 3, 無框) with checkmarks and color distinction for no-outline round
- **Contextual StepGuidance banner** — shows icon, mode description, and remaining strokes
- **Typed Toast** — success/error/info variants with slide-up entrance animation
- **VocabPractice ProgressBar** — animated fill showing practiced / total characters
- **Staggered card-in animation** — character cards appear with cascading entrance (40ms per card)
- **Just-completed flash** — inline success banner when returning from WriteCharacter
- **CompletionBanner** — replaces plain text with gradient card, celebration icons, and prominent CTA button
- **Custom Tailwind keyframes** — shake, pop, card-in, slide-up, confetti-drop (x3), star-burst, toast-in (no external deps)
- **Better visual hierarchy** — character highlighted in accent-light color, stroke count subtitle in header
- **Mobile touch** — `active:scale-90` on cards, `active:scale-95` on buttons, larger hit targets

## Files Changed

- `frontend/tailwind.config.js` — new keyframes + animations
- `frontend/src/components/stroke-order/WriteCharacter.tsx` — all WriteCharacter improvements
- `frontend/src/components/reading-steps/VocabPractice.tsx` — grid UX improvements

## Test plan

- [ ] Open a story, go to Step 3 (生字練習)
- [ ] Verify character cards animate in with stagger on page load
- [ ] Click a character card, verify WriteCharacter opens
- [ ] Write a wrong stroke — verify canvas shakes
- [ ] Complete all strokes — verify confetti and 🎉 animate on completion overlay
- [ ] Click "完成，回到練習清單" — verify just-completed flash banner appears
- [ ] Verify progress bar increments
- [ ] Practice all characters — verify CompletionBanner with celebration appears
- [ ] Test on mobile viewport (375px) — verify no layout issues