### PR TITLE
fix: ComprehensionChat auth token + 全站課文字體最小 2XL (Fixes #630)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -6,6 +6,7 @@ import ZhuyinToggle from '../ui/ZhuyinToggle';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import StoryStructureTable from './StoryStructureTable';
 import MultipleChoiceExercise from './MultipleChoiceExercise';
+import { useAuth } from '../../contexts/AuthContext';
 
 interface ComprehensionChatProps {
   story: Story;
@@ -29,6 +30,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   onFinish,
   onBack,
 }) => {
+  const { token } = useAuth();
   const [conversation, setConversation] = useState<ChatMessage[]>([]);
   const [inputText, setInputText] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -195,6 +197,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         // Genre-aware Socratic (#615)
         genre: story.genre,
         readingStrategy: story.readingStrategy,
+        token: token ?? undefined,
       });
       setConversation([{ role: 'ai', text: result.question }]);
       applyServerState(result);
@@ -326,6 +329,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         storyTitle: story.title,
         storyText,
         studentAnswer: text,
+        token: token ?? undefined,
       });
 
       applyServerState(result);
@@ -787,7 +791,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                           : 'border-transparent hover:border-gray-200 hover:bg-white/40'
                       }`}
                     >
-                      <p className={`text-xl text-gray-900 leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                      <p className={`text-2xl text-gray-900 leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                         {zhuyinLines ? zhuyinLines[idx] : line}
                       </p>
                     </div>

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -287,7 +287,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
                 key={idx}
                 className="rounded-2xl px-6 py-12 border-b border-gray-200 last:border-b-0 hover:bg-white/30 transition-all"
               >
-                <p className={`${isMobile ? 'text-xl' : 'text-2xl lg:text-3xl'} text-gray-800 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                <p className={`text-2xl lg:text-3xl text-gray-800 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                   {zhuyinLines ? zhuyinLines[idx] : line}
                 </p>
               </div>

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -177,7 +177,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 </svg>
                 <span className="text-xs font-bold text-accent-light uppercase tracking-widest">課文簡介</span>
               </div>
-              <p className={`text-gray-900 text-xl leading-[3rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+              <p className={`text-gray-900 text-2xl leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                 {processZhuyin(story.intro.background)}
               </p>
 

--- a/frontend/src/components/ui/FontSizeControl.tsx
+++ b/frontend/src/components/ui/FontSizeControl.tsx
@@ -7,9 +7,9 @@ const DEFAULT_LEVEL: FontSizeLevel = 'medium';
 export const FONT_SIZE_EVENT = 'lingoleap:font-size-change';
 
 export const FONT_SIZE_PX: Record<FontSizeLevel, number> = {
-  small: 14,
-  medium: 18,
-  large: 22,
+  small: 24,
+  medium: 28,
+  large: 32,
 };
 
 const LEVELS: FontSizeLevel[] = ['small', 'medium', 'large'];


### PR DESCRIPTION
Fixes #630

## Summary

- **Bug 1 (Critical)**: `ComprehensionChat.tsx` 呼叫 `sendComprehensionChat` 時未傳 auth token，導致 backend 回 401，前端觸發離線模式。修正：引入 `useAuth()` 取得 token，兩個呼叫點都補上 `token: token ?? undefined`
- **Bug 2**: `FontSizeControl` 最小字體 14px 過小。依用戶需求調整為最小 2XL (24px)：small 14→24, medium 18→28, large 22→32
- `ComprehensionChat` story panel、`Intro` 課文簡介、`FullReading` 全文朗讀頁：統一改為 text-2xl baseline

## Files Changed

- `frontend/src/components/reading-steps/ComprehensionChat.tsx`
- `frontend/src/components/ui/FontSizeControl.tsx`
- `frontend/src/components/reading-steps/Intro.tsx`
- `frontend/src/components/reading-steps/FullReading.tsx`

## Test plan

- [ ] 以登入學生身份進入課文理解步驟，確認蘇格拉底對話正常啟動（不顯示「無法連線到伺服器」）
- [ ] 確認 ComprehensionChat、Intro、FullReading 課文文字至少 24px
- [ ] 測試 FontSizeControl 小/中/大 三個等級切換，確認字體正確改變
- [ ] 行動裝置確認 FullReading 字體同樣為 text-2xl