### PR TITLE
fix(vocab-match): no hints + summary page + redo options (#710)

### DIFF
--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -1,18 +1,18 @@
 /**
  * VocabDefinitionMatch — Step Component for 語詞定義配對
  *
- * 支援兩種互動模式:
- *   - 選擇題 (Multiple Choice) — DEFAULT
- *   - 拖拉配對 (Drag & Drop)
+ * Click-to-match interaction (tap definition, then tap word).
+ *
+ * Flow:
+ * 1. matching — one attempt per pair; wrong = recorded silently, no reveal
+ * 2. summary  — show score + per-question result; offer retry options
  *
  * Props: { story, onFinish, zhuyinActive? }
  */
 import React, {
   useCallback,
   useEffect,
-  useRef,
   useState,
-  useMemo,
 } from 'react';
 import { Story, VocabItem } from '../../types';
 
@@ -31,10 +31,22 @@ export interface VocabDefinitionMatchProps {
   zhuyinActive?: boolean;
 }
 
-type InteractionMode = 'multiple-choice' | 'drag-drop';
+type MatchPhase = 'matching' | 'summary';
+
+/**
+ * Records the answer for one definition item.
+ * answeredWordIdx === null  → not yet answered
+ * answeredWordIdx === defIndex → correct
+ * answeredWordIdx !== defIndex → wrong
+ */
+interface AnswerRecord {
+  defIndex: number;         // which vocab item this is (position in vocab[])
+  answeredWordIdx: number | null;
+  correct: boolean | null;
+}
 
 /* ------------------------------------------------------------------ */
-/*  Utility: shuffle                                                    */
+/*  Helpers                                                             */
 /* ------------------------------------------------------------------ */
 
 function shuffle<T>(arr: T[]): T[] {
@@ -84,409 +96,279 @@ function NoDataFallback({ onFinish }: { onFinish: () => void }) {
   );
 }
 
-function CompletionScreen({
-  matched,
-  total,
-  onFinish,
-}: {
-  matched: number;
-  total: number;
+/* ------------------------------------------------------------------ */
+/*  SummaryScreen                                                       */
+/* ------------------------------------------------------------------ */
+
+interface SummaryScreenProps {
+  vocab: VocabItem[];
+  answers: AnswerRecord[];
+  onRetryWrong: () => void;
+  onRetryAll: () => void;
   onFinish: () => void;
-}) {
-  return (
-    <div className="flex flex-col items-center gap-8 px-6 py-16 text-center max-w-lg mx-auto animate-fade-in">
-      <div className="text-7xl select-none animate-bounce-in">🎉</div>
-      <div className="bg-emerald-50 border border-emerald-200 rounded-2xl px-10 py-6 shadow-sm">
-        <h3 className="text-3xl font-black text-emerald-800 mb-2">配對完成！</h3>
-        <p className="text-emerald-700 text-lg">
-          成功配對
-          <span className="font-black text-2xl mx-2 text-emerald-600">{matched}</span>
-          / {total} 組語詞
-        </p>
-      </div>
-      <button
-        onClick={onFinish}
-        className="rounded-xl bg-emerald-500 px-12 py-4 text-white font-bold hover:bg-emerald-600 active:scale-95 transition-all text-xl shadow-lg"
-      >
-        繼續下一步 →
-      </button>
-    </div>
-  );
 }
 
-/* ------------------------------------------------------------------ */
-/*  Mode Switcher                                                       */
-/* ------------------------------------------------------------------ */
+function SummaryScreen({
+  vocab,
+  answers,
+  onRetryWrong,
+  onRetryAll,
+  onFinish,
+}: SummaryScreenProps) {
+  const correctCount = answers.filter((a) => a.correct).length;
+  const total = answers.length;
+  const allCorrect = correctCount === total;
+  const pct = total > 0 ? Math.round((correctCount / total) * 100) : 0;
 
-const MODE_LABELS: { id: InteractionMode; label: string; icon: string }[] = [
-  { id: 'multiple-choice', label: '選擇題', icon: '☑' },
-  { id: 'drag-drop', label: '拖拉配對', icon: '✥' },
-];
+  const wrongAnswers = answers.filter((a) => !a.correct);
 
-function ModeSwitcher({
-  current,
-  onChange,
-}: {
-  current: InteractionMode;
-  onChange: (m: InteractionMode) => void;
-}) {
   return (
-    <div className="flex gap-1 bg-gray-100 rounded-xl p-1 mb-6 max-w-sm mx-auto">
-      {MODE_LABELS.map(({ id, label, icon }) => (
-        <button
-          key={id}
-          onClick={() => onChange(id)}
-          className={`flex-1 flex items-center justify-center gap-1 py-2 px-2 rounded-lg text-sm font-semibold transition-all duration-200 ${
-            current === id
-              ? 'bg-white text-[#5B4FC4] shadow-sm'
-              : 'text-gray-500 hover:text-gray-700'
+    <div className="max-w-2xl mx-auto px-4 py-8 animate-fade-in">
+      {/* Score card */}
+      <div
+        className={`rounded-2xl border-2 px-8 py-6 mb-8 text-center shadow-sm ${
+          allCorrect
+            ? 'bg-emerald-50 border-emerald-300'
+            : 'bg-amber-50 border-amber-300'
+        }`}
+      >
+        <div className="text-5xl select-none mb-3">
+          {allCorrect ? '🎉' : pct >= 60 ? '👍' : '💪'}
+        </div>
+        <h3
+          className={`text-2xl font-black mb-1 ${
+            allCorrect ? 'text-emerald-800' : 'text-amber-800'
           }`}
         >
-          <span>{icon}</span>
-          <span>{label}</span>
-        </button>
-      ))}
-    </div>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-/*  Mode 1: Multiple Choice (選擇題) — DEFAULT                          */
-/* ------------------------------------------------------------------ */
-
-interface MultipleChoiceProps {
-  vocab: VocabItem[];
-  onAllDone: (matched: number) => void;
-}
-
-function MultipleChoiceMode({ vocab, onAllDone }: MultipleChoiceProps) {
-  const [currentIdx, setCurrentIdx] = useState(0);
-  const [matchedSoFar, setMatchedSoFar] = useState(0);
-  const [feedback, setFeedback] = useState<'correct' | 'wrong' | null>(null);
-  const [wrongChoice, setWrongChoice] = useState<number | null>(null);
-
-  // Shuffle options once per question — recompute when currentIdx changes
-  const options = useMemo(() => {
-    const others = vocab
-      .map((_, i) => i)
-      .filter((i) => i !== currentIdx);
-    const distractors = shuffle(others).slice(0, 3);
-    return shuffle([currentIdx, ...distractors]);
-  }, [currentIdx, vocab]);
-
-  const handleChoice = (vocabIdx: number) => {
-    if (feedback !== null) return;
-    if (vocabIdx === currentIdx) {
-      setFeedback('correct');
-      const newMatched = matchedSoFar + 1;
-      setMatchedSoFar(newMatched);
-      setTimeout(() => {
-        setFeedback(null);
-        setWrongChoice(null);
-        if (currentIdx + 1 >= vocab.length) {
-          onAllDone(newMatched);
-        } else {
-          setCurrentIdx((i) => i + 1);
-        }
-      }, 700);
-    } else {
-      setFeedback('wrong');
-      setWrongChoice(vocabIdx);
-      setTimeout(() => {
-        setFeedback(null);
-        setWrongChoice(null);
-      }, 700);
-    }
-  };
-
-  const item = vocab[currentIdx];
-
-  return (
-    <div className="max-w-xl mx-auto px-4">
-      {/* Progress */}
-      <div className="mb-5 bg-white rounded-2xl shadow-sm border border-amber-100 px-5 py-3 flex items-center justify-between">
-        <span className="text-sm font-semibold text-gray-500">題目進度</span>
-        <span className="text-base font-black text-amber-700">
-          {currentIdx + 1}{' '}
-          <span className="text-gray-400 font-normal text-sm">/ {vocab.length}</span>
-        </span>
-      </div>
-
-      {/* Definition card */}
-      <div className="bg-white border-2 border-[#5B4FC4] rounded-2xl p-6 mb-6 shadow-sm">
-        <p className="text-xs font-semibold text-[#5B4FC4] uppercase tracking-wider mb-2">
-          定義
+          {allCorrect ? '全部答對！' : `答對 ${correctCount} / ${total} 題`}
+        </h3>
+        <p
+          className={`text-lg font-semibold ${
+            allCorrect ? 'text-emerald-600' : 'text-amber-600'
+          }`}
+        >
+          正確率 {pct}%
         </p>
-        <p className="text-lg text-gray-800 leading-relaxed">{item.definition}</p>
       </div>
 
-      {/* Options */}
-      <p className="text-center text-sm text-gray-500 mb-3 select-none">
-        請選出對應的語詞
-      </p>
-      <div className="grid grid-cols-2 gap-3">
-        {options.map((vocabIdx) => {
-          const isCorrect = feedback === 'correct' && vocabIdx === currentIdx;
-          const isWrong = feedback === 'wrong' && vocabIdx === wrongChoice;
-          const isRevealCorrect = feedback === 'wrong' && vocabIdx === currentIdx;
-
-          let cls =
-            'rounded-xl border-2 px-4 py-4 text-center font-bold text-xl transition-all duration-200 select-none ';
-          if (isCorrect || isRevealCorrect) {
-            cls +=
-              'bg-emerald-100 border-emerald-500 text-emerald-800 scale-105 shadow-md cursor-default';
-          } else if (isWrong) {
-            cls += 'bg-red-50 border-red-400 text-red-700 animate-shake cursor-pointer';
-          } else {
-            cls +=
-              'bg-white border-gray-200 text-gray-800 hover:border-[#5B4FC4] hover:bg-purple-50 hover:shadow-sm active:scale-95 cursor-pointer';
-          }
-
-          return (
-            <button
-              key={vocabIdx}
-              className={cls}
-              onClick={() => handleChoice(vocabIdx)}
-              disabled={feedback !== null}
-            >
-              {vocab[vocabIdx].word}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-/*  Mode 2: Drag & Drop (拖拉配對)                                      */
-/* ------------------------------------------------------------------ */
-
-interface DragDropProps {
-  vocab: VocabItem[];
-  shuffledWords: number[];
-  onAllDone: (matched: number) => void;
-}
-
-function DragDropMode({ vocab, shuffledWords, onAllDone }: DragDropProps) {
-  // dragging: which vocabIdx is being dragged
-  const [draggingVocabIdx, setDraggingVocabIdx] = useState<number | null>(null);
-  // placements: defIdx -> vocabIdx (tentative, may be wrong or correct)
-  const [placements, setPlacements] = useState<Map<number, number>>(new Map());
-  // confirmed: set of defIdx that are correctly placed
-  const [confirmed, setConfirmed] = useState<Set<number>>(new Set());
-  // wrongFlash: set of defIdx currently flashing red
-  const [wrongFlash, setWrongFlash] = useState<Set<number>>(new Set());
-  // hoverTarget: defIdx being dragged over
-  const [hoverTarget, setHoverTarget] = useState<number | null>(null);
-  // touchSelected: vocabIdx selected via tap (for mobile)
-  const [touchSelected, setTouchSelected] = useState<number | null>(null);
-
-  const attemptPlace = useCallback(
-    (defIdx: number, vocabIdx: number) => {
-      if (confirmed.has(defIdx)) return;
-
-      setPlacements((prev) => {
-        const next = new Map(prev);
-        // Remove this vocabIdx from any previous slot
-        for (const [k, v] of next.entries()) {
-          if (v === vocabIdx) next.delete(k);
-        }
-        next.set(defIdx, vocabIdx);
-        return next;
-      });
-
-      if (vocabIdx === defIdx) {
-        // Correct
-        setConfirmed((prev) => {
-          const next = new Set(prev);
-          next.add(defIdx);
-          if (next.size === vocab.length) {
-            setTimeout(() => onAllDone(next.size), 600);
-          }
-          return next;
-        });
-      } else {
-        // Wrong — flash then bounce back
-        setWrongFlash((prev) => new Set([...prev, defIdx]));
-        setTimeout(() => {
-          setPlacements((prev) => {
-            const next = new Map(prev);
-            next.delete(defIdx);
-            return next;
-          });
-          setWrongFlash((prev) => {
-            const next = new Set(prev);
-            next.delete(defIdx);
-            return next;
-          });
-        }, 650);
-      }
-    },
-    [confirmed, vocab.length, onAllDone],
-  );
-
-  const handleDragStart = (vocabIdx: number) => {
-    setDraggingVocabIdx(vocabIdx);
-    setTouchSelected(null);
-  };
-  const handleDragEnd = () => {
-    setDraggingVocabIdx(null);
-    setHoverTarget(null);
-  };
-  const handleDrop = (defIdx: number) => {
-    if (draggingVocabIdx === null) return;
-    setHoverTarget(null);
-    attemptPlace(defIdx, draggingVocabIdx);
-    setDraggingVocabIdx(null);
-  };
-
-  // Touch / tap flow: tap word → select; tap slot → place
-  const handleTouchStart = (vocabIdx: number) => {
-    if (confirmed.has(vocabIdx)) return;
-    setTouchSelected((prev) => (prev === vocabIdx ? null : vocabIdx));
-  };
-  const handleSlotTap = (defIdx: number) => {
-    if (touchSelected !== null) {
-      attemptPlace(defIdx, touchSelected);
-      setTouchSelected(null);
-    }
-  };
-
-  // Which vocabIdx are in confirmed/pending placements (not bouncing back)
-  const placedVocabIdxSet = useMemo(() => {
-    const s = new Set<number>();
-    placements.forEach((vocabIdx, defIdx) => {
-      if (!wrongFlash.has(defIdx)) s.add(vocabIdx);
-    });
-    return s;
-  }, [placements, wrongFlash]);
-
-  return (
-    <div className="max-w-xl mx-auto px-4">
-      {/* Progress */}
-      <div className="mb-5 bg-white rounded-2xl shadow-sm border border-amber-100 px-5 py-3 flex items-center justify-between">
-        <span className="text-sm font-semibold text-gray-500">配對進度</span>
-        <span className="text-base font-black text-amber-700">
-          {confirmed.size}{' '}
-          <span className="text-gray-400 font-normal text-sm">/ {vocab.length}</span>
-        </span>
-      </div>
-
-      <p className="text-center text-sm text-amber-800 bg-amber-100 rounded-xl py-2 px-4 mb-4 select-none font-medium">
-        拖拉語詞卡片到對應的定義欄位，手機可先點選語詞再點選欄位
-      </p>
-
-      {/* Word bank */}
-      <div className="mb-5">
-        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2 text-center">
-          語詞庫
-        </p>
-        <div className="flex flex-wrap gap-2 justify-center min-h-[56px] bg-gray-50 rounded-xl p-3 border border-gray-200">
-          {shuffledWords.map((vocabIdx) => {
-            const isPlaced = placedVocabIdxSet.has(vocabIdx);
-            if (isPlaced) return null;
-
-            const isDragging = draggingVocabIdx === vocabIdx;
-            const isTouchSelected = touchSelected === vocabIdx;
-
-            let cls =
-              'rounded-xl border-2 px-5 py-3 text-center font-bold text-xl select-none transition-all duration-200 ';
-            if (isDragging) {
-              cls +=
-                'border-[#5B4FC4] bg-purple-100 text-purple-900 shadow-xl scale-105 opacity-80 cursor-grabbing';
-            } else if (isTouchSelected) {
-              cls +=
-                'border-[#5B4FC4] bg-purple-100 text-purple-900 shadow-md scale-105 cursor-pointer';
-            } else {
-              cls +=
-                'border-gray-200 bg-white text-gray-800 hover:border-[#5B4FC4] hover:bg-purple-50 hover:shadow-sm active:scale-95 cursor-grab';
-            }
-
-            return (
-              <div
-                key={vocabIdx}
-                draggable
-                onDragStart={() => handleDragStart(vocabIdx)}
-                onDragEnd={handleDragEnd}
-                onTouchStart={() => handleTouchStart(vocabIdx)}
-                onClick={() => handleTouchStart(vocabIdx)}
-                className={cls}
-              >
-                {vocab[vocabIdx].word}
-              </div>
-            );
-          })}
-        </div>
-        {touchSelected !== null && (
-          <p className="text-center text-xs text-[#5B4FC4] mt-2 font-medium">
-            已選「{vocab[touchSelected].word}」— 點選下方欄位放入
-          </p>
-        )}
-      </div>
-
-      {/* Definition slots */}
-      <div className="flex flex-col gap-3">
-        <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1 text-center">
-          定義欄位
-        </p>
-        {vocab.map((item, defIdx) => {
-          const placedVocabIdx = placements.get(defIdx) ?? null;
-          const isCorrect = confirmed.has(defIdx);
-          const isWrong = wrongFlash.has(defIdx);
-          const isOver = hoverTarget === defIdx && !isCorrect;
-
-          let cls =
-            'rounded-2xl border-2 px-4 py-4 min-h-[80px] flex flex-col gap-2 transition-all duration-200 cursor-pointer ';
-          if (isCorrect) {
-            cls += 'bg-emerald-50 border-emerald-400 cursor-default';
-          } else if (isWrong) {
-            cls += 'bg-red-50 border-red-400 animate-shake';
-          } else if (isOver) {
-            cls += 'bg-purple-50 border-[#5B4FC4] scale-[1.01] shadow-md';
-          } else if (placedVocabIdx !== null) {
-            cls += 'bg-amber-50 border-amber-400';
-          } else {
-            cls += 'bg-white border-dashed border-gray-300 hover:border-[#5B4FC4]';
-          }
+      {/* Per-question results */}
+      <div className="flex flex-col gap-3 mb-8">
+        <h4 className="text-sm font-bold text-gray-500 uppercase tracking-wider mb-1">
+          每題結果
+        </h4>
+        {answers.map((ans, idx) => {
+          const item = vocab[ans.defIndex];
+          const isCorrect = ans.correct;
+          const studentWord =
+            ans.answeredWordIdx !== null ? vocab[ans.answeredWordIdx]?.word : '—';
 
           return (
             <div
-              key={defIdx}
-              className={cls}
-              onDragOver={(e) => {
-                e.preventDefault();
-                if (!isCorrect) setHoverTarget(defIdx);
-              }}
-              onDragLeave={() => setHoverTarget(null)}
-              onDrop={(e) => {
-                e.preventDefault();
-                handleDrop(defIdx);
-              }}
-              onClick={() => handleSlotTap(defIdx)}
+              key={idx}
+              className={`rounded-xl border-2 px-4 py-3 flex items-start gap-3 ${
+                isCorrect
+                  ? 'bg-emerald-50 border-emerald-200'
+                  : 'bg-red-50 border-red-200'
+              }`}
             >
-              <p className="text-sm text-gray-700 leading-relaxed">{item.definition}</p>
-              <div className="flex items-center justify-center h-8">
-                {isCorrect ? (
-                  <span className="font-bold text-base text-emerald-700 flex items-center gap-1">
-                    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-emerald-500 text-white text-xs font-bold">
-                      ✓
-                    </span>
-                    {placedVocabIdx !== null ? vocab[placedVocabIdx].word : ''}
-                  </span>
-                ) : placedVocabIdx !== null ? (
-                  <span className="font-bold text-base text-amber-800">
-                    {vocab[placedVocabIdx].word}
-                  </span>
-                ) : (
-                  <span className="text-xs text-gray-400 select-none">
-                    拖拉語詞到這裡
-                  </span>
-                )}
+              {/* Status icon */}
+              <span
+                className={`mt-0.5 flex-shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold text-white ${
+                  isCorrect ? 'bg-emerald-500' : 'bg-red-500'
+                }`}
+              >
+                {isCorrect ? '✓' : '✗'}
+              </span>
+
+              {/* Content */}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-gray-500 leading-snug mb-1">
+                  {item?.definition}
+                </p>
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+                  <span className="text-gray-500">正確答案：</span>
+                  <span className="font-bold text-gray-800">{item?.word}</span>
+                  {!isCorrect && (
+                    <>
+                      <span className="text-gray-400">|</span>
+                      <span className="text-gray-500">你的答案：</span>
+                      <span className="font-bold text-red-600">{studentWord}</span>
+                    </>
+                  )}
+                </div>
               </div>
             </div>
           );
         })}
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex flex-col sm:flex-row gap-3 justify-center">
+        {!allCorrect && (
+          <button
+            onClick={onRetryWrong}
+            className="rounded-xl border-2 border-[#5B4FC4] text-[#5B4FC4] px-6 py-3 font-bold hover:bg-[#5B4FC4] hover:text-white transition-all active:scale-95"
+          >
+            只重做錯題（{wrongAnswers.length} 題）
+          </button>
+        )}
+        <button
+          onClick={onRetryAll}
+          className="rounded-xl border-2 border-gray-300 text-gray-700 px-6 py-3 font-bold hover:bg-gray-100 transition-all active:scale-95"
+        >
+          全部重做
+        </button>
+        <button
+          onClick={onFinish}
+          className="rounded-xl bg-[#5B4FC4] px-8 py-3 text-white font-bold hover:bg-[#4a3fb0] transition-all active:scale-95 shadow-md"
+        >
+          繼續下一步 →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  MatchingExercise — the interactive matching UI                     */
+/* ------------------------------------------------------------------ */
+
+interface MatchingExerciseProps {
+  vocab: VocabItem[];
+  /** Subset of defIndices to practice (all or wrong-only) */
+  activeDefIndices: number[];
+  shuffledWords: number[];
+  answers: AnswerRecord[];
+  selectedDef: number | null;
+  selectedWord: number | null;
+  onDefClick: (defIdx: number) => void;
+  onWordClick: (wordIdx: number) => void;
+  answeredCount: number;
+}
+
+function MatchingExercise({
+  vocab,
+  activeDefIndices,
+  shuffledWords,
+  answers,
+  selectedDef,
+  selectedWord,
+  onDefClick,
+  onWordClick,
+  answeredCount,
+}: MatchingExerciseProps) {
+  const total = activeDefIndices.length;
+  const pct = total > 0 ? (answeredCount / total) * 100 : 0;
+
+  return (
+    <div className="max-w-3xl mx-auto px-4">
+      {/* Progress bar */}
+      <div className="mb-6 bg-white rounded-2xl shadow-sm border border-amber-100 px-5 py-4">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-base font-semibold text-gray-600">作答進度</span>
+          <span className="text-lg font-black text-amber-700">
+            {answeredCount} <span className="text-gray-400 font-normal text-sm">/ {total}</span>
+          </span>
+        </div>
+        <div className="h-4 bg-amber-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-gradient-to-r from-amber-400 to-amber-500 rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${pct}%` }}
+            role="progressbar"
+            aria-valuenow={answeredCount}
+            aria-valuemin={0}
+            aria-valuemax={total}
+          />
+        </div>
+      </div>
+
+      {/* Instruction */}
+      <p className="text-center text-base text-amber-800 bg-amber-100 rounded-xl py-2.5 px-4 mb-6 select-none font-medium">
+        先點選左邊的「定義」，再點選右邊對應的「語詞」
+      </p>
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-2 gap-4">
+        {/* Left: definitions */}
+        <div className="flex flex-col gap-3">
+          <h3 className="text-center text-sm font-bold text-gray-500 uppercase tracking-wider mb-1">
+            定義
+          </h3>
+          {activeDefIndices.map((defIdx) => {
+            const item = vocab[defIdx];
+            const ans = answers.find((a) => a.defIndex === defIdx);
+            const isAnswered = ans?.answeredWordIdx !== null && ans?.answeredWordIdx !== undefined;
+            const isSelected = selectedDef === defIdx;
+
+            let cardClass =
+              'rounded-2xl border-2 px-4 py-4 text-left cursor-pointer transition-all duration-200 text-base leading-relaxed min-h-[88px] select-none ';
+
+            if (isAnswered) {
+              cardClass += 'bg-gray-50 border-gray-200 text-gray-400 cursor-default';
+            } else if (isSelected) {
+              cardClass += 'bg-amber-100 border-amber-500 text-amber-900 shadow-md scale-[1.02]';
+            } else {
+              cardClass += 'bg-white border-gray-200 text-gray-700 hover:border-amber-300 hover:bg-amber-50 hover:shadow-sm';
+            }
+
+            return (
+              <button
+                key={defIdx}
+                className={cardClass}
+                onClick={() => !isAnswered && onDefClick(defIdx)}
+                disabled={isAnswered}
+                aria-pressed={isSelected}
+                aria-label={`定義 ${defIdx + 1}: ${item?.definition}`}
+              >
+                {isAnswered && (
+                  <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gray-400 text-white text-xs font-bold mr-2 flex-shrink-0">✓</span>
+                )}
+                {item?.definition}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Right: shuffled vocabulary words — only show words for active defs */}
+        <div className="flex flex-col gap-3">
+          <h3 className="text-center text-sm font-bold text-gray-500 uppercase tracking-wider mb-1">
+            語詞
+          </h3>
+          {shuffledWords
+            .filter((wi) => activeDefIndices.includes(wi))
+            .map((vocabIdx) => {
+              const ans = answers.find((a) => a.defIndex === vocabIdx);
+              const isAnswered = ans?.answeredWordIdx !== null && ans?.answeredWordIdx !== undefined;
+              const isSelected = selectedWord === vocabIdx;
+
+              let cardClass =
+                'rounded-2xl border-2 px-4 py-4 text-center cursor-pointer transition-all duration-200 font-bold text-xl min-h-[88px] flex items-center justify-center select-none gap-2 ';
+
+              if (isAnswered) {
+                cardClass += 'bg-gray-50 border-gray-200 text-gray-400 cursor-default';
+              } else if (isSelected) {
+                cardClass += 'bg-amber-100 border-amber-500 text-amber-900 shadow-md scale-[1.02]';
+              } else {
+                cardClass += 'bg-white border-gray-200 text-gray-800 hover:border-amber-300 hover:bg-amber-50 hover:shadow-sm';
+              }
+
+              return (
+                <button
+                  key={vocabIdx}
+                  className={cardClass}
+                  onClick={() => !isAnswered && onWordClick(vocabIdx)}
+                  disabled={isAnswered}
+                  aria-pressed={isSelected}
+                  aria-label={`語詞：${vocab[vocabIdx]?.word}`}
+                >
+                  {isAnswered && (
+                    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-gray-400 text-white text-xs font-bold flex-shrink-0">✓</span>
+                  )}
+                  {vocab[vocabIdx]?.word}
+                </button>
+              );
+            })}
+        </div>
       </div>
     </div>
   );
@@ -500,91 +382,167 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
   story,
   onFinish,
 }) => {
-  const storageModeKey = `vocabDef_mode_${story.id}`;
   const vocab: VocabItem[] = story.vocabulary ?? [];
   const hasData = vocab.length > 0;
 
-  const [mode, setMode] = useState<InteractionMode>(() => {
-    try {
-      const saved = localStorage.getItem(storageModeKey) as InteractionMode | null;
-      if (
-        saved &&
-        ['multiple-choice', 'drag-drop'].includes(saved)
-      ) {
-        return saved;
+  // Which defIndices are active in the current round
+  const [activeDefIndices, setActiveDefIndices] = useState<number[]>(() =>
+    vocab.map((_, i) => i),
+  );
+
+  // Shuffled word order (re-generated on retry-all)
+  const [shuffledWords, setShuffledWords] = useState<number[]>(() =>
+    shuffle(vocab.map((_, i) => i)),
+  );
+
+  const [phase, setPhase] = useState<MatchPhase>('matching');
+
+  // Per-question answer records for the current round
+  const [answers, setAnswers] = useState<AnswerRecord[]>(() =>
+    vocab.map((_, i) => ({ defIndex: i, answeredWordIdx: null, correct: null })),
+  );
+
+  // Selected items
+  const [selectedDef, setSelectedDef] = useState<number | null>(null);
+  const [selectedWord, setSelectedWord] = useState<number | null>(null);
+
+  const answeredCount = answers.filter(
+    (a) => activeDefIndices.includes(a.defIndex) && a.answeredWordIdx !== null,
+  ).length;
+
+  // Auto-advance to summary when all active defs answered
+  useEffect(() => {
+    if (!hasData) return;
+    if (phase === 'matching' && activeDefIndices.length > 0 && answeredCount === activeDefIndices.length) {
+      setTimeout(() => setPhase('summary'), 400);
+    }
+  }, [answeredCount, activeDefIndices.length, phase, hasData]);
+
+  // Record an answer: one shot — no retries, no reveals
+  const tryMatch = useCallback(
+    (defIdx: number, wordIdx: number) => {
+      const isCorrect = defIdx === wordIdx;
+      setAnswers((prev) =>
+        prev.map((a) =>
+          a.defIndex === defIdx
+            ? { ...a, answeredWordIdx: wordIdx, correct: isCorrect }
+            : a,
+        ),
+      );
+      setSelectedDef(null);
+      setSelectedWord(null);
+    },
+    [],
+  );
+
+  const handleDefClick = useCallback(
+    (defIdx: number) => {
+      const ans = answers.find((a) => a.defIndex === defIdx);
+      if (ans?.answeredWordIdx !== null && ans?.answeredWordIdx !== undefined) return;
+
+      if (selectedWord !== null) {
+        tryMatch(defIdx, selectedWord);
+      } else if (selectedDef === defIdx) {
+        setSelectedDef(null);
+      } else {
+        setSelectedDef(defIdx);
       }
-    } catch {}
-    return 'multiple-choice';
-  });
+    },
+    [answers, selectedWord, selectedDef, tryMatch],
+  );
 
-  const [isDone, setIsDone] = useState(false);
-  const [matchedCount, setMatchedCount] = useState(0);
-  // Increment to force-remount the active mode on mode change
-  const [modeKey, setModeKey] = useState(0);
+  const handleWordClick = useCallback(
+    (wordIdx: number) => {
+      // Word is "answered" when its corresponding defIndex answer is filled
+      const ans = answers.find((a) => a.defIndex === wordIdx);
+      if (ans?.answeredWordIdx !== null && ans?.answeredWordIdx !== undefined) return;
 
-  // Stable shuffled word order for drag-drop
-  const shuffledWords = useRef<number[]>(shuffle(vocab.map((_, i) => i)));
+      if (selectedDef !== null) {
+        tryMatch(selectedDef, wordIdx);
+      } else if (selectedWord === wordIdx) {
+        setSelectedWord(null);
+      } else {
+        setSelectedWord(wordIdx);
+      }
+    },
+    [answers, selectedDef, selectedWord, tryMatch],
+  );
 
-  const handleModeChange = (m: InteractionMode) => {
-    setMode(m);
-    setIsDone(false);
-    setMatchedCount(0);
-    setModeKey((k) => k + 1);
-    try {
-      localStorage.setItem(storageModeKey, m);
-    } catch {}
-  };
+  const handleRetryWrong = useCallback(() => {
+    const wrongIndices = answers
+      .filter((a) => activeDefIndices.includes(a.defIndex) && !a.correct)
+      .map((a) => a.defIndex);
 
-  const handleAllDone = useCallback((matched: number) => {
-    setMatchedCount(matched);
-    setIsDone(true);
-  }, []);
+    // Reset only the wrong answers
+    setAnswers((prev) =>
+      prev.map((a) =>
+        wrongIndices.includes(a.defIndex)
+          ? { ...a, answeredWordIdx: null, correct: null }
+          : a,
+      ),
+    );
+    setActiveDefIndices(wrongIndices);
+    // Reshuffle only wrong words
+    setShuffledWords(shuffle(wrongIndices));
+    setSelectedDef(null);
+    setSelectedWord(null);
+    setPhase('matching');
+  }, [answers, activeDefIndices]);
+
+  const handleRetryAll = useCallback(() => {
+    const allIndices = vocab.map((_, i) => i);
+    setAnswers(vocab.map((_, i) => ({ defIndex: i, answeredWordIdx: null, correct: null })));
+    setActiveDefIndices(allIndices);
+    setShuffledWords(shuffle(allIndices));
+    setSelectedDef(null);
+    setSelectedWord(null);
+    setPhase('matching');
+  }, [vocab]);
 
   const handleFinish = useCallback(() => {
-    try {
-      localStorage.removeItem(storageModeKey);
-    } catch {}
-    onFinish({ matchedCount, totalCount: vocab.length });
-  }, [onFinish, matchedCount, vocab.length, storageModeKey]);
+    const correctCount = answers.filter(
+      (a) => activeDefIndices.includes(a.defIndex) && a.correct,
+    ).length;
+    onFinish({ matchedCount: correctCount, totalCount: vocab.length });
+  }, [onFinish, answers, activeDefIndices, vocab.length]);
 
-  const modeSubtitles: Record<InteractionMode, string> = {
-    'multiple-choice': '看定義，選出對應的語詞',
-    'drag-drop': '拖拉語詞卡片到對應的定義欄位',
-  };
+  // Build the summary answers only for the current active round
+  const summaryAnswers = answers.filter((a) => activeDefIndices.includes(a.defIndex));
 
   return (
     <div className="flex flex-col min-h-full bg-amber-50">
-      <StepHeader title="語詞定義配對" subtitle={modeSubtitles[mode]} />
+      <StepHeader
+        title="語詞定義配對"
+        subtitle={
+          phase === 'matching'
+            ? '點選左邊的定義，再點選右邊對應的語詞，完成配對'
+            : '作答結果'
+        }
+      />
 
       <div className="flex-1 overflow-auto py-6">
         {!hasData ? (
           <NoDataFallback onFinish={handleFinish} />
-        ) : isDone ? (
-          <CompletionScreen
-            matched={matchedCount}
-            total={vocab.length}
+        ) : phase === 'summary' ? (
+          <SummaryScreen
+            vocab={vocab}
+            answers={summaryAnswers}
+            onRetryWrong={handleRetryWrong}
+            onRetryAll={handleRetryAll}
             onFinish={handleFinish}
           />
         ) : (
-          <>
-            <ModeSwitcher current={mode} onChange={handleModeChange} />
-
-            {mode === 'multiple-choice' && (
-              <MultipleChoiceMode
-                key={`mc-${modeKey}`}
-                vocab={vocab}
-                onAllDone={handleAllDone}
-              />
-            )}
-            {mode === 'drag-drop' && (
-              <DragDropMode
-                key={`dd-${modeKey}`}
-                vocab={vocab}
-                shuffledWords={shuffledWords.current}
-                onAllDone={handleAllDone}
-              />
-            )}
-          </>
+          <MatchingExercise
+            vocab={vocab}
+            activeDefIndices={activeDefIndices}
+            shuffledWords={shuffledWords}
+            answers={answers}
+            selectedDef={selectedDef}
+            selectedWord={selectedWord}
+            onDefClick={handleDefClick}
+            onWordClick={handleWordClick}
+            answeredCount={answeredCount}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Fixes #710 — 語詞定義配對 作答不給提示 + 最後總結算 + 錯題重做

- **No hints during answering**: wrong answer is silently recorded and the pair is immediately marked "answered" (gray). No shake animation, no correct-answer reveal.
- **Summary page after all questions**: shows score %, correct rate, and per-question breakdown — student's answer vs correct answer, wrong items highlighted red.
- **Two redo buttons**:
  - 「只重做錯題」— resets only wrong pairs, reshuffles their word bank
  - 「全部重做」— resets all pairs and reshuffles everything
- Applies to the click-to-match mode (the single interaction mode in this component).
- Accent color `#5B4FC4` used for primary CTA and retry-wrong button border.
- Removed localStorage progress persistence (incompatible with one-shot answer model).

## Test plan

- [ ] Open 語詞定義配對 step for any lesson that has vocabulary
- [ ] Click a definition, then click a wrong word → pair turns gray immediately, no hint shown
- [ ] Click a definition, then click the correct word → pair turns gray (answered)
- [ ] After all pairs answered → summary screen appears automatically
- [ ] Summary shows correct count / total + per-question breakdown
- [ ] Wrong answers shown in red with student's chosen word
- [ ] "只重做錯題" button only shows if there are wrong answers; clicking it resets those pairs only
- [ ] "全部重做" resets all pairs with reshuffled word order
- [ ] "繼續下一步" calls onFinish and advances the stepper

🤖 Generated with [Claude Code](https://claude.com/claude-code)