### PR TITLE
fix: replace alert() with non-blocking toast notifications (Fixes #426)

### DIFF
--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -1,0 +1,124 @@
+/**
+ * Toast — lightweight non-blocking notification component.
+ * Auto-dismisses after `duration` ms (default 3500).
+ * Accessible via role="alert" + aria-live="assertive".
+ */
+import React, { useEffect, useState } from 'react';
+
+export type ToastType = 'info' | 'success' | 'warning' | 'error';
+
+interface ToastProps {
+  message: string;
+  type?: ToastType;
+  duration?: number;
+  onClose: () => void;
+}
+
+const typeStyles: Record<ToastType, string> = {
+  info: 'bg-blue-50 border-blue-300 text-blue-800',
+  success: 'bg-green-50 border-green-300 text-green-800',
+  warning: 'bg-amber-50 border-amber-300 text-amber-800',
+  error: 'bg-red-50 border-red-300 text-red-800',
+};
+
+const typeIcons: Record<ToastType, React.ReactNode> = {
+  info: (
+    <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  success: (
+    <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  warning: (
+    <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+    </svg>
+  ),
+  error: (
+    <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+};
+
+export const Toast: React.FC<ToastProps> = ({
+  message,
+  type = 'info',
+  duration = 3500,
+  onClose,
+}) => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setVisible(false);
+      setTimeout(onClose, 300); // wait for fade-out transition
+    }, duration);
+    return () => clearTimeout(timer);
+  }, [duration, onClose]);
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      className={`
+        fixed bottom-6 left-1/2 -translate-x-1/2 z-50
+        flex items-center gap-2 px-4 py-3 rounded-lg border shadow-lg
+        text-sm font-medium max-w-sm w-max
+        transition-all duration-300
+        ${typeStyles[type]}
+        ${visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}
+      `}
+    >
+      {typeIcons[type]}
+      <span>{message}</span>
+      <button
+        onClick={() => {
+          setVisible(false);
+          setTimeout(onClose, 300);
+        }}
+        aria-label="關閉通知"
+        className="ml-2 opacity-60 hover:opacity-100 transition-opacity cursor-pointer"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+/**
+ * useToast — hook for managing a single toast notification.
+ *
+ * Usage:
+ *   const { toast, showToast } = useToast();
+ *   showToast('訊息', 'warning');
+ *   return <>{toast}</>;
+ */
+export function useToast() {
+  const [toastState, setToastState] = useState<{
+    message: string;
+    type: ToastType;
+    key: number;
+  } | null>(null);
+
+  const showToast = (message: string, type: ToastType = 'info') => {
+    setToastState({ message, type, key: Date.now() });
+  };
+
+  const toast = toastState ? (
+    <Toast
+      key={toastState.key}
+      message={toastState.message}
+      type={toastState.type}
+      onClose={() => setToastState(null)}
+    />
+  ) : null;
+
+  return { toast, showToast };
+}

--- a/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
+++ b/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
@@ -10,6 +10,7 @@ import {
   SubmissionResponse,
   AssignmentApiError,
 } from '../../services/assignmentApi';
+import { useToast } from '../../components/ui/Toast';
 
 interface Props {
   assignmentId: number;
@@ -63,6 +64,7 @@ const AssignmentDetailPanel: React.FC<Props> = ({
   onGraded,
 }) => {
   const { token } = useAuth();
+  const { toast, showToast } = useToast();
   const [gradingId, setGradingId] = useState<number | null>(null);
   const [gradeInput, setGradeInput] = useState<Record<number, string>>({});
   const [savingId, setSavingId] = useState<number | null>(null);
@@ -178,6 +180,7 @@ const AssignmentDetailPanel: React.FC<Props> = ({
 
   return (
     <div>
+      {toast}
       {/* Stats bar + actions */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex gap-4 text-xs text-gray-500">
@@ -216,8 +219,9 @@ const AssignmentDetailPanel: React.FC<Props> = ({
           {pending > 0 && (
             <button
               onClick={() =>
-                alert(
-                  `已標記提醒 ${pending} 位未完成學生。\n（實際通知功能待串接推播服務）`,
+                showToast(
+                  `已標記提醒 ${pending} 位未完成學生（實際通知功能待串接推播服務）`,
+                  'warning',
                 )
               }
               className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg border border-amber-300 text-amber-700 text-xs font-medium hover:bg-amber-50 transition-colors cursor-pointer"


### PR DESCRIPTION
Fixes #426

## Summary
- Created `frontend/src/components/ui/Toast.tsx` — a lightweight, reusable toast notification component with `useToast` hook
- Replaced the blocking `alert()` in `AssignmentDetailPanel.tsx` (remind-students button) with a non-blocking amber warning toast that auto-dismisses after 3.5 seconds
- Toast supports 4 types (`info`, `success`, `warning`, `error`) with matching icons and Tailwind colours consistent with the platform palette
- Accessible: `role="alert"`, `aria-live="assertive"`, `aria-atomic="true"`, manual close button with `aria-label`

## Test plan
- [ ] Open teacher dashboard → Assignment tab → expand any assignment that has pending students
- [ ] Click the "提醒 N 人" button
- [ ] Verify: no browser `alert()` dialog appears
- [ ] Verify: an amber toast notification slides in at the bottom-centre of the screen
- [ ] Verify: toast auto-dismisses after ~3.5 seconds without user interaction
- [ ] Verify: the X button on the toast closes it immediately
- [ ] Verify: the page remains fully interactive while the toast is visible

## Files changed
- `frontend/src/components/ui/Toast.tsx` — new reusable Toast component + `useToast` hook
- `frontend/src/pages/teacher/AssignmentDetailPanel.tsx` — import `useToast`, replace `alert()` with `showToast()`

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)