### PR TITLE
feat: cross-text learning pattern analysis (Fixes #253)

### DIFF
--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -4,6 +4,7 @@ Teacher Dashboard API — classroom overview and student learning progress.
 import csv
 import io
 import logging
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -1572,3 +1573,289 @@ def mark_all_notifications_read(
 
     logger.info("Teacher %d marked all %d notifications as read", current_user.id, len(new_keys))
     return {"marked": len(new_keys)}
+
+
+# ── Cross-Text Learning Pattern Analysis (Issue #253) ─────────────────────────
+
+
+class TextPerformanceSummary(BaseModel):
+    story_slug: str
+    story_title: str | None
+    attempt_count: int
+    avg_score: float | None
+    avg_accuracy: float | None
+    avg_comprehension_score: float | None
+    first_attempt_at: datetime | None
+    last_attempt_at: datetime | None
+
+
+class StudentCrossTextPattern(BaseModel):
+    student_id: int
+    student_name: str
+    total_texts_attempted: int
+    total_sessions: int
+    overall_avg_score: float | None
+    score_trend: list[dict]  # [{date, score, story_slug, title}] sorted by date
+    text_performance: list[TextPerformanceSummary]
+    repeated_error_chars: list[dict]  # [{char, error_count, story_count, story_slugs}]
+    strong_texts: list[str]   # story_slugs where avg_score >= 80
+    weak_texts: list[str]     # story_slugs where avg_score < 60
+
+
+class ClassroomCrossTextPattern(BaseModel):
+    classroom_id: int
+    classroom_name: str
+    total_students: int
+    total_sessions: int
+    text_difficulty_ranking: list[dict]  # [{story_slug, title, avg_score, attempt_count}]
+    class_score_trend: list[dict]  # [{date, avg_score}]
+    common_error_chars: list[dict]  # [{char, student_count, total_errors}]
+    student_patterns: list[StudentCrossTextPattern]
+
+
+@router.get(
+    "/teacher/classrooms/{classroom_id}/cross-text-analysis",
+    response_model=ClassroomCrossTextPattern,
+)
+def get_cross_text_analysis(
+    classroom_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Aggregate cross-text learning pattern analysis for a classroom.
+
+    Returns per-student and class-level views of:
+    - Score trends across texts over time
+    - Common error characters recurring across multiple texts
+    - Text difficulty ranking based on average class performance
+    - Individual student strengths and weaknesses by text
+    """
+    classroom = _check_classroom_access(current_user, classroom_id, db)
+
+    student_rows = (
+        db.query(User)
+        .join(ClassroomStudent, ClassroomStudent.student_id == User.id)
+        .filter(ClassroomStudent.classroom_id == classroom_id)
+        .all()
+    )
+    student_ids = [s.id for s in student_rows]
+    student_map = {s.id: s.display_name or s.username for s in student_rows}
+
+    if not student_ids:
+        return ClassroomCrossTextPattern(
+            classroom_id=classroom_id,
+            classroom_name=classroom.name,
+            total_students=0,
+            total_sessions=0,
+            text_difficulty_ranking=[],
+            class_score_trend=[],
+            common_error_chars=[],
+            student_patterns=[],
+        )
+
+    # Fetch all completed sessions for all students in classroom
+    all_sessions = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.student_id.in_(student_ids),
+            LearningSession.status == "completed",
+            LearningSession.story_slug.isnot(None),
+        )
+        .order_by(LearningSession.started_at.asc())
+        .all()
+    )
+
+    # Fetch all character errors for classroom sessions
+    session_ids = [s.id for s in all_sessions]
+    all_char_errors: list[CharacterError] = []
+    if session_ids:
+        all_char_errors = (
+            db.query(CharacterError)
+            .filter(CharacterError.session_id.in_(session_ids))
+            .all()
+        )
+
+    # Build story title lookup (best-effort)
+    def _get_title(slug: str) -> str | None:
+        try:
+            story = get_lesson_by_id(int(slug))
+            return story["title"] if story else None
+        except (ValueError, TypeError):
+            return slug
+
+    # ── Class-level score trend (daily avg) ──────────────────────────────────
+    daily_scores: dict[str, list[float]] = defaultdict(list)
+    for s in all_sessions:
+        if s.overall_score is not None:
+            day = s.started_at.strftime("%Y-%m-%d")
+            daily_scores[day].append(s.overall_score)
+
+    class_score_trend = [
+        {"date": day, "avg_score": round(sum(scores) / len(scores), 1)}
+        for day, scores in sorted(daily_scores.items())
+    ]
+
+    # ── Text difficulty ranking ───────────────────────────────────────────────
+    text_scores: dict[str, list[float]] = defaultdict(list)
+    text_attempts: dict[str, int] = defaultdict(int)
+    for s in all_sessions:
+        if s.story_slug:
+            text_attempts[s.story_slug] += 1
+            if s.overall_score is not None:
+                text_scores[s.story_slug].append(s.overall_score)
+
+    text_difficulty_ranking = sorted(
+        [
+            {
+                "story_slug": slug,
+                "title": _get_title(slug),
+                "avg_score": round(sum(text_scores[slug]) / len(text_scores[slug]), 1)
+                if text_scores[slug]
+                else None,
+                "attempt_count": text_attempts[slug],
+            }
+            for slug in text_attempts
+        ],
+        key=lambda x: (x["avg_score"] is None, x["avg_score"] or 0),
+    )
+
+    # ── Common error chars across class ──────────────────────────────────────
+    sid_to_student: dict[int, int] = {s.id: s.student_id for s in all_sessions}
+    sid_to_slug: dict[int, str] = {
+        s.id: s.story_slug for s in all_sessions if s.story_slug
+    }
+
+    char_student_set: dict[str, set[int]] = defaultdict(set)
+    char_total_errors: dict[str, int] = defaultdict(int)
+    for err in all_char_errors:
+        student_id = sid_to_student.get(err.session_id)
+        if student_id:
+            char_student_set[err.character].add(student_id)
+            char_total_errors[err.character] += 1
+
+    common_error_chars = sorted(
+        [
+            {
+                "char": char,
+                "student_count": len(students),
+                "total_errors": char_total_errors[char],
+            }
+            for char, students in char_student_set.items()
+        ],
+        key=lambda x: (-x["student_count"], -x["total_errors"]),
+    )[:20]
+
+    # ── Per-student patterns ──────────────────────────────────────────────────
+    student_patterns: list[StudentCrossTextPattern] = []
+
+    for sid in student_ids:
+        s_sessions = [s for s in all_sessions if s.student_id == sid]
+        if not s_sessions:
+            continue
+
+        s_session_ids = {s.id for s in s_sessions}
+        s_errors = [e for e in all_char_errors if e.session_id in s_session_ids]
+
+        # Score trend
+        score_trend = [
+            {
+                "date": s.started_at.strftime("%Y-%m-%d"),
+                "score": s.overall_score,
+                "story_slug": s.story_slug,
+                "title": _get_title(s.story_slug) if s.story_slug else None,
+            }
+            for s in s_sessions
+            if s.overall_score is not None
+        ]
+
+        # Text performance breakdown
+        slug_sessions: dict[str, list[LearningSession]] = defaultdict(list)
+        for s in s_sessions:
+            if s.story_slug:
+                slug_sessions[s.story_slug].append(s)
+
+        text_performance = []
+        strong_texts: list[str] = []
+        weak_texts: list[str] = []
+        for slug, slug_sess in slug_sessions.items():
+            scores = [s.overall_score for s in slug_sess if s.overall_score is not None]
+            accuracies = [s.accuracy for s in slug_sess if s.accuracy is not None]
+            comp_scores = [
+                s.comprehension_score for s in slug_sess if s.comprehension_score is not None
+            ]
+            avg_sc = round(sum(scores) / len(scores), 1) if scores else None
+            text_performance.append(
+                TextPerformanceSummary(
+                    story_slug=slug,
+                    story_title=_get_title(slug),
+                    attempt_count=len(slug_sess),
+                    avg_score=avg_sc,
+                    avg_accuracy=round(sum(accuracies) / len(accuracies), 1)
+                    if accuracies
+                    else None,
+                    avg_comprehension_score=round(sum(comp_scores) / len(comp_scores), 1)
+                    if comp_scores
+                    else None,
+                    first_attempt_at=min(s.started_at for s in slug_sess),
+                    last_attempt_at=max(s.started_at for s in slug_sess),
+                )
+            )
+            if avg_sc is not None:
+                if avg_sc >= 80:
+                    strong_texts.append(slug)
+                elif avg_sc < 60:
+                    weak_texts.append(slug)
+
+        # Repeated error chars (appearing in 2+ different texts)
+        char_slug_set: dict[str, set[str]] = defaultdict(set)
+        char_count: dict[str, int] = defaultdict(int)
+        for err in s_errors:
+            slug = sid_to_slug.get(err.session_id)
+            if slug:
+                char_slug_set[err.character].add(slug)
+            char_count[err.character] += 1
+
+        repeated_error_chars = sorted(
+            [
+                {
+                    "char": char,
+                    "error_count": char_count[char],
+                    "story_count": len(slugs),
+                    "story_slugs": list(slugs),
+                }
+                for char, slugs in char_slug_set.items()
+                if len(slugs) >= 2
+            ],
+            key=lambda x: (-x["story_count"], -x["error_count"]),
+        )[:10]
+
+        all_scores = [s.overall_score for s in s_sessions if s.overall_score is not None]
+        student_patterns.append(
+            StudentCrossTextPattern(
+                student_id=sid,
+                student_name=student_map.get(sid, f"Student {sid}"),
+                total_texts_attempted=len(slug_sessions),
+                total_sessions=len(s_sessions),
+                overall_avg_score=round(sum(all_scores) / len(all_scores), 1)
+                if all_scores
+                else None,
+                score_trend=score_trend,
+                text_performance=sorted(text_performance, key=lambda x: x.story_slug),
+                repeated_error_chars=repeated_error_chars,
+                strong_texts=strong_texts,
+                weak_texts=weak_texts,
+            )
+        )
+
+    student_patterns.sort(key=lambda x: -x.total_sessions)
+
+    return ClassroomCrossTextPattern(
+        classroom_id=classroom_id,
+        classroom_name=classroom.name,
+        total_students=len(student_ids),
+        total_sessions=len(all_sessions),
+        text_difficulty_ranking=text_difficulty_ranking,
+        class_score_trend=class_score_trend,
+        common_error_chars=common_error_chars,
+        student_patterns=student_patterns,
+    )

--- a/backend/app/services/cross_text_analysis_service.py
+++ b/backend/app/services/cross_text_analysis_service.py
@@ -1,0 +1,430 @@
+"""
+Cross-Text Learning Pattern Analysis — Issue #253.
+
+Analyses a student's performance across ALL completed texts to surface:
+  - text_type_performance: how they perform by genre / difficulty / category
+  - vocabulary_growth: unique vocab words encountered per session over time
+  - difficulty_progression: score trajectory ordered by text grade
+  - common_error_patterns: characters that appear as errors in multiple texts
+
+No DB writes — pure read-only analysis over existing LearningSession data.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session as DbSession
+
+from ..models.session import CharacterError, LearningSession
+from ..models.text import Text
+
+logger = logging.getLogger(__name__)
+
+# Minimum completed sessions to generate meaningful patterns
+MIN_SESSIONS_FOR_ANALYSIS = 2
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _score(session: LearningSession) -> float | None:
+    """Return the best available aggregate score for a session."""
+    return session.overall_score or session.accuracy
+
+
+def _completed_sessions_with_text(
+    student_id: int,
+    db: "DbSession",
+) -> list[tuple[LearningSession, Text | None]]:
+    """Fetch all completed sessions that have an associated text record.
+
+    Sessions are sorted by completion time ascending.
+    """
+    sessions = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.student_id == student_id,
+            LearningSession.status == "completed",
+        )
+        .order_by(LearningSession.completed_at.asc())
+        .all()
+    )
+
+    pairs: list[tuple[LearningSession, Text | None]] = []
+    for s in sessions:
+        text: Text | None = None
+        if s.text_id:
+            text = db.query(Text).filter(Text.id == s.text_id).first()
+        pairs.append((s, text))
+    return pairs
+
+
+# ── text-type performance ─────────────────────────────────────────────────────
+
+
+def _build_text_type_performance(
+    pairs: list[tuple[LearningSession, Text | None]],
+) -> dict:
+    """Aggregate mean score / attempt count by genre, category, and grade.
+
+    Returns::
+        {
+            "by_genre": [{"genre": "記敘文", "avg_score": 85.0, "attempts": 3}],
+            "by_category": [...],
+            "by_grade": [{"grade": 5, "avg_score": 78.0, "attempts": 2}],
+        }
+    """
+    genre_scores: dict[str, list[float]] = defaultdict(list)
+    category_scores: dict[str, list[float]] = defaultdict(list)
+    grade_scores: dict[int, list[float]] = defaultdict(list)
+
+    for session, text in pairs:
+        score = _score(session)
+        if score is None or text is None:
+            continue
+        genre_scores[text.genre].append(score)
+        category_scores[text.category].append(score)
+        grade_scores[text.grade].append(score)
+
+    def _aggregate(raw: dict) -> list[dict]:
+        result = []
+        for key, scores in sorted(raw.items(), key=lambda x: str(x[0])):
+            result.append({
+                "label": str(key),
+                "avg_score": round(sum(scores) / len(scores), 1),
+                "attempts": len(scores),
+            })
+        return result
+
+    def _aggregate_grade(raw: dict[int, list[float]]) -> list[dict]:
+        result = []
+        for grade in sorted(raw.keys()):
+            scores = raw[grade]
+            result.append({
+                "grade": grade,
+                "avg_score": round(sum(scores) / len(scores), 1),
+                "attempts": len(scores),
+            })
+        return result
+
+    return {
+        "by_genre": _aggregate(genre_scores),
+        "by_category": _aggregate(category_scores),
+        "by_grade": _aggregate_grade(grade_scores),
+    }
+
+
+# ── vocabulary growth ─────────────────────────────────────────────────────────
+
+
+def _build_vocabulary_growth(
+    pairs: list[tuple[LearningSession, Text | None]],
+) -> list[dict]:
+    """Return a timeline of cumulative unique vocabulary words encountered.
+
+    Each entry represents one completed session::
+        [
+            {
+                "session_index": 1,
+                "completed_at": "2025-01-10T...",
+                "text_title": "...",
+                "new_words": 8,
+                "cumulative_words": 8,
+            },
+            ...
+        ]
+    """
+    seen_words: set[str] = set()
+    timeline: list[dict] = []
+
+    for idx, (session, text) in enumerate(pairs, start=1):
+        if session.completed_at is None:
+            continue
+
+        # Collect vocab from the text's vocabulary list (if any)
+        new_words: set[str] = set()
+        if text and text.vocabulary:
+            for entry in text.vocabulary:
+                word: str | None = None
+                if isinstance(entry, dict):
+                    word = entry.get("word") or entry.get("character")
+                elif isinstance(entry, str):
+                    word = entry
+                if word and word not in seen_words:
+                    new_words.add(word)
+
+        seen_words |= new_words
+        timeline.append({
+            "session_index": idx,
+            "completed_at": session.completed_at.isoformat(),
+            "text_title": text.title if text else (session.story_slug or ""),
+            "new_words": len(new_words),
+            "cumulative_words": len(seen_words),
+        })
+
+    return timeline
+
+
+# ── difficulty progression ────────────────────────────────────────────────────
+
+
+def _build_difficulty_progression(
+    pairs: list[tuple[LearningSession, Text | None]],
+) -> list[dict]:
+    """Return sessions sorted by completion time showing score vs text grade.
+
+    Each entry::
+        {
+            "session_index": 1,
+            "completed_at": "...",
+            "text_title": "...",
+            "grade": 5,
+            "score": 82.5,
+        }
+    """
+    progression: list[dict] = []
+    for idx, (session, text) in enumerate(pairs, start=1):
+        if session.completed_at is None:
+            continue
+        score = _score(session)
+        progression.append({
+            "session_index": idx,
+            "completed_at": session.completed_at.isoformat(),
+            "text_title": text.title if text else (session.story_slug or ""),
+            "grade": text.grade if text else None,
+            "genre": text.genre if text else None,
+            "score": round(score, 1) if score is not None else None,
+        })
+    return progression
+
+
+# ── common error patterns ─────────────────────────────────────────────────────
+
+
+def _build_common_error_patterns(
+    student_id: int,
+    pairs: list[tuple[LearningSession, Text | None]],
+    db: "DbSession",
+) -> list[dict]:
+    """Identify characters that appear as errors in multiple distinct texts.
+
+    Returns top-10 recurring error characters::
+        [
+            {
+                "character": "繁",
+                "error_count": 5,
+                "text_count": 3,
+                "error_type": "pronunciation",
+            },
+            ...
+        ]
+    """
+    session_ids = [s.id for s, _ in pairs]
+    if not session_ids:
+        return []
+
+    errors = (
+        db.query(CharacterError)
+        .filter(CharacterError.session_id.in_(session_ids))
+        .all()
+    )
+
+    # Map session_id -> text title for context
+    session_to_text: dict[int, str] = {}
+    for session, text in pairs:
+        session_to_text[session.id] = text.title if text else (session.story_slug or "")
+
+    # Accumulate error counts and distinct texts per character
+    char_error_count: Counter[str] = Counter()
+    char_text_set: dict[str, set[str]] = defaultdict(set)
+    char_error_type: dict[str, Counter[str]] = defaultdict(Counter)
+
+    for err in errors:
+        char_error_count[err.character] += 1
+        char_text_set[err.character].add(session_to_text.get(err.session_id, ""))
+        char_error_type[err.character][err.error_type] += 1
+
+    # Only surface characters that appear across >= 2 distinct texts
+    recurring = [
+        char for char, texts in char_text_set.items() if len(texts) >= 2
+    ]
+    recurring.sort(key=lambda c: char_error_count[c], reverse=True)
+
+    result = []
+    for char in recurring[:10]:
+        dominant_type = char_error_type[char].most_common(1)[0][0]
+        result.append({
+            "character": char,
+            "error_count": char_error_count[char],
+            "text_count": len(char_text_set[char]),
+            "dominant_error_type": dominant_type,
+        })
+    return result
+
+
+# ── public API ────────────────────────────────────────────────────────────────
+
+
+def analyze_cross_text_patterns(student_id: int, db: "DbSession") -> dict:
+    """Main entry point — analyse cross-text learning patterns for a student.
+
+    Returns::
+        {
+            "student_id": 42,
+            "total_completed_texts": 7,
+            "has_enough_data": True,
+            "text_type_performance": { ... },
+            "vocabulary_growth": [ ... ],
+            "difficulty_progression": [ ... ],
+            "common_error_patterns": [ ... ],
+            "summary": {
+                "strongest_genre": "記敘文",
+                "weakest_genre": "文言文",
+                "total_vocabulary_words": 64,
+                "recurring_error_chars": 3,
+            },
+        }
+    """
+    pairs = _completed_sessions_with_text(student_id, db)
+
+    has_enough = len(pairs) >= MIN_SESSIONS_FOR_ANALYSIS
+
+    if not has_enough:
+        logger.info(
+            "Student %d has only %d completed sessions — skipping full analysis",
+            student_id,
+            len(pairs),
+        )
+        return {
+            "student_id": student_id,
+            "total_completed_texts": len(pairs),
+            "has_enough_data": False,
+            "text_type_performance": {"by_genre": [], "by_category": [], "by_grade": []},
+            "vocabulary_growth": [],
+            "difficulty_progression": [],
+            "common_error_patterns": [],
+            "summary": {
+                "strongest_genre": None,
+                "weakest_genre": None,
+                "total_vocabulary_words": 0,
+                "recurring_error_chars": 0,
+            },
+        }
+
+    text_type_performance = _build_text_type_performance(pairs)
+    vocabulary_growth = _build_vocabulary_growth(pairs)
+    difficulty_progression = _build_difficulty_progression(pairs)
+    common_error_patterns = _build_common_error_patterns(student_id, pairs, db)
+
+    # Derive summary insights
+    by_genre = text_type_performance["by_genre"]
+    strongest_genre: str | None = None
+    weakest_genre: str | None = None
+    if by_genre:
+        sorted_genres = sorted(by_genre, key=lambda g: g["avg_score"], reverse=True)
+        if len(sorted_genres) >= 1:
+            strongest_genre = sorted_genres[0]["label"]
+        if len(sorted_genres) >= 2:
+            weakest_genre = sorted_genres[-1]["label"]
+
+    total_vocab = vocabulary_growth[-1]["cumulative_words"] if vocabulary_growth else 0
+
+    logger.info(
+        "Cross-text analysis for student %d: %d sessions, %d vocab words, %d recurring errors",
+        student_id,
+        len(pairs),
+        total_vocab,
+        len(common_error_patterns),
+    )
+
+    return {
+        "student_id": student_id,
+        "total_completed_texts": len(pairs),
+        "has_enough_data": True,
+        "text_type_performance": text_type_performance,
+        "vocabulary_growth": vocabulary_growth,
+        "difficulty_progression": difficulty_progression,
+        "common_error_patterns": common_error_patterns,
+        "summary": {
+            "strongest_genre": strongest_genre,
+            "weakest_genre": weakest_genre,
+            "total_vocabulary_words": total_vocab,
+            "recurring_error_chars": len(common_error_patterns),
+        },
+    }
+
+
+def analyze_class_cross_text_patterns(
+    student_ids: list[int],
+    db: "DbSession",
+) -> dict:
+    """Class-level aggregation of cross-text patterns.
+
+    Aggregates individual student analyses into class-wide insights::
+        {
+            "total_students": 25,
+            "students_with_enough_data": 18,
+            "class_genre_performance": [...],
+            "class_common_errors": [...],
+            "student_summaries": [...],
+        }
+    """
+    if not student_ids:
+        return {
+            "total_students": 0,
+            "students_with_enough_data": 0,
+            "class_genre_performance": [],
+            "class_common_errors": [],
+            "student_summaries": [],
+        }
+
+    # Collect genre scores across all students
+    class_genre_scores: dict[str, list[float]] = defaultdict(list)
+    class_error_count: Counter[str] = Counter()
+    student_summaries: list[dict] = []
+    students_with_data = 0
+
+    for sid in student_ids:
+        analysis = analyze_cross_text_patterns(sid, db)
+        if analysis["has_enough_data"]:
+            students_with_data += 1
+            for entry in analysis["text_type_performance"]["by_genre"]:
+                class_genre_scores[entry["label"]].append(entry["avg_score"])
+            for err in analysis["common_error_patterns"]:
+                class_error_count[err["character"]] += err["error_count"]
+
+        student_summaries.append({
+            "student_id": sid,
+            "total_completed_texts": analysis["total_completed_texts"],
+            "has_enough_data": analysis["has_enough_data"],
+            "summary": analysis["summary"],
+        })
+
+    # Aggregate class genre performance
+    class_genre_performance = [
+        {
+            "genre": genre,
+            "class_avg_score": round(sum(scores) / len(scores), 1),
+            "student_count": len(scores),
+        }
+        for genre, scores in sorted(class_genre_scores.items())
+    ]
+
+    # Top class-wide recurring errors
+    class_common_errors = [
+        {"character": char, "total_errors": count}
+        for char, count in class_error_count.most_common(10)
+    ]
+
+    return {
+        "total_students": len(student_ids),
+        "students_with_enough_data": students_with_data,
+        "class_genre_performance": class_genre_performance,
+        "class_common_errors": class_common_errors,
+        "student_summaries": student_summaries,
+    }

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -14,12 +14,14 @@ import TextManagementTab from './TextManagementTab';
 import StudentListTab from './StudentListTab';
 import AssignmentTab from './AssignmentTab';
 import ClassroomAnalytics from './ClassroomAnalytics';
+import CrossTextAnalytics from './CrossTextAnalytics';
 
-type TabKey = 'progress' | 'texts' | 'assignments' | 'students' | 'analytics';
+type TabKey = 'progress' | 'texts' | 'assignments' | 'students' | 'analytics' | 'cross-text';
 
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'progress', label: '學生進度' },
   { key: 'analytics', label: '學習分析' },
+  { key: 'cross-text', label: '跨課文分析' },
   { key: 'texts', label: '課文管理' },
   { key: 'assignments', label: '作業管理' },
   { key: 'students', label: '學生名單' },
@@ -373,6 +375,10 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
 
           {activeTab === 'analytics' && (
             <ClassroomAnalytics classroomId={classroomId} />
+          )}
+
+          {activeTab === 'cross-text' && (
+            <CrossTextAnalytics classroomId={classroomId} />
           )}
 
           {activeTab === 'texts' && (

--- a/frontend/src/pages/teacher/CrossTextAnalytics.tsx
+++ b/frontend/src/pages/teacher/CrossTextAnalytics.tsx
@@ -1,0 +1,507 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  getCrossTextAnalysis,
+  ClassroomCrossTextPattern,
+  StudentCrossTextPattern,
+  TeacherApiError,
+} from '../../services/teacherApi';
+
+interface CrossTextAnalyticsProps {
+  classroomId: number;
+}
+
+type ViewMode = 'class' | 'student';
+
+function scoreColor(score: number | null): string {
+  if (score === null) return '#6366f1';
+  if (score >= 80) return '#10b981';
+  if (score >= 60) return '#f59e0b';
+  return '#ef4444';
+}
+
+function ScoreBadge({ score }: { score: number | null }) {
+  return (
+    <span
+      className="inline-block px-2 py-0.5 rounded text-white text-xs font-semibold"
+      style={{ backgroundColor: scoreColor(score) }}
+    >
+      {score !== null ? score : '--'}
+    </span>
+  );
+}
+
+function ClassOverviewPanel({ data }: { data: ClassroomCrossTextPattern }) {
+  const lastTrend = data.class_score_trend[data.class_score_trend.length - 1];
+
+  return (
+    <div className="space-y-6">
+      {/* Summary stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: '學生人數', value: data.total_students },
+          { label: '總學習次數', value: data.total_sessions },
+          { label: '已練習課文數', value: data.text_difficulty_ranking.length },
+          {
+            label: '最新班級均分',
+            value: lastTrend ? `${lastTrend.avg_score} 分` : '--',
+          },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            className="bg-white rounded-xl border border-gray-200 p-4 text-center shadow-sm"
+          >
+            <div className="text-2xl font-bold text-indigo-600">{stat.value}</div>
+            <div className="text-sm text-gray-500 mt-1">{stat.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Class score trend */}
+      {data.class_score_trend.length > 1 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+          <h3 className="text-base font-semibold text-gray-700 mb-4">班級整體分數趨勢</h3>
+          <ResponsiveContainer width="100%" height={200}>
+            <LineChart data={data.class_score_trend}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v: string) => v.slice(5)}
+              />
+              <YAxis domain={[0, 100]} tick={{ fontSize: 11 }} />
+              <Tooltip formatter={(v: number) => [`${v} 分`, '班級平均']} />
+              <Line
+                type="monotone"
+                dataKey="avg_score"
+                stroke="#6366f1"
+                strokeWidth={2}
+                dot={{ r: 3 }}
+                name="班級平均"
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {/* Text difficulty ranking */}
+      {data.text_difficulty_ranking.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+          <h3 className="text-base font-semibold text-gray-700 mb-1">課文難易排行</h3>
+          <p className="text-xs text-gray-400 mb-4">依班級平均分由低到高排列</p>
+          <ResponsiveContainer
+            width="100%"
+            height={Math.max(200, data.text_difficulty_ranking.length * 36)}
+          >
+            <BarChart
+              data={data.text_difficulty_ranking}
+              layout="vertical"
+              margin={{ left: 8, right: 40, top: 4, bottom: 4 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" horizontal={false} />
+              <XAxis type="number" domain={[0, 100]} tick={{ fontSize: 11 }} />
+              <YAxis
+                type="category"
+                dataKey="title"
+                width={96}
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v: string) =>
+                  v && v.length > 6 ? `${v.slice(0, 6)}...` : v || '未知'
+                }
+              />
+              <Tooltip
+                formatter={(v: number) => [`${v} 分`, '班級平均']}
+                labelFormatter={(label: string) => `課文：${label}`}
+              />
+              <Bar dataKey="avg_score" name="班級平均分" radius={[0, 4, 4, 0]}>
+                {data.text_difficulty_ranking.map((entry, idx) => (
+                  <Cell key={idx} fill={scoreColor(entry.avg_score)} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+          <div className="flex gap-4 mt-3 text-xs text-gray-500">
+            <span>
+              <span className="inline-block w-3 h-3 rounded-sm bg-green-500 mr-1" />
+              80+ 分
+            </span>
+            <span>
+              <span className="inline-block w-3 h-3 rounded-sm bg-amber-400 mr-1" />
+              60-79 分
+            </span>
+            <span>
+              <span className="inline-block w-3 h-3 rounded-sm bg-red-500 mr-1" />
+              60 分以下
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Common class-level error chars */}
+      {data.common_error_chars.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+          <h3 className="text-base font-semibold text-gray-700 mb-4">
+            班級常見錯字（多人共同出錯）
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {data.common_error_chars.map((item) => (
+              <div
+                key={item.char}
+                className="flex flex-col items-center bg-red-50 border border-red-200 rounded-lg px-3 py-2 min-w-[56px]"
+              >
+                <span className="text-xl font-bold text-red-600">{item.char}</span>
+                <span className="text-xs text-gray-500 mt-0.5">{item.student_count} 人</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StudentDetailPanel({ pattern }: { pattern: StudentCrossTextPattern }) {
+  return (
+    <div className="space-y-5">
+      {/* Header stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {[
+          { label: '已嘗試課文', value: pattern.total_texts_attempted },
+          { label: '學習次數', value: pattern.total_sessions },
+          {
+            label: '平均分',
+            value:
+              pattern.overall_avg_score !== null ? `${pattern.overall_avg_score} 分` : '--',
+          },
+          { label: '強項課文', value: pattern.strong_texts.length },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            className="bg-white rounded-lg border border-gray-200 p-3 text-center shadow-sm"
+          >
+            <div className="text-xl font-bold text-indigo-600">{stat.value}</div>
+            <div className="text-xs text-gray-500 mt-1">{stat.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Score trend */}
+      {pattern.score_trend.length > 1 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm">
+          <h4 className="text-sm font-semibold text-gray-700 mb-3">分數學習曲線</h4>
+          <ResponsiveContainer width="100%" height={180}>
+            <LineChart data={pattern.score_trend}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 10 }}
+                tickFormatter={(v: string) => v.slice(5)}
+              />
+              <YAxis domain={[0, 100]} tick={{ fontSize: 10 }} />
+              <Tooltip
+                formatter={(v: number) => [`${v} 分`, '分數']}
+                labelFormatter={(
+                  _: string,
+                  payload: Array<{ payload: { title: string | null } }>,
+                ) => payload?.[0]?.payload?.title || ''}
+              />
+              <Line
+                type="monotone"
+                dataKey="score"
+                stroke="#6366f1"
+                strokeWidth={2}
+                dot={{ r: 3 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {/* Text performance table */}
+      {pattern.text_performance.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm">
+          <h4 className="text-sm font-semibold text-gray-700 mb-3">各課文學習成效</h4>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-gray-500 border-b border-gray-200">
+                  <th className="text-left pb-2 pr-4">課文</th>
+                  <th className="text-center pb-2 px-3">練習次數</th>
+                  <th className="text-center pb-2 px-3">平均分</th>
+                  <th className="text-center pb-2 px-3">朗讀準確率</th>
+                  <th className="text-center pb-2 px-3">閱讀理解</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pattern.text_performance.map((tp) => (
+                  <tr key={tp.story_slug} className="border-b border-gray-100 last:border-0">
+                    <td className="py-2 pr-4 font-medium text-gray-700 max-w-[140px] truncate">
+                      {tp.story_title || tp.story_slug}
+                    </td>
+                    <td className="py-2 px-3 text-center text-gray-600">
+                      {tp.attempt_count}
+                    </td>
+                    <td className="py-2 px-3 text-center">
+                      <ScoreBadge score={tp.avg_score} />
+                    </td>
+                    <td className="py-2 px-3 text-center text-gray-600">
+                      {tp.avg_accuracy !== null ? `${tp.avg_accuracy}%` : '--'}
+                    </td>
+                    <td className="py-2 px-3 text-center">
+                      <ScoreBadge score={tp.avg_comprehension_score} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Cross-text recurring errors */}
+      {pattern.repeated_error_chars.length > 0 && (
+        <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm">
+          <h4 className="text-sm font-semibold text-gray-700 mb-3">
+            跨課文反覆錯誤字（出現於 2 篇以上）
+          </h4>
+          <div className="flex flex-wrap gap-2">
+            {pattern.repeated_error_chars.map((item) => (
+              <div
+                key={item.char}
+                className="flex flex-col items-center bg-orange-50 border border-orange-200 rounded-lg px-3 py-2 min-w-[60px]"
+              >
+                <span className="text-2xl font-bold text-orange-600">{item.char}</span>
+                <span className="text-xs text-gray-500">{item.story_count} 篇課文</span>
+                <span className="text-xs text-red-400">錯 {item.error_count} 次</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Strengths and weaknesses */}
+      {(pattern.strong_texts.length > 0 || pattern.weak_texts.length > 0) && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {pattern.strong_texts.length > 0 && (
+            <div className="bg-green-50 border border-green-200 rounded-xl p-4">
+              <h4 className="text-sm font-semibold text-green-700 mb-2">強項課文 (80+ 分)</h4>
+              <ul className="space-y-1">
+                {pattern.strong_texts.map((slug) => {
+                  const tp = pattern.text_performance.find((t) => t.story_slug === slug);
+                  return (
+                    <li key={slug} className="text-sm text-green-600">
+                      {tp?.story_title || slug}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+          {pattern.weak_texts.length > 0 && (
+            <div className="bg-red-50 border border-red-200 rounded-xl p-4">
+              <h4 className="text-sm font-semibold text-red-700 mb-2">
+                待加強課文 (60 分以下)
+              </h4>
+              <ul className="space-y-1">
+                {pattern.weak_texts.map((slug) => {
+                  const tp = pattern.text_performance.find((t) => t.story_slug === slug);
+                  return (
+                    <li key={slug} className="text-sm text-red-600">
+                      {tp?.story_title || slug}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StudentSelector({
+  students,
+  selected,
+  onSelect,
+}: {
+  students: StudentCrossTextPattern[];
+  selected: number | null;
+  onSelect: (id: number) => void;
+}) {
+  return (
+    <div className="w-full md:w-56 flex-shrink-0">
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        <div className="px-4 py-3 bg-gray-50 border-b border-gray-200">
+          <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+            學生列表
+          </span>
+        </div>
+        <ul className="divide-y divide-gray-100 max-h-[480px] overflow-y-auto">
+          {students.map((s) => (
+            <li key={s.student_id}>
+              <button
+                onClick={() => onSelect(s.student_id)}
+                className={`w-full text-left px-4 py-3 hover:bg-indigo-50 transition-colors ${
+                  selected === s.student_id
+                    ? 'bg-indigo-50 border-l-2 border-indigo-500'
+                    : ''
+                }`}
+              >
+                <div className="text-sm font-medium text-gray-700 truncate">
+                  {s.student_name}
+                </div>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="text-xs text-gray-400">{s.total_texts_attempted} 篇</span>
+                  {s.overall_avg_score !== null && (
+                    <ScoreBadge score={s.overall_avg_score} />
+                  )}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+const CrossTextAnalytics: React.FC<CrossTextAnalyticsProps> = ({ classroomId }) => {
+  const { token } = useAuth();
+  const [data, setData] = useState<ClassroomCrossTextPattern | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [viewMode, setViewMode] = useState<ViewMode>('class');
+  const [selectedStudentId, setSelectedStudentId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const result = await getCrossTextAnalysis(token, classroomId);
+      setData(result);
+      if (result.student_patterns.length > 0 && selectedStudentId === null) {
+        setSelectedStudentId(result.student_patterns[0].student_id);
+      }
+    } catch (err) {
+      if (err instanceof TeacherApiError) {
+        setError(err.message);
+      } else {
+        setError('無法載入跨課文分析資料');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, classroomId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (isLoading) {
+    return (
+      <div className="p-6 space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-32 bg-gray-100 animate-pulse rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6 text-center text-red-500">
+        <p>{error}</p>
+        <button onClick={load} className="mt-3 text-sm text-indigo-600 hover:underline">
+          重試
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  if (data.total_sessions === 0) {
+    return (
+      <div className="p-8 text-center text-gray-500">
+        <p className="text-4xl mb-3">📚</p>
+        <p className="font-medium">尚無學習記錄</p>
+        <p className="text-sm mt-1">學生完成課文練習後，跨課文模式分析將自動生成。</p>
+      </div>
+    );
+  }
+
+  const selectedPattern = data.student_patterns.find(
+    (p) => p.student_id === selectedStudentId,
+  );
+
+  return (
+    <div className="p-5 space-y-5">
+      {/* View mode toggle */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-gray-500 font-medium">檢視模式：</span>
+        <div className="flex rounded-lg border border-gray-200 overflow-hidden">
+          <button
+            onClick={() => setViewMode('class')}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              viewMode === 'class'
+                ? 'bg-indigo-600 text-white'
+                : 'bg-white text-gray-600 hover:bg-gray-50'
+            }`}
+          >
+            班級總覽
+          </button>
+          <button
+            onClick={() => setViewMode('student')}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              viewMode === 'student'
+                ? 'bg-indigo-600 text-white'
+                : 'bg-white text-gray-600 hover:bg-gray-50'
+            }`}
+          >
+            個別學生
+          </button>
+        </div>
+      </div>
+
+      {viewMode === 'class' ? (
+        <ClassOverviewPanel data={data} />
+      ) : (
+        <div className="flex flex-col md:flex-row gap-5">
+          <StudentSelector
+            students={data.student_patterns}
+            selected={selectedStudentId}
+            onSelect={setSelectedStudentId}
+          />
+          <div className="flex-1 min-w-0">
+            {selectedPattern ? (
+              <>
+                <h3 className="text-base font-semibold text-gray-700 mb-4">
+                  {selectedPattern.student_name} 的跨課文學習模式
+                </h3>
+                <StudentDetailPanel pattern={selectedPattern} />
+              </>
+            ) : (
+              <div className="text-center text-gray-400 py-12">請從左側選擇學生</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CrossTextAnalytics;

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -506,3 +506,69 @@ export async function markAllNotificationsRead(
   });
   return handleResponse<{ marked: number }>(res);
 }
+
+// ── Cross-Text Analysis (Issue #253) ─────────────────────────────────────────
+
+export interface TextPerformanceSummary {
+  story_slug: string;
+  story_title: string | null;
+  attempt_count: number;
+  avg_score: number | null;
+  avg_accuracy: number | null;
+  avg_comprehension_score: number | null;
+  first_attempt_at: string | null;
+  last_attempt_at: string | null;
+}
+
+export interface RepeatedErrorChar {
+  char: string;
+  error_count: number;
+  story_count: number;
+  story_slugs: string[];
+}
+
+export interface StudentCrossTextPattern {
+  student_id: number;
+  student_name: string;
+  total_texts_attempted: number;
+  total_sessions: number;
+  overall_avg_score: number | null;
+  score_trend: Array<{
+    date: string;
+    score: number | null;
+    story_slug: string;
+    title: string | null;
+  }>;
+  text_performance: TextPerformanceSummary[];
+  repeated_error_chars: RepeatedErrorChar[];
+  strong_texts: string[];
+  weak_texts: string[];
+}
+
+export interface ClassroomCrossTextPattern {
+  classroom_id: number;
+  classroom_name: string;
+  total_students: number;
+  total_sessions: number;
+  text_difficulty_ranking: Array<{
+    story_slug: string;
+    title: string | null;
+    avg_score: number | null;
+    attempt_count: number;
+  }>;
+  class_score_trend: Array<{ date: string; avg_score: number }>;
+  common_error_chars: Array<{ char: string; student_count: number; total_errors: number }>;
+  student_patterns: StudentCrossTextPattern[];
+}
+
+/** Fetch cross-text learning pattern analysis for a classroom. */
+export async function getCrossTextAnalysis(
+  token: string,
+  classroomId: number,
+): Promise<ClassroomCrossTextPattern> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/classrooms/${classroomId}/cross-text-analysis`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return handleResponse<ClassroomCrossTextPattern>(res);
+}


### PR DESCRIPTION
Fixes #253

## Summary

- **Backend**: New `GET /api/teacher/classrooms/{id}/cross-text-analysis` endpoint aggregating student performance across all attempted texts
- **Backend**: New `cross_text_analysis_service.py` with reusable analysis logic (score trends, error patterns, difficulty ranking)
- **Frontend**: New `CrossTextAnalytics` component with Recharts charts (class score trend line chart, text difficulty horizontal bar chart, per-student drill-down)
- **Frontend**: New "跨課文分析" tab added to the classroom detail dashboard between "學習分析" and "課文管理"

## Features

### Class-level view
- Summary stats (students, sessions, texts attempted, latest avg score)
- Class score trend over time (line chart)
- Text difficulty ranking by class average score (color-coded bar chart)
- Most common error characters across the class

### Per-student view
- Student selector sidebar with score badges
- Individual score learning curve over time
- Per-text performance table (avg score, accuracy, comprehension)
- Cross-text recurring error characters (appearing in 2+ texts)
- Strength/weakness text lists (80+/60- thresholds)

## Test plan

- [ ] Open a classroom with completed learning sessions
- [ ] Navigate to the "跨課文分析" tab
- [ ] Verify class overview loads with score trend and difficulty charts
- [ ] Switch to "個別學生" view and select a student
- [ ] Verify per-student score curve and text performance table render
- [ ] Verify empty state shows correctly for classrooms with no sessions
- [ ] Verify API endpoint returns 200 with correct JSON shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)