### PR TITLE
fix(vocab): #726 — 造句 tab active state + 筆順 tab deactivate in sentence phase

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -426,10 +426,10 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           {/* Mode toggle tabs */}
           <div className="flex bg-gray-100 rounded-xl p-1 gap-1">
             <button
-              onClick={() => setActiveTab('stroke')}
+              onClick={() => { setActiveTab('stroke'); if (phase === 'sentence') setPhase('grid'); }}
               className={[
                 'flex-1 flex items-center justify-center gap-2 py-2 rounded-lg text-sm font-semibold transition-all',
-                activeTab === 'stroke'
+                activeTab === 'stroke' && phase !== 'sentence'
                   ? 'bg-white text-gray-900 shadow-sm'
                   : 'text-gray-500 hover:text-gray-700',
               ].join(' ')}
@@ -444,7 +444,9 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
               onClick={() => setPhase('sentence')}
               className={[
                 'flex-1 flex items-center justify-center gap-2 py-2 rounded-lg text-sm font-semibold transition-all',
-                'text-gray-500 hover:text-gray-700',
+                phase === 'sentence'
+                  ? 'bg-white text-gray-900 shadow-sm'
+                  : 'text-gray-500 hover:text-gray-700',
               ].join(' ')}
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary

- 造句練習 tab: hardcoded inactive styling replaced with `phase === 'sentence'` conditional — shows `bg-white text-gray-900 shadow-sm` when active
- 筆順練習 tab: active condition changed from `activeTab === 'stroke'` to `activeTab === 'stroke' && phase !== 'sentence'` — deactivates when in sentence phase
- 筆順練習 tab onClick: added `if (phase === 'sentence') setPhase('grid')` to reset phase when switching back from sentence view

Closes #726

## Test plan

- [ ] Navigate to 生字練習 (VocabPractice) step
- [ ] Click 造句練習 tab — verify it shows white/active style
- [ ] Verify 筆順練習 tab shows inactive (gray) when in sentence phase
- [ ] Click 筆順練習 tab while in sentence phase — verify it returns to grid view with 筆順 tab active

🤖 Generated with [Claude Code](https://claude.com/claude-code)