### PR TITLE
feat(reading): annotation side panel + click-to-scroll highlight (#718)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -101,8 +101,16 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   // Undo stack
   const [undoStack, setUndoStack] = useState<Annotation[][]>([]);
 
+  // Highlighted annotation id (for jump-to animation)
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
+
+  // Side panel visibility (mobile: toggle; desktop: always visible)
+  const [panelOpen, setPanelOpen] = useState(false);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
+  // Map annotation id → span DOM element for scroll-to
+  const annSpanRefs = useRef<Map<string, HTMLElement>>(new Map());
 
   // ── Zhuyin ─────────────────────────────────────────────────────────────
 
@@ -153,6 +161,41 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     importantCount: annotations.filter((a) => a.type === 'important').length,
   }), [annotations]);
 
+  // ── Side panel — sorted list of annotations ────────────────────────────
+
+  const sortedAnnotations = useMemo(() =>
+    [...annotations].sort((a, b) =>
+      a.paragraphIndex !== b.paragraphIndex
+        ? a.paragraphIndex - b.paragraphIndex
+        : a.charStart - b.charStart
+    ),
+    [annotations]
+  );
+
+  // Derive the display text for a given annotation
+  const getAnnotationText = useCallback((ann: Annotation): string => {
+    const raw = story.content[ann.paragraphIndex];
+    if (!raw) return '';
+    return raw.slice(ann.charStart, ann.charEnd);
+  }, [story.content]);
+
+  // ── Jump-to annotation ─────────────────────────────────────────────────
+
+  const jumpToAnnotation = useCallback((id: string) => {
+    const el = annSpanRefs.current.get(id);
+    if (!el) return;
+
+    // Scroll the span into view inside the scroll container
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+    // Flash highlight
+    setHighlightedId(id);
+    setTimeout(() => setHighlightedId(null), 1500);
+
+    // On mobile: close panel after jump
+    setPanelOpen(false);
+  }, []);
+
   // ── Selection helpers ──────────────────────────────────────────────────
 
   /**
@@ -182,7 +225,6 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     if (!paraIdxStr || startEl !== endEl) return null;
 
     const paragraphIndex = parseInt(paraIdxStr, 10);
-    const paraEl = startEl; // same element
 
     // Compute char offsets relative to the original paragraph text.
     // Uses the selected text to find its position in the raw paragraph string,
@@ -294,6 +336,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       setUndoStack((stack) => [...stack.slice(-19), prev]);
       return prev.filter((a) => a.id !== id);
     });
+    annSpanRefs.current.delete(id);
   }, []);
 
   // ── Undo ──────────────────────────────────────────────────────────────
@@ -312,6 +355,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   const clearAll = useCallback(() => {
     setUndoStack((stack) => [...stack.slice(-19), annotations]);
     setAnnotations([]);
+    annSpanRefs.current.clear();
   }, [annotations]);
 
   // ── Render paragraph with annotation spans ─────────────────────────────
@@ -365,13 +409,27 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       if (!seg.annotation) {
         return <React.Fragment key={seg.start}>{chars}</React.Fragment>;
       }
-      const cfg = TYPE_CONFIG[seg.annotation.type];
+      const ann = seg.annotation;
+      const cfg = TYPE_CONFIG[ann.type];
+      const isHighlighted = highlightedId === ann.id;
       return (
         <span
-          key={seg.annotation.id}
-          className={`cursor-pointer ${cfg.className}`}
+          key={ann.id}
+          ref={(el) => {
+            if (el) {
+              annSpanRefs.current.set(ann.id, el);
+            } else {
+              annSpanRefs.current.delete(ann.id);
+            }
+          }}
+          data-ann-id={ann.id}
+          className={`cursor-pointer transition-all duration-300 ${cfg.className} ${
+            isHighlighted
+              ? 'ring-2 ring-offset-1 ring-indigo-500 rounded scale-105 inline-block animate-pulse'
+              : ''
+          }`}
           title={`${cfg.icon} ${cfg.label} (點擊移除)`}
-          onClick={() => removeAnnotation(seg.annotation!.id)}
+          onClick={() => removeAnnotation(ann.id)}
           role="mark"
           aria-label={`${cfg.label}標記：${chars}`}
         >
@@ -380,6 +438,188 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       );
     });
   }
+
+  // ── Side Panel ─────────────────────────────────────────────────────────
+
+  const SidePanel = () => (
+    <aside
+      aria-label="已標記詞語清單"
+      className="flex flex-col bg-white border-l border-gray-200 w-52 flex-shrink-0 overflow-hidden"
+    >
+      {/* Panel header */}
+      <div className="flex-shrink-0 px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+        <h2 className="text-sm font-bold text-gray-700 flex items-center gap-1.5">
+          <span aria-hidden="true">📋</span>
+          已標記詞語
+        </h2>
+        {sortedAnnotations.length > 0 && (
+          <span className="text-xs bg-indigo-100 text-indigo-700 font-bold px-2 py-0.5 rounded-full">
+            {sortedAnnotations.length}
+          </span>
+        )}
+      </div>
+
+      {/* Panel list */}
+      <div className="flex-1 overflow-y-auto">
+        {sortedAnnotations.length === 0 ? (
+          <div className="px-4 py-6 text-center text-gray-400 text-sm leading-relaxed">
+            <div className="text-2xl mb-2" aria-hidden="true">✏️</div>
+            選取課文文字<br />並標記後<br />會出現在這裡
+          </div>
+        ) : (
+          <ul className="divide-y divide-gray-100" role="list">
+            {sortedAnnotations.map((ann) => {
+              const text = getAnnotationText(ann);
+              const cfg = TYPE_CONFIG[ann.type];
+              const isHighlighted = highlightedId === ann.id;
+              return (
+                <li
+                  key={ann.id}
+                  className={`group flex items-center gap-2 px-3 py-2.5 transition-colors ${
+                    isHighlighted
+                      ? 'bg-indigo-50'
+                      : 'hover:bg-gray-50'
+                  }`}
+                >
+                  {/* Jump button */}
+                  <button
+                    type="button"
+                    onClick={() => jumpToAnnotation(ann.id)}
+                    className="flex-1 flex items-start gap-2 text-left min-w-0"
+                    aria-label={`跳轉到標記：${text}`}
+                    title="點擊跳轉到課文位置"
+                  >
+                    <span className="flex-shrink-0 text-sm mt-0.5" aria-hidden="true">
+                      {cfg.icon}
+                    </span>
+                    <span
+                      className={`text-sm font-medium leading-snug break-all ${
+                        ann.type === 'unknown'
+                          ? 'text-red-700 underline decoration-red-400 decoration-2 underline-offset-2'
+                          : 'text-yellow-800 bg-yellow-100 px-1 rounded'
+                      }`}
+                    >
+                      {text}
+                    </span>
+                  </button>
+                  {/* Delete button */}
+                  <button
+                    type="button"
+                    onClick={() => removeAnnotation(ann.id)}
+                    aria-label={`刪除標記：${text}`}
+                    title="刪除此標記"
+                    className="flex-shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-red-500 transition-all p-0.5 rounded"
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+
+  // ── Mobile panel overlay ───────────────────────────────────────────────
+
+  const MobilePanelOverlay = () => (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/30 z-40 lg:hidden"
+        onClick={() => setPanelOpen(false)}
+        aria-hidden="true"
+      />
+      {/* Drawer sliding in from right */}
+      <div
+        className="fixed top-0 right-0 bottom-0 w-64 bg-white z-50 shadow-2xl flex flex-col lg:hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="已標記詞語清單"
+      >
+        {/* Close button */}
+        <div className="flex-shrink-0 flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-gray-50">
+          <h2 className="text-sm font-bold text-gray-700 flex items-center gap-1.5">
+            <span aria-hidden="true">📋</span>
+            已標記詞語
+            {sortedAnnotations.length > 0 && (
+              <span className="ml-1 text-xs bg-indigo-100 text-indigo-700 font-bold px-2 py-0.5 rounded-full">
+                {sortedAnnotations.length}
+              </span>
+            )}
+          </h2>
+          <button
+            type="button"
+            onClick={() => setPanelOpen(false)}
+            aria-label="關閉標記清單"
+            className="text-gray-500 hover:text-gray-700 p-1 rounded-lg hover:bg-gray-100 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        {/* List */}
+        <div className="flex-1 overflow-y-auto">
+          {sortedAnnotations.length === 0 ? (
+            <div className="px-4 py-6 text-center text-gray-400 text-sm leading-relaxed">
+              <div className="text-2xl mb-2" aria-hidden="true">✏️</div>
+              選取課文文字<br />並標記後<br />會出現在這裡
+            </div>
+          ) : (
+            <ul className="divide-y divide-gray-100" role="list">
+              {sortedAnnotations.map((ann) => {
+                const text = getAnnotationText(ann);
+                const cfg = TYPE_CONFIG[ann.type];
+                const isHighlighted = highlightedId === ann.id;
+                return (
+                  <li
+                    key={ann.id}
+                    className={`group flex items-center gap-2 px-3 py-3 transition-colors ${
+                      isHighlighted ? 'bg-indigo-50' : 'hover:bg-gray-50'
+                    }`}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => jumpToAnnotation(ann.id)}
+                      className="flex-1 flex items-start gap-2 text-left min-w-0"
+                      aria-label={`跳轉到標記：${text}`}
+                    >
+                      <span className="flex-shrink-0 text-sm mt-0.5" aria-hidden="true">
+                        {cfg.icon}
+                      </span>
+                      <span
+                        className={`text-sm font-medium leading-snug break-all ${
+                          ann.type === 'unknown'
+                            ? 'text-red-700 underline decoration-red-400 decoration-2 underline-offset-2'
+                            : 'text-yellow-800 bg-yellow-100 px-1 rounded'
+                        }`}
+                      >
+                        {text}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => removeAnnotation(ann.id)}
+                      aria-label={`刪除標記：${text}`}
+                      className="flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors p-0.5 rounded"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </>
+  );
 
   // ── Render ─────────────────────────────────────────────────────────────
 
@@ -448,6 +688,22 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
           清除全部
         </button>
 
+        {/* Mobile: toggle panel button */}
+        <button
+          type="button"
+          onClick={() => setPanelOpen(true)}
+          aria-label={`查看已標記詞語（${summary.totalMarks} 個）`}
+          className="lg:hidden relative flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-bold border border-indigo-300 text-indigo-700 bg-indigo-50 hover:bg-indigo-100 transition-all"
+        >
+          <span aria-hidden="true">📋</span>
+          標記清單
+          {summary.totalMarks > 0 && (
+            <span className="absolute -top-1.5 -right-1.5 w-5 h-5 flex items-center justify-center bg-[#5B4FC4] text-white text-xs font-black rounded-full">
+              {summary.totalMarks}
+            </span>
+          )}
+        </button>
+
         {/* Zhuyin toggle */}
         {zhuyinActiveProp === undefined && (
           <ZhuyinToggle
@@ -470,75 +726,88 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
         </div>
       </div>
 
-      {/* ── Main text area ─────────────────────────────────────────────── */}
-      <div
-        ref={containerRef}
-        className="flex-1 overflow-y-auto relative"
-        onMouseUp={handleMouseUp}
-        onTouchEnd={handleTouchEnd}
-        style={{ WebkitUserSelect: 'text', userSelect: 'text' } as React.CSSProperties}
-      >
-        <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
-          {story.content.map((rawPara, paraIdx) => {
-            const displayText = zhuyinParagraphs?.[paraIdx] ?? rawPara;
-            return (
-              <p
-                key={paraIdx}
-                data-para-idx={paraIdx}
-                className="text-gray-900 leading-loose"
-                style={{
-                  fontSize: `${fontSizePx}px`,
-                  lineHeight: zhuyinActive ? '3.8rem' : '2.8rem',
-                  letterSpacing: zhuyinActive ? '0.35em' : '0.05em',
+      {/* ── Body: text area + side panel ───────────────────────────────── */}
+      <div className="flex-1 flex overflow-hidden">
+
+        {/* ── Main text area ─────────────────────────────────────────── */}
+        <div
+          ref={containerRef}
+          className="flex-1 overflow-y-auto relative"
+          onMouseUp={handleMouseUp}
+          onTouchEnd={handleTouchEnd}
+          style={{ WebkitUserSelect: 'text', userSelect: 'text' } as React.CSSProperties}
+        >
+          <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+            {story.content.map((rawPara, paraIdx) => {
+              const displayText = zhuyinParagraphs?.[paraIdx] ?? rawPara;
+              return (
+                <p
+                  key={paraIdx}
+                  data-para-idx={paraIdx}
+                  className="text-gray-900 leading-loose"
+                  style={{
+                    fontSize: `${fontSizePx}px`,
+                    lineHeight: zhuyinActive ? '3.8rem' : '2.8rem',
+                    letterSpacing: zhuyinActive ? '0.35em' : '0.05em',
+                  }}
+                >
+                  {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}
+                </p>
+              );
+            })}
+          </div>
+
+          {/* ── Floating toolbar — larger for touch ──────────────────── */}
+          {toolbar.visible && (
+            <div
+              ref={toolbarRef}
+              role="toolbar"
+              aria-label="標記選取文字"
+              className="absolute z-50 flex items-center gap-2 bg-white border-2 border-amber-300 rounded-2xl shadow-2xl px-3 py-2 -translate-x-1/2 -translate-y-full"
+              style={{ left: toolbar.x, top: toolbar.y }}
+            >
+              {(Object.entries(TYPE_CONFIG) as Array<[AnnotationType, typeof TYPE_CONFIG[AnnotationType]]>).map(
+                ([type, cfg]) => (
+                  <button
+                    key={type}
+                    type="button"
+                    onPointerDown={(e) => {
+                      // Use pointerdown so we act before selection is cleared
+                      e.preventDefault();
+                      applyAnnotation(type);
+                    }}
+                    className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-black border-2 transition-all min-h-[44px] active:scale-95 ${cfg.activeClass}`}
+                  >
+                    <span aria-hidden="true">{cfg.icon}</span>
+                    {cfg.label}
+                  </button>
+                )
+              )}
+              <button
+                type="button"
+                onPointerDown={(e) => {
+                  e.preventDefault();
+                  window.getSelection()?.removeAllRanges();
+                  hideToolbar();
                 }}
+                className="ml-1 px-3 py-2 rounded-xl text-base text-gray-400 hover:text-gray-700 border-2 border-gray-200 hover:bg-gray-50 transition-all min-h-[44px]"
+                aria-label="取消"
               >
-                {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}
-              </p>
-            );
-          })}
+                ✕
+              </button>
+            </div>
+          )}
         </div>
 
-        {/* ── Floating toolbar — larger for touch ──────────────────────── */}
-        {toolbar.visible && (
-          <div
-            ref={toolbarRef}
-            role="toolbar"
-            aria-label="標記選取文字"
-            className="absolute z-50 flex items-center gap-2 bg-white border-2 border-amber-300 rounded-2xl shadow-2xl px-3 py-2 -translate-x-1/2 -translate-y-full"
-            style={{ left: toolbar.x, top: toolbar.y }}
-          >
-            {(Object.entries(TYPE_CONFIG) as Array<[AnnotationType, typeof TYPE_CONFIG[AnnotationType]]>).map(
-              ([type, cfg]) => (
-                <button
-                  key={type}
-                  type="button"
-                  onPointerDown={(e) => {
-                    // Use pointerdown so we act before selection is cleared
-                    e.preventDefault();
-                    applyAnnotation(type);
-                  }}
-                  className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-black border-2 transition-all min-h-[44px] active:scale-95 ${cfg.activeClass}`}
-                >
-                  <span aria-hidden="true">{cfg.icon}</span>
-                  {cfg.label}
-                </button>
-              )
-            )}
-            <button
-              type="button"
-              onPointerDown={(e) => {
-                e.preventDefault();
-                window.getSelection()?.removeAllRanges();
-                hideToolbar();
-              }}
-              className="ml-1 px-3 py-2 rounded-xl text-base text-gray-400 hover:text-gray-700 border-2 border-gray-200 hover:bg-gray-50 transition-all min-h-[44px]"
-              aria-label="取消"
-            >
-              ✕
-            </button>
-          </div>
-        )}
+        {/* ── Desktop side panel (lg+) ────────────────────────────────── */}
+        <div className="hidden lg:flex">
+          <SidePanel />
+        </div>
+
       </div>
+
+      {/* ── Mobile panel overlay ──────────────────────────────────────── */}
+      {panelOpen && <MobilePanelOverlay />}
 
       {/* ── Summary bar + finish button ────────────────────────────────── */}
       <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between gap-4">


### PR DESCRIPTION
## Summary

- Adds a **right-side panel** (desktop `lg+`) to `ReadingAnnotation` that lists every annotated word/phrase sorted by paragraph position
- **Click-to-scroll**: clicking any panel item smooth-scrolls the text area to the annotation span and plays a 1.5-second ring+pulse highlight animation
- **Delete from panel**: hover over any panel item to reveal the (×) delete button — removes from both panel and text
- **Mobile**: a "標記清單" button in the top bar (with badge count) opens a right-side drawer overlay
- All annotation spans register with a `annSpanRefs` callback-ref map for O(1) scroll-target lookup
- Build verified: `✓ built in 5.35s`, zero TypeScript errors

## Layout

```
┌──────────────────────┬───────────────┐
│                      │  已標記詞語    │
│   課文內容            │  ❓ 疑難雜症   │
│   （可標記文字）       │  💛 龍爭虎鬥  │
│                      │  ❓ 目不轉睛   │
│                      │  ...           │
└──────────────────────┴───────────────┘
```

## Test plan

- [ ] Add several annotations (both ❓ and 💛 types) in the reading text
- [ ] Verify the side panel (desktop) lists them in reading order
- [ ] Click a panel item — text should smooth-scroll to it and pulse for ~1.5s
- [ ] Click (×) in panel — annotation removed from both panel and text
- [ ] Mobile: "標記清單" button badge shows count; tapping opens drawer; tapping item jumps then closes drawer
- [ ] Undo/Clear all still works as before

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)