### PR TITLE
fix: show story title in learning history page (Fixes #578)

### DIFF
--- a/backend/app/routes/learning/learning_sessions.py
+++ b/backend/app/routes/learning/learning_sessions.py
@@ -84,10 +84,14 @@ def list_my_sessions(
         .limit(limit)
         .all()
     )
-    return SessionListResponse(
-        items=[SessionSummaryResponse.model_validate(s) for s in items],
-        total=total,
-    )
+    summaries = []
+    for s in items:
+        summary = SessionSummaryResponse.model_validate(s)
+        # Resolve human-readable title from the linked Text record (if available)
+        if s.text is not None:
+            summary.story_title = s.text.title
+        summaries.append(summary)
+    return SessionListResponse(items=summaries, total=total)
 
 
 @router.get("/learning/sessions/{session_id}", response_model=SessionDetailResponse)

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -24,6 +24,7 @@ class SessionUpdateRequest(BaseModel):
 class SessionSummaryResponse(BaseModel):
     id: int
     story_slug: str | None
+    story_title: str | None = None  # human-readable title, e.g. "第六課 牛頓的故事"
     status: str
     current_step: int
     accuracy: float | None

--- a/frontend/src/pages/student/LearningHistory.tsx
+++ b/frontend/src/pages/student/LearningHistory.tsx
@@ -72,7 +72,7 @@ const SessionCard: React.FC<{ s: LearningSummary; onNavigate: (path: string) => 
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
             <h3 className="text-sm font-medium text-gray-900 truncate">
-              {s.story_slug ?? '未知課文'}
+              {s.story_title ?? s.story_slug ?? '未知課文'}
             </h3>
             <StatusBadge status={s.status} />
           </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -475,6 +475,7 @@ export async function fetchLearningSessions(
 export interface LearningSummary {
   id: number;
   story_slug: string | null;
+  story_title: string | null;
   status: string;
   current_step: number;
   accuracy: number | null;


### PR DESCRIPTION
Fixes #578

## Summary
- Added `story_title: str | None` to `SessionSummaryResponse` schema in `backend/app/schemas/session.py`
- Updated `list_my_sessions` route to populate `story_title` from the linked `Text` record (`s.text.title`) — same pattern used by the `/progress` endpoint
- Added `story_title: string | null` to `LearningSummary` interface in `frontend/src/services/api.ts`
- Updated `LearningHistory.tsx` line 75 to display `story_title ?? story_slug ?? '未知課文'`

The `/progress` page fix (`story_title` on `TextProgressItem`) was already merged in staging. This PR completes the fix for the `/history` page.

## Test plan
- [ ] Open the learning history page (`/history`)
- [ ] Confirm sessions show course titles (e.g. "第六課 牛頓的故事") instead of raw numeric IDs ("6", "11")
- [ ] Confirm sessions whose story has no linked `Text` record still fall back to `story_slug`, not blank