### PR TITLE
fix: configure SQLAlchemy connection pool size (Fixes #521)

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -6,6 +6,10 @@ from .config import settings
 _engine_kwargs = {}
 if not settings.database_url.startswith("sqlite"):
     _engine_kwargs["pool_pre_ping"] = True
+    _engine_kwargs["pool_size"] = 10
+    _engine_kwargs["max_overflow"] = 5
+    _engine_kwargs["pool_timeout"] = 30
+    _engine_kwargs["pool_recycle"] = 1800
 
 engine = create_engine(
     settings.database_url,


### PR DESCRIPTION
Fixes #521

## Summary
- 在 `backend/app/database.py` 為 Cloud SQL (non-SQLite) 連線加上顯式 pool 設定
- `pool_size=10`：每個 Cloud Run instance 的常駐連線數
- `max_overflow=5`：高峰時額外允許的連線（最高 15）
- `pool_timeout=30`：等不到連線時 30 秒後 fail fast，避免 request 無限卡住
- `pool_recycle=1800`：每 30 分鐘回收連線（Cloud SQL proxy 官方建議）

SQLite（本機測試）不套用這些設定，維持原有行為。

## Test plan
- [ ] Backend 啟動正常，無 pool 相關錯誤
- [ ] CI 測試全部通過
- [ ] Beta 50 人同時使用時不出現 `OperationalError: connection pool exhausted`