### PR TITLE
fix: eliminate N+1 API calls on student progress page (#429)

### DIFF
--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -1255,6 +1255,54 @@ def list_student_instructions(
     return instructions
 
 
+@router.get(
+    "/teacher/classrooms/{classroom_id}/instruction-counts",
+    response_model=dict[int, int],
+)
+def get_classroom_instruction_counts(
+    classroom_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get active instruction counts for all students in a classroom (bulk, avoids N+1).
+
+    Returns a mapping of student_id -> active_instruction_count.
+    Students with zero instructions are included with count 0.
+    """
+    classroom = _check_classroom_access(current_user, classroom_id, db)
+
+    # Get all student IDs enrolled in this classroom
+    student_ids = [
+        row[0]
+        for row in db.query(ClassroomStudent.student_id)
+        .filter(ClassroomStudent.classroom_id == classroom.id)
+        .all()
+    ]
+
+    if not student_ids:
+        return {}
+
+    # Single aggregated query: count active instructions per student
+    rows = (
+        db.query(
+            TeacherInstruction.student_id,
+            func.count(TeacherInstruction.id).label("cnt"),
+        )
+        .filter(
+            TeacherInstruction.student_id.in_(student_ids),
+            TeacherInstruction.teacher_id == current_user.id,
+            TeacherInstruction.is_active == True,  # noqa: E712
+        )
+        .group_by(TeacherInstruction.student_id)
+        .all()
+    )
+
+    counts_from_db = {row.student_id: row.cnt for row in rows}
+
+    # Include all students, defaulting to 0 for those with no instructions
+    return {sid: counts_from_db.get(sid, 0) for sid in student_ids}
+
+
 @router.patch(
     "/teacher/instructions/{instruction_id}",
     response_model=InstructionResponse,

--- a/backend/tests/test_teacher_instructions.py
+++ b/backend/tests/test_teacher_instructions.py
@@ -628,3 +628,103 @@ class TestSocraticAgentIntegration:
 
         prompt = agent._build_system_prompt(state)
         assert "教師特別指示" not in prompt
+
+
+# ===========================================================================
+# GET /api/teacher/classrooms/{classroom_id}/instruction-counts — Bulk counts
+# ===========================================================================
+
+
+class TestBulkInstructionCounts:
+    """Tests for the bulk instruction-counts endpoint (fixes N+1 problem, Issue #429)."""
+
+    def test_returns_counts_for_classroom(self, client, teacher, student1, classroom_with_student):
+        """Should return a dict with the enrolled student's active instruction count."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_with_student}/instruction-counts",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, dict)
+        # student1 should be present; counts created by TestCreateInstruction are active
+        assert str(student1["user_id"]) in data or student1["user_id"] in data
+        student_count = data.get(str(student1["user_id"])) or data.get(student1["user_id"]) or 0
+        assert student_count >= 1
+
+    def test_empty_classroom_returns_empty_dict(self, client, teacher, school_id):
+        """A classroom with no students should return an empty dict."""
+        create_resp = client.post(
+            "/api/classrooms",
+            json={"name": "Empty Classroom for Count Test", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        assert create_resp.status_code == 201
+        empty_classroom_id = create_resp.json()["id"]
+
+        resp = client.get(
+            f"/api/teacher/classrooms/{empty_classroom_id}/instruction-counts",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {}
+
+    def test_other_teacher_cannot_access(self, client, other_teacher, classroom_with_student):
+        """A teacher who does not own the classroom should get 403."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_with_student}/instruction-counts",
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+    def test_requires_auth(self, client, classroom_with_student):
+        """Unauthenticated request should get 401."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_with_student}/instruction-counts",
+        )
+        assert resp.status_code == 401
+
+    def test_deleted_instructions_not_counted(self, client, teacher, student1, classroom_with_student):
+        """Soft-deleted instructions (is_active=False) should not be counted."""
+        # Create a fresh instruction
+        create_resp = client.post(
+            f"/api/teacher/students/{student1['user_id']}/instructions",
+            json={
+                "classroom_id": classroom_with_student,
+                "instruction_type": "general",
+                "content": "Instruction to be deleted for count test",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert create_resp.status_code == 201
+        instruction_id = create_resp.json()["id"]
+
+        # Get count before deletion
+        before_resp = client.get(
+            f"/api/teacher/classrooms/{classroom_with_student}/instruction-counts",
+            headers=auth_header(teacher["token"]),
+        )
+        before_count = (
+            before_resp.json().get(str(student1["user_id"]))
+            or before_resp.json().get(student1["user_id"])
+            or 0
+        )
+
+        # Soft-delete the instruction
+        del_resp = client.delete(
+            f"/api/teacher/instructions/{instruction_id}",
+            headers=auth_header(teacher["token"]),
+        )
+        assert del_resp.status_code == 200
+
+        # Count should decrease by 1
+        after_resp = client.get(
+            f"/api/teacher/classrooms/{classroom_with_student}/instruction-counts",
+            headers=auth_header(teacher["token"]),
+        )
+        after_count = (
+            after_resp.json().get(str(student1["user_id"]))
+            or after_resp.json().get(student1["user_id"])
+            or 0
+        )
+        assert after_count == before_count - 1

--- a/frontend/src/pages/teacher/StudentProgressTab.tsx
+++ b/frontend/src/pages/teacher/StudentProgressTab.tsx
@@ -12,8 +12,8 @@ import {
 import { useAuth } from '../../contexts/AuthContext';
 import {
   getClassroomProgress,
+  getClassroomInstructionCounts,
   getStudentSessions,
-  getStudentInstructions,
   exportClassroomReport,
   addStudentTag,
   removeStudentTag,
@@ -294,22 +294,16 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   }, [loadProgress]);
 
 
-  // Load instruction counts for each student
-  const loadInstructionCounts = useCallback(async (students: StudentProgress[]) => {
-    if (!token || students.length === 0) return;
-    const counts: Record<number, number> = {};
-    await Promise.all(
-      students.map(async (s) => {
-        try {
-          const instructions = await getStudentInstructions(token, s.student_id);
-          counts[s.student_id] = instructions.length;
-        } catch {
-          counts[s.student_id] = 0;
-        }
-      }),
-    );
-    setInstructionCounts(counts);
-  }, [token]);
+  // Load instruction counts for all students in one bulk request (avoids N+1)
+  const loadInstructionCounts = useCallback(async (_students: StudentProgress[]) => {
+    if (!token) return;
+    try {
+      const counts = await getClassroomInstructionCounts(token, classroomId);
+      setInstructionCounts(counts);
+    } catch {
+      // Non-fatal: leave counts at zero
+    }
+  }, [token, classroomId]);
 
   useEffect(() => {
     if (progress.length > 0) {

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -419,6 +419,18 @@ export async function getStudentInstructions(
   return handleResponse<TeacherInstruction[]>(res);
 }
 
+/** Get active instruction counts for all students in a classroom (bulk, avoids N+1). */
+export async function getClassroomInstructionCounts(
+  token: string,
+  classroomId: number,
+): Promise<Record<number, number>> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/classrooms/${classroomId}/instruction-counts`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return handleResponse<Record<number, number>>(res);
+}
+
 /** Update an instruction. */
 export async function updateInstruction(
   token: string,


### PR DESCRIPTION
## 問題根因

`StudentProgressTab` 的 `loadInstructionCounts()` 對每位學生各發一次 `GET /teacher/students/{id}/instructions`，班級有 N 個學生就會送 N 個請求。30 人班級 = 30 次額外 API call，嚴重拖慢載入。

## 修法

### Backend (`backend/app/routes/teacher.py`)
新增一個 bulk endpoint：
```
GET /api/teacher/classrooms/{classroom_id}/instruction-counts
→ { student_id: active_count, ... }
```
用一個 `GROUP BY` aggregated SQL query 取代 N 次個別查詢。所有未有指示的學生預設回傳 0，不會遺漏。

### Frontend (`frontend/src/services/teacherApi.ts`)
新增 `getClassroomInstructionCounts(token, classroomId)` 對應新 endpoint。

### Frontend (`frontend/src/pages/teacher/StudentProgressTab.tsx`)
`loadInstructionCounts` 改為呼叫單一 bulk API，移除 `Promise.all` 迴圈。N 次請求 → 1 次請求。

### Tests (`backend/tests/test_teacher_instructions.py`)
新增 `TestBulkInstructionCounts` 測試類別，涵蓋：
- 正常回傳計數
- 空班級回傳空 dict
- 其他教師無法存取（403）
- 未登入（401）
- 已刪除的指示不計入

## 驗收標準確認

- [x] 頁面載入時不再對每個學生發獨立的 API 請求（N→1）
- [x] 功能不變（教師仍能看到指示數量 badge）
- [x] 後端授權邏輯與現有 `_check_classroom_access` 一致

## Test plan
- [ ] 開啟教師端 StudentProgressTab，確認 Network tab 只有一次 `/instruction-counts` 請求（非 N 次 `/students/{id}/instructions`）
- [ ] 驗證指示 badge 數字正確顯示
- [ ] 開啟/關閉 TeacherInstructionPanel 後，badge 正確更新

Closes #429

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)