### PR TITLE
feat: add three-level comprehension scoring to Socratic dialogue (Fixes #243)

### DIFF
--- a/backend/tests/test_comprehension_score.py
+++ b/backend/tests/test_comprehension_score.py
@@ -121,7 +121,11 @@ def client():
 
 
 def _register_user(client, suffix: str | None = None) -> dict:
-    """Register a user and return {email, password, token, name}."""
+    """Register a user, verify email (dev mode), login, and return {email, password, token, name}.
+
+    Updated for Issue #460: register no longer auto-verifies or returns an access token.
+    We use the verification_token returned in dev mode to verify, then login.
+    """
     unique = suffix or uuid.uuid4().hex[:8]
     email = f"comp_score_{unique}@example.com"
     password = "SecurePass123!"
@@ -132,11 +136,23 @@ def _register_user(client, suffix: str | None = None) -> dict:
         "name": name,
     })
     assert resp.status_code == 201, resp.text
+
+    # Verify email using the dev-mode verification_token
+    verification_token = resp.json()["verification_token"]
+    assert verification_token is not None
+    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+    assert verify_resp.status_code == 200, verify_resp.text
+
+    # Login to get a JWT access token
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    token = login_resp.json()["access_token"]
+
     return {
         "email": email,
         "password": password,
         "name": name,
-        "token": resp.json()["access_token"],
+        "token": token,
     }
 
 

--- a/frontend/src/pages/learning/ReportPage.tsx
+++ b/frontend/src/pages/learning/ReportPage.tsx
@@ -4,7 +4,12 @@ import AssessmentReport from '../../components/reading-steps/AssessmentReport';
 import XPAwardToast, { type XPAwardResult } from '../../components/gamification/XPAwardToast';
 import { useLearningContext } from '../../layouts/LearningLayout';
 import { useAuth } from '../../contexts/AuthContext';
-import { reportSessionComplete } from '../../services/api';
+import {
+  reportSessionComplete,
+  fetchDialogueHistory,
+  getComprehensionScore,
+  type ComprehensionScoreResult,
+} from '../../services/api';
 
 const ReportPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
@@ -14,6 +19,10 @@ const ReportPage: React.FC = () => {
 
   const [xpResult, setXpResult] = useState<XPAwardResult | null>(null);
   const [showXpToast, setShowXpToast] = useState(false);
+
+  // Three-level comprehension scores (Issue #243)
+  const [comprehensionScores, setComprehensionScores] = useState<ComprehensionScoreResult | null>(null);
+  const [comprehensionScoresLoading, setComprehensionScoresLoading] = useState(false);
 
   // Clear active session from localStorage when report is reached
   useEffect(() => {
@@ -58,6 +67,43 @@ const ReportPage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dbSessionId]);
 
+  // Fetch 3-level comprehension scores when dialogue data is available (Issue #243)
+  useEffect(() => {
+    if (!dbSessionId || !token || !selectedStory || !session?.comprehensionResult) return;
+
+    setComprehensionScoresLoading(true);
+    fetchDialogueHistory(token, dbSessionId)
+      .then((history) => {
+        if (!history.turns || history.turns.length === 0) {
+          setComprehensionScoresLoading(false);
+          return;
+        }
+        // Filter to only ai/student turns (exclude 'feedback' turns used for internal bookkeeping)
+        const dialogueTurns = history.turns
+          .filter((t) => t.role === 'ai' || t.role === 'student')
+          .map((t) => ({ role: t.role as 'ai' | 'student', text: t.text }));
+        // Join paragraph array into a single string for the AI evaluation prompt
+        const storyText = Array.isArray(selectedStory.content)
+          ? selectedStory.content.join('\n')
+          : (selectedStory.content as string);
+        return getComprehensionScore(token, dbSessionId, {
+          storyTitle: selectedStory.title,
+          storyText,
+          dialogueTurns,
+        });
+      })
+      .then((scores) => {
+        if (scores) setComprehensionScores(scores);
+      })
+      .catch((err: Error) => {
+        // Non-critical — AssessmentReport falls back to basic comprehension result
+        console.warn('Comprehension scoring failed (non-blocking):', err.message);
+      })
+      .finally(() => setComprehensionScoresLoading(false));
+  // Run once per report page load — dbSessionId is the stable identifier
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dbSessionId]);
+
   const handleDismissToast = useCallback(() => {
     setShowXpToast(false);
     setXpResult(null);
@@ -72,6 +118,8 @@ const ReportPage: React.FC = () => {
         onGoToVocab={() => navigate(`/learn/${storyId}/vocab`)}
         dbSessionId={dbSessionId}
         token={token}
+        comprehensionScores={comprehensionScores}
+        comprehensionScoresLoading={comprehensionScoresLoading}
         readingGoals={
           assignmentReadingGoals
             ? {


### PR DESCRIPTION
Fixes #243

## Summary

- **Backend** (already implemented in previous session): `evaluate_comprehension()` in `ai_service.py` uses Gemini to score 3 levels (字面/推論/評鑑) 0-100, weighted average for overall score; results cached in `LearningSession` DB columns; route `POST /api/learning/sessions/{id}/comprehension-score` returns all scores + feedback
- **Frontend wiring** (this PR): `ReportPage.tsx` now fetches dialogue history and calls the scoring API when the student completes comprehension dialogue; passes `comprehensionScores` + `comprehensionScoresLoading` props to `AssessmentReport`
- **Test fix**: `_register_user` helper in `test_comprehension_score.py` updated to use email-verification + login flow (regression from Issue #460 auth change); all 13 tests now pass

## Test plan

- [ ] Complete a full learning session with Socratic dialogue (ComprehensionChat step)
- [ ] Navigate to the report page
- [ ] Section 6 "課文理解力評估" should show a loading spinner then display:
  - Overall score circle (0-100)
  - Three bars: 字面理解 / 推論理解 / 評鑑理解 each with score + feedback text
- [ ] If dialogue was skipped, Section 6 should show "尚未完成課文理解對話"
- [ ] Backend tests: `cd backend && python -m pytest tests/test_comprehension_score.py -v` — all 13 should pass