### PR TITLE
fix(vocab-app): #732 — first-try tracking + summary screen with retry

### DIFF
--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -2,13 +2,16 @@
  * FillInBlankExercise — ④ 語詞應用（選詞填句）(#615)
  *
  * Issue #698: one-at-a-time + disappearing word bank
+ * Issue #732: first-try correctness tracking + summary screen with retry
  *
  * UX:
  *   - Top: fixed word bank showing only remaining (unused) words
  *   - Below: one fill-in-the-blank sentence at a time
  *   - Correct → word disappears from bank + advance to next question
- *   - Wrong  → show hint, word stays in bank
- *   - No per-sentence option buttons; all selection happens via the top bank
+ *   - Wrong  → show hint, word stays in bank; question is marked ❌ for summary
+ *   - After all questions: summary screen with real score + per-question results
+ *   - "重做錯題" retries only first-try-wrong questions
+ *   - "全部重做" restarts all questions
  */
 import React, { useEffect, useState } from 'react';
 import { FillInBlankItem } from '../../types';
@@ -19,6 +22,17 @@ interface Props {
   onComplete: (score: number, total: number) => void;
   /** Story ID used to namespace the localStorage key (Issue #709). */
   storyId?: string | number;
+}
+
+// ---------------------------------------------------------------------------
+// Per-question result (for summary)
+// ---------------------------------------------------------------------------
+
+interface QuestionResult {
+  sentenceIdx: number;        // index in the original sentences array
+  firstTryCorrect: boolean;
+  studentFirstAnswer: string | null;  // code of wrong first answer (null if first-try correct)
+  correctAnswer: string;      // correct code
 }
 
 // ---------------------------------------------------------------------------
@@ -33,6 +47,9 @@ interface SavedProgress {
   currentIdx: number;
   usedCodes: string[];
   score: number;
+  firstTryResults: QuestionResult[];
+  pendingRetryIndices?: number[];
+  retryMode?: boolean;
 }
 
 function loadProgress(storyId: string | number | undefined): SavedProgress | null {
@@ -73,13 +90,23 @@ function clearAnswers(storyId: string | number | undefined): void {
 // Component
 // ---------------------------------------------------------------------------
 
+type Phase = 'exercise' | 'summary';
+
 const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete, storyId }) => {
   const bankEntries = Object.entries(vocabBank).sort(([a], [b]) => a.localeCompare(b));
 
   // Restore progress from localStorage if available
   const savedProgress = loadProgress(storyId);
 
-  // Index of the current sentence being answered
+  // ---- exercise state ----
+  const [phase, setPhase] = useState<Phase>('exercise');
+  // Whether we are replaying only wrong questions
+  const [retryMode, setRetryMode] = useState(savedProgress?.retryMode ?? false);
+  // Indices (into original sentences[]) queued for retry
+  const [retryIndices, setRetryIndices] = useState<number[]>(
+    savedProgress?.pendingRetryIndices ?? [],
+  );
+  // Index into activeSentences
   const [currentIdx, setCurrentIdx] = useState(savedProgress?.currentIdx ?? 0);
   // Codes that have been correctly used and should disappear from bank
   const [usedCodes, setUsedCodes] = useState<Set<string>>(
@@ -89,29 +116,58 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
   const [selected, setSelected] = useState<string | null>(null);
   // Feedback state for current question
   const [feedback, setFeedback] = useState<'idle' | 'correct' | 'wrong'>('idle');
-  // Track score
-  const [score, setScore] = useState(savedProgress?.score ?? 0);
+  // Whether this question has already had a wrong attempt (first-try used up)
+  const [firstTryUsed, setFirstTryUsed] = useState(false);
 
-  // Persist progress to localStorage after every correct answer
+  // ---- scoring & results ----
+  // Score counts first-try-correct questions only
+  const [score, setScore] = useState(savedProgress?.score ?? 0);
+  // Per-question first-try results (accumulated during the original run)
+  const [firstTryResults, setFirstTryResults] = useState<QuestionResult[]>(
+    savedProgress?.firstTryResults ?? [],
+  );
+
+  // Active sentences = full list in normal mode, retry subset in retry mode
+  const activeSentences: FillInBlankItem[] = retryMode
+    ? retryIndices.map((i) => sentences[i])
+    : sentences;
+
+  const total = activeSentences.length;
+  const done = currentIdx >= total;
+
+  // Persist progress after every state change
   useEffect(() => {
     if (storyId == null) return;
     saveProgress(storyId, {
       currentIdx,
       usedCodes: Array.from(usedCodes),
       score,
+      firstTryResults,
+      pendingRetryIndices: retryIndices,
+      retryMode,
     });
-  }, [currentIdx, usedCodes, score, storyId]);
+  }, [currentIdx, usedCodes, score, firstTryResults, retryIndices, retryMode, storyId]);
 
-  const total = sentences.length;
-  const done = currentIdx >= total;
+  // Switch to summary when all active questions are done
+  useEffect(() => {
+    if (done && phase === 'exercise') {
+      setPhase('summary');
+    }
+  }, [done, phase]);
 
   // Available words = all words minus correctly used ones
   const availableEntries = bankEntries.filter(([code]) => !usedCodes.has(code));
 
-  const currentSentence = !done ? sentences[currentIdx] : null;
+  const currentSentence = !done ? activeSentences[currentIdx] : null;
+  // Original index of the current sentence (for result recording)
+  const currentOriginalIdx = retryMode ? retryIndices[currentIdx] : currentIdx;
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
 
   function handleSelect(code: string) {
-    if (feedback === 'correct') return; // waiting for auto-advance
+    if (feedback === 'correct') return;
     setSelected(code);
     setFeedback('idle');
   }
@@ -120,20 +176,52 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
     if (!selected || !currentSentence) return;
 
     if (selected === currentSentence.answer) {
-      // Correct
+      // Correct answer — remove from bank, advance
       const newUsed = new Set(usedCodes);
       newUsed.add(selected);
       setUsedCodes(newUsed);
-      setScore((s) => s + 1);
+
+      // Record first-try result only if not already recorded for this original question
+      const alreadyRecorded = firstTryResults.some((r) => r.sentenceIdx === currentOriginalIdx);
+      if (!alreadyRecorded) {
+        const isFirstTryCorrect = !firstTryUsed;
+        if (isFirstTryCorrect) setScore((s) => s + 1);
+        setFirstTryResults((prev) => [
+          ...prev,
+          {
+            sentenceIdx: currentOriginalIdx,
+            firstTryCorrect: isFirstTryCorrect,
+            studentFirstAnswer: null,  // wrong answer was already recorded on the wrong attempt
+            correctAnswer: currentSentence.answer,
+          },
+        ]);
+      }
+
       setFeedback('correct');
-      // Brief pause so student sees green flash, then advance
       setTimeout(() => {
         setCurrentIdx((i) => i + 1);
         setSelected(null);
         setFeedback('idle');
+        setFirstTryUsed(false);
       }, 900);
     } else {
-      // Wrong
+      // Wrong answer — record on first mistake only
+      if (!firstTryUsed) {
+        setFirstTryResults((prev) => {
+          const alreadyRecorded = prev.some((r) => r.sentenceIdx === currentOriginalIdx);
+          if (alreadyRecorded) return prev;
+          return [
+            ...prev,
+            {
+              sentenceIdx: currentOriginalIdx,
+              firstTryCorrect: false,
+              studentFirstAnswer: selected,
+              correctAnswer: currentSentence!.answer,
+            },
+          ];
+        });
+        setFirstTryUsed(true);
+      }
       setFeedback('wrong');
     }
   }
@@ -143,7 +231,40 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
     setFeedback('idle');
   }
 
-  // Render the sentence with the blank slot
+  // ---- Summary actions ----
+
+  function handleRetryWrong() {
+    const wrongIndices = firstTryResults
+      .filter((r) => !r.firstTryCorrect)
+      .map((r) => r.sentenceIdx);
+    setRetryIndices(wrongIndices);
+    setRetryMode(true);
+    setCurrentIdx(0);
+    setUsedCodes(new Set());
+    setSelected(null);
+    setFeedback('idle');
+    setFirstTryUsed(false);
+    setPhase('exercise');
+  }
+
+  function handleRetryAll() {
+    setRetryMode(false);
+    setRetryIndices([]);
+    setCurrentIdx(0);
+    setUsedCodes(new Set());
+    setScore(0);
+    setFirstTryResults([]);
+    setSelected(null);
+    setFeedback('idle');
+    setFirstTryUsed(false);
+    setPhase('exercise');
+    clearAnswers(storyId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render helpers
+  // ---------------------------------------------------------------------------
+
   function renderSentence(sentence: string) {
     const parts = sentence.split('(　　)');
 
@@ -177,29 +298,121 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
     );
   }
 
-  if (done) {
+  // ---------------------------------------------------------------------------
+  // Summary screen
+  // ---------------------------------------------------------------------------
+
+  if (phase === 'summary') {
+    const firstTryScore = firstTryResults.filter((r) => r.firstTryCorrect).length;
+    const firstTryTotal = sentences.length;
+    const allCorrect = firstTryScore === firstTryTotal;
+    const wrongCount = firstTryResults.filter((r) => !r.firstTryCorrect).length;
+
     return (
-      <div className="flex flex-col items-center gap-4 p-6 max-w-2xl mx-auto animate-fade-in">
-        <div className={`rounded-2xl px-8 py-4 text-center w-full ${score === total ? 'bg-emerald-50 border border-emerald-200' : 'bg-amber-50 border border-amber-200'}`}>
-          <p className="text-2xl font-black text-gray-800">
-            {score === total ? '全對！太棒了！' : `答對 ${score}／${total} 題`}
+      <div className="flex flex-col gap-5 p-4 max-w-2xl mx-auto animate-fade-in">
+        {/* Score header */}
+        <div
+          className={`rounded-2xl px-6 py-5 text-center border ${
+            allCorrect
+              ? 'bg-emerald-50 border-emerald-200'
+              : 'bg-amber-50 border-amber-200'
+          }`}
+        >
+          <p className="text-3xl font-black text-gray-800 mb-1">
+            {allCorrect ? '全對！太棒了！' : `一次答對 ${firstTryScore}／${firstTryTotal} 題`}
+          </p>
+          <p className="text-sm text-gray-500">
+            {allCorrect
+              ? '每一題都一次答對，表現優異！'
+              : '以下是各題的一次作答結果'}
           </p>
         </div>
-        <button
-          onClick={() => { clearAnswers(storyId); onComplete(score, total); }}
-          className="rounded-xl bg-[#5B4FC4] px-10 py-3 text-base font-bold text-white hover:bg-[#4a3fa8] active:scale-95 transition-all shadow-md min-h-[52px]"
-        >
-          繼續 →
-        </button>
+
+        {/* Per-question breakdown */}
+        <div className="flex flex-col gap-3">
+          {sentences.map((s, idx) => {
+            const result = firstTryResults.find((r) => r.sentenceIdx === idx);
+            const correct = result?.firstTryCorrect ?? false;
+            const correctCode = result?.correctAnswer ?? '';
+            const wrongCode = result?.studentFirstAnswer ?? null;
+
+            return (
+              <div
+                key={idx}
+                className={`rounded-xl border p-4 ${
+                  correct
+                    ? 'bg-emerald-50 border-emerald-200'
+                    : 'bg-red-50 border-red-200'
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-xl flex-shrink-0 mt-0.5">
+                    {correct ? '✅' : '❌'}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-base text-gray-700 leading-relaxed mb-1">
+                      {s.sentence.replace(
+                        '(　　)',
+                        `【${vocabBank[correctCode] ?? correctCode}】`,
+                      )}
+                    </p>
+                    {!correct && wrongCode && (
+                      <p className="text-sm text-red-600">
+                        你選了：
+                        <span className="font-semibold mx-1">
+                          {wrongCode}·{vocabBank[wrongCode] ?? wrongCode}
+                        </span>
+                        <span className="text-gray-500 mx-1">→ 正確答案：</span>
+                        <span className="font-semibold text-emerald-700">
+                          {correctCode}·{vocabBank[correctCode] ?? correctCode}
+                        </span>
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex flex-col gap-3">
+          {wrongCount > 0 && (
+            <button
+              onClick={handleRetryWrong}
+              className="rounded-xl border-2 border-[#5B4FC4] bg-white px-8 py-3 text-base font-bold text-[#5B4FC4] hover:bg-[#5B4FC4]/5 active:scale-95 transition-all shadow-sm min-h-[52px]"
+            >
+              重做錯題（{wrongCount} 題）
+            </button>
+          )}
+          <button
+            onClick={handleRetryAll}
+            className="rounded-xl border border-gray-300 bg-white px-8 py-3 text-base font-medium text-gray-600 hover:bg-gray-50 active:scale-95 transition-all min-h-[52px]"
+          >
+            全部重做
+          </button>
+          <button
+            onClick={() => { clearAnswers(storyId); onComplete(firstTryScore, firstTryTotal); }}
+            className="rounded-xl bg-[#5B4FC4] px-10 py-3 text-base font-bold text-white hover:bg-[#4a3fa8] active:scale-95 transition-all shadow-md min-h-[52px]"
+          >
+            繼續 →
+          </button>
+        </div>
       </div>
     );
   }
+
+  // ---------------------------------------------------------------------------
+  // Exercise screen
+  // ---------------------------------------------------------------------------
 
   return (
     <div className="flex flex-col gap-5 p-4 max-w-2xl mx-auto">
       {/* Progress */}
       <div className="bg-white rounded-2xl border border-[#5B4FC4]/20 shadow-sm px-5 py-3 flex items-center justify-between">
-        <span className="text-base text-gray-600 font-medium">第 {currentIdx + 1} 題</span>
+        <span className="text-base text-gray-600 font-medium">
+          {retryMode ? `重做錯題 第 ${currentIdx + 1} 題` : `第 ${currentIdx + 1} 題`}
+        </span>
         <span className="text-lg font-black text-[#5B4FC4]">
           {currentIdx + 1} <span className="text-gray-400 font-normal text-sm">/ {total}</span>
         </span>
@@ -253,10 +466,22 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
             {feedback === 'wrong' && <span className="ml-1 text-lg">❌</span>}
           </p>
 
+          {/* First-try status hint */}
+          {feedback === 'idle' && !firstTryUsed && (
+            <p className="ml-9 text-xs text-[#5B4FC4]/60 font-medium mb-2">
+              一次答對才算答對
+            </p>
+          )}
+          {feedback === 'idle' && firstTryUsed && (
+            <p className="ml-9 text-xs text-amber-600 font-medium mb-2">
+              已有錯誤紀錄，找出正確答案繼續
+            </p>
+          )}
+
           {/* Feedback message */}
           {feedback === 'correct' && (
             <p className="ml-9 text-sm text-emerald-700 font-semibold animate-fade-in">
-              答對了！進入下一題…
+              {firstTryUsed ? '答對了，繼續下一題…' : '一次答對！進入下一題…'}
             </p>
           )}
           {feedback === 'wrong' && (


### PR DESCRIPTION
## Problem

`FillInBlankExercise` let students keep guessing until correct, so the final score always showed "全部答對 5/5" — meaningless as a learning signal.

## Changes

**New state:**
- `firstTryUsed` flag — set to `true` on the first wrong attempt for a question; subsequent wrong answers do not overwrite the ❌ record
- `firstTryResults: QuestionResult[]` — one entry per original question with `firstTryCorrect`, `studentFirstAnswer` (wrong code), and `correctAnswer`
- `score` now only increments on a first-try-correct answer
- `phase: 'exercise' | 'summary'` — switches to `'summary'` when all active questions are done

**Summary screen (appears after last question):**
- Header: `一次答對 N／M 題` (or `全對！太棒了！`)
- Per-question cards: ✅/❌ icon + sentence with correct answer filled in + "你選了 X → 正確答案 Y" for wrong questions
- **重做錯題（N題）** — retries only wrong-first-attempt questions in a new pass
- **全部重做** — full reset back to question 1
- **繼續 →** — calls `onComplete(firstTryScore, total)`

**Retry mode:**
- `retryIndices` maps retry-pass positions back to original sentence indices
- Results always recorded against original index so summary stays accurate
- `localStorage` `SavedProgress` extended with `firstTryResults`, `pendingRetryIndices`, `retryMode`

**Unchanged behavior:**
- Student must still reach the correct answer to advance (same as before)
- Word bank disappearing-word UX (#698) unchanged
- Green/red flash + 900ms delay unchanged

## Build proof

```
✓ 851 modules transformed.
✓ built in 5.08s
```
Zero TypeScript errors.

## Test plan

- [ ] Answer Q1 wrong, then correct → summary shows ❌ for Q1
- [ ] Answer Q2 correct on first try → summary shows ✅ for Q2
- [ ] Score header shows correct first-try count (not total)
- [ ] "重做錯題" button appears only when there are wrong questions; shows correct count
- [ ] Clicking "重做錯題" shows only wrong questions in retry pass
- [ ] After retry pass, summary re-appears (original score preserved)
- [ ] "全部重做" resets everything including score
- [ ] "繼續 →" passes firstTryScore to onComplete
- [ ] Reload mid-exercise — progress (including firstTryResults) restores from localStorage

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)