### PR TITLE
fix(reading): #746 — annotation side panel sticky (add h-full)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -625,7 +625,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
 
   return (
     <div
-      className="flex-1 flex flex-col bg-amber-50 overflow-hidden select-none"
+      className="flex-1 flex flex-col h-full bg-amber-50 overflow-hidden select-none"
       style={{
         fontFamily: zhuyinActive
           ? "'BpmfIansui', 'Iansui', 'Noto Sans TC', sans-serif"


### PR DESCRIPTION
## Summary

- Fixes #746: annotation side panel was scrolling away with the page instead of staying fixed
- Root cause: `ReadingAnnotation` root div was missing `h-full`, which `ComprehensionChat` already has
- Without `h-full`, `flex-1` inside the outer `overflow-y-auto` step content container allows the component to grow to its full content height — so both text area and side panel scroll together as one unit
- Adding `h-full` caps the component at the container's visible height, making `overflow-hidden` + internal `overflow-y-auto` on the text area effective — text scrolls, panel stays fixed

## Change

`frontend/src/components/reading-steps/ReadingAnnotation.tsx` line 628:

```diff
- className="flex-1 flex flex-col bg-amber-50 overflow-hidden select-none"
+ className="flex-1 flex flex-col h-full bg-amber-50 overflow-hidden select-none"
```

## Test plan

- [ ] Open a story and navigate to 閱讀標記 step
- [ ] On desktop (lg+): scroll the story text — the right side panel (已標記詞語) should stay fixed
- [ ] Add annotations — they should appear in the panel without the panel scrolling away
- [ ] On mobile: panel button + drawer should still work normally
- [ ] Build passes: `✓ built in 6.77s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)