### PR TITLE
fix: MyTextsTab modal 缺少鍵盤/焦點管理 (#385)

### DIFF
--- a/frontend/src/pages/teacher/MyTextsTab.tsx
+++ b/frontend/src/pages/teacher/MyTextsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import {
   listMyTexts,
@@ -393,8 +393,12 @@ const MyTextsTab: React.FC = () => {
 
       {/* ── Create/Edit Modal ─────────────────────────────────────────── */}
       {showForm && (
-        <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 overflow-y-auto py-8">
-          <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4">
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 overflow-y-auto py-8"
+          onKeyDown={(e) => { if (e.key === 'Escape') closeForm(); }}
+          onClick={(e) => { if (e.target === e.currentTarget) closeForm(); }}
+        >
+          <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4" role="dialog" aria-modal="true" aria-label={editingId !== null ? '編輯課文' : '新增課文'}>
             <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
               <h3 className="text-base font-semibold text-gray-800">
                 {editingId !== null ? '編輯課文' : '新增課文'}
@@ -422,6 +426,7 @@ const MyTextsTab: React.FC = () => {
                     value={form.title}
                     onChange={(e) => setForm((p) => ({ ...p, title: e.target.value }))}
                     placeholder="請輸入課文標題"
+                    autoFocus
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
                     required
                   />


### PR DESCRIPTION
## Summary
- 新增 Escape 關閉 modal
- 新增 backdrop click 關閉
- 新增 `aria-modal` + `role="dialog"` 無障礙屬性
- 標題 input autoFocus

## Test plan
- [ ] 開啟 modal 後按 Escape 可關閉
- [ ] 點擊 modal 外圍可關閉
- [ ] 開啟 modal 後焦點自動在標題欄

Closes #385

🤖 Generated with [Claude Code](https://claude.ai/code)