### PR TITLE
fix: remove hardcoded JWT secret, add gitleaks scanning (#484)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,26 @@
+name: Secret Scan (Gitleaks)
+
+on:
+  pull_request:
+    branches: [main, staging]
+  push:
+    branches: [main, staging]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Gitleaks secret scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,38 @@
+# Gitleaks configuration for LingoLeap
+# https://github.com/gitleaks/gitleaks
+
+title = "LingoLeap Gitleaks Config"
+
+[extend]
+useDefault = true
+
+# Allowlist patterns that are NOT real secrets
+[allowlist]
+  description = "Known safe patterns"
+
+  # Test files, example configs, documentation
+  paths = [
+    '''(^|\/)tests\/''',
+    '''(^|\/)docs\/''',
+    '''\.md$''',
+    '''\.example$''',
+  ]
+
+  regexes = [
+    # Placeholder / example values
+    '''(?i)(example|placeholder|changeme|your[_-]?key|xxx+|test[_-]?key)''',
+    # Google Cloud Run service URLs (not secrets)
+    '''https://[\w-]+-\d+\.[\w-]+\.run\.app''',
+    # Firebase URLs
+    '''https://[\w-]+\.web\.app''',
+    # GCS public URLs
+    '''https://storage\.googleapis\.com/[\w-]+''',
+    # Artifact Registry paths
+    '''asia-east1-docker\.pkg\.dev/[\w-]+/[\w-]+''',
+    # SQLite local dev database
+    '''sqlite:///''',
+    # Redis localhost
+    '''redis://localhost''',
+    # Business email addresses in docs
+    '''[\w.]+@(junyiacademy|gmail|google)\.org''',
+  ]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     allowed_origins: str = "http://localhost:3000"
     gcs_bucket: str = "lingoleap-assets"
     gcs_public_url: str = "https://storage.googleapis.com/lingoleap-assets"
-    jwt_secret_key: str = "dev-secret-change-in-production"
+    jwt_secret_key: str = ""
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 480  # 8 hours
     google_client_id: str = ""  # set GOOGLE_CLIENT_ID env var in Cloud Run

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,12 +36,12 @@ logger = logging.getLogger(__name__)
 _env = os.environ.get("ENVIRONMENT", "development")
 _is_dev = _env in ("development", "preview")
 
-if settings.jwt_secret_key == "dev-secret-change-in-production":
+if not settings.jwt_secret_key:
     if not _is_dev:
         raise RuntimeError("JWT_SECRET_KEY must be set in production!")
     else:
         import warnings
-        warnings.warn("Using default JWT secret key — NOT suitable for production", stacklevel=2)
+        warnings.warn("JWT_SECRET_KEY is empty — auth endpoints will fail. Set it in .env", stacklevel=2)
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
## Summary
- Remove hardcoded JWT secret default (`"dev-secret-change-in-production"`) from `config.py` — replaced with empty string so no secret value ever appears in source code
- Update `main.py` startup validation to check for empty `JWT_SECRET_KEY` (production still crashes on missing key; dev shows warning)
- Add `.gitleaks.toml` configuration with allowlist for safe patterns (test files, GCP URLs, localhost, example values)
- Add `.github/workflows/secret-scan.yml` — runs [gitleaks](https://github.com/gitleaks/gitleaks) on every PR to staging/main

## Context
Resolves GitGuardian alert (4 internal incidents). The main culprit was the hardcoded JWT default visible in git history. While historical commits still contain the old value, this PR ensures:
1. The secret no longer exists in current source code
2. Future PRs are scanned for secrets automatically
3. Production deployment still enforces `JWT_SECRET_KEY` via env var

Closes #484

## Test plan
- [ ] Backend starts locally without `JWT_SECRET_KEY` set (warning shown, no crash in dev)
- [ ] Backend crashes in production (`ENVIRONMENT=production`) if `JWT_SECRET_KEY` is missing
- [ ] `gitleaks detect` runs cleanly against the repo with `.gitleaks.toml` config
- [ ] `secret-scan.yml` workflow triggers on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)