### PR TITLE
fix: add migration for schools.allowed_email_domains (Fixes #603)

### DIFF
--- a/backend/alembic/versions/w3x4y5z6a7b8_add_allowed_email_domains_to_schools.py
+++ b/backend/alembic/versions/w3x4y5z6a7b8_add_allowed_email_domains_to_schools.py
@@ -1,0 +1,30 @@
+"""add allowed_email_domains to schools
+
+Revision ID: w3x4y5z6a7b8
+Revises: v2w3x4y5z6a7
+Create Date: 2026-03-20 07:00:00.000000
+
+"""
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "w3x4y5z6a7b8"
+down_revision: Union[str, None] = "v2w3x4y5z6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add allowed_email_domains JSON column to schools table
+    op.add_column(
+        "schools",
+        sa.Column("allowed_email_domains", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("schools", "allowed_email_domains")


### PR DESCRIPTION
## Summary
- Adds missing Alembic migration for `schools.allowed_email_domains` JSON column
- Without this, all new user registrations fail with 500 (UndefinedColumn error)
- Discovered during staging QA check today

## Root Cause
`School` model has `allowed_email_domains: Mapped[list | None] = mapped_column(JSON, nullable=True)` but no corresponding migration was ever created.

## Test plan
- [ ] Verify registration succeeds on staging after deploy
- [ ] POST /api/auth/register with valid email → should return 201

Fixes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)