### PR TITLE
fix: AI report cache invalidation when enrichment changes (Fixes #540)

### DIFF
--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -18,6 +18,18 @@ from ...services.ai_service import generate_reading_analysis, GeminiContentFilte
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+# Session.ai_analysis cache: v2 wraps response + enrichment fingerprint so we can
+# invalidate when the client sends richer data (Fixes #540 — stale cache after
+# comprehension/vocab/dictation completes).
+AI_ANALYSIS_CACHE_V2 = "ai_analysis_v2"
+_LEGACY_ANALYSIS_KEYS = frozenset({
+    "analysis_summary",
+    "strengths",
+    "areas_for_improvement",
+    "practice_suggestions",
+    "encouragement_message",
+})
+
 
 class AIAnalysisRequest(BaseModel):
     story_title: str = Field(..., max_length=200)
@@ -41,6 +53,67 @@ class AIAnalysisResponse(BaseModel):
     encouragement_message: str
 
 
+def _enrichment_cache_signature(payload: AIAnalysisRequest) -> str:
+    """Stable string for comparing which optional metrics were included in the request."""
+    c = payload.comprehension_score
+    if c is not None:
+        c = round(float(c), 4)
+    parts = [
+        c,
+        payload.vocab_practiced_count,
+        payload.vocab_total_count,
+        payload.dictation_correct_count,
+        payload.dictation_total_count,
+    ]
+    return json.dumps(parts, separators=(",", ":"), ensure_ascii=False)
+
+
+def _try_return_cached_ai_analysis(
+    raw: str | None,
+    payload: AIAnalysisRequest,
+) -> AIAnalysisResponse | None:
+    """Return cached AIAnalysisResponse if still valid for this payload; else None."""
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    sig = _enrichment_cache_signature(payload)
+
+    if data.get("format") == AI_ANALYSIS_CACHE_V2:
+        if data.get("enrichment_sig") == sig:
+            resp = data.get("response")
+            if isinstance(resp, dict) and _LEGACY_ANALYSIS_KEYS.issubset(resp.keys()):
+                return AIAnalysisResponse(**{k: resp[k] for k in _LEGACY_ANALYSIS_KEYS})
+        return None
+
+    # Legacy: flat response JSON only (pre-#540). If the client now sends any
+    # enrichment, ignore cache — it was generated without cross-step context.
+    if _LEGACY_ANALYSIS_KEYS.issubset(data.keys()):
+        if sig != "[null,null,null,null,null]":
+            logger.info("Ignoring legacy AI analysis cache — request has enrichment data")
+            return None
+        try:
+            return AIAnalysisResponse(**{k: data[k] for k in _LEGACY_ANALYSIS_KEYS})
+        except Exception:
+            return None
+
+    return None
+
+
+def _wrap_ai_analysis_for_cache(analysis: dict, payload: AIAnalysisRequest) -> str:
+    wrapped = {
+        "format": AI_ANALYSIS_CACHE_V2,
+        "enrichment_sig": _enrichment_cache_signature(payload),
+        "response": analysis,
+    }
+    return json.dumps(wrapped, ensure_ascii=False)
+
+
 @router.post(
     "/learning/sessions/{session_id}/ai-analysis",
     response_model=AIAnalysisResponse,
@@ -54,9 +127,10 @@ async def get_ai_analysis(
 ):
     """Generate AI reading diagnosis and improvement suggestions.
 
-    If the session already has a cached analysis, returns it immediately
-    without calling Gemini again. Otherwise calls Gemini and caches the
-    result in the session's ai_analysis column.
+    Caches in ``session.ai_analysis`` with an enrichment fingerprint (#540).
+    Legacy flat JSON caches are ignored when the client sends comprehension /
+    vocab / dictation metrics so the report can regenerate after later steps
+    complete.
 
     Rate limited: 5 requests per minute per user/IP.
     """
@@ -66,13 +140,13 @@ async def get_ai_analysis(
     if session.student_id != current_user.id:
         raise HTTPException(status_code=403, detail="Not your session")
 
-    # Return cached result if available
+    cached_resp = _try_return_cached_ai_analysis(session.ai_analysis, payload)
+    if cached_resp is not None:
+        return cached_resp
     if session.ai_analysis:
         try:
-            cached = json.loads(session.ai_analysis)
-            return AIAnalysisResponse(**cached)
+            json.loads(session.ai_analysis)
         except (json.JSONDecodeError, TypeError):
-            # Corrupted cache — regenerate
             logger.warning("Corrupted ai_analysis cache for session %d, regenerating", session_id)
 
     # Call Gemini
@@ -105,8 +179,8 @@ async def get_ai_analysis(
         logger.error("AI analysis generation failed for session %d: %s", session_id, e)
         raise HTTPException(status_code=503, detail="AI service unavailable")
 
-    # Cache the result
-    session.ai_analysis = json.dumps(analysis, ensure_ascii=False)
+    # Cache the result (versioned + enrichment fingerprint — #540)
+    session.ai_analysis = _wrap_ai_analysis_for_cache(analysis, payload)
     db.commit()
 
     logger.info("Generated AI analysis for session %d", session_id)

--- a/backend/tests/test_ai_analysis.py
+++ b/backend/tests/test_ai_analysis.py
@@ -30,6 +30,7 @@ from app.main import app
 from app.database import get_db
 from app.models import Base
 from app.models.user import Role
+from app.models.session import LearningSession
 
 # ---------------------------------------------------------------------------
 # Test database setup
@@ -194,7 +195,7 @@ def _create_session(client, token: str, slug: str = "ai-test") -> int:
 
 
 class TestSessionBasedAIAnalysis:
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_returns_analysis_for_valid_session(self, mock_gen, client, user_a):
         mock_gen.return_value = MOCK_ANALYSIS
         session_id = _create_session(client, user_a["token"], "analysis-valid")
@@ -213,7 +214,7 @@ class TestSessionBasedAIAnalysis:
         assert data["encouragement_message"] == MOCK_ANALYSIS["encouragement_message"]
         mock_gen.assert_called_once()
 
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_cached_analysis_returned_without_calling_gemini(self, mock_gen, client, user_a):
         mock_gen.return_value = MOCK_ANALYSIS
         session_id = _create_session(client, user_a["token"], "analysis-cache")
@@ -265,7 +266,7 @@ class TestSessionBasedAIAnalysis:
         )
         assert resp.status_code == 401
 
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_response_schema(self, mock_gen, client, user_a):
         mock_gen.return_value = MOCK_ANALYSIS
         session_id = _create_session(client, user_a["token"], "analysis-schema")
@@ -285,7 +286,7 @@ class TestSessionBasedAIAnalysis:
         assert len(data["strengths"]) > 0
         assert len(data["practice_suggestions"]) > 0
 
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_503_when_gemini_fails(self, mock_gen, client, user_a):
         mock_gen.side_effect = RuntimeError("Gemini connection error")
         session_id = _create_session(client, user_a["token"], "analysis-503")
@@ -298,7 +299,7 @@ class TestSessionBasedAIAnalysis:
         assert resp.status_code == 503
         assert "AI service" in resp.json()["detail"]
 
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_503_on_timeout(self, mock_gen, client, user_a):
         mock_gen.side_effect = TimeoutError("AI response timeout (30s)")
         session_id = _create_session(client, user_a["token"], "analysis-timeout")
@@ -311,6 +312,42 @@ class TestSessionBasedAIAnalysis:
         assert resp.status_code == 503
         assert "timeout" in resp.json()["detail"].lower()
 
+    @patch(
+        "app.routes.learning.learning_reading.generate_reading_analysis",
+        new_callable=AsyncMock,
+    )
+    def test_legacy_cache_skipped_when_enrichment_added_issue_540(
+        self, mock_gen, client, user_a
+    ):
+        """#540: Flat cached analysis must not win once client sends comprehension/vocab data."""
+        mock_gen.return_value = MOCK_ANALYSIS
+        session_id = _create_session(client, user_a["token"], "analysis-540-legacy")
+
+        db = TestingSessionLocal()
+        row = db.query(LearningSession).filter(LearningSession.id == session_id).one()
+        row.ai_analysis = json.dumps(MOCK_ANALYSIS, ensure_ascii=False)
+        db.commit()
+        db.close()
+
+        rich_payload = {**ANALYSIS_PAYLOAD, "comprehension_score": 82.0}
+        resp = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=rich_payload,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp.status_code == 200
+        mock_gen.assert_called_once()
+
+        # Second identical request hits v2 cache — no extra Gemini call
+        resp2 = client.post(
+            f"/api/learning/sessions/{session_id}/ai-analysis",
+            json=rich_payload,
+            headers=auth_header(user_a["token"]),
+        )
+        assert resp2.status_code == 200
+        assert resp2.json() == resp.json()
+        assert mock_gen.call_count == 1
+
 
 # ===========================================================================
 # POST /api/learning/ai-analysis — Standalone
@@ -318,7 +355,7 @@ class TestSessionBasedAIAnalysis:
 
 
 class TestStandaloneAIAnalysis:
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_standalone_returns_analysis(self, mock_gen, client, user_a):
         mock_gen.return_value = MOCK_ANALYSIS
 
@@ -340,7 +377,7 @@ class TestStandaloneAIAnalysis:
         )
         assert resp.status_code == 401
 
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_standalone_503_when_gemini_fails(self, mock_gen, client, user_a):
         mock_gen.side_effect = RuntimeError("Gemini unavailable")
 
@@ -369,7 +406,7 @@ class TestStandaloneAIAnalysis:
         )
         assert resp.status_code == 422
 
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_standalone_response_schema(self, mock_gen, client, user_a):
         mock_gen.return_value = MOCK_ANALYSIS
 
@@ -385,7 +422,7 @@ class TestStandaloneAIAnalysis:
         }
         assert set(data.keys()) == expected_keys
 
-    @patch("app.routes.learning.generate_reading_analysis", new_callable=AsyncMock)
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
     def test_standalone_accepts_comprehension_and_vocab_data(self, mock_gen, client, user_a):
         """Issue #415: AI analysis should accept optional comprehension and vocab data."""
         mock_gen.return_value = MOCK_ANALYSIS


### PR DESCRIPTION
## Root cause
Session `ai_analysis` was returned whenever set, **without** checking whether the new request included comprehension / vocab / dictation metrics. Students who triggered AI analysis **before** finishing later steps got a **stale** cached report in step 7.

## Fix
- **v2 cache**: wrap `{ format, enrichment_sig, response }`
- **Legacy** flat JSON: still used when request has no enrichment; **ignored** when any enrichment field is present so Gemini runs again.

## Tests
`pytest tests/test_ai_analysis.py` — 18 passed

Made with [Cursor](https://cursor.com)