### PR TITLE
feat: add smoke test to staging deploy (Fixes #581)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -176,6 +176,67 @@ jobs:
           echo "**Backend:** ${BACKEND_URL}" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
 
+  smoke-test:
+    name: Smoke test staging API
+    needs: [deploy-backend, deploy-frontend]
+    if: always() && !cancelled() && (needs.deploy-backend.result == 'success' || needs.deploy-frontend.result == 'success')
+    runs-on: ubuntu-latest
+    env:
+      STAGING_BACKEND: https://lingoleap-backend-staging-958347263320.asia-east1.run.app
+    steps:
+      - name: Wait for Cloud Run to be ready
+        run: sleep 15
+
+      - name: Smoke test /health (expect 200)
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STAGING_BACKEND}/health")
+          echo "/health -> $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "FAIL: /health returned $STATUS, expected 200"
+            exit 1
+          fi
+
+      - name: Smoke test /api/teacher/story-tags (expect 200 or 401, not 500)
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STAGING_BACKEND}/api/teacher/story-tags")
+          echo "/api/teacher/story-tags -> $STATUS"
+          if [ "$STATUS" = "500" ]; then
+            echo "FAIL: /api/teacher/story-tags returned 500"
+            exit 1
+          fi
+
+      - name: Smoke test /api/schools (expect 200 or 401, not 500)
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STAGING_BACKEND}/api/schools")
+          echo "/api/schools -> $STATUS"
+          if [ "$STATUS" = "500" ]; then
+            echo "FAIL: /api/schools returned 500"
+            exit 1
+          fi
+
+      - name: Smoke test /api/organizations (expect 200 or 401, not 500)
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STAGING_BACKEND}/api/organizations")
+          echo "/api/organizations -> $STATUS"
+          if [ "$STATUS" = "500" ]; then
+            echo "FAIL: /api/organizations returned 500"
+            exit 1
+          fi
+
+      - name: Smoke test summary
+        if: always()
+        run: |
+          echo "## Smoke Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Target**: ${STAGING_BACKEND}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Endpoint | Acceptable Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|------------------|" >> $GITHUB_STEP_SUMMARY
+          echo "| GET /health | 200 only |" >> $GITHUB_STEP_SUMMARY
+          echo "| GET /api/teacher/story-tags | 200 or 401 (not 500) |" >> $GITHUB_STEP_SUMMARY
+          echo "| GET /api/schools | 200 or 401 (not 500) |" >> $GITHUB_STEP_SUMMARY
+          echo "| GET /api/organizations | 200 or 401 (not 500) |" >> $GITHUB_STEP_SUMMARY
+
   cleanup-images:
     name: Cleanup old AR images
     needs: [deploy-backend, deploy-frontend]


### PR DESCRIPTION
Fixes #581

## Summary

- Adds a `smoke-test` job to `staging-deploy.yml` that runs after `deploy-backend` and `deploy-frontend`
- Only runs when at least one deploy job succeeds (`needs.deploy-backend.result == 'success' || needs.deploy-frontend.result == 'success'`)
- Waits 15s for Cloud Run to become ready, then curls 4 endpoints against the staging backend URL

## Endpoints checked

| Endpoint | Pass condition |
|----------|---------------|
| GET /health | must return 200 |
| GET /api/teacher/story-tags | must NOT return 500 (200 or 401 accepted) |
| GET /api/schools | must NOT return 500 (200 or 401 accepted) |
| GET /api/organizations | must NOT return 500 (200 or 401 accepted) |

Any 500 response fails the job immediately with a clear error message.

## Test plan

- [ ] Merge this PR to staging and verify the `smoke-test` job appears in the workflow run
- [ ] Confirm all 4 endpoints pass on current staging
- [ ] To verify failure detection: temporarily break an endpoint and confirm the job fails