### PR TITLE
feat: sentence practice after stroke order (Fixes #109)

### DIFF
--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -22,7 +22,13 @@ from ..schemas.session import (
     SessionSummaryResponse,
     SessionUpdateRequest,
 )
-from ..services.ai_service import evaluate_comprehension, generate_reading_analysis, generate_socratic_question
+from ..services.ai_service import (
+    evaluate_comprehension,
+    generate_example_sentences,
+    generate_reading_analysis,
+    generate_socratic_question,
+    validate_student_sentence,
+)
 from ..services.socratic_agent import socratic_agent
 from ..services.stuck_detection_service import build_recommendations, detect_stuck_points
 
@@ -945,6 +951,15 @@ class RecommendationsResponse(BaseModel):
     response_model=StuckPointsResponse,
 )
 def get_stuck_points(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Detect learning stuck-points for a student."""
+    _verify_student_access(student_id, current_user, db)
+    data = detect_stuck_points(student_id, db)
+    return StuckPointsResponse(**data)
+
 
 # Step names for all 6 learning steps
 STEP_NAMES = {
@@ -1078,26 +1093,83 @@ def get_student_progress(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Detect learning stuck-points for a student.
+    """Return per-text completion progress for a student.
 
-    Accessible by the student themselves or their teacher.
+    Aggregates all learning sessions grouped by story_slug, keeping the
+    most-recent session per text to compute step completion status and
+    a rule-based next-step recommendation.
 
-    Returns:
-    - story_stuck: stories attempted 3+ times without ≥5% accuracy improvement
-    - character_stuck: characters with 3+ errors across sessions (last 30 days)
-    - is_declining: True if last 3 sessions show strictly declining accuracy
-    - accuracy_trend: list of accuracy values (oldest → newest, last 10 sessions)
+    Access: student themselves, or a teacher of their classroom.
     """
     _verify_student_access(student_id, current_user, db)
-    data = detect_stuck_points(student_id, db)
-    logger.info(
-        "Stuck-point detection for student %d: %d story stuck, %d char stuck, declining=%s",
-        student_id,
-        len(data["story_stuck"]),
-        len(data["character_stuck"]),
-        data["is_declining"],
+
+    sessions = (
+        db.query(LearningSession)
+        .filter(LearningSession.student_id == student_id)
+        .order_by(LearningSession.started_at.desc(), LearningSession.id.desc())
+        .all()
     )
-    return StuckPointsResponse(**data)
+
+    # Keep only the most recent session per story_slug
+    seen: set[str] = set()
+    latest_per_text: list[LearningSession] = []
+    for s in sessions:
+        slug = s.story_slug or f"session-{s.id}"
+        if slug not in seen:
+            seen.add(slug)
+            latest_per_text.append(s)
+
+    texts: list[TextProgressItem] = []
+    scores: list[float] = []
+
+    for s in latest_per_text:
+        slug = s.story_slug or f"session-{s.id}"
+        step_statuses = _compute_step_completion(s)
+        completed_count = sum(1 for v in step_statuses.values() if v == "completed")
+        completion_pct = round(completed_count / 6 * 100)
+
+        step_items = [
+            StepStatusItem(
+                step_key=key,
+                step_label=STEP_LABELS[num],
+                status=step_statuses[key],
+            )
+            for num, key in STEP_NAMES.items()
+        ]
+
+        next_step = _recommend_next_step(s)
+
+        if s.overall_score is not None:
+            scores.append(s.overall_score)
+
+        texts.append(TextProgressItem(
+            story_slug=slug,
+            latest_session_id=s.id,
+            status=s.status,
+            steps=step_items,
+            completion_pct=completion_pct,
+            overall_score=s.overall_score,
+            accuracy=s.accuracy,
+            started_at=s.started_at,
+            completed_at=s.completed_at,
+            next_step=next_step,
+        ))
+
+    texts_completed = sum(1 for t in texts if t.status == "completed")
+    average_score = round(sum(scores) / len(scores), 1) if scores else None
+
+    logger.info(
+        "Progress for student %d: %d texts, %d completed",
+        student_id, len(texts), texts_completed,
+    )
+
+    return StudentProgressResponse(
+        student_id=student_id,
+        texts_attempted=len(texts),
+        texts_completed=texts_completed,
+        average_score=average_score,
+        texts=texts,
+    )
 
 
 @router.get(
@@ -1266,80 +1338,105 @@ def get_student_dashboard(
         longest_streak=longest_streak,
         daily_activity=daily_activity,
         completed_story_slugs=completed_story_slugs,
-    """Return per-text completion progress for a student.
+    )
 
-    Aggregates all learning sessions grouped by story_slug, keeping the
-    most-recent session per text to compute step completion status and
-    a rule-based next-step recommendation.
 
-    Access: student themselves, or a teacher of their classroom.
+
+# ── Sentence Practice (Issue #109) ──────────────────────────────────────────
+
+
+class ExampleSentencesRequest(BaseModel):
+    character: str = Field(..., min_length=1, max_length=1, description="The Chinese character to generate sentences for")
+    story_title: str = Field(..., min_length=1, max_length=100)
+
+
+class ExampleSentenceItem(BaseModel):
+    sentence: str
+    explanation: str
+
+
+class ExampleSentencesResponse(BaseModel):
+    sentences: list[ExampleSentenceItem]
+
+
+class ValidateSentenceRequest(BaseModel):
+    character: str = Field(..., min_length=1, max_length=1, description="The target character that must appear in the sentence")
+    student_sentence: str = Field(..., min_length=1, max_length=200, description="The student's composed sentence")
+    story_title: str = Field(..., min_length=1, max_length=100)
+
+
+class ValidateSentenceResponse(BaseModel):
+    is_correct: bool
+    feedback: str
+    suggestion: str
+
+
+@router.post(
+    "/learning/sentence-practice/example-sentences",
+    response_model=ExampleSentencesResponse,
+    dependencies=[Depends(ai_limit_10_per_min)],
+)
+async def get_example_sentences(
+    payload: ExampleSentencesRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Generate 2 AI example sentences for a vocabulary character.
+
+    Used in the sentence practice phase after stroke order practice (Issue #109).
+    Rate limited: 10 requests per minute per user/IP.
     """
-    _verify_student_access(student_id, current_user, db)
+    try:
+        result = await generate_example_sentences(
+            character=payload.character,
+            story_title=payload.story_title,
+        )
+    except TimeoutError:
+        raise HTTPException(status_code=503, detail="AI service timeout")
+    except Exception as e:
+        logger.error("Example sentence generation failed for char=%s: %s", payload.character, e)
+        raise HTTPException(status_code=503, detail="AI service unavailable")
 
-    sessions = (
-        db.query(LearningSession)
-        .filter(LearningSession.student_id == student_id)
-        .order_by(LearningSession.started_at.desc(), LearningSession.id.desc())
-        .all()
+    return ExampleSentencesResponse(
+        sentences=[ExampleSentenceItem(**s) for s in result.get("sentences", [])],
     )
 
-    # Keep only the most recent session per story_slug
-    seen: set[str] = set()
-    latest_per_text: list[LearningSession] = []
-    for s in sessions:
-        slug = s.story_slug or f"session-{s.id}"
-        if slug not in seen:
-            seen.add(slug)
-            latest_per_text.append(s)
 
-    texts: list[TextProgressItem] = []
-    scores: list[float] = []
+@router.post(
+    "/learning/sentence-practice/validate",
+    response_model=ValidateSentenceResponse,
+    dependencies=[Depends(ai_limit_10_per_min)],
+)
+async def validate_sentence(
+    payload: ValidateSentenceRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Validate a student's composed sentence for a vocabulary character.
 
-    for s in latest_per_text:
-        slug = s.story_slug or f"session-{s.id}"
-        step_statuses = _compute_step_completion(s)
-        completed_count = sum(1 for v in step_statuses.values() if v == "completed")
-        completion_pct = round(completed_count / 6 * 100)
+    Returns AI feedback on whether the sentence is grammatically correct
+    and uses the target character appropriately (Issue #109).
+    Rate limited: 10 requests per minute per user/IP.
+    """
+    # Basic check: target character must appear in the sentence
+    if payload.character not in payload.student_sentence:
+        return ValidateSentenceResponse(
+            is_correct=False,
+            feedback="你的句子裡沒有包含目標生字喔！",
+            suggestion=f"請記得在句子中使用「{payload.character}」這個字。",
+        )
 
-        step_items = [
-            StepStatusItem(
-                step_key=key,
-                step_label=STEP_LABELS[num],
-                status=step_statuses[key],
-            )
-            for num, key in STEP_NAMES.items()
-        ]
+    try:
+        result = await validate_student_sentence(
+            character=payload.character,
+            student_sentence=payload.student_sentence,
+            story_title=payload.story_title,
+        )
+    except TimeoutError:
+        raise HTTPException(status_code=503, detail="AI service timeout")
+    except Exception as e:
+        logger.error(
+            "Sentence validation failed for char=%s sentence=%s: %s",
+            payload.character, payload.student_sentence[:50], e,
+        )
+        raise HTTPException(status_code=503, detail="AI service unavailable")
 
-        next_step = _recommend_next_step(s)
-
-        if s.overall_score is not None:
-            scores.append(s.overall_score)
-
-        texts.append(TextProgressItem(
-            story_slug=slug,
-            latest_session_id=s.id,
-            status=s.status,
-            steps=step_items,
-            completion_pct=completion_pct,
-            overall_score=s.overall_score,
-            accuracy=s.accuracy,
-            started_at=s.started_at,
-            completed_at=s.completed_at,
-            next_step=next_step,
-        ))
-
-    texts_completed = sum(1 for t in texts if t.status == "completed")
-    average_score = round(sum(scores) / len(scores), 1) if scores else None
-
-    logger.info(
-        "Progress for student %d: %d texts, %d completed",
-        student_id, len(texts), texts_completed,
-    )
-
-    return StudentProgressResponse(
-        student_id=student_id,
-        texts_attempted=len(texts),
-        texts_completed=texts_completed,
-        average_score=average_score,
-        texts=texts,
-    )
+    return ValidateSentenceResponse(**result)

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -428,3 +428,138 @@ async def grade_exit_ticket(question: str, student_answer: str, reference_text: 
     """
     # TODO: implement with Gemini API (Step 6)
     return {"score": 0, "feedback": "批改功能尚未實作"}
+
+
+# ── Sentence Practice (Issue #109) ──────────────────────────────────────────
+
+EXAMPLE_SENTENCES_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "sentences": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "sentence": {"type": "string"},
+                    "explanation": {"type": "string"},
+                },
+                "required": ["sentence", "explanation"],
+            },
+            "minItems": 2,
+            "maxItems": 2,
+        }
+    },
+    "required": ["sentences"],
+}
+
+SENTENCE_VALIDATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "is_correct": {"type": "boolean"},
+        "feedback": {"type": "string"},
+        "suggestion": {"type": "string"},
+    },
+    "required": ["is_correct", "feedback", "suggestion"],
+}
+
+
+async def generate_example_sentences(character: str, story_title: str) -> dict:
+    """Generate 2 example sentences for a Chinese character.
+
+    Returns {"sentences": [{"sentence": str, "explanation": str}, ...]}
+    Each sentence uses the target character in a contextually appropriate way
+    suited for elementary/middle school students.
+    """
+    safe_char = sanitize_ai_input(character)
+    safe_title = sanitize_ai_input(story_title)
+
+    system_prompt = f"""{TUTOR_PERSONA}
+
+你是一位專業的國語文教師，請為學生示範如何使用生字造句。
+
+目標生字：「{safe_char}」
+課文名稱：《{safe_title}》
+
+請造 2 個包含目標生字的例句，要求：
+1. 符合國小高年級～國中的語文程度
+2. 句子自然流暢，生動有趣
+3. 幫助學生理解這個字的用法
+4. 用繁體中文（zh-TW）
+
+請以 JSON 格式輸出，包含 sentences 陣列，每個元素有：
+- sentence（例句）
+- explanation（簡短說明這個字在句中的意思）"""
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[genai_types.Part(text=f"請為生字「{safe_char}」造兩個例句。")],
+        )
+    ]
+
+    result = await generate_structured_response(
+        system_prompt=system_prompt,
+        contents=contents,
+        response_schema=EXAMPLE_SENTENCES_SCHEMA,
+        max_tokens=512,
+        temperature=0.8,
+    )
+    return result
+
+
+async def validate_student_sentence(
+    character: str,
+    student_sentence: str,
+    story_title: str,
+) -> dict:
+    """Validate a student's sentence for a given character.
+
+    Returns {"is_correct": bool, "feedback": str, "suggestion": str}
+    - is_correct: True if grammatically correct and uses the character appropriately
+    - feedback: encouraging feedback message (in Chinese)
+    - suggestion: improvement hint if not correct (empty string if correct)
+    """
+    safe_char = sanitize_ai_input(character)
+    safe_sentence = sanitize_ai_input(student_sentence)
+    safe_title = sanitize_ai_input(story_title)
+
+    system_prompt = f"""{TUTOR_PERSONA}
+
+你是一位親切的國語文老師，正在批改學生的造句練習。
+
+目標生字：「{safe_char}」
+課文：《{safe_title}》
+
+評估標準：
+1. 句子是否包含目標生字「{safe_char}」
+2. 句子是否語法正確、語意通順
+3. 目標生字的用法是否恰當
+4. 適合國小高年級～國中程度
+
+請給予鼓勵性的評語，用繁體中文（zh-TW）回覆。
+- 若造句正確：is_correct=true，給予鼓勵
+- 若有問題：is_correct=false，指出問題並提供改進建議
+
+注意：只要學生的句子基本語法正確、有使用目標生字，就算通過。
+不要過度嚴格，給予適度的鼓勵。"""
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[genai_types.Part(text=f"學生的造句：「{safe_sentence}」\n請評估這個造句是否正確。")],
+        )
+    ]
+
+    result = await generate_structured_response(
+        system_prompt=system_prompt,
+        contents=contents,
+        response_schema=SENTENCE_VALIDATION_SCHEMA,
+        max_tokens=256,
+        temperature=0.3,
+    )
+
+    # Ensure suggestion is empty string if correct
+    if result.get("is_correct") and not result.get("suggestion"):
+        result["suggestion"] = ""
+
+    return result

--- a/backend/tests/test_sentence_practice.py
+++ b/backend/tests/test_sentence_practice.py
@@ -1,0 +1,313 @@
+"""
+Tests for sentence practice API endpoints (Issue #109).
+
+Covers:
+- POST /api/learning/sentence-practice/example-sentences
+- POST /api/learning/sentence-practice/validate
+
+Uses SQLite in-memory DB. AI calls are mocked via unittest.mock.
+
+Run with:
+    cd /Users/young/project/chinese-literacy-platform-issue-109/backend
+    python -m pytest tests/test_sentence_practice.py -v
+"""
+
+import sys
+import os
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "org_owner", "display_name": "Org Owner", "scope_level": "organization"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+]
+
+
+@pytest.fixture(scope="module")
+def db_engine():
+    Base.metadata.create_all(bind=engine)
+    with engine.begin() as conn:
+        for role_data in SEED_ROLES:
+            conn.execute(
+                Role.__table__.insert().prefix_with("OR IGNORE"),
+                role_data,
+            )
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def db_session(db_engine):
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture
+def client(db_session):
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_student_and_login(client: TestClient) -> str:
+    """Register a student and return JWT token."""
+    import uuid
+    email = f"student_{uuid.uuid4().hex[:8]}@test.com"
+    password = "TestPass123!"
+
+    res = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": "Test Student",
+        "role": "student",
+        "copyright_confirmed": True,
+    })
+    assert res.status_code in (200, 201), f"Register failed: {res.text}"
+
+    login_res = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_res.status_code == 200, f"Login failed: {login_res.text}"
+    return login_res.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: example-sentences endpoint
+# ---------------------------------------------------------------------------
+
+class TestExampleSentences:
+    def test_example_sentences_returns_two_sentences(self, client: TestClient):
+        """Endpoint returns exactly 2 example sentences for a valid character."""
+        token = _create_student_and_login(client)
+        mock_result = {
+            "sentences": [
+                {"sentence": "老師講述這個故事的來源。", "explanation": "來源：事物的起點或出處"},
+                {"sentence": "這首歌的靈感來源於童年。", "explanation": "來源：靈感的起點"},
+            ]
+        }
+        with patch(
+            "app.routes.learning.generate_example_sentences",
+            new=AsyncMock(return_value=mock_result),
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/example-sentences",
+                json={"character": "源", "story_title": "測試課文"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 200
+        data = res.json()
+        assert "sentences" in data
+        assert len(data["sentences"]) == 2
+        for s in data["sentences"]:
+            assert "sentence" in s
+            assert "explanation" in s
+
+    def test_example_sentences_requires_auth(self, client: TestClient):
+        """Without auth token, endpoint returns 401 or 403."""
+        with patch(
+            "app.routes.learning.generate_example_sentences",
+            new=AsyncMock(return_value={"sentences": []}),
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/example-sentences",
+                json={"character": "水", "story_title": "課文"},
+            )
+        assert res.status_code in (401, 403)
+
+    def test_example_sentences_rejects_multi_char(self, client: TestClient):
+        """Endpoint rejects character field with more than 1 character."""
+        token = _create_student_and_login(client)
+        res = client.post(
+            "/api/learning/sentence-practice/example-sentences",
+            json={"character": "多字", "story_title": "課文"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert res.status_code == 422
+
+    def test_example_sentences_handles_ai_timeout(self, client: TestClient):
+        """Returns 503 when AI service times out."""
+        token = _create_student_and_login(client)
+        with patch(
+            "app.routes.learning.generate_example_sentences",
+            new=AsyncMock(side_effect=TimeoutError("AI timeout")),
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/example-sentences",
+                json={"character": "水", "story_title": "課文"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Tests: validate endpoint
+# ---------------------------------------------------------------------------
+
+class TestValidateSentence:
+    def test_validate_correct_sentence(self, client: TestClient):
+        """Returns is_correct=True for a grammatically correct sentence."""
+        token = _create_student_and_login(client)
+        mock_result = {
+            "is_correct": True,
+            "feedback": "造句非常好！",
+            "suggestion": "",
+        }
+        with patch(
+            "app.routes.learning.validate_student_sentence",
+            new=AsyncMock(return_value=mock_result),
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/validate",
+                json={
+                    "character": "水",
+                    "student_sentence": "我每天喝很多水保持健康。",
+                    "story_title": "課文",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["is_correct"] is True
+        assert data["feedback"] != ""
+        assert data["suggestion"] == ""
+
+    def test_validate_sentence_missing_target_char(self, client: TestClient):
+        """Returns is_correct=False without calling AI when char not in sentence."""
+        token = _create_student_and_login(client)
+        with patch(
+            "app.routes.learning.validate_student_sentence",
+            new=AsyncMock(return_value={"is_correct": True, "feedback": "", "suggestion": ""}),
+        ) as mock_ai:
+            res = client.post(
+                "/api/learning/sentence-practice/validate",
+                json={
+                    "character": "水",
+                    "student_sentence": "我每天都很快樂。",  # 沒有包含「水」
+                    "story_title": "課文",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            # AI should NOT be called for this pre-validation failure
+            mock_ai.assert_not_called()
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["is_correct"] is False
+        assert "水" in data["suggestion"]
+
+    def test_validate_incorrect_sentence(self, client: TestClient):
+        """Returns is_correct=False with feedback for an incorrect sentence."""
+        token = _create_student_and_login(client)
+        mock_result = {
+            "is_correct": False,
+            "feedback": "句子語法有點問題，請再修改看看。",
+            "suggestion": "試試：「這杯水很清涼。」",
+        }
+        with patch(
+            "app.routes.learning.validate_student_sentence",
+            new=AsyncMock(return_value=mock_result),
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/validate",
+                json={
+                    "character": "水",
+                    "student_sentence": "水 是 好",
+                    "story_title": "課文",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 200
+        data = res.json()
+        assert data["is_correct"] is False
+        assert data["feedback"] != ""
+        assert data["suggestion"] != ""
+
+    def test_validate_requires_auth(self, client: TestClient):
+        """Without auth token, endpoint returns 401 or 403."""
+        res = client.post(
+            "/api/learning/sentence-practice/validate",
+            json={
+                "character": "水",
+                "student_sentence": "我喝水。",
+                "story_title": "課文",
+            },
+        )
+        assert res.status_code in (401, 403)
+
+    def test_validate_rejects_empty_sentence(self, client: TestClient):
+        """Endpoint rejects empty student_sentence."""
+        token = _create_student_and_login(client)
+        res = client.post(
+            "/api/learning/sentence-practice/validate",
+            json={
+                "character": "水",
+                "student_sentence": "",
+                "story_title": "課文",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert res.status_code == 422
+
+    def test_validate_handles_ai_error(self, client: TestClient):
+        """Returns 503 when AI service encounters an error."""
+        token = _create_student_and_login(client)
+        with patch(
+            "app.routes.learning.validate_student_sentence",
+            new=AsyncMock(side_effect=Exception("AI error")),
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/validate",
+                json={
+                    "character": "水",
+                    "student_sentence": "我每天喝水保持健康。",
+                    "story_title": "課文",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 503

--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -1,0 +1,509 @@
+/**
+ * SentencePractice — Issue #109
+ *
+ * After stroke order practice, students compose 2 sentences using each
+ * practiced vocabulary character. AI validates grammar and word usage.
+ */
+import React, { useState, useCallback } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+interface ExampleSentence {
+  sentence: string;
+  explanation: string;
+}
+
+type SentenceStatus = 'idle' | 'loading' | 'correct' | 'incorrect';
+
+interface SentenceEntry {
+  text: string;
+  status: SentenceStatus;
+  feedback: string;
+  suggestion: string;
+}
+
+interface CharacterPracticeState {
+  exampleSentences: ExampleSentence[] | null;
+  examplesLoading: boolean;
+  examplesError: string;
+  sentences: [SentenceEntry, SentenceEntry];
+  allCorrect: boolean;
+}
+
+function makeSentenceEntry(): SentenceEntry {
+  return { text: '', status: 'idle', feedback: '', suggestion: '' };
+}
+
+function makeCharState(): CharacterPracticeState {
+  return {
+    exampleSentences: null,
+    examplesLoading: false,
+    examplesError: '',
+    sentences: [makeSentenceEntry(), makeSentenceEntry()],
+    allCorrect: false,
+  };
+}
+
+// ── API helpers ───────────────────────────────────────────────────────────
+
+async function fetchExampleSentences(
+  character: string,
+  storyTitle: string,
+  token: string | null,
+): Promise<ExampleSentence[]> {
+  const res = await fetch(`${API_BASE}/api/learning/sentence-practice/example-sentences`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ character, story_title: storyTitle }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = await res.json();
+  return data.sentences as ExampleSentence[];
+}
+
+async function validateSentence(
+  character: string,
+  studentSentence: string,
+  storyTitle: string,
+  token: string | null,
+): Promise<{ is_correct: boolean; feedback: string; suggestion: string }> {
+  const res = await fetch(`${API_BASE}/api/learning/sentence-practice/validate`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({
+      character,
+      student_sentence: studentSentence,
+      story_title: storyTitle,
+    }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+// ── Highlight target character in a sentence ──────────────────────────────
+
+function HighlightedSentence({ sentence, target }: { sentence: string; target: string }) {
+  const parts = sentence.split(target);
+  return (
+    <span>
+      {parts.map((part, i) => (
+        <React.Fragment key={i}>
+          {part}
+          {i < parts.length - 1 && (
+            <span className="text-accent font-bold underline underline-offset-2">{target}</span>
+          )}
+        </React.Fragment>
+      ))}
+    </span>
+  );
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────
+
+interface SentencePracticeProps {
+  /** Characters the student completed stroke order practice for */
+  practicedChars: string[];
+  storyTitle: string;
+  onFinish: () => void;
+  onBack: () => void;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────
+
+const SentencePractice: React.FC<SentencePracticeProps> = ({
+  practicedChars,
+  storyTitle,
+  onFinish,
+  onBack,
+}) => {
+  const { token } = useAuth();
+  const [currentCharIndex, setCurrentCharIndex] = useState(0);
+  const [charStates, setCharStates] = useState<Record<string, CharacterPracticeState>>(() => {
+    const init: Record<string, CharacterPracticeState> = {};
+    for (const ch of practicedChars) {
+      init[ch] = makeCharState();
+    }
+    return init;
+  });
+  const [completedChars, setCompletedChars] = useState<Set<string>>(new Set());
+
+  const currentChar = practicedChars[currentCharIndex] ?? '';
+  const currentState = charStates[currentChar] ?? makeCharState();
+
+  // ── Load example sentences for current character ──────────────────────
+
+  const loadExamples = useCallback(async () => {
+    if (!currentChar) return;
+    if (charStates[currentChar]?.exampleSentences) return; // already loaded
+
+    setCharStates(prev => ({
+      ...prev,
+      [currentChar]: { ...prev[currentChar], examplesLoading: true, examplesError: '' },
+    }));
+
+    try {
+      const examples = await fetchExampleSentences(currentChar, storyTitle, token);
+      setCharStates(prev => ({
+        ...prev,
+        [currentChar]: { ...prev[currentChar], examplesLoading: false, exampleSentences: examples },
+      }));
+    } catch {
+      setCharStates(prev => ({
+        ...prev,
+        [currentChar]: {
+          ...prev[currentChar],
+          examplesLoading: false,
+          examplesError: '例句載入失敗，請稍後再試。',
+        },
+      }));
+    }
+  }, [currentChar, charStates, storyTitle]);
+
+  // Auto-load examples when we navigate to a character
+  React.useEffect(() => {
+    loadExamples();
+  }, [loadExamples]);
+
+  // ── Update sentence text ──────────────────────────────────────────────
+
+  const updateSentenceText = useCallback(
+    (sentenceIndex: 0 | 1, text: string) => {
+      setCharStates(prev => {
+        const state = prev[currentChar];
+        const updated: [SentenceEntry, SentenceEntry] = [
+          { ...state.sentences[0] },
+          { ...state.sentences[1] },
+        ];
+        updated[sentenceIndex] = { ...updated[sentenceIndex], text, status: 'idle', feedback: '', suggestion: '' };
+        return { ...prev, [currentChar]: { ...state, sentences: updated } };
+      });
+    },
+    [currentChar],
+  );
+
+  // ── Validate a sentence ──────────────────────────────────────────────
+
+  const handleValidate = useCallback(
+    async (sentenceIndex: 0 | 1) => {
+      const sentence = currentState.sentences[sentenceIndex];
+      if (!sentence.text.trim()) return;
+
+      // Set loading state
+      setCharStates(prev => {
+        const state = prev[currentChar];
+        const updated: [SentenceEntry, SentenceEntry] = [
+          { ...state.sentences[0] },
+          { ...state.sentences[1] },
+        ];
+        updated[sentenceIndex] = { ...updated[sentenceIndex], status: 'loading' };
+        return { ...prev, [currentChar]: { ...state, sentences: updated } };
+      });
+
+      try {
+        const result = await validateSentence(currentChar, sentence.text.trim(), storyTitle, token);
+        setCharStates(prev => {
+          const state = prev[currentChar];
+          const updated: [SentenceEntry, SentenceEntry] = [
+            { ...state.sentences[0] },
+            { ...state.sentences[1] },
+          ];
+          updated[sentenceIndex] = {
+            ...updated[sentenceIndex],
+            status: result.is_correct ? 'correct' : 'incorrect',
+            feedback: result.feedback,
+            suggestion: result.suggestion,
+          };
+          const bothCorrect = updated[0].status === 'correct' && updated[1].status === 'correct';
+          return {
+            ...prev,
+            [currentChar]: { ...state, sentences: updated, allCorrect: bothCorrect },
+          };
+        });
+      } catch {
+        setCharStates(prev => {
+          const state = prev[currentChar];
+          const updated: [SentenceEntry, SentenceEntry] = [
+            { ...state.sentences[0] },
+            { ...state.sentences[1] },
+          ];
+          updated[sentenceIndex] = {
+            ...updated[sentenceIndex],
+            status: 'incorrect',
+            feedback: '評估失敗，請再試一次。',
+            suggestion: '',
+          };
+          return { ...prev, [currentChar]: { ...state, sentences: updated } };
+        });
+      }
+    },
+    [currentChar, currentState, storyTitle],
+  );
+
+  // ── Navigation ────────────────────────────────────────────────────────
+
+  const handleCompleteCurrentChar = () => {
+    setCompletedChars(prev => new Set(prev).add(currentChar));
+    if (currentCharIndex < practicedChars.length - 1) {
+      setCurrentCharIndex(i => i + 1);
+    }
+  };
+
+  const handleFinish = () => {
+    onFinish();
+  };
+
+  // ── Early exit: no practiced chars ───────────────────────────────────
+
+  if (practicedChars.length === 0) {
+    return (
+      <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden">
+        <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 text-xs text-gray-600">
+          {storyTitle} — 造句練習
+        </div>
+        <div className="flex-1 flex flex-col items-center justify-center text-center px-6 py-12">
+          <p className="text-gray-500 text-sm mb-6">沒有需要造句練習的生字。</p>
+          <button
+            onClick={onFinish}
+            className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95"
+          >
+            繼續
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const allCharsDone = practicedChars.every(ch => completedChars.has(ch));
+  const isCurrentDone = completedChars.has(currentChar);
+  const currentAllCorrect = currentState.allCorrect;
+
+  return (
+    <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden" style={{ fontFamily: "'Iansui', 'Noto Sans TC', sans-serif" }}>
+
+      {/* Tab bar */}
+      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
+        <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
+          {storyTitle} — 造句練習
+        </div>
+        <div className="flex-1" />
+        <span className="text-[10px] text-gray-500">
+          {currentCharIndex + 1} / {practicedChars.length} 字
+        </span>
+      </div>
+
+      {/* Character tab nav */}
+      {practicedChars.length > 1 && (
+        <div className="bg-white border-b border-gray-100 px-4 py-2 flex gap-2 overflow-x-auto shrink-0">
+          {practicedChars.map((ch, i) => {
+            const done = completedChars.has(ch);
+            const active = i === currentCharIndex;
+            return (
+              <button
+                key={ch}
+                onClick={() => setCurrentCharIndex(i)}
+                className={[
+                  'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all',
+                  active
+                    ? 'bg-accent text-white shadow'
+                    : done
+                      ? 'bg-emerald-100 text-emerald-700'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+                ].join(' ')}
+              >
+                {ch}
+                {done && (
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Main content */}
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        <div className="max-w-2xl mx-auto space-y-6">
+
+          {/* Header */}
+          <div>
+            <h2 className="text-xl font-black text-gray-900 mb-1">
+              造句練習
+              <span className="ml-3 text-4xl text-accent">{currentChar}</span>
+            </h2>
+            <p className="text-sm text-gray-600">
+              用「{currentChar}」造兩個句子，讓 AI 幫你批改。
+            </p>
+          </div>
+
+          {/* Example sentences panel */}
+          <div className="bg-white rounded-2xl border border-gray-200 p-4">
+            <div className="flex items-center gap-2 mb-3">
+              <span className="text-xs font-bold text-gray-500 uppercase tracking-wider">AI 例句示範</span>
+            </div>
+
+            {currentState.examplesLoading && (
+              <div className="flex items-center gap-2 text-sm text-gray-500">
+                <svg className="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                AI 正在生成例句...
+              </div>
+            )}
+
+            {currentState.examplesError && (
+              <div className="text-sm text-red-600">
+                {currentState.examplesError}
+                <button onClick={loadExamples} className="ml-2 text-accent underline">重試</button>
+              </div>
+            )}
+
+            {currentState.exampleSentences && (
+              <div className="space-y-3">
+                {currentState.exampleSentences.map((ex, i) => (
+                  <div key={i} className="bg-amber-50 rounded-xl p-3">
+                    <p className="text-base text-gray-800 leading-relaxed">
+                      <HighlightedSentence sentence={ex.sentence} target={currentChar} />
+                    </p>
+                    <p className="text-xs text-gray-500 mt-1">{ex.explanation}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Student sentence inputs */}
+          <div className="space-y-4">
+            {([0, 1] as const).map(idx => {
+              const entry = currentState.sentences[idx];
+              return (
+                <div key={idx} className="bg-white rounded-2xl border border-gray-200 p-4">
+                  <label className="text-xs font-bold text-gray-500 uppercase tracking-wider block mb-2">
+                    第 {idx + 1} 句
+                  </label>
+
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={entry.text}
+                      onChange={e => updateSentenceText(idx, e.target.value)}
+                      onKeyDown={e => {
+                        if (e.key === 'Enter' && entry.text.trim()) {
+                          handleValidate(idx);
+                        }
+                      }}
+                      disabled={entry.status === 'loading' || isCurrentDone}
+                      placeholder={`用「${currentChar}」造一個句子…`}
+                      className={[
+                        'flex-1 rounded-xl border px-3 py-2 text-base outline-none transition-all',
+                        entry.status === 'correct'
+                          ? 'border-emerald-400 bg-emerald-50 text-emerald-900'
+                          : entry.status === 'incorrect'
+                            ? 'border-red-300 bg-red-50 text-red-900'
+                            : 'border-gray-200 bg-gray-50 focus:border-accent focus:bg-white text-gray-800',
+                      ].join(' ')}
+                    />
+                    <button
+                      onClick={() => handleValidate(idx)}
+                      disabled={!entry.text.trim() || entry.status === 'loading' || isCurrentDone}
+                      className={[
+                        'px-4 py-2 rounded-xl text-sm font-bold transition-all active:scale-95',
+                        entry.status === 'loading'
+                          ? 'bg-gray-200 text-gray-500 cursor-wait'
+                          : entry.status === 'correct'
+                            ? 'bg-emerald-500 text-white'
+                            : 'bg-accent hover:bg-accent-hover text-white disabled:opacity-40 disabled:cursor-not-allowed',
+                      ].join(' ')}
+                    >
+                      {entry.status === 'loading' ? (
+                        <svg className="w-4 h-4 animate-spin" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                      ) : entry.status === 'correct' ? '通過' : '批改'}
+                    </button>
+                  </div>
+
+                  {/* Feedback */}
+                  {(entry.status === 'correct' || entry.status === 'incorrect') && (
+                    <div className={[
+                      'mt-3 rounded-xl px-3 py-2 text-sm',
+                      entry.status === 'correct'
+                        ? 'bg-emerald-50 text-emerald-800'
+                        : 'bg-red-50 text-red-800',
+                    ].join(' ')}>
+                      <p className="font-medium">{entry.feedback}</p>
+                      {entry.suggestion && (
+                        <p className="mt-1 text-xs opacity-80">{entry.suggestion}</p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Completion message for current char */}
+          {currentAllCorrect && !isCurrentDone && (
+            <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center">
+              <p className="text-emerald-800 font-bold text-lg">「{currentChar}」造句全部正確！</p>
+              {currentCharIndex < practicedChars.length - 1 ? (
+                <button
+                  onClick={handleCompleteCurrentChar}
+                  className="mt-3 px-6 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold transition-all active:scale-95"
+                >
+                  繼續下一個字
+                </button>
+              ) : (
+                <button
+                  onClick={() => { handleCompleteCurrentChar(); }}
+                  className="mt-3 px-6 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold transition-all active:scale-95"
+                >
+                  完成所有造句
+                </button>
+              )}
+            </div>
+          )}
+
+          {isCurrentDone && (
+            <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-3 text-center">
+              <p className="text-emerald-700 text-sm font-medium">「{currentChar}」已完成</p>
+            </div>
+          )}
+
+        </div>
+      </div>
+
+      {/* Bottom actions */}
+      <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
+        <button
+          onClick={onBack}
+          className="px-4 py-3 rounded-xl text-base text-gray-600 hover:text-gray-800 transition-colors"
+        >
+          回到生字練習
+        </button>
+        <button
+          onClick={handleFinish}
+          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
+        >
+          {allCharsDone ? '完成，查看報告' : '跳過，查看報告'}
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+
+    </div>
+  );
+};
+
+export default SentencePractice;

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -4,6 +4,7 @@ import { Story, ReadingAttempt, VocabResult } from '../../types';
 import { hasStrokeData } from '../stroke-order/strokeData';
 import WriteCharacter from '../stroke-order/WriteCharacter';
 import PronunciationPractice from './PronunciationPractice';
+import SentencePractice from './SentencePractice';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
 import RadicalDecomposition from './RadicalDecomposition';
@@ -17,7 +18,7 @@ interface VocabPracticeProps {
   onBack: () => void;
 }
 
-type Phase = 'grid' | 'practice' | 'pronunciation';
+type Phase = 'grid' | 'practice' | 'pronunciation' | 'sentence';
 
 type PracticeMode = 'stroke' | 'pronunciation';
 
@@ -237,6 +238,18 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
         character={practicingChar}
         onComplete={handlePracticeComplete}
         onBack={handlePracticeBack}
+      />
+    );
+  }
+
+  /* ── Sentence phase: compose sentences after stroke practice ── */
+  if (phase === 'sentence') {
+    return (
+      <SentencePractice
+        practicedChars={Array.from(practicedChars)}
+        storyTitle={story.title}
+        onFinish={() => onFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
+        onBack={() => setPhase('grid')}
       />
     );
   }
@@ -531,6 +544,20 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
             </div>
           )}
 
+          {/* Sentence practice prompt when all done */}
+          {allDone && (
+            <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center">
+              <p className="text-emerald-800 font-bold mb-2">太棒了！所有生字都練習完了！</p>
+              <p className="text-emerald-700 text-sm mb-3">接下來，試著用這些生字各造兩個句子吧！</p>
+              <button
+                onClick={() => setPhase('sentence')}
+                className="px-6 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-sm transition-all active:scale-95"
+              >
+                開始造句練習
+              </button>
+            </div>
+          )}
+
           {allDone && (
             <CompletionBanner
               count={practicedChars.size}
@@ -548,15 +575,25 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
         >
           回到朗讀
         </button>
-        <button
-          onClick={() => onFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
-          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
-        >
-          {practicedChars.size > 0 || pronouncedChars.size > 0 ? '完成，查看報告' : '跳過，查看報告'}
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-          </svg>
-        </button>
+        <div className="flex items-center gap-3">
+          {practicedChars.size > 0 && !allDone && (
+            <button
+              onClick={() => setPhase('sentence')}
+              className="px-5 py-3 rounded-xl font-bold text-base border border-accent text-accent hover:bg-accent/10 transition-all active:scale-95"
+            >
+              造句練習
+            </button>
+          )}
+          <button
+            onClick={() => onFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
+            className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
+          >
+            {practicedChars.size > 0 || pronouncedChars.size > 0 ? '完成，查看報告' : '跳過，查看報告'}
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #109

## Summary

- Adds AI-powered sentence composition practice after stroke order training
- For each practiced vocabulary character, students write 2 sentences
- Gemini AI generates 2 example sentences with the target character highlighted
- AI validates student sentences for grammar correctness and proper word usage
- Encouraging feedback with improvement suggestions for incorrect sentences

## Changes

### Backend
- `ai_service.py`: `generate_example_sentences()` + `validate_student_sentence()` using gemini-2.5-flash
- `learning.py`: 2 new endpoints — `POST /api/learning/sentence-practice/example-sentences` and `POST /api/learning/sentence-practice/validate`, rate-limited at 10/min

### Frontend
- New `SentencePractice.tsx` component with:
  - AI example sentences panel (auto-loaded per character)
  - 2 text inputs for student sentences
  - Per-sentence AI validation with color-coded feedback
  - Character tab navigation for multi-character practice
- `VocabPractice.tsx` updated to include `SentencePractice` phase after stroke grid

### Tests
- 10 backend tests in `test_sentence_practice.py` (all passing)
  - Auth enforcement, character validation, missing char pre-check
  - AI timeout/error handling, mock-based AI responses

## Test plan

1. Open a story and complete the read-aloud step (or skip)
2. Go to 生字練習 (VocabPractice)
3. Practice stroke order for at least one character
4. When "太棒了！所有生字都練習完了！" appears, click "開始造句練習"
5. Verify AI example sentences load for the character
6. Type a sentence containing the target character and click "批改"
7. Verify correct sentences show green feedback
8. Type a sentence WITHOUT the target character — should immediately fail without calling AI
9. Complete 2 correct sentences and verify "完成" flow