### PR TITLE
fix(tts): phoneme corrections for 喝采/打的漂亮 mispronunciations (Fixes #765)

### DIFF
--- a/backend/app/routes/tts.py
+++ b/backend/app/routes/tts.py
@@ -1,5 +1,5 @@
 """
-TTS route — Issue #663 (synthesize) + Issue #667 (sentence mapping).
+TTS route — Issue #663 (synthesize) + Issue #667 (sentence mapping) + Issue #765 (regenerate).
 
 POST /api/tts/synthesize
   Body: { "text": "..." }
@@ -15,6 +15,12 @@ GET /api/tts/mapping/{lesson_id}
   Structure:
     { "lesson_id": 1, "paragraphs": [{"index": 0, "sentences": [{"text": ..., "hash": ..., "chars": ...}]}] }
 
+POST /api/tts/regenerate
+  Body: { "text": "..." }
+  Deletes cached audio for the given text (L1 + GCS) then re-synthesises from scratch.
+  Used to fix sentences with incorrect phoneme readings (Issue #765).
+  Response: { "status": "ok", "key": "...", "gcs_deleted": [...], "bytes": N }
+
 Falls back gracefully: if TTS fails (quota, auth, etc.) the frontend
 is expected to fall back to Web Speech API on its own.
 """
@@ -27,7 +33,13 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
-from ..services.tts_service import TTSError, build_lesson_tts_mapping, synthesize_sentence, synthesize_speech
+from ..services.tts_service import (
+    TTSError,
+    build_lesson_tts_mapping,
+    delete_tts_cache,
+    synthesize_sentence,
+    synthesize_speech,
+)
 from ..services.lesson_loader import get_lesson_by_id
 
 logger = logging.getLogger(__name__)
@@ -130,3 +142,42 @@ def get_tts_mapping(lesson_id: int) -> dict:
         raise HTTPException(status_code=404, detail=f"Lesson {lesson_id} not found")
 
     return build_lesson_tts_mapping(lesson)
+
+
+@router.post("/regenerate")
+def regenerate(req: TTSRequest) -> dict:
+    """Delete cached audio for *text* and re-synthesise from scratch (Issue #765).
+
+    Use this endpoint when a specific sentence has a known mispronunciation
+    in its cached audio (e.g. wrong tone for 喝采). The endpoint:
+      1. Deletes the GCS cached file (both azure/sentences/ and tts-cache/ paths).
+      2. Evicts the L1 in-memory cache entry.
+      3. Calls Azure TTS (with phoneme corrections applied) to produce fresh audio.
+      4. Stores the new audio in L1 + GCS.
+
+    Returns:
+        200  application/json — { "status": "ok", "key": "...", "gcs_deleted": [...], "bytes": N }
+        503  application/json — TTS unavailable.
+    """
+    # Step 1: delete existing caches
+    delete_result = delete_tts_cache(req.text)
+    logger.info(
+        "TTS regenerate: key=%s, l1=%s, gcs_deleted=%s",
+        delete_result["key"][:8],
+        delete_result["l1_deleted"],
+        delete_result["gcs_deleted"],
+    )
+
+    # Step 2: re-synthesise (phoneme corrections in _synthesize_azure will apply)
+    try:
+        audio_bytes = synthesize_speech(req.text)
+    except TTSError as exc:
+        logger.warning("TTS regenerate synthesis failed: %s", exc)
+        raise HTTPException(status_code=503, detail="TTS service unavailable during regenerate")
+
+    return {
+        "status": "ok",
+        "key": delete_result["key"],
+        "gcs_deleted": delete_result["gcs_deleted"],
+        "bytes": len(audio_bytes),
+    }

--- a/backend/app/services/tts_service.py
+++ b/backend/app/services/tts_service.py
@@ -137,6 +137,67 @@ class TTSError(RuntimeError):
 
 
 # ---------------------------------------------------------------------------
+# Phoneme correction — Issue #765
+# ---------------------------------------------------------------------------
+# Azure SSML phoneme tag format (zh-TW Zhuyin):
+#   <phoneme alphabet="x-microsoft-zhuyin" ph="ㄏㄜˋ">喝</phoneme>
+#
+# Each entry is (pattern, replacement_ssml).
+# Patterns are matched in order; first match wins for each occurrence.
+# The replacement is raw SSML (already XML-safe) that replaces the matched text.
+
+_PHONEME_CORRECTIONS: list[tuple[str, str]] = [
+    # 喝采 / 喝彩 — 喝 should be hè (ㄏㄜˋ), not hē (ㄏㄜ)
+    (
+        "喝采",
+        '<phoneme alphabet="x-microsoft-zhuyin" ph="ㄏㄜˋ">喝</phoneme>采',
+    ),
+    (
+        "喝彩",
+        '<phoneme alphabet="x-microsoft-zhuyin" ph="ㄏㄜˋ">喝</phoneme>彩',
+    ),
+    # 打得漂亮 / 打的漂亮 — 的/得 should be neutral tone "de", not dì/dí
+    # Cover both orthographies since the source text may use either
+    (
+        "打的漂亮",
+        '打<phoneme alphabet="x-microsoft-zhuyin" ph="˙ㄉㄜ">的</phoneme>漂亮',
+    ),
+    (
+        "打得漂亮",
+        '打<phoneme alphabet="x-microsoft-zhuyin" ph="˙ㄉㄜ">得</phoneme>漂亮',
+    ),
+]
+
+
+def _apply_phoneme_corrections(text_escaped: str) -> str:
+    """Apply known phoneme corrections to XML-escaped SSML content.
+
+    Scans *text_escaped* (already XML-escaped plain text) for known
+    mispronunciation patterns and wraps them with Azure SSML <phoneme> tags.
+
+    The replacements are inserted as raw SSML markup so they must NOT be
+    re-escaped after this step.
+
+    Args:
+        text_escaped: XML-escaped text (& → &amp; etc. already applied).
+
+    Returns:
+        SSML fragment with phoneme corrections applied.
+    """
+    result = text_escaped
+    for pattern, replacement in _PHONEME_CORRECTIONS:
+        if pattern in result:
+            result = result.replace(pattern, replacement)
+            logger.debug("Phoneme correction applied: %r → %r", pattern, replacement)
+    return result
+
+
+def _has_phoneme_corrections(text: str) -> bool:
+    """Return True if *text* contains any known mispronunciation patterns."""
+    return any(pattern in text for pattern, _ in _PHONEME_CORRECTIONS)
+
+
+# ---------------------------------------------------------------------------
 # Azure Speech — REST API synthesis
 # ---------------------------------------------------------------------------
 
@@ -144,8 +205,12 @@ def _synthesize_azure(text: str) -> bytes:
     """Synthesise text via Azure Speech Service REST API.
 
     Voice: zh-TW-HsiaoChenNeural (Taiwan accent, female)
-    Output: audio-16khz-128kbitrate-mono-mp3
+    Output: audio-48khz-192kbitrate-mono-mp3
     Rate: 0.95 (slightly slower than natural for reading practice)
+
+    When *text* contains known mispronunciation patterns (see
+    _PHONEME_CORRECTIONS), the SSML body is enriched with <phoneme> tags
+    so Azure reads the characters with the correct tones.
 
     Raises:
         TTSError: if Azure key is missing, HTTP error, or empty audio returned.
@@ -165,10 +230,13 @@ def _synthesize_azure(text: str) -> bytes:
         .replace("'", "&apos;")
     )
 
+    # Apply phoneme corrections (inserts raw SSML tags — must come after escaping)
+    ssml_body = _apply_phoneme_corrections(text_escaped)
+
     ssml = (
         '<speak version="1.0" xmlns="http://www.w3.org/2001/10/synthesis" xml:lang="zh-TW">'
         f'<voice name="{AZURE_TTS_VOICE}">'
-        f'<prosody rate="0.95">{text_escaped}</prosody>'
+        f'<prosody rate="0.95">{ssml_body}</prosody>'
         "</voice>"
         "</speak>"
     )
@@ -422,6 +490,51 @@ def _l1_put(key: str, audio_bytes: bytes) -> None:
         oldest_key = next(iter(_TTS_CACHE))
         del _TTS_CACHE[oldest_key]
     _TTS_CACHE[key] = audio_bytes
+
+
+def delete_tts_cache(text: str) -> dict:
+    """Delete cached audio for *text* from L1 and GCS (both azure and google paths).
+
+    Used by the /api/tts/regenerate admin endpoint to force re-synthesis
+    after phoneme corrections are added.
+
+    Args:
+        text: The exact text whose cache should be invalidated.
+
+    Returns:
+        Dict with keys "key", "l1_deleted" (bool), "gcs_deleted" (list of paths deleted).
+    """
+    key = _cache_key(text)
+    deleted_paths: list[str] = []
+
+    # L1 eviction
+    l1_deleted = key in _TTS_CACHE
+    if l1_deleted:
+        del _TTS_CACHE[key]
+        logger.info("L1 cache evicted (key=%s)", key[:8])
+
+    # GCS deletion — try both provider paths
+    bucket = _get_gcs_bucket()
+    if bucket is not None:
+        for provider in ("azure", "google"):
+            if provider == "azure":
+                blob_path = f"azure/sentences/{key}.mp3"
+            else:
+                blob_path = f"tts-cache/{key}.mp3"
+            try:
+                blob = bucket.blob(blob_path)
+                if blob.exists():
+                    blob.delete()
+                    deleted_paths.append(blob_path)
+                    logger.info("GCS cache deleted: %s", blob_path)
+            except Exception as exc:
+                logger.warning("GCS cache delete error (%s): %s", blob_path, exc)
+
+    return {
+        "key": key,
+        "l1_deleted": l1_deleted,
+        "gcs_deleted": deleted_paths,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_tts_service.py
+++ b/backend/tests/test_tts_service.py
@@ -672,3 +672,221 @@ class TestAzureGoogleFallback:
         # provider is passed as positional arg[2] or keyword arg
         provider_used = args[2] if len(args) > 2 else kwargs.get("provider", "google")
         assert provider_used == "google"
+
+
+# ---------------------------------------------------------------------------
+# 10. Phoneme corrections — Issue #765
+# ---------------------------------------------------------------------------
+
+class TestPhonemeCorrections:
+    """Phoneme corrections must inject SSML <phoneme> tags for known mispronunciations."""
+
+    def test_he_cai_detected(self):
+        """'喝采' in text should trigger a phoneme correction."""
+        from app.services.tts_service import _has_phoneme_corrections
+        assert _has_phoneme_corrections("贏得全國人民的尊敬及喝采") is True
+
+    def test_he_cai2_detected(self):
+        """'喝彩' variant also triggers a phoneme correction."""
+        from app.services.tts_service import _has_phoneme_corrections
+        assert _has_phoneme_corrections("觀眾喝彩叫好") is True
+
+    def test_da_de_piaoliang_detected(self):
+        """'打的漂亮' triggers a phoneme correction."""
+        from app.services.tts_service import _has_phoneme_corrections
+        assert _has_phoneme_corrections("她，打的漂亮，雖然輸了比賽") is True
+
+    def test_no_corrections_for_plain_text(self):
+        """Text without known mispronunciations should return False."""
+        from app.services.tts_service import _has_phoneme_corrections
+        assert _has_phoneme_corrections("她是一個好學生") is False
+
+    def test_apply_he_cai_correction(self):
+        """'喝采' must be wrapped with phoneme tag for hè (ㄏㄜˋ)."""
+        from app.services.tts_service import _apply_phoneme_corrections
+        result = _apply_phoneme_corrections("贏得喝采")
+        assert '<phoneme' in result
+        assert 'ㄏㄜˋ' in result
+        assert '喝</phoneme>采' in result
+
+    def test_apply_he_cai2_correction(self):
+        """'喝彩' must also get the phoneme correction."""
+        from app.services.tts_service import _apply_phoneme_corrections
+        result = _apply_phoneme_corrections("觀眾喝彩")
+        assert '<phoneme' in result
+        assert 'ㄏㄜˋ' in result
+
+    def test_apply_da_de_piaoliang_correction(self):
+        """'打的漂亮' — '的' must be corrected to neutral tone de (˙ㄉㄜ)."""
+        from app.services.tts_service import _apply_phoneme_corrections
+        result = _apply_phoneme_corrections("打的漂亮")
+        assert '<phoneme' in result
+        assert '˙ㄉㄜ' in result
+
+    def test_no_correction_applied_for_plain_text(self):
+        """Text without patterns should pass through unchanged."""
+        from app.services.tts_service import _apply_phoneme_corrections
+        text = "她是一個好學生"
+        result = _apply_phoneme_corrections(text)
+        assert result == text
+        assert '<phoneme' not in result
+
+    def test_azure_ssml_contains_phoneme_for_he_cai(self):
+        """Full Azure SSML output must contain phoneme tag when text has 喝采."""
+        import app.services.tts_service as tts_mod
+
+        captured_request = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured_request["data"] = req.data.decode("utf-8")
+            resp = MagicMock()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            resp.read.return_value = b"AUDIO"
+            return resp
+
+        with patch.object(tts_mod, "AZURE_SPEECH_KEY", "fake-key"), \
+             patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            tts_mod._synthesize_azure("贏得全國人民的尊敬及喝采")
+
+        ssml = captured_request["data"]
+        assert '<phoneme' in ssml
+        assert 'ㄏㄜˋ' in ssml
+
+    def test_azure_ssml_no_phoneme_for_plain_text(self):
+        """SSML for plain text must NOT contain phoneme tags."""
+        import app.services.tts_service as tts_mod
+
+        captured_request = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured_request["data"] = req.data.decode("utf-8")
+            resp = MagicMock()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            resp.read.return_value = b"AUDIO"
+            return resp
+
+        with patch.object(tts_mod, "AZURE_SPEECH_KEY", "fake-key"), \
+             patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            tts_mod._synthesize_azure("她是一個好學生")
+
+        ssml = captured_request["data"]
+        assert '<phoneme' not in ssml
+
+
+# ---------------------------------------------------------------------------
+# 11. Cache deletion — delete_tts_cache (Issue #765)
+# ---------------------------------------------------------------------------
+
+class TestDeleteTtsCache:
+    """delete_tts_cache must evict L1 and delete GCS blobs."""
+
+    def test_l1_eviction_when_present(self):
+        """Key present in L1 cache must be removed."""
+        import app.services.tts_service as tts_mod
+        from app.services.tts_service import delete_tts_cache, _cache_key
+
+        text = "測試刪除L1"
+        key = _cache_key(text)
+        tts_mod._TTS_CACHE[key] = b"CACHED"
+
+        with patch("app.services.tts_service._get_gcs_bucket", return_value=None):
+            result = delete_tts_cache(text)
+
+        assert result["l1_deleted"] is True
+        assert key not in tts_mod._TTS_CACHE
+
+    def test_l1_eviction_when_absent(self):
+        """Key absent from L1 must return l1_deleted=False without error."""
+        import app.services.tts_service as tts_mod
+        from app.services.tts_service import delete_tts_cache, _cache_key
+
+        text = "不在快取裡的句子"
+        key = _cache_key(text)
+        tts_mod._TTS_CACHE.pop(key, None)  # ensure not present
+
+        with patch("app.services.tts_service._get_gcs_bucket", return_value=None):
+            result = delete_tts_cache(text)
+
+        assert result["l1_deleted"] is False
+
+    def test_gcs_blobs_deleted(self):
+        """delete_tts_cache must call blob.delete() for existing GCS blobs."""
+        from app.services.tts_service import delete_tts_cache, _cache_key
+        import app.services.tts_service as tts_mod
+
+        text = "測試GCS刪除"
+        key = _cache_key(text)
+        tts_mod._TTS_CACHE.pop(key, None)
+
+        mock_blob = MagicMock()
+        mock_blob.exists.return_value = True
+
+        mock_bucket = MagicMock()
+        mock_bucket.blob.return_value = mock_blob
+
+        with patch("app.services.tts_service._get_gcs_bucket", return_value=mock_bucket):
+            result = delete_tts_cache(text)
+
+        assert mock_blob.delete.call_count >= 1
+        assert len(result["gcs_deleted"]) >= 1
+
+    def test_gcs_unavailable_does_not_raise(self):
+        """If GCS bucket is None, delete_tts_cache should succeed silently."""
+        from app.services.tts_service import delete_tts_cache
+
+        with patch("app.services.tts_service._get_gcs_bucket", return_value=None):
+            result = delete_tts_cache("任何文字")
+
+        assert "key" in result
+        assert result["gcs_deleted"] == []
+
+
+# ---------------------------------------------------------------------------
+# 12. Regenerate endpoint — POST /api/tts/regenerate (Issue #765)
+# ---------------------------------------------------------------------------
+
+class TestRegenerateEndpoint:
+    """POST /api/tts/regenerate must delete cache and re-synthesise."""
+
+    def _make_app(self):
+        from fastapi import FastAPI
+        from app.routes.tts import router
+        app = FastAPI()
+        app.include_router(router)
+        return app
+
+    @patch("app.services.tts_service._gcs_get", return_value=None)
+    @patch("app.services.tts_service._gcs_put")
+    @patch("app.services.tts_service._TTS_CACHE", {})
+    @patch("app.services.tts_service._get_gcs_bucket", return_value=None)
+    def test_regenerate_returns_ok(self, mock_bucket, mock_gcs_put, mock_gcs_get):
+        """POST /api/tts/regenerate must return 200 with status=ok (uses Azure path)."""
+        import app.services.tts_service as tts_mod
+        from fastapi.testclient import TestClient
+        import urllib.request
+
+        fake_response = MagicMock()
+        fake_response.__enter__ = lambda s: s
+        fake_response.__exit__ = MagicMock(return_value=False)
+        fake_response.read.return_value = b"REGENERATED_AUDIO"
+
+        with patch.object(tts_mod, "AZURE_SPEECH_KEY", "fake-key"), \
+             patch("urllib.request.urlopen", return_value=fake_response):
+            client = TestClient(self._make_app())
+            response = client.post("/api/tts/regenerate", json={"text": "她贏得了喝采"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert "key" in data
+        assert "bytes" in data
+
+    def test_regenerate_rejects_empty_text(self):
+        """POST /api/tts/regenerate must reject empty text with 422."""
+        from fastapi.testclient import TestClient
+
+        client = TestClient(self._make_app())
+        response = client.post("/api/tts/regenerate", json={"text": ""})
+        assert response.status_code == 422


### PR DESCRIPTION
Fixes #765

## 問題
Azure TTS 對「喝采」的「喝」讀成 hē（喝水），實際應讀 hè（喝采/喝彩）。
「打的漂亮」的「的」讀成 dì/dí，應讀輕聲 de（結構助詞）。

## 修復方式

使用 Azure SSML `<phoneme>` 標籤強制指定正確聲調：

- `喝采` / `喝彩` → `<phoneme alphabet="x-microsoft-zhuyin" ph="ㄏㄜˋ">喝</phoneme>`
- `打的漂亮` / `打得漂亮` → `<phoneme alphabet="x-microsoft-zhuyin" ph="˙ㄉㄜ">的/得</phoneme>`

## 新增端點

`POST /api/tts/regenerate` — 刪除指定文字的 GCS 快取後重新合成，供修正舊快取使用。

## 測試

16 個新測試，全部通過：
- `TestPhonemeCorrections` (10 tests) — 偵測、SSML 輸出驗證
- `TestDeleteTtsCache` (4 tests) — L1 + GCS 快取刪除
- `TestRegenerateEndpoint` (2 tests) — 端點驗證

## Test plan

1. 部署後呼叫 `POST /api/tts/regenerate` 帶入問題句子
2. 確認回應 `{ "status": "ok", "gcs_deleted": [...], "bytes": N }`
3. 再次播放該句子，確認「喝」讀 hè 而非 hē