### PR TITLE
fix: remove duplicate DiffDisplay from panel expand (Fixes #751)

### DIFF
--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -390,6 +390,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const activeLineRef = useRef<HTMLDivElement>(null);
   // Per-paragraph refs for scroll-to behavior from side panel
   const paragraphRefsRef = useRef<Array<HTMLDivElement | null>>([]);
+  // Ref to the main diff section in the right panel (for "查看詳細" scroll-to)
+  const diffSectionRef = useRef<HTMLDivElement>(null);
   const recognitionRef = useRef<any>(null);
   // Ref to the currently playing TTS audio element.
   const utteranceRef = useRef<HTMLAudioElement | null>(null);
@@ -1621,11 +1623,17 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                             <span className="text-gray-400">漏字 {summary.missingCount} 字</span>
                           )}
                         </div>
-                        {/* Diff display */}
-                        {paraResult && paraResult.diffTokens.length > 0 && (
-                          <div className="bg-white rounded-lg border border-gray-200 px-2 py-2">
-                            <DiffDisplay tokens={paraResult.diffTokens} showLegend={false} className="text-sm" />
-                          </div>
+                        {/* 查看詳細按鈕 — scroll to main diff section */}
+                        {paraResult && paraResult.diffTokens.length > 0 && idx === currentLineIndex && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              diffSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                            }}
+                            className="text-xs text-accent hover:text-accent-hover font-medium underline underline-offset-2"
+                          >
+                            查看詳細 ↓
+                          </button>
                         )}
                         {/* AI feedback */}
                         {summary.feedback && (
@@ -1654,7 +1662,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
           {/* Diff result for current paragraph — shown after evaluation */}
           {!isSessionActive && rightPanelDiffTokens && (
-            <div className="space-y-2">
+            <div ref={diffSectionRef} className="space-y-2">
               <div className="flex items-center gap-2">
                 <p className="text-[9px] font-bold text-gray-400 uppercase tracking-widest">逐字比對（第 {currentLineIndex + 1} 段）</p>
                 {paragraphSummary?.geminiPending && (


### PR DESCRIPTION
Fixes #751

## Summary
- Removed full `DiffDisplay` from the per-paragraph expand section in the 朗讀回饋 panel
- The compact score row (正確率 %, 念錯 N 字, 漏字 N 字) remains visible — no information loss
- Added a "查看詳細 ↓" button (only shown when the expanded paragraph is the current one and diff tokens exist) that calls `scrollIntoView` on the existing `DiffDisplay` in the main content area below
- Added `diffSectionRef` to the main diff section div to enable the scroll target

## Why only for `currentLineIndex`
The main diff section already only shows the current paragraph's diff (`rightPanelDiffTokens` = current paragraph). Showing the scroll button for a non-current completed paragraph would link to the wrong diff, so the button is conditionally rendered only when `idx === currentLineIndex`.

## Test plan
- Open LiveTutor on any story with 2+ paragraphs
- Complete paragraph 1 recording
- In the 朗讀進度 panel, expand paragraph 1 — confirm no DiffDisplay, only score summary + "查看詳細 ↓"
- Click "查看詳細 ↓" — confirm page scrolls to the DiffDisplay below
- Confirm DiffDisplay in main area still shows correctly
- `npm run build` passes (verified locally)