### PR TITLE
fix: add focus trap to Modal components (Fixes #433)

### DIFF
--- a/frontend/src/components/FeedbackButton.tsx
+++ b/frontend/src/components/FeedbackButton.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { submitFeedback, type FeedbackCategory } from '../services/feedbackApi';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 const CATEGORY_OPTIONS: { value: FeedbackCategory; label: string }[] = [
   { value: 'bug', label: '問題回報' },
@@ -18,6 +19,24 @@ const FeedbackButton: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState('');
   const [showTooltip, setShowTooltip] = useState(false);
 
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const isOpen = modalState !== 'idle';
+
+  // Focus trap — active when modal is open.
+  useFocusTrap(dialogRef, isOpen);
+
+  // Escape key closes the modal.
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
   const openModal = () => {
     setCategory('bug');
     setTitle('');
@@ -28,6 +47,8 @@ const FeedbackButton: React.FC = () => {
 
   const closeModal = () => {
     setModalState('idle');
+    // Restore focus to the trigger button after a short delay to allow DOM update.
+    requestAnimationFrame(() => triggerRef.current?.focus());
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -69,6 +90,7 @@ const FeedbackButton: React.FC = () => {
             </div>
           )}
           <button
+            ref={triggerRef}
             onClick={openModal}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
@@ -94,15 +116,21 @@ const FeedbackButton: React.FC = () => {
       </div>
 
       {/* Modal overlay */}
-      {modalState !== 'idle' && (
+      {isOpen && (
         <div
           className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4"
+          aria-modal="true"
+          role="dialog"
+          aria-labelledby="feedback-modal-title"
           onClick={(e) => {
             if (e.target === e.currentTarget) closeModal();
           }}
         >
           <div className="absolute inset-0 bg-black/30 backdrop-blur-sm" />
-          <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 space-y-4">
+          <div
+            ref={dialogRef}
+            className="relative bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 space-y-4"
+          >
 
             {/* Success state */}
             {modalState === 'success' && (
@@ -149,7 +177,7 @@ const FeedbackButton: React.FC = () => {
               <>
                 {/* Header */}
                 <div className="flex items-center justify-between">
-                  <h2 className="text-lg font-bold text-gray-900">回報問題</h2>
+                  <h2 id="feedback-modal-title" className="text-lg font-bold text-gray-900">回報問題</h2>
                   <button
                     onClick={closeModal}
                     className="text-gray-400 hover:text-gray-600 transition-colors"

--- a/frontend/src/components/TermsModal.tsx
+++ b/frontend/src/components/TermsModal.tsx
@@ -6,7 +6,8 @@
  * accepting.
  */
 
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 interface TermsModalProps {
   /** Called after the user successfully accepts terms (API call already done). */
@@ -28,6 +29,10 @@ const TermsModal: React.FC<TermsModalProps> = ({ onAccepted, onAccept }) => {
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // TermsModal is always visible when mounted — focus trap is always active.
+  useFocusTrap(dialogRef, true);
 
   const allChecked = checked.every(Boolean);
 
@@ -57,11 +62,19 @@ const TermsModal: React.FC<TermsModalProps> = ({ onAccepted, onAccept }) => {
 
   return (
     /* Backdrop — non-dismissable (no onClick on backdrop) */
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="w-full max-w-lg rounded-2xl bg-white shadow-2xl flex flex-col max-h-[90vh]">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="terms-modal-title"
+    >
+      <div
+        ref={dialogRef}
+        className="w-full max-w-lg rounded-2xl bg-white shadow-2xl flex flex-col max-h-[90vh]"
+      >
         {/* Header */}
         <div className="px-6 pt-6 pb-4 border-b border-gray-100">
-          <h2 className="text-xl font-bold text-gray-900">使用條款同意書</h2>
+          <h2 id="terms-modal-title" className="text-xl font-bold text-gray-900">使用條款同意書</h2>
           <p className="mt-1 text-sm text-gray-500">
             請閱讀並勾選以下所有同意事項，方可使用本平台。
           </p>

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,55 @@
+/**
+ * useFocusTrap — React hook for WAI-ARIA Dialog focus management.
+ *
+ * When `active` is true:
+ *  - Saves the previously focused element so it can be restored on close.
+ *  - Moves focus to the first focusable element inside the container.
+ *  - Traps Tab / Shift+Tab so focus cannot leave the container.
+ *
+ * Usage:
+ *   const dialogRef = useRef<HTMLDivElement>(null);
+ *   useFocusTrap(dialogRef, isOpen);
+ */
+
+import { useEffect, useRef } from 'react';
+import { trapFocus, focusFirst, saveFocus } from '../utils/accessibility';
+
+/**
+ * @param containerRef  Ref to the modal/dialog container element.
+ * @param active        Whether the focus trap should be active (modal is open).
+ */
+export function useFocusTrap(
+  containerRef: React.RefObject<HTMLElement | null>,
+  active: boolean,
+): void {
+  // Keep a stable ref to the cleanup functions so we can call them on deactivation.
+  const cleanupRef = useRef<(() => void)[]>([]);
+
+  useEffect(() => {
+    if (!active) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Save where focus was before the modal opened so we can restore it on close.
+    const restoreFocus = saveFocus();
+
+    // Move focus into the modal.
+    focusFirst(container);
+
+    // Trap Tab / Shift+Tab inside the modal.
+    const removeTrap = trapFocus(container);
+
+    // Store cleanup functions.
+    cleanupRef.current = [removeTrap, restoreFocus];
+
+    return () => {
+      // Remove keydown listener.
+      removeTrap();
+      // Return focus to the triggering element.
+      restoreFocus();
+      cleanupRef.current = [];
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+}

--- a/frontend/src/pages/teacher/MyTextsTab.tsx
+++ b/frontend/src/pages/teacher/MyTextsTab.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import {
   listMyTexts,
   createMyText,
@@ -77,6 +78,10 @@ const MyTextsTab: React.FC = () => {
   // Delete state
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Focus management for the Create/Edit modal
+  const formDialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(formDialogRef, showForm);
 
   const loadTexts = useCallback(async () => {
     if (!token) return;
@@ -402,7 +407,7 @@ const MyTextsTab: React.FC = () => {
           onKeyDown={(e) => { if (e.key === 'Escape') closeForm(); }}
           onClick={(e) => { if (e.target === e.currentTarget) closeForm(); }}
         >
-          <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4" role="dialog" aria-modal="true" aria-label={editingId !== null ? '編輯課文' : '新增課文'}>
+          <div ref={formDialogRef} className="bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4" role="dialog" aria-modal="true" aria-label={editingId !== null ? '編輯課文' : '新增課文'}>
             <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
               <h3 className="text-base font-semibold text-gray-800">
                 {editingId !== null ? '編輯課文' : '新增課文'}


### PR DESCRIPTION
Fixes #433

## Summary

- Add `useFocusTrap` hook (`frontend/src/hooks/useFocusTrap.ts`) that composes the existing `trapFocus`, `focusFirst`, and `saveFocus` utilities from `accessibility.ts` — no new dependencies
- Apply to **TermsModal**: focus moves to the first checkbox on open; Tab stays inside the dialog; added `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
- Apply to **FeedbackButton** modal: Tab stays inside, Escape closes, focus returns to the floating button on close; added ARIA attributes
- Apply to **MyTextsTab** Create/Edit modal: Tab stays inside the form; Escape + `autoFocus` were already in place from #385/#394

## How it works

`useFocusTrap(ref, active)` — when `active` becomes `true`:
1. Saves the currently focused element (`saveFocus`)
2. Moves focus to the first focusable element inside the container (`focusFirst`)
3. Installs a `keydown` listener that wraps Tab/Shift+Tab at the boundaries (`trapFocus`)

On `active` → `false` (or unmount): removes the listener and restores focus to the original element.

## Test plan

- [ ] Open TermsModal (new user / terms not accepted) — Tab cycles through checkboxes and the confirm button without escaping to the page behind
- [ ] Open FeedbackButton modal — Tab cycles through category/title/description/buttons; Esc closes and focus returns to the floating button
- [ ] Open MyTextsTab Create form — Tab cycles inside the form; Esc closes
- [ ] Shift+Tab from the first element wraps to the last in each modal
- [ ] TypeScript: `tsc --noEmit` shows no new errors (only the pre-existing App.tsx JSX tag issue on staging)