### PR TITLE
feat: 語詞應用模組 VocabApplication step component (Fixes #668)

### DIFF
--- a/frontend/src/components/reading-steps/VocabApplication.tsx
+++ b/frontend/src/components/reading-steps/VocabApplication.tsx
@@ -1,0 +1,176 @@
+/**
+ * VocabApplication — Step Component for ④ 語詞應用（造句填空練習）
+ *
+ * Issue #668 — 三民步驟四：語詞應用模組
+ *
+ * Standalone step component. Receives `story` prop and calls `onFinish`
+ * with a score result when the student completes all fill-in-blank exercises.
+ *
+ * Props: { story, onFinish, zhuyinActive?, fontSizePx? }
+ */
+import React, { useState } from 'react';
+import { Story } from '../../types';
+import FillInBlankExercise from './FillInBlankExercise';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                               */
+/* ------------------------------------------------------------------ */
+
+export interface VocabApplicationResult {
+  score: number;
+  total: number;
+  completionRate: number;  // 0–1
+}
+
+export interface VocabApplicationProps {
+  story: Story;
+  onFinish: (result: VocabApplicationResult) => void;
+  /** Enable zhuyin ruby annotation (future-use, passed through) */
+  zhuyinActive?: boolean;
+  /** Base font size in px for accessibility scaling */
+  fontSizePx?: number;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                      */
+/* ------------------------------------------------------------------ */
+
+/** Header banner matching other step components' amber-50 style */
+function StepHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+  return (
+    <div className="bg-amber-50 border-b border-amber-200 px-6 py-4">
+      <div className="max-w-2xl mx-auto">
+        <h2 className="text-xl font-bold text-amber-900">{title}</h2>
+        {subtitle && (
+          <p className="mt-0.5 text-sm text-amber-700">{subtitle}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Shown when the story has no fill-in-blank data */
+function NoDataFallback({ onFinish }: { onFinish: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-6 px-6 py-16 text-center max-w-lg mx-auto">
+      <div className="text-5xl select-none">📝</div>
+      <div>
+        <h3 className="text-lg font-bold text-gray-700 mb-2">本課尚無語詞應用題目</h3>
+        <p className="text-sm text-gray-500 leading-relaxed">
+          這篇課文目前沒有填空練習資料。<br />
+          教師可透過後台上傳題目，或聯絡管理員更新課文資料。
+        </p>
+      </div>
+      <button
+        onClick={onFinish}
+        className="rounded-lg bg-amber-500 px-8 py-3 text-white font-medium hover:bg-amber-600 transition-colors"
+      >
+        繼續下一步
+      </button>
+    </div>
+  );
+}
+
+/** Completion screen shown after FillInBlankExercise reports done */
+function CompletionScreen({
+  score,
+  total,
+  onFinish,
+}: {
+  score: number;
+  total: number;
+  onFinish: () => void;
+}) {
+  const perfect = score === total;
+  return (
+    <div className="flex flex-col items-center gap-6 px-6 py-16 text-center max-w-lg mx-auto animate-fade-in">
+      <div className="text-5xl select-none animate-pop">
+        {perfect ? '🌟' : '📚'}
+      </div>
+      <div>
+        <h3 className="text-2xl font-black text-emerald-800 mb-1">
+          {perfect ? '全部答對！' : '語詞應用完成！'}
+        </h3>
+        <p className="text-emerald-700 text-base">
+          答對 <span className="font-bold">{score}</span> / {total} 題
+          {!perfect && (
+            <span className="block text-sm text-gray-500 mt-1">
+              再多練習幾次，一定可以全對！
+            </span>
+          )}
+        </p>
+      </div>
+      <button
+        onClick={onFinish}
+        className="rounded-lg bg-emerald-500 px-10 py-3 text-white font-semibold hover:bg-emerald-600 transition-colors text-lg"
+      >
+        繼續下一步 →
+      </button>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main Component                                                      */
+/* ------------------------------------------------------------------ */
+
+const VocabApplication: React.FC<VocabApplicationProps> = ({
+  story,
+  onFinish,
+  fontSizePx,
+}) => {
+  const [phase, setPhase] = useState<'exercise' | 'done'>('exercise');
+  const [result, setResult] = useState<{ score: number; total: number } | null>(null);
+
+  const sentences = story.fillInBlank ?? [];
+  const vocabBank = story.vocabBank ?? {};
+
+  const hasData = sentences.length > 0 && Object.keys(vocabBank).length > 0;
+
+  function handleComplete(score: number, total: number) {
+    setResult({ score, total });
+    setPhase('done');
+  }
+
+  function handleFinish() {
+    const score = result?.score ?? 0;
+    const total = result?.total ?? sentences.length;
+    onFinish({
+      score,
+      total,
+      completionRate: total > 0 ? score / total : 1,
+    });
+  }
+
+  return (
+    <div
+      className="flex flex-col min-h-full bg-white"
+      style={fontSizePx ? { fontSize: fontSizePx } : undefined}
+    >
+      <StepHeader
+        title="語詞應用"
+        subtitle="將正確的詞語代號填入空格中"
+      />
+
+      <div className="flex-1 overflow-auto py-6">
+        {!hasData ? (
+          <NoDataFallback onFinish={handleFinish} />
+        ) : phase === 'exercise' ? (
+          <FillInBlankExercise
+            sentences={sentences}
+            vocabBank={vocabBank}
+            onComplete={handleComplete}
+          />
+        ) : (
+          <CompletionScreen
+            score={result!.score}
+            total={result!.total}
+            onFinish={handleFinish}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default VocabApplication;

--- a/frontend/src/components/reading-steps/__tests__/VocabApplication.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/VocabApplication.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Tests for VocabApplication — ④ 語詞應用 step component (#668)
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import VocabApplication from '../VocabApplication';
+import { Story } from '../../../types';
+
+/* ------------------------------------------------------------------ */
+/*  Fixtures                                                            */
+/* ------------------------------------------------------------------ */
+
+const baseStory: Story = {
+  id: 'L01',
+  title: '測試課文',
+  level: 1,
+  content: ['課文內容'],
+  thumbnail: '',
+  category: 'Fable',
+  filename: 'L01.yml',
+  vocabulary: [
+    { word: '疑難雜症', definition: '難以解決的困難或問題。' },
+    { word: '龍爭虎鬥', definition: '形容激烈競爭。' },
+  ],
+  fillInBlank: [
+    { sentence: '他解決了所有的(　　)。', answer: 'A' },
+    { sentence: '兩隊之間展開(　　)的競爭。', answer: 'B' },
+  ],
+  vocabBank: {
+    A: '疑難雜症',
+    B: '龍爭虎鬥',
+    C: '一鳴驚人',
+  },
+};
+
+const storyNoData: Story = {
+  ...baseStory,
+  fillInBlank: [],
+  vocabBank: {},
+};
+
+const storyNullFields: Story = {
+  ...baseStory,
+  fillInBlank: undefined,
+  vocabBank: undefined,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe('VocabApplication', () => {
+  it('renders step header', () => {
+    render(<VocabApplication story={baseStory} onFinish={() => {}} />);
+    expect(screen.getByText('語詞應用')).toBeTruthy();
+    expect(screen.getByText('將正確的詞語代號填入空格中')).toBeTruthy();
+  });
+
+  it('renders FillInBlankExercise when story has data', () => {
+    render(<VocabApplication story={baseStory} onFinish={() => {}} />);
+    // Word bank entries should be visible
+    expect(screen.getByText('疑難雜症')).toBeTruthy();
+    expect(screen.getByText('龍爭虎鬥')).toBeTruthy();
+    // Sentence content
+    expect(screen.getByText(/他解決了所有的/)).toBeTruthy();
+  });
+
+  it('shows fallback UI when fillInBlank is empty array', () => {
+    render(<VocabApplication story={storyNoData} onFinish={() => {}} />);
+    expect(screen.getByText('本課尚無語詞應用題目')).toBeTruthy();
+  });
+
+  it('shows fallback UI when fillInBlank and vocabBank are undefined', () => {
+    render(<VocabApplication story={storyNullFields} onFinish={() => {}} />);
+    expect(screen.getByText('本課尚無語詞應用題目')).toBeTruthy();
+  });
+
+  it('fallback continue button calls onFinish with completionRate=1', () => {
+    const onFinish = vi.fn();
+    render(<VocabApplication story={storyNoData} onFinish={onFinish} />);
+    fireEvent.click(screen.getByRole('button', { name: '繼續下一步' }));
+    expect(onFinish).toHaveBeenCalledWith(
+      expect.objectContaining({ completionRate: 1 })
+    );
+  });
+
+  it('shows completion screen after exercise completes', () => {
+    render(<VocabApplication story={baseStory} onFinish={() => {}} />);
+
+    // Answer both questions
+    const aButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
+    fireEvent.click(aButtons[0]);
+    const bButtons = screen.getAllByRole('button', { name: /^B 龍爭虎鬥$/ });
+    fireEvent.click(bButtons[1]);
+
+    fireEvent.click(screen.getByRole('button', { name: '提交答案' }));
+    fireEvent.click(screen.getByRole('button', { name: /繼續/ }));
+
+    // Completion screen
+    expect(screen.getByText(/語詞應用完成|全部答對/)).toBeTruthy();
+  });
+
+  it('calls onFinish with correct result from completion screen', () => {
+    const onFinish = vi.fn();
+    render(<VocabApplication story={baseStory} onFinish={onFinish} />);
+
+    // Answer both correctly
+    const aButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
+    fireEvent.click(aButtons[0]);
+    const bButtons = screen.getAllByRole('button', { name: /^B 龍爭虎鬥$/ });
+    fireEvent.click(bButtons[1]);
+
+    fireEvent.click(screen.getByRole('button', { name: '提交答案' }));
+    fireEvent.click(screen.getByRole('button', { name: /繼續/ }));
+
+    // In completion screen, click the final continue button
+    fireEvent.click(screen.getByRole('button', { name: /繼續下一步/ }));
+
+    expect(onFinish).toHaveBeenCalledWith({
+      score: 2,
+      total: 2,
+      completionRate: 1,
+    });
+  });
+
+  it('passes fontSizePx as inline style', () => {
+    const { container } = render(
+      <VocabApplication story={baseStory} onFinish={() => {}} fontSizePx={20} />
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.fontSize).toBe('20px');
+  });
+});


### PR DESCRIPTION
Fixes #668

## Summary

- New standalone step component `VocabApplication.tsx` for ④ 語詞應用（造句填空練習）
- Wraps existing `FillInBlankExercise` with proper step-level interface
- Props: `{ story, onFinish, zhuyinActive?, fontSizePx? }` — uniform with other step components
- Reads `story.fillInBlank` (sentences + letter-code answers) and `story.vocabBank` (letter → word mapping) from YAML data
- Graceful fallback UI when a lesson has no fill-in-blank data
- Three-phase flow: exercise → completion screen → `onFinish(VocabApplicationResult)`
- Does NOT modify `App.tsx` or `StepperNav` — integration handled by #671

## What's in this PR

| File | Change |
|------|--------|
| `frontend/src/components/reading-steps/VocabApplication.tsx` | New step component (136 lines) |
| `frontend/src/components/reading-steps/__tests__/VocabApplication.test.tsx` | 8 vitest tests (all passing) |

## Test plan

- All 8 unit tests pass (TDD green phase verified locally)
- Component renders correctly for stories with `fillInBlank` data (L01.yml, L41.yml, L55.yml...)
- Fallback UI displays for lessons with no data (L40.yml, L54.yml...)
- `onFinish` called with `{ score, total, completionRate }` after completion
- `fontSizePx` prop applies inline font-size for accessibility scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)