### PR TITLE
WIP-fix: 逐段朗讀不準確的BUG (fix: 641)

### DIFF
--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -223,6 +223,12 @@ async def generate_structured_response(
 
     Uses response_mime_type="application/json" and response_schema
     to get structured JSON output from Gemini.
+
+        Notes:
+        - Disable thinking for deterministic schema-bound JSON tasks so token
+            budget is preserved for visible output (avoids premature MAX_TOKENS).
+        - Disable automatic function calling because this helper never passes
+            tools and does not need AFC orchestration overhead.
     """
     client = _get_client()
     last_error = None
@@ -240,6 +246,10 @@ async def generate_structured_response(
                         response_schema=response_schema,
                         max_output_tokens=max_tokens,
                         temperature=temperature,
+                        thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
+                        automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(
+                            disable=True
+                        ),
                     ),
                 ),
                 timeout=GEMINI_TIMEOUT,

--- a/backend/app/services/reading_evaluation_service.py
+++ b/backend/app/services/reading_evaluation_service.py
@@ -334,6 +334,10 @@ async def evaluate_reading_with_ai(
         "請根據以上規則評分，輸出 JSON。"
     )
 
+    # Dynamic token budget for per-char diff output.
+    # 81 chars can already produce large JSON arrays; fixed 1024 is often too tight.
+    ai_max_tokens = max(1024, min(4096, t_len * 24 + 256))
+
     contents = [
         genai_types.Content(
             role="user",
@@ -346,7 +350,7 @@ async def evaluate_reading_with_ai(
             system_prompt=_SYSTEM_PROMPT,
             contents=contents,
             response_schema=_RESPONSE_SCHEMA,
-            max_tokens=1024,
+            max_tokens=ai_max_tokens,
             temperature=0.1,  # Low temp for deterministic evaluation
         )
 

--- a/backend/tests/test_reading_evaluation_service.py
+++ b/backend/tests/test_reading_evaluation_service.py
@@ -288,6 +288,25 @@ async def test_ai_path_thresholds_in_response():
     assert "reading_excellent" in result["thresholds"]
 
 
+@pytest.mark.asyncio
+async def test_ai_path_uses_dynamic_max_tokens_for_long_text():
+    """Long targets should request a larger token budget than 1024."""
+    long_target = "天" * 120
+    with patch(
+        "app.services.reading_evaluation_service.generate_structured_response",
+        new=AsyncMock(return_value={"diff_tokens": [], "feedback": "加油"}),
+    ) as mocked_generate:
+        await evaluate_reading_with_ai(
+            spoken_text=long_target,
+            target_text=long_target,
+        )
+
+    kwargs = mocked_generate.await_args.kwargs
+    assert "max_tokens" in kwargs
+    assert kwargs["max_tokens"] > 1024
+    assert kwargs["max_tokens"] <= 4096
+
+
 # ---------------------------------------------------------------------------
 # evaluate_reading_with_ai — fallback on AI error
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### 問題說明

在測試逐段朗讀功能時，即使使用耳機麥克風，仍頻繁出現辨識結果異常的情況。經檢查後發現問題並非來自語音輸入，而是後端 AI 評分流程異常。

從 log 可觀察到，同一請求會重試兩次，且 Gemini 回應皆出現 FinishReason.MAX_TOKENS，導致回傳的 JSON 被截斷，甚至出現格式錯誤（例如字串未結束）。雖然系統後續有進行 JSON 修補，但因內容已不完整，最終造成評分結果嚴重失真。

### 問題原因

本問題並非單純輸出內容過長，而是 Gemini 2.5 預設啟用的機制（如 thinking 與 Automatic Function Calling, AFC）會額外消耗 token 預算，導致實際可用於 JSON 輸出的 token 不足，進而造成輸出被截斷。

### 修正內容

1. 關閉 thinking 與 AFC

在結構化 JSON 回應中，關閉 Gemini 的 thinking 與 AFC 功能，確保 token 預算優先用於實際輸出內容。

修改檔案：
``backend/app/services/ai_service.py``

```python
thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(
    disable=True
),
```

2. 調整 max_tokens 為動態配置

根據目標句長度動態計算所需 token，避免固定上限導致輸出不足或浪費資源。

修改檔案：
`` backend/app/services/reading_evaluation_service.py ``

`` ai_max_tokens = max(1024, min(4096, t_len * 24 + 256)) ``

並套用於呼叫 AI 評分時：
``` python
ai_result = await generate_structured_response(
    system_prompt=_SYSTEM_PROMPT,
    contents=contents,
    response_schema=_RESPONSE_SCHEMA,
    max_tokens=ai_max_tokens,
    temperature=0.1,
)
```