### PR TITLE
fix: LibraryPage 非同步載入 layout shift (#384)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -159,8 +159,10 @@ const LibraryPage: React.FC = () => {
       {showResumePrompt && (
         <SessionResumePrompt onDismiss={() => setShowResumePrompt(false)} />
       )}
-      <StudentProgressDashboard onDashboardLoaded={setCompletedSlugs} />
-      <div className="mt-6">
+      <div className="min-h-[120px]">
+        <StudentProgressDashboard onDashboardLoaded={setCompletedSlugs} />
+      </div>
+      <div className="mt-6 min-h-[200px]">
         <RecommendedStories />
       </div>
       <StoryLibrary onStartReading={handleSelectStory} completedSlugs={completedSlugs} />


### PR DESCRIPTION
## Summary
- StudentProgressDashboard 和 RecommendedStories 載入時造成頁面跳動
- 加上 `min-h-[120px]` 和 `min-h-[200px]` 佔位

## Test plan
- [ ] 進入圖書館頁面，內容載入時不再跳動
- [ ] 載入完成後外觀正常

Closes #384

🤖 Generated with [Claude Code](https://claude.ai/code)