### PR TITLE
fix: ClassroomDetail tab 小螢幕溢出 (#380)

### DIFF
--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -354,13 +354,13 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
         {/* Tabbed content card */}
         <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
           {/* Tab bar */}
-          <div className="border-b border-gray-200">
-            <nav className="flex -mb-px" aria-label="Tabs">
+          <div className="border-b border-gray-200 overflow-x-auto">
+            <nav className="flex -mb-px whitespace-nowrap" aria-label="Tabs">
               {TABS.map((tab) => (
                 <button
                   key={tab.key}
                   onClick={() => setActiveTab(tab.key)}
-                  className={`px-5 py-3 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
+                  className={`px-5 py-3 text-sm font-medium border-b-2 transition-colors cursor-pointer shrink-0 ${
                     activeTab === tab.key
                       ? 'border-accent text-accent'
                       : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'


### PR DESCRIPTION
## Summary
- 班級詳情頁的 tab 列在小螢幕上溢出不可捲動
- 新增 `overflow-x-auto` + `whitespace-nowrap` + `shrink-0`

## Test plan
- [ ] 手機尺寸下查看班級詳情頁，tab 可水平滑動
- [ ] 桌面版 tab 顯示正常

Closes #380

🤖 Generated with [Claude Code](https://claude.ai/code)