### PR TITLE
fix: 作業「繼續」按鈕恢復上次步驟 (#372)

### DIFF
--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { Outlet, useParams, useNavigate, useOutletContext } from 'react-router-dom';
+import { Outlet, useParams, useNavigate, useOutletContext, useLocation } from 'react-router-dom';
 import {
   Story,
   ReadingAttempt,

--- a/frontend/src/pages/student/MyAssignments.tsx
+++ b/frontend/src/pages/student/MyAssignments.tsx
@@ -7,6 +7,17 @@ import {
   StudentAssignmentResponse,
   AssignmentApiError,
 } from '../../services/assignmentApi';
+import { loadActiveSession } from '../../services/api';
+
+const STEP_NUMBER_TO_PATH: Record<number, string> = {
+  1: 'intro',
+  2: 'tutor',
+  3: 'comprehension',
+  4: 'vocab',
+  5: 'dictation',
+  6: 'full-reading',
+  7: 'report',
+};
 
 type FilterTab = 'pending' | 'completed' | 'all';
 
@@ -18,7 +29,7 @@ const FILTER_TABS: { key: FilterTab; label: string }[] = [
 
 const MyAssignments: React.FC = () => {
   const navigate = useNavigate();
-  const { token } = useAuth();
+  const { token, user } = useAuth();
 
   const [assignments, setAssignments] = useState<StudentAssignmentResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -141,7 +152,11 @@ const MyAssignments: React.FC = () => {
             // Restore assignment ID so LearningLayout can auto-submit on completion.
             sessionStorage.setItem('activeAssignmentId', String(a.assignment_id));
             // story_id is set for YAML texts; text_id for DB texts
-            navigate(`/learn/${a.story_id ?? a.text_id}/intro`);
+            const textKey = a.story_id ?? a.text_id;
+            // Resume from last saved step if available
+            const saved = user ? loadActiveSession(String(user.id)) : null;
+            const savedStep = saved && saved.storyId === String(textKey) ? STEP_NUMBER_TO_PATH[saved.currentStep] : null;
+            navigate(`/learn/${textKey}/${savedStep || 'intro'}`);
           }}
           className="px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-xs font-medium transition-colors cursor-pointer shrink-0"
         >


### PR DESCRIPTION
## Summary
- 學生按「繼續」時從 localStorage 讀取上次學習步驟
- 跳回正確的步驟而非每次回到 intro

## Test plan
- [ ] 開始作業 → 走到第 3 步 → 離開 → 按「繼續」→ 回到第 3 步
- [ ] 新作業按「開始」仍從 intro 開始

Closes #372

🤖 Generated with [Claude Code](https://claude.ai/code)