### PR TITLE
fix(decomposition): fix 24 compound chars with only 1 component (Fixes #795)

### DIFF
--- a/frontend/src/data/decomposition-sources.json
+++ b/frontend/src/data/decomposition-sources.json
@@ -2,7 +2,7 @@
   "sources": [
     {
       "name": "手動修正 (MANUAL_CORRECTIONS)",
-      "count": 1,
+      "count": 25,
       "priority": 0,
       "license": "internal"
     },
@@ -14,7 +14,7 @@
     },
     {
       "name": "makemeahanzi",
-      "count": 2599,
+      "count": 2575,
       "priority": 2,
       "license": "LGPL",
       "url": "https://github.com/skishore/makemeahanzi"
@@ -31,8 +31,8 @@
   "totalLessonChars": 2791,
   "coverage": "98.0%",
   "breakdown": {
-    "pictophonetic": 1750,
-    "ideographic": 729,
+    "pictophonetic": 1727,
+    "ideographic": 728,
     "pictographic": 120,
     "chaizi_fallback": 134,
     "no_data": 57

--- a/frontend/src/data/decompositions-generated.json
+++ b/frontend/src/data/decompositions-generated.json
@@ -1180,12 +1180,17 @@
     ]
   },
   "但": {
-    "formula": "旦",
+    "formula": "亻 + 旦",
     "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
       {
         "radical": "旦",
         "role": "聲符",
-        "label": "讀音"
+        "label": "旦"
       }
     ]
   },
@@ -1220,12 +1225,17 @@
     ]
   },
   "低": {
-    "formula": "氐",
+    "formula": "亻 + 氐",
     "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
       {
         "radical": "氐",
         "role": "聲符",
-        "label": "讀音"
+        "label": "氐"
       }
     ]
   },
@@ -3230,8 +3240,13 @@
     ]
   },
   "列": {
-    "formula": "刂",
+    "formula": "歹 + 刂",
     "components": [
+      {
+        "radical": "歹",
+        "role": "部件",
+        "label": "歹"
+      },
       {
         "radical": "刂",
         "role": "形符",
@@ -4495,12 +4510,22 @@
     ]
   },
   "參": {
-    "formula": "彡",
+    "formula": "⺶ + 大 + 彡",
     "components": [
+      {
+        "radical": "⺶",
+        "role": "部件",
+        "label": "羊頭"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
       {
         "radical": "彡",
         "role": "聲符",
-        "label": "讀音"
+        "label": "紋飾"
       }
     ]
   },
@@ -5665,8 +5690,13 @@
     ]
   },
   "員": {
-    "formula": "貝",
+    "formula": "口 + 貝",
     "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
       {
         "radical": "貝",
         "role": "形符",
@@ -7495,12 +7525,22 @@
     ]
   },
   "塌": {
-    "formula": "土",
+    "formula": "土 + 日 + 羽",
     "components": [
       {
         "radical": "土",
         "role": "形符",
         "label": "土"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "羽",
+        "role": "部件",
+        "label": "羽毛"
       }
     ]
   },
@@ -7565,8 +7605,18 @@
     ]
   },
   "塞": {
-    "formula": "土",
+    "formula": "宀 + 二 + 土",
     "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "二",
+        "role": "部件",
+        "label": "二"
+      },
       {
         "radical": "土",
         "role": "形符",
@@ -9465,12 +9515,17 @@
     ]
   },
   "容": {
-    "formula": "宀",
+    "formula": "宀 + 谷",
     "components": [
       {
         "radical": "宀",
         "role": "形符",
         "label": "房頂"
+      },
+      {
+        "radical": "谷",
+        "role": "聲符",
+        "label": "山谷"
       }
     ]
   },
@@ -12180,11 +12235,26 @@
     ]
   },
   "德": {
-    "formula": "心",
+    "formula": "彳 + 十 + 罒 + 心",
     "components": [
       {
-        "radical": "心",
+        "radical": "彳",
         "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
         "label": "心"
       }
     ]
@@ -13040,12 +13110,17 @@
     ]
   },
   "惱": {
-    "formula": "忄",
+    "formula": "忄 + 囟",
     "components": [
       {
         "radical": "忄",
         "role": "形符",
         "label": "心旁"
+      },
+      {
+        "radical": "囟",
+        "role": "聲符",
+        "label": "腦頂"
       }
     ]
   },
@@ -14490,12 +14565,22 @@
     ]
   },
   "拋": {
-    "formula": "扌",
+    "formula": "扌 + 九 + 力",
     "components": [
       {
         "radical": "扌",
         "role": "形符",
         "label": "手旁"
+      },
+      {
+        "radical": "九",
+        "role": "部件",
+        "label": "九"
+      },
+      {
+        "radical": "力",
+        "role": "部件",
+        "label": "力量"
       }
     ]
   },
@@ -14560,12 +14645,17 @@
     ]
   },
   "拖": {
-    "formula": "扌",
+    "formula": "扌 + 它",
     "components": [
       {
         "radical": "扌",
         "role": "形符",
         "label": "手旁"
+      },
+      {
+        "radical": "它",
+        "role": "聲符",
+        "label": "它"
       }
     ]
   },
@@ -15170,12 +15260,22 @@
     ]
   },
   "探": {
-    "formula": "扌",
+    "formula": "扌 + 穴 + 木",
     "components": [
       {
         "radical": "扌",
         "role": "形符",
         "label": "手旁"
+      },
+      {
+        "radical": "穴",
+        "role": "部件",
+        "label": "穴"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
       }
     ]
   },
@@ -17050,8 +17150,18 @@
     ]
   },
   "春": {
-    "formula": "日",
+    "formula": "三 + 人 + 日",
     "components": [
+      {
+        "radical": "三",
+        "role": "部件",
+        "label": "三"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
       {
         "radical": "日",
         "role": "形符",
@@ -19500,8 +19610,18 @@
     ]
   },
   "款": {
-    "formula": "欠",
+    "formula": "士 + 示 + 欠",
     "components": [
+      {
+        "radical": "士",
+        "role": "部件",
+        "label": "士"
+      },
+      {
+        "radical": "示",
+        "role": "部件",
+        "label": "祭祀"
+      },
       {
         "radical": "欠",
         "role": "形符",
@@ -20305,12 +20425,17 @@
     ]
   },
   "沒": {
-    "formula": "氵",
+    "formula": "氵 + 殳",
     "components": [
       {
         "radical": "氵",
         "role": "形符",
         "label": "水旁"
+      },
+      {
+        "radical": "殳",
+        "role": "聲符",
+        "label": "殳"
       }
     ]
   },
@@ -20435,12 +20560,22 @@
     ]
   },
   "沿": {
-    "formula": "氵",
+    "formula": "氵 + 几 + 口",
     "components": [
       {
         "radical": "氵",
         "role": "形符",
         "label": "水旁"
+      },
+      {
+        "radical": "几",
+        "role": "部件",
+        "label": "几"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
       }
     ]
   },
@@ -24370,12 +24505,17 @@
     ]
   },
   "疫": {
-    "formula": "疒",
+    "formula": "疒 + 殳",
     "components": [
       {
         "radical": "疒",
         "role": "形符",
         "label": "病旁"
+      },
+      {
+        "radical": "殳",
+        "role": "聲符",
+        "label": "殳"
       }
     ]
   },
@@ -26365,12 +26505,17 @@
     ]
   },
   "秀": {
-    "formula": "禾",
+    "formula": "禾 + 乃",
     "components": [
       {
         "radical": "禾",
         "role": "形符",
         "label": "穀物"
+      },
+      {
+        "radical": "乃",
+        "role": "部件",
+        "label": "乃"
       }
     ]
   },
@@ -27800,12 +27945,17 @@
     ]
   },
   "約": {
-    "formula": "糹",
+    "formula": "糹 + 勺",
     "components": [
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲線"
+      },
+      {
+        "radical": "勺",
+        "role": "聲符",
+        "label": "勺"
       }
     ]
   },
@@ -34900,12 +35050,32 @@
     ]
   },
   "贏": {
-    "formula": "貝",
+    "formula": "亡 + 口 + 月 + 貝 + 凡",
     "components": [
+      {
+        "radical": "亡",
+        "role": "部件",
+        "label": "亡"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      },
       {
         "radical": "貝",
         "role": "形符",
         "label": "貝"
+      },
+      {
+        "radical": "凡",
+        "role": "部件",
+        "label": "凡"
       }
     ]
   },
@@ -38815,12 +38985,22 @@
     ]
   },
   "雜": {
-    "formula": "隹",
+    "formula": "九 + 木 + 隹",
     "components": [
+      {
+        "radical": "九",
+        "role": "部件",
+        "label": "九"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
       {
         "radical": "隹",
         "role": "聲符",
-        "label": "讀音"
+        "label": "短尾鳥"
       }
     ]
   },
@@ -39075,12 +39255,22 @@
     ]
   },
   "霸": {
-    "formula": "雨",
+    "formula": "雨 + 革 + 月",
     "components": [
       {
         "radical": "雨",
         "role": "形符",
         "label": "雨"
+      },
+      {
+        "radical": "革",
+        "role": "部件",
+        "label": "皮革"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
       }
     ]
   },
@@ -40885,8 +41075,18 @@
     ]
   },
   "黑": {
-    "formula": "灬",
+    "formula": "口 + 土 + 灬",
     "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
       {
         "radical": "灬",
         "role": "部件",

--- a/scripts/build-decomposition-data.py
+++ b/scripts/build-decomposition-data.py
@@ -58,6 +58,220 @@ MANUAL_CORRECTIONS: dict[str, dict] = {
             {"radical": "頁", "role": "聲符", "label": "頭部"},
         ],
     },
+    # --------------------------------------------------------------------------
+    # Characters where makemeahanzi pictophonetic only has semantic OR phonetic
+    # (missing the other half), so the auto-builder emits only 1 component.
+    # Fixed by listing all visible surface components in stroke order.
+    # --------------------------------------------------------------------------
+
+    # 雜: decomp ⿰⿳亠从木隹 — semantic missing; phonetic=隹; surface: 九+木+隹
+    "雜": {
+        "formula": "九 + 木 + 隹",
+        "components": [
+            {"radical": "九", "role": "部件", "label": "九"},
+            {"radical": "木", "role": "部件", "label": "木"},
+            {"radical": "隹", "role": "聲符", "label": "短尾鳥"},
+        ],
+    },
+    # 德: decomp ⿰彳⿱⿱十罒⿱一心 — phonetic missing; semantic=心; surface: 彳+十+罒+心
+    "德": {
+        "formula": "彳 + 十 + 罒 + 心",
+        "components": [
+            {"radical": "彳", "role": "形符", "label": "行旁"},
+            {"radical": "十", "role": "部件", "label": "十"},
+            {"radical": "罒", "role": "部件", "label": "網罟"},
+            {"radical": "心", "role": "部件", "label": "心"},
+        ],
+    },
+    # 惱: decomp ⿰忄⿱巛囟 — phonetic missing; semantic=忄; surface: 忄+囟
+    "惱": {
+        "formula": "忄 + 囟",
+        "components": [
+            {"radical": "忄", "role": "形符", "label": "心旁"},
+            {"radical": "囟", "role": "聲符", "label": "腦頂"},
+        ],
+    },
+    # 贏: decomp ⿵吂⿲⺼貝？ — phonetic missing; semantic=貝; surface: 亡+口+月+貝+凡
+    "贏": {
+        "formula": "亡 + 口 + 月 + 貝 + 凡",
+        "components": [
+            {"radical": "亡", "role": "部件", "label": "亡"},
+            {"radical": "口", "role": "部件", "label": "口"},
+            {"radical": "月", "role": "部件", "label": "月亮"},
+            {"radical": "貝", "role": "形符", "label": "貝"},
+            {"radical": "凡", "role": "部件", "label": "凡"},
+        ],
+    },
+    # 參: decomp ⿳厽人彡 — semantic missing; phonetic=彡; surface: ⺶+大+彡
+    "參": {
+        "formula": "⺶ + 大 + 彡",
+        "components": [
+            {"radical": "⺶", "role": "部件", "label": "羊頭"},
+            {"radical": "大", "role": "部件", "label": "大"},
+            {"radical": "彡", "role": "聲符", "label": "紋飾"},
+        ],
+    },
+    # 霸: decomp ⿱雨⿰革月 — phonetic missing; semantic=雨; surface: 雨+革+月
+    "霸": {
+        "formula": "雨 + 革 + 月",
+        "components": [
+            {"radical": "雨", "role": "形符", "label": "雨"},
+            {"radical": "革", "role": "部件", "label": "皮革"},
+            {"radical": "月", "role": "部件", "label": "月亮"},
+        ],
+    },
+    # 但: decomp ⿰亻旦 — semantic missing; phonetic=旦; surface: 亻+旦
+    "但": {
+        "formula": "亻 + 旦",
+        "components": [
+            {"radical": "亻", "role": "形符", "label": "人旁"},
+            {"radical": "旦", "role": "聲符", "label": "旦"},
+        ],
+    },
+    # 低: decomp ⿰亻氐 — semantic missing; phonetic=氐; surface: 亻+氐
+    "低": {
+        "formula": "亻 + 氐",
+        "components": [
+            {"radical": "亻", "role": "形符", "label": "人旁"},
+            {"radical": "氐", "role": "聲符", "label": "氐"},
+        ],
+    },
+    # 列: decomp ⿰歹刂 — phonetic missing; semantic=刂; surface: 歹+刂
+    "列": {
+        "formula": "歹 + 刂",
+        "components": [
+            {"radical": "歹", "role": "部件", "label": "歹"},
+            {"radical": "刂", "role": "形符", "label": "刀旁"},
+        ],
+    },
+    # 沒: decomp ⿰氵⿱？又 — phonetic missing; semantic=氵; surface: 氵+殳
+    "沒": {
+        "formula": "氵 + 殳",
+        "components": [
+            {"radical": "氵", "role": "形符", "label": "水旁"},
+            {"radical": "殳", "role": "聲符", "label": "殳"},
+        ],
+    },
+    # 沿: decomp ⿰氵⿱几口 — phonetic missing; semantic=氵; surface: 氵+几+口
+    "沿": {
+        "formula": "氵 + 几 + 口",
+        "components": [
+            {"radical": "氵", "role": "形符", "label": "水旁"},
+            {"radical": "几", "role": "部件", "label": "几"},
+            {"radical": "口", "role": "部件", "label": "口"},
+        ],
+    },
+    # 春: decomp ⿱？日 — phonetic missing; semantic=日; surface: 三+人+日 (屯+日)
+    "春": {
+        "formula": "三 + 人 + 日",
+        "components": [
+            {"radical": "三", "role": "部件", "label": "三"},
+            {"radical": "人", "role": "部件", "label": "人"},
+            {"radical": "日", "role": "形符", "label": "太陽"},
+        ],
+    },
+    # 黑: decomp ⿱？灬 — ideographic; surface: 口+土+灬
+    "黑": {
+        "formula": "口 + 土 + 灬",
+        "components": [
+            {"radical": "口", "role": "部件", "label": "口"},
+            {"radical": "土", "role": "部件", "label": "土"},
+            {"radical": "灬", "role": "部件", "label": "火底"},
+        ],
+    },
+    # 約: decomp ⿰糹勺 — phonetic missing; semantic=糹; surface: 糹+勺
+    "約": {
+        "formula": "糹 + 勺",
+        "components": [
+            {"radical": "糹", "role": "形符", "label": "絲線"},
+            {"radical": "勺", "role": "聲符", "label": "勺"},
+        ],
+    },
+    # 探: decomp ⿰扌⿱？木 — phonetic missing; semantic=扌; surface: 扌+穴+木
+    "探": {
+        "formula": "扌 + 穴 + 木",
+        "components": [
+            {"radical": "扌", "role": "形符", "label": "手旁"},
+            {"radical": "穴", "role": "部件", "label": "穴"},
+            {"radical": "木", "role": "部件", "label": "木"},
+        ],
+    },
+    # 拋: decomp ⿰扌⿺尢力 — phonetic missing; semantic=扌; surface: 扌+九+力
+    "拋": {
+        "formula": "扌 + 九 + 力",
+        "components": [
+            {"radical": "扌", "role": "形符", "label": "手旁"},
+            {"radical": "九", "role": "部件", "label": "九"},
+            {"radical": "力", "role": "部件", "label": "力量"},
+        ],
+    },
+    # 拖: decomp ⿰扌⿱亻也 — phonetic missing; semantic=扌; surface: 扌+它
+    "拖": {
+        "formula": "扌 + 它",
+        "components": [
+            {"radical": "扌", "role": "形符", "label": "手旁"},
+            {"radical": "它", "role": "聲符", "label": "它"},
+        ],
+    },
+    # 塌: decomp ⿰土⿱日羽 — phonetic missing; semantic=土; surface: 土+日+羽
+    "塌": {
+        "formula": "土 + 日 + 羽",
+        "components": [
+            {"radical": "土", "role": "形符", "label": "土"},
+            {"radical": "日", "role": "部件", "label": "太陽"},
+            {"radical": "羽", "role": "部件", "label": "羽毛"},
+        ],
+    },
+    # 塞: decomp ⿱宀⿱？土 — phonetic missing; semantic=土; surface: 宀+二+土
+    "塞": {
+        "formula": "宀 + 二 + 土",
+        "components": [
+            {"radical": "宀", "role": "部件", "label": "房頂"},
+            {"radical": "二", "role": "部件", "label": "二"},
+            {"radical": "土", "role": "形符", "label": "土"},
+        ],
+    },
+    # 員: decomp ⿱口貝 — phonetic missing; semantic=貝; surface: 口+貝
+    "員": {
+        "formula": "口 + 貝",
+        "components": [
+            {"radical": "口", "role": "部件", "label": "口"},
+            {"radical": "貝", "role": "形符", "label": "貝"},
+        ],
+    },
+    # 容: decomp ⿱宀谷 — phonetic missing; semantic=宀; surface: 宀+谷
+    "容": {
+        "formula": "宀 + 谷",
+        "components": [
+            {"radical": "宀", "role": "形符", "label": "房頂"},
+            {"radical": "谷", "role": "聲符", "label": "山谷"},
+        ],
+    },
+    # 疫: decomp ⿸疒殳 — phonetic missing; semantic=疒; surface: 疒+殳
+    "疫": {
+        "formula": "疒 + 殳",
+        "components": [
+            {"radical": "疒", "role": "形符", "label": "病旁"},
+            {"radical": "殳", "role": "聲符", "label": "殳"},
+        ],
+    },
+    # 秀: decomp ⿱禾乃 — phonetic missing; semantic=禾; surface: 禾+乃
+    "秀": {
+        "formula": "禾 + 乃",
+        "components": [
+            {"radical": "禾", "role": "形符", "label": "穀物"},
+            {"radical": "乃", "role": "部件", "label": "乃"},
+        ],
+    },
+    # 款: decomp ⿰⿱士示欠 — phonetic missing; semantic=欠; surface: 士+示+欠
+    "款": {
+        "formula": "士 + 示 + 欠",
+        "components": [
+            {"radical": "士", "role": "部件", "label": "士"},
+            {"radical": "示", "role": "部件", "label": "祭祀"},
+            {"radical": "欠", "role": "形符", "label": "欠"},
+        ],
+    },
 }
 
 


### PR DESCRIPTION
Fixes #795

## Summary

- Added 24 entries to `MANUAL_CORRECTIONS` in `scripts/build-decomposition-data.py` for compound characters where makemeahanzi's `pictophonetic` etymology only fills one of `semantic`/`phonetic`, causing the auto-builder to emit a single component
- Regenerated `frontend/src/data/decompositions-generated.json`
- `龍` remains 1 component (it is a pictographic 獨體字, correct as-is)
- Single-component character count: **201 → 177** (-24)
- Manual corrections count: **1 → 25**

## Fixed characters

| 字 | Before | After |
|----|--------|-------|
| 雜 | 隹 (1) | 九+木+隹 (3) |
| 德 | 心 (1) | 彳+十+罒+心 (4) |
| 惱 | 忄 (1) | 忄+囟 (2) |
| 贏 | 貝 (1) | 亡+口+月+貝+凡 (5) |
| 參 | 彡 (1) | ⺶+大+彡 (3) |
| 霸 | 雨 (1) | 雨+革+月 (3) |
| 但 | 旦 (1) | 亻+旦 (2) |
| 低 | 氐 (1) | 亻+氐 (2) |
| 列 | 刂 (1) | 歹+刂 (2) |
| 沒 | 氵 (1) | 氵+殳 (2) |
| 沿 | 氵 (1) | 氵+几+口 (3) |
| 春 | 日 (1) | 三+人+日 (3) |
| 黑 | 灬 (1) | 口+土+灬 (3) |
| 約 | 糹 (1) | 糹+勺 (2) |
| 探 | 扌 (1) | 扌+穴+木 (3) |
| 拋 | 扌 (1) | 扌+九+力 (3) |
| 拖 | 扌 (1) | 扌+它 (2) |
| 塌 | 土 (1) | 土+日+羽 (3) |
| 塞 | 土 (1) | 宀+二+土 (3) |
| 員 | 貝 (1) | 口+貝 (2) |
| 容 | 宀 (1) | 宀+谷 (2) |
| 疫 | 疒 (1) | 疒+殳 (2) |
| 秀 | 禾 (1) | 禾+乃 (2) |
| 款 | 欠 (1) | 士+示+欠 (3) |

## Test plan

- [x] `npm run build` passes
- [x] All 24 target chars verified to have 2+ components in generated JSON
- [x] Single-component count reduced from 201 to 177