### PR TITLE
fix: add JSON repair fallback and increase exit ticket max_tokens (Fixes #479)

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -32,6 +32,118 @@ def _get_client() -> genai.Client:
     return genai.Client(vertexai=True, project="lingoleap-dev", location="us-central1")
 
 
+def _repair_json(raw: str) -> str | None:
+    """Attempt basic JSON repair on a potentially truncated/malformed string.
+
+    Strategy:
+    1. Strip markdown code fences (```json ... ```)
+    2. Walk forward tracking bracket depth and string state, recording every
+       position where the outermost bracket closes (depth == 0).
+    3. If the outermost bracket never closes (truncated mid-content), scan
+       backwards from the end for the last close bracket (`}` or `]`) that is
+       not inside a string. Truncate there, strip trailing commas, then append
+       the closing brackets needed to balance the open bracket stack.
+
+    Returns the repaired JSON string if successful, None otherwise.
+    """
+    text = raw.strip()
+
+    # Strip markdown code fences
+    if text.startswith("```"):
+        # Remove opening fence (```json or ```)
+        text = text[text.find("\n") + 1:] if "\n" in text else text[3:]
+    if text.endswith("```"):
+        text = text[: text.rfind("```")]
+    text = text.strip()
+
+    if not text:
+        return None
+
+    # Must start with a JSON container
+    if not text.startswith("{") and not text.startswith("["):
+        return None
+
+    # Walk forward tracking brackets and string state.
+    # Build a stack of open brackets and record positions where depth returns to 0.
+    last_balanced_pos = -1
+    # close_positions: list of (pos, bracket_stack_snapshot_after_close)
+    # We only need the last close position outside a string.
+    last_outer_close_pos = -1  # last pos of any `}` or `]` outside a string
+    in_string = False
+    escape_next = False
+    bracket_stack: list[str] = []
+
+    for i, ch in enumerate(text):
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == "\\" and in_string:
+            escape_next = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch in ("{", "["):
+            bracket_stack.append(ch)
+        elif ch in ("}", "]"):
+            if bracket_stack:
+                bracket_stack.pop()
+            if not bracket_stack:
+                last_balanced_pos = i
+            # Record last close bracket outside a string regardless of depth
+            last_outer_close_pos = i
+
+    # Case 1: JSON was complete — return the complete portion
+    if last_balanced_pos != -1:
+        return text[: last_balanced_pos + 1]
+
+    # Case 2: Truncated — find the last close bracket, truncate there,
+    # strip trailing comma/whitespace, then close all open brackets.
+    if last_outer_close_pos == -1:
+        return None
+
+    truncated = text[: last_outer_close_pos + 1].rstrip().rstrip(",").rstrip()
+
+    # Rebuild bracket_stack for the truncated portion to know what to close
+    in_string = False
+    escape_next = False
+    close_stack: list[str] = []
+
+    for ch in truncated:
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == "\\" and in_string:
+            escape_next = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch in ("{", "["):
+            close_stack.append(ch)
+        elif ch in ("}", "]"):
+            if close_stack:
+                close_stack.pop()
+
+    # Append the matching closing brackets in reverse
+    closing = ""
+    for opener in reversed(close_stack):
+        closing += "}" if opener == "{" else "]"
+
+    candidate = truncated + closing
+    try:
+        json.loads(candidate)
+        return candidate
+    except Exception:
+        pass
+
+    return None
+
+
 async def generate_structured_response(
     system_prompt: str,
     contents: list[genai_types.Content],
@@ -64,7 +176,43 @@ async def generate_structured_response(
                 ),
                 timeout=GEMINI_TIMEOUT,
             )
-            return json.loads(response.text)
+
+            # Log raw response for debugging (truncated to avoid log spam)
+            raw_text = response.text if response.text is not None else ""
+            logger.debug(
+                "Gemini raw response (first 500 chars): %s",
+                raw_text[:500],
+                extra={"event": "gemini_raw_response", "length": len(raw_text)},
+            )
+
+            if not raw_text:
+                raise ValueError("Gemini returned empty/None response text")
+
+            try:
+                return json.loads(raw_text)
+            except json.JSONDecodeError as json_err:
+                logger.warning(
+                    "JSON parse failed (%s), attempting repair. Raw (first 200): %s",
+                    json_err,
+                    raw_text[:200],
+                    extra={"event": "gemini_json_repair_attempt"},
+                )
+                repaired = _repair_json(raw_text)
+                if repaired is not None:
+                    try:
+                        result = json.loads(repaired)
+                        logger.warning(
+                            "JSON repair succeeded (original_len=%d, repaired_len=%d)",
+                            len(raw_text),
+                            len(repaired),
+                            extra={"event": "gemini_json_repair_success"},
+                        )
+                        return result
+                    except json.JSONDecodeError:
+                        pass
+                # Repair failed — raise original error so retry logic handles it
+                raise json_err
+
         except asyncio.TimeoutError:
             logger.error(
                 "Gemini API timeout after %ds",
@@ -495,7 +643,7 @@ async def generate_exit_ticket(
             system_prompt=_EXIT_TICKET_SYSTEM_PROMPT,
             contents=contents,
             response_schema=EXIT_TICKET_SCHEMA,
-            max_tokens=1024,
+            max_tokens=2048,
             temperature=0.5,
         )
         questions = result.get("questions", [])

--- a/backend/tests/test_json_repair.py
+++ b/backend/tests/test_json_repair.py
@@ -1,0 +1,164 @@
+"""
+Unit tests for _repair_json() in ai_service.py (Issue #479).
+
+Tests cover:
+- Valid JSON passes through unchanged (no repair needed)
+- Truncated object repaired by bracket matching
+- Truncated array repaired by bracket matching
+- Markdown code fences stripped before repair
+- None/empty response text raises ValueError via generate_structured_response
+- Already-valid JSON after fence strip returns correctly
+"""
+
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from app.services.ai_service import _repair_json
+
+
+class TestRepairJsonValidInput:
+    """Valid JSON should be parseable (repair returns same string or longer balanced)."""
+
+    def test_valid_object_returned(self):
+        raw = '{"key": "value", "num": 42}'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+        assert parsed["num"] == 42
+
+    def test_valid_array_returned(self):
+        raw = '[{"id": 1}, {"id": 2}]'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert len(parsed) == 2
+
+    def test_nested_object_returned(self):
+        raw = '{"outer": {"inner": "hello"}, "list": [1, 2, 3]}'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["outer"]["inner"] == "hello"
+
+
+class TestRepairJsonTruncated:
+    """Truncated JSON should be repaired to the last balanced bracket."""
+
+    def test_truncated_object_repaired(self):
+        # Simulates Gemini cutting off mid-field
+        raw = '{"questions": [{"id": 1, "question": "What is", "options": ["a", "b", "c", "d"], "correct_index": 0, "explanation": "Because"}]}'
+        # Truncate it
+        truncated = raw[:80]  # cuts off in the middle
+        result = _repair_json(truncated)
+        # May or may not succeed depending on where brackets balanced — just check no exception
+        # If repair finds a balanced point, it returns valid JSON
+        if result is not None:
+            parsed = json.loads(result)
+            assert isinstance(parsed, dict)
+
+    def test_truncated_array_repaired(self):
+        # Array with one complete object followed by truncated second
+        raw = '[{"id": 1, "val": "complete"}, {"id": 2, "val": "truncated'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert isinstance(parsed, list)
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == 1
+
+    def test_object_with_complete_first_key_repaired(self):
+        # Object where only first key-value pair is complete before truncation
+        raw = '{"status": "ok", "data": "incomplet'
+        result = _repair_json(raw)
+        # The outer { never closes, so repair may return None or partial
+        # Either is acceptable — just must not raise
+        if result is not None:
+            json.loads(result)  # must be valid JSON if returned
+
+    def test_nested_truncated_repaired(self):
+        # Nested: outer closes, inner truncated
+        raw = '{"a": {"b": 1}, "c": {"d": "truncat'
+        result = _repair_json(raw)
+        # {"a": {"b": 1}} should be recoverable if the walk finds depth=0 at pos 14
+        if result is not None:
+            parsed = json.loads(result)
+            assert isinstance(parsed, dict)
+
+
+class TestRepairJsonMarkdownFences:
+    """Markdown code fences should be stripped before repair."""
+
+    def test_json_fence_stripped(self):
+        raw = '```json\n{"key": "value"}\n```'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+
+    def test_plain_fence_stripped(self):
+        raw = '```\n{"key": "value"}\n```'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+
+    def test_truncated_with_fence(self):
+        # Fence + truncated JSON
+        raw = '```json\n[{"id": 1, "val": "ok"}, {"id": 2, "val": "cut'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert len(parsed) == 1
+        assert parsed[0]["id"] == 1
+
+    def test_fence_only_opening(self):
+        # Only opening fence, no closing
+        raw = '```json\n{"key": "value"}'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["key"] == "value"
+
+
+class TestRepairJsonEdgeCases:
+    """Edge cases and invalid inputs."""
+
+    def test_empty_string_returns_none(self):
+        result = _repair_json("")
+        assert result is None
+
+    def test_whitespace_only_returns_none(self):
+        result = _repair_json("   \n  ")
+        assert result is None
+
+    def test_plain_text_returns_none(self):
+        result = _repair_json("This is not JSON at all")
+        assert result is None
+
+    def test_string_with_escaped_quotes(self):
+        raw = '{"message": "He said \\"hello\\" to me", "count": 1}'
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert parsed["count"] == 1
+
+    def test_exit_ticket_style_truncation(self):
+        # Realistic exit ticket truncation: 3 questions, 4th is cut
+        raw = (
+            '{"questions": ['
+            '{"id": 1, "question": "Q1?", "options": ["A", "B", "C", "D"], "correct_index": 0, "explanation": "Exp1"},'
+            '{"id": 2, "question": "Q2?", "options": ["A", "B", "C", "D"], "correct_index": 1, "explanation": "Exp2"},'
+            '{"id": 3, "question": "Q3?", "options": ["A", "B", "C", "D"], "correct_index": 2, "explanation": "Exp3"},'
+            '{"id": 4, "question": "Q4 trunca'
+        )
+        result = _repair_json(raw)
+        assert result is not None
+        parsed = json.loads(result)
+        assert "questions" in parsed
+        assert len(parsed["questions"]) == 3  # 4th was truncated, only 3 recovered


### PR DESCRIPTION
Fixes #479

## Summary

- Add `_repair_json()` helper in `ai_service.py` that handles truncated/malformed Gemini responses: strips markdown code fences, then finds the last balanced bracket position and closes open brackets to produce valid JSON
- In `generate_structured_response()`: log raw response at DEBUG level (first 500 chars), raise `ValueError` on empty/None response text, attempt repair on `JSONDecodeError` before re-raising to let retry logic handle unrecoverable failures
- Increase `generate_exit_ticket()` `max_tokens` from 1024 to 2048 to prevent truncation of 3–5 MCQ JSON responses
- Cloud Run staging memory updated from 256Mi to 512Mi (done via gcloud, takes effect immediately)

## Test plan

- [ ] 16 unit tests in `backend/tests/test_json_repair.py` — all passing locally
- [ ] Verify CI passes on PR preview deploy
- [ ] Test exit ticket generation on PR preview (造句 / 出場券 should no longer return 503)