### PR TITLE
fix(reading): side panel click-to-scroll (Fixes #759)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -183,10 +183,19 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
 
   const jumpToAnnotation = useCallback((id: string) => {
     const el = annSpanRefs.current.get(id);
-    if (!el) return;
+    const container = containerRef.current;
+    if (!el || !container) return;
 
-    // Scroll the span into view inside the scroll container
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Manually scroll only the inner text-area container so that outer
+    // overflow-y-auto ancestors (LearningContent wrapper, AppShell <main>)
+    // are not touched. Using scrollIntoView() would bubble up and scroll
+    // those outer containers as well, causing no visible movement inside
+    // the annotation text area.
+    const elRect = el.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const offset =
+      elRect.top - containerRect.top + container.scrollTop - containerRect.height / 2 + elRect.height / 2;
+    container.scrollTo({ top: offset, behavior: 'smooth' });
 
     // Flash highlight
     setHighlightedId(id);

--- a/frontend/src/components/reading-steps/__tests__/ReadingAnnotation.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/ReadingAnnotation.test.tsx
@@ -153,6 +153,41 @@ describe('ReadingAnnotation', () => {
     expect(screen.queryByTestId('zhuyin-toggle')).toBeNull();
   });
 
+  it('jumpToAnnotation scrolls the inner container (not scrollIntoView)', async () => {
+    // Set up an annotation so the side-panel jump button is rendered
+    const seeded = [
+      { id: 'ann-jump', paragraphIndex: 0, charStart: 0, charEnd: 2, type: 'unknown' },
+    ];
+    localStorageMock.setItem(`annotations_test-story-001`, JSON.stringify(seeded));
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+
+    // scrollIntoView must NOT be called — we use container.scrollTo instead
+    const scrollIntoViewSpy = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy;
+
+    // scrollTo spy on the container element
+    const scrollToSpy = vi.fn();
+    const textArea = document.querySelector('.overflow-y-auto.relative') as HTMLElement;
+    if (textArea) {
+      textArea.scrollTo = scrollToSpy;
+    }
+
+    // Click the jump button in the desktop side panel
+    const jumpBtn = screen.getByLabelText(/跳轉到標記/);
+    await act(async () => {
+      fireEvent.click(jumpBtn);
+    });
+
+    // The inner container's scrollTo must be called with smooth behavior
+    if (textArea) {
+      expect(scrollToSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ behavior: 'smooth' })
+      );
+    }
+    // scrollIntoView must NOT have been called on any element
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled();
+  });
+
   it('renders marks on annotated text (seeded from localStorage)', () => {
     const seeded = [
       { id: 'ann-x', paragraphIndex: 0, charStart: 0, charEnd: 2, type: 'unknown' },


### PR DESCRIPTION
Fixes #759

## Root Cause

`jumpToAnnotation` was calling `el.scrollIntoView({ behavior: 'smooth', block: 'center' })` on the annotation span. The component layout has multiple nested `overflow-y-auto` containers:

1. `AppShell <main>` — `overflow-y-auto`
2. `LearningContent` inner div — `overflow-y-auto`
3. `containerRef` div (the text area) — `overflow-y-auto`

`scrollIntoView()` bubbles up and scrolls **all** scrollable ancestors, not just the inner one. Because the outer containers are already scrolled to show the component, they scroll slightly (or not at all visually), and the inner `containerRef` never scrolls — so clicking a panel item had no visible effect.

## Fix

Replace `el.scrollIntoView()` with a manual `container.scrollTo()` calculation using `containerRef.current`, so only the inner text-area scrolls:

```ts
const elRect = el.getBoundingClientRect();
const containerRect = container.getBoundingClientRect();
const offset =
  elRect.top - containerRect.top + container.scrollTop - containerRect.height / 2 + elRect.height / 2;
container.scrollTo({ top: offset, behavior: 'smooth' });
```

## Test Plan

- Added vitest test asserting `container.scrollTo` is called with `{ behavior: 'smooth' }` and `scrollIntoView` is NOT called
- `npm run build` passes
- Manual: mark a word in a long story, scroll the text area away, click the word in the side panel — text area scrolls back to that word with flash highlight