### PR TITLE
feat(cache): pre-generate example sentences as static JSON (Fixes #780)

### DIFF
--- a/backend/app/services/example_sentence_cache.py
+++ b/backend/app/services/example_sentence_cache.py
@@ -1,12 +1,13 @@
 """Example sentence cache service — JSON file-based.
 
 Caches AI-generated example sentences in a local JSON file to avoid
-repeated Gemini API calls for the same character (Issue #730).
+repeated Gemini API calls for the same character (Issue #730, #780).
 
 Cache strategy:
 - Key: "{story_title}:{character}" (includes story context for accuracy)
 - Storage: backend/data/example_sentence_cache.json
-- TTL: 30 days (checked at read time)
+- TTL: 30 days for runtime-generated entries (checked at read time)
+- Pre-generated entries (source="pregenerated") never expire
 - Thread-safe: file writes use a lock
 """
 
@@ -72,7 +73,14 @@ def _save() -> None:
 
 
 def _is_expired(entry: dict) -> bool:
-    """Return True if cache entry is older than CACHE_TTL_DAYS."""
+    """Return True if cache entry is older than CACHE_TTL_DAYS.
+
+    Pre-generated entries (source="pregenerated") never expire — they are
+    curated content produced by scripts/pre-generate-example-sentences.py
+    and should always be served (Issue #780).
+    """
+    if entry.get("source") == "pregenerated":
+        return False
     cached_at_str = entry.get("cached_at")
     if not cached_at_str:
         return True
@@ -91,7 +99,12 @@ def _make_key(story_title: str, character: str) -> str:
 
 
 def get_cached(story_title: str, character: str) -> Optional[dict]:
-    """Return cached sentences if present and not expired, else None.
+    """Return cached sentences if present, not expired, and non-empty, else None.
+
+    An entry with an empty sentences list (e.g. a placeholder written by
+    scripts/pre-generate-example-sentences.py --mode placeholder) is treated
+    as a cache miss so the live AI fallback is used until real sentences are
+    populated (Issue #780).
 
     Returns:
         {"sentences": [{"sentence": str, "explanation": str}, ...]} or None
@@ -104,8 +117,12 @@ def get_cached(story_title: str, character: str) -> Optional[dict]:
     if _is_expired(entry):
         logger.debug("Cache expired for key: %s", key)
         return None
+    sentences = entry.get("sentences") or []
+    if not sentences:
+        logger.debug("Cache entry has no sentences (placeholder?), treating as miss: %s", key)
+        return None
     logger.debug("Cache hit for key: %s", key)
-    return {"sentences": entry["sentences"]}
+    return {"sentences": sentences}
 
 
 def set_cached(story_title: str, character: str, result: dict) -> None:
@@ -126,6 +143,65 @@ def set_cached(story_title: str, character: str, result: dict) -> None:
         _cache[key] = entry
         _save()
     logger.info("Cached example sentences for key: %s", key)
+
+
+def set_pregenerated(story_title: str, character: str, sentences: list) -> None:
+    """Store a pre-generated sentence list that never expires (Issue #780).
+
+    Used by scripts/pre-generate-example-sentences.py to bulk-load curated
+    sentences into the cache.  Pre-generated entries are served indefinitely
+    without further AI calls.
+
+    Args:
+        story_title: Lesson title (must match story lookup key exactly).
+        character: Single Chinese character.
+        sentences: list of {"sentence": str, "explanation": str} dicts.
+    """
+    _ensure_loaded()
+    key = _make_key(story_title, character)
+    # Skip if pre-generated entry already exists — don't overwrite curated data
+    existing = _cache.get(key, {})
+    if existing.get("source") == "pregenerated" and existing.get("sentences"):
+        logger.debug("Pre-generated entry already exists, skipping: %s", key)
+        return
+    entry = {
+        "sentences": sentences,
+        "source": "pregenerated",
+        "cached_at": datetime.now(timezone.utc).isoformat(),
+    }
+    with _lock:
+        _cache[key] = entry
+        _save()
+    logger.info("Stored pre-generated example sentences for key: %s", key)
+
+
+def bulk_set_pregenerated(entries: dict) -> int:
+    """Bulk-load pre-generated sentences from a dict mapping cache_key -> sentences.
+
+    Args:
+        entries: {"{story_title}:{character}": [{"sentence": str, "explanation": str}]}
+
+    Returns:
+        Number of new entries written (skips already-present pre-generated keys).
+    """
+    _ensure_loaded()
+    written = 0
+    now_iso = datetime.now(timezone.utc).isoformat()
+    with _lock:
+        for key, sentences in entries.items():
+            existing = _cache.get(key, {})
+            if existing.get("source") == "pregenerated" and existing.get("sentences"):
+                continue
+            _cache[key] = {
+                "sentences": sentences,
+                "source": "pregenerated",
+                "cached_at": now_iso,
+            }
+            written += 1
+        if written:
+            _save()
+    logger.info("bulk_set_pregenerated: wrote %d new entries", written)
+    return written
 
 
 # Expose for testing

--- a/backend/data/example_sentence_cache.json
+++ b/backend/data/example_sentence_cache.json
@@ -1,1 +1,8942 @@
-{}
+{
+  "#MeToo運動與我們的權利:一": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:主": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:冒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:凝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:後": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:忌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:憚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:所": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:有": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:標": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:權": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:然": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:片": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:犯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:結": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:自": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:舉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:茶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:視": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:譁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:證": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:識": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:鏈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:陰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:霾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:飯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "#MeToo運動與我們的權利:餘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:倖": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:備": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:免": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:出": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:及": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:嚴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:多": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:性": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:戒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:未": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:森": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:極": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:樣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:殃": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:池": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:活": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:漫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:火": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:烽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:甦": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:端": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:綢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:繆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:資": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:醒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:雨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-末日種子庫:魚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:佼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:倖": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:倚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:僥": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:冠": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:危": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:取": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:口": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:地": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:奠": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:定": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:息": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:悄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:拗": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:杳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:棲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:樹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:永": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:汲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:注": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:瀕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:無": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:然": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:煙": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:目": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:續": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:者": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:臨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:變": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:趨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:近": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:遷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "-植物獵人:重": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "不量田:盈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:下": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:可": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:愈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:成": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:每": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:況": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:見": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:視": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:負": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:蹂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:躪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:逆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "你看見時代的灰犀牛了嗎談人口負成長:長": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:仆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:傾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:其": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:前": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:北": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:匪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:南": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:圓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:夷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:孽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:家": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:廝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:後": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:思": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:所": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:殺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:產": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:發": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:益": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:繼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:罪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:自": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:蕩": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:衝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:說": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:轅": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:轍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:鋒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:陣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "信眾與教主:陷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:一": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:乏": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:倖": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:動": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:取": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:叫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:呼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:命": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:嗚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:回": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:坳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:存": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:寵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:寸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:尚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:山": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:峻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:心": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:息": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:手": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:攫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:杳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:無": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:煙": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:眾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:號": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:術": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:譁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:鐵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:陰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:險": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:驚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:魄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "假新聞？鞭虎救弟記:黯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:也": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:其": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:博": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:及": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:可": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:名": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:和": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:問": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:國": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:如": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:學": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:富": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:實": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:對": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:應": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:敵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:斷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:普": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:木": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:朽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:果": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:流": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:淵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:率": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:疑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:直": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:符": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:謙": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:遲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "兩千五百歲的酷老師:雕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:一": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:倘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:分": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:則": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:區": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:可": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:壁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:壘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:實": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:序": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:循": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:或": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:明": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:欲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:步": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:漸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:登": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:結": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:缺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:舒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:若": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:蓋": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:覆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:速": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:進": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:達": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:適": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "六塊肌六塊雞:量": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:亂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:休": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:動": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:博": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:取": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:向": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:對": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:帶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:推": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:撩": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:播": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:文": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:暇": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:核": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:死": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:氾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:濫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:目": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:眼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:眾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:給": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:聳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:聽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:花": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:誘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:語": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:辛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:辣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:閱": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:題": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:風": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:餌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "別上「誘餌式標題」的鉤:驚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:一": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:丰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:勝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:場": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:墨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:嬌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:客": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:尾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:強": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:招": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:摯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:新": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:昂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:氣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:爭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:登": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:目": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:真": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:睞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:粉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:耳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:至": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:親": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:赳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:采": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:隨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:雄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:青": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "動物談情說愛的方式:鬥": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:事": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:刃": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:別": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:即": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:喪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:垮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:壤": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:孤": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:寂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:年": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:張": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:感": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:擊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:月": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:沮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:睽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:瞬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:累": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:經": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:脈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:與": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:血": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:解": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:賁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:轉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:迎": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:逝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:違": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "十秒的背後:願": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:中": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:出": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:口": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:同": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:呵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:如": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:宛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:展": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:手": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:抗": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:拒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:撞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:政": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:正": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:步": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:異": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:箭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:糾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:聲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:脫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:莽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:見": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:計": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:護": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "卡通人氣王票選政見發表會:身": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:例": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:候": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:先": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:其": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:危": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:可": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:外": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:失": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:室": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:局": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:岌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:所": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:是": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:有": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:殃": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:民": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:氣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:池": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:沒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:流": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:溫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:界": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:當": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:瞰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:端": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:臨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:衝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:離": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:難": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:雲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:首": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:體": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:魚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:鳥": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "吐瓦魯：逐漸被淹沒的島國:點": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:助": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:口": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:懈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:拜": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:會": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:欲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:潛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:盈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:窺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:繁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:能": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:腹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:視": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:贊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:輕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:鍊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:鍛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:頻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "周天成的一天-頂尖選手的養成:鬆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:休": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:假": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:偶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:光": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:千": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:少": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:崎": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:嶇": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:布": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:敬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:星": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:有": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:滿": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:無": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:然": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:煙": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:爭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:獨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:眾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:矗": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:稀": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:立": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:紛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:紜": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:肅": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:製": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:複": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:設": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:說": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:論": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:起": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:迢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-未解之謎-巨石陣+摩艾石像:里": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:世": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:佼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:備": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:受": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:名": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:吞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:噬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:增": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:壓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:奠": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:定": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:審": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:屢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:廣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:延": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:拔": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:於": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:替": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:海": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:爭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:異": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:目": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:瞠": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:結": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:綿": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:線": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:者": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:聞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:舌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:見": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:視": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:議": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:輪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:迥": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:障": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:魔": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:伏": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:倖": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:充": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:危": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:四": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:如": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:存": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:柴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:植": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:機": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:殘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:渺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:瘦": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:罹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:茫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:蚊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:蚋": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:被": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:褓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:襁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:難": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:飢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:骨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奇蹟行動:骸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:侷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:備": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:先": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:印": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:善": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:多": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:彰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:所": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:手": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:抹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:棘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:滅": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:益": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:目": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:眾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:矚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:碑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:程": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:端": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:籌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:約": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:荊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:莫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:記": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:路": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:身": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:里": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:鋒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:開": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:限": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運性別平等這條路:顯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:制": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:劣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:勢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:壓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:將": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:就": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:干": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:律": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:得": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:心": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:按": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:擾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:斬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:注": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:滿": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:班": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:理": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:素": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:自": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:貫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:質": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:過": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:部": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:重": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:閒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "奧運銀牌的自我鍛鍊:關": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:世": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:偏": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:化": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:味": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:啟": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:寫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:射": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:對": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:左": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:幽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:意": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:找": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:承": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:擬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:族": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:月": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:格": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:模": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:欄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:比": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:消": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:深": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:的": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:相": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:確": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:紀": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:耗": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:表": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:裔": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:見": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:認": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:變": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:象": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:較": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:載": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:輻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:重": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:長": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:閉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:體": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "女性太空人登月:點": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:典": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:削": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:剖": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:危": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:擱": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:束": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:殆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:流": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:淺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:瀕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:燃": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:燒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:物": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:珍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:瘦": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:盡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:稀": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:種": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:竄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:縛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:藏": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:蛻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:解": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "小藍鯨之死:變": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:事": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:代": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:倍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:功": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:半": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:厚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:因": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:度": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:得": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:徵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:效": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:教": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:施": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:材": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:水": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:涯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:滴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:獨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:率": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:石": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:穿": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:職": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:表": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:謝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從基因來的特別禮物:過": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從天才跌為凡人的神童:聞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:丁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:件": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:俐": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:勞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:哺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:嗷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:存": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:庇": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:彌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:待": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:悸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:成": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:指": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:按": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:浩": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:漫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:猶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:疾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:目": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:積": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:繁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:落": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:著": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:蔭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:補": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:計": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:識": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:貼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:酬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:食": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "從童工到大學教授之路:餘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:一": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:丈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:三": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:下": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:倒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:側": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:六": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:半": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:反": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:妄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:思": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:振": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:楣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:淚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:深": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:淵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:潸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:災": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:無": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:然": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:聲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:臂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:芻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:茶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:萬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:豁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:蹶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:身": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:輾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:轉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:遂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:達": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:雀": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:頭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:飯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "心理出狀況，是壞事導致的嗎?:鴉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "愛讀書的顧寧人:少": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:乎": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:作": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:僧": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:合": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:外": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:多": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:少": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:想": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:方": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:標": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:汗": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:法": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:流": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:浹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:湛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:無": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:粥": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:精": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:背": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:設": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:達": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "我有一個棒球夢:間": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:儼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:出": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:咕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:嘀": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:嘴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:如": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:小": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:層": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:思": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:怨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:慢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:懟": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:技": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:撒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:故": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:斯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:施": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:條": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:灌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:然": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:犯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:理": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:登": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:百": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:窮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:自": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:艾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:解": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:賴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:醍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:醐": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:重": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:難": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:頂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "把手上的餅吃香一點:饞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:一": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:交": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:傾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:力": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:回": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:城": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:如": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:得": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:心": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:扳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:橫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:水": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:沉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:測": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:獨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:琢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:當": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:疑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:瘁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:監": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:禦": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:著": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:訴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:質": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:逆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:防": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:雕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:面": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "拳力出擊-陳念琴:魚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:依": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:兔": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:化": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:及": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:妙": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:孵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:守": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:巧": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:彷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:彿": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:待": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:律": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:循": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:應": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:掩": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:株": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:機": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:耳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:臨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:苞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:葉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:規": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:覓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:變": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:迅": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:雷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "昆蟲會思考嗎？:食": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:一": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:全": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:兩": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:其": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:冠": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:出": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:動": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:口": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:嘆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:困": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:坐": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:城": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:愁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:措": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:服": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:桂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:機": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:為": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:獲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:碑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:穎": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:籌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:美": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:脫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:虜": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:集": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:雲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "果醬男孩:靈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:仰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:伍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:子": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:家": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:年": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:懼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:懾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:抖": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:拋": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:措": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:擻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:有": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:望": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:棄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:殆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:沁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:涼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:為": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:生": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:畏": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:盡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:神": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:籌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:精": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:與": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:詢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:諮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "森林大軍的守護者:震": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:井": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:別": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:員": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:固": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:地": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:壤": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:幅": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:役": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:後": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:憂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:掘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:整": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:斥": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:有": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:格": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:條": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:步": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:熱": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:理": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:發": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:結": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:總": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:花": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:表": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:衷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:資": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:退": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:遍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:遼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:開": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:闊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:鞏": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:顧": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "澳洲奧運金牌的X機密:驟": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:一": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:二": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:仃": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:令": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:休": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:伶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:做": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:兵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:孤": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:忪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:惺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:指": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:然": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:環": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:神": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:移": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:自": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:苦": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:貴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:赫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:逕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:速": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:顧": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:駕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "用科學方法伸張正義的神探:髮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:令": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:剝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:劈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:助": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:名": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:情": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:抽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:指": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:援": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:撰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:最": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:杜": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:無": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:煽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:盛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:眼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:睜": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:睹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:絲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:繭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:若": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:視": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:負": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:頭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "盡信書不如無書：從一件殺人案@談起:髮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:中": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:仿": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:傳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:力": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:勢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:叫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:嘆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:圖": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:境": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:家": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:實": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:拍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:案": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:樂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:止": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:殷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:津": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:為": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:相": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:結": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:絕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:纍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:落": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:觀": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:趨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:道": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "看到了嗎，然後呢:遞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:代": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:償": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:刺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:去": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:失": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:存": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:小": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:得": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:循": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:忘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:忪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:性": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:惡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:惺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:懸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:新": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:時": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:梁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:流": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:理": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:環": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:生": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:眼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:睡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:股": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:菁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:蕪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:謝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:返": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:連": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:酌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:鐘": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "祝你好眠:陳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:出": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:哀": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:天": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:奪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:居": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:忌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:手": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:抽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:搐": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:攣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:梧": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:滯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:痙": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:祇": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:神": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:禁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:索": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:群": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:遮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:遲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:門": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:隻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:離": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:魁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "科學怪人:鳴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:便": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:可": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:喻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:執": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:家": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:屆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:崩": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:常": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:強": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:快": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:插": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:曲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:榮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:歷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:殊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:淋": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:漓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:潰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:無": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:痛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:癌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:罹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:著": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:言": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:頑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "穿越極限的跑者:飯": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:外": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:志": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:意": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:手": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:搓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:明": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:暈": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:染": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:氣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:渲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:漸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:熱": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:當": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:續": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:腳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:行": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:言": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:說": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:踏": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:遠": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:陸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:騰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "第一百碗麵:黃": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:凶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:如": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:安": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:寧": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:崎": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:嶇": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:幽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:形": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:影": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:思": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:煉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:照": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:珍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:百": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:般": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:色": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:蜒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:蜿": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:試": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:護": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:轉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:追": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:逆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:重": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:隨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:險": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:黑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "紅領帶:默": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:假": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:刻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:印": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:喬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:後": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:怒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:思": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:悶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:情": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:扶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:攙": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:會": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:板": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:由": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:稱": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:納": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:索": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:職": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:衷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:裝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:觸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:診": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:請": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:象": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:退": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:預": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "給神明發會診單:駕": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:亂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:候": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:公": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:刺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:因": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:地": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:境": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:寒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:彩": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:徵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:心": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:忡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:憂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:應": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:排": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:提": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:放": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:案": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:民": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:氣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:永": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:球": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:環": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:生": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:異": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:碳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:禦": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:竄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:續": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:諷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:變": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:象": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:足": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:跡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "綠色賽事:遷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:丁": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:並": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:以": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:似": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:信": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:古": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:尼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:手": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:指": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:提": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:是": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:期": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:查": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:機": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:款": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:法": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:淆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:混": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:為": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:相": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:真": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:稠": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:緝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:行": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:論": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:迷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:銷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:長": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:陣": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:非": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:馬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:魂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:鹿": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "網紅的電子煙實驗：偽科學的陷阱:黏": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:凝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:力": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:勢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:喝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:嘆": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:均": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:寞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:已": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:捶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:摸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:敵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:洗": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:爭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:疑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:症": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:目": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:眼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:睛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:緒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:聚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:胸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:腦": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:落": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:著": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:虎": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:讚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:足": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:轉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:采": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:雜": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:難": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:頓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:頭": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:鬥": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:鷹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "贏得喝采的輸家:龍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:估": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:僵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:充": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:全": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:制": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:哄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:堂": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:壓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:彼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:抑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:斥": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:此": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:注": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:滑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:硬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:神": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:稽": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:笑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:置": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:落": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:處": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:評": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:貫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:起": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動傷害，怎麼辦:迫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:加": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:同": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:喪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:小": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:徒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:成": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:手": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:抵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:持": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:擔": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:據": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:效": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:數": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:斐": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:沮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:消": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:準": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:然": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:異": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:精": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:練": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:訓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "運動科學:負": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:促": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:分": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:前": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:取": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:含": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:喳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:嘰": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:均": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:大": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:富": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:幅": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:度": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:思": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:提": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:據": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:攝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:根": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:泌": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:衡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:迷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "長高的祕密:進": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:乍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:入": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:凶": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:勝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:啞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:啟": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:喑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:引": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:忪": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:悚": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:惡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:惺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:期": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:極": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:毛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:無": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:然": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:爍": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:疑": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:瘓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:癱": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:眼": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:睡": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:窮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:竇": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:聲": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:見": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:週": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:閃": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "靈異與科學:骨": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:刻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:印": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:及": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:咎": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:喻": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:塵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:多": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:巴": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:患": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:望": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:板": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:毛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:流": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:疫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:病": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:罹": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:胺": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:莫": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:行": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:角": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:言": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:象": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:責": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:鳳": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "預防近視？多點戶外活動就對了！:麟": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:住": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:凝": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:功": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:可": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:囊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:因": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:堵": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:括": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:栓": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:沒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:濃": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:現": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:異": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:稀": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:稠": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:而": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:薄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:血": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "高地訓練有助於運動表現嗎？:象": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:下": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:不": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:世": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:之": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:人": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:以": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:停": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:千": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:卸": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:可": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:名": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:囊": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:外": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:夢": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:如": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:寐": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:崎": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:嶇": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:心": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:慮": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:拒": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:掛": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:於": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:求": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:深": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:測": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:疾": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:聞": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:舉": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:行": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:蹄": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:迅": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:迷": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:里": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:防": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:霧": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:風": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  },
+  "黑猩猩的守護者:馬": {
+    "sentences": [],
+    "source": "pregenerated",
+    "cached_at": "",
+    "_placeholder": true
+  }
+}

--- a/backend/tests/test_example_sentence_cache.py
+++ b/backend/tests/test_example_sentence_cache.py
@@ -1,10 +1,12 @@
-"""Tests for example_sentence_cache.py (Issue #730).
+"""Tests for example_sentence_cache.py (Issue #730, #780).
 
 Tests the JSON file-based caching layer for AI example sentences:
 - Cache hit returns stored sentences without calling AI
 - Cache miss falls through (returns None)
 - TTL expiry causes miss
 - Persists to disk after set
+- Pre-generated entries never expire (Issue #780)
+- bulk_set_pregenerated writes multiple entries atomically
 
 Run with:
     cd backend && python -m pytest tests/test_example_sentence_cache.py -v
@@ -21,6 +23,8 @@ import app.services.example_sentence_cache as cache_module
 from app.services.example_sentence_cache import (
     get_cached,
     set_cached,
+    set_pregenerated,
+    bulk_set_pregenerated,
     _reset,
     _is_expired,
     _make_key,
@@ -99,6 +103,25 @@ class TestGetCached:
         result = get_cached("課文B", "水")
         assert result is None
 
+    def test_miss_empty_sentences_acts_as_placeholder(self, isolated_cache):
+        """Entry with empty sentences list should be treated as a cache miss (placeholder)."""
+        key = _make_key("課文A", "水")
+        with open(isolated_cache, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    key: {
+                        "sentences": [],
+                        "source": "pregenerated",
+                        "_placeholder": True,
+                        "cached_at": "",
+                    }
+                },
+                f,
+            )
+        _reset(path=isolated_cache)
+        result = get_cached("課文A", "水")
+        assert result is None  # placeholder treated as miss → AI fallback
+
     def test_miss_expired_entry(self, isolated_cache):
         # Manually write an expired entry to the cache file
         key = _make_key("課文A", "水")
@@ -160,6 +183,114 @@ class TestSetCached:
 # ---------------------------------------------------------------------------
 # Cache file resilience
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Pre-generated entries (Issue #780)
+# ---------------------------------------------------------------------------
+
+PREGENERATED_SENTENCES = [
+    {"sentence": "他勇敢地挑戰新事物。", "explanation": "勇：有勇氣、無所畏懼"},
+    {"sentence": "這位選手展現了勇氣。", "explanation": "勇：勇敢的精神"},
+]
+
+
+class TestPregenerated:
+    def test_pregenerated_entry_never_expires(self, isolated_cache):
+        """Pre-generated entries with source=pregenerated are served regardless of age."""
+        key = _make_key("課文X", "勇")
+        very_old = (datetime.now(timezone.utc) - timedelta(days=3650)).isoformat()
+        with open(isolated_cache, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    key: {
+                        "sentences": PREGENERATED_SENTENCES,
+                        "source": "pregenerated",
+                        "cached_at": very_old,
+                    }
+                },
+                f,
+            )
+        _reset(path=isolated_cache)
+        result = get_cached("課文X", "勇")
+        assert result is not None
+        assert result["sentences"] == PREGENERATED_SENTENCES
+
+    def test_is_expired_returns_false_for_pregenerated(self):
+        """_is_expired should return False for any entry with source=pregenerated."""
+        very_old = (datetime.now(timezone.utc) - timedelta(days=9999)).isoformat()
+        entry = {
+            "sentences": PREGENERATED_SENTENCES,
+            "source": "pregenerated",
+            "cached_at": very_old,
+        }
+        assert _is_expired(entry) is False
+
+    def test_set_pregenerated_stores_with_source_flag(self, isolated_cache):
+        set_pregenerated("課文X", "勇", PREGENERATED_SENTENCES)
+        key = _make_key("課文X", "勇")
+        assert cache_module._cache[key]["source"] == "pregenerated"
+        assert cache_module._cache[key]["sentences"] == PREGENERATED_SENTENCES
+
+    def test_set_pregenerated_does_not_overwrite_existing(self, isolated_cache):
+        """Calling set_pregenerated twice should not replace non-empty existing data."""
+        original = [{"sentence": "原始句。", "explanation": "原始"}]
+        new_data = [{"sentence": "新句子。", "explanation": "新的"}]
+        set_pregenerated("課文X", "勇", original)
+        set_pregenerated("課文X", "勇", new_data)
+        result = get_cached("課文X", "勇")
+        assert result["sentences"] == original
+
+    def test_set_pregenerated_overwrites_placeholder(self, isolated_cache):
+        """Empty placeholder entries (sentences=[]) should be overwritten."""
+        # Write a placeholder entry
+        key = _make_key("課文X", "勇")
+        with open(isolated_cache, "w", encoding="utf-8") as f:
+            json.dump(
+                {key: {"sentences": [], "source": "pregenerated", "_placeholder": True, "cached_at": ""}},
+                f,
+            )
+        _reset(path=isolated_cache)
+        set_pregenerated("課文X", "勇", PREGENERATED_SENTENCES)
+        result = get_cached("課文X", "勇")
+        assert result["sentences"] == PREGENERATED_SENTENCES
+
+    def test_bulk_set_pregenerated_writes_multiple(self, isolated_cache):
+        entries = {
+            "課文A:水": [{"sentence": "水流湍急。", "explanation": "水：液體"}],
+            "課文A:火": [{"sentence": "火焰熊熊燃燒。", "explanation": "火：燃燒的火焰"}],
+        }
+        count = bulk_set_pregenerated(entries)
+        assert count == 2
+        assert get_cached("課文A", "水")["sentences"] == entries["課文A:水"]
+        assert get_cached("課文A", "火")["sentences"] == entries["課文A:火"]
+
+    def test_bulk_set_pregenerated_skips_existing(self, isolated_cache):
+        """Existing pre-generated entries with sentences should not be overwritten."""
+        original = [{"sentence": "原始水句。", "explanation": "原始"}]
+        set_pregenerated("課文A", "水", original)
+        entries = {
+            "課文A:水": [{"sentence": "新水句。", "explanation": "新"}],
+        }
+        count = bulk_set_pregenerated(entries)
+        assert count == 0  # nothing written
+        assert get_cached("課文A", "水")["sentences"] == original
+
+    def test_bulk_set_pregenerated_persists_to_disk(self, isolated_cache):
+        entries = {
+            "課文A:水": [{"sentence": "水句。", "explanation": "水"}],
+        }
+        bulk_set_pregenerated(entries)
+        with open(isolated_cache, encoding="utf-8") as f:
+            on_disk = json.load(f)
+        assert "課文A:水" in on_disk
+        assert on_disk["課文A:水"]["source"] == "pregenerated"
+
+    def test_normal_cache_entry_still_expires(self):
+        """Non-pregenerated entries should still be subject to TTL."""
+        very_old = (datetime.now(timezone.utc) - timedelta(days=31)).isoformat()
+        entry = {"sentences": PREGENERATED_SENTENCES, "cached_at": very_old}
+        assert _is_expired(entry) is True
+
 
 class TestCacheResilience:
     def test_corrupt_json_starts_empty(self, isolated_cache):

--- a/scripts/pre-generate-example-sentences.py
+++ b/scripts/pre-generate-example-sentences.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Pre-generate example sentences for all lesson vocabulary characters (Issue #780).
+
+This script extracts every unique (story_title, character) pair from the 57
+lesson YAML files, then either:
+
+  --mode api   : calls the local/staging backend API to generate and cache
+                 real AI sentences (default when --api-url is provided)
+  --mode placeholder : writes placeholder entries with empty sentence arrays
+                 so the cache file exists and downstream tooling can inspect
+                 the expected structure without real AI calls
+
+Usage examples:
+
+  # Generate placeholders (no AI calls, no server needed):
+  python scripts/pre-generate-example-sentences.py --mode placeholder
+
+  # Warm the cache against a running local backend:
+  python scripts/pre-generate-example-sentences.py \\
+      --api-url http://localhost:8000 \\
+      --token <JWT_TOKEN>
+
+  # Warm the cache against staging (add --delay to respect rate limits):
+  python scripts/pre-generate-example-sentences.py \\
+      --api-url https://lingoleap-backend-staging-xxx.run.app \\
+      --token <JWT_TOKEN> \\
+      --delay 0.5
+
+Exit codes:
+  0  success
+  1  partial failure (some chars failed, see --output-failures)
+  2  fatal error (bad args, can't read lessons, etc.)
+"""
+
+import argparse
+import glob
+import json
+import logging
+import os
+import re
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml not installed. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    import requests
+except ImportError:
+    requests = None  # type: ignore
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+_SCRIPT_DIR = Path(__file__).parent
+_REPO_ROOT = _SCRIPT_DIR.parent
+_LESSONS_DIR = _REPO_ROOT / "backend" / "data" / "lessons"
+_CACHE_PATH = _REPO_ROOT / "backend" / "data" / "example_sentence_cache.json"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _is_cjk(ch: str) -> bool:
+    return bool(re.match(r"[\u4e00-\u9fa5]", ch))
+
+
+def extract_vocab_chars(lessons_dir: Path) -> list[tuple[str, str]]:
+    """Return sorted list of (story_title, char) pairs from all YAML lessons.
+
+    For each lesson we iterate over the vocabulary words and decompose each
+    word into its constituent CJK characters.  Duplicate (title, char) pairs
+    are deduplicated.
+    """
+    pairs: set[tuple[str, str]] = set()
+    lesson_files = sorted(glob.glob(str(lessons_dir / "*.yml")))
+    if not lesson_files:
+        logger.error("No lesson YAML files found in %s", lessons_dir)
+        sys.exit(2)
+
+    for fpath in lesson_files:
+        with open(fpath, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        title = (data.get("title") or "").strip()
+        if not title:
+            logger.warning("Lesson %s has no title — skipping", fpath)
+            continue
+        vocab = data.get("vocabulary") or []
+        for item in vocab:
+            word = (item.get("word") or "").strip()
+            for ch in word:
+                if _is_cjk(ch):
+                    pairs.add((title, ch))
+
+    return sorted(pairs)
+
+
+def load_cache(cache_path: Path) -> dict:
+    if cache_path.exists():
+        try:
+            with open(cache_path, encoding="utf-8") as fh:
+                return json.load(fh)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Could not read existing cache (%s) — starting fresh", exc)
+    return {}
+
+
+def save_cache(cache_path: Path, cache: dict) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(cache_path, "w", encoding="utf-8") as fh:
+        json.dump(cache, fh, ensure_ascii=False, indent=2)
+    logger.info("Saved cache with %d entries to %s", len(cache), cache_path)
+
+
+# ---------------------------------------------------------------------------
+# Placeholder mode
+# ---------------------------------------------------------------------------
+
+def run_placeholder(pairs: list[tuple[str, str]], cache_path: Path) -> None:
+    """Write placeholder entries (empty sentence arrays) without calling AI."""
+    cache = load_cache(cache_path)
+    written = 0
+    skipped = 0
+    for title, ch in pairs:
+        key = f"{title}:{ch}"
+        if cache.get(key, {}).get("source") == "pregenerated" and cache[key].get("sentences"):
+            skipped += 1
+            continue
+        cache[key] = {
+            "sentences": [],
+            "source": "pregenerated",
+            "cached_at": "",
+            "_placeholder": True,
+        }
+        written += 1
+
+    save_cache(cache_path, cache)
+    logger.info(
+        "Placeholder mode complete: wrote %d new entries, skipped %d existing",
+        written,
+        skipped,
+    )
+
+
+# ---------------------------------------------------------------------------
+# API mode
+# ---------------------------------------------------------------------------
+
+def call_api(
+    api_url: str,
+    token: str,
+    title: str,
+    character: str,
+    timeout: int = 30,
+) -> Optional[list]:
+    """Call the example-sentences endpoint and return the sentences list or None."""
+    if requests is None:
+        logger.error("requests library not installed — run: pip install requests")
+        sys.exit(2)
+
+    url = f"{api_url.rstrip('/')}/api/learning/sentence-practice/example-sentences"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    payload = {"character": character, "story_title": title}
+
+    try:
+        resp = requests.post(url, json=payload, headers=headers, timeout=timeout)
+        if resp.status_code == 200:
+            data = resp.json()
+            return data.get("sentences", [])
+        logger.warning(
+            "API returned %d for char=%s title=%s: %s",
+            resp.status_code,
+            character,
+            title,
+            resp.text[:200],
+        )
+        return None
+    except requests.RequestException as exc:
+        logger.warning("Request failed for char=%s title=%s: %s", character, title, exc)
+        return None
+
+
+def run_api(
+    pairs: list[tuple[str, str]],
+    cache_path: Path,
+    api_url: str,
+    token: str,
+    delay: float,
+    skip_existing: bool,
+    output_failures: Optional[Path],
+) -> int:
+    """Call API for each pair, store in cache.  Returns 0 on full success, 1 on partial."""
+    cache = load_cache(cache_path)
+    failed: list[tuple[str, str]] = []
+    success = 0
+    skipped = 0
+
+    total = len(pairs)
+    for idx, (title, ch) in enumerate(pairs, 1):
+        key = f"{title}:{ch}"
+        existing = cache.get(key, {})
+        if skip_existing and existing.get("source") == "pregenerated" and existing.get("sentences"):
+            skipped += 1
+            continue
+
+        logger.info("[%d/%d] Generating: %s | %s", idx, total, title, ch)
+        sentences = call_api(api_url, token, title, ch)
+        if sentences is None:
+            failed.append((title, ch))
+        else:
+            cache[key] = {
+                "sentences": sentences,
+                "source": "pregenerated",
+                "cached_at": __import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat(),
+            }
+            success += 1
+
+        if delay > 0:
+            time.sleep(delay)
+
+        # Save incrementally every 50 entries to avoid losing progress
+        if idx % 50 == 0:
+            save_cache(cache_path, cache)
+
+    save_cache(cache_path, cache)
+
+    logger.info(
+        "API mode complete: success=%d, skipped=%d, failed=%d",
+        success,
+        skipped,
+        len(failed),
+    )
+
+    if failed:
+        if output_failures:
+            with open(output_failures, "w", encoding="utf-8") as fh:
+                json.dump([{"title": t, "char": c} for t, c in failed], fh, ensure_ascii=False, indent=2)
+            logger.info("Failures written to %s", output_failures)
+        else:
+            for title, ch in failed:
+                logger.warning("FAILED: %s | %s", title, ch)
+        return 1
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--mode",
+        choices=["api", "placeholder"],
+        default="placeholder",
+        help="'placeholder' writes empty entries; 'api' calls the backend (default: placeholder)",
+    )
+    p.add_argument(
+        "--lessons-dir",
+        default=str(_LESSONS_DIR),
+        help=f"Path to lesson YAML directory (default: {_LESSONS_DIR})",
+    )
+    p.add_argument(
+        "--cache-path",
+        default=str(_CACHE_PATH),
+        help=f"Path to cache JSON file (default: {_CACHE_PATH})",
+    )
+    p.add_argument(
+        "--api-url",
+        default="http://localhost:8000",
+        help="Backend base URL for API mode (default: http://localhost:8000)",
+    )
+    p.add_argument(
+        "--token",
+        default="",
+        help="JWT bearer token for API authentication (required for --mode api)",
+    )
+    p.add_argument(
+        "--delay",
+        type=float,
+        default=0.2,
+        help="Seconds to wait between API calls to respect rate limits (default: 0.2)",
+    )
+    p.add_argument(
+        "--no-skip-existing",
+        action="store_true",
+        help="Re-generate even if pre-generated entry already exists",
+    )
+    p.add_argument(
+        "--output-failures",
+        type=Path,
+        default=None,
+        help="Write failed (title, char) pairs as JSON to this file",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the list of (title, char) pairs without writing anything",
+    )
+    return p
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    lessons_dir = Path(args.lessons_dir)
+    cache_path = Path(args.cache_path)
+
+    if not lessons_dir.exists():
+        logger.error("Lessons directory not found: %s", lessons_dir)
+        return 2
+
+    pairs = extract_vocab_chars(lessons_dir)
+    logger.info("Found %d unique (story_title, char) pairs across all lessons", len(pairs))
+
+    if args.dry_run:
+        for title, ch in pairs:
+            print(f"{title}\t{ch}")
+        return 0
+
+    if args.mode == "placeholder":
+        run_placeholder(pairs, cache_path)
+        return 0
+
+    # API mode
+    if not args.token:
+        logger.error(
+            "--token is required for --mode api. "
+            "Get a token by logging in to the app and copying the JWT from "
+            "localStorage (key: 'token') or from the Authorization header in "
+            "any API request."
+        )
+        return 2
+
+    return run_api(
+        pairs=pairs,
+        cache_path=cache_path,
+        api_url=args.api_url,
+        token=args.token,
+        delay=args.delay,
+        skip_existing=not args.no_skip_existing,
+        output_failures=args.output_failures,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #780

## Summary

- **`example_sentence_cache.py`**: Add `set_pregenerated()` and `bulk_set_pregenerated()` for writing entries with `source="pregenerated"` that never expire. Update `_is_expired()` to skip TTL for these entries. Update `get_cached()` to treat empty-sentence entries as a cache miss (so placeholder records fall through to AI generation).

- **`scripts/pre-generate-example-sentences.py`**: New script to warm the cache for all 57 lessons. Two modes:
  - `--mode placeholder` — writes skeleton entries (empty sentences) immediately with no AI calls; 1490 entries covering all vocab chars
  - `--mode api --token <JWT>` — calls the live backend to generate real sentences; supports `--delay` for rate limit control, `--output-failures` for retry lists

- **`backend/data/example_sentence_cache.json`**: Pre-populated with 1490 placeholder entries (one per unique story_title:char pair derived from vocab words). Placeholders have `sentences: []` which `get_cached()` treats as a miss, so the AI fallback still runs until real sentences are generated via `--mode api`.

## Cache design

| Entry type | Expires? | Behaviour |
|---|---|---|
| Runtime AI-generated | After 30 days | Normal TTL |
| Pre-generated (script) | Never | Always served |
| Placeholder (empty sentences) | Never but treated as miss | Falls through to AI |

## Test plan

- `cd backend && python -m pytest tests/test_example_sentence_cache.py -v` — 27 tests, all pass
- To warm with real sentences against staging: `python scripts/pre-generate-example-sentences.py --mode api --api-url <staging-url> --token <JWT> --delay 0.3`