### PR TITLE
feat: 教師設定課文朗讀目標（語速 + 正確率）(Fixes #414)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -627,6 +627,11 @@ def start_assignment(
             story_id=assignment.story_id,
             text_id=assignment.text_id,
             status="in_progress",
+            target_cpm=assignment.target_cpm,
+            target_accuracy=assignment.target_accuracy,
+            difficulty_label=assignment.difficulty_label,
+            effective_cpm=assignment.target_cpm if assignment.target_cpm is not None else DEFAULT_TARGET_CPM,
+            effective_accuracy=assignment.target_accuracy if assignment.target_accuracy is not None else DEFAULT_TARGET_ACCURACY,
         )
 
     # story_slug for LearningSession: use story_id (YAML) or text_id as string
@@ -658,6 +663,11 @@ def start_assignment(
         story_id=assignment.story_id,
         text_id=assignment.text_id,
         status="in_progress",
+        target_cpm=assignment.target_cpm,
+        target_accuracy=assignment.target_accuracy,
+        difficulty_label=assignment.difficulty_label,
+        effective_cpm=assignment.target_cpm if assignment.target_cpm is not None else DEFAULT_TARGET_CPM,
+        effective_accuracy=assignment.target_accuracy if assignment.target_accuracy is not None else DEFAULT_TARGET_ACCURACY,
     )
 
 

--- a/backend/app/schemas/assignment.py
+++ b/backend/app/schemas/assignment.py
@@ -134,3 +134,9 @@ class StartAssignmentResponse(BaseModel):
     story_id: str | None      # set if platform text
     text_id: int | None       # set if DB text
     status: str
+    # Reading goals (Issue #414) — let student know the target before starting
+    target_cpm: int | None = None
+    target_accuracy: float | None = None
+    difficulty_label: str | None = None
+    effective_cpm: int = DEFAULT_TARGET_CPM
+    effective_accuracy: float = DEFAULT_TARGET_ACCURACY

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -1610,3 +1610,137 @@ class TestTeacherFeedback:
         )
         assert resp.status_code == 200
         assert resp.json()["teacher_feedback"] == "更新後的評語"
+
+
+# ---------------------------------------------------------------------------
+# Issue #414 — Reading goals in StartAssignmentResponse
+# ---------------------------------------------------------------------------
+
+class TestReadingGoalsInStartResponse:
+    """Tests that /start returns reading goals so the student knows the target
+    before and during the learning session (Issue #414)."""
+
+    @pytest.fixture
+    def setup(self, client, school_id):
+        """Create teacher + student + classroom + assignment with reading goals."""
+        teacher = _register_and_login(client, "rg414_teacher")
+        student = _register_and_login(client, "rg414_student")
+        _make_student_role(student["user_id"], school_id)
+
+        cls_resp = client.post(
+            "/api/classrooms",
+            headers=auth_header(teacher["token"]),
+            json={"name": "Reading Goals 414 Class", "school_id": school_id},
+        )
+        classroom_id = cls_resp.json()["id"]
+        client.post(
+            f"/api/classrooms/{classroom_id}/students",
+            headers=auth_header(teacher["token"]),
+            json={"student_id": student["user_id"]},
+        )
+        # Create assignment WITH custom reading goals
+        asn_resp = client.post(
+            f"/api/classrooms/{classroom_id}/assignments",
+            headers=auth_header(teacher["token"]),
+            json={
+                "classroom_id": classroom_id,
+                "story_id": "1",
+                "target_cpm": 160,
+                "target_accuracy": 85.0,
+                "difficulty_label": "中級",
+            },
+        )
+        assignment_id = asn_resp.json()["id"]
+        return {
+            "teacher": teacher,
+            "student": student,
+            "classroom_id": classroom_id,
+            "assignment_id": assignment_id,
+        }
+
+    def test_start_response_includes_reading_goals(self, client, setup):
+        """StartAssignmentResponse must include effective_cpm, effective_accuracy,
+        target_cpm, target_accuracy, and difficulty_label (Issue #414)."""
+        resp = client.post(
+            f"/api/assignments/{setup['assignment_id']}/start",
+            headers=auth_header(setup["student"]["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Core fields still present
+        assert "session_id" in data
+        assert "story_id" in data
+        assert "status" in data
+
+        # Reading goal fields (Issue #414)
+        assert "target_cpm" in data, "StartAssignmentResponse missing target_cpm"
+        assert "target_accuracy" in data, "StartAssignmentResponse missing target_accuracy"
+        assert "difficulty_label" in data, "StartAssignmentResponse missing difficulty_label"
+        assert "effective_cpm" in data, "StartAssignmentResponse missing effective_cpm"
+        assert "effective_accuracy" in data, "StartAssignmentResponse missing effective_accuracy"
+
+        assert data["target_cpm"] == 160
+        assert data["target_accuracy"] == 85.0
+        assert data["difficulty_label"] == "中級"
+        assert data["effective_cpm"] == 160
+        assert data["effective_accuracy"] == 85.0
+
+    def test_start_response_uses_defaults_when_no_goals_set(self, client, school_id):
+        """When teacher sets no reading goals, effective values use system defaults."""
+        teacher = _register_and_login(client, "rg414b_teacher")
+        student = _register_and_login(client, "rg414b_student")
+        _make_student_role(student["user_id"], school_id)
+
+        cls_resp = client.post(
+            "/api/classrooms",
+            headers=auth_header(teacher["token"]),
+            json={"name": "Reading Goals 414b Class", "school_id": school_id},
+        )
+        classroom_id = cls_resp.json()["id"]
+        client.post(
+            f"/api/classrooms/{classroom_id}/students",
+            headers=auth_header(teacher["token"]),
+            json={"student_id": student["user_id"]},
+        )
+        # Create assignment WITHOUT reading goals
+        asn_resp = client.post(
+            f"/api/classrooms/{classroom_id}/assignments",
+            headers=auth_header(teacher["token"]),
+            json={"classroom_id": classroom_id, "story_id": "1"},
+        )
+        assignment_id = asn_resp.json()["id"]
+
+        resp = client.post(
+            f"/api/assignments/{assignment_id}/start",
+            headers=auth_header(student["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # target fields should be null (not set by teacher)
+        assert data["target_cpm"] is None
+        assert data["target_accuracy"] is None
+        assert data["difficulty_label"] is None
+
+        # effective fields should use system defaults
+        from app.schemas.assignment import DEFAULT_TARGET_CPM, DEFAULT_TARGET_ACCURACY
+        assert data["effective_cpm"] == DEFAULT_TARGET_CPM
+        assert data["effective_accuracy"] == DEFAULT_TARGET_ACCURACY
+
+    def test_start_idempotent_still_returns_goals(self, client, setup):
+        """Second call to /start (idempotent path) must also return reading goals."""
+        # First call — creates session
+        client.post(
+            f"/api/assignments/{setup['assignment_id']}/start",
+            headers=auth_header(setup["student"]["token"]),
+        )
+        # Second call — idempotent
+        resp = client.post(
+            f"/api/assignments/{setup['assignment_id']}/start",
+            headers=auth_header(setup["student"]["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "effective_cpm" in data
+        assert data["effective_cpm"] == 160

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -31,6 +31,15 @@ const EMPTY_ATTEMPT: ReadingAttempt = {
   timestamp: 0,
 };
 
+/** Reading goals for an assignment session (Issue #414). */
+export interface AssignmentReadingGoals {
+  target_cpm: number | null;
+  target_accuracy: number | null;
+  difficulty_label: string | null;
+  effective_cpm: number;
+  effective_accuracy: number;
+}
+
 export interface LearningContext {
   selectedStory: Story | null;
   session: LearningSession | null;
@@ -52,6 +61,8 @@ export interface LearningContext {
   completedParagraphsSet: Set<number>;
   /** Notify layout that a paragraph was completed (Issue #85). */
   handleParagraphComplete: (paragraphIndex: number) => void;
+  /** Reading goals set by teacher for the active assignment (Issue #414). Null for free-play. */
+  assignmentReadingGoals: AssignmentReadingGoals | null;
 }
 
 /**
@@ -90,6 +101,15 @@ const LearningLayout: React.FC = () => {
   const [dbSessionId, setDbSessionId] = useState<number | null>(null);
   /** Progressive paragraph unlock tracking (Issue #85). */
   const [completedParagraphsSet, setCompletedParagraphsSet] = useState<Set<number>>(new Set());
+  /** Reading goals from the active assignment, loaded from sessionStorage (Issue #414). */
+  const [assignmentReadingGoals, setAssignmentReadingGoals] = useState<AssignmentReadingGoals | null>(() => {
+    try {
+      const raw = sessionStorage.getItem('activeAssignmentGoals');
+      return raw ? (JSON.parse(raw) as AssignmentReadingGoals) : null;
+    } catch {
+      return null;
+    }
+  });
   /** Whether the session idle-timeout warning modal is visible (Issue #408). */
   const [showTimeoutWarning, setShowTimeoutWarning] = useState(false);
   /** Ref to the idle-timer reset function so handleContinueLearning can call it. */
@@ -318,6 +338,7 @@ const LearningLayout: React.FC = () => {
       const assignmentId = parseInt(assignmentIdStr, 10);
       if (!isNaN(assignmentId)) {
         sessionStorage.removeItem('activeAssignmentId');
+        sessionStorage.removeItem('activeAssignmentGoals');
         // Fire-and-forget: best-effort auto-submit; errors are silent to avoid disrupting the report view.
         submitAssignment(token, assignmentId).catch((err) => {
           console.warn('[LearningLayout] Auto-submit assignment failed:', err);
@@ -388,6 +409,7 @@ const LearningLayout: React.FC = () => {
     dbSessionId,
     completedParagraphsSet,
     handleParagraphComplete,
+    assignmentReadingGoals,
   };
 
   return (

--- a/frontend/src/pages/learning/ReportPage.tsx
+++ b/frontend/src/pages/learning/ReportPage.tsx
@@ -8,7 +8,7 @@ import { reportSessionComplete } from '../../services/api';
 
 const ReportPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
-  const { selectedStory, session, handleRetry, handleSessionComplete, dbSessionId } = useLearningContext();
+  const { selectedStory, session, handleRetry, handleSessionComplete, dbSessionId, assignmentReadingGoals } = useLearningContext();
   const { user, token } = useAuth();
   const navigate = useNavigate();
 
@@ -72,6 +72,15 @@ const ReportPage: React.FC = () => {
         onGoToVocab={() => navigate(`/learn/${storyId}/vocab`)}
         dbSessionId={dbSessionId}
         token={token}
+        readingGoals={
+          assignmentReadingGoals
+            ? {
+                effectiveCpm: assignmentReadingGoals.effective_cpm,
+                effectiveAccuracy: assignmentReadingGoals.effective_accuracy,
+                difficultyLabel: assignmentReadingGoals.difficulty_label,
+              }
+            : undefined
+        }
       />
 
       {showXpToast && xpResult && (

--- a/frontend/src/pages/student/MyAssignments.tsx
+++ b/frontend/src/pages/student/MyAssignments.tsx
@@ -8,6 +8,7 @@ import {
   AssignmentApiError,
 } from '../../services/assignmentApi';
 import { loadActiveSession } from '../../services/api';
+import ReadingGoalsBadge from '../../components/ui/ReadingGoalsBadge';
 
 const STEP_NUMBER_TO_PATH: Record<number, string> = {
   1: 'intro',
@@ -76,6 +77,17 @@ const MyAssignments: React.FC = () => {
       const result = await startAssignment(token, assignmentId);
       // Store assignment ID in sessionStorage so LearningLayout can auto-submit on completion.
       sessionStorage.setItem('activeAssignmentId', String(assignmentId));
+      // Store reading goals so LearningLayout can pass them to AssessmentReport (Issue #414).
+      sessionStorage.setItem(
+        'activeAssignmentGoals',
+        JSON.stringify({
+          target_cpm: result.target_cpm,
+          target_accuracy: result.target_accuracy,
+          difficulty_label: result.difficulty_label,
+          effective_cpm: result.effective_cpm,
+          effective_accuracy: result.effective_accuracy,
+        }),
+      );
       // story_id is set for YAML texts; text_id for DB texts
       const textKey = result.story_id ?? String(result.text_id);
       navigate(`/learn/${textKey}/intro`);
@@ -151,6 +163,17 @@ const MyAssignments: React.FC = () => {
           onClick={() => {
             // Restore assignment ID so LearningLayout can auto-submit on completion.
             sessionStorage.setItem('activeAssignmentId', String(a.assignment_id));
+            // Restore reading goals so AssessmentReport can show goal comparison (Issue #414).
+            sessionStorage.setItem(
+              'activeAssignmentGoals',
+              JSON.stringify({
+                target_cpm: a.target_cpm,
+                target_accuracy: a.target_accuracy,
+                difficulty_label: a.difficulty_label,
+                effective_cpm: a.effective_cpm,
+                effective_accuracy: a.effective_accuracy,
+              }),
+            );
             // story_id is set for YAML texts; text_id for DB texts
             const textKey = a.story_id ?? a.text_id;
             // Resume from last saved step if available
@@ -300,6 +323,19 @@ const MyAssignments: React.FC = () => {
                           提交於 {formatDate(a.submitted_at)}
                         </span>
                       )}
+                    </div>
+
+                    {/* Reading goals badge (Issue #414) */}
+                    <div className="mt-2">
+                      <ReadingGoalsBadge
+                        goals={{
+                          effectiveCpm: a.effective_cpm,
+                          effectiveAccuracy: a.effective_accuracy,
+                          difficultyLabel: a.difficulty_label,
+                          isCustom: a.target_cpm != null || a.target_accuracy != null,
+                        }}
+                        variant="compact"
+                      />
                     </div>
 
                     {/* Issue #424: per-student teacher feedback */}

--- a/frontend/src/services/assignmentApi.ts
+++ b/frontend/src/services/assignmentApi.ts
@@ -85,6 +85,12 @@ export interface StartAssignmentResponse {
   story_id: string | null;
   text_id: number | null;
   status: string;
+  // Reading goals (Issue #414) — returned so student knows the target
+  target_cpm: number | null;
+  target_accuracy: number | null;
+  difficulty_label: string | null;
+  effective_cpm: number;
+  effective_accuracy: number;
 }
 
 // --- Error class ---


### PR DESCRIPTION
Fixes #414

## Summary
- **Backend**: `StartAssignmentResponse` now includes `target_cpm`, `target_accuracy`, `difficulty_label`, `effective_cpm`, `effective_accuracy` — student gets reading goals at assignment start (both new-session and idempotent paths)
- **Frontend**: `StartAssignmentResponse` type updated to include goal fields
- **Frontend**: `MyAssignments` stores goals to sessionStorage on start/resume and shows `ReadingGoalsBadge` on each assignment card so students see the target before starting
- **Frontend**: `LearningLayout` loads goals from sessionStorage into context (`assignmentReadingGoals`) and clears on session complete
- **Frontend**: `ReportPage` passes goals from context to `AssessmentReport` so `GoalAchievementCard` is displayed after completing an assignment

## Acceptance Criteria
- [x] 教師可為課文設定語速和正確率目標 (via existing `ReadingGoalsForm` in `AssignmentTab`)
- [x] 學生端能看到目標值 (`ReadingGoalsBadge` on MyAssignments card)
- [x] 練習結果有達標/未達標判斷 (`GoalAchievementCard` in AssessmentReport)

## Test plan
1. Teacher creates assignment with custom target (e.g. 160 CPM, 85% accuracy)
2. Student opens My Assignments — should see the goal badges on the card
3. Student starts/resumes the assignment and completes it
4. Student views the report — GoalAchievementCard should show pass/fail vs the teacher-set goals
5. Test with no goals set — should show default values (150 CPM, 90%)

## Changes
- `backend/app/schemas/assignment.py` — add goal fields to `StartAssignmentResponse`
- `backend/app/routes/assignments.py` — populate goal fields in both return paths of `/start`
- `backend/tests/test_assignments.py` — 3 new TDD tests
- `frontend/src/services/assignmentApi.ts` — add goal fields to `StartAssignmentResponse`
- `frontend/src/pages/student/MyAssignments.tsx` — show badge + persist goals to sessionStorage
- `frontend/src/layouts/LearningLayout.tsx` — load goals into context
- `frontend/src/pages/learning/ReportPage.tsx` — pass goals to AssessmentReport

🤖 Generated with [Claude Code](https://claude.ai/code)