### PR TITLE
fix(vocab): remove confirm phase, start directly in grid (#735)

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -19,7 +19,7 @@ interface VocabPracticeProps {
   onBack: () => void;
 }
 
-type Phase = 'confirm' | 'grid' | 'practice' | 'pronunciation' | 'sentence' | 'zhuyin-game';
+type Phase = 'grid' | 'practice' | 'pronunciation' | 'sentence' | 'zhuyin-game';
 
 type PracticeMode = 'stroke' | 'pronunciation' | 'zhuyin' | 'fillinblank';
 
@@ -154,11 +154,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   };
   const savedProgress = useRef(loadSaved());
 
-  const [phase, setPhase] = useState<Phase>(() => {
-    const p = savedProgress.current?.phase;
-    // Only restore grid phase (not mid-practice)
-    return (p === 'grid') ? 'grid' : 'confirm';
-  });
+  const [phase, setPhase] = useState<Phase>('grid');
   const [practicingChar, setPracticingChar] = useState(savedProgress.current?.practicingChar ?? '');
   const [practicedChars, setPracticedChars] = useState<Set<string>>(
     () => new Set(savedProgress.current?.practicedChars ?? [])
@@ -182,7 +178,6 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
   // ── localStorage persistence ────────────────────────────────────────
   useEffect(() => {
-    if (phase === 'confirm') return; // Nothing to save yet
     try {
       localStorage.setItem(storageKey, JSON.stringify({
         practicedChars: Array.from(practicedChars),
@@ -275,47 +270,6 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   const handleRadicalToggle = (ch: string) => {
     setRadicalChar(prev => (prev === ch ? null : ch));
   };
-
-  /* ── Confirm phase: ask student whether to start vocab practice ── */
-  if (phase === 'confirm') {
-    const suggestedCount = attempt.mispronouncedWords.filter(hasStrokeData).length;
-    const totalVocabCount = displayChars.length;
-    const charCount = suggestedCount > 0 ? suggestedCount : totalVocabCount;
-
-    return (
-      <div className="flex-1 flex flex-col items-center justify-center bg-amber-50 px-6 py-12">
-        <div className="max-w-sm w-full bg-white rounded-3xl shadow-lg border border-amber-100 p-8 flex flex-col items-center gap-6 text-center">
-          <div className="w-16 h-16 rounded-full bg-amber-100 flex items-center justify-center text-3xl select-none">
-            ✏️
-          </div>
-          <div>
-            <h2 className="text-xl font-black text-gray-900 mb-2">
-              要練習這一課的生字嗎？
-            </h2>
-            <p className="text-sm text-gray-500">
-              {suggestedCount > 0
-                ? `剛才朗讀有 ${suggestedCount} 個字需要加強，要練習看看嗎？`
-                : `這一課有 ${charCount} 個生字，要練習嗎？`}
-            </p>
-          </div>
-          <div className="w-full flex flex-col gap-3">
-            <button
-              onClick={() => setPhase('grid')}
-              className="w-full py-3.5 rounded-2xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-md transition-all active:scale-95"
-            >
-              好！開始練習
-            </button>
-            <button
-              onClick={() => handleFinish({ practicedChars: [], totalChars: charCount })}
-              className="w-full py-3 rounded-2xl font-semibold text-base text-gray-500 hover:text-gray-800 hover:bg-gray-100 transition-all active:scale-95"
-            >
-              跳過
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   /* ── Pronunciation practice phase ── */
   if (phase === 'pronunciation') {


### PR DESCRIPTION
## Summary

Fixes #735

- Removed the `'confirm'` phase from `VocabPractice` entirely — component now starts directly in `'grid'` phase
- Deleted the "要練習這一課的生字嗎？" confirmation screen (40+ lines removed)
- Simplified `useState<Phase>` default from a conditional expression to plain `'grid'`
- Removed stale localStorage guard that skipped saving when `phase === 'confirm'`
- Footer skip path already exists: the primary CTA shows "跳過，查看報告" when no characters have been practiced

## Test plan

- [ ] Navigate to 生字練習 step — confirm screen should NOT appear, character grid loads immediately
- [ ] Click "跳過，查看報告" button without practicing any character — should advance to next step
- [ ] Practice one or more characters — button label should change to "完成，查看報告"
- [ ] Verify no TypeScript/build errors (build passed locally: `✓ built in 4.71s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)