### PR TITLE
feat: 全步驟 localStorage progress 持久化 (Fixes #678)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -34,7 +34,25 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   dbSessionId,
 }) => {
   const { token } = useAuth();
-  const [conversation, setConversation] = useState<ChatMessage[]>([]);
+
+  // ── localStorage persistence ────────────────────────────────────────
+  const storageKey = `comprehension_progress_${story.id}`;
+  type SavedComprehension = {
+    conversation: ChatMessage[];
+    understoodCount: number;
+    requiredCount: number;
+    isSessionComplete: boolean;
+  };
+  const loadSaved = (): SavedComprehension | null => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch { return null; }
+  };
+  const savedRef = useRef(loadSaved());
+
+  const [conversation, setConversation] = useState<ChatMessage[]>(() => savedRef.current?.conversation ?? []);
   const [inputText, setInputText] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,9 +72,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   const [sessionId] = useState(() =>
     dbSessionId ? `db-${dbSessionId}` : crypto.randomUUID()
   );
-  const [understoodCount, setUnderstoodCount] = useState(0);
-  const [requiredCount, setRequiredCount] = useState(3);
-  const [isSessionComplete, setIsSessionComplete] = useState(false);
+  const [understoodCount, setUnderstoodCount] = useState(() => savedRef.current?.understoodCount ?? 0);
+  const [requiredCount, setRequiredCount] = useState(() => savedRef.current?.requiredCount ?? 3);
+  const [isSessionComplete, setIsSessionComplete] = useState(() => savedRef.current?.isSessionComplete ?? false);
   const [highlightedParagraph, setHighlightedParagraph] = useState<number | null>(null);
   const [offlineMode, setOfflineMode] = useState(false);
   const [mockQuestionIndex, setMockQuestionIndex] = useState(0);
@@ -282,6 +300,19 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     fetchFirstQuestion();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ── Save conversation progress to localStorage ──────────────────────
+  useEffect(() => {
+    if (conversation.length === 0) return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({
+        conversation,
+        understoodCount,
+        requiredCount,
+        isSessionComplete,
+      }));
+    } catch {}
+  }, [conversation, understoodCount, requiredCount, isSessionComplete, storageKey]);
+
   const handleSubmit = useCallback(async (overrideText?: string) => {
     const text = (overrideText ?? inputText).trim();
     if (!text || isLoading || isSessionComplete || isSubmittingRef.current) return;
@@ -405,7 +436,13 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   };
 
   // Clear session and start over from scratch (Issue #632)
+  const handleFinish = useCallback(() => {
+    try { localStorage.removeItem(storageKey); } catch {}
+    onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length });
+  }, [storageKey, onFinish, understoodCount, requiredCount, isSessionComplete, conversation.length]);
+
   const handleRestart = useCallback(async () => {
+    try { localStorage.removeItem(storageKey); } catch {}
     setConversation([]);
     setUnderstoodCount(0);
     setIsSessionComplete(false);
@@ -668,7 +705,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             重新開始
           </button>
           <button
-            onClick={() => onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length })}
+            onClick={handleFinish}
             className="flex-1 py-3 rounded-xl font-bold text-base bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2"
           >
             繼續，生字練習
@@ -867,7 +904,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 <span className="text-[10px] text-gray-600">
                   {understoodCount} / {requiredCount} 理解
                 </span>
-                <button onClick={() => onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length })} className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors">
+                <button onClick={handleFinish} className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors">
                   跳過
                 </button>
               </div>
@@ -973,7 +1010,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                     {understoodCount} / {requiredCount} 理解
                   </span>
                   <button
-                    onClick={() => onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length })}
+                    onClick={handleFinish}
                     className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors pr-3"
                   >
                     跳過

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -20,13 +20,25 @@ interface FullReadingProps {
 
 const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPanelWidthChange, onFinish, onBack }) => {
   const isMobile = useIsMobile();
+  const storageKey = `fullReading_progress_${story.id}`;
+
+  type SavedResult = { matchRate: number; feedback: string; diffTokens: DiffToken[]; cpm: number; durationMs: number; errorBreakdown: { correct: number; wrong: number; missing: number; extra: number } };
+  const loadSaved = (): { result: SavedResult; transcript: string } | null => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch { return null; }
+  };
+  const savedProgress = useRef(loadSaved());
+
   const [isPreparing, setIsPreparing]           = useState(false);
   const [isSessionActive, setIsSessionActive]   = useState(false);
   const [isTtsSpeaking, setIsTtsSpeaking]       = useState(false);
   const [isTtsPaused, setIsTtsPaused]           = useState(false);
-  const [streamingTranscript, setStreamingTranscript] = useState('');
+  const [streamingTranscript, setStreamingTranscript] = useState(() => savedProgress.current?.transcript ?? '');
   const [micError, setMicError]                 = useState('');
-  const [result, setResult]                     = useState<{ matchRate: number; feedback: string; diffTokens: DiffToken[]; cpm: number; durationMs: number; errorBreakdown: { correct: number; wrong: number; missing: number; extra: number } } | null>(null);
+  const [result, setResult]                     = useState<SavedResult | null>(() => savedProgress.current?.result ?? null);
   const [zhuyinEnabled, setZhuyinEnabled]       = useState(true);
   const [zhuyinReady, setZhuyinReady]           = useState(false);
 
@@ -44,6 +56,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
   /* ---- Audio recorder (for student playback review) ---- */
   const audioRecorder = useAudioRecorder(120);
+
+  /* ---- localStorage persistence ---- */
+  useEffect(() => {
+    if (!result) return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({ result, transcript: streamingTranscript }));
+    } catch {}
+  }, [result, streamingTranscript, storageKey]);
 
   /* ---- Zhuyin ---- */
   useEffect(() => {
@@ -418,14 +438,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {result ? (
             <div className="space-y-2">
               <button
-                onClick={() => { setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); }}
+                onClick={() => { try { localStorage.removeItem(storageKey); } catch {} setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); }}
                 aria-label="重新開始全文朗讀"
                 className="w-full py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
               >
                 再試一次
               </button>
               <button
-                onClick={() => onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript, cpm: result.cpm, durationMs: result.durationMs, errorBreakdown: result.errorBreakdown })}
+                onClick={() => { try { localStorage.removeItem(storageKey); } catch {} onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript, cpm: result.cpm, durationMs: result.durationMs, errorBreakdown: result.errorBreakdown }); }}
                 aria-label="完成全文朗讀，查看學習報告"
                 className="w-full py-3 rounded-xl text-base font-bold bg-emerald-600 hover:bg-emerald-500 text-white transition-all flex items-center justify-center gap-2 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1"
               >

--- a/frontend/src/components/reading-steps/KnowledgeStation.tsx
+++ b/frontend/src/components/reading-steps/KnowledgeStation.tsx
@@ -2,7 +2,7 @@
  * 知識補給站 — 三民學習單第九步
  * 顯示課文相關的 YouTube 影片和延伸資料
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { Story } from '../../types';
 
 interface KnowledgeStationProps {
@@ -12,6 +12,18 @@ interface KnowledgeStationProps {
 }
 
 const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish }) => {
+  const storageKey = `knowledge_viewed_${story.id}`;
+
+  // Mark as viewed on mount; clear on finish
+  useEffect(() => {
+    try { localStorage.setItem(storageKey, JSON.stringify({ viewed: true })); } catch {}
+  }, [storageKey]);
+
+  const handleFinish = () => {
+    try { localStorage.removeItem(storageKey); } catch {}
+    onFinish();
+  };
+
   const videoUrl = story.knowledgeVideoUrl;
 
   // Extract YouTube video ID from URL
@@ -78,7 +90,7 @@ const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish }) 
           {/* Finish button */}
           <div className="flex justify-center pt-4">
             <button
-              onClick={onFinish}
+              onClick={handleFinish}
               className="px-8 py-3 rounded-xl text-base font-bold bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95"
             >
               繼續前往報告

--- a/frontend/src/components/reading-steps/VocabApplication.tsx
+++ b/frontend/src/components/reading-steps/VocabApplication.tsx
@@ -8,7 +8,7 @@
  *
  * Props: { story, onFinish, zhuyinActive?, fontSizePx? }
  */
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Story } from '../../types';
 import FillInBlankExercise from './FillInBlankExercise';
 
@@ -119,8 +119,25 @@ const VocabApplication: React.FC<VocabApplicationProps> = ({
   onFinish,
   fontSizePx,
 }) => {
-  const [phase, setPhase] = useState<'exercise' | 'done'>('exercise');
-  const [result, setResult] = useState<{ score: number; total: number } | null>(null);
+  const storageKey = `vocabApp_progress_${story.id}`;
+  const loadSaved = () => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return null;
+      return JSON.parse(raw) as { phase: 'exercise' | 'done'; result: { score: number; total: number } | null };
+    } catch { return null; }
+  };
+  const savedProgress = useRef(loadSaved());
+
+  const [phase, setPhase] = useState<'exercise' | 'done'>(() => savedProgress.current?.phase ?? 'exercise');
+  const [result, setResult] = useState<{ score: number; total: number } | null>(() => savedProgress.current?.result ?? null);
+
+  // ── localStorage persistence ────────────────────────────────────────
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({ phase, result }));
+    } catch {}
+  }, [phase, result, storageKey]);
 
   const sentences = story.fillInBlank ?? [];
   const vocabBank = story.vocabBank ?? {};
@@ -133,6 +150,7 @@ const VocabApplication: React.FC<VocabApplicationProps> = ({
   }
 
   function handleFinish() {
+    try { localStorage.removeItem(storageKey); } catch {}
     const score = result?.score ?? 0;
     const total = result?.total ?? sentences.length;
     onFinish({

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -1,5 +1,4 @@
-
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Story, ReadingAttempt, VocabResult } from '../../types';
 import { hasStrokeData } from '../stroke-order/strokeData';
 import WriteCharacter from '../stroke-order/WriteCharacter';
@@ -145,9 +144,25 @@ function CharCard({ label, isSuggested, isPracticed, animDelay, onClick }: CharC
 /* ================================================================ */
 
 const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish, onBack }) => {
-  const [phase, setPhase] = useState<Phase>('confirm');
-  const [practicingChar, setPracticingChar] = useState('');
-  const [practicedChars, setPracticedChars] = useState<Set<string>>(new Set());
+  const storageKey = `vocabPractice_progress_${story.id}`;
+  const loadSaved = () => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return null;
+      return JSON.parse(raw) as { practicedChars: string[]; phase: Phase; practicingChar: string };
+    } catch { return null; }
+  };
+  const savedProgress = useRef(loadSaved());
+
+  const [phase, setPhase] = useState<Phase>(() => {
+    const p = savedProgress.current?.phase;
+    // Only restore grid phase (not mid-practice)
+    return (p === 'grid') ? 'grid' : 'confirm';
+  });
+  const [practicingChar, setPracticingChar] = useState(savedProgress.current?.practicingChar ?? '');
+  const [practicedChars, setPracticedChars] = useState<Set<string>>(
+    () => new Set(savedProgress.current?.practicedChars ?? [])
+  );
   const [pronouncedChars, setPronoucedChars] = useState<Set<string>>(new Set());
   const [activeTab, setActiveTab] = useState<PracticeMode>('stroke');
   const [zhuyinEnabled, setZhuyinEnabled] = useState(true);
@@ -164,6 +179,18 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
       .then(() => setZhuyinReady(true))
       .catch((err) => console.error('Failed to load zhuyin data:', err));
   }, []);
+
+  // ── localStorage persistence ────────────────────────────────────────
+  useEffect(() => {
+    if (phase === 'confirm') return; // Nothing to save yet
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({
+        practicedChars: Array.from(practicedChars),
+        phase,
+        practicingChar,
+      }));
+    } catch {}
+  }, [practicedChars, phase, practicingChar, storageKey]);
 
   const processZhuyin = useCallback((text: string): string => {
     if (!zhuyinActive) return text;
@@ -239,6 +266,11 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     setPhase('grid');
   };
 
+  const handleFinish = (result: VocabResult) => {
+    try { localStorage.removeItem(storageKey); } catch {}
+    onFinish(result);
+  };
+
   /** Toggle the radical panel for a character. Long-press / secondary action. */
   const handleRadicalToggle = (ch: string) => {
     setRadicalChar(prev => (prev === ch ? null : ch));
@@ -274,7 +306,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
               好！開始練習
             </button>
             <button
-              onClick={() => onFinish({ practicedChars: [], totalChars: charCount })}
+              onClick={() => handleFinish({ practicedChars: [], totalChars: charCount })}
               className="w-full py-3 rounded-2xl font-semibold text-base text-gray-500 hover:text-gray-800 hover:bg-gray-100 transition-all active:scale-95"
             >
               跳過
@@ -315,7 +347,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
       <SentencePractice
         practicedChars={Array.from(practicedChars)}
         storyTitle={story.title}
-        onFinish={() => onFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
+        onFinish={() => handleFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
         onBack={() => setPhase('grid')}
       />
     );
@@ -612,7 +644,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           {allDone && (
             <CompletionBanner
               count={practicedChars.size}
-              onFinish={() => onFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
+              onFinish={() => handleFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
             />
           )}
           </>}
@@ -637,7 +669,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
             </button>
           )}
           <button
-            onClick={() => onFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
+            onClick={() => handleFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
             className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
           >
             {practicedChars.size > 0 || pronouncedChars.size > 0 ? '完成，查看報告' : '跳過，查看報告'}

--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -243,6 +243,16 @@ function getCellsBetween(start: CellPos, end: CellPos): CellPos[] {
 // ---------------------------------------------------------------------------
 
 export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProps) {
+  const storageKey = `wordSearch_progress_${story.id}`;
+  const loadSaved = () => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return null;
+      return JSON.parse(raw) as { foundWords: string[]; elapsedTime: number };
+    } catch { return null; }
+  };
+  const savedRef = useRef(loadSaved());
+
   const vocabWords = useMemo(
     () => (story.vocabulary ?? []).map((v) => v.word).filter((w) => [...w].length >= 2),
     [story.vocabulary]
@@ -261,24 +271,59 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
     return map;
   }, [placedWords]);
 
-  const [foundWords, setFoundWords] = useState<Set<string>>(new Set());
-  const [highlightedCells, setHighlightedCells] = useState<Set<string>>(new Set());
+  const [foundWords, setFoundWords] = useState<Set<string>>(() => new Set(savedRef.current?.foundWords ?? []));
+  const [highlightedCells, setHighlightedCells] = useState<Set<string>>(() => {
+    // Restore highlighted cells from saved found words
+    const saved = savedRef.current?.foundWords ?? [];
+    if (saved.length === 0) return new Set<string>();
+    const cells = new Set<string>();
+    // We can't restore exact cell positions here since grid is regenerated randomly
+    // Just restore found words state; cells will be re-highlighted as words are re-found
+    return cells;
+  });
   const [dragCells, setDragCells] = useState<Set<string>>(new Set());
   const [dragStart, setDragStart] = useState<CellPos | null>(null);
   const [flashCells, setFlashCells] = useState<Set<string>>(new Set());
   const [finished, setFinished] = useState(false);
   const [justFound, setJustFound] = useState<string | null>(null);
 
+  // Restore highlighted cells for already-found words on mount
+  useEffect(() => {
+    if (savedRef.current?.foundWords && savedRef.current.foundWords.length > 0) {
+      const restoredCells = new Set<string>();
+      for (const word of savedRef.current.foundWords) {
+        const keys = wordKeysMap.get(word);
+        if (keys) keys.forEach(k => restoredCells.add(k));
+      }
+      if (restoredCells.size > 0) {
+        setHighlightedCells(restoredCells);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const timerRunning = !finished && vocabWords.length > 0;
   const elapsed = useTimer(timerRunning);
   const allFound = foundWords.size === placedWords.length && placedWords.length > 0;
 
+  // ── localStorage persistence ────────────────────────────────────────
+  useEffect(() => {
+    if (foundWords.size === 0) return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({
+        foundWords: Array.from(foundWords),
+        elapsedTime: elapsed,
+      }));
+    } catch {}
+  }, [foundWords, elapsed, storageKey]);
+
   useEffect(() => {
     if (allFound && !finished) {
       setFinished(true);
+      try { localStorage.removeItem(storageKey); } catch {}
       setTimeout(() => onFinish(elapsed), 800);
     }
-  }, [allFound, finished, onFinish, elapsed]);
+  }, [allFound, finished, onFinish, elapsed, storageKey]);
 
   // Resolve a touch/mouse event to a grid cell position
   const resolveCell = useCallback((e: React.MouseEvent | React.TouchEvent): CellPos | null => {


### PR DESCRIPTION
Fixes #678

## Summary

- FullReading: save result + CPM after evaluation; restore on refresh; clear on finish or retry
- VocabPractice: save practicedChars + current phase; restore to grid (not mid-practice); clear on finish
- VocabApplication: save phase + score; restore completion state; clear on finish
- ComprehensionChat: save conversation history + progress counts; restore on refresh; clear on finish/restart
- VocabWordSearch: save foundWords + elapsed time; restore highlighted cells via wordKeysMap; clear on completion
- KnowledgeStation: mark viewed on mount; clear on finish

All localStorage calls wrapped in try/catch for private browsing safety.

## Storage Keys

| Step | Key |
|------|-----|
| 全文朗讀 | `fullReading_progress_{storyId}` |
| 生字練習 | `vocabPractice_progress_{storyId}` |
| 語詞應用 | `vocabApp_progress_{storyId}` |
| 課文理解 | `comprehension_progress_{storyId}` |
| 語詞複習 | `wordSearch_progress_{storyId}` |
| 知識補給站 | `knowledge_viewed_{storyId}` |

## Test plan

- [ ] Open any story, start VocabPractice, practice a few characters, then refresh — check the practiced chars are still marked
- [ ] Open FullReading, complete a reading, then refresh — check result (score/diff) is restored
- [ ] Open ComprehensionChat, answer 1-2 questions, refresh — conversation is restored
- [ ] Finish any step — check localStorage key is removed
- [ ] Test in private browsing — no errors thrown, graceful degradation
- [ ] Build passes: `npm run build` shows no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)