### PR TITLE
fix: health check uses correct google-genai SDK import

### DIFF
--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -64,7 +64,7 @@ def health_detailed(db: Session = Depends(get_db)):
     # 2. AI service check (Vertex AI SDK available + project configured)
     # ------------------------------------------------------------------
     try:
-        import google.cloud.aiplatform as aiplatform  # type: ignore
+        from google import genai  # noqa: F401
         gcp_project = os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("GCLOUD_PROJECT")
         if gcp_project:
             components["ai_service"] = {"status": "ok", "provider": "vertex_ai"}
@@ -75,10 +75,10 @@ def health_detailed(db: Session = Depends(get_db)):
                 "detail": "GOOGLE_CLOUD_PROJECT not set",
             }
     except ImportError:
-        logger.warning("Health check — google-cloud-aiplatform SDK not installed")
+        logger.warning("Health check — google-genai SDK not installed")
         components["ai_service"] = {
             "status": "error",
-            "detail": "Vertex AI SDK not available",
+            "detail": "google-genai SDK not available",
         }
         overall_healthy = False
 


### PR DESCRIPTION
## Summary

- `backend/app/routes/health.py` was importing `google.cloud.aiplatform` (not installed) instead of `google.genai` (the SDK actually used by this project)
- This caused `/api/health/detailed` to always report `ai_service: error` with "Vertex AI SDK not available"
- Fix replaces the wrong import with `from google import genai  # noqa: F401`
- Also updated the error message strings to reference `google-genai` instead of `Vertex AI SDK`

## Test plan

- Deploy and call `GET /api/health/detailed`
- `components.ai_service.status` should be `"ok"` (when `GOOGLE_CLOUD_PROJECT` is set) instead of `"error"`
- Confirm `GET /api/health` still returns `{"status": "ok"}`