### PR TITLE
fix: handle Gemini content filter/safety refusal gracefully (Fixes #526)

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -26,6 +26,74 @@ MAX_RETRIES = 3
 RETRY_BASE_DELAY = 1.0  # seconds
 GEMINI_TIMEOUT = 30  # seconds
 
+CONTENT_FILTER_FRIENDLY_MSG = "老師小幫手暫時無法回答這個問題，請試試其他問法"
+
+
+class GeminiContentFilterError(Exception):
+    """Raised when Gemini refuses a response due to its safety/content filter.
+
+    This is NOT an API error — Gemini returned a valid response, but blocked
+    the content. Callers should return a friendly fallback to the student
+    instead of a 500 error.
+    """
+
+
+def _check_safety_filter(response) -> None:
+    """Inspect a Gemini response and raise GeminiContentFilterError if blocked.
+
+    Checks three signals (in order of reliability):
+    1. response.candidates is empty — entire prompt was blocked
+    2. candidates[0].finish_reason == SAFETY — output was blocked mid-generation
+    3. response.prompt_feedback.block_reason is set — prompt-level block
+
+    Must be called BEFORE accessing response.text, which raises a confusing
+    ValueError when the response has no content due to safety filtering.
+    """
+    # Signal 1: no candidates at all (prompt-level block)
+    if not response.candidates:
+        block_reason = None
+        try:
+            block_reason = str(response.prompt_feedback.block_reason)
+        except Exception:
+            pass
+        logger.warning(
+            "Gemini content filter: no candidates returned (block_reason=%s)",
+            block_reason,
+            extra={"event": "gemini_content_filter", "block_reason": block_reason},
+        )
+        raise GeminiContentFilterError(
+            f"Gemini blocked response (no candidates, block_reason={block_reason})"
+        )
+
+    # Signal 2: finish_reason == SAFETY
+    finish_reason = str(response.candidates[0].finish_reason)
+    if "SAFETY" in finish_reason:
+        logger.warning(
+            "Gemini content filter: finish_reason=SAFETY",
+            extra={"event": "gemini_content_filter", "finish_reason": finish_reason},
+        )
+        raise GeminiContentFilterError(
+            f"Gemini blocked response (finish_reason={finish_reason})"
+        )
+
+    # Signal 3: prompt_feedback.block_reason set but candidates exist (edge case)
+    try:
+        block_reason = response.prompt_feedback.block_reason
+        if block_reason and str(block_reason) not in ("0", "BLOCK_REASON_UNSPECIFIED", "None"):
+            logger.warning(
+                "Gemini content filter: prompt_feedback.block_reason=%s",
+                block_reason,
+                extra={"event": "gemini_content_filter", "block_reason": str(block_reason)},
+            )
+            raise GeminiContentFilterError(
+                f"Gemini blocked response (prompt_feedback.block_reason={block_reason})"
+            )
+    except GeminiContentFilterError:
+        raise
+    except Exception:
+        # prompt_feedback attribute may not exist on all response types — safe to ignore
+        pass
+
 
 def _get_client() -> genai.Client:
     """Return a Gemini client via Vertex AI (uses Cloud Run service account)."""
@@ -177,6 +245,11 @@ async def generate_structured_response(
                 timeout=GEMINI_TIMEOUT,
             )
 
+            # Check for safety filter BEFORE accessing response.text.
+            # When Gemini blocks content, response.text raises a confusing
+            # ValueError. We intercept this with a clear, named exception.
+            _check_safety_filter(response)
+
             # Extract finish_reason for diagnostics (MAX_TOKENS = truncated output)
             finish_reason = None
             if response.candidates:
@@ -259,6 +332,10 @@ async def generate_structured_response(
                 # Repair failed — raise original error so retry logic handles it
                 raise json_err
 
+        except GeminiContentFilterError:
+            # Safety filter is deterministic — no point retrying.
+            # Propagate immediately so callers can return a friendly response.
+            raise
         except asyncio.TimeoutError:
             logger.error(
                 "Gemini API timeout after %ds",
@@ -384,6 +461,8 @@ async def generate_socratic_question(
             temperature=0.7,
         ),
     )
+    # Guard against safety filter before accessing response.text (#526)
+    _check_safety_filter(response)
     return response.text.strip()
 
 

--- a/backend/tests/test_gemini_content_filter.py
+++ b/backend/tests/test_gemini_content_filter.py
@@ -1,0 +1,309 @@
+"""
+Unit tests for Gemini content filter / safety refusal handling (Issue #526).
+
+Tests cover:
+- _check_safety_filter raises GeminiContentFilterError when candidates is empty
+- _check_safety_filter raises GeminiContentFilterError when finish_reason == SAFETY
+- _check_safety_filter raises GeminiContentFilterError when block_reason is set
+- _check_safety_filter passes through for normal responses
+- generate_structured_response propagates GeminiContentFilterError immediately (no retry)
+- generate_socratic_question raises GeminiContentFilterError when safety filter fires
+- CONTENT_FILTER_FRIENDLY_MSG is defined and non-empty
+"""
+
+import asyncio
+import sys
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from app.services.ai_service import (
+    CONTENT_FILTER_FRIENDLY_MSG,
+    GeminiContentFilterError,
+    _check_safety_filter,
+    generate_structured_response,
+    generate_socratic_question,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build mock Gemini response objects
+# ---------------------------------------------------------------------------
+
+
+def _make_response(
+    *,
+    candidates=True,
+    finish_reason="FinishReason.STOP",
+    block_reason=None,
+    text='{"key": "value"}',
+):
+    """Build a minimal mock of a Gemini GenerateContentResponse."""
+    response = MagicMock()
+
+    if candidates:
+        candidate = MagicMock()
+        candidate.finish_reason = finish_reason
+        response.candidates = [candidate]
+    else:
+        response.candidates = []
+
+    # prompt_feedback
+    feedback = MagicMock()
+    feedback.block_reason = block_reason
+    response.prompt_feedback = feedback
+
+    response.text = text
+    return response
+
+
+# ---------------------------------------------------------------------------
+# _check_safety_filter unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSafetyFilter:
+    """Unit tests for the _check_safety_filter helper."""
+
+    def test_empty_candidates_raises(self):
+        """No candidates = prompt-level block; must raise GeminiContentFilterError."""
+        response = _make_response(candidates=False, block_reason=None)
+        with pytest.raises(GeminiContentFilterError):
+            _check_safety_filter(response)
+
+    def test_empty_candidates_with_block_reason_raises(self):
+        """No candidates with explicit block_reason still raises."""
+        response = _make_response(candidates=False, block_reason="HARM_CATEGORY_DANGEROUS")
+        with pytest.raises(GeminiContentFilterError):
+            _check_safety_filter(response)
+
+    def test_finish_reason_safety_raises(self):
+        """finish_reason containing 'SAFETY' must raise GeminiContentFilterError."""
+        response = _make_response(finish_reason="FinishReason.SAFETY")
+        with pytest.raises(GeminiContentFilterError):
+            _check_safety_filter(response)
+
+    def test_finish_reason_safety_short_raises(self):
+        """Plain string 'SAFETY' also triggers the filter."""
+        response = _make_response(finish_reason="SAFETY")
+        with pytest.raises(GeminiContentFilterError):
+            _check_safety_filter(response)
+
+    def test_block_reason_set_raises(self):
+        """prompt_feedback.block_reason set to a non-unspecified value should raise."""
+        response = _make_response(
+            finish_reason="FinishReason.STOP",
+            block_reason="HARM_CATEGORY_SEXUALLY_EXPLICIT",
+        )
+        with pytest.raises(GeminiContentFilterError):
+            _check_safety_filter(response)
+
+    def test_normal_response_passes(self):
+        """Normal STOP response with no block_reason should not raise."""
+        response = _make_response(finish_reason="FinishReason.STOP", block_reason=None)
+        # Should not raise
+        _check_safety_filter(response)
+
+    def test_max_tokens_response_passes(self):
+        """MAX_TOKENS finish_reason is not a safety issue — should not raise."""
+        response = _make_response(finish_reason="FinishReason.MAX_TOKENS", block_reason=None)
+        _check_safety_filter(response)
+
+    def test_block_reason_unspecified_passes(self):
+        """BLOCK_REASON_UNSPECIFIED means no block — should not raise."""
+        response = _make_response(
+            finish_reason="FinishReason.STOP",
+            block_reason="BLOCK_REASON_UNSPECIFIED",
+        )
+        _check_safety_filter(response)
+
+    def test_block_reason_zero_passes(self):
+        """block_reason == '0' is the numeric unspecified value — should not raise."""
+        response = _make_response(finish_reason="FinishReason.STOP", block_reason="0")
+        _check_safety_filter(response)
+
+    def test_block_reason_none_passes(self):
+        """block_reason == None means no block — should not raise."""
+        response = _make_response(finish_reason="FinishReason.STOP", block_reason=None)
+        _check_safety_filter(response)
+
+    def test_error_message_is_descriptive(self):
+        """The raised error should include the finish_reason for debugging."""
+        response = _make_response(finish_reason="FinishReason.SAFETY")
+        with pytest.raises(GeminiContentFilterError, match="SAFETY"):
+            _check_safety_filter(response)
+
+
+# ---------------------------------------------------------------------------
+# generate_structured_response: safety filter propagates without retry
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateStructuredResponseContentFilter:
+    """generate_structured_response must propagate GeminiContentFilterError immediately."""
+
+    @pytest.mark.asyncio
+    async def test_safety_filter_raises_immediately(self):
+        """When Gemini returns a SAFETY response, GeminiContentFilterError is raised."""
+        mock_response = _make_response(finish_reason="FinishReason.SAFETY")
+
+        with patch("app.services.ai_service._get_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.models.generate_content.return_value = mock_response
+            mock_client_factory.return_value = mock_client
+
+            with pytest.raises(GeminiContentFilterError):
+                await generate_structured_response(
+                    system_prompt="test",
+                    contents=[],
+                    response_schema={"type": "OBJECT", "properties": {}},
+                )
+
+    @pytest.mark.asyncio
+    async def test_safety_filter_not_retried(self):
+        """Safety filter must NOT trigger retries — generate_content called exactly once."""
+        mock_response = _make_response(finish_reason="FinishReason.SAFETY")
+
+        with patch("app.services.ai_service._get_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.models.generate_content.return_value = mock_response
+            mock_client_factory.return_value = mock_client
+
+            with pytest.raises(GeminiContentFilterError):
+                await generate_structured_response(
+                    system_prompt="test",
+                    contents=[],
+                    response_schema={"type": "OBJECT", "properties": {}},
+                )
+
+            # Should have been called exactly once, not retried 3 times
+            assert mock_client.models.generate_content.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_candidates_raises_immediately(self):
+        """Empty candidates (prompt-level block) raises GeminiContentFilterError."""
+        mock_response = _make_response(candidates=False)
+
+        with patch("app.services.ai_service._get_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.models.generate_content.return_value = mock_response
+            mock_client_factory.return_value = mock_client
+
+            with pytest.raises(GeminiContentFilterError):
+                await generate_structured_response(
+                    system_prompt="test",
+                    contents=[],
+                    response_schema={"type": "OBJECT", "properties": {}},
+                )
+
+    @pytest.mark.asyncio
+    async def test_normal_response_succeeds(self):
+        """Normal response still works correctly after adding the safety check."""
+        mock_response = _make_response(
+            finish_reason="FinishReason.STOP",
+            text='{"answer": "hello"}',
+        )
+
+        with patch("app.services.ai_service._get_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.models.generate_content.return_value = mock_response
+            mock_client_factory.return_value = mock_client
+
+            result = await generate_structured_response(
+                system_prompt="test",
+                contents=[],
+                response_schema={"type": "OBJECT", "properties": {}},
+            )
+            assert result == {"answer": "hello"}
+
+
+# ---------------------------------------------------------------------------
+# generate_socratic_question: safety filter handled
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSocraticQuestionContentFilter:
+    """generate_socratic_question must raise GeminiContentFilterError on safety block."""
+
+    @pytest.mark.asyncio
+    async def test_safety_filter_raises(self):
+        """Safety block in generate_socratic_question raises GeminiContentFilterError."""
+        mock_response = _make_response(finish_reason="FinishReason.SAFETY")
+
+        with patch("app.services.ai_service._get_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.models.generate_content.return_value = mock_response
+            mock_client_factory.return_value = mock_client
+
+            with pytest.raises(GeminiContentFilterError):
+                await generate_socratic_question(
+                    story_title="測試課文",
+                    story_text="這是一篇測試課文的內容。",
+                    conversation=[],
+                )
+
+    @pytest.mark.asyncio
+    async def test_empty_candidates_raises(self):
+        """Empty candidates in generate_socratic_question raises GeminiContentFilterError."""
+        mock_response = _make_response(candidates=False)
+
+        with patch("app.services.ai_service._get_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.models.generate_content.return_value = mock_response
+            mock_client_factory.return_value = mock_client
+
+            with pytest.raises(GeminiContentFilterError):
+                await generate_socratic_question(
+                    story_title="測試課文",
+                    story_text="這是一篇測試課文的內容。",
+                    conversation=[],
+                )
+
+    @pytest.mark.asyncio
+    async def test_normal_question_returned(self):
+        """Normal response returns the question text correctly."""
+        mock_response = _make_response(
+            finish_reason="FinishReason.STOP",
+            text="課文中的主角做了什麼事？",
+        )
+
+        with patch("app.services.ai_service._get_client") as mock_client_factory:
+            mock_client = MagicMock()
+            mock_client.models.generate_content.return_value = mock_response
+            mock_client_factory.return_value = mock_client
+
+            result = await generate_socratic_question(
+                story_title="測試課文",
+                story_text="這是一篇測試課文的內容。",
+                conversation=[],
+            )
+            assert result == "課文中的主角做了什麼事？"
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestContentFilterConstants:
+    """Verify the friendly message constant is properly defined."""
+
+    def test_friendly_message_defined(self):
+        """CONTENT_FILTER_FRIENDLY_MSG must be a non-empty string."""
+        assert isinstance(CONTENT_FILTER_FRIENDLY_MSG, str)
+        assert len(CONTENT_FILTER_FRIENDLY_MSG) > 0
+
+    def test_friendly_message_in_chinese(self):
+        """Friendly message should contain Chinese characters for student readability."""
+        # Check for at least one CJK character (U+4E00–U+9FFF)
+        has_chinese = any("\u4e00" <= ch <= "\u9fff" for ch in CONTENT_FILTER_FRIENDLY_MSG)
+        assert has_chinese, f"Expected Chinese in message: {CONTENT_FILTER_FRIENDLY_MSG!r}"
+
+    def test_gemini_content_filter_error_is_exception(self):
+        """GeminiContentFilterError must be a proper Exception subclass."""
+        err = GeminiContentFilterError("test")
+        assert isinstance(err, Exception)
+        assert str(err) == "test"


### PR DESCRIPTION
Fixes #526

## Summary

- Add `GeminiContentFilterError` — a named exception distinct from generic AI errors
- Add `_check_safety_filter(response)` — inspects three safety block signals before `response.text` is accessed
- Add `CONTENT_FILTER_FRIENDLY_MSG` constant — "老師小幫手暫時無法回答這個問題，請試試其他問法"
- Apply the check in both `generate_structured_response` and `generate_socratic_question`
- Safety filter errors propagate immediately without retry (deterministic, not transient)

## Root cause

When Gemini's safety filter fires it returns a valid HTTP 200 response but with no content. Accessing `response.text` in that state raises a confusing internal `ValueError`. The generic `except Exception` retry loop then retried the identical prompt 3 times before giving up with a 500 error.

## Three signals checked

| Signal | Description |
|--------|-------------|
| `response.candidates == []` | Entire prompt blocked at the input level |
| `candidates[0].finish_reason == SAFETY` | Output blocked mid-generation |
| `prompt_feedback.block_reason` set | Prompt-level block with explicit reason |

## Existing callers already have fallbacks

- `learning.py` route: `except Exception` → `_fallback_question()`
- `socratic_agent.py` `start_session`: `except Exception` → hardcoded fallback question
- `generate_exit_ticket`: already has `except Exception` → `{"questions": [], "fallback": True}`

No route changes needed — the named exception propagates cleanly through the existing handlers.

## Test plan

- 21 new unit tests in `tests/test_gemini_content_filter.py`
- Covers: all three signal paths, no-retry guarantee (call_count == 1), normal response passthrough, friendly message constants
- `python -m pytest tests/test_gemini_content_filter.py -v` → 21/21 pass