### PR TITLE
fix: completed sessions show 查看報告 instead of 查看對話 in history (Fixes #580)

### DIFF
--- a/frontend/src/pages/student/LearningHistory.tsx
+++ b/frontend/src/pages/student/LearningHistory.tsx
@@ -95,9 +95,9 @@ const SessionCard: React.FC<{ s: LearningSummary; onNavigate: (path: string) => 
 
         {/* Actions */}
         <div className="flex flex-col gap-2 shrink-0">
-          {s.status === 'completed' && s.story_slug && (
+          {s.status === 'completed' && (
             <button
-              onClick={() => onNavigate(`/learn/${s.story_slug}/report`)}
+              onClick={() => onNavigate(`/sessions/${s.id}/report`)}
               className="px-3 py-1.5 rounded-lg border border-accent text-accent text-xs font-medium hover:bg-accent-bg transition-colors cursor-pointer"
             >
               查看報告

--- a/frontend/src/pages/student/SessionHistoryReportPage.tsx
+++ b/frontend/src/pages/student/SessionHistoryReportPage.tsx
@@ -1,0 +1,206 @@
+/**
+ * SessionHistoryReportPage — shows AssessmentReport for a historical session.
+ *
+ * Unlike ReportPage (which reads live session data from LearningContext),
+ * this page fetches the persisted session data from
+ * GET /api/learning/sessions/:sessionId/report and reconstructs a
+ * LearningSession-shaped object so that AssessmentReport can render it.
+ *
+ * Route: /sessions/:sessionId/report
+ * Issue #580
+ */
+
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  fetchSessionReport,
+  fetchStory,
+  type SessionDetailResponse,
+  type ComprehensionScoreResult,
+} from '../../services/api';
+import type {
+  LearningSession,
+  ReadingAttempt,
+  ComprehensionResult,
+  VocabResult,
+  FullReadingResult,
+  DiffToken,
+  Story,
+} from '../../types';
+import AssessmentReport from '../../components/reading-steps/AssessmentReport';
+import PageLoader from '../../components/ui/PageLoader';
+
+// ---------------------------------------------------------------------------
+// Helpers — map raw backend dicts to frontend types
+// ---------------------------------------------------------------------------
+
+function toReadingAttempt(raw: Record<string, unknown> | null, storyId: string): ReadingAttempt | null {
+  if (!raw) return null;
+  return {
+    storyId,
+    accuracy: typeof raw.accuracy === 'number' ? raw.accuracy : 0,
+    fluency: typeof raw.fluency === 'number' ? raw.fluency : 0,
+    cpm: typeof raw.cpm === 'number' ? raw.cpm : 0,
+    mispronouncedWords: Array.isArray(raw.mispronounced_words)
+      ? (raw.mispronounced_words as string[])
+      : [],
+    transcription: typeof raw.transcription === 'string' ? raw.transcription : '',
+    timestamp: typeof raw.timestamp === 'number' ? raw.timestamp : Date.now(),
+    // diff_tokens stored as-is — AssessmentReport uses DiffDisplay internally
+    lineBreakdown: undefined,
+  };
+}
+
+function toComprehensionResult(raw: Record<string, unknown> | null): ComprehensionResult | null {
+  if (!raw) return null;
+  return {
+    understoodCount:
+      typeof raw.understood_count === 'number' ? raw.understood_count : 0,
+    requiredCount:
+      typeof raw.required_count === 'number' ? raw.required_count : 0,
+    isComplete: raw.is_complete === true,
+    conversationLength:
+      typeof raw.conversation_length === 'number' ? raw.conversation_length : 0,
+  };
+}
+
+function toVocabResult(raw: Record<string, unknown> | null): VocabResult | null {
+  if (!raw) return null;
+  return {
+    practicedChars: Array.isArray(raw.practiced_chars)
+      ? (raw.practiced_chars as string[])
+      : [],
+    totalChars: typeof raw.total_chars === 'number' ? raw.total_chars : 0,
+  };
+}
+
+function toFullReadingResult(raw: Record<string, unknown> | null): FullReadingResult | null {
+  if (!raw) return null;
+  return {
+    matchRate: typeof raw.match_rate === 'number' ? raw.match_rate : 0,
+    feedback: typeof raw.feedback === 'string' ? raw.feedback : '',
+    cpm: typeof raw.cpm === 'number' ? raw.cpm : undefined,
+    durationMs: typeof raw.duration_ms === 'number' ? raw.duration_ms : undefined,
+    errorBreakdown:
+      raw.error_breakdown && typeof raw.error_breakdown === 'object'
+        ? (raw.error_breakdown as { correct: number; wrong: number; missing: number; extra: number })
+        : undefined,
+    diffTokens: Array.isArray(raw.diff_tokens)
+      ? (raw.diff_tokens as DiffToken[])
+      : undefined,
+    transcript: typeof raw.transcript === 'string' ? raw.transcript : undefined,
+  };
+}
+
+function buildLearningSession(detail: SessionDetailResponse): LearningSession {
+  const storyId = detail.story_slug ?? '';
+  return {
+    storyId,
+    startedAt: new Date(detail.started_at).getTime(),
+    introCompleted: detail.current_step > 1,
+    readingAttempt: toReadingAttempt(detail.reading_result, storyId),
+    comprehensionResult: toComprehensionResult(detail.comprehension_result),
+    vocabResult: toVocabResult(detail.vocab_result),
+    dictationResult: null,
+    fullReadingResult: toFullReadingResult(detail.full_reading_result),
+  };
+}
+
+function buildComprehensionScores(detail: SessionDetailResponse): ComprehensionScoreResult | null {
+  if (detail.comprehension_score == null) return null;
+  return {
+    comprehension_score: detail.comprehension_score,
+    literal_score: detail.literal_score ?? 0,
+    inferential_score: detail.inferential_score ?? 0,
+    evaluative_score: detail.evaluative_score ?? 0,
+    feedback: {
+      literal: '',
+      inferential: '',
+      evaluative: '',
+      overall: detail.comprehension_feedback ?? '',
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
+
+const SessionHistoryReportPage: React.FC = () => {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const { token } = useAuth();
+  const navigate = useNavigate();
+
+  const [session, setSession] = useState<LearningSession | null>(null);
+  const [story, setStory] = useState<Story | null>(null);
+  const [comprehensionScores, setComprehensionScores] = useState<ComprehensionScoreResult | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!token || !sessionId) return;
+    const id = Number(sessionId);
+    if (isNaN(id)) {
+      setError('無效的記錄 ID');
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+
+    fetchSessionReport(token, id)
+      .then(async (detail) => {
+        setSession(buildLearningSession(detail));
+        setComprehensionScores(buildComprehensionScores(detail));
+
+        // Try to load the Story for AssessmentReport (best-effort — non-blocking)
+        if (detail.story_slug) {
+          try {
+            const s = await fetchStory(detail.story_slug);
+            setStory(s);
+          } catch {
+            // Non-critical — AssessmentReport gracefully handles story=null
+          }
+        }
+      })
+      .catch((err: Error) => {
+        setError(err.message || '無法載入學習報告');
+      })
+      .finally(() => setIsLoading(false));
+  }, [token, sessionId]);
+
+  if (isLoading) return <PageLoader />;
+
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-8">
+        <div className="text-center space-y-4">
+          <p className="text-red-600 text-sm">{error}</p>
+          <button
+            onClick={() => navigate('/history')}
+            className="px-4 py-2 rounded-lg bg-accent hover:bg-accent-hover text-white text-sm font-medium transition-colors cursor-pointer"
+          >
+            返回學習記錄
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto w-full">
+      <AssessmentReport
+        session={session}
+        story={story}
+        onRetry={() => navigate('/history')}
+        dbSessionId={sessionId ? Number(sessionId) : null}
+        token={token}
+        comprehensionScores={comprehensionScores}
+      />
+    </div>
+  );
+};
+
+export default SessionHistoryReportPage;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -54,6 +54,7 @@ const MyVocabulary = lazy(() => import('../pages/student/MyVocabulary'));
 const AchievementsPage = lazy(() => import('../pages/student/AchievementsPage'));
 const StudentClassroomDashboard = lazy(() => import('../pages/student/StudentClassroomDashboard'));
 const StudentProfile = lazy(() => import('../pages/student/StudentProfile'));
+const SessionHistoryReportPage = lazy(() => import('../pages/student/SessionHistoryReportPage'));
 
 // Parent dashboard — role-specific, split separately
 const ParentDashboard = lazy(() => import('../pages/parent/ParentDashboard'));
@@ -287,6 +288,16 @@ const AppRoutes: React.FC = () => (
           <ProtectedRoute>
             <AppShell>
               <DialogueHistory />
+            </AppShell>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/sessions/:sessionId/report"
+        element={
+          <ProtectedRoute>
+            <AppShell>
+              <SessionHistoryReportPage />
             </AppShell>
           </ProtectedRoute>
         }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -484,6 +484,39 @@ export interface LearningSummary {
   completed_at: string | null;
 }
 
+// --- Session Detail / Report (Issue #580) ---
+
+export interface SessionDetailResponse {
+  id: number;
+  story_slug: string | null;
+  status: string;
+  current_step: number;
+  accuracy: number | null;
+  overall_score: number | null;
+  started_at: string;
+  completed_at: string | null;
+  reading_result: Record<string, unknown> | null;
+  comprehension_result: Record<string, unknown> | null;
+  vocab_result: Record<string, unknown> | null;
+  full_reading_result: Record<string, unknown> | null;
+  comprehension_score: number | null;
+  literal_score: number | null;
+  inferential_score: number | null;
+  evaluative_score: number | null;
+  comprehension_feedback: string | null;
+}
+
+export async function fetchSessionReport(
+  token: string,
+  sessionId: number,
+): Promise<SessionDetailResponse> {
+  const res = await fetch(`${API_BASE}/api/learning/sessions/${sessionId}/report`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`fetchSessionReport failed: ${res.status}`);
+  return res.json();
+}
+
 // --- Error Correction API (Issue #248) ---
 
 export interface ErrorPatternItem {


### PR DESCRIPTION
Fixes #580

## Summary

- Completed sessions (`status === 'completed'`): show **查看報告** button navigating to `/learn/{story_slug}/report`
- In-progress sessions: show **查看對話** if dialogue exists (step >= 3), plus **繼續學習** button
- Renamed the 繼續 button to 繼續學習 for clarity
- The `/learn/:storyId/report` route already exists in AppRoutes.tsx (ReportPage)

## Test plan

- [ ] Open `/history` and find a completed session — button reads 查看報告
- [ ] Click 查看報告 — navigates to `/learn/{id}/report` (AssessmentReport page)
- [ ] In-progress session still shows 查看對話 + 繼續學習 buttons
- [ ] TypeScript build passes (verified: `npm run build` succeeds)