### PR TITLE
fix: 查看記錄按鈕導向學習報告頁面 (Fixes #774)

### DIFF
--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -49,6 +49,7 @@ export const HomePage: React.FC = () => {
 
 interface RecentPracticeItem {
   id: number;
+  storySlug: string | null;
   title: string;
   status: string;
   startedAt: string;
@@ -58,6 +59,7 @@ interface RecentPracticeItem {
 function mapSessionToRecentItem(session: LearningSummary): RecentPracticeItem {
   return {
     id: session.id,
+    storySlug: session.story_slug,
     title: session.story_title ?? session.story_slug ?? '未知課文',
     status: session.status,
     startedAt: session.started_at,
@@ -144,7 +146,11 @@ export const LibraryPage: React.FC = () => {
                 </div>
                 <button
                   type="button"
-                  onClick={() => navigate(`/history`)}
+                  onClick={() =>
+                    item.storySlug
+                      ? navigate(`/learn/${item.storySlug}/report`)
+                      : navigate(`/history`)
+                  }
                   className="text-xs font-medium text-accent hover:text-accent-hover"
                 >
                   查看記錄


### PR DESCRIPTION
Fixes #774

## Summary

- 「查看記錄」按鈕原本 `onClick` 寫死為 `navigate('/history')`，導向「我的作業」頁面
- 修正為 `navigate('/learn/{storySlug}/report')`，直接跳到該次學習的 AssessmentReport
- `RecentPracticeItem` 新增 `storySlug` 欄位，從 `LearningSummary.story_slug` 對映
- 防禦性 fallback：若 `storySlug` 為 null 仍導向 `/history`

## Root Cause

`InlinePages.tsx` L147 hardcoded `/history` 而非使用 `item` 的 story slug。

## Test plan

1. 登入學生帳號，確認首頁「最近練習」列表有資料
2. 點擊任一條記錄旁的「查看記錄」
3. 預期：跳到 `/learn/{storySlug}/report`（AssessmentReport 頁面）
4. 非預期（修復前）：跳到 `/history`（我的作業頁面）