### PR TITLE
fix: normalize L-prefix story_id in GET /api/stories/{id} (Fixes #590)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -85,11 +85,14 @@ def list_stories(
 def get_story(story_id: str):
     """Get full story detail by ID (lesson_number).
 
-    Accepts a numeric string (e.g. "3"). Non-numeric or unknown IDs return 404.
+    Accepts a numeric string (e.g. "3") or L-prefixed format (e.g. "L06").
+    Non-numeric or unknown IDs return 404.
     This prevents 422 errors when legacy sessions store slug-format story_slugs.
     """
+    # Normalize "L06" → "6" format (assignments store story_id with L-prefix)
+    normalized = story_id.lstrip("Ll")
     try:
-        numeric_id = int(story_id)
+        numeric_id = int(normalized)
     except (ValueError, TypeError):
         raise HTTPException(status_code=404, detail="Story not found")
     story = get_lesson_by_id(numeric_id)


### PR DESCRIPTION
Fixes #590

## Summary

- `backend/app/routes/stories.py`: Strip leading `L`/`l` prefix before `int()` conversion in `get_story()`
- Accepts both `"6"` (numeric) and `"L06"` (L-prefix) formats
- `int("L06")` was throwing `ValueError` → HTTP 404 when students started assignments

## Root Cause

Assignments store `story_id` as `"L06"` (matching YAML filenames `L06.yml`). The `get_story()` endpoint only accepted pure numeric strings, so `int("L06")` raised `ValueError` → 404.

## Fix

```python
# Before
numeric_id = int(story_id)  # int("L06") → ValueError → 404

# After
normalized = story_id.lstrip("Ll")  # "L06" → "6"
numeric_id = int(normalized)         # int("6") → 6
```

## Test plan

- [ ] `GET /api/stories/L06` returns 200 with story data
- [ ] `GET /api/stories/6` still returns 200 (backward compat)
- [ ] `GET /api/stories/invalid` still returns 404
- [ ] Student can start assignment and enter lesson page without 404