### PR TITLE
fix(sentence-practice): stop infinite retry loop causing 429 (#693)

### DIFF
--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -4,7 +4,7 @@
  * After stroke order practice, students compose 2 sentences using each
  * practiced vocabulary character. AI validates grammar and word usage.
  */
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? '';
@@ -136,6 +136,10 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   });
   const [completedChars, setCompletedChars] = useState<Set<string>>(new Set());
 
+  // Tracks characters that have been loaded or are currently loading,
+  // avoiding circular dependency on charStates inside the loadExamples callback.
+  const loadedCharsRef = useRef<Set<string>>(new Set());
+
   const currentChar = practicedChars[currentCharIndex] ?? '';
   const currentState = charStates[currentChar] ?? makeCharState();
 
@@ -143,7 +147,12 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
 
   const loadExamples = useCallback(async () => {
     if (!currentChar) return;
-    if (charStates[currentChar]?.exampleSentences) return; // already loaded
+    // Use ref instead of charStates to avoid adding charStates as a dependency
+    // (which would cause an infinite loop: error → setCharStates → new charStates
+    //  → new loadExamples → useEffect fires → loadExamples called again → 429)
+    if (loadedCharsRef.current.has(currentChar)) return;
+
+    loadedCharsRef.current.add(currentChar);
 
     setCharStates(prev => ({
       ...prev,
@@ -157,6 +166,8 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
         [currentChar]: { ...prev[currentChar], examplesLoading: false, exampleSentences: examples },
       }));
     } catch {
+      // Remove from ref so the retry button can re-attempt
+      loadedCharsRef.current.delete(currentChar);
       setCharStates(prev => ({
         ...prev,
         [currentChar]: {
@@ -166,7 +177,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
         },
       }));
     }
-  }, [currentChar, charStates, storyTitle]);
+  }, [currentChar, storyTitle, token]);
 
   // Auto-load examples when we navigate to a character
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

- **Root cause**: `loadExamples` useCallback had `charStates` in its dependency array. On API failure, `setCharStates` was called → new `charStates` reference → new `loadExamples` function → `useEffect` re-fired → API called again → infinite loop → 429 Too Many Requests.
- **Fix**: Replace the `charStates[currentChar]?.exampleSentences` guard inside the callback with a `useRef<Set<string>>` (`loadedCharsRef`) that tracks which characters have been loaded or are currently loading. The ref is populated before the fetch and cleared on error, so the retry button still works. `charStates` is removed from the `useCallback` dependency array entirely.
- Also added `token` to the dependency array (was previously missing — stale closure risk if token refreshed mid-session).

## Files changed

- `frontend/src/components/reading-steps/SentencePractice.tsx`

## Test plan

- [ ] Open SentencePractice with a character
- [ ] Verify example sentences load once (single API call in Network tab)
- [ ] Simulate API failure (block the endpoint) — confirm the error message appears and NO retry loop fires
- [ ] Click the retry button — confirm a single new API call is made
- [ ] Navigate to a second character — confirm it loads once with no loop

Fixes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)