### PR TITLE
fix(tutor): persist completedParagraphsSet to localStorage (#689)

### DIFF
--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -121,8 +121,20 @@ const LearningLayout: React.FC = () => {
       return null;
     }
   });
-  /** Progressive paragraph unlock tracking (Issue #85). */
-  const [completedParagraphsSet, setCompletedParagraphsSet] = useState<Set<number>>(new Set());
+  /** Progressive paragraph unlock tracking (Issue #85).
+   * Restored from localStorage on mount so progress survives page refresh (Issue #689). */
+  const [completedParagraphsSet, setCompletedParagraphsSet] = useState<Set<number>>(() => {
+    try {
+      const raw = localStorage.getItem(`tutor_completed_${storyId}`);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) return new Set<number>(parsed as number[]);
+      }
+    } catch {
+      // Non-fatal — start fresh
+    }
+    return new Set<number>();
+  });
   /** Reading goals from the active assignment, loaded from sessionStorage (Issue #414). */
   const [assignmentReadingGoals, setAssignmentReadingGoals] = useState<AssignmentReadingGoals | null>(() => {
     try {
@@ -172,11 +184,13 @@ const LearningLayout: React.FC = () => {
   );
 
   /** Clear active session from localStorage and sessionStorage (called on completion).
-   * Removing the sessionStorage key means the next visit creates a fresh DB session. */
+   * Removing the sessionStorage key means the next visit creates a fresh DB session.
+   * Also clears the tutor paragraph progress so a fresh session starts at zero (Issue #689). */
   const clearPersistedSession = useCallback(() => {
     if (!user) return;
     clearActiveSession(String(user.id));
     try { sessionStorage.removeItem(`db-session-${storyId}`); } catch { /* non-fatal */ }
+    try { localStorage.removeItem(`tutor_completed_${storyId}`); } catch { /* non-fatal */ }
   }, [user, storyId]);
 
   // ── Idle-timeout warning (Issue #408) ────────────────────────────────────
@@ -434,12 +448,19 @@ const LearningLayout: React.FC = () => {
     }
   }, [clearPersistedSession, token]);
 
-  /** Mark a paragraph as completed in both local state and session (Issue #85). */
+  /** Mark a paragraph as completed in both local state and session (Issue #85).
+   * Also persists to localStorage so progress survives page refresh (Issue #689). */
   const handleParagraphComplete = useCallback((paragraphIndex: number) => {
     setCompletedParagraphsSet((prev) => {
       if (prev.has(paragraphIndex)) return prev;
       const updated = new Set(prev);
       updated.add(paragraphIndex);
+      // Persist to localStorage (L1 cache) — key per story so different stories don't collide
+      try {
+        localStorage.setItem(`tutor_completed_${storyId}`, JSON.stringify(Array.from(updated)));
+      } catch {
+        // Non-fatal — in-memory state still updated
+      }
       return updated;
     });
     setSession((prev) => {
@@ -449,7 +470,7 @@ const LearningLayout: React.FC = () => {
       existing.add(paragraphIndex);
       return { ...prev, completedParagraphs: Array.from(existing) };
     });
-  }, []);
+  }, [storyId]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Problem

`completedParagraphsSet` in `LearningLayout.tsx` was initialized as `new Set()` on every mount. After a page refresh or a new browser session, all paragraph completion progress was lost, causing:
- FullReading page to show wrong progress (e.g. "0/5" instead of "5/5")
- Students needing to re-read already-completed paragraphs

## Root Cause (5-Why)

The `useState` initializer at line 125 was `new Set()` — it never read localStorage, so nothing persisted across mounts.

## Fix (3 changes to `LearningLayout.tsx`)

1. **Lazy initializer** — `useState` now reads `localStorage.getItem('tutor_completed_{storyId}')` on mount and restores any saved progress.
2. **Write on complete** — `handleParagraphComplete` now writes the updated set to `localStorage` after every paragraph completion.
3. **Clear on finish** — `clearPersistedSession` now also removes the localStorage key so a fully-completed session starts clean on the next visit.

The localStorage key is scoped per story (`tutor_completed_{storyId}`) so different stories don't interfere with each other.

## Verification

- `npm run build` — clean build, 0 errors, 0 warnings

## Test Plan

- [ ] Open a story in LiveTutor, complete 2 paragraphs
- [ ] Refresh the page — verify those 2 paragraphs are still unlocked
- [ ] Open FullReading — verify progress shows "2/N" not "0/N"
- [ ] Complete all paragraphs, reach the report page
- [ ] Revisit the same story — verify it starts at 0 (cleared on session complete)

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)