### PR TITLE
feat: show student reading metrics in teacher grading view (Fixes #423)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -137,6 +137,38 @@ def _has_role(user_id: int, role_name: str, db: Session) -> bool:
     ) is not None
 
 
+def _extract_reading_metrics(
+    sub: AssignmentSubmission, db: Session
+) -> tuple[float | None, float | None, list[str]]:
+    """Extract reading metrics (accuracy, cpm, error_chars) from the linked LearningSession.
+
+    Returns (reading_accuracy, reading_cpm, reading_error_chars).
+    All values are None/[] when no session exists or data hasn't been recorded yet.
+    """
+    if sub.session_id is None:
+        return None, None, []
+
+    session = (
+        db.query(LearningSession)
+        .filter(LearningSession.id == sub.session_id)
+        .first()
+    )
+    if session is None:
+        return None, None, []
+
+    accuracy = session.accuracy  # stored directly on session
+    cpm: float | None = None
+    error_chars: list[str] = []
+
+    if session.reading_result and isinstance(session.reading_result, dict):
+        cpm = session.reading_result.get("cpm")
+        raw_errors = session.reading_result.get("error_chars", [])
+        if isinstance(raw_errors, list):
+            error_chars = [str(c) for c in raw_errors]
+
+    return accuracy, cpm, error_chars
+
+
 # ── Student Endpoints (registered first to avoid path parameter conflicts) ───
 # /assignments/my must be registered before /assignments/{assignment_id}
 # so FastAPI doesn't try to parse "my" as an integer assignment_id.
@@ -394,6 +426,7 @@ def get_assignment_detail(
     submission_responses = []
     for sub in submissions:
         student = db.query(User).filter(User.id == sub.student_id).first()
+        r_accuracy, r_cpm, r_error_chars = _extract_reading_metrics(sub, db)
         submission_responses.append(
             SubmissionResponse(
                 id=sub.id,
@@ -403,6 +436,10 @@ def get_assignment_detail(
                 status=sub.status,
                 submitted_at=sub.submitted_at,
                 score=sub.score,
+                # Reading metrics (Issue #423)
+                reading_accuracy=r_accuracy,
+                reading_cpm=r_cpm,
+                reading_error_chars=r_error_chars,
             )
         )
 
@@ -480,6 +517,7 @@ def grade_submission(
     db.refresh(submission)
 
     student = db.query(User).filter(User.id == submission.student_id).first()
+    r_accuracy, r_cpm, r_error_chars = _extract_reading_metrics(submission, db)
     logger.info(
         "Teacher %d graded submission %d (score=%s)",
         current_user.id, submission_id, payload.score,
@@ -492,6 +530,10 @@ def grade_submission(
         status=submission.status,
         submitted_at=submission.submitted_at,
         score=submission.score,
+        # Reading metrics (Issue #423)
+        reading_accuracy=r_accuracy,
+        reading_cpm=r_cpm,
+        reading_error_chars=r_error_chars,
     )
 
 

--- a/backend/app/schemas/assignment.py
+++ b/backend/app/schemas/assignment.py
@@ -59,6 +59,10 @@ class SubmissionResponse(BaseModel):
     status: str
     submitted_at: datetime | None
     score: float | None
+    # Reading metrics from linked LearningSession (Issue #423)
+    reading_accuracy: float | None = None   # LiveTutor accuracy %
+    reading_cpm: float | None = None         # chars per minute from reading_result
+    reading_error_chars: list[str] = []      # mispronounced/skipped chars
 
     model_config = {"from_attributes": True}
 

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -142,7 +142,15 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    token = resp.json()["access_token"]
+    # Verify email using the dev-mode token returned in the response
+    verification_token = resp.json()["verification_token"]
+    assert verification_token is not None
+    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+    assert verify_resp.status_code == 200
+    # Login to get a JWT token
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200
+    token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))
     user_id = me_resp.json()["id"]
     return {"email": email, "name": name, "token": token, "user_id": user_id}
@@ -970,6 +978,20 @@ class TestDeleteAssignment:
                 "classroom_id": classroom_with_students,
                 "story_id": VALID_STORY_ID,
                 "title": "Protected Assignment",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert create_resp.status_code == 201
+        assignment_id = create_resp.json()["id"]
+
+        resp = client.delete(
+            f"/api/assignments/{assignment_id}",
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert resp.status_code == 403
+
+
+# ====================================================================
 # Student detail endpoint — GET /api/assignments/my/{id}
 # ====================================================================
 
@@ -1275,3 +1297,121 @@ class TestNotificationService:
                 db=mock_db,
             )
         assert any("assignment_graded" in r.message for r in caplog.records)
+
+
+# ====================================================================
+# Issue #423 — Teacher grading: reading metrics visible in submission
+# ====================================================================
+
+class TestSubmissionReadingMetrics:
+    """Verify that SubmissionResponse includes reading metrics (accuracy, cpm, error_chars)
+    pulled from the linked LearningSession when available."""
+
+    def _create_assignment_and_start(self, client, teacher, student, classroom_id):
+        """Create assignment, start it as student. Returns (assignment_id, session_id)."""
+        create_resp = client.post(
+            f"/api/classrooms/{classroom_id}/assignments",
+            json={
+                "classroom_id": classroom_id,
+                "story_id": VALID_STORY_ID,
+                "title": "Reading Metrics Test",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert create_resp.status_code == 201
+        assignment_id = create_resp.json()["id"]
+
+        start_resp = client.post(
+            f"/api/assignments/{assignment_id}/start",
+            headers=auth_header(student["token"]),
+        )
+        assert start_resp.status_code == 200
+        session_id = start_resp.json()["session_id"]
+        return assignment_id, session_id
+
+    def test_submission_response_has_reading_metrics_fields(
+        self, client, teacher, student1, classroom_with_students
+    ):
+        """SubmissionResponse must always include reading_metrics fields (nullable)."""
+        assignment_id, _ = self._create_assignment_and_start(
+            client, teacher, student1, classroom_with_students
+        )
+        resp = client.get(
+            f"/api/assignments/{assignment_id}",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        subs = resp.json()["submissions"]
+        # student1 has a submission
+        sub1 = next((s for s in subs if s["student_id"] == student1["user_id"]), None)
+        assert sub1 is not None
+        # reading metrics fields must be present
+        assert "reading_accuracy" in sub1
+        assert "reading_cpm" in sub1
+        assert "reading_error_chars" in sub1
+
+    def test_submission_reading_metrics_populated_after_session_update(
+        self, client, teacher, student1, classroom_with_students
+    ):
+        """After the student updates their session with reading data,
+        the teacher sees the metrics in the submission response."""
+        assignment_id, session_id = self._create_assignment_and_start(
+            client, teacher, student1, classroom_with_students
+        )
+
+        # Student updates the session with reading data
+        patch_resp = client.patch(
+            f"/api/learning/sessions/{session_id}",
+            json={
+                "accuracy": 85.5,
+                "reading_result": {
+                    "cpm": 142.3,
+                    "accuracy": 85.5,
+                    "error_chars": ["的", "了"],
+                },
+            },
+            headers=auth_header(student1["token"]),
+        )
+        assert patch_resp.status_code == 200
+
+        # Teacher views assignment detail — reading metrics must be present
+        resp = client.get(
+            f"/api/assignments/{assignment_id}",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        subs = resp.json()["submissions"]
+        sub1 = next((s for s in subs if s["student_id"] == student1["user_id"]), None)
+        assert sub1 is not None
+        assert sub1["reading_accuracy"] == pytest.approx(85.5, abs=0.1)
+        assert sub1["reading_cpm"] == pytest.approx(142.3, abs=0.1)
+        assert sub1["reading_error_chars"] == ["的", "了"]
+
+    def test_submission_reading_metrics_null_when_no_session(
+        self, client, teacher, student2, classroom_with_students
+    ):
+        """A pending submission (no session started) must have null reading metrics."""
+        # Create a NEW assignment so student2 has a fresh pending submission
+        create_resp = client.post(
+            f"/api/classrooms/{classroom_with_students}/assignments",
+            json={
+                "classroom_id": classroom_with_students,
+                "story_id": VALID_STORY_ID,
+                "title": "Reading Metrics Null Test",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert create_resp.status_code == 201
+        assignment_id = create_resp.json()["id"]
+
+        resp = client.get(
+            f"/api/assignments/{assignment_id}",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        subs = resp.json()["submissions"]
+        sub2 = next((s for s in subs if s["student_id"] == student2["user_id"]), None)
+        assert sub2 is not None
+        assert sub2["reading_accuracy"] is None
+        assert sub2["reading_cpm"] is None
+        assert sub2["reading_error_chars"] == []

--- a/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
+++ b/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
@@ -69,6 +69,8 @@ const AssignmentDetailPanel: React.FC<Props> = ({
   const [gradeInput, setGradeInput] = useState<Record<number, string>>({});
   const [savingId, setSavingId] = useState<number | null>(null);
   const [gradeError, setGradeError] = useState('');
+  // Track which submission row has reading metrics expanded (Issue #423)
+  const [expandedMetricsId, setExpandedMetricsId] = useState<number | null>(null);
 
   // Bulk comment state
   const [showBulkComment, setShowBulkComment] = useState(false);
@@ -308,69 +310,135 @@ const AssignmentDetailPanel: React.FC<Props> = ({
             <th className="pb-1.5 font-medium text-center">狀態</th>
             <th className="pb-1.5 font-medium">提交時間</th>
             <th className="pb-1.5 font-medium text-center">分數</th>
+            <th className="pb-1.5 font-medium text-center">朗讀數據</th>
             <th className="pb-1.5 font-medium text-center">批改</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
           {detail.submissions.map((sub) => (
-            <tr key={sub.id}>
-              <td className="py-1.5 text-gray-700">{sub.student_name}</td>
-              <td className="py-1.5 text-center">{statusBadge(sub.status)}</td>
-              <td className="py-1.5 text-gray-500">{formatDate(sub.submitted_at)}</td>
-              <td className="py-1.5 text-gray-700 text-center font-medium">
-                {gradingId === sub.id ? (
-                  <input
-                    type="number"
-                    min="0"
-                    max="100"
-                    value={gradeInput[sub.id] ?? ''}
-                    onChange={(e) =>
-                      setGradeInput((prev) => ({
-                        ...prev,
-                        [sub.id]: e.target.value,
-                      }))
-                    }
-                    className="w-16 h-6 px-1.5 rounded border border-gray-300 text-center text-xs focus:outline-none focus:border-accent"
-                    placeholder="0-100"
-                  />
-                ) : sub.score != null ? (
-                  `${Math.round(sub.score)}%`
-                ) : (
-                  '-'
-                )}
-              </td>
-              <td className="py-1.5 text-center">
-                {gradingId === sub.id ? (
-                  <div className="flex items-center justify-center gap-1">
+            <React.Fragment key={sub.id}>
+              <tr>
+                <td className="py-1.5 text-gray-700">{sub.student_name}</td>
+                <td className="py-1.5 text-center">{statusBadge(sub.status)}</td>
+                <td className="py-1.5 text-gray-500">{formatDate(sub.submitted_at)}</td>
+                <td className="py-1.5 text-gray-700 text-center font-medium">
+                  {gradingId === sub.id ? (
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      value={gradeInput[sub.id] ?? ''}
+                      onChange={(e) =>
+                        setGradeInput((prev) => ({
+                          ...prev,
+                          [sub.id]: e.target.value,
+                        }))
+                      }
+                      className="w-16 h-6 px-1.5 rounded border border-gray-300 text-center text-xs focus:outline-none focus:border-accent"
+                      placeholder="0-100"
+                    />
+                  ) : sub.score != null ? (
+                    `${Math.round(sub.score)}%`
+                  ) : (
+                    '-'
+                  )}
+                </td>
+                <td className="py-1.5 text-center">
+                  {/* Show expand button only when any reading data exists */}
+                  {sub.reading_accuracy != null || sub.reading_cpm != null || sub.reading_error_chars.length > 0 ? (
                     <button
-                      onClick={() => handleSaveGrade(sub)}
-                      disabled={savingId === sub.id}
-                      className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
+                      onClick={() =>
+                        setExpandedMetricsId((prev) => (prev === sub.id ? null : sub.id))
+                      }
+                      className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-blue-200 text-blue-600 text-xs hover:bg-blue-50 cursor-pointer transition-colors"
+                      title="展開朗讀數據"
                     >
-                      {savingId === sub.id ? '...' : '儲存'}
+                      {expandedMetricsId === sub.id ? '收合' : '查看'}
                     </button>
+                  ) : (
+                    <span className="text-gray-300">—</span>
+                  )}
+                </td>
+                <td className="py-1.5 text-center">
+                  {gradingId === sub.id ? (
+                    <div className="flex items-center justify-center gap-1">
+                      <button
+                        onClick={() => handleSaveGrade(sub)}
+                        disabled={savingId === sub.id}
+                        className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
+                      >
+                        {savingId === sub.id ? '...' : '儲存'}
+                      </button>
+                      <button
+                        onClick={() => {
+                          setGradingId(null);
+                          setGradeError('');
+                        }}
+                        className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+                      >
+                        取消
+                      </button>
+                    </div>
+                  ) : sub.status === 'submitted' || sub.status === 'graded' ? (
                     <button
-                      onClick={() => {
-                        setGradingId(null);
-                        setGradeError('');
-                      }}
+                      onClick={() => handleGradeClick(sub)}
                       className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
                     >
-                      取消
+                      {sub.status === 'graded' ? '重新批改' : '批改'}
                     </button>
-                  </div>
-                ) : sub.status === 'submitted' || sub.status === 'graded' ? (
-                  <button
-                    onClick={() => handleGradeClick(sub)}
-                    className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                  >
-                    {sub.status === 'graded' ? '重新批改' : '批改'}
-                  </button>
-                ) : (
-                  <span className="text-gray-300">—</span>
-                )}
-              </td>
-            </tr>
+                  ) : (
+                    <span className="text-gray-300">—</span>
+                  )}
+                </td>
+              </tr>
+              {/* Reading metrics expanded row (Issue #423) */}
+              {expandedMetricsId === sub.id && (
+                <tr>
+                  <td colSpan={6} className="pb-2 pt-0">
+                    <div className="mx-1 p-2.5 bg-blue-50 border border-blue-100 rounded-lg">
+                      <p className="text-xs font-medium text-blue-800 mb-2">
+                        朗讀學習數據 — {sub.student_name}
+                      </p>
+                      <div className="flex flex-wrap gap-4">
+                        <div className="text-center">
+                          <div className="text-lg font-bold text-blue-700">
+                            {sub.reading_accuracy != null
+                              ? `${sub.reading_accuracy.toFixed(1)}%`
+                              : '—'}
+                          </div>
+                          <div className="text-xs text-gray-500">正確率</div>
+                        </div>
+                        <div className="text-center">
+                          <div className="text-lg font-bold text-blue-700">
+                            {sub.reading_cpm != null
+                              ? `${Math.round(sub.reading_cpm)}`
+                              : '—'}
+                          </div>
+                          <div className="text-xs text-gray-500">語速（字/分）</div>
+                        </div>
+                        {sub.reading_error_chars.length > 0 && (
+                          <div>
+                            <div className="text-xs text-gray-500 mb-1">
+                              錯誤字詞（{sub.reading_error_chars.length} 個）
+                            </div>
+                            <div className="flex flex-wrap gap-1">
+                              {sub.reading_error_chars.map((ch, i) => (
+                                <span
+                                  key={i}
+                                  className="inline-block px-1.5 py-0.5 rounded bg-red-100 text-red-700 text-xs font-medium"
+                                >
+                                  {ch}
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
           ))}
         </tbody>
       </table>

--- a/frontend/src/services/assignmentApi.ts
+++ b/frontend/src/services/assignmentApi.ts
@@ -51,6 +51,10 @@ export interface SubmissionResponse {
   status: string;
   submitted_at: string | null;
   score: number | null;
+  // Reading metrics from linked LearningSession (Issue #423)
+  reading_accuracy: number | null;
+  reading_cpm: number | null;
+  reading_error_chars: string[];
 }
 
 export interface AssignmentDetailResponse extends AssignmentResponse {


### PR DESCRIPTION
Fixes #423

## Summary

- **Backend**: Extends `SubmissionResponse` with `reading_accuracy`, `reading_cpm`, `reading_error_chars` fields sourced from the student's linked `LearningSession`
- **Backend**: New `_extract_reading_metrics()` helper reads `session.accuracy` and `session.reading_result` JSONB (cpm + error_chars)
- **Frontend**: `SubmissionResponse` TypeScript type updated with the 3 new fields
- **Frontend**: `AssignmentDetailPanel` gains an expandable reading metrics row — teacher clicks "查看" to see accuracy %, CPM, and individual error characters without leaving the grading panel
- **Also fixed**: Pre-existing syntax error in `test_assignments.py` + broken `_register_user()` helper (register no longer returns `access_token` directly)

## Test plan

- [ ] Open teacher grading panel for an assignment where a student has completed the LiveTutor step
- [ ] A "查看" button appears in the "朗讀數據" column for that student
- [ ] Clicking "查看" expands a row showing: 正確率 %, 語速 (字/分), 錯誤字詞 list
- [ ] Students who haven't started yet show "—" in the column (no button)
- [ ] Grading (score save) still works normally
- [ ] Backend unit tests: `TestSubmissionReadingMetrics` — 3 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)