### PR TITLE
feat: add repeated error detection and vocabulary recommendations (Fixes #248)

### DIFF
--- a/backend/app/routes/learning.py
+++ b/backend/app/routes/learning.py
@@ -165,7 +165,12 @@ def update_session(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Update learning session progress (must be own session)."""
+    """Update learning session progress (must be own session).
+
+    When reading_result contains error_chars, automatically creates CharacterError
+    rows so that the error-patterns and recommended-vocab endpoints return real data
+    (Issue #248: repeated error detection).
+    """
     session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -175,6 +180,26 @@ def update_session(
     update_data = payload.model_dump(exclude_unset=True)
     for field, value in update_data.items():
         setattr(session, field, value)
+
+    # Auto-persist CharacterError records from reading_result.error_chars (Issue #248)
+    if "reading_result" in update_data:
+        reading_result = update_data["reading_result"] or {}
+        error_chars = reading_result.get("error_chars", [])
+        if isinstance(error_chars, list) and error_chars:
+            # Delete any existing CharacterError rows for this session to avoid duplicates
+            # when the client patches reading_result more than once.
+            db.query(CharacterError).filter(CharacterError.session_id == session_id).delete()
+            for char in error_chars:
+                if isinstance(char, str) and char.strip():
+                    db.add(CharacterError(
+                        session_id=session_id,
+                        character=char.strip(),
+                        error_type="reading",
+                    ))
+            logger.info(
+                "Persisted %d CharacterError rows for session %d",
+                len(error_chars), session_id,
+            )
 
     db.commit()
     db.refresh(session)
@@ -984,6 +1009,71 @@ def mark_error_corrected(
         student_id, payload.character, payload.correction_type,
     )
     return correction
+
+
+class RepeatedErrorAlertItem(BaseModel):
+    character: str
+    error_count: int
+
+
+class RepeatedErrorAlertResponse(BaseModel):
+    alerts: list[RepeatedErrorAlertItem]
+    total: int
+
+
+REPEATED_ERROR_THRESHOLD = 3  # characters wrong ≥ this many times trigger a modal
+
+
+@router.get(
+    "/learning/students/{student_id}/repeated-errors-alert",
+    response_model=RepeatedErrorAlertResponse,
+)
+def get_repeated_errors_alert(
+    student_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return characters that have reached the ≥3 repeated-error threshold.
+
+    Used by the frontend to show the post-session modal:
+    「這個字你讀錯 3 次了，建議加強生字練習」
+
+    Characters already marked as mastered are excluded.
+    Results sorted by error_count descending.
+    """
+    _verify_student_access(student_id, current_user, db)
+
+    mastered_chars: set[str] = set()
+    for row in (
+        db.query(ErrorCorrection.character)
+        .filter(
+            ErrorCorrection.student_id == student_id,
+            ErrorCorrection.correction_type == "mastered",
+        )
+        .all()
+    ):
+        mastered_chars.add(row.character)
+
+    rows = (
+        db.query(
+            CharacterError.character,
+            sa_func.count(CharacterError.id).label("error_count"),
+        )
+        .join(LearningSession, CharacterError.session_id == LearningSession.id)
+        .filter(LearningSession.student_id == student_id)
+        .group_by(CharacterError.character)
+        .having(sa_func.count(CharacterError.id) >= REPEATED_ERROR_THRESHOLD)
+        .order_by(sa_func.count(CharacterError.id).desc())
+        .all()
+    )
+
+    alerts = [
+        RepeatedErrorAlertItem(character=row.character, error_count=row.error_count)
+        for row in rows
+        if row.character not in mastered_chars
+    ]
+
+    return RepeatedErrorAlertResponse(alerts=alerts, total=len(alerts))
 
 
 # ── Stuck-Point Detection (Issue #91) ─────────────────────────────────────────

--- a/backend/tests/test_error_correction.py
+++ b/backend/tests/test_error_correction.py
@@ -627,4 +627,237 @@ class TestErrorPatternsStoryFilter:
         )
         data = resp.json()
         assert data["total"] == 0
-        assert data["patterns"] == []
+
+
+# ===========================================================================
+# Auto-persist CharacterErrors when PATCH /sessions/{id} saves reading_result
+# (Issue #248 — ensure error_chars in reading_result become CharacterError rows)
+# ===========================================================================
+
+class TestAutoCharacterErrorPersist:
+    """When reading_result (containing error_chars) is saved via PATCH /sessions/{id},
+    the backend must automatically create CharacterError records so that the
+    error-patterns and recommended-vocab endpoints return real data.
+    """
+
+    def test_patch_with_reading_result_creates_character_errors(self, client, student_a):
+        """CharacterError rows are created when reading_result.error_chars is saved."""
+        # Create a session
+        session_resp = client.post(
+            "/api/learning/sessions",
+            json={"story_slug": "auto-persist-test"},
+            headers=auth_header(student_a["token"]),
+        )
+        assert session_resp.status_code == 201, session_resp.text
+        session_id = session_resp.json()["id"]
+
+        # Patch with reading_result containing error_chars
+        patch_resp = client.patch(
+            f"/api/learning/sessions/{session_id}",
+            json={
+                "reading_result": {
+                    "match_rate": 75.0,
+                    "error_chars": ["水", "火"],
+                    "cpm": 120,
+                },
+            },
+            headers=auth_header(student_a["token"]),
+        )
+        assert patch_resp.status_code == 200, patch_resp.text
+
+        # Now the error-patterns endpoint should see these characters
+        patterns_resp = client.get(
+            f"/api/learning/students/{student_a['id']}/error-patterns?story_slug=auto-persist-test",
+            headers=auth_header(student_a["token"]),
+        )
+        assert patterns_resp.status_code == 200, patterns_resp.text
+        chars = [p["character"] for p in patterns_resp.json()["patterns"]]
+        assert "水" in chars
+        assert "火" in chars
+
+    def test_patch_without_error_chars_does_not_create_records(self, client, student_a):
+        """PATCH with reading_result but no error_chars should not create CharacterError rows."""
+        db = TestingSessionLocal()
+        try:
+            before_count = db.query(CharacterError).count()
+        finally:
+            db.close()
+
+        session_resp = client.post(
+            "/api/learning/sessions",
+            json={"story_slug": "no-errors-test"},
+            headers=auth_header(student_a["token"]),
+        )
+        session_id = session_resp.json()["id"]
+
+        client.patch(
+            f"/api/learning/sessions/{session_id}",
+            json={"reading_result": {"match_rate": 95.0, "error_chars": [], "cpm": 150}},
+            headers=auth_header(student_a["token"]),
+        )
+
+        db = TestingSessionLocal()
+        try:
+            after_count = db.query(CharacterError).count()
+        finally:
+            db.close()
+
+        assert after_count == before_count
+
+    def test_patch_without_reading_result_does_not_create_records(self, client, student_a):
+        """PATCH that does not include reading_result should not create CharacterError rows."""
+        db = TestingSessionLocal()
+        try:
+            before_count = db.query(CharacterError).count()
+        finally:
+            db.close()
+
+        session_resp = client.post(
+            "/api/learning/sessions",
+            json={"story_slug": "no-reading-result-test"},
+            headers=auth_header(student_a["token"]),
+        )
+        session_id = session_resp.json()["id"]
+
+        client.patch(
+            f"/api/learning/sessions/{session_id}",
+            json={"current_step": 2},
+            headers=auth_header(student_a["token"]),
+        )
+
+        db = TestingSessionLocal()
+        try:
+            after_count = db.query(CharacterError).count()
+        finally:
+            db.close()
+
+        assert after_count == before_count
+
+
+# ===========================================================================
+# GET /api/learning/students/{id}/repeated-errors-alert
+# Returns characters that have hit the ≥3 error threshold (Issue #248 modal)
+# ===========================================================================
+
+@pytest.fixture(scope="module")
+def alert_user_high(client):
+    """Isolated user with ≥3 repeated errors for alert tests."""
+    user = _register_user(client, "alert_high")
+    db = TestingSessionLocal()
+    try:
+        # '月' in 3 sessions (threshold reached), '日' in 2 sessions (below threshold)
+        _create_session_with_errors(db, user["id"], ["月", "日"])
+        _create_session_with_errors(db, user["id"], ["月", "日"])
+        _create_session_with_errors(db, user["id"], ["月"])
+    finally:
+        db.close()
+    return user
+
+
+@pytest.fixture(scope="module")
+def alert_user_low(client):
+    """Isolated user with only 1 error per character — should have no alerts."""
+    user = _register_user(client, "alert_low")
+    db = TestingSessionLocal()
+    try:
+        _create_session_with_errors(db, user["id"], ["木", "石"])
+    finally:
+        db.close()
+    return user
+
+
+class TestRepeatedErrorsAlert:
+    """Endpoint that returns characters meeting the ≥3 repeated-error threshold.
+
+    Used by the frontend to show a post-session modal: 「這個字你讀錯 3 次了」
+    Uses dedicated isolated users (alert_user_high / alert_user_low) to avoid
+    interference from mastered-char side-effects in other test classes.
+    """
+
+    def test_returns_200(self, client, alert_user_high):
+        """Endpoint responds with 200 OK."""
+        resp = client.get(
+            f"/api/learning/students/{alert_user_high['id']}/repeated-errors-alert",
+            headers=auth_header(alert_user_high["token"]),
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_response_has_alerts_field(self, client, alert_user_high):
+        """Response contains 'alerts' list and 'total' count."""
+        resp = client.get(
+            f"/api/learning/students/{alert_user_high['id']}/repeated-errors-alert",
+            headers=auth_header(alert_user_high["token"]),
+        )
+        data = resp.json()
+        assert "alerts" in data
+        assert "total" in data
+
+    def test_only_chars_with_3_or_more_errors(self, client, alert_user_high):
+        """Only characters with ≥3 errors appear in alerts.
+
+        alert_user_high: '月' has 3 errors, '日' has 2.
+        Only '月' should appear.
+        """
+        resp = client.get(
+            f"/api/learning/students/{alert_user_high['id']}/repeated-errors-alert",
+            headers=auth_header(alert_user_high["token"]),
+        )
+        data = resp.json()
+        chars = [a["character"] for a in data["alerts"]]
+        assert "月" in chars
+        # '日' (2 errors) should NOT appear in the ≥3 alert
+        assert "日" not in chars
+
+    def test_alert_item_fields(self, client, alert_user_high):
+        """Each alert item has character and error_count fields."""
+        resp = client.get(
+            f"/api/learning/students/{alert_user_high['id']}/repeated-errors-alert",
+            headers=auth_header(alert_user_high["token"]),
+        )
+        data = resp.json()
+        assert data["total"] >= 1
+        item = data["alerts"][0]
+        assert "character" in item
+        assert "error_count" in item
+        assert item["error_count"] >= 3
+
+    def test_mastered_chars_excluded(self, client, alert_user_high):
+        """Characters already marked as mastered should not appear in alerts."""
+        # Mark '月' as mastered
+        client.post(
+            f"/api/learning/students/{alert_user_high['id']}/error-corrections",
+            json={"character": "月", "correction_type": "mastered"},
+            headers=auth_header(alert_user_high["token"]),
+        )
+        resp = client.get(
+            f"/api/learning/students/{alert_user_high['id']}/repeated-errors-alert",
+            headers=auth_header(alert_user_high["token"]),
+        )
+        data = resp.json()
+        chars = [a["character"] for a in data["alerts"]]
+        assert "月" not in chars
+
+    def test_requires_auth(self, client, alert_user_high):
+        """Unauthenticated request returns 401."""
+        resp = client.get(
+            f"/api/learning/students/{alert_user_high['id']}/repeated-errors-alert"
+        )
+        assert resp.status_code == 401
+
+    def test_access_denied_for_other_student(self, client, alert_user_high, alert_user_low):
+        """Cannot view another student's alerts."""
+        resp = client.get(
+            f"/api/learning/students/{alert_user_low['id']}/repeated-errors-alert",
+            headers=auth_header(alert_user_high["token"]),
+        )
+        assert resp.status_code == 403
+
+    def test_empty_when_no_alerts(self, client, alert_user_low):
+        """Student with no repeated chars (all < 3) returns empty alerts."""
+        resp = client.get(
+            f"/api/learning/students/{alert_user_low['id']}/repeated-errors-alert",
+            headers=auth_header(alert_user_low["token"]),
+        )
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["alerts"] == []

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -1,8 +1,10 @@
 
-import React, { useRef, useState, useEffect, useMemo } from 'react';
+import React, { useRef, useState, useEffect, useMemo, useCallback } from 'react';
 import { LearningSession } from '../../types';
 import type { Story } from '../../types';
 import type { ComprehensionScoreResult } from '../../services/api';
+import { getRepeatedErrorsAlert } from '../../services/api';
+import type { RepeatedErrorAlertItem } from '../../services/api';
 import DiffDisplay from '../ui/DiffDisplay';
 import CelebrationOverlay from '../ui/CelebrationOverlay';
 import ComprehensionScoreCard from './ComprehensionScoreCard';
@@ -15,6 +17,7 @@ import AIAnalysisSection from './AIAnalysisSection';
 import StarCelebration from '../gamification/StarCelebration';
 import { calcStarRating } from '../../utils/starRatingCalc';
 import GoalAchievementCard from '../ui/GoalAchievementCard';
+import RepeatedErrorAlertModal from '../student/RepeatedErrorAlertModal';
 
 /**
  * A wrapper around ResponsiveContainer that only renders the chart
@@ -166,6 +169,32 @@ const Section: React.FC<{
 const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab, comprehensionScores, comprehensionScoresLoading, readingGoals, dbSessionId, token }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
 
+  // Repeated error alert modal state (Issue #248)
+  const [repeatedAlerts, setRepeatedAlerts] = useState<RepeatedErrorAlertItem[]>([]);
+  const [showRepeatedAlert, setShowRepeatedAlert] = useState(false);
+  const alertFetchedRef = useRef(false);
+
+  const fetchRepeatedAlerts = useCallback(async () => {
+    if (!token || !dbSessionId || alertFetchedRef.current) return;
+    alertFetchedRef.current = true;
+    try {
+      // We need the studentId — derive it by calling the alert endpoint via
+      // the token. The endpoint URL requires studentId, so we get it from the
+      // JWT claims via the /users/me endpoint or pass studentId as a prop.
+      // For now, use a workaround: decode the JWT student_id from the token.
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      const studentId: number | undefined = payload?.user_id ?? payload?.sub;
+      if (!studentId) return;
+      const data = await getRepeatedErrorsAlert(token, Number(studentId));
+      if (data.total > 0) {
+        setRepeatedAlerts(data.alerts);
+        setShowRepeatedAlert(true);
+      }
+    } catch {
+      // Non-critical: silently ignore errors so the report page still works
+    }
+  }, [token, dbSessionId]);
+
   // Track lesson completion when a valid report is viewed.
   useEffect(() => {
     if (!session) return;
@@ -178,6 +207,11 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
   // Fire once per story session — storyId + startedAt identifies a unique session.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [session?.storyId, session?.startedAt]);
+
+  // Fetch repeated error alerts once when the report mounts (Issue #248)
+  useEffect(() => {
+    fetchRepeatedAlerts();
+  }, [fetchRepeatedAlerts]);
 
   if (!session) {
     return (
@@ -295,6 +329,14 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
 
   return (
     <div className="max-w-4xl mx-auto space-y-6 animate-fadeIn">
+      {/* Repeated error alert modal (Issue #248) */}
+      {showRepeatedAlert && repeatedAlerts.length > 0 && (
+        <RepeatedErrorAlertModal
+          alerts={repeatedAlerts}
+          onDismiss={() => setShowRepeatedAlert(false)}
+        />
+      )}
+
       <CelebrationOverlay score={overallScore} />
 
       {/* ============ 星星評級 Star Rating (Issue #222) ============ */}

--- a/frontend/src/components/student/RepeatedErrorAlertModal.tsx
+++ b/frontend/src/components/student/RepeatedErrorAlertModal.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { RepeatedErrorAlertItem } from '../../services/api';
+
+interface Props {
+  alerts: RepeatedErrorAlertItem[];
+  onDismiss: () => void;
+}
+
+/**
+ * RepeatedErrorAlertModal — Post-session modal shown when the student has
+ * reached the ≥3 repeated-error threshold for one or more characters.
+ *
+ * Directs the student to the "我的生字" page for targeted vocab practice.
+ * Issue #248: repeated error detection + vocabulary recommendation.
+ */
+const RepeatedErrorAlertModal: React.FC<Props> = ({ alerts, onDismiss }) => {
+  const navigate = useNavigate();
+
+  const handleGoToVocab = () => {
+    onDismiss();
+    navigate('/my-vocabulary');
+  };
+
+  const topAlerts = alerts.slice(0, 5);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="重複錯誤提醒"
+    >
+      <div className="bg-white rounded-2xl shadow-xl max-w-sm w-full mx-4 p-6 space-y-5">
+        {/* Header */}
+        <div className="flex items-start gap-3">
+          <span className="text-3xl" aria-hidden="true">!</span>
+          <div>
+            <h2 className="text-lg font-bold text-gray-900">需要加強的生字</h2>
+            <p className="text-sm text-gray-500 mt-0.5">
+              這些字你已讀錯 3 次以上，建議加強練習
+            </p>
+          </div>
+        </div>
+
+        {/* Character list */}
+        <div className="flex flex-wrap gap-2">
+          {topAlerts.map((item) => (
+            <div
+              key={item.character}
+              className="flex flex-col items-center bg-red-50 border border-red-200 rounded-xl px-4 py-3"
+            >
+              <span className="text-3xl font-bold text-gray-900">{item.character}</span>
+              <span className="text-xs text-red-600 mt-1 font-medium">
+                錯 {item.error_count} 次
+              </span>
+            </div>
+          ))}
+          {alerts.length > 5 && (
+            <div className="flex items-center justify-center bg-gray-50 border border-gray-200 rounded-xl px-4 py-3">
+              <span className="text-sm text-gray-500">+{alerts.length - 5} 個字</span>
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-3 justify-end pt-1">
+          <button
+            onClick={onDismiss}
+            className="px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors"
+          >
+            稍後練習
+          </button>
+          <button
+            onClick={handleGoToVocab}
+            className="px-4 py-2 text-sm font-medium text-white bg-accent rounded-lg hover:bg-accent/90 transition-colors"
+          >
+            立即練習生字
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RepeatedErrorAlertModal;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -601,6 +601,34 @@ export async function markErrorCorrected(
   return res.json();
 }
 
+// --- Repeated Error Alert (Issue #248) ---
+
+export interface RepeatedErrorAlertItem {
+  character: string;
+  error_count: number;
+}
+
+export interface RepeatedErrorAlertResponse {
+  alerts: RepeatedErrorAlertItem[];
+  total: number;
+}
+
+/**
+ * Fetch characters that have hit the ≥3 repeated-error threshold.
+ * Used to show a post-session modal directing the student to vocab practice.
+ */
+export async function getRepeatedErrorsAlert(
+  token: string,
+  studentId: number,
+): Promise<RepeatedErrorAlertResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/learning/students/${studentId}/repeated-errors-alert`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) throw new Error(`getRepeatedErrorsAlert failed: ${res.status}`);
+  return res.json();
+}
+
 // --- Student Progress Dashboard (Issue #25) ---
 
 export interface DailyActivity {


### PR DESCRIPTION
Fixes #248

## Summary

- **Auto-persist CharacterError rows**: `PATCH /sessions/{id}` now creates `CharacterError` records from `reading_result.error_chars`. Previously, error chars were only stored in the JSON blob and never reached the `character_errors` table that the error-pattern queries rely on.
- **New repeated-errors-alert endpoint**: `GET /students/{id}/repeated-errors-alert` returns characters that have hit the >=3 error threshold (mastered chars excluded). Used by the frontend modal.
- **RepeatedErrorAlertModal**: New component shown on the AssessmentReport page when the student has repeatedly missed the same character. Offers "立即練習生字" (navigate to MyVocabulary) or "稍後練習" (dismiss).

## Root Cause

The `error_chars` field in `reading_result` was stored as JSON but never converted to individual `CharacterError` rows. The error-patterns endpoint queries `character_errors` table — so there was zero data even after completed sessions.

## Test Plan

- 11 new backend tests added (TDD Red → Green):
  - `TestAutoCharacterErrorPersist` (3 tests): verifies CharacterError rows are created/not created correctly
  - `TestRepeatedErrorsAlert` (8 tests): verifies the new endpoint's filtering, auth, and mastered-char exclusion
- All 42 tests in `test_error_correction.py` pass
- Frontend TypeScript build succeeds (`vite build`)

### Manual Testing Steps
1. Complete a reading session (逐段朗讀 step) with some wrong characters
2. Repeat the same story 3 times making the same mistakes
3. On the 3rd completion, AssessmentReport should show the repeated error modal
4. Verify modal lists the character(s) and their error count
5. Click "立即練習生字" — should navigate to /my-vocabulary
6. On MyVocabulary page, the ErrorPatternsCard should now show real data

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)