### PR TITLE
feat: polish UI of 4 new learning step components

### DIFF
--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -18,13 +18,16 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
   const [answers, setAnswers] = useState<Record<number, string>>({});
   const [submitted, setSubmitted] = useState(false);
 
+  const answeredCount = Object.keys(answers).length;
+  const allAnswered = answeredCount >= sentences.length;
+
   function handleSelect(sentenceIdx: number, code: string) {
     if (submitted) return;
     setAnswers((prev) => ({ ...prev, [sentenceIdx]: code }));
   }
 
   function handleSubmit() {
-    if (Object.keys(answers).length < sentences.length) return;
+    if (!allAnswered) return;
     setSubmitted(true);
   }
 
@@ -48,19 +51,19 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
 
     const badge = (
       <span
-        className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-sm font-semibold border mx-0.5
+        className={`inline-flex items-center gap-1 rounded-lg px-3 py-1 text-base font-semibold border mx-1 transition-all
           ${!submitted
             ? chosen
-              ? 'bg-blue-100 border-blue-400 text-blue-800'
+              ? 'bg-indigo-100 border-indigo-400 text-indigo-900'
               : 'bg-gray-100 border-dashed border-gray-400 text-gray-400'
             : isCorrect
-              ? 'bg-green-100 border-green-500 text-green-800'
+              ? 'bg-emerald-100 border-emerald-500 text-emerald-900'
               : 'bg-red-100 border-red-400 text-red-700 line-through'
           }`}
       >
         {chosen ? `${chosen} ${vocabBank[chosen]}` : '＿＿'}
         {submitted && isWrong && (
-          <span className="not-italic text-green-700 no-underline ml-1">
+          <span className="not-italic text-emerald-700 no-underline ml-1 font-normal text-sm">
             → {correct} {vocabBank[correct]}
           </span>
         )}
@@ -77,80 +80,117 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
   }
 
   return (
-    <div className="flex flex-col gap-5 p-4 max-w-2xl mx-auto">
+    <div className="flex flex-col gap-6 p-4 max-w-2xl mx-auto">
+      {/* Progress indicator */}
+      {!submitted && (
+        <div className="bg-white rounded-2xl border border-indigo-100 shadow-sm px-5 py-3 flex items-center justify-between">
+          <span className="text-base text-gray-600 font-medium">已作答</span>
+          <span className="text-lg font-black text-indigo-700">
+            {answeredCount} <span className="text-gray-400 font-normal text-sm">/ {sentences.length}</span>
+          </span>
+        </div>
+      )}
+
       {/* Word bank */}
-      <div className="rounded-xl border border-gray-200 bg-gray-50 p-4">
-        <p className="text-xs text-gray-500 mb-2 font-medium">詞語題庫：將正確的詞語代號填入空格中</p>
-        <div className="flex flex-wrap gap-2">
+      <div className="rounded-2xl border border-indigo-200 bg-indigo-50 p-5 shadow-sm">
+        <p className="text-sm text-indigo-700 mb-3 font-semibold">詞語題庫：將正確的詞語代號填入空格中</p>
+        <div className="flex flex-wrap gap-3">
           {bankEntries.map(([code, word]) => (
             <span
               key={code}
-              className="rounded-md border border-gray-300 bg-white px-3 py-1 text-sm"
+              className="rounded-xl border border-indigo-200 bg-white px-4 py-2 text-base shadow-sm"
             >
-              <span className="font-bold text-blue-600">{code}</span>
-              <span className="mx-1 text-gray-400">·</span>
-              {word}
+              <span className="font-black text-indigo-600 text-lg">{code}</span>
+              <span className="mx-1.5 text-gray-300">·</span>
+              <span className="text-gray-800 font-medium">{word}</span>
             </span>
           ))}
         </div>
       </div>
 
       {/* Sentences */}
-      <div className="flex flex-col gap-3">
-        {sentences.map((s, idx) => (
-          <div key={idx} className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
-            <p className="text-sm leading-relaxed text-gray-800 mb-3">
-              ({idx + 1}) {renderSentence(s.sentence, idx)}
-            </p>
+      <div className="flex flex-col gap-4">
+        {sentences.map((s, idx) => {
+          const isCorrect = submitted && answers[idx] === s.answer;
+          const isWrong = submitted && answers[idx] !== s.answer;
+          return (
+            <div
+              key={idx}
+              className={`rounded-2xl border-2 bg-white p-5 shadow-sm transition-all duration-200 ${
+                isCorrect
+                  ? 'border-emerald-300 bg-emerald-50'
+                  : isWrong
+                  ? 'border-red-300 bg-red-50'
+                  : 'border-gray-200'
+              }`}
+            >
+              {/* Question number + sentence */}
+              <p className="text-lg leading-loose text-gray-800 mb-4 flex items-start gap-2">
+                <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-indigo-100 text-indigo-700 font-black text-sm flex-shrink-0 mt-0.5">
+                  {idx + 1}
+                </span>
+                <span>
+                  {renderSentence(s.sentence, idx)}
+                  {submitted && (
+                    <span className="ml-2 text-lg">
+                      {isCorrect ? '✅' : '❌'}
+                    </span>
+                  )}
+                </span>
+              </p>
 
-            {!submitted && (
-              <div className="flex flex-wrap gap-1.5">
-                {bankEntries.map(([code, word]) => (
-                  <button
-                    key={code}
-                    onClick={() => handleSelect(idx, code)}
-                    className={`rounded px-2.5 py-1 text-xs border transition-all
-                      ${answers[idx] === code
-                        ? 'bg-blue-500 border-blue-500 text-white font-semibold'
-                        : 'bg-white border-gray-200 text-gray-700 hover:border-blue-400'
-                      }`}
-                  >
-                    {code} {word}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        ))}
+              {!submitted && (
+                <div className="flex flex-wrap gap-2 ml-9">
+                  {bankEntries.map(([code, word]) => (
+                    <button
+                      key={code}
+                      onClick={() => handleSelect(idx, code)}
+                      className={`rounded-xl px-4 py-2 text-base border-2 transition-all active:scale-95 font-medium min-h-[44px]
+                        ${answers[idx] === code
+                          ? 'bg-indigo-600 border-indigo-600 text-white font-bold shadow-md'
+                          : 'bg-white border-gray-200 text-gray-700 hover:border-indigo-400 hover:bg-indigo-50'
+                        }`}
+                    >
+                      <span className="font-black">{code}</span>
+                      <span className="ml-1.5 text-sm">{word}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
 
       {/* Action buttons */}
       {!submitted ? (
         <button
           onClick={handleSubmit}
-          disabled={Object.keys(answers).length < sentences.length}
-          className="self-center rounded-lg bg-blue-500 px-8 py-2.5 text-white text-sm font-medium
-            disabled:opacity-40 disabled:cursor-not-allowed hover:bg-blue-600 transition-colors"
+          disabled={!allAnswered}
+          className="self-center rounded-xl bg-indigo-600 px-12 py-4 text-white text-lg font-bold
+            disabled:opacity-40 disabled:cursor-not-allowed hover:bg-indigo-700 active:scale-95 transition-all shadow-lg min-h-[56px]"
         >
-          提交答案
+          {allAnswered ? '提交答案' : `還有 ${sentences.length - answeredCount} 題未填`}
         </button>
       ) : (
-        <div className="flex flex-col items-center gap-3">
-          <p className="text-lg font-semibold text-gray-800">
-            {score === sentences.length
-              ? '全對！太棒了！'
-              : `答對 ${score}／${sentences.length} 題`}
-          </p>
-          <div className="flex gap-3">
+        <div className="flex flex-col items-center gap-4 animate-fade-in">
+          <div className={`rounded-2xl px-8 py-4 text-center ${score === sentences.length ? 'bg-emerald-50 border border-emerald-200' : 'bg-amber-50 border border-amber-200'}`}>
+            <p className="text-2xl font-black text-gray-800">
+              {score === sentences.length
+                ? '全對！太棒了！'
+                : `答對 ${score}／${sentences.length} 題`}
+            </p>
+          </div>
+          <div className="flex gap-4">
             <button
               onClick={handleRetry}
-              className="rounded-lg border border-gray-300 px-5 py-2 text-sm text-gray-600 hover:bg-gray-50"
+              className="rounded-xl border-2 border-gray-300 px-7 py-3 text-base font-semibold text-gray-600 hover:bg-gray-50 active:scale-95 transition-all min-h-[52px]"
             >
               再試一次
             </button>
             <button
               onClick={() => onComplete(score, sentences.length)}
-              className="rounded-lg bg-blue-500 px-5 py-2 text-sm text-white hover:bg-blue-600"
+              className="rounded-xl bg-indigo-600 px-7 py-3 text-base font-bold text-white hover:bg-indigo-700 active:scale-95 transition-all shadow-md min-h-[52px]"
             >
               繼續 →
             </button>

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -459,12 +459,15 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       </nav>
 
       {/* ── Instruction banner ─────────────────────────────────────────── */}
-      <div className="flex-shrink-0 bg-amber-100 border-b border-amber-200 px-6 py-2 flex items-center gap-2 text-sm text-amber-800">
-        <span className="text-base" aria-hidden="true">📖</span>
-        <span>
-          <strong>第一次閱讀</strong>：選取不太了解的字、詞或句，按 <strong>❓ 不懂</strong> 做記號。
-          <strong className="ml-3">第二次閱讀</strong>：選取重要的地方，按 <strong>💛 重要</strong> 標記。
-        </span>
+      <div className="flex-shrink-0 bg-amber-100 border-b border-amber-200 px-6 py-3 flex items-start gap-3 text-amber-900">
+        <span className="text-xl flex-shrink-0 mt-0.5" aria-hidden="true">📖</span>
+        <div className="text-sm leading-relaxed">
+          <span className="font-black text-base">選取課文中不太了解的字詞，標記起來</span>
+          <div className="mt-0.5 text-amber-800">
+            <strong>第一次閱讀</strong>：選取後按 <strong>❓ 不懂</strong> 做記號。
+            <strong className="ml-3">第二次閱讀</strong>：選取重要的地方，按 <strong>💛 重要</strong> 標記。
+          </div>
+        </div>
       </div>
 
       {/* ── Main text area ─────────────────────────────────────────────── */}
@@ -495,13 +498,13 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
           })}
         </div>
 
-        {/* ── Floating toolbar ─────────────────────────────────────────── */}
+        {/* ── Floating toolbar — larger for touch ──────────────────────── */}
         {toolbar.visible && (
           <div
             ref={toolbarRef}
             role="toolbar"
             aria-label="標記選取文字"
-            className="absolute z-50 flex items-center gap-1 bg-white border border-gray-200 rounded-xl shadow-xl px-2 py-1.5 -translate-x-1/2 -translate-y-full"
+            className="absolute z-50 flex items-center gap-2 bg-white border-2 border-amber-300 rounded-2xl shadow-2xl px-3 py-2 -translate-x-1/2 -translate-y-full"
             style={{ left: toolbar.x, top: toolbar.y }}
           >
             {(Object.entries(TYPE_CONFIG) as Array<[AnnotationType, typeof TYPE_CONFIG[AnnotationType]]>).map(
@@ -514,7 +517,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
                     e.preventDefault();
                     applyAnnotation(type);
                   }}
-                  className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-bold border transition-all ${cfg.activeClass}`}
+                  className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-black border-2 transition-all min-h-[44px] active:scale-95 ${cfg.activeClass}`}
                 >
                   <span aria-hidden="true">{cfg.icon}</span>
                   {cfg.label}
@@ -528,7 +531,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
                 window.getSelection()?.removeAllRanges();
                 hideToolbar();
               }}
-              className="ml-1 px-2 py-1.5 rounded-lg text-sm text-gray-400 hover:text-gray-700 border border-gray-200 hover:bg-gray-50 transition-all"
+              className="ml-1 px-3 py-2 rounded-xl text-base text-gray-400 hover:text-gray-700 border-2 border-gray-200 hover:bg-gray-50 transition-all min-h-[44px]"
               aria-label="取消"
             >
               ✕
@@ -539,26 +542,30 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
 
       {/* ── Summary bar + finish button ────────────────────────────────── */}
       <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between gap-4">
-        {/* Mark count summary */}
-        <div className="flex items-center gap-4 text-sm text-gray-600">
-          <span>
-            已標記：
-            <strong className="ml-1 text-gray-900">{summary.totalMarks}</strong> 處
-          </span>
-          {summary.unknownCount > 0 && (
-            <span className="flex items-center gap-1">
-              <span aria-hidden="true">❓</span>
-              <span className="text-red-600 font-bold">{summary.unknownCount}</span>
-            </span>
-          )}
-          {summary.importantCount > 0 && (
-            <span className="flex items-center gap-1">
-              <span aria-hidden="true">💛</span>
-              <span className="text-yellow-700 font-bold">{summary.importantCount}</span>
-            </span>
-          )}
-          {summary.totalMarks === 0 && (
-            <span className="text-gray-400">（還沒有標記）</span>
+        {/* Mark count summary — more visual */}
+        <div className="flex items-center gap-3">
+          {summary.totalMarks === 0 ? (
+            <span className="text-sm text-gray-400">（還沒有標記）</span>
+          ) : (
+            <>
+              <span className="text-sm text-gray-600">
+                已標記
+                <strong className="mx-1 text-lg text-gray-900">{summary.totalMarks}</strong>
+                處
+              </span>
+              {summary.unknownCount > 0 && (
+                <span className="flex items-center gap-1 bg-red-50 border border-red-200 px-2.5 py-1 rounded-full text-sm font-bold text-red-700">
+                  <span aria-hidden="true">❓</span>
+                  {summary.unknownCount}
+                </span>
+              )}
+              {summary.importantCount > 0 && (
+                <span className="flex items-center gap-1 bg-yellow-50 border border-yellow-200 px-2.5 py-1 rounded-full text-sm font-bold text-yellow-800">
+                  <span aria-hidden="true">💛</span>
+                  {summary.importantCount}
+                </span>
+              )}
+            </>
           )}
         </div>
 

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -31,6 +31,7 @@ interface PairState {
   defIndex: number;   // index in vocab array
   matched: boolean;
   flashWrong: boolean;
+  flashCorrect: boolean;
 }
 
 /* ------------------------------------------------------------------ */
@@ -43,7 +44,7 @@ function StepHeader({ title, subtitle }: { title: string; subtitle?: string }) {
       <div className="max-w-2xl mx-auto">
         <h2 className="text-xl font-bold text-amber-900">{title}</h2>
         {subtitle && (
-          <p className="mt-0.5 text-sm text-amber-700">{subtitle}</p>
+          <p className="mt-1 text-base text-amber-700">{subtitle}</p>
         )}
       </div>
     </div>
@@ -63,7 +64,7 @@ function NoDataFallback({ onFinish }: { onFinish: () => void }) {
       </div>
       <button
         onClick={onFinish}
-        className="rounded-lg bg-amber-500 px-8 py-3 text-white font-medium hover:bg-amber-600 transition-colors"
+        className="rounded-xl bg-amber-500 px-8 py-3 text-white font-semibold text-lg hover:bg-amber-600 transition-colors"
       >
         繼續下一步
       </button>
@@ -81,17 +82,19 @@ function CompletionScreen({
   onFinish: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center gap-6 px-6 py-16 text-center max-w-lg mx-auto">
-      <div className="text-5xl select-none">🎉</div>
-      <div>
-        <h3 className="text-2xl font-black text-emerald-800 mb-1">配對完成！</h3>
-        <p className="text-emerald-700 text-base">
-          成功配對 <span className="font-bold">{matched}</span> / {total} 組語詞
+    <div className="flex flex-col items-center gap-8 px-6 py-16 text-center max-w-lg mx-auto animate-fade-in">
+      <div className="text-7xl select-none animate-bounce-in">🎉</div>
+      <div className="bg-emerald-50 border border-emerald-200 rounded-2xl px-10 py-6 shadow-sm">
+        <h3 className="text-3xl font-black text-emerald-800 mb-2">配對完成！</h3>
+        <p className="text-emerald-700 text-lg">
+          成功配對
+          <span className="font-black text-2xl mx-2 text-emerald-600">{matched}</span>
+          / {total} 組語詞
         </p>
       </div>
       <button
         onClick={onFinish}
-        className="rounded-lg bg-emerald-500 px-10 py-3 text-white font-semibold hover:bg-emerald-600 transition-colors text-lg"
+        className="rounded-xl bg-emerald-500 px-12 py-4 text-white font-bold hover:bg-emerald-600 active:scale-95 transition-all text-xl shadow-lg"
       >
         繼續下一步 →
       </button>
@@ -154,6 +157,7 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
       defIndex: i,
       matched: saved ? saved.matchedIndices.includes(i) : false,
       flashWrong: false,
+      flashCorrect: false,
     }));
   });
 
@@ -181,7 +185,7 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
   // Auto-advance to done when all matched
   useEffect(() => {
     if (hasData && matchedCount === vocab.length && phase === 'matching') {
-      setPhase('done');
+      setTimeout(() => setPhase('done'), 600);
     }
   }, [matchedCount, vocab.length, phase, hasData]);
 
@@ -191,7 +195,16 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
       setPairs((prev) =>
         prev.map((p) => (p.defIndex === defIndex ? { ...p, flashWrong: false } : p)),
       );
-    }, 600);
+    }, 550);
+  }, []);
+
+  // Flash-correct cleanup
+  const clearCorrect = useCallback((defIndex: number) => {
+    setTimeout(() => {
+      setPairs((prev) =>
+        prev.map((p) => (p.defIndex === defIndex ? { ...p, flashCorrect: false } : p)),
+      );
+    }, 400);
   }, []);
 
   // Attempt a match: selectedDef must match selectedWord's vocab index
@@ -199,14 +212,22 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
     (defIdx: number, wordIdx: number) => {
       setAttempts((a) => a + 1);
       if (defIdx === wordIdx) {
-        // Correct
+        // Correct — flash green then set matched
         setPairs((prev) =>
           prev.map((p) =>
-            p.defIndex === defIdx ? { ...p, matched: true, flashWrong: false } : p,
+            p.defIndex === defIdx ? { ...p, flashCorrect: true } : p,
           ),
         );
+        clearCorrect(defIdx);
+        setTimeout(() => {
+          setPairs((prev) =>
+            prev.map((p) =>
+              p.defIndex === defIdx ? { ...p, matched: true, flashCorrect: false } : p,
+            ),
+          );
+        }, 300);
       } else {
-        // Wrong — flash both
+        // Wrong — shake animation
         setPairs((prev) =>
           prev.map((p) =>
             p.defIndex === defIdx ? { ...p, flashWrong: true } : p,
@@ -217,7 +238,7 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
       setSelectedDef(null);
       setSelectedWord(null);
     },
-    [clearFlash],
+    [clearFlash, clearCorrect],
   );
 
   const handleDefClick = useCallback(
@@ -264,7 +285,7 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
   }, [onFinish, matchedCount, vocab.length, storageKey]);
 
   return (
-    <div className="flex flex-col min-h-full bg-white">
+    <div className="flex flex-col min-h-full bg-amber-50">
       <StepHeader
         title="語詞定義配對"
         subtitle="點選左邊的定義，再點選右邊對應的語詞，完成配對"
@@ -321,26 +342,32 @@ function MatchingExercise({
   onWordClick,
   matchedCount,
 }: MatchingExerciseProps) {
+  const pct = vocab.length > 0 ? (matchedCount / vocab.length) * 100 : 0;
+
   return (
     <div className="max-w-3xl mx-auto px-4">
-      {/* Progress bar */}
-      <div className="mb-6">
-        <div className="flex items-center justify-between text-sm text-gray-500 mb-1">
-          <span>配對進度</span>
-          <span className="font-medium text-amber-700">
-            {matchedCount} / {vocab.length}
+      {/* Progress bar — enhanced */}
+      <div className="mb-6 bg-white rounded-2xl shadow-sm border border-amber-100 px-5 py-4">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-base font-semibold text-gray-600">配對進度</span>
+          <span className="text-lg font-black text-amber-700">
+            {matchedCount} <span className="text-gray-400 font-normal text-sm">/ {vocab.length}</span>
           </span>
         </div>
-        <div className="h-2 bg-amber-100 rounded-full overflow-hidden">
+        <div className="h-4 bg-amber-100 rounded-full overflow-hidden">
           <div
-            className="h-full bg-amber-400 rounded-full transition-all duration-500"
-            style={{ width: `${(matchedCount / vocab.length) * 100}%` }}
+            className="h-full bg-gradient-to-r from-amber-400 to-amber-500 rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${pct}%` }}
+            role="progressbar"
+            aria-valuenow={matchedCount}
+            aria-valuemin={0}
+            aria-valuemax={vocab.length}
           />
         </div>
       </div>
 
       {/* Hint text */}
-      <p className="text-center text-sm text-gray-400 mb-6 select-none">
+      <p className="text-center text-base text-amber-800 bg-amber-100 rounded-xl py-2.5 px-4 mb-6 select-none font-medium">
         先點選左邊的「定義」，再點選右邊對應的「語詞」
       </p>
 
@@ -348,26 +375,29 @@ function MatchingExercise({
       <div className="grid grid-cols-2 gap-4">
         {/* Left: definitions (in original vocab order) */}
         <div className="flex flex-col gap-3">
-          <h3 className="text-center text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
+          <h3 className="text-center text-sm font-bold text-gray-500 uppercase tracking-wider mb-1">
             定義
           </h3>
           {vocab.map((item, defIdx) => {
             const pairState = pairs[defIdx];
             const isMatched = pairState?.matched ?? false;
             const isFlashWrong = pairState?.flashWrong ?? false;
+            const isFlashCorrect = pairState?.flashCorrect ?? false;
             const isSelected = selectedDef === defIdx;
 
             let cardClass =
-              'rounded-xl border-2 px-4 py-3 text-left cursor-pointer transition-all duration-200 text-sm leading-relaxed min-h-[72px] select-none ';
+              'rounded-2xl border-2 px-4 py-4 text-left cursor-pointer transition-all duration-200 text-base leading-relaxed min-h-[88px] select-none ';
 
             if (isMatched) {
-              cardClass += 'bg-emerald-50 border-emerald-400 text-emerald-800 cursor-default opacity-70';
+              cardClass += 'bg-emerald-50 border-emerald-400 text-emerald-800 cursor-default';
+            } else if (isFlashCorrect) {
+              cardClass += 'bg-emerald-100 border-emerald-500 text-emerald-800 scale-105 shadow-lg';
             } else if (isFlashWrong) {
-              cardClass += 'bg-red-50 border-red-400 text-red-700 animate-pulse';
+              cardClass += 'bg-red-50 border-red-400 text-red-700 animate-shake';
             } else if (isSelected) {
-              cardClass += 'bg-amber-100 border-amber-500 text-amber-900 shadow-md';
+              cardClass += 'bg-amber-100 border-amber-500 text-amber-900 shadow-md scale-[1.02]';
             } else {
-              cardClass += 'bg-white border-gray-200 text-gray-700 hover:border-amber-300 hover:bg-amber-50';
+              cardClass += 'bg-white border-gray-200 text-gray-700 hover:border-amber-300 hover:bg-amber-50 hover:shadow-sm';
             }
 
             return (
@@ -380,7 +410,7 @@ function MatchingExercise({
                 aria-label={`定義 ${defIdx + 1}: ${item.definition}`}
               >
                 {isMatched && (
-                  <span className="inline-block mr-1 text-emerald-500 font-bold">✓</span>
+                  <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-emerald-500 text-white text-xs font-bold mr-2 flex-shrink-0">✓</span>
                 )}
                 {item.definition}
               </button>
@@ -390,23 +420,26 @@ function MatchingExercise({
 
         {/* Right: shuffled vocabulary words */}
         <div className="flex flex-col gap-3">
-          <h3 className="text-center text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
+          <h3 className="text-center text-sm font-bold text-gray-500 uppercase tracking-wider mb-1">
             語詞
           </h3>
           {shuffledWords.map((vocabIdx) => {
             const pairState = pairs[vocabIdx];
             const isMatched = pairState?.matched ?? false;
+            const isFlashCorrect = pairState?.flashCorrect ?? false;
             const isSelected = selectedWord === vocabIdx;
 
             let cardClass =
-              'rounded-xl border-2 px-4 py-3 text-center cursor-pointer transition-all duration-200 font-bold text-lg min-h-[72px] flex items-center justify-center select-none ';
+              'rounded-2xl border-2 px-4 py-4 text-center cursor-pointer transition-all duration-200 font-bold text-xl min-h-[88px] flex items-center justify-center select-none gap-2 ';
 
             if (isMatched) {
-              cardClass += 'bg-emerald-50 border-emerald-400 text-emerald-700 cursor-default opacity-70';
+              cardClass += 'bg-emerald-50 border-emerald-400 text-emerald-700 cursor-default';
+            } else if (isFlashCorrect) {
+              cardClass += 'bg-emerald-100 border-emerald-500 text-emerald-700 scale-105 shadow-lg';
             } else if (isSelected) {
-              cardClass += 'bg-amber-100 border-amber-500 text-amber-900 shadow-md';
+              cardClass += 'bg-amber-100 border-amber-500 text-amber-900 shadow-md scale-[1.02]';
             } else {
-              cardClass += 'bg-white border-gray-200 text-gray-800 hover:border-amber-300 hover:bg-amber-50';
+              cardClass += 'bg-white border-gray-200 text-gray-800 hover:border-amber-300 hover:bg-amber-50 hover:shadow-sm';
             }
 
             return (
@@ -419,7 +452,7 @@ function MatchingExercise({
                 aria-label={`語詞：${vocab[vocabIdx].word}`}
               >
                 {isMatched && (
-                  <span className="mr-1 text-emerald-500">✓</span>
+                  <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-emerald-500 text-white text-xs font-bold flex-shrink-0">✓</span>
                 )}
                 {vocab[vocabIdx].word}
               </button>

--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -475,14 +475,14 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
   // ---- Empty vocabulary state ----
   if (vocabWords.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 gap-4 text-gray-500">
-        <div className="text-4xl" aria-hidden="true">📚</div>
-        <p className="text-sm">本課無語詞資料，無法產生方格遊戲</p>
+      <div className="flex flex-col items-center justify-center py-16 gap-6 text-gray-500">
+        <div className="text-5xl" aria-hidden="true">📚</div>
+        <p className="text-base font-medium">本課無語詞資料，無法產生方格遊戲</p>
         <button
           onClick={() => onFinish(0)}
-          className="mt-2 px-6 py-2 bg-indigo-500 text-white rounded-lg text-sm font-medium hover:bg-indigo-600 transition-colors"
+          className="mt-2 px-8 py-3 bg-indigo-600 text-white rounded-xl text-base font-bold hover:bg-indigo-700 active:scale-95 transition-all shadow-md min-h-[52px]"
         >
-          繼續
+          繼續下一步
         </button>
       </div>
     );
@@ -491,17 +491,19 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
   // ---- Completion screen ----
   if (finished) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 gap-6">
-        <div className="text-6xl" role="img" aria-label="慶祝">🎉</div>
-        <h2 className="text-2xl font-bold text-emerald-600">全部找到了！</h2>
-        <p className="text-gray-500 text-sm">共花了 {formatTime(elapsed)}</p>
-        <div className="flex flex-wrap gap-2 justify-center max-w-sm">
+      <div className="flex flex-col items-center justify-center py-16 gap-8 animate-fade-in">
+        <div className="text-8xl animate-bounce-in" role="img" aria-label="慶祝">🎉</div>
+        <div className="bg-emerald-50 border border-emerald-200 rounded-2xl px-10 py-6 text-center shadow-sm">
+          <h2 className="text-3xl font-black text-emerald-700 mb-2">全部找到了！</h2>
+          <p className="text-gray-500 text-base">共花了 <span className="font-bold text-gray-700">{formatTime(elapsed)}</span></p>
+        </div>
+        <div className="flex flex-wrap gap-3 justify-center max-w-sm">
           {placedWords.map((pw) => (
             <span
               key={pw.word}
-              className="px-3 py-1 bg-emerald-100 text-emerald-700 rounded-full text-sm font-medium"
+              className="px-4 py-2 bg-emerald-100 text-emerald-800 rounded-xl text-base font-bold border border-emerald-200"
             >
-              {pw.word}
+              ✓ {pw.word}
             </span>
           ))}
         </div>
@@ -509,32 +511,41 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
     );
   }
 
-  const cellSizePx = Math.min(44, Math.floor((Math.min(400, window.innerWidth - 32)) / size));
-  const fontSizePx = Math.max(12, Math.floor(cellSizePx * 0.55));
+  // Ensure minimum 44px touch targets per design guidelines
+  const cellSizePx = Math.max(44, Math.min(52, Math.floor((Math.min(440, window.innerWidth - 32)) / size)));
+  const fontSizePx = Math.max(14, Math.floor(cellSizePx * 0.55));
 
   return (
     <div className="flex flex-col gap-4 px-2 py-4 select-none">
-      {/* Header */}
+      {/* Header — larger and more prominent */}
       <div className="flex items-center justify-between px-2">
         <div>
-          <h2 className="text-base font-bold text-gray-800">找一找：語詞方格</h2>
-          <p className="text-xs text-gray-500 mt-0.5">
-            找出 {placedWords.length} 個語詞，已找到 {foundWords.size} 個
+          <h2 className="text-lg font-black text-gray-800">找一找：語詞方格</h2>
+          <p className="text-sm text-gray-500 mt-0.5 font-medium">
+            找出
+            <span className="font-black text-indigo-700 mx-1">{foundWords.size}</span>
+            /
+            <span className="mx-1">{placedWords.length}</span>
+            個語詞
           </p>
         </div>
-        <div className="flex items-center gap-1 text-indigo-600 font-mono font-bold text-sm bg-indigo-50 px-3 py-1.5 rounded-full">
-          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <div className="flex items-center gap-1.5 text-indigo-700 font-mono font-black text-base bg-indigo-50 px-4 py-2 rounded-xl border border-indigo-100">
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           {formatTime(elapsed)}
         </div>
       </div>
 
-      {/* Progress bar */}
+      {/* Progress bar — thicker and more visible */}
       <div className="px-2">
-        <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+        <div className="h-4 bg-gray-100 rounded-full overflow-hidden shadow-inner">
           <div
-            className="h-full bg-emerald-500 rounded-full transition-all duration-500 ease-out"
+            className="h-full bg-gradient-to-r from-emerald-400 to-emerald-500 rounded-full transition-all duration-500 ease-out"
+            role="progressbar"
+            aria-valuenow={foundWords.size}
+            aria-valuemin={0}
+            aria-valuemax={placedWords.length}
             style={{
               width: placedWords.length === 0 ? '0%' : (foundWords.size / placedWords.length) * 100 + '%',
             }}
@@ -545,7 +556,7 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
       {/* Found toast */}
       {justFound && (
         <div
-          className="fixed top-16 left-1/2 -translate-x-1/2 z-50 bg-emerald-500 text-white px-5 py-2.5 rounded-full font-bold text-sm shadow-lg pointer-events-none"
+          className="fixed top-16 left-1/2 -translate-x-1/2 z-50 bg-emerald-500 text-white px-6 py-3 rounded-2xl font-black text-base shadow-xl pointer-events-none animate-bounce-in"
           role="status"
           aria-live="polite"
         >
@@ -553,10 +564,10 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
         </div>
       )}
 
-      <div className="flex flex-col lg:flex-row gap-4 items-start">
+      <div className="flex flex-col lg:flex-row gap-6 items-start">
         {/* Grid */}
         <div
-          className="flex-shrink-0 mx-auto touch-none cursor-crosshair"
+          className="flex-shrink-0 mx-auto touch-none cursor-crosshair rounded-2xl overflow-hidden border-2 border-gray-200 shadow-sm"
           role="grid"
           aria-label="語詞方格，拖選字元以找出語詞"
           onMouseDown={onMouseDown}
@@ -577,7 +588,7 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
                       data-row={r}
                       data-col={c}
                       className={
-                        'border border-gray-200 text-center font-medium transition-colors duration-100 ' +
+                        'border border-gray-100 text-center font-bold transition-colors duration-100 ' +
                         getCellClass(r, c)
                       }
                       style={{
@@ -598,9 +609,9 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
           </table>
         </div>
 
-        {/* Word list */}
-        <div className="flex flex-col gap-2 w-full lg:w-52">
-          <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wide px-1">
+        {/* Word list — more prominent */}
+        <div className="flex flex-col gap-3 w-full lg:w-56">
+          <h3 className="text-sm font-black text-gray-600 uppercase tracking-wide px-1">
             待找語詞
           </h3>
           <div className="flex flex-wrap lg:flex-col gap-2">
@@ -611,23 +622,15 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
                 <div
                   key={pw.word}
                   className={
-                    'flex items-center gap-2 px-3 py-2 rounded-lg border transition-all duration-300 ' +
+                    'flex items-center gap-2 px-4 py-3 rounded-xl border-2 transition-all duration-300 min-h-[52px] ' +
                     (found
-                      ? 'bg-emerald-50 border-emerald-200 opacity-70'
+                      ? 'bg-emerald-50 border-emerald-300'
                       : 'bg-white border-gray-200')
                   }
                 >
-                  <span
-                    className={
-                      'text-sm font-bold ' +
-                      (found ? 'text-emerald-500 line-through' : 'text-gray-700')
-                    }
-                  >
-                    {pw.word}
-                  </span>
-                  {found && (
+                  {found ? (
                     <svg
-                      className="w-4 h-4 text-emerald-500 flex-shrink-0"
+                      className="w-5 h-5 text-emerald-500 flex-shrink-0"
                       fill="currentColor"
                       viewBox="0 0 20 20"
                       aria-label="已找到"
@@ -638,14 +641,24 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
                         clipRule="evenodd"
                       />
                     </svg>
+                  ) : (
+                    <span className="w-5 h-5 flex-shrink-0 rounded-full border-2 border-dashed border-gray-300" />
                   )}
+                  <span
+                    className={
+                      'text-base font-black ' +
+                      (found ? 'text-emerald-600 line-through' : 'text-gray-800')
+                    }
+                  >
+                    {pw.word}
+                  </span>
                   {!found && vocabItem?.definition && (
                     <span
-                      className="hidden lg:block text-xs text-gray-400 truncate max-w-[120px]"
+                      className="hidden lg:block text-xs text-gray-400 truncate flex-1"
                       title={vocabItem.definition}
                     >
-                      {vocabItem.definition.length > 18
-                        ? vocabItem.definition.slice(0, 18) + '...'
+                      {vocabItem.definition.length > 16
+                        ? vocabItem.definition.slice(0, 16) + '...'
                         : vocabItem.definition}
                     </span>
                   )}
@@ -663,7 +676,7 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
       </div>
 
       {/* Instructions */}
-      <p className="text-xs text-gray-400 text-center px-4 mt-2">
+      <p className="text-sm text-gray-400 text-center px-4 mt-2 bg-gray-50 rounded-xl py-2.5 mx-2">
         拖曳選取字元，水平或垂直圈出語詞
       </p>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -85,3 +85,39 @@
     }
   }
 }
+
+/* ── Custom animations for interactive learning components ── */
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  15%       { transform: translateX(-6px); }
+  30%       { transform: translateX(6px); }
+  45%       { transform: translateX(-5px); }
+  60%       { transform: translateX(5px); }
+  75%       { transform: translateX(-3px); }
+  90%       { transform: translateX(3px); }
+}
+
+@keyframes pop {
+  0%   { transform: scale(0.7); opacity: 0; }
+  60%  { transform: scale(1.15); opacity: 1; }
+  80%  { transform: scale(0.95); }
+  100% { transform: scale(1); }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes bounce-in {
+  0%   { transform: scale(0.3); opacity: 0; }
+  50%  { transform: scale(1.05); opacity: 1; }
+  70%  { transform: scale(0.9); }
+  100% { transform: scale(1); }
+}
+
+.animate-shake      { animation: shake 0.5s ease-in-out; }
+.animate-pop        { animation: pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1); }
+.animate-fade-in    { animation: fade-in 0.3s ease-out; }
+.animate-bounce-in  { animation: bounce-in 0.45s cubic-bezier(0.34, 1.56, 0.64, 1); }


### PR DESCRIPTION
## Summary

Visual polish for 4 new step components to match quality of existing steps (LiveTutor, ComprehensionChat, VocabPractice). No functionality changes — only visual improvements.

### Changes per component

**ReadingAnnotation**
- Larger instruction banner with primary CTA text at top: "選取課文中不太了解的字詞，標記起來"
- Floating toolbar upgraded: 44px+ touch targets, thicker amber border, bigger text/padding
- Summary bar: pill-style badges for mark counts (red for unknown, yellow for important)

**VocabDefinitionMatch**
- Cards enlarged: `min-h-[88px]`, `rounded-2xl`, `text-base`
- Correct match: scale+green-flash animation before setting matched
- Wrong match: `animate-shake` (CSS keyframe) instead of `animate-pulse`
- Progress bar: gradient fill, h-4, enclosed in white card with shadow
- Background changed to `amber-50` to match other steps
- Completion screen: `bounce-in` emoji animation, bigger card with border

**FillInBlankExercise**
- Color theme: `blue` → `indigo` (brand accent per design system)
- Choice buttons: `min-h-[44px]`, `border-2`, `rounded-xl`, `text-base`
- Progress counter card shows X / Y answered
- Submit button: `min-h-[56px]`, shows remaining count when not all answered
- Question cards: color-coded border on submit (green/red)
- Numbered circle indicator per question

**VocabWordSearch**
- Cell size: enforced `Math.max(44, ...)` minimum (was `Math.min(44, ...)` — was never 44!)
- Progress bar: `h-4` (was `h-2`), gradient fill
- Word list cards: `min-h-[52px]`, `border-2`, dashed circle for unfound words
- Found toast: larger font, `bounce-in` animation
- Victory screen: `bounce-in` emoji, bigger found-word chips
- Instructions text styled in gray box instead of bare text

**index.css**
- Added 4 keyframe animations: `shake`, `pop`, `fade-in`, `bounce-in`
- All respect `prefers-reduced-motion` via existing global rule

## Test plan

- [ ] Open any lesson → proceed to ReadingAnnotation step → select text → verify toolbar is large and visible
- [ ] Proceed to VocabDefinitionMatch → wrong match should shake, correct match should flash green
- [ ] Proceed to VocabApplication → verify indigo buttons are 44px+ height, submit button shows count
- [ ] Proceed to VocabWordSearch → verify grid cells are at least 44px, word list has larger cards
- [ ] Build passes: `npm run build` in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)