### PR TITLE
fix(full-reading): #806 — sync completedParagraphsSet from LiveTutor localStorage on mount

### DIFF
--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -122,13 +122,39 @@ const LearningLayout: React.FC = () => {
     }
   });
   /** Progressive paragraph unlock tracking (Issue #85).
-   * Restored from localStorage on mount so progress survives page refresh (Issue #689). */
+   * Restored from localStorage on mount so progress survives page refresh (Issue #689).
+   *
+   * Fix #806: also fall back to LiveTutor's own localStorage key (`liveTutor_progress_*`)
+   * so that when `tutor_completed_*` was cleared at session end but the user returns to
+   * the same story before LiveTutor clears its own cache, FullReading still sees all
+   * paragraphs as done. */
   const [completedParagraphsSet, setCompletedParagraphsSet] = useState<Set<number>>(() => {
     try {
       const raw = localStorage.getItem(`tutor_completed_${storyId}`);
       if (raw) {
         const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed)) return new Set<number>(parsed as number[]);
+        if (Array.isArray(parsed) && (parsed as number[]).length > 0) {
+          return new Set<number>(parsed as number[]);
+        }
+      }
+    } catch {
+      // Non-fatal — continue to fallback
+    }
+    // Fallback: LiveTutor persists its own progress under a different key.
+    // If the user refreshed the page or started a new session for the same story
+    // before LiveTutor cleared its own cache, read completed paragraphs from there.
+    try {
+      const liveTutorRaw = localStorage.getItem(`liveTutor_progress_${storyId}`);
+      if (liveTutorRaw) {
+        const liveTutorParsed = JSON.parse(liveTutorRaw) as {
+          completedParagraphs?: unknown;
+        };
+        if (
+          Array.isArray(liveTutorParsed.completedParagraphs) &&
+          (liveTutorParsed.completedParagraphs as number[]).length > 0
+        ) {
+          return new Set<number>(liveTutorParsed.completedParagraphs as number[]);
+        }
       }
     } catch {
       // Non-fatal — start fresh
@@ -185,12 +211,15 @@ const LearningLayout: React.FC = () => {
 
   /** Clear active session from localStorage and sessionStorage (called on completion).
    * Removing the sessionStorage key means the next visit creates a fresh DB session.
-   * Also clears the tutor paragraph progress so a fresh session starts at zero (Issue #689). */
+   * Also clears the tutor paragraph progress so a fresh session starts at zero (Issue #689).
+   * Fix #806: also clear LiveTutor's own cache key so stale paragraph data from a
+   * completed session never bleeds into a new session for the same story. */
   const clearPersistedSession = useCallback(() => {
     if (!user) return;
     clearActiveSession(String(user.id));
     try { sessionStorage.removeItem(`db-session-${storyId}`); } catch { /* non-fatal */ }
     try { localStorage.removeItem(`tutor_completed_${storyId}`); } catch { /* non-fatal */ }
+    try { localStorage.removeItem(`liveTutor_progress_${storyId}`); } catch { /* non-fatal */ }
   }, [user, storyId]);
 
   // ── Idle-timeout warning (Issue #408) ────────────────────────────────────


### PR DESCRIPTION
## Root Cause

`LearningLayout` tracks which LiveTutor paragraphs are done in `completedParagraphsSet`, persisted as `tutor_completed_${storyId}` in localStorage. `clearPersistedSession` (called when a session ends) removes that key.

`LiveTutor` keeps its own localStorage under `liveTutor_progress_${storyId}`, cleared only when the user clicks "觀看總結報告" (`handleFinish`).

**Scenario that triggers the bug:**
1. User completes all paragraphs — LiveTutor shows ✅, `tutor_completed_*` populated
2. User finishes session — `clearPersistedSession` removes `tutor_completed_*`, but NOT `liveTutor_progress_*`
3. User opens the same story again without completing LiveTutor this time
4. `LearningLayout` mounts: `completedParagraphsSet = {}` (key gone)
5. `LiveTutor` mounts: restores all paragraphs from its own cache, shows "觀看總結報告"
6. User clicks "觀看總結報告" → `handleFinish` → navigates to FullReading
7. `FullReadingPage` sees `completedParagraphsSet.size === 0` → shows "全文朗讀尚未解鎖"

## Fix

Two changes in `LearningLayout.tsx`:

1. **Initialiser fallback**: when `tutor_completed_*` is empty, fall back to reading `liveTutor_progress_*` for the completed paragraph set — so restored LiveTutor sessions are also visible to FullReading.

2. **`clearPersistedSession` also clears `liveTutor_progress_*`**: prevents stale paragraph data from a completed session bleeding into a new one.

## Test plan
- [ ] Complete all paragraphs in LiveTutor for a story → navigate to FullReading → should be unlocked (no 0/5 message)
- [ ] Complete full session (view report) → reopen same story → LiveTutor should start fresh (no stale completed paragraphs)
- [ ] Refresh browser mid-session after completing some paragraphs → FullReading gate should reflect actual progress
- [ ] `npm run build` passes ✅

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)