### PR TITLE
fix(vocab): remove 讀得很棒 praise text from VocabPractice

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -416,11 +416,9 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
             <h2 className="text-xl font-black text-gray-900 mb-1">生字練習</h2>
 
             <p className="text-sm text-gray-600">
-              {attempt === null
-                ? '還沒有朗讀紀錄，以下是這篇課文的生字，點一點來練習筆順吧！'
-                : needPracticeSet.size > 0
-                  ? `以下 ${Math.min(needPracticeSet.size, 12)} 個字可以再練習看看，選一個模式開始練習吧！`
-                  : '讀得很棒！沒有漏字。想再練習這篇的字嗎？'}
+              {attempt === null || needPracticeSet.size === 0
+                ? '以下是這篇課文的生字，點一點來練習筆順吧！'
+                : `以下 ${Math.min(needPracticeSet.size, 12)} 個字可以再練習看看，選一個模式開始練習吧！`}
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

- Removes the "讀得很棒！沒有漏字。想再練習這篇的字嗎？" text shown in `VocabPractice` when no mispronounced words were detected
- Replaces both the `attempt === null` and `needPracticeSet.size === 0` branches with a single neutral prompt: "以下是這篇課文的生字，點一點來練習筆順吧！"
- Build passes cleanly (852 modules, 0 errors)

Closes #731

## Test plan

- [ ] Navigate to 生字練習 step after a reading session with no mispronounced words — confirm the praise text is gone
- [ ] Navigate to 生字練習 step with no prior reading attempt — confirm neutral text shows
- [ ] Navigate to 生字練習 step with mispronounced words — confirm "以下 N 個字可以再練習看看" still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)