### PR TITLE
feat: redesign StepperNav from horizontal header to vertical left sidebar

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { AppView, Story, LearningSession } from '../types';
 import { useIsMobile } from '../hooks/useIsMobile';
-import { useAuth } from '../contexts/AuthContext';
 import { ACTIVE_STEPS } from '../config/stepConfig';
 
 interface StepperNavProps {
@@ -87,17 +85,17 @@ function getMiniSummary(stepDef: StepDef, session: LearningSession | null): stri
   }
 }
 
-// -- Circle sub-component --
-const StepCircle: React.FC<{
+// -- Step badge sub-component --
+const StepBadge: React.FC<{
   step: number;
   status: StepStatus;
   size?: 'sm' | 'md';
 }> = ({ step, status, size = 'md' }) => {
-  const sizeClasses = size === 'sm' ? 'w-5 h-5 text-[10px]' : 'w-5 h-5 text-[10px]';
+  const sizeClasses = size === 'sm' ? 'w-6 h-6 text-xs' : 'w-7 h-7 text-sm';
 
   const styleMap: Record<StepStatus, string> = {
     disabled:  'bg-gray-200 text-gray-400',
-    idle:      'bg-gray-200 text-gray-900',
+    idle:      'bg-gray-200 text-gray-700',
     active:    'bg-accent text-white',
     completed: 'bg-emerald-500 text-white',
   };
@@ -107,7 +105,7 @@ const StepCircle: React.FC<{
       className={`${sizeClasses} rounded-full flex items-center justify-center font-bold shrink-0 ${styleMap[status]}`}
     >
       {status === 'completed' ? (
-        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
           <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
         </svg>
       ) : (
@@ -117,200 +115,228 @@ const StepCircle: React.FC<{
   );
 };
 
-// -- Active circle for desktop (inverted colors) --
-const DesktopActiveCircle: React.FC<{ step: number }> = ({ step }) => (
-  <span className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0 bg-white text-accent">
-    {step}
-  </span>
-);
+// ── Desktop vertical sidebar ──────────────────────────────────────────────
 
-const StepperNav: React.FC<StepperNavProps> = ({
+const DesktopSidebar: React.FC<StepperNavProps> = ({
   currentView,
   session,
   selectedStory,
   onNavigate,
 }) => {
-  const [mobileNavOpen, setMobileNavOpen] = useState(false);
-  const isMobile = useIsMobile();
-  const navigate = useNavigate();
-  const { user } = useAuth();
-  const avatarInitial = user?.name?.charAt(0) ?? '?';
-
-  const handleNavigate = (view: AppView) => {
-    onNavigate(view);
-    setMobileNavOpen(false);
-  };
-
-  if (isMobile) {
-    return (
-      <nav className="flex items-center gap-1 text-xs font-medium relative">
-        {/* Compact step circles */}
-        {steps.map((stepDef) => {
-          const status = getStepStatus(stepDef, currentView, session, selectedStory);
-          return (
-            <button
-              key={stepDef.view}
-              onClick={() => { if (status !== 'disabled') handleNavigate(stepDef.view); }}
-              disabled={status === 'disabled'}
-              aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${status === 'active' ? '目前' : status === 'completed' ? '已完成' : status === 'disabled' ? '未解鎖' : '未完成'}）`}
-              aria-current={status === 'active' ? 'step' : undefined}
-              className="shrink-0 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 rounded-full"
-            >
-              <StepCircle step={stepDef.step} status={status} size="sm" />
-            </button>
-          );
-        })}
-
-        {/* Hamburger */}
-        <button
-          onClick={() => setMobileNavOpen(!mobileNavOpen)}
-          aria-label={mobileNavOpen ? '關閉導覽選單' : '展開導覽選單'}
-          aria-expanded={mobileNavOpen}
-          aria-haspopup="menu"
-          className="ml-1 p-1 rounded hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
-        >
-          <svg className="w-4 h-4 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-
-        {/* Dropdown */}
-        {mobileNavOpen && (
-          <>
-            <div className="fixed inset-0 z-40" onClick={() => setMobileNavOpen(false)} />
-            <div className="absolute right-0 top-full mt-1 z-50 bg-white border border-gray-200 rounded-xl shadow-lg py-1 min-w-[180px]">
-              {/* Home button */}
-              <button
-                onClick={() => handleNavigate(AppView.HOME)}
-                className={`w-full text-left px-3 py-2 text-xs flex items-center gap-2 ${
-                  currentView === AppView.HOME ? 'bg-accent/10 text-accent font-bold' : 'text-gray-700 hover:bg-gray-50'
-                }`}
-              >
-                首頁
-              </button>
-
-              {/* Step items */}
-              {steps.map((stepDef) => {
-                const status = getStepStatus(stepDef, currentView, session, selectedStory);
-                const summary = status === 'completed' ? getMiniSummary(stepDef, session) : null;
-                const isActive = status === 'active';
-                const isDisabled = status === 'disabled';
-                return (
-                  <button
-                    key={stepDef.view}
-                    onClick={() => { if (!isDisabled) handleNavigate(stepDef.view); }}
-                    disabled={isDisabled}
-                    aria-current={isActive ? 'step' : undefined}
-                    className={`w-full text-left px-3 py-2 text-xs flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-inset ${
-                      isActive ? 'bg-accent/10 text-accent font-bold'
-                      : isDisabled ? 'text-gray-300 cursor-not-allowed'
-                      : 'text-gray-700 hover:bg-gray-50'
-                    }`}
-                  >
-                    <StepCircle step={stepDef.step} status={status} size="sm" />
-                    <span className="flex flex-col">
-                      <span>{stepDef.label}</span>
-                      {summary && (
-                        <span className="text-[10px] text-emerald-600 font-normal">{summary}</span>
-                      )}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </>
-        )}
-
-        {/* Avatar + Achievements link */}
-        <div className="ml-2 flex items-center gap-1 pl-2 border-l border-gray-200">
-          <button
-            onClick={() => navigate('/achievements')}
-            className="flex items-center gap-1 hover:opacity-80 transition-opacity"
-            aria-label="成就頁面"
-          >
-            <div className="w-6 h-6 rounded-full bg-accent text-white flex items-center justify-center text-xs font-bold" aria-label={user?.name ?? '使用者'}>
-              {avatarInitial}
-            </div>
-          </button>
-        </div>
-      </nav>
-    );
-  }
-
-  // -- Desktop layout --
   return (
-    <nav className="flex items-center gap-1 text-sm font-medium">
-      {/* Home */}
-      <button
-        onClick={() => onNavigate(AppView.HOME)}
-        aria-current={currentView === AppView.HOME ? 'page' : undefined}
-        className={`px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
-          currentView === AppView.HOME
-            ? 'bg-accent text-white'
-            : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
-        }`}
-      >
-        首頁
-      </button>
+    <nav
+      aria-label="學習步驟導覽"
+      className="hidden md:flex flex-col w-52 shrink-0 bg-white border-r border-gray-200 overflow-y-auto py-4 gap-1"
+    >
+      {/* Story title */}
+      {selectedStory && (
+        <div className="px-4 pb-3 border-b border-gray-100 mb-1">
+          <p className="text-[11px] text-gray-400 uppercase tracking-wider font-semibold mb-0.5">目前課文</p>
+          <p className="text-xs font-semibold text-gray-700 line-clamp-2 leading-snug">
+            {selectedStory.title}
+          </p>
+        </div>
+      )}
 
-      <span className="text-gray-300 select-none">&middot;</span>
-
-      {/* Steps 1-6 */}
-      {steps.map((stepDef, i, arr) => {
+      {/* Step list */}
+      {steps.map((stepDef) => {
         const status = getStepStatus(stepDef, currentView, session, selectedStory);
         const summary = status === 'completed' ? getMiniSummary(stepDef, session) : null;
         const isActive = status === 'active';
         const isDisabled = status === 'disabled';
 
         return (
-          <React.Fragment key={stepDef.view}>
-            <button
-              onClick={() => !isDisabled && onNavigate(stepDef.view)}
-              disabled={isDisabled}
-              aria-current={isActive ? 'step' : undefined}
-              aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${isActive ? '目前' : isDisabled ? '未解鎖' : status === 'completed' ? '已完成' : '未完成'}）`}
-              className={`flex items-center gap-1 px-2 py-1 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
-                isActive
-                  ? 'bg-accent text-white'
-                  : isDisabled
-                  ? 'text-gray-400 cursor-not-allowed'
-                  : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
-              }`}
-            >
-              {isActive ? (
-                <DesktopActiveCircle step={stepDef.step} />
-              ) : (
-                <StepCircle step={stepDef.step} status={status} />
-              )}
-              <span className="hidden md:flex md:items-center md:gap-1">
-                <span>{stepDef.label}</span>
-                {summary && (
-                  <span className="text-[10px] text-emerald-600 font-normal">{summary}</span>
-                )}
+          <button
+            key={stepDef.view}
+            onClick={() => !isDisabled && onNavigate(stepDef.view)}
+            disabled={isDisabled}
+            aria-current={isActive ? 'step' : undefined}
+            aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${isActive ? '目前' : isDisabled ? '未解鎖' : status === 'completed' ? '已完成' : '未完成'}）`}
+            className={`mx-2 flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
+              isActive
+                ? 'bg-accent/10 text-accent'
+                : isDisabled
+                ? 'text-gray-300 cursor-not-allowed'
+                : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+            }`}
+          >
+            <StepBadge step={stepDef.step} status={status} size="md" />
+            <span className="flex flex-col min-w-0">
+              <span className={`text-sm leading-tight ${isActive ? 'font-semibold' : 'font-medium'}`}>
+                {stepDef.label}
               </span>
-            </button>
-            {i < arr.length - 1 && (
-              <span className="text-gray-300 select-none">&middot;</span>
-            )}
-          </React.Fragment>
+              {summary && (
+                <span className="text-[11px] text-emerald-600 font-normal mt-0.5">{summary}</span>
+              )}
+            </span>
+          </button>
         );
       })}
-
-      {/* User avatar + Achievements link */}
-      <div className="ml-3 flex items-center gap-1 pl-3 border-l border-gray-200">
-        <button
-          onClick={() => navigate('/achievements')}
-          className="flex items-center gap-1 hover:opacity-80 transition-opacity"
-          aria-label="成就頁面"
-        >
-          <div className="w-6 h-6 rounded-full bg-accent text-white flex items-center justify-center text-xs font-bold" aria-label={user?.name ?? '使用者'}>
-            {avatarInitial}
-          </div>
-          <span className="text-[10px] text-gray-500 hidden sm:block">{user?.name}</span>
-        </button>
-      </div>
     </nav>
   );
+};
+
+// ── Mobile compact bar + bottom sheet overlay ─────────────────────────────
+
+const MobileStepBar: React.FC<StepperNavProps> = ({
+  currentView,
+  session,
+  selectedStory,
+  onNavigate,
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const currentStepDef = steps.find((s) => s.view === currentView);
+  const currentStatus = currentStepDef
+    ? getStepStatus(currentStepDef, currentView, session, selectedStory)
+    : 'idle';
+
+  const handleNavigate = (view: AppView) => {
+    onNavigate(view);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      {/* Compact top bar — mobile only */}
+      <div className="flex items-center gap-3 px-4 py-2 bg-white border-b border-gray-200 shrink-0">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          {currentStepDef ? (
+            <>
+              <StepBadge step={currentStepDef.step} status={currentStatus} size="sm" />
+              <span className="text-sm font-semibold text-gray-800 truncate">
+                {currentStepDef.label}
+              </span>
+              <span className="text-xs text-gray-400 shrink-0">
+                {currentStepDef.step} / {steps.length}
+              </span>
+            </>
+          ) : (
+            <span className="text-sm text-gray-500">選擇步驟</span>
+          )}
+        </div>
+
+        <button
+          onClick={() => setOpen(true)}
+          aria-label="展開所有步驟"
+          aria-expanded={open}
+          aria-haspopup="dialog"
+          className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          <svg className="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Bottom sheet overlay */}
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/40"
+            onClick={() => setOpen(false)}
+            aria-hidden="true"
+          />
+          <div
+            role="dialog"
+            aria-label="學習步驟清單"
+            aria-modal="true"
+            className="fixed inset-x-0 bottom-0 z-50 bg-white rounded-t-2xl shadow-2xl max-h-[80vh] flex flex-col"
+          >
+            {/* Sheet handle */}
+            <div className="flex justify-center pt-3 pb-1">
+              <div className="w-10 h-1 rounded-full bg-gray-300" />
+            </div>
+
+            {/* Sheet header */}
+            <div className="flex items-center justify-between px-5 py-3 border-b border-gray-100">
+              <div>
+                <h2 className="text-base font-semibold text-gray-900">學習步驟</h2>
+                {selectedStory && (
+                  <p className="text-xs text-gray-500 mt-0.5 truncate max-w-xs">{selectedStory.title}</p>
+                )}
+              </div>
+              <button
+                onClick={() => setOpen(false)}
+                aria-label="關閉"
+                className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+              >
+                <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Step list */}
+            <nav
+              aria-label="學習步驟導覽"
+              className="overflow-y-auto py-3 px-3 flex flex-col gap-1"
+            >
+              {steps.map((stepDef) => {
+                const status = getStepStatus(stepDef, currentView, session, selectedStory);
+                const summary = status === 'completed' ? getMiniSummary(stepDef, session) : null;
+                const isActive = status === 'active';
+                const isDisabled = status === 'disabled';
+
+                return (
+                  <button
+                    key={stepDef.view}
+                    onClick={() => !isDisabled && handleNavigate(stepDef.view)}
+                    disabled={isDisabled}
+                    aria-current={isActive ? 'step' : undefined}
+                    className={`flex items-center gap-3 px-4 py-3 rounded-xl transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                      isActive
+                        ? 'bg-accent/10 text-accent'
+                        : isDisabled
+                        ? 'text-gray-300 cursor-not-allowed'
+                        : 'text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    <StepBadge step={stepDef.step} status={status} size="sm" />
+                    <span className="flex flex-col">
+                      <span className={`text-base leading-snug ${isActive ? 'font-semibold' : 'font-medium'}`}>
+                        {stepDef.label}
+                      </span>
+                      {summary && (
+                        <span className="text-xs text-emerald-600 font-normal mt-0.5">{summary}</span>
+                      )}
+                    </span>
+                    {isActive && (
+                      <span className="ml-auto text-xs font-medium bg-accent/10 text-accent px-2 py-0.5 rounded-full shrink-0">
+                        目前
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </nav>
+          </div>
+        </>
+      )}
+    </>
+  );
+};
+
+// ── Main export ───────────────────────────────────────────────────────────
+
+/**
+ * StepperNav — vertical sidebar on desktop, compact bar + bottom sheet on mobile.
+ *
+ * Desktop (md+): fixed-width left column (208px / w-52) with numbered step rows.
+ * Mobile (<md): slim top bar showing current step + hamburger; tapping opens a
+ * bottom sheet with the full step list.
+ *
+ * This component is rendered OUTSIDE the header. It lives as a sibling to the
+ * main learning content area (see LearningAppShell in AppShell.tsx).
+ */
+const StepperNav: React.FC<StepperNavProps> = (props) => {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return <MobileStepBar {...props} />;
+  }
+
+  return <DesktopSidebar {...props} />;
 };
 
 export default StepperNav;

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -2,18 +2,22 @@
  * AppShell — the authenticated app chrome (header + sidebar + main area).
  *
  * LearningAppShell — thin wrapper that puts LearningLayout inside AppShell,
- * used for all /learn/:storyId/* routes.
+ * used for all /learn/:storyId/* routes. It also renders the StepperNav as a
+ * vertical left sidebar alongside the learning content (moved out of the header).
  */
 import React, { useState, useEffect, useCallback, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
+import { useLearningNav } from '../../contexts/LearningNavContext';
 import { getMyAssignments } from '../../services/assignmentApi';
 import { AppView } from '../../types';
 import { VIEW_TO_PATH } from '../../config/stepConfig';
+import { useAppView } from '../../hooks/useAppView';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import LearningLayout from '../../layouts/LearningLayout';
+import StepperNav from '../StepperNav';
 import { OnboardingWrapper } from '../../pages/app/InlinePages';
 
 /** The authenticated app shell with header + sidebar. */
@@ -78,7 +82,7 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
         跳至主要內容
       </a>
 
-      {/* Header — extracted to components/layout/Header.tsx */}
+      {/* Header — global chrome only (logo, user info, logout). No stepper here. */}
       <Header onStepperNavigate={handleStepperNavigate} />
 
       {/* Body: sidebar + main content */}
@@ -106,13 +110,65 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
 };
 
 /**
+ * Inner content for the learning flow: StepperNav sidebar + LearningLayout.
+ * Rendered inside AppShell's <main> element.
+ *
+ * Desktop: flex-row — [StepperNav 208px] + [LearningLayout fills rest]
+ * Mobile: flex-col — [StepperNav compact bar] stacked above [LearningLayout]
+ */
+const LearningContent: React.FC = () => {
+  const navigate = useNavigate();
+  const currentView = useAppView();
+  const { session: navSession, selectedStory: navStory } = useLearningNav();
+
+  const handleStepperNavigate = (view: AppView) => {
+    switch (view) {
+      case AppView.HOME:
+        navigate('/');
+        break;
+      case AppView.LIBRARY:
+        navigate('/library');
+        break;
+      default: {
+        const pathId = VIEW_TO_PATH[view];
+        if (pathId) {
+          const match = window.location.pathname.match(/\/learn\/([^/]+)/);
+          const storyId = match?.[1];
+          if (storyId) {
+            navigate(`/learn/${storyId}/${pathId}`);
+          }
+        }
+        break;
+      }
+    }
+  };
+
+  return (
+    <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
+      {/* Vertical step sidebar (desktop) / compact bar (mobile) */}
+      <StepperNav
+        currentView={currentView}
+        session={navSession}
+        selectedStory={navStory}
+        onNavigate={handleStepperNavigate}
+      />
+
+      {/* Learning step content — scrollable, with bottom padding for mobile tab bar */}
+      <div className="flex-1 overflow-y-auto pb-14 md:pb-0">
+        <LearningLayout />
+      </div>
+    </div>
+  );
+};
+
+/**
  * AppShell wrapper specifically for the learning flow.
- * Passes session and selectedStory to StepperNav via LearningLayout context.
+ * Renders StepperNav as a sidebar alongside LearningLayout.
  */
 export const LearningAppShell: React.FC = () => {
   return (
     <AppShell>
-      <LearningLayout />
+      <LearningContent />
     </AppShell>
   );
 };

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,10 +2,12 @@
  * Header — slim global app bar.
  *
  * Layout (left → center → right):
- *   Logo | StepperNav (learning mode) or context title | User + Logout
+ *   Logo | context title (story name when in learning mode) | User + Logout
  *
- * The header intentionally contains only global chrome (identity, context,
- * logout).  Page-level navigation lives in Sidebar.
+ * The StepperNav has moved out of the header into a vertical left sidebar
+ * that sits alongside the learning content area (see LearningAppShell in
+ * AppShell.tsx). The header now only shows global chrome: identity, context
+ * title, notifications, and logout.
  */
 
 import React from 'react';
@@ -13,28 +15,18 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useLearningNav } from '../../contexts/LearningNavContext';
 import { hasRole } from '../../services/authApi';
-import { useAppView } from '../../hooks/useAppView';
 import { AppView } from '../../types';
-import StepperNav from '../StepperNav';
 import NotificationBell from '../teacher/NotificationBell';
 
-// ---------------------------------------------------------------------------
-// Data-driven nav items for the header right rail (legacy fallback items
-// that are NOT in the sidebar — e.g. teacher notification bell).
-// Most page-level links have been moved to Sidebar; only global-chrome items
-// live here.
-// ---------------------------------------------------------------------------
-
 export interface HeaderProps {
-  /** Called when StepperNav step button is clicked. */
+  /** Kept for API compatibility with AppShell — no longer used by Header itself. */
   onStepperNavigate: (view: AppView) => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ onStepperNavigate }) => {
+const Header: React.FC<HeaderProps> = () => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
-  const currentView = useAppView();
-  const { session: navSession, selectedStory: navStory } = useLearningNav();
+  const { selectedStory: navStory } = useLearningNav();
 
   const isTeacher = hasRole(
     user,
@@ -47,23 +39,7 @@ const Header: React.FC<HeaderProps> = ({ onStepperNavigate }) => {
     'homeroom_teacher',
   );
 
-  // Learning step views — stepper is shown in header when a story is active
-  const learningViews: AppView[] = [
-    AppView.ADMIN_DASHBOARD,
-    AppView.TEACHER_DASHBOARD,
-    AppView.CLASSROOM_DETAIL,
-    AppView.MY_ASSIGNMENTS,
-    AppView.MY_VOCABULARY,
-    AppView.LEARNING_HISTORY,
-    AppView.DIALOGUE_HISTORY,
-    AppView.STUDENT_PROGRESS,
-    AppView.STUDENT_HOME,
-    AppView.TEACHER_HOME,
-    AppView.STUDENT_CLASSROOM_DASHBOARD,
-    AppView.STUDENT_PROFILE,
-  ];
-
-  const showStepper = navStory != null && !learningViews.includes(currentView);
+  // In learning mode show the story title as context; otherwise nothing in center.
   const contextTitle = navStory?.title ?? null;
 
   return (
@@ -90,30 +66,23 @@ const Header: React.FC<HeaderProps> = ({ onStepperNavigate }) => {
         </span>
       </button>
 
-      {/* Center — StepperNav in learning mode, or context title otherwise */}
-      <div className="flex-1 flex items-center justify-center px-4 min-w-0">
-        {showStepper ? (
-          <StepperNav
-            currentView={currentView}
-            session={navSession}
-            selectedStory={navStory}
-            onNavigate={onStepperNavigate}
-          />
-        ) : contextTitle ? (
+      {/* Center — story title when in learning mode */}
+      {contextTitle && (
+        <div className="flex-1 flex items-center justify-center px-4 min-w-0">
           <span
             className="text-sm font-medium text-gray-500 truncate"
             aria-live="polite"
           >
             {contextTitle}
           </span>
-        ) : null}
-      </div>
+        </div>
+      )}
 
       {/* Right rail — notifications (teacher) + user info + logout */}
       <div
         role="navigation"
         aria-label="全局操作列"
-        className="flex items-center gap-1 shrink-0"
+        className="flex items-center gap-1 shrink-0 ml-auto"
       >
         {/* Teacher notification bell */}
         {isTeacher && (


### PR DESCRIPTION
## Summary

- **Problem**: 10 learning steps overflowed the horizontal header bar, text was cut off
- **Fix**: Moved StepperNav from header center to a dedicated vertical left sidebar

### Desktop (md+)
- 208px fixed left sidebar with numbered step rows
- Active step: accent-color background + bold label
- Completed steps: green checkmark badge
- Disabled steps: gray, cursor-not-allowed
- Story title shown at the top of the sidebar

### Mobile (<768px)
- Compact top bar showing current step badge + label + "N / total" count
- Hamburger icon opens a bottom sheet with the full step list
- Clean bottom sheet with drag handle, story title, and close button

### Architecture changes
- `StepperNav.tsx`: complete rewrite — `DesktopSidebar` + `MobileStepBar` sub-components, removed avatar/navigate imports no longer needed
- `Header.tsx`: removed StepperNav render, now only shows story title as context indicator
- `AppShell.tsx`: new `LearningContent` component wraps `[StepperNav | LearningLayout]` in flex-row (desktop) / flex-col (mobile); `LearningAppShell` uses it

## Test plan

- [ ] Desktop: open a learning story, verify 10 steps appear as left sidebar
- [ ] Desktop: navigate between steps, verify active/completed/idle states update
- [ ] Mobile: verify compact step bar appears below header
- [ ] Mobile: tap hamburger, verify bottom sheet opens with all steps
- [ ] Mobile: tap a step in sheet, verify navigation works and sheet closes
- [ ] Non-learning pages (library, teacher dashboard): verify no sidebar stepper appears
- [ ] Build passes (vite build clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)