### PR TITLE
feat: listening comprehension module with TTS and AI evaluation (Fixes #251)

### DIFF
--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -30,6 +30,7 @@ from ..services.ai_service import (
     generate_socratic_question,
     validate_student_sentence,
 )
+from ..services.listening_service import evaluate_retelling
 from ..services.socratic_agent import socratic_agent
 from ..services.stuck_detection_service import build_recommendations, detect_stuck_points
 from ..services.learning_path_service import recommend_next_stories
@@ -1518,5 +1519,67 @@ async def validate_sentence(
             payload.character, payload.student_sentence[:50], e,
         )
         raise HTTPException(status_code=503, detail="AI service unavailable")
+
+
+# ── Listening Comprehension (Issue #251) ─────────────────────────────────────
+
+
+class ListeningEvaluateRequest(BaseModel):
+    story_title: str = Field(..., max_length=200)
+    original_text: str = Field(..., max_length=10000)
+    student_retelling: str = Field(..., min_length=1, max_length=2000)
+
+
+class ListeningEvaluateResponse(BaseModel):
+    score: float
+    key_points_covered: list[str]
+    key_points_missed: list[str]
+    feedback: str
+    encouragement: str
+
+
+@router.post(
+    "/learning/listening/evaluate",
+    response_model=ListeningEvaluateResponse,
+    dependencies=[Depends(ai_limit_5_per_min)],
+)
+async def evaluate_listening_retelling(
+    payload: ListeningEvaluateRequest,
+    current_user: User = Depends(get_current_user),
+    _db: Session = Depends(get_db),
+):
+    """Evaluate a student's retelling of a story they listened to.
+
+    Uses Gemini AI to assess how completely the student captured key points
+    from the original text. Rate limited: 5 requests per minute.
+
+    Returns a score (0-100), covered/missed key points, and feedback.
+    """
+    try:
+        result = await evaluate_retelling(
+            original_text=payload.original_text,
+            student_retelling=payload.student_retelling,
+            story_title=payload.story_title,
+        )
+    except TimeoutError:
+        raise HTTPException(status_code=503, detail="AI service timeout")
+    except Exception as e:
+        logger.error("Listening evaluation failed: %s", e)
+        raise HTTPException(status_code=503, detail="AI service unavailable")
+
+    logger.info(
+        "Listening eval for user %d, story=%s: score=%.1f",
+        current_user.id,
+        payload.story_title,
+        result["score"],
+    )
+
+    return ListeningEvaluateResponse(
+        score=result["score"],
+        key_points_covered=result.get("key_points_covered", []),
+        key_points_missed=result.get("key_points_missed", []),
+        feedback=result.get("feedback", ""),
+        encouragement=result.get("encouragement", ""),
+    )
 
     return ValidateSentenceResponse(**result)

--- a/backend/app/services/listening_service.py
+++ b/backend/app/services/listening_service.py
@@ -1,0 +1,134 @@
+"""
+Listening comprehension evaluation service.
+
+Evaluates how well a student's retelling captures the key points
+of the original story text, using Gemini AI for structured analysis.
+"""
+
+import logging
+
+from google.genai import types as genai_types
+
+from .ai_service import generate_structured_response
+from .input_sanitizer import sanitize_ai_input
+from .persona import TUTOR_PERSONA
+
+logger = logging.getLogger(__name__)
+
+RETELLING_EVAL_SCHEMA = {
+    "type": "OBJECT",
+    "properties": {
+        "score": {
+            "type": "NUMBER",
+            "description": "Overall retelling score 0-100",
+        },
+        "key_points_covered": {
+            "type": "ARRAY",
+            "items": {"type": "STRING"},
+            "description": "Key points the student successfully captured",
+        },
+        "key_points_missed": {
+            "type": "ARRAY",
+            "items": {"type": "STRING"},
+            "description": "Key points the student missed or stated incorrectly",
+        },
+        "feedback": {
+            "type": "STRING",
+            "description": "Warm, encouraging feedback in Traditional Chinese (2-4 sentences)",
+        },
+        "encouragement": {
+            "type": "STRING",
+            "description": "Short encouragement message (1 sentence)",
+        },
+    },
+    "required": [
+        "score",
+        "key_points_covered",
+        "key_points_missed",
+        "feedback",
+        "encouragement",
+    ],
+}
+
+
+async def evaluate_retelling(
+    original_text: str,
+    student_retelling: str,
+    story_title: str = "課文",
+) -> dict:
+    """Evaluate a student's retelling against the original story text.
+
+    Uses Gemini to assess how completely and accurately the student
+    captured the key points from the story they listened to.
+
+    Args:
+        original_text: The full story text the student listened to.
+        student_retelling: The student's spoken/typed retelling.
+        story_title: Title of the story (for context in prompts).
+
+    Returns:
+        Dict with keys: score, key_points_covered, key_points_missed,
+                        feedback, encouragement.
+    """
+    # Sanitise student input to prevent prompt injection
+    sanitized_retelling, _ = sanitize_ai_input(student_retelling)
+
+    system_prompt = (
+        f"{TUTOR_PERSONA}\n\n"
+        "你同時也是一位國小國語文聽力理解評估專家。\n\n"
+        "任務：評估學生在聽完課文後的覆述內容。\n\n"
+        "評分標準：\n"
+        "- 90-100分：覆述涵蓋所有主要情節、人物、事件，細節豐富\n"
+        "- 75-89分：涵蓋大部分主要情節，偶有遺漏次要細節\n"
+        "- 60-74分：涵蓋部分重要情節，有明顯遺漏\n"
+        "- 45-59分：只覆述了少數關鍵訊息\n"
+        "- 0-44分：覆述內容極少或與原文無關\n\n"
+        "評估重點：\n"
+        "1. 主要事件是否被提及\n"
+        "2. 人物角色是否正確\n"
+        "3. 因果關係是否理解\n"
+        "4. 重要細節是否掌握\n\n"
+        "回覆規則：\n"
+        "- 必須使用臺灣繁體中文（zh-TW），嚴禁大陸用語\n"
+        "- 語氣溫暖、鼓勵，適合國小高年級至國中生\n"
+        "- key_points_covered 和 key_points_missed 各列 1-5 點\n"
+        "- feedback 要具體，說明哪裡做得好、哪裡可以更完整"
+    )
+
+    user_prompt = (
+        f"課文標題：{story_title}\n\n"
+        f"原始課文：\n{original_text}\n\n"
+        f"學生覆述：\n{sanitized_retelling}\n\n"
+        "請評估學生的覆述品質，給出分數和詳細回饋。"
+    )
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[genai_types.Part(text=user_prompt)],
+        )
+    ]
+
+    result = await generate_structured_response(
+        system_prompt=system_prompt,
+        contents=contents,
+        response_schema=RETELLING_EVAL_SCHEMA,
+        max_tokens=1024,
+        temperature=0.5,
+    )
+
+    # Clamp score to [0, 100]
+    result["score"] = max(0, min(100, float(result.get("score", 0))))
+
+    logger.info(
+        "Listening evaluation complete: score=%.1f, covered=%d, missed=%d",
+        result["score"],
+        len(result.get("key_points_covered", [])),
+        len(result.get("key_points_missed", [])),
+        extra={
+            "event": "listening_eval_complete",
+            "score": result["score"],
+        },
+    )
+
+    return result

--- a/backend/tests/test_listening.py
+++ b/backend/tests/test_listening.py
@@ -1,0 +1,261 @@
+"""
+Tests for the Listening Comprehension module (Issue #251).
+
+Covers:
+- evaluate_retelling() service function (mocked Gemini)
+- POST /api/learning/listening/evaluate endpoint
+
+Run with:
+    cd /path/to/chinese-literacy-platform/backend
+    python -m pytest tests/test_listening.py -v
+"""
+
+import sys
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "org_owner", "display_name": "Org Owner", "scope_level": "organization"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        session.add(Role(**role_data))
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register_and_login(client: TestClient) -> str:
+    """Register a student and return their access token."""
+    unique = uuid.uuid4().hex[:8]
+    email = f"listen_{unique}@example.com"
+    resp = client.post(
+        "/api/auth/register",
+        json={"email": email, "password": "Test1234!", "name": "Listen Tester"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Mock AI response
+# ---------------------------------------------------------------------------
+
+MOCK_EVAL_RESULT = {
+    "score": 75.0,
+    "key_points_covered": ["主角是一隻兔子", "兔子跑得很快"],
+    "key_points_missed": ["烏龜最後贏得比賽"],
+    "feedback": "你掌握了主要角色和情節，不過結局的部分可以更完整。",
+    "encouragement": "繼續努力，你做得很好！",
+}
+
+# ---------------------------------------------------------------------------
+# Unit tests: evaluate_retelling() service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_retelling_returns_expected_keys():
+    """evaluate_retelling() returns all required keys."""
+    with patch(
+        "app.services.listening_service.generate_structured_response",
+        new=AsyncMock(return_value=MOCK_EVAL_RESULT),
+    ):
+        from app.services.listening_service import evaluate_retelling
+
+        result = await evaluate_retelling(
+            original_text="從前有一隻烏龜和兔子比賽跑步，最後烏龜贏了。",
+            student_retelling="有一隻兔子和一隻動物賽跑，兔子跑得很快。",
+            story_title="龜兔賽跑",
+        )
+
+    assert set(result.keys()) >= {"score", "key_points_covered", "key_points_missed", "feedback", "encouragement"}
+    assert 0 <= result["score"] <= 100
+    assert isinstance(result["key_points_covered"], list)
+    assert isinstance(result["key_points_missed"], list)
+
+
+@pytest.mark.asyncio
+async def test_evaluate_retelling_clamps_score_above_100():
+    """evaluate_retelling() clamps score > 100 to 100."""
+    with patch(
+        "app.services.listening_service.generate_structured_response",
+        new=AsyncMock(return_value={**MOCK_EVAL_RESULT, "score": 999}),
+    ):
+        from app.services.listening_service import evaluate_retelling
+
+        result = await evaluate_retelling(original_text="課文", student_retelling="覆述")
+    assert result["score"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_evaluate_retelling_clamps_score_below_0():
+    """evaluate_retelling() clamps score < 0 to 0."""
+    with patch(
+        "app.services.listening_service.generate_structured_response",
+        new=AsyncMock(return_value={**MOCK_EVAL_RESULT, "score": -50}),
+    ):
+        from app.services.listening_service import evaluate_retelling
+
+        result = await evaluate_retelling(original_text="課文", student_retelling="覆述")
+    assert result["score"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests: POST /api/learning/listening/evaluate
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_endpoint_unauthenticated(client):
+    """Unauthenticated request returns 401."""
+    res = client.post(
+        "/api/learning/listening/evaluate",
+        json={
+            "story_title": "龜兔賽跑",
+            "original_text": "課文內容",
+            "student_retelling": "我的覆述",
+        },
+    )
+    assert res.status_code == 401
+
+
+def test_evaluate_endpoint_empty_retelling(client):
+    """Request with empty student_retelling fails validation (422)."""
+    token = _register_and_login(client)
+    res = client.post(
+        "/api/learning/listening/evaluate",
+        headers=_auth_header(token),
+        json={
+            "story_title": "龜兔賽跑",
+            "original_text": "課文內容",
+            "student_retelling": "",  # empty string — min_length=1 should reject
+        },
+    )
+    assert res.status_code == 422
+
+
+def test_evaluate_endpoint_success(client):
+    """Valid authenticated request returns 200 with expected fields."""
+    token = _register_and_login(client)
+
+    with patch(
+        "app.services.listening_service.generate_structured_response",
+        new=AsyncMock(return_value=MOCK_EVAL_RESULT),
+    ):
+        res = client.post(
+            "/api/learning/listening/evaluate",
+            headers=_auth_header(token),
+            json={
+                "story_title": "龜兔賽跑",
+                "original_text": "從前有一隻烏龜和兔子比賽跑步，最後烏龜贏了。",
+                "student_retelling": "有一隻兔子和動物賽跑，兔子跑很快。",
+            },
+        )
+
+    assert res.status_code == 200
+    data = res.json()
+    assert "score" in data
+    assert "key_points_covered" in data
+    assert "key_points_missed" in data
+    assert "feedback" in data
+    assert "encouragement" in data
+    assert isinstance(data["score"], float)
+    assert isinstance(data["key_points_covered"], list)
+    assert isinstance(data["key_points_missed"], list)
+    assert 0 <= data["score"] <= 100
+
+
+def test_evaluate_endpoint_ai_failure_returns_503(client):
+    """AI exception causes endpoint to return 503."""
+    token = _register_and_login(client)
+
+    with patch(
+        "app.services.listening_service.generate_structured_response",
+        new=AsyncMock(side_effect=Exception("Gemini unavailable")),
+    ):
+        res = client.post(
+            "/api/learning/listening/evaluate",
+            headers=_auth_header(token),
+            json={
+                "story_title": "龜兔賽跑",
+                "original_text": "從前有一隻烏龜和兔子比賽跑步。",
+                "student_retelling": "有一隻兔子和動物賽跑。",
+            },
+        )
+
+    assert res.status_code == 503
+    assert "unavailable" in res.json()["detail"].lower()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,6 +57,7 @@ const TutorPage = lazy(() => import('./pages/learning/TutorPage'));
 const ComprehensionPage = lazy(() => import('./pages/learning/ComprehensionPage'));
 const VocabPage = lazy(() => import('./pages/learning/VocabPage'));
 const DictationPage = lazy(() => import('./pages/learning/DictationPage'));
+const ListeningPage = lazy(() => import('./pages/learning/ListeningPage'));
 const FullReadingPage = lazy(() => import('./pages/learning/FullReadingPage'));
 const ReportPage = lazy(() => import('./pages/learning/ReportPage'));
 
@@ -773,6 +774,7 @@ const App: React.FC = () => {
             <Route path="comprehension" element={<ComprehensionPage />} />
             <Route path="vocab" element={<VocabPage />} />
             <Route path="dictation" element={<DictationPage />} />
+            <Route path="listening" element={<ListeningPage />} />
             <Route path="full-reading" element={<FullReadingPage />} />
             <Route path="report" element={<ReportPage />} />
             {/* Default: redirect to intro */}

--- a/frontend/src/components/reading-steps/ListeningPractice.tsx
+++ b/frontend/src/components/reading-steps/ListeningPractice.tsx
@@ -1,0 +1,725 @@
+/**
+ * ListeningPractice — Issue #251
+ *
+ * Three-phase listening comprehension exercise:
+ *   Phase 1: Play story text via Web Speech API SpeechSynthesis (zh-TW)
+ *   Phase 2: Student retells what they heard (voice or text input)
+ *   Phase 3: Show AI evaluation with score and feedback
+ */
+
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { Story } from '../../types';
+import { evaluateListeningRetelling, ListeningEvaluateResponse } from '../../services/api';
+import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
+import { useAuth } from '../../contexts/AuthContext';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ListeningResult {
+  score: number;
+  keyPointsCovered: string[];
+  keyPointsMissed: string[];
+  feedback: string;
+}
+
+interface ListeningPracticeProps {
+  story: Story;
+  onFinish: (result: ListeningResult) => void;
+  onBack: () => void;
+}
+
+type Phase = 'play' | 'retell' | 'results';
+type PlayState = 'idle' | 'playing' | 'paused' | 'done';
+
+// ── TTS helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Speak text using Web Speech API SpeechSynthesis with zh-TW voice.
+ * Returns a cleanup function that cancels speech.
+ */
+function createSpeaker(text: string, rate: number): {
+  start: (onEnd: () => void, onError: (e: string) => void) => void;
+  cancel: () => void;
+} {
+  let utteranceRef: SpeechSynthesisUtterance | null = null;
+
+  const start = (onEnd: () => void, onError: (e: string) => void) => {
+    if (!window.speechSynthesis) {
+      onError('SpeechSynthesis not supported');
+      return;
+    }
+    window.speechSynthesis.cancel();
+
+    const utt = new SpeechSynthesisUtterance(text);
+    utt.lang = 'zh-TW';
+    utt.rate = rate;
+    utt.pitch = 1.0;
+
+    // Prefer zh-TW voice
+    const voices = window.speechSynthesis.getVoices();
+    const twVoice =
+      voices.find((v) => v.lang === 'zh-TW') ||
+      voices.find((v) => v.lang.startsWith('zh'));
+    if (twVoice) utt.voice = twVoice;
+
+    utt.onend = onEnd;
+    utt.onerror = (e) => onError(e.error ?? 'speech error');
+
+    utteranceRef = utt;
+    window.speechSynthesis.speak(utt);
+  };
+
+  const cancel = () => {
+    window.speechSynthesis?.cancel();
+    utteranceRef = null;
+  };
+
+  return { start, cancel };
+}
+
+function isTTSSupported(): boolean {
+  return typeof window !== 'undefined' && 'speechSynthesis' in window;
+}
+
+// ── Score colour helper ───────────────────────────────────────────────────────
+
+function scoreColour(score: number): string {
+  if (score >= 80) return 'text-green-600';
+  if (score >= 60) return 'text-yellow-600';
+  return 'text-red-500';
+}
+
+function scoreLabel(score: number): string {
+  if (score >= 90) return '非常優秀！';
+  if (score >= 75) return '表現良好';
+  if (score >= 60) return '尚可，繼續加油';
+  if (score >= 45) return '需要多練習';
+  return '請再聽一次試試看';
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+const ListeningPractice: React.FC<ListeningPracticeProps> = ({
+  story,
+  onFinish,
+  onBack,
+}) => {
+  const { token } = useAuth();
+
+  // Phase management
+  const [phase, setPhase] = useState<Phase>('play');
+
+  // Phase 1 — playback
+  const [playState, setPlayState] = useState<PlayState>('idle');
+  const [playRate, setPlayRate] = useState(0.85);
+  const [ttsError, setTtsError] = useState<string | null>(null);
+  const speakerRef = useRef<ReturnType<typeof createSpeaker> | null>(null);
+
+  // Phase 2 — retelling
+  const [retelling, setRetelling] = useState('');
+  const [retellMode, setRetellMode] = useState<'text' | 'voice'>('text');
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isEvaluating, setIsEvaluating] = useState(false);
+
+  // Phase 3 — results
+  const [evalResult, setEvalResult] = useState<ListeningEvaluateResponse | null>(null);
+
+  // Voice input for retelling
+  const {
+    status: speechStatus,
+    transcript: speechTranscript,
+    isSupported: speechSupported,
+    errorMessage: speechError,
+    startListening,
+    stopListening,
+    clearTranscript,
+  } = useSpeechRecognition('zh-TW', (finalText) => {
+    setRetelling((prev) => (prev ? prev + ' ' + finalText : finalText).trim());
+  });
+
+  // Sync interim speech transcript to retelling textarea
+  useEffect(() => {
+    if (speechStatus === 'listening' && speechTranscript) {
+      // Show interim results live (appended to existing text, trimmed)
+    }
+  }, [speechStatus, speechTranscript]);
+
+  // Cleanup speech on unmount
+  useEffect(() => {
+    return () => {
+      speakerRef.current?.cancel();
+    };
+  }, []);
+
+  // Full text to read aloud — join all paragraphs
+  const fullText = story.content.join('\n');
+
+  // ── Phase 1: Playback ──────────────────────────────────────────────────────
+
+  const handlePlay = useCallback(() => {
+    if (!isTTSSupported()) {
+      setTtsError('你的瀏覽器不支援語音合成功能，請改用 Chrome。');
+      return;
+    }
+    setTtsError(null);
+    setPlayState('playing');
+
+    const speaker = createSpeaker(fullText, playRate);
+    speakerRef.current = speaker;
+
+    speaker.start(
+      () => setPlayState('done'),
+      (errMsg) => {
+        setTtsError(`播放發生錯誤：${errMsg}`);
+        setPlayState('idle');
+      },
+    );
+  }, [fullText, playRate]);
+
+  const handlePause = useCallback(() => {
+    if (window.speechSynthesis?.speaking) {
+      window.speechSynthesis.pause();
+      setPlayState('paused');
+    }
+  }, []);
+
+  const handleResume = useCallback(() => {
+    if (window.speechSynthesis?.paused) {
+      window.speechSynthesis.resume();
+      setPlayState('playing');
+    }
+  }, []);
+
+  const handleStop = useCallback(() => {
+    speakerRef.current?.cancel();
+    setPlayState('idle');
+  }, []);
+
+  const handleReplay = useCallback(() => {
+    handleStop();
+    // Brief delay to let SpeechSynthesis fully reset
+    setTimeout(handlePlay, 100);
+  }, [handleStop, handlePlay]);
+
+  const handleProceedToRetell = useCallback(() => {
+    speakerRef.current?.cancel();
+    setPhase('retell');
+  }, []);
+
+  // ── Phase 2: Retelling ─────────────────────────────────────────────────────
+
+  const handleVoiceToggle = useCallback(() => {
+    if (speechStatus === 'listening') {
+      stopListening();
+    } else {
+      clearTranscript();
+      setRetellMode('voice');
+      startListening();
+    }
+  }, [speechStatus, startListening, stopListening, clearTranscript]);
+
+  const handleSubmitRetelling = useCallback(async () => {
+    const trimmed = retelling.trim();
+    if (!trimmed) {
+      setSubmitError('請先說出或輸入你的覆述內容。');
+      return;
+    }
+    if (!token) {
+      setSubmitError('請先登入再提交。');
+      return;
+    }
+
+    setSubmitError(null);
+    setIsEvaluating(true);
+
+    try {
+      const result = await evaluateListeningRetelling(token, {
+        storyTitle: story.title,
+        originalText: fullText,
+        studentRetelling: trimmed,
+      });
+      setEvalResult(result);
+      setPhase('results');
+    } catch (err) {
+      setSubmitError(
+        err instanceof Error ? err.message : 'AI 評估失敗，請稍後再試。',
+      );
+    } finally {
+      setIsEvaluating(false);
+    }
+  }, [retelling, token, story.title, fullText]);
+
+  // ── Phase 3: Results ───────────────────────────────────────────────────────
+
+  const handleFinish = useCallback(() => {
+    if (!evalResult) return;
+    onFinish({
+      score: evalResult.score,
+      keyPointsCovered: evalResult.key_points_covered,
+      keyPointsMissed: evalResult.key_points_missed,
+      feedback: evalResult.feedback,
+    });
+  }, [evalResult, onFinish]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 sm:p-6 max-w-2xl mx-auto w-full space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => {
+            speakerRef.current?.cancel();
+            onBack();
+          }}
+          className="text-sm text-gray-500 hover:text-gray-700 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          aria-label="返回上一步"
+        >
+          ← 返回
+        </button>
+        <h1 className="text-lg font-bold text-gray-900">聽力理解練習</h1>
+        <div className="w-16" aria-hidden="true" />
+      </div>
+
+      {/* Progress indicators */}
+      <div className="flex gap-2" role="group" aria-label="練習進度">
+        {(['play', 'retell', 'results'] as Phase[]).map((p, i) => (
+          <div
+            key={p}
+            className={`flex-1 h-1.5 rounded-full transition-colors ${
+              phase === p
+                ? 'bg-accent'
+                : i < ['play', 'retell', 'results'].indexOf(phase)
+                  ? 'bg-accent/40'
+                  : 'bg-gray-200'
+            }`}
+            aria-label={
+              p === 'play' ? '步驟一：聆聽' : p === 'retell' ? '步驟二：覆述' : '步驟三：結果'
+            }
+          />
+        ))}
+      </div>
+
+      {/* ── Phase 1: Play ─────────────────────────────────────────────────── */}
+      {phase === 'play' && (
+        <div className="space-y-6">
+          <div className="bg-blue-50 rounded-xl p-4 space-y-2">
+            <h2 className="font-semibold text-blue-800 text-base">步驟一：仔細聆聽課文</h2>
+            <p className="text-blue-700 text-sm">
+              點擊播放，認真聆聽「{story.title}」的內容。
+              聽完後你需要用自己的話說出課文的重點。
+            </p>
+          </div>
+
+          {/* Speed control */}
+          <div className="space-y-2">
+            <label htmlFor="play-rate" className="text-sm font-medium text-gray-700">
+              播放速度：{playRate === 0.7 ? '慢速' : playRate === 0.85 ? '標準' : '快速'}
+            </label>
+            <div className="flex items-center gap-3">
+              <span className="text-xs text-gray-500">慢</span>
+              <input
+                id="play-rate"
+                type="range"
+                min="0.7"
+                max="1.1"
+                step="0.2"
+                value={playRate}
+                onChange={(e) => {
+                  setPlayRate(parseFloat(e.target.value));
+                  if (playState === 'playing' || playState === 'paused') {
+                    handleStop();
+                  }
+                }}
+                disabled={playState === 'playing'}
+                className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer disabled:opacity-50"
+                aria-label="調整播放速度"
+              />
+              <span className="text-xs text-gray-500">快</span>
+            </div>
+          </div>
+
+          {/* Playback controls */}
+          <div className="flex flex-wrap gap-3 justify-center">
+            {playState === 'idle' && (
+              <button
+                type="button"
+                onClick={handlePlay}
+                className="flex items-center gap-2 px-6 py-3 bg-accent hover:bg-accent-hover text-white rounded-xl font-semibold text-base shadow-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                aria-label="播放課文"
+              >
+                <span aria-hidden="true">▶</span> 播放課文
+              </button>
+            )}
+
+            {playState === 'playing' && (
+              <>
+                <button
+                  type="button"
+                  onClick={handlePause}
+                  className="flex items-center gap-2 px-5 py-3 bg-yellow-500 hover:bg-yellow-600 text-white rounded-xl font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2"
+                  aria-label="暫停播放"
+                >
+                  <span aria-hidden="true">⏸</span> 暫停
+                </button>
+                <button
+                  type="button"
+                  onClick={handleStop}
+                  className="flex items-center gap-2 px-5 py-3 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-xl font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+                  aria-label="停止播放"
+                >
+                  <span aria-hidden="true">⏹</span> 停止
+                </button>
+              </>
+            )}
+
+            {playState === 'paused' && (
+              <>
+                <button
+                  type="button"
+                  onClick={handleResume}
+                  className="flex items-center gap-2 px-5 py-3 bg-accent hover:bg-accent-hover text-white rounded-xl font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+                  aria-label="繼續播放"
+                >
+                  <span aria-hidden="true">▶</span> 繼續
+                </button>
+                <button
+                  type="button"
+                  onClick={handleStop}
+                  className="flex items-center gap-2 px-5 py-3 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-xl font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+                  aria-label="停止播放"
+                >
+                  <span aria-hidden="true">⏹</span> 停止
+                </button>
+              </>
+            )}
+
+            {playState === 'done' && (
+              <button
+                type="button"
+                onClick={handleReplay}
+                className="flex items-center gap-2 px-5 py-3 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded-xl font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+                aria-label="重新播放"
+              >
+                <span aria-hidden="true">↺</span> 重聽
+              </button>
+            )}
+          </div>
+
+          {/* Status text */}
+          <div className="text-center">
+            {playState === 'playing' && (
+              <p className="text-sm text-accent animate-pulse" role="status" aria-live="polite">
+                正在播放中...
+              </p>
+            )}
+            {playState === 'paused' && (
+              <p className="text-sm text-yellow-600" role="status">
+                已暫停
+              </p>
+            )}
+            {playState === 'done' && (
+              <p className="text-sm text-green-600 font-medium" role="status">
+                播放完畢！可以重聽，或繼續下一步。
+              </p>
+            )}
+          </div>
+
+          {ttsError && (
+            <div
+              role="alert"
+              className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700"
+            >
+              {ttsError}
+            </div>
+          )}
+
+          {/* Proceed button — available once playback started at least once */}
+          {(playState === 'done' || playState === 'idle' && false) && (
+            <button
+              type="button"
+              onClick={handleProceedToRetell}
+              className="w-full py-3 bg-accent hover:bg-accent-hover text-white rounded-xl font-semibold text-base shadow-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            >
+              我聽完了，開始覆述 →
+            </button>
+          )}
+
+          {/* Allow skipping to retell even if not done playing */}
+          {playState !== 'idle' && playState !== 'done' && (
+            <button
+              type="button"
+              onClick={handleProceedToRetell}
+              className="w-full py-2 text-sm text-gray-500 hover:text-gray-700 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              跳過，直接覆述
+            </button>
+          )}
+
+          {/* Allow skipping even before playing for accessibility */}
+          {playState === 'idle' && (
+            <button
+              type="button"
+              onClick={handleProceedToRetell}
+              className="w-full py-2 text-sm text-gray-400 hover:text-gray-600 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              略過播放，直接覆述
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* ── Phase 2: Retell ───────────────────────────────────────────────── */}
+      {phase === 'retell' && (
+        <div className="space-y-6">
+          <div className="bg-green-50 rounded-xl p-4 space-y-2">
+            <h2 className="font-semibold text-green-800 text-base">步驟二：用自己的話覆述</h2>
+            <p className="text-green-700 text-sm">
+              試著說出你剛才聽到的課文重點。不需要一字不差，
+              用自己的話表達你記得的內容就可以。
+            </p>
+          </div>
+
+          {/* Input mode toggle */}
+          <div
+            className="flex rounded-lg overflow-hidden border border-gray-200"
+            role="group"
+            aria-label="輸入方式"
+          >
+            <button
+              type="button"
+              onClick={() => {
+                if (speechStatus === 'listening') stopListening();
+                setRetellMode('text');
+              }}
+              className={`flex-1 py-2 text-sm font-medium transition-colors ${
+                retellMode === 'text'
+                  ? 'bg-accent text-white'
+                  : 'bg-white text-gray-600 hover:bg-gray-50'
+              }`}
+              aria-pressed={retellMode === 'text'}
+            >
+              鍵盤輸入
+            </button>
+            <button
+              type="button"
+              onClick={() => setRetellMode('voice')}
+              className={`flex-1 py-2 text-sm font-medium transition-colors ${
+                retellMode === 'voice'
+                  ? 'bg-accent text-white'
+                  : 'bg-white text-gray-600 hover:bg-gray-50'
+              } ${!speechSupported ? 'opacity-50 cursor-not-allowed' : ''}`}
+              disabled={!speechSupported}
+              aria-pressed={retellMode === 'voice'}
+              title={speechSupported ? undefined : '你的瀏覽器不支援語音輸入'}
+            >
+              語音輸入
+            </button>
+          </div>
+
+          {/* Text input */}
+          {retellMode === 'text' && (
+            <div className="space-y-2">
+              <label htmlFor="retelling-text" className="sr-only">
+                輸入覆述內容
+              </label>
+              <textarea
+                id="retelling-text"
+                value={retelling}
+                onChange={(e) => setRetelling(e.target.value)}
+                placeholder="在這裡輸入你記得的課文內容..."
+                rows={6}
+                maxLength={2000}
+                className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 text-base placeholder-gray-400 resize-none focus:outline-none focus:border-accent focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+                aria-label="覆述內容輸入框"
+              />
+              <p className="text-xs text-right text-gray-400">
+                {retelling.length} / 2000
+              </p>
+            </div>
+          )}
+
+          {/* Voice input */}
+          {retellMode === 'voice' && (
+            <div className="space-y-4">
+              <div className="flex justify-center">
+                <button
+                  type="button"
+                  onClick={handleVoiceToggle}
+                  className={`w-20 h-20 rounded-full flex items-center justify-center text-3xl shadow-lg transition-all focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-offset-2 ${
+                    speechStatus === 'listening'
+                      ? 'bg-red-500 hover:bg-red-600 focus-visible:ring-red-400 animate-pulse'
+                      : 'bg-accent hover:bg-accent-hover focus-visible:ring-accent'
+                  }`}
+                  aria-label={speechStatus === 'listening' ? '停止錄音' : '開始錄音'}
+                >
+                  {speechStatus === 'listening' ? '⏹' : '🎤'}
+                </button>
+              </div>
+
+              <p
+                className="text-center text-sm text-gray-600"
+                role="status"
+                aria-live="polite"
+              >
+                {speechStatus === 'listening'
+                  ? '正在聆聽，說完後點擊停止...'
+                  : speechStatus === 'error'
+                    ? speechError
+                    : '點擊麥克風開始說話'}
+              </p>
+
+              {/* Live transcript preview */}
+              {speechStatus === 'listening' && speechTranscript && (
+                <p className="text-sm text-gray-500 italic text-center px-4">
+                  「{speechTranscript}」
+                </p>
+              )}
+
+              {/* Accumulated retelling so far */}
+              {retelling && (
+                <div className="bg-gray-50 rounded-xl p-4 space-y-2">
+                  <p className="text-xs font-medium text-gray-500">已記錄的覆述：</p>
+                  <p className="text-sm text-gray-800 leading-relaxed">{retelling}</p>
+                  <button
+                    type="button"
+                    onClick={() => setRetelling('')}
+                    className="text-xs text-red-500 hover:text-red-700 transition-colors"
+                  >
+                    清除重錄
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {submitError && (
+            <div
+              role="alert"
+              className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700"
+            >
+              {submitError}
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => setPhase('play')}
+              className="px-4 py-3 border border-gray-200 text-gray-600 rounded-xl font-medium text-sm hover:bg-gray-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              ← 重聽
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmitRetelling}
+              disabled={isEvaluating || !retelling.trim()}
+              className="flex-1 py-3 bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white rounded-xl font-semibold text-base shadow-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+              aria-busy={isEvaluating}
+            >
+              {isEvaluating ? '評估中...' : '提交覆述'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Phase 3: Results ──────────────────────────────────────────────── */}
+      {phase === 'results' && evalResult && (
+        <div className="space-y-6">
+          {/* Score card */}
+          <div className="bg-white border border-gray-200 rounded-2xl p-6 text-center shadow-sm space-y-2">
+            <p className="text-sm text-gray-500 font-medium">聽力理解得分</p>
+            <p
+              className={`text-6xl font-black ${scoreColour(evalResult.score)}`}
+              aria-label={`得分 ${Math.round(evalResult.score)} 分`}
+            >
+              {Math.round(evalResult.score)}
+            </p>
+            <p className={`text-lg font-semibold ${scoreColour(evalResult.score)}`}>
+              {scoreLabel(evalResult.score)}
+            </p>
+          </div>
+
+          {/* Feedback */}
+          <div className="bg-amber-50 rounded-xl p-4 space-y-2">
+            <h3 className="font-semibold text-amber-800 text-sm">老師的評語</h3>
+            <p className="text-amber-900 text-sm leading-relaxed">{evalResult.feedback}</p>
+          </div>
+
+          {/* Key points covered */}
+          {evalResult.key_points_covered.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="font-semibold text-green-700 text-sm flex items-center gap-1">
+                <span aria-hidden="true">✓</span> 你掌握到的重點
+              </h3>
+              <ul className="space-y-1" aria-label="掌握到的重點">
+                {evalResult.key_points_covered.map((point, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-2 text-sm text-gray-700 bg-green-50 rounded-lg px-3 py-2"
+                  >
+                    <span className="text-green-500 mt-0.5 shrink-0" aria-hidden="true">✓</span>
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Key points missed */}
+          {evalResult.key_points_missed.length > 0 && (
+            <div className="space-y-2">
+              <h3 className="font-semibold text-orange-600 text-sm flex items-center gap-1">
+                <span aria-hidden="true">○</span> 可以補充的重點
+              </h3>
+              <ul className="space-y-1" aria-label="可以補充的重點">
+                {evalResult.key_points_missed.map((point, i) => (
+                  <li
+                    key={i}
+                    className="flex items-start gap-2 text-sm text-gray-700 bg-orange-50 rounded-lg px-3 py-2"
+                  >
+                    <span className="text-orange-400 mt-0.5 shrink-0" aria-hidden="true">○</span>
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Encouragement */}
+          {evalResult.encouragement && (
+            <div className="text-center py-2">
+              <p className="text-sm text-gray-600 italic">{evalResult.encouragement}</p>
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => {
+                setPhase('play');
+                setRetelling('');
+                setEvalResult(null);
+                setPlayState('idle');
+              }}
+              className="px-4 py-3 border border-gray-200 text-gray-600 rounded-xl font-medium text-sm hover:bg-gray-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              再練習一次
+            </button>
+            <button
+              type="button"
+              onClick={handleFinish}
+              className="flex-1 py-3 bg-accent hover:bg-accent-hover text-white rounded-xl font-semibold text-base shadow-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            >
+              完成練習 →
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ListeningPractice;

--- a/frontend/src/pages/learning/FullReadingPage.tsx
+++ b/frontend/src/pages/learning/FullReadingPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import FullReading from '../../components/reading-steps/FullReading';
 import { useLearningContext } from '../../layouts/LearningLayout';
@@ -13,6 +13,9 @@ const FullReadingPage: React.FC = () => {
     completedParagraphsSet,
   } = useLearningContext();
   const navigate = useNavigate();
+
+  // Whether the user has seen/dismissed the optional listening prompt (Issue #251)
+  const [listeningPromptDismissed, setListeningPromptDismissed] = useState(false);
 
   if (!selectedStory) return null;
 
@@ -60,6 +63,39 @@ const FullReadingPage: React.FC = () => {
         >
           返回逐段練習
         </button>
+      </div>
+    );
+  }
+
+  // Optional: offer listening comprehension practice before full reading (Issue #251)
+  if (!listeningPromptDismissed) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center p-6 gap-6 max-w-md mx-auto text-center">
+        <div className="text-5xl" aria-hidden="true">🎧</div>
+        <div className="space-y-2">
+          <h2 className="text-xl font-bold text-gray-900">想挑戰聽力理解嗎？</h2>
+          <p className="text-gray-600 text-sm leading-relaxed">
+            聽力理解練習是選做題目。聽完課文後，試著用自己的話說出重點，AI 會給你評分和回饋！
+          </p>
+        </div>
+
+        <div className="w-full space-y-3">
+          <button
+            type="button"
+            onClick={() => navigate(`/learn/${storyId}/listening`)}
+            className="w-full py-4 bg-accent hover:bg-accent-hover text-white rounded-xl font-semibold text-base shadow-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+          >
+            進行聽力理解練習
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setListeningPromptDismissed(true)}
+            className="w-full py-3 border border-gray-200 text-gray-500 hover:bg-gray-50 rounded-xl font-medium text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            跳過，直接全文朗讀 →
+          </button>
+        </div>
       </div>
     );
   }

--- a/frontend/src/pages/learning/ListeningPage.tsx
+++ b/frontend/src/pages/learning/ListeningPage.tsx
@@ -1,0 +1,32 @@
+/**
+ * ListeningPage — Issue #251
+ *
+ * Optional step in the learning flow: listening comprehension practice.
+ * Route: /learn/:storyId/listening
+ */
+
+import React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import ListeningPractice from '../../components/reading-steps/ListeningPractice';
+import { useLearningContext } from '../../layouts/LearningLayout';
+
+const ListeningPage: React.FC = () => {
+  const { storyId } = useParams<{ storyId: string }>();
+  const { selectedStory } = useLearningContext();
+  const navigate = useNavigate();
+
+  if (!selectedStory) return null;
+
+  return (
+    <ListeningPractice
+      story={selectedStory}
+      onFinish={(_result) => {
+        // Listening is an optional step — navigate forward to full-reading
+        navigate(`/learn/${storyId}/full-reading`);
+      }}
+      onBack={() => navigate(`/learn/${storyId}/dictation`)}
+    />
+  );
+};
+
+export default ListeningPage;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -864,3 +864,44 @@ export async function reportSessionComplete(
   if (!res.ok) throw new Error(`reportSessionComplete failed: ${res.status}`);
   return res.json();
 }
+
+// --- Listening Comprehension API (Issue #251) ---
+
+export interface ListeningEvaluateResponse {
+  score: number;
+  key_points_covered: string[];
+  key_points_missed: string[];
+  feedback: string;
+  encouragement: string;
+}
+
+/**
+ * Evaluate a student's retelling of a story they listened to.
+ * Calls POST /api/learning/listening/evaluate.
+ */
+export async function evaluateListeningRetelling(
+  token: string,
+  payload: {
+    storyTitle: string;
+    originalText: string;
+    studentRetelling: string;
+  },
+): Promise<ListeningEvaluateResponse> {
+  const res = await fetch(`${API_BASE}/api/learning/listening/evaluate`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      story_title: payload.storyTitle,
+      original_text: payload.originalText,
+      student_retelling: payload.studentRetelling,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ detail: 'Unknown error' }));
+    throw new Error(body.detail || `Listening evaluation failed: ${res.status}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
Fixes #251

## Summary

- **Backend**: New `listening_service.py` with `evaluate_retelling()` — uses Gemini 2.5-flash to score student retelling (0-100), identify covered/missed key points, and generate encouraging feedback in zh-TW
- **Backend**: New endpoint `POST /api/learning/listening/evaluate` in `learning.py` with auth guard, Pydantic validation (min_length=1 on retelling), and 5-req/min rate limit
- **Frontend**: New `ListeningPractice.tsx` — 3-phase component:
  - Phase 1: Play story text via Web Speech API SpeechSynthesis (zh-TW voice, adjustable speed 0.7x–1.1x, pause/resume/replay)
  - Phase 2: Student retells via keyboard or voice input (reuses `useSpeechRecognition` hook from #217)
  - Phase 3: AI evaluation results with score, covered/missed key points, and feedback
- **Frontend**: New `ListeningPage.tsx` route at `/learn/:storyId/listening`
- **Frontend**: Optional listening practice offered from `FullReadingPage` as an interstitial prompt — students can choose to do it or skip to full reading

## Test plan

- [ ] Build passes (CI)
- [ ] Backend unit tests: `python -m pytest tests/test_listening.py -v` — 7 tests pass
- [ ] Preview URL deploys successfully
- [ ] TTS plays story text in zh-TW voice at selected speed
- [ ] Pause/resume/replay controls work
- [ ] Voice input captures retelling (in Chrome)
- [ ] Text input accepts retelling
- [ ] Submit retelling returns AI evaluation with score and key points
- [ ] Optional listening prompt appears before full reading
- [ ] "Skip" button bypasses listening and goes to full reading directly
- [ ] Unauthenticated request to evaluate endpoint returns 401
- [ ] Empty retelling submission returns 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)