### PR TITLE
fix: logout on 401 from teacher APIs (expired JWT UX)

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { login as apiLogin, register as apiRegister, getMe, acceptTerms as apiAcceptTerms, googleLogin as apiGoogleLogin, AuthUser, AuthError, RegisterResponse } from '../services/authApi';
+import { SESSION_UNAUTHORIZED_EVENT } from '../services/sessionGuard';
 
 const TOKEN_KEY = 'lingoleap_token';
 
@@ -113,6 +114,16 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setMustChangePassword(false);
     setLoginPassword(null);
   }, []);
+
+  // Any service that gets 401 (expired / invalid JWT) should fire this event so we
+  // don't keep showing "logged in" while classroom tabs fail.
+  useEffect(() => {
+    const handler = () => {
+      logout();
+    };
+    window.addEventListener(SESSION_UNAUTHORIZED_EVENT, handler);
+    return () => window.removeEventListener(SESSION_UNAUTHORIZED_EVENT, handler);
+  }, [logout]);
 
   const clearMustChangePassword = useCallback(() => {
     setMustChangePassword(false);

--- a/frontend/src/services/assignmentApi.ts
+++ b/frontend/src/services/assignmentApi.ts
@@ -7,6 +7,8 @@
  *   Exactly one of story_id or text_id is set on each assignment.
  */
 
+import { onApiUnauthorized } from './sessionGuard';
+
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
 // --- Response types ---
@@ -115,6 +117,7 @@ function authHeaders(token: string): Record<string, string> {
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
+    onApiUnauthorized(res);
     let message = `Request failed: ${res.status}`;
     try {
       const body = await res.json();
@@ -235,6 +238,7 @@ export async function deleteAssignment(
     },
   );
   if (!res.ok) {
+    onApiUnauthorized(res);
     let message = `Request failed: ${res.status}`;
     try {
       const body = await res.json();

--- a/frontend/src/services/classroomApi.ts
+++ b/frontend/src/services/classroomApi.ts
@@ -3,6 +3,8 @@
  * Follows the same pattern as authApi.ts.
  */
 
+import { onApiUnauthorized } from './sessionGuard';
+
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
 // --- Response types ---
@@ -58,6 +60,7 @@ function authHeaders(token: string): Record<string, string> {
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
+    onApiUnauthorized(res);
     let message = `Request failed: ${res.status}`;
     try {
       const body = await res.json();
@@ -356,7 +359,10 @@ export function exportClassroomReport(token: string, classroomId: number): void 
   const url = `${API_BASE}/api/teacher/classrooms/${classroomId}/export`;
   fetch(url, { headers: { Authorization: `Bearer ${token}` } })
     .then((res) => {
-      if (!res.ok) throw new Error(`Export failed: ${res.status}`);
+      if (!res.ok) {
+        onApiUnauthorized(res);
+        throw new Error(`Export failed: ${res.status}`);
+      }
       return res.blob();
     })
     .then((blob) => {

--- a/frontend/src/services/sessionGuard.ts
+++ b/frontend/src/services/sessionGuard.ts
@@ -1,0 +1,19 @@
+/**
+ * When an authenticated API returns HTTP 401, dispatch an event so AuthProvider
+ * can clear localStorage + context. Prevents stale "logged in" UI while JWT
+ * is expired or rejected (user otherwise only sees raw "Invalid or expired token"
+ * inside tabs).
+ */
+export const SESSION_UNAUTHORIZED_EVENT = 'lingoleap:session-unauthorized';
+
+export function notifySessionUnauthorized(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(SESSION_UNAUTHORIZED_EVENT));
+}
+
+/** Call when `!res.ok` before reading body, so 401 triggers session clear. */
+export function onApiUnauthorized(res: Response): void {
+  if (res.status === 401) {
+    notifySessionUnauthorized();
+  }
+}

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -3,6 +3,8 @@
  * Follows the same pattern as classroomApi.ts.
  */
 
+import { onApiUnauthorized } from './sessionGuard';
+
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
 // --- Response types ---
@@ -54,6 +56,7 @@ function authHeaders(token: string): Record<string, string> {
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
+    onApiUnauthorized(res);
     let message = `Request failed: ${res.status}`;
     try {
       const body = await res.json();
@@ -203,6 +206,7 @@ export async function unassignText(
     },
   );
   if (!res.ok) {
+    onApiUnauthorized(res);
     let message = `Request failed: ${res.status}`;
     try {
       const body = await res.json();
@@ -219,7 +223,10 @@ export async function exportClassroomReport(token: string, classroomId: number):
   const res = await fetch(`${API_BASE}/api/teacher/classrooms/${classroomId}/export`, {
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) throw new TeacherApiError('Export failed', res.status);
+  if (!res.ok) {
+    onApiUnauthorized(res);
+    throw new TeacherApiError('Export failed', res.status);
+  }
   return res.blob();
 }
 
@@ -305,6 +312,7 @@ export async function removeStudentTag(
     },
   );
   if (!res.ok) {
+    onApiUnauthorized(res);
     let message = `Request failed: ${res.status}`;
     try {
       const body = await res.json();

--- a/frontend/src/services/teacherTextsApi.ts
+++ b/frontend/src/services/teacherTextsApi.ts
@@ -3,6 +3,8 @@
  * Wraps /api/teacher/my-texts endpoints.
  */
 
+import { onApiUnauthorized } from './sessionGuard';
+
 const API_BASE = import.meta.env.VITE_API_URL ?? '';
 
 export class TeacherTextsApiError extends Error {
@@ -17,6 +19,7 @@ export class TeacherTextsApiError extends Error {
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
+    onApiUnauthorized(res);
     let detail = `HTTP ${res.status}`;
     try {
       const body = await res.json();


### PR DESCRIPTION
## Problem
Teacher classroom tabs showed `Invalid or expired token` while header still looked logged in — JWT expired/invalid but no session refresh.

## Fix
- `sessionGuard`: fire `lingoleap:session-unauthorized` on HTTP 401 from teacher/classroom/assignment/my-texts APIs
- `AuthProvider`: listen and `logout()` (clear localStorage + state)

## Test
- `cd frontend && npm run test` — pass

Made with [Cursor](https://cursor.com)