### PR TITLE
fix: clarify /progress vs /history UX separation (Fixes #598)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -286,7 +286,7 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
         { icon: '📊', label: '學習進度', path: '/progress' },
         { icon: '🏆', label: '成就', path: '/achievements' },
         { icon: '📖', label: '生字本', path: '/vocabulary' },
-        { icon: '📝', label: '學習記錄', path: '/history' },
+        { icon: '📝', label: '對話記錄', path: '/history' },
         { icon: '🏫', label: '我的班級', path: '/classroom-dashboard' },
         { icon: '🔗', label: '加入班級', path: '/join' },
         { icon: '👤', label: '個人檔案', path: '/profile' },

--- a/frontend/src/pages/student/LearningHistory.tsx
+++ b/frontend/src/pages/student/LearningHistory.tsx
@@ -106,7 +106,7 @@ const SessionCard: React.FC<{ s: LearningSummary; onNavigate: (path: string) => 
           {s.status === 'in_progress' && s.story_slug && !isNaN(Number(s.story_slug)) && (
             <button
               onClick={() => onNavigate(`/learn/${s.story_slug}/intro`)}
-              className="px-3 py-1.5 rounded-lg bg-blue-500 hover:bg-blue-600 text-white text-xs font-medium transition-colors cursor-pointer"
+              className="px-3 py-1.5 rounded-lg border border-blue-400 text-blue-600 hover:bg-blue-50 text-xs font-medium transition-colors cursor-pointer"
             >
               繼續
             </button>
@@ -162,8 +162,19 @@ const LearningHistory: React.FC = () => {
       <div className="max-w-2xl mx-auto space-y-6">
         {/* Page title */}
         <div>
-          <h1 className="text-xl font-bold text-gray-900">學習記錄</h1>
-          <p className="text-sm text-gray-500 mt-1">查看過去的課文學習和理解對話</p>
+          <h1 className="text-xl font-bold text-gray-900">對話記錄</h1>
+          <p className="text-sm text-gray-500 mt-1">每次學習的詳細紀錄，可查看 AI 課文理解對話</p>
+        </div>
+
+        {/* Cross-link to /progress */}
+        <div className="flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg px-4 py-2.5 text-sm">
+          <span className="text-blue-700">想追蹤每篇課文的六步驟完成狀況？</span>
+          <button
+            onClick={() => navigate('/progress')}
+            className="ml-3 shrink-0 text-xs font-medium text-blue-600 hover:text-blue-800 underline cursor-pointer"
+          >
+            前往學習進度
+          </button>
         </div>
 
         {/* Error */}

--- a/frontend/src/pages/student/StudentProgress.tsx
+++ b/frontend/src/pages/student/StudentProgress.tsx
@@ -166,6 +166,17 @@ const StudentProgress: React.FC = () => {
           <p className="text-sm text-gray-500 mt-1">追蹤每篇課文的六步驟完成狀況</p>
         </div>
 
+        {/* Cross-link to /history */}
+        <div className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-lg px-4 py-2.5 text-sm">
+          <span className="text-gray-600">想查看每次學習的 AI 對話紀錄？</span>
+          <button
+            onClick={() => navigate('/history')}
+            className="ml-3 shrink-0 text-xs font-medium text-gray-500 hover:text-gray-700 underline cursor-pointer"
+          >
+            前往對話記錄
+          </button>
+        </div>
+
         {/* Error */}
         {error && (
           <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">


### PR DESCRIPTION
Fixes #598

## Summary

The `/progress` (學習進度) and `/history` (學習記錄) pages had overlapping surface UI that made them look like duplicates to students, even though they serve different purposes:

- `/progress` — **per-text aggregate view**: 6-step completion pills, progress bar, overall stats. \"How far am I through each text?\"
- `/history` — **per-session log**: every individual session, \"查看對話\" link for AI dialogue review. \"What did I do each time?\"

Changes:
- **Sidebar**: rename `📝 學習記錄` → `📝 對話記錄` to surface the unique feature
- **`/history` page**: rename title to \"對話記錄\", update subtitle to call out AI dialogue, add cross-link banner pointing to `/progress`
- **`/history` in-progress tab**: de-emphasize \"繼續\" button (outline instead of filled blue) since `/progress` is the primary place to continue learning
- **`/progress` page**: add cross-link banner pointing to `/history` for students wanting per-session detail

## Test plan

- [ ] Open sidebar as a student — check `/history` nav item now says \"對話記錄\"
- [ ] Visit `/history` — confirm page title is \"對話記錄\", subtitle mentions AI 對話, cross-link banner appears linking to `/progress`
- [ ] Visit `/progress` — confirm cross-link banner appears linking to `/history`
- [ ] On `/history` in-progress tab — confirm \"繼續\" button renders as outline style (not filled blue)
- [ ] Click cross-link banners on both pages — confirm navigation works correctly