### PR TITLE
feat: Google OAuth login via Google Sign-In (Fixes #27)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     jwt_secret_key: str = "dev-secret-change-in-production"
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 480  # 8 hours
+    google_client_id: str = ""  # set GOOGLE_CLIENT_ID env var in Cloud Run
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -33,6 +33,8 @@ class User(Base):
     password_reset_expires: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     # Email verification token (placeholder for future email integration)
     email_verification_token: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Google OAuth — nullable so existing email/password users are unaffected
+    google_id: Mapped[str | None] = mapped_column(String(128), unique=True, nullable=True, index=True)
     terms_accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     terms_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
     privacy_accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -8,12 +8,15 @@ from ..auth.dependencies import get_current_user
 from ..auth.jwt import create_access_token
 from ..auth.password import hash_password, verify_password
 from ..auth.rate_limiter import InMemoryRateLimiter
+from ..config import settings
 from ..database import get_db
 from ..models.user import User
 from ..schemas.auth import (
     ChangePasswordRequest,
     ForgotPasswordRequest,
     ForgotPasswordResponse,
+    GoogleLoginRequest,
+    GoogleLoginResponse,
     LoginRequest,
     RegisterRequest,
     ResetPasswordRequest,
@@ -254,6 +257,88 @@ def verify_email(req: VerifyEmailRequest, db: Session = Depends(get_db)):
     db.commit()
 
     return VerifyEmailResponse(message="電子郵件驗證成功！")
+
+
+
+@router.post("/google", response_model=GoogleLoginResponse)
+def google_login(req: GoogleLoginRequest, request: Request, db: Session = Depends(get_db)):
+    """Authenticate (or register) a user via Google Sign-In credential (id_token).
+
+    Flow:
+    1. Verify the id_token with Google's public keys.
+    2. If a user with matching google_id exists -> login.
+    3. Else if a user with matching email exists -> link the Google account.
+    4. Else -> create a new user account (email_verified=True, no password).
+    """
+    client_ip = request.client.host if request.client else "unknown"
+    if not rate_limiter.check(f"google-login:{client_ip}", max_requests=20, window_seconds=60):
+        raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
+
+    if not settings.google_client_id:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google OAuth is not configured on this server.",
+        )
+
+    # Verify the Google id_token
+    try:
+        from google.oauth2 import id_token as google_id_token
+        from google.auth.transport import requests as google_requests
+
+        id_info = google_id_token.verify_oauth2_token(
+            req.credential,
+            google_requests.Request(),
+            settings.google_client_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"Invalid Google credential: {exc}",
+        )
+
+    google_sub = id_info["sub"]          # stable unique Google user ID
+    email: str = id_info.get("email", "")
+    name: str = id_info.get("name", "") or email.split("@")[0]
+    picture: str | None = id_info.get("picture")
+
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Google account does not expose an email address.",
+        )
+
+    is_new_user = False
+
+    # 1. Look up by google_id (returning user)
+    user = db.query(User).filter(User.google_id == google_sub, User.is_active == True).first()
+
+    if user is None:
+        # 2. Look up by email (link existing account)
+        user = db.query(User).filter(User.email == email, User.is_active == True).first()
+        if user is not None:
+            user.google_id = google_sub
+            if picture and not user.avatar_url:
+                user.avatar_url = picture
+        else:
+            # 3. Create new account — no password (use a random unusable hash)
+            unusable_hash = hash_password(secrets.token_hex(32))
+            user = User(
+                email=email,
+                password_hash=unusable_hash,
+                name=name,
+                avatar_url=picture,
+                google_id=google_sub,
+                email_verified=True,  # Google already verified the email
+            )
+            db.add(user)
+            is_new_user = True
+
+    user.last_login_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(user)
+
+    token = create_access_token(user.id)
+    return GoogleLoginResponse(access_token=token, is_new_user=is_new_user)
 
 @router.post("/accept-terms", response_model=UserResponse)
 def accept_terms(

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -52,3 +52,13 @@ class VerifyEmailRequest(BaseModel):
 
 class VerifyEmailResponse(BaseModel):
     message: str
+
+class GoogleLoginRequest(BaseModel):
+    """Credential from Google Sign-In for Web (id_token issued by Google)."""
+    credential: str
+
+
+class GoogleLoginResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    is_new_user: bool = False

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ alembic>=1.13
 google-cloud-storage>=2.14
 pyyaml>=6.0
 pyjwt>=2.8
+google-auth>=2.28
 bcrypt>=4.0
 python-multipart>=0.0.9
 python-json-logger>=2.0.0

--- a/backend/tests/test_google_oauth.py
+++ b/backend/tests/test_google_oauth.py
@@ -1,0 +1,244 @@
+"""
+TDD tests for Google OAuth endpoint: POST /api/auth/google
+
+Tests use unittest.mock to patch google.oauth2.id_token.verify_oauth2_token
+so no real Google credentials are needed.
+
+Run with:
+    cd /Users/young/project/chinese-literacy-platform-issue-27/backend
+    python -m pytest tests/test_google_oauth.py -v
+"""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import User
+from app.auth.password import hash_password
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite test database setup
+# ---------------------------------------------------------------------------
+SQLALCHEMY_TEST_URL = "sqlite://"
+
+engine = create_engine(
+    SQLALCHEMY_TEST_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture(autouse=True)
+def setup_database():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def client():
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_GOOGLE_CLIENT_ID = "fake-client-id.apps.googleusercontent.com"
+FAKE_CREDENTIAL = "fake.jwt.credential"
+
+FAKE_ID_INFO = {
+    "sub": "google-uid-12345",
+    "email": "newuser@gmail.com",
+    "name": "New User",
+    "picture": "https://lh3.googleusercontent.com/photo.jpg",
+}
+
+
+def mock_verify(credential, request, client_id):
+    """Simulates a successful Google token verification."""
+    return FAKE_ID_INFO
+
+
+def patch_google(monkeypatch):
+    """Patch settings.google_client_id and Google verify function."""
+    monkeypatch.setattr("app.config.settings.google_client_id", FAKE_GOOGLE_CLIENT_ID)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGoogleLoginNewUser:
+    """New Google user — should create account and return token."""
+
+    def test_creates_new_user_returns_token(self, client, monkeypatch):
+        patch_google(monkeypatch)
+        # The endpoint imports google.oauth2.id_token inside the function body,
+        # so we patch the module-level path used at runtime.
+        with patch("google.oauth2.id_token.verify_oauth2_token", side_effect=mock_verify):
+            response = client.post(
+                "/api/auth/google",
+                json={"credential": FAKE_CREDENTIAL},
+            )
+
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert "access_token" in data
+        assert data["is_new_user"] is True
+
+    def test_user_stored_in_db(self, client, monkeypatch):
+        patch_google(monkeypatch)
+        with patch("google.oauth2.id_token.verify_oauth2_token", side_effect=mock_verify):
+            client.post("/api/auth/google", json={"credential": FAKE_CREDENTIAL})
+
+        db = TestingSessionLocal()
+        user = db.query(User).filter(User.email == FAKE_ID_INFO["email"]).first()
+        db.close()
+
+        assert user is not None
+        assert user.google_id == FAKE_ID_INFO["sub"]
+        assert user.email_verified is True
+        assert user.avatar_url == FAKE_ID_INFO["picture"]
+
+    def test_email_verified_true_for_new_user(self, client, monkeypatch):
+        patch_google(monkeypatch)
+        with patch("google.oauth2.id_token.verify_oauth2_token", side_effect=mock_verify):
+            client.post("/api/auth/google", json={"credential": FAKE_CREDENTIAL})
+
+        db = TestingSessionLocal()
+        user = db.query(User).filter(User.email == FAKE_ID_INFO["email"]).first()
+        db.close()
+        assert user.email_verified is True
+
+
+class TestGoogleLoginExistingEmailUser:
+    """Existing user registered with email — Google account should be linked."""
+
+    def _create_existing_user(self):
+        db = TestingSessionLocal()
+        user = User(
+            email=FAKE_ID_INFO["email"],
+            password_hash=hash_password("SomePassword123"),
+            name="Existing User",
+            email_verified=True,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        db.close()
+        return user
+
+    def test_links_google_id_to_existing_account(self, client, monkeypatch):
+        self._create_existing_user()
+        patch_google(monkeypatch)
+
+        with patch("google.oauth2.id_token.verify_oauth2_token", side_effect=mock_verify):
+            response = client.post("/api/auth/google", json={"credential": FAKE_CREDENTIAL})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert data["is_new_user"] is False
+
+        db = TestingSessionLocal()
+        user = db.query(User).filter(User.email == FAKE_ID_INFO["email"]).first()
+        db.close()
+        assert user.google_id == FAKE_ID_INFO["sub"]
+
+    def test_does_not_create_duplicate_user(self, client, monkeypatch):
+        self._create_existing_user()
+        patch_google(monkeypatch)
+
+        with patch("google.oauth2.id_token.verify_oauth2_token", side_effect=mock_verify):
+            client.post("/api/auth/google", json={"credential": FAKE_CREDENTIAL})
+
+        db = TestingSessionLocal()
+        count = db.query(User).filter(User.email == FAKE_ID_INFO["email"]).count()
+        db.close()
+        assert count == 1
+
+
+class TestGoogleLoginReturningUser:
+    """User already has google_id — should login directly."""
+
+    def _create_google_user(self):
+        db = TestingSessionLocal()
+        user = User(
+            email=FAKE_ID_INFO["email"],
+            password_hash=hash_password("unused"),
+            name="Google User",
+            google_id=FAKE_ID_INFO["sub"],
+            email_verified=True,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        db.close()
+
+    def test_returning_user_gets_token(self, client, monkeypatch):
+        self._create_google_user()
+        patch_google(monkeypatch)
+
+        with patch("google.oauth2.id_token.verify_oauth2_token", side_effect=mock_verify):
+            response = client.post("/api/auth/google", json={"credential": FAKE_CREDENTIAL})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "access_token" in data
+        assert data["is_new_user"] is False
+
+
+class TestGoogleLoginErrorCases:
+    """Error handling for invalid credentials and misconfiguration."""
+
+    def test_returns_503_when_client_id_not_configured(self, client, monkeypatch):
+        monkeypatch.setattr("app.config.settings.google_client_id", "")
+        response = client.post("/api/auth/google", json={"credential": FAKE_CREDENTIAL})
+        assert response.status_code == 503
+
+    def test_returns_401_on_invalid_google_token(self, client, monkeypatch):
+        patch_google(monkeypatch)
+
+        def bad_verify(credential, request, client_id):
+            raise ValueError("Token signature is invalid.")
+
+        with patch("google.oauth2.id_token.verify_oauth2_token", side_effect=bad_verify):
+            response = client.post("/api/auth/google", json={"credential": "bad.token"})
+
+        assert response.status_code == 401
+
+    def test_returns_400_on_missing_email(self, client, monkeypatch):
+        patch_google(monkeypatch)
+
+        def no_email_verify(credential, request, client_id):
+            return {"sub": "uid-999", "name": "No Email"}
+
+        with patch("google.oauth2.id_token.verify_oauth2_token", side_effect=no_email_verify):
+            response = client.post("/api/auth/google", json={"credential": FAKE_CREDENTIAL})
+
+        assert response.status_code == 400

--- a/frontend/src/components/GoogleSignInButton.tsx
+++ b/frontend/src/components/GoogleSignInButton.tsx
@@ -1,0 +1,110 @@
+/**
+ * GoogleSignInButton
+ *
+ * Renders the official Google Sign-In button using the Google Identity Services
+ * (GSI) script. The button is rendered by Google's library so that it complies
+ * with Google's branding guidelines and works across all supported browsers.
+ *
+ * GOOGLE_CLIENT_ID must be set as VITE_GOOGLE_CLIENT_ID in the environment.
+ * If the variable is missing the button is not rendered (feature flag behaviour).
+ */
+import React, { useEffect, useRef } from 'react';
+
+interface GoogleSignInButtonProps {
+  onCredential: (credential: string) => void;
+  /** Width in pixels (Google library accepts 200-400). Defaults to 400. */
+  width?: number;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        id: {
+          initialize: (config: {
+            client_id: string;
+            callback: (response: { credential: string }) => void;
+            auto_select?: boolean;
+            cancel_on_tap_outside?: boolean;
+          }) => void;
+          renderButton: (
+            parent: HTMLElement,
+            options: {
+              theme?: string;
+              size?: string;
+              width?: number;
+              text?: string;
+              shape?: string;
+              locale?: string;
+            },
+          ) => void;
+          prompt: () => void;
+        };
+      };
+    };
+  }
+}
+
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined;
+const GSI_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
+
+const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
+  onCredential,
+  width = 400,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!GOOGLE_CLIENT_ID) return;
+
+    const initButton = () => {
+      if (!window.google || !containerRef.current) return;
+      window.google.accounts.id.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        callback: (response) => {
+          if (response.credential) {
+            onCredential(response.credential);
+          }
+        },
+        auto_select: false,
+        cancel_on_tap_outside: true,
+      });
+      window.google.accounts.id.renderButton(containerRef.current, {
+        theme: 'outline',
+        size: 'large',
+        width,
+        text: 'signin_with',
+        shape: 'rectangular',
+        locale: 'zh-TW',
+      });
+    };
+
+    // If script already loaded
+    if (window.google) {
+      initButton();
+      return;
+    }
+
+    // Inject GSI script once
+    if (!document.querySelector(`script[src="${GSI_SCRIPT_SRC}"]`)) {
+      const script = document.createElement('script');
+      script.src = GSI_SCRIPT_SRC;
+      script.async = true;
+      script.defer = true;
+      script.onload = initButton;
+      document.head.appendChild(script);
+    } else {
+      // Script tag exists but not yet loaded — wait for it
+      const existing = document.querySelector<HTMLScriptElement>(`script[src="${GSI_SCRIPT_SRC}"]`);
+      if (existing) {
+        existing.addEventListener('load', initButton);
+      }
+    }
+  }, [onCredential, width]);
+
+  if (!GOOGLE_CLIENT_ID) return null;
+
+  return <div ref={containerRef} className="w-full flex justify-center" />;
+};
+
+export default GoogleSignInButton;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { login as apiLogin, register as apiRegister, getMe, acceptTerms as apiAcceptTerms, AuthUser, AuthError } from '../services/authApi';
+import { login as apiLogin, register as apiRegister, getMe, acceptTerms as apiAcceptTerms, googleLogin as apiGoogleLogin, AuthUser, AuthError } from '../services/authApi';
 
 const TOKEN_KEY = 'lingoleap_token';
 
@@ -18,6 +18,7 @@ interface AuthContextValue {
   /** Re-fetch user data from /api/users/me and update the context. */
   refreshUser: () => Promise<void>;
   acceptTerms: () => Promise<void>;
+  loginWithGoogle: (credential: string) => Promise<{ isNewUser: boolean }>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -99,6 +100,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(userData);
   }, []);
 
+  const loginWithGoogle = useCallback(async (credential: string): Promise<{ isNewUser: boolean }> => {
+    const response = await apiGoogleLogin(credential);
+    const newToken = response.access_token;
+    localStorage.setItem(TOKEN_KEY, newToken);
+    setToken(newToken);
+    const userData = await getMe(newToken);
+    setUser(userData);
+    return { isNewUser: response.is_new_user };
+  }, []);
+
   const logout = useCallback(() => {
     localStorage.removeItem(TOKEN_KEY);
     setToken(null);
@@ -146,6 +157,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     clearMustChangePassword,
     refreshUser,
     acceptTerms,
+    loginWithGoogle,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { AuthError } from '../services/authApi';
 import { trackEvent } from '../utils/analytics';
+import GoogleSignInButton from '../components/GoogleSignInButton';
 
 interface LoginPageProps {
   onSwitchToRegister?: () => void;
@@ -12,7 +13,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/';
-  const { login } = useAuth();
+  const { login, loginWithGoogle } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -51,7 +52,26 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
     }
   };
 
+  const handleGoogleCredential = async (credential: string) => {
+    setError('');
+    setIsSubmitting(true);
+    try {
+      await loginWithGoogle(credential);
+      trackEvent('auth', 'google_login_success');
+      navigate(from, { replace: true });
+    } catch (err) {
+      if (err instanceof AuthError) {
+        setError(err.message);
+      } else {
+        setError('Google 登入失敗，請稍後再試');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
+
     <div className="min-h-screen flex flex-col items-center justify-center bg-amber-50 px-4">
       <div className="w-full max-w-sm">
         {/* Logo / Brand */}
@@ -127,6 +147,21 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
             </button>
           </div>
         </form>
+
+        {/* Google Sign-In */}
+        <div className="mt-4">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="px-2 bg-amber-50 text-gray-400">或</span>
+            </div>
+          </div>
+          <div className="mt-4">
+            <GoogleSignInButton onCredential={handleGoogleCredential} width={352} />
+          </div>
+        </div>
 
         {/* Switch to Register */}
         <p className="text-center text-sm text-gray-500 mt-6">

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { AuthError } from '../services/authApi';
 import PasswordStrengthIndicator from '../components/PasswordStrengthIndicator';
+import GoogleSignInButton from '../components/GoogleSignInButton';
 
 interface RegisterPageProps {
   onSwitchToLogin?: () => void;
@@ -10,7 +11,7 @@ interface RegisterPageProps {
 
 const RegisterPage: React.FC<RegisterPageProps> = ({ onSwitchToLogin }) => {
   const navigate = useNavigate();
-  const { register } = useAuth();
+  const { register, loginWithGoogle } = useAuth();
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -71,7 +72,29 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ onSwitchToLogin }) => {
     }
   };
 
+  const handleGoogleCredential = async (credential: string) => {
+    setError('');
+    setIsSubmitting(true);
+    try {
+      const result = await loginWithGoogle(credential);
+      if (result.isNewUser) {
+        navigate('/', { replace: true });
+      } else {
+        navigate('/', { replace: true });
+      }
+    } catch (err) {
+      if (err instanceof AuthError) {
+        setError(err.message);
+      } else {
+        setError('Google 登入失敗，請稍後再試');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
+
     <div className="min-h-screen flex flex-col items-center justify-center bg-amber-50 px-4">
       <div className="w-full max-w-sm">
         {/* Logo / Brand */}
@@ -169,6 +192,21 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ onSwitchToLogin }) => {
             {isSubmitting ? '註冊中...' : '建立帳號'}
           </button>
         </form>
+
+        {/* Google Sign-In */}
+        <div className="mt-4">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="px-2 bg-amber-50 text-gray-400">或</span>
+            </div>
+          </div>
+          <div className="mt-4">
+            <GoogleSignInButton onCredential={handleGoogleCredential} width={352} />
+          </div>
+        </div>
 
         {/* Switch to Login */}
         <p className="text-center text-sm text-gray-500 mt-6">

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -162,3 +162,18 @@ export async function resetPassword(token: string, newPassword: string): Promise
     throw new AuthError(message, res.status);
   }
 }
+
+export interface GoogleLoginResponse {
+  access_token: string;
+  token_type: string;
+  is_new_user: boolean;
+}
+
+export async function googleLogin(credential: string): Promise<GoogleLoginResponse> {
+  const res = await fetch(`${API_BASE}/api/auth/google`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ credential }),
+  });
+  return handleAuthResponse<GoogleLoginResponse>(res);
+}


### PR DESCRIPTION
Fixes #27

## Summary

- **Backend**: New `POST /api/auth/google` endpoint that verifies a Google `id_token` using the `google-auth` library. Handles three cases: returning Google user (lookup by `google_id`), existing email user (account linking), and brand-new user (auto-registration)
- **Backend**: `google_id` nullable column added to `User` model (no migration impact — existing rows get `NULL`; a dedicated Alembic migration PR will handle Cloud SQL)
- **Backend**: `GOOGLE_CLIENT_ID` env var wired through `Settings`; `google-auth>=2.28` added to `requirements.txt`
- **Frontend**: `GoogleSignInButton` component loads the official Google Identity Services (GSI) script and renders Google's branded button
- **Frontend**: `loginWithGoogle()` added to `AuthContext`
- **Frontend**: Google Sign-In button with divider added to both `LoginPage` and `RegisterPage`
- **Tests**: 9 TDD tests (all pass) covering new-user creation, email-account linking, returning-user login, and error cases (503/401/400)

## Setup required before testing

Set `GOOGLE_CLIENT_ID` in Cloud Run env vars (both backend services) and `VITE_GOOGLE_CLIENT_ID` in the frontend Cloud Run env. Without these values the button does not render (frontend) and the endpoint returns 503 (backend) — this is intentional feature-flag behaviour.

## Test plan

- [ ] Deploy preview and set env vars
- [ ] Open Preview URL login page — confirm Google Sign-In button appears
- [ ] Click Google button — complete OAuth flow with a real Google account
- [ ] Verify JWT returned and user is redirected to home
- [ ] Sign in again with same Google account — confirm no duplicate user created
- [ ] Register with email first, then sign in with Google using same email — confirm account linking (no duplicate)
- [ ] Confirm existing email/password login still works (regression)
- [ ] Run `python -m pytest tests/test_google_oauth.py -v` (9/9 pass)