### PR TITLE
fix: ComprehensionChat 對話 refresh 後消失 — persist dbSessionId to sessionStorage

### DIFF
--- a/backend/app/routes/learning/learning_comprehension.py
+++ b/backend/app/routes/learning/learning_comprehension.py
@@ -146,6 +146,20 @@ async def comprehension_chat(
     is_resumed = False
     conversation_history: list[ConversationHistoryItem] = []
 
+    # Validate db_session_id ownership to prevent IDOR (Insecure Direct Object Reference).
+    # A malicious user cannot read or write another student's dialogue by guessing session IDs.
+    if payload.db_session_id is not None:
+        owned = (
+            db.query(LearningSession.id)
+            .filter(
+                LearningSession.id == payload.db_session_id,
+                LearningSession.student_id == current_user.id,
+            )
+            .first()
+        )
+        if not owned:
+            raise HTTPException(status_code=403, detail="Session not found")
+
     try:
         if payload.student_answer is None:
             # Fetch active teacher instructions for this student (Issue #90)

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -97,8 +97,16 @@ const LearningLayout: React.FC = () => {
   const [rightPanelWidth, setRightPanelWidth] = useState(320);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  /** DB LearningSession integer ID — created when the user starts the intro (Issue #242) */
-  const [dbSessionId, setDbSessionId] = useState<number | null>(null);
+  /** DB LearningSession integer ID — created when the user starts the intro (Issue #242).
+   * Persisted to sessionStorage so refresh within the same browser tab restores the session. */
+  const [dbSessionId, setDbSessionId] = useState<number | null>(() => {
+    try {
+      const raw = sessionStorage.getItem(`db-session-${storyId}`);
+      return raw ? parseInt(raw, 10) : null;
+    } catch {
+      return null;
+    }
+  });
   /** Progressive paragraph unlock tracking (Issue #85). */
   const [completedParagraphsSet, setCompletedParagraphsSet] = useState<Set<number>>(new Set());
   /** Reading goals from the active assignment, loaded from sessionStorage (Issue #414). */
@@ -129,11 +137,13 @@ const LearningLayout: React.FC = () => {
     [user, storyId],
   );
 
-  /** Clear active session from localStorage (called on completion). */
+  /** Clear active session from localStorage and sessionStorage (called on completion).
+   * Removing the sessionStorage key means the next visit creates a fresh DB session. */
   const clearPersistedSession = useCallback(() => {
     if (!user) return;
     clearActiveSession(String(user.id));
-  }, [user]);
+    try { sessionStorage.removeItem(`db-session-${storyId}`); } catch { /* non-fatal */ }
+  }, [user, storyId]);
 
   // ── Idle-timeout warning (Issue #408) ────────────────────────────────────
 
@@ -264,7 +274,10 @@ const LearningLayout: React.FC = () => {
       })
         .then((res) => (res.ok ? res.json() : null))
         .then((data) => {
-          if (data?.id) setDbSessionId(data.id);
+          if (data?.id) {
+            setDbSessionId(data.id);
+            try { sessionStorage.setItem(`db-session-${storyId}`, String(data.id)); } catch { /* non-fatal */ }
+          }
         })
         .catch(() => {
           // Non-fatal — dialogue won't be persisted but learning still works


### PR DESCRIPTION
## 問題

PR #634 已把每個 dialogue turn 存進 DB，但 `dbSessionId` 只活在 React state。
頁面 refresh → React state 歸零 → `dbSessionId = null` → ComprehensionChat 用 `crypto.randomUUID()` 產生新 sessionId → 找不到 DB 紀錄 → 從頭開始出題。

## 修法

**`LearningLayout.tsx`** 三個 spot：
1. `useState` 初始化時讀 `sessionStorage.getItem('db-session-{storyId}')`
2. 建立 DB session 後寫入 `sessionStorage.setItem('db-session-{storyId}', id)`
3. `clearPersistedSession`（學習完成時）加 `sessionStorage.removeItem(...)` → 下次進來是新的

**Session 邊界**：tab 關掉 / 完成學習 → 新 session；refresh / 中途離開 → resume ✓

**`learning_comprehension.py`**：加 IDOR 防護 — 驗證 `db_session_id` 屬於 `current_user`，防止用戶 A 猜到用戶 B 的 session ID 讀取對話。

## 測試

- ✅ 73/73 frontend tests pass
- ✅ `npm run build` 無 error

## 驗證方式

1. 登入 → 選課文 → 開始 → 進入課文理解 → 回答 1 題
2. 按 F5 refresh
3. 期望：對話歷史還在，不從頭開始

🤖 Generated with [Claude Code](https://claude.com/claude-code)