### PR TITLE
feat: 教師端多校切換 UI (Fixes #572)

### DIFF
--- a/frontend/src/components/teacher/SchoolSwitcher.tsx
+++ b/frontend/src/components/teacher/SchoolSwitcher.tsx
@@ -1,0 +1,131 @@
+/**
+ * SchoolSwitcher — combobox for teachers in multiple schools.
+ *
+ * Only renders when `hasMultipleSchools` is true (WorkspaceContext).
+ * Fetches school names once per mount (or when teacherSchoolIds changes)
+ * and displays a select bound to activeSchoolId / setActiveSchoolId.
+ *
+ * Implements #572.
+ */
+
+import React, { useEffect, useState, useId } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useWorkspace } from '../../contexts/WorkspaceContext';
+import { getSchool, SchoolApiError } from '../../services/schoolApi';
+
+interface SchoolOption {
+  id: number;
+  label: string;
+}
+
+const SchoolSwitcher: React.FC = () => {
+  const { token } = useAuth();
+  const {
+    activeSchoolId,
+    setActiveSchoolId,
+    teacherSchoolIds,
+    hasMultipleSchools,
+  } = useWorkspace();
+
+  const [options, setOptions] = useState<SchoolOption[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const selectId = useId();
+
+  useEffect(() => {
+    if (!token || teacherSchoolIds.length === 0) return;
+
+    let cancelled = false;
+    setIsLoading(true);
+
+    Promise.all(
+      teacherSchoolIds.map(async (id) => {
+        try {
+          const school = await getSchool(token, id);
+          return { id, label: school.display_name ?? school.name };
+        } catch (err) {
+          if (err instanceof SchoolApiError && err.status === 404) {
+            // school may not be accessible; fall back to ID label
+            return { id, label: `學校 #${id}` };
+          }
+          return { id, label: `學校 #${id}` };
+        }
+      }),
+    ).then((results) => {
+      if (!cancelled) {
+        setOptions(results.sort((a, b) => a.label.localeCompare(b.label, 'zh-TW')));
+        setIsLoading(false);
+      }
+    });
+
+    return () => { cancelled = true; };
+  }, [token, teacherSchoolIds]);
+
+  // Single-school teachers: don't render anything
+  if (!hasMultipleSchools) return null;
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const id = parseInt(e.target.value, 10);
+    if (!Number.isNaN(id)) setActiveSchoolId(id);
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <label
+        htmlFor={selectId}
+        className="text-sm font-medium text-gray-600 whitespace-nowrap"
+      >
+        目前學校
+      </label>
+      <div className="relative">
+        {/* Building icon */}
+        <svg
+          className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+          />
+        </svg>
+        <select
+          id={selectId}
+          value={activeSchoolId ?? ''}
+          onChange={handleChange}
+          disabled={isLoading || options.length === 0}
+          aria-label="切換目前學校"
+          className="h-9 pl-8 pr-8 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm
+                     focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent
+                     transition-colors appearance-none disabled:opacity-60 disabled:cursor-not-allowed
+                     min-w-[140px]"
+        >
+          {isLoading ? (
+            <option value="">載入中...</option>
+          ) : (
+            options.map((opt) => (
+              <option key={opt.id} value={opt.id}>
+                {opt.label}
+              </option>
+            ))
+          )}
+        </select>
+        {/* Chevron */}
+        <svg
+          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+export default SchoolSwitcher;

--- a/frontend/src/pages/teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/teacher/TeacherDashboard.tsx
@@ -7,6 +7,7 @@ import {
   ClassroomResponse,
   ClassroomApiError,
 } from '../../services/classroomApi';
+import SchoolSwitcher from '../../components/teacher/SchoolSwitcher';
 
 interface TeacherDashboardProps {
   onSelectClassroom: (classroomId: number) => void;
@@ -14,9 +15,8 @@ interface TeacherDashboardProps {
 
 const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }) => {
   const { token, user } = useAuth();
-  const { activeSchoolId: teacherSchoolId } = useWorkspace();
+  const { activeSchoolId: teacherSchoolId, hasMultipleSchools } = useWorkspace();
   const [classrooms, setClassrooms] = useState<ClassroomResponse[]>([]);
-  const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
 
@@ -31,15 +31,22 @@ const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }
   const [isCreating, setIsCreating] = useState(false);
   const [createError, setCreateError] = useState('');
 
-  const filteredClassrooms = useMemo(() => {
-    return classrooms
+  /**
+   * When the teacher is in multiple schools, filter classrooms to the
+   * currently-selected school. Single-school teachers see all classrooms.
+   */
+  const visibleClassrooms = useMemo(() => {
+    const base = hasMultipleSchools && teacherSchoolId != null
+      ? classrooms.filter((cr) => cr.school_id === teacherSchoolId)
+      : classrooms;
+    return base
       .filter((cr) => !searchQuery || cr.name.toLowerCase().includes(searchQuery.toLowerCase()))
       .sort((a, b) => {
         if (sortBy === 'grade') return (a.grade ?? 99) - (b.grade ?? 99);
         if (sortBy === 'students') return b.student_count - a.student_count;
         return a.name.localeCompare(b.name, 'zh-TW');
       });
-  }, [classrooms, searchQuery, sortBy]);
+  }, [classrooms, searchQuery, sortBy, hasMultipleSchools, teacherSchoolId]);
 
   const loadClassrooms = useCallback(async () => {
     if (!token) return;
@@ -48,7 +55,6 @@ const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }
     try {
       const data = await listMyClassrooms(token);
       setClassrooms(data.items);
-      setTotal(data.total);
     } catch (err) {
       if (err instanceof ClassroomApiError) {
         setError(err.message);
@@ -111,23 +117,32 @@ const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }
     </div>
   );
 
+  // Count used in the subtitle: visible after school filter, before text search
+  const schoolFilteredCount = hasMultipleSchools && teacherSchoolId != null
+    ? classrooms.filter((cr) => cr.school_id === teacherSchoolId).length
+    : classrooms.length;
+
   return (
     <div className="flex-1 overflow-y-auto p-6 sm:p-8">
       <div className="max-w-5xl mx-auto space-y-6">
         {/* Page header */}
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div>
             <h1 className="text-2xl font-bold text-gray-900">班級管理</h1>
             <p className="text-sm text-gray-500 mt-1">
-              {isLoading ? '載入中...' : `共 ${total} 個班級`}
+              {isLoading ? '載入中...' : `共 ${schoolFilteredCount} 個班級`}
             </p>
           </div>
-          <button
-            onClick={() => setShowCreateForm(true)}
-            className="bg-accent hover:bg-accent-hover text-white px-5 py-2.5 rounded-lg font-medium text-sm transition-colors"
-          >
-            建立班級
-          </button>
+          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+            {/* School switcher — only shown when teacher belongs to multiple schools */}
+            <SchoolSwitcher />
+            <button
+              onClick={() => setShowCreateForm(true)}
+              className="bg-accent hover:bg-accent-hover text-white px-5 py-2.5 rounded-lg font-medium text-sm transition-colors whitespace-nowrap"
+            >
+              建立班級
+            </button>
+          </div>
         </div>
 
         {/* Search & sort */}
@@ -255,16 +270,23 @@ const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }
         )}
 
         {/* No search results */}
-        {!isLoading && !error && classrooms.length > 0 && filteredClassrooms.length === 0 && (
+        {!isLoading && !error && visibleClassrooms.length === 0 && classrooms.length > 0 && searchQuery && (
           <div className="text-center py-8 text-sm text-gray-500">
             找不到符合「{searchQuery}」的班級
           </div>
         )}
 
+        {/* No classrooms in selected school (multi-school, no text query) */}
+        {!isLoading && !error && visibleClassrooms.length === 0 && classrooms.length > 0 && !searchQuery && hasMultipleSchools && (
+          <div className="text-center py-8 text-sm text-gray-500">
+            此學校目前沒有班級
+          </div>
+        )}
+
         {/* Classroom grid */}
-        {!isLoading && !error && filteredClassrooms.length > 0 && (
+        {!isLoading && !error && visibleClassrooms.length > 0 && (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {filteredClassrooms.map((cr) => {
+            {visibleClassrooms.map((cr) => {
               const isCoTeacher = user?.id != null && cr.teacher_id !== user.id;
               return (
                 <button
@@ -302,7 +324,7 @@ const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }
           </div>
         )}
 
-        {/* Empty state */}
+        {/* Empty state — no classrooms at all */}
         {!isLoading && !error && classrooms.length === 0 && (
           <div className="text-center py-16">
             <div className="inline-flex items-center justify-center w-16 h-16 bg-accent-bg rounded-2xl mb-4">


### PR DESCRIPTION
Fixes #572

## Summary
- New `SchoolSwitcher` component renders a school combobox in the `TeacherDashboard` page header, visible **only** when `hasMultipleSchools` is true (single-school teachers see no change)
- Fetches school display names via `getSchool()` API in parallel for all `teacherSchoolIds`, falls back to `學校 #N` if unreachable
- `TeacherDashboard` now filters the classroom list by `activeSchoolId` (front-end `classroom.school_id` comparison) when the teacher is in multiple schools
- Subtitle count reflects per-school total, not global total
- School selection persists across refreshes via `WorkspaceContext` localStorage (`lingoleap_workspace_school`)

## Test plan
- [ ] Log in as a teacher assigned to exactly one school — no school switcher visible, all classrooms shown as before
- [ ] Log in as a teacher assigned to two or more schools — school switcher appears in the header row next to "建立班級"
- [ ] Switch school in dropdown — classroom list updates immediately to show only classrooms belonging to that school
- [ ] Refresh page after switching school — selected school is remembered
- [ ] Create a new classroom while school A is selected — classroom is created under school A's `school_id`