### PR TITLE
feat: ReadingAnnotation component — text selection marks (Fixes #670)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -1,0 +1,586 @@
+import React, {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  useMemo,
+} from 'react';
+import { Story } from '../../types';
+import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
+import ZhuyinToggle from '../ui/ZhuyinToggle';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type AnnotationType = 'unknown' | 'important';
+
+export interface Annotation {
+  id: string;
+  paragraphIndex: number;
+  charStart: number;
+  charEnd: number;
+  type: AnnotationType;
+}
+
+export interface AnnotationSummary {
+  totalMarks: number;
+  unknownCount: number;
+  importantCount: number;
+}
+
+interface ReadingAnnotationProps {
+  story: Story;
+  onFinish: (summary: AnnotationSummary) => void;
+  zhuyinActive?: boolean;
+  fontSizePx?: number;
+}
+
+// ── Config ─────────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = (storyId: string) => `annotations_${storyId}`;
+
+const TYPE_CONFIG: Record<AnnotationType, { label: string; icon: string; className: string; activeClass: string }> = {
+  unknown: {
+    label: '不懂',
+    icon: '❓',
+    className: 'underline decoration-red-500 decoration-2 underline-offset-2',
+    activeClass: 'bg-red-100 border-red-400 text-red-800',
+  },
+  important: {
+    label: '重要',
+    icon: '💛',
+    className: 'bg-yellow-200',
+    activeClass: 'bg-yellow-300 border-yellow-500 text-yellow-900',
+  },
+};
+
+// ── ID generator ───────────────────────────────────────────────────────────
+
+let _idCounter = 0;
+function genId(): string {
+  return `ann-${Date.now()}-${++_idCounter}`;
+}
+
+// ── Main Component ─────────────────────────────────────────────────────────
+
+const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
+  story,
+  onFinish,
+  zhuyinActive: zhuyinActiveProp,
+  fontSizePx = 22,
+}) => {
+  // Zhuyin state (internal if not controlled via prop)
+  const [zhuyinEnabled, setZhuyinEnabled] = useState(true);
+  const [zhuyinReady, setZhuyinReady] = useState(false);
+  const zhuyinActive = zhuyinActiveProp !== undefined
+    ? zhuyinActiveProp
+    : (zhuyinReady && zhuyinEnabled);
+
+  // Annotations persisted to localStorage
+  const [annotations, setAnnotations] = useState<Annotation[]>(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY(story.id));
+      return raw ? (JSON.parse(raw) as Annotation[]) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  // Active mark tool
+  const [activeTool, setActiveTool] = useState<AnnotationType>('unknown');
+
+  // Floating toolbar state
+  const [toolbar, setToolbar] = useState<{
+    visible: boolean;
+    x: number;
+    y: number;
+    paragraphIndex: number;
+    charStart: number;
+    charEnd: number;
+  }>({ visible: false, x: 0, y: 0, paragraphIndex: -1, charStart: 0, charEnd: 0 });
+
+  // Undo stack
+  const [undoStack, setUndoStack] = useState<Annotation[][]>([]);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
+
+  // ── Zhuyin ─────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    PolyphonicProcessor.instance.loadPolyphonicData()
+      .then(() => setZhuyinReady(true))
+      .catch((err) => console.error('Failed to load zhuyin data:', err));
+  }, []);
+
+  const processZhuyin = useCallback(
+    (text: string): string => {
+      if (!zhuyinActive) return text;
+      try {
+        return buildZhuyinString(PolyphonicProcessor.instance.process(text));
+      } catch {
+        return text;
+      }
+    },
+    [zhuyinActive]
+  );
+
+  const zhuyinParagraphs = useMemo(() => {
+    if (!zhuyinActive) return null;
+    try {
+      return story.content.map((p) =>
+        buildZhuyinString(PolyphonicProcessor.instance.process(p))
+      );
+    } catch {
+      return null;
+    }
+  }, [story.content, zhuyinActive]);
+
+  // ── Persist annotations ────────────────────────────────────────────────
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY(story.id), JSON.stringify(annotations));
+    } catch {
+      // Storage full — ignore
+    }
+  }, [annotations, story.id]);
+
+  // ── Summary ────────────────────────────────────────────────────────────
+
+  const summary = useMemo<AnnotationSummary>(() => ({
+    totalMarks: annotations.length,
+    unknownCount: annotations.filter((a) => a.type === 'unknown').length,
+    importantCount: annotations.filter((a) => a.type === 'important').length,
+  }), [annotations]);
+
+  // ── Selection helpers ──────────────────────────────────────────────────
+
+  /**
+   * Given a Selection that spans inside a paragraph <p data-para-idx="N">,
+   * compute character offsets into the raw paragraph text.
+   * Returns null if selection is empty or crosses paragraph boundaries.
+   */
+  function getSelectionInfo(): {
+    paragraphIndex: number;
+    charStart: number;
+    charEnd: number;
+    rect: DOMRect;
+  } | null {
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
+
+    const range = sel.getRangeAt(0);
+    if (range.collapsed) return null;
+
+    // Find the paragraph element from start container
+    const startEl = range.startContainer.parentElement?.closest('[data-para-idx]') as HTMLElement | null;
+    const endEl = range.endContainer.parentElement?.closest('[data-para-idx]') as HTMLElement | null;
+    if (!startEl || !endEl) return null;
+
+    // Must be same paragraph
+    const paraIdxStr = startEl.getAttribute('data-para-idx');
+    if (!paraIdxStr || startEl !== endEl) return null;
+
+    const paragraphIndex = parseInt(paraIdxStr, 10);
+    const paraEl = startEl; // same element
+
+    // Walk text nodes of the paragraph to compute char offsets
+    function charOffsetInPara(node: Node, offsetInNode: number): number {
+      let count = 0;
+      const walker = document.createTreeWalker(paraEl, NodeFilter.SHOW_TEXT);
+      let current = walker.nextNode();
+      while (current) {
+        if (current === node) {
+          return count + offsetInNode;
+        }
+        count += (current.textContent ?? '').length;
+        current = walker.nextNode();
+      }
+      return count + offsetInNode;
+    }
+
+    const charStart = charOffsetInPara(range.startContainer, range.startOffset);
+    const charEnd = charOffsetInPara(range.endContainer, range.endOffset);
+
+    if (charStart >= charEnd) return null;
+
+    const rect = range.getBoundingClientRect();
+    return { paragraphIndex, charStart, charEnd, rect };
+  }
+
+  // ── Text selection events ──────────────────────────────────────────────
+
+  const hideToolbar = useCallback(() => {
+    setToolbar((t) => ({ ...t, visible: false }));
+  }, []);
+
+  const showToolbarForSelection = useCallback(() => {
+    const info = getSelectionInfo();
+    if (!info) {
+      hideToolbar();
+      return;
+    }
+
+    const containerRect = containerRef.current?.getBoundingClientRect();
+    if (!containerRect) return;
+
+    // Position toolbar above the selection
+    const x = info.rect.left + info.rect.width / 2 - containerRect.left;
+    const y = info.rect.top - containerRect.top - 8; // 8px gap above
+
+    setToolbar({
+      visible: true,
+      x,
+      y,
+      paragraphIndex: info.paragraphIndex,
+      charStart: info.charStart,
+      charEnd: info.charEnd,
+    });
+  }, [hideToolbar]);
+
+  const handleMouseUp = useCallback(() => {
+    // Small delay so selection is stable
+    setTimeout(showToolbarForSelection, 50);
+  }, [showToolbarForSelection]);
+
+  // Touch: show toolbar after touch end
+  const handleTouchEnd = useCallback(() => {
+    setTimeout(showToolbarForSelection, 150);
+  }, [showToolbarForSelection]);
+
+  // Click outside hides toolbar
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      if (toolbarRef.current && toolbarRef.current.contains(e.target as Node)) return;
+      hideToolbar();
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [hideToolbar]);
+
+  // ── Apply annotation from toolbar ─────────────────────────────────────
+
+  const applyAnnotation = useCallback((type: AnnotationType) => {
+    if (!toolbar.visible) return;
+    const { paragraphIndex, charStart, charEnd } = toolbar;
+
+    setAnnotations((prev) => {
+      const snapshot = prev;
+      setUndoStack((stack) => [...stack.slice(-19), snapshot]);
+
+      // Remove any existing annotations that fully overlap
+      const filtered = prev.filter(
+        (a) =>
+          a.paragraphIndex !== paragraphIndex ||
+          a.charEnd <= charStart ||
+          a.charStart >= charEnd
+      );
+
+      const newAnn: Annotation = {
+        id: genId(),
+        paragraphIndex,
+        charStart,
+        charEnd,
+        type,
+      };
+
+      return [...filtered, newAnn];
+    });
+
+    // Clear selection
+    window.getSelection()?.removeAllRanges();
+    hideToolbar();
+  }, [toolbar, hideToolbar]);
+
+  // ── Remove annotation on click ─────────────────────────────────────────
+
+  const removeAnnotation = useCallback((id: string) => {
+    setAnnotations((prev) => {
+      setUndoStack((stack) => [...stack.slice(-19), prev]);
+      return prev.filter((a) => a.id !== id);
+    });
+  }, []);
+
+  // ── Undo ──────────────────────────────────────────────────────────────
+
+  const undo = useCallback(() => {
+    setUndoStack((stack) => {
+      if (stack.length === 0) return stack;
+      const prev = stack[stack.length - 1];
+      setAnnotations(prev);
+      return stack.slice(0, -1);
+    });
+  }, []);
+
+  // ── Clear all ─────────────────────────────────────────────────────────
+
+  const clearAll = useCallback(() => {
+    setUndoStack((stack) => [...stack.slice(-19), annotations]);
+    setAnnotations([]);
+  }, [annotations]);
+
+  // ── Render paragraph with annotation spans ─────────────────────────────
+
+  /**
+   * Splits a paragraph's raw text into segments:
+   * plain text and annotated ranges.
+   * Then wraps annotated segments in styled <span> elements.
+   */
+  function renderAnnotatedParagraph(
+    rawText: string,
+    displayText: string,
+    paraIdx: number
+  ): React.ReactNode {
+    const paraAnnotations = annotations
+      .filter((a) => a.paragraphIndex === paraIdx)
+      .sort((a, b) => a.charStart - b.charStart);
+
+    if (paraAnnotations.length === 0) {
+      // No annotations — render plain (possibly zhuyin) text
+      return displayText;
+    }
+
+    // Build segments from raw text char offsets, render display text char-by-char
+    // NOTE: when zhuyin is active, displayText has different length than rawText.
+    // We annotate by raw char positions and render rawText characters
+    // (zhuyin adds ruby annotations which we can't easily split here).
+    // So when zhuyin is active, we fall back to rendering rawText for annotated paragraphs.
+    const textToRender = zhuyinActive ? rawText : displayText;
+
+    const segments: Array<{ start: number; end: number; annotation?: Annotation }> = [];
+    let cursor = 0;
+
+    for (const ann of paraAnnotations) {
+      const s = Math.min(ann.charStart, textToRender.length);
+      const e = Math.min(ann.charEnd, textToRender.length);
+      if (s > cursor) {
+        segments.push({ start: cursor, end: s });
+      }
+      if (e > s) {
+        segments.push({ start: s, end: e, annotation: ann });
+      }
+      cursor = Math.max(cursor, e);
+    }
+    if (cursor < textToRender.length) {
+      segments.push({ start: cursor, end: textToRender.length });
+    }
+
+    return segments.map((seg) => {
+      const chars = textToRender.slice(seg.start, seg.end);
+      if (!seg.annotation) {
+        return <React.Fragment key={seg.start}>{chars}</React.Fragment>;
+      }
+      const cfg = TYPE_CONFIG[seg.annotation.type];
+      return (
+        <span
+          key={seg.annotation.id}
+          className={`cursor-pointer ${cfg.className}`}
+          title={`${cfg.icon} ${cfg.label} (點擊移除)`}
+          onClick={() => removeAnnotation(seg.annotation!.id)}
+          role="mark"
+          aria-label={`${cfg.label}標記：${chars}`}
+        >
+          {chars}
+        </span>
+      );
+    });
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      className="flex-1 flex flex-col bg-amber-50 overflow-hidden select-none"
+      style={{
+        fontFamily: zhuyinActive
+          ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"
+          : "'Iansui', 'Noto Sans TC', sans-serif",
+      }}
+    >
+      {/* ── Top bar ────────────────────────────────────────────────────── */}
+      <nav
+        aria-label="閱讀標記工具列"
+        className="flex-shrink-0 bg-white border-b border-gray-200 px-4 py-2 flex items-center gap-3 flex-wrap"
+      >
+        {/* Story title */}
+        <span className="text-sm font-bold text-gray-700 mr-1">{story.title}</span>
+        <span className="text-gray-300 text-xs" aria-hidden="true">›</span>
+        <span className="text-xs text-amber-700 font-bold">閱讀標記</span>
+
+        <div className="flex-1" />
+
+        {/* Tool selector */}
+        <div className="flex items-center gap-2" role="group" aria-label="標記類型">
+          {(Object.entries(TYPE_CONFIG) as Array<[AnnotationType, typeof TYPE_CONFIG[AnnotationType]]>).map(
+            ([type, cfg]) => (
+              <button
+                key={type}
+                type="button"
+                onClick={() => setActiveTool(type)}
+                aria-pressed={activeTool === type}
+                className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-bold border transition-all ${
+                  activeTool === type
+                    ? `${cfg.activeClass} border-current`
+                    : 'bg-white border-gray-300 text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                <span aria-hidden="true">{cfg.icon}</span>
+                {cfg.label}
+              </button>
+            )
+          )}
+        </div>
+
+        {/* Undo */}
+        <button
+          type="button"
+          onClick={undo}
+          disabled={undoStack.length === 0}
+          aria-label="復原上一步"
+          className="px-2.5 py-1.5 rounded-lg text-sm border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+        >
+          ↩ 復原
+        </button>
+
+        {/* Clear all */}
+        <button
+          type="button"
+          onClick={clearAll}
+          disabled={annotations.length === 0}
+          aria-label="清除所有標記"
+          className="px-2.5 py-1.5 rounded-lg text-sm border border-red-200 text-red-600 hover:bg-red-50 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+        >
+          清除全部
+        </button>
+
+        {/* Zhuyin toggle */}
+        {zhuyinActiveProp === undefined && (
+          <ZhuyinToggle
+            enabled={zhuyinEnabled}
+            ready={zhuyinReady}
+            onToggle={() => setZhuyinEnabled((v) => !v)}
+          />
+        )}
+      </nav>
+
+      {/* ── Instruction banner ─────────────────────────────────────────── */}
+      <div className="flex-shrink-0 bg-amber-100 border-b border-amber-200 px-6 py-2 flex items-center gap-2 text-sm text-amber-800">
+        <span className="text-base" aria-hidden="true">📖</span>
+        <span>
+          <strong>第一次閱讀</strong>：選取不太了解的字、詞或句，按 <strong>❓ 不懂</strong> 做記號。
+          <strong className="ml-3">第二次閱讀</strong>：選取重要的地方，按 <strong>💛 重要</strong> 標記。
+        </span>
+      </div>
+
+      {/* ── Main text area ─────────────────────────────────────────────── */}
+      <div
+        ref={containerRef}
+        className="flex-1 overflow-y-auto relative"
+        onMouseUp={handleMouseUp}
+        onTouchEnd={handleTouchEnd}
+        style={{ WebkitUserSelect: 'text', userSelect: 'text' } as React.CSSProperties}
+      >
+        <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+          {story.content.map((rawPara, paraIdx) => {
+            const displayText = zhuyinParagraphs?.[paraIdx] ?? rawPara;
+            return (
+              <p
+                key={paraIdx}
+                data-para-idx={paraIdx}
+                className="text-gray-900 leading-loose"
+                style={{
+                  fontSize: `${fontSizePx}px`,
+                  lineHeight: zhuyinActive ? '3.8rem' : '2.8rem',
+                  letterSpacing: zhuyinActive ? '0.35em' : '0.05em',
+                }}
+              >
+                {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}
+              </p>
+            );
+          })}
+        </div>
+
+        {/* ── Floating toolbar ─────────────────────────────────────────── */}
+        {toolbar.visible && (
+          <div
+            ref={toolbarRef}
+            role="toolbar"
+            aria-label="標記選取文字"
+            className="absolute z-50 flex items-center gap-1 bg-white border border-gray-200 rounded-xl shadow-xl px-2 py-1.5 -translate-x-1/2 -translate-y-full"
+            style={{ left: toolbar.x, top: toolbar.y }}
+          >
+            {(Object.entries(TYPE_CONFIG) as Array<[AnnotationType, typeof TYPE_CONFIG[AnnotationType]]>).map(
+              ([type, cfg]) => (
+                <button
+                  key={type}
+                  type="button"
+                  onPointerDown={(e) => {
+                    // Use pointerdown so we act before selection is cleared
+                    e.preventDefault();
+                    applyAnnotation(type);
+                  }}
+                  className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-bold border transition-all ${cfg.activeClass}`}
+                >
+                  <span aria-hidden="true">{cfg.icon}</span>
+                  {cfg.label}
+                </button>
+              )
+            )}
+            <button
+              type="button"
+              onPointerDown={(e) => {
+                e.preventDefault();
+                window.getSelection()?.removeAllRanges();
+                hideToolbar();
+              }}
+              className="ml-1 px-2 py-1.5 rounded-lg text-sm text-gray-400 hover:text-gray-700 border border-gray-200 hover:bg-gray-50 transition-all"
+              aria-label="取消"
+            >
+              ✕
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* ── Summary bar + finish button ────────────────────────────────── */}
+      <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between gap-4">
+        {/* Mark count summary */}
+        <div className="flex items-center gap-4 text-sm text-gray-600">
+          <span>
+            已標記：
+            <strong className="ml-1 text-gray-900">{summary.totalMarks}</strong> 處
+          </span>
+          {summary.unknownCount > 0 && (
+            <span className="flex items-center gap-1">
+              <span aria-hidden="true">❓</span>
+              <span className="text-red-600 font-bold">{summary.unknownCount}</span>
+            </span>
+          )}
+          {summary.importantCount > 0 && (
+            <span className="flex items-center gap-1">
+              <span aria-hidden="true">💛</span>
+              <span className="text-yellow-700 font-bold">{summary.importantCount}</span>
+            </span>
+          )}
+          {summary.totalMarks === 0 && (
+            <span className="text-gray-400">（還沒有標記）</span>
+          )}
+        </div>
+
+        {/* Finish button */}
+        <button
+          type="button"
+          onClick={() => onFinish(summary)}
+          className="px-8 py-3 rounded-xl font-bold text-base bg-amber-600 hover:bg-amber-700 text-white shadow-lg transition-all active:scale-95 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+        >
+          完成標記
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ReadingAnnotation;

--- a/frontend/src/components/reading-steps/__tests__/ReadingAnnotation.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/ReadingAnnotation.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import ReadingAnnotation from '../ReadingAnnotation';
+import { Story } from '../../../types';
+
+// ── Mock zhuyin (heavy processor not needed in unit tests) ──────────────────
+
+vi.mock('../../zhuyin/polyphonicProcessor', () => ({
+  PolyphonicProcessor: {
+    instance: {
+      loadPolyphonicData: vi.fn().mockResolvedValue(undefined),
+      process: vi.fn((text: string) => text),
+    },
+  },
+  buildZhuyinString: vi.fn((text: string) => text),
+}));
+
+vi.mock('../../ui/ZhuyinToggle', () => ({
+  default: ({ onToggle }: { onToggle: () => void }) => (
+    <button onClick={onToggle} data-testid="zhuyin-toggle">注音切換</button>
+  ),
+}));
+
+// ── Mock localStorage ──────────────────────────────────────────────────────
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+// ── Fixture ────────────────────────────────────────────────────────────────
+
+const mockStory: Story = {
+  id: 'test-story-001',
+  title: '測試故事',
+  level: 3,
+  content: ['第一段的文字內容，用來測試標記功能。', '第二段更多文字，讓我們試試看。'],
+  thumbnail: '/thumb.jpg',
+  category: 'Fable',
+  vocab: [],
+  sentences: [],
+  intro: { author: '作者', background: '背景介紹' },
+} as unknown as Story;
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('ReadingAnnotation', () => {
+  const onFinish = vi.fn();
+
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders story paragraphs', () => {
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+    expect(screen.getByText(/第一段的文字內容/)).toBeTruthy();
+    expect(screen.getByText(/第二段更多文字/)).toBeTruthy();
+  });
+
+  it('shows instruction banner', () => {
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+    expect(screen.getByText(/第一次閱讀/)).toBeTruthy();
+    expect(screen.getByText(/第二次閱讀/)).toBeTruthy();
+  });
+
+  it('shows mark tool buttons in toolbar', () => {
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+    // Both mark types should be in the top toolbar
+    const unknownBtns = screen.getAllByText('不懂');
+    const importantBtns = screen.getAllByText('重要');
+    expect(unknownBtns.length).toBeGreaterThan(0);
+    expect(importantBtns.length).toBeGreaterThan(0);
+  });
+
+  it('initially shows 0 marks in summary', () => {
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+    expect(screen.getByText(/已標記/)).toBeTruthy();
+    expect(screen.getByText('0')).toBeTruthy();
+    expect(screen.getByText(/還沒有標記/)).toBeTruthy();
+  });
+
+  it('calls onFinish with summary when finish button clicked', () => {
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+    const finishBtn = screen.getByText(/完成標記/);
+    fireEvent.click(finishBtn);
+    expect(onFinish).toHaveBeenCalledWith({
+      totalMarks: 0,
+      unknownCount: 0,
+      importantCount: 0,
+    });
+  });
+
+  it('undo and clear buttons are disabled initially', () => {
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+    const undoBtn = screen.getByLabelText('復原上一步');
+    const clearBtn = screen.getByLabelText('清除所有標記');
+    expect(undoBtn).toHaveProperty('disabled', true);
+    expect(clearBtn).toHaveProperty('disabled', true);
+  });
+
+  it('persists annotations to localStorage on render', async () => {
+    // Pre-seed localStorage with an annotation
+    const existing = [
+      {
+        id: 'ann-seed',
+        paragraphIndex: 0,
+        charStart: 0,
+        charEnd: 3,
+        type: 'unknown',
+      },
+    ];
+    localStorageMock.setItem(`annotations_test-story-001`, JSON.stringify(existing));
+
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+
+    // Mark count should reflect the persisted annotation (total count in <strong>)
+    expect(screen.getByText('1', { selector: 'strong' })).toBeTruthy();
+    expect(screen.queryByText(/還沒有標記/)).toBeNull();
+  });
+
+  it('loads annotations from localStorage on mount', () => {
+    const seeded = [
+      { id: 'a1', paragraphIndex: 0, charStart: 0, charEnd: 2, type: 'important' },
+    ];
+    localStorageMock.setItem(`annotations_test-story-001`, JSON.stringify(seeded));
+
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+
+    // importantCount shown in summary bar — both total (strong) and importantCount (span) = '1'
+    const allOnes = screen.getAllByText('1');
+    expect(allOnes.length).toBeGreaterThan(0);
+  });
+
+  it('displays 注音切換 toggle when zhuyinActive prop is not set', () => {
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+    expect(screen.getByTestId('zhuyin-toggle')).toBeTruthy();
+  });
+
+  it('hides 注音切換 toggle when zhuyinActive prop is provided', () => {
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} zhuyinActive={false} />);
+    expect(screen.queryByTestId('zhuyin-toggle')).toBeNull();
+  });
+
+  it('renders marks on annotated text (seeded from localStorage)', () => {
+    const seeded = [
+      { id: 'ann-x', paragraphIndex: 0, charStart: 0, charEnd: 2, type: 'unknown' },
+    ];
+    localStorageMock.setItem(`annotations_test-story-001`, JSON.stringify(seeded));
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+
+    // The mark span should have role="mark"
+    const marks = screen.getAllByRole('mark');
+    expect(marks.length).toBeGreaterThan(0);
+  });
+
+  it('removes annotation when mark span is clicked', async () => {
+    const seeded = [
+      { id: 'ann-rm', paragraphIndex: 0, charStart: 0, charEnd: 2, type: 'important' },
+    ];
+    localStorageMock.setItem(`annotations_test-story-001`, JSON.stringify(seeded));
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+
+    // Initial count — total is shown in the <strong> element
+    const totalCount = screen.getByText('1', { selector: 'strong' });
+    expect(totalCount).toBeTruthy();
+
+    // Click the mark to remove it
+    const marks = screen.getAllByRole('mark');
+    await act(async () => {
+      fireEvent.click(marks[0]);
+    });
+
+    // Count should be 0 now
+    expect(screen.getByText('0', { selector: 'strong' })).toBeTruthy();
+    expect(screen.getByText(/還沒有標記/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #670

## Summary

- New standalone component `ReadingAnnotation.tsx` for the 三民 "讀全文-做記號" step
- Students select text with mouse/touch → floating toolbar appears → apply mark type
- Two mark types: ❓ 不懂 (red underline) / 💛 重要 (yellow highlight)
- Marks persist to `localStorage` (key: `annotations_{storyId}`)
- Undo stack (20 levels), clear all, mark count summary
- Full zhuyin support (internal toggle or via `zhuyinActive` prop)
- Tap/click an existing mark to remove it
- Does NOT touch StepperNav/App.tsx — purely standalone component

## Props

```ts
interface ReadingAnnotationProps {
  story: Story;
  onFinish: (summary: { totalMarks, unknownCount, importantCount }) => void;
  zhuyinActive?: boolean;   // if omitted, component manages its own toggle
  fontSizePx?: number;      // default 22
}
```

## Test plan

- 12 unit tests (vitest + testing-library) — all passing
- Verify PR Preview deploys successfully
- Open a lesson → manually integrate component to test text selection UX on mobile

## Notes

- Does not yet integrate into StepperNav (tracked separately in #671)
- localStorage → DB persistence is a future task (noted in issue)