### PR TITLE
fix: 生字練習筆順練習崩潰 React #300 (Fixes #445)

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -191,6 +191,23 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     return optional.slice(0, 12);
   }, [story.content, attempt.mispronouncedWords]);
 
+  // Pronunciation tab: all characters are candidates (no stroke-data filter needed)
+  const pronunciationChars = useMemo(() => {
+    const suggested = attempt.mispronouncedWords.filter(ch => /[\u4e00-\u9fa5]/.test(ch));
+    if (suggested.length > 0) return suggested.slice(0, 12);
+    const seen = new Set<string>();
+    const optional: string[] = [];
+    for (const line of story.content) {
+      for (const ch of line) {
+        if (/[\u4e00-\u9fa5]/.test(ch) && !seen.has(ch)) {
+          optional.push(ch);
+          seen.add(ch);
+        }
+      }
+    }
+    return optional.slice(0, 12);
+  }, [story.content, attempt.mispronouncedWords]);
+
   const handlePractice = (ch: string, mode: PracticeMode = 'stroke') => {
     setPracticingChar(ch);
     setPhase(mode === 'stroke' ? 'practice' : 'pronunciation');
@@ -258,23 +275,6 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   const strokeDone = displayChars.length > 0 && displayChars.every(ch => practicedChars.has(ch));
   const pronounceDone = displayChars.length > 0 && displayChars.every(ch => pronouncedChars.has(ch));
   const allDone = strokeDone && pronounceDone;
-
-  // Pronunciation tab: all characters are candidates (no stroke-data filter needed)
-  const pronunciationChars = useMemo(() => {
-    const suggested = attempt.mispronouncedWords.filter(ch => /[\u4e00-\u9fa5]/.test(ch));
-    if (suggested.length > 0) return suggested.slice(0, 12);
-    const seen = new Set<string>();
-    const optional: string[] = [];
-    for (const line of story.content) {
-      for (const ch of line) {
-        if (/[\u4e00-\u9fa5]/.test(ch) && !seen.has(ch)) {
-          optional.push(ch);
-          seen.add(ch);
-        }
-      }
-    }
-    return optional.slice(0, 12);
-  }, [story.content, attempt.mispronouncedWords]);
 
   const currentChars = activeTab === 'stroke' ? displayChars : pronunciationChars;
   const currentPracticedSet = activeTab === 'stroke' ? practicedChars : pronouncedChars;


### PR DESCRIPTION
## 問題
點擊筆順練習按鈕後，React 拋出 error #300（Rendered fewer hooks than during the previous render）。

## 根本原因
`pronunciationChars` 的 `useMemo` 位於三個條件式 `return` 之後，違反 Rules of Hooks。

## 修正
將 `pronunciationChars` 的 `useMemo` 移到所有條件式 `return` 之前。

Fixes #445