### PR TITLE
feat: add step_progress JSONB column via Alembic migration

### DIFF
--- a/backend/alembic/versions/x4y5z6a7b8c9_add_step_progress_to_learning_sessions.py
+++ b/backend/alembic/versions/x4y5z6a7b8c9_add_step_progress_to_learning_sessions.py
@@ -1,0 +1,30 @@
+"""add step_progress to learning_sessions
+
+Revision ID: x4y5z6a7b8c9
+Revises: w3x4y5z6a7b8
+Create Date: 2026-03-28 00:00:00.000000
+
+"""
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "x4y5z6a7b8c9"
+down_revision: Union[str, None] = "w3x4y5z6a7b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "learning_sessions",
+        sa.Column("step_progress", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("learning_sessions", "step_progress")


### PR DESCRIPTION
## Summary

- Add `step_progress JSONB` column to `LearningSession` SQLAlchemy model (`backend/app/models/session.py`)
- Create Alembic migration `x4y5z6a7b8c9` chained after the current head `w3x4y5z6a7b8`
- Migration uses `nullable=True` — safe to run on existing DBs with live rows
- The raw SQL patch in `entrypoint.sh` (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS step_progress`) is now superseded; `entrypoint.sh` in staging HEAD is already clean

## Changes

- `backend/app/models/session.py` — add `step_progress: Mapped[dict | None] = mapped_column(JSONB, nullable=True)`
- `backend/alembic/versions/x4y5z6a7b8c9_add_step_progress_to_learning_sessions.py` — new migration

## Test plan

- [ ] `RUN_MIGRATIONS=true alembic upgrade head` runs without error on staging DB
- [ ] Column `step_progress` appears in `\d learning_sessions` in psql
- [ ] `alembic downgrade -1` removes the column cleanly
- [ ] Backend container boots and health endpoint returns 200

## Notes

Alembic was already fully initialized in this repo (env.py reads `DATABASE_URL` from environment, not hardcoded). This PR only adds the missing migration for `step_progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)