### PR TITLE
fix(ui): #724 — light bg for found words in WordSearch

### DIFF
--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -462,7 +462,7 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
 
   function getCellClass(row: number, col: number): string {
     const key = row + ',' + col;
-    if (highlightedCells.has(key)) return 'bg-[#5B4FC4] text-white font-black ring-2 ring-inset ring-white';
+    if (highlightedCells.has(key)) return 'bg-indigo-100 text-indigo-700 font-black';
     if (dragCells.has(key)) return 'bg-indigo-300 text-white font-bold';
     if (flashCells.has(key)) return 'bg-red-300 text-white';
     return 'bg-white text-gray-800 hover:bg-indigo-50';


### PR DESCRIPTION
## Summary
- Found word cells changed from dark purple (`bg-[#5B4FC4]`) to light indigo (`bg-indigo-100 text-indigo-700`)
- Red rounded border overlay now clearly visible against light background

Closes follow-up from #724

## Test plan
- [ ] Open WordSearch, find a word — confirm light background with visible red border

🤖 Generated with [Claude Code](https://claude.com/claude-code)