### PR TITLE
feat: genre-aware Socratic dialogue (#615 Sprint 1)

### DIFF
--- a/backend/app/routes/learning/learning_comprehension.py
+++ b/backend/app/routes/learning/learning_comprehension.py
@@ -95,6 +95,9 @@ class ComprehensionChatRequest(BaseModel):
     cpm: float | None = Field(None, gt=0)
     # Optional DB learning session ID — when provided, dialogue turns are persisted (Issue #242)
     db_session_id: int | None = None
+    # Genre-aware Socratic (#615)
+    genre: str | None = None
+    reading_strategy: str | None = None
 
 
 class ComprehensionChatResponse(BaseModel):
@@ -152,6 +155,8 @@ async def comprehension_chat(
                 accuracy=payload.accuracy,
                 cpm=payload.cpm,
                 teacher_instructions=teacher_instructions_content or None,
+                genre=payload.genre,
+                reading_strategy=payload.reading_strategy,
             )
         else:
             result = await socratic_agent.process_answer(

--- a/backend/app/services/socratic_agent.py
+++ b/backend/app/services/socratic_agent.py
@@ -34,6 +34,9 @@ class SessionState:
     cpm: float | None = None
     # Teacher special instructions for individualized learning (Issue #90)
     teacher_instructions: list[str] | None = None
+    # Genre-aware Socratic (#615)
+    genre: str | None = None
+    reading_strategy: str | None = None
 
 
 class SessionStore:
@@ -157,9 +160,44 @@ class SocraticAgent:
                 reading_info += f"- 讀錯的字：{', '.join(state.mispronounced_words)}\n"
             reading_info += "→ 提問時可以特別關注這些字相關的段落和內容\n"
 
+        # Build genre-aware guidance section (#615)
+        genre_section = ""
+        if state.genre and state.genre != "無":
+            genre_prompts = {
+                "記敘文": (
+                    "這是一篇【記敘文】。\n"
+                    "重點提問方向：\n"
+                    "- factual：人物（誰）、時地（何時/何地）、事件（發生什麼）\n"
+                    "- inferential：人物動機（為什麼）、心理情感、因果關係\n"
+                    "- evaluative：主題（這個故事告訴我們什麼）、連結自身經驗\n"
+                ),
+                "說明文": (
+                    "這是一篇【說明文】。\n"
+                    "重點提問方向：\n"
+                    "- factual：主要說明對象、重要事實、數字資料\n"
+                    "- inferential：說明結構（分類/比較/因果）、各段落關係\n"
+                    "- evaluative：這個知識對生活有何影響？還有哪些想知道的？\n"
+                ),
+                "議論文": (
+                    "這是一篇【議論文】。\n"
+                    "重點提問方向：\n"
+                    "- factual：作者的論點（主張）是什麼\n"
+                    "- inferential：作者用哪些論據支持論點？論據夠充分嗎？\n"
+                    "- evaluative：你同意作者的看法嗎？為什麼？\n"
+                ),
+            }
+            genre_section = genre_prompts.get(state.genre, f"文體：{state.genre}\n")
+
+        strategy_section = ""
+        if state.reading_strategy and state.reading_strategy not in ("無", ""):
+            strategy_section = (
+                f"本課閱讀策略：【{state.reading_strategy}】\n"
+                f"→ 請在 inferential/evaluative 階段，將問題引導至學生練習此策略\n"
+            )
+
         return f"""{TUTOR_PERSONA}
 你擅長用蘇格拉底式問答引導學生深入理解課文。
-
+{genre_section}{strategy_section}
 課文標題：{state.story_title}
 
 課文內容（每段前標有段落索引）：
@@ -220,6 +258,8 @@ class SocraticAgent:
         accuracy: float | None = None,
         cpm: float | None = None,
         teacher_instructions: list[str] | None = None,
+        genre: str | None = None,
+        reading_strategy: str | None = None,
     ) -> AgentResponse:
         """Start a new session — generate the first question."""
         state = SessionState(
@@ -230,6 +270,8 @@ class SocraticAgent:
             accuracy=accuracy,
             cpm=cpm,
             teacher_instructions=teacher_instructions,
+            genre=genre,
+            reading_strategy=reading_strategy,
         )
 
         system_prompt = self._build_system_prompt(state)

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -190,6 +190,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         mispronouncedWords: attempt.mispronouncedWords?.length ? attempt.mispronouncedWords : undefined,
         accuracy: attempt.accuracy || undefined,
         cpm: attempt.cpm || undefined,
+        // Genre-aware Socratic (#615)
+        genre: story.genre,
+        readingStrategy: story.readingStrategy,
       });
       setConversation([{ role: 'ai', text: result.question }]);
       applyServerState(result);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -398,6 +398,9 @@ export async function sendComprehensionChat(payload: {
   cpm?: number;
   /** DB LearningSession integer ID — when provided, dialogue turns are persisted (Issue #242) */
   dbSessionId?: number;
+  /** Genre-aware Socratic (#615) */
+  genre?: string;
+  readingStrategy?: string;
   token?: string;
 }): Promise<ChatResponse> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
@@ -414,6 +417,8 @@ export async function sendComprehensionChat(payload: {
       accuracy: payload.accuracy,
       cpm: payload.cpm,
       db_session_id: payload.dbSessionId ?? null,
+      genre: payload.genre ?? null,
+      reading_strategy: payload.readingStrategy ?? null,
     }),
   });
   if (res.status === 422) {


### PR DESCRIPTION
## Summary

Pass `genre` and `reading_strategy` from lesson YAMLs through the API payload into the Socratic AI prompt. 55/57 lesson YAMLs already have these fields filled — **0 DB migrations, minimal risk**.

### What changes

| File | Change |
|------|--------|
| `socratic_agent.py` | `SessionState` + `_build_system_prompt()` genre/strategy awareness |
| `learning_comprehension.py` | `ComprehensionChatRequest` + `start_session()` new fields |
| `api.ts` | `sendComprehensionChat()` new params |
| `ComprehensionChat.tsx` | Pass `story.genre` + `story.readingStrategy` on session start |

### Effect

Before: All genres get identical generic prompts.

After:
- 記敘文 → prompt focuses on character motivation, 人物心理, cause-effect
- 說明文 → prompt focuses on structure analysis, categories, knowledge application
- 議論文 → prompt focuses on argument identification, evidence evaluation
- reading_strategy → AI is reminded to guide students to practice the lesson's specific strategy in inferential/evaluative phases

### Risk
Low — genre/readingStrategy are optional (nullable). If not provided, prompt unchanged from current behavior.

Closes #615 (Sprint 1 only — 文章重點表 is Sprint 2)

## Test plan
- [ ] Start ComprehensionChat on a 記敘文 lesson → first question is character/event focused
- [ ] Start ComprehensionChat on a 說明文 lesson → first question asks about facts/structure
- [ ] Start ComprehensionChat with no genre (null) → prompt unchanged (regression check)