### PR TITLE
fix: add unique error ID to ErrorBoundary for user bug reports (Fixes #437)

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -9,6 +9,23 @@ interface ErrorBoundaryProps {
 interface ErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
+  errorId: string | null;
+}
+
+/**
+ * Generates a short, human-readable error ID based on a timestamp and a
+ * random suffix.  Format: ERR-<base36-ts>-<4-char-random>
+ * Example: ERR-m5kx2a-7f3q
+ *
+ * This ID is:
+ * - Included in the structured console log so Cloud Logging can correlate it.
+ * - Shown to the user so they can paste it into a bug report.
+ * - Never derived from the error message / stack, so it leaks no internals.
+ */
+function generateErrorId(): string {
+  const ts = Date.now().toString(36); // e.g. "m5kx2a"
+  const rand = Math.random().toString(36).slice(2, 6); // 4 chars
+  return `ERR-${ts}-${rand}`;
 }
 
 /**
@@ -26,15 +43,17 @@ interface ErrorBoundaryState {
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false, error: null, errorId: null };
     this.handleReset = this.handleReset.bind(this);
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { hasError: true, error };
+    return { hasError: true, error, errorId: generateErrorId() };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
+    const { errorId } = this.state;
+
     // Log to console — Cloud Logging ingests stdout/stderr from Cloud Run.
     // Keep this structured so Cloud Logging can parse it as JSON when the
     // browser forwards logs (e.g. via Cloud Logging agent or custom transport).
@@ -42,6 +61,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       JSON.stringify({
         severity: 'ERROR',
         event: 'react_render_error',
+        errorId,
         message: error.message,
         // Stack trace without full local file paths to avoid leaking dev env info.
         componentStack: info.componentStack
@@ -53,11 +73,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   handleReset(): void {
-    this.setState({ hasError: false, error: null });
+    this.setState({ hasError: false, error: null, errorId: null });
   }
 
   render(): React.ReactNode {
-    const { hasError, error } = this.state;
+    const { hasError, error, errorId } = this.state;
     const { children, fallback } = this.props;
 
     if (!hasError || !error) {
@@ -68,7 +88,13 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       return fallback(error, this.handleReset);
     }
 
-    return <DefaultErrorUI error={error} onReset={this.handleReset} />;
+    return (
+      <DefaultErrorUI
+        error={error}
+        errorId={errorId ?? ''}
+        onReset={this.handleReset}
+      />
+    );
   }
 }
 
@@ -76,45 +102,77 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 // Default error UI
 // ---------------------------------------------------------------------------
 
-const DefaultErrorUI: React.FC<{ error: Error; onReset: () => void }> = ({
-  error,
-  onReset,
-}) => (
-  <div className="min-h-screen flex items-center justify-center bg-amber-50 p-6">
-    <div className="bg-white rounded-2xl shadow-lg p-8 max-w-md w-full text-center space-y-4">
-      <div className="w-14 h-14 bg-red-100 rounded-full flex items-center justify-center mx-auto">
-        <span className="text-red-500 text-2xl" aria-hidden="true">!</span>
-      </div>
+const DefaultErrorUI: React.FC<{
+  error: Error;
+  errorId: string;
+  onReset: () => void;
+}> = ({ error, errorId, onReset }) => {
+  const [copied, setCopied] = React.useState(false);
 
-      <h1 className="text-xl font-bold text-gray-900">頁面發生錯誤</h1>
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(errorId);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: the error ID is selectable so the user can copy manually
+    }
+  };
 
-      <p className="text-sm text-gray-600 leading-relaxed">
-        很抱歉，頁面遇到了一個問題。請嘗試重新載入，或聯絡系統管理員。
-      </p>
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-amber-50 p-6">
+      <div className="bg-white rounded-2xl shadow-lg p-8 max-w-md w-full text-center space-y-4">
+        <div className="w-14 h-14 bg-red-100 rounded-full flex items-center justify-center mx-auto">
+          <span className="text-red-500 text-2xl" aria-hidden="true">!</span>
+        </div>
 
-      {/* Show a brief, non-sensitive error hint in development */}
-      {process.env.NODE_ENV !== 'production' && (
-        <p className="text-xs text-red-400 font-mono bg-red-50 rounded px-3 py-2 text-left break-words">
-          {error.message}
+        <h1 className="text-xl font-bold text-gray-900">頁面發生錯誤</h1>
+
+        <p className="text-sm text-gray-600 leading-relaxed">
+          很抱歉，頁面遇到了一個問題。請嘗試重新載入，或聯絡系統管理員。
         </p>
-      )}
 
-      <div className="flex gap-3 justify-center pt-2">
-        <button
-          onClick={onReset}
-          className="px-5 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors"
-        >
-          重新載入
-        </button>
-        <button
-          onClick={() => window.location.reload()}
-          className="px-5 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium rounded-lg transition-colors"
-        >
-          整頁重整
-        </button>
+        {/* Error ID — safe to show in all environments; contains no internals */}
+        <div className="bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 space-y-1">
+          <p className="text-xs text-gray-500">錯誤代碼（回報問題時請提供）</p>
+          <div className="flex items-center justify-center gap-2">
+            <code className="text-sm font-mono text-gray-800 select-all">
+              {errorId}
+            </code>
+            <button
+              onClick={handleCopy}
+              aria-label="複製錯誤代碼"
+              className="text-xs px-2 py-1 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded transition-colors"
+            >
+              {copied ? '已複製' : '複製'}
+            </button>
+          </div>
+        </div>
+
+        {/* Show a brief, non-sensitive error hint in development */}
+        {process.env.NODE_ENV !== 'production' && (
+          <p className="text-xs text-red-400 font-mono bg-red-50 rounded px-3 py-2 text-left break-words">
+            {error.message}
+          </p>
+        )}
+
+        <div className="flex gap-3 justify-center pt-2">
+          <button
+            onClick={onReset}
+            className="px-5 py-2 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors"
+          >
+            重新載入
+          </button>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-5 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 text-sm font-medium rounded-lg transition-colors"
+          >
+            整頁重整
+          </button>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default ErrorBoundary;


### PR DESCRIPTION
Fixes #437

## Summary
- Added `generateErrorId()` helper that produces a short collision-resistant ID in the format `ERR-<base36-timestamp>-<4-char-random>` (e.g. `ERR-m5kx2a-7f3q`)
- `ErrorBoundaryState` gains an `errorId` field, generated atomically inside `getDerivedStateFromError` so it is ready before `componentDidCatch` logs it
- `componentDidCatch` now includes `errorId` in the structured JSON log, so Cloud Logging entries can be looked up by the ID a user reports
- `DefaultErrorUI` displays the error ID in a grey box with a "複製" button (copies to clipboard, shows "已複製" confirmation for 2 s); the `<code>` element has `select-all` so users can also highlight and copy manually
- The dev-only `error.message` hint is preserved below the error ID box
- No internal paths, stack traces, or other sensitive data are exposed in production

## Test plan
- [ ] Open app in production mode: error screen shows `ERR-xxxxx-xxxx` and no stack trace
- [ ] Click "複製" — paste into any text field confirms the ID was copied
- [ ] Click "重新載入" — state resets, error ID is cleared
- [ ] Open app in dev mode: error message hint still appears below the ID box
- [ ] Check browser console: structured log entry includes matching `errorId`