### PR TITLE
fix(stepper): add completion checkmarks for 5 new steps #690

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -43,14 +43,19 @@ function getStepStatus(
   const isCompleted = (() => {
     if (!session) return false;
     switch (stepDef.view) {
-      case AppView.INTRO:          return session.introCompleted;
-      case AppView.TUTOR:          return session.readingAttempt !== null;
-      case AppView.VOCAB:          return session.vocabResult !== null;
-      case AppView.DICTATION:      return session.dictationResult !== null;
-      case AppView.COMPREHENSION:  return session.comprehensionResult !== null;
-      case AppView.FULL_READING:   return session.fullReadingResult !== null;
-      case AppView.REPORT:         return false; // destination step, never "completed"
-      default:                     return false;
+      case AppView.INTRO:                    return session.introCompleted;
+      case AppView.TUTOR:                    return session.readingAttempt !== null;
+      case AppView.VOCAB:                    return session.vocabResult !== null;
+      case AppView.DICTATION:               return session.dictationResult !== null;
+      case AppView.COMPREHENSION:           return session.comprehensionResult !== null;
+      case AppView.FULL_READING:            return session.fullReadingResult !== null;
+      case AppView.READING_ANNOTATION:      return session.readingAnnotationCompleted === true;
+      case AppView.VOCAB_DEFINITION_MATCH:  return session.vocabDefinitionMatchCompleted === true;
+      case AppView.VOCAB_APPLICATION:       return session.vocabApplicationCompleted === true;
+      case AppView.VOCAB_WORD_SEARCH:       return session.vocabWordSearchCompleted === true;
+      case AppView.KNOWLEDGE_STATION:       return session.knowledgeStationCompleted === true;
+      case AppView.REPORT:                  return false; // destination step, never "completed"
+      default:                              return false;
     }
   })();
 

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -369,6 +369,7 @@ const LearningLayout: React.FC = () => {
 
   const handleFinishReadingAnnotation = useCallback(
     (_summary: AnnotationSummary) => {
+      setSession((prev) => (prev ? { ...prev, readingAnnotationCompleted: true } : null));
       persistStep(STEP_PATH_TO_NUMBER['tutor']);
       navigate(`/learn/${storyId}/tutor`);
     },
@@ -377,6 +378,7 @@ const LearningLayout: React.FC = () => {
 
   const handleFinishVocabDefinitionMatch = useCallback(
     (_result: VocabDefinitionMatchResult) => {
+      setSession((prev) => (prev ? { ...prev, vocabDefinitionMatchCompleted: true } : null));
       persistStep(STEP_PATH_TO_NUMBER['vocab-application']);
       navigate(`/learn/${storyId}/vocab-application`);
     },
@@ -385,6 +387,7 @@ const LearningLayout: React.FC = () => {
 
   const handleFinishVocabApplication = useCallback(
     (_result: VocabApplicationResult) => {
+      setSession((prev) => (prev ? { ...prev, vocabApplicationCompleted: true } : null));
       persistStep(STEP_PATH_TO_NUMBER['comprehension']);
       navigate(`/learn/${storyId}/comprehension`);
     },
@@ -393,6 +396,7 @@ const LearningLayout: React.FC = () => {
 
   const handleFinishVocabWordSearch = useCallback(
     (_elapsedSeconds: number) => {
+      setSession((prev) => (prev ? { ...prev, vocabWordSearchCompleted: true } : null));
       persistStep(STEP_PATH_TO_NUMBER['knowledge-station']);
       navigate(`/learn/${storyId}/knowledge-station`);
     },
@@ -401,6 +405,7 @@ const LearningLayout: React.FC = () => {
 
   const handleFinishKnowledgeStation = useCallback(
     () => {
+      setSession((prev) => (prev ? { ...prev, knowledgeStationCompleted: true } : null));
       persistStep(STEP_PATH_TO_NUMBER['report']);
       navigate(`/learn/${storyId}/report`);
     },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -184,6 +184,12 @@ export interface LearningSession {
   fullReadingResult: FullReadingResult | null;
   /** Paragraph indices (0-based) completed during LiveTutor (progressive unlock). */
   completedParagraphs?: number[];
+  /** Completion flags for the 5 new steps (issue #690). */
+  readingAnnotationCompleted?: boolean;
+  vocabDefinitionMatchCompleted?: boolean;
+  vocabApplicationCompleted?: boolean;
+  vocabWordSearchCompleted?: boolean;
+  knowledgeStationCompleted?: boolean;
 }
 
 export interface LiveMessage {


### PR DESCRIPTION
## Root Cause

`getStepStatus()` in `StepperNav.tsx` fell to `default: return false` for all 5 new steps because:

1. `LearningSession` had no result fields for `READING_ANNOTATION`, `VOCAB_DEFINITION_MATCH`, `VOCAB_APPLICATION`, `VOCAB_WORD_SEARCH`, `KNOWLEDGE_STATION`
2. The `switch` in `getStepStatus` had no cases for those `AppView` values
3. The `handleFinish*` callbacks in `LearningLayout.tsx` for the new steps only called `persistStep()` + `navigate()` — they never updated the session

## Fix (3 files, 24 lines added)

| File | Change |
|------|--------|
| `frontend/src/types.ts` | Add 5 optional boolean fields to `LearningSession` |
| `frontend/src/layouts/LearningLayout.tsx` | Set each flag to `true` in the corresponding `handleFinish*` callback |
| `frontend/src/components/StepperNav.tsx` | Add `switch` cases for all 5 new `AppView` values |

## Verification

`cd frontend && npm run build` — passes with no errors or warnings.

## Test Plan

- [ ] Complete 閱讀標記 step → sidebar shows green checkmark
- [ ] Complete 語詞定義 step → sidebar shows green checkmark
- [ ] Complete 語詞應用 step → sidebar shows green checkmark
- [ ] Complete 語詞複習 step → sidebar shows green checkmark
- [ ] Complete 知識補給站 step → sidebar shows green checkmark
- [ ] Previously completed steps (逐段朗讀, 生字練習, etc.) still show checkmarks correctly

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)