### PR TITLE
feat: WorkspaceContext for multi-role/multi-school switching (Related to #547, #548, #549, #557)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import ErrorBoundary from './components/ErrorBoundary';
 import { AuthProvider } from './contexts/AuthContext';
+import { WorkspaceProvider } from './contexts/WorkspaceContext';
 import { LearningNavProvider } from './contexts/LearningNavContext';
 import TermsGate from './components/auth/TermsGate';
 import AppRoutes from './routes/AppRoutes';
@@ -21,11 +22,13 @@ const App: React.FC = () => {
     <ErrorBoundary>
       <BrowserRouter>
         <AuthProvider>
-          <LearningNavProvider>
-            <TermsGate>
-              <AppRoutes />
-            </TermsGate>
-          </LearningNavProvider>
+          <WorkspaceProvider>
+            <LearningNavProvider>
+              <TermsGate>
+                <AppRoutes />
+              </TermsGate>
+            </LearningNavProvider>
+          </WorkspaceProvider>
         </AuthProvider>
       </BrowserRouter>
     </ErrorBoundary>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -7,7 +7,7 @@
 import React, { useState, useEffect, useCallback, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
-import { hasRole } from '../../services/authApi';
+import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { getMyAssignments } from '../../services/assignmentApi';
 import { AppView } from '../../types';
 import Header from './Header';
@@ -18,17 +18,15 @@ import { OnboardingWrapper } from '../../pages/app/InlinePages';
 
 /** The authenticated app shell with header + sidebar. */
 export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { user, token } = useAuth();
+  const { token } = useAuth();
+  const { activeView } = useWorkspace();
   const navigate = useNavigate();
 
   // Pending assignment count for the student nav badge
   const [pendingAssignmentCount, setPendingAssignmentCount] = useState(0);
-  const isStudentOnly =
-    user !== null &&
-    !hasRole(user, 'teacher', 'system_admin', 'principal', 'director', 'org_owner', 'org_admin', 'homeroom_teacher');
 
   const refreshPendingCount = useCallback(async () => {
-    if (!token || !isStudentOnly) return;
+    if (!token || activeView !== 'student') return;
     try {
       const assignments = await getMyAssignments(token);
       const count = assignments.filter(
@@ -38,7 +36,7 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
     } catch {
       // Silently ignore — badge is non-critical
     }
-  }, [token, isStudentOnly]);
+  }, [token, activeView]);
 
   useEffect(() => {
     refreshPendingCount();

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -11,7 +11,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
-import { hasRole } from '../../services/authApi';
+import { useWorkspace, type WorkspaceView } from '../../contexts/WorkspaceContext';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -260,26 +260,25 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
   );
 
   // ---------------------------------------------------------------------------
-  // Build nav items based on roles
+  // Workspace context — determines which nav items to show
   // ---------------------------------------------------------------------------
 
-  const isTeacher = hasRole(
-    user,
-    'teacher',
-    'system_admin',
-    'principal',
-    'director',
-    'org_owner',
-    'org_admin',
-    'homeroom_teacher',
-  );
-  const isAdmin = hasRole(user, 'system_admin', 'org_owner', 'org_admin');
-  const isParent = hasRole(user, 'parent') && !isTeacher;
-  const isStudentOnly = !isTeacher;
+  const { activeView, setActiveView, availableViews, hasMultipleViews } = useWorkspace();
 
-  const roleLabel = isAdmin ? '管理員' : isTeacher ? '老師' : isParent ? '家長' : '學生';
+  const VIEW_LABELS: Record<WorkspaceView, { icon: string; label: string }> = {
+    admin: { icon: '⚙️', label: '管理員' },
+    teacher: { icon: '🏫', label: '老師' },
+    student: { icon: '📚', label: '學生' },
+    parent: { icon: '👨‍👩‍👧', label: '家長' },
+  };
 
-  const studentItems: NavItem[] = isStudentOnly
+  const roleLabel = VIEW_LABELS[activeView].label;
+
+  // ---------------------------------------------------------------------------
+  // Build nav items based on active workspace view
+  // ---------------------------------------------------------------------------
+
+  const studentItems: NavItem[] = activeView === 'student'
     ? [
         { icon: '🏠', label: '主頁', path: '/student' },
         { icon: '📚', label: '圖書館', path: '/library' },
@@ -294,7 +293,7 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
       ]
     : [];
 
-  const teacherItems: NavItem[] = isTeacher
+  const teacherItems: NavItem[] = activeView === 'teacher' || activeView === 'admin'
     ? [
         { icon: '🏠', label: '主頁', path: '/teacher-home' },
         { icon: '🏫', label: '班級管理', path: '/teacher' },
@@ -303,11 +302,11 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
       ]
     : [];
 
-  const adminItems: NavItem[] = isAdmin
+  const adminItems: NavItem[] = activeView === 'admin'
     ? [{ icon: '⚙️', label: '系統管理', path: '/admin' }]
     : [];
 
-  const parentItems: NavItem[] = isParent
+  const parentItems: NavItem[] = activeView === 'parent'
     ? [{ icon: '👨‍👩‍👧', label: '孩子進度', path: '/parent' }]
     : [];
 
@@ -329,15 +328,36 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
           ${collapsed ? 'w-14' : 'w-56'}
         `}
       >
-        {/* User + role (Issue #556) */}
+        {/* User + role switcher (Issue #556, #557) */}
         {user && (
           <div className={`shrink-0 border-b border-gray-100 py-3 ${collapsed ? 'px-2 flex justify-center' : 'px-3'}`}>
             <div className={`flex items-center gap-2 ${collapsed ? 'flex-col' : ''}`}>
               <span className="text-lg shrink-0" aria-hidden="true">👤</span>
               {!collapsed && (
-                <div className="min-w-0">
+                <div className="min-w-0 flex-1">
                   <p className="text-sm font-medium text-gray-900 truncate">{user.name}</p>
-                  <p className="text-xs text-gray-500">{roleLabel}</p>
+                  {hasMultipleViews ? (
+                    <select
+                      value={activeView}
+                      onChange={(e) => {
+                        setActiveView(e.target.value as WorkspaceView);
+                        const home: Record<WorkspaceView, string> = {
+                          teacher: '/teacher-home', student: '/student',
+                          admin: '/admin', parent: '/parent',
+                        };
+                        navigate(home[e.target.value as WorkspaceView]);
+                      }}
+                      className="mt-0.5 text-xs text-gray-500 bg-transparent border border-gray-200 rounded px-1.5 py-0.5 cursor-pointer hover:border-gray-400 focus:outline-none focus:ring-1 focus:ring-accent w-full"
+                    >
+                      {availableViews.map((v) => (
+                        <option key={v} value={v}>
+                          {VIEW_LABELS[v].icon} {VIEW_LABELS[v].label}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <p className="text-xs text-gray-500">{roleLabel}</p>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -1,0 +1,172 @@
+/**
+ * WorkspaceContext — manages the user's active "view" across the app.
+ *
+ * Solves #547 (hierarchy navigation), #548 (multi-school teacher),
+ * #549 (multi-school student), #557 (multi-role switching).
+ *
+ * Persists activeView + activeSchoolId to localStorage so they survive
+ * page refreshes. Auto-initialises from the user's role list on login.
+ */
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import { useAuth } from './AuthContext';
+import type { AuthUser, UserRole } from '../services/authApi';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The four possible "views" the sidebar can render. */
+export type WorkspaceView = 'teacher' | 'student' | 'admin' | 'parent';
+
+interface WorkspaceContextValue {
+  /** Current sidebar view. Determines which nav items are shown. */
+  activeView: WorkspaceView;
+  /** Switch the sidebar view. Persisted to localStorage. */
+  setActiveView: (view: WorkspaceView) => void;
+
+  /** Currently-selected school ID (for teachers in multiple schools). */
+  activeSchoolId: number | null;
+  /** Switch active school. Persisted to localStorage. */
+  setActiveSchoolId: (id: number | null) => void;
+
+  /** All distinct views available to this user (derived from roles). */
+  availableViews: WorkspaceView[];
+  /** All school IDs the current user has a teacher role in. */
+  teacherSchoolIds: number[];
+  /** All school IDs the current user has a student role in. */
+  studentSchoolIds: number[];
+
+  /** Convenience: does the user have more than one view? */
+  hasMultipleViews: boolean;
+  /** Convenience: is the user a teacher in more than one school? */
+  hasMultipleSchools: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const LS_VIEW_KEY = 'lingoleap_workspace_view';
+const LS_SCHOOL_KEY = 'lingoleap_workspace_school';
+
+const TEACHER_ROLES = new Set([
+  'teacher', 'homeroom_teacher', 'principal', 'director',
+]);
+const ADMIN_ROLES = new Set(['system_admin', 'org_owner', 'org_admin']);
+
+function deriveAvailableViews(user: AuthUser | null): WorkspaceView[] {
+  if (!user) return [];
+  const views = new Set<WorkspaceView>();
+  for (const r of user.roles) {
+    if (ADMIN_ROLES.has(r.role_name)) views.add('admin');
+    if (TEACHER_ROLES.has(r.role_name)) views.add('teacher');
+    if (r.role_name === 'student') views.add('student');
+    if (r.role_name === 'parent') views.add('parent');
+  }
+  // Admin users also get teacher view (they manage classrooms)
+  if (views.has('admin') && !views.has('teacher')) views.add('teacher');
+  return Array.from(views);
+}
+
+function deriveSchoolIds(user: AuthUser | null, roleNames: Set<string>): number[] {
+  if (!user) return [];
+  const ids = new Set<number>();
+  for (const r of user.roles) {
+    if (roleNames.has(r.role_name) && r.scope_type === 'school' && r.scope_id) {
+      const id = parseInt(r.scope_id, 10);
+      if (!Number.isNaN(id)) ids.add(id);
+    }
+  }
+  return Array.from(ids).sort((a, b) => a - b);
+}
+
+function pickDefaultView(available: WorkspaceView[], stored: string | null): WorkspaceView {
+  if (stored && available.includes(stored as WorkspaceView)) {
+    return stored as WorkspaceView;
+  }
+  // Priority: admin > teacher > student > parent
+  const priority: WorkspaceView[] = ['admin', 'teacher', 'student', 'parent'];
+  for (const v of priority) {
+    if (available.includes(v)) return v;
+  }
+  return 'student';
+}
+
+function pickDefaultSchool(schoolIds: number[], stored: string | null): number | null {
+  if (schoolIds.length === 0) return null;
+  if (stored) {
+    const id = parseInt(stored, 10);
+    if (!Number.isNaN(id) && schoolIds.includes(id)) return id;
+  }
+  return schoolIds[0];
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+
+export function useWorkspace(): WorkspaceContextValue {
+  const ctx = useContext(WorkspaceContext);
+  if (!ctx) {
+    throw new Error('useWorkspace must be used within a WorkspaceProvider');
+  }
+  return ctx;
+}
+
+export const WorkspaceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user } = useAuth();
+
+  const availableViews = useMemo(() => deriveAvailableViews(user), [user]);
+  const teacherSchoolIds = useMemo(() => deriveSchoolIds(user, TEACHER_ROLES), [user]);
+  const studentSchoolIds = useMemo(
+    () => deriveSchoolIds(user, new Set(['student'])),
+    [user],
+  );
+
+  const [activeView, setActiveViewRaw] = useState<WorkspaceView>(() =>
+    pickDefaultView(availableViews, localStorage.getItem(LS_VIEW_KEY)),
+  );
+  const [activeSchoolId, setActiveSchoolIdRaw] = useState<number | null>(() =>
+    pickDefaultSchool(teacherSchoolIds, localStorage.getItem(LS_SCHOOL_KEY)),
+  );
+
+  // Re-derive when user changes (login/logout)
+  useEffect(() => {
+    const views = deriveAvailableViews(user);
+    const storedView = localStorage.getItem(LS_VIEW_KEY);
+    setActiveViewRaw(pickDefaultView(views, storedView));
+
+    const schools = deriveSchoolIds(user, TEACHER_ROLES);
+    const storedSchool = localStorage.getItem(LS_SCHOOL_KEY);
+    setActiveSchoolIdRaw(pickDefaultSchool(schools, storedSchool));
+  }, [user]);
+
+  const setActiveView = useCallback((view: WorkspaceView) => {
+    setActiveViewRaw(view);
+    try { localStorage.setItem(LS_VIEW_KEY, view); } catch { /* ignore */ }
+  }, []);
+
+  const setActiveSchoolId = useCallback((id: number | null) => {
+    setActiveSchoolIdRaw(id);
+    try {
+      if (id != null) localStorage.setItem(LS_SCHOOL_KEY, String(id));
+      else localStorage.removeItem(LS_SCHOOL_KEY);
+    } catch { /* ignore */ }
+  }, []);
+
+  const value = useMemo<WorkspaceContextValue>(() => ({
+    activeView,
+    setActiveView,
+    activeSchoolId,
+    setActiveSchoolId,
+    availableViews,
+    teacherSchoolIds,
+    studentSchoolIds,
+    hasMultipleViews: availableViews.length > 1,
+    hasMultipleSchools: teacherSchoolIds.length > 1,
+  }), [activeView, setActiveView, activeSchoolId, setActiveSchoolId, availableViews, teacherSchoolIds, studentSchoolIds]);
+
+  return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
+};

--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -14,6 +14,7 @@ import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router-
 import { lazy } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { hasRole } from '../../services/authApi';
+import { useWorkspace } from '../../contexts/WorkspaceContext';
 import StoryLibrary from '../student/StoryLibrary';
 import WriteCharacter from '../../components/stroke-order/WriteCharacter';
 import SessionResumePrompt from '../../components/SessionResumePrompt';
@@ -32,16 +33,18 @@ const OnboardingGuide = lazy(() => import('../../components/OnboardingGuide'));
  * Returns null while auth is loading to prevent flash redirects.
  */
 export const HomePage: React.FC = () => {
-  const { user, isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
+  const { activeView } = useWorkspace();
 
-  // Wait for auth to resolve before redirecting — prevents flash on load
   if (isLoading || !isAuthenticated) return null;
 
-  if (hasRole(user, 'teacher', 'system_admin', 'principal', 'director', 'org_owner', 'org_admin', 'homeroom_teacher')) {
-    return <Navigate to="/teacher-home" replace />;
-  }
-
-  return <Navigate to="/student" replace />;
+  const homeMap: Record<string, string> = {
+    admin: '/admin',
+    teacher: '/teacher-home',
+    student: '/student',
+    parent: '/parent',
+  };
+  return <Navigate to={homeMap[activeView] ?? '/student'} replace />;
 };
 
 interface RecentPracticeItem {

--- a/frontend/src/pages/teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/teacher/TeacherDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
+import { useWorkspace } from '../../contexts/WorkspaceContext';
 import {
   listMyClassrooms,
   createClassroom,
@@ -12,15 +13,8 @@ interface TeacherDashboardProps {
 }
 
 const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }) => {
-  const { token, user } = useAuth();
-
-  // Derive school_id from user's teacher role
-  const teacherSchoolId = useMemo(() => {
-    const teacherRole = user?.roles.find(
-      (r) => r.role_name === 'teacher' && r.scope_type === 'school' && r.scope_id
-    );
-    return teacherRole?.scope_id ? parseInt(teacherRole.scope_id, 10) : null;
-  }, [user]);
+  const { token } = useAuth();
+  const { activeSchoolId: teacherSchoolId } = useWorkspace();
   const [classrooms, setClassrooms] = useState<ClassroomResponse[]>([]);
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(true);

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -24,10 +24,28 @@ export interface AuthUser {
   terms_version: string | null;
 }
 
-/** Check if user has a specific role */
+/** Check if user has a specific role (ignores scope). */
 export function hasRole(user: AuthUser | null, ...roleNames: string[]): boolean {
   if (!user) return false;
   return user.roles.some((r) => roleNames.includes(r.role_name));
+}
+
+/**
+ * Check if user has a role scoped to a specific school.
+ * Falls back to platform-scoped roles (e.g. system_admin).
+ */
+export function hasRoleInSchool(
+  user: AuthUser | null,
+  schoolId: number | null,
+  ...roleNames: string[]
+): boolean {
+  if (!user) return false;
+  return user.roles.some((r) => {
+    if (!roleNames.includes(r.role_name)) return false;
+    if (r.scope_type === 'platform') return true;
+    if (r.scope_type === 'school' && schoolId != null && r.scope_id === String(schoolId)) return true;
+    return false;
+  });
 }
 
 export interface AuthTokenResponse {


### PR DESCRIPTION
## Summary
- 新增 `WorkspaceContext` 解決多角色/多學校切換問題
- Sidebar 角色切換 dropdown — 有多角色時可即時切換（老師↔學生↔管理員↔家長）
- `activeSchoolId` 支援教師在多學校間切換
- 所有 workspace 狀態持久化到 localStorage

## Changes
- **WorkspaceContext** (`contexts/WorkspaceContext.tsx`): 核心 context，管理 `activeView` + `activeSchoolId`，從 user roles 自動推導 `availableViews` 和 `teacherSchoolIds`
- **Sidebar**: 角色 badge 變成 dropdown switcher（只在多角色時顯示）
- **HomePage**: redirect 邏輯改用 `activeView` 而非 `hasRole`
- **TeacherDashboard**: 用 `activeSchoolId` 取代 hardcode 第一個 teacher role
- **AppShell**: 用 `activeView` 取代 `hasRole` 判斷
- **authApi**: 新增 `hasRoleInSchool()` 給未來需要 scoped 權限檢查的地方

## Architecture
```
AuthContext (user, token)
  └── WorkspaceContext (activeView, activeSchoolId)
        ├── Sidebar (nav items based on activeView)
        ├── HomePage (redirect based on activeView)
        └── TeacherDashboard (schoolId from workspace)
```

## Test plan
- [ ] 單角色使用者：sidebar 顯示角色文字（無 dropdown）
- [ ] 多角色使用者（如 admin+teacher）：sidebar 顯示 dropdown，可切換
- [ ] 切換角色後自動跳轉到對應首頁
- [ ] 切換後 sidebar 項目正確更新
- [ ] 重新整理後記住上次選的角色（localStorage）
- [ ] 教師只有一個學校時，正常顯示班級

Made with [Cursor](https://cursor.com)