### PR TITLE
fix(decomposition): add 頁 to 穎 + MANUAL_CORRECTIONS override table (Fixes #790)

### DIFF
--- a/frontend/src/data/decomposition-sources.json
+++ b/frontend/src/data/decomposition-sources.json
@@ -1,6 +1,12 @@
 {
   "sources": [
     {
+      "name": "手動修正 (MANUAL_CORRECTIONS)",
+      "count": 1,
+      "priority": 0,
+      "license": "internal"
+    },
+    {
       "name": "手動編寫",
       "count": 43,
       "priority": 1,
@@ -8,7 +14,7 @@
     },
     {
       "name": "makemeahanzi",
-      "count": 2600,
+      "count": 2599,
       "priority": 2,
       "license": "LGPL",
       "url": "https://github.com/skishore/makemeahanzi"
@@ -25,7 +31,7 @@
   "totalLessonChars": 2791,
   "coverage": "98.0%",
   "breakdown": {
-    "pictophonetic": 1751,
+    "pictophonetic": 1750,
     "ideographic": 729,
     "pictographic": 120,
     "chaizi_fallback": 134,

--- a/frontend/src/data/decompositions-generated.json
+++ b/frontend/src/data/decompositions-generated.json
@@ -25935,7 +25935,7 @@
       {
         "radical": "頁",
         "role": "部件",
-        "label": "頁"
+        "label": "頭部"
       }
     ]
   },
@@ -26695,7 +26695,7 @@
     ]
   },
   "穎": {
-    "formula": "禾 + 匕",
+    "formula": "禾 + 匕 + 頁",
     "components": [
       {
         "radical": "禾",
@@ -26704,8 +26704,13 @@
       },
       {
         "radical": "匕",
+        "role": "部件",
+        "label": "匕首"
+      },
+      {
+        "radical": "頁",
         "role": "聲符",
-        "label": "讀音"
+        "label": "頭部"
       }
     ]
   },
@@ -39310,7 +39315,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "丁",
@@ -39325,7 +39330,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "工",
@@ -39340,7 +39345,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "川",
@@ -39360,7 +39365,7 @@
       {
         "radical": "頁",
         "role": "部件",
-        "label": "頁"
+        "label": "頭部"
       }
     ]
   },
@@ -39370,7 +39375,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "予",
@@ -39385,7 +39390,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "元",
@@ -39400,7 +39405,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "屯",
@@ -39415,7 +39420,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "皮",
@@ -39430,7 +39435,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "令",
@@ -39445,7 +39450,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "吉",
@@ -39460,7 +39465,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "豆",
@@ -39475,7 +39480,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "巠",
@@ -39505,7 +39510,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "是",
@@ -39520,7 +39525,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "客",
@@ -39535,7 +39540,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "彥",
@@ -39550,7 +39555,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "原",
@@ -39565,7 +39570,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "真",
@@ -39580,7 +39585,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "雇",
@@ -39595,7 +39600,7 @@
       {
         "radical": "頁",
         "role": "形符",
-        "label": "頁"
+        "label": "頭部"
       },
       {
         "radical": "㬎",

--- a/scripts/build-decomposition-data.py
+++ b/scripts/build-decomposition-data.py
@@ -34,6 +34,32 @@ import yaml  # PyYAML
 # ---------------------------------------------------------------------------
 IDS_OPERATORS = set("⿰⿱⿲⿳⿴⿵⿶⿷⿸⿹⿺⿻")
 
+# IDS operator → left-to-right / top-to-bottom ordering of operands
+# The values represent the natural stroke-order position of each operand slot
+# ⿰ left+right, ⿱ top+bottom, ⿲ left+mid+right, ⿳ top+mid+bottom
+# ⿴⿵⿶⿷ enclosure (outer first), ⿸⿹⿺ corner (outer first)
+IDS_ORDER_PRESERVED = set("⿰⿱⿲⿳⿴⿵⿶⿷⿸⿹⿺⿻")  # All operators: keep IDS operand order
+
+
+# ---------------------------------------------------------------------------
+# MANUAL_CORRECTIONS — override known-bad decompositions
+# Add entries here for characters where makemeahanzi/chaizi give wrong results.
+# Priority: always applied before any automatic source.
+# ---------------------------------------------------------------------------
+MANUAL_CORRECTIONS: dict[str, dict] = {
+    # 穎: makemeahanzi gives only 禾+匕 (incomplete pictophonetic).
+    # Correct structure: 禾 (semantic, grain) + 頃 (phonetic), where 頃 = 匕+頁
+    # For teaching purposes, show all three surface components in stroke order.
+    "穎": {
+        "formula": "禾 + 匕 + 頁",
+        "components": [
+            {"radical": "禾", "role": "形符", "label": "穀物"},
+            {"radical": "匕", "role": "部件", "label": "匕首"},
+            {"radical": "頁", "role": "聲符", "label": "頭部"},
+        ],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # Friendly labels for common radicals (used when etymology.hint is absent)
@@ -180,6 +206,8 @@ RADICAL_LABELS: dict[str, str] = {
     "邑": "城邑",
     # Jade/king
     "⺩": "玉旁",
+    # Head/page
+    "頁": "頭部",
     # Leather
     "革": "皮革",
     # Bone
@@ -404,7 +432,14 @@ def main() -> None:
         "no_data": 0,
     }
 
+    manual_count = 0
     for char in sorted(lesson_chars):
+        # Step 0: Apply manual corrections (highest priority)
+        if char in MANUAL_CORRECTIONS:
+            result[char] = MANUAL_CORRECTIONS[char]
+            manual_count += 1
+            continue
+
         # Try makemeahanzi first
         entry = mma.get(char)
         if entry:
@@ -437,6 +472,12 @@ def main() -> None:
     sources_meta = {
         "sources": [
             {
+                "name": "手動修正 (MANUAL_CORRECTIONS)",
+                "count": manual_count,
+                "priority": 0,
+                "license": "internal",
+            },
+            {
                 "name": "手動編寫",
                 "count": 43,
                 "priority": 1,
@@ -464,6 +505,7 @@ def main() -> None:
     }
 
     print(f"\nBuilt {total} decompositions out of {len(lesson_chars)} lesson chars ({coverage_pct}%)")
+    print(f"  manual corrections: {manual_count}")
     print(f"  pictophonetic : {stats['pictophonetic']}")
     print(f"  ideographic   : {stats['ideographic']}")
     print(f"  pictographic  : {stats['pictographic']}")


### PR DESCRIPTION
Fixes #790

## Summary
- 穎 was showing only 禾+匕 (missing 頁). Now correctly shows 禾+匕+頁.
- Adds a `MANUAL_CORRECTIONS` dict to `scripts/build-decomposition-data.py` — a persistent override table for characters where makemeahanzi/chaizi give incomplete or pedagogically-wrong results. Manual corrections take priority over all automatic sources.
- Adds 頁 (頭部) to `RADICAL_LABELS` so the label renders correctly in the UI.
- Regenerates `frontend/src/data/decompositions-generated.json`.

## Root cause
makemeahanzi classifies 穎 as pictophonetic with semantic=禾 and phonetic=匕, which is incorrect — the actual phonetic component is 頃 (匕+頁). The fix adds 頁 back at the override level rather than patching the upstream data.

## Spot-check results
| Character | Before | After |
|-----------|--------|-------|
| 穎 | 禾 + 匕 | 禾 + 匕 + 頁 |
| 戴 | 十 + 戈 + 異 | 十 + 戈 + 異 (unchanged, correct) |
| 資 | 貝 + 次 | 貝 + 次 (unchanged) |
| 愛 | 爫 + 冖 + 心 + 夂 | 爫 + 冖 + 心 + 夂 (unchanged) |

## Test plan
- [ ] Open PR Preview URL, navigate to a lesson containing 穎
- [ ] Check VocabPractice decomposition panel: 穎 should show 禾 + 匕 + 頁
- [ ] `npm run build` passes (verified locally)