### PR TITLE
fix(layout): make LearningContent overflow-hidden so ReadingAnnotation scroll works (Fixes #815)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -153,8 +153,11 @@ const LearningContent: React.FC = () => {
         onNavigate={handleStepperNavigate}
       />
 
-      {/* Learning step content — scrollable, with bottom padding for mobile tab bar */}
-      <div className="flex-1 overflow-y-auto pb-14 md:pb-0">
+      {/* Learning step content — overflow-hidden so each step manages its own scroll.
+          ReadingAnnotation, LiveTutor, and other steps use h-full + internal overflow-y-auto
+          and require a height-bounded parent; overflow-y-auto here would let them expand
+          unboundedly and make their internal containerRef never scroll (#815). */}
+      <div className="flex-1 overflow-hidden pb-14 md:pb-0">
         <LearningLayout />
       </div>
     </div>


### PR DESCRIPTION
## Root Cause

The `LearningContent` inner wrapper in `AppShell.tsx` used `overflow-y-auto`, which let child step components like `ReadingAnnotation` grow unboundedly in height.

`ReadingAnnotation` has `h-full` on its root and uses an inner `div` with `overflow-y-auto` as the scrollable text container (`containerRef`). When the parent wrapper is `overflow-y-auto` instead of `overflow-hidden`, the child's `flex-1 h-full` never receives a bounded height — the outer wrapper absorbs the scroll instead of the inner `containerRef` div.

As a result, `jumpToAnnotation` called `containerRef.current.scrollTo(...)` on a div whose `scrollTop` was always `0` (nothing to scroll inside it), producing no visible movement when clicking panel items.

## Fix

Change `overflow-y-auto` → `overflow-hidden` on the `LearningContent` step wrapper div in `AppShell.tsx` (line 160). Each step component (`ReadingAnnotation`, `LiveTutor`, etc.) manages its own internal scroll via `h-full` + `overflow-y-auto` on its inner container.

## Files Changed

- `frontend/src/components/layout/AppShell.tsx` — 1 line change

## Test Plan

- [ ] Mark several words in ReadingAnnotation (step 1)
- [ ] Click an item in the right side panel — text area should scroll to that word and flash highlight
- [ ] Verify other steps (LiveTutor, ComprehensionChat) still scroll normally
- [ ] `npm run build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)