### PR TITLE
fix(vocab): embed SentencePractice as inline tab in VocabPractice (Fixes #781)

### DIFF
--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -115,6 +115,8 @@ interface SentencePracticeProps {
   storyTitle: string;
   onFinish: () => void;
   onBack: () => void;
+  /** When true, renders as an inline tab panel (no outer wrapper, no tab bar, no bottom actions bar) */
+  inline?: boolean;
 }
 
 // ── Component ─────────────────────────────────────────────────────────────
@@ -124,6 +126,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   storyTitle,
   onFinish,
   onBack,
+  inline = false,
 }) => {
   const { token } = useAuth();
   const [currentCharIndex, setCurrentCharIndex] = useState(0);
@@ -275,6 +278,13 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   // ── Early exit: no practiced chars ───────────────────────────────────
 
   if (practicedChars.length === 0) {
+    if (inline) {
+      return (
+        <div className="flex flex-col items-center justify-center text-center py-12">
+          <p className="text-gray-500 text-sm">沒有需要造句練習的生字。</p>
+        </div>
+      );
+    }
     return (
       <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden">
         <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 text-xs text-gray-600">
@@ -297,54 +307,8 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   const isCurrentDone = completedChars.has(currentChar);
   const currentAllCorrect = currentState.allCorrect;
 
-  return (
-    <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden" style={{ fontFamily: "'Iansui', 'Noto Sans TC', sans-serif" }}>
-
-      {/* Tab bar */}
-      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
-        <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
-          {storyTitle} — 造句練習
-        </div>
-        <div className="flex-1" />
-        <span className="text-[10px] text-gray-500">
-          {currentCharIndex + 1} / {practicedChars.length} 字
-        </span>
-      </div>
-
-      {/* Character tab nav */}
-      {practicedChars.length > 1 && (
-        <div className="bg-white border-b border-gray-100 px-4 py-2 flex gap-2 overflow-x-auto shrink-0">
-          {practicedChars.map((ch, i) => {
-            const done = completedChars.has(ch);
-            const active = i === currentCharIndex;
-            return (
-              <button
-                key={ch}
-                onClick={() => setCurrentCharIndex(i)}
-                className={[
-                  'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all',
-                  active
-                    ? 'bg-accent text-white shadow'
-                    : done
-                      ? 'bg-emerald-100 text-emerald-700'
-                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
-                ].join(' ')}
-              >
-                {ch}
-                {done && (
-                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
-                  </svg>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
-
-      {/* Main content */}
-      <div className="flex-1 overflow-y-auto px-6 py-6">
-        <div className="max-w-2xl mx-auto space-y-6">
+  const innerContent = (
+    <div className="max-w-2xl mx-auto space-y-6">
 
           {/* Header */}
           <div>
@@ -491,7 +455,97 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
             </div>
           )}
 
+    </div>
+  );
+
+  // Inline mode: render content directly inside VocabPractice's scroll area (no outer wrapper, no tab bar, no bottom bar)
+  if (inline) {
+    return (
+      <>
+        {/* Character tab nav — shown inline above content */}
+        {practicedChars.length > 1 && (
+          <div className="bg-white border border-gray-100 rounded-xl px-3 py-2 flex gap-2 overflow-x-auto">
+            {practicedChars.map((ch, i) => {
+              const done = completedChars.has(ch);
+              const active = i === currentCharIndex;
+              return (
+                <button
+                  key={ch}
+                  onClick={() => setCurrentCharIndex(i)}
+                  className={[
+                    'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all',
+                    active
+                      ? 'bg-accent text-white shadow'
+                      : done
+                        ? 'bg-emerald-100 text-emerald-700'
+                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+                  ].join(' ')}
+                >
+                  {ch}
+                  {done && (
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
+                    </svg>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+        {innerContent}
+      </>
+    );
+  }
+
+  // Standalone mode: full-page layout with tab bar and bottom actions
+  return (
+    <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden" style={{ fontFamily: "'Iansui', 'Noto Sans TC', sans-serif" }}>
+
+      {/* Tab bar */}
+      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
+        <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
+          {storyTitle} — 造句練習
         </div>
+        <div className="flex-1" />
+        <span className="text-[10px] text-gray-500">
+          {currentCharIndex + 1} / {practicedChars.length} 字
+        </span>
+      </div>
+
+      {/* Character tab nav */}
+      {practicedChars.length > 1 && (
+        <div className="bg-white border-b border-gray-100 px-4 py-2 flex gap-2 overflow-x-auto shrink-0">
+          {practicedChars.map((ch, i) => {
+            const done = completedChars.has(ch);
+            const active = i === currentCharIndex;
+            return (
+              <button
+                key={ch}
+                onClick={() => setCurrentCharIndex(i)}
+                className={[
+                  'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all',
+                  active
+                    ? 'bg-accent text-white shadow'
+                    : done
+                      ? 'bg-emerald-100 text-emerald-700'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200',
+                ].join(' ')}
+              >
+                {ch}
+                {done && (
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
+                  </svg>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Main content */}
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        {innerContent}
       </div>
 
       {/* Bottom actions */}

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -19,9 +19,9 @@ interface VocabPracticeProps {
   onBack: () => void;
 }
 
-type Phase = 'grid' | 'practice' | 'pronunciation' | 'sentence' | 'zhuyin-game';
+type Phase = 'grid' | 'practice' | 'pronunciation' | 'zhuyin-game';
 
-type PracticeMode = 'stroke' | 'pronunciation' | 'zhuyin' | 'fillinblank';
+type PracticeMode = 'stroke' | 'pronunciation' | 'zhuyin' | 'fillinblank' | 'sentence';
 
 /* ================================================================ */
 /*  Progress bar                                                     */
@@ -294,18 +294,6 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     );
   }
 
-  /* ── Sentence phase: compose sentences after stroke practice ── */
-  if (phase === 'sentence') {
-    return (
-      <SentencePractice
-        practicedChars={Array.from(practicedChars)}
-        storyTitle={story.title}
-        onFinish={() => handleFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
-        onBack={() => setPhase('grid')}
-      />
-    );
-  }
-
   /* ── Zhuyin phonetic game phase ── */
   if (phase === 'zhuyin-game') {
     return (
@@ -325,7 +313,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   const currentChars = activeTab === 'stroke' ? displayChars : activeTab === 'pronunciation' ? pronunciationChars : [];
   const currentPracticedSet = activeTab === 'stroke' ? practicedChars : activeTab === 'pronunciation' ? pronouncedChars : new Set<string>();
   const currentDone = activeTab === 'stroke' ? strokeDone : activeTab === 'pronunciation' ? pronounceDone : false;
-  // 'zhuyin' and 'fillinblank' tabs are handled separately above; these vars only matter for stroke/pronunciation
+  // 'zhuyin', 'fillinblank', and 'sentence' tabs are handled separately; these vars only matter for stroke/pronunciation
 
   // Characters for which we have radical decomposition data
   const charsWithRadical = displayChars.filter(ch => getDecomposition(ch) !== null);
@@ -352,7 +340,9 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
               ? `發音 ${pronouncedChars.size} / ${pronunciationChars.length}`
               : activeTab === 'fillinblank'
                 ? '語詞應用'
-                : '注音遊戲'}
+                : activeTab === 'sentence'
+                  ? '造句練習'
+                  : '注音遊戲'}
         </span>
         <ZhuyinToggle enabled={zhuyinEnabled} ready={zhuyinReady} onToggle={() => setZhuyinEnabled(!zhuyinEnabled)} />
       </div>
@@ -378,10 +368,10 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           {/* Mode toggle tabs */}
           <div className="flex bg-gray-100 rounded-xl p-1 gap-1">
             <button
-              onClick={() => { setActiveTab('stroke'); if (phase === 'sentence') setPhase('grid'); }}
+              onClick={() => setActiveTab('stroke')}
               className={[
                 'flex-1 flex items-center justify-center gap-2 py-2 rounded-lg text-sm font-semibold transition-all',
-                activeTab === 'stroke' && phase !== 'sentence'
+                activeTab === 'stroke'
                   ? 'bg-white text-gray-900 shadow-sm'
                   : 'text-gray-500 hover:text-gray-700',
               ].join(' ')}
@@ -393,10 +383,10 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
               {strokeDone && <span className="w-2 h-2 bg-emerald-500 rounded-full" />}
             </button>
             <button
-              onClick={() => setPhase('sentence')}
+              onClick={() => setActiveTab('sentence')}
               className={[
                 'flex-1 flex items-center justify-center gap-2 py-2 rounded-lg text-sm font-semibold transition-all',
-                phase === 'sentence'
+                activeTab === 'sentence'
                   ? 'bg-white text-gray-900 shadow-sm'
                   : 'text-gray-500 hover:text-gray-700',
               ].join(' ')}
@@ -441,8 +431,19 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
             </div>
           )}
 
-          {/* Character grid — hidden when zhuyin or fillinblank tab is active */}
-          {activeTab !== 'zhuyin' && activeTab !== 'fillinblank' && <>{/* Character grid */}
+          {/* Sentence practice — inline tab panel */}
+          {activeTab === 'sentence' && (
+            <SentencePractice
+              practicedChars={displayChars.length > 0 ? displayChars : Array.from(practicedChars)}
+              storyTitle={story.title}
+              onFinish={() => handleFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
+              onBack={() => setActiveTab('stroke')}
+              inline
+            />
+          )}
+
+          {/* Character grid — hidden when zhuyin, fillinblank, or sentence tab is active */}
+          {activeTab !== 'zhuyin' && activeTab !== 'fillinblank' && activeTab !== 'sentence' && <>{/* Character grid */}
           {currentChars.length === 0 ? (
             <div className="text-gray-400 text-sm py-8 text-center">
               {activeTab === 'stroke'
@@ -589,7 +590,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
               <p className="text-emerald-800 font-bold mb-2">太棒了！所有生字都練習完了！</p>
               <p className="text-emerald-700 text-sm mb-3">接下來，試著用這些生字各造兩個句子吧！</p>
               <button
-                onClick={() => setPhase('sentence')}
+                onClick={() => setActiveTab('sentence')}
                 className="px-6 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-sm transition-all active:scale-95"
               >
                 開始造句練習


### PR DESCRIPTION
Fixes #781

## Summary

- **Root cause**: Clicking the 造句練習 tab called `setPhase('sentence')`, which triggered an early return rendering `<SentencePractice>` as a full-page component takeover — replacing the entire VocabPractice view with its own tab bar, scroll area, and bottom actions
- **Fix**: Moved 造句練習 from `Phase` (full-page) to `PracticeMode` (inline tab). When `activeTab === 'sentence'`, `SentencePractice` renders inline inside the VocabPractice scroll area via a new `inline` prop
- Added `inline` prop to `SentencePractice`: suppresses the outer `flex-1` wrapper, standalone tab bar, and bottom actions — rendering just the content within the parent's layout

## Test plan

1. Open any story and navigate to 生字練習 step
2. Click the 造句練習 tab — verify it switches inline without navigating to a new page
3. The VocabPractice tab bar (筆順練習 / 造句練習) stays visible at the top
4. Clicking 筆順練習 tab switches back to the character grid
5. When all chars are practiced, the "開始造句練習" button switches to 造句練習 tab inline
6. `npm run build` passes without errors