### PR TITLE
feat: 學生登入顯示班級與老師資訊 (#462)

### DIFF
--- a/backend/app/routes/classrooms.py
+++ b/backend/app/routes/classrooms.py
@@ -27,6 +27,8 @@ from ..schemas.classroom import (
     ClassroomUpdateRequest,
     CreatedStudentInfo,
     CsvUploadResponse,
+    StudentEnrolledClassroom,
+    StudentEnrolledClassroomsResponse,
     StudentInClassroomResponse,
     StudentSearchRequest,
     StudentSearchResult,
@@ -301,6 +303,43 @@ def download_csv_template(
         media_type="text/csv; charset=UTF-8",
         headers={"Content-Disposition": 'attachment; filename="student-import-template.csv"'},
     )
+
+
+@router.get("/classrooms/my-enrollments", response_model=StudentEnrolledClassroomsResponse)
+def list_my_enrolled_classrooms(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return the classrooms the current user is enrolled in as a student.
+
+    IMPORTANT: This route MUST appear before /classrooms/{classroom_id} so that
+    FastAPI does not try to parse 'my-enrollments' as an integer classroom_id.
+
+    Returns classroom details including teacher name for the student dashboard.
+    """
+    rows = (
+        db.query(ClassroomStudent, Classroom, User)
+        .join(Classroom, Classroom.id == ClassroomStudent.classroom_id)
+        .join(User, User.id == Classroom.teacher_id)
+        .filter(ClassroomStudent.student_id == current_user.id)
+        .order_by(ClassroomStudent.enrolled_at.desc())
+        .all()
+    )
+
+    classrooms = [
+        StudentEnrolledClassroom(
+            id=classroom.id,
+            name=classroom.name,
+            grade=classroom.grade,
+            teacher_id=classroom.teacher_id,
+            teacher_name=teacher.name,
+            is_active=classroom.is_active,
+            enrolled_at=cs.enrolled_at,
+        )
+        for cs, classroom, teacher in rows
+    ]
+
+    return StudentEnrolledClassroomsResponse(classrooms=classrooms, total=len(classrooms))
 
 
 @router.get("/classrooms/{classroom_id}", response_model=ClassroomDetailResponse)

--- a/backend/app/schemas/classroom.py
+++ b/backend/app/schemas/classroom.py
@@ -110,3 +110,25 @@ class CsvUploadResponse(BaseModel):
     skipped_count: int
     errors: list[BatchStudentError]
     created: list[CreatedStudentInfo]
+
+
+# ── Student Enrolled Classrooms ───────────────────────────────────────────────
+
+
+class StudentEnrolledClassroom(BaseModel):
+    """Classroom info from the student's perspective, including teacher name."""
+
+    id: int
+    name: str
+    grade: int | None
+    teacher_id: int
+    teacher_name: str
+    is_active: bool
+    enrolled_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class StudentEnrolledClassroomsResponse(BaseModel):
+    classrooms: list[StudentEnrolledClassroom]
+    total: int

--- a/frontend/src/pages/student/StudentHome.tsx
+++ b/frontend/src/pages/student/StudentHome.tsx
@@ -3,6 +3,7 @@
  *
  * Combines:
  * - Welcome message with user's name
+ * - Classroom context card (班級 + 老師) if enrolled — Issue #462
  * - Quick action cards (start reading, continue assignment, practice vocabulary)
  * - StudentProgressDashboard (streak, chart, stats)
  * - RecommendedStories
@@ -11,12 +12,16 @@
  * Route: /student
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import StudentProgressDashboard from '../../components/student/StudentProgressDashboard';
 import RecommendedStories from '../../components/student/RecommendedStories';
 import SessionResumePrompt from '../../components/SessionResumePrompt';
+import {
+  fetchMyEnrolledClassrooms,
+  type StudentEnrolledClassroom,
+} from '../../services/api';
 
 // ---------------------------------------------------------------------------
 // Quick action card data
@@ -55,16 +60,112 @@ const QUICK_ACTIONS: QuickAction[] = [
 ];
 
 // ---------------------------------------------------------------------------
+// ClassroomContextCard — shows the student's enrolled classroom(s)
+// ---------------------------------------------------------------------------
+
+interface ClassroomContextCardProps {
+  classrooms: StudentEnrolledClassroom[];
+  onSelectClassroom: (classroomId: number) => void;
+}
+
+const ClassroomContextCard: React.FC<ClassroomContextCardProps> = ({
+  classrooms,
+  onSelectClassroom,
+}) => {
+  if (classrooms.length === 0) {
+    return (
+      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4 flex items-center gap-3">
+        <span className="text-2xl" aria-hidden="true">🏫</span>
+        <div>
+          <p className="text-sm font-semibold text-amber-800">尚未加入班級</p>
+          <p className="text-xs text-amber-600 mt-0.5">
+            請向老師索取班級加入碼，或等待老師將你加入班級。
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (classrooms.length === 1) {
+    const c = classrooms[0];
+    return (
+      <button
+        type="button"
+        onClick={() => onSelectClassroom(c.id)}
+        className="w-full text-left bg-indigo-50 hover:bg-indigo-100 border border-indigo-200 rounded-2xl p-4 flex items-center gap-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+        aria-label={`進入班級 ${c.name}`}
+      >
+        <span className="text-3xl shrink-0" aria-hidden="true">🏫</span>
+        <div className="flex-1 min-w-0">
+          <p className="text-xs text-indigo-500 font-medium">你的班級</p>
+          <p className="text-base font-bold text-indigo-900 truncate">{c.name}</p>
+          <p className="text-xs text-indigo-600 mt-0.5">老師：{c.teacher_name}</p>
+        </div>
+        <span className="text-indigo-400 shrink-0" aria-hidden="true">→</span>
+      </button>
+    );
+  }
+
+  // Multiple classrooms — show a selection list
+  return (
+    <div className="bg-white border border-gray-100 rounded-2xl shadow-sm p-4 space-y-2">
+      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+        你的班級
+      </p>
+      {classrooms.map((c) => (
+        <button
+          key={c.id}
+          type="button"
+          onClick={() => onSelectClassroom(c.id)}
+          className="w-full text-left flex items-center gap-3 px-3 py-2 rounded-xl hover:bg-indigo-50 border border-transparent hover:border-indigo-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400"
+          aria-label={`進入班級 ${c.name}`}
+        >
+          <span className="text-xl shrink-0" aria-hidden="true">🏫</span>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-gray-900 truncate">{c.name}</p>
+            <p className="text-xs text-gray-500">老師：{c.teacher_name}</p>
+          </div>
+          <span className="text-gray-400 shrink-0" aria-hidden="true">→</span>
+        </button>
+      ))}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
 const StudentHome: React.FC = () => {
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const navigate = useNavigate();
   const [showResumePrompt, setShowResumePrompt] = useState(true);
+  const [classrooms, setClassrooms] = useState<StudentEnrolledClassroom[]>([]);
+  const [classroomsLoaded, setClassroomsLoaded] = useState(false);
 
-  // Get first name for greeting (use first 2 chars if Chinese name)
+  // Get first name for greeting
   const firstName = user?.name ?? '同學';
+
+  // Fetch enrolled classrooms on mount
+  useEffect(() => {
+    if (!token) return;
+    fetchMyEnrolledClassrooms(token)
+      .then((res) => {
+        setClassrooms(res.classrooms);
+        // Auto-navigate if exactly one classroom
+        if (res.classrooms.length === 1 && res.classrooms[0].is_active) {
+          navigate(`/library?classroom=${res.classrooms[0].id}`, { replace: true });
+        }
+      })
+      .catch(() => {
+        // Non-fatal: student may not be enrolled yet
+      })
+      .finally(() => setClassroomsLoaded(true));
+  }, [token, navigate]);
+
+  const handleSelectClassroom = (classroomId: number) => {
+    navigate(`/library?classroom=${classroomId}`);
+  };
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -95,6 +196,22 @@ const StudentHome: React.FC = () => {
             </div>
           </div>
         </div>
+
+        {/* Classroom context card — only shown once classrooms have been fetched */}
+        {classroomsLoaded && (
+          <section aria-labelledby="classroom-context-title">
+            <h2
+              id="classroom-context-title"
+              className="text-base font-bold text-gray-700 mb-3"
+            >
+              我的班級
+            </h2>
+            <ClassroomContextCard
+              classrooms={classrooms}
+              onSelectClassroom={handleSelectClassroom}
+            />
+          </section>
+        )}
 
         {/* Quick actions */}
         <section aria-labelledby="quick-actions-title">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -905,3 +905,36 @@ export async function evaluateListeningRetelling(
   }
   return res.json();
 }
+
+// --- Student Enrolled Classrooms (Issue #462) ---
+
+export interface StudentEnrolledClassroom {
+  id: number;
+  name: string;
+  grade: number | null;
+  teacher_id: number;
+  teacher_name: string;
+  is_active: boolean;
+  enrolled_at: string;
+}
+
+export interface StudentEnrolledClassroomsResponse {
+  classrooms: StudentEnrolledClassroom[];
+  total: number;
+}
+
+/**
+ * Return the classrooms the current student is enrolled in.
+ * Calls GET /api/classrooms/my-enrollments.
+ */
+export async function fetchMyEnrolledClassrooms(
+  token: string,
+): Promise<StudentEnrolledClassroomsResponse> {
+  const res = await fetch(`${API_BASE}/api/classrooms/my-enrollments`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`fetchMyEnrolledClassrooms failed: ${res.status}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
Fixes #462

## Summary

- Add `GET /api/classrooms/my-enrollments` — returns classrooms the current student is enrolled in, with teacher name. Route is placed before `{classroom_id}` to avoid FastAPI routing conflict.
- Add `StudentEnrolledClassroom` and `StudentEnrolledClassroomsResponse` schemas in `backend/app/schemas/classroom.py`
- Add `fetchMyEnrolledClassrooms(token)` in `frontend/src/services/api.ts`
- Enhance `StudentHome.tsx`:
  - Fetches enrolled classrooms on mount
  - Auto-navigates to `/library?classroom=N` when student has exactly one active classroom
  - Shows `ClassroomContextCard`: 0 classrooms → "尚未加入班級", 1 classroom → name + teacher card, multiple → selection list

## Test plan

- [ ] Student with 1 classroom: login → auto-navigate to `/library?classroom=N`
- [ ] Student with multiple classrooms: login → see selection list on StudentHome
- [ ] Student with no classroom: login → see "尚未加入班級" message
- [ ] `GET /api/classrooms/my-enrollments` returns correct classroom + teacher name