### PR TITLE
fix(radicals): #713 — add data source label to decomposition

### DIFF
--- a/frontend/src/components/reading-steps/RadicalDecomposition.tsx
+++ b/frontend/src/components/reading-steps/RadicalDecomposition.tsx
@@ -11,6 +11,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   getDecomposition,
+  getDecompositionSource,
   getRadicalInfo,
   getRelatedChars,
   initGeneratedDecompositions,
@@ -193,6 +194,13 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
           </div>
         )}
       </div>
+
+      {/* Data source label */}
+      <p className="text-[10px] text-gray-400 text-right mt-2 pr-1">
+        {getDecompositionSource(char) === 'hand-curated'
+          ? '資料來源：教學團隊手動編寫'
+          : '資料來源：makemeahanzi（開源漢字資料庫）'}
+      </p>
     </div>
   );
 };

--- a/frontend/src/data/radicals.ts
+++ b/frontend/src/data/radicals.ts
@@ -758,6 +758,13 @@ export function getDecomposition(char: string): CharDecomposition | null {
   return null;
 }
 
+/** Returns the source of decomposition data for a character */
+export function getDecompositionSource(char: string): 'hand-curated' | 'generated' | null {
+  if (charDecomposition[char]) return 'hand-curated';
+  if (_generatedCache && _generatedCache[char]) return 'generated';
+  return null;
+}
+
 /**
  * Returns related characters for a given radical.
  * Excludes the source character itself from the list.


### PR DESCRIPTION
## Summary
- Added `getDecompositionSource(char)` helper
- RadicalDecomposition shows subtle source label at bottom

## Test plan
- [ ] Open 生字練習 → 部件 → see source label

🤖 Generated with [Claude Code](https://claude.com/claude-code)