### PR TITLE
ci: add dependency security scanning with npm audit + pip-audit (Fixes #273)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,214 @@
+name: Dependency Security Audit
+
+on:
+  pull_request:
+    branches: [staging, main]
+  schedule:
+    # Every Monday at 09:00 UTC (17:00 Taiwan time)
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  npm-audit:
+    name: npm audit (frontend)
+    runs-on: ubuntu-latest
+    outputs:
+      has_vulnerabilities: ${{ steps.audit.outputs.has_vulnerabilities }}
+      audit_summary: ${{ steps.audit.outputs.audit_summary }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run npm audit
+        id: audit
+        working-directory: frontend
+        run: |
+          set +e
+          # Run audit and capture output; --audit-level=high blocks on High+Critical
+          AUDIT_OUTPUT=$(npm audit --audit-level=high --json 2>&1)
+          AUDIT_EXIT=$?
+          set -e
+
+          # Parse summary from JSON
+          VULN_COUNT=$(echo "$AUDIT_OUTPUT" | jq -r '.metadata.vulnerabilities | (.high // 0) + (.critical // 0)' 2>/dev/null || echo "0")
+          TOTAL_COUNT=$(echo "$AUDIT_OUTPUT" | jq -r '.metadata.vulnerabilities | (.info // 0) + (.low // 0) + (.moderate // 0) + (.high // 0) + (.critical // 0)' 2>/dev/null || echo "0")
+
+          if [ "$AUDIT_EXIT" -ne 0 ]; then
+            echo "has_vulnerabilities=true" >> "$GITHUB_OUTPUT"
+            SUMMARY="npm audit found High/Critical vulnerabilities (total issues: $TOTAL_COUNT, high+critical: $VULN_COUNT)"
+          else
+            echo "has_vulnerabilities=false" >> "$GITHUB_OUTPUT"
+            SUMMARY="npm audit passed (total issues: $TOTAL_COUNT, no High/Critical found)"
+          fi
+
+          echo "audit_summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+
+          # Save full output for report job
+          echo "$AUDIT_OUTPUT" > /tmp/npm-audit-output.json
+
+          # Print human-readable output
+          npm audit --audit-level=high 2>&1 || true
+
+          # Exit with original code to fail the job if high/critical found
+          exit $AUDIT_EXIT
+
+      - name: Upload npm audit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-results
+          path: /tmp/npm-audit-output.json
+          retention-days: 30
+
+  pip-audit:
+    name: pip-audit (backend)
+    runs-on: ubuntu-latest
+    outputs:
+      has_vulnerabilities: ${{ steps.audit.outputs.has_vulnerabilities }}
+      audit_summary: ${{ steps.audit.outputs.audit_summary }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Run pip-audit
+        id: audit
+        run: |
+          set +e
+          # Run audit and capture output in JSON format
+          AUDIT_OUTPUT=$(pip-audit -r backend/requirements.txt --format json 2>&1)
+          AUDIT_EXIT=$?
+          set -e
+
+          # Parse vulnerability count
+          VULN_COUNT=$(echo "$AUDIT_OUTPUT" | jq -r '[.[] | select(.vulns | length > 0)] | length' 2>/dev/null || echo "0")
+
+          if [ "$AUDIT_EXIT" -ne 0 ]; then
+            echo "has_vulnerabilities=true" >> "$GITHUB_OUTPUT"
+            SUMMARY="pip-audit found $VULN_COUNT vulnerable package(s)"
+          else
+            echo "has_vulnerabilities=false" >> "$GITHUB_OUTPUT"
+            SUMMARY="pip-audit passed (no known vulnerabilities found)"
+          fi
+
+          echo "audit_summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+
+          # Save JSON output for report job
+          echo "$AUDIT_OUTPUT" > /tmp/pip-audit-output.json
+
+          # Print human-readable output
+          pip-audit -r backend/requirements.txt 2>&1 || true
+
+          exit $AUDIT_EXIT
+
+      - name: Upload pip-audit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pip-audit-results
+          path: /tmp/pip-audit-output.json
+          retention-days: 30
+
+  report:
+    name: Report vulnerabilities
+    runs-on: ubuntu-latest
+    needs: [npm-audit, pip-audit]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - name: Download npm audit results
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-audit-results
+          path: /tmp/artifacts/npm
+        continue-on-error: true
+
+      - name: Download pip-audit results
+        uses: actions/download-artifact@v4
+        with:
+          name: pip-audit-results
+          path: /tmp/artifacts/pip
+        continue-on-error: true
+
+      - name: Compose PR comment
+        id: compose
+        run: |
+          NPM_STATUS="${{ needs.npm-audit.result }}"
+          PIP_STATUS="${{ needs.pip-audit.result }}"
+          NPM_SUMMARY="${{ needs.npm-audit.outputs.audit_summary }}"
+          PIP_SUMMARY="${{ needs.pip-audit.outputs.audit_summary }}"
+
+          if [ "$NPM_STATUS" = "success" ]; then
+            NPM_ICON=":white_check_mark:"
+          else
+            NPM_ICON=":x:"
+          fi
+
+          if [ "$PIP_STATUS" = "success" ]; then
+            PIP_ICON=":white_check_mark:"
+          else
+            PIP_ICON=":x:"
+          fi
+
+          OVERALL_STATUS="passed"
+          if [ "$NPM_STATUS" != "success" ] || [ "$PIP_STATUS" != "success" ]; then
+            OVERALL_STATUS="found vulnerabilities"
+          fi
+
+          BODY="## :shield: Dependency Security Audit
+
+          Scan $OVERALL_STATUS. See details below.
+
+          | Tool | Status | Summary |
+          |------|--------|---------|
+          | npm audit (frontend) | $NPM_ICON | $NPM_SUMMARY |
+          | pip-audit (backend) | $PIP_ICON | $PIP_SUMMARY |
+
+          <details>
+          <summary>npm audit JSON output</summary>
+
+          \`\`\`json
+          $(cat /tmp/artifacts/npm/npm-audit-output.json 2>/dev/null | head -100 || echo 'No output available')
+          \`\`\`
+          </details>
+
+          <details>
+          <summary>pip-audit JSON output</summary>
+
+          \`\`\`json
+          $(cat /tmp/artifacts/pip/pip-audit-output.json 2>/dev/null | head -100 || echo 'No output available')
+          \`\`\`
+          </details>
+
+          > Audit run at: $(date -u '+%Y-%m-%d %H:%M UTC')"
+
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: security-audit
+          message: ${{ steps.compose.outputs.body }}

--- a/scripts/security-check.sh
+++ b/scripts/security-check.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# scripts/security-check.sh
+# Local dependency security scan: runs npm audit + pip-audit and prints a summary.
+# Usage: bash scripts/security-check.sh [--fail-on-vuln]
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAIL_ON_VULN=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --fail-on-vuln) FAIL_ON_VULN=true ;;
+  esac
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+NPM_STATUS="skipped"
+PIP_STATUS="skipped"
+
+echo ""
+echo -e "${BLUE}=== LingoLeap Dependency Security Check ===${NC}"
+echo ""
+
+# ── npm audit ─────────────────────────────────────────────────────────────────
+echo -e "${BLUE}[1/2] npm audit (frontend)${NC}"
+
+if ! command -v npm &>/dev/null; then
+  echo -e "${YELLOW}  npm not found — skipping frontend audit${NC}"
+else
+  if [ ! -f "$REPO_ROOT/frontend/package-lock.json" ]; then
+    echo -e "${YELLOW}  package-lock.json missing — run 'npm install' in frontend/ first${NC}"
+    NPM_STATUS="skipped"
+  else
+    pushd "$REPO_ROOT/frontend" > /dev/null
+    set +e
+    npm audit --audit-level=high 2>&1
+    NPM_EXIT=$?
+    set -e
+    popd > /dev/null
+
+    if [ "$NPM_EXIT" -eq 0 ]; then
+      NPM_STATUS="passed"
+      echo -e "${GREEN}  npm audit: PASSED (no High/Critical vulnerabilities)${NC}"
+    else
+      NPM_STATUS="failed"
+      echo -e "${RED}  npm audit: FAILED (High or Critical vulnerabilities found)${NC}"
+    fi
+  fi
+fi
+
+echo ""
+
+# ── pip-audit ─────────────────────────────────────────────────────────────────
+echo -e "${BLUE}[2/2] pip-audit (backend)${NC}"
+
+if ! command -v pip-audit &>/dev/null; then
+  echo -e "${YELLOW}  pip-audit not found — installing...${NC}"
+  pip install pip-audit --quiet
+fi
+
+if [ ! -f "$REPO_ROOT/backend/requirements.txt" ]; then
+  echo -e "${YELLOW}  backend/requirements.txt not found — skipping${NC}"
+  PIP_STATUS="skipped"
+else
+  set +e
+  pip-audit -r "$REPO_ROOT/backend/requirements.txt" 2>&1
+  PIP_EXIT=$?
+  set -e
+
+  if [ "$PIP_EXIT" -eq 0 ]; then
+    PIP_STATUS="passed"
+    echo -e "${GREEN}  pip-audit: PASSED (no known vulnerabilities)${NC}"
+  else
+    PIP_STATUS="failed"
+    echo -e "${RED}  pip-audit: FAILED (vulnerabilities found)${NC}"
+  fi
+fi
+
+echo ""
+echo -e "${BLUE}=== Summary ===${NC}"
+echo ""
+
+print_status() {
+  local label="$1"
+  local status="$2"
+  case "$status" in
+    passed)  echo -e "  ${GREEN}PASS${NC}  $label" ;;
+    failed)  echo -e "  ${RED}FAIL${NC}  $label" ;;
+    skipped) echo -e "  ${YELLOW}SKIP${NC}  $label" ;;
+  esac
+}
+
+print_status "npm audit (frontend)" "$NPM_STATUS"
+print_status "pip-audit (backend)"  "$PIP_STATUS"
+
+echo ""
+
+OVERALL_FAILED=false
+[ "$NPM_STATUS" = "failed" ] && OVERALL_FAILED=true
+[ "$PIP_STATUS" = "failed" ] && OVERALL_FAILED=true
+
+if $OVERALL_FAILED; then
+  echo -e "${RED}Vulnerabilities detected. Review the output above for details.${NC}"
+  if $FAIL_ON_VULN; then
+    exit 1
+  fi
+else
+  echo -e "${GREEN}All checks passed.${NC}"
+fi
+
+echo ""


### PR DESCRIPTION
Fixes #273

## Summary

- Add `.github/workflows/security-audit.yml` with three jobs:
  - `npm-audit`: runs `npm audit --audit-level=high` in `frontend/`, blocks on High/Critical CVEs
  - `pip-audit`: runs `pip-audit -r backend/requirements.txt`, blocks on any known vulnerability
  - `report`: posts a sticky PR comment with pass/fail table and collapsible JSON detail (PR events only)
- Triggers: `pull_request` (branches: staging, main), weekly schedule (Monday 09:00 UTC), `workflow_dispatch`
- Artifacts retained 30 days for audit trail
- Add `scripts/security-check.sh` for local scanning with colored summary output; supports `--fail-on-vuln` flag

## Test plan

- [ ] Open a PR to staging and verify `npm-audit` and `pip-audit` jobs appear in CI checks
- [ ] Confirm `report` job posts a sticky comment to the PR with scan results
- [ ] Trigger `workflow_dispatch` manually from Actions tab to verify weekly-schedule path works
- [ ] Run `bash scripts/security-check.sh` locally and verify colored output with pass/fail summary