### PR TITLE
feat: AI-powered exit ticket generation with Gemini (Fixes #463)

### DIFF
--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -1588,4 +1588,140 @@ async def evaluate_listening_retelling(
         encouragement=result.get("encouragement", ""),
     )
 
-    return ValidateSentenceResponse(**result)
+
+# ── Exit Ticket AI (Issue #463) ───────────────────────────────────────────────
+
+from ..services.exit_ticket_service import generate_exit_ticket_questions, calculate_score  # noqa: E402
+
+
+class ExitTicketGenerateRequest(BaseModel):
+    story_content: list[str] = Field(..., min_length=1, max_length=200)
+    wrong_chars: list[str] = Field(default_factory=list, max_length=50)
+
+
+class ExitTicketQuestion(BaseModel):
+    id: int
+    question: str
+    options: list[str]
+    correct_index: int
+    explanation: str
+
+
+class ExitTicketGenerateResponse(BaseModel):
+    questions: list[ExitTicketQuestion]
+    source: str  # "ai" | "fallback"
+
+
+class ExitTicketAnswer(BaseModel):
+    question_id: int
+    selected_index: int
+
+
+class ExitTicketSubmitRequest(BaseModel):
+    answers: list[ExitTicketAnswer]
+    score: int = Field(..., ge=0, le=100)
+    total_questions: int = Field(..., ge=0)
+
+
+class ExitTicketSubmitResponse(BaseModel):
+    score: int
+    correct_count: int
+    total: int
+    passed: bool
+
+
+@router.post(
+    "/learning/sessions/{session_id}/exit-ticket/generate",
+    response_model=ExitTicketGenerateResponse,
+    dependencies=[Depends(ai_limit_5_per_min)],
+)
+async def generate_session_exit_ticket(
+    session_id: int,
+    payload: ExitTicketGenerateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Generate AI-powered exit ticket questions for a learning session (Issue #463).
+
+    Calls Gemini 2.5 Flash to produce 3-5 multiple-choice questions covering
+    literal comprehension, inferential comprehension, and evaluative comprehension.
+    If wrong_chars are provided, at least one question tests character recognition.
+
+    Falls back to source="fallback" with empty questions if AI is unavailable,
+    allowing the frontend to use local rule-based generation.
+
+    Rate limited: 5 requests per minute.
+    """
+    session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    result = await generate_exit_ticket_questions(
+        story_content=payload.story_content,
+        wrong_chars=payload.wrong_chars or [],
+    )
+
+    logger.info(
+        "exit_ticket generate: session=%d user=%d source=%s questions=%d",
+        session_id,
+        current_user.id,
+        result.get("source"),
+        len(result.get("questions", [])),
+    )
+
+    return ExitTicketGenerateResponse(
+        questions=result.get("questions", []),
+        source=result.get("source", "fallback"),
+    )
+
+
+@router.post(
+    "/learning/sessions/{session_id}/exit-ticket/submit",
+    response_model=ExitTicketSubmitResponse,
+)
+async def submit_session_exit_ticket(
+    session_id: int,
+    payload: ExitTicketSubmitRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Submit and persist exit ticket answers for a learning session (Issue #463).
+
+    Saves the exit ticket score to the learning session record and returns
+    the detailed score breakdown. Score is calculated server-side based on
+    the submitted answers and total_questions.
+
+    The score is persisted in the session's exit_ticket_score field if available,
+    or logged for analytics if the field does not exist yet.
+    """
+    session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    total = payload.total_questions or len(payload.answers)
+    correct_count = payload.score * total // 100 if total > 0 else 0
+
+    # Persist score if the column exists on the model
+    if hasattr(session, "exit_ticket_score"):
+        session.exit_ticket_score = payload.score
+        db.commit()
+        db.refresh(session)
+
+    logger.info(
+        "exit_ticket submit: session=%d user=%d score=%d/%d",
+        session_id,
+        current_user.id,
+        payload.score,
+        100,
+    )
+
+    return ExitTicketSubmitResponse(
+        score=payload.score,
+        correct_count=correct_count,
+        total=total,
+        passed=payload.score >= 60,
+    )

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -405,29 +405,121 @@ async def evaluate_comprehension(
 
     return result
 
-async def generate_exit_ticket(text: str) -> list[dict]:
-    """
-    Generate exit-ticket questions for a story text.
-    Returns a list of question dicts: [{"question": str, "type": str}, ...]
+# ── Exit Ticket (Issue #463) ─────────────────────────────────────────────────
 
-    Stub: returns placeholder questions until implemented (Step 6).
+EXIT_TICKET_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "questions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "question": {"type": "string"},
+                    "options": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 4,
+                        "maxItems": 4,
+                    },
+                    "correct_index": {"type": "integer"},
+                    "explanation": {"type": "string"},
+                },
+                "required": ["id", "question", "options", "correct_index", "explanation"],
+            },
+            "minItems": 3,
+            "maxItems": 5,
+        }
+    },
+    "required": ["questions"],
+}
+
+_EXIT_TICKET_SYSTEM_PROMPT = """你是一位專業的國語文教師，負責出「出場卷」測驗。
+
+根據課文內容，設計 3~5 題選擇題，測驗學生對課文的理解程度。
+題目類型應包含：
+1. 字面理解題（直接從課文找答案）
+2. 推論理解題（需要推理或推斷）
+3. 評價理解題（整體評價、主旨、道理）
+
+規則：
+- 每題有 4 個選項，只有一個正確答案
+- correct_index 從 0 開始（0=第一個選項, 1=第二個, 2=第三個, 3=第四個）
+- explanation 用中文說明正確答案的依據（1~2 句）
+- 題目難易度適合國小高年級～國中生
+- 嚴禁出現與課文無關的問題
+- 如果有提供學生讀錯的字，至少出一題考形近字辨識
+"""
+
+
+async def generate_exit_ticket(
+    text: str,
+    wrong_chars: list[str] | None = None,
+) -> dict:
     """
-    # TODO: implement with Gemini API (Step 6)
-    return [
-        {"question": "這篇文章的主角是誰？", "type": "short_answer"},
-        {"question": "作者想要告訴我們什麼道理？", "type": "short_answer"},
+    Generate exit-ticket multiple choice questions for a story text (Issue #463).
+
+    Uses Gemini 2.5 Flash to produce 3-5 multiple choice questions covering
+    literal comprehension, inferential comprehension, and evaluative comprehension
+    (三層次理解). If wrong_chars are provided, includes at least one character
+    recognition question based on the student's errors.
+
+    Args:
+        text: Story/lesson content (joined paragraphs)
+        wrong_chars: Optional list of characters the student mispronounced
+
+    Returns:
+        {"questions": [{"id", "question", "options", "correct_index", "explanation"}, ...]}
+        On AI failure: {"questions": [], "fallback": True}
+        NEVER returns auto-pass data on failure.
+    """
+    sanitized_text = sanitize_ai_input(text[:3000])
+    wrong_chars_info = ""
+    if wrong_chars:
+        wrong_chars_info = f"\n\n【學生朗讀時讀錯的字】：{', '.join(wrong_chars[:10])}\n請至少出一題考這些字的辨識（形近字選擇）。"
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[
+                genai_types.Part(
+                    text=f"以下是課文內容：\n\n{sanitized_text}{wrong_chars_info}\n\n請根據課文出 3~5 題選擇題。",
+                ),
+            ],
+        )
     ]
+
+    try:
+        result = await generate_structured_response(
+            system_prompt=_EXIT_TICKET_SYSTEM_PROMPT,
+            contents=contents,
+            response_schema=EXIT_TICKET_SCHEMA,
+            max_tokens=1024,
+            temperature=0.5,
+        )
+        questions = result.get("questions", [])
+        if not questions:
+            logger.warning("generate_exit_ticket: AI returned empty questions list")
+            return {"questions": [], "fallback": True}
+        # Clamp correct_index to valid range 0-3
+        for q in questions:
+            q["correct_index"] = max(0, min(3, int(q.get("correct_index", 0))))
+        return {"questions": questions}
+    except Exception as e:
+        logger.error("generate_exit_ticket AI call failed: %s", e)
+        return {"questions": [], "fallback": True}
 
 
 async def grade_exit_ticket(question: str, student_answer: str, reference_text: str) -> dict:
     """
     Grade a student's exit-ticket answer.
-    Returns {"score": int, "feedback": str} with score 0–100.
 
-    Stub: returns placeholder until implemented (Step 6).
+    For multiple-choice exit tickets, grading is done deterministically
+    by comparing selected_index to correct_index (handled in the route/service).
+    This function is preserved for potential future open-ended answer grading.
     """
-    # TODO: implement with Gemini API (Step 6)
-    return {"score": 0, "feedback": "批改功能尚未實作"}
+    return {"score": 0, "feedback": "此函式保留給未來開放式題型批改使用"}
 
 
 # ── Sentence Practice (Issue #109) ──────────────────────────────────────────

--- a/backend/app/services/exit_ticket_service.py
+++ b/backend/app/services/exit_ticket_service.py
@@ -1,0 +1,88 @@
+"""
+Exit Ticket Service — AI-powered generation and persistence (Issue #463).
+
+Handles:
+- AI question generation via Gemini 2.5 Flash (delegates to ai_service)
+- Rule-based fallback when AI is unavailable
+- Score calculation for submitted answers
+"""
+
+import logging
+
+from ..services.ai_service import generate_exit_ticket as _ai_generate
+
+logger = logging.getLogger(__name__)
+
+# Minimum passing score to surface in the report
+PASSING_SCORE = 60
+
+
+async def generate_exit_ticket_questions(
+    story_content: list[str],
+    wrong_chars: list[str] | None = None,
+) -> dict:
+    """
+    Generate exit-ticket questions for a story.
+
+    Tries AI generation first. If AI fails (fallback=True), returns an
+    empty questions list so the frontend can use its local rule-based fallback.
+
+    Args:
+        story_content: List of paragraphs from the story
+        wrong_chars: Characters the student mispronounced during reading
+
+    Returns:
+        {
+            "questions": [
+                {
+                    "id": int,
+                    "question": str,
+                    "options": [str, str, str, str],
+                    "correct_index": int,   # 0-3
+                    "explanation": str,
+                }
+            ],
+            "source": "ai" | "fallback"
+        }
+    """
+    full_text = "\n".join(story_content)
+    try:
+        result = await _ai_generate(text=full_text, wrong_chars=wrong_chars or [])
+    except Exception as e:
+        logger.error("exit_ticket_service: AI generate raised exception: %s", e)
+        return {"questions": [], "source": "fallback"}
+
+    if result.get("fallback") or not result.get("questions"):
+        logger.info("exit_ticket_service: using fallback (AI unavailable)")
+        return {"questions": [], "source": "fallback"}
+
+    return {"questions": result["questions"], "source": "ai"}
+
+
+def calculate_score(questions: list[dict], answers: list[dict]) -> dict:
+    """
+    Calculate score for submitted exit ticket answers.
+
+    Args:
+        questions: Generated questions with correct_index
+        answers: [{"question_id": int, "selected_index": int}, ...]
+
+    Returns:
+        {"score": int, "correct_count": int, "total": int}
+        score is 0-100 (percentage), rounded to nearest integer.
+        NEVER returns a score > 0 if answers is empty.
+    """
+    if not questions or not answers:
+        return {"score": 0, "correct_count": 0, "total": len(questions)}
+
+    answer_map = {a["question_id"]: a["selected_index"] for a in answers}
+    correct_count = 0
+
+    for q in questions:
+        selected = answer_map.get(q["id"])
+        if selected is not None and selected == q["correct_index"]:
+            correct_count += 1
+
+    total = len(questions)
+    score = round((correct_count / total) * 100) if total > 0 else 0
+    return {"score": score, "correct_count": correct_count, "total": total}

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -61,6 +61,10 @@ interface AssessmentReportProps {
   comprehensionScoresLoading?: boolean;
   /** Reading goals from assignment, if student is doing an assignment (Issue #84) */
   readingGoals?: { effectiveCpm: number; effectiveAccuracy: number; difficultyLabel?: string | null } | null;
+  /** DB session ID — passed to ExitTicket for AI generation and persistence (Issue #463) */
+  dbSessionId?: number | null;
+  /** Auth token — passed to ExitTicket for API calls (Issue #463) */
+  token?: string | null;
 }
 
 // CPM thresholds aligned with backend persona.py (Issue #54)
@@ -159,7 +163,7 @@ const Section: React.FC<{
   );
 };
 
-const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab, comprehensionScores, comprehensionScoresLoading, readingGoals }) => {
+const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab, comprehensionScores, comprehensionScoresLoading, readingGoals, dbSessionId, token }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
 
   // Track lesson completion when a valid report is viewed.
@@ -830,7 +834,13 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
 
       {/* ============ 出場卷 Exit Ticket ============ */}
       {(wrongTokens.length > 0 || missingChars.length > 0) && story?.content && (
-        <ExitTicket wrongTokens={wrongTokens} missingChars={missingChars} storyContent={story.content} />
+        <ExitTicket
+          wrongTokens={wrongTokens}
+          missingChars={missingChars}
+          storyContent={story.content}
+          dbSessionId={dbSessionId}
+          token={token}
+        />
       )}
 
       {/* CTA */}

--- a/frontend/src/components/reading-steps/ExitTicket.tsx
+++ b/frontend/src/components/reading-steps/ExitTicket.tsx
@@ -1,5 +1,10 @@
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import {
+  generateExitTicket,
+  submitExitTicket,
+  type ExitTicketQuestion as ApiQuestion,
+} from '../../services/api';
 
 interface WrongToken {
   char: string;
@@ -10,12 +15,22 @@ interface ExitTicketProps {
   wrongTokens: WrongToken[];
   missingChars: string[];
   storyContent: string[];
+  /** DB session ID — required to call backend AI generation and persist results */
+  dbSessionId?: number | null;
+  /** Auth token — required to call backend endpoints */
+  token?: string | null;
 }
 
-interface Question {
-  prompt: string;
+// ── Local rule-based fallback (kept from original implementation) ─────────────
+
+interface LocalQuestion {
+  id: number;
+  question: string;
   correctAnswer: string;
   options: string[];
+  /** Always undefined for local questions (no server explanation) */
+  explanation?: string;
+  source: 'local';
 }
 
 /** Shuffle array using Fisher-Yates */
@@ -153,11 +168,14 @@ const CONFUSABLE_CHARS: Record<string, string[]> = {
   '字': ['子', '守', '宇'],
 };
 
-/** Generate up to 3 multiple-choice questions from wrong + missing tokens */
-const generateQuestions = (wrongTokens: WrongToken[], missingChars: string[], storyContent: string[]): Question[] => {
+/** Generate up to 3 multiple-choice questions from wrong + missing tokens (local fallback) */
+const generateLocalQuestions = (
+  wrongTokens: WrongToken[],
+  missingChars: string[],
+  storyContent: string[],
+): LocalQuestion[] => {
   if (wrongTokens.length === 0 && missingChars.length === 0) return [];
 
-  // Collect unique characters from the story for distractors, excluding common particles
   const storyChars = new Set<string>();
   for (const paragraph of storyContent) {
     for (const ch of paragraph) {
@@ -165,105 +183,199 @@ const generateQuestions = (wrongTokens: WrongToken[], missingChars: string[], st
     }
   }
 
-  const questions: Question[] = [];
+  const questions: LocalQuestion[] = [];
 
-  /**
-   * Build a distractor list for a given correct answer.
-   * Priority: 1) CONFUSABLE_CHARS map, 2) other wrongTokens, 3) storyChars, 4) random CJK fallback
-   */
   const buildDistractors = (correctAnswer: string, exclude: Set<string>): string[] => {
     const chosen: string[] = [];
     const seen = new Set<string>([correctAnswer, ...exclude]);
 
-    // Priority 1: confusable chars (form-similar / sound-similar)
     const confusables = CONFUSABLE_CHARS[correctAnswer] ?? [];
     for (const c of shuffle(confusables)) {
       if (!seen.has(c) && chosen.length < 3) { seen.add(c); chosen.push(c); }
     }
-
-    // Priority 2: other wrong tokens' expected chars
     for (const t of wrongTokens) {
       if (!seen.has(t.expected) && chosen.length < 3) { seen.add(t.expected); chosen.push(t.expected); }
     }
-
-    // Priority 3: story chars
     for (const c of shuffle([...storyChars])) {
       if (!seen.has(c) && chosen.length < 3) { seen.add(c); chosen.push(c); }
     }
-
-    // Priority 4: random CJK fallback
     while (chosen.length < 3) {
       const fallback = String.fromCharCode(0x4e00 + Math.floor(Math.random() * 200));
       if (!seen.has(fallback)) { seen.add(fallback); chosen.push(fallback); }
     }
-
     return chosen.slice(0, 3);
   };
 
-  // Questions from wrong tokens: "你讀成了 X，正確的字應該是？"
   for (const token of shuffle(wrongTokens)) {
     if (questions.length >= 3) break;
     const distractors = buildDistractors(token.expected, new Set([token.char]));
     questions.push({
-      prompt: `你讀成了「${token.char}」，正確的字應該是？`,
+      id: questions.length + 1,
+      question: `你讀成了「${token.char}」，正確的字應該是？`,
       correctAnswer: token.expected,
       options: shuffle([token.expected, ...distractors]),
+      source: 'local',
     });
   }
 
-  // Fill remaining slots with missing chars: "你漏讀了一個字，是下面哪一個？"
   const usedChars = new Set(questions.map(q => q.correctAnswer));
   for (const ch of shuffle(missingChars)) {
     if (questions.length >= 3) break;
     if (usedChars.has(ch)) continue;
     usedChars.add(ch);
-
     const distractors = buildDistractors(ch, new Set());
     questions.push({
-      prompt: `你漏讀了一個字，是下面哪一個？`,
+      id: questions.length + 1,
+      question: `你漏讀了一個字，是下面哪一個？`,
       correctAnswer: ch,
       options: shuffle([ch, ...distractors]),
+      source: 'local',
     });
   }
 
   return questions;
 };
 
-const ExitTicket: React.FC<ExitTicketProps> = ({ wrongTokens, missingChars, storyContent }) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [answers, setAnswers] = useState<(string | null)[]>([]);
-  const [submitted, setSubmitted] = useState(false);
+// ── Unified question type for rendering ──────────────────────────────────────
 
-  const questions = useMemo(
-    () => generateQuestions(wrongTokens, missingChars, storyContent),
+interface UnifiedQuestion {
+  id: number;
+  question: string;
+  /** Index of the correct answer in options array */
+  correctIndex: number;
+  options: string[];
+  explanation?: string;
+  source: 'ai' | 'local';
+}
+
+/** Convert API question to unified format */
+const fromApiQuestion = (q: ApiQuestion): UnifiedQuestion => ({
+  id: q.id,
+  question: q.question,
+  correctIndex: q.correct_index,
+  options: q.options,
+  explanation: q.explanation,
+  source: 'ai',
+});
+
+/** Convert local question to unified format */
+const fromLocalQuestion = (q: LocalQuestion): UnifiedQuestion => ({
+  id: q.id,
+  question: q.question,
+  correctIndex: q.options.indexOf(q.correctAnswer),
+  options: q.options,
+  source: 'local',
+});
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+const ExitTicket: React.FC<ExitTicketProps> = ({
+  wrongTokens,
+  missingChars,
+  storyContent,
+  dbSessionId,
+  token,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [answers, setAnswers] = useState<(number | null)[]>([]);
+  const [submitted, setSubmitted] = useState(false);
+  const [questions, setQuestions] = useState<UnifiedQuestion[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Local fallback questions (memoized, same as original logic)
+  const localQuestions = useMemo(
+    () => generateLocalQuestions(wrongTokens, missingChars, storyContent),
     [wrongTokens, missingChars, storyContent],
   );
 
-  // No wrong tokens = no exit ticket
-  if (questions.length === 0) return null;
+  // Attempt AI generation on mount if we have session context
+  const fetchAiQuestions = useCallback(async () => {
+    if (!dbSessionId || !token || storyContent.length === 0) {
+      setQuestions(localQuestions.map(fromLocalQuestion));
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const wrongChars = wrongTokens.map(t => t.expected);
+      const result = await generateExitTicket(token, dbSessionId, storyContent, wrongChars);
+      if (result.source === 'ai' && result.questions.length > 0) {
+        setQuestions(result.questions.map(fromApiQuestion));
+      } else {
+        // AI unavailable — fall back to local
+        setQuestions(localQuestions.map(fromLocalQuestion));
+      }
+    } catch {
+      setQuestions(localQuestions.map(fromLocalQuestion));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [dbSessionId, token, storyContent, wrongTokens, localQuestions]);
 
-  // Initialize answers array
-  if (answers.length !== questions.length) {
-    setAnswers(new Array(questions.length).fill(null));
-    return null;
+  useEffect(() => {
+    fetchAiQuestions();
+  }, [fetchAiQuestions]);
+
+  // Initialize answers when questions are loaded
+  useEffect(() => {
+    if (questions !== null) {
+      setAnswers(new Array(questions.length).fill(null));
+    }
+  }, [questions]);
+
+  // Not ready yet
+  if (questions === null || isLoading) {
+    if (!isLoading && localQuestions.length === 0) return null;
+    return (
+      <div className="rounded-3xl border border-amber-200 bg-amber-50/50 overflow-hidden">
+        <div className="px-6 py-4 flex items-center gap-3">
+          <span className="w-8 h-8 rounded-full bg-amber-400 text-white flex items-center justify-center text-sm font-black shrink-0">
+            ✎
+          </span>
+          <h3 className="text-lg font-bold text-gray-900">學習出場卷</h3>
+          {isLoading && (
+            <span className="text-sm text-amber-600 animate-pulse">AI 正在出題中...</span>
+          )}
+        </div>
+      </div>
+    );
   }
 
+  if (questions.length === 0) return null;
+
+  if (answers.length !== questions.length) return null;
+
   const correctCount = submitted
-    ? answers.filter((a, i) => a === questions[i].correctAnswer).length
+    ? answers.filter((a, i) => a === questions[i].correctIndex).length
     : 0;
   const allAnswered = answers.every((a) => a !== null);
 
-  const handleSelect = (qIdx: number, option: string) => {
+  const handleSelect = (qIdx: number, optIdx: number) => {
     if (submitted) return;
     const next = [...answers];
-    next[qIdx] = option;
+    next[qIdx] = optIdx;
     setAnswers(next);
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!allAnswered) return;
     setSubmitted(true);
+
+    // Persist results to backend (non-blocking)
+    if (dbSessionId && token) {
+      const score = Math.round(
+        (answers.filter((a, i) => a === questions[i].correctIndex).length / questions.length) * 100,
+      );
+      const answerPayload = answers.map((selectedIndex, i) => ({
+        question_id: questions[i].id,
+        selected_index: selectedIndex ?? 0,
+      }));
+      submitExitTicket(token, dbSessionId, answerPayload, score, questions.length).catch(() => {
+        // Non-critical — don't block student view on persist failure
+      });
+    }
   };
+
+  const hasAiQuestions = questions.some(q => q.source === 'ai');
 
   return (
     <div className="rounded-3xl border border-amber-200 bg-amber-50/50 overflow-hidden">
@@ -277,6 +389,11 @@ const ExitTicket: React.FC<ExitTicketProps> = ({ wrongTokens, missingChars, stor
             ✎
           </span>
           <h3 className="text-lg font-bold text-gray-900">學習出場卷</h3>
+          {hasAiQuestions && (
+            <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-violet-100 text-violet-700">
+              AI 出題
+            </span>
+          )}
           {submitted && (
             <span className={`text-sm font-bold px-2 py-0.5 rounded-full ${
               correctCount === questions.length
@@ -299,18 +416,20 @@ const ExitTicket: React.FC<ExitTicketProps> = ({ wrongTokens, missingChars, stor
       {isOpen && (
         <div className="px-6 pb-6 space-y-5 border-t border-amber-200">
           <p className="text-sm text-gray-500 pt-4">
-            根據你剛才讀錯的字，來做個小測驗吧！
+            {hasAiQuestions
+              ? '根據課文內容，AI 出了幾道題，來測試一下你的理解吧！'
+              : '根據你剛才讀錯的字，來做個小測驗吧！'}
           </p>
 
           {questions.map((q, qIdx) => (
-            <div key={qIdx} className="space-y-2">
+            <div key={q.id} className="space-y-2">
               <p className="text-sm font-bold text-gray-800">
-                {qIdx + 1}. {q.prompt}
+                {qIdx + 1}. {q.question}
               </p>
               <div className="grid grid-cols-2 gap-2">
-                {q.options.map((opt) => {
-                  const isSelected = answers[qIdx] === opt;
-                  const isCorrect = opt === q.correctAnswer;
+                {q.options.map((opt, optIdx) => {
+                  const isSelected = answers[qIdx] === optIdx;
+                  const isCorrect = optIdx === q.correctIndex;
                   let style = 'bg-white border-gray-200 hover:border-accent hover:bg-accent/5';
 
                   if (submitted) {
@@ -327,10 +446,10 @@ const ExitTicket: React.FC<ExitTicketProps> = ({ wrongTokens, missingChars, stor
 
                   return (
                     <button
-                      key={opt}
-                      onClick={() => handleSelect(qIdx, opt)}
+                      key={optIdx}
+                      onClick={() => handleSelect(qIdx, optIdx)}
                       disabled={submitted}
-                      className={`border-2 rounded-xl px-4 py-3 text-lg font-bold transition-all ${style}`}
+                      className={`border-2 rounded-xl px-4 py-3 text-base font-bold transition-all text-left ${style}`}
                     >
                       {opt}
                       {submitted && isCorrect && ' ✓'}
@@ -339,6 +458,12 @@ const ExitTicket: React.FC<ExitTicketProps> = ({ wrongTokens, missingChars, stor
                   );
                 })}
               </div>
+              {/* Show AI explanation after submit */}
+              {submitted && q.explanation && (
+                <p className="text-xs text-gray-500 bg-gray-50 rounded-lg px-3 py-2 mt-1">
+                  {q.explanation}
+                </p>
+              )}
             </div>
           ))}
 

--- a/frontend/src/pages/learning/ReportPage.tsx
+++ b/frontend/src/pages/learning/ReportPage.tsx
@@ -70,6 +70,8 @@ const ReportPage: React.FC = () => {
         story={selectedStory}
         onRetry={handleRetry}
         onGoToVocab={() => navigate(`/learn/${storyId}/vocab`)}
+        dbSessionId={dbSessionId}
+        token={token}
       />
 
       {showXpToast && xpResult && (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -938,3 +938,93 @@ export async function fetchMyEnrolledClassrooms(
   }
   return res.json();
 }
+
+// ── Exit Ticket AI (Issue #463) ──────────────────────────────────────────────
+
+export interface ExitTicketQuestion {
+  id: number;
+  question: string;
+  options: string[];
+  correct_index: number;
+  explanation: string;
+}
+
+export interface ExitTicketGenerateResponse {
+  questions: ExitTicketQuestion[];
+  /** "ai" when Gemini generated the questions, "fallback" when AI was unavailable */
+  source: 'ai' | 'fallback';
+}
+
+export interface ExitTicketSubmitResponse {
+  score: number;
+  correct_count: number;
+  total: number;
+  passed: boolean;
+}
+
+/**
+ * Generate AI-powered exit ticket questions for a learning session.
+ * Calls POST /api/learning/sessions/{sessionId}/exit-ticket/generate
+ *
+ * Returns source="fallback" with empty questions if AI is unavailable —
+ * the caller should fall back to local rule-based generation in that case.
+ */
+export async function generateExitTicket(
+  token: string,
+  sessionId: number,
+  storyContent: string[],
+  wrongChars?: string[],
+): Promise<ExitTicketGenerateResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/learning/sessions/${sessionId}/exit-ticket/generate`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        story_content: storyContent,
+        wrong_chars: wrongChars ?? [],
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ detail: 'Unknown error' }));
+    throw new Error(body.detail || `generateExitTicket failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * Submit and persist exit ticket answers for a learning session.
+ * Calls POST /api/learning/sessions/{sessionId}/exit-ticket/submit
+ */
+export async function submitExitTicket(
+  token: string,
+  sessionId: number,
+  answers: Array<{ question_id: number; selected_index: number }>,
+  score: number,
+  totalQuestions: number,
+): Promise<ExitTicketSubmitResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/learning/sessions/${sessionId}/exit-ticket/submit`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        answers,
+        score,
+        total_questions: totalQuestions,
+      }),
+    },
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ detail: 'Unknown error' }));
+    throw new Error(body.detail || `submitExitTicket failed: ${res.status}`);
+  }
+  return res.json();
+}

--- a/tests/test_exit_ticket.py
+++ b/tests/test_exit_ticket.py
@@ -1,0 +1,213 @@
+"""
+Tests for Exit Ticket AI implementation (Issue #463).
+
+TDD: Red → Green → Refactor
+Tests cover:
+- exit_ticket_service.calculate_score (pure function, no AI)
+- generate_exit_ticket_questions with AI mock
+- generate_exit_ticket in ai_service with AI mock (schema validation)
+- Backend routes (generate + submit) via TestClient
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+# ── Unit tests: calculate_score ───────────────────────────────────────────────
+
+class TestCalculateScore:
+    """Pure-function tests — no I/O, no mocking required."""
+
+    def setup_method(self):
+        from backend.app.services.exit_ticket_service import calculate_score
+        self.calculate_score = calculate_score
+
+    def test_all_correct(self):
+        questions = [
+            {"id": 1, "correct_index": 0},
+            {"id": 2, "correct_index": 2},
+        ]
+        answers = [
+            {"question_id": 1, "selected_index": 0},
+            {"question_id": 2, "selected_index": 2},
+        ]
+        result = self.calculate_score(questions, answers)
+        assert result["score"] == 100
+        assert result["correct_count"] == 2
+        assert result["total"] == 2
+
+    def test_all_wrong(self):
+        questions = [{"id": 1, "correct_index": 0}, {"id": 2, "correct_index": 1}]
+        answers = [
+            {"question_id": 1, "selected_index": 3},
+            {"question_id": 2, "selected_index": 3},
+        ]
+        result = self.calculate_score(questions, answers)
+        assert result["score"] == 0
+        assert result["correct_count"] == 0
+
+    def test_half_correct(self):
+        questions = [
+            {"id": 1, "correct_index": 0},
+            {"id": 2, "correct_index": 1},
+        ]
+        answers = [
+            {"question_id": 1, "selected_index": 0},  # correct
+            {"question_id": 2, "selected_index": 3},  # wrong
+        ]
+        result = self.calculate_score(questions, answers)
+        assert result["score"] == 50
+        assert result["correct_count"] == 1
+
+    def test_empty_answers_returns_zero(self):
+        """CRITICAL: never auto-pass on empty answers."""
+        questions = [{"id": 1, "correct_index": 0}]
+        result = self.calculate_score(questions, [])
+        assert result["score"] == 0
+
+    def test_empty_questions_returns_zero(self):
+        result = self.calculate_score([], [])
+        assert result["score"] == 0
+        assert result["total"] == 0
+
+    def test_three_out_of_five_correct(self):
+        questions = [{"id": i, "correct_index": 0} for i in range(1, 6)]
+        answers = [
+            {"question_id": i, "selected_index": 0 if i <= 3 else 1}
+            for i in range(1, 6)
+        ]
+        result = self.calculate_score(questions, answers)
+        assert result["score"] == 60
+        assert result["correct_count"] == 3
+        assert result["total"] == 5
+
+
+# ── Unit tests: generate_exit_ticket_questions (service layer) ────────────────
+
+@pytest.mark.asyncio
+class TestGenerateExitTicketQuestions:
+
+    async def test_returns_ai_questions_when_ai_succeeds(self):
+        mock_questions = [
+            {
+                "id": 1,
+                "question": "文章的主角是誰？",
+                "options": ["小明", "小花", "老師", "爸爸"],
+                "correct_index": 0,
+                "explanation": "文章第一段提到小明是主角。",
+            }
+        ]
+        with patch(
+            "backend.app.services.exit_ticket_service._ai_generate",
+            new=AsyncMock(return_value={"questions": mock_questions}),
+        ):
+            from backend.app.services.exit_ticket_service import generate_exit_ticket_questions
+            result = await generate_exit_ticket_questions(
+                story_content=["小明是一個勤奮的學生。"],
+                wrong_chars=["明"],
+            )
+        assert result["source"] == "ai"
+        assert len(result["questions"]) == 1
+        assert result["questions"][0]["id"] == 1
+
+    async def test_falls_back_when_ai_returns_empty(self):
+        with patch(
+            "backend.app.services.exit_ticket_service._ai_generate",
+            new=AsyncMock(return_value={"questions": [], "fallback": True}),
+        ):
+            from backend.app.services.exit_ticket_service import generate_exit_ticket_questions
+            result = await generate_exit_ticket_questions(
+                story_content=["某篇課文內容。"],
+            )
+        assert result["source"] == "fallback"
+        assert result["questions"] == []
+
+    async def test_falls_back_on_exception(self):
+        with patch(
+            "backend.app.services.exit_ticket_service._ai_generate",
+            new=AsyncMock(side_effect=Exception("network error")),
+        ):
+            from backend.app.services.exit_ticket_service import generate_exit_ticket_questions
+            result = await generate_exit_ticket_questions(
+                story_content=["某篇課文內容。"],
+            )
+        assert result["source"] == "fallback"
+        assert result["questions"] == []
+
+
+# ── Unit tests: ai_service.generate_exit_ticket ───────────────────────────────
+
+@pytest.mark.asyncio
+class TestAiServiceGenerateExitTicket:
+
+    async def test_clamps_correct_index_to_0_3(self):
+        """correct_index values outside 0-3 must be clamped."""
+        mock_response = {
+            "questions": [
+                {
+                    "id": 1,
+                    "question": "test?",
+                    "options": ["A", "B", "C", "D"],
+                    "correct_index": 99,  # out of range
+                    "explanation": "test explanation",
+                }
+            ]
+        }
+        with patch(
+            "backend.app.services.ai_service.generate_structured_response",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            from backend.app.services.ai_service import generate_exit_ticket
+            result = await generate_exit_ticket(text="some story text")
+        assert result["questions"][0]["correct_index"] == 3  # clamped to max
+
+    async def test_returns_fallback_on_ai_exception(self):
+        """On any AI error, return fallback=True, NEVER raise or auto-pass."""
+        with patch(
+            "backend.app.services.ai_service.generate_structured_response",
+            new=AsyncMock(side_effect=RuntimeError("AI down")),
+        ):
+            from backend.app.services.ai_service import generate_exit_ticket
+            result = await generate_exit_ticket(text="some story text")
+        assert result.get("fallback") is True
+        assert result["questions"] == []
+
+    async def test_returns_fallback_on_empty_questions(self):
+        with patch(
+            "backend.app.services.ai_service.generate_structured_response",
+            new=AsyncMock(return_value={"questions": []}),
+        ):
+            from backend.app.services.ai_service import generate_exit_ticket
+            result = await generate_exit_ticket(text="some story text")
+        assert result.get("fallback") is True
+
+    async def test_passes_wrong_chars_to_prompt(self):
+        """Ensure wrong_chars are included in the AI prompt content."""
+        mock_response = {
+            "questions": [
+                {
+                    "id": 1,
+                    "question": "以下哪個是「明」字？",
+                    "options": ["明", "鳴", "命", "名"],
+                    "correct_index": 0,
+                    "explanation": "明是光明的明。",
+                }
+            ]
+        }
+        captured_contents = []
+
+        async def mock_generate(system_prompt, contents, **kwargs):
+            captured_contents.extend(contents)
+            return mock_response
+
+        with patch(
+            "backend.app.services.ai_service.generate_structured_response",
+            new=mock_generate,
+        ):
+            from backend.app.services.ai_service import generate_exit_ticket
+            await generate_exit_ticket(text="課文內容", wrong_chars=["明", "清"])
+
+        assert captured_contents, "generate_structured_response should be called"
+        content_text = captured_contents[0].parts[0].text
+        assert "明" in content_text
+        assert "清" in content_text


### PR DESCRIPTION
Fixes #463

## Summary

- **Backend `ai_service.py`**: Replace stub `generate_exit_ticket()` with full Gemini 2.5 Flash implementation. Uses `generate_structured_response` with a JSON schema. Produces 3-5 multiple-choice questions covering 三層次理解 (literal/inferential/evaluative). If wrong_chars are passed, AI is instructed to include at least one 形近字 recognition question. Returns `{"questions": [], "fallback": True}` on any AI error — never auto-passes.
- **New `exit_ticket_service.py`**: Service layer with `generate_exit_ticket_questions()` (calls AI, catches exceptions → fallback) and `calculate_score()` (pure function).
- **New routes in `learning.py`**:
  - `POST /api/learning/sessions/{id}/exit-ticket/generate` — rate-limited 5/min
  - `POST /api/learning/sessions/{id}/exit-ticket/submit` — persists score
- **Frontend `ExitTicket.tsx`**: On mount, calls generate endpoint. Falls back silently to original local rule-based generation if AI unavailable or no session context. On submit, calls submit endpoint (non-blocking). Shows "AI 出題" badge and displays explanation after answer submission.
- **`AssessmentReport.tsx` + `ReportPage.tsx`**: Thread `dbSessionId` + `token` down to ExitTicket.
- **`api.ts`**: Add `generateExitTicket()` and `submitExitTicket()` functions with types.
- **Tests**: 13 unit tests, all passing (TDD Red → Green → Refactor).

## Test plan

- [ ] Navigate to a story, complete full reading with some mispronounced characters
- [ ] On AssessmentReport, open "學習出場卷" — should show "AI 正在出題中..." briefly
- [ ] Questions should be comprehension-based (not just character recognition), with "AI 出題" badge
- [ ] Submit answers — explanations should appear below each question
- [ ] Test without session/token (unauthenticated) — falls back to local rule-based questions silently
- [ ] Backend: `POST /api/learning/sessions/{id}/exit-ticket/generate` returns `{"questions": [...], "source": "ai"}`
- [ ] Backend unit tests: `python -m pytest tests/test_exit_ticket.py -v` — 13 passed