### PR TITLE
feat: add structured JSON audit logging for student PII access (Fixes #522)

### DIFF
--- a/backend/app/routes/classrooms/classroom_students.py
+++ b/backend/app/routes/classrooms/classroom_students.py
@@ -1,7 +1,7 @@
 """Student management endpoints: add, remove, list, search students in a classroom."""
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
@@ -14,6 +14,7 @@ from ...schemas.classroom import (
     StudentSearchRequest,
     StudentSearchResult,
 )
+from ...services.audit_logger import AuditAction, audit_log_endpoint
 from .helpers import (
     get_classroom_or_404,
     require_member_or_admin,
@@ -78,6 +79,7 @@ def add_student_to_classroom(
 def remove_student_from_classroom(
     classroom_id: int,
     student_id: int,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -96,6 +98,12 @@ def remove_student_from_classroom(
     if cs is None:
         raise HTTPException(status_code=404, detail="Student not in classroom")
 
+    audit_log_endpoint(
+        request=request,
+        action=AuditAction.DELETE_STUDENT,
+        user_id=current_user.id,
+        target_student_id=student_id,
+    )
     db.delete(cs)
     db.commit()
     logger.info("Removed student %d from classroom %d", student_id, classroom_id)
@@ -108,12 +116,20 @@ def remove_student_from_classroom(
 )
 def list_classroom_students(
     classroom_id: int,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     """List all students enrolled in a classroom. Owner, co-teachers, and admins can access."""
     classroom = get_classroom_or_404(classroom_id, db)
     require_member_or_admin(classroom, current_user, db)
+
+    audit_log_endpoint(
+        request=request,
+        action=AuditAction.LIST_STUDENTS,
+        user_id=current_user.id,
+        target_student_id=None,
+    )
 
     enrollments = (
         db.query(ClassroomStudent)

--- a/backend/app/routes/teacher/teacher_reports.py
+++ b/backend/app/routes/teacher/teacher_reports.py
@@ -4,7 +4,7 @@ import io
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -16,6 +16,7 @@ from ...models.school import ClassroomStudent
 from ...models.session import CharacterError, ErrorCorrection, LearningSession
 from ...models.gamification import StudentStreak, StudentXPLog
 from ...models.user import User
+from ...services.audit_logger import AuditAction, audit_log_endpoint
 from .teacher_schemas import ErrorVocabItem
 
 router = APIRouter(tags=["teacher"])
@@ -81,6 +82,7 @@ def get_classroom_error_vocab(
 @router.get("/teacher/classrooms/{classroom_id}/export")
 def export_classroom_report(
     classroom_id: int,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -90,6 +92,12 @@ def export_classroom_report(
              已掌握生字, 連續學習天數, 累積XP, 最近學習日期
     """
     classroom = _check_classroom_access(current_user, classroom_id, db)
+    audit_log_endpoint(
+        request=request,
+        action=AuditAction.EXPORT_REPORT,
+        user_id=current_user.id,
+        target_student_id=None,
+    )
 
     enrollments = (
         db.query(ClassroomStudent)

--- a/backend/app/routes/teacher/teacher_students.py
+++ b/backend/app/routes/teacher/teacher_students.py
@@ -1,7 +1,7 @@
 """Teacher student management endpoints: sessions, dialogue, tags, learning curve, stuck overview."""
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
@@ -11,6 +11,7 @@ from ...models.school import Classroom, ClassroomStudent
 from ...models.session import DialogueTurn, LearningSession
 from ...models.student_tag import StudentTag
 from ...models.user import User
+from ...services.audit_logger import AuditAction, audit_log_endpoint
 from ...services.lesson_loader import get_lesson_by_id
 from ...services.stuck_detection_service import build_recommendations, detect_stuck_points
 from .teacher_schemas import (
@@ -55,6 +56,7 @@ def _require_teacher_owns_student(
 )
 def get_student_sessions(
     student_id: int,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -74,6 +76,13 @@ def get_student_sessions(
     )
     if not enrollment:
         raise HTTPException(status_code=403, detail="Not authorized to view this student's sessions")
+
+    audit_log_endpoint(
+        request=request,
+        action=AuditAction.VIEW_STUDENT,
+        user_id=current_user.id,
+        target_student_id=student_id,
+    )
 
     sessions = (
         db.query(LearningSession)
@@ -114,6 +123,7 @@ def get_student_sessions(
 def get_teacher_student_dialogue(
     student_id: int,
     session_id: int,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -134,6 +144,13 @@ def get_teacher_student_dialogue(
     )
     if not enrollment:
         raise HTTPException(status_code=403, detail="Not authorized to view this student's sessions")
+
+    audit_log_endpoint(
+        request=request,
+        action=AuditAction.VIEW_SESSION,
+        user_id=current_user.id,
+        target_student_id=student_id,
+    )
 
     # Verify the session belongs to the student
     session = (
@@ -261,6 +278,7 @@ def remove_student_tag(
 )
 def get_student_learning_curve(
     student_id: int,
+    request: Request,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
@@ -281,6 +299,13 @@ def get_student_learning_curve(
     )
     if not enrollment:
         raise HTTPException(status_code=403, detail="Not authorized to view this student's data")
+
+    audit_log_endpoint(
+        request=request,
+        action=AuditAction.VIEW_STUDENT,
+        user_id=current_user.id,
+        target_student_id=student_id,
+    )
 
     # Sessions with scores, ordered oldest first
     sessions = (

--- a/backend/app/services/audit_logger.py
+++ b/backend/app/services/audit_logger.py
@@ -1,0 +1,111 @@
+"""Audit logging service for sensitive student PII access (Issue #522).
+
+Emits structured JSON log records to the "audit" logger.
+Cloud Run forwards stdout/stderr to Cloud Logging automatically, so these logs
+will appear as structured log entries when the JSON is parsed by Cloud Logging.
+
+Usage:
+    # Direct call:
+    audit_log(
+        action=AuditAction.VIEW_STUDENT,
+        user_id=current_user.id,
+        target_student_id=student_id,
+        ip_address=request.client.host,
+        endpoint=str(request.url.path),
+        method=request.method,
+    )
+
+    # Inside a FastAPI route with a Request object:
+    audit_log_endpoint(
+        request=request,
+        action=AuditAction.VIEW_STUDENT,
+        user_id=current_user.id,
+        target_student_id=student_id,
+    )
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional
+
+from fastapi import Request
+
+_audit_logger = logging.getLogger("audit")
+
+
+class AuditAction(str, Enum):
+    """Enumeration of auditable actions on student PII."""
+
+    VIEW_STUDENT = "view_student"
+    LIST_STUDENTS = "list_students"
+    VIEW_SESSION = "view_session"
+    EXPORT_REPORT = "export_report"
+    DELETE_STUDENT = "delete_student"
+
+
+def audit_log(
+    *,
+    action: AuditAction,
+    user_id: int,
+    target_student_id: Optional[int],
+    ip_address: str,
+    endpoint: str,
+    method: str,
+) -> None:
+    """Emit a structured JSON audit log record.
+
+    The "audit" logger uses the standard Python logging infrastructure.
+    Cloud Run captures stdout/stderr and Cloud Logging parses JSON lines
+    automatically, making these searchable in the Cloud Logging console.
+
+    Args:
+        action: The AuditAction describing what was done.
+        user_id: The authenticated user performing the action.
+        target_student_id: The student whose data was accessed (None for
+            classroom-level actions that don't target a single student).
+        ip_address: Client IP address from request.client.host.
+        endpoint: URL path (e.g. "/api/teacher/students/42").
+        method: HTTP method (e.g. "GET").
+    """
+    payload = {
+        "audit": True,
+        "user_id": user_id,
+        "action": action.value if isinstance(action, AuditAction) else str(action),
+        "target_student_id": target_student_id,
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "ip_address": ip_address,
+        "endpoint": endpoint,
+        "method": method,
+    }
+    _audit_logger.info(json.dumps(payload, ensure_ascii=False))
+
+
+def audit_log_endpoint(
+    *,
+    request: Request,
+    action: AuditAction,
+    user_id: int,
+    target_student_id: Optional[int] = None,
+) -> None:
+    """Convenience wrapper that extracts IP, endpoint, and method from a Request.
+
+    Args:
+        request: The FastAPI Request object from the route handler.
+        action: The AuditAction describing what was done.
+        user_id: The authenticated user performing the action.
+        target_student_id: The student whose data was accessed (optional).
+    """
+    ip_address = "unknown"
+    if request.client:
+        ip_address = request.client.host
+
+    audit_log(
+        action=action,
+        user_id=user_id,
+        target_student_id=target_student_id,
+        ip_address=ip_address,
+        endpoint=str(request.url.path),
+        method=request.method,
+    )

--- a/backend/tests/test_audit_logger.py
+++ b/backend/tests/test_audit_logger.py
@@ -1,0 +1,179 @@
+"""
+Tests for audit_logger service (Issue #522).
+
+Covers:
+- audit_log() function emits structured JSON log
+- Decorator @audit_log captures action, user_id, target_student_id, ip, endpoint, method
+- Log record has audit=True marker
+
+Run with:
+    cd backend
+    python -m pytest tests/test_audit_logger.py -v
+"""
+
+import json
+import logging
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import FastAPI, Depends, Request
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.services.audit_logger import audit_log, AuditAction
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for audit_log() function
+# ---------------------------------------------------------------------------
+
+class TestAuditLogFunction:
+    """Test the audit_log() helper function directly."""
+
+    def test_audit_log_emits_json_record(self, caplog):
+        """audit_log() must emit a log record with audit=True."""
+        with caplog.at_level(logging.INFO, logger="audit"):
+            audit_log(
+                action=AuditAction.VIEW_STUDENT,
+                user_id=1,
+                target_student_id=99,
+                ip_address="127.0.0.1",
+                endpoint="/api/teacher/students/99",
+                method="GET",
+            )
+
+        assert len(caplog.records) >= 1
+        record = caplog.records[-1]
+        # Must be emitted on the audit logger
+        assert record.name == "audit"
+
+    def test_audit_log_record_has_required_fields(self, caplog):
+        """Log message must be parseable JSON with all required fields."""
+        with caplog.at_level(logging.INFO, logger="audit"):
+            audit_log(
+                action=AuditAction.VIEW_STUDENT,
+                user_id=42,
+                target_student_id=7,
+                ip_address="10.0.0.1",
+                endpoint="/api/teacher/students/7",
+                method="GET",
+            )
+
+        record = caplog.records[-1]
+        payload = json.loads(record.getMessage())
+
+        assert payload["audit"] is True
+        assert payload["user_id"] == 42
+        assert payload["action"] == "view_student"
+        assert payload["target_student_id"] == 7
+        assert payload["ip_address"] == "10.0.0.1"
+        assert payload["endpoint"] == "/api/teacher/students/7"
+        assert payload["method"] == "GET"
+        assert "timestamp" in payload
+
+    def test_audit_log_timestamp_is_iso_format(self, caplog):
+        """timestamp field must be a valid ISO-8601 string ending in Z."""
+        from datetime import datetime
+
+        with caplog.at_level(logging.INFO, logger="audit"):
+            audit_log(
+                action=AuditAction.EXPORT_REPORT,
+                user_id=5,
+                target_student_id=None,
+                ip_address="192.168.0.1",
+                endpoint="/api/teacher/classrooms/3/export",
+                method="GET",
+            )
+
+        record = caplog.records[-1]
+        payload = json.loads(record.getMessage())
+        ts = payload["timestamp"]
+        # Should parse without error
+        datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+    def test_audit_log_target_student_id_optional(self, caplog):
+        """target_student_id may be None for classroom-level actions."""
+        with caplog.at_level(logging.INFO, logger="audit"):
+            audit_log(
+                action=AuditAction.LIST_STUDENTS,
+                user_id=10,
+                target_student_id=None,
+                ip_address="1.2.3.4",
+                endpoint="/api/teacher/classrooms/1/students",
+                method="GET",
+            )
+
+        record = caplog.records[-1]
+        payload = json.loads(record.getMessage())
+        assert payload["target_student_id"] is None
+        assert payload["action"] == "list_students"
+
+
+# ---------------------------------------------------------------------------
+# Tests for AuditAction enum
+# ---------------------------------------------------------------------------
+
+class TestAuditAction:
+    """Verify AuditAction enum has the expected values."""
+
+    def test_view_student_value(self):
+        assert AuditAction.VIEW_STUDENT == "view_student"
+
+    def test_list_students_value(self):
+        assert AuditAction.LIST_STUDENTS == "list_students"
+
+    def test_view_session_value(self):
+        assert AuditAction.VIEW_SESSION == "view_session"
+
+    def test_export_report_value(self):
+        assert AuditAction.EXPORT_REPORT == "export_report"
+
+    def test_delete_student_value(self):
+        assert AuditAction.DELETE_STUDENT == "delete_student"
+
+
+# ---------------------------------------------------------------------------
+# Integration-style test: decorator applied to a simple FastAPI route
+# ---------------------------------------------------------------------------
+
+class TestAuditLogDecorator:
+    """Test that the @audit_log_endpoint decorator emits an audit record."""
+
+    def test_decorator_emits_audit_record(self, caplog):
+        """Calling a decorated route must emit an audit log record."""
+        from app.services.audit_logger import audit_log_endpoint
+
+        mini_app = FastAPI()
+
+        @mini_app.get("/test/students/{student_id}")
+        def dummy_route(student_id: int, request: Request):
+            audit_log_endpoint(
+                request=request,
+                action=AuditAction.VIEW_STUDENT,
+                user_id=1,
+                target_student_id=student_id,
+            )
+            return {"ok": True}
+
+        client = TestClient(mini_app)
+
+        with caplog.at_level(logging.INFO, logger="audit"):
+            resp = client.get("/test/students/55")
+
+        assert resp.status_code == 200
+        audit_records = [r for r in caplog.records if r.name == "audit"]
+        assert len(audit_records) == 1
+
+        payload = json.loads(audit_records[0].getMessage())
+        assert payload["audit"] is True
+        assert payload["action"] == "view_student"
+        assert payload["target_student_id"] == 55
+        assert payload["user_id"] == 1
+        assert payload["endpoint"] == "/test/students/55"
+        assert payload["method"] == "GET"


### PR DESCRIPTION
Fixes #522

## Summary
- New `backend/app/services/audit_logger.py` with `AuditAction` enum, `audit_log()` function, and `audit_log_endpoint()` convenience wrapper
- Structured JSON emitted to the `audit` Python logger — Cloud Run auto-forwards stdout/stderr to Cloud Logging, making records searchable without any infra changes
- Applied to 6 sensitive endpoints across 3 route files:
  - `GET /teacher/students/{id}/sessions` — VIEW_STUDENT
  - `GET /teacher/students/{id}/sessions/{id}/dialogue` — VIEW_SESSION
  - `GET /teacher/students/{id}/learning-curve` — VIEW_STUDENT
  - `GET /teacher/classrooms/{id}/export` — EXPORT_REPORT
  - `DELETE /classrooms/{id}/students/{id}` — DELETE_STUDENT
  - `GET /classrooms/{id}/students` — LIST_STUDENTS

## Log format
Each access emits a JSON line like:
```json
{"audit": true, "user_id": 1, "action": "view_student", "target_student_id": 42, "timestamp": "2026-03-20T13:00:00Z", "ip_address": "1.2.3.4", "endpoint": "/api/teacher/students/42/sessions", "method": "GET"}
```

## Test plan
- 10 unit tests in `tests/test_audit_logger.py` — all passing
- Tests cover: JSON structure, required fields, timestamp ISO format, optional target_student_id, AuditAction enum values, and decorator integration
- No regressions: pre-existing test suite failures are unrelated (SQLite/JWT env issues on staging that existed before this PR)