### PR TITLE
fix: del index.html CSP localhost

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <!-- Content-Security-Policy: browser-level fallback.
          The primary CSP is set by SecurityHeadersMiddleware in backend/app/main.py.
          This meta tag covers direct frontend hosting (Firebase Hosting / CDN). -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' http://localhost:8000 http://127.0.0.1:8000 https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com;" />
     <!-- Note: frame-ancestors is intentionally omitted from this meta tag.
          Per CSP spec, frame-ancestors is a navigation directive and is ignored
          when delivered via <meta> elements (causes browser console warnings).


### PR DESCRIPTION
### 問題說明

[pr #451](https://github.com/Youngger9765/chinese-literacy-platform/pull/451) 的本地開發 CSP 沒有移除

### 解決方法

``` html
<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com;" />
```