### PR TITLE
feat: gamification system with XP, achievements, and streaks (Fixes #26)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from .routes.privacy import router as privacy_router
 from .routes.cleanup import router as cleanup_router
 from .routes.dictionary import router as dictionary_router
 from .routes.parents import router as parents_router
+from .routes.gamification import router as gamification_router
 from .utils.logging_config import setup_logging
 
 # Initialise structured logging before anything else
@@ -217,6 +218,7 @@ app.include_router(privacy_router, prefix="/api", tags=["privacy"])
 app.include_router(cleanup_router, prefix="/api", tags=["admin-cleanup"])
 app.include_router(dictionary_router, prefix="/api", tags=["dictionary"])
 app.include_router(parents_router, prefix="/api", tags=["parents"])
+app.include_router(gamification_router, prefix="/api", tags=["gamification"])
 
 
 def seed_default_data():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,3 +12,4 @@ from .teacher_instruction import TeacherInstruction  # noqa: F401
 from .notification_read import TeacherNotificationRead  # noqa: F401
 from .dictionary import DictionaryCache  # noqa: F401
 from .parent_link import ParentInviteCode, ParentStudentLink  # noqa: F401
+from .gamification import StudentXPLog, StudentBadge, StudentStreak  # noqa: F401

--- a/backend/app/models/gamification.py
+++ b/backend/app/models/gamification.py
@@ -1,0 +1,250 @@
+"""Gamification models: XP log, level snapshots, and achievement badges."""
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+# ── XP Configuration (defined in code, not DB) ───────────────────────────────
+
+XP_REWARDS = {
+    "session_complete": 20,       # completed a full learning session
+    "accuracy_70": 10,            # reading accuracy >= 70%
+    "accuracy_90": 20,            # reading accuracy >= 90%
+    "comprehension_pass": 10,     # passed comprehension questions
+    "streak_bonus": 5,            # daily login streak bonus (per day)
+    "first_story": 30,            # bonus for completing very first story
+    "vocab_practice": 5,          # completed vocabulary practice step
+}
+
+# Cumulative XP thresholds per level (index = level-1, value = XP needed to reach it)
+LEVEL_THRESHOLDS = [
+    0,    # Level 1  — starting level
+    100,  # Level 2
+    250,  # Level 3
+    500,  # Level 4
+    800,  # Level 5
+    1200, # Level 6
+    1700, # Level 7
+    2300, # Level 8
+    3000, # Level 9
+    4000, # Level 10 — max
+]
+
+LEVEL_NAMES = [
+    "初學者",   # 1
+    "求知者",   # 2
+    "閱讀者",   # 3
+    "探索者",   # 4
+    "思考者",   # 5
+    "朗讀家",   # 6
+    "文字匠",   # 7
+    "智慧者",   # 8
+    "文學人",   # 9
+    "國文之星", # 10
+]
+
+
+def xp_to_level(total_xp: int) -> int:
+    """Return 1-based level for the given cumulative XP."""
+    level = 1
+    for i, threshold in enumerate(LEVEL_THRESHOLDS):
+        if total_xp >= threshold:
+            level = i + 1
+        else:
+            break
+    return min(level, len(LEVEL_THRESHOLDS))
+
+
+def level_progress(total_xp: int) -> dict:
+    """Return level metadata for a student's total XP."""
+    level = xp_to_level(total_xp)
+    current_threshold = LEVEL_THRESHOLDS[level - 1]
+    next_threshold = LEVEL_THRESHOLDS[level] if level < len(LEVEL_THRESHOLDS) else None
+
+    if next_threshold is None:
+        pct = 100
+        xp_in_level = total_xp - current_threshold
+        xp_needed = 0
+    else:
+        xp_in_level = total_xp - current_threshold
+        xp_range = next_threshold - current_threshold
+        pct = min(100, round(xp_in_level / xp_range * 100))
+        xp_needed = next_threshold - total_xp
+
+    return {
+        "level": level,
+        "level_name": LEVEL_NAMES[level - 1],
+        "total_xp": total_xp,
+        "current_level_xp": xp_in_level,
+        "next_level_xp": next_threshold,
+        "xp_to_next": max(0, xp_needed),
+        "progress_pct": pct,
+    }
+
+
+# ── Badge catalogue (defined in code) ────────────────────────────────────────
+
+BADGE_CATALOGUE = {
+    "first_story": {
+        "name": "第一步",
+        "description": "完成第一篇課文學習",
+        "icon": "star",
+        "color": "yellow",
+    },
+    "story_5": {
+        "name": "勤讀者",
+        "description": "累計完成 5 篇課文",
+        "icon": "book",
+        "color": "blue",
+    },
+    "story_10": {
+        "name": "閱讀達人",
+        "description": "累計完成 10 篇課文",
+        "icon": "book-open",
+        "color": "purple",
+    },
+    "story_25": {
+        "name": "博覽群書",
+        "description": "累計完成 25 篇課文",
+        "icon": "library",
+        "color": "gold",
+    },
+    "streak_3": {
+        "name": "三日不輟",
+        "description": "連續學習 3 天",
+        "icon": "fire",
+        "color": "orange",
+    },
+    "streak_7": {
+        "name": "週週精進",
+        "description": "連續學習 7 天",
+        "icon": "fire",
+        "color": "red",
+    },
+    "streak_30": {
+        "name": "月月堅持",
+        "description": "連續學習 30 天",
+        "icon": "trophy",
+        "color": "gold",
+    },
+    "accuracy_90": {
+        "name": "精準朗讀",
+        "description": "朗讀準確度達到 90%",
+        "icon": "mic",
+        "color": "green",
+    },
+    "accuracy_100": {
+        "name": "完美表現",
+        "description": "朗讀準確度達到 100%",
+        "icon": "award",
+        "color": "gold",
+    },
+    "level_5": {
+        "name": "思考者",
+        "description": "升級到第 5 級",
+        "icon": "brain",
+        "color": "indigo",
+    },
+    "level_10": {
+        "name": "國文之星",
+        "description": "升級到最高等級",
+        "icon": "crown",
+        "color": "gold",
+    },
+    "xp_500": {
+        "name": "積分達人",
+        "description": "累計獲得 500 XP",
+        "icon": "zap",
+        "color": "yellow",
+    },
+    "xp_1000": {
+        "name": "千分英雄",
+        "description": "累計獲得 1000 XP",
+        "icon": "zap",
+        "color": "orange",
+    },
+}
+
+
+# ── DB Models ─────────────────────────────────────────────────────────────────
+
+
+class StudentXPLog(Base):
+    """One row per XP award event for a student."""
+
+    __tablename__ = "student_xp_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    student_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Event type, e.g. "session_complete", "accuracy_90"
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    xp_earned: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Optional reference to the learning session that triggered this award
+    session_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("learning_sessions.id", ondelete="SET NULL"), nullable=True
+    )
+    # Human-readable note
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    student: Mapped["User"] = relationship("User")  # type: ignore[name-defined]
+
+
+class StudentBadge(Base):
+    """Records which badges a student has unlocked."""
+
+    __tablename__ = "student_badges"
+    __table_args__ = (UniqueConstraint("student_id", "badge_key"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    student_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Key into BADGE_CATALOGUE
+    badge_key: Mapped[str] = mapped_column(String(50), nullable=False)
+    unlocked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    student: Mapped["User"] = relationship("User")  # type: ignore[name-defined]
+
+
+class StudentStreak(Base):
+    """Tracks consecutive daily learning days per student."""
+
+    __tablename__ = "student_streaks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    student_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    current_streak: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    longest_streak: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_activity_date: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    student: Mapped["User"] = relationship("User")  # type: ignore[name-defined]

--- a/backend/app/routes/gamification.py
+++ b/backend/app/routes/gamification.py
@@ -1,0 +1,221 @@
+"""Gamification API routes.
+
+Endpoints:
+  GET  /api/gamification/summary/{student_id}        — full XP + badges + streak summary
+  GET  /api/gamification/points/{student_id}         — XP and level info
+  GET  /api/gamification/achievements/{student_id}   — earned and available badges
+  GET  /api/gamification/streak/{student_id}         — streak info
+  GET  /api/gamification/leaderboard/{classroom_id}  — class leaderboard
+  POST /api/gamification/award-xp                    — award XP for an event (internal/admin)
+"""
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..auth.dependencies import get_current_user
+from ..database import get_db
+from ..models.school import Classroom, ClassroomStudent
+from ..models.user import User
+from ..services.gamification_service import (
+    award_xp,
+    get_classroom_leaderboard,
+    get_student_summary,
+    process_session_completion,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/gamification", tags=["gamification"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas (inline Pydantic for simplicity)
+# ---------------------------------------------------------------------------
+
+
+class AwardXPRequest(BaseModel):
+    student_id: int
+    event_type: str
+    session_id: int | None = None
+    note: str | None = None
+
+
+class SessionCompleteRequest(BaseModel):
+    student_id: int
+    session_id: int
+    reading_accuracy: float | None = None
+    comprehension_passed: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_can_view(current_user: User, student_id: int, db: Session) -> None:
+    """Raise 403 if the current user is neither the student nor a teacher/admin."""
+    if current_user.id == student_id:
+        return  # viewing own data
+
+    # Check if current user is a teacher who has this student
+    from ..models.school import ClassroomStudent, Classroom
+
+    is_teacher = (
+        db.query(Classroom)
+        .join(ClassroomStudent, ClassroomStudent.classroom_id == Classroom.id)
+        .filter(
+            Classroom.teacher_id == current_user.id,
+            ClassroomStudent.student_id == student_id,
+        )
+        .first()
+        is not None
+    )
+    if is_teacher:
+        return
+
+    # Check admin roles
+    from ..models.user import UserRole
+    admin_roles = {"system_admin", "org_admin", "org_owner"}
+    user_role_names = {
+        ur.role.name
+        for ur in db.query(UserRole)
+        .filter(UserRole.user_id == current_user.id, UserRole.is_active == True)
+        .all()
+        if ur.role
+    }
+    if admin_roles & user_role_names:
+        return
+
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/summary/{student_id}")
+def get_summary(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Full gamification summary: XP, level, badges, streak."""
+    _assert_can_view(current_user, student_id, db)
+    student = db.query(User).filter(User.id == student_id).first()
+    if not student:
+        raise HTTPException(status_code=404, detail="Student not found")
+    return get_student_summary(db, student_id)
+
+
+@router.get("/points/{student_id}")
+def get_points(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return XP total and level breakdown for a student."""
+    _assert_can_view(current_user, student_id, db)
+    summary = get_student_summary(db, student_id)
+    return {
+        "student_id": student_id,
+        "total_xp": summary["total_xp"],
+        "stories_completed": summary["stories_completed"],
+        "level_info": summary["level_info"],
+    }
+
+
+@router.get("/achievements/{student_id}")
+def get_achievements(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return unlocked badges and full badge catalogue for a student."""
+    _assert_can_view(current_user, student_id, db)
+    summary = get_student_summary(db, student_id)
+    return {
+        "student_id": student_id,
+        "badges": summary["badges"],
+        "all_badges": summary["all_badges"],
+        "total_unlocked": len(summary["badges"]),
+    }
+
+
+@router.get("/streak/{student_id}")
+def get_streak(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return streak information for a student."""
+    _assert_can_view(current_user, student_id, db)
+    summary = get_student_summary(db, student_id)
+    return {"student_id": student_id, **summary["streak"]}
+
+
+@router.get("/leaderboard/{classroom_id}")
+def get_leaderboard(
+    classroom_id: int,
+    limit: int = Query(10, ge=1, le=50),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Return class leaderboard ranked by total XP."""
+    classroom = db.query(Classroom).filter(Classroom.id == classroom_id).first()
+    if not classroom:
+        raise HTTPException(status_code=404, detail="Classroom not found")
+
+    # Only the classroom teacher, admins, or enrolled students can see the leaderboard
+    is_teacher = classroom.teacher_id == current_user.id
+    is_student = (
+        db.query(ClassroomStudent)
+        .filter(
+            ClassroomStudent.classroom_id == classroom_id,
+            ClassroomStudent.student_id == current_user.id,
+        )
+        .first()
+        is not None
+    )
+    if not is_teacher and not is_student:
+        # Check admin roles
+        from ..models.user import UserRole
+        admin_roles = {"system_admin", "org_admin", "org_owner"}
+        user_role_names = {
+            ur.role.name
+            for ur in db.query(UserRole)
+            .filter(UserRole.user_id == current_user.id, UserRole.is_active == True)
+            .all()
+            if ur.role
+        }
+        if not (admin_roles & user_role_names):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    entries = get_classroom_leaderboard(db, classroom_id, limit=limit)
+    return {
+        "classroom_id": classroom_id,
+        "entries": entries,
+        "total_students": len(entries),
+    }
+
+
+@router.post("/session-complete")
+def on_session_complete(
+    body: SessionCompleteRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Award XP and badges when a student completes a learning session.
+
+    Can be called by the student themselves or a teacher/admin.
+    """
+    _assert_can_view(current_user, body.student_id, db)
+    result = process_session_completion(
+        db,
+        student_id=body.student_id,
+        session_id=body.session_id,
+        reading_accuracy=body.reading_accuracy,
+        comprehension_passed=body.comprehension_passed,
+    )
+    return result

--- a/backend/app/services/gamification_service.py
+++ b/backend/app/services/gamification_service.py
@@ -1,0 +1,406 @@
+"""Gamification service: award XP, check badges, update streaks.
+
+Called from learning routes after a session is completed. Handles:
+  - Awarding XP for various events
+  - Checking and unlocking achievement badges
+  - Updating daily streak counters
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from ..models.gamification import (
+    BADGE_CATALOGUE,
+    XP_REWARDS,
+    StudentBadge,
+    StudentStreak,
+    StudentXPLog,
+    level_progress,
+    xp_to_level,
+)
+from ..models.school import Classroom, ClassroomStudent
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_or_create_xp_log_entry(db: Session, student_id: int) -> tuple[int, list[StudentXPLog]]:
+    """Return the student's cumulative XP and all XP log rows.
+
+    We compute cumulative XP from the log to avoid a separate summary table,
+    keeping the schema simple while still allowing full auditability.
+    """
+    logs = (
+        db.query(StudentXPLog)
+        .filter(StudentXPLog.student_id == student_id)
+        .all()
+    )
+    total = sum(log.xp_earned for log in logs)
+    return total, logs
+
+
+def _get_or_create_streak(db: Session, student_id: int) -> StudentStreak:
+    streak = db.query(StudentStreak).filter(StudentStreak.student_id == student_id).first()
+    if streak is None:
+        streak = StudentStreak(student_id=student_id)
+        db.add(streak)
+        db.flush()
+    return streak
+
+
+def _get_unlocked_badge_keys(db: Session, student_id: int) -> set[str]:
+    rows = db.query(StudentBadge.badge_key).filter(StudentBadge.student_id == student_id).all()
+    return {r.badge_key for r in rows}
+
+
+def _award_badge(db: Session, student_id: int, badge_key: str) -> StudentBadge | None:
+    """Award a badge if not already unlocked. Returns the new row or None."""
+    existing = (
+        db.query(StudentBadge)
+        .filter(
+            StudentBadge.student_id == student_id,
+            StudentBadge.badge_key == badge_key,
+        )
+        .first()
+    )
+    if existing:
+        return None
+    badge = StudentBadge(student_id=student_id, badge_key=badge_key)
+    db.add(badge)
+    logger.info("Badge unlocked: student=%d badge=%s", student_id, badge_key)
+    return badge
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def award_xp(
+    db: Session,
+    student_id: int,
+    event_type: str,
+    session_id: int | None = None,
+    note: str | None = None,
+    xp_override: int | None = None,
+) -> StudentXPLog:
+    """Award XP to a student for an event. Returns the log row."""
+    xp = xp_override if xp_override is not None else XP_REWARDS.get(event_type, 0)
+    if xp <= 0:
+        raise ValueError(f"No XP configured for event_type={event_type!r}")
+
+    log = StudentXPLog(
+        student_id=student_id,
+        event_type=event_type,
+        xp_earned=xp,
+        session_id=session_id,
+        note=note or event_type,
+    )
+    db.add(log)
+    db.flush()
+    logger.info("XP awarded: student=%d event=%s xp=%d", student_id, event_type, xp)
+    return log
+
+
+def update_streak(db: Session, student_id: int, activity_date: date | None = None) -> StudentStreak:
+    """Update a student's daily streak. Call once per session completion."""
+    today = activity_date or datetime.now(timezone.utc).date()
+    streak = _get_or_create_streak(db, student_id)
+
+    if streak.last_activity_date is None:
+        # First ever activity
+        streak.current_streak = 1
+        streak.longest_streak = 1
+        streak.last_activity_date = datetime.combine(today, datetime.min.time()).replace(tzinfo=timezone.utc)
+    else:
+        last_date = streak.last_activity_date
+        if hasattr(last_date, "date"):
+            last_date = last_date.date()
+
+        delta = (today - last_date).days
+        if delta == 0:
+            # Same day — no change
+            pass
+        elif delta == 1:
+            # Consecutive day
+            streak.current_streak += 1
+            streak.longest_streak = max(streak.longest_streak, streak.current_streak)
+            streak.last_activity_date = datetime.combine(today, datetime.min.time()).replace(tzinfo=timezone.utc)
+        else:
+            # Gap — reset
+            streak.current_streak = 1
+            streak.last_activity_date = datetime.combine(today, datetime.min.time()).replace(tzinfo=timezone.utc)
+
+    db.flush()
+    return streak
+
+
+def check_and_award_badges(
+    db: Session,
+    student_id: int,
+    session_id: int | None = None,
+    reading_accuracy: float | None = None,
+) -> list[str]:
+    """Check all badge conditions for a student and unlock any newly earned ones.
+
+    Returns list of newly unlocked badge keys.
+    """
+    total_xp, logs = _get_or_create_xp_log_entry(db, student_id)
+    stories_completed = sum(1 for log in logs if log.event_type == "session_complete")
+    level = xp_to_level(total_xp)
+    streak = _get_or_create_streak(db, student_id)
+    unlocked = _get_unlocked_badge_keys(db, student_id)
+    newly_unlocked: list[str] = []
+
+    def _try(badge_key: str, condition: bool) -> None:
+        if condition and badge_key not in unlocked and badge_key in BADGE_CATALOGUE:
+            row = _award_badge(db, student_id, badge_key)
+            if row:
+                newly_unlocked.append(badge_key)
+
+    # Story completion badges
+    _try("first_story", stories_completed >= 1)
+    _try("story_5", stories_completed >= 5)
+    _try("story_10", stories_completed >= 10)
+    _try("story_25", stories_completed >= 25)
+
+    # Streak badges
+    _try("streak_3", streak.current_streak >= 3)
+    _try("streak_7", streak.current_streak >= 7)
+    _try("streak_30", streak.current_streak >= 30)
+
+    # Accuracy badges
+    if reading_accuracy is not None:
+        _try("accuracy_90", reading_accuracy >= 90.0)
+        _try("accuracy_100", reading_accuracy >= 100.0)
+
+    # Level badges
+    _try("level_5", level >= 5)
+    _try("level_10", level >= 10)
+
+    # XP milestone badges
+    _try("xp_500", total_xp >= 500)
+    _try("xp_1000", total_xp >= 1000)
+
+    return newly_unlocked
+
+
+def process_session_completion(
+    db: Session,
+    student_id: int,
+    session_id: int,
+    reading_accuracy: float | None = None,
+    comprehension_passed: bool = False,
+    activity_date: date | None = None,
+) -> dict:
+    """Main entry point: called when a learning session is fully completed.
+
+    Awards XP, updates streak, checks badges, commits all changes.
+    Returns a summary dict with XP earned, badges unlocked, and level info.
+    """
+    xp_earned: list[StudentXPLog] = []
+    notes: list[str] = []
+
+    # --- Base session XP ---
+    total_xp_before, _ = _get_or_create_xp_log_entry(db, student_id)
+    is_first_story = total_xp_before == 0
+
+    log = award_xp(db, student_id, "session_complete", session_id=session_id, note="完成課文學習")
+    xp_earned.append(log)
+
+    # --- First story bonus ---
+    if is_first_story:
+        log2 = award_xp(db, student_id, "first_story", session_id=session_id, note="第一篇故事完成！")
+        xp_earned.append(log2)
+        notes.append("第一篇故事加分！")
+
+    # --- Accuracy bonuses ---
+    if reading_accuracy is not None:
+        if reading_accuracy >= 90.0:
+            log3 = award_xp(db, student_id, "accuracy_90", session_id=session_id, note=f"朗讀準確度 {reading_accuracy:.0f}%")
+            xp_earned.append(log3)
+        elif reading_accuracy >= 70.0:
+            log4 = award_xp(db, student_id, "accuracy_70", session_id=session_id, note=f"朗讀準確度 {reading_accuracy:.0f}%")
+            xp_earned.append(log4)
+
+    # --- Comprehension bonus ---
+    if comprehension_passed:
+        log5 = award_xp(db, student_id, "comprehension_pass", session_id=session_id, note="理解測驗通過")
+        xp_earned.append(log5)
+
+    # --- Update streak ---
+    streak = update_streak(db, student_id, activity_date=activity_date)
+
+    # --- Streak daily bonus ---
+    if streak.current_streak > 1:
+        log6 = award_xp(db, student_id, "streak_bonus", session_id=session_id, note=f"連續學習 {streak.current_streak} 天")
+        xp_earned.append(log6)
+
+    # --- Compute new totals ---
+    new_total_xp = total_xp_before + sum(l.xp_earned for l in xp_earned)
+    lv_info = level_progress(new_total_xp)
+
+    # --- Check badges ---
+    newly_unlocked = check_and_award_badges(
+        db, student_id, session_id=session_id, reading_accuracy=reading_accuracy
+    )
+
+    db.commit()
+
+    total_xp_this_session = sum(l.xp_earned for l in xp_earned)
+    logger.info(
+        "Session completion processed: student=%d session=%d xp_gained=%d new_total=%d badges=%s",
+        student_id,
+        session_id,
+        total_xp_this_session,
+        new_total_xp,
+        newly_unlocked,
+    )
+
+    return {
+        "xp_earned": total_xp_this_session,
+        "xp_breakdown": [
+            {"event_type": l.event_type, "xp": l.xp_earned, "note": l.note}
+            for l in xp_earned
+        ],
+        "new_total_xp": new_total_xp,
+        "level_info": lv_info,
+        "streak": {
+            "current": streak.current_streak,
+            "longest": streak.longest_streak,
+        },
+        "badges_unlocked": newly_unlocked,
+        "notes": notes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Query helpers used by the API routes
+# ---------------------------------------------------------------------------
+
+
+def get_student_summary(db: Session, student_id: int) -> dict:
+    """Return full gamification summary for a student."""
+    total_xp, logs = _get_or_create_xp_log_entry(db, student_id)
+    stories_completed = sum(1 for l in logs if l.event_type == "session_complete")
+    lv_info = level_progress(total_xp)
+
+    streak = _get_or_create_streak(db, student_id)
+    db.flush()
+
+    badges = (
+        db.query(StudentBadge)
+        .filter(StudentBadge.student_id == student_id)
+        .order_by(StudentBadge.unlocked_at)
+        .all()
+    )
+    badge_list = []
+    for b in badges:
+        info = BADGE_CATALOGUE.get(b.badge_key, {})
+        badge_list.append(
+            {
+                "key": b.badge_key,
+                "name": info.get("name", b.badge_key),
+                "description": info.get("description", ""),
+                "icon": info.get("icon", "award"),
+                "color": info.get("color", "gray"),
+                "unlocked_at": b.unlocked_at.isoformat(),
+            }
+        )
+
+    return {
+        "student_id": student_id,
+        "total_xp": total_xp,
+        "stories_completed": stories_completed,
+        "level_info": lv_info,
+        "streak": {
+            "current": streak.current_streak,
+            "longest": streak.longest_streak,
+            "last_activity_date": (
+                streak.last_activity_date.date().isoformat()
+                if streak.last_activity_date
+                else None
+            ),
+        },
+        "badges": badge_list,
+        "all_badges": [
+            {
+                "key": key,
+                "name": info["name"],
+                "description": info["description"],
+                "icon": info["icon"],
+                "color": info["color"],
+                "unlocked": key in {b["key"] for b in badge_list},
+            }
+            for key, info in BADGE_CATALOGUE.items()
+        ],
+    }
+
+
+def get_classroom_leaderboard(db: Session, classroom_id: int, limit: int = 10) -> list[dict]:
+    """Return top N students in a classroom ranked by total XP."""
+    from sqlalchemy import func as sqlfunc
+    from ..models.user import User
+
+    # Get all student IDs in classroom
+    student_ids = [
+        row.student_id
+        for row in db.query(ClassroomStudent.student_id)
+        .filter(ClassroomStudent.classroom_id == classroom_id)
+        .all()
+    ]
+    if not student_ids:
+        return []
+
+    # Aggregate XP per student
+    xp_rows = (
+        db.query(
+            StudentXPLog.student_id,
+            sqlfunc.sum(StudentXPLog.xp_earned).label("total_xp"),
+            sqlfunc.count(StudentXPLog.id).filter(
+                StudentXPLog.event_type == "session_complete"
+            ).label("stories"),
+        )
+        .filter(StudentXPLog.student_id.in_(student_ids))
+        .group_by(StudentXPLog.student_id)
+        .order_by(sqlfunc.sum(StudentXPLog.xp_earned).desc())
+        .limit(limit)
+        .all()
+    )
+
+    # Build map for quick lookup
+    xp_map = {row.student_id: (int(row.total_xp), int(row.stories)) for row in xp_rows}
+
+    # For students with no XP logs at all
+    for sid in student_ids:
+        if sid not in xp_map:
+            xp_map[sid] = (0, 0)
+
+    # Fetch user names
+    users = db.query(User).filter(User.id.in_(student_ids)).all()
+    user_map = {u.id: u.name for u in users}
+
+    ranked = sorted(xp_map.items(), key=lambda kv: kv[1][0], reverse=True)[:limit]
+
+    result = []
+    for rank, (student_id, (total_xp, stories)) in enumerate(ranked, start=1):
+        lv = xp_to_level(total_xp)
+        result.append(
+            {
+                "rank": rank,
+                "student_id": student_id,
+                "name": user_map.get(student_id, "—"),
+                "total_xp": total_xp,
+                "level": lv,
+                "stories_completed": stories,
+            }
+        )
+
+    return result

--- a/backend/tests/test_gamification.py
+++ b/backend/tests/test_gamification.py
@@ -1,0 +1,310 @@
+"""TDD tests for the gamification service (XP, badges, streaks, levels).
+
+Pure-logic tests use no DB. Service-level tests use SQLite in-memory.
+"""
+from __future__ import annotations
+
+import pytest
+from datetime import date, datetime, timezone, timedelta
+
+from app.models.gamification import (
+    BADGE_CATALOGUE,
+    LEVEL_THRESHOLDS,
+    LEVEL_NAMES,
+    StudentBadge,
+    StudentStreak,
+    StudentXPLog,
+    level_progress,
+    xp_to_level,
+)
+
+
+# ── Fixtures: in-memory SQLite database ───────────────────────────────────────
+
+
+@pytest.fixture()
+def db_session():
+    """Create an isolated in-memory SQLite DB for each test."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from app.models.base import Base
+    # Import all models so they register their tables
+    import app.models  # noqa: F401
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)
+
+
+def _make_user(db_session, user_id: int = 1):
+    """Insert a minimal User row so FK constraints pass."""
+    from sqlalchemy import text
+    # Insert directly to avoid importing full User model with its hashing
+    db_session.execute(
+        text(
+            "INSERT INTO users (id, email, password_hash, name, is_active, email_verified,"
+            " onboarding_completed, created_at, updated_at)"
+            " VALUES (:id, :email, 'x', :name, 1, 0, 0,"
+            " CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        ),
+        {"id": user_id, "email": f"student{user_id}@test.com", "name": f"Student{user_id}"},
+    )
+    db_session.commit()
+
+
+def _make_session(db_session, session_id: int = 1, student_id: int = 1, status: str = "completed"):
+    """Insert a minimal LearningSession row."""
+    from sqlalchemy import text
+    db_session.execute(
+        text(
+            "INSERT INTO learning_sessions (id, student_id, status, current_step, started_at)"
+            " VALUES (:id, :student_id, :status, 1, CURRENT_TIMESTAMP)"
+        ),
+        {"id": session_id, "student_id": student_id, "status": status},
+    )
+    db_session.commit()
+
+
+# ── Unit tests: level calculation (pure functions, no DB) ─────────────────────
+
+
+class TestXpToLevel:
+    def test_zero_xp_is_level_1(self):
+        assert xp_to_level(0) == 1
+
+    def test_99_xp_is_level_1(self):
+        assert xp_to_level(99) == 1
+
+    def test_exactly_100_xp_is_level_2(self):
+        assert xp_to_level(100) == 2
+
+    def test_249_xp_is_level_2(self):
+        assert xp_to_level(249) == 2
+
+    def test_250_xp_is_level_3(self):
+        assert xp_to_level(250) == 3
+
+    def test_4000_xp_is_level_10(self):
+        assert xp_to_level(4000) == 10
+
+    def test_9999_xp_capped_at_level_10(self):
+        assert xp_to_level(9999) == 10
+
+    def test_negative_xp_is_level_1(self):
+        assert xp_to_level(-10) == 1
+
+
+class TestLevelProgress:
+    def test_returns_all_required_fields(self):
+        result = level_progress(0)
+        for key in ("level", "level_name", "total_xp", "current_level_xp",
+                    "next_level_xp", "xp_to_next", "progress_pct"):
+            assert key in result
+
+    def test_level_1_at_0_xp(self):
+        result = level_progress(0)
+        assert result["level"] == 1
+        assert result["level_name"] == "初學者"
+        assert result["progress_pct"] == 0
+
+    def test_level_1_halfway(self):
+        result = level_progress(50)
+        assert result["level"] == 1
+        assert result["progress_pct"] == 50
+
+    def test_level_2_name(self):
+        result = level_progress(100)
+        assert result["level_name"] == "求知者"
+
+    def test_max_level_progress_100(self):
+        result = level_progress(4000)
+        assert result["progress_pct"] == 100
+        assert result["xp_to_next"] == 0
+        assert result["next_level_xp"] is None
+
+    def test_level_name_count_matches_thresholds(self):
+        assert len(LEVEL_NAMES) == len(LEVEL_THRESHOLDS)
+
+
+class TestLevelProgressEdge:
+    def test_xp_exactly_at_threshold(self):
+        for i, threshold in enumerate(LEVEL_THRESHOLDS[1:], start=2):
+            result = level_progress(threshold)
+            assert result["level"] == i, f"XP={threshold} should be level {i}"
+
+    def test_progress_never_exceeds_100(self):
+        for xp in range(0, 5000, 50):
+            result = level_progress(xp)
+            assert result["progress_pct"] <= 100
+
+
+# ── Integration tests: process_session_completion ─────────────────────────────
+
+
+class TestProcessSessionCompletion:
+    """Integration tests using in-memory SQLite."""
+
+    def test_base_xp_awarded(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+
+        result = process_session_completion(db_session, student_id=1, session_id=1)
+        assert result["xp_earned"] >= 20
+
+    def test_result_has_required_keys(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+
+        result = process_session_completion(db_session, student_id=1, session_id=1)
+        for key in ("xp_earned", "new_total_xp", "level_info", "streak", "badges_unlocked"):
+            assert key in result
+
+    def test_first_story_bonus_on_no_prior_xp(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+
+        result = process_session_completion(db_session, student_id=1, session_id=1)
+        # session_complete(20) + first_story(30) = 50 minimum
+        assert result["xp_earned"] >= 50
+
+    def test_accuracy_90_bonus(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+        _make_session(db_session, 2, 1)  # second session
+
+        # Seed prior XP so it's not first story
+        db_session.add(StudentXPLog(student_id=1, event_type="session_complete", xp_earned=20, session_id=1))
+        db_session.commit()
+
+        result = process_session_completion(db_session, student_id=1, session_id=2,
+                                            reading_accuracy=95.0)
+        # Should include accuracy_90 bonus
+        event_types = [e["event_type"] for e in result["xp_breakdown"]]
+        assert "accuracy_90" in event_types
+
+    def test_accuracy_70_bonus(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+        _make_session(db_session, 2, 1)
+
+        db_session.add(StudentXPLog(student_id=1, event_type="session_complete", xp_earned=20, session_id=1))
+        db_session.commit()
+
+        result = process_session_completion(db_session, student_id=1, session_id=2,
+                                            reading_accuracy=75.0)
+        event_types = [e["event_type"] for e in result["xp_breakdown"]]
+        assert "accuracy_70" in event_types
+        assert "accuracy_90" not in event_types
+
+    def test_comprehension_passed_bonus(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+
+        result = process_session_completion(db_session, student_id=1, session_id=1,
+                                            comprehension_passed=True)
+        event_types = [e["event_type"] for e in result["xp_breakdown"]]
+        assert "comprehension_pass" in event_types
+
+    def test_first_story_badge_unlocked(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+
+        result = process_session_completion(db_session, student_id=1, session_id=1)
+        assert "first_story" in result["badges_unlocked"]
+
+    def test_first_story_badge_not_awarded_twice(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+        _make_session(db_session, 2, 1)
+
+        result1 = process_session_completion(db_session, student_id=1, session_id=1)
+        assert "first_story" in result1["badges_unlocked"]
+
+        result2 = process_session_completion(db_session, student_id=1, session_id=2)
+        assert "first_story" not in result2["badges_unlocked"]
+
+    def test_new_total_xp_accumulates(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+        _make_session(db_session, 2, 1)
+
+        r1 = process_session_completion(db_session, student_id=1, session_id=1)
+        r2 = process_session_completion(db_session, student_id=1, session_id=2)
+        assert r2["new_total_xp"] > r1["new_total_xp"]
+
+    def test_level_info_in_result(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+
+        result = process_session_completion(db_session, student_id=1, session_id=1)
+        lv = result["level_info"]
+        assert lv["level"] >= 1
+        assert lv["level_name"] in LEVEL_NAMES
+
+
+# ── Integration tests: update_streak ─────────────────────────────────────────
+
+
+class TestUpdateStreak:
+    def test_first_activity_creates_streak(self, db_session):
+        from app.services.gamification_service import update_streak
+        _make_user(db_session, 1)
+
+        streak = update_streak(db_session, student_id=1, activity_date=date(2026, 3, 9))
+        assert streak.current_streak == 1
+        assert streak.longest_streak == 1
+
+    def test_consecutive_day_extends_streak(self, db_session):
+        from app.services.gamification_service import update_streak
+        _make_user(db_session, 1)
+
+        update_streak(db_session, student_id=1, activity_date=date(2026, 3, 8))
+        streak = update_streak(db_session, student_id=1, activity_date=date(2026, 3, 9))
+        assert streak.current_streak == 2
+        assert streak.longest_streak == 2
+
+    def test_same_day_does_not_extend_streak(self, db_session):
+        from app.services.gamification_service import update_streak
+        _make_user(db_session, 1)
+
+        update_streak(db_session, student_id=1, activity_date=date(2026, 3, 9))
+        streak = update_streak(db_session, student_id=1, activity_date=date(2026, 3, 9))
+        assert streak.current_streak == 1
+
+    def test_gap_resets_streak(self, db_session):
+        from app.services.gamification_service import update_streak
+        _make_user(db_session, 1)
+
+        update_streak(db_session, student_id=1, activity_date=date(2026, 3, 1))
+        update_streak(db_session, student_id=1, activity_date=date(2026, 3, 2))
+        # Gap of 3 days
+        streak = update_streak(db_session, student_id=1, activity_date=date(2026, 3, 9))
+        assert streak.current_streak == 1
+
+    def test_longest_streak_preserved_after_reset(self, db_session):
+        from app.services.gamification_service import update_streak
+        _make_user(db_session, 1)
+
+        # Build a 3-day streak
+        for d in [date(2026, 3, 1), date(2026, 3, 2), date(2026, 3, 3)]:
+            update_streak(db_session, student_id=1, activity_date=d)
+        # Gap — reset
+        streak = update_streak(db_session, student_id=1, activity_date=date(2026, 3, 9))
+        assert streak.current_streak == 1
+        assert streak.longest_streak == 3

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import StudentProgressDashboard from './components/student/StudentProgressDashbo
 import NotificationBell from './components/teacher/NotificationBell';
 import ParentDashboard from './pages/parent/ParentDashboard';
 import HelpPage from './pages/HelpPage';
+import AchievementsPage from './pages/student/AchievementsPage';
 
 /** Redirect authenticated users away from auth pages. */
 const PublicOnlyRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -671,6 +672,16 @@ const App: React.FC = () => {
               <ProtectedRoute>
                 <AppShell>
                   <StudentProgress />
+                </AppShell>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/achievements"
+            element={
+              <ProtectedRoute>
+                <AppShell>
+                  <AchievementsPage />
                 </AppShell>
               </ProtectedRoute>
             }

--- a/frontend/src/components/gamification/AchievementCard.tsx
+++ b/frontend/src/components/gamification/AchievementCard.tsx
@@ -1,0 +1,107 @@
+/**
+ * AchievementCard — displays a single achievement badge.
+ *
+ * Shows the badge icon (emoji mapped from icon key), name, description,
+ * and whether the student has unlocked it. Locked badges appear dimmed.
+ */
+
+import React from 'react';
+
+export interface BadgeInfo {
+  key: string;
+  name: string;
+  description: string;
+  icon: string;   // icon key from BADGE_CATALOGUE (e.g. "fire", "book")
+  color: string;  // color key (e.g. "orange", "blue", "gold")
+  unlocked?: boolean;
+  unlocked_at?: string;
+}
+
+interface AchievementCardProps {
+  badge: BadgeInfo;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+// Map icon keys to emoji
+const ICON_EMOJI: Record<string, string> = {
+  star: '⭐',
+  book: '📚',
+  'book-open': '📖',
+  library: '🏛️',
+  fire: '🔥',
+  trophy: '🏆',
+  mic: '🎤',
+  award: '🥇',
+  brain: '🧠',
+  crown: '👑',
+  zap: '⚡',
+};
+
+// Map color keys to Tailwind classes
+const COLOR_MAP: Record<string, { bg: string; ring: string; text: string }> = {
+  yellow: { bg: 'bg-yellow-50', ring: 'ring-yellow-300', text: 'text-yellow-700' },
+  blue: { bg: 'bg-blue-50', ring: 'ring-blue-300', text: 'text-blue-700' },
+  purple: { bg: 'bg-purple-50', ring: 'ring-purple-300', text: 'text-purple-700' },
+  gold: { bg: 'bg-amber-50', ring: 'ring-amber-400', text: 'text-amber-700' },
+  orange: { bg: 'bg-orange-50', ring: 'ring-orange-300', text: 'text-orange-700' },
+  red: { bg: 'bg-red-50', ring: 'ring-red-300', text: 'text-red-700' },
+  green: { bg: 'bg-green-50', ring: 'ring-green-300', text: 'text-green-700' },
+  indigo: { bg: 'bg-indigo-50', ring: 'ring-indigo-300', text: 'text-indigo-700' },
+  gray: { bg: 'bg-gray-50', ring: 'ring-gray-300', text: 'text-gray-600' },
+};
+
+function getColors(color: string, unlocked: boolean) {
+  if (!unlocked) return { bg: 'bg-gray-50', ring: 'ring-gray-200', text: 'text-gray-400' };
+  return COLOR_MAP[color] ?? COLOR_MAP.gray;
+}
+
+const AchievementCard: React.FC<AchievementCardProps> = ({ badge, size = 'md' }) => {
+  const unlocked = badge.unlocked ?? true;
+  const emoji = ICON_EMOJI[badge.icon] ?? '🏅';
+  const colors = getColors(badge.color, unlocked);
+
+  const sizeClasses = {
+    sm: { card: 'p-3', icon: 'text-3xl', name: 'text-sm', desc: 'text-xs' },
+    md: { card: 'p-4', icon: 'text-4xl', name: 'text-base', desc: 'text-xs' },
+    lg: { card: 'p-5', icon: 'text-5xl', name: 'text-lg', desc: 'text-sm' },
+  }[size];
+
+  return (
+    <div
+      className={`
+        rounded-2xl border-2 ${colors.bg}
+        ${unlocked ? `ring-2 ${colors.ring}` : 'border-gray-200 opacity-50'}
+        ${sizeClasses.card}
+        flex flex-col items-center gap-2 text-center transition-all duration-200
+        ${unlocked ? 'shadow-sm hover:shadow-md' : ''}
+      `}
+      title={badge.description}
+    >
+      <div
+        className={`
+          ${sizeClasses.icon} leading-none
+          ${unlocked ? '' : 'grayscale'}
+        `}
+      >
+        {unlocked ? emoji : '🔒'}
+      </div>
+
+      <div>
+        <div className={`font-black ${sizeClasses.name} ${unlocked ? colors.text : 'text-gray-400'}`}>
+          {badge.name}
+        </div>
+        <div className={`${sizeClasses.desc} text-gray-500 mt-0.5 leading-snug`}>
+          {badge.description}
+        </div>
+      </div>
+
+      {unlocked && badge.unlocked_at && (
+        <div className="text-xs text-gray-400">
+          {new Date(badge.unlocked_at).toLocaleDateString('zh-TW')}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AchievementCard;

--- a/frontend/src/components/gamification/BadgeGrid.tsx
+++ b/frontend/src/components/gamification/BadgeGrid.tsx
@@ -1,0 +1,121 @@
+/**
+ * BadgeGrid — shows all badges (unlocked highlighted, locked grayed out).
+ * Elementary-student friendly with large icons and short descriptions.
+ */
+import React from 'react';
+import type { BadgeInfo } from '../../services/gamificationApi';
+
+interface BadgeGridProps {
+  badges: BadgeInfo[];           // All badges (unlocked have unlocked=true)
+  /** If provided, show only this many badges before "show more" */
+  previewCount?: number;
+}
+
+const ICON_MAP: Record<string, string> = {
+  star:      '⭐',
+  book:      '📖',
+  'book-open': '📚',
+  library:   '🏛',
+  fire:      '🔥',
+  trophy:    '🏆',
+  mic:       '🎤',
+  award:     '🎖',
+  brain:     '🧠',
+  crown:     '👑',
+  zap:       '⚡',
+};
+
+const COLOR_MAP: Record<string, { unlocked: string; locked: string }> = {
+  yellow: { unlocked: 'bg-yellow-50 border-yellow-300 shadow-yellow-100', locked: 'bg-gray-50 border-gray-200' },
+  blue:   { unlocked: 'bg-blue-50 border-blue-300 shadow-blue-100',       locked: 'bg-gray-50 border-gray-200' },
+  purple: { unlocked: 'bg-purple-50 border-purple-300 shadow-purple-100', locked: 'bg-gray-50 border-gray-200' },
+  gold:   { unlocked: 'bg-amber-50 border-amber-400 shadow-amber-100',    locked: 'bg-gray-50 border-gray-200' },
+  orange: { unlocked: 'bg-orange-50 border-orange-300 shadow-orange-100', locked: 'bg-gray-50 border-gray-200' },
+  red:    { unlocked: 'bg-red-50 border-red-300 shadow-red-100',          locked: 'bg-gray-50 border-gray-200' },
+  green:  { unlocked: 'bg-green-50 border-green-300 shadow-green-100',    locked: 'bg-gray-50 border-gray-200' },
+  indigo: { unlocked: 'bg-indigo-50 border-indigo-300 shadow-indigo-100', locked: 'bg-gray-50 border-gray-200' },
+  gray:   { unlocked: 'bg-gray-100 border-gray-400',                      locked: 'bg-gray-50 border-gray-200' },
+};
+
+function getColorClass(color: string, unlocked: boolean): string {
+  const palette = COLOR_MAP[color] ?? COLOR_MAP.gray;
+  return unlocked ? palette.unlocked : palette.locked;
+}
+
+function getIcon(icon: string): string {
+  return ICON_MAP[icon] ?? '🏅';
+}
+
+interface BadgeCardProps {
+  badge: BadgeInfo;
+}
+
+const BadgeCard: React.FC<BadgeCardProps> = ({ badge }) => {
+  const colorClass = getColorClass(badge.color, badge.unlocked);
+  const icon = getIcon(badge.icon);
+
+  return (
+    <div
+      className={`relative flex flex-col items-center gap-1 p-3 rounded-2xl border-2 shadow-sm transition-all ${colorClass} ${
+        badge.unlocked ? 'opacity-100' : 'opacity-40 grayscale'
+      }`}
+      title={badge.description}
+    >
+      {/* Lock overlay for unearned badges */}
+      {!badge.unlocked && (
+        <div className="absolute inset-0 flex items-center justify-center rounded-2xl">
+          <span className="text-gray-300 text-2xl">🔒</span>
+        </div>
+      )}
+
+      <span className="text-3xl leading-none">{icon}</span>
+      <span className="text-xs font-bold text-center text-gray-700 leading-tight">
+        {badge.name}
+      </span>
+      <span className="text-[10px] text-center text-gray-500 leading-tight">
+        {badge.description}
+      </span>
+
+      {badge.unlocked && badge.unlocked_at && (
+        <span className="text-[9px] text-gray-400 mt-0.5">
+          {new Date(badge.unlocked_at).toLocaleDateString('zh-TW', { month: 'short', day: 'numeric' })}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const BadgeGrid: React.FC<BadgeGridProps> = ({ badges, previewCount }) => {
+  const [showAll, setShowAll] = React.useState(false);
+  const displayed = previewCount && !showAll ? badges.slice(0, previewCount) : badges;
+  const remaining = previewCount ? badges.length - previewCount : 0;
+
+  if (badges.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-400 text-sm">
+        完成第一篇課文就能獲得徽章！
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-3">
+        {displayed.map((badge) => (
+          <BadgeCard key={badge.key} badge={badge} />
+        ))}
+      </div>
+
+      {previewCount && !showAll && remaining > 0 && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="mt-3 w-full text-sm text-blue-600 hover:text-blue-700 font-medium py-1"
+        >
+          顯示全部 {badges.length} 個徽章
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default BadgeGrid;

--- a/frontend/src/components/gamification/GamificationProfile.tsx
+++ b/frontend/src/components/gamification/GamificationProfile.tsx
@@ -1,0 +1,180 @@
+/**
+ * GamificationProfile — full page showing a student's XP, level,
+ * badges, streak, and class leaderboard.
+ *
+ * Route: /gamification  (student only)
+ */
+import React, { useEffect, useState } from 'react';
+import {
+  fetchGamificationSummary,
+  fetchLeaderboard,
+  type GamificationSummary,
+  type LeaderboardResponse,
+} from '../../services/gamificationApi';
+import XPBar from './XPBar';
+import BadgeGrid from './BadgeGrid';
+import StreakBadge from './StreakBadge';
+import Leaderboard from './Leaderboard';
+
+interface GamificationProfileProps {
+  studentId: number;
+  token: string;
+  classroomId?: number;
+}
+
+type Tab = 'profile' | 'badges' | 'leaderboard';
+
+const GamificationProfile: React.FC<GamificationProfileProps> = ({
+  studentId,
+  token,
+  classroomId,
+}) => {
+  const [summary, setSummary] = useState<GamificationSummary | null>(null);
+  const [leaderboard, setLeaderboard] = useState<LeaderboardResponse | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('profile');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      fetchGamificationSummary(studentId, token),
+      classroomId ? fetchLeaderboard(classroomId, token) : Promise.resolve(null),
+    ])
+      .then(([s, l]) => {
+        setSummary(s);
+        setLeaderboard(l);
+      })
+      .catch((err: Error) => {
+        setError(err.message || '載入失敗');
+      })
+      .finally(() => setLoading(false));
+  }, [studentId, token, classroomId]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-16">
+        <div className="text-gray-400 text-sm animate-pulse">載入中...</div>
+      </div>
+    );
+  }
+
+  if (error || !summary) {
+    return (
+      <div className="flex flex-col items-center py-16 gap-4">
+        <div className="text-4xl">😵</div>
+        <p className="text-gray-500 text-sm">{error ?? '無法載入資料'}</p>
+      </div>
+    );
+  }
+
+  const TAB_LABELS: { id: Tab; label: string; icon: string }[] = [
+    { id: 'profile', label: '我的成長', icon: '⭐' },
+    { id: 'badges', label: '徽章牆', icon: '🏅' },
+    { id: 'leaderboard', label: '排行榜', icon: '📊' },
+  ];
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6 space-y-4">
+      {/* Header */}
+      <div className="text-center">
+        <h1 className="text-2xl font-black text-gray-800">我的學習成就</h1>
+        <p className="text-sm text-gray-500 mt-1">繼續閱讀，提升等級！</p>
+      </div>
+
+      {/* Level + XP bar always visible */}
+      <XPBar levelInfo={summary.level_info} />
+
+      {/* Quick stats row */}
+      <div className="grid grid-cols-3 gap-3 text-center">
+        <div className="rounded-xl bg-blue-50 border border-blue-100 p-3">
+          <div className="text-2xl font-black text-blue-600">{summary.stories_completed}</div>
+          <div className="text-xs text-gray-500 mt-0.5">完成課文</div>
+        </div>
+        <div className="rounded-xl bg-orange-50 border border-orange-100 p-3">
+          <div className="text-2xl font-black text-orange-500">{summary.streak.current}</div>
+          <div className="text-xs text-gray-500 mt-0.5">連續天數</div>
+        </div>
+        <div className="rounded-xl bg-purple-50 border border-purple-100 p-3">
+          <div className="text-2xl font-black text-purple-600">{summary.badges.length}</div>
+          <div className="text-xs text-gray-500 mt-0.5">獲得徽章</div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex rounded-xl bg-gray-100 p-1 gap-1">
+        {TAB_LABELS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-sm font-bold transition-all ${
+              activeTab === tab.id
+                ? 'bg-white shadow text-gray-800'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            <span>{tab.icon}</span>
+            <span>{tab.label}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'profile' && (
+        <div className="space-y-4">
+          <StreakBadge streak={summary.streak} />
+
+          {/* Recent badges preview */}
+          {summary.badges.length > 0 && (
+            <div>
+              <h3 className="text-sm font-bold text-gray-600 mb-2">最新徽章</h3>
+              <BadgeGrid badges={summary.badges.slice(-3)} />
+            </div>
+          )}
+
+          {/* All-badge locked preview */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-sm font-bold text-gray-600">成就進度</h3>
+              <button
+                onClick={() => setActiveTab('badges')}
+                className="text-xs text-blue-500 hover:text-blue-600"
+              >
+                查看全部
+              </button>
+            </div>
+            <BadgeGrid badges={summary.all_badges} previewCount={6} />
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'badges' && (
+        <div>
+          <div className="text-sm text-gray-500 mb-3">
+            已解鎖 <strong>{summary.badges.length}</strong> / {summary.all_badges.length} 個徽章
+          </div>
+          <BadgeGrid badges={summary.all_badges} />
+        </div>
+      )}
+
+      {activeTab === 'leaderboard' && (
+        <div>
+          {leaderboard ? (
+            <Leaderboard
+              entries={leaderboard.entries}
+              currentStudentId={studentId}
+              classroomName={undefined}
+            />
+          ) : (
+            <div className="text-center py-12 text-gray-400 text-sm">
+              需要加入班級才能看到排行榜
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GamificationProfile;

--- a/frontend/src/components/gamification/Leaderboard.tsx
+++ b/frontend/src/components/gamification/Leaderboard.tsx
@@ -1,0 +1,111 @@
+/**
+ * Leaderboard — shows class ranking by XP.
+ * Highlights the current student's row.
+ */
+import React from 'react';
+import type { LeaderboardEntry } from '../../services/gamificationApi';
+
+interface LeaderboardProps {
+  entries: LeaderboardEntry[];
+  currentStudentId?: number;
+  classroomName?: string;
+  /** Max entries to display before truncating */
+  limit?: number;
+}
+
+const RANK_STYLES: Record<number, { bg: string; text: string; icon: string }> = {
+  1: { bg: 'bg-amber-50 border-amber-300',   text: 'text-amber-700', icon: '🥇' },
+  2: { bg: 'bg-gray-50 border-gray-300',     text: 'text-gray-600',  icon: '🥈' },
+  3: { bg: 'bg-orange-50 border-orange-200', text: 'text-orange-600', icon: '🥉' },
+};
+
+function getRankStyle(rank: number) {
+  return RANK_STYLES[rank] ?? { bg: 'bg-white border-gray-100', text: 'text-gray-500', icon: String(rank) };
+}
+
+interface EntryRowProps {
+  entry: LeaderboardEntry;
+  isMe: boolean;
+}
+
+const EntryRow: React.FC<EntryRowProps> = ({ entry, isMe }) => {
+  const style = getRankStyle(entry.rank);
+  const isTopThree = entry.rank <= 3;
+
+  return (
+    <div
+      className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${style.bg} ${
+        isMe ? 'ring-2 ring-blue-400 ring-offset-1' : ''
+      } transition-all`}
+    >
+      {/* Rank */}
+      <div className={`w-8 text-center font-black text-lg ${style.text} shrink-0`}>
+        {isTopThree ? style.icon : entry.rank}
+      </div>
+
+      {/* Avatar placeholder */}
+      <div className="w-9 h-9 rounded-full bg-gradient-to-br from-blue-200 to-purple-200 flex items-center justify-center shrink-0">
+        <span className="text-sm font-bold text-white">
+          {entry.name.charAt(0)}
+        </span>
+      </div>
+
+      {/* Name + Level */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className={`font-bold text-gray-800 truncate ${isMe ? 'text-blue-700' : ''}`}>
+            {entry.name}
+            {isMe && <span className="ml-1 text-xs text-blue-500">(我)</span>}
+          </span>
+          <span className="shrink-0 text-xs text-gray-400 font-medium">Lv.{entry.level}</span>
+        </div>
+        <div className="text-xs text-gray-400">
+          完成 {entry.stories_completed} 篇課文
+        </div>
+      </div>
+
+      {/* XP */}
+      <div className="shrink-0 text-right">
+        <div className="font-black text-gray-800">{entry.total_xp}</div>
+        <div className="text-xs text-gray-400">XP</div>
+      </div>
+    </div>
+  );
+};
+
+const Leaderboard: React.FC<LeaderboardProps> = ({
+  entries,
+  currentStudentId,
+  classroomName,
+  limit,
+}) => {
+  const displayed = limit ? entries.slice(0, limit) : entries;
+
+  if (entries.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-400">
+        <div className="text-4xl mb-2">📊</div>
+        <p className="text-sm">排行榜還沒有資料，快去完成課文！</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {classroomName && (
+        <h3 className="text-base font-bold text-gray-600 mb-3">{classroomName} 排行榜</h3>
+      )}
+      <div className="flex flex-col gap-2">
+        {displayed.map((entry) => (
+          <EntryRow
+            key={entry.student_id}
+            entry={entry}
+            isMe={entry.student_id === currentStudentId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Leaderboard;

--- a/frontend/src/components/gamification/PointsBadge.tsx
+++ b/frontend/src/components/gamification/PointsBadge.tsx
@@ -1,0 +1,110 @@
+/**
+ * PointsBadge — compact XP display widget.
+ *
+ * Shows the student's current level name, total XP, and a progress bar
+ * toward the next level. Designed to fit in nav bars or dashboard headers.
+ */
+
+import React from 'react';
+
+export interface LevelInfo {
+  level: number;
+  level_name: string;
+  total_xp: number;
+  current_level_xp: number;
+  next_level_xp: number | null;
+  xp_to_next: number;
+  progress_pct: number;
+}
+
+interface PointsBadgeProps {
+  levelInfo: LevelInfo;
+  /** compact = just icon + XP number; full = level name + progress bar */
+  variant?: 'compact' | 'full';
+  className?: string;
+}
+
+const LEVEL_COLORS: Record<number, string> = {
+  1: 'from-slate-400 to-slate-500',
+  2: 'from-blue-400 to-blue-500',
+  3: 'from-cyan-400 to-cyan-500',
+  4: 'from-teal-400 to-teal-500',
+  5: 'from-green-400 to-green-500',
+  6: 'from-yellow-400 to-yellow-500',
+  7: 'from-orange-400 to-orange-500',
+  8: 'from-red-400 to-red-500',
+  9: 'from-purple-400 to-purple-500',
+  10: 'from-yellow-400 to-amber-500',
+};
+
+function levelColor(level: number): string {
+  return LEVEL_COLORS[level] ?? LEVEL_COLORS[1];
+}
+
+const PointsBadge: React.FC<PointsBadgeProps> = ({
+  levelInfo,
+  variant = 'compact',
+  className = '',
+}) => {
+  const color = levelColor(levelInfo.level);
+
+  if (variant === 'compact') {
+    return (
+      <div
+        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gradient-to-r ${color} text-white text-sm font-bold shadow-sm ${className}`}
+        title={`等級 ${levelInfo.level} ${levelInfo.level_name} — ${levelInfo.total_xp} XP`}
+      >
+        <span className="text-xs opacity-80">Lv.{levelInfo.level}</span>
+        <span>{levelInfo.total_xp} XP</span>
+      </div>
+    );
+  }
+
+  // Full variant
+  return (
+    <div className={`rounded-2xl bg-white border border-gray-100 shadow-sm p-4 ${className}`}>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <div
+            className={`w-10 h-10 rounded-full bg-gradient-to-br ${color} flex items-center justify-center text-white font-black text-lg shadow`}
+          >
+            {levelInfo.level}
+          </div>
+          <div>
+            <div className="text-xs text-gray-500 font-medium">等級 {levelInfo.level}</div>
+            <div className="text-base font-black text-gray-800">{levelInfo.level_name}</div>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-2xl font-black text-gray-800">{levelInfo.total_xp}</div>
+          <div className="text-xs text-gray-400">XP 總計</div>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      {levelInfo.next_level_xp !== null ? (
+        <div>
+          <div className="flex justify-between text-xs text-gray-400 mb-1">
+            <span>{levelInfo.current_level_xp} XP</span>
+            <span>還需 {levelInfo.xp_to_next} XP</span>
+          </div>
+          <div className="h-2.5 rounded-full bg-gray-100 overflow-hidden">
+            <div
+              className={`h-full rounded-full bg-gradient-to-r ${color} transition-all duration-500`}
+              style={{ width: `${levelInfo.progress_pct}%` }}
+            />
+          </div>
+          <div className="text-xs text-gray-400 mt-1 text-right">
+            距離等級 {levelInfo.level + 1}
+          </div>
+        </div>
+      ) : (
+        <div className="text-center text-sm font-bold text-yellow-600 mt-1">
+          已達最高等級！
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PointsBadge;

--- a/frontend/src/components/gamification/StreakBadge.tsx
+++ b/frontend/src/components/gamification/StreakBadge.tsx
@@ -1,0 +1,57 @@
+/**
+ * StreakBadge — shows current and longest learning streak.
+ * Compact widget suitable for dashboards or profile pages.
+ */
+import React from 'react';
+import type { StreakInfo } from '../../services/gamificationApi';
+
+interface StreakBadgeProps {
+  streak: StreakInfo;
+  compact?: boolean;
+}
+
+const StreakBadge: React.FC<StreakBadgeProps> = ({ streak, compact = false }) => {
+  const { current, longest } = streak;
+
+  if (compact) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <span className="text-orange-500 text-lg">🔥</span>
+        <span className="text-sm font-bold text-gray-700">{current}</span>
+        <span className="text-xs text-gray-500">天</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-orange-100 bg-orange-50 p-4 shadow-sm">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-2xl">🔥</span>
+        <span className="font-bold text-gray-700">連續學習</span>
+      </div>
+
+      <div className="flex items-end gap-4">
+        <div className="text-center">
+          <div className="text-4xl font-black text-orange-600">{current}</div>
+          <div className="text-xs text-gray-500 mt-0.5">目前連續天數</div>
+        </div>
+        <div className="text-center">
+          <div className="text-2xl font-black text-gray-400">{longest}</div>
+          <div className="text-xs text-gray-400 mt-0.5">最長紀錄</div>
+        </div>
+      </div>
+
+      {current === 0 && (
+        <p className="mt-2 text-xs text-gray-400">今天完成一篇課文就能開始連續！</p>
+      )}
+      {current > 0 && current < 3 && (
+        <p className="mt-2 text-xs text-orange-500 font-medium">繼續加油，連續 3 天可解鎖徽章！</p>
+      )}
+      {current >= 3 && (
+        <p className="mt-2 text-xs text-orange-600 font-bold">太棒了！持續學習！</p>
+      )}
+    </div>
+  );
+};
+
+export default StreakBadge;

--- a/frontend/src/components/gamification/StreakIndicator.tsx
+++ b/frontend/src/components/gamification/StreakIndicator.tsx
@@ -1,0 +1,140 @@
+/**
+ * StreakIndicator — shows the student's daily learning streak.
+ *
+ * Displays a flame emoji + current streak count.
+ * Variants: compact (inline badge) and full (card with longest streak).
+ */
+
+import React from 'react';
+
+export interface StreakData {
+  current: number;
+  longest: number;
+  last_activity_date: string | null;
+}
+
+interface StreakIndicatorProps {
+  streak: StreakData;
+  variant?: 'compact' | 'full';
+  className?: string;
+}
+
+function flameColor(streak: number): string {
+  if (streak === 0) return 'text-gray-400';
+  if (streak < 3) return 'text-orange-400';
+  if (streak < 7) return 'text-orange-500';
+  if (streak < 14) return 'text-red-500';
+  return 'text-red-600';
+}
+
+function streakLabel(streak: number): string {
+  if (streak === 0) return '尚未開始';
+  if (streak === 1) return '開始學習！';
+  if (streak < 3) return '持續下去！';
+  if (streak < 7) return '很有進步！';
+  if (streak < 14) return '太厲害了！';
+  if (streak < 30) return '學習達人！';
+  return '傳說等級！';
+}
+
+const StreakIndicator: React.FC<StreakIndicatorProps> = ({
+  streak,
+  variant = 'compact',
+  className = '',
+}) => {
+  const flame = streak.current > 0 ? '🔥' : '💤';
+  const color = flameColor(streak.current);
+
+  if (variant === 'compact') {
+    return (
+      <div
+        className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full bg-orange-50 border border-orange-200 ${className}`}
+        title={`連續學習 ${streak.current} 天（最長 ${streak.longest} 天）`}
+      >
+        <span className="text-base leading-none">{flame}</span>
+        <span className={`font-black text-sm ${color}`}>
+          {streak.current}
+        </span>
+        <span className="text-xs text-gray-400">天</span>
+      </div>
+    );
+  }
+
+  // Full card variant
+  return (
+    <div className={`rounded-2xl bg-white border border-orange-100 shadow-sm p-4 ${className}`}>
+      <div className="flex items-center gap-3 mb-3">
+        <span className="text-5xl leading-none">{flame}</span>
+        <div>
+          <div className="text-xs text-gray-500 font-medium">連續學習</div>
+          <div className={`text-4xl font-black ${color}`}>
+            {streak.current} <span className="text-xl">天</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="text-sm font-bold text-orange-600 mb-2">
+        {streakLabel(streak.current)}
+      </div>
+
+      {/* Mini calendar: last 7 days */}
+      <StreakCalendar lastActivityDate={streak.last_activity_date} current={streak.current} />
+
+      <div className="mt-3 flex items-center justify-between text-xs text-gray-400">
+        <span>最長連續學習</span>
+        <span className="font-bold text-gray-600">{streak.longest} 天</span>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Renders a 7-day dot calendar showing which days had activity.
+ * We infer activity from last_activity_date + current streak length.
+ */
+const StreakCalendar: React.FC<{ lastActivityDate: string | null; current: number }> = ({
+  lastActivityDate,
+  current,
+}) => {
+  const today = new Date();
+  const days: { label: string; active: boolean }[] = [];
+
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const dayLabel = d.toLocaleDateString('zh-TW', { weekday: 'short' }).slice(0, 1);
+
+    let active = false;
+    if (lastActivityDate && current > 0) {
+      const last = new Date(lastActivityDate);
+      last.setHours(0, 0, 0, 0);
+      d.setHours(0, 0, 0, 0);
+      const diffDays = Math.floor((last.getTime() - d.getTime()) / 86400000);
+      // active if within the current streak window
+      active = diffDays >= 0 && diffDays < current;
+    }
+
+    days.push({ label: dayLabel, active });
+  }
+
+  return (
+    <div className="flex justify-between gap-1">
+      {days.map((day, idx) => (
+        <div key={idx} className="flex flex-col items-center gap-1">
+          <div
+            className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold transition-all
+              ${day.active
+                ? 'bg-orange-400 text-white shadow-sm'
+                : 'bg-gray-100 text-gray-400'
+              }`}
+          >
+            {day.active ? '🔥' : ''}
+          </div>
+          <div className="text-xs text-gray-400">{day.label}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default StreakIndicator;

--- a/frontend/src/components/gamification/XPAwardToast.tsx
+++ b/frontend/src/components/gamification/XPAwardToast.tsx
@@ -1,0 +1,158 @@
+/**
+ * XPAwardToast — animated overlay shown after session completion.
+ * Shows XP earned, level up (if any), and new badges.
+ * Auto-dismisses after 4 seconds or on button click.
+ */
+import React, { useEffect, useState } from 'react';
+import type { SessionCompletionResult } from '../../services/gamificationApi';
+
+interface XPAwardToastProps {
+  result: SessionCompletionResult;
+  onDismiss: () => void;
+}
+
+const BADGE_ICONS: Record<string, string> = {
+  first_story: '⭐',
+  story_5:     '📖',
+  story_10:    '📚',
+  story_25:    '🏛',
+  streak_3:    '🔥',
+  streak_7:    '🔥',
+  streak_30:   '🏆',
+  accuracy_90: '🎤',
+  accuracy_100:'🎖',
+  level_5:     '🧠',
+  level_10:    '👑',
+  xp_500:      '⚡',
+  xp_1000:     '⚡',
+};
+
+const BADGE_NAMES: Record<string, string> = {
+  first_story: '第一步',
+  story_5:     '勤讀者',
+  story_10:    '閱讀達人',
+  story_25:    '博覽群書',
+  streak_3:    '三日不輟',
+  streak_7:    '週週精進',
+  streak_30:   '月月堅持',
+  accuracy_90: '精準朗讀',
+  accuracy_100:'完美表現',
+  level_5:     '思考者',
+  level_10:    '國文之星',
+  xp_500:      '積分達人',
+  xp_1000:     '千分英雄',
+};
+
+const XPAwardToast: React.FC<XPAwardToastProps> = ({ result, onDismiss }) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Trigger animation in
+    const showTimer = setTimeout(() => setVisible(true), 50);
+    // Auto-dismiss after 4 seconds
+    const hideTimer = setTimeout(() => {
+      setVisible(false);
+      setTimeout(onDismiss, 300);
+    }, 4000);
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(hideTimer);
+    };
+  }, [onDismiss]);
+
+  const { xp_earned, new_total_xp, level_info, badges_unlocked } = result;
+  const levelUp = result.level_info.level > (new_total_xp - xp_earned >= 100 ? 2 : 1);
+
+  return (
+    <div
+      className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 transition-all duration-300 ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
+      }`}
+    >
+      <div className="bg-white rounded-3xl shadow-2xl border-2 border-blue-100 px-6 py-5 min-w-[280px] max-w-sm">
+        {/* XP gained */}
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <span className="text-2xl">⚡</span>
+            <div>
+              <div className="font-black text-2xl text-blue-600">+{xp_earned} XP</div>
+              <div className="text-xs text-gray-400">累計 {new_total_xp} XP</div>
+            </div>
+          </div>
+          {level_info && (
+            <div className="text-right">
+              <div className="text-xs text-gray-500">現在等級</div>
+              <div className="font-black text-lg text-gray-700">Lv.{level_info.level}</div>
+            </div>
+          )}
+        </div>
+
+        {/* Level up banner */}
+        {levelUp && (
+          <div className="bg-gradient-to-r from-amber-400 to-orange-400 rounded-xl py-2 px-3 mb-3 text-center">
+            <span className="text-white font-black text-sm">升級了！{level_info.level_name}</span>
+          </div>
+        )}
+
+        {/* Streak */}
+        {result.streak.current > 1 && (
+          <div className="flex items-center gap-1.5 mb-3">
+            <span className="text-orange-500">🔥</span>
+            <span className="text-sm text-gray-600">
+              連續 <strong>{result.streak.current}</strong> 天學習！
+            </span>
+          </div>
+        )}
+
+        {/* New badges */}
+        {badges_unlocked.length > 0 && (
+          <div className="mb-3">
+            <div className="text-xs text-gray-500 font-medium mb-1.5">解鎖新徽章</div>
+            <div className="flex flex-wrap gap-2">
+              {badges_unlocked.map((key) => (
+                <div
+                  key={key}
+                  className="flex items-center gap-1 bg-yellow-50 border border-yellow-200 rounded-full px-2 py-1"
+                >
+                  <span className="text-base">{BADGE_ICONS[key] ?? '🏅'}</span>
+                  <span className="text-xs font-bold text-yellow-700">
+                    {BADGE_NAMES[key] ?? key}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* XP progress bar */}
+        {level_info && (
+          <div className="mb-3">
+            <div className="h-2 rounded-full bg-blue-50 border border-blue-100 overflow-hidden">
+              <div
+                className="h-full bg-blue-500 rounded-full transition-all duration-700"
+                style={{ width: `${level_info.progress_pct}%` }}
+              />
+            </div>
+            {level_info.next_level_xp && (
+              <div className="text-xs text-gray-400 text-right mt-0.5">
+                距下一級 {level_info.xp_to_next} XP
+              </div>
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={() => {
+            setVisible(false);
+            setTimeout(onDismiss, 300);
+          }}
+          className="w-full text-sm text-blue-600 font-medium py-1 hover:text-blue-700"
+        >
+          繼續
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default XPAwardToast;

--- a/frontend/src/components/gamification/XPBar.tsx
+++ b/frontend/src/components/gamification/XPBar.tsx
@@ -1,0 +1,88 @@
+/**
+ * XPBar — shows student's current level, XP progress bar, and level name.
+ * Designed for elementary school students: large text, vivid colors, encouraging.
+ */
+import React from 'react';
+import type { LevelInfo } from '../../services/gamificationApi';
+
+interface XPBarProps {
+  levelInfo: LevelInfo;
+  /** If true, renders a compact single-line version (e.g. inside a header). */
+  compact?: boolean;
+}
+
+const LEVEL_COLORS: Record<number, { bg: string; bar: string; badge: string }> = {
+  1:  { bg: 'bg-slate-100',   bar: 'bg-slate-400',   badge: 'bg-slate-500 text-white' },
+  2:  { bg: 'bg-blue-50',     bar: 'bg-blue-400',    badge: 'bg-blue-500 text-white' },
+  3:  { bg: 'bg-teal-50',     bar: 'bg-teal-500',    badge: 'bg-teal-600 text-white' },
+  4:  { bg: 'bg-green-50',    bar: 'bg-green-500',   badge: 'bg-green-600 text-white' },
+  5:  { bg: 'bg-lime-50',     bar: 'bg-lime-500',    badge: 'bg-lime-600 text-white' },
+  6:  { bg: 'bg-yellow-50',   bar: 'bg-yellow-400',  badge: 'bg-yellow-500 text-white' },
+  7:  { bg: 'bg-orange-50',   bar: 'bg-orange-500',  badge: 'bg-orange-600 text-white' },
+  8:  { bg: 'bg-red-50',      bar: 'bg-red-500',     badge: 'bg-red-600 text-white' },
+  9:  { bg: 'bg-purple-50',   bar: 'bg-purple-500',  badge: 'bg-purple-600 text-white' },
+  10: { bg: 'bg-amber-50',    bar: 'bg-amber-500',   badge: 'bg-amber-600 text-white' },
+};
+
+function getColors(level: number) {
+  return LEVEL_COLORS[level] ?? LEVEL_COLORS[1];
+}
+
+const XPBar: React.FC<XPBarProps> = ({ levelInfo, compact = false }) => {
+  const { level, level_name, total_xp, progress_pct, xp_to_next, next_level_xp } = levelInfo;
+  const colors = getColors(level);
+  const isMaxLevel = next_level_xp === null;
+
+  if (compact) {
+    return (
+      <div className="flex items-center gap-3 min-w-0">
+        <span className={`shrink-0 text-xs font-black px-2 py-0.5 rounded-full ${colors.badge}`}>
+          Lv.{level}
+        </span>
+        <div className="flex-1 min-w-0">
+          <div className={`h-2 rounded-full ${colors.bg} overflow-hidden`}>
+            <div
+              className={`h-full rounded-full transition-all duration-700 ${colors.bar}`}
+              style={{ width: `${progress_pct}%` }}
+            />
+          </div>
+        </div>
+        <span className="shrink-0 text-xs text-gray-500 font-medium">{total_xp} XP</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`rounded-2xl border border-gray-100 ${colors.bg} p-4 shadow-sm`}>
+      {/* Level badge + name */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className={`text-sm font-black px-3 py-1 rounded-full ${colors.badge}`}>
+            Lv.{level}
+          </span>
+          <span className="font-bold text-gray-700">{level_name}</span>
+        </div>
+        <span className="text-sm font-semibold text-gray-500">{total_xp} XP</span>
+      </div>
+
+      {/* Progress bar */}
+      <div className={`h-4 rounded-full ${colors.bg} border border-gray-200 overflow-hidden shadow-inner`}>
+        <div
+          className={`h-full rounded-full transition-all duration-700 ${colors.bar}`}
+          style={{ width: `${progress_pct}%` }}
+        />
+      </div>
+
+      {/* XP to next */}
+      <div className="mt-2 text-xs text-gray-500 text-right">
+        {isMaxLevel ? (
+          <span className="font-bold text-amber-600">已達最高等級！</span>
+        ) : (
+          <span>距離下一級還需 <strong>{xp_to_next}</strong> XP</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default XPBar;

--- a/frontend/src/pages/learning/ReportPage.tsx
+++ b/frontend/src/pages/learning/ReportPage.tsx
@@ -1,18 +1,58 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import AssessmentReport from '../../components/reading-steps/AssessmentReport';
+import XPAwardToast from '../../components/gamification/XPAwardToast';
 import { useLearningContext } from '../../layouts/LearningLayout';
+import { useAuth } from '../../contexts/AuthContext';
+import { awardSessionCompletion, type SessionCompletionResult } from '../../services/gamificationApi';
 
 const ReportPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
-  const { selectedStory, session, handleRetry, handleSessionComplete } = useLearningContext();
+  const { selectedStory, session, handleRetry, handleSessionComplete, dbSessionId } = useLearningContext();
+  const { user, token } = useAuth();
   const navigate = useNavigate();
 
-  // Clear the active session from localStorage when the report is reached —
-  // this means the student completed the full learning flow.
+  const [xpResult, setXpResult] = useState<SessionCompletionResult | null>(null);
+  const [showXpToast, setShowXpToast] = useState(false);
+
+  // Clear active session and award XP when report is reached
   useEffect(() => {
     handleSessionComplete();
   }, [handleSessionComplete]);
+
+  // Award XP once we have a dbSessionId (set after backend session creation)
+  useEffect(() => {
+    if (!dbSessionId || !token || !user?.id) return;
+
+    const readingAccuracy = session?.readingAttempt?.accuracy ?? null;
+    const comprehensionPct = session?.comprehensionResult
+      ? Math.round(
+          (session.comprehensionResult.understoodCount /
+            Math.max(session.comprehensionResult.requiredCount, 1)) *
+            100
+        )
+      : null;
+    const comprehensionPassed = comprehensionPct !== null && comprehensionPct >= 60;
+
+    awardSessionCompletion(parseInt(user.id, 10), dbSessionId, readingAccuracy, comprehensionPassed, token)
+      .then((result) => {
+        if (result.xp_earned > 0) {
+          setXpResult(result);
+          setShowXpToast(true);
+        }
+      })
+      .catch((err: Error) => {
+        // Non-critical — don't show error to student
+        console.warn('XP award failed (non-blocking):', err.message);
+      });
+    // Only run once per report page load
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dbSessionId]);
+
+  const handleDismissToast = useCallback(() => {
+    setShowXpToast(false);
+    setXpResult(null);
+  }, []);
 
   return (
     <div className="p-8 max-w-4xl mx-auto w-full">
@@ -22,6 +62,10 @@ const ReportPage: React.FC = () => {
         onRetry={handleRetry}
         onGoToVocab={() => navigate(`/learn/${storyId}/vocab`)}
       />
+
+      {showXpToast && xpResult && (
+        <XPAwardToast result={xpResult} onDismiss={handleDismissToast} />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/student/AchievementsPage.tsx
+++ b/frontend/src/pages/student/AchievementsPage.tsx
@@ -1,0 +1,133 @@
+/**
+ * AchievementsPage — full gamification dashboard for students.
+ *
+ * Route: /achievements
+ * Issue #26
+ *
+ * Shows:
+ *   - XP level and progress bar (PointsBadge)
+ *   - Streak indicator (StreakIndicator)
+ *   - All badges (AchievementCard) — unlocked first, then locked
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import PointsBadge, { LevelInfo } from '../../components/gamification/PointsBadge';
+import StreakIndicator, { StreakData } from '../../components/gamification/StreakIndicator';
+import AchievementCard, { BadgeInfo } from '../../components/gamification/AchievementCard';
+import { getGamificationSummary, GamificationSummary } from '../../services/api';
+
+const AchievementsPage: React.FC = () => {
+  const { user, token } = useAuth();
+  const [summary, setSummary] = useState<GamificationSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user || !token) return;
+    setLoading(true);
+    getGamificationSummary(user.id, token)
+      .then(setSummary)
+      .catch((err) => setError(err.message ?? '載入失敗'))
+      .finally(() => setLoading(false));
+  }, [user, token]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-[40vh]">
+        <div className="animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full" />
+      </div>
+    );
+  }
+
+  if (error || !summary) {
+    return (
+      <div className="max-w-lg mx-auto mt-12 p-6 rounded-2xl bg-red-50 border border-red-200 text-center">
+        <div className="text-3xl mb-2">😕</div>
+        <div className="text-red-700 font-bold">{error ?? '資料載入失敗'}</div>
+      </div>
+    );
+  }
+
+  const unlockedBadges: BadgeInfo[] = summary.badges;
+  const allBadges: BadgeInfo[] = summary.all_badges;
+  const lockedBadges = allBadges.filter((b) => !b.unlocked);
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-6">
+      {/* Header */}
+      <div className="text-center">
+        <h1 className="text-2xl font-black text-gray-800">我的成就</h1>
+        <p className="text-gray-500 text-sm mt-1">學習積分、連續紀錄與成就徽章</p>
+      </div>
+
+      {/* Top row: XP card + Streak card */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <PointsBadge levelInfo={summary.level_info as LevelInfo} variant="full" />
+        <StreakIndicator streak={summary.streak as StreakData} variant="full" />
+      </div>
+
+      {/* Quick stats */}
+      <div className="grid grid-cols-3 gap-3">
+        <StatCard label="完成課文" value={summary.stories_completed} unit="篇" emoji="📚" />
+        <StatCard label="已解鎖成就" value={unlockedBadges.length} unit="個" emoji="🏅" />
+        <StatCard label="最長連續" value={summary.streak.longest} unit="天" emoji="🔥" />
+      </div>
+
+      {/* Unlocked badges */}
+      {unlockedBadges.length > 0 && (
+        <section>
+          <h2 className="text-base font-black text-gray-700 mb-3">
+            已解鎖成就 ({unlockedBadges.length})
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {unlockedBadges.map((badge) => (
+              <AchievementCard key={badge.key} badge={badge} size="md" />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Locked badges */}
+      {lockedBadges.length > 0 && (
+        <section>
+          <h2 className="text-base font-black text-gray-700 mb-3">
+            待解鎖成就 ({lockedBadges.length})
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {lockedBadges.map((badge) => (
+              <AchievementCard key={badge.key} badge={{ ...badge, unlocked: false }} size="md" />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {unlockedBadges.length === 0 && lockedBadges.length === 0 && (
+        <div className="text-center py-8 text-gray-400">
+          <div className="text-4xl mb-2">🎯</div>
+          <div>完成課文學習來解鎖成就！</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ── Sub-components ─────────────────────────────────────────────────────────
+
+const StatCard: React.FC<{
+  label: string;
+  value: number;
+  unit: string;
+  emoji: string;
+}> = ({ label, value, unit, emoji }) => (
+  <div className="rounded-2xl bg-white border border-gray-100 shadow-sm p-3 text-center">
+    <div className="text-2xl mb-1">{emoji}</div>
+    <div className="text-2xl font-black text-gray-800">
+      {value}
+      <span className="text-sm font-medium text-gray-500 ml-0.5">{unit}</span>
+    </div>
+    <div className="text-xs text-gray-400 mt-0.5">{label}</div>
+  </div>
+);
+
+export default AchievementsPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -705,3 +705,133 @@ export async function fetchChildDashboard(
   if (!res.ok) throw new Error(`fetchChildDashboard failed: ${res.status}`);
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Gamification API (Issue #26)
+// ---------------------------------------------------------------------------
+
+export interface GamificationLevelInfo {
+  level: number;
+  level_name: string;
+  total_xp: number;
+  current_level_xp: number;
+  next_level_xp: number | null;
+  xp_to_next: number;
+  progress_pct: number;
+}
+
+export interface GamificationStreak {
+  current: number;
+  longest: number;
+  last_activity_date: string | null;
+}
+
+export interface GamificationBadge {
+  key: string;
+  name: string;
+  description: string;
+  icon: string;
+  color: string;
+  unlocked?: boolean;
+  unlocked_at?: string;
+}
+
+export interface GamificationSummary {
+  student_id: number;
+  total_xp: number;
+  stories_completed: number;
+  level_info: GamificationLevelInfo;
+  streak: GamificationStreak;
+  badges: GamificationBadge[];
+  all_badges: GamificationBadge[];
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  student_id: number;
+  name: string;
+  total_xp: number;
+  level: number;
+  stories_completed: number;
+}
+
+export interface LeaderboardResponse {
+  classroom_id: number;
+  entries: LeaderboardEntry[];
+  total_students: number;
+}
+
+export async function getGamificationSummary(
+  studentId: number,
+  token: string,
+): Promise<GamificationSummary> {
+  const res = await fetch(`${API_BASE}/api/gamification/summary/${studentId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`getGamificationSummary failed: ${res.status}`);
+  return res.json();
+}
+
+export async function getGamificationPoints(
+  studentId: number,
+  token: string,
+): Promise<{ student_id: number; total_xp: number; stories_completed: number; level_info: GamificationLevelInfo }> {
+  const res = await fetch(`${API_BASE}/api/gamification/points/${studentId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`getGamificationPoints failed: ${res.status}`);
+  return res.json();
+}
+
+export async function getGamificationStreak(
+  studentId: number,
+  token: string,
+): Promise<GamificationStreak & { student_id: number }> {
+  const res = await fetch(`${API_BASE}/api/gamification/streak/${studentId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`getGamificationStreak failed: ${res.status}`);
+  return res.json();
+}
+
+export async function getClassroomLeaderboard(
+  classroomId: number,
+  token: string,
+  limit = 10,
+): Promise<LeaderboardResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/gamification/leaderboard/${classroomId}?limit=${limit}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) throw new Error(`getClassroomLeaderboard failed: ${res.status}`);
+  return res.json();
+}
+
+export async function reportSessionComplete(
+  studentId: number,
+  sessionId: number,
+  token: string,
+  opts: { readingAccuracy?: number; comprehensionPassed?: boolean } = {},
+): Promise<{
+  xp_earned: number;
+  new_total_xp: number;
+  level_info: GamificationLevelInfo;
+  streak: GamificationStreak;
+  badges_unlocked: string[];
+}> {
+  const res = await fetch(`${API_BASE}/api/gamification/session-complete`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      student_id: studentId,
+      session_id: sessionId,
+      reading_accuracy: opts.readingAccuracy ?? null,
+      comprehension_passed: opts.comprehensionPassed ?? false,
+    }),
+  });
+  if (!res.ok) throw new Error(`reportSessionComplete failed: ${res.status}`);
+  return res.json();
+}

--- a/frontend/src/services/gamificationApi.ts
+++ b/frontend/src/services/gamificationApi.ts
@@ -1,0 +1,149 @@
+/**
+ * Gamification API service.
+ * Wraps all calls to /api/gamification/* endpoints.
+ */
+
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+
+export interface LevelInfo {
+  level: number;
+  level_name: string;
+  total_xp: number;
+  current_level_xp: number;
+  next_level_xp: number | null;
+  xp_to_next: number;
+  progress_pct: number;
+}
+
+export interface BadgeInfo {
+  key: string;
+  name: string;
+  description: string;
+  icon: string;
+  color: string;
+  unlocked: boolean;
+  unlocked_at?: string;
+}
+
+export interface StreakInfo {
+  current: number;
+  longest: number;
+  last_activity_date: string | null;
+}
+
+export interface XPBreakdownEntry {
+  event_type: string;
+  xp: number;
+  note: string;
+}
+
+export interface GamificationSummary {
+  student_id: number;
+  total_xp: number;
+  stories_completed: number;
+  level_info: LevelInfo;
+  streak: StreakInfo;
+  badges: BadgeInfo[];
+  all_badges: BadgeInfo[];
+}
+
+export interface SessionCompletionResult {
+  xp_earned: number;
+  xp_breakdown: XPBreakdownEntry[];
+  new_total_xp: number;
+  level_info: LevelInfo;
+  streak: StreakInfo;
+  badges_unlocked: string[];
+  notes: string[];
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  student_id: number;
+  name: string;
+  total_xp: number;
+  level: number;
+  stories_completed: number;
+}
+
+export interface LeaderboardResponse {
+  classroom_id: number | null;
+  entries: LeaderboardEntry[];
+  total_students: number;
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+/**
+ * Fetch the full gamification summary for a student.
+ */
+export async function fetchGamificationSummary(
+  studentId: number,
+  token: string
+): Promise<GamificationSummary> {
+  const res = await fetch(`${API_BASE}/api/gamification/summary/${studentId}`, {
+    headers: authHeaders(token),
+  });
+  if (!res.ok) throw new Error(`fetchGamificationSummary failed: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Award XP and badges when a learning session is completed.
+ * Idempotent: safe to call multiple times for the same session.
+ */
+export async function awardSessionCompletion(
+  studentId: number,
+  sessionId: number,
+  readingAccuracy: number | null,
+  comprehensionPassed: boolean,
+  token: string
+): Promise<SessionCompletionResult> {
+  const res = await fetch(`${API_BASE}/api/gamification/session-complete`, {
+    method: 'POST',
+    headers: authHeaders(token),
+    body: JSON.stringify({
+      student_id: studentId,
+      session_id: sessionId,
+      reading_accuracy: readingAccuracy,
+      comprehension_passed: comprehensionPassed,
+    }),
+  });
+  if (!res.ok) throw new Error(`awardSessionCompletion failed: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Fetch classroom leaderboard.
+ */
+export async function fetchLeaderboard(
+  classroomId: number,
+  token: string,
+  limit = 10
+): Promise<LeaderboardResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/gamification/leaderboard/${classroomId}?limit=${limit}`,
+    { headers: authHeaders(token) }
+  );
+  if (!res.ok) throw new Error(`fetchLeaderboard failed: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Fetch achievements (unlocked badges + full catalogue) for a student.
+ */
+export async function fetchAchievements(
+  studentId: number,
+  token: string
+): Promise<{ badges: BadgeInfo[]; all_badges: BadgeInfo[]; total_unlocked: number }> {
+  const res = await fetch(`${API_BASE}/api/gamification/achievements/${studentId}`, {
+    headers: authHeaders(token),
+  });
+  if (!res.ok) throw new Error(`fetchAchievements failed: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
Fixes #26

## Summary

- **Backend models** (`gamification.py`): `StudentXPLog` (XP audit log), `StudentBadge` (unlocked badges), `StudentStreak` (consecutive days). Includes in-code XP table (`XP_REWARDS`), 10-level progression (`LEVEL_THRESHOLDS`/`LEVEL_NAMES`), and 13-badge catalogue (`BADGE_CATALOGUE`).
- **Gamification service** (`gamification_service.py`): `process_session_completion` awards XP for session completion, accuracy bonuses (70%/90%), comprehension pass, first-story bonus, streak bonus; calls `update_streak` and `check_and_award_badges`. Query helpers for summary and classroom leaderboard.
- **API routes** (`/api/gamification/`): `summary/{student_id}`, `points/{student_id}`, `achievements/{student_id}`, `streak/{student_id}`, `leaderboard/{classroom_id}`, `session-complete` (POST). Role-based access: students see own data, teachers see their class, admins see all.
- **Frontend components**: `PointsBadge` (compact/full XP level display), `AchievementCard` (locked/unlocked badge), `StreakIndicator` (flame + 7-day calendar), `BadgeGrid`, `XPBar`, `StreakBadge`.
- **AchievementsPage** at `/achievements`: full dashboard with XP card, streak card, stats row, unlocked badges, and locked badge catalogue.
- **API layer**: gamification functions added to `api.ts` and `gamificationApi.ts`.

## Test plan

- [ ] Run backend tests: `cd backend && pytest tests/test_gamification.py -v` — all 31 tests should pass
- [ ] Visit `/achievements` as a logged-in student — page loads with level card and streak card
- [ ] Complete a learning session — call `POST /api/gamification/session-complete` and verify XP awarded
- [ ] Complete first story — verify `first_story` badge unlocked in response
- [ ] Practice 3 consecutive days — verify `streak_3` badge unlocked
- [ ] Check leaderboard: `GET /api/gamification/leaderboard/{classroom_id}` returns ranked students

🤖 Generated with [Claude Code](https://claude.com/claude-code)