### PR TITLE
fix: add missing semesters table migration (Fixes #595)

### DIFF
--- a/backend/alembic/versions/v2w3x4y5z6a7_create_semesters_table.py
+++ b/backend/alembic/versions/v2w3x4y5z6a7_create_semesters_table.py
@@ -1,0 +1,66 @@
+"""create semesters table
+
+Revision ID: v2w3x4y5z6a7
+Revises: u1v2w3x4y5z6
+Create Date: 2026-03-20 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "v2w3x4y5z6a7"
+down_revision: Union[str, None] = "u1v2w3x4y5z6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "semesters",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("school_id", sa.Integer(), nullable=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column("grace_days", sa.Integer(), nullable=False, server_default="7"),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("created_by_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["school_id"],
+            ["schools.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_id"],
+            ["users.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("school_id", "name", name="uq_semester_school_name"),
+    )
+    op.create_index(
+        op.f("ix_semesters_school_id"), "semesters", ["school_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_semesters_is_active"), "semesters", ["is_active"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_semesters_is_active"), table_name="semesters")
+    op.drop_index(op.f("ix_semesters_school_id"), table_name="semesters")
+    op.drop_table("semesters")


### PR DESCRIPTION
Fixes #595

## Summary

- 新增 Alembic migration `v2w3x4y5z6a7_create_semesters_table.py`
- 建立 `semesters` 表，對應 `backend/app/models/semester.py` 中的 Semester model
- 與 PR #577 (story_tags) 相同根本原因：model 有定義但缺少對應 migration

## Changes

- `backend/alembic/versions/v2w3x4y5z6a7_create_semesters_table.py` — 新增 semesters 表 migration
  - 欄位：`id`, `school_id` (FK→schools, nullable), `name`, `start_date`, `end_date`, `grace_days` (default 7), `is_active` (default false), `created_by_id` (FK→users, nullable), `created_at`, `updated_at`
  - 索引：`ix_semesters_school_id`, `ix_semesters_is_active`
  - Unique constraint：`uq_semester_school_name` (school_id, name)
  - `down_revision`: `u1v2w3x4y5z6` (接在 story_tags migration 之後)

## Test plan

- [ ] CI migration check passes
- [ ] `semesters` table 在 staging DB 上成功建立
- [ ] `/api/semesters` 相關端點不再回傳 500