### PR TITLE
fix(steps): #729 — move 語詞複習 before 課文理解 to keep vocab steps consecutive

### DIFF
--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -97,6 +97,14 @@ export const STEP_CONFIG: StepConfig[] = [
     enabled: true,
   },
   {
+    id: 'vocab-word-search',
+    label: '語詞複習',
+    view: AppView.VOCAB_WORD_SEARCH,
+    dbStepNumber: 10,
+    needsStory: true,
+    enabled: true,
+  },
+  {
     id: 'comprehension',
     label: '課文理解',
     view: AppView.COMPREHENSION,
@@ -111,14 +119,6 @@ export const STEP_CONFIG: StepConfig[] = [
     dbStepNumber: 5,
     needsStory: true,
     enabled: false, // hidden per product decision 2026-03-27
-  },
-  {
-    id: 'vocab-word-search',
-    label: '語詞複習',
-    view: AppView.VOCAB_WORD_SEARCH,
-    dbStepNumber: 10,
-    needsStory: true,
-    enabled: true,
   },
   {
     id: 'knowledge-station',


### PR DESCRIPTION
## Summary

- Reorders `STEP_CONFIG` array in `stepConfig.ts` so vocab-related steps are consecutive: 語詞定義 → 語詞應用 → **語詞複習** → 課文理解
- Previously 課文理解 was inserted between 語詞應用 and 語詞複習, breaking the 三民學習單 flow
- All `dbStepNumber` values are unchanged — no DB migration needed
- 聽寫練習 remains `enabled: false` (product decision 2026-03-27)

**New enabled step order:**
1. 閱讀標記
2. 逐段朗讀
3. 全文朗讀
4. 生字練習
5. 語詞定義
6. 語詞應用
7. 語詞複習
8. 課文理解
9. 知識補給站
10. 報告

## Test plan
- [ ] Open any lesson and verify StepperNav shows vocab steps (語詞定義, 語詞應用, 語詞複習) grouped together before 課文理解
- [ ] Verify 報告 is still last
- [ ] Verify 聽寫練習 is not visible in StepperNav
- [ ] Verify navigation between steps works (Next/Previous buttons)

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)