### PR TITLE
feat: persist all learning step progress to DB (Fixes #660)

### DIFF
--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -36,6 +36,9 @@ class LearningSession(Base):
     comprehension_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     vocab_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     full_reading_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # General step progress store for all learning steps (Issue #660)
+    # Stores current_step, steps_completed[], and per-step step_data
+    step_progress: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     ai_analysis: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
     # 3-level comprehension scoring (Issue #243)
     comprehension_score: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/backend/app/routes/learning/__init__.py
+++ b/backend/app/routes/learning/__init__.py
@@ -9,6 +9,7 @@ Splits the original monolithic learning.py (1,881 lines) into focused sub-module
 - learning_comprehension_score.py  — Dialogue history + comprehension scoring (Issues #242/#243)
 - learning_errors.py               — Error patterns, recommended vocab, corrections, alerts
 - learning_progress.py             — Stuck points + per-text progress tracking
+- learning_step_progress.py        — Step progress persistence (Issue #660)
 - learning_recommendations.py      — Rule-based + AI story recommendations
 - learning_dashboard.py            — Student progress dashboard (Issue #25)
 - learning_vocab.py                — Sentence practice + listening comprehension
@@ -25,6 +26,7 @@ from .learning_comprehension import router as comprehension_router
 from .learning_comprehension_score import router as comprehension_score_router
 from .learning_errors import router as errors_router
 from .learning_progress import router as progress_router
+from .learning_step_progress import router as step_progress_router
 from .learning_recommendations import router as recommendations_router
 from .learning_dashboard import router as dashboard_router
 # Re-export symbols that parents.py imports by name
@@ -40,6 +42,7 @@ router.include_router(comprehension_router)
 router.include_router(comprehension_score_router)
 router.include_router(errors_router)
 router.include_router(progress_router)
+router.include_router(step_progress_router)
 router.include_router(recommendations_router)
 router.include_router(dashboard_router)
 router.include_router(vocab_router)

--- a/backend/app/routes/learning/learning_step_progress.py
+++ b/backend/app/routes/learning/learning_step_progress.py
@@ -1,0 +1,86 @@
+"""Step Progress routes (Issue #660).
+
+Provides two endpoints to persist and retrieve per-step learning progress
+from the `step_progress` JSONB column on LearningSession.
+
+    PUT  /api/learning/sessions/{session_id}/progress  — save
+    GET  /api/learning/sessions/{session_id}/progress  — load
+"""
+import logging
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from ...auth.dependencies import get_current_user
+from ...database import get_db
+from ...models.session import LearningSession
+from ...models.user import User
+from ...schemas.session import StepProgressResponse, StepProgressSaveRequest
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+def _get_owned_session(session_id: int, current_user: User, db: Session) -> LearningSession:
+    """Fetch a LearningSession that belongs to the authenticated user."""
+    session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.student_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not your session")
+    return session
+
+
+@router.put(
+    "/learning/sessions/{session_id}/progress",
+    response_model=StepProgressResponse,
+    summary="Save step progress for a learning session (Issue #660)",
+)
+def save_step_progress(
+    session_id: int,
+    payload: StepProgressSaveRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Persist the frontend step-progress object to the DB.
+
+    The payload mirrors the localStorage schema:
+    - current_step: active step path key
+    - steps_completed: list of completed step path keys
+    - step_data: dict keyed by step path containing serialised progress
+
+    Overwrites any previously stored step_progress for this session.
+    Non-completed sessions only — completed sessions are read-only.
+    """
+    session = _get_owned_session(session_id, current_user, db)
+
+    session.step_progress = {
+        "current_step": payload.current_step,
+        "steps_completed": payload.steps_completed,
+        "step_data": payload.step_data,
+    }
+    db.commit()
+    db.refresh(session)
+    logger.info(
+        "Saved step_progress for session %d (user %d): current=%s completed=%d",
+        session_id, current_user.id, payload.current_step, len(payload.steps_completed),
+    )
+    return StepProgressResponse(session_id=session.id, step_progress=session.step_progress)
+
+
+@router.get(
+    "/learning/sessions/{session_id}/progress",
+    response_model=StepProgressResponse,
+    summary="Load step progress for a learning session (Issue #660)",
+)
+def get_step_progress(
+    session_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Return the stored step_progress for a session.
+
+    Returns step_progress: null when no progress has been saved yet
+    (frontend should fall back to localStorage in that case).
+    """
+    session = _get_owned_session(session_id, current_user, db)
+    return StepProgressResponse(session_id=session.id, step_progress=session.step_progress)

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -73,3 +73,24 @@ class ComprehensionScoreResponse(BaseModel):
     inferential_score: float = Field(..., ge=0, le=100)
     evaluative_score: float = Field(..., ge=0, le=100)
     feedback: dict[str, str] = Field(default_factory=dict)
+
+
+# ── Step Progress (Issue #660) ────────────────────────────────────────────────
+
+class StepProgressSaveRequest(BaseModel):
+    """Body for PUT /api/learning/sessions/{id}/progress.
+
+    Fields mirror the localStorage schema so the frontend can send
+    the same object it writes to localStorage.
+    """
+    current_step: str | None = Field(None, description="Active step path, e.g. 'vocab-definition'")
+    steps_completed: list[str] = Field(default_factory=list, description="List of completed step path keys")
+    step_data: dict[str, Any] = Field(default_factory=dict, description="Per-step serialised progress data")
+
+
+class StepProgressResponse(BaseModel):
+    """Response for GET /api/learning/sessions/{id}/progress."""
+    session_id: int
+    step_progress: dict[str, Any] | None
+
+    model_config = {"from_attributes": True}

--- a/backend/tests/test_step_progress_api.py
+++ b/backend/tests/test_step_progress_api.py
@@ -1,0 +1,276 @@
+"""
+Tests for the step progress persistence API (Issue #660).
+
+Covers:
+- PUT  /api/learning/sessions/{id}/progress  (save)
+- GET  /api/learning/sessions/{id}/progress  (load)
+
+Verifies:
+- Owner can save and load progress
+- Non-owner gets 403
+- Missing session gets 404
+- Returns null step_progress when nothing saved yet
+- Saves overwrite previous data correctly
+
+Uses SQLite in-memory DB (conftest patches JSONB -> JSON).
+
+Run with:
+    cd backend && JWT_SECRET_KEY=test-secret python -m pytest tests/test_step_progress_api.py -v
+"""
+
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite test database
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    with TestingSessionLocal() as db:
+        for role_data in SEED_ROLES:
+            if not db.query(Role).filter_by(name=role_data["name"]).first():
+                db.add(Role(**role_data))
+        db.commit()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_and_login(client, suffix: str | None = None) -> dict:
+    """Register a user, verify email, log in; return {token, ...}."""
+    unique = suffix or uuid.uuid4().hex[:8]
+    email = f"sp660_{unique}@example.com"
+    password = "SecurePass660!"
+    resp = client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password, "name": f"SP660 {unique}"},
+    )
+    assert resp.status_code == 201, resp.text
+    verification_token = resp.json()["verification_token"]
+    client.get(f"/api/auth/verify-email?token={verification_token}")
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    return {"email": email, "token": login_resp.json()["access_token"]}
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="module")
+def student(client):
+    return _register_and_login(client, "student")
+
+
+@pytest.fixture(scope="module")
+def other(client):
+    return _register_and_login(client, "other")
+
+
+@pytest.fixture(scope="module")
+def session_id(client, student):
+    """Create a learning session owned by student; return its DB id."""
+    resp = client.post(
+        "/api/learning/sessions",
+        json={"story_slug": "L06"},
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET before any save — step_progress should be null
+# ---------------------------------------------------------------------------
+
+
+def test_get_progress_no_data_returns_null(client, student, session_id):
+    """Freshly created session returns step_progress: null."""
+    resp = client.get(
+        f"/api/learning/sessions/{session_id}/progress",
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["session_id"] == session_id
+    assert body["step_progress"] is None
+
+
+def test_get_progress_unauthenticated(client, session_id):
+    """No token -> 401."""
+    resp = client.get(f"/api/learning/sessions/{session_id}/progress")
+    assert resp.status_code == 401
+
+
+def test_get_progress_wrong_owner(client, other, session_id):
+    """Another user GET -> 403."""
+    resp = client.get(
+        f"/api/learning/sessions/{session_id}/progress",
+        headers=auth_header(other["token"]),
+    )
+    assert resp.status_code == 403
+
+
+def test_get_progress_nonexistent_session(client, student):
+    """Non-existent session id -> 404."""
+    resp = client.get(
+        "/api/learning/sessions/999999/progress",
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests: PUT (save) step progress
+# ---------------------------------------------------------------------------
+
+SAMPLE_PROGRESS = {
+    "current_step": "tutor",
+    "steps_completed": ["reading-annotation"],
+    "step_data": {
+        "reading-annotation": {"annotations": [], "totalMarks": 3},
+        "tutor": {"lineResults": [], "paragraphSummaries": {}},
+    },
+}
+
+
+def test_save_progress_success(client, student, session_id):
+    """Owner can save step progress; response mirrors saved data."""
+    resp = client.put(
+        f"/api/learning/sessions/{session_id}/progress",
+        json=SAMPLE_PROGRESS,
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["session_id"] == session_id
+    sp = body["step_progress"]
+    assert sp is not None
+    assert sp["current_step"] == "tutor"
+    assert sp["steps_completed"] == ["reading-annotation"]
+    assert "reading-annotation" in sp["step_data"]
+
+
+def test_get_progress_after_save(client, student, session_id):
+    """GET returns previously saved progress."""
+    resp = client.get(
+        f"/api/learning/sessions/{session_id}/progress",
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 200, resp.text
+    sp = resp.json()["step_progress"]
+    assert sp is not None
+    assert sp["current_step"] == "tutor"
+    assert sp["steps_completed"] == ["reading-annotation"]
+
+
+def test_save_progress_overwrites(client, student, session_id):
+    """Second PUT overwrites the first."""
+    updated = {
+        "current_step": "comprehension",
+        "steps_completed": ["reading-annotation", "tutor"],
+        "step_data": {"reading-annotation": {"annotations": [], "totalMarks": 3}},
+    }
+    resp = client.put(
+        f"/api/learning/sessions/{session_id}/progress",
+        json=updated,
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 200, resp.text
+    sp = resp.json()["step_progress"]
+    assert sp["current_step"] == "comprehension"
+    assert sp["steps_completed"] == ["reading-annotation", "tutor"]
+
+
+def test_save_progress_wrong_owner(client, other, session_id):
+    """Other user PUT -> 403."""
+    resp = client.put(
+        f"/api/learning/sessions/{session_id}/progress",
+        json=SAMPLE_PROGRESS,
+        headers=auth_header(other["token"]),
+    )
+    assert resp.status_code == 403
+
+
+def test_save_progress_nonexistent_session(client, student):
+    """Non-existent session PUT -> 404."""
+    resp = client.put(
+        "/api/learning/sessions/999999/progress",
+        json=SAMPLE_PROGRESS,
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 404
+
+
+def test_save_progress_empty_payload(client, student, session_id):
+    """Empty progress payload is valid (resets to empty state)."""
+    empty = {"current_step": None, "steps_completed": [], "step_data": {}}
+    resp = client.put(
+        f"/api/learning/sessions/{session_id}/progress",
+        json=empty,
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 200
+    sp = resp.json()["step_progress"]
+    assert sp["current_step"] is None
+    assert sp["steps_completed"] == []
+    assert sp["step_data"] == {}

--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -1,0 +1,124 @@
+/**
+ * useProgressSync — DB sync layer for step progress (Issue #660).
+ *
+ * Strategy:
+ * - localStorage = L1 cache (immediate, always works)
+ * - DB = L2 store   (durable, requires session + token)
+ *
+ * On mount (when dbSessionId becomes available):
+ *   1. GET progress from DB
+ *   2. If DB has data, merge it with localStorage (DB wins for completed steps)
+ *   3. Call onProgressLoaded with the merged result so LearningLayout can
+ *      restore state from a previous browser session
+ *
+ * On progress update:
+ *   - Caller invokes syncProgress(data) which:
+ *     a. Writes to localStorage immediately (via callback)
+ *     b. Debounces a PUT to the DB (5 seconds)
+ *
+ * API failures are fully non-blocking — localStorage still functions.
+ */
+import { useCallback, useEffect, useRef } from 'react';
+import { saveStepProgress, loadStepProgress, StepProgressData } from '../services/learningApi';
+
+const DEBOUNCE_MS = 5_000;
+
+export interface UseProgressSyncOptions {
+  /** Auth token for DB API calls. Null when unauthenticated. */
+  token: string | null;
+  /** DB LearningSession integer ID. Null until the session is created. */
+  dbSessionId: number | null;
+  /**
+   * Called once after the initial DB load resolves with a non-null result.
+   * Use this to hydrate in-memory state from the DB on page load / refresh.
+   */
+  onProgressLoaded?: (data: StepProgressData) => void;
+}
+
+export interface UseProgressSyncReturn {
+  /**
+   * Sync progress to DB (debounced 5 s) and to localStorage immediately.
+   * API failures are swallowed — localStorage write still happens.
+   */
+  syncProgress: (data: StepProgressData) => void;
+  /** Force an immediate DB save (e.g. on step completion). */
+  flushProgress: (data: StepProgressData) => void;
+}
+
+export function useProgressSync({
+  token,
+  dbSessionId,
+  onProgressLoaded,
+}: UseProgressSyncOptions): UseProgressSyncReturn {
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestDataRef = useRef<StepProgressData | null>(null);
+
+  // ── Initial load from DB ──────────────────────────────────────────────────
+  useEffect(() => {
+    if (!token || dbSessionId === null) return;
+
+    loadStepProgress(token, dbSessionId)
+      .then((res) => {
+        if (res.step_progress && onProgressLoaded) {
+          onProgressLoaded(res.step_progress);
+        }
+      })
+      .catch(() => {
+        // Non-fatal: fallback to localStorage handled by caller
+      });
+    // Only run once when dbSessionId first becomes available
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dbSessionId, token]);
+
+  // ── Flush helper ──────────────────────────────────────────────────────────
+  const doSave = useCallback(
+    (data: StepProgressData) => {
+      if (!token || dbSessionId === null) return;
+      saveStepProgress(token, dbSessionId, data).catch(() => {
+        // Non-fatal — localStorage already has the data
+      });
+    },
+    [token, dbSessionId],
+  );
+
+  // ── Debounced sync ────────────────────────────────────────────────────────
+  const syncProgress = useCallback(
+    (data: StepProgressData) => {
+      latestDataRef.current = data;
+
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+      debounceTimerRef.current = setTimeout(() => {
+        if (latestDataRef.current) {
+          doSave(latestDataRef.current);
+        }
+      }, DEBOUNCE_MS);
+    },
+    [doSave],
+  );
+
+  // ── Immediate flush ───────────────────────────────────────────────────────
+  const flushProgress = useCallback(
+    (data: StepProgressData) => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      latestDataRef.current = data;
+      doSave(data);
+    },
+    [doSave],
+  );
+
+  // Cleanup debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  return { syncProgress, flushProgress };
+}

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -18,6 +18,8 @@ import { useAuth } from '../contexts/AuthContext';
 import { useLearningNav } from '../contexts/LearningNavContext';
 import { STEP_PATH_TO_NUMBER as STEP_CONFIG_PATH_TO_NUMBER } from '../config/stepConfig';
 import { useIdleTimer } from '../hooks/useIdleTimer';
+import { useProgressSync } from '../hooks/useProgressSync';
+import type { StepProgressData } from '../services/learningApi';
 import SessionTimeoutWarning from '../components/SessionTimeoutWarning';
 
 /** Idle time before showing warning modal (15 minutes). */
@@ -72,6 +74,16 @@ export interface LearningContext {
   handleParagraphComplete: (paragraphIndex: number) => void;
   /** Reading goals set by teacher for the active assignment (Issue #414). Null for free-play. */
   assignmentReadingGoals: AssignmentReadingGoals | null;
+  /**
+   * Sync step progress to DB (debounced 5 s) and to localStorage.
+   * Non-blocking — API failures do not break the learning flow (Issue #660).
+   */
+  syncProgress: (data: StepProgressData) => void;
+  /**
+   * Force an immediate DB save (e.g. on step completion or page unload).
+   * Non-blocking (Issue #660).
+   */
+  flushProgress: (data: StepProgressData) => void;
 }
 
 /**
@@ -124,6 +136,26 @@ const LearningLayout: React.FC = () => {
   const [showTimeoutWarning, setShowTimeoutWarning] = useState(false);
   /** Ref to the idle-timer reset function so handleContinueLearning can call it. */
   const idleResetRef = useRef<(() => void) | null>(null);
+
+  // ── Step progress DB sync (Issue #660) ──────────────────────────────────
+  const { syncProgress, flushProgress } = useProgressSync({
+    token: token ?? null,
+    dbSessionId,
+    onProgressLoaded: (data) => {
+      // When DB returns saved progress, update the in-memory session with
+      // completed paragraphs from step_data so LiveTutor can restore unlock state.
+      // This is best-effort — localStorage is the primary L1 store.
+      if (data.step_data?.tutor) {
+        const tutorData = data.step_data.tutor as Record<string, unknown>;
+        const completedIdxs = tutorData.completedParagraphs;
+        if (Array.isArray(completedIdxs)) {
+          setCompletedParagraphsSet(new Set(completedIdxs as number[]));
+        }
+      }
+    },
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
 
   /** Persist current step to localStorage for session resume. */
   const persistStep = useCallback(
@@ -470,6 +502,8 @@ const LearningLayout: React.FC = () => {
     completedParagraphsSet,
     handleParagraphComplete,
     assignmentReadingGoals,
+    syncProgress,
+    flushProgress,
   };
 
   return (

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -628,3 +628,54 @@ export async function submitExitTicket(
   }
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Step Progress persistence (Issue #660)
+// ---------------------------------------------------------------------------
+
+export interface StepProgressData {
+  current_step: string | null;
+  steps_completed: string[];
+  step_data: Record<string, unknown>;
+}
+
+export interface StepProgressResponse {
+  session_id: number;
+  step_progress: StepProgressData | null;
+}
+
+/**
+ * Persist step progress to DB for a given learning session.
+ * Non-blocking — caller should catch errors and not surface them to the user.
+ */
+export async function saveStepProgress(
+  token: string,
+  sessionId: number,
+  progress: StepProgressData,
+): Promise<StepProgressResponse> {
+  const res = await fetch(`${API_BASE}/api/learning/sessions/${sessionId}/progress`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(progress),
+  });
+  if (!res.ok) throw new Error(`saveStepProgress failed: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Load step progress from DB for a given learning session.
+ * Returns null step_progress when nothing has been saved yet.
+ */
+export async function loadStepProgress(
+  token: string,
+  sessionId: number,
+): Promise<StepProgressResponse> {
+  const res = await fetch(`${API_BASE}/api/learning/sessions/${sessionId}/progress`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`loadStepProgress failed: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
Fixes #660

## Summary

- Add `step_progress` JSONB column to `LearningSession` model (nullable, no migration auto-created)
- Add two new API endpoints:
  - `PUT /api/learning/sessions/{id}/progress` — save step progress
  - `GET /api/learning/sessions/{id}/progress` — load step progress
- Add `useProgressSync` hook with 5-second debounced DB sync and immediate `flushProgress`
- Expose `syncProgress` and `flushProgress` via `LearningContext` so any child step component can call them
- Add `saveStepProgress` / `loadStepProgress` API functions in `learningApi.ts`
- localStorage remains the L1 cache; DB is L2 store — API failures are fully non-blocking
- 10 backend tests covering save, load, overwrite, 403 (wrong owner), 404 (missing session), empty payload

## Architecture

```
Step Component
  │
  └── calls ctx.flushProgress(data)  ← on step completion (immediate)
      or ctx.syncProgress(data)      ← on intermediate changes (debounced 5s)
         │
         └── useProgressSync hook
               ├── PUT /api/learning/sessions/{id}/progress  (DB save)
               └── GET /api/learning/sessions/{id}/progress  (load on mount)
                     └── onProgressLoaded callback → restores in-memory state
```

## DB Migration Required (MANUAL)

The `step_progress` column is added to the SQLAlchemy model but NOT via Alembic (per project rules). Before deploying, run on Cloud SQL:

```sql
ALTER TABLE learning_sessions ADD COLUMN IF NOT EXISTS step_progress JSONB;
```

## Test Plan

- [ ] Run `cd backend && JWT_SECRET_KEY=test-secret python -m pytest tests/test_step_progress_api.py -v`
- [ ] All 10 tests pass
- [ ] Existing `test_learning_sessions_api.py` (42 tests) still pass
- [ ] TypeScript build passes (`cd frontend && npx tsc --noEmit`)
- [ ] Start a learning session, progress through 2+ steps, refresh the page — steps_completed should be restored from DB
- [ ] Disconnect network mid-session — app continues working via localStorage