### PR TITLE
fix(ui): #741 #720 — unify story text font size across all reading steps

### DIFF
--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -1327,10 +1327,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                   {/* Paragraph text — STATIC: text and colors never change during reading.
                       Only show plain text at all times. Background highlight is on the container above. */}
                   <p
-                    className={`leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
+                    className={`text-2xl lg:text-3xl leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''} ${
                       status === 'current' ? 'text-gray-900 font-bold' : 'text-gray-600'
                     }`}
-                    style={{ fontSize: fontSizePx }}
                   >
                     {status === 'locked' ? (
                       <span className="blur-sm select-none">{zhuyinLines ? zhuyinLines[idx] : line}</span>

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -744,12 +744,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
                 <p
                   key={paraIdx}
                   data-para-idx={paraIdx}
-                  className="text-gray-900"
-                  style={{
-                    fontSize: `${fontSizePx}px`,
-                    lineHeight: zhuyinActive ? '3.8rem' : '3.5rem',
-                    letterSpacing: zhuyinActive ? '0.35em' : '0.05em',
-                  }}
+                  className={`text-2xl lg:text-3xl text-gray-900 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}
                 >
                   {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}
                 </p>


### PR DESCRIPTION
## Summary

- **ReadingAnnotation**: replaced `style={{ fontSize: \`${fontSizePx}px\` }}` + `leading-loose` with `text-2xl lg:text-3xl leading-[3.5rem] lg:leading-[3.5rem]`
- **LiveTutor**: removed `style={{ fontSize: fontSizePx }}` from paragraph `<p>`, added `text-2xl lg:text-3xl` to existing className
- **FullReading**: already used `text-2xl lg:text-3xl leading-[3.5rem]` — no change needed
- **ComprehensionChat**: already used `text-2xl lg:text-3xl leading-[3.5rem]` — no change needed

All 4 reading-step components now render story text at the same size: `text-2xl` (mobile) / `text-3xl` (desktop) with `leading-[3.5rem]`.

Closes #741. Related #720.

## Test plan

- [ ] 閱讀標記 (ReadingAnnotation) — story text matches ComprehensionChat size
- [ ] 逐段朗讀 (LiveTutor) — paragraph text matches ComprehensionChat size
- [ ] 全文朗讀 (FullReading) — unchanged, still correct
- [ ] 課文理解 (ComprehensionChat) — unchanged, still the reference
- [ ] Test with zhuyin toggle on/off (tracking class still applied)
- [ ] Test mobile and desktop breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)