### PR TITLE
fix: eliminate N+1 queries in teacher dashboard (Fixes #525)

### DIFF
--- a/backend/app/routes/classrooms.py
+++ b/backend/app/routes/classrooms.py
@@ -7,7 +7,7 @@ import string
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.responses import StreamingResponse
 from sqlalchemy import func, or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from ..auth.dependencies import get_current_user
 from ..auth.password import hash_password
@@ -304,8 +304,35 @@ def list_my_classrooms(
     )
     total = query.count()
     items = query.order_by(Classroom.created_at.desc()).offset(offset).limit(limit).all()
+
+    if not items:
+        return ClassroomListResponse(items=[], total=total)
+
+    # Batch-load student counts for all classrooms (avoid N COUNT queries)
+    classroom_ids = [c.id for c in items]
+    student_count_rows = (
+        db.query(ClassroomStudent.classroom_id, func.count(ClassroomStudent.id).label("cnt"))
+        .filter(ClassroomStudent.classroom_id.in_(classroom_ids))
+        .group_by(ClassroomStudent.classroom_id)
+        .all()
+    )
+    student_counts = {row.classroom_id: row.cnt for row in student_count_rows}
+
     return ClassroomListResponse(
-        items=[_classroom_to_response(c, db) for c in items],
+        items=[
+            ClassroomResponse(
+                id=c.id,
+                name=c.name,
+                school_id=c.school_id,
+                teacher_id=c.teacher_id,
+                grade=c.grade,
+                join_code=c.join_code,
+                is_active=c.is_active,
+                created_at=c.created_at,
+                student_count=student_counts.get(c.id, 0),
+            )
+            for c in items
+        ],
         total=total,
     )
 
@@ -381,7 +408,17 @@ def get_classroom_detail(
     db: Session = Depends(get_db),
 ):
     """Get classroom detail including student list. Owner, co-teachers, and admins can access."""
-    classroom = _get_classroom_or_404(classroom_id, db)
+    # Use joinedload to avoid N+1: classroom_students + each student in one query
+    classroom = (
+        db.query(Classroom)
+        .options(
+            joinedload(Classroom.classroom_students).joinedload(ClassroomStudent.student)
+        )
+        .filter(Classroom.id == classroom_id)
+        .first()
+    )
+    if classroom is None:
+        raise HTTPException(status_code=404, detail="Classroom not found")
     _require_member_or_admin(classroom, current_user, db)
     return _classroom_to_detail_response(classroom)
 
@@ -505,6 +542,14 @@ def list_classroom_students(
     classroom = _get_classroom_or_404(classroom_id, db)
     _require_member_or_admin(classroom, current_user, db)
 
+    # joinedload to avoid N+1 on cs.student access
+    enrollments = (
+        db.query(ClassroomStudent)
+        .options(joinedload(ClassroomStudent.student))
+        .filter(ClassroomStudent.classroom_id == classroom_id)
+        .all()
+    )
+
     return [
         StudentInClassroomResponse(
             id=cs.student.id,
@@ -512,7 +557,7 @@ def list_classroom_students(
             email=cs.student.email,
             enrolled_at=cs.enrolled_at,
         )
-        for cs in classroom.classroom_students
+        for cs in enrollments
     ]
 
 

--- a/backend/app/routes/teacher.py
+++ b/backend/app/routes/teacher.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from ..auth.dependencies import get_current_user
 from ..database import get_db
@@ -282,15 +282,17 @@ def get_classroom_progress(
     """Get learning progress for all students in a classroom."""
     classroom = _check_classroom_access(current_user, classroom_id, db)
 
-    # Get all students in the classroom
+    # Get all students in the classroom — joinedload to avoid N+1 on enrollment.student
     enrollments = (
         db.query(ClassroomStudent)
+        .options(joinedload(ClassroomStudent.student))
         .filter(ClassroomStudent.classroom_id == classroom_id)
         .all()
     )
 
-    # Batch-load tags for all students to avoid N+1 queries
     student_ids_in_classroom = [e.student_id for e in enrollments]
+
+    # Batch-load tags for all students to avoid N+1 queries
     tags_by_student: dict[int, list[StudentTag]] = {}
     if student_ids_in_classroom:
         all_tags = (
@@ -301,24 +303,36 @@ def get_classroom_progress(
         for tag in all_tags:
             tags_by_student.setdefault(tag.student_id, []).append(tag)
 
+    # Batch-load session counts per student (single aggregation query, not N queries)
+    session_count_rows = (
+        db.query(LearningSession.student_id, func.count(LearningSession.id).label("cnt"))
+        .filter(LearningSession.student_id.in_(student_ids_in_classroom))
+        .group_by(LearningSession.student_id)
+        .all()
+        if student_ids_in_classroom else []
+    )
+    session_counts: dict[int, int] = {row.student_id: row.cnt for row in session_count_rows}
+
+    # Batch-load latest session per student using a window function approach:
+    # fetch all sessions ordered desc and keep only the first per student in Python.
+    all_sessions_for_latest = (
+        db.query(LearningSession)
+        .filter(LearningSession.student_id.in_(student_ids_in_classroom))
+        .order_by(LearningSession.student_id, LearningSession.started_at.desc())
+        .all()
+        if student_ids_in_classroom else []
+    )
+    latest_session_by_student: dict[int, LearningSession] = {}
+    for s in all_sessions_for_latest:
+        if s.student_id not in latest_session_by_student:
+            latest_session_by_student[s.student_id] = s
+
     results = []
     for enrollment in enrollments:
         student = enrollment.student
 
-        # Get total session count for this student
-        total_sessions = (
-            db.query(func.count(LearningSession.id))
-            .filter(LearningSession.student_id == student.id)
-            .scalar()
-        )
-
-        # Get the most recent session for this student
-        latest_session = (
-            db.query(LearningSession)
-            .filter(LearningSession.student_id == student.id)
-            .order_by(LearningSession.started_at.desc())
-            .first()
-        )
+        total_sessions = session_counts.get(student.id, 0)
+        latest_session = latest_session_by_student.get(student.id)
 
         last_session_date = None
         last_text_title = None
@@ -833,6 +847,7 @@ def get_classroom_alerts(
 
     enrollments = (
         db.query(ClassroomStudent)
+        .options(joinedload(ClassroomStudent.student))
         .filter(ClassroomStudent.classroom_id == classroom_id)
         .all()
     )
@@ -840,31 +855,43 @@ def get_classroom_alerts(
     if not enrollments:
         return []
 
+    student_ids = [e.student_id for e in enrollments]
     now = datetime.now(timezone.utc)
     fourteen_days_ago = now - timedelta(days=14)
+
+    # Batch-load all scored sessions for alert analysis (single query instead of N)
+    all_scored_sessions = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.student_id.in_(student_ids),
+            LearningSession.overall_score.isnot(None),
+        )
+        .order_by(LearningSession.student_id, LearningSession.started_at.asc())
+        .all()
+    )
+    scored_sessions_by_student: dict[int, list[LearningSession]] = {}
+    for s in all_scored_sessions:
+        scored_sessions_by_student.setdefault(s.student_id, []).append(s)
+
+    # Batch-load latest session per student (single query instead of N)
+    all_sessions_ordered = (
+        db.query(LearningSession)
+        .filter(LearningSession.student_id.in_(student_ids))
+        .order_by(LearningSession.student_id, LearningSession.started_at.desc())
+        .all()
+    )
+    latest_session_by_student: dict[int, LearningSession] = {}
+    for s in all_sessions_ordered:
+        if s.student_id not in latest_session_by_student:
+            latest_session_by_student[s.student_id] = s
+
     alerts: list[StudentAlertResponse] = []
 
     for enrollment in enrollments:
         student = enrollment.student
 
-        # Fetch all completed sessions for this student (with a score), ordered asc
-        student_sessions = (
-            db.query(LearningSession)
-            .filter(
-                LearningSession.student_id == student.id,
-                LearningSession.overall_score.isnot(None),
-            )
-            .order_by(LearningSession.started_at.asc())
-            .all()
-        )
-
-        # Most recent session across all statuses (to determine last_session_date)
-        latest_session = (
-            db.query(LearningSession)
-            .filter(LearningSession.student_id == student.id)
-            .order_by(LearningSession.started_at.desc())
-            .first()
-        )
+        student_sessions = scored_sessions_by_student.get(student.id, [])
+        latest_session = latest_session_by_student.get(student.id)
         last_session_date = latest_session.started_at if latest_session else None
 
         # ── Alert: inactive ──────────────────────────────────────────────────
@@ -1019,6 +1046,7 @@ def get_at_risk_students(
 
     enrollments = (
         db.query(ClassroomStudent)
+        .options(joinedload(ClassroomStudent.student))
         .filter(ClassroomStudent.classroom_id == classroom_id)
         .all()
     )
@@ -1654,6 +1682,7 @@ def get_classroom_stuck_overview(
 
     enrollments = (
         db.query(ClassroomStudent)
+        .options(joinedload(ClassroomStudent.student))
         .filter(ClassroomStudent.classroom_id == classroom_id)
         .all()
     )
@@ -1744,29 +1773,54 @@ def _build_classroom_alerts_for_teacher(
     def _make_aware(dt: datetime) -> datetime:
         return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
-    for classroom in classrooms:
-        enrollments = (
-            db.query(ClassroomStudent)
-            .filter(ClassroomStudent.classroom_id == classroom.id)
-            .all()
+    # Batch-load all enrollments across all classrooms in a single query (avoid N per-classroom queries)
+    all_classroom_ids = [c.id for c in classrooms]
+    all_enrollments = (
+        db.query(ClassroomStudent)
+        .options(joinedload(ClassroomStudent.student))
+        .filter(ClassroomStudent.classroom_id.in_(all_classroom_ids))
+        .all()
+        if all_classroom_ids else []
+    )
+    enrollments_by_classroom: dict[int, list[ClassroomStudent]] = {}
+    for e in all_enrollments:
+        enrollments_by_classroom.setdefault(e.classroom_id, []).append(e)
+
+    all_student_ids = list({e.student_id for e in all_enrollments})
+
+    # Batch-load all scored sessions and latest sessions for all students at once
+    all_scored_sessions_notif = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.student_id.in_(all_student_ids),
+            LearningSession.overall_score.isnot(None),
         )
+        .order_by(LearningSession.student_id, LearningSession.started_at.asc())
+        .all()
+        if all_student_ids else []
+    )
+    scored_sessions_by_student_notif: dict[int, list[LearningSession]] = {}
+    for s in all_scored_sessions_notif:
+        scored_sessions_by_student_notif.setdefault(s.student_id, []).append(s)
+
+    all_sessions_for_latest_notif = (
+        db.query(LearningSession)
+        .filter(LearningSession.student_id.in_(all_student_ids))
+        .order_by(LearningSession.student_id, LearningSession.started_at.desc())
+        .all()
+        if all_student_ids else []
+    )
+    latest_session_by_student_notif: dict[int, LearningSession] = {}
+    for s in all_sessions_for_latest_notif:
+        if s.student_id not in latest_session_by_student_notif:
+            latest_session_by_student_notif[s.student_id] = s
+
+    for classroom in classrooms:
+        enrollments = enrollments_by_classroom.get(classroom.id, [])
         for enrollment in enrollments:
             student = enrollment.student
-            student_sessions = (
-                db.query(LearningSession)
-                .filter(
-                    LearningSession.student_id == student.id,
-                    LearningSession.overall_score.isnot(None),
-                )
-                .order_by(LearningSession.started_at.asc())
-                .all()
-            )
-            latest_session = (
-                db.query(LearningSession)
-                .filter(LearningSession.student_id == student.id)
-                .order_by(LearningSession.started_at.desc())
-                .first()
-            )
+            student_sessions = scored_sessions_by_student_notif.get(student.id, [])
+            latest_session = latest_session_by_student_notif.get(student.id)
             last_session_date = latest_session.started_at if latest_session else None
 
             is_inactive = last_session_date is None or _make_aware(last_session_date) < fourteen_days_ago

--- a/backend/tests/test_teacher_dashboard_n1.py
+++ b/backend/tests/test_teacher_dashboard_n1.py
@@ -1,0 +1,315 @@
+"""
+Regression tests for Issue #525 — Teacher Dashboard N+1 query elimination.
+
+Verifies that key teacher dashboard endpoints do NOT issue N queries
+(one per student) when loading data for a classroom with multiple students.
+
+Strategy: use SQLAlchemy event listener to count SQL statements emitted
+during each endpoint call. For N students, an N+1 pattern would produce
+at least 2*N queries. Our batch approach must stay well below that.
+"""
+
+import sys
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event, text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, UserRole
+from app.models.school import School, Classroom, ClassroomStudent
+from app.models.session import LearningSession
+from app.models.user import User
+from app.auth.password import hash_password
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite DB setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=OFF")  # Disable FK for easier seeding
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+_SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Org Admin", "scope_level": "organization"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+]
+
+_state: dict = {}
+
+NUM_STUDENTS = 10  # enough to detect N+1 but fast enough for unit tests
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    """Create tables, seed data, override FastAPI DB dependency."""
+    from sqlalchemy.dialects.postgresql import JSONB
+    from sqlalchemy import JSON
+
+    # Patch JSONB -> JSON for SQLite compatibility
+    for table in Base.metadata.sorted_tables:
+        for col in table.columns:
+            if isinstance(col.type, JSONB):
+                col.type = JSON()
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+
+    # Roles
+    for r in _SEED_ROLES:
+        db.add(Role(**r))
+    db.commit()
+
+    # School
+    school = School(name="N+1 Test School")
+    db.add(school)
+    db.commit()
+    db.refresh(school)
+
+    # Teacher user
+    teacher_user = User(
+        email="n1test_teacher@example.com",
+        username="n1test_teacher",
+        password_hash=hash_password("Password1!"),
+        name="N1 Teacher",
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(teacher_user)
+    db.commit()
+    db.refresh(teacher_user)
+
+    # Classroom
+    classroom = Classroom(
+        name="N+1 Test Class",
+        school_id=school.id,
+        teacher_id=teacher_user.id,
+        join_code="N1TEST",
+    )
+    db.add(classroom)
+    db.commit()
+    db.refresh(classroom)
+    classroom_id = classroom.id  # capture before session closes
+
+    # Students + enrollments + sessions
+    for i in range(NUM_STUDENTS):
+        student = User(
+            email=f"n1student{i}@example.com",
+            username=f"n1student{i}",
+            password_hash=hash_password("Password1!"),
+            name=f"Student {i}",
+            is_active=True,
+            email_verified=True,
+        )
+        db.add(student)
+        db.commit()
+        db.refresh(student)
+
+        # Enroll
+        db.add(ClassroomStudent(classroom_id=classroom_id, student_id=student.id))
+
+        # 3 sessions per student
+        for j in range(3):
+            started = datetime.now(timezone.utc) - timedelta(days=j)
+            db.add(LearningSession(
+                student_id=student.id,
+                story_slug=str(j + 1),
+                status="completed",
+                overall_score=float(70 + i + j),
+                started_at=started,
+                completed_at=started + timedelta(minutes=15),
+            ))
+
+    db.commit()
+    db.close()
+
+    _state["teacher_email"] = "n1test_teacher@example.com"
+    _state["classroom_id"] = classroom_id
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    # Reset rate limiter if present
+    try:
+        from app.routes.auth import rate_limiter
+        rate_limiter.reset()
+    except Exception:
+        pass
+
+    yield
+
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def teacher_token(client):
+    resp = client.post("/api/auth/login", json={
+        "email": _state["teacher_email"],
+        "password": "Password1!",
+    })
+    assert resp.status_code == 200, f"Login failed: {resp.json()}"
+    return resp.json()["access_token"]
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def count_queries_during(fn) -> int:
+    """Count the number of SQL statements emitted while calling fn()."""
+    count = 0
+
+    def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        nonlocal count
+        count += 1
+
+    event.listen(engine, "before_cursor_execute", before_cursor_execute)
+    try:
+        fn()
+    finally:
+        event.remove(engine, "before_cursor_execute", before_cursor_execute)
+
+    return count
+
+
+# ---------------------------------------------------------------------------
+# N+1 Regression Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProgressEndpointNoN1:
+    """GET /api/teacher/classrooms/{id}/progress must not issue N+1 queries."""
+
+    def test_progress_returns_200(self, client, teacher_token):
+        classroom_id = _state["classroom_id"]
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/progress",
+            headers=auth_header(teacher_token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == NUM_STUDENTS
+
+    def test_progress_query_count_is_bounded(self, client, teacher_token):
+        """With NUM_STUDENTS students, N+1 would produce ≥ 2*N queries.
+        Our batch approach should stay well below that (target: < N queries total).
+        """
+        classroom_id = _state["classroom_id"]
+
+        def call():
+            client.get(
+                f"/api/teacher/classrooms/{classroom_id}/progress",
+                headers=auth_header(teacher_token),
+            )
+
+        n_queries = count_queries_during(call)
+
+        # N+1 worst case = auth(1) + classroom(1) + student_ids(1) + tags(1)
+        #                  + N*session_count + N*latest_session = 2N+4 = 24 queries
+        # Our batch approach: auth + classroom + enrollments_joinedload + tags
+        #                     + session_counts + all_sessions_for_latest
+        # = approximately 6 constant queries regardless of N
+        # Allow generous headroom (< N) to be future-proof
+        assert n_queries < NUM_STUDENTS, (
+            f"Progress endpoint issued {n_queries} queries for {NUM_STUDENTS} students. "
+            f"Expected < {NUM_STUDENTS} (N+1 would be ~{2 * NUM_STUDENTS + 4})."
+        )
+
+
+class TestAlertsEndpointNoN1:
+    """GET /api/teacher/classrooms/{id}/alerts must not issue N+1 queries."""
+
+    def test_alerts_returns_200(self, client, teacher_token):
+        classroom_id = _state["classroom_id"]
+        resp = client.get(
+            f"/api/teacher/classrooms/{classroom_id}/alerts",
+            headers=auth_header(teacher_token),
+        )
+        assert resp.status_code == 200
+
+    def test_alerts_query_count_is_bounded(self, client, teacher_token):
+        """Alerts endpoint was the worst N+1 offender: 2 queries per student."""
+        classroom_id = _state["classroom_id"]
+
+        def call():
+            client.get(
+                f"/api/teacher/classrooms/{classroom_id}/alerts",
+                headers=auth_header(teacher_token),
+            )
+
+        n_queries = count_queries_during(call)
+
+        # N+1 worst case: 2N + overhead ≈ 24 queries for 10 students
+        # Batch approach: ~5-6 constant queries
+        assert n_queries < NUM_STUDENTS, (
+            f"Alerts endpoint issued {n_queries} queries for {NUM_STUDENTS} students. "
+            f"Expected < {NUM_STUDENTS} (N+1 would be ~{2 * NUM_STUDENTS + 3})."
+        )
+
+
+class TestNotificationsEndpointNoN1:
+    """GET /api/teacher/notifications must not issue N+1 queries."""
+
+    def test_notifications_returns_200(self, client, teacher_token):
+        resp = client.get(
+            "/api/teacher/notifications",
+            headers=auth_header(teacher_token),
+        )
+        assert resp.status_code == 200
+
+    def test_notifications_query_count_is_bounded(self, client, teacher_token):
+        """Notifications endpoint had nested N+1: classrooms × students × 2 queries."""
+
+        def call():
+            client.get(
+                "/api/teacher/notifications",
+                headers=auth_header(teacher_token),
+            )
+
+        n_queries = count_queries_during(call)
+
+        # Worst case was: classrooms query + N_classrooms*(enrollments + N_students*2 queries)
+        # For 1 classroom with 10 students = 21+ queries
+        # Batch approach = ~7 constant queries
+        assert n_queries < NUM_STUDENTS * 2, (
+            f"Notifications endpoint issued {n_queries} queries for {NUM_STUDENTS} students. "
+            f"Expected < {NUM_STUDENTS * 2}."
+        )


### PR DESCRIPTION
Fixes #525

## Summary

Verified and fixed N+1 query patterns in teacher dashboard backend endpoints. The issue reported that loading 30 students × 57 lessons could trigger 50+ DB queries. After analysis, found 8 distinct N+1 locations.

**Endpoints fixed:**

| Endpoint | Before | After |
|---------|--------|-------|
| `GET /teacher/classrooms/{id}/progress` | 2 queries per student (count + latest session) | 2 batch queries total |
| `GET /teacher/classrooms/{id}/alerts` | 2 queries per student | 2 batch queries total |
| `GET /teacher/notifications` | nested: classrooms × students × 2 queries | 3 batch queries total |
| `GET /teacher/classrooms/{id}/at-risk-students` | N lazy-load queries on enrollment.student | joinedload |
| `GET /teacher/classrooms/{id}/stuck-overview` | N lazy-load queries on enrollment.student | joinedload |
| `GET /classrooms/{id}` | N lazy-loads on classroom_students → student | joinedload chain |
| `GET /classrooms/{id}/students` | lazy relationship traversal | explicit joinedload query |
| `GET /classrooms` (list) | N COUNT queries for student_count | single GROUP BY aggregation |

**Key techniques used:**
- `joinedload(ClassroomStudent.student)` to avoid per-student lazy loads
- Batch aggregation queries (`GROUP BY student_id`) instead of per-student scalar queries
- Pre-fetching all sessions ordered by student_id + started_at, then slicing in Python for "latest per student"

## Test plan

- Added `backend/tests/test_teacher_dashboard_n1.py` with 6 regression tests
- Tests use SQLAlchemy `before_cursor_execute` event to count actual SQL statements
- For 10-student classroom: query count must stay below N (10) — previous N+1 would produce 20+
- All 6 tests pass: ✅
- Existing tests: same 2 pre-existing failures as on staging branch (unrelated setup issue), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)