### PR TITLE
fix: 最近練習顯示課文標題而非 slug (Fixes #624)

### DIFF
--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -58,7 +58,7 @@ interface RecentPracticeItem {
 function mapSessionToRecentItem(session: LearningSummary): RecentPracticeItem {
   return {
     id: session.id,
-    title: session.story_slug ?? '未知課文',
+    title: session.story_title ?? session.story_slug ?? '未知課文',
     status: session.status,
     startedAt: session.started_at,
     completedAt: session.completed_at,


### PR DESCRIPTION
Fixes #624

## Summary

- `InlinePages.tsx` 第 61 行：將 `session.story_slug` 改為 `session.story_title ?? session.story_slug ?? '未知課文'`
- 一行修正，使「最近練習」卡片顯示實際課文標題而非數字 ID

## Root Cause

`mapSessionToRecentItem()` 直接使用 `story_slug`（數字 ID）作為顯示標題，但 `LearningSummary` type 已有 `story_title` 欄位未被使用。

## Test plan

- [ ] 登入有練習記錄的學生帳號
- [ ] 查看首頁「最近練習」區塊
- [ ] 確認卡片顯示課文名稱（如「那一片綠」）而非數字 ID（如「5"」）
- [ ] 確認無 story_title 的舊 session 仍 fallback 顯示 story_slug