### PR TITLE
fix(vocab): #698 — 語詞應用一次一題 + 選過詞語從題庫消失

### DIFF
--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -1,8 +1,14 @@
 /**
  * FillInBlankExercise — ④ 語詞應用（選詞填句）(#615)
  *
- * Shows vocab word bank (A~G codes) and sentences with blanks.
- * Student picks the correct code for each blank, submits to check.
+ * Issue #698: one-at-a-time + disappearing word bank
+ *
+ * UX:
+ *   - Top: fixed word bank showing only remaining (unused) words
+ *   - Below: one fill-in-the-blank sentence at a time
+ *   - Correct → word disappears from bank + advance to next question
+ *   - Wrong  → show hint, word stays in bank
+ *   - No per-sentence option buttons; all selection happens via the top bank
  */
 import React, { useState } from 'react';
 import { FillInBlankItem } from '../../types';
@@ -15,186 +21,202 @@ interface Props {
 
 const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete }) => {
   const bankEntries = Object.entries(vocabBank).sort(([a], [b]) => a.localeCompare(b));
-  const [answers, setAnswers] = useState<Record<number, string>>({});
-  const [submitted, setSubmitted] = useState(false);
 
-  const answeredCount = Object.keys(answers).length;
-  const allAnswered = answeredCount >= sentences.length;
+  // Index of the current sentence being answered
+  const [currentIdx, setCurrentIdx] = useState(0);
+  // Codes that have been correctly used and should disappear from bank
+  const [usedCodes, setUsedCodes] = useState<Set<string>>(new Set());
+  // The code selected for the current question (pending confirmation)
+  const [selected, setSelected] = useState<string | null>(null);
+  // Feedback state for current question
+  const [feedback, setFeedback] = useState<'idle' | 'correct' | 'wrong'>('idle');
+  // Track score
+  const [score, setScore] = useState(0);
 
-  function handleSelect(sentenceIdx: number, code: string) {
-    if (submitted) return;
-    setAnswers((prev) => ({ ...prev, [sentenceIdx]: code }));
+  const total = sentences.length;
+  const done = currentIdx >= total;
+
+  // Available words = all words minus correctly used ones
+  const availableEntries = bankEntries.filter(([code]) => !usedCodes.has(code));
+
+  const currentSentence = !done ? sentences[currentIdx] : null;
+
+  function handleSelect(code: string) {
+    if (feedback === 'correct') return; // waiting for auto-advance
+    setSelected(code);
+    setFeedback('idle');
   }
 
-  function handleSubmit() {
-    if (!allAnswered) return;
-    setSubmitted(true);
+  function handleConfirm() {
+    if (!selected || !currentSentence) return;
+
+    if (selected === currentSentence.answer) {
+      // Correct
+      const newUsed = new Set(usedCodes);
+      newUsed.add(selected);
+      setUsedCodes(newUsed);
+      setScore((s) => s + 1);
+      setFeedback('correct');
+      // Brief pause so student sees green flash, then advance
+      setTimeout(() => {
+        setCurrentIdx((i) => i + 1);
+        setSelected(null);
+        setFeedback('idle');
+      }, 900);
+    } else {
+      // Wrong
+      setFeedback('wrong');
+    }
   }
 
-  function handleRetry() {
-    setAnswers({});
-    setSubmitted(false);
+  function handleRetryCurrentQuestion() {
+    setSelected(null);
+    setFeedback('idle');
   }
 
-  const score = submitted
-    ? sentences.filter((s, i) => answers[i] === s.answer).length
-    : 0;
-
-  // Render sentence text with (　　) replaced by a word badge
-  function renderSentence(sentence: string, idx: number) {
-    const chosen = answers[idx];
-    const correct = sentences[idx].answer;
-
+  // Render the sentence with the blank slot
+  function renderSentence(sentence: string) {
     const parts = sentence.split('(　　)');
-    const isCorrect = submitted && chosen === correct;
-    const isWrong = submitted && chosen !== correct;
 
-    const badge = (
-      <span
-        className={`inline-flex items-center gap-1 rounded-lg px-3 py-1 text-base font-semibold border mx-1 transition-all
-          ${!submitted
-            ? chosen
-              ? 'bg-indigo-100 border-indigo-400 text-indigo-900'
-              : 'bg-gray-100 border-dashed border-gray-400 text-gray-400'
-            : isCorrect
+    const blankContent = selected
+      ? (
+        <span
+          className={`inline-flex items-center gap-1 rounded-lg px-3 py-1 text-base font-semibold border mx-1
+            ${feedback === 'correct'
               ? 'bg-emerald-100 border-emerald-500 text-emerald-900'
-              : 'bg-red-100 border-red-400 text-red-700 line-through'
-          }`}
-      >
-        {chosen ? `${chosen} ${vocabBank[chosen]}` : '＿＿'}
-        {submitted && isWrong && (
-          <span className="not-italic text-emerald-700 no-underline ml-1 font-normal text-sm">
-            → {correct} {vocabBank[correct]}
-          </span>
-        )}
-      </span>
-    );
+              : feedback === 'wrong'
+              ? 'bg-red-100 border-red-400 text-red-700'
+              : 'bg-[#5B4FC4]/10 border-[#5B4FC4]/40 text-[#5B4FC4]'
+            }`}
+        >
+          <span className="font-black">{selected}</span>
+          <span className="ml-1">{vocabBank[selected]}</span>
+        </span>
+      )
+      : (
+        <span className="inline-block rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 text-gray-400 px-6 py-1 mx-1 text-base min-w-[80px] text-center">
+          ＿＿
+        </span>
+      );
 
     return (
       <span>
         {parts[0]}
-        {badge}
-        {parts[1]}
+        {blankContent}
+        {parts[1] ?? ''}
       </span>
     );
   }
 
-  return (
-    <div className="flex flex-col gap-6 p-4 max-w-2xl mx-auto">
-      {/* Progress indicator */}
-      {!submitted && (
-        <div className="bg-white rounded-2xl border border-indigo-100 shadow-sm px-5 py-3 flex items-center justify-between">
-          <span className="text-base text-gray-600 font-medium">已作答</span>
-          <span className="text-lg font-black text-indigo-700">
-            {answeredCount} <span className="text-gray-400 font-normal text-sm">/ {sentences.length}</span>
-          </span>
+  if (done) {
+    return (
+      <div className="flex flex-col items-center gap-4 p-6 max-w-2xl mx-auto animate-fade-in">
+        <div className={`rounded-2xl px-8 py-4 text-center w-full ${score === total ? 'bg-emerald-50 border border-emerald-200' : 'bg-amber-50 border border-amber-200'}`}>
+          <p className="text-2xl font-black text-gray-800">
+            {score === total ? '全對！太棒了！' : `答對 ${score}／${total} 題`}
+          </p>
         </div>
-      )}
-
-      {/* Word bank */}
-      <div className="rounded-2xl border border-indigo-200 bg-indigo-50 p-5 shadow-sm">
-        <p className="text-sm text-indigo-700 mb-3 font-semibold">詞語題庫：將正確的詞語代號填入空格中</p>
-        <div className="flex flex-wrap gap-3">
-          {bankEntries.map(([code, word]) => (
-            <span
-              key={code}
-              className="rounded-xl border border-indigo-200 bg-white px-4 py-2 text-base shadow-sm"
-            >
-              <span className="font-black text-indigo-600 text-lg">{code}</span>
-              <span className="mx-1.5 text-gray-300">·</span>
-              <span className="text-gray-800 font-medium">{word}</span>
-            </span>
-          ))}
-        </div>
-      </div>
-
-      {/* Sentences */}
-      <div className="flex flex-col gap-4">
-        {sentences.map((s, idx) => {
-          const isCorrect = submitted && answers[idx] === s.answer;
-          const isWrong = submitted && answers[idx] !== s.answer;
-          return (
-            <div
-              key={idx}
-              className={`rounded-2xl border-2 bg-white p-5 shadow-sm transition-all duration-200 ${
-                isCorrect
-                  ? 'border-emerald-300 bg-emerald-50'
-                  : isWrong
-                  ? 'border-red-300 bg-red-50'
-                  : 'border-gray-200'
-              }`}
-            >
-              {/* Question number + sentence */}
-              <p className="text-lg leading-loose text-gray-800 mb-4 flex items-start gap-2">
-                <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-indigo-100 text-indigo-700 font-black text-sm flex-shrink-0 mt-0.5">
-                  {idx + 1}
-                </span>
-                <span>
-                  {renderSentence(s.sentence, idx)}
-                  {submitted && (
-                    <span className="ml-2 text-lg">
-                      {isCorrect ? '✅' : '❌'}
-                    </span>
-                  )}
-                </span>
-              </p>
-
-              {!submitted && (
-                <div className="flex flex-wrap gap-2 ml-9">
-                  {bankEntries.map(([code, word]) => (
-                    <button
-                      key={code}
-                      onClick={() => handleSelect(idx, code)}
-                      className={`rounded-xl px-4 py-2 text-base border-2 transition-all active:scale-95 font-medium min-h-[44px]
-                        ${answers[idx] === code
-                          ? 'bg-indigo-600 border-indigo-600 text-white font-bold shadow-md'
-                          : 'bg-white border-gray-200 text-gray-700 hover:border-indigo-400 hover:bg-indigo-50'
-                        }`}
-                    >
-                      <span className="font-black">{code}</span>
-                      <span className="ml-1.5 text-sm">{word}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Action buttons */}
-      {!submitted ? (
         <button
-          onClick={handleSubmit}
-          disabled={!allAnswered}
-          className="self-center rounded-xl bg-indigo-600 px-12 py-4 text-white text-lg font-bold
-            disabled:opacity-40 disabled:cursor-not-allowed hover:bg-indigo-700 active:scale-95 transition-all shadow-lg min-h-[56px]"
+          onClick={() => onComplete(score, total)}
+          className="rounded-xl bg-[#5B4FC4] px-10 py-3 text-base font-bold text-white hover:bg-[#4a3fa8] active:scale-95 transition-all shadow-md min-h-[52px]"
         >
-          {allAnswered ? '提交答案' : `還有 ${sentences.length - answeredCount} 題未填`}
+          繼續 →
         </button>
-      ) : (
-        <div className="flex flex-col items-center gap-4 animate-fade-in">
-          <div className={`rounded-2xl px-8 py-4 text-center ${score === sentences.length ? 'bg-emerald-50 border border-emerald-200' : 'bg-amber-50 border border-amber-200'}`}>
-            <p className="text-2xl font-black text-gray-800">
-              {score === sentences.length
-                ? '全對！太棒了！'
-                : `答對 ${score}／${sentences.length} 題`}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5 p-4 max-w-2xl mx-auto">
+      {/* Progress */}
+      <div className="bg-white rounded-2xl border border-[#5B4FC4]/20 shadow-sm px-5 py-3 flex items-center justify-between">
+        <span className="text-base text-gray-600 font-medium">第 {currentIdx + 1} 題</span>
+        <span className="text-lg font-black text-[#5B4FC4]">
+          {currentIdx + 1} <span className="text-gray-400 font-normal text-sm">/ {total}</span>
+        </span>
+      </div>
+
+      {/* Word bank — top, fixed, shows only remaining words */}
+      <div className="rounded-2xl border border-[#5B4FC4]/30 bg-[#5B4FC4]/5 p-5 shadow-sm">
+        <p className="text-sm text-[#5B4FC4] mb-3 font-semibold">詞語題庫（點選詞語填入空格）</p>
+        {availableEntries.length === 0 ? (
+          <p className="text-sm text-gray-400 italic">所有詞語都已使用完畢</p>
+        ) : (
+          <div className="flex flex-wrap gap-3">
+            {availableEntries.map(([code, word]) => (
+              <button
+                key={code}
+                onClick={() => handleSelect(code)}
+                disabled={feedback === 'correct'}
+                className={`rounded-xl border-2 px-4 py-2 text-base transition-all active:scale-95 font-medium min-h-[44px]
+                  ${selected === code
+                    ? 'bg-[#5B4FC4] border-[#5B4FC4] text-white shadow-md font-bold'
+                    : 'bg-white border-[#5B4FC4]/30 text-gray-700 hover:border-[#5B4FC4] hover:bg-[#5B4FC4]/5'
+                  }
+                  disabled:opacity-50 disabled:cursor-not-allowed`}
+              >
+                <span className="font-black text-lg">{code}</span>
+                <span className="mx-1.5 text-gray-300">·</span>
+                <span>{word}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Current sentence */}
+      {currentSentence && (
+        <div
+          className={`rounded-2xl border-2 bg-white p-5 shadow-sm transition-all duration-200
+            ${feedback === 'correct'
+              ? 'border-emerald-300 bg-emerald-50'
+              : feedback === 'wrong'
+              ? 'border-red-300 bg-red-50'
+              : 'border-gray-200'
+            }`}
+        >
+          <p className="text-lg leading-loose text-gray-800 mb-4 flex items-start gap-2">
+            <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-[#5B4FC4]/15 text-[#5B4FC4] font-black text-sm flex-shrink-0 mt-0.5">
+              {currentIdx + 1}
+            </span>
+            <span>{renderSentence(currentSentence.sentence)}</span>
+            {feedback === 'correct' && <span className="ml-1 text-lg">✅</span>}
+            {feedback === 'wrong' && <span className="ml-1 text-lg">❌</span>}
+          </p>
+
+          {/* Feedback message */}
+          {feedback === 'correct' && (
+            <p className="ml-9 text-sm text-emerald-700 font-semibold animate-fade-in">
+              答對了！進入下一題…
             </p>
-          </div>
-          <div className="flex gap-4">
-            <button
-              onClick={handleRetry}
-              className="rounded-xl border-2 border-gray-300 px-7 py-3 text-base font-semibold text-gray-600 hover:bg-gray-50 active:scale-95 transition-all min-h-[52px]"
-            >
-              再試一次
-            </button>
-            <button
-              onClick={() => onComplete(score, sentences.length)}
-              className="rounded-xl bg-indigo-600 px-7 py-3 text-base font-bold text-white hover:bg-indigo-700 active:scale-95 transition-all shadow-md min-h-[52px]"
-            >
-              繼續 →
-            </button>
-          </div>
+          )}
+          {feedback === 'wrong' && (
+            <div className="ml-9 flex flex-col gap-2 animate-fade-in">
+              <p className="text-sm text-red-600 font-semibold">
+                不對喔！再想想看，正確答案是哪個詞語？
+              </p>
+              <button
+                onClick={handleRetryCurrentQuestion}
+                className="self-start rounded-lg border border-red-200 bg-white px-4 py-1.5 text-sm text-red-600 hover:bg-red-50 transition-colors"
+              >
+                重新選擇
+              </button>
+            </div>
+          )}
+
+          {/* Confirm button */}
+          {feedback === 'idle' && (
+            <div className="ml-9 mt-2">
+              <button
+                onClick={handleConfirm}
+                disabled={!selected}
+                className="rounded-xl bg-[#5B4FC4] px-8 py-2.5 text-white text-base font-bold
+                  disabled:opacity-40 disabled:cursor-not-allowed hover:bg-[#4a3fa8] active:scale-95 transition-all shadow min-h-[44px]"
+              >
+                {selected ? '確認填入' : '請先選擇詞語'}
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/reading-steps/__tests__/FillInBlankExercise.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/FillInBlankExercise.test.tsx
@@ -1,4 +1,13 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+/**
+ * Tests for FillInBlankExercise (#698)
+ *
+ * New UX: one-at-a-time + disappearing word bank
+ * - Top word bank shows only unused words
+ * - One sentence shown at a time
+ * - Correct answer → word disappears + advance
+ * - Wrong answer → hint shown, word stays
+ */
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import FillInBlankExercise from '../FillInBlankExercise';
 import { FillInBlankItem } from '../../../types';
@@ -14,8 +23,8 @@ const sentences: FillInBlankItem[] = [
   { sentence: '兩隊之間展開(　　)的競爭。', answer: 'B' },
 ];
 
-describe('FillInBlankExercise', () => {
-  it('renders word bank entries', () => {
+describe('FillInBlankExercise (#698)', () => {
+  it('renders word bank entries in top bank area', () => {
     render(
       <FillInBlankExercise
         sentences={sentences}
@@ -28,7 +37,7 @@ describe('FillInBlankExercise', () => {
     expect(screen.getByText('一鳴驚人')).toBeTruthy();
   });
 
-  it('submit button is disabled when not all blanks are filled', () => {
+  it('shows only the first sentence initially (one at a time)', () => {
     render(
       <FillInBlankExercise
         sentences={sentences}
@@ -36,11 +45,13 @@ describe('FillInBlankExercise', () => {
         onComplete={() => {}}
       />
     );
-    const submitBtn = screen.getByRole('button', { name: '提交答案' });
-    expect(submitBtn).toBeDisabled();
+    // First sentence text should be visible
+    expect(screen.getByText(/他解決了所有的/)).toBeTruthy();
+    // Second sentence should NOT be visible yet
+    expect(screen.queryByText(/兩隊之間展開/)).toBeNull();
   });
 
-  it('submit button is enabled after all blanks are filled', () => {
+  it('confirm button is disabled until a word is selected', () => {
     render(
       <FillInBlankExercise
         sentences={sentences}
@@ -48,20 +59,107 @@ describe('FillInBlankExercise', () => {
         onComplete={() => {}}
       />
     );
-
-    // Select answer for sentence 0 — click the per-sentence option buttons
-    // The option buttons appear inside each sentence card
-    const allOptionButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
-    fireEvent.click(allOptionButtons[0]);
-
-    const allOptionButtonsB = screen.getAllByRole('button', { name: /^B 龍爭虎鬥$/ });
-    fireEvent.click(allOptionButtonsB[1]);
-
-    const submitBtn = screen.getByRole('button', { name: '提交答案' });
-    expect(submitBtn).not.toBeDisabled();
+    const confirmBtn = screen.getByRole('button', { name: '請先選擇詞語' });
+    expect(confirmBtn).toBeDisabled();
   });
 
-  it('after submit shows correct answer in green and wrong answer in red with correction', () => {
+  it('confirm button enables after selecting a word from bank', () => {
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={() => {}}
+      />
+    );
+    // Click word A from the top bank
+    const bankBtns = screen.getAllByRole('button');
+    const aBankBtn = bankBtns.find((b) => b.textContent?.includes('疑難雜症') && b.textContent?.includes('A'));
+    expect(aBankBtn).toBeTruthy();
+    fireEvent.click(aBankBtn!);
+
+    expect(screen.getByRole('button', { name: '確認填入' })).not.toBeDisabled();
+  });
+
+  it('wrong answer shows hint and word stays in bank', () => {
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={() => {}}
+      />
+    );
+    // Select B (wrong for sentence 0 which expects A)
+    const bankBtns = screen.getAllByRole('button');
+    const bBankBtn = bankBtns.find((b) => b.textContent?.includes('龍爭虎鬥') && b.textContent?.includes('B'));
+    fireEvent.click(bBankBtn!);
+    fireEvent.click(screen.getByRole('button', { name: '確認填入' }));
+
+    // Wrong feedback shown
+    expect(screen.getByText(/不對喔/)).toBeTruthy();
+    // B is still in the bank (not removed) — may appear in bank + blank slot
+    expect(screen.getAllByText('龍爭虎鬥').length).toBeGreaterThanOrEqual(1);
+    // Still on question 1
+    expect(screen.getByText(/他解決了所有的/)).toBeTruthy();
+  });
+
+  it('correct answer advances to next question after delay', async () => {
+    vi.useFakeTimers();
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={() => {}}
+      />
+    );
+    // Select A (correct for sentence 0)
+    const bankBtns = screen.getAllByRole('button');
+    const aBankBtn = bankBtns.find((b) => b.textContent?.includes('疑難雜症') && b.textContent?.includes('A'));
+    fireEvent.click(aBankBtn!);
+    fireEvent.click(screen.getByRole('button', { name: '確認填入' }));
+
+    // Shows correct feedback
+    expect(screen.getByText(/答對了/)).toBeTruthy();
+
+    // After the 900ms timeout, advances to sentence 2
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText(/兩隊之間展開/)).toBeTruthy();
+    vi.useRealTimers();
+  });
+
+  it('used word disappears from bank after correct answer', async () => {
+    vi.useFakeTimers();
+    render(
+      <FillInBlankExercise
+        sentences={sentences}
+        vocabBank={vocabBank}
+        onComplete={() => {}}
+      />
+    );
+    // Answer sentence 0 correctly with A
+    const bankBtns = screen.getAllByRole('button');
+    const aBankBtn = bankBtns.find((b) => b.textContent?.includes('疑難雜症') && b.textContent?.includes('A'));
+    fireEvent.click(aBankBtn!);
+    fireEvent.click(screen.getByRole('button', { name: '確認填入' }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    // A/疑難雜症 should no longer be in the bank buttons
+    const updatedBtns = screen.getAllByRole('button');
+    const aStillInBank = updatedBtns.find(
+      (b) => b.textContent?.includes('A') && b.textContent?.includes('疑難雜症')
+    );
+    expect(aStillInBank).toBeUndefined();
+
+    vi.useRealTimers();
+  });
+
+  it('onComplete is called with correct score after all questions answered', async () => {
+    vi.useFakeTimers();
     const onComplete = vi.fn();
     render(
       <FillInBlankExercise
@@ -71,57 +169,24 @@ describe('FillInBlankExercise', () => {
       />
     );
 
-    // Select A (correct) for sentence 0, C (wrong) for sentence 1
-    const aButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
-    fireEvent.click(aButtons[0]);
-    const cButtons = screen.getAllByRole('button', { name: /^C 一鳴驚人$/ });
-    fireEvent.click(cButtons[1]);
+    // Answer sentence 0 correctly: A
+    const bankBtns0 = screen.getAllByRole('button');
+    const aBankBtn = bankBtns0.find((b) => b.textContent?.includes('疑難雜症'));
+    fireEvent.click(aBankBtn!);
+    fireEvent.click(screen.getByRole('button', { name: '確認填入' }));
+    await act(async () => { vi.advanceTimersByTime(1000); });
 
-    fireEvent.click(screen.getByRole('button', { name: '提交答案' }));
+    // Answer sentence 1 correctly: B
+    const bankBtns1 = screen.getAllByRole('button');
+    const bBankBtn = bankBtns1.find((b) => b.textContent?.includes('龍爭虎鬥'));
+    fireEvent.click(bBankBtn!);
+    fireEvent.click(screen.getByRole('button', { name: '確認填入' }));
+    await act(async () => { vi.advanceTimersByTime(1000); });
 
-    // Correct badge should show green styling (bg-green-100 class present in DOM)
-    // Wrong badge should show correction hint
-    expect(screen.getByText(/→ B 龍爭虎鬥/)).toBeTruthy();
-  });
-
-  it('retry button resets state', () => {
-    render(
-      <FillInBlankExercise
-        sentences={sentences}
-        vocabBank={vocabBank}
-        onComplete={() => {}}
-      />
-    );
-
-    const aButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
-    fireEvent.click(aButtons[0]);
-    const bButtons = screen.getAllByRole('button', { name: /^B 龍爭虎鬥$/ });
-    fireEvent.click(bButtons[1]);
-    fireEvent.click(screen.getByRole('button', { name: '提交答案' }));
-    fireEvent.click(screen.getByRole('button', { name: '再試一次' }));
-
-    // Submit button should be disabled again (blanks cleared)
-    expect(screen.getByRole('button', { name: '提交答案' })).toBeDisabled();
-  });
-
-  it('onComplete is called with correct score when continue button is clicked', () => {
-    const onComplete = vi.fn();
-    render(
-      <FillInBlankExercise
-        sentences={sentences}
-        vocabBank={vocabBank}
-        onComplete={onComplete}
-      />
-    );
-
-    // Answer both correctly (A and B)
-    const aButtons = screen.getAllByRole('button', { name: /^A 疑難雜症$/ });
-    fireEvent.click(aButtons[0]);
-    const bButtons = screen.getAllByRole('button', { name: /^B 龍爭虎鬥$/ });
-    fireEvent.click(bButtons[1]);
-    fireEvent.click(screen.getByRole('button', { name: '提交答案' }));
+    // Should now show final score screen with continue button
     fireEvent.click(screen.getByRole('button', { name: /繼續/ }));
-
     expect(onComplete).toHaveBeenCalledWith(2, 2);
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #698 — two UX problems in VocabApplication / FillInBlankExercise:

- **Problem 1**: All fill-in-the-blank sentences were shown at once (high cognitive load)
- **Problem 2**: Selected words did not disappear from the shared word bank, causing confusion across questions

## Changes

Only `FillInBlankExercise.tsx` and its test file are changed.

### New UX flow
- Top area: fixed "詞語題庫" showing only **remaining unused words**
- Below: **one sentence at a time** (no more all-at-once display)
- Student clicks a word from bank → it appears in the blank → clicks "確認填入"
- **Correct** → word disappears from bank, 900ms success flash, advance to next question
- **Wrong** → hint message + "重新選擇" button; word stays in bank
- No per-sentence option buttons (options only in top bank area)

### Implementation notes
- Replaced batch-submit model with per-question confirm flow
- `usedCodes: Set<string>` tracks correctly answered words and filters them out of the bank
- `currentIdx` tracks which question is active
- 900ms `setTimeout` on correct answer gives students visual feedback before advancing
- All 8 tests updated and passing

## Test plan
- [ ] Open VocabApplication step for a lesson with vocab data
- [ ] Confirm only one sentence is shown at a time
- [ ] Select a word from top bank → it appears in the blank
- [ ] Submit correct answer → word disappears from bank, advances to next question
- [ ] Submit wrong answer → hint shown, word stays in bank, can retry
- [ ] Complete all questions → score screen appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)