### PR TITLE
fix: 破音字 STT matching — 兩/二 number normalization + 一 tone sandhi tests (#638)

### DIFF
--- a/frontend/src/components/zhuyin/polyphonicProcessor.test.ts
+++ b/frontend/src/components/zhuyin/polyphonicProcessor.test.ts
@@ -201,3 +201,106 @@ describe('PolyphonicProcessor — Issue #219: polyphonic character ss mapping', 
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// 一 tone sandhi regression tests (Issue #638)
+// ---------------------------------------------------------------------------
+//
+// Documents the CURRENT behavior of getNewToneForYiBu for 一.
+// Standard Mandarin tone sandhi rules for 一:
+//   Before 4th tone → 2nd tone (ss01)  e.g. 一個 yí gè
+//   Before 1st/2nd/3rd tone → 4th tone (ss02)  e.g. 一天 yì tiān
+//   In number context (第一, 十一, 一百...) → 1st tone (0000)
+//   Standalone → 1st tone (0000)
+//
+// Known limitations (tracked in Issue #611):
+//   - When 一 is the FIRST character in text (prevChar == null), the processor
+//     returns 0000 (1st tone) regardless of the following character tone.
+//     This means 一年/一天/一起 at the START of text incorrectly show 1st tone.
+//     This is a pedagogical simplification — correct for in-context reading
+//     where 一 is preceded by other characters.
+//   - 一個/一是 also use specialYiCases/nextCharSet1 → 0000 (1st tone).
+//     Standard pronunciation for 一個 is yí gè (2nd tone), but the app
+//     treats it as 1st for simplicity.
+//
+// These tests document CURRENT behavior so regressions are caught.
+// When fixing the linguistic accuracy (Issue #611), update tests accordingly.
+
+import { getToneForChar } from '../zhuyin/toneData';
+
+describe('一 tone sandhi regression tests (Issue #638)', () => {
+  let proc: import('../zhuyin/polyphonicProcessor').PolyphonicProcessor;
+
+  beforeAll(async () => {
+    const { PolyphonicProcessor } = await import('../zhuyin/polyphonicProcessor');
+    (PolyphonicProcessor as unknown as { _instance: unknown })._instance = undefined;
+    proc = PolyphonicProcessor.instance;
+    // Inject empty polyphonic data — 一/不 sandhi uses toneData.ts, not polyphonicData
+    (proc as unknown as { polyphonicData: unknown; _loaded: boolean }).polyphonicData = { data: {} };
+    (proc as unknown as { _loaded: boolean })._loaded = true;
+  });
+
+  const ssOf = (text: string) =>
+    proc.process(text).find(c => c.char === '一')?.styleSet;
+
+  describe('number / ordinal context → 1st tone (0000)', () => {
+    it('一百 → 0000 (一 is first char; 百 is in nextCharSet1)', () => {
+      expect(ssOf('一百')).toBe('0000');
+    });
+    it('一千 → 0000 (千 is in nextCharSet1)', () => {
+      expect(ssOf('一千')).toBe('0000');
+    });
+    it('一萬 → 0000 (萬 is in nextCharSet1)', () => {
+      expect(ssOf('一萬')).toBe('0000');
+    });
+    it('第一 → 0000 (第 is in prevCharSet1 → ordinal context)', () => {
+      expect(ssOf('第一')).toBe('0000');
+    });
+    it('十一 → 0000 (十 is in prevCharSet1 → number context)', () => {
+      expect(ssOf('十一')).toBe('0000');
+    });
+  });
+
+  describe('一 as first character in text → currently 0000 (known limitation)', () => {
+    // NOTE: Standard tone sandhi would give ss02 for 一天/一年/一起 and ss01 for 一個.
+    // The processor returns 0000 because prevChar==null triggers the early-return path.
+    // See Issue #611 for the planned fix.
+    it('一天 → 0000 (known limitation: should be ss02, yì tiān)', () => {
+      expect(getToneForChar('天')).toBe(1);
+      expect(ssOf('一天')).toBe('0000');
+    });
+    it('一年 → 0000 (known limitation: should be ss02, yì nián)', () => {
+      expect(getToneForChar('年')).toBe(2);
+      expect(ssOf('一年')).toBe('0000');
+    });
+    it('一起 → 0000 (known limitation: should be ss02, yì qǐ)', () => {
+      expect(getToneForChar('起')).toBe(3);
+      expect(ssOf('一起')).toBe('0000');
+    });
+    it('一個 → 0000 (specialYiCases override; standard yí gè would be ss01)', () => {
+      expect(getToneForChar('個')).toBe(4);
+      expect(ssOf('一個')).toBe('0000');
+    });
+  });
+
+  describe('tone sandhi DOES apply when 一 has a preceding char + nextChar not in nextCharSet1', () => {
+    // Use characters NOT in nextCharSet1 or specialYiCases to exercise the real sandhi path.
+    // 種 (zhǒng, 3rd tone) and 步 (bù, 4th tone) are not in any exception sets.
+    it('做一種 → 一 gets ss02 (4th tone; 種 = 3rd, prevChar 做 not in prevCharSet1)', () => {
+      expect(getToneForChar('種')).toBe(3);
+      const result = proc.process('做一種');
+      expect(result.find(c => c.char === '一')?.styleSet).toBe('ss02');
+    });
+    it('做一步 → 一 gets ss01 (2nd tone; 步 = 4th, before-4th-tone sandhi)', () => {
+      expect(getToneForChar('步')).toBe(4);
+      const result = proc.process('做一步');
+      expect(result.find(c => c.char === '一')?.styleSet).toBe('ss01');
+    });
+  });
+
+  describe('standalone → 1st tone (0000)', () => {
+    it('standalone 一 → 0000', () => {
+      expect(ssOf('一')).toBe('0000');
+    });
+  });
+});

--- a/frontend/src/utils/textDiff.test.ts
+++ b/frontend/src/utils/textDiff.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for textDiff utilities: normalizeForComparison, diffCharacters.
+ *
+ * Covers Issue #638: 破音字 STT matching — 兩/二 number normalization + 一 tone sandhi.
+ *
+ * Key scenarios:
+ * 1. Arabic → Chinese number conversion (100 → 一百, 214 → 二百一十四)
+ * 2. 兩/二 spoken variant normalization (兩百 ≡ 二百 in STT matching)
+ * 3. Homophone-tolerant diff accuracy (同音異字 treated as correct)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeForComparison, diffCharacters } from './textDiff';
+
+// ---------------------------------------------------------------------------
+// normalizeForComparison
+// ---------------------------------------------------------------------------
+
+describe('normalizeForComparison — Arabic number conversion', () => {
+  it('100 → 一百', () => {
+    expect(normalizeForComparison('100')).toBe('一百');
+  });
+
+  it('214 → 二百一十四', () => {
+    expect(normalizeForComparison('214')).toBe('二百一十四');
+  });
+
+  it('10 → 十 (standalone tens, no leading 一)', () => {
+    expect(normalizeForComparison('10')).toBe('十');
+  });
+
+  it('110 → 一百一十', () => {
+    expect(normalizeForComparison('110')).toBe('一百一十');
+  });
+
+  it('2021 → 兩千零二十一 is normalized to 二千零二十一', () => {
+    // 2021 → intToChinese produces 二千零二十一
+    expect(normalizeForComparison('2021')).toBe('二千零二十一');
+  });
+
+  it('strips punctuation and spaces', () => {
+    expect(normalizeForComparison('「100次」')).toBe('一百次');
+  });
+});
+
+describe('normalizeForComparison — 兩/二 variant normalization', () => {
+  it('兩百 normalizes to 二百', () => {
+    expect(normalizeForComparison('兩百')).toBe('二百');
+  });
+
+  it('兩千 normalizes to 二千', () => {
+    expect(normalizeForComparison('兩千')).toBe('二千');
+  });
+
+  it('兩萬 normalizes to 二萬', () => {
+    expect(normalizeForComparison('兩萬')).toBe('二萬');
+  });
+
+  it('兩億 normalizes to 二億', () => {
+    expect(normalizeForComparison('兩億')).toBe('二億');
+  });
+
+  it('兩百一十四 normalizes to 二百一十四', () => {
+    expect(normalizeForComparison('兩百一十四')).toBe('二百一十四');
+  });
+
+  it('兩 standalone (not before 百/千/萬/億) is NOT changed', () => {
+    // 兩個人 — 兩 used as a measure word, should stay
+    expect(normalizeForComparison('兩個人')).toBe('兩個人');
+  });
+
+  it('兩岸 — 兩 not before number unit, should stay', () => {
+    expect(normalizeForComparison('兩岸')).toBe('兩岸');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STT matching: spoken vs target with number variants
+// ---------------------------------------------------------------------------
+
+describe('diffCharacters — STT matching with number normalization', () => {
+  it('STT "兩百一十四" matches target "214" as 100% correct', () => {
+    const result = diffCharacters('兩百一十四', '214', { useHomophone: true });
+    // Both normalize to 二百一十四
+    expect(result.matchRate).toBe(1);
+    expect(result.correctCount).toBe(5); // 二百一十四 = 5 chars
+    expect(result.wrongCount).toBe(0);
+    expect(result.missingCount).toBe(0);
+  });
+
+  it('STT "一百" matches target "100" as 100% correct', () => {
+    const result = diffCharacters('一百', '100', { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+    expect(result.correctCount).toBe(2);
+  });
+
+  it('STT "兩百" matches target "二百" as 100% correct', () => {
+    const result = diffCharacters('兩百', '二百', { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+    expect(result.correctCount).toBe(2);
+    expect(result.wrongCount).toBe(0);
+  });
+
+  it('STT "累計兩百一十四周" matches target "累計214周" fully', () => {
+    const result = diffCharacters('累計兩百一十四周', '累計214周', { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+    expect(result.wrongCount).toBe(0);
+  });
+});

--- a/frontend/src/utils/textDiff.ts
+++ b/frontend/src/utils/textDiff.ts
@@ -49,8 +49,19 @@ const intToChinese = (num: number): string => {
 
 const normalizeNumbers = (text: string) => text.replace(/\d+/g, m => intToChinese(parseInt(m, 10)));
 
+/**
+ * Normalize spoken variants of Chinese numbers for comparison.
+ * In spoken Mandarin, 兩 (liǎng) is commonly used instead of 二 (èr) before
+ * 百/千/萬/億. Both forms are correct; we collapse them to 二 so STT output
+ * ("兩百一十四") matches the canonical written form ("二百一十四").
+ */
+const normalizeChineseNumberVariants = (text: string) =>
+  text.replace(/兩(?=[百千萬億])/g, '二');
+
 export const normalizeForComparison = (text: string) =>
-  normalizeNumbers(cleanChineseText(text)).replace(/[「」『』，。！？：；、\s]/g, '');
+  normalizeChineseNumberVariants(
+    normalizeNumbers(cleanChineseText(text))
+  ).replace(/[「」『』，。！？：；、\s]/g, '');
 
 /**
  * LCS-based diff: compare spoken text against target text, producing


### PR DESCRIPTION
## Summary

Fixes two known 破音字 STT matching issues confirmed in the 2026-03-21 meeting with 方大哥:

### 1. 兩/二 number normalization (`textDiff.ts`)

When course text has Arabic numerals (e.g. `214周`), `normalizeNumbers()` converts them to `二百一十四`. But STT commonly returns `兩百一十四` (using 兩 instead of 二), causing a mismatch — since `isHomophone('兩', '二')` is false (different pinyin: liang vs er).

**Fix**: Added `normalizeChineseNumberVariants()` that converts `兩百/千/萬/億` → `二百/千/萬/億` before comparison. Only applies in numeric contexts (before 百/千/萬/億), not general uses like 兩岸.

Before: `累計兩百一十四周` vs target `214` → mismatch  
After: both normalize to `二百一十四` → 100% match

### 2. 一 tone sandhi test coverage (`polyphonicProcessor.test.ts`)

Added regression tests documenting current behavior with detailed comments about known limitations (tracked in #611 for future linguistic accuracy work).

Key tests added:
- Number context: 一百/千/萬 → 1st tone ✓
- Ordinal context: 第一, 十一 → 1st tone ✓  
- In-context sandhi: 做一種 → ss02 (4th tone), 做一步 → ss01 (2nd tone) ✓
- Known limitation documented: 一 as first char defaults to 1st tone (Issue #611)

### 3. New test file (`textDiff.test.ts`)

17 new tests covering `normalizeForComparison` edge cases — previously untested.

## Test Plan
- [x] All 73 frontend unit tests pass (`vitest run`)
- [x] `textDiff.test.ts`: 17/17 new tests pass including STT matching scenarios
- [x] `polyphonicProcessor.test.ts`: 24/24 tests pass (12 existing + 12 new)

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)