### PR TITLE
fix: display Chinese name for first_session achievement (Fixes #527)

### DIFF
--- a/backend/app/models/gamification.py
+++ b/backend/app/models/gamification.py
@@ -97,6 +97,12 @@ def level_progress(total_xp: int) -> dict:
 # ── Badge catalogue (defined in code) ────────────────────────────────────────
 
 BADGE_CATALOGUE = {
+    "first_session": {
+        "name": "初次學習",
+        "description": "完成第一次學習活動",
+        "icon": "star",
+        "color": "yellow",
+    },
     "first_story": {
         "name": "第一步",
         "description": "完成第一篇課文學習",

--- a/backend/tests/test_gamification.py
+++ b/backend/tests/test_gamification.py
@@ -144,6 +144,31 @@ class TestLevelProgressEdge:
             assert result["progress_pct"] <= 100
 
 
+class TestBadgeCatalogue:
+    """Tests for badge catalogue completeness — issue #527."""
+
+    def test_first_session_badge_exists(self):
+        assert "first_session" in BADGE_CATALOGUE
+
+    def test_first_session_has_chinese_name(self):
+        badge = BADGE_CATALOGUE["first_session"]
+        assert "name" in badge
+        # Name must not be the raw English key
+        assert badge["name"] != "first_session"
+        # Should contain at least one CJK character
+        assert any("\u4e00" <= ch <= "\u9fff" for ch in badge["name"])
+
+    def test_all_badges_have_chinese_names(self):
+        """Regression: every badge in BADGE_CATALOGUE must have a non-empty Chinese name."""
+        for key, info in BADGE_CATALOGUE.items():
+            name = info.get("name", "")
+            assert name, f"Badge {key!r} is missing 'name'"
+            assert name != key, f"Badge {key!r} name is the same as the key (raw English)"
+            assert any("\u4e00" <= ch <= "\u9fff" for ch in name), (
+                f"Badge {key!r} name {name!r} has no Chinese characters"
+            )
+
+
 # ── Integration tests: process_session_completion ─────────────────────────────
 
 


### PR DESCRIPTION
Fixes #527

## Root Cause

`first_session` was stored as a badge key in the database but had no entry in `BADGE_CATALOGUE`. The `get_student_summary` fallback `info.get("name", b.badge_key)` returned the raw English key when the key was absent from the catalogue.

## Changes

- `backend/app/models/gamification.py` — added `first_session` entry to `BADGE_CATALOGUE` with Chinese name `初次學習`
- `backend/tests/test_gamification.py` — added `TestBadgeCatalogue` regression tests to ensure all badges have Chinese display names

## Test plan

- [ ] Visit /achievements after deploying preview
- [ ] Confirm `first_session` badge shows "初次學習" instead of raw key
- [ ] All existing badges ("第一步", "勤讀者", etc.) still display correctly