### PR TITLE
fix: resolve ClassroomDetail 422 error on story slug lookup (#366)

### DIFF
--- a/backend/tests/test_stories_api.py
+++ b/backend/tests/test_stories_api.py
@@ -469,6 +469,24 @@ class TestGetStoryDetailEndpoint:
         assert "detail" in data
         assert data["detail"] == "Story not found"
 
+    def test_slug_format_returns_404_not_422(self, client):
+        """Legacy sessions stored slug-format story_slugs (e.g. 'long-gao-de-mi-mi-3').
+        The endpoint must return 404, not 422, so the frontend can handle it gracefully.
+        Regression test for #366.
+        """
+        resp = client.get("/api/stories/long-gao-de-mi-mi-3")
+        assert resp.status_code == 404
+
+    def test_slug_format_with_hyphens_returns_404(self, client):
+        """Another legacy slug format — must not crash with 422."""
+        resp = client.get("/api/stories/some-slug-title")
+        assert resp.status_code == 404
+
+    def test_alpha_only_id_returns_404_not_422(self, client):
+        """Purely alphabetic path params must return 404, not 422."""
+        resp = client.get("/api/stories/abc")
+        assert resp.status_code == 404
+
     def test_story_id_matches_lesson_number(self, client):
         resp = client.get("/api/stories/1")
         data = resp.json()


### PR DESCRIPTION
## Summary

- **Root cause**: Legacy `LearningSession` records stored slug-format `story_slug` values (e.g. `long-gao-de-mi-mi-3`) instead of numeric lesson numbers. When the frontend called `GET /api/stories/long-gao-de-mi-mi-3`, FastAPI's path-param type coercion (`int`) returned 422 instead of 404. This caused `Cannot read properties of null (reading 'submissions')` cascade in `AssignmentDetailPanel`.
- **Backend fix** (already in staging via `2c329f0`): `stories/{story_id}` parameter changed from `int` to `str`; manual `int()` parse now returns 404 for non-numeric slugs.
- **Frontend guards** (already in staging via `2c329f0`): `LearningHistory` hides "繼續" button for legacy slug sessions; `StudentProgress` redirects to `/library` for non-numeric slugs.
- **This PR adds**: Regression tests that lock the 404 behavior for slug-format IDs, preventing future regressions.

## Test plan

- [x] `test_slug_format_returns_404_not_422` — `GET /api/stories/long-gao-de-mi-mi-3` → 404
- [x] `test_slug_format_with_hyphens_returns_404` — hyphenated slug → 404
- [x] `test_alpha_only_id_returns_404_not_422` — alphabetic id → 404
- [x] All 80 existing `test_stories_api.py` tests pass
- [x] Frontend build passes

Closes #366

🤖 Generated with [Claude Code](https://claude.ai/claude-code)