### PR TITLE
ci: automate staging pipeline end-to-end

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,19 +72,19 @@ jobs:
           echo "Deployment URL did not become healthy within 10 minutes."
           exit 1
 
-      - name: Run E2E tests (core flows only)
+      - name: Run E2E tests (m1-m6 core flows)
         working-directory: frontend
         env:
           PLAYWRIGHT_BASE_URL: ${{ steps.resolve-url.outputs.base_url }}
           CI: 'true'
         run: |
           npx playwright test \
-            e2e/auth-flow.spec.ts \
-            e2e/story-selection.spec.ts \
-            e2e/learning-flow.spec.ts \
-            e2e/student-flow.spec.ts \
-            e2e/teacher-flow.spec.ts \
-            e2e/teacher-dashboard.spec.ts \
+            e2e/m1-auth.spec.ts \
+            e2e/m2-teacher.spec.ts \
+            e2e/m3-student.spec.ts \
+            e2e/m4-admin.spec.ts \
+            e2e/m5-infra.spec.ts \
+            e2e/m6-learning.spec.ts \
             --reporter=github \
             --timeout=60000
 

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -300,14 +300,7 @@ jobs:
           STAGING_URL="https://lingoleap-frontend-staging-958347263320.asia-east1.run.app"
           for ISSUE_NUM in $ISSUES; do
             echo "Commenting on issue #${ISSUE_NUM}"
-            BODY="## Deployed to Staging
-
-Smoke tests passed. E2E tests are now running in parallel.
-
-**Staging URL**: ${STAGING_URL}
-
-Next step: wait for E2E test results, then request case owner testing."
-            gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$BODY"
+            gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$(printf '## Deployed to Staging\n\nSmoke tests passed.\n\n**Staging URL**: %s\n\nNext step: request case owner testing.' "${STAGING_URL}")"
           done
 
   cleanup-branch:


### PR DESCRIPTION
## Summary

- **Fix 1**: Re-enable `e2e-tests.yml` (was `.disabled`) and add `push: branches: [staging]` trigger so E2E tests run automatically after every staging deploy, not only on PRs
- **Fix 2**: Add `notify-staging` job to `staging-deploy.yml` — parses `Fixes/Closes/Refs #N` from commit message and comments on each referenced issue after smoke tests pass
- **Fix 3**: Add `cleanup-branch` job to `staging-deploy.yml` — auto-deletes remote `fix/issue-*`, `feat/issue-*`, `feature/issue-*` branches after merge to staging (merge commit format only)

Note: The companion change to `~/.claude/agents/git-issue-pr-flow.md` (Phase 3.5 post-staging verification instructions) lives in the dotfiles repo and is applied separately.

## Security

All untrusted inputs (`github.event.head_commit.message`) are passed through `env:` blocks and read as shell variables — not interpolated directly into `run:` scripts. This follows GitHub's recommended expression injection prevention pattern.

## Test plan

- [ ] Merge a feature branch to staging with `Fixes #N` in commit message — verify issue receives a comment
- [ ] Verify E2E workflow triggers on push to staging (check Actions tab)
- [ ] Merge via merge commit (not squash) — verify feature branch is deleted from remote
- [ ] Merge via squash (no `from owner/branch` in message) — verify cleanup step exits gracefully with "skipping" message
- [ ] Merge a branch without `Fixes #N` — verify notify step exits gracefully with "skipping" message