### PR TITLE
fix(listening): add TTS playback progress bar (Fixes #763)

### DIFF
--- a/frontend/src/components/reading-steps/ListeningPractice.tsx
+++ b/frontend/src/components/reading-steps/ListeningPractice.tsx
@@ -12,7 +12,7 @@ import { Story } from '../../types';
 import { evaluateListeningRetelling, ListeningEvaluateResponse } from '../../services/learningApi';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { useAuth } from '../../contexts/AuthContext';
-import { speakText as cloudSpeakText, cancelTts } from '../../services/ttsApi';
+import { speakTextWithProgress, cancelTts, TtsProgressInfo } from '../../services/ttsApi';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -36,14 +36,22 @@ type PlayState = 'idle' | 'playing' | 'paused' | 'done';
 
 /**
  * Speak text using Azure TTS (zh-TW).
- * Returns a speaker object with start/cancel interface matching prior API.
+ * Returns a speaker object with start/cancel interface.
  */
-function createSpeaker(text: string, rate: number): {
-  start: (onEnd: () => void, onError: (e: string) => void) => void;
+function createSpeaker(text: string, _rate: number): {
+  start: (
+    onEnd: () => void,
+    onError: (e: string) => void,
+    onProgress: (info: TtsProgressInfo) => void,
+  ) => void;
   cancel: () => void;
 } {
-  const start = (onEnd: () => void, onError: (e: string) => void) => {
-    cloudSpeakText(text, rate)
+  const start = (
+    onEnd: () => void,
+    onError: (e: string) => void,
+    onProgress: (info: TtsProgressInfo) => void,
+  ) => {
+    speakTextWithProgress(text, onProgress)
       .then(onEnd)
       .catch((err: Error) => onError(err?.message ?? 'speech error'));
   };
@@ -93,6 +101,7 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({
   const [playState, setPlayState] = useState<PlayState>('idle');
   const [playRate, setPlayRate] = useState(0.85);
   const [ttsError, setTtsError] = useState<string | null>(null);
+  const [ttsProgress, setTtsProgress] = useState<TtsProgressInfo | null>(null);
   const speakerRef = useRef<ReturnType<typeof createSpeaker> | null>(null);
 
   // Phase 2 — retelling
@@ -142,23 +151,30 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({
       return;
     }
     setTtsError(null);
+    setTtsProgress(null);
     setPlayState('playing');
 
     const speaker = createSpeaker(fullText, playRate);
     speakerRef.current = speaker;
 
     speaker.start(
-      () => setPlayState('done'),
+      () => {
+        setPlayState('done');
+        setTtsProgress(null);
+      },
       (errMsg) => {
         setTtsError(`播放發生錯誤：${errMsg}`);
         setPlayState('idle');
+        setTtsProgress(null);
       },
+      (info) => setTtsProgress(info),
     );
   }, [fullText, playRate]);
 
   const handlePause = useCallback(() => {
     cancelTts();
     setPlayState('paused');
+    setTtsProgress(null);
   }, []);
 
   const handleResume = useCallback(() => {
@@ -170,6 +186,7 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({
   const handleStop = useCallback(() => {
     speakerRef.current?.cancel();
     setPlayState('idle');
+    setTtsProgress(null);
   }, []);
 
   const handleReplay = useCallback(() => {
@@ -382,6 +399,35 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({
               </button>
             )}
           </div>
+
+          {/* TTS Progress bar — shown while playing */}
+          {playState === 'playing' && (
+            <div className="space-y-2" aria-label="播放進度">
+              <div className="flex items-center gap-3">
+                <div
+                  className="flex-1 h-2.5 bg-gray-200 rounded-full overflow-hidden"
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={ttsProgress ? Math.round(ttsProgress.progress * 100) : 0}
+                  aria-label="音檔播放進度"
+                >
+                  <div
+                    className="h-full bg-accent rounded-full transition-all duration-300 ease-linear"
+                    style={{ width: `${ttsProgress ? ttsProgress.progress * 100 : 0}%` }}
+                  />
+                </div>
+                <span className="text-xs text-gray-500 tabular-nums min-w-[3rem] text-right">
+                  {ttsProgress
+                    ? `${ttsProgress.sentenceIndex + 1} / ${ttsProgress.totalSentences}`
+                    : '— / —'}
+                </span>
+              </div>
+              <p className="text-xs text-gray-400 text-center">
+                第 {ttsProgress ? ttsProgress.sentenceIndex + 1 : '—'} 句，共 {ttsProgress ? ttsProgress.totalSentences : '—'} 句
+              </p>
+            </div>
+          )}
 
           {/* Status text */}
           <div className="text-center">

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -54,6 +54,36 @@ export async function speakText(text: string): Promise<void> {
   await _speakViaBackend(text);
 }
 
+/**
+ * Progress info emitted during speakTextWithProgress playback.
+ */
+export interface TtsProgressInfo {
+  /** Sentence currently playing (0-based) */
+  sentenceIndex: number;
+  /** Total number of sentences */
+  totalSentences: number;
+  /** Overall progress 0–1 based on sentences completed + within-sentence position */
+  progress: number;
+}
+
+/**
+ * Like speakText, but fires `onProgress` on each sentence start and on
+ * `timeupdate` within each sentence so callers can render a progress bar.
+ *
+ * @param text - Text to synthesise.
+ * @param onProgress - Called with progress info as playback advances.
+ * @returns Promise that resolves when all sentences finish, or rejects on fatal error.
+ */
+export async function speakTextWithProgress(
+  text: string,
+  onProgress: (info: TtsProgressInfo) => void,
+): Promise<void> {
+  if (!text.trim()) return;
+  cancelTts();
+  _cancelRequested = false;
+  await _speakViaBackendWithProgress(text, onProgress);
+}
+
 // Exported for testing only
 export const _testInternals = {
   reset() {
@@ -124,6 +154,30 @@ function _splitSentences(text: string): string[] {
 // Private: backend sequential playback
 // ---------------------------------------------------------------------------
 
+async function _fetchAudioUrl(sentence: string): Promise<string> {
+  let audioUrl = _urlCache.get(sentence);
+  if (!audioUrl) {
+    const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: sentence }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`TTS backend responded ${response.status}`);
+    }
+
+    const blob = await response.blob();
+    if (blob.size === 0) {
+      throw new Error('TTS backend returned empty audio');
+    }
+
+    audioUrl = URL.createObjectURL(blob);
+    _urlCache.set(sentence, audioUrl);
+  }
+  return audioUrl;
+}
+
 async function _speakViaBackend(text: string): Promise<void> {
   const cleaned = _cleanForTts(text);
   if (!cleaned) return;
@@ -135,39 +189,56 @@ async function _speakViaBackend(text: string): Promise<void> {
     if (_cancelRequested) break;
     if (!sentence.trim()) continue;
 
-    // Check URL cache first
-    let audioUrl = _urlCache.get(sentence);
+    const audioUrl = await _fetchAudioUrl(sentence);
+    if (_cancelRequested) break;
+    await _playSingleAudio(audioUrl);
+  }
+}
 
-    if (!audioUrl) {
-      const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: sentence }),
-      });
+async function _speakViaBackendWithProgress(
+  text: string,
+  onProgress: (info: TtsProgressInfo) => void,
+): Promise<void> {
+  const cleaned = _cleanForTts(text);
+  if (!cleaned) return;
 
-      if (!response.ok) {
-        throw new Error(`TTS backend responded ${response.status}`);
-      }
+  const sentences = _splitSentences(cleaned);
+  if (sentences.length === 0) return;
 
-      const blob = await response.blob();
-      if (blob.size === 0) {
-        throw new Error('TTS backend returned empty audio');
-      }
+  const total = sentences.length;
 
-      audioUrl = URL.createObjectURL(blob);
-      _urlCache.set(sentence, audioUrl);
-    }
+  for (let i = 0; i < total; i++) {
+    if (_cancelRequested) break;
+    const sentence = sentences[i];
+    if (!sentence.trim()) continue;
 
+    // Emit start of this sentence
+    onProgress({ sentenceIndex: i, totalSentences: total, progress: i / total });
+
+    const audioUrl = await _fetchAudioUrl(sentence);
     if (_cancelRequested) break;
 
-    await _playSingleAudio(audioUrl);
+    await _playSingleAudio(audioUrl, (currentTime, duration) => {
+      const withinSentence = duration > 0 ? currentTime / duration : 0;
+      const progress = (i + withinSentence) / total;
+      onProgress({ sentenceIndex: i, totalSentences: total, progress });
+    });
+  }
+
+  if (!_cancelRequested) {
+    // Emit 100% when all sentences finished
+    onProgress({ sentenceIndex: total - 1, totalSentences: total, progress: 1 });
   }
 }
 
 /**
  * Play a single audio URL and wait for it to finish.
+ * Optional `onTimeUpdate` fires with (currentTime, duration) during playback.
  */
-function _playSingleAudio(audioUrl: string): Promise<void> {
+function _playSingleAudio(
+  audioUrl: string,
+  onTimeUpdate?: (currentTime: number, duration: number) => void,
+): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     if (_cancelRequested) {
       resolve();
@@ -176,6 +247,12 @@ function _playSingleAudio(audioUrl: string): Promise<void> {
 
     const audio = new Audio(audioUrl);
     _currentAudio = audio;
+
+    if (onTimeUpdate) {
+      audio.ontimeupdate = () => {
+        onTimeUpdate(audio.currentTime, audio.duration || 0);
+      };
+    }
 
     audio.onended = () => {
       _currentAudio = null;


### PR DESCRIPTION
Fixes #763

## Summary
- Add `speakTextWithProgress()` to `ttsApi.ts` — fires a progress callback with `{ sentenceIndex, totalSentences, progress }` on every sentence start and on `timeupdate` within each sentence
- Refactor `_playSingleAudio` to accept an optional `onTimeUpdate` callback for fine-grained progress
- Extract `_fetchAudioUrl` helper to remove duplication between the two playback paths
- Export `TtsProgressInfo` type so consumers can type their state
- `ListeningPractice.tsx` now shows an animated indigo progress bar + sentence counter ("第 N 句，共 M 句") while TTS is playing; bar and counter reset on stop/pause/done

## Test plan
- [ ] Open a lesson and navigate to the 聽力理解練習 step
- [ ] Click "播放課文" — progress bar should appear and fill smoothly as audio plays sentence by sentence
- [ ] Sentence counter ("第 N 句，共 M 句") should increment as each sentence completes
- [ ] Click "暫停" — bar disappears; click "繼續" — bar restarts from 0 (expected, resume restarts from beginning per existing behaviour)
- [ ] Click "停止" — bar disappears
- [ ] After playback completes — bar disappears and "播放完畢" message shows
- [ ] `npm run build` passes (verified locally)
- [ ] All 5 ttsApi unit tests pass (verified locally)