### PR TITLE
fix: font size applies immediately without page refresh (Fixes #262)

### DIFF
--- a/frontend/src/components/ui/FontSizeControl.tsx
+++ b/frontend/src/components/ui/FontSizeControl.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export type FontSizeLevel = 'small' | 'medium' | 'large';
 
 const STORAGE_KEY = 'lingoleap-font-size';
 const DEFAULT_LEVEL: FontSizeLevel = 'medium';
+export const FONT_SIZE_EVENT = 'lingoleap:font-size-change';
 
 export const FONT_SIZE_PX: Record<FontSizeLevel, number> = {
   small: 14,
@@ -19,10 +20,14 @@ const LABELS: Record<FontSizeLevel, string> = {
   large: '大',
 };
 
+function isFontSizeLevel(value: unknown): value is FontSizeLevel {
+  return value === 'small' || value === 'medium' || value === 'large';
+}
+
 function readStoredLevel(): FontSizeLevel {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === 'small' || stored === 'medium' || stored === 'large') return stored;
+    if (isFontSizeLevel(stored)) return stored;
   } catch {
     // ignore
   }
@@ -35,18 +40,21 @@ interface FontSizeControlProps {
 
 export default function FontSizeControl({ onChange }: FontSizeControlProps) {
   const [level, setLevel] = useState<FontSizeLevel>(readStoredLevel);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
 
   useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, level);
-      // The browser's 'storage' event only fires for cross-tab writes, not same-tab.
-      // Dispatch a synthetic event so useFontSize() in the same page updates immediately.
-      window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY, newValue: level }));
+      window.dispatchEvent(new CustomEvent(FONT_SIZE_EVENT, { detail: { level } }));
     } catch {
       // ignore
     }
-    onChange?.(level, FONT_SIZE_PX[level]);
-  }, [level, onChange]);
+    onChangeRef.current?.(level, FONT_SIZE_PX[level]);
+  }, [level]);
 
   return (
     <div
@@ -81,9 +89,25 @@ export function useFontSize(): { level: FontSizeLevel; px: number } {
   const [level, setLevel] = useState<FontSizeLevel>(readStoredLevel);
 
   useEffect(() => {
-    const handler = () => setLevel(readStoredLevel());
-    window.addEventListener('storage', handler);
-    return () => window.removeEventListener('storage', handler);
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) {
+        setLevel(readStoredLevel());
+      }
+    };
+    const handleFontSizeChange = (event: Event) => {
+      const nextLevel = (event as CustomEvent<{ level?: unknown }>).detail?.level;
+      if (isFontSizeLevel(nextLevel)) {
+        setLevel(nextLevel);
+      }
+    };
+
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener(FONT_SIZE_EVENT, handleFontSizeChange);
+
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener(FONT_SIZE_EVENT, handleFontSizeChange);
+    };
   }, []);
 
   return { level, px: FONT_SIZE_PX[level] };


### PR DESCRIPTION
## 問題

選擇字體大小後，需要重整頁面才會套用設定（stgst 回報）。

## 根本原因

`useFontSize()` 監聽 `window.storage` 事件，但瀏覽器只在**其他 tab** 寫入 localStorage 時才觸發此事件，同一頁面的寫入不會觸發。因此 `FontSizeControl` 更新 localStorage 後，同頁面的 `useFontSize()` 收不到通知，課文字體維持舊值直到重整。

## 修復

在 `FontSizeControl` 的 `useEffect` 寫入 localStorage 後，手動 dispatch 一個 synthetic `StorageEvent`，令同頁面監聽者立即收到通知。

```diff
  localStorage.setItem(STORAGE_KEY, level);
+ window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY, newValue: level }));
```

**變更檔案：** `frontend/src/components/ui/FontSizeControl.tsx`
