### PR TITLE
feat: 教師端班級錯字熱力圖 (Fixes #403)

### DIFF
--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -192,6 +192,30 @@ class AtRiskStudentResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class ErrorHeatmapStudentEntry(BaseModel):
+    id: int
+    name: str
+
+    model_config = {"from_attributes": True}
+
+
+class ErrorHeatmapErrorEntry(BaseModel):
+    student_id: int
+    character: str
+    error_count: int
+
+    model_config = {"from_attributes": True}
+
+
+class ErrorHeatmapResponse(BaseModel):
+    """Student × character error matrix for classroom teachers."""
+    students: list[ErrorHeatmapStudentEntry]
+    characters: list[str]  # sorted by total error count desc
+    errors: list[ErrorHeatmapErrorEntry]  # only non-zero cells
+
+    model_config = {"from_attributes": True}
+
+
 # ── Endpoints ────────────────────────────────────────────────────────────────
 
 
@@ -486,6 +510,89 @@ def get_classroom_error_vocab(
         )
         for row in rows
     ]
+
+
+@router.get(
+    "/teacher/classrooms/{classroom_id}/error-heatmap",
+    response_model=ErrorHeatmapResponse,
+)
+def get_classroom_error_heatmap(
+    classroom_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get student × character error matrix for a classroom.
+
+    Returns all enrolled students, all characters that have at least one error,
+    and non-zero (student, character) error counts.  Characters are ordered by
+    total error count descending so the most problematic characters appear first.
+    """
+    _check_classroom_access(current_user, classroom_id, db)
+
+    # Get enrolled students in enrollment order
+    enrollments = (
+        db.query(ClassroomStudent)
+        .filter(ClassroomStudent.classroom_id == classroom_id)
+        .all()
+    )
+    if not enrollments:
+        return ErrorHeatmapResponse(students=[], characters=[], errors=[])
+
+    student_ids = [e.student_id for e in enrollments]
+    students_map = {e.student_id: e.student for e in enrollments}
+
+    # Query aggregated error counts: (student_id, character) → count
+    rows = (
+        db.query(
+            LearningSession.student_id,
+            CharacterError.character,
+            func.count(CharacterError.id).label("error_count"),
+        )
+        .join(CharacterError, CharacterError.session_id == LearningSession.id)
+        .filter(LearningSession.student_id.in_(student_ids))
+        .group_by(LearningSession.student_id, CharacterError.character)
+        .all()
+    )
+
+    if not rows:
+        students = [
+            ErrorHeatmapStudentEntry(id=s_id, name=students_map[s_id].name)
+            for s_id in student_ids
+        ]
+        return ErrorHeatmapResponse(students=students, characters=[], errors=[])
+
+    # Build character → total error count for ordering
+    char_totals: dict[str, int] = defaultdict(int)
+    for row in rows:
+        char_totals[row.character] += row.error_count
+
+    # Sort characters by total errors descending, then alphabetically for stability
+    sorted_characters = sorted(
+        char_totals.keys(),
+        key=lambda c: (-char_totals[c], c),
+    )
+
+    # Build student list in enrollment order
+    students = [
+        ErrorHeatmapStudentEntry(id=s_id, name=students_map[s_id].name)
+        for s_id in student_ids
+    ]
+
+    # Build error entries (only non-zero cells)
+    error_entries = [
+        ErrorHeatmapErrorEntry(
+            student_id=row.student_id,
+            character=row.character,
+            error_count=row.error_count,
+        )
+        for row in rows
+    ]
+
+    return ErrorHeatmapResponse(
+        students=students,
+        characters=sorted_characters,
+        errors=error_entries,
+    )
 
 
 @router.get(

--- a/backend/tests/test_error_heatmap.py
+++ b/backend/tests/test_error_heatmap.py
@@ -1,0 +1,367 @@
+"""
+Tests for GET /api/teacher/classrooms/{id}/error-heatmap endpoint.
+
+This endpoint returns a student × character error matrix, letting teachers
+see at a glance which students struggle with which characters.
+
+Response shape:
+  {
+    "students": [{"id": 1, "name": "..."}, ...],
+    "characters": ["字", "的", ...],
+    "errors": [{"student_id": 1, "character": "字", "error_count": 3}, ...]
+  }
+
+Run with:
+    cd backend && python -m pytest tests/test_error_heatmap.py -v
+"""
+
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+from app.models.school import School, Classroom, ClassroomStudent
+from app.models.session import LearningSession, CharacterError
+
+
+# ---------------------------------------------------------------------------
+# Test database setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        session.add(Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        ))
+    session.commit()
+
+
+def _seed_school(session) -> int:
+    school = School(name="Error Heatmap Test School")
+    session.add(school)
+    session.commit()
+    session.refresh(school)
+    return school.id
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+_test_school_id: int = 0
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    global _test_school_id
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    _test_school_id = _seed_school(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def school_id():
+    return _test_school_id
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _register_user(client, suffix: str) -> dict:
+    """Register a new user using dev-mode email verification flow."""
+    unique = uuid.uuid4().hex[:8]
+    email = f"eh_{suffix}_{unique}@example.com"
+    password = "SecurePass123!"
+    name = f"Eh {suffix.title()} {unique}"
+
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": name,
+    })
+    assert resp.status_code == 201, resp.text
+
+    verification_token = resp.json().get("verification_token")
+    assert verification_token is not None, "Expected dev-mode verification_token"
+    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+    assert verify_resp.status_code == 200, verify_resp.text
+
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    token = login_resp.json()["access_token"]
+
+    me_resp = client.get("/api/users/me", headers=auth_header(token))
+    assert me_resp.status_code == 200, me_resp.text
+
+    return {
+        "token": token,
+        "id": me_resp.json()["id"],
+        "email": email,
+        "name": name,
+    }
+
+
+def _seed_classroom(teacher_id: int, school_id: int, name: str = "Error Heatmap Class") -> int:
+    db = TestingSessionLocal()
+    classroom = Classroom(name=name, teacher_id=teacher_id, school_id=school_id)
+    db.add(classroom)
+    db.commit()
+    db.refresh(classroom)
+    cid = classroom.id
+    db.close()
+    return cid
+
+
+def _enroll_student(classroom_id: int, student_id: int):
+    db = TestingSessionLocal()
+    db.add(ClassroomStudent(classroom_id=classroom_id, student_id=student_id))
+    db.commit()
+    db.close()
+
+
+def _seed_character_errors(student_id: int, classroom_id: int, errors: list[tuple[str, str]]):
+    """errors: list of (character, error_type) tuples."""
+    db = TestingSessionLocal()
+    sess = LearningSession(
+        student_id=student_id,
+        classroom_id=classroom_id,
+        story_slug="test-story",
+        status="completed",
+    )
+    db.add(sess)
+    db.flush()
+    for character, error_type in errors:
+        db.add(CharacterError(session_id=sess.id, character=character, error_type=error_type))
+    db.commit()
+    db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def teacher(client):
+    return _register_user(client, "teacher")
+
+
+@pytest.fixture(scope="module")
+def other_teacher(client):
+    return _register_user(client, "other_teacher")
+
+
+@pytest.fixture(scope="module")
+def student_a(client):
+    return _register_user(client, "student_a")
+
+
+@pytest.fixture(scope="module")
+def student_b(client):
+    return _register_user(client, "student_b")
+
+
+@pytest.fixture(scope="module")
+def classroom(teacher, school_id):
+    return _seed_classroom(teacher["id"], school_id)
+
+
+@pytest.fixture(scope="module")
+def empty_classroom(teacher, school_id):
+    return _seed_classroom(teacher["id"], school_id, name="Empty Error Heatmap Class")
+
+
+@pytest.fixture(scope="module")
+def seeded_classroom(classroom, student_a, student_b):
+    """Classroom with enrolled students and character error data."""
+    _enroll_student(classroom, student_a["id"])
+    _enroll_student(classroom, student_b["id"])
+
+    # student_a errors: "字" x3, "的" x1
+    _seed_character_errors(student_a["id"], classroom, [
+        ("字", "stroke_order"),
+        ("字", "stroke_order"),
+        ("字", "wrong_character"),
+        ("的", "pronunciation"),
+    ])
+
+    # student_b errors: "字" x1, "學" x2
+    _seed_character_errors(student_b["id"], classroom, [
+        ("字", "stroke_order"),
+        ("學", "stroke_order"),
+        ("學", "wrong_character"),
+    ])
+
+    return classroom
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHeatmapEndpoint:
+    def test_returns_correct_structure(self, client, teacher, seeded_classroom):
+        """Response must have students, characters, errors keys."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{seeded_classroom}/error-heatmap",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "students" in data
+        assert "characters" in data
+        assert "errors" in data
+
+    def test_students_list(self, client, teacher, seeded_classroom, student_a, student_b):
+        """Both enrolled students with errors should appear."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{seeded_classroom}/error-heatmap",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        student_ids = [s["id"] for s in data["students"]]
+        assert student_a["id"] in student_ids
+        assert student_b["id"] in student_ids
+
+    def test_characters_list_contains_error_chars(self, client, teacher, seeded_classroom):
+        """Characters that had errors must appear in characters list."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{seeded_classroom}/error-heatmap",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        chars = data["characters"]
+        assert "字" in chars
+        assert "的" in chars
+        assert "學" in chars
+
+    def test_error_counts_aggregated_per_student_per_character(
+        self, client, teacher, seeded_classroom, student_a, student_b
+    ):
+        """student_a has 3 errors on '字'; student_b has 1 error on '字'."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{seeded_classroom}/error-heatmap",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        errors = data["errors"]
+
+        def get_count(student_id, character):
+            entry = next(
+                (e for e in errors if e["student_id"] == student_id and e["character"] == character),
+                None,
+            )
+            return entry["error_count"] if entry else 0
+
+        assert get_count(student_a["id"], "字") == 3
+        assert get_count(student_a["id"], "的") == 1
+        # student_a has no '學' errors — entry may be absent (count=0)
+        assert get_count(student_a["id"], "學") == 0
+
+        assert get_count(student_b["id"], "字") == 1
+        assert get_count(student_b["id"], "學") == 2
+        # student_b has no '的' errors — entry may be absent (count=0)
+        assert get_count(student_b["id"], "的") == 0
+
+    def test_characters_ordered_by_total_errors_descending(
+        self, client, teacher, seeded_classroom
+    ):
+        """Characters with most total errors should appear first."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{seeded_classroom}/error-heatmap",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        chars = data["characters"]
+        # '字' has 4 total errors (3+1), '學' has 2, '的' has 1
+        assert chars.index("字") < chars.index("學")
+        assert chars.index("學") < chars.index("的")
+
+    def test_empty_classroom_returns_empty_lists(self, client, teacher, empty_classroom):
+        """Empty classroom should return empty lists."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{empty_classroom}/error-heatmap",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["students"] == []
+        assert data["characters"] == []
+        assert data["errors"] == []
+
+    def test_unauthenticated_returns_401_or_403(self, client, seeded_classroom):
+        """No token should return 401 or 403."""
+        resp = client.get(f"/api/teacher/classrooms/{seeded_classroom}/error-heatmap")
+        assert resp.status_code in (401, 403)
+
+    def test_other_teacher_forbidden(self, client, other_teacher, seeded_classroom):
+        """Teacher who does not own the classroom should get 403."""
+        resp = client.get(
+            f"/api/teacher/classrooms/{seeded_classroom}/error-heatmap",
+            headers=auth_header(other_teacher["token"]),
+        )
+        assert resp.status_code == 403

--- a/frontend/src/components/teacher/ErrorHeatmapChart.tsx
+++ b/frontend/src/components/teacher/ErrorHeatmapChart.tsx
@@ -1,0 +1,118 @@
+/**
+ * ErrorHeatmapChart — student × character error frequency grid.
+ *
+ * Rows = students, Columns = characters (sorted by total errors desc).
+ * Cell color intensity = error count: white (0), light-orange (1-2),
+ * orange (3-4), deep-red (5+).
+ * Responsive: on small screens the table scrolls horizontally.
+ */
+
+import React from 'react';
+import { ClassroomErrorHeatmap } from '../../services/teacherApi';
+
+interface ErrorHeatmapChartProps {
+  data: ClassroomErrorHeatmap;
+}
+
+function getErrorColor(count: number): string {
+  if (count === 0) return 'bg-gray-100 text-gray-300';
+  if (count <= 2) return 'bg-orange-200 text-orange-800';
+  if (count <= 4) return 'bg-orange-400 text-white';
+  return 'bg-red-500 text-white';
+}
+
+const ErrorHeatmapChart: React.FC<ErrorHeatmapChartProps> = ({ data }) => {
+  const { students, characters, errors } = data;
+
+  if (students.length === 0 || characters.length === 0) {
+    return (
+      <div className="text-center py-8 text-gray-400 text-sm">
+        尚無錯字記錄可顯示
+      </div>
+    );
+  }
+
+  // Build lookup: "student_id:character" -> error_count
+  const errorMap = new Map<string, number>();
+  for (const entry of errors) {
+    errorMap.set(`${entry.student_id}:${entry.character}`, entry.error_count);
+  }
+
+  return (
+    <div className="overflow-auto max-h-[500px]">
+      <table className="min-w-full border-collapse text-xs">
+        <thead className="sticky top-0 bg-white z-10">
+          <tr>
+            {/* Student name column header */}
+            <th className="sticky left-0 bg-white z-20 px-3 py-2 text-left font-semibold text-gray-700 border-b border-r border-gray-200 min-w-[90px]">
+              學生
+            </th>
+            {characters.map((char) => (
+              <th
+                key={char}
+                className="px-1 py-2 font-medium text-gray-600 border-b border-gray-200 w-10 min-w-[40px] text-center"
+                title={char}
+              >
+                {char}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {students.map((student, rowIdx) => (
+            <tr
+              key={student.id}
+              className={rowIdx % 2 === 0 ? 'bg-white' : 'bg-gray-50'}
+            >
+              {/* Student name cell — sticky left */}
+              <td className="sticky left-0 bg-inherit px-3 py-1.5 text-gray-800 font-medium border-r border-gray-200 min-w-[90px] whitespace-nowrap">
+                {student.name}
+              </td>
+              {characters.map((char) => {
+                const count = errorMap.get(`${student.id}:${char}`) ?? 0;
+                const colorClass = getErrorColor(count);
+                const tooltip = count > 0
+                  ? `${student.name} / "${char}"：${count} 次錯誤`
+                  : `${student.name} / "${char}"：無錯誤`;
+
+                return (
+                  <td
+                    key={char}
+                    className="px-1 py-1 text-center"
+                    title={tooltip}
+                  >
+                    <span
+                      className={`inline-flex items-center justify-center w-8 h-7 rounded font-semibold ${colorClass}`}
+                    >
+                      {count > 0 ? count : ''}
+                    </span>
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Legend */}
+      <div className="flex items-center gap-4 mt-3 px-1 flex-wrap">
+        <span className="text-xs text-gray-500 font-medium">圖例：</span>
+        <LegendItem color="bg-gray-100 border border-gray-200 text-gray-300" label="無錯誤" />
+        <LegendItem color="bg-orange-200 text-orange-800" label="1-2 次" />
+        <LegendItem color="bg-orange-400 text-white" label="3-4 次" />
+        <LegendItem color="bg-red-500 text-white" label="5 次以上" />
+      </div>
+    </div>
+  );
+};
+
+function LegendItem({ color, label }: { color: string; label: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className={`inline-block w-5 h-4 rounded text-xs ${color}`} />
+      <span className="text-xs text-gray-500">{label}</span>
+    </div>
+  );
+}
+
+export default ErrorHeatmapChart;

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -17,14 +17,16 @@ import AssignmentTab from './AssignmentTab';
 import ClassroomAnalytics from './ClassroomAnalytics';
 import CrossTextAnalytics from './CrossTextAnalytics';
 import AtRiskStudents from '../../components/teacher/AtRiskStudents';
+import ErrorHeatmapTab from './ErrorHeatmapTab';
 
-type TabKey = 'progress' | 'texts' | 'my-texts' | 'assignments' | 'students' | 'analytics' | 'cross-text' | 'at-risk';
+type TabKey = 'progress' | 'texts' | 'my-texts' | 'assignments' | 'students' | 'analytics' | 'cross-text' | 'at-risk' | 'error-heatmap';
 
 const TABS: { key: TabKey; label: string }[] = [
   { key: 'progress', label: '學生進度' },
   { key: 'analytics', label: '學習分析' },
   { key: 'cross-text', label: '跨課文分析' },
   { key: 'at-risk', label: '早期介入' },
+  { key: 'error-heatmap', label: '錯字熱力圖' },
   { key: 'texts', label: '課文管理' },
   { key: 'my-texts', label: '我的課文' },
   { key: 'assignments', label: '作業管理' },
@@ -387,6 +389,10 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
 
           {activeTab === 'at-risk' && (
             <AtRiskStudents classroomId={classroomId} />
+          )}
+
+          {activeTab === 'error-heatmap' && (
+            <ErrorHeatmapTab classroomId={classroomId} />
           )}
 
           {activeTab === 'texts' && (

--- a/frontend/src/pages/teacher/ErrorHeatmapTab.tsx
+++ b/frontend/src/pages/teacher/ErrorHeatmapTab.tsx
@@ -1,0 +1,127 @@
+/**
+ * ErrorHeatmapTab — classroom tab showing which students struggle with
+ * which characters.
+ *
+ * Fetches from GET /api/teacher/classrooms/{id}/error-heatmap and renders
+ * an ErrorHeatmapChart plus a summary of the top problematic characters.
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  getClassroomErrorHeatmap,
+  ClassroomErrorHeatmap,
+  TeacherApiError,
+} from '../../services/teacherApi';
+import ErrorHeatmapChart from '../../components/teacher/ErrorHeatmapChart';
+
+interface ErrorHeatmapTabProps {
+  classroomId: number;
+}
+
+const ErrorHeatmapTab: React.FC<ErrorHeatmapTabProps> = ({ classroomId }) => {
+  const { token } = useAuth();
+  const [data, setData] = useState<ClassroomErrorHeatmap | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const loadData = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const heatmap = await getClassroomErrorHeatmap(token, classroomId);
+      setData(heatmap);
+    } catch (err) {
+      if (err instanceof TeacherApiError) {
+        setError(err.message);
+      } else {
+        setError('無法載入錯字分析資料');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, classroomId]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  if (isLoading) {
+    return (
+      <div className="p-6 space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-6 bg-gray-200 animate-pulse rounded w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3 flex items-center justify-between">
+          <span>{error}</span>
+          <button onClick={loadData} className="text-red-600 underline text-xs hover:text-red-800 cursor-pointer">
+            重試
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  // Compute top characters by total error count for summary
+  const charTotals: Record<string, number> = {};
+  for (const entry of data.errors) {
+    charTotals[entry.character] = (charTotals[entry.character] ?? 0) + entry.error_count;
+  }
+  const topChars = Object.entries(charTotals)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 5);
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div>
+        <h3 className="text-sm font-semibold text-gray-900">錯字熱力圖</h3>
+        <p className="text-xs text-gray-500 mt-0.5">
+          顏色越深表示該學生在該字的錯誤次數越多。欄位依全班錯誤次數由多至少排列。
+        </p>
+      </div>
+
+      {/* Summary cards — top problematic characters */}
+      {topChars.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-gray-600 mb-2">全班最常出錯的字</p>
+          <div className="flex flex-wrap gap-2">
+            {topChars.map(([char, total]) => (
+              <div
+                key={char}
+                className="flex items-center gap-1.5 bg-red-50 border border-red-200 rounded-lg px-3 py-1.5"
+              >
+                <span className="text-lg font-bold text-red-700 leading-none">{char}</span>
+                <span className="text-xs text-red-500">{total} 次</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Heatmap */}
+      <div className="rounded-lg border border-gray-200 overflow-hidden">
+        <ErrorHeatmapChart data={data} />
+      </div>
+
+      {/* Empty state hint when no errors recorded */}
+      {data.errors.length === 0 && data.students.length > 0 && (
+        <p className="text-sm text-gray-400 text-center py-4">
+          此班級尚未記錄任何錯字資料
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default ErrorHeatmapTab;

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -707,3 +707,34 @@ export async function listStoryTags(token: string): Promise<StoryTagData[]> {
   });
   return handleResponse<StoryTagData[]>(res);
 }
+
+// --- Error Heatmap types ---
+
+export interface ErrorHeatmapStudent {
+  id: number;
+  name: string;
+}
+
+export interface ErrorHeatmapError {
+  student_id: number;
+  character: string;
+  error_count: number;
+}
+
+export interface ClassroomErrorHeatmap {
+  students: ErrorHeatmapStudent[];
+  characters: string[];
+  errors: ErrorHeatmapError[];
+}
+
+/** Get student × character error heatmap for a classroom. */
+export async function getClassroomErrorHeatmap(
+  token: string,
+  classroomId: number,
+): Promise<ClassroomErrorHeatmap> {
+  const res = await fetch(
+    `${API_BASE}/api/teacher/classrooms/${classroomId}/error-heatmap`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  return handleResponse<ClassroomErrorHeatmap>(res);
+}


### PR DESCRIPTION
Fixes #403

## Summary

- **Backend**: New endpoint `GET /api/teacher/classrooms/{id}/error-heatmap` aggregates `CharacterError` records per (student, character) pair, returns a sparse matrix with characters sorted by total error count descending
- **Frontend**: `ErrorHeatmapChart` — CSS table grid (no heavy chart library), color intensity maps to error frequency (white → light-orange → orange → red). `ErrorHeatmapTab` wraps it with loading state and top-5 summary cards. New "錯字熱力圖" tab added to `ClassroomDetail`
- **Mobile**: table scrolls horizontally so it remains usable on small screens

## Test plan

- [ ] Backend: 8 unit tests in `backend/tests/test_error_heatmap.py` — all pass
- [ ] Frontend: build succeeds with no TypeScript errors
- [ ] Open ClassroomDetail for a classroom that has students with learning sessions containing character errors
- [ ] Click "錯字熱力圖" tab — verify grid appears with correct counts
- [ ] Verify empty classroom shows "尚無錯字記錄可顯示"
- [ ] Verify mobile layout scrolls horizontally

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)