### PR TITLE
fix(vocab-practice): add 造句練習 tab + remove footer redundant buttons (#715)

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -441,6 +441,18 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
               筆順練習
               {strokeDone && <span className="w-2 h-2 bg-emerald-500 rounded-full" />}
             </button>
+            <button
+              onClick={() => setPhase('sentence')}
+              className={[
+                'flex-1 flex items-center justify-center gap-2 py-2 rounded-lg text-sm font-semibold transition-all',
+                'text-gray-500 hover:text-gray-700',
+              ].join(' ')}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-3 3v-3z" />
+              </svg>
+              造句練習
+            </button>
             {/* 發音練習 and 注音遊戲 tabs hidden per product decision 2026-03-27 */}
             {/* 語詞應用 tab removed — now a separate step (#668 VocabApplication) */}
           </div>
@@ -654,32 +666,16 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
       </div>
 
       {/* Bottom actions */}
-      <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
+      <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-end">
         <button
-          onClick={onBack}
-          className="px-4 py-3 rounded-xl text-base text-gray-500 hover:text-gray-800 transition-colors"
+          onClick={() => handleFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
+          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
         >
-          回到朗讀
+          {practicedChars.size > 0 || pronouncedChars.size > 0 ? '完成，查看報告' : '跳過，查看報告'}
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
         </button>
-        <div className="flex items-center gap-3">
-          {practicedChars.size > 0 && !allDone && (
-            <button
-              onClick={() => setPhase('sentence')}
-              className="px-5 py-3 rounded-xl font-bold text-base border border-accent text-accent hover:bg-accent/10 transition-all active:scale-95"
-            >
-              造句練習
-            </button>
-          )}
-          <button
-            onClick={() => handleFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
-            className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2"
-          >
-            {practicedChars.size > 0 || pronouncedChars.size > 0 ? '完成，查看報告' : '跳過，查看報告'}
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </button>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Add a **造句練習** tab in the mode toggle bar so students can freely switch between stroke practice and sentence practice
- Remove **回到朗讀** button from footer (not the right place for back-navigation in a mid-flow step)
- Remove **造句練習** button from footer (now accessible via the tab — no duplication)
- Footer now shows only the single 完成/跳過查看報告 CTA

Closes #715

## Changes

`frontend/src/components/reading-steps/VocabPractice.tsx`
- Mode toggle bar: added 造句練習 button (with chat-bubble icon, calls `setPhase('sentence')` on click)
- Footer: removed `回到朗讀` button and conditional `造句練習` button; simplified to single right-aligned CTA

## Test plan

- [ ] Open 生字練習 step — verify two tabs are visible: 筆順練習 and 造句練習
- [ ] Click 造句練習 tab — verify navigates into sentence practice view
- [ ] Click back in sentence practice — verify returns to character grid
- [ ] Verify footer shows only 完成，查看報告 / 跳過，查看報告 (no 回到朗讀, no 造句練習 button)
- [ ] Build passes: `cd frontend && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)