### PR TITLE
feat: add CSV report export for classroom student progress (Fixes #235)

### DIFF
--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -17,7 +17,7 @@ from ..auth.dependencies import get_current_user
 from ..database import get_db
 from ..dependencies.tenant import _check_classroom_access
 from ..models.school import Classroom, ClassroomStudent, ClassroomText
-from ..models.session import CharacterError, LearningSession, DialogueTurn
+from ..models.session import CharacterError, ErrorCorrection, LearningSession, DialogueTurn
 from ..models.student_tag import StudentTag
 from ..models.story_tag import StoryTag
 from ..models.teacher_instruction import TeacherInstruction
@@ -30,6 +30,7 @@ from ..schemas.teacher_instruction import (
     InstructionUpdate,
 )
 from ..models.user import User
+from ..models.gamification import StudentXPLog, StudentStreak
 from ..services.lesson_loader import get_lesson_by_id
 from ..services.stuck_detection_service import build_recommendations, detect_stuck_points
 from ..services.prediction_service import predict_learning_difficulty
@@ -1072,7 +1073,11 @@ def export_classroom_report(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Export classroom student progress as a UTF-8 BOM CSV file."""
+    """Export classroom student progress as a UTF-8 BOM CSV file.
+
+    Columns: 學生姓名, 已完成課文數, 平均正確率, 平均語速(CPM), 總學習次數,
+             已掌握生字, 連續學習天數, 累積XP, 最近學習日期
+    """
     classroom = _check_classroom_access(current_user, classroom_id, db)
 
     enrollments = (
@@ -1083,6 +1088,7 @@ def export_classroom_report(
 
     # Batch-load all sessions for students in this classroom to avoid N+1 queries
     student_ids = [e.student_id for e in enrollments]
+
     all_sessions = (
         db.query(LearningSession)
         .filter(LearningSession.student_id.in_(student_ids))
@@ -1095,9 +1101,54 @@ def export_classroom_report(
     for s in all_sessions:
         sessions_by_student.setdefault(s.student_id, []).append(s)
 
+    # Batch-load XP totals (sum of xp_earned per student)
+    xp_rows = (
+        db.query(StudentXPLog.student_id, func.sum(StudentXPLog.xp_earned).label("total_xp"))
+        .filter(StudentXPLog.student_id.in_(student_ids))
+        .group_by(StudentXPLog.student_id)
+        .all()
+        if student_ids
+        else []
+    )
+    xp_by_student: dict[int, int] = {row.student_id: int(row.total_xp) for row in xp_rows}
+
+    # Batch-load current streaks
+    streak_rows = (
+        db.query(StudentStreak)
+        .filter(StudentStreak.student_id.in_(student_ids))
+        .all()
+        if student_ids
+        else []
+    )
+    streak_by_student: dict[int, int] = {row.student_id: row.current_streak for row in streak_rows}
+
+    # Batch-load mastered character counts
+    mastered_rows = (
+        db.query(ErrorCorrection.student_id, func.count(ErrorCorrection.id).label("cnt"))
+        .filter(
+            ErrorCorrection.student_id.in_(student_ids),
+            ErrorCorrection.correction_type == "mastered",
+        )
+        .group_by(ErrorCorrection.student_id)
+        .all()
+        if student_ids
+        else []
+    )
+    mastered_by_student: dict[int, int] = {row.student_id: int(row.cnt) for row in mastered_rows}
+
     output = io.StringIO()
     writer = csv.writer(output)
-    writer.writerow(["學生姓名", "已完成課文數", "平均正確率", "總學習次數", "最近學習日期"])
+    writer.writerow([
+        "學生姓名",
+        "已完成課文數",
+        "平均正確率",
+        "平均語速(CPM)",
+        "總學習次數",
+        "已掌握生字",
+        "連續學習天數",
+        "累積XP",
+        "最近學習日期",
+    ])
 
     for enrollment in enrollments:
         student = enrollment.student
@@ -1110,6 +1161,14 @@ def export_classroom_report(
         scores = [s.accuracy for s in sessions if s.accuracy is not None]
         avg_accuracy = f"{sum(scores) / len(scores):.1f}%" if scores else ""
 
+        # Average CPM from reading_result JSONB field
+        cpm_values = [
+            s.reading_result["cpm"]
+            for s in sessions
+            if s.reading_result and isinstance(s.reading_result, dict) and s.reading_result.get("cpm") is not None
+        ]
+        avg_cpm = f"{sum(cpm_values) / len(cpm_values):.0f}" if cpm_values else ""
+
         latest = max(sessions, key=lambda s: s.started_at, default=None)
         last_date = latest.started_at.strftime("%Y-%m-%d") if latest else ""
 
@@ -1117,7 +1176,11 @@ def export_classroom_report(
             _sanitize_csv_cell(student.name),
             completed_texts,
             avg_accuracy,
+            avg_cpm,
             total_sessions,
+            mastered_by_student.get(student.id, 0),
+            streak_by_student.get(student.id, 0),
+            xp_by_student.get(student.id, 0),
             last_date,
         ])
 

--- a/backend/tests/test_report_export.py
+++ b/backend/tests/test_report_export.py
@@ -331,7 +331,7 @@ class TestExportClassroomReport:
         assert student2["name"] in lines[1]
 
     def test_csv_has_expected_columns(self, client, teacher, school_id):
-        """CSV header must contain all required column names."""
+        """CSV header must contain all required column names including new gamification fields."""
         create_resp = client.post(
             "/api/classrooms",
             json={"name": "Columns Check Class", "school_id": school_id},
@@ -346,11 +346,17 @@ class TestExportClassroomReport:
         assert resp.status_code == 200
         content = resp.content.decode("utf-8-sig")
         header = content.splitlines()[0]
+        # Core progress columns
         assert "學生姓名" in header
         assert "已完成課文數" in header
         assert "平均正確率" in header
         assert "總學習次數" in header
         assert "最近學習日期" in header
+        # New gamification/performance columns (#235)
+        assert "平均語速(CPM)" in header
+        assert "已掌握生字" in header
+        assert "連續學習天數" in header
+        assert "累積XP" in header
 
     def test_requires_auth(self, client, teacher, school_id):
         create_resp = client.post(

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -5,6 +5,7 @@ import {
   updateClassroom,
   addStudent,
   removeStudent,
+  exportClassroomReport,
   ClassroomDetailResponse,
   StudentInClassroomResponse,
   ClassroomApiError,
@@ -59,6 +60,9 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
 
   // Toggle active loading
   const [isTogglingActive, setIsTogglingActive] = useState(false);
+
+  // Export CSV
+  const [isExporting, setIsExporting] = useState(false);
 
   // Remove confirmation
   const [removingStudentId, setRemovingStudentId] = useState<number | null>(null);
@@ -135,6 +139,14 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
     } finally {
       setIsTogglingActive(false);
     }
+  };
+
+  const handleExportCsv = () => {
+    if (!token || isExporting) return;
+    setIsExporting(true);
+    exportClassroomReport(token, classroomId);
+    // Reset after a short delay to re-enable the button
+    setTimeout(() => setIsExporting(false), 2000);
   };
 
   const handleAddStudent = async (e: React.FormEvent) => {
@@ -347,6 +359,15 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
                   }`}
                 >
                   {isTogglingActive ? '更新中...' : classroom.is_active ? '停用' : '啟用'}
+                </button>
+                <button
+                  onClick={handleExportCsv}
+                  disabled={isExporting}
+                  className={`px-3 py-1.5 rounded-lg border border-blue-300 text-blue-700 text-sm hover:bg-blue-50 transition-colors cursor-pointer ${
+                    isExporting ? 'opacity-50 cursor-not-allowed' : ''
+                  }`}
+                >
+                  {isExporting ? '匯出中...' : '匯出 CSV'}
                 </button>
               </div>
             </div>

--- a/frontend/src/services/classroomApi.ts
+++ b/frontend/src/services/classroomApi.ts
@@ -297,3 +297,28 @@ export function downloadCsvTemplate(token: string): void {
       URL.revokeObjectURL(blobUrl);
     });
 }
+
+// --- Export classroom report as CSV (#235) ---
+
+export function exportClassroomReport(token: string, classroomId: number): void {
+  const url = `${API_BASE}/api/teacher/classrooms/${classroomId}/export`;
+  fetch(url, { headers: { Authorization: `Bearer ${token}` } })
+    .then((res) => {
+      if (!res.ok) throw new Error(`Export failed: ${res.status}`);
+      return res.blob();
+    })
+    .then((blob) => {
+      const today = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+      const blobUrl = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = blobUrl;
+      a.download = `classroom-${classroomId}-report-${today}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(blobUrl);
+    })
+    .catch((err) => {
+      console.error('Failed to export classroom report:', err);
+    });
+}


### PR DESCRIPTION
Fixes #235

## Summary

- Extended `GET /api/teacher/classrooms/{id}/export` to include 4 new columns: 平均語速(CPM), 已掌握生字, 連續學習天數, 累積XP
- All gamification data loaded in batch (3 extra queries total) to avoid N+1 performance issues
- Added `exportClassroomReport()` function to `classroomApi.ts`
- Added "匯出 CSV" button to teacher ClassroomDetail page (alongside Edit/Enable-Disable buttons)
- Updated `test_report_export.py` to assert all 9 CSV column headers are present

## CSV columns (9 total)

| # | Column | Source |
|---|--------|--------|
| 1 | 學生姓名 | User.name |
| 2 | 已完成課文數 | completed LearningSession distinct story_slug count |
| 3 | 平均正確率 | avg(LearningSession.accuracy) |
| 4 | 平均語速(CPM) | avg(LearningSession.reading_result["cpm"]) |
| 5 | 總學習次數 | count(LearningSession) |
| 6 | 已掌握生字 | count(ErrorCorrection where type="mastered") |
| 7 | 連續學習天數 | StudentStreak.current_streak |
| 8 | 累積XP | sum(StudentXPLog.xp_earned) |
| 9 | 最近學習日期 | max(LearningSession.started_at) |

## Test plan

- [ ] Open teacher dashboard, navigate to a classroom
- [ ] Verify "匯出 CSV" button appears in top-right of classroom info card
- [ ] Click button — browser should download a .csv file
- [ ] Open CSV in Excel/Numbers — confirm UTF-8 BOM renders Chinese headers correctly
- [ ] Verify all 9 column headers are present
- [ ] Verify student rows contain correct data