### PR TITLE
fix(tts): #736 — TTS play buttons loading state + duplicate click prevention

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -36,6 +36,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
   const [isSessionActive, setIsSessionActive]   = useState(false);
   const [isTtsSpeaking, setIsTtsSpeaking]       = useState(false);
   const [isTtsPaused, setIsTtsPaused]           = useState(false);
+  const [isTtsLoading, setIsTtsLoading]         = useState(false); // true while TTS is buffering before playback starts
   const [streamingTranscript, setStreamingTranscript] = useState(() => savedProgress.current?.transcript ?? '');
   const [micError, setMicError]                 = useState('');
   const [result, setResult]                     = useState<SavedResult | null>(() => savedProgress.current?.result ?? null);
@@ -143,6 +144,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
     if (!window.speechSynthesis) return;
     window.speechSynthesis.cancel();
     setIsTtsPaused(false);
+    setIsTtsLoading(true); // show loading until the first utterance begins
 
     const doSpeak = () => {
       const voices = window.speechSynthesis.getVoices();
@@ -158,9 +160,9 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
         if (preferred) u.voice = preferred;
         return u;
       });
-      utterances[0].onstart = () => setIsTtsSpeaking(true);
-      utterances[utterances.length - 1].onend = () => { setIsTtsSpeaking(false); setIsTtsPaused(false); };
-      utterances[utterances.length - 1].onerror = () => { setIsTtsSpeaking(false); setIsTtsPaused(false); };
+      utterances[0].onstart = () => { setIsTtsLoading(false); setIsTtsSpeaking(true); };
+      utterances[utterances.length - 1].onend = () => { setIsTtsLoading(false); setIsTtsSpeaking(false); setIsTtsPaused(false); };
+      utterances[utterances.length - 1].onerror = () => { setIsTtsLoading(false); setIsTtsSpeaking(false); setIsTtsPaused(false); };
       utterances.forEach(u => window.speechSynthesis.speak(u));
     };
 
@@ -173,7 +175,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
   const pauseTts = () => { window.speechSynthesis?.pause(); setIsTtsPaused(true); };
   const resumeTts = () => { window.speechSynthesis?.resume(); setIsTtsPaused(false); };
-  const stopTts = () => { window.speechSynthesis?.cancel(); setIsTtsSpeaking(false); setIsTtsPaused(false); };
+  const stopTts = () => { window.speechSynthesis?.cancel(); setIsTtsLoading(false); setIsTtsSpeaking(false); setIsTtsPaused(false); };
 
   /* ---- STT ---- */
   const startSession = () => {
@@ -512,13 +514,23 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
             <div className="flex gap-2">
               <button
                 onClick={speakFullStory}
-                aria-label="播放全文系統示範朗讀"
-                className="flex-1 py-3 rounded-xl text-base font-bold bg-gray-200 hover:bg-gray-300 text-gray-800 transition-all flex items-center justify-center gap-1.5 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+                disabled={isTtsLoading}
+                aria-label={isTtsLoading ? '載入中' : '播放全文系統示範朗讀'}
+                aria-busy={isTtsLoading}
+                className={`flex-1 py-3 rounded-xl text-base font-bold transition-all flex items-center justify-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
+                  isTtsLoading
+                    ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                    : 'bg-gray-200 hover:bg-gray-300 text-gray-800 active:scale-95'
+                }`}
               >
-                <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
-                </svg>
-                系統朗讀
+                {isTtsLoading ? (
+                  <div className="w-3.5 h-3.5 flex-shrink-0 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" aria-hidden="true" />
+                ) : (
+                  <svg className="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" />
+                  </svg>
+                )}
+                {isTtsLoading ? '載入中...' : '系統朗讀'}
               </button>
               <button
                 onClick={startSession}

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -347,6 +347,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const [zhuyinReady, setZhuyinReady] = useState(false);
   const [isTtsSpeaking, setIsTtsSpeaking] = useState(false);
   const [isTtsPaused, setIsTtsPaused] = useState(false);
+  const [isTtsLoading, setIsTtsLoading] = useState(false); // true while fetch is in-flight, before audio starts
   const [isAnalyzing, setIsAnalyzing] = useState(false); // legacy — kept for status bar compat
   const [isAwaitingGemini, setIsAwaitingGemini] = useState(false);
   const [lastDiffTokens, setLastDiffTokens] = useState<DiffToken[] | null>(null);
@@ -1019,6 +1020,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     if (!text) return;
     cancelTts();
     setIsTtsPaused(false);
+    setIsTtsLoading(true); // show loading state while network fetch is in-flight
 
     const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
@@ -1030,6 +1032,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     };
 
     const startCursorAnimation = () => {
+      setIsTtsLoading(false); // audio started — no longer loading
       setIsTtsSpeaking(true);
       setSpeakingProgress(0);
       setRealtimeDiffTokens(null);
@@ -1049,6 +1052,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
     const onSpeechEnd = () => {
       stopTtsAnimation();
+      setIsTtsLoading(false);
       setIsTtsSpeaking(false);
       setIsTtsPaused(false);
     };
@@ -1134,6 +1138,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       ua.currentTime = 0;
     }
     cancelTts();
+    setIsTtsLoading(false);
     setIsTtsSpeaking(false);
     setIsTtsPaused(false);
   };
@@ -1275,7 +1280,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                               if (utteranceRef.current) { const _u = utteranceRef.current; if (_u instanceof HTMLAudioElement) { _u.onended = null; _u.onerror = null; _u.pause(); } else { (_u as SpeechSynthesisUtterance).onend = null; (_u as SpeechSynthesisUtterance).onerror = null; (_u as SpeechSynthesisUtterance).onboundary = null; } utteranceRef.current = null; }
                               if (ttsRafRef.current !== null) { cancelAnimationFrame(ttsRafRef.current); ttsRafRef.current = null; }
                               cancelTts();
-                              setIsTtsSpeaking(false); setIsTtsPaused(false);
+                              setIsTtsLoading(false); setIsTtsSpeaking(false); setIsTtsPaused(false);
                             } else {
                               // Speak this paragraph's text via speakCurrentParagraph
                               // (navigating to that line first if needed)
@@ -1286,29 +1291,35 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                                 const text = story.content[idx];
                                 if (text) {
                                   cancelTts();
-                                  setIsTtsSpeaking(true);
+                                  setIsTtsLoading(true); // loading while ttsApi module + fetch in-flight
                                   import('../../services/ttsApi').then(({ speakText: sp }) => {
+                                    setIsTtsLoading(false);
+                                    setIsTtsSpeaking(true);
                                     sp(text).finally(() => { setIsTtsSpeaking(false); setIsTtsPaused(false); });
-                                  });
+                                  }).catch(() => { setIsTtsLoading(false); });
                                 }
                               }
                             }
                           }}
-                          disabled={idx === currentLineIndex && (isSessionActive || isPreparing)}
+                          disabled={isTtsLoading || (idx === currentLineIndex && (isSessionActive || isPreparing))}
                           className={`px-4 py-2 rounded-lg text-sm font-bold flex items-center gap-1.5 transition-all ${
-                            idx === currentLineIndex && (isSessionActive || isPreparing)
+                            isTtsLoading || (idx === currentLineIndex && (isSessionActive || isPreparing))
                               ? 'bg-gray-100 text-gray-300 cursor-not-allowed'
                               : isTtsSpeaking && idx === currentLineIndex
                                 ? 'bg-red-100 hover:bg-red-200 text-red-600'
                                 : 'bg-gray-100 hover:bg-gray-200 text-gray-700'
                           }`}
+                          aria-label={isTtsLoading ? '載入中' : isTtsSpeaking && idx === currentLineIndex ? '停止朗讀' : 'AI 示範朗讀'}
+                          aria-busy={isTtsLoading}
                         >
-                          {isTtsSpeaking && idx === currentLineIndex ? (
-                            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><rect x="6" y="6" width="4" height="12" rx="1" /><rect x="14" y="6" width="4" height="12" rx="1" /></svg>
+                          {isTtsLoading ? (
+                            <div className="w-4 h-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin" aria-hidden="true" />
+                          ) : isTtsSpeaking && idx === currentLineIndex ? (
+                            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="6" width="4" height="12" rx="1" /><rect x="14" y="6" width="4" height="12" rx="1" /></svg>
                           ) : (
-                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" /></svg>
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" /></svg>
                           )}
-                          {isTtsSpeaking && idx === currentLineIndex ? '停止' : 'AI 朗讀'}
+                          {isTtsLoading ? '載入中...' : isTtsSpeaking && idx === currentLineIndex ? '停止' : 'AI 朗讀'}
                         </button>
                         {/* A/B test: Web Speech API button for comparison */}
                         <button


### PR DESCRIPTION
## Summary

- **Root cause**: TTS play buttons had no feedback between click and when audio began. The `isTtsSpeaking` state was only set inside `audio.onplay` (after the network fetch completed), leaving a window where repeated clicks would fire multiple API requests and overlapping audio.
- **LiveTutor.tsx**: Added `isTtsLoading` state. `speakCurrentParagraph()` sets it `true` immediately on click, clears it in `startCursorAnimation` (when `audio.onplay` fires). The AI 朗讀 button is disabled + shows a spinner + "載入中..." label while loading.
- **LiveTutor.tsx (non-current paragraph path)**: The dynamic `import('../../services/ttsApi')` path also tracks loading state — `isTtsLoading = true` before the import, cleared after the module resolves and `speakText` is called.
- **FullReading.tsx**: Added `isTtsLoading` around `speakFullStory()`. Set on click, cleared in `utterances[0].onstart`. 系統朗讀 button disabled with spinner during load.
- Both `stopTts()` implementations clear `isTtsLoading` so cancelling during load never leaves the button stuck.
- Added `aria-busy` and updated `aria-label` on loading buttons for accessibility.

## State flow

```
idle → [click] → loading (spinner, disabled) → playing (stop button) → idle
                     ↓ (stop/error)
                   idle
```

## Test plan
- [ ] LiveTutor: click "AI 朗讀" button — spinner appears immediately, button disabled until audio starts
- [ ] LiveTutor: spam-clicking the button during loading has no effect (no duplicate audio)
- [ ] LiveTutor: clicking a non-current paragraph's AI 朗讀 button shows spinner during load
- [ ] FullReading: click "系統朗讀" — spinner appears, button disabled until Web Speech begins
- [ ] FullReading: clicking stop during loading correctly clears loading state
- [ ] Both: error path (e.g. backend down) — loading state clears, button returns to idle

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)