### PR TITLE
fix: remove frame-ancestors from CSP meta tag (Fixes #535)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,14 @@
     <!-- Content-Security-Policy: browser-level fallback.
          The primary CSP is set by SecurityHeadersMiddleware in backend/app/main.py.
          This meta tag covers direct frontend hosting (Firebase Hosting / CDN). -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-ancestors 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com;" />
+    <!-- Note: frame-ancestors is intentionally omitted from this meta tag.
+         Per CSP spec, frame-ancestors is a navigation directive and is ignored
+         when delivered via <meta> elements (causes browser console warnings).
+         Anti-clickjacking is enforced via HTTP headers in SecurityHeadersMiddleware:
+           Content-Security-Policy: frame-ancestors 'none'
+           X-Frame-Options: DENY
+         See: https://www.w3.org/TR/CSP3/#frame-ancestors-and-frame-options -->
     <title>AI 朗讀助教 — 國語文閱讀學習平台</title>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&display=swap" rel="stylesheet">
     <style>

--- a/frontend/src/__tests__/csp-meta-tag.test.ts
+++ b/frontend/src/__tests__/csp-meta-tag.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, it, expect } from 'vitest'
+
+/**
+ * TDD test for #535: CSP frame-ancestors meta tag warning
+ *
+ * The `frame-ancestors` directive is a navigation directive that browsers
+ * IGNORE when delivered via <meta http-equiv="Content-Security-Policy">.
+ * It must only appear in HTTP response headers.
+ *
+ * The backend SecurityHeadersMiddleware already sets:
+ *   Content-Security-Policy: ... frame-ancestors 'none'; ...
+ *   X-Frame-Options: DENY
+ *
+ * So the meta tag version is both redundant and causes a console warning.
+ */
+describe('CSP meta tag — frame-ancestors directive', () => {
+  const indexHtml = readFileSync(
+    resolve(__dirname, '../../index.html'),
+    'utf-8'
+  )
+
+  it('should NOT contain frame-ancestors in the CSP meta tag', () => {
+    // Extract the CSP meta tag content
+    const cspMetaMatch = indexHtml.match(
+      /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]+)"/
+    )
+    expect(cspMetaMatch).not.toBeNull()
+
+    const cspContent = cspMetaMatch![1]
+    expect(cspContent).not.toContain('frame-ancestors')
+  })
+
+  it('should still have a CSP meta tag with essential directives', () => {
+    expect(indexHtml).toContain('http-equiv="Content-Security-Policy"')
+    expect(indexHtml).toContain("default-src 'self'")
+  })
+})


### PR DESCRIPTION
Fixes #535

## Summary
- Removed `frame-ancestors 'none'` from the CSP `<meta>` tag in `frontend/index.html`
- Per CSP spec (W3C), `frame-ancestors` is a navigation directive and is **ignored** when delivered via `<meta>` elements — causing a console warning on every page load
- Anti-clickjacking protection is already correctly enforced via HTTP headers in `SecurityHeadersMiddleware` (`Content-Security-Policy: frame-ancestors 'none'` + `X-Frame-Options: DENY`)
- Added an explanatory comment in `index.html` to document why `frame-ancestors` is intentionally absent from the meta tag
- Added vitest regression test in `frontend/src/__tests__/csp-meta-tag.test.ts`

## Root Cause
`index.html` line 9 included `frame-ancestors 'none'` in the CSP meta tag. The CSP Level 3 spec explicitly states frame-ancestors cannot be set via meta (https://www.w3.org/TR/CSP3/#frame-ancestors-and-frame-options).

## Test plan
- [x] TDD: wrote failing test → fixed → test passes (2/2)
- [x] `frontend/index.html` no longer contains `frame-ancestors` in meta tag
- [x] Backend `SecurityHeadersMiddleware` still sets `frame-ancestors 'none'` via HTTP header (unchanged)
- [ ] Verify PR Preview loads without the CSP warning in browser console