### PR TITLE
fix(ui): align story text font size in ReadingAnnotation to match ComprehensionChat (#741 #720)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -66,7 +66,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   story,
   onFinish,
   zhuyinActive: zhuyinActiveProp,
-  fontSizePx = 22,
+  fontSizePx = 28,
 }) => {
   // Zhuyin state (internal if not controlled via prop)
   const [zhuyinEnabled, setZhuyinEnabled] = useState(true);
@@ -744,10 +744,10 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
                 <p
                   key={paraIdx}
                   data-para-idx={paraIdx}
-                  className="text-gray-900 leading-loose"
+                  className="text-gray-900"
                   style={{
                     fontSize: `${fontSizePx}px`,
-                    lineHeight: zhuyinActive ? '3.8rem' : '2.8rem',
+                    lineHeight: zhuyinActive ? '3.8rem' : '3.5rem',
                     letterSpacing: zhuyinActive ? '0.35em' : '0.05em',
                   }}
                 >


### PR DESCRIPTION
## Summary

- **ReadingAnnotation**: bumped default `fontSizePx` from `22` to `28` (matches `useFontSize` medium level — same value used by LiveTutor and ComprehensionChat)
- **ReadingAnnotation**: updated non-zhuyin `lineHeight` from `2.8rem` to `3.5rem` (matches `leading-[3.5rem]` used in ComprehensionChat and FullReading)
- **FullReading**: already had `text-2xl lg:text-3xl leading-[3.5rem]` — no change needed
- **LiveTutor**: already used `useFontSize()` (28px default) with `leading-[3.5rem]` — no change needed

## Root cause

`ReadingAnnotation` had a hardcoded default `fontSizePx = 22` (22px) while ComprehensionChat renders at `text-2xl` (24px) / `text-3xl` (30px) and LiveTutor uses `useFontSize` medium = 28px. The 6px gap was visible to users.

## Files changed

- `frontend/src/components/reading-steps/ReadingAnnotation.tsx`

## Test plan

- [ ] Open 閱讀標記 (ReadingAnnotation) — story text should be visually same size as 課文理解 (ComprehensionChat)
- [ ] Open 逐段朗讀 (LiveTutor) — confirm same visual size
- [ ] Open 全文朗讀 (FullReading) — confirm same visual size
- [ ] Toggle zhuyin on/off in ReadingAnnotation — line height should increase with zhuyin

Closes #741
Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)