### PR TITLE
fix: 已完成課文「查看對話」改為「查看報告」(Fixes #580)

### DIFF
--- a/frontend/src/pages/student/LearningHistory.tsx
+++ b/frontend/src/pages/student/LearningHistory.tsx
@@ -4,7 +4,7 @@
  * Sessions are split into "進行中" and "已完成" tabs.
  *
  * Route: /history
- * Issue #242, #553
+ * Issue #242, #553, #580
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
@@ -95,7 +95,15 @@ const SessionCard: React.FC<{ s: LearningSummary; onNavigate: (path: string) => 
 
         {/* Actions */}
         <div className="flex flex-col gap-2 shrink-0">
-          {hasDialogue && (
+          {s.status === 'completed' && s.story_slug && (
+            <button
+              onClick={() => onNavigate(`/learn/${s.story_slug}/report`)}
+              className="px-3 py-1.5 rounded-lg border border-accent text-accent text-xs font-medium hover:bg-accent-bg transition-colors cursor-pointer"
+            >
+              查看報告
+            </button>
+          )}
+          {hasDialogue && s.status !== 'completed' && (
             <button
               onClick={() => onNavigate(`/sessions/${s.id}/dialogue`)}
               className="px-3 py-1.5 rounded-lg border border-accent text-accent text-xs font-medium hover:bg-accent-bg transition-colors cursor-pointer"


### PR DESCRIPTION
Fixes #580

## Summary
- 已完成 session（`status === 'completed'`）：按鈕改為「查看報告」，導向 `/learn/{story_slug}/report`
- 進行中 session（`current_step >= 3`）：保留「查看對話」按鈕，連結維持不變

## 變更檔案
- `frontend/src/pages/student/LearningHistory.tsx` — `SessionCard` 元件 actions 區塊

## Test plan
- [ ] 開啟 `/history` 頁面，切換到「已完成」tab
- [ ] 確認已完成課文顯示「查看報告」按鈕，點擊後導向 `/learn/{story_slug}/report`
- [ ] 切換到「進行中」tab，確認有對話記錄的 session 仍顯示「查看對話」按鈕

🤖 Generated with [Claude Code](https://claude.com/claude-code)