### PR TITLE
refactor: StepperNav 步驟順序模組化 (Fixes #671)

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { AppView, Story, LearningSession } from '../types';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { useAuth } from '../contexts/AuthContext';
+import { ACTIVE_STEPS } from '../config/stepConfig';
 
 interface StepperNavProps {
   currentView: AppView;
@@ -20,15 +21,16 @@ interface StepDef {
   needsStory: boolean;
 }
 
-const steps: StepDef[] = [
-  { step: 1, label: '簡介',    view: AppView.INTRO,         needsStory: true  },
-  { step: 2, label: '逐段朗讀', view: AppView.TUTOR,         needsStory: true  },
-  { step: 3, label: '課文理解', view: AppView.COMPREHENSION, needsStory: true  },
-  { step: 4, label: '生字練習', view: AppView.VOCAB,         needsStory: true  },
-  { step: 5, label: '聽寫練習', view: AppView.DICTATION,     needsStory: true  },
-  { step: 6, label: '全文朗讀', view: AppView.FULL_READING,  needsStory: true  },
-  { step: 7, label: '報告',    view: AppView.REPORT,        needsStory: false },
-];
+/**
+ * Steps are derived from the central ACTIVE_STEPS config so that reordering
+ * or adding steps only requires editing stepConfig.ts.
+ */
+const steps: StepDef[] = ACTIVE_STEPS.map((s, i) => ({
+  step: i + 1,
+  label: s.label,
+  view: s.view,
+  needsStory: s.needsStory,
+}));
 
 function getStepStatus(
   stepDef: StepDef,

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { getMyAssignments } from '../../services/assignmentApi';
 import { AppView } from '../../types';
+import { VIEW_TO_PATH } from '../../config/stepConfig';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import LearningLayout from '../../layouts/LearningLayout';
@@ -50,32 +51,20 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
       case AppView.LIBRARY:
         navigate('/library');
         break;
-      // Learning step navigation: extract storyId from current URL
-      case AppView.INTRO:
-      case AppView.TUTOR:
-      case AppView.COMPREHENSION:
-      case AppView.VOCAB:
-      case AppView.DICTATION:
-      case AppView.FULL_READING:
-      case AppView.REPORT: {
-        const match = window.location.pathname.match(/\/learn\/([^/]+)/);
-        const storyId = match?.[1];
-        if (storyId) {
-          const stepPath: Record<string, string> = {
-            [AppView.INTRO]: 'intro',
-            [AppView.TUTOR]: 'tutor',
-            [AppView.COMPREHENSION]: 'comprehension',
-            [AppView.VOCAB]: 'vocab',
-            [AppView.DICTATION]: 'dictation',
-            [AppView.FULL_READING]: 'full-reading',
-            [AppView.REPORT]: 'report',
-          };
-          navigate(`/learn/${storyId}/${stepPath[view]}`);
+      default: {
+        // Learning step navigation: look up path from config-driven VIEW_TO_PATH map.
+        // ACTIVE_STEPS drives which views are valid learning steps, so any view
+        // that resolves in VIEW_TO_PATH is a learning step.
+        const pathId = VIEW_TO_PATH[view];
+        if (pathId) {
+          const match = window.location.pathname.match(/\/learn\/([^/]+)/);
+          const storyId = match?.[1];
+          if (storyId) {
+            navigate(`/learn/${storyId}/${pathId}`);
+          }
         }
         break;
       }
-      default:
-        break;
     }
   };
 

--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -1,0 +1,126 @@
+/**
+ * stepConfig.ts — single source of truth for the learning step order.
+ *
+ * Each entry in STEP_CONFIG defines one step in the learning flow.
+ * The array order controls the display order in StepperNav and the
+ * step numbers shown to students (1-based index).
+ *
+ * To reorder steps: move entries in the array.
+ * To add a new step: append a new entry (and add its route in AppRoutes.tsx).
+ * To disable a step: set `enabled: false` (StepperNav will skip it).
+ *
+ * Future: this config can be fetched from the DB per-lesson or per-teacher
+ * preference instead of being a static file.
+ */
+
+import { AppView } from '../types';
+
+export interface StepConfig {
+  /** Unique identifier — must match the URL path segment under /learn/:storyId/ */
+  id: string;
+  /** Display label shown in StepperNav */
+  label: string;
+  /** AppView enum value used by the legacy view routing system */
+  view: AppView;
+  /**
+   * 1-based step number stored in DB (learning_sessions.current_step).
+   * Must match the value that was previously hard-coded in STEP_PATH_TO_NUMBER.
+   * Changing this would require a DB migration — do not change without care.
+   */
+  dbStepNumber: number;
+  /**
+   * Whether a story must be selected before this step is accessible.
+   * false only for steps that make sense without a loaded story (e.g. HOME, REPORT).
+   */
+  needsStory: boolean;
+  /** When false the step is excluded from StepperNav entirely (not yet implemented steps). */
+  enabled: boolean;
+}
+
+/**
+ * Default step order for the 7-step learning flow.
+ *
+ * To customise order per lesson/teacher, override this array at runtime
+ * (future: load from DB/API and pass to StepperNav as a prop).
+ */
+export const STEP_CONFIG: StepConfig[] = [
+  {
+    id: 'intro',
+    label: '簡介',
+    view: AppView.INTRO,
+    dbStepNumber: 1,
+    needsStory: true,
+    enabled: true,
+  },
+  {
+    id: 'tutor',
+    label: '逐段朗讀',
+    view: AppView.TUTOR,
+    dbStepNumber: 2,
+    needsStory: true,
+    enabled: true,
+  },
+  {
+    id: 'comprehension',
+    label: '課文理解',
+    view: AppView.COMPREHENSION,
+    dbStepNumber: 3,
+    needsStory: true,
+    enabled: true,
+  },
+  {
+    id: 'vocab',
+    label: '生字練習',
+    view: AppView.VOCAB,
+    dbStepNumber: 4,
+    needsStory: true,
+    enabled: true,
+  },
+  {
+    id: 'dictation',
+    label: '聽寫練習',
+    view: AppView.DICTATION,
+    dbStepNumber: 5,
+    needsStory: true,
+    enabled: true,
+  },
+  {
+    id: 'full-reading',
+    label: '全文朗讀',
+    view: AppView.FULL_READING,
+    dbStepNumber: 6,
+    needsStory: true,
+    enabled: true,
+  },
+  {
+    id: 'report',
+    label: '報告',
+    view: AppView.REPORT,
+    dbStepNumber: 7,
+    needsStory: false,
+    enabled: true,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Derived lookup maps — computed once from STEP_CONFIG so consumers don't
+// need to re-derive them.  Import these instead of building your own maps.
+// ---------------------------------------------------------------------------
+
+/** All enabled steps in display order. */
+export const ACTIVE_STEPS = STEP_CONFIG.filter((s) => s.enabled);
+
+/** Map from URL path id (e.g. "intro") to dbStepNumber (e.g. 1). */
+export const STEP_PATH_TO_NUMBER: Record<string, number> = Object.fromEntries(
+  STEP_CONFIG.map((s) => [s.id, s.dbStepNumber]),
+);
+
+/** Map from AppView to URL path id (e.g. AppView.INTRO → "intro"). */
+export const VIEW_TO_PATH: Record<string, string> = Object.fromEntries(
+  STEP_CONFIG.map((s) => [s.view, s.id]),
+);
+
+/** Map from URL path id to AppView (e.g. "intro" → AppView.INTRO). */
+export const PATH_TO_VIEW: Record<string, AppView> = Object.fromEntries(
+  STEP_CONFIG.map((s) => [s.id, s.view]),
+);

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -13,6 +13,7 @@ import { fetchStory, saveActiveSession, clearActiveSession } from '../services/a
 import { submitAssignment } from '../services/assignmentApi';
 import { useAuth } from '../contexts/AuthContext';
 import { useLearningNav } from '../contexts/LearningNavContext';
+import { STEP_PATH_TO_NUMBER as STEP_CONFIG_PATH_TO_NUMBER } from '../config/stepConfig';
 import { useIdleTimer } from '../hooks/useIdleTimer';
 import SessionTimeoutWarning from '../components/SessionTimeoutWarning';
 
@@ -67,16 +68,9 @@ export interface LearningContext {
 
 /**
  * Map from step name in URL path to numeric step index (1-based, matching DB).
+ * Sourced from stepConfig.ts — the single source of truth for step definitions.
  */
-const STEP_PATH_TO_NUMBER: Record<string, number> = {
-  intro: 1,
-  tutor: 2,
-  comprehension: 3,
-  vocab: 4,
-  dictation: 5,
-  'full-reading': 6,
-  report: 7,
-};
+const STEP_PATH_TO_NUMBER = STEP_CONFIG_PATH_TO_NUMBER;
 
 /**
  * Wraps the learning flow routes (/learn/:storyId/*).


### PR DESCRIPTION
Fixes #671

## Summary

- New file `frontend/src/config/stepConfig.ts` — single source of truth for the 7-step learning flow
- `STEP_CONFIG` array controls step order, label, URL path, AppView, and DB step number
- Three consuming files updated to derive their maps from the config instead of duplicating hardcoded values

## Changes

| File | Change |
|------|--------|
| `frontend/src/config/stepConfig.ts` | **New** — step registry + derived lookup maps |
| `frontend/src/components/StepperNav.tsx` | Reads `ACTIVE_STEPS` from config instead of hardcoded array |
| `frontend/src/components/layout/AppShell.tsx` | Uses `VIEW_TO_PATH` lookup; switch handles new steps automatically |
| `frontend/src/layouts/LearningLayout.tsx` | Imports `STEP_PATH_TO_NUMBER` from config instead of redeclaring |

## How to add a new step in the future

1. Add entry to `STEP_CONFIG` in `stepConfig.ts`
2. Add `<Route>` in `AppRoutes.tsx`
3. Implement the page component

No changes needed in StepperNav, AppShell, or LearningLayout.

## Test plan

- [ ] All 7 learning steps still render and navigate correctly
- [ ] StepperNav shows correct step numbers, labels, and status (active/completed/disabled)
- [ ] Step completion status (checkmarks) still appears after finishing each step
- [ ] Mobile nav dropdown still shows all steps
- [ ] No visual regressions in StepperNav UI
- [ ] Build passes: `npm run build` exits 0

Build verified locally: `vite build` clean, 4 files changed.