### PR TITLE
feat: cross-text learning pattern analysis for teachers and students (Fixes #253)

### DIFF
--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -32,6 +32,7 @@ from ..services.ai_service import (
 )
 from ..services.socratic_agent import socratic_agent
 from ..services.stuck_detection_service import build_recommendations, detect_stuck_points
+from ..services.cross_text_analysis_service import analyze_cross_text_patterns  # Issue #253
 
 router = APIRouter(tags=["learning"])
 logger = logging.getLogger(__name__)
@@ -1471,3 +1472,25 @@ async def validate_sentence(
         raise HTTPException(status_code=503, detail="AI service unavailable")
 
     return ValidateSentenceResponse(**result)
+
+
+# ── Cross-Text Analysis — student-facing (Issue #253) ─────────────────────────
+
+
+@router.get("/learning/cross-text-analysis/{student_id}")  # Issue #253
+def get_student_cross_text_analysis(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return cross-text learning pattern analysis for a student.
+
+    Access: the student themselves, their teacher, or their linked parent.
+    Uses _verify_student_access for consistent access control.
+    Issue #253.
+    """
+    target = db.query(User).filter(User.id == student_id).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="找不到此學生")
+    _verify_student_access(student_id, current_user, db)
+    return analyze_cross_text_patterns(student_id, db)

--- a/backend/tests/test_cross_text_analysis.py
+++ b/backend/tests/test_cross_text_analysis.py
@@ -1,0 +1,459 @@
+"""
+Tests for Cross-Text Learning Pattern Analysis — Issue #253.
+
+Covers:
+- cross_text_analysis_service unit tests (pure logic)
+- GET /api/learning/cross-text-analysis/{student_id} endpoint
+
+Uses SQLite in-memory DB to avoid external dependencies.
+
+Run with:
+    cd backend && python -m pytest tests/test_cross_text_analysis.py -v
+"""
+
+import sys
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, UserRole
+from app.models.session import LearningSession, CharacterError
+from app.models.text import Text
+from app.services.cross_text_analysis_service import (
+    analyze_cross_text_patterns,
+    _build_text_type_performance,
+    _build_vocabulary_growth,
+    _build_common_error_patterns,
+    MIN_SESSIONS_FOR_ANALYSIS,
+)
+
+# ---------------------------------------------------------------------------
+# DB setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "class"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "family"},
+]
+
+
+@pytest.fixture(scope="module")
+def db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    for r in SEED_ROLES:
+        if not session.query(Role).filter_by(name=r["name"]).first():
+            session.add(Role(**r))
+    session.commit()
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client(db):
+    def _override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _uid() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _register_and_login(client, suffix: str = "student") -> dict:
+    """Register a user and return {token, user_id}."""
+    uid = _uid()
+    email = f"{suffix}_{uid}@test.com"
+    res = client.post(
+        "/api/auth/register",
+        json={
+            "email": email,
+            "password": "Password123!",
+            "name": f"{suffix} {uid}",
+            "terms_accepted": True,
+            "copyright_confirmed": True,
+        },
+    )
+    assert res.status_code == 201, res.text
+    token = res.json()["access_token"]
+    me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    return {"token": token, "user_id": me.json()["id"]}
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_text_in_db(db, title: str, genre: str = "記敘文", category: str = "Fable", grade: int = 5) -> Text:
+    text = Text(
+        title=title,
+        paragraphs=["段落一"],
+        char_count=10,
+        grade=grade,
+        grade_code=f"G{grade}-1",
+        genre=genre,
+        text_type="單",
+        category=category,
+        vocabulary=[{"word": f"詞{_uid()}", "definition": "測試"}],
+    )
+    db.add(text)
+    db.flush()
+    return text
+
+
+def _make_completed_session(db, student_id: int, text: Text, score: float = 80.0) -> LearningSession:
+    s = LearningSession(
+        student_id=student_id,
+        text_id=text.id,
+        story_slug=f"slug-{text.id}",
+        status="completed",
+        current_step=6,
+        overall_score=score,
+        completed_at=datetime.now(timezone.utc),
+    )
+    db.add(s)
+    db.flush()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure service functions with mocked data
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTextTypePerformance:
+    """Pure logic tests — no DB required."""
+
+    def _mock_text(self, genre: str, category: str, grade: int) -> MagicMock:
+        t = MagicMock()
+        t.genre = genre
+        t.category = category
+        t.grade = grade
+        return t
+
+    def _mock_session(self, score: float | None) -> MagicMock:
+        s = MagicMock(spec=LearningSession)
+        s.overall_score = score
+        s.accuracy = None
+        return s
+
+    def test_empty_input_returns_empty_lists(self):
+        result = _build_text_type_performance([])
+        assert result["by_genre"] == []
+        assert result["by_category"] == []
+        assert result["by_grade"] == []
+
+    def test_groups_by_genre_and_averages(self):
+        t1 = self._mock_text("記敘文", "Fable", 5)
+        t2 = self._mock_text("記敘文", "Fable", 5)
+        t3 = self._mock_text("說明文", "Science", 6)
+        pairs = [
+            (self._mock_session(80.0), t1),
+            (self._mock_session(90.0), t2),
+            (self._mock_session(70.0), t3),
+        ]
+        result = _build_text_type_performance(pairs)
+        genres = {g["label"]: g for g in result["by_genre"]}
+
+        assert "記敘文" in genres
+        assert "說明文" in genres
+        assert genres["記敘文"]["avg_score"] == 85.0
+        assert genres["記敘文"]["attempts"] == 2
+        assert genres["說明文"]["avg_score"] == 70.0
+
+    def test_skips_sessions_without_score(self):
+        t1 = self._mock_text("議論文", "Opinion", 7)
+        pairs = [(self._mock_session(None), t1)]
+        result = _build_text_type_performance(pairs)
+        assert result["by_genre"] == []
+
+    def test_skips_sessions_without_text(self):
+        s = self._mock_session(85.0)
+        pairs = [(s, None)]
+        result = _build_text_type_performance(pairs)
+        assert result["by_genre"] == []
+
+
+class TestBuildVocabularyGrowth:
+    """Pure logic tests for vocabulary accumulation."""
+
+    def _mock_session(self, title: str) -> MagicMock:
+        s = MagicMock(spec=LearningSession)
+        s.completed_at = datetime.now(timezone.utc)
+        s.story_slug = f"slug-{title}"
+        return s
+
+    def _mock_text(self, vocab_words: list, title: str = "課文") -> MagicMock:
+        t = MagicMock(spec=Text)
+        t.title = title
+        t.vocabulary = [{"word": w} for w in vocab_words]
+        return t
+
+    def test_cumulative_count_increases(self):
+        t1 = self._mock_text(["蝴蝶", "春天"], "課文A")
+        t2 = self._mock_text(["地球", "月亮"], "課文B")
+        pairs = [(self._mock_session("A"), t1), (self._mock_session("B"), t2)]
+        result = _build_vocabulary_growth(pairs)
+
+        assert len(result) == 2
+        assert result[0]["new_words"] == 2
+        assert result[0]["cumulative_words"] == 2
+        assert result[1]["new_words"] == 2
+        assert result[1]["cumulative_words"] == 4
+
+    def test_duplicate_words_not_double_counted(self):
+        t1 = self._mock_text(["共同詞"], "課文A")
+        t2 = self._mock_text(["共同詞"], "課文B")
+        pairs = [(self._mock_session("A"), t1), (self._mock_session("B"), t2)]
+        result = _build_vocabulary_growth(pairs)
+
+        assert result[-1]["cumulative_words"] == 1
+
+    def test_empty_vocabulary_returns_zero_new_words(self):
+        t1 = self._mock_text([], "課文A")
+        pairs = [(self._mock_session("A"), t1)]
+        result = _build_vocabulary_growth(pairs)
+        assert result[0]["new_words"] == 0
+
+
+class TestBuildCommonErrorPatterns:
+    """DB-required tests for cross-session error analysis."""
+
+    def test_returns_chars_recurring_across_multiple_texts(self, db):
+        t1 = _make_text_in_db(db, f"錯誤測試A-{_uid()}", genre="記敘文", grade=5)
+        t2 = _make_text_in_db(db, f"錯誤測試B-{_uid()}", genre="記敘文", grade=5)
+
+        from app.models.user import User as UserModel
+        user = UserModel(
+            email=f"error_test_{_uid()}@test.com",
+            password_hash="hashed",
+            name="Error Test",
+        )
+        db.add(user)
+        db.flush()
+        student_id = user.id
+
+        s1 = _make_completed_session(db, student_id, t1)
+        s2 = _make_completed_session(db, student_id, t2)
+
+        db.add(CharacterError(session_id=s1.id, character="難", error_type="pronunciation"))
+        db.add(CharacterError(session_id=s2.id, character="難", error_type="pronunciation"))
+        db.add(CharacterError(session_id=s1.id, character="易", error_type="tone"))
+        db.commit()
+
+        pairs = [(s1, t1), (s2, t2)]
+        result = _build_common_error_patterns(student_id, pairs, db)
+
+        chars = [e["character"] for e in result]
+        assert "難" in chars
+        assert "易" not in chars
+
+        entry = next(e for e in result if e["character"] == "難")
+        assert entry["text_count"] == 2
+        assert entry["error_count"] == 2
+
+    def test_empty_pairs_returns_empty_list(self, db):
+        from app.models.user import User as UserModel
+        user = UserModel(
+            email=f"empty_pairs_{_uid()}@test.com",
+            password_hash="hashed",
+            name="Empty Pairs",
+        )
+        db.add(user)
+        db.commit()
+        result = _build_common_error_patterns(user.id, [], db)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — API endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTextAnalysisEndpoint:
+    """Integration tests for GET /api/learning/cross-text-analysis/{student_id}."""
+
+    def test_student_can_access_own_analysis(self, client):
+        data = _register_and_login(client, "self_access")
+        res = client.get(
+            f"/api/learning/cross-text-analysis/{data['user_id']}",
+            headers=_headers(data["token"]),
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["student_id"] == data["user_id"]
+        assert "has_enough_data" in body
+        assert "summary" in body
+
+    def test_student_cannot_access_other_student_analysis(self, client):
+        student_a = _register_and_login(client, "cross_a")
+        student_b = _register_and_login(client, "cross_b")
+
+        res = client.get(
+            f"/api/learning/cross-text-analysis/{student_b['user_id']}",
+            headers=_headers(student_a["token"]),
+        )
+        assert res.status_code == 403
+
+    def test_returns_not_enough_data_for_new_student(self, client):
+        data = _register_and_login(client, "newstudent")
+        res = client.get(
+            f"/api/learning/cross-text-analysis/{data['user_id']}",
+            headers=_headers(data["token"]),
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["has_enough_data"] is False
+        assert body["total_completed_texts"] == 0
+
+    def test_404_for_nonexistent_student(self, client):
+        data = _register_and_login(client, "requester404")
+        res = client.get(
+            "/api/learning/cross-text-analysis/999999",
+            headers=_headers(data["token"]),
+        )
+        assert res.status_code == 404
+
+    def test_requires_authentication(self, client):
+        res = client.get("/api/learning/cross-text-analysis/1")
+        assert res.status_code == 401
+
+    def test_returns_full_analysis_with_enough_data(self, client, db):
+        data = _register_and_login(client, "datarich")
+        student_id = data["user_id"]
+
+        t1 = _make_text_in_db(db, f"跨文一-{_uid()}", genre="記敘文", grade=5)
+        t2 = _make_text_in_db(db, f"跨文二-{_uid()}", genre="說明文", grade=6)
+        _make_completed_session(db, student_id, t1, score=82.0)
+        _make_completed_session(db, student_id, t2, score=75.0)
+        db.commit()
+
+        res = client.get(
+            f"/api/learning/cross-text-analysis/{student_id}",
+            headers=_headers(data["token"]),
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["has_enough_data"] is True
+        assert body["total_completed_texts"] >= MIN_SESSIONS_FOR_ANALYSIS
+        assert len(body["text_type_performance"]["by_genre"]) >= 1
+        assert body["summary"]["strongest_genre"] is not None
+        assert isinstance(body["vocabulary_growth"], list)
+        assert isinstance(body["difficulty_progression"], list)
+        assert isinstance(body["common_error_patterns"], list)
+
+
+class TestAnalyzeCrossTextPatterns:
+    """Unit tests for top-level service function using the DB."""
+
+    def test_not_enough_data_flag(self, db):
+        from app.models.user import User as UserModel
+        user = UserModel(
+            email=f"nodata_{_uid()}@test.com",
+            password_hash="hashed",
+            name="No Data",
+        )
+        db.add(user)
+        db.commit()
+
+        result = analyze_cross_text_patterns(user.id, db)
+        assert result["has_enough_data"] is False
+        assert result["total_completed_texts"] == 0
+        assert result["summary"]["strongest_genre"] is None
+        assert result["summary"]["total_vocabulary_words"] == 0
+
+    def test_result_structure_with_enough_data(self, db):
+        from app.models.user import User as UserModel
+        user = UserModel(
+            email=f"struct_{_uid()}@test.com",
+            password_hash="hashed",
+            name="Struct Student",
+        )
+        db.add(user)
+        db.flush()
+
+        t1 = _make_text_in_db(db, f"結構一-{_uid()}", genre="記敘文", grade=5)
+        t2 = _make_text_in_db(db, f"結構二-{_uid()}", genre="說明文", grade=6)
+        _make_completed_session(db, user.id, t1, score=88.0)
+        _make_completed_session(db, user.id, t2, score=72.0)
+        db.commit()
+
+        result = analyze_cross_text_patterns(user.id, db)
+
+        assert result["has_enough_data"] is True
+        assert result["total_completed_texts"] >= 2
+        assert isinstance(result["text_type_performance"], dict)
+        assert isinstance(result["vocabulary_growth"], list)
+        assert isinstance(result["difficulty_progression"], list)
+        assert isinstance(result["common_error_patterns"], list)
+        assert isinstance(result["summary"], dict)
+        assert "strongest_genre" in result["summary"]
+        assert "weakest_genre" in result["summary"]
+        assert "total_vocabulary_words" in result["summary"]
+        assert "recurring_error_chars" in result["summary"]
+
+    def test_strongest_genre_identified(self, db):
+        from app.models.user import User as UserModel
+        user = UserModel(
+            email=f"genre_{_uid()}@test.com",
+            password_hash="hashed",
+            name="Genre Student",
+        )
+        db.add(user)
+        db.flush()
+
+        for _ in range(2):
+            t = _make_text_in_db(db, f"高分-{_uid()}", genre="記敘文", grade=5)
+            _make_completed_session(db, user.id, t, score=95.0)
+
+        t_low = _make_text_in_db(db, f"低分-{_uid()}", genre="說明文", grade=6)
+        _make_completed_session(db, user.id, t_low, score=50.0)
+        db.commit()
+
+        result = analyze_cross_text_patterns(user.id, db)
+        assert result["has_enough_data"] is True
+        assert result["summary"]["strongest_genre"] == "記敘文"

--- a/frontend/src/components/analytics/CrossTextAnalysis.tsx
+++ b/frontend/src/components/analytics/CrossTextAnalysis.tsx
@@ -1,0 +1,330 @@
+/**
+ * CrossTextAnalysis — student-facing cross-text learning pattern component.
+ *
+ * Displays:
+ *   - Performance summary by text genre and category
+ *   - Vocabulary growth timeline
+ *   - Difficulty progression across completed texts
+ *   - Recurring error characters
+ *
+ * Issue #253
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  getCrossTextAnalysis,
+  CrossTextAnalysisResult,
+  CrossTextGenreEntry,
+} from '../../services/api';
+
+interface CrossTextAnalysisProps {
+  studentId: number;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function scoreColor(score: number): string {
+  if (score >= 80) return '#10b981';
+  if (score >= 60) return '#f59e0b';
+  return '#ef4444';
+}
+
+function ScorePill({ score }: { score: number | null }) {
+  if (score === null) return <span className="text-gray-400 text-sm">--</span>;
+  return (
+    <span
+      className="inline-block px-2 py-0.5 rounded text-white text-xs font-semibold"
+      style={{ backgroundColor: scoreColor(score) }}
+    >
+      {score}
+    </span>
+  );
+}
+
+// ── Genre/Category Bar Chart ───────────────────────────────────────────────
+
+interface GenreChartProps {
+  data: CrossTextGenreEntry[];
+  title: string;
+}
+
+function GenreChart({ data, title }: GenreChartProps) {
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-6 text-gray-400 text-sm">尚無資料</div>
+    );
+  }
+
+  const chartData = data.map((d) => ({
+    name: d.label,
+    分數: d.avg_score,
+    次數: d.attempts,
+  }));
+
+  return (
+    <div>
+      <p className="text-sm font-semibold text-gray-700 mb-2">{title}</p>
+      <ResponsiveContainer width="100%" height={160}>
+        <BarChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+          <YAxis domain={[0, 100]} tick={{ fontSize: 11 }} />
+          <Tooltip
+            formatter={(value: number, name: string) =>
+              name === '分數' ? [`${value} 分`, '平均分數'] : [`${value} 次`, '練習次數']
+            }
+          />
+          <Bar
+            dataKey="分數"
+            fill="#6366f1"
+            radius={[3, 3, 0, 0]}
+            maxBarSize={40}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+// ── Vocabulary Growth Timeline ─────────────────────────────────────────────
+
+function VocabGrowthChart({ data }: { data: CrossTextAnalysisResult['vocabulary_growth'] }) {
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-6 text-gray-400 text-sm">尚無詞彙資料</div>
+    );
+  }
+
+  const chartData = data.map((d) => ({
+    課文: d.text_title.length > 6 ? d.text_title.slice(0, 6) + '…' : d.text_title,
+    累積詞彙: d.cumulative_words,
+    新詞: d.new_words,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={180}>
+      <LineChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="課文" tick={{ fontSize: 11 }} />
+        <YAxis tick={{ fontSize: 11 }} />
+        <Tooltip />
+        <Line
+          type="monotone"
+          dataKey="累積詞彙"
+          stroke="#6366f1"
+          strokeWidth={2}
+          dot={{ r: 3 }}
+          activeDot={{ r: 5 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+// ── Difficulty Progression Chart ──────────────────────────────────────────
+
+function DifficultyProgressionChart({
+  data,
+}: {
+  data: CrossTextAnalysisResult['difficulty_progression'];
+}) {
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-6 text-gray-400 text-sm">尚無進度資料</div>
+    );
+  }
+
+  const chartData = data.map((d) => ({
+    課文: d.text_title.length > 6 ? d.text_title.slice(0, 6) + '…' : d.text_title,
+    分數: d.score,
+    年級: d.grade,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={180}>
+      <LineChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="課文" tick={{ fontSize: 11 }} />
+        <YAxis domain={[0, 100]} tick={{ fontSize: 11 }} />
+        <Tooltip
+          formatter={(value: number | null) =>
+            value !== null ? [`${value} 分`, '得分'] : ['--', '得分']
+          }
+        />
+        <Line
+          type="monotone"
+          dataKey="分數"
+          stroke="#10b981"
+          strokeWidth={2}
+          dot={{ r: 3 }}
+          activeDot={{ r: 5 }}
+          connectNulls
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+
+// ── Main Component ─────────────────────────────────────────────────────────
+
+const CrossTextAnalysis: React.FC<CrossTextAnalysisProps> = ({ studentId }) => {
+  const { token } = useAuth();
+  const [data, setData] = useState<CrossTextAnalysisResult | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const result = await getCrossTextAnalysis(token, studentId);
+      setData(result);
+    } catch {
+      setError('無法載入跨課文分析資料');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, studentId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-gray-400 text-sm">
+        載入跨課文分析中...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700 text-sm">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  if (!data.has_enough_data) {
+    return (
+      <div className="rounded-lg bg-blue-50 border border-blue-200 p-6 text-center">
+        <p className="text-blue-700 font-medium">需要更多學習記錄</p>
+        <p className="text-blue-600 text-sm mt-1">
+          目前已完成 {data.total_completed_texts} 篇課文。完成至少 2 篇課文後，即可查看跨課文學習模式分析。
+        </p>
+      </div>
+    );
+  }
+
+  const { summary, text_type_performance, vocabulary_growth, difficulty_progression, common_error_patterns } = data;
+
+  return (
+    <div className="space-y-6">
+      {/* Summary Row */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div className="bg-white rounded-lg border border-gray-200 p-3 text-center">
+          <p className="text-2xl font-bold text-indigo-600">{data.total_completed_texts}</p>
+          <p className="text-xs text-gray-500 mt-0.5">已完成課文</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-3 text-center">
+          <p className="text-2xl font-bold text-emerald-600">{summary.total_vocabulary_words}</p>
+          <p className="text-xs text-gray-500 mt-0.5">累積詞彙量</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-3 text-center">
+          <p className="text-lg font-bold text-indigo-600 truncate">{summary.strongest_genre ?? '--'}</p>
+          <p className="text-xs text-gray-500 mt-0.5">最強文體</p>
+        </div>
+        <div className="bg-white rounded-lg border border-gray-200 p-3 text-center">
+          <p className="text-xl font-bold text-amber-500">{summary.recurring_error_chars}</p>
+          <p className="text-xs text-gray-500 mt-0.5">反覆錯誤字</p>
+        </div>
+      </div>
+
+      {/* Genre & Category Performance */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-sm font-semibold text-gray-800 mb-4">各文體表現</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <GenreChart data={text_type_performance.by_genre} title="依文體" />
+          <GenreChart data={text_type_performance.by_category} title="依類別" />
+        </div>
+      </div>
+
+      {/* Vocabulary Growth */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-sm font-semibold text-gray-800 mb-2">詞彙累積成長</h3>
+        <VocabGrowthChart data={vocabulary_growth} />
+      </div>
+
+      {/* Difficulty Progression */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-sm font-semibold text-gray-800 mb-2">各課文得分趨勢</h3>
+        <DifficultyProgressionChart data={difficulty_progression} />
+        <div className="mt-3 overflow-x-auto">
+          <table className="min-w-full text-xs">
+            <thead>
+              <tr className="border-b border-gray-100">
+                <th className="text-left py-1 pr-4 text-gray-500 font-medium">課文</th>
+                <th className="text-left py-1 pr-4 text-gray-500 font-medium">文體</th>
+                <th className="text-left py-1 pr-4 text-gray-500 font-medium">年級</th>
+                <th className="text-left py-1 text-gray-500 font-medium">得分</th>
+              </tr>
+            </thead>
+            <tbody>
+              {difficulty_progression.map((row, i) => (
+                <tr key={i} className="border-b border-gray-50">
+                  <td className="py-1 pr-4 text-gray-700 max-w-[120px] truncate">{row.text_title}</td>
+                  <td className="py-1 pr-4 text-gray-600">{row.genre ?? '--'}</td>
+                  <td className="py-1 pr-4 text-gray-600">{row.grade ? `${row.grade} 年級` : '--'}</td>
+                  <td className="py-1"><ScorePill score={row.score} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* Recurring Error Characters */}
+      {common_error_patterns.length > 0 && (
+        <div className="bg-white rounded-lg border border-gray-200 p-4">
+          <h3 className="text-sm font-semibold text-gray-800 mb-3">反覆出現的錯誤字</h3>
+          <div className="flex flex-wrap gap-2">
+            {common_error_patterns.map((err) => (
+              <div
+                key={err.character}
+                className="flex items-center gap-1.5 bg-red-50 border border-red-200 rounded-lg px-3 py-1.5"
+                title={`出現 ${err.text_count} 篇課文，共 ${err.error_count} 次錯誤`}
+              >
+                <span className="text-lg font-bold text-red-700">{err.character}</span>
+                <div className="text-xs text-red-500">
+                  <div>{err.text_count} 篇</div>
+                  <div>{err.error_count} 次</div>
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-gray-400 mt-2">
+            以上字在 2 篇以上課文中重複出現錯誤，建議加強練習。
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CrossTextAnalysis;

--- a/frontend/src/pages/student/StudentProgress.tsx
+++ b/frontend/src/pages/student/StudentProgress.tsx
@@ -19,6 +19,7 @@ import {
   TextProgressItem,
   StepStatusItem,
 } from '../../services/api';
+import CrossTextAnalysis from '../../components/analytics/CrossTextAnalysis';
 
 const STEP_ROUTE: Record<string, string> = {
   intro: 'intro',
@@ -225,6 +226,14 @@ const StudentProgress: React.FC = () => {
                 <TextCard key={t.story_slug} item={t} />
               ))}
             </div>
+
+            {/* Cross-text pattern analysis — shown after 2+ completed texts (Issue #253) */}
+            {data.texts_completed >= 2 && user && (
+              <div>
+                <h2 className="text-base font-bold text-gray-900 mb-3">跨課文學習分析</h2>
+                <CrossTextAnalysis studentId={user.id} />
+              </div>
+            )}
           </>
         )}
       </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -835,3 +835,68 @@ export async function reportSessionComplete(
   if (!res.ok) throw new Error(`reportSessionComplete failed: ${res.status}`);
   return res.json();
 }
+
+// ── Cross-Text Analysis — student-facing (Issue #253) ─────────────────────────
+
+export interface CrossTextVocabEntry {
+  session_index: number;
+  completed_at: string;
+  text_title: string;
+  new_words: number;
+  cumulative_words: number;
+}
+
+export interface CrossTextDifficultyEntry {
+  session_index: number;
+  completed_at: string;
+  text_title: string;
+  grade: number | null;
+  genre: string | null;
+  score: number | null;
+}
+
+export interface CrossTextErrorEntry {
+  character: string;
+  error_count: number;
+  text_count: number;
+  dominant_error_type: string;
+}
+
+export interface CrossTextGenreEntry {
+  label: string;
+  avg_score: number;
+  attempts: number;
+}
+
+export interface CrossTextAnalysisResult {
+  student_id: number;
+  total_completed_texts: number;
+  has_enough_data: boolean;
+  text_type_performance: {
+    by_genre: CrossTextGenreEntry[];
+    by_category: CrossTextGenreEntry[];
+    by_grade: Array<{ grade: number; avg_score: number; attempts: number }>;
+  };
+  vocabulary_growth: CrossTextVocabEntry[];
+  difficulty_progression: CrossTextDifficultyEntry[];
+  common_error_patterns: CrossTextErrorEntry[];
+  summary: {
+    strongest_genre: string | null;
+    weakest_genre: string | null;
+    total_vocabulary_words: number;
+    recurring_error_chars: number;
+  };
+}
+
+/** Fetch cross-text learning pattern analysis for a student. Issue #253. */
+export async function getCrossTextAnalysis(
+  token: string,
+  studentId: number,
+): Promise<CrossTextAnalysisResult> {
+  const res = await fetch(
+    `${API_BASE}/api/learning/cross-text-analysis/${studentId}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) throw new Error(`getCrossTextAnalysis failed: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
Fixes #253

## Summary

- **Backend**: New `cross_text_analysis_service.py` with read-only analysis over existing `LearningSession` data
  - `analyze_cross_text_patterns(student_id, db)` — per-student analysis
  - `analyze_class_cross_text_patterns(student_ids, db)` — class-level aggregation
- **Backend**: `GET /api/teacher/classrooms/{id}/cross-text-analysis` — teacher dashboard endpoint with per-student + class-wide views (score trends, common error chars, text difficulty ranking)
- **Backend**: `GET /api/learning/cross-text-analysis/{student_id}` — student-facing endpoint with genre/vocabulary/difficulty/error pattern breakdown
- **Frontend Teacher**: `CrossTextAnalytics` page with class overview + per-student drill-down, integrated as "跨課文分析" tab in `ClassroomDetail`
- **Frontend Student**: `CrossTextAnalysis` component with bar charts (genre performance), line charts (vocab growth + score trend), error character display; integrated in `StudentProgress` page after 2+ completed texts
- **Tests**: 18 tests covering service unit logic + API endpoint integration (all passing)

## Test Plan

- [ ] Teacher: Open classroom detail → "跨課文分析" tab → verify class score trend and common error characters display
- [ ] Teacher: Switch to per-student view → verify individual score trend and error patterns
- [ ] Student: Complete 2+ texts → visit progress page → verify "跨課文學習分析" section appears with genre charts and vocab growth
- [ ] Student: Verify new student (0 completed texts) sees "需要更多學習記錄" message
- [ ] API: `GET /api/learning/cross-text-analysis/{own_id}` returns 200 for student
- [ ] API: Student accessing another student's analysis returns 403
- [ ] Backend tests: `cd backend && python -m pytest tests/test_cross_text_analysis.py -v` → 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)