### PR TITLE
fix: remove unnecessary GOOGLE_CLOUD_PROJECT check from health endpoint

### DIFF
--- a/backend/app/routes/health.py
+++ b/backend/app/routes/health.py
@@ -61,19 +61,12 @@ def health_detailed(db: Session = Depends(get_db)):
         overall_healthy = False
 
     # ------------------------------------------------------------------
-    # 2. AI service check (Vertex AI SDK available + project configured)
+    # 2. AI service check (Vertex AI SDK available)
     # ------------------------------------------------------------------
     try:
         from google import genai  # noqa: F401
-        gcp_project = os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("GCLOUD_PROJECT")
-        if gcp_project:
-            components["ai_service"] = {"status": "ok", "provider": "vertex_ai"}
-        else:
-            # SDK is installed but project not configured — warn, don't fail
-            components["ai_service"] = {
-                "status": "degraded",
-                "detail": "GOOGLE_CLOUD_PROJECT not set",
-            }
+        # ai_service.py hardcodes project="lingoleap-dev", no env var needed
+        components["ai_service"] = {"status": "ok", "provider": "vertex_ai"}
     except ImportError:
         logger.warning("Health check — google-genai SDK not installed")
         components["ai_service"] = {


### PR DESCRIPTION
## Summary
- `ai_service.py` hardcodes `project="lingoleap-dev"`, so `GOOGLE_CLOUD_PROJECT` env var is never read
- Health endpoint was incorrectly reporting `ai_service` as `degraded` with detail `"GOOGLE_CLOUD_PROJECT not set"` whenever the env var was absent
- Fix: remove the env var branch entirely — a successful `google.genai` import is sufficient to mark `ai_service` as `ok`

## Changes
- `backend/app/routes/health.py` — removed 7 lines of dead env-var logic, replaced with a single `"status": "ok"` assignment

## Test plan
- [ ] Deploy to preview and call `GET /api/health/detailed`
- [ ] Verify `components.ai_service.status` is `"ok"` (not `"degraded"`)
- [ ] Verify overall `status` is `"ok"` when DB is also healthy