### PR TITLE
feat: add Sentry error tracking (Fixes #582)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,8 @@ import uuid
 import traceback
 from contextlib import asynccontextmanager
 
+import sentry_sdk
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -35,6 +37,26 @@ from .auth.rate_limiter import general_rate_limiter
 setup_logging()
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Sentry error tracking
+# ---------------------------------------------------------------------------
+# To enable Sentry, set the SENTRY_DSN environment variable in Cloud Run:
+#   gcloud run services update lingoleap-backend \
+#     --set-env-vars SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project-id>
+#
+# ENVIRONMENT env var controls the Sentry environment tag (default: "production").
+# Leave SENTRY_DSN unset (or empty) in local dev to skip initialisation.
+_sentry_dsn = os.environ.get("SENTRY_DSN", "").strip()
+if _sentry_dsn:
+    sentry_sdk.init(
+        dsn=_sentry_dsn,
+        environment=os.environ.get("ENVIRONMENT", "production"),
+        traces_sample_rate=0.1,
+    )
+    logger.info("Sentry initialised (environment=%s)", os.environ.get("ENVIRONMENT", "production"))
+else:
+    logger.info("Sentry not initialised — SENTRY_DSN is not set")
 
 _env = os.environ.get("ENVIRONMENT", "development")
 _is_dev = _env in ("development", "preview")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,3 +22,4 @@ bcrypt>=4.0
 python-multipart>=0.0.9
 python-json-logger>=2.0.0
 slowapi>=0.1.9
+sentry-sdk[fastapi]>=2.0


### PR DESCRIPTION
Fixes #582

## Summary

- Added `sentry-sdk[fastapi]>=2.0` to `backend/requirements.txt`
- Initialized Sentry in `backend/app/main.py` before FastAPI app creation
- DSN is read from the `SENTRY_DSN` env var — if not set, init is skipped gracefully (no crash)
- `environment` tag is read from the `ENVIRONMENT` env var (default: `"production"`)
- `traces_sample_rate=0.1` (10% of transactions traced for performance)
- No secrets hardcoded anywhere

## Test plan

- [ ] Build succeeds (sentry-sdk installs cleanly)
- [ ] With `SENTRY_DSN` unset: server starts normally, logs "Sentry not initialised"
- [ ] With `SENTRY_DSN` set: server starts and logs "Sentry initialised (environment=...)"
- [ ] 5xx errors in production will appear in Sentry dashboard after SENTRY_DSN is configured in Cloud Run