### PR TITLE
fix(sidebar): use PATH_TO_VIEW for automatic learning step mapping (#696)

### DIFF
--- a/frontend/src/hooks/useAppView.ts
+++ b/frontend/src/hooks/useAppView.ts
@@ -1,5 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import { AppView } from '../types';
+import { PATH_TO_VIEW } from '../config/stepConfig';
 
 /**
  * Derive the current AppView from the route path.
@@ -27,14 +28,12 @@ export function useAppView(): AppView {
   if (pathname === '/profile') return AppView.STUDENT_PROFILE;
 
   // Learning flow: /learn/:storyId/<step>
+  // Use PATH_TO_VIEW from stepConfig so any new step is automatically mapped
+  // without needing a manual update here.
   if (pathname.includes('/learn/')) {
-    if (pathname.endsWith('/intro')) return AppView.INTRO;
-    if (pathname.endsWith('/tutor')) return AppView.TUTOR;
-    if (pathname.endsWith('/comprehension')) return AppView.COMPREHENSION;
-    if (pathname.endsWith('/vocab')) return AppView.VOCAB;
-    if (pathname.endsWith('/dictation')) return AppView.DICTATION;
-    if (pathname.endsWith('/full-reading')) return AppView.FULL_READING;
-    if (pathname.endsWith('/report')) return AppView.REPORT;
+    const stepId = pathname.split('/').pop() ?? '';
+    const view = PATH_TO_VIEW[stepId];
+    if (view !== undefined) return view;
   }
 
   return AppView.HOME;


### PR DESCRIPTION
## Summary

- Fixes #696: sidebar 不顯示新步驟 active 狀態
- `useAppView.ts` 的 learning flow section 原本只有 7 個 hardcoded `endsWith` 判斷，缺少 `reading-annotation`、`vocab-definition`、`vocab-application`、`vocab-word-search`、`knowledge-station`
- 改用 `PATH_TO_VIEW`（從 `stepConfig.ts` import）做自動 lookup，未來新增步驟不需要再更新此檔案

## Root cause

`useAppView.ts` line 30-38 hardcoded 7 舊步驟的 path → AppView mapping，新步驟沒有對應 entry，導致 sidebar active 狀態無法亮起

## Fix

```ts
// Before: 7 separate hardcoded checks
if (pathname.endsWith('/tutor')) return AppView.TUTOR;
// ... etc

// After: single lookup via stepConfig
const stepId = pathname.split('/').pop() ?? '';
const view = PATH_TO_VIEW[stepId];
if (view !== undefined) return view;
```

## Test plan

- [ ] Navigate to `/learn/:storyId/reading-annotation` → sidebar 閱讀標記 應 highlight
- [ ] Navigate to `/learn/:storyId/vocab-definition` → sidebar 語詞定義 應 highlight
- [ ] Navigate to `/learn/:storyId/vocab-application` → sidebar 語詞應用 應 highlight
- [ ] Navigate to `/learn/:storyId/vocab-word-search` → sidebar 語詞複習 應 highlight
- [ ] Navigate to `/learn/:storyId/knowledge-station` → sidebar 知識補給站 應 highlight
- [ ] 原有步驟（tutor, full-reading, vocab, comprehension, report）active 狀態依然正常
- [ ] `npm run build` passes ✓

Generated with [Claude Code](https://claude.com/claude-code)