### PR TITLE
feat(tts): remove Web Speech API, use Azure TTS only (#737)

### DIFF
--- a/frontend/src/__tests__/ttsApi.test.ts
+++ b/frontend/src/__tests__/ttsApi.test.ts
@@ -1,13 +1,14 @@
 /**
- * Unit tests for ttsApi retry/cooldown logic (Issue #663).
+ * Unit tests for ttsApi (Issue #737 — Azure TTS only, Web Speech API removed).
  *
- * Tests the backend retry mechanism:
- * - First failure sets cooldown, does NOT permanently disable
- * - After cooldown expires, retries backend
- * - After 3 consecutive failures, permanently falls back
- * - Success resets failure count
+ * Tests:
+ * - speakText() calls backend /api/tts/synthesize for each sentence
+ * - Successful backend response plays audio
+ * - Backend failure rejects the promise
+ * - cancelTts() stops playback
+ * - Empty/whitespace text resolves immediately without fetching
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock fetch globally before importing the module
 const fetchMock = vi.fn();
@@ -21,7 +22,6 @@ class MockAudio {
   currentTime = 0;
 
   play() {
-    // Store callback, trigger it async
     audioOnEnded = () => this.onended?.();
     setTimeout(() => audioOnEnded?.(), 0);
     return Promise.resolve();
@@ -37,32 +37,7 @@ vi.stubGlobal('URL', {
   revokeObjectURL: vi.fn(),
 });
 
-// Mock SpeechSynthesisUtterance as a class
-class MockUtterance {
-  lang = '';
-  rate = 1;
-  pitch = 1;
-  voice: unknown = null;
-  onend: (() => void) | null = null;
-  onerror: ((e: unknown) => void) | null = null;
-  constructor(public text: string) {}
-}
-vi.stubGlobal('SpeechSynthesisUtterance', MockUtterance);
-
-// Mock SpeechSynthesis
-const mockSpeak = vi.fn().mockImplementation((u: MockUtterance) => {
-  setTimeout(() => u.onend?.(), 0);
-});
-const mockCancel = vi.fn();
-const mockGetVoices = vi.fn().mockReturnValue([]);
-vi.stubGlobal('speechSynthesis', {
-  speak: mockSpeak,
-  cancel: mockCancel,
-  getVoices: mockGetVoices,
-  onvoiceschanged: null,
-});
-
-import { speakText, _testInternals } from '../services/ttsApi';
+import { speakText, cancelTts, _testInternals } from '../services/ttsApi';
 
 // Helper: make fetch return a successful audio blob
 function mockFetchSuccess() {
@@ -81,13 +56,10 @@ function mockFetchFailure(status = 503) {
   });
 }
 
-describe('ttsApi retry logic', () => {
+describe('ttsApi — Azure TTS only', () => {
   beforeEach(() => {
     _testInternals.reset();
     fetchMock.mockReset();
-    mockSpeak.mockImplementation((u: MockUtterance) => {
-      setTimeout(() => u.onend?.(), 0);
-    });
     vi.useFakeTimers();
   });
 
@@ -95,94 +67,53 @@ describe('ttsApi retry logic', () => {
     vi.useRealTimers();
   });
 
-  it('first failure sets cooldown but does NOT permanently disable', async () => {
-    mockFetchFailure();
+  it('resolves immediately for empty text without calling fetch', async () => {
+    await speakText('');
+    expect(fetchMock).not.toHaveBeenCalled();
 
-    const promise = speakText('測試');
-    await vi.runAllTimersAsync();
-    await promise;
-
-    const state = _testInternals.getState();
-    expect(state._consecutiveFailures).toBe(1);
-    expect(state._permanentlyFallback).toBe(false);
-    expect(state._lastFailureTime).toBeGreaterThan(0);
-  });
-
-  it('during cooldown, skips backend and uses Web Speech directly', async () => {
-    // First call: backend fails
-    mockFetchFailure();
-    let promise = speakText('測試一');
-    await vi.runAllTimersAsync();
-    await promise;
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-
-    // Second call within cooldown: should NOT call fetch
-    fetchMock.mockReset();
-    promise = speakText('測試二');
-    await vi.runAllTimersAsync();
-    await promise;
+    await speakText('   ');
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('after cooldown expires, retries backend', async () => {
-    // First call: backend fails
-    mockFetchFailure();
-    let promise = speakText('測試');
+  it('calls backend /api/tts/synthesize for non-empty text', async () => {
+    mockFetchSuccess();
+    const promise = speakText('你好。');
     await vi.runAllTimersAsync();
     await promise;
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/api/tts/synthesize'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
 
-    // Advance past cooldown
-    vi.advanceTimersByTime(_testInternals.BACKEND_COOLDOWN_MS + 100);
+  it('rejects when backend returns non-ok response', async () => {
+    mockFetchFailure(503);
+    // Attach rejection handler immediately to avoid unhandled rejection warning
+    const promise = speakText('測試。');
+    const rejection = promise.catch((e) => e);
+    await vi.runAllTimersAsync();
+    const err = await rejection;
+    expect(err).toBeInstanceOf(Error);
+  });
 
-    // Next call: should retry backend
+  it('cancelTts stops playback mid-sequence', async () => {
     mockFetchSuccess();
-    promise = speakText('再試');
+    mockFetchSuccess();
+    const promise = speakText('第一句。第二句。');
+    // Cancel immediately
+    cancelTts();
+    await vi.runAllTimersAsync();
+    // Promise should resolve (cancel = graceful stop, not reject)
+    await promise;
+  });
+
+  it('sentence splitting: long text is split and fetches per-sentence', async () => {
+    // Two short sentences — should result in 2 fetch calls
+    mockFetchSuccess();
+    mockFetchSuccess();
+    const promise = speakText('第一句。第二句。');
     await vi.runAllTimersAsync();
     await promise;
     expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it('after 3 consecutive failures, permanently falls back', async () => {
-    for (let i = 0; i < _testInternals.MAX_CONSECUTIVE_FAILURES; i++) {
-      mockFetchFailure();
-      // Advance past cooldown for each retry
-      vi.advanceTimersByTime(_testInternals.BACKEND_COOLDOWN_MS + 100);
-      const promise = speakText(`失敗${i}`);
-      await vi.runAllTimersAsync();
-      await promise;
-    }
-
-    const state = _testInternals.getState();
-    expect(state._consecutiveFailures).toBe(_testInternals.MAX_CONSECUTIVE_FAILURES);
-    expect(state._permanentlyFallback).toBe(true);
-
-    // Even after cooldown, should NOT retry
-    fetchMock.mockReset();
-    vi.advanceTimersByTime(_testInternals.BACKEND_COOLDOWN_MS + 100);
-    const promise = speakText('不該再試');
-    await vi.runAllTimersAsync();
-    await promise;
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it('success resets consecutive failure count', async () => {
-    // Fail once
-    mockFetchFailure();
-    let promise = speakText('失敗');
-    await vi.runAllTimersAsync();
-    await promise;
-    expect(_testInternals.getState()._consecutiveFailures).toBe(1);
-
-    // Advance past cooldown, then succeed
-    vi.advanceTimersByTime(_testInternals.BACKEND_COOLDOWN_MS + 100);
-    mockFetchSuccess();
-    promise = speakText('成功');
-    await vi.runAllTimersAsync();
-    await promise;
-
-    const state = _testInternals.getState();
-    expect(state._consecutiveFailures).toBe(0);
-    expect(state._permanentlyFallback).toBe(false);
   });
 });

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -1,5 +1,6 @@
 
 import React, { useRef, useState, useEffect, useMemo, useCallback } from 'react';
+import { speakText as azureSpeakText } from '../../services/ttsApi';
 import { LearningSession } from '../../types';
 import type { Story } from '../../types';
 import type { ComprehensionScoreResult } from '../../services/learningApi';
@@ -93,12 +94,9 @@ const getCurrentSegment = (cpm: number) => {
   return 3;
 };
 
-/** Speak a Chinese character/word using Web Speech API */
+/** Speak a Chinese character/word using Azure TTS */
 const speakText = (text: string) => {
-  const u = new SpeechSynthesisUtterance(text);
-  u.lang = 'zh-TW';
-  u.rate = 0.8;
-  window.speechSynthesis.speak(u);
+  azureSpeakText(text).catch(() => {});
 };
 
 /** Generate practice suggestions based on performance */

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -7,6 +7,7 @@ import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProc
 import ZhuyinToggle from '../ui/ZhuyinToggle';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { useAudioRecorder } from '../../hooks/useAudioRecorder';
+import { speakText as azureSpeakText, cancelTts } from '../../services/ttsApi';
 
 /* ------------------------------------------------------------------ */
 
@@ -135,52 +136,34 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
     return () => {
       isSessionActiveRef.current = false;
       if (recognitionRef.current) { try { recognitionRef.current.abort(); } catch (_) {} }
-      window.speechSynthesis?.cancel();
+      cancelTts();
     };
   }, []);
 
-  /* ---- TTS: read full story ---- */
+  /* ---- TTS: read full story via Azure TTS ---- */
   const speakFullStory = useCallback(() => {
-    if (!window.speechSynthesis) return;
-    window.speechSynthesis.cancel();
+    cancelTts();
     setIsTtsPaused(false);
-    setIsTtsLoading(true); // show loading until the first utterance begins
+    setIsTtsSpeaking(true);
+    azureSpeakText(fullText)
+      .then(() => { setIsTtsSpeaking(false); setIsTtsPaused(false); })
+      .catch(() => { setIsTtsSpeaking(false); setIsTtsPaused(false); });
+  }, [fullText]);
 
-    const doSpeak = () => {
-      const voices = window.speechSynthesis.getVoices();
-      const preferred =
-        voices.find(v => v.name.includes('Google') && v.name.includes('Taiwan')) ||
-        voices.find(v => v.name.includes('Google') && v.lang === 'zh-TW') ||
-        voices.find(v => v.lang === 'zh-TW') ||
-        voices.find(v => v.lang.startsWith('zh'));
-
-      const utterances = story.content.map(paragraph => {
-        const u = new SpeechSynthesisUtterance(paragraph);
-        u.lang = 'zh-TW'; u.rate = 1.0;
-        if (preferred) u.voice = preferred;
-        return u;
-      });
-      utterances[0].onstart = () => { setIsTtsLoading(false); setIsTtsSpeaking(true); };
-      utterances[utterances.length - 1].onend = () => { setIsTtsLoading(false); setIsTtsSpeaking(false); setIsTtsPaused(false); };
-      utterances[utterances.length - 1].onerror = () => { setIsTtsLoading(false); setIsTtsSpeaking(false); setIsTtsPaused(false); };
-      utterances.forEach(u => window.speechSynthesis.speak(u));
-    };
-
-    if (window.speechSynthesis.getVoices().length === 0) {
-      window.speechSynthesis.onvoiceschanged = () => { window.speechSynthesis.onvoiceschanged = null; doSpeak(); };
-    } else {
-      doSpeak();
-    }
-  }, [story.content]);
-
-  const pauseTts = () => { window.speechSynthesis?.pause(); setIsTtsPaused(true); };
-  const resumeTts = () => { window.speechSynthesis?.resume(); setIsTtsPaused(false); };
-  const stopTts = () => { window.speechSynthesis?.cancel(); setIsTtsLoading(false); setIsTtsSpeaking(false); setIsTtsPaused(false); };
+  const pauseTts = () => { cancelTts(); setIsTtsPaused(true); };
+  const resumeTts = () => {
+    setIsTtsPaused(false);
+    setIsTtsSpeaking(true);
+    azureSpeakText(fullText)
+      .then(() => { setIsTtsSpeaking(false); setIsTtsPaused(false); })
+      .catch(() => { setIsTtsSpeaking(false); setIsTtsPaused(false); });
+  };
+  const stopTts = () => { cancelTts(); setIsTtsSpeaking(false); setIsTtsPaused(false); };
 
   /* ---- STT ---- */
   const startSession = () => {
     if (isSessionActiveRef.current) return;
-    window.speechSynthesis?.cancel();
+    cancelTts();
     setIsTtsSpeaking(false);
     setIsTtsPaused(false);
     setIsPreparing(true);

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -3,6 +3,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { Story } from '../../types';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
+import { speakText as azureSpeakText, cancelTts } from '../../services/ttsApi';
 
 const CATEGORY_LABEL: Record<string, string> = {
   Fable: '寓言故事',
@@ -41,41 +42,17 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
   }, [zhuyinActive]);
 
   const speakIntro = useCallback(() => {
-    if (!window.speechSynthesis || !story.intro) return;
-    window.speechSynthesis.cancel();
-
+    if (!story.intro) return;
+    cancelTts();
     const text = `${story.title}。作者：${story.intro.author}。${story.intro.background}`;
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.lang = 'zh-TW';
-    utterance.rate = 0.95;
-
-    const doSpeak = () => {
-      const voices = window.speechSynthesis.getVoices();
-      const preferred =
-        voices.find(v => v.name.includes('Google') && v.name.includes('Taiwan')) ||
-        voices.find(v => v.name.includes('Google') && v.lang === 'zh-TW') ||
-        voices.find(v => v.lang === 'zh-TW') ||
-        voices.find(v => v.lang.startsWith('zh'));
-      if (preferred) utterance.voice = preferred;
-
-      utterance.onstart = () => setIsSpeaking(true);
-      utterance.onend = () => setIsSpeaking(false);
-      utterance.onerror = () => setIsSpeaking(false);
-      window.speechSynthesis.speak(utterance);
-    };
-
-    if (window.speechSynthesis.getVoices().length === 0) {
-      window.speechSynthesis.onvoiceschanged = () => {
-        window.speechSynthesis.onvoiceschanged = null;
-        doSpeak();
-      };
-    } else {
-      doSpeak();
-    }
+    setIsSpeaking(true);
+    azureSpeakText(text)
+      .then(() => setIsSpeaking(false))
+      .catch(() => setIsSpeaking(false));
   }, [story]);
 
   const stopSpeaking = () => {
-    window.speechSynthesis?.cancel();
+    cancelTts();
     setIsSpeaking(false);
   };
 

--- a/frontend/src/components/reading-steps/ListeningPractice.tsx
+++ b/frontend/src/components/reading-steps/ListeningPractice.tsx
@@ -2,7 +2,7 @@
  * ListeningPractice — Issue #251
  *
  * Three-phase listening comprehension exercise:
- *   Phase 1: Play story text via Cloud TTS Neural2 (zh-TW), Web Speech API fallback
+ *   Phase 1: Play story text via Azure TTS (zh-TW)
  *   Phase 2: Student retells what they heard (voice or text input)
  *   Phase 3: Show AI evaluation with score and feedback
  */
@@ -35,7 +35,7 @@ type PlayState = 'idle' | 'playing' | 'paused' | 'done';
 // ── TTS helpers ───────────────────────────────────────────────────────────────
 
 /**
- * Speak text using Cloud TTS Neural2 (zh-TW) with Web Speech API fallback.
+ * Speak text using Azure TTS (zh-TW).
  * Returns a speaker object with start/cancel interface matching prior API.
  */
 function createSpeaker(text: string, rate: number): {
@@ -157,23 +157,15 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({
   }, [fullText, playRate]);
 
   const handlePause = useCallback(() => {
-    // Cloud TTS uses <audio> element; pause via cancelTts and track state.
-    // Web Speech API fallback also honours this via window.speechSynthesis.pause().
     cancelTts();
-    if (window.speechSynthesis?.speaking) {
-      window.speechSynthesis.pause();
-    }
     setPlayState('paused');
   }, []);
 
   const handleResume = useCallback(() => {
     // Re-trigger playback from beginning when resuming after pause
     // (HTML audio pause/resume position tracking is not exposed via ttsApi)
-    if (window.speechSynthesis?.paused) {
-      window.speechSynthesis.resume();
-      setPlayState('playing');
-    }
-  }, []);
+    handlePlay();
+  }, [handlePlay]);
 
   const handleStop = useCallback(() => {
     speakerRef.current?.cancel();
@@ -182,7 +174,6 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({
 
   const handleReplay = useCallback(() => {
     handleStop();
-    // Brief delay to let SpeechSynthesis fully reset
     setTimeout(handlePlay, 100);
   }, [handleStop, handlePlay]);
 

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -387,9 +387,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const scrollRef = useRef<HTMLDivElement>(null);
   const activeLineRef = useRef<HTMLDivElement>(null);
   const recognitionRef = useRef<any>(null);
-  // Strong ref to TTS utterance — prevents Chrome GC bug where a local utterance
-  // gets collected mid-playback, silencing onend/onboundary callbacks.
-  const utteranceRef = useRef<SpeechSynthesisUtterance | HTMLAudioElement | null>(null);
+  // Ref to the currently playing TTS audio element.
+  const utteranceRef = useRef<HTMLAudioElement | null>(null);
   // rAF loop for TTS cursor animation — Chrome's onboundary doesn't fire per-char for Chinese.
   const ttsRafRef = useRef<number | null>(null);
   const ttsStartTimeRef = useRef<number>(0);
@@ -799,16 +798,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     // the previous utterance cannot stomp on the STT cursor position.
     if (utteranceRef.current) {
       const cur = utteranceRef.current;
-      if (cur instanceof HTMLAudioElement) {
-        cur.onended = null;
-        cur.onerror = null;
-        cur.pause();
-      } else {
-        (cur as SpeechSynthesisUtterance).onstart = null;
-        (cur as SpeechSynthesisUtterance).onboundary = null;
-        (cur as SpeechSynthesisUtterance).onend = null;
-        (cur as SpeechSynthesisUtterance).onerror = null;
-      }
+      cur.onended = null;
+      cur.onerror = null;
+      cur.pause();
       utteranceRef.current = null;
     }
     if (ttsRafRef.current !== null) {
@@ -1071,60 +1063,25 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         if (blob.size === 0) throw new Error('Empty TTS audio');
         const url = URL.createObjectURL(blob);
         const audio = new Audio(url);
-        utteranceRef.current = audio as unknown as SpeechSynthesisUtterance;
+        utteranceRef.current = audio;
         audio.onplay = startCursorAnimation;
         audio.onended = onSpeechEnd;
         audio.onerror = onSpeechEnd;
         return audio.play();
       })
       .catch(() => {
-        // Fallback: Web Speech API
-        if (!window.speechSynthesis) { onSpeechEnd(); return; }
-        window.speechSynthesis.cancel();
-        const utterance = new SpeechSynthesisUtterance(text);
-        utteranceRef.current = utterance;
-        utterance.lang = 'zh-TW';
-        utterance.rate = 1.0;
-        const voices = window.speechSynthesis.getVoices();
-        const preferred =
-          voices.find(v => v.name.includes('Google') && v.name.includes('Taiwan')) ||
-          voices.find(v => v.lang === 'zh-TW') ||
-          voices.find(v => v.lang.startsWith('zh'));
-        if (preferred) utterance.voice = preferred;
-        utterance.onstart = startCursorAnimation;
-        utterance.onboundary = (e) => { setSpeakingProgress(e.charIndex); };
-        utterance.onend = onSpeechEnd;
-        utterance.onerror = onSpeechEnd;
-
-        const doSpeak = () => window.speechSynthesis.speak(utterance);
-        if (window.speechSynthesis.getVoices().length === 0) {
-          window.speechSynthesis.onvoiceschanged = () => {
-            window.speechSynthesis.onvoiceschanged = null;
-            doSpeak();
-          };
-        } else {
-          doSpeak();
-        }
+        onSpeechEnd();
       });
   }, [story.content, currentLineIndex]);
 
   const pauseTts = () => {
-    // Pause <audio> element if playing via Cloud TTS
     const ua = utteranceRef.current;
-    if (ua && ua instanceof HTMLAudioElement) {
-      ua.pause();
-    } else {
-      window.speechSynthesis?.pause();
-    }
+    if (ua) ua.pause();
     setIsTtsPaused(true);
   };
   const resumeTts = () => {
     const ua = utteranceRef.current;
-    if (ua && ua instanceof HTMLAudioElement) {
-      ua.play().catch(() => {});
-    } else {
-      window.speechSynthesis?.resume();
-    }
+    if (ua) ua.play().catch(() => {});
     setIsTtsPaused(false);
   };
   const stopTts = () => {
@@ -1277,7 +1234,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                           onClick={() => {
                             if (idx !== currentLineIndex) { stopSession(); setRetryCount(0); setCurrentLineIndex(idx); }
                             if (isTtsSpeaking) {
-                              if (utteranceRef.current) { const _u = utteranceRef.current; if (_u instanceof HTMLAudioElement) { _u.onended = null; _u.onerror = null; _u.pause(); } else { (_u as SpeechSynthesisUtterance).onend = null; (_u as SpeechSynthesisUtterance).onerror = null; (_u as SpeechSynthesisUtterance).onboundary = null; } utteranceRef.current = null; }
+                              if (utteranceRef.current) { const _u = utteranceRef.current; _u.onended = null; _u.onerror = null; _u.pause(); utteranceRef.current = null; }
                               if (ttsRafRef.current !== null) { cancelAnimationFrame(ttsRafRef.current); ttsRafRef.current = null; }
                               cancelTts();
                               setIsTtsLoading(false); setIsTtsSpeaking(false); setIsTtsPaused(false);
@@ -1320,32 +1277,6 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" /></svg>
                           )}
                           {isTtsLoading ? '載入中...' : isTtsSpeaking && idx === currentLineIndex ? '停止' : 'AI 朗讀'}
-                        </button>
-                        {/* A/B test: Web Speech API button for comparison */}
-                        <button
-                          onClick={() => {
-                            const text = story.content[idx];
-                            if (!text) return;
-                            if (window.speechSynthesis.speaking) {
-                              window.speechSynthesis.cancel();
-                              return;
-                            }
-                            const utt = new SpeechSynthesisUtterance(text);
-                            utt.lang = 'zh-TW';
-                            utt.rate = 0.9;
-                            const voices = window.speechSynthesis.getVoices();
-                            const best = voices.find(v => v.name.includes('Google') && v.name.includes('Taiwan'))
-                              || voices.find(v => v.lang === 'zh-TW');
-                            if (best) utt.voice = best;
-                            window.speechSynthesis.speak(utt);
-                          }}
-                          disabled={idx === currentLineIndex && (isSessionActive || isPreparing)}
-                          className={`px-4 py-2 rounded-lg text-sm font-bold flex items-center gap-1.5 transition-all bg-amber-50 hover:bg-amber-100 text-amber-700 border border-amber-200 ${
-                            idx === currentLineIndex && (isSessionActive || isPreparing) ? 'opacity-40 cursor-not-allowed' : ''
-                          }`}
-                        >
-                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" /></svg>
-                          瀏覽器朗讀
                         </button>
                         {/* Start / Submit / Retry — context-dependent */}
                         {idx === currentLineIndex ? (

--- a/frontend/src/components/reading-steps/PronunciationPractice.tsx
+++ b/frontend/src/components/reading-steps/PronunciationPractice.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useAudioRecorder } from '../../hooks/useAudioRecorder';
+import { speakText as azureSpeakText, cancelTts } from '../../services/ttsApi';
 
 interface PronunciationPracticeProps {
   character: string;
@@ -14,21 +15,7 @@ const MAX_ATTEMPTS = 3;
 const SHORT_RECORDING_SECONDS = 5;
 
 function speakCharacter(character: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (!('speechSynthesis' in window)) {
-      reject(new Error('不支援語音合成'));
-      return;
-    }
-    window.speechSynthesis.cancel();
-    const utterance = new SpeechSynthesisUtterance(character);
-    utterance.lang = 'zh-TW';
-    utterance.rate = 0.8;
-    utterance.pitch = 1;
-    utterance.volume = 1;
-    utterance.onend = () => resolve();
-    utterance.onerror = (e) => reject(new Error(e.error));
-    window.speechSynthesis.speak(utterance);
-  });
+  return azureSpeakText(character);
 }
 
 const PronunciationPractice: React.FC<PronunciationPracticeProps> = ({
@@ -139,7 +126,7 @@ const PronunciationPractice: React.FC<PronunciationPracticeProps> = ({
       if (studentAudioRef.current) {
         studentAudioRef.current.pause();
       }
-      window.speechSynthesis?.cancel();
+      cancelTts();
     };
   }, []);
 

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -5,7 +5,8 @@
  * 1. Splits text into sentences (matching backend _split_sentences / _clean_for_tts)
  * 2. Fetches each sentence from /api/tts/synthesize (stored per-sentence in GCS)
  * 3. Plays audio blobs sequentially — one sentence finishes, next one starts
- * 4. Falls back to browser Web Speech API if backend is unavailable
+ *
+ * Azure TTS is the sole TTS source. Web Speech API has been removed (#737).
  *
  * Usage:
  *   import { speakText, cancelTts } from '../../services/ttsApi';
@@ -26,16 +27,8 @@ let _currentAudio: HTMLAudioElement | null = null;
 // Flag to signal cancellation mid-sequence
 let _cancelRequested = false;
 
-// Backend retry state: cooldown after failure, permanent fallback after 3 consecutive failures.
-const BACKEND_COOLDOWN_MS = 30_000; // 30 seconds before retrying after a failure
-const MAX_CONSECUTIVE_FAILURES = 3;
-
-let _consecutiveFailures = 0;
-let _permanentlyFallback = false;
-let _lastFailureTime = 0;
-
 /**
- * Stop any TTS currently in progress (backend or Web Speech API).
+ * Stop any TTS currently in progress.
  */
 export function cancelTts(): void {
   _cancelRequested = true;
@@ -44,76 +37,31 @@ export function cancelTts(): void {
     _currentAudio.currentTime = 0;
     _currentAudio = null;
   }
-  if (typeof window !== 'undefined' && window.speechSynthesis) {
-    window.speechSynthesis.cancel();
-  }
 }
 
 /**
- * Synthesise and play *text* in Traditional Chinese.
+ * Synthesise and play *text* in Traditional Chinese via Azure TTS.
  *
  * Splits text into sentences and plays each one sequentially via the backend.
- * Falls back to browser Web Speech API if backend is unavailable.
  *
  * @param text - Text to synthesise (keep under 5000 chars per request).
- * @param rate - Playback speed multiplier (default 0.9, applied to Web Speech fallback).
  * @returns Promise that resolves when all sentences finish, or rejects on fatal error.
  */
-export async function speakText(text: string, rate = 0.9): Promise<void> {
+export async function speakText(text: string): Promise<void> {
   if (!text.trim()) return;
   cancelTts();
   _cancelRequested = false;
-
-  // Try backend TTS first (unless permanently fallen back or in cooldown)
-  if (!_permanentlyFallback && _isBackendAvailable()) {
-    try {
-      await _speakViaBackend(text);
-      // Reset failure count on success
-      _consecutiveFailures = 0;
-      return;
-    } catch (err) {
-      _consecutiveFailures++;
-      _lastFailureTime = Date.now();
-      if (_consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-        console.warn(`[TTS] ${MAX_CONSECUTIVE_FAILURES} consecutive failures — permanently falling back to Web Speech API`);
-        _permanentlyFallback = true;
-      } else {
-        console.warn(`[TTS] Backend TTS failed (${_consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES}), cooldown ${BACKEND_COOLDOWN_MS / 1000}s:`, err);
-      }
-    }
-  }
-
-  // Fallback: browser Web Speech API (whole text at once)
-  await _speakViaBrowserApi(text, rate);
-}
-
-// ---------------------------------------------------------------------------
-// Private: backend availability check
-// ---------------------------------------------------------------------------
-
-function _isBackendAvailable(): boolean {
-  if (_permanentlyFallback) return false;
-  if (_consecutiveFailures === 0) return true;
-  // In cooldown: wait before retrying
-  return Date.now() - _lastFailureTime >= BACKEND_COOLDOWN_MS;
+  await _speakViaBackend(text);
 }
 
 // Exported for testing only
 export const _testInternals = {
   reset() {
-    _consecutiveFailures = 0;
-    _permanentlyFallback = false;
-    _lastFailureTime = 0;
     _cancelRequested = false;
     _urlCache.clear();
   },
-  getState() {
-    return { _consecutiveFailures, _permanentlyFallback, _lastFailureTime };
-  },
   splitSentences: _splitSentences,
   cleanForTts: _cleanForTts,
-  BACKEND_COOLDOWN_MS,
-  MAX_CONSECUTIVE_FAILURES,
 };
 
 // ---------------------------------------------------------------------------
@@ -241,49 +189,3 @@ function _playSingleAudio(audioUrl: string): Promise<void> {
   });
 }
 
-// ---------------------------------------------------------------------------
-// Private: Web Speech API fallback
-// ---------------------------------------------------------------------------
-
-function _speakViaBrowserApi(text: string, rate: number): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    if (typeof window === 'undefined' || !window.speechSynthesis) {
-      reject(new Error('Web Speech API not available'));
-      return;
-    }
-
-    window.speechSynthesis.cancel();
-
-    const utterance = new SpeechSynthesisUtterance(text);
-    utterance.lang = 'zh-TW';
-    utterance.rate = rate;
-    utterance.pitch = 1.0;
-
-    // Prefer Google Taiwan voice when available
-    const voices = window.speechSynthesis.getVoices();
-    const preferred =
-      voices.find((v) => v.name.includes('Google') && v.name.includes('Taiwan')) ||
-      voices.find((v) => v.lang === 'zh-TW') ||
-      voices.find((v) => v.lang.startsWith('zh'));
-    if (preferred) utterance.voice = preferred;
-
-    utterance.onend = () => resolve();
-    utterance.onerror = (e) => reject(new Error(e.error ?? 'speech error'));
-    window.speechSynthesis.speak(utterance);
-
-    // If voices not loaded yet, retry after voiceschanged fires
-    if (voices.length === 0) {
-      window.speechSynthesis.onvoiceschanged = () => {
-        window.speechSynthesis.onvoiceschanged = null;
-        window.speechSynthesis.cancel();
-        const v2 = window.speechSynthesis.getVoices();
-        const best =
-          v2.find((v) => v.name.includes('Google') && v.name.includes('Taiwan')) ||
-          v2.find((v) => v.lang === 'zh-TW') ||
-          v2.find((v) => v.lang.startsWith('zh'));
-        if (best) utterance.voice = best;
-        window.speechSynthesis.speak(utterance);
-      };
-    }
-  });
-}


### PR DESCRIPTION
## Summary

- Remove all `speechSynthesis` / `SpeechSynthesisUtterance` / Web Speech API code from the entire frontend
- Azure TTS (`ttsApi.ts` → backend `/api/tts/synthesize`) is now the sole TTS source
- Remove the "瀏覽器朗讀" A/B test button from LiveTutor
- Update unit tests: replace obsolete retry/cooldown/fallback tests with Azure-TTS-only coverage

## Files changed

| File | Change |
|------|--------|
| `ttsApi.ts` | Remove `_speakViaBrowserApi`, retry/cooldown state, simplify `speakText` |
| `LiveTutor.tsx` | Remove "瀏覽器朗讀" button, remove Web Speech fallback in `speakCurrentParagraph`, simplify `utteranceRef` type |
| `FullReading.tsx` | Replace `speakFullStory` Web Speech impl with Azure TTS via `speakText` |
| `AssessmentReport.tsx` | Replace local `speakText` (Web Speech) with `azureSpeakText` import |
| `Intro.tsx` | Replace `speakIntro` Web Speech impl with Azure TTS |
| `PronunciationPractice.tsx` | Replace `speakCharacter` Web Speech impl with Azure TTS |
| `ListeningPractice.tsx` | Remove Web Speech pause/resume branches |
| `ttsApi.test.ts` | Rewrite tests for Azure-only behaviour |

## Verification

- `npx vite build` — passes, 0 errors
- `npx vitest run src/__tests__/ttsApi.test.ts` — 5/5 tests pass
- `grep -r speechSynthesis frontend/src` — **zero matches**

## Test plan

- [ ] Intro page: click "朗讀簡介" — Azure TTS plays
- [ ] LiveTutor: click "AI 朗讀" button — Azure TTS plays, "瀏覽器朗讀" button is gone
- [ ] FullReading: click listen button — Azure TTS plays
- [ ] AssessmentReport: click character play button — Azure TTS plays
- [ ] PronunciationPractice: reference audio plays via Azure TTS
- [ ] ListeningPractice: story plays via Azure TTS

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)