### PR TITLE
test: add vitest unit tests for exercise components (Fixes #647)

### DIFF
--- a/frontend/src/components/reading-steps/__tests__/FillInBlankExercise.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/FillInBlankExercise.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import FillInBlankExercise from '../FillInBlankExercise';
+import { FillInBlankItem } from '../../../types';
+
+const vocabBank: Record<string, string> = {
+  A: '疑難雜症',
+  B: '龍爭虎鬥',
+  C: '一鳴驚人',
+};
+
+const sentences: FillInBlankItem[] = [
+  { sentence: '他解決了所有的(　　)。', answer: 'A' },
+  { sentence: '兩隊之間展開(　　)的競爭。', answer: 'B' },
+];
+
+describe('FillInBlankExercise', () => {
+  it('renders word bank entries', () => {
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={() => {}}
+      />
+    );
+    expect(screen.getByText('疑難雜症')).toBeTruthy();
+    expect(screen.getByText('龍爭虎鬥')).toBeTruthy();
+    expect(screen.getByText('一鳴驚人')).toBeTruthy();
+  });
+
+  it('submit button is disabled when not all blanks are filled', () => {
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={() => {}}
+      />
+    );
+    const submitBtn = screen.getByRole('button', { name: '提交答案' });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it('submit button is enabled after all blanks are filled', () => {
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={() => {}}
+      />
+    );
+
+    // Select answer for sentence 0 — click the per-sentence option buttons
+    // The option buttons appear inside each sentence card
+    const allOptionButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
+    fireEvent.click(allOptionButtons[0]);
+
+    const allOptionButtonsB = screen.getAllByRole('button', { name: /^B 龍爭虎鬥$/ });
+    fireEvent.click(allOptionButtonsB[1]);
+
+    const submitBtn = screen.getByRole('button', { name: '提交答案' });
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it('after submit shows correct answer in green and wrong answer in red with correction', () => {
+    const onComplete = vi.fn();
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={onComplete}
+      />
+    );
+
+    // Select A (correct) for sentence 0, C (wrong) for sentence 1
+    const aButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
+    fireEvent.click(aButtons[0]);
+    const cButtons = screen.getAllByRole('button', { name: /^C 一鳴驚人$/ });
+    fireEvent.click(cButtons[1]);
+
+    fireEvent.click(screen.getByRole('button', { name: '提交答案' }));
+
+    // Correct badge should show green styling (bg-green-100 class present in DOM)
+    // Wrong badge should show correction hint
+    expect(screen.getByText(/→ B 龍爭虎鬥/)).toBeTruthy();
+  });
+
+  it('retry button resets state', () => {
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={() => {}}
+      />
+    );
+
+    const aButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
+    fireEvent.click(aButtons[0]);
+    const bButtons = screen.getAllByRole('button', { name: /^B 龍爭虎鬥$/ });
+    fireEvent.click(bButtons[1]);
+    fireEvent.click(screen.getByRole('button', { name: '提交答案' }));
+    fireEvent.click(screen.getByRole('button', { name: '再試一次' }));
+
+    // Submit button should be disabled again (blanks cleared)
+    expect(screen.getByRole('button', { name: '提交答案' })).toBeDisabled();
+  });
+
+  it('onComplete is called with correct score when continue button is clicked', () => {
+    const onComplete = vi.fn();
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={onComplete}
+      />
+    );
+
+    // Answer both correctly (A and B)
+    const aButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
+    fireEvent.click(aButtons[0]);
+    const bButtons = screen.getAllByRole('button', { name: /^B 龍爭虎鬥$/ });
+    fireEvent.click(bButtons[1]);
+    fireEvent.click(screen.getByRole('button', { name: '提交答案' }));
+    fireEvent.click(screen.getByRole('button', { name: /繼續/ }));
+
+    expect(onComplete).toHaveBeenCalledWith(2, 2);
+  });
+});

--- a/frontend/src/components/reading-steps/__tests__/MultipleChoiceExercise.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/MultipleChoiceExercise.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MultipleChoiceExercise from '../MultipleChoiceExercise';
+import { MultipleChoiceItem } from '../../../types';
+
+const questions: MultipleChoiceItem[] = [
+  {
+    question: '文章的主題是什麼？',
+    options: ['自然環境', '科技發展', '人際關係', '歷史文化'],
+    answer: 'B',
+    explanation: '文章主要討論科技對社會的影響。',
+  },
+  {
+    question: '作者的態度是？',
+    options: ['樂觀', '悲觀', '中立', '批判'],
+    answer: 'A',
+    explanation: '作者對未來持樂觀態度。',
+  },
+];
+
+describe('MultipleChoiceExercise', () => {
+  it('renders first question and all options', () => {
+    render(<MultipleChoiceExercise questions={questions} onComplete={() => {}} />);
+    expect(screen.getByText(/文章的主題是什麼？/)).toBeTruthy();
+    expect(screen.getByText('自然環境')).toBeTruthy();
+    expect(screen.getByText('科技發展')).toBeTruthy();
+    expect(screen.getByText('人際關係')).toBeTruthy();
+    expect(screen.getByText('歷史文化')).toBeTruthy();
+  });
+
+  it('shows progress counter', () => {
+    render(<MultipleChoiceExercise questions={questions} onComplete={() => {}} />);
+    expect(screen.getByText(/第 1 題／共 2 題/)).toBeTruthy();
+  });
+
+  it('selecting correct answer reveals explanation and correct styling text', () => {
+    render(<MultipleChoiceExercise questions={questions} onComplete={() => {}} />);
+
+    // Answer B is correct — click the B option button
+    const optionB = screen.getByText('科技發展').closest('button');
+    fireEvent.click(optionB!);
+
+    // Explanation should appear
+    expect(screen.getByText(/文章主要討論科技對社會的影響/)).toBeTruthy();
+    // Next button appears
+    expect(screen.getByRole('button', { name: /下一題/ })).toBeTruthy();
+  });
+
+  it('selecting wrong answer shows explanation and next button', () => {
+    render(<MultipleChoiceExercise questions={questions} onComplete={() => {}} />);
+
+    const optionA = screen.getByText('自然環境').closest('button');
+    fireEvent.click(optionA!);
+
+    // Explanation still appears
+    expect(screen.getByText(/文章主要討論科技對社會的影響/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /下一題/ })).toBeTruthy();
+  });
+
+  it('clicking next moves to the next question', () => {
+    render(<MultipleChoiceExercise questions={questions} onComplete={() => {}} />);
+
+    // Answer first question
+    const optionB = screen.getByText('科技發展').closest('button');
+    fireEvent.click(optionB!);
+    fireEvent.click(screen.getByRole('button', { name: /下一題/ }));
+
+    // Second question now visible
+    expect(screen.getByText(/作者的態度是？/)).toBeTruthy();
+    expect(screen.getByText(/第 2 題／共 2 題/)).toBeTruthy();
+  });
+
+  it('last question shows 完成測驗 button and calls onComplete', () => {
+    const onComplete = vi.fn();
+    render(<MultipleChoiceExercise questions={questions} onComplete={onComplete} />);
+
+    // Answer question 1
+    fireEvent.click(screen.getByText('科技發展').closest('button')!);
+    fireEvent.click(screen.getByRole('button', { name: /下一題/ }));
+
+    // Answer question 2 (correct = A = 樂觀)
+    fireEvent.click(screen.getByText('樂觀').closest('button')!);
+
+    expect(screen.getByRole('button', { name: /完成測驗/ })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /完成測驗/ }));
+
+    expect(onComplete).toHaveBeenCalledWith(expect.any(Number), 2);
+  });
+
+  it('options are disabled after selection', () => {
+    render(<MultipleChoiceExercise questions={questions} onComplete={() => {}} />);
+
+    const optionA = screen.getByText('自然環境').closest('button');
+    fireEvent.click(optionA!);
+
+    // All option buttons should now be disabled
+    const allOptionButtons = screen
+      .getAllByRole('button')
+      .filter((btn) => ['自然環境', '科技發展', '人際關係', '歷史文化'].some((t) => btn.textContent?.includes(t)));
+    allOptionButtons.forEach((btn) => expect(btn).toBeDisabled());
+  });
+});

--- a/frontend/src/components/reading-steps/__tests__/StoryStructureTable.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/StoryStructureTable.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import StoryStructureTable from '../StoryStructureTable';
+
+const simpleRows = [
+  { label: '主角', value: '小明' },
+  { label: '主題', value: '友情的重要性' },
+];
+
+const groupedRows = [
+  {
+    label: '事例',
+    value: '',
+    sub_rows: [
+      { label: '背景', value: '小明轉學到新學校' },
+      { label: '經過', value: '遇到熱心同學阿偉' },
+      { label: '結果', value: '兩人成為好朋友' },
+    ],
+  },
+];
+
+function mockFetchSuccess(data: object) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    })
+  );
+}
+
+function mockFetchError() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    })
+  );
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('StoryStructureTable', () => {
+  it('shows loading spinner while fetching', () => {
+    // fetch never resolves during this test
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})));
+    render(<StoryStructureTable storyId="lesson-01" />);
+    expect(screen.getByText(/正在整理文章重點/)).toBeTruthy();
+  });
+
+  it('shows error message on fetch failure', async () => {
+    mockFetchError();
+    render(<StoryStructureTable storyId="lesson-01" />);
+    await waitFor(() =>
+      expect(screen.getByText(/無法載入文章重點表/)).toBeTruthy()
+    );
+  });
+
+  it('renders simple rows (no sub_rows)', async () => {
+    mockFetchSuccess({ rows: simpleRows });
+    render(<StoryStructureTable storyId="lesson-01" />);
+    await waitFor(() => expect(screen.getByText('主角')).toBeTruthy());
+    expect(screen.getByText('小明')).toBeTruthy();
+    expect(screen.getByText('主題')).toBeTruthy();
+    expect(screen.getByText('友情的重要性')).toBeTruthy();
+  });
+
+  it('renders grouped rows with sub_rows', async () => {
+    mockFetchSuccess({ rows: groupedRows });
+    render(<StoryStructureTable storyId="lesson-01" />);
+    await waitFor(() => expect(screen.getByText('事例')).toBeTruthy());
+    expect(screen.getByText('背景')).toBeTruthy();
+    expect(screen.getByText('小明轉學到新學校')).toBeTruthy();
+    expect(screen.getByText('經過')).toBeTruthy();
+    expect(screen.getByText('結果')).toBeTruthy();
+  });
+
+  it('shows 文章重點表 header title', async () => {
+    mockFetchSuccess({ rows: simpleRows });
+    render(<StoryStructureTable storyId="lesson-01" />);
+    await waitFor(() => expect(screen.getByText(/文章重點表/)).toBeTruthy());
+  });
+
+  it('re-fetches when storyId prop changes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ rows: simpleRows }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { rerender } = render(<StoryStructureTable storyId="lesson-01" />);
+    await waitFor(() => expect(screen.getByText('主角')).toBeTruthy());
+
+    rerender(<StoryStructureTable storyId="lesson-02" />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    // Second call should use the new storyId
+    const secondCallUrl = (fetchMock.mock.calls[1][0] as string);
+    expect(secondCallUrl).toContain('lesson-02');
+  });
+});


### PR DESCRIPTION
Fixes #647

## Summary

Adds 19 unit tests across three previously-untested components from the 三民教材 feature (#615):

| Component | Tests added | Coverage |
|-----------|-------------|----------|
| `FillInBlankExercise` | 6 | word bank render, submit guard, correct/wrong feedback, retry, onComplete |
| `MultipleChoiceExercise` | 7 | question render, correct/wrong reveal, explanation, progress counter, onComplete, disabled state |
| `StoryStructureTable` | 6 | loading spinner, fetch error, simple rows, grouped sub-rows, header, re-fetch on prop change |

Total: **73 → 92 tests** (all passing).

## Test plan

```bash
cd frontend
npm test
# Expect: 10 test files, 92 tests, all passed
```

## Notes

- Tests use `vitest` + `@testing-library/react`, same setup as existing tests
- `StoryStructureTable` uses `vi.stubGlobal('fetch', ...)` to mock the API call without a real server
- No production code was changed — tests only