### PR TITLE
fix(radicals): init radical meanings so 226 radicals show descriptions

### DIFF
--- a/frontend/src/components/reading-steps/RadicalDecomposition.tsx
+++ b/frontend/src/components/reading-steps/RadicalDecomposition.tsx
@@ -15,6 +15,7 @@ import {
   getRadicalInfo,
   getRelatedChars,
   initGeneratedDecompositions,
+  initRadicalMeanings,
   RadicalRole,
   RelatedChar,
 } from '../../data/radicals';
@@ -72,7 +73,8 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
   // forceUpdate triggers a re-render after the data is available so that
   // characters not in the hand-curated set are shown immediately.
   useEffect(() => {
-    initGeneratedDecompositions().then(() => forceUpdate(n => n + 1));
+    Promise.all([initGeneratedDecompositions(), initRadicalMeanings()])
+      .then(() => forceUpdate(n => n + 1));
   }, []);
 
   const decomp = getDecomposition(char);

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -8,7 +8,7 @@ import ZhuyinPhoneticGame from './ZhuyinPhoneticGame';
 import { PolyphonicProcessor, buildZhuyinString } from '../zhuyin/polyphonicProcessor';
 import ZhuyinToggle from '../ui/ZhuyinToggle';
 import RadicalDecomposition from './RadicalDecomposition';
-import { getDecomposition, initGeneratedDecompositions } from '../../data/radicals';
+import { getDecomposition, initGeneratedDecompositions, initRadicalMeanings } from '../../data/radicals';
 import DictionaryPanel from '../dictionary/DictionaryPanel';
 import FillInBlankExercise from './FillInBlankExercise';
 
@@ -147,7 +147,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   // Load generated decomposition data so getDecomposition() covers 2700+ chars
   const [decompReady, setDecompReady] = useState(false);
   useEffect(() => {
-    initGeneratedDecompositions().then(() => setDecompReady(true));
+    Promise.all([initGeneratedDecompositions(), initRadicalMeanings()]).then(() => setDecompReady(true));
   }, []);
   const storageKey = `vocabPractice_progress_${story.id}`;
   const loadSaved = () => {


### PR DESCRIPTION
initRadicalMeanings() was never called — 226 moedict radical meanings were invisible. Now loaded alongside decomposition data. 🤖 Generated with [Claude Code](https://claude.com/claude-code)