### PR TITLE
fix: remove hardcoded level 12 from StepperNav (#382)

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -271,9 +271,8 @@ const StepperNav: React.FC<StepperNavProps> = ({
       })}
 
       {/* User avatar */}
-      <div className="ml-3 flex items-center gap-1 pl-3 border-l border-gray-200">
+      <div className="ml-3 flex items-center pl-3 border-l border-gray-200">
         <div className="w-6 h-6 rounded-full bg-gray-200"></div>
-        <span className="text-[10px] text-gray-500 hidden sm:block">等級 12</span>
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- Removed fake "等級 12" text from desktop StepperNav
- Will be re-added when gamification API integration is ready

## Test plan
- [ ] Check desktop header nav → no "等級 12" shown next to avatar

Closes #382

🤖 Generated with [Claude Code](https://claude.ai/code)