### PR TITLE
feat: lift 我的課文 and 作業管理 to teacher sidebar (Related to #550)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -42,6 +42,10 @@ function isActive(pathname: string, path: string): boolean {
   if (path === '/student' || path === '/teacher-home') {
     return pathname === path;
   }
+  // /teacher matches only dashboard and classroom detail, not /teacher/my-texts or /teacher/assignments
+  if (path === '/teacher') {
+    return pathname === '/teacher' || /^\/teacher\/classroom\/\d+/.test(pathname);
+  }
   return pathname === path || pathname.startsWith(`${path}/`);
 }
 
@@ -294,6 +298,8 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
     ? [
         { icon: '🏠', label: '主頁', path: '/teacher-home' },
         { icon: '🏫', label: '班級管理', path: '/teacher' },
+        { icon: '📖', label: '我的課文', path: '/teacher/my-texts' },
+        { icon: '📋', label: '作業管理', path: '/teacher/assignments' },
       ]
     : [];
 

--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -12,28 +12,24 @@ import {
 } from '../../services/classroomApi';
 import StudentProgressTab from './StudentProgressTab';
 import TextManagementTab from './TextManagementTab';
-import MyTextsTab from './MyTextsTab';
 import StudentListTab from './StudentListTab';
-import AssignmentTab from './AssignmentTab';
 import ClassroomAnalytics from './ClassroomAnalytics';
 import CrossTextAnalytics from './CrossTextAnalytics';
 import AtRiskStudents from '../../components/teacher/AtRiskStudents';
 import ErrorHeatmapTab from './ErrorHeatmapTab';
 import CoTeachingTab from './CoTeachingTab';
 
-type TabKey = 'progress' | 'texts' | 'my-texts' | 'assignments' | 'students' | 'analytics' | 'cross-text' | 'at-risk' | 'error-heatmap' | 'teachers';
+type TabKey = 'progress' | 'texts' | 'students' | 'analytics' | 'cross-text' | 'at-risk' | 'error-heatmap' | 'teachers';
 
-const TABS: { key: TabKey; label: string }[] = [
-  { key: 'progress', label: '學生進度' },
-  { key: 'analytics', label: '學習分析' },
-  { key: 'cross-text', label: '跨課文分析' },
-  { key: 'at-risk', label: '早期介入' },
-  { key: 'error-heatmap', label: '錯字熱力圖' },
-  { key: 'texts', label: '課文管理' },
-  { key: 'my-texts', label: '我的課文' },
-  { key: 'assignments', label: '作業管理' },
-  { key: 'students', label: '學生名單' },
-  { key: 'teachers', label: '協同教師' },
+const TABS: { key: TabKey; label: string; group?: 'core' | 'analysis' | 'other' }[] = [
+  { key: 'progress', label: '學生進度', group: 'core' },
+  { key: 'students', label: '學生名單', group: 'core' },
+  { key: 'texts', label: '課文管理', group: 'core' },
+  { key: 'analytics', label: '學習分析', group: 'analysis' },
+  { key: 'cross-text', label: '跨課文分析', group: 'analysis' },
+  { key: 'at-risk', label: '早期介入', group: 'analysis' },
+  { key: 'error-heatmap', label: '錯字熱力圖', group: 'analysis' },
+  { key: 'teachers', label: '協同教師', group: 'other' },
 ];
 
 interface ClassroomDetailProps {
@@ -380,20 +376,31 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
         <div className="bg-white rounded-xl border border-gray-200 shadow-sm">
           {/* Tab bar */}
           <div className="border-b border-gray-200 overflow-x-auto">
-            <nav className="flex -mb-px whitespace-nowrap" aria-label="Tabs">
-              {TABS.map((tab) => (
-                <button
-                  key={tab.key}
-                  onClick={() => setActiveTab(tab.key)}
-                  className={`px-5 py-3 text-sm font-medium border-b-2 transition-colors cursor-pointer shrink-0 ${
-                    activeTab === tab.key
-                      ? 'border-accent text-accent'
-                      : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                  }`}
-                >
-                  {tab.label}
-                </button>
-              ))}
+            <nav className="flex -mb-px whitespace-nowrap items-center" aria-label="Tabs">
+              {TABS.map((tab, i) => {
+                const prevGroup = TABS[i - 1]?.group;
+                const showDivider = prevGroup && prevGroup !== tab.group;
+                return (
+                  <React.Fragment key={tab.key}>
+                    {showDivider && (
+                      <span
+                        className="shrink-0 w-px h-5 bg-gray-200 mx-1"
+                        aria-hidden="true"
+                      />
+                    )}
+                    <button
+                      onClick={() => setActiveTab(tab.key)}
+                      className={`px-5 py-3 text-sm font-medium border-b-2 transition-colors cursor-pointer shrink-0 ${
+                        activeTab === tab.key
+                          ? 'border-accent text-accent'
+                          : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                      }`}
+                    >
+                      {tab.label}
+                    </button>
+                  </React.Fragment>
+                );
+              })}
             </nav>
           </div>
 
@@ -420,14 +427,6 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
 
           {activeTab === 'texts' && (
             <TextManagementTab classroomId={classroomId} />
-          )}
-
-          {activeTab === 'my-texts' && (
-            <MyTextsTab />
-          )}
-
-          {activeTab === 'assignments' && (
-            <AssignmentTab classroomId={classroomId} />
           )}
 
           {activeTab === 'students' && (

--- a/frontend/src/pages/teacher/TeacherAssignmentsPage.tsx
+++ b/frontend/src/pages/teacher/TeacherAssignmentsPage.tsx
@@ -1,0 +1,148 @@
+/**
+ * TeacherAssignmentsPage — standalone page for managing assignments across classrooms.
+ * Route: /teacher/assignments
+ * Lifted from ClassroomDetail tab to sidebar level (#550).
+ * Teacher selects a classroom, then sees assignments for that classroom.
+ */
+import React, { useState, useEffect, useCallback } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { listMyClassrooms, ClassroomResponse, ClassroomApiError } from '../../services/classroomApi';
+import AssignmentTab from './AssignmentTab';
+
+const TeacherAssignmentsPage: React.FC = () => {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const classroomIdParam = searchParams.get('classroom');
+
+  const [classrooms, setClassrooms] = useState<ClassroomResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [selectedId, setSelectedId] = useState<number | null>(() => {
+    const id = classroomIdParam ? parseInt(classroomIdParam, 10) : NaN;
+    return Number.isNaN(id) ? null : id;
+  });
+
+  const loadClassrooms = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const data = await listMyClassrooms(token);
+      setClassrooms(data.items);
+      if (data.items.length > 0) {
+        const ids = new Set(data.items.map((c) => c.id));
+        const valid = selectedId && ids.has(selectedId);
+        if (!valid) {
+          const first = data.items[0].id;
+          setSelectedId(first);
+          setSearchParams({ classroom: String(first) }, { replace: true });
+        }
+      }
+    } catch (err) {
+      if (err instanceof ClassroomApiError) {
+        setError(err.message);
+      } else {
+        setError('無法載入班級列表');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void loadClassrooms();
+  }, [loadClassrooms]);
+
+  useEffect(() => {
+    const id = classroomIdParam ? parseInt(classroomIdParam, 10) : NaN;
+    if (!Number.isNaN(id)) setSelectedId(id);
+  }, [classroomIdParam]);
+
+  const handleSelectClassroom = (id: number) => {
+    setSelectedId(id);
+    setSearchParams({ classroom: String(id) }, { replace: true });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+        <div className="max-w-4xl mx-auto">
+          <div className="h-6 bg-gray-200 animate-pulse rounded w-32 mb-6" />
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-6">
+            <div className="h-48 bg-gray-100 animate-pulse rounded" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-xl font-bold text-gray-900 mb-6">作業管理</h1>
+          <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl p-6">
+            <p>{error}</p>
+            <button
+              onClick={() => void loadClassrooms()}
+              className="mt-3 text-sm text-red-600 underline hover:text-red-800"
+            >
+              重試
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (classrooms.length === 0) {
+    return (
+      <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-xl font-bold text-gray-900 mb-6">作業管理</h1>
+          <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-8 text-center text-gray-500">
+            <p>尚無班級，請先建立班級。</p>
+            <button
+              type="button"
+              onClick={() => navigate('/teacher')}
+              className="mt-2 text-accent hover:underline cursor-pointer"
+            >
+              前往班級管理
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <h1 className="text-xl font-bold text-gray-900">作業管理</h1>
+          <label className="flex items-center gap-2 text-sm">
+            <span className="text-gray-600">班級：</span>
+            <select
+              value={selectedId ?? ''}
+              onChange={(e) => handleSelectClassroom(Number(e.target.value))}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-gray-900 bg-white focus:outline-none focus:ring-2 focus:ring-accent/40"
+            >
+              {classrooms.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                  {c.grade != null ? ` (${c.grade} 年級)` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {selectedId && <AssignmentTab classroomId={selectedId} />}
+      </div>
+    </div>
+  );
+};
+
+export default TeacherAssignmentsPage;

--- a/frontend/src/pages/teacher/TeacherMyTextsPage.tsx
+++ b/frontend/src/pages/teacher/TeacherMyTextsPage.tsx
@@ -1,0 +1,20 @@
+/**
+ * TeacherMyTextsPage — standalone page for teacher's custom texts.
+ * Route: /teacher/my-texts
+ * Lifted from ClassroomDetail tab to sidebar level (#550).
+ */
+import React from 'react';
+import MyTextsTab from './MyTextsTab';
+
+const TeacherMyTextsPage: React.FC = () => {
+  return (
+    <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-xl font-bold text-gray-900 mb-6">我的課文</h1>
+        <MyTextsTab />
+      </div>
+    </div>
+  );
+};
+
+export default TeacherMyTextsPage;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -61,6 +61,8 @@ const ParentDashboard = lazy(() => import('../pages/parent/ParentDashboard'));
 // New home pages for each role
 const StudentHome = lazy(() => import('../pages/student/StudentHome'));
 const TeacherHome = lazy(() => import('../pages/teacher/TeacherHome'));
+const TeacherMyTextsPage = lazy(() => import('../pages/teacher/TeacherMyTextsPage'));
+const TeacherAssignmentsPage = lazy(() => import('../pages/teacher/TeacherAssignmentsPage'));
 const ProjectHubPage = lazy(() => import('../pages/ProjectHubPage'));
 
 // Utility pages — rarely visited after first load
@@ -175,6 +177,26 @@ const AppRoutes: React.FC = () => (
           <ProtectedRoute>
             <AppShell>
               <ClassroomDetailPage />
+            </AppShell>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/teacher/my-texts"
+        element={
+          <ProtectedRoute>
+            <AppShell>
+              <TeacherMyTextsPage />
+            </AppShell>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/teacher/assignments"
+        element={
+          <ProtectedRoute>
+            <AppShell>
+              <TeacherAssignmentsPage />
             </AppShell>
           </ProtectedRoute>
         }


### PR DESCRIPTION
## Summary
- 老師 sidebar 新增「我的課文」「作業管理」兩個項目，解決 sidebar 太空、功能塞在班級內的問題
- 班級詳情 tab 移除「我的課文」「作業管理」，並重新分組（核心 / 分析 / 其他）減少視覺擁擠

## Changes
- **Sidebar**: 新增 我的課文 (/teacher/my-texts)、作業管理 (/teacher/assignments)
- **TeacherMyTextsPage**: 獨立頁面，包裝 MyTextsTab
- **TeacherAssignmentsPage**: 獨立頁面，班級選擇器 + AssignmentTab，支援 ?classroom=id URL
- **ClassroomDetail**: 移除 my-texts、assignments tab，tab 分組並加視覺分隔

## Test plan
- [ ] 老師登入後 sidebar 顯示 4 項：主頁、班級管理、我的課文、作業管理
- [ ] 點「我的課文」進入 /teacher/my-texts，可正常管理自訂課文
- [ ] 點「作業管理」進入 /teacher/assignments，可選班級並管理作業
- [ ] 進入班級詳情，tab 為 8 個（無我的課文、作業管理），有分組分隔線


Made with [Cursor](https://cursor.com)