### PR TITLE
fix: remove internal filename from StoryCard (#371)

### DIFF
--- a/frontend/src/components/student/StoryCard.tsx
+++ b/frontend/src/components/student/StoryCard.tsx
@@ -83,9 +83,6 @@ const StoryCard: React.FC<StoryCardProps> = ({ story, isLoading, isCompleted, on
             <span className="text-xs text-green-600 font-medium">已完成</span>
           )}
         </div>
-        {story.filename && (
-          <div className="text-[10px] text-gray-400 font-mono mt-1">{story.filename}</div>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove `story.filename` display (e.g. `lesson_05_fox.yaml`) from StoryCard
- Students should not see internal file identifiers

## Test plan
- [ ] Open library page, verify no filename shown on story cards

Closes #371

🤖 Generated with [Claude Code](https://claude.ai/code)