### PR TITLE
fix: restrict /auth/register to teachers only (Fixes #457)

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -49,10 +49,22 @@ def _enforce_password_strength(password: str) -> None:
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
 def register(req: RegisterRequest, request: Request, db: Session = Depends(get_db)):
-    """Register a new user account."""
+    """Register a new teacher account.
+
+    This endpoint is for teacher self-registration only (issue #457).
+    Student accounts must be created by teachers via classroom management
+    (POST /classrooms/{id}/students or CSV upload).
+    """
     client_ip = request.client.host if request.client else "unknown"
     if not rate_limiter.check(f"register:{client_ip}", max_requests=5, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
+
+    # Block student self-registration. Students are created by teachers only.
+    if req.role is not None and req.role.lower() == "student":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="學生帳號由老師建立，請聯繫你的老師取得帳號。",
+        )
 
     # Validate password strength before checking for duplicates
     _enforce_password_strength(req.password)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -6,6 +6,9 @@ class RegisterRequest(BaseModel):
     # min_length removed here so auth route can return a descriptive Chinese error
     password: str = Field(..., min_length=1, max_length=128)
     name: str = Field(..., min_length=1, max_length=100)
+    # Optional role hint. Only "teacher" (or omitted) is allowed for self-registration.
+    # Students must be created by teachers via classroom management (issue #457).
+    role: str | None = Field(None, max_length=50)
 
 
 class LoginRequest(BaseModel):

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -441,6 +441,47 @@ class TestRegisterEndpoint:
         })
         assert login_resp.status_code == 200
 
+    def test_register_student_role_rejected_with_403(self, client):
+        """Students must NOT be able to self-register.
+        /auth/register is teacher-only (issue #457)."""
+        resp = client.post("/api/auth/register", json={
+            "email": "student_self@example.com",
+            "password": "StrongPass1!",
+            "name": "Student Self",
+            "role": "student",
+        })
+        assert resp.status_code == 403
+
+    def test_register_student_role_returns_correct_message(self, client):
+        """Error message should guide the student to ask their teacher."""
+        resp = client.post("/api/auth/register", json={
+            "email": "student_msg@example.com",
+            "password": "StrongPass1!",
+            "name": "Student Msg",
+            "role": "student",
+        })
+        assert resp.status_code == 403
+        assert "老師" in resp.json()["detail"]
+
+    def test_register_no_role_defaults_to_teacher_allowed(self, client):
+        """When no role is specified the endpoint registers a teacher (default flow)."""
+        resp = client.post("/api/auth/register", json={
+            "email": "norole_teacher@example.com",
+            "password": "StrongPass1!",
+            "name": "No Role Teacher",
+        })
+        assert resp.status_code == 201
+
+    def test_register_teacher_role_explicitly_allowed(self, client):
+        """Explicitly passing role=teacher should succeed."""
+        resp = client.post("/api/auth/register", json={
+            "email": "explicit_teacher@example.com",
+            "password": "StrongPass1!",
+            "name": "Explicit Teacher",
+            "role": "teacher",
+        })
+        assert resp.status_code == 201
+
 
 # ===========================================================================
 # Integration tests — POST /api/auth/login

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -103,7 +103,12 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ onSwitchToLogin }) => {
             <span className="text-white font-black text-2xl">L</span>
           </div>
           <h1 className="text-2xl font-black text-gray-900">AI 朗讀助教</h1>
-          <p className="text-gray-500 text-sm mt-1">建立你的帳號</p>
+          <p className="text-gray-500 text-sm mt-1">教師註冊</p>
+        </div>
+
+        {/* Student notice */}
+        <div className="bg-amber-100 border border-amber-300 text-amber-800 text-sm rounded-lg px-4 py-3 mb-2">
+          學生帳號由老師在班級管理中建立，請聯繫你的老師取得帳號。
         </div>
 
         {/* Form Card */}


### PR DESCRIPTION
Fixes #457

## Summary
- `/auth/register` endpoint now rejects `role=student` with HTTP 403 and message: 「學生帳號由老師建立，請聯繫你的老師取得帳號。」
- `RegisterRequest` schema gains an optional `role` field (max 50 chars)
- Teacher registration (explicit `role=teacher` or no role specified) continues to work unchanged
- `RegisterPage.tsx` title updated to 「教師註冊」with a student-facing notice banner

## Changed files
- `backend/app/routes/auth.py` — student self-registration guard
- `backend/app/schemas/auth.py` — optional `role` field on RegisterRequest
- `backend/tests/test_auth_api.py` — 4 new TDD tests
- `frontend/src/pages/RegisterPage.tsx` — UI reflects teacher-only registration

## Test plan
- [x] `test_register_student_role_rejected_with_403` — student role returns 403
- [x] `test_register_student_role_returns_correct_message` — detail contains 「老師」
- [x] `test_register_no_role_defaults_to_teacher_allowed` — no role returns 201
- [x] `test_register_teacher_role_explicitly_allowed` — explicit teacher role returns 201
- [x] All 91 existing auth tests still pass