### PR TITLE
fix: add frame-src directive to CSP to allow YouTube iframes (Fixes #626)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <!-- Content-Security-Policy: browser-level fallback.
          The primary CSP is set by SecurityHeadersMiddleware in backend/app/main.py.
          This meta tag covers direct frontend hosting (Firebase Hosting / CDN). -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.run.app https://*.googleapis.com https://*.firebaseapp.com https://*.cloudfunctions.net https://us-central1-aiplatform.googleapis.com https://www.google-analytics.com https://analytics.google.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com;" />
     <!-- Note: frame-ancestors is intentionally omitted from this meta tag.
          Per CSP spec, frame-ancestors is a navigation directive and is ignored
          when delivered via <meta> elements (causes browser console warnings).


### PR DESCRIPTION
Fixes #626

## Summary
- Added `frame-src https://www.youtube.com https://www.youtube-nocookie.com;` to the CSP meta tag in `frontend/index.html`
- Without this directive, browsers fall back to `default-src 'self'` which blocks all cross-origin iframes, causing YouTube embeds in 知識補給站 to show a blocked content error

## Root cause
CSP `frame-src` was missing. Browser enforces `default-src 'self'` as fallback, which blocks `https://www.youtube.com` iframes.

## Change
One-line change to `frontend/index.html` — appends `frame-src https://www.youtube.com https://www.youtube-nocookie.com;` to the existing CSP meta tag.

## Test plan
- [ ] Open 知識補給站 page
- [ ] Verify YouTube video embeds load without "blocked content" error
- [ ] Check browser console — no CSP violations for youtube.com