### PR TITLE
feat: 隱藏家長功能 (feat: 804)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,7 @@ ANTHROPIC_API_KEY=your-anthropic-api-key-here
 DATABASE_URL=postgresql://user:pass@localhost:5432/lingoleap
 REDIS_URL=redis://localhost:6379
 ALLOWED_ORIGINS=http://localhost:3000
+PARENT_PORTAL_ENABLED=false
 
 # TTS Provider (azure | google)
 # azure = Azure Speech Service (Taiwan accent, zh-TW-HsiaoChenNeural) — default primary

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 480  # 8 hours
     google_client_id: str = ""  # set GOOGLE_CLIENT_ID env var in Cloud Run
+    parent_portal_enabled: bool = False
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -41,6 +41,33 @@ PASSWORD_RESET_EXPIRY_HOURS = 1
 EMAIL_VERIFICATION_TOKEN_BYTES = 32
 
 
+def _has_active_role(db: Session, user_id: int, role_name: str) -> bool:
+    """Return whether the user has an active role with the given name."""
+    return (
+        db.query(UserRole)
+        .join(Role, UserRole.role_id == Role.id)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.is_active == True,
+            Role.name == role_name,
+        )
+        .first()
+        is not None
+    )
+
+
+def _ensure_parent_login_allowed(user: User, db: Session) -> None:
+    """Raise 403 when parent logins are temporarily disabled by feature flag."""
+    if settings.parent_portal_enabled:
+        return
+
+    if _has_active_role(db, user.id, "parent"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="家長功能目前暫時關閉，請聯繫老師或管理員。",
+        )
+
+
 def _enforce_password_strength(password: str) -> None:
     """Raise HTTP 422 with a Chinese error message if password is too weak."""
     result = validate_password_strength(password)
@@ -218,6 +245,8 @@ def login(req: LoginRequest, request: Request, db: Session = Depends(get_db)):
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password",
         )
+
+    _ensure_parent_login_allowed(user, db)
 
     # Require email verification before allowing login (issue #460).
     # Batch-created student accounts keep email_verified=True (they have no real email).
@@ -505,6 +534,7 @@ def google_login(req: GoogleLoginRequest, request: Request, db: Session = Depend
         # 2. Look up by email (link existing account)
         user = db.query(User).filter(User.email == email, User.is_active == True).first()
         if user is not None:
+            _ensure_parent_login_allowed(user, db)
             user.google_id = google_sub
             if picture and not user.avatar_url:
                 user.avatar_url = picture
@@ -521,6 +551,8 @@ def google_login(req: GoogleLoginRequest, request: Request, db: Session = Depend
             )
             db.add(user)
             is_new_user = True
+    else:
+        _ensure_parent_login_allowed(user, db)
 
     user.last_login_at = datetime.now(timezone.utc)
     db.commit()

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -34,7 +34,7 @@ from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.database import get_db
 from app.models import Base
-from app.models.user import Role
+from app.models.user import Role, User, UserRole
 from app.auth.password import hash_password, verify_password
 from app.auth.jwt import create_access_token, decode_token
 from app.config import settings
@@ -156,6 +156,30 @@ def registered_user(client):
 def auth_header(token: str) -> dict:
     """Build an Authorization header dict."""
     return {"Authorization": f"Bearer {token}"}
+
+
+def _assign_role_to_user(email: str, role_name: str) -> None:
+    """Assign an active role to a user in the test database."""
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).first()
+        assert user is not None
+        role = db.query(Role).filter(Role.name == role_name).first()
+        assert role is not None
+        existing = (
+            db.query(UserRole)
+            .filter(
+                UserRole.user_id == user.id,
+                UserRole.role_id == role.id,
+                UserRole.is_active == True,
+            )
+            .first()
+        )
+        if existing is None:
+            db.add(UserRole(user_id=user.id, role_id=role.id, scope_type="platform"))
+            db.commit()
+    finally:
+        db.close()
 
 
 # ===========================================================================
@@ -818,6 +842,29 @@ class TestLoginEndpoint:
         })
         assert resp_wrong_email.json()["detail"] == resp_wrong_pass.json()["detail"]
         assert resp_wrong_email.status_code == resp_wrong_pass.status_code
+
+    def test_login_blocks_parent_role_when_parent_portal_disabled(self, client, registered_user, monkeypatch):
+        _assign_role_to_user(registered_user["email"], "parent")
+        monkeypatch.setattr("app.config.settings.parent_portal_enabled", False)
+
+        resp = client.post("/api/auth/login", json={
+            "email": registered_user["email"],
+            "password": registered_user["password"],
+        })
+
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "家長功能目前暫時關閉，請聯繫老師或管理員。"
+
+    def test_login_allows_parent_role_when_parent_portal_enabled(self, client, registered_user, monkeypatch):
+        _assign_role_to_user(registered_user["email"], "parent")
+        monkeypatch.setattr("app.config.settings.parent_portal_enabled", True)
+
+        resp = client.post("/api/auth/login", json={
+            "email": registered_user["email"],
+            "password": registered_user["password"],
+        })
+
+        assert resp.status_code == 200
 
 
 # ===========================================================================

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -518,7 +518,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       localStorage.setItem(storageKey, JSON.stringify({
         lineResults,
         paragraphSummaries: Object.fromEntries(
-          Object.entries(paragraphSummaries).map(([k, v]) => [k, { ...v, geminiPending: false }])
+          (Object.entries(paragraphSummaries) as Array<[string, ParagraphSummaryData]>).map(([k, v]) => [
+            k,
+            { ...v, geminiPending: false },
+          ])
         ),
         completedParagraphs: Array.from(completedParagraphs),
         currentLineIndex,
@@ -1160,7 +1163,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       {/* LEFT: Story text panel — completely static, no dynamic text changes */}
       <div className="flex flex-col bg-amber-50 flex-1 min-h-0 overflow-hidden">
         <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2">
-          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
+          <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-t-accent border-x border-x-gray-200 text-xs text-gray-800 gap-2">
             {processZhuyin(story.filename)}
           </div>
           <div className="flex-1" />

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -1,0 +1,10 @@
+/**
+ * Centralized frontend feature flags.
+ *
+ * Parent portal is hidden by default and can be re-enabled with:
+ * VITE_PARENT_PORTAL_ENABLED=true
+ */
+
+const rawParentPortalFlag = import.meta.env.VITE_PARENT_PORTAL_ENABLED as string | undefined;
+
+export const PARENT_PORTAL_ENABLED = rawParentPortalFlag === 'true';

--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -10,6 +10,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from './AuthContext';
 import type { AuthUser, UserRole } from '../services/authApi';
+import { PARENT_PORTAL_ENABLED } from '../config/featureFlags';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,7 +62,7 @@ function deriveAvailableViews(user: AuthUser | null): WorkspaceView[] {
     if (ADMIN_ROLES.has(r.role_name)) views.add('admin');
     if (TEACHER_ROLES.has(r.role_name)) views.add('teacher');
     if (r.role_name === 'student') views.add('student');
-    if (r.role_name === 'parent') views.add('parent');
+    if (PARENT_PORTAL_ENABLED && r.role_name === 'parent') views.add('parent');
   }
   // Admin users also get teacher view (they manage classrooms)
   if (views.has('admin') && !views.has('teacher')) views.add('teacher');

--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -15,6 +15,7 @@ import { lazy } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { hasRole } from '../../services/authApi';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
+import { PARENT_PORTAL_ENABLED } from '../../config/featureFlags';
 import StoryLibrary from '../student/StoryLibrary';
 import WriteCharacter from '../../components/stroke-order/WriteCharacter';
 import SessionResumePrompt from '../../components/SessionResumePrompt';
@@ -42,7 +43,7 @@ export const HomePage: React.FC = () => {
     admin: '/admin',
     teacher: '/teacher-home',
     student: '/student',
-    parent: '/parent',
+    parent: PARENT_PORTAL_ENABLED ? '/parent' : '/student',
   };
   return <Navigate to={homeMap[activeView] ?? '/student'} replace />;
 };

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -18,6 +18,7 @@ import {
   TeacherDashboardPage,
 } from '../pages/app/InlinePages';
 import PageLoader from '../components/ui/PageLoader';
+import { PARENT_PORTAL_ENABLED } from '../config/featureFlags';
 
 // Auth pages — eager-loaded (small, needed immediately on first visit)
 import LoginPage from '../pages/LoginPage';
@@ -215,16 +216,18 @@ const AppRoutes: React.FC = () => (
           </ProtectedRoute>
         }
       />
-      <Route
-        path="/parent"
-        element={
-          <ProtectedRoute>
-            <AppShell>
-              <ParentDashboard />
-            </AppShell>
-          </ProtectedRoute>
-        }
-      />
+      {PARENT_PORTAL_ENABLED && (
+        <Route
+          path="/parent"
+          element={
+            <ProtectedRoute>
+              <AppShell>
+                <ParentDashboard />
+              </AppShell>
+            </ProtectedRoute>
+          }
+        />
+      )}
       <Route
         path="/assignments"
         element={


### PR DESCRIPTION
### 修改內容

1. 後端加入可切換旗標，預設關閉家長功能
`backend/app/config.py`
`backend/.env.example`

2. 後端封鎖家長角色登入
當帳號有 parent 角色且旗標關閉時，登入會回 403。
一般帳密登入與 Google 登入都已套用。

3. 前端隱藏家長頁入口
新增前端旗標，預設關閉。

4. 前端不再顯示家長視圖與家長路由
家長不會出現在可切換視圖中，/parent 路由也不會註冊。

### 如何重新開啟家長功能
後端環境變數設為 PARENT_PORTAL_ENABLED=true
前端環境變數設為 VITE_PARENT_PORTAL_ENABLED=true
重新部署前後端即可恢復