### PR TITLE
feat: 蘇格拉底對話歷史紀錄 (Fixes #418)

### DIFF
--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -17,7 +17,7 @@ from ..auth.dependencies import get_current_user
 from ..database import get_db
 from ..dependencies.tenant import _check_classroom_access
 from ..models.school import Classroom, ClassroomStudent, ClassroomText
-from ..models.session import CharacterError, LearningSession
+from ..models.session import CharacterError, LearningSession, DialogueTurn
 from ..models.student_tag import StudentTag
 from ..models.teacher_instruction import TeacherInstruction
 from ..models.notification_read import TeacherNotificationRead
@@ -623,6 +623,85 @@ def get_student_sessions(
         )
 
     return results
+
+
+# ── Teacher Dialogue History (Issue #418) ─────────────────────────────────────
+
+
+class TeacherDialogueTurnResponse(BaseModel):
+    id: int
+    turn_order: int
+    role: str
+    text: str
+    is_correct: bool | None
+    phase: str | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class TeacherDialogueHistoryResponse(BaseModel):
+    session_id: int
+    student_id: int
+    story_slug: str | None
+    turns: list[TeacherDialogueTurnResponse]
+    total: int
+
+
+@router.get(
+    "/teacher/students/{student_id}/sessions/{session_id}/dialogue",
+    response_model=TeacherDialogueHistoryResponse,
+)
+def get_teacher_student_dialogue(
+    student_id: int,
+    session_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return the Socratic dialogue history for a student's learning session.
+
+    The requesting teacher must own a classroom that contains the student.
+    Returns an empty turns list if the session exists but has no recorded dialogue.
+    """
+    # Verify teacher owns a classroom containing this student
+    enrollment = (
+        db.query(ClassroomStudent)
+        .join(Classroom, ClassroomStudent.classroom_id == Classroom.id)
+        .filter(
+            ClassroomStudent.student_id == student_id,
+            Classroom.teacher_id == current_user.id,
+        )
+        .first()
+    )
+    if not enrollment:
+        raise HTTPException(status_code=403, detail="Not authorized to view this student's sessions")
+
+    # Verify the session belongs to the student
+    session = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.id == session_id,
+            LearningSession.student_id == student_id,
+        )
+        .first()
+    )
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    turns = (
+        db.query(DialogueTurn)
+        .filter(DialogueTurn.learning_session_id == session_id)
+        .order_by(DialogueTurn.turn_order)
+        .all()
+    )
+
+    return TeacherDialogueHistoryResponse(
+        session_id=session_id,
+        student_id=student_id,
+        story_slug=session.story_slug,
+        turns=[TeacherDialogueTurnResponse.model_validate(t) for t in turns],
+        total=len(turns),
+    )
 
 
 @router.get(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -28,10 +28,16 @@ _patch_jsonb_columns()
 
 
 def pytest_runtest_setup(item):
-    """Reset the rate limiter before each test (including module-scoped fixtures).
+    """Reset rate limiters before each test (including module-scoped fixtures).
 
     Using a hook instead of a fixture ensures the reset happens before
     module-scoped fixtures that call /api/auth/register.
     """
     from app.routes.auth import rate_limiter
     rate_limiter.reset()
+    # Also reset the global per-IP rate limiter so tests don't hit 429
+    try:
+        from app.auth.rate_limiter import general_rate_limiter
+        general_rate_limiter.reset()
+    except (ImportError, AttributeError):
+        pass

--- a/backend/tests/test_dialogue_history.py
+++ b/backend/tests/test_dialogue_history.py
@@ -35,6 +35,7 @@ from app.database import get_db
 from app.models import Base
 from app.models.user import Role
 from app.models.session import LearningSession, DialogueTurn
+from app.models.school import Classroom, ClassroomStudent, School
 
 # ---------------------------------------------------------------------------
 # SQLite in-memory test database
@@ -111,6 +112,11 @@ def client():
 
 
 def _register_user(client, suffix: str | None = None) -> dict:
+    """Register a teacher user (only teachers can self-register).
+
+    Uses the register → verify-email → login flow required since issue #460.
+    """
+    from app.auth.password import hash_password
     unique = suffix or uuid.uuid4().hex[:8]
     email = f"diag_user_{unique}@example.com"
     password = "SecurePass123!"
@@ -120,11 +126,60 @@ def _register_user(client, suffix: str | None = None) -> dict:
         "name": f"DialogueUser {unique}",
     })
     assert resp.status_code == 201, resp.text
+    # Verify email using dev-mode verification_token
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+        assert verify_resp.status_code == 200, verify_resp.text
+    # Login to get JWT
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    token = login_resp.json()["access_token"]
+    me_resp = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})
+    user_id = me_resp.json().get("id")
     return {
         "email": email,
         "password": password,
-        "token": resp.json()["access_token"],
+        "token": token,
+        "user_id": user_id,
     }
+
+
+def _create_student_in_db(client) -> dict:
+    """Create a student user directly in the DB (bypasses self-reg restriction).
+
+    Students cannot self-register since issue #457 — they're created by teachers
+    via batch import. For tests, we create them directly in the DB with
+    email_verified=True, then log in to get a JWT.
+    """
+    from app.auth.password import hash_password
+    from app.models.user import User as UserModel
+
+    unique = uuid.uuid4().hex[:8]
+    email = f"stu_diag_{unique}@example.com"
+    password = "SecurePass123!"
+
+    db = TestingSessionLocal()
+    try:
+        user = UserModel(
+            email=email,
+            password_hash=hash_password(password),
+            name=f"Student {unique}",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        user_id = user.id
+    finally:
+        db.close()
+
+    # Login to get JWT
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    token = login_resp.json()["access_token"]
+    return {"email": email, "password": password, "token": token, "user_id": user_id}
 
 
 def auth_header(token: str) -> dict:
@@ -536,3 +591,183 @@ class TestDialoguePersistence:
         assert data["total"] == 1
         assert data["turns"][0]["role"] == "ai"
         assert data["turns"][0]["text"] == "這篇課文的主角是誰？"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/teacher/students/{student_id}/sessions/{session_id}/dialogue
+# Issue #418 — teacher can view student dialogue history
+# ---------------------------------------------------------------------------
+
+
+class TestTeacherDialogueHistory:
+    """Teacher endpoint for viewing a student's Socratic dialogue history."""
+
+    def _setup_teacher_student_classroom(self, client):
+        """
+        Register a teacher and student, create a classroom, enroll the student.
+        Returns (teacher_token, student_token, student_user_id, classroom_id).
+        """
+        teacher = _register_user(client)
+        student = _create_student_in_db(client)
+
+        teacher_id = teacher["user_id"]
+        student_id = student["user_id"]
+
+        # Create school, classroom owned by teacher, and enroll student directly in DB
+        db = TestingSessionLocal()
+        try:
+            school = School(name=f"Test School {uuid.uuid4().hex[:6]}")
+            db.add(school)
+            db.commit()
+            db.refresh(school)
+
+            classroom = Classroom(
+                name=f"Classroom for {teacher_id}",
+                teacher_id=teacher_id,
+                school_id=school.id,
+            )
+            db.add(classroom)
+            db.commit()
+            db.refresh(classroom)
+            classroom_id = classroom.id
+
+            enrollment = ClassroomStudent(
+                classroom_id=classroom_id,
+                student_id=student_id,
+            )
+            db.add(enrollment)
+            db.commit()
+        finally:
+            db.close()
+
+        return teacher["token"], student["token"], student_id, classroom_id
+
+    def test_teacher_can_view_student_dialogue(self, client):
+        """Teacher with classroom access can retrieve student's dialogue turns."""
+        teacher_token, student_token, student_id, _ = self._setup_teacher_student_classroom(client)
+
+        # Create a learning session for the student
+        session_resp = client.post(
+            "/api/learning/sessions",
+            json={"story_slug": "teacher-dialogue-story"},
+            headers=auth_header(student_token),
+        )
+        assert session_resp.status_code == 201, session_resp.text
+        session_id = session_resp.json()["id"]
+
+        # Seed some dialogue turns
+        db = TestingSessionLocal()
+        try:
+            socratic_id = str(uuid.uuid4())
+            db.add_all([
+                DialogueTurn(
+                    socratic_session_id=socratic_id,
+                    learning_session_id=session_id,
+                    turn_order=0,
+                    role="ai",
+                    text="這篇課文的主角是誰？",
+                    phase="factual",
+                ),
+                DialogueTurn(
+                    socratic_session_id=socratic_id,
+                    learning_session_id=session_id,
+                    turn_order=1,
+                    role="student",
+                    text="小英",
+                    phase="factual",
+                ),
+                DialogueTurn(
+                    socratic_session_id=socratic_id,
+                    learning_session_id=session_id,
+                    turn_order=2,
+                    role="feedback",
+                    text="答對了！",
+                    is_correct=True,
+                    phase="factual",
+                ),
+            ])
+            db.commit()
+        finally:
+            db.close()
+
+        resp = client.get(
+            f"/api/teacher/students/{student_id}/sessions/{session_id}/dialogue",
+            headers=auth_header(teacher_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_id"] == session_id
+        assert data["student_id"] == student_id
+        assert data["story_slug"] == "teacher-dialogue-story"
+        assert data["total"] == 3
+        turns = data["turns"]
+        assert [t["turn_order"] for t in turns] == [0, 1, 2]
+        assert turns[0]["role"] == "ai"
+        assert turns[1]["role"] == "student"
+        assert turns[2]["role"] == "feedback"
+        assert turns[2]["is_correct"] is True
+
+    def test_teacher_gets_empty_list_when_no_dialogue(self, client):
+        """Returns empty turns list when session has no dialogue recorded."""
+        teacher_token, student_token, student_id, _ = self._setup_teacher_student_classroom(client)
+
+        session_resp = client.post(
+            "/api/learning/sessions",
+            json={"story_slug": "no-dialogue-story"},
+            headers=auth_header(student_token),
+        )
+        session_id = session_resp.json()["id"]
+
+        resp = client.get(
+            f"/api/teacher/students/{student_id}/sessions/{session_id}/dialogue",
+            headers=auth_header(teacher_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["turns"] == []
+
+    def test_teacher_gets_404_for_wrong_student(self, client):
+        """Returns 404 when session_id doesn't belong to the specified student_id."""
+        teacher_token, student_token, student_id, _ = self._setup_teacher_student_classroom(client)
+
+        # Create session for student
+        session_resp = client.post(
+            "/api/learning/sessions",
+            json={"story_slug": "mismatch-story"},
+            headers=auth_header(student_token),
+        )
+        session_id = session_resp.json()["id"]
+
+        # Use a different (non-existent) student_id
+        resp = client.get(
+            f"/api/teacher/students/99999/sessions/{session_id}/dialogue",
+            headers=auth_header(teacher_token),
+        )
+        assert resp.status_code == 403  # 403 before 404 (student not in teacher's classroom)
+
+    def test_unauthorized_teacher_gets_403(self, client):
+        """A teacher without classroom access is blocked."""
+        _, student_token, student_id, _ = self._setup_teacher_student_classroom(client)
+
+        # Register a different teacher with no classrooms
+        other_teacher = _register_user(client)
+        other_teacher_token = other_teacher["token"]
+
+        session_resp = client.post(
+            "/api/learning/sessions",
+            json={"story_slug": "forbidden-story"},
+            headers=auth_header(student_token),
+        )
+        session_id = session_resp.json()["id"]
+
+        resp = client.get(
+            f"/api/teacher/students/{student_id}/sessions/{session_id}/dialogue",
+            headers=auth_header(other_teacher_token),
+        )
+        assert resp.status_code == 403
+
+    def test_unauthenticated_request_gets_401(self, client):
+        """Returns 401 when not authenticated."""
+        resp = client.get("/api/teacher/students/1/sessions/1/dialogue")
+        assert resp.status_code == 401

--- a/frontend/src/pages/teacher/StudentProgressTab.tsx
+++ b/frontend/src/pages/teacher/StudentProgressTab.tsx
@@ -14,6 +14,7 @@ import {
   getClassroomProgress,
   getClassroomInstructionCounts,
   getStudentSessions,
+  getTeacherStudentDialogue,
   exportClassroomReport,
   addStudentTag,
   removeStudentTag,
@@ -21,6 +22,8 @@ import {
   StudentProgress,
   StudentTag,
   StudentSession,
+  TeacherDialogueTurn,
+  TeacherDialogueHistoryResponse,
   LearningCurvePoint,
   TeacherApiError,
 } from '../../services/teacherApi';
@@ -239,6 +242,125 @@ const TagManager: React.FC<TagManagerProps> = ({
   );
 };
 
+// ── Dialogue Modal (Issue #418) ────────────────────────────────────────────
+
+const PHASE_LABEL: Record<string, string> = {
+  factual: '事實理解',
+  inferential: '推論思考',
+  evaluative: '評估反思',
+};
+
+const DialogueModal: React.FC<{
+  data: TeacherDialogueHistoryResponse;
+  storyTitle: string | null;
+  studentName: string;
+  onClose: () => void;
+}> = ({ data, storyTitle, studentName, onClose }) => {
+  const headerTitle = storyTitle
+    ? `${studentName} — 《${storyTitle}》對話紀錄`
+    : `${studentName} — 對話紀錄`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="學生對話紀錄"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-100 shrink-0">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-sm font-semibold text-gray-800 truncate">{headerTitle}</h2>
+            <p className="text-xs text-gray-400 mt-0.5">共 {data.total} 則訊息</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="關閉對話紀錄"
+            className="flex-shrink-0 p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Turns */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          {data.turns.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-sm text-gray-500">這次學習沒有對話記錄</p>
+            </div>
+          ) : (
+            data.turns.map((turn) => <DialogueTurnRow key={turn.id} turn={turn} />)
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const DialogueTurnRow: React.FC<{ turn: TeacherDialogueTurn }> = ({ turn }) => {
+  if (turn.role === 'ai') {
+    return (
+      <div className="flex gap-2.5">
+        <div className="flex-shrink-0 w-6 h-6 rounded-full bg-accent flex items-center justify-center mt-0.5">
+          <span className="text-white text-[9px] font-bold">AI</span>
+        </div>
+        <div className="flex-1 max-w-[85%]">
+          {turn.phase && (
+            <span className="inline-block mb-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-accent-bg text-accent">
+              {PHASE_LABEL[turn.phase] ?? turn.phase}
+            </span>
+          )}
+          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-3.5 py-2.5">
+            <p className="text-sm text-accent-hover leading-relaxed">{turn.text}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (turn.role === 'student') {
+    return (
+      <div className="flex gap-2.5 flex-row-reverse">
+        <div className="flex-shrink-0 w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center mt-0.5">
+          <svg className="w-3 h-3 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+        </div>
+        <div className="max-w-[85%]">
+          <div className="bg-accent rounded-2xl rounded-tr-sm px-3.5 py-2.5">
+            <p className="text-sm text-white leading-relaxed">{turn.text}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (turn.role === 'feedback') {
+    return (
+      <div className="mx-8">
+        <div className={`rounded-xl px-3 py-2 text-xs border ${
+          turn.is_correct
+            ? 'bg-emerald-50 border-emerald-200 text-emerald-800'
+            : 'bg-amber-50 border-amber-200 text-amber-800'
+        }`}>
+          <span className="mr-1">{turn.is_correct ? '✓' : '💡'}</span>
+          {turn.text}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+// ── Main Component ─────────────────────────────────────────────────────────
+
 const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) => {
   const { token } = useAuth();
   const [progress, setProgress] = useState<StudentProgress[]>([]);
@@ -251,6 +373,14 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   const [isLoadingSessions, setIsLoadingSessions] = useState(false);
   const [sessions, setSessions] = useState<StudentSession[]>([]);
   const sessionCache = useRef<Record<number, StudentSession[]>>({});
+
+  // Dialogue modal state (Issue #418)
+  const [dialogueModal, setDialogueModal] = useState<{
+    data: TeacherDialogueHistoryResponse;
+    storyTitle: string | null;
+    studentName: string;
+  } | null>(null);
+  const [loadingDialogueSessionId, setLoadingDialogueSessionId] = useState<number | null>(null);
 
   // Instruction panel state
   const [instructionTarget, setInstructionTarget] = useState<{ id: number; name: string } | null>(null);
@@ -376,6 +506,25 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
     }
   }, [expandedStudentId, token]);
 
+  // Load and show dialogue history for a session (Issue #418)
+  const handleViewDialogue = useCallback(async (
+    studentId: number,
+    sessionId: number,
+    storyTitle: string | null,
+    studentName: string,
+  ) => {
+    if (!token) return;
+    setLoadingDialogueSessionId(sessionId);
+    try {
+      const data = await getTeacherStudentDialogue(token, studentId, sessionId);
+      setDialogueModal({ data, storyTitle, studentName });
+    } catch {
+      // Non-fatal — silently fail
+    } finally {
+      setLoadingDialogueSessionId(null);
+    }
+  }, [token]);
+
   // Update local tags after tag manager changes
   const handleTagsChanged = useCallback((studentId: number, tags: StudentTag[]) => {
     setProgress((prev) =>
@@ -486,6 +635,16 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
           currentTags={tagManagerStudent.tags}
           onClose={() => setTagManagerStudent(null)}
           onTagsChanged={handleTagsChanged}
+        />
+      )}
+
+      {/* Dialogue History Modal (Issue #418) */}
+      {dialogueModal && (
+        <DialogueModal
+          data={dialogueModal.data}
+          storyTitle={dialogueModal.storyTitle}
+          studentName={dialogueModal.studentName}
+          onClose={() => setDialogueModal(null)}
         />
       )}
 
@@ -662,6 +821,7 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                                 <th className="pb-1.5 font-medium">日期</th>
                                 <th className="pb-1.5 font-medium text-center">分數</th>
                                 <th className="pb-1.5 font-medium text-center">狀態</th>
+                                <th className="pb-1.5 font-medium text-center">對話</th>
                               </tr>
                             </thead>
                             <tbody className="divide-y divide-gray-100">
@@ -671,6 +831,28 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                                   <td className="py-1.5 text-gray-500">{formatDate(sess.started_at)}</td>
                                   <td className="py-1.5 text-gray-700 text-center font-medium">{formatScore(sess.overall_score)}</td>
                                   <td className="py-1.5 text-center">{statusLabel(sess.status)}</td>
+                                  <td className="py-1.5 text-center">
+                                    <button
+                                      type="button"
+                                      disabled={loadingDialogueSessionId === sess.id}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleViewDialogue(s.student_id, sess.id, sess.story_title, s.student_name);
+                                      }}
+                                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                                      title="查看蘇格拉底對話記錄"
+                                    >
+                                      {loadingDialogueSessionId === sess.id ? (
+                                        <span className="w-2.5 h-2.5 border border-accent border-t-transparent rounded-full animate-spin" />
+                                      ) : (
+                                        <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                                            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                                        </svg>
+                                      )}
+                                      對話
+                                    </button>
+                                  </td>
                                 </tr>
                               ))}
                             </tbody>

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -156,6 +156,39 @@ export async function getStudentSessions(
   return handleResponse<StudentSession[]>(res);
 }
 
+// ── Dialogue history (Issue #418) ──────────────────────────────────────────
+
+export interface TeacherDialogueTurn {
+  id: number;
+  turn_order: number;
+  role: string;
+  text: string;
+  is_correct: boolean | null;
+  phase: string | null;
+  created_at: string;
+}
+
+export interface TeacherDialogueHistoryResponse {
+  session_id: number;
+  student_id: number;
+  story_slug: string | null;
+  turns: TeacherDialogueTurn[];
+  total: number;
+}
+
+/** Fetch Socratic dialogue history for a student session (teacher view). */
+export async function getTeacherStudentDialogue(
+  token: string,
+  studentId: number,
+  sessionId: number,
+): Promise<TeacherDialogueHistoryResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/students/${studentId}/sessions/${sessionId}/dialogue`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return handleResponse<TeacherDialogueHistoryResponse>(res);
+}
+
 /** Unassign a text from a classroom. */
 export async function unassignText(
   token: string,


### PR DESCRIPTION
Fixes #418

## Summary

- **Backend**: Add `GET /api/teacher/students/{student_id}/sessions/{session_id}/dialogue` endpoint so teachers can view a student's Socratic dialogue turns. Authorization: teacher must own a classroom containing the student.
- **Backend**: Add `TeacherDialogueHistoryResponse` Pydantic schema with `student_id` field alongside existing `session_id`, `story_slug`, `turns`, `total`.
- **Frontend `teacherApi.ts`**: Add `getTeacherStudentDialogue()` function and `TeacherDialogueTurn` / `TeacherDialogueHistoryResponse` interfaces.
- **Frontend `StudentProgressTab.tsx`**: Add `DialogueModal` + `DialogueTurnRow` components; add a "查看對話" button in each session row of the expanded student panel.
- **Tests**: Fix `_register_user` to use register → verify-email → login flow (required since #460); add `_create_student_in_db` helper for test student creation (bypasses self-reg restriction from #457); add 5 new `TestTeacherDialogueHistory` tests; fix `conftest.py` to reset global rate limiter between tests.

## What already existed (Issue #242)

- `DialogueTurn` DB model + persistence in `comprehension/chat`
- `GET /api/learning/sessions/{id}/dialogue` (student-only endpoint)
- `DialogueHistory` student page at `/sessions/:sessionId/dialogue`
- Student can view own dialogue from LearningHistory

## What's new (Issue #418)

- Teacher access endpoint with classroom-ownership guard
- Teacher UI: dialogue modal accessible from session history table

## Test plan

- [ ] As a teacher, expand a student row in the Progress tab
- [ ] Click "查看對話" on a session that has dialogue turns
- [ ] Verify modal shows AI questions, student answers, and feedback bubbles with correct/incorrect indicators
- [ ] Verify modal closes on outside click or X button
- [ ] Verify "查看對話" on a session with no dialogue shows empty state message
- [ ] All 16 backend tests pass: `pytest backend/tests/test_dialogue_history.py -v`

🤖 Generated with [Claude Code](https://claude.ai/code)