### PR TITLE
feat: 登入頁快速角色選擇在所有環境顯示 (Fixes #628)

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -175,8 +175,8 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
           </button>
         </p>
 
-        {/* Quick login buttons (dev/demo only) — hidden in production */}
-        {import.meta.env.VITE_ENVIRONMENT === 'development' && (
+        {/* Quick login buttons (demo) */}
+        {(
           <div className="mt-8 border-t border-gray-200 pt-6">
             <p className="text-xs text-gray-400 text-center mb-3">快速登入（測試用）</p>
             <div className="grid grid-cols-3 gap-2">


### PR DESCRIPTION
Fixes #628

## Summary

- 移除 `VITE_ENVIRONMENT === 'development'` 條件判斷
- 快速登入按鈕（管理員 / 教師 / 學生）現在在所有環境都可見
- 方便 demo 展示和 staging 測試時快速切換角色

## Changes

- `frontend/src/pages/LoginPage.tsx` — 移除環境條件，改為無條件渲染快速登入區塊

## Test plan

- [ ] 開啟 PR Preview URL 登入頁
- [ ] 確認頁面底部出現「快速登入（測試用）」區塊，含管理員 / 教師 / 學生三個按鈕
- [ ] 點擊各按鈕確認可成功登入對應角色