### PR TITLE
feat: WCAG 2.1 AA compliance fixes — aria labels, focus styles, progressbars (Fixes #258)

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -147,7 +147,10 @@ const StepperNav: React.FC<StepperNavProps> = ({
             <button
               key={stepDef.view}
               onClick={() => { if (status !== 'disabled') handleNavigate(stepDef.view); }}
-              className="shrink-0 transition-colors"
+              disabled={status === 'disabled'}
+              aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${status === 'active' ? '目前' : status === 'completed' ? '已完成' : status === 'disabled' ? '未解鎖' : '未完成'}）`}
+              aria-current={status === 'active' ? 'step' : undefined}
+              className="shrink-0 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 rounded-full"
             >
               <StepCircle step={stepDef.step} status={status} size="sm" />
             </button>
@@ -157,7 +160,10 @@ const StepperNav: React.FC<StepperNavProps> = ({
         {/* Hamburger */}
         <button
           onClick={() => setMobileNavOpen(!mobileNavOpen)}
-          className="ml-1 p-1 rounded hover:bg-gray-100 transition-colors"
+          aria-label={mobileNavOpen ? '關閉導覽選單' : '展開導覽選單'}
+          aria-expanded={mobileNavOpen}
+          aria-haspopup="menu"
+          className="ml-1 p-1 rounded hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
         >
           <svg className="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
@@ -190,7 +196,8 @@ const StepperNav: React.FC<StepperNavProps> = ({
                     key={stepDef.view}
                     onClick={() => { if (!isDisabled) handleNavigate(stepDef.view); }}
                     disabled={isDisabled}
-                    className={`w-full text-left px-3 py-2 text-xs flex items-center gap-2 ${
+                    aria-current={isActive ? 'step' : undefined}
+                    className={`w-full text-left px-3 py-2 text-xs flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
                       isActive ? 'bg-accent/10 text-accent font-bold'
                       : isDisabled ? 'text-gray-300 cursor-not-allowed'
                       : 'text-gray-700 hover:bg-gray-50'
@@ -226,7 +233,8 @@ const StepperNav: React.FC<StepperNavProps> = ({
       {/* Home */}
       <button
         onClick={() => onNavigate(AppView.HOME)}
-        className={`px-2 py-1 rounded transition-colors ${
+        aria-current={currentView === AppView.HOME ? 'page' : undefined}
+        className={`px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
           currentView === AppView.HOME
             ? 'bg-accent text-white'
             : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
@@ -248,7 +256,10 @@ const StepperNav: React.FC<StepperNavProps> = ({
           <React.Fragment key={stepDef.view}>
             <button
               onClick={() => !isDisabled && onNavigate(stepDef.view)}
-              className={`flex items-center gap-1 px-2 py-1 rounded transition-colors ${
+              disabled={isDisabled}
+              aria-current={isActive ? 'step' : undefined}
+              aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${isActive ? '目前' : isDisabled ? '未解鎖' : status === 'completed' ? '已完成' : '未完成'}）`}
+              className={`flex items-center gap-1 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                 isActive
                   ? 'bg-accent text-white'
                   : isDisabled

--- a/frontend/src/components/reading-steps/DictationPractice.tsx
+++ b/frontend/src/components/reading-steps/DictationPractice.tsx
@@ -82,7 +82,14 @@ function speakText(text: string, rate = 0.85): Promise<void> {
 // ---- Sub-components ----
 
 const ProgressBar: React.FC<{ current: number; total: number }> = ({ current, total }) => (
-  <div className="w-full bg-gray-200 rounded-full h-1.5 mb-4">
+  <div
+    role="progressbar"
+    aria-valuenow={current}
+    aria-valuemin={1}
+    aria-valuemax={total}
+    aria-label={`聽寫進度：第 ${current} 題，共 ${total} 題`}
+    className="w-full bg-gray-200 rounded-full h-1.5 mb-4"
+  >
     <div
       className="bg-accent h-1.5 rounded-full transition-all duration-500"
       style={{ width: `${(current / total) * 100}%` }}
@@ -335,13 +342,14 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({ story, onFinish, 
             <button
               onClick={playCurrentWord}
               disabled={isSpeaking || !ttsSupported}
-              className={`w-24 h-24 rounded-full flex flex-col items-center justify-center gap-2 transition-all
+              aria-label={isSpeaking ? '正在播放詞語音頻' : '播放詞語音頻'}
+              aria-pressed={isSpeaking}
+              className={`w-24 h-24 rounded-full flex flex-col items-center justify-center gap-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
                 ${isSpeaking
                   ? 'bg-accent/10 border-2 border-accent scale-110'
                   : 'bg-gray-50 border-2 border-gray-200 hover:border-accent hover:bg-accent/5 active:scale-95'
                 }
               `}
-              title="重播音頻"
             >
               <SpeakerIcon animate={isSpeaking} />
               <span className="text-xs text-gray-500">{isSpeaking ? '播放中...' : '點我播放'}</span>
@@ -349,16 +357,18 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({ story, onFinish, 
 
             {/* Answer input */}
             <div className="w-full space-y-3">
-              <label className="block text-xs text-gray-500 font-medium text-center">
+              <label htmlFor="dictation-answer-input" className="block text-xs text-gray-500 font-medium text-center">
                 輸入你聽到的詞語
               </label>
               <input
+                id="dictation-answer-input"
                 ref={inputRef}
                 type="text"
                 value={answer}
                 onChange={(e) => setAnswer(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder="在此輸入..."
+                aria-label="聽寫答案輸入框，輸入你聽到的詞語，按 Enter 提交"
                 className="w-full text-center text-2xl font-bold py-4 px-4 rounded-xl border-2 border-gray-200 focus:border-accent focus:outline-none bg-white text-gray-900 placeholder-gray-300 transition-colors"
                 autoComplete="off"
                 autoCorrect="off"

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -419,36 +419,39 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
             <div className="space-y-2">
               <button
                 onClick={() => { setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); }}
-                className="w-full py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all active:scale-95"
+                aria-label="重新開始全文朗讀"
+                className="w-full py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
               >
                 再試一次
               </button>
               <button
                 onClick={() => onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript, cpm: result.cpm, durationMs: result.durationMs, errorBreakdown: result.errorBreakdown })}
-                className="w-full py-3 rounded-xl text-base font-bold bg-emerald-600 hover:bg-emerald-500 text-white transition-all flex items-center justify-center gap-2 active:scale-95"
+                aria-label="完成全文朗讀，查看學習報告"
+                className="w-full py-3 rounded-xl text-base font-bold bg-emerald-600 hover:bg-emerald-500 text-white transition-all flex items-center justify-center gap-2 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1"
               >
                 查看報告
-                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
                 </svg>
               </button>
             </div>
           ) : isPreparing ? (
-            <button disabled className="w-full py-3 rounded-xl text-base font-bold bg-gray-300 text-gray-500 cursor-wait flex items-center justify-center gap-2">
-              <div className="w-3 h-3 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+            <button disabled aria-label="正在準備語音辨識" aria-busy="true" className="w-full py-3 rounded-xl text-base font-bold bg-gray-300 text-gray-500 cursor-wait flex items-center justify-center gap-2">
+              <div className="w-3 h-3 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" aria-hidden="true" />
               準備中...
             </button>
           ) : isSessionActive ? (
             <button
               onClick={submitReading}
               disabled={!streamingTranscript}
-              className={`w-full py-3 rounded-xl text-base font-bold transition-all flex items-center justify-center gap-2 ${
+              aria-label={!streamingTranscript ? '請先開始朗讀' : '完成朗讀並送出'}
+              className={`w-full py-3 rounded-xl text-base font-bold transition-all flex items-center justify-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                 streamingTranscript
                   ? 'bg-emerald-600 hover:bg-emerald-500 text-white active:scale-95'
                   : 'bg-gray-300 text-gray-400 cursor-not-allowed'
               }`}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
               </svg>
               完成朗讀
@@ -458,13 +461,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
               {/* 暫停 / 繼續 */}
               <button
                 onClick={isTtsPaused ? resumeTts : pauseTts}
-                className={`flex-1 py-3 rounded-xl text-base font-bold transition-all flex items-center justify-center gap-1.5 active:scale-95 ${
+                aria-label={isTtsPaused ? '繼續系統朗讀' : '暫停系統朗讀'}
+                className={`flex-1 py-3 rounded-xl text-base font-bold transition-all flex items-center justify-center gap-1.5 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                   isTtsPaused
                     ? 'bg-emerald-700 hover:bg-emerald-600 text-white'
                     : 'bg-amber-700 hover:bg-amber-600 text-white'
                 }`}
               >
-                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   {isTtsPaused
                     ? <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
                     : <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 9v6m4-6v6" />
@@ -475,9 +479,10 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
               {/* 停止 */}
               <button
                 onClick={stopTts}
-                className="flex-1 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all flex items-center justify-center gap-1.5 active:scale-95"
+                aria-label="停止系統朗讀"
+                className="flex-1 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all flex items-center justify-center gap-1.5 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
               >
-                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 10h6v4H9z" />
                 </svg>
                 停止
@@ -487,18 +492,20 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
             <div className="flex gap-2">
               <button
                 onClick={speakFullStory}
-                className="flex-1 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all flex items-center justify-center gap-1.5 active:scale-95"
+                aria-label="播放全文系統示範朗讀"
+                className="flex-1 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all flex items-center justify-center gap-1.5 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
               >
-                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
                 </svg>
                 系統朗讀
               </button>
               <button
                 onClick={startSession}
-                className="flex-1 py-3 rounded-xl text-base font-bold bg-accent hover:bg-accent-hover text-white transition-all flex items-center justify-center gap-1.5 active:scale-95"
+                aria-label="開始全文朗讀，啟動語音辨識"
+                className="flex-1 py-3 rounded-xl text-base font-bold bg-accent hover:bg-accent-hover text-white transition-all flex items-center justify-center gap-1.5 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
               >
-                <div className="w-2.5 h-2.5 bg-white rounded-full" />
+                <div className="w-2.5 h-2.5 bg-white rounded-full" aria-hidden="true" />
                 開始朗讀
               </button>
             </div>
@@ -506,7 +513,8 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
           <button
             onClick={onBack}
-            className="w-full py-1.5 rounded-lg text-xs text-gray-400 hover:text-gray-600 transition-colors"
+            aria-label="返回生字練習"
+            className="w-full py-1.5 rounded-lg text-xs text-gray-400 hover:text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
           >
             ← 返回生字練習
           </button>

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -898,18 +898,21 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 {/* 系統朗讀 disabled while mic is initializing */}
                 <button
                   disabled
+                  aria-label="系統朗讀（準備中，暫不可用）"
                   className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-300 text-gray-500 cursor-not-allowed"
                 >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
                   </svg>
                   {processZhuyin('系統朗讀')}
                 </button>
                 <button
                   disabled
+                  aria-label="正在準備語音辨識"
+                  aria-busy="true"
                   className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-300 text-gray-600 cursor-wait"
                 >
-                  <div className="w-3 h-3 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
+                  <div className="w-3 h-3 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" aria-hidden="true" />
                   {processZhuyin('準備中...')}
                 </button>
               </>
@@ -917,13 +920,14 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               <button
                 onClick={submitSentence}
                 disabled={isAdvancing || !streamingUserInput}
+                aria-label={isAdvancing ? '請稍候，正在處理' : '完成這段朗讀'}
                 className={`flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 transition-all shadow active:scale-95 ${
                   isAdvancing || !streamingUserInput
                     ? 'bg-gray-300 text-gray-400 cursor-not-allowed opacity-50'
                     : 'bg-emerald-600 hover:bg-emerald-500 text-white'
                 }`}
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
                 </svg>
                 {processZhuyin(isAdvancing ? '請稍候...' : '完成這段')}
@@ -933,13 +937,14 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 {/* 暫停 / 繼續 */}
                 <button
                   onClick={isTtsPaused ? resumeTts : pauseTts}
+                  aria-label={isTtsPaused ? '繼續系統朗讀' : '暫停系統朗讀'}
                   className={`flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 transition-all shadow active:scale-95 ${
                     isTtsPaused
                       ? 'bg-emerald-700 hover:bg-emerald-600 text-white'
                       : 'bg-amber-700 hover:bg-amber-600 text-white'
                   }`}
                 >
-                  <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     {isTtsPaused
                       ? <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
                       : <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 9v6m4-6v6" />
@@ -950,9 +955,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 {/* 停止 */}
                 <button
                   onClick={stopTts}
+                  aria-label="停止系統朗讀"
                   className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all shadow active:scale-95"
                 >
-                  <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 10h6v4H9z" />
                   </svg>
                   {processZhuyin('停止')}
@@ -963,9 +969,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 {/* 系統朗讀 */}
                 <button
                   onClick={speakCurrentParagraph}
-                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all shadow active:scale-95"
+                  aria-label="播放這段的系統示範朗讀"
+                  className="flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all shadow active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
                 >
-                  <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
                   </svg>
                   {processZhuyin('系統朗讀')}
@@ -974,13 +981,14 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 <button
                   onClick={startSession}
                   disabled={isAdvancing}
-                  className={`flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 transition-all shadow active:scale-95 ${
+                  aria-label={isAdvancing ? '請稍候，正在處理' : '開始朗讀這段，啟動語音辨識'}
+                  className={`flex-1 py-3 rounded-xl font-bold text-base flex items-center justify-center gap-2 transition-all shadow active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                     isAdvancing
                       ? 'bg-gray-300 text-gray-400 cursor-not-allowed opacity-50'
                       : 'bg-accent hover:bg-accent-hover text-white'
                   }`}
                 >
-                  <div className="w-2.5 h-2.5 bg-white rounded-full" />
+                  <div className="w-2.5 h-2.5 bg-white rounded-full" aria-hidden="true" />
                   {processZhuyin(isAdvancing ? '請稍候...' : '開始朗讀')}
                 </button>
               </>
@@ -991,8 +999,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           <div className="border-t border-gray-100 pt-2">
             <button
               onClick={() => setShowRecorder(prev => !prev)}
-              className="w-full flex items-center justify-between px-2 py-1 text-xs text-gray-400 hover:text-gray-600 transition-colors"
+              aria-label={showRecorder ? '收起錄音重聽功能' : '展開錄音重聽功能'}
               aria-expanded={showRecorder}
+              aria-controls="recorder-panel"
+              className="w-full flex items-center justify-between px-2 py-1 text-xs text-gray-400 hover:text-gray-600 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 rounded"
             >
               <span className="flex items-center gap-1">
                 <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
@@ -1008,7 +1018,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               </svg>
             </button>
             {showRecorder && (
-              <div className="pt-2 pb-1">
+              <div id="recorder-panel" className="pt-2 pb-1">
                 <RecordingButton maxDurationSeconds={60} label="錄下這段朗讀，完成後可重聽" />
               </div>
             )}
@@ -1025,7 +1035,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                 }
               }}
               disabled={currentLineIndex === 0}
-              className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${
+              aria-label={currentLineIndex === 0 ? '已是第一段' : `返回第 ${currentLineIndex} 段`}
+              className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                 zhuyinActive ? 'tracking-[0.2em]' : ''
               } ${
                 currentLineIndex === 0
@@ -1048,8 +1059,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                   <button
                     onClick={handleFinish}
                     disabled={!allDone}
-                    title={!allDone ? '完成所有段落後才能查看報告' : undefined}
-                    className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''} ${
+                    aria-label={!allDone ? '請完成所有段落後查看總結報告' : '查看朗讀總結報告'}
+                    className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${zhuyinActive ? 'tracking-[0.2em]' : ''} ${
                       allDone
                         ? 'bg-emerald-600 hover:bg-emerald-500 text-white'
                         : 'bg-gray-300 text-gray-300 cursor-not-allowed'
@@ -1070,8 +1081,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                     }
                   }}
                   disabled={!nextUnlocked}
-                  title={!nextUnlocked ? '請先完成此段朗讀（正確率需達 60%）' : undefined}
-                  className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''} ${
+                  aria-label={!nextUnlocked ? '請先完成此段朗讀才能繼續（正確率需達 60%）' : `前往第 ${currentLineIndex + 2} 段`}
+                  className={`flex-1 py-3 rounded-lg text-base font-bold border border-gray-200 leading-[2.6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${zhuyinActive ? 'tracking-[0.2em]' : ''} ${
                     nextUnlocked
                       ? 'bg-gray-300 hover:bg-gray-200 text-gray-600'
                       : 'bg-gray-300 text-gray-300 cursor-not-allowed'
@@ -1086,7 +1097,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           {isSessionActive && (
             <button
               onClick={stopSession}
-              className={`w-full py-1.5 rounded-lg text-base font-bold text-gray-400 hover:text-gray-600 transition-colors leading-[2.6] ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}
+              aria-label="停止目前的朗讀練習"
+              className={`w-full py-1.5 rounded-lg text-base font-bold text-gray-400 hover:text-gray-600 transition-colors leading-[2.6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${zhuyinActive ? 'tracking-[0.2em]' : ''}`}
             >
               {processZhuyin('停止朗讀')}
             </button>

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -39,10 +39,17 @@ function ProgressBar({ done, total }: ProgressBarProps) {
     <div className="w-full px-6 py-2 bg-white border-b border-gray-100">
       <div className="max-w-2xl mx-auto">
         <div className="flex justify-between items-center mb-1">
-          <span className="text-[10px] font-medium text-gray-500">練習進度</span>
-          <span className="text-[10px] font-bold text-gray-700">{done} / {total} 字</span>
+          <span className="text-[10px] font-medium text-gray-500" aria-hidden="true">練習進度</span>
+          <span className="text-[10px] font-bold text-gray-700" aria-hidden="true">{done} / {total} 字</span>
         </div>
-        <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+        <div
+          role="progressbar"
+          aria-valuenow={done}
+          aria-valuemin={0}
+          aria-valuemax={total}
+          aria-label={`生字練習進度：已完成 ${done} 個，共 ${total} 個`}
+          className="h-2 bg-gray-100 rounded-full overflow-hidden"
+        >
           <div
             className="h-full bg-emerald-500 rounded-full transition-all duration-500 ease-out"
             style={{ width: `${pct}%` }}

--- a/frontend/src/components/reading-steps/ZhuyinPhoneticGame.tsx
+++ b/frontend/src/components/reading-steps/ZhuyinPhoneticGame.tsx
@@ -110,8 +110,8 @@ function buildChoices(correct: string, pool: string[], count = 4): string[] {
 
 function LoadingState() {
   return (
-    <div className="flex-1 flex flex-col items-center justify-center py-12 gap-4">
-      <div className="w-10 h-10 border-4 border-indigo-200 border-t-indigo-500 rounded-full animate-spin" />
+    <div className="flex-1 flex flex-col items-center justify-center py-12 gap-4" role="status" aria-label="載入注音資料中">
+      <div className="w-10 h-10 border-4 border-indigo-200 border-t-indigo-500 rounded-full animate-spin" aria-hidden="true" />
       <p className="text-sm text-gray-500">載入注音資料中…</p>
     </div>
   );
@@ -304,17 +304,28 @@ function PickGame({ mode, questions, onFinish, onBack }: PickGameProps) {
     <div className="flex-1 flex flex-col bg-indigo-50">
       {/* Header */}
       <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-2 shrink-0">
-        <button onClick={onBack} className="text-gray-400 hover:text-gray-700 transition-colors p-1">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <button
+          onClick={onBack}
+          aria-label="返回生字練習"
+          className="text-gray-400 hover:text-gray-700 transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
           </svg>
         </button>
         <span className="text-xs text-gray-700 font-semibold flex-1">選{modeLabel}練習</span>
-        <span className="text-xs text-gray-400">{progress}</span>
+        <span className="text-xs text-gray-400" aria-label={`第 ${qIdx + 1} 題，共 ${questions.length} 題`}>{progress}</span>
       </div>
 
       {/* Progress bar */}
-      <div className="w-full h-1.5 bg-gray-200">
+      <div
+        role="progressbar"
+        aria-valuenow={qIdx + 1}
+        aria-valuemin={1}
+        aria-valuemax={questions.length}
+        aria-label={`練習進度：第 ${qIdx + 1} 題，共 ${questions.length} 題`}
+        className="w-full h-1.5 bg-gray-200"
+      >
         <div
           className="h-full bg-indigo-500 transition-all duration-500"
           style={{ width: `${((qIdx) / questions.length) * 100}%` }}
@@ -367,6 +378,8 @@ function PickGame({ mode, questions, onFinish, onBack }: PickGameProps) {
                 key={choice}
                 onClick={() => handleChoice(choice)}
                 disabled={answerState !== 'idle'}
+                aria-label={`選擇 ${choice}${answerState !== 'idle' && isCorrectChoice ? '（正確答案）' : answerState !== 'idle' && isSelected && !isCorrectChoice ? '（答錯）' : ''}`}
+                aria-pressed={isSelected ? true : undefined}
                 className={btnClass}
               >
                 {choice}
@@ -462,17 +475,28 @@ function ComposeGame({ questions, onFinish, onBack }: ComposeGameProps) {
     <div className="flex-1 flex flex-col bg-indigo-50">
       {/* Header */}
       <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-2 shrink-0">
-        <button onClick={onBack} className="text-gray-400 hover:text-gray-700 transition-colors p-1">
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <button
+          onClick={onBack}
+          aria-label="返回生字練習"
+          className="text-gray-400 hover:text-gray-700 transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
           </svg>
         </button>
         <span className="text-xs text-gray-700 font-semibold flex-1">拼音合成練習</span>
-        <span className="text-xs text-gray-400">{progress}</span>
+        <span className="text-xs text-gray-400" aria-label={`第 ${qIdx + 1} 題，共 ${questions.length} 題`}>{progress}</span>
       </div>
 
       {/* Progress bar */}
-      <div className="w-full h-1.5 bg-gray-200">
+      <div
+        role="progressbar"
+        aria-valuenow={qIdx + 1}
+        aria-valuemin={1}
+        aria-valuemax={questions.length}
+        aria-label={`練習進度：第 ${qIdx + 1} 題，共 ${questions.length} 題`}
+        className="w-full h-1.5 bg-gray-200"
+      >
         <div
           className="h-full bg-indigo-500 transition-all duration-500"
           style={{ width: `${(qIdx / questions.length) * 100}%` }}

--- a/frontend/src/components/recording/RecordingButton.tsx
+++ b/frontend/src/components/recording/RecordingButton.tsx
@@ -83,9 +83,11 @@ const RecordingButton: React.FC<RecordingButtonProps> = ({
         {isRequesting && (
           <button
             disabled
+            aria-label="等待麥克風授權"
+            aria-busy="true"
             className="flex items-center gap-2 px-4 py-2 rounded-full bg-gray-400 text-white font-semibold text-sm shadow cursor-not-allowed"
           >
-            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+            <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
               <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
               <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
             </svg>
@@ -109,13 +111,14 @@ const RecordingButton: React.FC<RecordingButtonProps> = ({
 
         {/* Recording status indicator */}
         {isRecording && (
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2" role="status" aria-label={`錄音中，已錄 ${formatTime(elapsedSeconds)}`}>
             {/* Pulsing red dot */}
-            <span className="relative flex h-3 w-3">
+            <span className="relative flex h-3 w-3" aria-hidden="true">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
               <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500" />
             </span>
             <span
+              aria-hidden="true"
               className={`text-sm font-mono font-semibold tabular-nums ${
                 urgentCountdown ? 'text-red-600' : warningCountdown ? 'text-orange-500' : 'text-gray-700'
               }`}
@@ -128,6 +131,9 @@ const RecordingButton: React.FC<RecordingButtonProps> = ({
         {/* Countdown warning when recording */}
         {(urgentCountdown || warningCountdown) && (
           <span
+            role="timer"
+            aria-label={`剩餘錄音時間 ${formatTime(remainingSeconds)}`}
+            aria-live="polite"
             className={`text-xs font-medium px-2 py-0.5 rounded-full ${
               urgentCountdown
                 ? 'bg-red-100 text-red-700'


### PR DESCRIPTION
Fixes #258

## Summary

- **StepperNav**: Added `aria-label` + `aria-current` to step buttons (mobile + desktop), `aria-label`/`aria-expanded`/`aria-haspopup` to hamburger, `focus-visible:ring` to all nav buttons
- **RecordingButton**: `aria-label`/`aria-busy` on requesting state button; `role=status` + `aria-label` on recording timer; `role=timer` + `aria-live` on countdown warning
- **DictationPractice**: `role=progressbar` + `aria-value*` on progress bar; replaced `title` with proper `aria-label` on speaker button; `id` + `aria-label` on answer input for correct label association
- **ZhuyinPhoneticGame**: `role=status` on loading spinner; `aria-label` + focus rings on back buttons; `role=progressbar` + `aria-value*` on both game progress bars; `aria-label` + `aria-pressed` on choice answer buttons
- **VocabPractice**: `role=progressbar` + `aria-value*` + `aria-label` on practice progress bar
- **LiveTutor**: `aria-label` on all TTS controls (系統朗讀/暫停/停止/繼續/開始朗讀/完成這段); `aria-busy` on preparing spinners; `aria-label`/`aria-controls` on recorder accordion; descriptive `aria-label` on 上一段/下一段 buttons; focus rings on primary action buttons
- **FullReading**: `aria-label` on all TTS/session buttons; `aria-busy` on preparing state; `aria-hidden` on decorative SVG dots; focus rings on all interactive buttons

## What was already in place (no changes needed)

- Global `focus-visible` ring in `index.css` (WCAG 2.4.7)
- Skip-to-content link in `App.tsx` (WCAG 2.4.1)
- `prefers-reduced-motion` in CSS (WCAG 2.3.3)
- `Header`, `Sidebar`, `ComprehensionChat` — already had good accessibility

## Test plan

- [ ] Tab through the learning flow steps — each step button should show focus ring and announce name + status to screen reader
- [ ] Tab to hamburger button on mobile — should announce "展開導覽選單"
- [ ] In DictationPractice, speaker button should announce "播放詞語音頻" to screen reader
- [ ] In ZhuyinPhoneticGame, progress bar should announce current/total questions
- [ ] In LiveTutor, TTS buttons should announce their full action (not just icon)
- [ ] Recording countdown should be announced via `aria-live`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)