### PR TITLE
fix(radicals): exclude 獨體字 from decomposition display (Fixes #813)

### DIFF
--- a/frontend/src/components/reading-steps/RadicalDecomposition.tsx
+++ b/frontend/src/components/reading-steps/RadicalDecomposition.tsx
@@ -80,7 +80,24 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
   const decomp = getDecomposition(char);
 
   if (!decomp) {
-    return null; // Silently skip characters not in the database
+    // Character is an independent form (獨體字) or not in the database.
+    // Show a friendly educational message instead of silently hiding the panel.
+    return (
+      <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden shadow-sm">
+        <div className="px-4 py-3 bg-gradient-to-r from-indigo-50 to-purple-50 border-b border-gray-100 flex items-center gap-2">
+          <span className="text-base font-bold text-gray-700">部件拆解</span>
+        </div>
+        <div className="p-4 flex flex-col items-center gap-3 text-center">
+          <span className="text-4xl font-black text-gray-900 leading-none">{char}</span>
+          <p className="text-sm text-gray-600">
+            此字為<span className="font-semibold text-indigo-700">獨體字</span>，無法再拆解
+          </p>
+          <p className="text-xs text-gray-400">
+            獨體字是最小的漢字單位，本身就是一個完整的象形或指事字
+          </p>
+        </div>
+      </div>
+    );
   }
 
   // Collect unique radicals from components

--- a/frontend/src/data/decomposition-sources.json
+++ b/frontend/src/data/decomposition-sources.json
@@ -14,14 +14,14 @@
     },
     {
       "name": "makemeahanzi",
-      "count": 2575,
+      "count": 2382,
       "priority": 2,
       "license": "LGPL",
       "url": "https://github.com/skishore/makemeahanzi"
     },
     {
       "name": "kfcd/chaizi",
-      "count": 134,
+      "count": 121,
       "priority": 3,
       "license": "CC BY 3.0",
       "url": "https://github.com/kfcd/chaizi"
@@ -29,12 +29,13 @@
   ],
   "generatedAt": "2026-03-30",
   "totalLessonChars": 2791,
-  "coverage": "98.0%",
+  "coverage": "90.6%",
   "breakdown": {
-    "pictophonetic": 1727,
-    "ideographic": 728,
-    "pictographic": 120,
-    "chaizi_fallback": 134,
-    "no_data": 57
+    "pictophonetic": 1700,
+    "ideographic": 682,
+    "pictographic": 0,
+    "chaizi_fallback": 121,
+    "no_data": 55,
+    "independent": 208
   }
 }

--- a/frontend/src/data/decompositions-generated.json
+++ b/frontend/src/data/decompositions-generated.json
@@ -1,1 +1,39027 @@
-{"丁":{"formula":"丁","components":[{"radical":"丁","role":"部件","label":"象形字（獨體）"}]},"七":{"formula":"一 + 乚","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"乚","role":"部件","label":"乚"}]},"丈":{"formula":"一 + 乂","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"乂","role":"部件","label":"乂"}]},"三":{"formula":"一 + 二","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"二","role":"部件","label":"二"}]},"上":{"formula":"⺊ + 一","components":[{"radical":"⺊","role":"部件","label":"⺊"},{"radical":"一","role":"部件","label":"一"}]},"下":{"formula":"一 + 卜","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"卜","role":"部件","label":"占卜"}]},"不":{"formula":"一","components":[{"radical":"一","role":"部件","label":"一"}]},"丐":{"formula":"丐","components":[{"radical":"丐","role":"部件","label":"象形字（獨體）"}]},"且":{"formula":"且","components":[{"radical":"且","role":"部件","label":"象形字（獨體）"}]},"世":{"formula":"世","components":[{"radical":"世","role":"部件","label":"象形字（獨體）"}]},"丘":{"formula":"丘","components":[{"radical":"丘","role":"部件","label":"象形字（獨體）"}]},"丙":{"formula":"一 + 人 + 冂","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"人","role":"部件","label":"人"},{"radical":"冂","role":"部件","label":"邊界"}]},"並":{"formula":"丷 + 亚","components":[{"radical":"丷","role":"部件","label":"丷"},{"radical":"亚","role":"部件","label":"亚"}]},"中":{"formula":"口 + 丨","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"丰":{"formula":"丰","components":[{"radical":"丰","role":"部件","label":"象形字（獨體）"}]},"串":{"formula":"口 + 口 + 丨","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"丸":{"formula":"丸","components":[{"radical":"丸","role":"部件","label":"象形字（獨體）"}]},"主":{"formula":"主","components":[{"radical":"主","role":"部件","label":"象形字（獨體）"}]},"乃":{"formula":"丿","components":[{"radical":"丿","role":"部件","label":"撇"}]},"久":{"formula":"丿 + 入","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"入","role":"部件","label":"發生性關係"}]},"之":{"formula":"丶","components":[{"radical":"丶","role":"部件","label":"點"}]},"乍":{"formula":"丿 + 丅 + 二","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"丅","role":"部件","label":"丅"},{"radical":"二","role":"部件","label":"二"}]},"乎":{"formula":"丿 + 丷 + 一 + 亅","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"丷","role":"部件","label":"丷"},{"radical":"一","role":"部件","label":"一"},{"radical":"亅","role":"部件","label":"倒掛的鉤"}]},"乏":{"formula":"丿 + 之","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"之","role":"部件","label":"之"}]},"乖":{"formula":"千 + 北","components":[{"radical":"千","role":"部件","label":"千"},{"radical":"北","role":"部件","label":"北"}]},"乘":{"formula":"禾 + 北","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"北","role":"部件","label":"北"}]},"乙":{"formula":"乙","components":[{"radical":"乙","role":"部件","label":"象形字（獨體）"}]},"九":{"formula":"九","components":[{"radical":"九","role":"部件","label":"象形字（獨體）"}]},"乞":{"formula":"丿 + 一 + 乙","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"一","role":"部件","label":"一"},{"radical":"乙","role":"部件","label":"天干的第二位"}]},"也":{"formula":"卩 + 丨 + 乚","components":[{"radical":"卩","role":"部件","label":"跪坐"},{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"乚","role":"部件","label":"乚"}]},"乩":{"formula":"占 + 乚","components":[{"radical":"占","role":"形符","label":"占"},{"radical":"乚","role":"聲符","label":"讀音"}]},"乳":{"formula":"孚 + 乚","components":[{"radical":"孚","role":"聲符","label":"讀音"},{"radical":"乚","role":"形符","label":"乚"}]},"乾":{"formula":"龺 + 乞","components":[{"radical":"龺","role":"部件","label":"龺"},{"radical":"乞","role":"部件","label":"乞"}]},"亂":{"formula":"爫 + 冂 + 厶 + 又 + 乚","components":[{"radical":"爫","role":"部件","label":"爫"},{"radical":"冂","role":"部件","label":"邊界"},{"radical":"厶","role":"部件","label":"私"},{"radical":"又","role":"部件","label":"手"},{"radical":"乚","role":"部件","label":"乚"}]},"了":{"formula":"了","components":[{"radical":"了","role":"部件","label":"象形字（獨體）"}]},"予":{"formula":"龴 + 乛 + 亅","components":[{"radical":"龴","role":"部件","label":"龴"},{"radical":"乛","role":"部件","label":"乛"},{"radical":"亅","role":"部件","label":"倒掛的鉤"}]},"事":{"formula":"一 + 口 + 聿","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"聿","role":"部件","label":"筆"}]},"二":{"formula":"一 + 一","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"一","role":"部件","label":"一"}]},"于":{"formula":"二 + 亅","components":[{"radical":"二","role":"部件","label":"二"},{"radical":"亅","role":"部件","label":"倒掛的鉤"}]},"云":{"formula":"云","components":[{"radical":"云","role":"部件","label":"象形字（獨體）"}]},"互":{"formula":"二","components":[{"radical":"二","role":"部件","label":"二"}]},"五":{"formula":"二","components":[{"radical":"二","role":"部件","label":"二"}]},"井":{"formula":"井","components":[{"radical":"井","role":"部件","label":"象形字（獨體）"}]},"些":{"formula":"此 + 二","components":[{"radical":"此","role":"聲符","label":"讀音"},{"radical":"二","role":"形符","label":"二"}]},"亞":{"formula":"亞","components":[{"radical":"亞","role":"部件","label":"象形字（獨體）"}]},"亡":{"formula":"亠","components":[{"radical":"亠","role":"部件","label":"二一四部首之"}]},"交":{"formula":"六 + 乂","components":[{"radical":"六","role":"部件","label":"六"},{"radical":"乂","role":"部件","label":"乂"}]},"亦":{"formula":"亠","components":[{"radical":"亠","role":"部件","label":"二一四部首之"}]},"享":{"formula":"亠 + 口 + 子","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"子","role":"部件","label":"孩子"}]},"京":{"formula":"京","components":[{"radical":"京","role":"部件","label":"象形字（獨體）"}]},"亮":{"formula":"亮","components":[{"radical":"亮","role":"部件","label":"象形字（獨體）"}]},"人":{"formula":"人","components":[{"radical":"人","role":"部件","label":"象形字（獨體）"}]},"什":{"formula":"亻 + 十","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"十","role":"部件","label":"十"}]},"仁":{"formula":"亻 + 二","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"二","role":"部件","label":"二"}]},"仃":{"formula":"亻 + 丁","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"丁","role":"聲符","label":"讀音"}]},"仆":{"formula":"亻 + 卜","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"卜","role":"聲符","label":"讀音"}]},"今":{"formula":"人","components":[{"radical":"人","role":"部件","label":"人"}]},"介":{"formula":"人","components":[{"radical":"人","role":"部件","label":"人"}]},"仍":{"formula":"亻 + 乃","components":[{"radical":"亻","role":"聲符","label":"讀音"},{"radical":"乃","role":"形符","label":"乃"}]},"仔":{"formula":"亻 + 子","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"子","role":"部件","label":"孩子"}]},"他":{"formula":"亻 + 也","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"也","role":"部件","label":"也"}]},"付":{"formula":"亻 + 寸","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"寸","role":"部件","label":"量詞"}]},"代":{"formula":"亻 + 弋","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"弋","role":"部件","label":"射箭"}]},"令":{"formula":"人","components":[{"radical":"人","role":"部件","label":"人"}]},"以":{"formula":"□ + 丶 + 人","components":[{"radical":"□","role":"部件","label":"□"},{"radical":"丶","role":"部件","label":"點"},{"radical":"人","role":"部件","label":"人"}]},"仰":{"formula":"亻 + 卬","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"卬","role":"部件","label":"卬"}]},"仲":{"formula":"亻 + 中","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"中","role":"部件","label":"中"}]},"件":{"formula":"亻 + 牛","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"牛","role":"部件","label":"牛"}]},"任":{"formula":"亻 + 壬","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"壬","role":"聲符","label":"讀音"}]},"份":{"formula":"亻 + 分","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"分","role":"部件","label":"分"}]},"仿":{"formula":"亻 + 方","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"方","role":"聲符","label":"讀音"}]},"企":{"formula":"人 + 止","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"止","role":"部件","label":"停止"}]},"伍":{"formula":"亻 + 五","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"五","role":"部件","label":"五"}]},"伏":{"formula":"亻 + 犬","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"犬","role":"部件","label":"狗"}]},"伐":{"formula":"亻 + 戈","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"戈","role":"部件","label":"武器"}]},"休":{"formula":"亻 + 木","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"木","role":"部件","label":"樹木"}]},"伙":{"formula":"亻 + 火","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"火","role":"聲符","label":"讀音"}]},"伯":{"formula":"亻 + 白","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"白","role":"聲符","label":"讀音"}]},"估":{"formula":"亻 + 古","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"古","role":"聲符","label":"讀音"}]},"伴":{"formula":"亻 + 半","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"半","role":"聲符","label":"讀音"}]},"伶":{"formula":"亻 + 令","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"令","role":"聲符","label":"讀音"}]},"伸":{"formula":"亻 + 申","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"申","role":"部件","label":"申"}]},"似":{"formula":"亻 + 以","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"以","role":"部件","label":"以"}]},"但":{"formula":"亻 + 旦","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"旦","role":"聲符","label":"讀音"}]},"佈":{"formula":"亻 + 布","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"布","role":"部件","label":"布"}]},"位":{"formula":"亻 + 立","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"立","role":"部件","label":"站立"}]},"低":{"formula":"亻 + 氐","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"氐","role":"聲符","label":"讀音"}]},"住":{"formula":"亻 + 主","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"主","role":"部件","label":"主"}]},"佑":{"formula":"亻 + 右","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"右","role":"聲符","label":"讀音"}]},"佔":{"formula":"亻 + 占","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"占","role":"聲符","label":"讀音"}]},"何":{"formula":"人 + 可","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"可","role":"部件","label":"可"}]},"佛":{"formula":"亻 + 弗","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"弗","role":"聲符","label":"讀音"}]},"作":{"formula":"亻 + 乍","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"乍","role":"部件","label":"乍"}]},"你":{"formula":"亻 + 尔","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"尔","role":"部件","label":"尔"}]},"佩":{"formula":"亻 + 凡 + 巾","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"凡","role":"部件","label":"凡"},{"radical":"巾","role":"部件","label":"布"}]},"佳":{"formula":"亻 + 圭","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"圭","role":"聲符","label":"讀音"}]},"佼":{"formula":"亻 + 交","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"交","role":"聲符","label":"讀音"}]},"使":{"formula":"亻 + 吏","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"吏","role":"部件","label":"吏"}]},"來":{"formula":"木 + 从","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"从","role":"部件","label":"从"}]},"侈":{"formula":"亻 + 多","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"多","role":"部件","label":"多"}]},"例":{"formula":"亻 + 列","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"列","role":"聲符","label":"讀音"}]},"供":{"formula":"亻 + 共","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"共","role":"部件","label":"共同"}]},"依":{"formula":"亻 + 衣","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"衣","role":"聲符","label":"讀音"}]},"侵":{"formula":"人 + 彐 + 冖 + 又","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"彐","role":"部件","label":"豬頭"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"又","role":"部件","label":"手"}]},"侶":{"formula":"亻 + 呂","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"呂","role":"聲符","label":"讀音"}]},"侷":{"formula":"亻 + 局","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"局","role":"聲符","label":"讀音"}]},"便":{"formula":"人 + 更","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"更","role":"部件","label":"更"}]},"係":{"formula":"亻 + 系","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"系","role":"部件","label":"系"}]},"促":{"formula":"亻 + 足","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"足","role":"部件","label":"足旁"}]},"俄":{"formula":"我","components":[{"radical":"我","role":"聲符","label":"讀音"}]},"俊":{"formula":"亻 + 夋","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"夋","role":"聲符","label":"讀音"}]},"俐":{"formula":"亻 + 利","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"利","role":"聲符","label":"讀音"}]},"俗":{"formula":"亻 + 谷","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"谷","role":"聲符","label":"讀音"}]},"保":{"formula":"亻 + 呆","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"呆","role":"聲符","label":"讀音"}]},"俠":{"formula":"亻 + 夾","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"夾","role":"部件","label":"夾"}]},"信":{"formula":"人 + 言","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"言","role":"部件","label":"說話"}]},"修":{"formula":"攸 + 彡","components":[{"radical":"攸","role":"聲符","label":"讀音"},{"radical":"彡","role":"形符","label":"花紋"}]},"俱":{"formula":"亻 + 具","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"具","role":"聲符","label":"讀音"}]},"倆":{"formula":"亻 + 兩","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"兩","role":"部件","label":"兩"}]},"倉":{"formula":"人 + 户 + 口","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"户","role":"部件","label":"「戶」的異體"},{"radical":"口","role":"部件","label":"嘴巴"}]},"個":{"formula":"亻 + 固","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"固","role":"聲符","label":"讀音"}]},"倍":{"formula":"人 + 咅","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"咅","role":"部件","label":"咅"}]},"們":{"formula":"亻 + 門","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"門","role":"聲符","label":"讀音"}]},"倒":{"formula":"亻 + 到","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"到","role":"聲符","label":"讀音"}]},"倖":{"formula":"亻 + 幸","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"幸","role":"部件","label":"幸"}]},"倘":{"formula":"亻 + 尚","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"尚","role":"聲符","label":"讀音"}]},"候":{"formula":"亻 + 矦","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"矦","role":"聲符","label":"讀音"}]},"倚":{"formula":"亻 + 奇","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"奇","role":"聲符","label":"讀音"}]},"借":{"formula":"亻 + 昔","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"昔","role":"聲符","label":"讀音"}]},"倡":{"formula":"亻 + 昌","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"昌","role":"部件","label":"昌"}]},"倦":{"formula":"亻 + 卷","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"卷","role":"部件","label":"卷"}]},"倫":{"formula":"亻 + 侖","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"侖","role":"部件","label":"侖"}]},"倬":{"formula":"亻 + 卓","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"卓","role":"聲符","label":"讀音"}]},"值":{"formula":"亻 + 直","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"直","role":"聲符","label":"讀音"}]},"假":{"formula":"亻 + 叚","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"叚","role":"部件","label":"叚"}]},"偉":{"formula":"亻 + 韋","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"韋","role":"聲符","label":"讀音"}]},"偏":{"formula":"亻 + 扁","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"扁","role":"聲符","label":"讀音"}]},"偕":{"formula":"亻 + 皆","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"皆","role":"聲符","label":"讀音"}]},"做":{"formula":"亻 + 故","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"故","role":"部件","label":"故"}]},"停":{"formula":"亻 + 亭","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"亭","role":"聲符","label":"讀音"}]},"健":{"formula":"亻 + 建","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"建","role":"部件","label":"建"}]},"側":{"formula":"亻 + 則","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"則","role":"聲符","label":"讀音"}]},"偵":{"formula":"亻 + 貞","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"貞","role":"聲符","label":"讀音"}]},"偶":{"formula":"亻 + 禺","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"禺","role":"聲符","label":"讀音"}]},"偷":{"formula":"亻 + 俞","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"俞","role":"聲符","label":"讀音"}]},"偽":{"formula":"亻 + 為","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"為","role":"聲符","label":"讀音"}]},"傑":{"formula":"亻 + 桀","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"桀","role":"聲符","label":"讀音"}]},"傲":{"formula":"亻 + 敖","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"敖","role":"聲符","label":"讀音"}]},"傳":{"formula":"亻 + 專","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"專","role":"聲符","label":"讀音"}]},"債":{"formula":"亻 + 責","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"責","role":"部件","label":"責"}]},"傾":{"formula":"亻 + 頃","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"頃","role":"聲符","label":"讀音"}]},"僅":{"formula":"亻 + 堇","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"堇","role":"聲符","label":"讀音"}]},"像":{"formula":"亻 + 象","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"象","role":"聲符","label":"讀音"}]},"僕":{"formula":"亻 + 菐","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"菐","role":"聲符","label":"讀音"}]},"僥":{"formula":"亻 + 堯","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"堯","role":"聲符","label":"讀音"}]},"僧":{"formula":"亻 + 曾","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"曾","role":"聲符","label":"讀音"}]},"僭":{"formula":"亻 + 朁","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"朁","role":"聲符","label":"讀音"}]},"僱":{"formula":"亻 + 雇","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"雇","role":"部件","label":"雇"}]},"僵":{"formula":"亻 + 畺","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"畺","role":"聲符","label":"讀音"}]},"價":{"formula":"亻 + 賈","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"賈","role":"部件","label":"賈"}]},"僻":{"formula":"亻 + 辟","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"辟","role":"聲符","label":"讀音"}]},"儀":{"formula":"亻 + 義","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"義","role":"聲符","label":"讀音"}]},"億":{"formula":"亻 + 意","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"意","role":"聲符","label":"讀音"}]},"儒":{"formula":"亻 + 需","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"需","role":"聲符","label":"讀音"}]},"儘":{"formula":"亻 + 盡","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"盡","role":"聲符","label":"讀音"}]},"償":{"formula":"亻 + 賞","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"賞","role":"聲符","label":"讀音"}]},"優":{"formula":"亻 + 憂","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"憂","role":"聲符","label":"讀音"}]},"儲":{"formula":"亻 + 諸","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"諸","role":"聲符","label":"讀音"}]},"儼":{"formula":"亻 + 嚴","components":[{"radical":"亻","role":"形符","label":"人旁"},{"radical":"嚴","role":"聲符","label":"讀音"}]},"元":{"formula":"元","components":[{"radical":"元","role":"部件","label":"象形字（獨體）"}]},"兄":{"formula":"口 + 儿","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"儿","role":"部件","label":"同「人」"}]},"充":{"formula":"亠 + 允","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"允","role":"部件","label":"允"}]},"兇":{"formula":"凶 + 儿","components":[{"radical":"凶","role":"部件","label":"凶"},{"radical":"儿","role":"部件","label":"同「人」"}]},"先":{"formula":"土 + 儿","components":[{"radical":"土","role":"部件","label":"泥土"},{"radical":"儿","role":"部件","label":"同「人」"}]},"光":{"formula":"⺌ + 兀","components":[{"radical":"⺌","role":"部件","label":"⺌"},{"radical":"兀","role":"部件","label":"兀"}]},"克":{"formula":"十 + 兄","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"兄","role":"部件","label":"兄長"}]},"免":{"formula":"刀 + 口 + 丨 + 儿","components":[{"radical":"刀","role":"部件","label":"刀"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"儿","role":"部件","label":"同「人」"}]},"兒":{"formula":"儿 + 儿","components":[{"radical":"儿","role":"形符","label":"同「人」"},{"radical":"儿","role":"形符","label":"同「人」"}]},"兔":{"formula":"兔","components":[{"radical":"兔","role":"部件","label":"象形字（獨體）"}]},"入":{"formula":"乁 + 丿","components":[{"radical":"乁","role":"部件","label":"乁"},{"radical":"丿","role":"部件","label":"撇"}]},"內":{"formula":"冂 + 入","components":[{"radical":"冂","role":"部件","label":"邊界"},{"radical":"入","role":"部件","label":"發生性關係"}]},"全":{"formula":"入 + 玉","components":[{"radical":"入","role":"部件","label":"發生性關係"},{"radical":"玉","role":"部件","label":"玉石"}]},"兩":{"formula":"一 + 巾 + 入 + 入","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"巾","role":"部件","label":"布"},{"radical":"入","role":"部件","label":"發生性關係"},{"radical":"入","role":"部件","label":"發生性關係"}]},"八":{"formula":"丿 + 乁","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"乁","role":"部件","label":"乁"}]},"公":{"formula":"八 + 厶","components":[{"radical":"八","role":"部件","label":"八"},{"radical":"厶","role":"部件","label":"私"}]},"六":{"formula":"亠 + 八","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"八","role":"部件","label":"八"}]},"共":{"formula":"廾 + 一 + 八","components":[{"radical":"廾","role":"部件","label":"「廿」的異體"},{"radical":"一","role":"部件","label":"一"},{"radical":"八","role":"部件","label":"八"}]},"兵":{"formula":"丘 + 八","components":[{"radical":"丘","role":"部件","label":"丘"},{"radical":"八","role":"部件","label":"八"}]},"其":{"formula":"甘 + 一 + 八","components":[{"radical":"甘","role":"部件","label":"甘甜"},{"radical":"一","role":"部件","label":"一"},{"radical":"八","role":"部件","label":"八"}]},"具":{"formula":"目 + 一 + 八","components":[{"radical":"目","role":"部件","label":"眼睛"},{"radical":"一","role":"部件","label":"一"},{"radical":"八","role":"部件","label":"八"}]},"典":{"formula":"曲 + 八","components":[{"radical":"曲","role":"部件","label":"彎曲"},{"radical":"八","role":"部件","label":"八"}]},"兼":{"formula":"丷 + 彐 + 禾 + 禾","components":[{"radical":"丷","role":"部件","label":"丷"},{"radical":"彐","role":"部件","label":"豬頭"},{"radical":"禾","role":"部件","label":"穀物"},{"radical":"禾","role":"部件","label":"穀物"}]},"冉":{"formula":"冂 + 十 + 一","components":[{"radical":"冂","role":"部件","label":"邊界"},{"radical":"十","role":"部件","label":"十"},{"radical":"一","role":"部件","label":"一"}]},"冊":{"formula":"冂 + 卄","components":[{"radical":"冂","role":"部件","label":"邊界"},{"radical":"卄","role":"部件","label":"卄"}]},"再":{"formula":"再","components":[{"radical":"再","role":"部件","label":"象形字（獨體）"}]},"冒":{"formula":"目 + 冃","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"冃","role":"聲符","label":"讀音"}]},"冠":{"formula":"冖 + 元 + 寸","components":[{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"元","role":"部件","label":"元"},{"radical":"寸","role":"部件","label":"量詞"}]},"冤":{"formula":"冖 + 兔","components":[{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"兔","role":"部件","label":"兔"}]},"冥":{"formula":"冖 + 日 + 六","components":[{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"日","role":"部件","label":"太陽"},{"radical":"六","role":"部件","label":"六"}]},"冬":{"formula":"夂 + ⺀","components":[{"radical":"夂","role":"部件","label":"行走"},{"radical":"⺀","role":"部件","label":"⺀"}]},"冰":{"formula":"冫 + 水","components":[{"radical":"冫","role":"部件","label":"冰旁"},{"radical":"水","role":"部件","label":"水"}]},"冷":{"formula":"冫 + 令","components":[{"radical":"冫","role":"形符","label":"冰旁"},{"radical":"令","role":"聲符","label":"讀音"}]},"准":{"formula":"冫 + 隹","components":[{"radical":"冫","role":"形符","label":"冰旁"},{"radical":"隹","role":"聲符","label":"讀音"}]},"凌":{"formula":"冫 + 夌","components":[{"radical":"冫","role":"形符","label":"冰旁"},{"radical":"夌","role":"聲符","label":"讀音"}]},"凍":{"formula":"冫 + 東","components":[{"radical":"冫","role":"形符","label":"冰旁"},{"radical":"東","role":"聲符","label":"讀音"}]},"凝":{"formula":"冫 + 疑","components":[{"radical":"冫","role":"形符","label":"冰旁"},{"radical":"疑","role":"聲符","label":"讀音"}]},"凡":{"formula":"几 + 丶","components":[{"radical":"几","role":"部件","label":"小桌"},{"radical":"丶","role":"部件","label":"點"}]},"凶":{"formula":"凵 + 乂","components":[{"radical":"凵","role":"部件","label":"容器"},{"radical":"乂","role":"部件","label":"乂"}]},"凸":{"formula":"一","components":[{"radical":"一","role":"部件","label":"一"}]},"凹":{"formula":"一","components":[{"radical":"一","role":"部件","label":"一"}]},"出":{"formula":"屮 + 凵","components":[{"radical":"屮","role":"部件","label":"初生的草木"},{"radical":"凵","role":"部件","label":"容器"}]},"刀":{"formula":"㇆ + 丿","components":[{"radical":"㇆","role":"部件","label":"㇆"},{"radical":"丿","role":"部件","label":"撇"}]},"刃":{"formula":"刀 + 丶","components":[{"radical":"刀","role":"部件","label":"刀"},{"radical":"丶","role":"部件","label":"點"}]},"分":{"formula":"八 + 刀","components":[{"radical":"八","role":"部件","label":"八"},{"radical":"刀","role":"部件","label":"刀"}]},"切":{"formula":"七 + 刀","components":[{"radical":"七","role":"聲符","label":"讀音"},{"radical":"刀","role":"形符","label":"刀"}]},"刈":{"formula":"乂 + 刂","components":[{"radical":"乂","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"刑":{"formula":"开 + 刂","components":[{"radical":"开","role":"部件","label":"开"},{"radical":"刂","role":"部件","label":"刀旁"}]},"列":{"formula":"歹 + 刂","components":[{"radical":"歹","role":"部件","label":"死亡"},{"radical":"刂","role":"形符","label":"刀旁"}]},"初":{"formula":"衤 + 刀","components":[{"radical":"衤","role":"部件","label":"衣旁"},{"radical":"刀","role":"部件","label":"刀"}]},"判":{"formula":"半 + 刂","components":[{"radical":"半","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"別":{"formula":"另 + 刂","components":[{"radical":"另","role":"部件","label":"另"},{"radical":"刂","role":"部件","label":"刀旁"}]},"利":{"formula":"禾 + 刂","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"刂","role":"部件","label":"刀旁"}]},"刮":{"formula":"舌 + 刂","components":[{"radical":"舌","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"到":{"formula":"至 + 刂","components":[{"radical":"至","role":"形符","label":"到達"},{"radical":"刂","role":"聲符","label":"讀音"}]},"制":{"formula":"巾 + 刂","components":[{"radical":"巾","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"刷":{"formula":"尸 + 巾 + 刂","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"巾","role":"部件","label":"布"},{"radical":"刂","role":"部件","label":"刀旁"}]},"刺":{"formula":"朿 + 刂","components":[{"radical":"朿","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"刻":{"formula":"亥 + 刂","components":[{"radical":"亥","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"則":{"formula":"貝 + 刂","components":[{"radical":"貝","role":"部件","label":"錢財"},{"radical":"刂","role":"部件","label":"刀旁"}]},"削":{"formula":"肖 + 刂","components":[{"radical":"肖","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"剌":{"formula":"束 + 刂","components":[{"radical":"束","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"前":{"formula":"丷 + 一 + 肉 + 刀","components":[{"radical":"丷","role":"部件","label":"丷"},{"radical":"一","role":"部件","label":"一"},{"radical":"肉","role":"部件","label":"肉"},{"radical":"刀","role":"部件","label":"刀"}]},"剎":{"formula":"杀 + 刂","components":[{"radical":"杀","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"剖":{"formula":"咅 + 刂","components":[{"radical":"咅","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"剛":{"formula":"岡 + 刂","components":[{"radical":"岡","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"剝":{"formula":"彔 + 刂","components":[{"radical":"彔","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"剩":{"formula":"乘 + 刂","components":[{"radical":"乘","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"剪":{"formula":"前 + 刀","components":[{"radical":"前","role":"聲符","label":"讀音"},{"radical":"刀","role":"形符","label":"刀"}]},"副":{"formula":"畐 + 刂","components":[{"radical":"畐","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"割":{"formula":"害 + 刂","components":[{"radical":"害","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"創":{"formula":"倉 + 刂","components":[{"radical":"倉","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"劃":{"formula":"畫 + 刂","components":[{"radical":"畫","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"劇":{"formula":"豦 + 刂","components":[{"radical":"豦","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"劈":{"formula":"辟 + 刀","components":[{"radical":"辟","role":"聲符","label":"讀音"},{"radical":"刀","role":"形符","label":"刀"}]},"劉":{"formula":"卯 + 刂","components":[{"radical":"卯","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"劍":{"formula":"僉 + 刂","components":[{"radical":"僉","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"劑":{"formula":"齊 + 刂","components":[{"radical":"齊","role":"聲符","label":"讀音"},{"radical":"刂","role":"形符","label":"刀旁"}]},"力":{"formula":"丿","components":[{"radical":"丿","role":"部件","label":"撇"}]},"功":{"formula":"工 + 力","components":[{"radical":"工","role":"部件","label":"工匠"},{"radical":"力","role":"部件","label":"力量"}]},"加":{"formula":"力 + 口","components":[{"radical":"力","role":"部件","label":"力量"},{"radical":"口","role":"部件","label":"嘴巴"}]},"劣":{"formula":"少 + 力","components":[{"radical":"少","role":"形符","label":"少"},{"radical":"力","role":"聲符","label":"讀音"}]},"助":{"formula":"且 + 力","components":[{"radical":"且","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"努":{"formula":"奴 + 力","components":[{"radical":"奴","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"劫":{"formula":"去 + 力","components":[{"radical":"去","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勃":{"formula":"孛 + 力","components":[{"radical":"孛","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勇":{"formula":"甬 + 力","components":[{"radical":"甬","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勉":{"formula":"免 + 力","components":[{"radical":"免","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勒":{"formula":"革 + 力","components":[{"radical":"革","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"動":{"formula":"重 + 力","components":[{"radical":"重","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"務":{"formula":"矛 + 务","components":[{"radical":"矛","role":"形符","label":"長矛"},{"radical":"务","role":"聲符","label":"讀音"}]},"勝":{"formula":"月 + 劵","components":[{"radical":"月","role":"形符","label":"月亮"},{"radical":"劵","role":"聲符","label":"讀音"}]},"勞":{"formula":"炏 + 冖 + 力","components":[{"radical":"炏","role":"部件","label":"炏"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"力","role":"部件","label":"力量"}]},"勢":{"formula":"埶 + 力","components":[{"radical":"埶","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勤":{"formula":"堇 + 力","components":[{"radical":"堇","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勳":{"formula":"熏 + 力","components":[{"radical":"熏","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勵":{"formula":"厲 + 力","components":[{"radical":"厲","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勸":{"formula":"雚 + 力","components":[{"radical":"雚","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"勾":{"formula":"勹 + 厶","components":[{"radical":"勹","role":"部件","label":"包裹"},{"radical":"厶","role":"部件","label":"私"}]},"勿":{"formula":"勹 + 丿 + 丿","components":[{"radical":"勹","role":"部件","label":"包裹"},{"radical":"丿","role":"部件","label":"撇"},{"radical":"丿","role":"部件","label":"撇"}]},"包":{"formula":"勹 + 巳","components":[{"radical":"勹","role":"部件","label":"包裹"},{"radical":"巳","role":"部件","label":"巳"}]},"匏":{"formula":"夸 + 包","components":[{"radical":"夸","role":"形符","label":"夸"},{"radical":"包","role":"聲符","label":"讀音"}]},"化":{"formula":"人 + 匕","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"匕","role":"部件","label":"湯匙"}]},"北":{"formula":"北","components":[{"radical":"北","role":"部件","label":"象形字（獨體）"}]},"匠":{"formula":"匚 + 斤","components":[{"radical":"匚","role":"部件","label":"容器"},{"radical":"斤","role":"部件","label":"斧頭"}]},"匪":{"formula":"匚 + 非","components":[{"radical":"匚","role":"形符","label":"容器"},{"radical":"非","role":"聲符","label":"讀音"}]},"匹":{"formula":"匹","components":[{"radical":"匹","role":"部件","label":"象形字（獨體）"}]},"區":{"formula":"匸 + 品","components":[{"radical":"匸","role":"部件","label":"隱藏"},{"radical":"品","role":"部件","label":"品"}]},"十":{"formula":"一 + 丨","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"千":{"formula":"丿 + 十","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"十","role":"部件","label":"十"}]},"升":{"formula":"千 + 丨","components":[{"radical":"千","role":"部件","label":"千"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"午":{"formula":"丿 + 干","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"干","role":"部件","label":"盾牌"}]},"半":{"formula":"丷 + 牛","components":[{"radical":"丷","role":"部件","label":"丷"},{"radical":"牛","role":"部件","label":"牛"}]},"卑":{"formula":"白 + 十","components":[{"radical":"白","role":"部件","label":"白色"},{"radical":"十","role":"部件","label":"十"}]},"卓":{"formula":"⺊ + 早","components":[{"radical":"⺊","role":"部件","label":"⺊"},{"radical":"早","role":"部件","label":"早"}]},"協":{"formula":"十 + 劦","components":[{"radical":"十","role":"聲符","label":"讀音"},{"radical":"劦","role":"形符","label":"劦"}]},"南":{"formula":"南","components":[{"radical":"南","role":"部件","label":"象形字（獨體）"}]},"博":{"formula":"十 + 尃","components":[{"radical":"十","role":"形符","label":"十"},{"radical":"尃","role":"聲符","label":"讀音"}]},"占":{"formula":"⺊ + 口","components":[{"radical":"⺊","role":"部件","label":"⺊"},{"radical":"口","role":"部件","label":"嘴巴"}]},"卡":{"formula":"上 + 卜","components":[{"radical":"上","role":"部件","label":"上"},{"radical":"卜","role":"部件","label":"占卜"}]},"卦":{"formula":"圭 + 卜","components":[{"radical":"圭","role":"聲符","label":"讀音"},{"radical":"卜","role":"形符","label":"占卜"}]},"卯":{"formula":"卬 + 丿","components":[{"radical":"卬","role":"部件","label":"卬"},{"radical":"丿","role":"部件","label":"撇"}]},"印":{"formula":"卩","components":[{"radical":"卩","role":"部件","label":"跪坐"}]},"危":{"formula":"厃 + 㔾","components":[{"radical":"厃","role":"部件","label":"厃"},{"radical":"㔾","role":"部件","label":"㔾"}]},"即":{"formula":"卩","components":[{"radical":"卩","role":"部件","label":"跪坐"}]},"卵":{"formula":"卵","components":[{"radical":"卵","role":"部件","label":"象形字（獨體）"}]},"卸":{"formula":"止 + 卩","components":[{"radical":"止","role":"形符","label":"停止"},{"radical":"卩","role":"聲符","label":"讀音"}]},"卻":{"formula":"谷 + 卩","components":[{"radical":"谷","role":"聲符","label":"讀音"},{"radical":"卩","role":"形符","label":"跪坐"}]},"厄":{"formula":"厂 + 㔾","components":[{"radical":"厂","role":"部件","label":"山崖"},{"radical":"㔾","role":"部件","label":"㔾"}]},"厚":{"formula":"厂 + 日 + 子","components":[{"radical":"厂","role":"部件","label":"山崖"},{"radical":"日","role":"部件","label":"太陽"},{"radical":"子","role":"部件","label":"孩子"}]},"原":{"formula":"厂 + 泉","components":[{"radical":"厂","role":"形符","label":"山崖"},{"radical":"泉","role":"聲符","label":"讀音"}]},"厭":{"formula":"厂 + 猒","components":[{"radical":"厂","role":"形符","label":"山崖"},{"radical":"猒","role":"聲符","label":"讀音"}]},"去":{"formula":"土 + 厶","components":[{"radical":"土","role":"部件","label":"泥土"},{"radical":"厶","role":"部件","label":"私"}]},"參":{"formula":"⺶ + 大 + 彡","components":[{"radical":"⺶","role":"部件","label":"羊頭"},{"radical":"大","role":"部件","label":"大"},{"radical":"彡","role":"聲符","label":"紋飾"}]},"又":{"formula":"又","components":[{"radical":"又","role":"部件","label":"象形字（獨體）"}]},"叉":{"formula":"又 + 丶","components":[{"radical":"又","role":"部件","label":"手"},{"radical":"丶","role":"部件","label":"點"}]},"及":{"formula":"乃 + 乀","components":[{"radical":"乃","role":"部件","label":"乃"},{"radical":"乀","role":"部件","label":"乀"}]},"友":{"formula":"又","components":[{"radical":"又","role":"部件","label":"手"}]},"反":{"formula":"厂 + 又","components":[{"radical":"厂","role":"部件","label":"山崖"},{"radical":"又","role":"部件","label":"手"}]},"取":{"formula":"耳 + 又","components":[{"radical":"耳","role":"部件","label":"耳朵"},{"radical":"又","role":"部件","label":"手"}]},"受":{"formula":"爫 + 冖 + 又","components":[{"radical":"爫","role":"部件","label":"爫"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"又","role":"部件","label":"手"}]},"叢":{"formula":"丵","components":[{"radical":"丵","role":"形符","label":"丵"}]},"口":{"formula":"口","components":[{"radical":"口","role":"部件","label":"象形字（獨體）"}]},"古":{"formula":"十 + 口","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"口","role":"部件","label":"嘴巴"}]},"句":{"formula":"勹 + 口","components":[{"radical":"勹","role":"部件","label":"包裹"},{"radical":"口","role":"部件","label":"嘴巴"}]},"另":{"formula":"口 + 力","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"力","role":"部件","label":"力量"}]},"叨":{"formula":"口 + 刀","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"刀","role":"聲符","label":"讀音"}]},"只":{"formula":"口 + 八","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"八","role":"部件","label":"八"}]},"叫":{"formula":"口 + 丩","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"丩","role":"聲符","label":"讀音"}]},"叮":{"formula":"口 + 丁","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"丁","role":"聲符","label":"讀音"}]},"可":{"formula":"丁 + 口","components":[{"radical":"丁","role":"形符","label":"丁"},{"radical":"口","role":"聲符","label":"讀音"}]},"台":{"formula":"厶 + 口","components":[{"radical":"厶","role":"部件","label":"私"},{"radical":"口","role":"部件","label":"嘴巴"}]},"史":{"formula":"口 + 乂","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"乂","role":"部件","label":"乂"}]},"右":{"formula":"一 + 丿 + 口","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"丿","role":"部件","label":"撇"},{"radical":"口","role":"部件","label":"嘴巴"}]},"司":{"formula":"口","components":[{"radical":"口","role":"部件","label":"嘴巴"}]},"叼":{"formula":"口 + 刁","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"刁","role":"聲符","label":"讀音"}]},"吃":{"formula":"口 + 乞","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"乞","role":"聲符","label":"讀音"}]},"各":{"formula":"夂 + 口","components":[{"radical":"夂","role":"部件","label":"行走"},{"radical":"口","role":"部件","label":"嘴巴"}]},"合":{"formula":"人 + 一 + 口","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"一","role":"部件","label":"一"},{"radical":"口","role":"部件","label":"嘴巴"}]},"吉":{"formula":"士 + 口","components":[{"radical":"士","role":"部件","label":"未婚的男子"},{"radical":"口","role":"部件","label":"嘴巴"}]},"吊":{"formula":"口 + 巾","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"巾","role":"部件","label":"布"}]},"同":{"formula":"凡 + 口","components":[{"radical":"凡","role":"部件","label":"凡"},{"radical":"口","role":"部件","label":"嘴巴"}]},"名":{"formula":"夕 + 口","components":[{"radical":"夕","role":"部件","label":"傍晚"},{"radical":"口","role":"部件","label":"嘴巴"}]},"后":{"formula":"厂 + 一 + 口","components":[{"radical":"厂","role":"部件","label":"山崖"},{"radical":"一","role":"部件","label":"一"},{"radical":"口","role":"部件","label":"嘴巴"}]},"吐":{"formula":"口 + 土","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"土","role":"聲符","label":"讀音"}]},"向":{"formula":"丶 + 冂 + 口","components":[{"radical":"丶","role":"部件","label":"點"},{"radical":"冂","role":"部件","label":"邊界"},{"radical":"口","role":"部件","label":"嘴巴"}]},"吔":{"formula":"口 + 也","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"也","role":"部件","label":"也"}]},"吝":{"formula":"文 + 口","components":[{"radical":"文","role":"部件","label":"文字"},{"radical":"口","role":"部件","label":"嘴巴"}]},"吞":{"formula":"天 + 口","components":[{"radical":"天","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"吟":{"formula":"口 + 今","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"今","role":"聲符","label":"讀音"}]},"否":{"formula":"不 + 口","components":[{"radical":"不","role":"形符","label":"不"},{"radical":"口","role":"聲符","label":"讀音"}]},"吧":{"formula":"口 + 巴","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"巴","role":"聲符","label":"讀音"}]},"含":{"formula":"今 + 口","components":[{"radical":"今","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"吮":{"formula":"口 + 允","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"允","role":"聲符","label":"讀音"}]},"吵":{"formula":"口 + 少","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"少","role":"聲符","label":"讀音"}]},"吸":{"formula":"口 + 及","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"及","role":"聲符","label":"讀音"}]},"吻":{"formula":"口 + 勿","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"勿","role":"聲符","label":"讀音"}]},"吼":{"formula":"口 + 孔","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"孔","role":"聲符","label":"讀音"}]},"吾":{"formula":"五 + 口","components":[{"radical":"五","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"呀":{"formula":"口 + 牙","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"牙","role":"聲符","label":"讀音"}]},"呃":{"formula":"口 + 厄","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"厄","role":"聲符","label":"讀音"}]},"呆":{"formula":"口 + 木","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"木","role":"部件","label":"樹木"}]},"呈":{"formula":"口 + 王","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"王","role":"部件","label":"王旁"}]},"告":{"formula":"牛 + 口","components":[{"radical":"牛","role":"部件","label":"牛"},{"radical":"口","role":"部件","label":"嘴巴"}]},"呎":{"formula":"口 + 尺","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"尺","role":"聲符","label":"讀音"}]},"呢":{"formula":"口 + 尼","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"尼","role":"聲符","label":"讀音"}]},"周":{"formula":"冂 + 土 + 口","components":[{"radical":"冂","role":"部件","label":"邊界"},{"radical":"土","role":"部件","label":"泥土"},{"radical":"口","role":"部件","label":"嘴巴"}]},"味":{"formula":"口 + 未","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"未","role":"聲符","label":"讀音"}]},"呵":{"formula":"口 + 可","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"可","role":"聲符","label":"讀音"}]},"呼":{"formula":"口 + 乎","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"乎","role":"聲符","label":"讀音"}]},"命":{"formula":"令 + 口","components":[{"radical":"令","role":"部件","label":"令"},{"radical":"口","role":"部件","label":"嘴巴"}]},"咀":{"formula":"口 + 且","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"且","role":"聲符","label":"讀音"}]},"和":{"formula":"禾 + 口","components":[{"radical":"禾","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"咎":{"formula":"处 + 口","components":[{"radical":"处","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"咒":{"formula":"口 + 口 + 几","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"几","role":"部件","label":"小桌"}]},"咕":{"formula":"口 + 古","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"古","role":"聲符","label":"讀音"}]},"咖":{"formula":"口 + 加","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"加","role":"聲符","label":"讀音"}]},"咚":{"formula":"口 + 冬","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"冬","role":"聲符","label":"讀音"}]},"咦":{"formula":"口 + 夷","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"夷","role":"聲符","label":"讀音"}]},"咪":{"formula":"口 + 米","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"米","role":"聲符","label":"讀音"}]},"咬":{"formula":"口 + 交","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"交","role":"聲符","label":"讀音"}]},"咳":{"formula":"口 + 亥","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"亥","role":"聲符","label":"讀音"}]},"咸":{"formula":"戊 + 一 + 口","components":[{"radical":"戊","role":"部件","label":"戊"},{"radical":"一","role":"部件","label":"一"},{"radical":"口","role":"部件","label":"嘴巴"}]},"咽":{"formula":"口 + 因","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"因","role":"聲符","label":"讀音"}]},"哀":{"formula":"衣 + 口","components":[{"radical":"衣","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"品":{"formula":"口 + 口 + 口","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"}]},"哄":{"formula":"口 + 共","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"共","role":"聲符","label":"讀音"}]},"哆":{"formula":"口 + 多","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"多","role":"聲符","label":"讀音"}]},"哇":{"formula":"口 + 圭","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"圭","role":"聲符","label":"讀音"}]},"哈":{"formula":"口 + 合","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"合","role":"聲符","label":"讀音"}]},"員":{"formula":"口 + 貝","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"貝","role":"形符","label":"錢財"}]},"哥":{"formula":"可 + 可","components":[{"radical":"可","role":"部件","label":"可"},{"radical":"可","role":"部件","label":"可"}]},"哦":{"formula":"口 + 我","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"我","role":"聲符","label":"讀音"}]},"哨":{"formula":"口 + 肖","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"肖","role":"聲符","label":"讀音"}]},"哪":{"formula":"口 + 那","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"那","role":"聲符","label":"讀音"}]},"哭":{"formula":"口 + 口 + 犬","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"犬","role":"部件","label":"狗"}]},"哲":{"formula":"折 + 口","components":[{"radical":"折","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"哺":{"formula":"口 + 甫","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"甫","role":"聲符","label":"讀音"}]},"哼":{"formula":"口 + 亨","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"亨","role":"聲符","label":"讀音"}]},"唇":{"formula":"辰 + 口","components":[{"radical":"辰","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"唉":{"formula":"口 + 矣","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"矣","role":"聲符","label":"讀音"}]},"唚":{"formula":"口 + 彐","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"彐","role":"聲符","label":"讀音"}]},"售":{"formula":"隹 + 口","components":[{"radical":"隹","role":"部件","label":"鳥類"},{"radical":"口","role":"部件","label":"嘴巴"}]},"唯":{"formula":"口 + 隹","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"隹","role":"部件","label":"鳥類"}]},"唱":{"formula":"口 + 昌","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"昌","role":"聲符","label":"讀音"}]},"唸":{"formula":"口 + 念","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"念","role":"聲符","label":"讀音"}]},"唾":{"formula":"口 + 垂","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"垂","role":"聲符","label":"讀音"}]},"啃":{"formula":"口 + 肯","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"肯","role":"聲符","label":"讀音"}]},"啄":{"formula":"口 + 豖","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"豖","role":"聲符","label":"讀音"}]},"商":{"formula":"冏 + 章","components":[{"radical":"冏","role":"形符","label":"冏"},{"radical":"章","role":"聲符","label":"讀音"}]},"啊":{"formula":"口 + 阿","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"阿","role":"聲符","label":"讀音"}]},"問":{"formula":"門 + 口","components":[{"radical":"門","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"啜":{"formula":"口 + 叕","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"叕","role":"聲符","label":"讀音"}]},"啞":{"formula":"口 + 亞","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"亞","role":"聲符","label":"讀音"}]},"啟":{"formula":"启 + 攵","components":[{"radical":"启","role":"部件","label":"启"},{"radical":"攵","role":"部件","label":"敲打"}]},"啡":{"formula":"口 + 非","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"非","role":"聲符","label":"讀音"}]},"啤":{"formula":"口 + 卑","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"卑","role":"聲符","label":"讀音"}]},"啦":{"formula":"口 + 拉","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"拉","role":"聲符","label":"讀音"}]},"啼":{"formula":"口 + 帝","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"帝","role":"聲符","label":"讀音"}]},"喀":{"formula":"口 + 客","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"客","role":"聲符","label":"讀音"}]},"善":{"formula":"羊 + 丷 + 一 + 口","components":[{"radical":"羊","role":"部件","label":"羊"},{"radical":"丷","role":"部件","label":"丷"},{"radical":"一","role":"部件","label":"一"},{"radical":"口","role":"部件","label":"嘴巴"}]},"喉":{"formula":"口 + 侯","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"侯","role":"聲符","label":"讀音"}]},"喊":{"formula":"口 + 咸","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"咸","role":"聲符","label":"讀音"}]},"喑":{"formula":"口 + 音","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"音","role":"聲符","label":"讀音"}]},"喔":{"formula":"口 + 屋","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"屋","role":"聲符","label":"讀音"}]},"喘":{"formula":"口 + 耑","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"耑","role":"聲符","label":"讀音"}]},"喚":{"formula":"口 + 奐","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"奐","role":"聲符","label":"讀音"}]},"喜":{"formula":"壴 + 口","components":[{"radical":"壴","role":"部件","label":"壴"},{"radical":"口","role":"部件","label":"嘴巴"}]},"喝":{"formula":"口 + 曷","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"曷","role":"聲符","label":"讀音"}]},"喪":{"formula":"喪","components":[{"radical":"喪","role":"部件","label":"象形字（獨體）"}]},"喬":{"formula":"夭 + 高","components":[{"radical":"夭","role":"聲符","label":"讀音"},{"radical":"高","role":"形符","label":"上下距離遠的"}]},"喲":{"formula":"口 + 約","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"約","role":"聲符","label":"讀音"}]},"喳":{"formula":"口 + 查","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"查","role":"聲符","label":"讀音"}]},"喻":{"formula":"口 + 俞","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"俞","role":"聲符","label":"讀音"}]},"嗎":{"formula":"口 + 馬","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"馬","role":"聲符","label":"讀音"}]},"嗚":{"formula":"口 + 烏","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"烏","role":"聲符","label":"讀音"}]},"嗜":{"formula":"口 + 耆","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"耆","role":"聲符","label":"讀音"}]},"嗡":{"formula":"口 + 翁","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"翁","role":"聲符","label":"讀音"}]},"嗯":{"formula":"口 + 恩","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"恩","role":"聲符","label":"讀音"}]},"嗶":{"formula":"口 + 畢","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"畢","role":"聲符","label":"讀音"}]},"嗷":{"formula":"口 + 敖","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"敖","role":"聲符","label":"讀音"}]},"嘀":{"formula":"口 + 啇","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"啇","role":"聲符","label":"讀音"}]},"嘆":{"formula":"口 + 堇","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"堇","role":"聲符","label":"讀音"}]},"嘔":{"formula":"口 + 區","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"區","role":"聲符","label":"讀音"}]},"嘗":{"formula":"尚 + 旨","components":[{"radical":"尚","role":"聲符","label":"讀音"},{"radical":"旨","role":"形符","label":"旨"}]},"嘛":{"formula":"口 + 麻","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"麻","role":"聲符","label":"讀音"}]},"嘮":{"formula":"口 + 勞","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"勞","role":"聲符","label":"讀音"}]},"嘯":{"formula":"口 + 肅","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"肅","role":"聲符","label":"讀音"}]},"嘰":{"formula":"口 + 幾","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"幾","role":"聲符","label":"讀音"}]},"嘲":{"formula":"口 + 朝","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"朝","role":"聲符","label":"讀音"}]},"嘴":{"formula":"口 + 觜","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"觜","role":"聲符","label":"讀音"}]},"嘿":{"formula":"口 + 黑","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"黑","role":"聲符","label":"讀音"}]},"噁":{"formula":"惡 + 惡","components":[{"radical":"惡","role":"形符","label":"惡"},{"radical":"惡","role":"形符","label":"惡"}]},"噎":{"formula":"口 + 壹","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"壹","role":"聲符","label":"讀音"}]},"噗":{"formula":"口 + 菐","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"菐","role":"聲符","label":"讀音"}]},"器":{"formula":"口 + 口 + 犬 + 口 + 口","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"犬","role":"部件","label":"狗"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"}]},"噩":{"formula":"王 + 口 + 口 + 口 + 口","components":[{"radical":"王","role":"部件","label":"王旁"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"口","role":"部件","label":"嘴巴"}]},"噬":{"formula":"口 + 筮","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"筮","role":"聲符","label":"讀音"}]},"噴":{"formula":"口 + 賁","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"賁","role":"聲符","label":"讀音"}]},"噸":{"formula":"口 + 頓","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"頓","role":"聲符","label":"讀音"}]},"嚇":{"formula":"口 + 赫","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"赫","role":"聲符","label":"讀音"}]},"嚕":{"formula":"口 + 魯","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"魯","role":"聲符","label":"讀音"}]},"嚥":{"formula":"口 + 燕","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"燕","role":"聲符","label":"讀音"}]},"嚨":{"formula":"口 + 龍","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"龍","role":"聲符","label":"讀音"}]},"嚼":{"formula":"口 + 爵","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"爵","role":"聲符","label":"讀音"}]},"囉":{"formula":"口 + 羅","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"羅","role":"聲符","label":"讀音"}]},"囊":{"formula":"口 + 襄","components":[{"radical":"口","role":"形符","label":"嘴巴"},{"radical":"襄","role":"聲符","label":"讀音"}]},"囚":{"formula":"囗 + 人","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"人","role":"部件","label":"人"}]},"四":{"formula":"囗 + 儿","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"儿","role":"部件","label":"同「人」"}]},"回":{"formula":"囗 + 口","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"口","role":"部件","label":"嘴巴"}]},"因":{"formula":"囗 + 大","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"大","role":"部件","label":"大"}]},"困":{"formula":"囗 + 木","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"木","role":"部件","label":"樹木"}]},"固":{"formula":"囗 + 古","components":[{"radical":"囗","role":"形符","label":"口框"},{"radical":"古","role":"聲符","label":"讀音"}]},"圈":{"formula":"囗 + 卷","components":[{"radical":"囗","role":"形符","label":"口框"},{"radical":"卷","role":"聲符","label":"讀音"}]},"國":{"formula":"囗 + 或","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"或","role":"部件","label":"或"}]},"圍":{"formula":"囗 + 韋","components":[{"radical":"囗","role":"形符","label":"口框"},{"radical":"韋","role":"聲符","label":"讀音"}]},"園":{"formula":"囗 + 袁","components":[{"radical":"囗","role":"形符","label":"口框"},{"radical":"袁","role":"聲符","label":"讀音"}]},"圓":{"formula":"囗 + 員","components":[{"radical":"囗","role":"形符","label":"口框"},{"radical":"員","role":"聲符","label":"讀音"}]},"圖":{"formula":"囗 + 啚","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"啚","role":"部件","label":"啚"}]},"團":{"formula":"囗 + 專","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"專","role":"部件","label":"專"}]},"土":{"formula":"土","components":[{"radical":"土","role":"部件","label":"象形字（獨體）"}]},"在":{"formula":"才 + 土","components":[{"radical":"才","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"地":{"formula":"土 + 也","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"也","role":"聲符","label":"讀音"}]},"圾":{"formula":"土 + 及","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"及","role":"聲符","label":"讀音"}]},"址":{"formula":"土 + 止","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"止","role":"聲符","label":"讀音"}]},"均":{"formula":"土 + 匀","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"匀","role":"聲符","label":"讀音"}]},"坐":{"formula":"从 + 土","components":[{"radical":"从","role":"部件","label":"从"},{"radical":"土","role":"部件","label":"泥土"}]},"坡":{"formula":"土 + 皮","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"皮","role":"聲符","label":"讀音"}]},"坦":{"formula":"土 + 旦","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"旦","role":"聲符","label":"讀音"}]},"坳":{"formula":"土 + 幼","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"幼","role":"聲符","label":"讀音"}]},"垂":{"formula":"垂","components":[{"radical":"垂","role":"部件","label":"象形字（獨體）"}]},"垃":{"formula":"土 + 立","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"立","role":"聲符","label":"讀音"}]},"型":{"formula":"刑 + 土","components":[{"radical":"刑","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"垮":{"formula":"土 + 夸","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"夸","role":"聲符","label":"讀音"}]},"埃":{"formula":"土 + 矣","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"矣","role":"聲符","label":"讀音"}]},"埋":{"formula":"土 + 里","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"里","role":"聲符","label":"讀音"}]},"城":{"formula":"土 + 成","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"成","role":"聲符","label":"讀音"}]},"域":{"formula":"土 + 或","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"或","role":"聲符","label":"讀音"}]},"執":{"formula":"幸 + 丸","components":[{"radical":"幸","role":"部件","label":"幸"},{"radical":"丸","role":"部件","label":"丸"}]},"培":{"formula":"土 + 咅","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"咅","role":"聲符","label":"讀音"}]},"基":{"formula":"其 + 土","components":[{"radical":"其","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"埼":{"formula":"土 + 奇","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"奇","role":"聲符","label":"讀音"}]},"堂":{"formula":"尚 + 土","components":[{"radical":"尚","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"堅":{"formula":"臤 + 土","components":[{"radical":"臤","role":"部件","label":"臤"},{"radical":"土","role":"部件","label":"泥土"}]},"堆":{"formula":"土 + 隹","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"隹","role":"聲符","label":"讀音"}]},"堡":{"formula":"保 + 土","components":[{"radical":"保","role":"部件","label":"保"},{"radical":"土","role":"部件","label":"泥土"}]},"報":{"formula":"幸 + 卩 + 又","components":[{"radical":"幸","role":"部件","label":"幸"},{"radical":"卩","role":"部件","label":"跪坐"},{"radical":"又","role":"部件","label":"手"}]},"場":{"formula":"土 + 昜","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"昜","role":"聲符","label":"讀音"}]},"堵":{"formula":"土 + 者","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"者","role":"聲符","label":"讀音"}]},"塊":{"formula":"土 + 鬼","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"鬼","role":"聲符","label":"讀音"}]},"塌":{"formula":"土 + 日 + 羽","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"日","role":"部件","label":"太陽"},{"radical":"羽","role":"部件","label":"羽毛"}]},"塑":{"formula":"朔 + 土","components":[{"radical":"朔","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"塔":{"formula":"土 + 荅","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"荅","role":"聲符","label":"讀音"}]},"塗":{"formula":"氵 + 余","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"余","role":"聲符","label":"讀音"}]},"塘":{"formula":"土 + 唐","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"唐","role":"聲符","label":"讀音"}]},"塞":{"formula":"宀 + 二 + 土","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"二","role":"部件","label":"二"},{"radical":"土","role":"形符","label":"泥土"}]},"塢":{"formula":"土 + 烏","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"烏","role":"聲符","label":"讀音"}]},"填":{"formula":"土 + 真","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"真","role":"聲符","label":"讀音"}]},"塵":{"formula":"鹿 + 土","components":[{"radical":"鹿","role":"部件","label":"鹿"},{"radical":"土","role":"部件","label":"泥土"}]},"境":{"formula":"土 + 竟","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"竟","role":"聲符","label":"讀音"}]},"墓":{"formula":"莫 + 土","components":[{"radical":"莫","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"墜":{"formula":"隊 + 土","components":[{"radical":"隊","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"增":{"formula":"土 + 曾","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"曾","role":"聲符","label":"讀音"}]},"墨":{"formula":"黑 + 土","components":[{"radical":"黑","role":"部件","label":"黑色"},{"radical":"土","role":"部件","label":"泥土"}]},"墮":{"formula":"隋 + 土","components":[{"radical":"隋","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"墳":{"formula":"土 + 賁","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"賁","role":"聲符","label":"讀音"}]},"墾":{"formula":"貇 + 土","components":[{"radical":"貇","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"壁":{"formula":"辟 + 土","components":[{"radical":"辟","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"壇":{"formula":"土 + 亶","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"亶","role":"聲符","label":"讀音"}]},"壓":{"formula":"厭 + 土","components":[{"radical":"厭","role":"部件","label":"厭"},{"radical":"土","role":"部件","label":"泥土"}]},"壘":{"formula":"畾 + 土","components":[{"radical":"畾","role":"聲符","label":"讀音"},{"radical":"土","role":"形符","label":"泥土"}]},"壞":{"formula":"土 + 褱","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"褱","role":"聲符","label":"讀音"}]},"壤":{"formula":"土 + 襄","components":[{"radical":"土","role":"形符","label":"泥土"},{"radical":"襄","role":"聲符","label":"讀音"}]},"士":{"formula":"十 + 一","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"一","role":"部件","label":"一"}]},"壯":{"formula":"爿 + 士","components":[{"radical":"爿","role":"聲符","label":"讀音"},{"radical":"士","role":"形符","label":"未婚的男子"}]},"壽":{"formula":"士 + 乛 + 工 + 一 + 吋","components":[{"radical":"士","role":"部件","label":"未婚的男子"},{"radical":"乛","role":"部件","label":"乛"},{"radical":"工","role":"部件","label":"工匠"},{"radical":"一","role":"部件","label":"一"},{"radical":"吋","role":"部件","label":"吋"}]},"夏":{"formula":"一 + 自 + 夕","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"自","role":"部件","label":"自己"},{"radical":"夕","role":"部件","label":"傍晚"}]},"夕":{"formula":"夕","components":[{"radical":"夕","role":"部件","label":"象形字（獨體）"}]},"外":{"formula":"夕 + 卜","components":[{"radical":"夕","role":"部件","label":"傍晚"},{"radical":"卜","role":"部件","label":"占卜"}]},"多":{"formula":"夕 + 夕","components":[{"radical":"夕","role":"部件","label":"傍晚"},{"radical":"夕","role":"部件","label":"傍晚"}]},"夜":{"formula":"亠 + 亻 + 夕","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"亻","role":"部件","label":"人旁"},{"radical":"夕","role":"部件","label":"傍晚"}]},"夠":{"formula":"多 + 句","components":[{"radical":"多","role":"聲符","label":"讀音"},{"radical":"句","role":"形符","label":"句"}]},"夢":{"formula":"艹 + 罒 + 冖 + 夕","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"罒","role":"部件","label":"網罟"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"夕","role":"部件","label":"傍晚"}]},"夥":{"formula":"果 + 多","components":[{"radical":"果","role":"聲符","label":"讀音"},{"radical":"多","role":"形符","label":"多"}]},"大":{"formula":"一 + 人","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"人","role":"部件","label":"人"}]},"天":{"formula":"一 + 大","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"大","role":"部件","label":"大"}]},"太":{"formula":"大 + 丶","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"丶","role":"部件","label":"點"}]},"夫":{"formula":"一 + 大","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"大","role":"部件","label":"大"}]},"央":{"formula":"冂 + 大","components":[{"radical":"冂","role":"部件","label":"邊界"},{"radical":"大","role":"部件","label":"大"}]},"失":{"formula":"丿 + 夫","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"夫","role":"部件","label":"夫"}]},"夷":{"formula":"大 + 弓","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"弓","role":"部件","label":"弓箭"}]},"奇":{"formula":"大 + 可","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"可","role":"部件","label":"可"}]},"奈":{"formula":"大 + 示","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"示","role":"部件","label":"祭祀"}]},"奉":{"formula":"手 + 乀 + 一 + 十","components":[{"radical":"手","role":"部件","label":"手"},{"radical":"乀","role":"部件","label":"乀"},{"radical":"一","role":"部件","label":"一"},{"radical":"十","role":"部件","label":"十"}]},"奎":{"formula":"大 + 圭","components":[{"radical":"大","role":"形符","label":"大"},{"radical":"圭","role":"聲符","label":"讀音"}]},"奏":{"formula":"天","components":[{"radical":"天","role":"部件","label":"天"}]},"契":{"formula":"丰 + 刀 + 大","components":[{"radical":"丰","role":"部件","label":"丰"},{"radical":"刀","role":"部件","label":"刀"},{"radical":"大","role":"部件","label":"大"}]},"奔":{"formula":"大 + 卉","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"卉","role":"部件","label":"卉"}]},"套":{"formula":"大 + 镸","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"镸","role":"部件","label":"镸"}]},"奠":{"formula":"酋 + 大","components":[{"radical":"酋","role":"部件","label":"酋"},{"radical":"大","role":"部件","label":"大"}]},"奢":{"formula":"大 + 者","components":[{"radical":"大","role":"形符","label":"大"},{"radical":"者","role":"聲符","label":"讀音"}]},"奧":{"formula":"釆 + 大","components":[{"radical":"釆","role":"部件","label":"分別"},{"radical":"大","role":"部件","label":"大"}]},"奪":{"formula":"大 + 隹 + 寸","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"隹","role":"部件","label":"鳥類"},{"radical":"寸","role":"部件","label":"量詞"}]},"奮":{"formula":"大 + 隹 + 田","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"隹","role":"部件","label":"鳥類"},{"radical":"田","role":"部件","label":"田地"}]},"女":{"formula":"女","components":[{"radical":"女","role":"部件","label":"象形字（獨體）"}]},"奶":{"formula":"女 + 乃","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"乃","role":"聲符","label":"讀音"}]},"她":{"formula":"女 + 也","components":[{"radical":"女","role":"部件","label":"女旁"},{"radical":"也","role":"部件","label":"也"}]},"好":{"formula":"女 + 子","components":[{"radical":"女","role":"部件","label":"女旁"},{"radical":"子","role":"部件","label":"孩子"}]},"如":{"formula":"女 + 口","components":[{"radical":"女","role":"部件","label":"女旁"},{"radical":"口","role":"部件","label":"嘴巴"}]},"妄":{"formula":"亡 + 女","components":[{"radical":"亡","role":"聲符","label":"讀音"},{"radical":"女","role":"形符","label":"女旁"}]},"妒":{"formula":"女 + 户","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"户","role":"聲符","label":"讀音"}]},"妙":{"formula":"女 + 少","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"少","role":"聲符","label":"讀音"}]},"妝":{"formula":"爿 + 女","components":[{"radical":"爿","role":"聲符","label":"讀音"},{"radical":"女","role":"形符","label":"女旁"}]},"妤":{"formula":"女 + 予","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"予","role":"聲符","label":"讀音"}]},"妥":{"formula":"爫 + 女","components":[{"radical":"爫","role":"部件","label":"爫"},{"radical":"女","role":"部件","label":"女旁"}]},"妳":{"formula":"女 + 尔","components":[{"radical":"女","role":"部件","label":"女旁"},{"radical":"尔","role":"部件","label":"尔"}]},"妹":{"formula":"女 + 未","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"未","role":"聲符","label":"讀音"}]},"妻":{"formula":"十 + 彐 + 女","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"彐","role":"部件","label":"豬頭"},{"radical":"女","role":"部件","label":"女旁"}]},"姆":{"formula":"女 + 母","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"母","role":"聲符","label":"讀音"}]},"姊":{"formula":"女 + 丿 + ㇉ + 丨 + 丿","components":[{"radical":"女","role":"部件","label":"女旁"},{"radical":"丿","role":"部件","label":"撇"},{"radical":"㇉","role":"部件","label":"㇉"},{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"丿","role":"部件","label":"撇"}]},"始":{"formula":"女 + 台","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"台","role":"聲符","label":"讀音"}]},"姐":{"formula":"女 + 且","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"且","role":"聲符","label":"讀音"}]},"姓":{"formula":"女 + 生","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"生","role":"聲符","label":"讀音"}]},"委":{"formula":"禾 + 女","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"女","role":"部件","label":"女旁"}]},"姨":{"formula":"女 + 夷","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"夷","role":"聲符","label":"讀音"}]},"姿":{"formula":"次 + 女","components":[{"radical":"次","role":"聲符","label":"讀音"},{"radical":"女","role":"形符","label":"女旁"}]},"威":{"formula":"戌 + 女","components":[{"radical":"戌","role":"部件","label":"戌"},{"radical":"女","role":"部件","label":"女旁"}]},"娘":{"formula":"女 + 良","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"良","role":"聲符","label":"讀音"}]},"娥":{"formula":"女 + 我","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"我","role":"聲符","label":"讀音"}]},"婚":{"formula":"女 + 昏","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"昏","role":"聲符","label":"讀音"}]},"婞":{"formula":"女 + 幸","components":[{"radical":"女","role":"部件","label":"女旁"},{"radical":"幸","role":"部件","label":"幸"}]},"婦":{"formula":"女 + 帚","components":[{"radical":"女","role":"部件","label":"女旁"},{"radical":"帚","role":"部件","label":"帚"}]},"媒":{"formula":"女 + 某","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"某","role":"聲符","label":"讀音"}]},"媚":{"formula":"女 + 眉","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"眉","role":"聲符","label":"讀音"}]},"媽":{"formula":"女 + 馬","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"馬","role":"聲符","label":"讀音"}]},"嫁":{"formula":"女 + 家","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"家","role":"聲符","label":"讀音"}]},"嫉":{"formula":"女 + 疾","components":[{"radical":"女","role":"部件","label":"女旁"},{"radical":"疾","role":"部件","label":"疾"}]},"嫌":{"formula":"女 + 兼","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"兼","role":"聲符","label":"讀音"}]},"嫦":{"formula":"女 + 常","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"常","role":"聲符","label":"讀音"}]},"嬉":{"formula":"女 + 喜","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"喜","role":"聲符","label":"讀音"}]},"嬌":{"formula":"女 + 喬","components":[{"radical":"女","role":"形符","label":"女旁"},{"radical":"喬","role":"聲符","label":"讀音"}]},"嬰":{"formula":"女","components":[{"radical":"女","role":"形符","label":"女旁"}]},"子":{"formula":"子","components":[{"radical":"子","role":"部件","label":"象形字（獨體）"}]},"孔":{"formula":"子 + 乚","components":[{"radical":"子","role":"部件","label":"孩子"},{"radical":"乚","role":"部件","label":"乚"}]},"孕":{"formula":"乃 + 子","components":[{"radical":"乃","role":"部件","label":"乃"},{"radical":"子","role":"部件","label":"孩子"}]},"字":{"formula":"宀 + 子","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"子","role":"部件","label":"孩子"}]},"存":{"formula":"才 + 子","components":[{"radical":"才","role":"聲符","label":"讀音"},{"radical":"子","role":"形符","label":"孩子"}]},"孝":{"formula":"耂 + 子","components":[{"radical":"耂","role":"部件","label":"耂"},{"radical":"子","role":"部件","label":"孩子"}]},"孟":{"formula":"子 + 皿","components":[{"radical":"子","role":"部件","label":"孩子"},{"radical":"皿","role":"部件","label":"器皿"}]},"季":{"formula":"禾 + 子","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"子","role":"部件","label":"孩子"}]},"孤":{"formula":"子 + 瓜","components":[{"radical":"子","role":"形符","label":"孩子"},{"radical":"瓜","role":"聲符","label":"讀音"}]},"学":{"formula":"⺍ + 冖 + 子","components":[{"radical":"⺍","role":"部件","label":"⺍"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"子","role":"部件","label":"孩子"}]},"孩":{"formula":"子 + 亥","components":[{"radical":"子","role":"形符","label":"孩子"},{"radical":"亥","role":"聲符","label":"讀音"}]},"孫":{"formula":"子 + 系","components":[{"radical":"子","role":"部件","label":"孩子"},{"radical":"系","role":"部件","label":"系"}]},"孳":{"formula":"兹 + 子","components":[{"radical":"兹","role":"聲符","label":"讀音"},{"radical":"子","role":"形符","label":"孩子"}]},"孵":{"formula":"卵 + 孚","components":[{"radical":"卵","role":"部件","label":"卵"},{"radical":"孚","role":"部件","label":"孚"}]},"學":{"formula":"冖 + 子","components":[{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"子","role":"部件","label":"孩子"}]},"孽":{"formula":"薛 + 子","components":[{"radical":"薛","role":"聲符","label":"讀音"},{"radical":"子","role":"形符","label":"孩子"}]},"它":{"formula":"宀 + 匕","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"匕","role":"部件","label":"湯匙"}]},"宇":{"formula":"宀 + 于","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"于","role":"聲符","label":"讀音"}]},"守":{"formula":"宀 + 寸","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"寸","role":"部件","label":"量詞"}]},"安":{"formula":"宀 + 女","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"女","role":"部件","label":"女旁"}]},"完":{"formula":"宀 + 元","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"元","role":"聲符","label":"讀音"}]},"宏":{"formula":"宀 + 厷","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"厷","role":"聲符","label":"讀音"}]},"宗":{"formula":"宀 + 示","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"示","role":"部件","label":"祭祀"}]},"官":{"formula":"宀 + 㠯","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"㠯","role":"部件","label":"㠯"}]},"宙":{"formula":"宀 + 由","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"由","role":"聲符","label":"讀音"}]},"定":{"formula":"宀 + 疋","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"疋","role":"部件","label":"量詞"}]},"宛":{"formula":"宀 + 夗","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"夗","role":"聲符","label":"讀音"}]},"宜":{"formula":"宀 + 且","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"且","role":"部件","label":"且"}]},"客":{"formula":"宀 + 各","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"各","role":"部件","label":"各"}]},"宣":{"formula":"宣","components":[{"radical":"宣","role":"部件","label":"象形字（獨體）"}]},"室":{"formula":"宀 + 至","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"至","role":"聲符","label":"讀音"}]},"宰":{"formula":"宀 + 辛","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"辛","role":"部件","label":"辛苦"}]},"害":{"formula":"宀 + 丰 + 口","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"丰","role":"部件","label":"丰"},{"radical":"口","role":"部件","label":"嘴巴"}]},"宴":{"formula":"宀 + 妟","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"妟","role":"部件","label":"妟"}]},"宵":{"formula":"宀 + 肖","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"肖","role":"聲符","label":"讀音"}]},"家":{"formula":"宀 + 豕","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"豕","role":"聲符","label":"讀音"}]},"容":{"formula":"宀 + 谷","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"谷","role":"聲符","label":"山谷"}]},"宿":{"formula":"宀 + 佰","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"佰","role":"部件","label":"佰"}]},"寂":{"formula":"宀 + 叔","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"叔","role":"聲符","label":"讀音"}]},"寄":{"formula":"宀 + 奇","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"奇","role":"聲符","label":"讀音"}]},"密":{"formula":"宓 + 山","components":[{"radical":"宓","role":"部件","label":"宓"},{"radical":"山","role":"部件","label":"山"}]},"富":{"formula":"宀 + 畐","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"畐","role":"聲符","label":"讀音"}]},"寐":{"formula":"宀 + 爿 + 未","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"爿","role":"部件","label":"床板"},{"radical":"未","role":"部件","label":"未來"}]},"寒":{"formula":"宀 + 井 + 大 + 冰","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"井","role":"部件","label":"井"},{"radical":"大","role":"部件","label":"大"},{"radical":"冰","role":"部件","label":"冰"}]},"寓":{"formula":"宀 + 禺","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"禺","role":"聲符","label":"讀音"}]},"寞":{"formula":"宀 + 莫","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"莫","role":"聲符","label":"讀音"}]},"察":{"formula":"宀 + 祭","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"祭","role":"聲符","label":"讀音"}]},"寡":{"formula":"宀 + 直 + 分","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"直","role":"部件","label":"直"},{"radical":"分","role":"部件","label":"分"}]},"寢":{"formula":"宀 + 爿 + 彐 + 冖 + 又","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"爿","role":"部件","label":"床板"},{"radical":"彐","role":"部件","label":"豬頭"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"又","role":"部件","label":"手"}]},"實":{"formula":"宀 + 貫","components":[{"radical":"宀","role":"聲符","label":"讀音"},{"radical":"貫","role":"形符","label":"貫"}]},"寧":{"formula":"心 + 丁","components":[{"radical":"心","role":"形符","label":"心理"},{"radical":"丁","role":"聲符","label":"讀音"}]},"審":{"formula":"宀 + 番","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"番","role":"聲符","label":"讀音"}]},"寬":{"formula":"宀 + 苋","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"苋","role":"聲符","label":"讀音"}]},"寵":{"formula":"宀 + 龍","components":[{"radical":"宀","role":"形符","label":"房頂"},{"radical":"龍","role":"聲符","label":"讀音"}]},"寶":{"formula":"宀 + 珤 + 貝","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"珤","role":"部件","label":"珤"},{"radical":"貝","role":"部件","label":"錢財"}]},"寸":{"formula":"一 + 亅 + 丶","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"亅","role":"部件","label":"倒掛的鉤"},{"radical":"丶","role":"部件","label":"點"}]},"封":{"formula":"圭 + 寸","components":[{"radical":"圭","role":"部件","label":"圭"},{"radical":"寸","role":"部件","label":"量詞"}]},"射":{"formula":"射","components":[{"radical":"射","role":"部件","label":"象形字（獨體）"}]},"將":{"formula":"爿 + 夕 + 寸","components":[{"radical":"爿","role":"部件","label":"床板"},{"radical":"夕","role":"部件","label":"傍晚"},{"radical":"寸","role":"部件","label":"量詞"}]},"專":{"formula":"叀 + 寸","components":[{"radical":"叀","role":"聲符","label":"讀音"},{"radical":"寸","role":"形符","label":"量詞"}]},"尊":{"formula":"酋 + 寸","components":[{"radical":"酋","role":"部件","label":"酋"},{"radical":"寸","role":"部件","label":"量詞"}]},"尋":{"formula":"彐 + 工 + 口 + 寸","components":[{"radical":"彐","role":"部件","label":"豬頭"},{"radical":"工","role":"部件","label":"工匠"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"寸","role":"部件","label":"量詞"}]},"對":{"formula":"业 + 羊 + 寸","components":[{"radical":"业","role":"部件","label":"业"},{"radical":"羊","role":"部件","label":"羊"},{"radical":"寸","role":"部件","label":"量詞"}]},"導":{"formula":"道 + 寸","components":[{"radical":"道","role":"部件","label":"道"},{"radical":"寸","role":"部件","label":"量詞"}]},"小":{"formula":"亅 + 八","components":[{"radical":"亅","role":"部件","label":"倒掛的鉤"},{"radical":"八","role":"部件","label":"八"}]},"少":{"formula":"少","components":[{"radical":"少","role":"部件","label":"象形字（獨體）"}]},"尔":{"formula":"刀 + 小","components":[{"radical":"刀","role":"部件","label":"刀"},{"radical":"小","role":"部件","label":"小"}]},"尖":{"formula":"小 + 大","components":[{"radical":"小","role":"部件","label":"小"},{"radical":"大","role":"部件","label":"大"}]},"尚":{"formula":"小 + 冂 + 口","components":[{"radical":"小","role":"部件","label":"小"},{"radical":"冂","role":"部件","label":"邊界"},{"radical":"口","role":"部件","label":"嘴巴"}]},"尤":{"formula":"尢","components":[{"radical":"尢","role":"聲符","label":"讀音"}]},"就":{"formula":"京 + 尤","components":[{"radical":"京","role":"聲符","label":"讀音"},{"radical":"尤","role":"形符","label":"尤"}]},"尺":{"formula":"尸 + 乚","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"乚","role":"部件","label":"乚"}]},"尼":{"formula":"尸 + 匕","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"匕","role":"部件","label":"湯匙"}]},"尾":{"formula":"尸 + 毛","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"毛","role":"部件","label":"毛髮"}]},"尿":{"formula":"尸 + 水","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"水","role":"部件","label":"水"}]},"局":{"formula":"尺 + 口","components":[{"radical":"尺","role":"部件","label":"尺"},{"radical":"口","role":"部件","label":"嘴巴"}]},"居":{"formula":"户 + 古","components":[{"radical":"户","role":"形符","label":"「戶」的異體"},{"radical":"古","role":"聲符","label":"讀音"}]},"屈":{"formula":"尸 + 出","components":[{"radical":"尸","role":"形符","label":"身體"},{"radical":"出","role":"聲符","label":"讀音"}]},"屋":{"formula":"尸 + 至","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"至","role":"部件","label":"到達"}]},"屍":{"formula":"尸 + 死","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"死","role":"部件","label":"死"}]},"屎":{"formula":"尸 + 米","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"米","role":"部件","label":"米穀"}]},"屏":{"formula":"户 + 并","components":[{"radical":"户","role":"形符","label":"「戶」的異體"},{"radical":"并","role":"聲符","label":"讀音"}]},"屑":{"formula":"尸 + 肖","components":[{"radical":"尸","role":"形符","label":"身體"},{"radical":"肖","role":"聲符","label":"讀音"}]},"展":{"formula":"尸 + 衣","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"衣","role":"部件","label":"衣服"}]},"屢":{"formula":"尸 + 婁","components":[{"radical":"尸","role":"形符","label":"身體"},{"radical":"婁","role":"聲符","label":"讀音"}]},"層":{"formula":"尸 + 曾","components":[{"radical":"尸","role":"形符","label":"身體"},{"radical":"曾","role":"聲符","label":"讀音"}]},"屬":{"formula":"尸 + 禹","components":[{"radical":"尸","role":"形符","label":"身體"},{"radical":"禹","role":"聲符","label":"讀音"}]},"山":{"formula":"山","components":[{"radical":"山","role":"部件","label":"象形字（獨體）"}]},"岌":{"formula":"山 + 及","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"及","role":"聲符","label":"讀音"}]},"岐":{"formula":"山 + 支","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"支","role":"聲符","label":"讀音"}]},"岡":{"formula":"岡","components":[{"radical":"岡","role":"部件","label":"象形字（獨體）"}]},"岩":{"formula":"山 + 石","components":[{"radical":"山","role":"部件","label":"山"},{"radical":"石","role":"部件","label":"石頭"}]},"岸":{"formula":"山 + 厂 + 干","components":[{"radical":"山","role":"部件","label":"山"},{"radical":"厂","role":"部件","label":"山崖"},{"radical":"干","role":"部件","label":"盾牌"}]},"峭":{"formula":"山 + 肖","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"肖","role":"聲符","label":"讀音"}]},"峰":{"formula":"山 + 夆","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"夆","role":"聲符","label":"讀音"}]},"島":{"formula":"烏 + 山","components":[{"radical":"烏","role":"部件","label":"烏"},{"radical":"山","role":"部件","label":"山"}]},"峻":{"formula":"山 + 夋","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"夋","role":"聲符","label":"讀音"}]},"峽":{"formula":"山 + 夾","components":[{"radical":"山","role":"部件","label":"山"},{"radical":"夾","role":"部件","label":"夾"}]},"崇":{"formula":"山 + 宗","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"宗","role":"聲符","label":"讀音"}]},"崎":{"formula":"山 + 奇","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"奇","role":"聲符","label":"讀音"}]},"崑":{"formula":"山 + 昆","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"昆","role":"聲符","label":"讀音"}]},"崩":{"formula":"山 + 朋","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"朋","role":"聲符","label":"讀音"}]},"嵎":{"formula":"山 + 禺","components":[{"radical":"山","role":"部件","label":"山"},{"radical":"禺","role":"部件","label":"禺"}]},"嶄":{"formula":"山 + 斬","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"斬","role":"聲符","label":"讀音"}]},"嶇":{"formula":"山 + 區","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"區","role":"聲符","label":"讀音"}]},"嶺":{"formula":"山 + 令","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"令","role":"聲符","label":"讀音"}]},"嶼":{"formula":"山 + 與","components":[{"radical":"山","role":"形符","label":"山"},{"radical":"與","role":"聲符","label":"讀音"}]},"川":{"formula":"丿 + 丨 + 丨","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"州":{"formula":"川","components":[{"radical":"川","role":"部件","label":"河流"}]},"巡":{"formula":"辶 + 巛","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"巛","role":"部件","label":"河流"}]},"巢":{"formula":"巛 + 果","components":[{"radical":"巛","role":"部件","label":"河流"},{"radical":"果","role":"部件","label":"果"}]},"工":{"formula":"工","components":[{"radical":"工","role":"部件","label":"象形字（獨體）"}]},"左":{"formula":"左","components":[{"radical":"左","role":"部件","label":"象形字（獨體）"}]},"巧":{"formula":"工 + 丂","components":[{"radical":"工","role":"形符","label":"工匠"},{"radical":"丂","role":"聲符","label":"讀音"}]},"巨":{"formula":"匚","components":[{"radical":"匚","role":"部件","label":"容器"}]},"巫":{"formula":"巫","components":[{"radical":"巫","role":"部件","label":"象形字（獨體）"}]},"差":{"formula":"羊 + 工","components":[{"radical":"羊","role":"部件","label":"羊"},{"radical":"工","role":"部件","label":"工匠"}]},"己":{"formula":"己","components":[{"radical":"己","role":"部件","label":"象形字（獨體）"}]},"已":{"formula":"㇆ + 一 + 乚","components":[{"radical":"㇆","role":"部件","label":"㇆"},{"radical":"一","role":"部件","label":"一"},{"radical":"乚","role":"部件","label":"乚"}]},"巴":{"formula":"巳 + 丨","components":[{"radical":"巳","role":"部件","label":"巳"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"巷":{"formula":"共 + 己","components":[{"radical":"共","role":"部件","label":"共同"},{"radical":"己","role":"部件","label":"天干的第六位"}]},"巾":{"formula":"巾","components":[{"radical":"巾","role":"部件","label":"象形字（獨體）"}]},"市":{"formula":"亠 + 巾","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"巾","role":"部件","label":"布"}]},"布":{"formula":"巾","components":[{"radical":"巾","role":"部件","label":"布"}]},"帆":{"formula":"巾 + 凡","components":[{"radical":"巾","role":"形符","label":"布"},{"radical":"凡","role":"聲符","label":"讀音"}]},"希":{"formula":"乂 + 布","components":[{"radical":"乂","role":"部件","label":"乂"},{"radical":"布","role":"部件","label":"布"}]},"帕":{"formula":"巾 + 白","components":[{"radical":"巾","role":"部件","label":"布"},{"radical":"白","role":"部件","label":"白色"}]},"帝":{"formula":"帝","components":[{"radical":"帝","role":"部件","label":"象形字（獨體）"}]},"師":{"formula":"丿 + 㠯 + 帀","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"㠯","role":"部件","label":"㠯"},{"radical":"帀","role":"部件","label":"帀"}]},"席":{"formula":"广 + 廿 + 巾","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"廿","role":"部件","label":"廿"},{"radical":"巾","role":"部件","label":"布"}]},"帳":{"formula":"巾 + 長","components":[{"radical":"巾","role":"形符","label":"布"},{"radical":"長","role":"聲符","label":"讀音"}]},"帶":{"formula":"卌 + 冖 + 巾","components":[{"radical":"卌","role":"部件","label":"卌"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"巾","role":"部件","label":"布"}]},"常":{"formula":"尚 + 巾","components":[{"radical":"尚","role":"聲符","label":"讀音"},{"radical":"巾","role":"形符","label":"布"}]},"帽":{"formula":"巾 + 冒","components":[{"radical":"巾","role":"形符","label":"布"},{"radical":"冒","role":"聲符","label":"讀音"}]},"幅":{"formula":"巾 + 畐","components":[{"radical":"巾","role":"部件","label":"布"},{"radical":"畐","role":"部件","label":"畐"}]},"幕":{"formula":"莫 + 巾","components":[{"radical":"莫","role":"聲符","label":"讀音"},{"radical":"巾","role":"形符","label":"布"}]},"幟":{"formula":"巾 + 戠","components":[{"radical":"巾","role":"形符","label":"布"},{"radical":"戠","role":"聲符","label":"讀音"}]},"幣":{"formula":"敝 + 巾","components":[{"radical":"敝","role":"聲符","label":"讀音"},{"radical":"巾","role":"形符","label":"布"}]},"幫":{"formula":"封 + 帛","components":[{"radical":"封","role":"部件","label":"封"},{"radical":"帛","role":"部件","label":"帛"}]},"干":{"formula":"干","components":[{"radical":"干","role":"部件","label":"象形字（獨體）"}]},"平":{"formula":"平","components":[{"radical":"平","role":"部件","label":"象形字（獨體）"}]},"年":{"formula":"干","components":[{"radical":"干","role":"部件","label":"盾牌"}]},"并":{"formula":"丷 + 开","components":[{"radical":"丷","role":"部件","label":"丷"},{"radical":"开","role":"部件","label":"开"}]},"幸":{"formula":"土 + 丷 + 干","components":[{"radical":"土","role":"部件","label":"泥土"},{"radical":"丷","role":"部件","label":"丷"},{"radical":"干","role":"部件","label":"盾牌"}]},"幹":{"formula":"幹","components":[{"radical":"幹","role":"部件","label":"象形字（獨體）"}]},"幻":{"formula":"幺","components":[{"radical":"幺","role":"部件","label":"細小"}]},"幼":{"formula":"幺 + 力","components":[{"radical":"幺","role":"部件","label":"細小"},{"radical":"力","role":"部件","label":"力量"}]},"幽":{"formula":"山 + 幺 + 幺","components":[{"radical":"山","role":"部件","label":"山"},{"radical":"幺","role":"部件","label":"細小"},{"radical":"幺","role":"部件","label":"細小"}]},"幾":{"formula":"幾","components":[{"radical":"幾","role":"部件","label":"象形字（獨體）"}]},"庇":{"formula":"广 + 比","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"比","role":"聲符","label":"讀音"}]},"床":{"formula":"广 + 木","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"木","role":"部件","label":"樹木"}]},"序":{"formula":"广 + 予","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"予","role":"聲符","label":"讀音"}]},"底":{"formula":"广 + 氐","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"氐","role":"聲符","label":"讀音"}]},"店":{"formula":"广 + 占","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"占","role":"聲符","label":"讀音"}]},"庚":{"formula":"广 + 彐 + 人","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"彐","role":"部件","label":"豬頭"},{"radical":"人","role":"部件","label":"人"}]},"府":{"formula":"广 + 付","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"付","role":"聲符","label":"讀音"}]},"度":{"formula":"广 + 廿 + 又","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"廿","role":"部件","label":"廿"},{"radical":"又","role":"部件","label":"手"}]},"座":{"formula":"广 + 坐","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"坐","role":"部件","label":"坐"}]},"庫":{"formula":"广 + 車","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"車","role":"部件","label":"車輛"}]},"庭":{"formula":"广 + 廷","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"廷","role":"部件","label":"廷"}]},"康":{"formula":"广 + 隶","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"隶","role":"部件","label":"及"}]},"廁":{"formula":"广 + 則","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"則","role":"聲符","label":"讀音"}]},"廂":{"formula":"广 + 相","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"相","role":"聲符","label":"讀音"}]},"廉":{"formula":"广 + 兼","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"兼","role":"部件","label":"兼"}]},"廚":{"formula":"厂 + 豆","components":[{"radical":"厂","role":"形符","label":"山崖"},{"radical":"豆","role":"聲符","label":"讀音"}]},"廝":{"formula":"广 + 斯","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"斯","role":"聲符","label":"讀音"}]},"廟":{"formula":"广 + 朝","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"朝","role":"部件","label":"朝"}]},"廠":{"formula":"广 + 敞","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"敞","role":"聲符","label":"讀音"}]},"廢":{"formula":"發","components":[{"radical":"發","role":"聲符","label":"讀音"}]},"廣":{"formula":"广 + 黄","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"黄","role":"聲符","label":"讀音"}]},"廳":{"formula":"广 + 聽","components":[{"radical":"广","role":"形符","label":"房屋"},{"radical":"聽","role":"聲符","label":"讀音"}]},"延":{"formula":"丿 + 㢟","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"㢟","role":"部件","label":"㢟"}]},"廷":{"formula":"廴","components":[{"radical":"廴","role":"形符","label":"行走"}]},"建":{"formula":"廴 + 聿","components":[{"radical":"廴","role":"形符","label":"行走"},{"radical":"聿","role":"聲符","label":"讀音"}]},"弄":{"formula":"玉 + 廾","components":[{"radical":"玉","role":"部件","label":"玉石"},{"radical":"廾","role":"部件","label":"「廿」的異體"}]},"弊":{"formula":"敝 + 廾","components":[{"radical":"敝","role":"部件","label":"敝"},{"radical":"廾","role":"部件","label":"「廿」的異體"}]},"式":{"formula":"弋 + 工","components":[{"radical":"弋","role":"部件","label":"射箭"},{"radical":"工","role":"部件","label":"工匠"}]},"弓":{"formula":"弓","components":[{"radical":"弓","role":"部件","label":"象形字（獨體）"}]},"引":{"formula":"弓 + 丨","components":[{"radical":"弓","role":"部件","label":"弓箭"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"弗":{"formula":"弓 + 丨 + 丨","components":[{"radical":"弓","role":"部件","label":"弓箭"},{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"弟":{"formula":"丷 + 弔 + 丿","components":[{"radical":"丷","role":"部件","label":"丷"},{"radical":"弔","role":"部件","label":"弔"},{"radical":"丿","role":"部件","label":"撇"}]},"弱":{"formula":"弓 + 冫 + 弓 + 冫","components":[{"radical":"弓","role":"部件","label":"弓箭"},{"radical":"冫","role":"部件","label":"冰旁"},{"radical":"弓","role":"部件","label":"弓箭"},{"radical":"冫","role":"部件","label":"冰旁"}]},"張":{"formula":"弓 + 長","components":[{"radical":"弓","role":"形符","label":"弓箭"},{"radical":"長","role":"聲符","label":"讀音"}]},"強":{"formula":"弓 + 虫","components":[{"radical":"弓","role":"形符","label":"弓箭"},{"radical":"虫","role":"聲符","label":"讀音"}]},"彈":{"formula":"弓 + 單","components":[{"radical":"弓","role":"形符","label":"弓箭"},{"radical":"單","role":"聲符","label":"讀音"}]},"彌":{"formula":"弓 + 爾","components":[{"radical":"弓","role":"形符","label":"弓箭"},{"radical":"爾","role":"聲符","label":"讀音"}]},"彎":{"formula":"䜌 + 弓","components":[{"radical":"䜌","role":"聲符","label":"讀音"},{"radical":"弓","role":"形符","label":"弓箭"}]},"彙":{"formula":"彑 + 冖 + 果","components":[{"radical":"彑","role":"部件","label":"彑"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"果","role":"部件","label":"果"}]},"形":{"formula":"开 + 彡","components":[{"radical":"开","role":"部件","label":"开"},{"radical":"彡","role":"部件","label":"花紋"}]},"彥":{"formula":"文 + 彡","components":[{"radical":"文","role":"聲符","label":"讀音"},{"radical":"彡","role":"形符","label":"花紋"}]},"彩":{"formula":"采 + 彡","components":[{"radical":"采","role":"聲符","label":"讀音"},{"radical":"彡","role":"形符","label":"花紋"}]},"彪":{"formula":"虎 + 彡","components":[{"radical":"虎","role":"部件","label":"虎"},{"radical":"彡","role":"部件","label":"花紋"}]},"彰":{"formula":"章 + 彡","components":[{"radical":"章","role":"聲符","label":"讀音"},{"radical":"彡","role":"形符","label":"花紋"}]},"影":{"formula":"景 + 彡","components":[{"radical":"景","role":"聲符","label":"讀音"},{"radical":"彡","role":"形符","label":"花紋"}]},"彷":{"formula":"彳 + 方","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"方","role":"聲符","label":"讀音"}]},"役":{"formula":"彳 + 殳","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"殳","role":"部件","label":"武器"}]},"彼":{"formula":"彳 + 皮","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"皮","role":"聲符","label":"讀音"}]},"彿":{"formula":"彳 + 弗","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"弗","role":"聲符","label":"讀音"}]},"往":{"formula":"彳 + 王","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"王","role":"聲符","label":"讀音"}]},"待":{"formula":"彳 + 寺","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"寺","role":"部件","label":"寺"}]},"很":{"formula":"彳 + 艮","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"艮","role":"聲符","label":"讀音"}]},"徉":{"formula":"彳 + 羊","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"羊","role":"聲符","label":"讀音"}]},"律":{"formula":"彳 + 聿","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"聿","role":"部件","label":"筆"}]},"後":{"formula":"彳 + 幺 + 夂","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"幺","role":"部件","label":"細小"},{"radical":"夂","role":"部件","label":"行走"}]},"徐":{"formula":"彳 + 余","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"余","role":"聲符","label":"讀音"}]},"徑":{"formula":"彳 + 巠","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"巠","role":"聲符","label":"讀音"}]},"徒":{"formula":"彳 + 走","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"走","role":"部件","label":"行走"}]},"得":{"formula":"彳 + 旦 + 寸","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"旦","role":"部件","label":"旦"},{"radical":"寸","role":"部件","label":"量詞"}]},"徜":{"formula":"彳 + 尚","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"尚","role":"聲符","label":"讀音"}]},"從":{"formula":"彳 + 从","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"从","role":"聲符","label":"讀音"}]},"復":{"formula":"彳 + 复","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"复","role":"部件","label":"复"}]},"循":{"formula":"彳 + 盾","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"盾","role":"聲符","label":"讀音"}]},"微":{"formula":"彳 + 山 + 兀 + 攴","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"山","role":"部件","label":"山"},{"radical":"兀","role":"部件","label":"兀"},{"radical":"攴","role":"部件","label":"輕擊"}]},"徵":{"formula":"彳 + 正","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"正","role":"聲符","label":"讀音"}]},"德":{"formula":"彳 + 十 + 罒 + 心","components":[{"radical":"彳","role":"形符","label":"行旁"},{"radical":"十","role":"部件","label":"十"},{"radical":"罒","role":"部件","label":"網罟"},{"radical":"心","role":"部件","label":"心理"}]},"徹":{"formula":"切 + 彳","components":[{"radical":"切","role":"形符","label":"切"},{"radical":"彳","role":"聲符","label":"讀音"}]},"心":{"formula":"心","components":[{"radical":"心","role":"部件","label":"象形字（獨體）"}]},"必":{"formula":"心 + 丿","components":[{"radical":"心","role":"部件","label":"心理"},{"radical":"丿","role":"部件","label":"撇"}]},"忌":{"formula":"己 + 心","components":[{"radical":"己","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"忍":{"formula":"刃 + 心","components":[{"radical":"刃","role":"部件","label":"刃"},{"radical":"心","role":"部件","label":"心理"}]},"志":{"formula":"士 + 心","components":[{"radical":"士","role":"部件","label":"未婚的男子"},{"radical":"心","role":"部件","label":"心理"}]},"忘":{"formula":"亡 + 心","components":[{"radical":"亡","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"忙":{"formula":"忄 + 亡","components":[{"radical":"忄","role":"部件","label":"心旁"},{"radical":"亡","role":"部件","label":"亡"}]},"忠":{"formula":"中 + 心","components":[{"radical":"中","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"忡":{"formula":"忄 + 中","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"中","role":"聲符","label":"讀音"}]},"忪":{"formula":"忄 + 公","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"公","role":"聲符","label":"讀音"}]},"快":{"formula":"忄 + 夬","components":[{"radical":"忄","role":"部件","label":"心旁"},{"radical":"夬","role":"部件","label":"夬"}]},"忱":{"formula":"忄 + 冘","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"冘","role":"聲符","label":"讀音"}]},"念":{"formula":"今 + 心","components":[{"radical":"今","role":"部件","label":"今"},{"radical":"心","role":"部件","label":"心理"}]},"忽":{"formula":"勿 + 心","components":[{"radical":"勿","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"怎":{"formula":"乍 + 心","components":[{"radical":"乍","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"怒":{"formula":"奴 + 心","components":[{"radical":"奴","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"怕":{"formula":"忄 + 白","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"白","role":"聲符","label":"讀音"}]},"怖":{"formula":"忄 + 布","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"布","role":"聲符","label":"讀音"}]},"思":{"formula":"田 + 心","components":[{"radical":"田","role":"部件","label":"田地"},{"radical":"心","role":"部件","label":"心理"}]},"怠":{"formula":"台 + 心","components":[{"radical":"台","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"怡":{"formula":"忄 + 台","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"台","role":"聲符","label":"讀音"}]},"急":{"formula":"刍 + 心","components":[{"radical":"刍","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"性":{"formula":"忄 + 生","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"生","role":"聲符","label":"讀音"}]},"怨":{"formula":"夗 + 心","components":[{"radical":"夗","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"怪":{"formula":"心 + 圣","components":[{"radical":"心","role":"部件","label":"心理"},{"radical":"圣","role":"部件","label":"圣"}]},"恆":{"formula":"忄 + 亙","components":[{"radical":"忄","role":"部件","label":"心旁"},{"radical":"亙","role":"部件","label":"亙"}]},"恐":{"formula":"巩 + 心","components":[{"radical":"巩","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"恕":{"formula":"如 + 心","components":[{"radical":"如","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"恙":{"formula":"羊 + 心","components":[{"radical":"羊","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"恢":{"formula":"忄 + 灰","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"灰","role":"聲符","label":"讀音"}]},"恤":{"formula":"忄 + 血","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"血","role":"聲符","label":"讀音"}]},"恨":{"formula":"忄 + 艮","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"艮","role":"聲符","label":"讀音"}]},"恩":{"formula":"因 + 心","components":[{"radical":"因","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"恭":{"formula":"共 + ⺗","components":[{"radical":"共","role":"聲符","label":"讀音"},{"radical":"⺗","role":"形符","label":"⺗"}]},"息":{"formula":"自 + 心","components":[{"radical":"自","role":"部件","label":"自己"},{"radical":"心","role":"部件","label":"心理"}]},"恰":{"formula":"忄 + 合","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"合","role":"聲符","label":"讀音"}]},"悄":{"formula":"忄 + 肖","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"肖","role":"聲符","label":"讀音"}]},"悅":{"formula":"忄 + 兌","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"兌","role":"聲符","label":"讀音"}]},"悉":{"formula":"釆 + 心","components":[{"radical":"釆","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"悍":{"formula":"忄 + 旱","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"旱","role":"聲符","label":"讀音"}]},"悔":{"formula":"忄 + 每","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"每","role":"聲符","label":"讀音"}]},"悖":{"formula":"忄 + 孛","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"孛","role":"聲符","label":"讀音"}]},"悚":{"formula":"忄 + 束","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"束","role":"聲符","label":"讀音"}]},"悠":{"formula":"攸 + 心","components":[{"radical":"攸","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"患":{"formula":"串 + 心","components":[{"radical":"串","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"您":{"formula":"你 + 心","components":[{"radical":"你","role":"部件","label":"你"},{"radical":"心","role":"部件","label":"心理"}]},"悲":{"formula":"非 + 心","components":[{"radical":"非","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"悶":{"formula":"門 + 心","components":[{"radical":"門","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"悸":{"formula":"忄 + 季","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"季","role":"聲符","label":"讀音"}]},"情":{"formula":"忄 + 青","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"青","role":"聲符","label":"讀音"}]},"惋":{"formula":"忄 + 宛","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"宛","role":"聲符","label":"讀音"}]},"惑":{"formula":"或 + 心","components":[{"radical":"或","role":"部件","label":"或"},{"radical":"心","role":"部件","label":"心理"}]},"惕":{"formula":"忄 + 易","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"易","role":"聲符","label":"讀音"}]},"惜":{"formula":"忄 + 昔","components":[{"radical":"忄","role":"部件","label":"心旁"},{"radical":"昔","role":"部件","label":"昔"}]},"惡":{"formula":"亞 + 心","components":[{"radical":"亞","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"惰":{"formula":"忄 + 左","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"左","role":"聲符","label":"讀音"}]},"惱":{"formula":"忄 + 囟","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"囟","role":"聲符","label":"腦頂"}]},"想":{"formula":"相 + 心","components":[{"radical":"相","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"惹":{"formula":"若 + 心","components":[{"radical":"若","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"惺":{"formula":"忄 + 星","components":[{"radical":"忄","role":"部件","label":"心旁"},{"radical":"星","role":"部件","label":"星"}]},"愁":{"formula":"秋 + 心","components":[{"radical":"秋","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"愈":{"formula":"俞 + 心","components":[{"radical":"俞","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"意":{"formula":"音 + 心","components":[{"radical":"音","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"愚":{"formula":"禺 + 心","components":[{"radical":"禺","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"愛":{"formula":"爫 + 冖 + 心 + 夂","components":[{"radical":"爫","role":"部件","label":"爫"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"心","role":"部件","label":"心理"},{"radical":"夂","role":"部件","label":"行走"}]},"感":{"formula":"咸 + 心","components":[{"radical":"咸","role":"部件","label":"咸"},{"radical":"心","role":"部件","label":"心理"}]},"愧":{"formula":"忄 + 鬼","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"鬼","role":"聲符","label":"讀音"}]},"慈":{"formula":"兹 + 心","components":[{"radical":"兹","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"態":{"formula":"能 + 心","components":[{"radical":"能","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"慌":{"formula":"忄 + 荒","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"荒","role":"聲符","label":"讀音"}]},"慎":{"formula":"忄 + 真","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"真","role":"聲符","label":"讀音"}]},"慕":{"formula":"莫 + ⺗","components":[{"radical":"莫","role":"聲符","label":"讀音"},{"radical":"⺗","role":"形符","label":"⺗"}]},"慘":{"formula":"忄 + 參","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"參","role":"聲符","label":"讀音"}]},"慢":{"formula":"忄 + 曼","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"曼","role":"聲符","label":"讀音"}]},"慣":{"formula":"忄 + 貫","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"貫","role":"聲符","label":"讀音"}]},"慧":{"formula":"彗 + 心","components":[{"radical":"彗","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"慨":{"formula":"忄 + 既","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"既","role":"聲符","label":"讀音"}]},"慮":{"formula":"虍 + 思","components":[{"radical":"虍","role":"部件","label":"老虎身上的花"},{"radical":"思","role":"部件","label":"思"}]},"慰":{"formula":"尉 + 心","components":[{"radical":"尉","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"慶":{"formula":"鹿 + 心 + 夂","components":[{"radical":"鹿","role":"部件","label":"鹿"},{"radical":"心","role":"部件","label":"心理"},{"radical":"夂","role":"部件","label":"行走"}]},"慾":{"formula":"欲 + 心","components":[{"radical":"欲","role":"部件","label":"欲"},{"radical":"心","role":"部件","label":"心理"}]},"憂":{"formula":"忄 + 頁","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"頁","role":"聲符","label":"讀音"}]},"憊":{"formula":"備 + 心","components":[{"radical":"備","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"憐":{"formula":"忄 + 粦","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"粦","role":"聲符","label":"讀音"}]},"憑":{"formula":"馮 + 心","components":[{"radical":"馮","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"憚":{"formula":"忄 + 單","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"單","role":"聲符","label":"讀音"}]},"憤":{"formula":"忄 + 賁","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"賁","role":"聲符","label":"讀音"}]},"憶":{"formula":"忄 + 意","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"意","role":"聲符","label":"讀音"}]},"憾":{"formula":"忄 + 感","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"感","role":"聲符","label":"讀音"}]},"懂":{"formula":"忄 + 董","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"董","role":"聲符","label":"讀音"}]},"懇":{"formula":"貇 + 心","components":[{"radical":"貇","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"懈":{"formula":"忄 + 解","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"解","role":"聲符","label":"讀音"}]},"應":{"formula":"倠 + 心","components":[{"radical":"倠","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"懊":{"formula":"忄 + 奥","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"奥","role":"聲符","label":"讀音"}]},"懟":{"formula":"對 + 心","components":[{"radical":"對","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"懲":{"formula":"徴 + 心","components":[{"radical":"徴","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"懶":{"formula":"忄 + 賴","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"賴","role":"聲符","label":"讀音"}]},"懷":{"formula":"忄 + 褱","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"褱","role":"聲符","label":"讀音"}]},"懸":{"formula":"縣 + 心","components":[{"radical":"縣","role":"部件","label":"縣"},{"radical":"心","role":"部件","label":"心理"}]},"懼":{"formula":"忄 + 瞿","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"瞿","role":"聲符","label":"讀音"}]},"懾":{"formula":"忄 + 聶","components":[{"radical":"忄","role":"形符","label":"心旁"},{"radical":"聶","role":"聲符","label":"讀音"}]},"戀":{"formula":"䜌 + 心","components":[{"radical":"䜌","role":"聲符","label":"讀音"},{"radical":"心","role":"形符","label":"心理"}]},"戈":{"formula":"戈","components":[{"radical":"戈","role":"部件","label":"象形字（獨體）"}]},"戊":{"formula":"丿 + 戈","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"戈","role":"部件","label":"武器"}]},"戎":{"formula":"戈","components":[{"radical":"戈","role":"部件","label":"武器"}]},"成":{"formula":"戊 + ㇆","components":[{"radical":"戊","role":"部件","label":"戊"},{"radical":"㇆","role":"部件","label":"㇆"}]},"我":{"formula":"扌 + 戈","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"戈","role":"部件","label":"武器"}]},"戒":{"formula":"戈 + 廾","components":[{"radical":"戈","role":"部件","label":"武器"},{"radical":"廾","role":"部件","label":"「廿」的異體"}]},"或":{"formula":"戈 + 口 + 一","components":[{"radical":"戈","role":"部件","label":"武器"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"一","role":"部件","label":"一"}]},"战":{"formula":"占 + 戈","components":[{"radical":"占","role":"聲符","label":"讀音"},{"radical":"戈","role":"形符","label":"武器"}]},"戚":{"formula":"戊 + 尗","components":[{"radical":"戊","role":"部件","label":"戊"},{"radical":"尗","role":"部件","label":"尗"}]},"截":{"formula":"十 + 隹 + 戈","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"隹","role":"部件","label":"鳥類"},{"radical":"戈","role":"部件","label":"武器"}]},"戰":{"formula":"單 + 戈","components":[{"radical":"單","role":"聲符","label":"讀音"},{"radical":"戈","role":"形符","label":"武器"}]},"戴":{"formula":"十 + 戈 + 異","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"戈","role":"部件","label":"武器"},{"radical":"異","role":"部件","label":"異"}]},"戶":{"formula":"戶","components":[{"radical":"戶","role":"部件","label":"象形字（獨體）"}]},"房":{"formula":"户 + 方","components":[{"radical":"户","role":"形符","label":"「戶」的異體"},{"radical":"方","role":"聲符","label":"讀音"}]},"所":{"formula":"户 + 斤","components":[{"radical":"户","role":"部件","label":"「戶」的異體"},{"radical":"斤","role":"部件","label":"斧頭"}]},"扇":{"formula":"户 + 羽","components":[{"radical":"户","role":"部件","label":"「戶」的異體"},{"radical":"羽","role":"部件","label":"羽毛"}]},"手":{"formula":"手","components":[{"radical":"手","role":"部件","label":"象形字（獨體）"}]},"才":{"formula":"扌","components":[{"radical":"扌","role":"部件","label":"手旁"}]},"打":{"formula":"扌 + 丁","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"丁","role":"聲符","label":"讀音"}]},"扔":{"formula":"扌 + 乃","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"乃","role":"聲符","label":"讀音"}]},"托":{"formula":"扌 + 乇","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"乇","role":"部件","label":"乇"}]},"扛":{"formula":"扌 + 工","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"工","role":"部件","label":"工匠"}]},"扣":{"formula":"扌 + 口","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"口","role":"聲符","label":"讀音"}]},"扭":{"formula":"扌 + 丑","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"丑","role":"聲符","label":"讀音"}]},"扮":{"formula":"扌 + 分","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"分","role":"聲符","label":"讀音"}]},"扯":{"formula":"扌 + 止","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"止","role":"聲符","label":"讀音"}]},"扳":{"formula":"扌 + 反","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"反","role":"聲符","label":"讀音"}]},"扶":{"formula":"扌 + 夫","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"夫","role":"聲符","label":"讀音"}]},"批":{"formula":"扌 + 比","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"比","role":"聲符","label":"讀音"}]},"找":{"formula":"扌 + 戈","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"戈","role":"部件","label":"武器"}]},"承":{"formula":"了 + 三","components":[{"radical":"了","role":"部件","label":"了"},{"radical":"三","role":"部件","label":"三"}]},"技":{"formula":"扌 + 支","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"支","role":"聲符","label":"讀音"}]},"抉":{"formula":"扌 + 夬","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"夬","role":"部件","label":"夬"}]},"把":{"formula":"扌 + 巴","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"巴","role":"聲符","label":"讀音"}]},"抑":{"formula":"扌 + 卬","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"卬","role":"聲符","label":"讀音"}]},"抓":{"formula":"扌 + 爪","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"爪","role":"部件","label":"爪子"}]},"投":{"formula":"扌 + 殳","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"殳","role":"聲符","label":"讀音"}]},"抖":{"formula":"扌 + 斗","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"斗","role":"聲符","label":"讀音"}]},"抗":{"formula":"扌 + 亢","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"亢","role":"部件","label":"亢"}]},"折":{"formula":"扌 + 斤","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"斤","role":"部件","label":"斧頭"}]},"抛":{"formula":"扌","components":[{"radical":"扌","role":"形符","label":"手旁"}]},"披":{"formula":"扌 + 皮","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"皮","role":"部件","label":"皮膚"}]},"抬":{"formula":"扌 + 台","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"台","role":"聲符","label":"讀音"}]},"抱":{"formula":"扌 + 包","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"包","role":"部件","label":"包"}]},"抵":{"formula":"扌 + 氐","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"氐","role":"聲符","label":"讀音"}]},"抹":{"formula":"扌 + 末","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"末","role":"聲符","label":"讀音"}]},"抽":{"formula":"扌 + 由","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"由","role":"聲符","label":"讀音"}]},"抿":{"formula":"扌 + 民","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"民","role":"聲符","label":"讀音"}]},"拆":{"formula":"扌 + 斥","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"斥","role":"聲符","label":"讀音"}]},"拇":{"formula":"扌 + 母","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"母","role":"聲符","label":"讀音"}]},"拉":{"formula":"扌 + 立","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"立","role":"聲符","label":"讀音"}]},"拋":{"formula":"扌 + 九 + 力","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"九","role":"部件","label":"九"},{"radical":"力","role":"部件","label":"力量"}]},"拍":{"formula":"扌 + 白","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"白","role":"聲符","label":"讀音"}]},"拐":{"formula":"扌 + 另","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"另","role":"部件","label":"另"}]},"拒":{"formula":"扌 + 巨","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"巨","role":"聲符","label":"讀音"}]},"拔":{"formula":"扌 + 犮","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"犮","role":"聲符","label":"讀音"}]},"拖":{"formula":"扌 + 它","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"它","role":"聲符","label":"讀音"}]},"拗":{"formula":"扌 + 幼","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"幼","role":"聲符","label":"讀音"}]},"拚":{"formula":"扌 + 弁","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"弁","role":"聲符","label":"讀音"}]},"招":{"formula":"扌 + 召","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"召","role":"部件","label":"召"}]},"拜":{"formula":"手 + 手","components":[{"radical":"手","role":"部件","label":"手"},{"radical":"手","role":"部件","label":"手"}]},"括":{"formula":"扌 + 舌","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"舌","role":"聲符","label":"讀音"}]},"拭":{"formula":"扌 + 式","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"式","role":"聲符","label":"讀音"}]},"拯":{"formula":"扌 + 丞","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"丞","role":"部件","label":"丞"}]},"拳":{"formula":"龹 + 手","components":[{"radical":"龹","role":"聲符","label":"讀音"},{"radical":"手","role":"形符","label":"手"}]},"拼":{"formula":"扌 + 并","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"并","role":"聲符","label":"讀音"}]},"拾":{"formula":"扌 + 合","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"合","role":"部件","label":"合"}]},"拿":{"formula":"合 + 手","components":[{"radical":"合","role":"聲符","label":"讀音"},{"radical":"手","role":"形符","label":"手"}]},"持":{"formula":"扌 + 寺","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"寺","role":"聲符","label":"讀音"}]},"指":{"formula":"扌 + 旨","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"旨","role":"部件","label":"旨"}]},"按":{"formula":"扌 + 安","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"安","role":"聲符","label":"讀音"}]},"挑":{"formula":"扌 + 兆","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"兆","role":"聲符","label":"讀音"}]},"挖":{"formula":"扌 + 穵","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"穵","role":"部件","label":"穵"}]},"挪":{"formula":"扌 + 那","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"那","role":"聲符","label":"讀音"}]},"挫":{"formula":"扌 + 坐","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"坐","role":"聲符","label":"讀音"}]},"振":{"formula":"扌 + 辰","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"辰","role":"聲符","label":"讀音"}]},"挺":{"formula":"扌 + 廷","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"廷","role":"聲符","label":"讀音"}]},"挽":{"formula":"扌 + 免","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"免","role":"聲符","label":"讀音"}]},"捉":{"formula":"扌 + 足","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"足","role":"聲符","label":"讀音"}]},"捏":{"formula":"扌 + 圼","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"圼","role":"聲符","label":"讀音"}]},"捐":{"formula":"扌 + 肙","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"肙","role":"聲符","label":"讀音"}]},"捕":{"formula":"扌 + 甫","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"甫","role":"聲符","label":"讀音"}]},"捧":{"formula":"扌 + 奉","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"奉","role":"部件","label":"奉"}]},"捨":{"formula":"扌 + 舍","components":[{"radical":"扌","role":"聲符","label":"讀音"},{"radical":"舍","role":"形符","label":"舍"}]},"捲":{"formula":"扌 + 卷","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"卷","role":"聲符","label":"讀音"}]},"捶":{"formula":"扌 + 垂","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"垂","role":"聲符","label":"讀音"}]},"捷":{"formula":"扌 + 疌","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"疌","role":"聲符","label":"讀音"}]},"掃":{"formula":"扌 + 帚","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"帚","role":"部件","label":"帚"}]},"授":{"formula":"扌 + 受","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"受","role":"聲符","label":"讀音"}]},"掉":{"formula":"扌 + 卓","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"卓","role":"聲符","label":"讀音"}]},"掌":{"formula":"尚 + 手","components":[{"radical":"尚","role":"聲符","label":"讀音"},{"radical":"手","role":"形符","label":"手"}]},"掏":{"formula":"扌 + 匋","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"匋","role":"聲符","label":"讀音"}]},"掐":{"formula":"扌 + 臽","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"臽","role":"聲符","label":"讀音"}]},"排":{"formula":"扌 + 非","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"非","role":"聲符","label":"讀音"}]},"掘":{"formula":"扌 + 屈","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"屈","role":"聲符","label":"讀音"}]},"掛":{"formula":"扌 + 卦","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"卦","role":"聲符","label":"讀音"}]},"採":{"formula":"扌 + 采","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"采","role":"聲符","label":"讀音"}]},"探":{"formula":"扌 + 穴 + 木","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"穴","role":"部件","label":"洞穴"},{"radical":"木","role":"部件","label":"樹木"}]},"接":{"formula":"扌 + 妾","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"妾","role":"聲符","label":"讀音"}]},"控":{"formula":"扌 + 空","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"空","role":"聲符","label":"讀音"}]},"推":{"formula":"扌 + 隹","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"隹","role":"聲符","label":"讀音"}]},"掩":{"formula":"扌 + 奄","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"奄","role":"聲符","label":"讀音"}]},"措":{"formula":"扌 + 昔","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"昔","role":"聲符","label":"讀音"}]},"描":{"formula":"扌 + 苗","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"苗","role":"聲符","label":"讀音"}]},"提":{"formula":"扌 + 是","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"是","role":"聲符","label":"讀音"}]},"插":{"formula":"扌 + 臿","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"臿","role":"聲符","label":"讀音"}]},"揚":{"formula":"扌 + 昜","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"昜","role":"聲符","label":"讀音"}]},"換":{"formula":"扌 + 奐","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"奐","role":"聲符","label":"讀音"}]},"握":{"formula":"扌 + 屋","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"屋","role":"聲符","label":"讀音"}]},"揪":{"formula":"扌 + 秋","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"秋","role":"聲符","label":"讀音"}]},"揭":{"formula":"扌 + 曷","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"曷","role":"聲符","label":"讀音"}]},"揮":{"formula":"扌 + 軍","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"軍","role":"部件","label":"軍"}]},"援":{"formula":"扌 + 爰","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"爰","role":"部件","label":"爰"}]},"損":{"formula":"扌 + 員","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"員","role":"聲符","label":"讀音"}]},"搏":{"formula":"扌 + 尃","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"尃","role":"聲符","label":"讀音"}]},"搐":{"formula":"扌 + 畜","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"畜","role":"聲符","label":"讀音"}]},"搓":{"formula":"扌 + 差","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"差","role":"聲符","label":"讀音"}]},"搖":{"formula":"扌 + 䍃","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"䍃","role":"聲符","label":"讀音"}]},"搗":{"formula":"扌 + 島","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"島","role":"聲符","label":"讀音"}]},"搜":{"formula":"扌 + 叟","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"叟","role":"聲符","label":"讀音"}]},"搞":{"formula":"扌 + 高","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"高","role":"聲符","label":"讀音"}]},"搬":{"formula":"扌 + 般","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"般","role":"聲符","label":"讀音"}]},"搭":{"formula":"扌 + 荅","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"荅","role":"聲符","label":"讀音"}]},"搶":{"formula":"扌 + 倉","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"倉","role":"聲符","label":"讀音"}]},"摔":{"formula":"扌 + 率","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"率","role":"聲符","label":"讀音"}]},"摘":{"formula":"扌 + 啇","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"啇","role":"部件","label":"啇"}]},"摧":{"formula":"扌 + 崔","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"崔","role":"聲符","label":"讀音"}]},"摩":{"formula":"麻 + 手","components":[{"radical":"麻","role":"聲符","label":"讀音"},{"radical":"手","role":"形符","label":"手"}]},"摯":{"formula":"執 + 手","components":[{"radical":"執","role":"部件","label":"執"},{"radical":"手","role":"部件","label":"手"}]},"摸":{"formula":"扌 + 莫","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"莫","role":"聲符","label":"讀音"}]},"撇":{"formula":"扌 + 敝","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"敝","role":"聲符","label":"讀音"}]},"撐":{"formula":"扌 + 牚","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"牚","role":"聲符","label":"讀音"}]},"撒":{"formula":"扌 + 散","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"散","role":"部件","label":"散"}]},"撓":{"formula":"扌 + 堯","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"堯","role":"聲符","label":"讀音"}]},"撞":{"formula":"扌 + 童","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"童","role":"聲符","label":"讀音"}]},"撩":{"formula":"扌 + 尞","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"尞","role":"聲符","label":"讀音"}]},"撫":{"formula":"扌 + 無","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"無","role":"聲符","label":"讀音"}]},"播":{"formula":"扌 + 番","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"番","role":"部件","label":"番"}]},"撰":{"formula":"扌 + 巽","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"巽","role":"聲符","label":"讀音"}]},"撲":{"formula":"扌 + 菐","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"菐","role":"聲符","label":"讀音"}]},"撿":{"formula":"扌 + 僉","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"僉","role":"聲符","label":"讀音"}]},"擁":{"formula":"扌 + 雍","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"雍","role":"聲符","label":"讀音"}]},"擂":{"formula":"扌 + 雷","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"雷","role":"聲符","label":"讀音"}]},"擅":{"formula":"扌 + 亶","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"亶","role":"聲符","label":"讀音"}]},"擇":{"formula":"扌 + 睪","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"睪","role":"聲符","label":"讀音"}]},"擊":{"formula":"毄 + 手","components":[{"radical":"毄","role":"部件","label":"毄"},{"radical":"手","role":"部件","label":"手"}]},"擋":{"formula":"扌 + 當","components":[{"radical":"扌","role":"部件","label":"手旁"},{"radical":"當","role":"部件","label":"當"}]},"操":{"formula":"扌 + 喿","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"喿","role":"聲符","label":"讀音"}]},"擔":{"formula":"扌 + 詹","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"詹","role":"聲符","label":"讀音"}]},"據":{"formula":"扌 + 豦","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"豦","role":"聲符","label":"讀音"}]},"擠":{"formula":"扌 + 齊","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"齊","role":"聲符","label":"讀音"}]},"擦":{"formula":"扌 + 察","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"察","role":"聲符","label":"讀音"}]},"擬":{"formula":"扌 + 疑","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"疑","role":"聲符","label":"讀音"}]},"擱":{"formula":"扌 + 閣","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"閣","role":"聲符","label":"讀音"}]},"擴":{"formula":"扌 + 廣","components":[{"radical":"扌","role":"聲符","label":"讀音"},{"radical":"廣","role":"形符","label":"廣"}]},"擺":{"formula":"扌 + 罷","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"罷","role":"聲符","label":"讀音"}]},"擻":{"formula":"扌 + 數","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"數","role":"聲符","label":"讀音"}]},"擾":{"formula":"扌 + 憂","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"憂","role":"聲符","label":"讀音"}]},"攀":{"formula":"樊 + 手","components":[{"radical":"樊","role":"聲符","label":"讀音"},{"radical":"手","role":"形符","label":"手"}]},"攏":{"formula":"扌 + 龍","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"龍","role":"聲符","label":"讀音"}]},"攙":{"formula":"扌 + 毚","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"毚","role":"聲符","label":"讀音"}]},"攜":{"formula":"扌 + 巂","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"巂","role":"聲符","label":"讀音"}]},"攝":{"formula":"扌 + 聶","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"聶","role":"聲符","label":"讀音"}]},"攣":{"formula":"䜌 + 手","components":[{"radical":"䜌","role":"聲符","label":"讀音"},{"radical":"手","role":"形符","label":"手"}]},"攤":{"formula":"扌 + 難","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"難","role":"聲符","label":"讀音"}]},"攫":{"formula":"扌 + 矍","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"矍","role":"聲符","label":"讀音"}]},"支":{"formula":"十 + 又","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"又","role":"部件","label":"手"}]},"收":{"formula":"丩 + 攵","components":[{"radical":"丩","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"改":{"formula":"己 + 攵","components":[{"radical":"己","role":"部件","label":"天干的第六位"},{"radical":"攵","role":"部件","label":"敲打"}]},"攻":{"formula":"工 + 攵","components":[{"radical":"工","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"放":{"formula":"方 + 攵","components":[{"radical":"方","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"政":{"formula":"正 + 攵","components":[{"radical":"正","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"故":{"formula":"古 + 攵","components":[{"radical":"古","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"效":{"formula":"交 + 攵","components":[{"radical":"交","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"敏":{"formula":"每 + 攵","components":[{"radical":"每","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"救":{"formula":"求 + 攵","components":[{"radical":"求","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"敗":{"formula":"貝 + 攵","components":[{"radical":"貝","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"敘":{"formula":"余 + 攵","components":[{"radical":"余","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"教":{"formula":"孝 + 攵","components":[{"radical":"孝","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"敢":{"formula":"耳 + 攵","components":[{"radical":"耳","role":"部件","label":"耳朵"},{"radical":"攵","role":"部件","label":"敲打"}]},"散":{"formula":"⺼ + 攵","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"攵","role":"部件","label":"敲打"}]},"敦":{"formula":"享 + 攵","components":[{"radical":"享","role":"形符","label":"享"},{"radical":"攵","role":"聲符","label":"讀音"}]},"敬":{"formula":"茍 + 攴","components":[{"radical":"茍","role":"部件","label":"茍"},{"radical":"攴","role":"部件","label":"輕擊"}]},"敲":{"formula":"高 + 攴","components":[{"radical":"高","role":"聲符","label":"讀音"},{"radical":"攴","role":"形符","label":"輕擊"}]},"整":{"formula":"敕 + 正","components":[{"radical":"敕","role":"形符","label":"敕"},{"radical":"正","role":"聲符","label":"讀音"}]},"敵":{"formula":"啇 + 攵","components":[{"radical":"啇","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"數":{"formula":"婁 + 攵","components":[{"radical":"婁","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"斃":{"formula":"敝 + 死","components":[{"radical":"敝","role":"聲符","label":"讀音"},{"radical":"死","role":"形符","label":"死"}]},"文":{"formula":"文","components":[{"radical":"文","role":"部件","label":"象形字（獨體）"}]},"斐":{"formula":"非 + 文","components":[{"radical":"非","role":"聲符","label":"讀音"},{"radical":"文","role":"形符","label":"文字"}]},"斗":{"formula":"十","components":[{"radical":"十","role":"部件","label":"十"}]},"料":{"formula":"米 + 斗","components":[{"radical":"米","role":"部件","label":"米穀"},{"radical":"斗","role":"部件","label":"量器"}]},"斜":{"formula":"余 + 斗","components":[{"radical":"余","role":"聲符","label":"讀音"},{"radical":"斗","role":"形符","label":"量器"}]},"斤":{"formula":"厂 + 丅","components":[{"radical":"厂","role":"部件","label":"山崖"},{"radical":"丅","role":"部件","label":"丅"}]},"斥":{"formula":"斤 + 丶","components":[{"radical":"斤","role":"部件","label":"斧頭"},{"radical":"丶","role":"部件","label":"點"}]},"斧":{"formula":"父 + 斤","components":[{"radical":"父","role":"聲符","label":"讀音"},{"radical":"斤","role":"形符","label":"斧頭"}]},"斬":{"formula":"車 + 斤","components":[{"radical":"車","role":"聲符","label":"讀音"},{"radical":"斤","role":"形符","label":"斧頭"}]},"斯":{"formula":"其 + 斤","components":[{"radical":"其","role":"部件","label":"其他"},{"radical":"斤","role":"部件","label":"斧頭"}]},"新":{"formula":"亲 + 斤","components":[{"radical":"亲","role":"部件","label":"亲"},{"radical":"斤","role":"部件","label":"斧頭"}]},"斷":{"formula":"幺 + 幺 + 一 + 幺 + 幺 + 斤","components":[{"radical":"幺","role":"部件","label":"細小"},{"radical":"幺","role":"部件","label":"細小"},{"radical":"一","role":"部件","label":"一"},{"radical":"幺","role":"部件","label":"細小"},{"radical":"幺","role":"部件","label":"細小"},{"radical":"斤","role":"部件","label":"斧頭"}]},"方":{"formula":"亠 + 勹","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"勹","role":"部件","label":"包裹"}]},"施":{"formula":"方 + 丿 + 一 + 也","components":[{"radical":"方","role":"部件","label":"方向"},{"radical":"丿","role":"部件","label":"撇"},{"radical":"一","role":"部件","label":"一"},{"radical":"也","role":"部件","label":"也"}]},"旁":{"formula":"立 + 方","components":[{"radical":"立","role":"形符","label":"站立"},{"radical":"方","role":"聲符","label":"讀音"}]},"旅":{"formula":"方 + 氏","components":[{"radical":"方","role":"部件","label":"方向"},{"radical":"氏","role":"部件","label":"姓氏"}]},"旋":{"formula":"方 + 疋","components":[{"radical":"方","role":"部件","label":"方向"},{"radical":"疋","role":"部件","label":"量詞"}]},"族":{"formula":"方 + 矢","components":[{"radical":"方","role":"部件","label":"方向"},{"radical":"矢","role":"部件","label":"箭"}]},"旗":{"formula":"方 + 其","components":[{"radical":"方","role":"形符","label":"方向"},{"radical":"其","role":"聲符","label":"讀音"}]},"既":{"formula":"旡","components":[{"radical":"旡","role":"部件","label":"打嗝"}]},"日":{"formula":"日","components":[{"radical":"日","role":"部件","label":"象形字（獨體）"}]},"旦":{"formula":"日 + 一","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"一","role":"部件","label":"一"}]},"旨":{"formula":"匕 + 日","components":[{"radical":"匕","role":"部件","label":"湯匙"},{"radical":"日","role":"部件","label":"太陽"}]},"早":{"formula":"日 + 十","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"十","role":"部件","label":"十"}]},"旱":{"formula":"日 + 干","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"干","role":"部件","label":"盾牌"}]},"昂":{"formula":"日 + 卬","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"卬","role":"聲符","label":"讀音"}]},"昆":{"formula":"日 + 比","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"比","role":"部件","label":"比較"}]},"昇":{"formula":"日 + 升","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"升","role":"部件","label":"升"}]},"昌":{"formula":"日 + 曰","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"曰","role":"部件","label":"說"}]},"明":{"formula":"日 + 月","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"月","role":"部件","label":"月亮"}]},"昏":{"formula":"氏 + 日","components":[{"radical":"氏","role":"部件","label":"姓氏"},{"radical":"日","role":"部件","label":"太陽"}]},"易":{"formula":"日 + 勿","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"勿","role":"部件","label":"勿"}]},"星":{"formula":"日 + 生","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"生","role":"聲符","label":"讀音"}]},"映":{"formula":"日 + 央","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"央","role":"聲符","label":"讀音"}]},"春":{"formula":"三 + 人 + 日","components":[{"radical":"三","role":"部件","label":"三"},{"radical":"人","role":"部件","label":"人"},{"radical":"日","role":"形符","label":"太陽"}]},"昨":{"formula":"日 + 乍","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"乍","role":"聲符","label":"讀音"}]},"是":{"formula":"日 + 疋","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"疋","role":"部件","label":"量詞"}]},"昱":{"formula":"日 + 立","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"立","role":"聲符","label":"讀音"}]},"時":{"formula":"日 + 寺","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"寺","role":"聲符","label":"讀音"}]},"晉":{"formula":"一 + 厶 + 厶 + 一 + 日","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"厶","role":"部件","label":"私"},{"radical":"厶","role":"部件","label":"私"},{"radical":"一","role":"部件","label":"一"},{"radical":"日","role":"部件","label":"太陽"}]},"晒":{"formula":"日 + 西","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"西","role":"聲符","label":"讀音"}]},"晚":{"formula":"日 + 免","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"免","role":"部件","label":"免"}]},"晨":{"formula":"日 + 辰","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"辰","role":"聲符","label":"讀音"}]},"普":{"formula":"並 + 日","components":[{"radical":"並","role":"部件","label":"並"},{"radical":"日","role":"部件","label":"太陽"}]},"景":{"formula":"日 + 京","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"京","role":"部件","label":"京"}]},"晰":{"formula":"日 + 析","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"析","role":"聲符","label":"讀音"}]},"晴":{"formula":"日 + 青","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"青","role":"聲符","label":"讀音"}]},"智":{"formula":"知 + 日","components":[{"radical":"知","role":"部件","label":"知"},{"radical":"日","role":"部件","label":"太陽"}]},"暇":{"formula":"日 + 叚","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"叚","role":"聲符","label":"讀音"}]},"暈":{"formula":"日 + 軍","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"軍","role":"聲符","label":"讀音"}]},"暑":{"formula":"日 + 者","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"者","role":"聲符","label":"讀音"}]},"暖":{"formula":"日 + 爰","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"爰","role":"聲符","label":"讀音"}]},"暗":{"formula":"日 + 音","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"音","role":"聲符","label":"讀音"}]},"暢":{"formula":"申 + 昜","components":[{"radical":"申","role":"形符","label":"申"},{"radical":"昜","role":"聲符","label":"讀音"}]},"暨":{"formula":"既 + 旦","components":[{"radical":"既","role":"聲符","label":"讀音"},{"radical":"旦","role":"形符","label":"旦"}]},"暫":{"formula":"斬 + 日","components":[{"radical":"斬","role":"聲符","label":"讀音"},{"radical":"日","role":"形符","label":"太陽"}]},"暴":{"formula":"日 + 共 + 水","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"共","role":"部件","label":"共同"},{"radical":"水","role":"部件","label":"水"}]},"曆":{"formula":"厤 + 日","components":[{"radical":"厤","role":"形符","label":"厤"},{"radical":"日","role":"聲符","label":"讀音"}]},"曙":{"formula":"日 + 署","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"署","role":"聲符","label":"讀音"}]},"曝":{"formula":"日 + 暴","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"暴","role":"聲符","label":"讀音"}]},"曠":{"formula":"日 + 廣","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"廣","role":"部件","label":"廣"}]},"曬":{"formula":"日 + 麗","components":[{"radical":"日","role":"形符","label":"太陽"},{"radical":"麗","role":"聲符","label":"讀音"}]},"曰":{"formula":"口 + 一","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"一","role":"部件","label":"一"}]},"曲":{"formula":"曲","components":[{"radical":"曲","role":"部件","label":"象形字（獨體）"}]},"曳":{"formula":"曰 + 乁 + 丿","components":[{"radical":"曰","role":"部件","label":"說"},{"radical":"乁","role":"部件","label":"乁"},{"radical":"丿","role":"部件","label":"撇"}]},"更":{"formula":"一 + 日 + 人","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"日","role":"部件","label":"太陽"},{"radical":"人","role":"部件","label":"人"}]},"書":{"formula":"聿 + 曰","components":[{"radical":"聿","role":"部件","label":"筆"},{"radical":"曰","role":"部件","label":"說"}]},"曼":{"formula":"日 + 罒 + 又","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"罒","role":"部件","label":"網罟"},{"radical":"又","role":"部件","label":"手"}]},"曾":{"formula":"丷 + 日","components":[{"radical":"丷","role":"部件","label":"丷"},{"radical":"日","role":"部件","label":"太陽"}]},"替":{"formula":"夫 + 夫 + 日","components":[{"radical":"夫","role":"部件","label":"夫"},{"radical":"夫","role":"部件","label":"夫"},{"radical":"日","role":"部件","label":"太陽"}]},"最":{"formula":"日 + 取","components":[{"radical":"日","role":"部件","label":"太陽"},{"radical":"取","role":"部件","label":"取"}]},"會":{"formula":"亼 + 日","components":[{"radical":"亼","role":"部件","label":"亼"},{"radical":"日","role":"部件","label":"太陽"}]},"月":{"formula":"月","components":[{"radical":"月","role":"部件","label":"象形字（獨體）"}]},"有":{"formula":"月","components":[{"radical":"月","role":"聲符","label":"讀音"}]},"朋":{"formula":"月 + 月","components":[{"radical":"月","role":"部件","label":"月亮"},{"radical":"月","role":"部件","label":"月亮"}]},"服":{"formula":"月 + 卩 + 又","components":[{"radical":"月","role":"部件","label":"月亮"},{"radical":"卩","role":"部件","label":"跪坐"},{"radical":"又","role":"部件","label":"手"}]},"朗":{"formula":"良 + 月","components":[{"radical":"良","role":"聲符","label":"讀音"},{"radical":"月","role":"形符","label":"月亮"}]},"望":{"formula":"亡 + 月 + 王","components":[{"radical":"亡","role":"部件","label":"亡"},{"radical":"月","role":"部件","label":"月亮"},{"radical":"王","role":"部件","label":"王旁"}]},"朝":{"formula":"龺 + 月","components":[{"radical":"龺","role":"聲符","label":"讀音"},{"radical":"月","role":"形符","label":"月亮"}]},"期":{"formula":"其 + 月","components":[{"radical":"其","role":"聲符","label":"讀音"},{"radical":"月","role":"形符","label":"月亮"}]},"木":{"formula":"木","components":[{"radical":"木","role":"部件","label":"象形字（獨體）"}]},"未":{"formula":"一 + 木","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"木","role":"部件","label":"樹木"}]},"末":{"formula":"木 + 一","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"一","role":"部件","label":"一"}]},"本":{"formula":"木 + 一","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"一","role":"部件","label":"一"}]},"札":{"formula":"木 + 乚","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"乚","role":"部件","label":"乚"}]},"朵":{"formula":"几 + 木","components":[{"radical":"几","role":"部件","label":"小桌"},{"radical":"木","role":"部件","label":"樹木"}]},"朽":{"formula":"木 + 丂","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"丂","role":"部件","label":"丂"}]},"杉":{"formula":"木 + 彡","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"彡","role":"聲符","label":"讀音"}]},"李":{"formula":"木 + 子","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"子","role":"聲符","label":"讀音"}]},"杏":{"formula":"木 + 口","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"口","role":"部件","label":"嘴巴"}]},"材":{"formula":"木 + 才","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"才","role":"聲符","label":"讀音"}]},"村":{"formula":"木 + 寸","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"寸","role":"聲符","label":"讀音"}]},"杜":{"formula":"木 + 土","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"土","role":"聲符","label":"讀音"}]},"束":{"formula":"木 + 口","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"口","role":"部件","label":"嘴巴"}]},"杯":{"formula":"木 + 不","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"不","role":"聲符","label":"讀音"}]},"東":{"formula":"木 + 日","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"日","role":"部件","label":"太陽"}]},"杳":{"formula":"木 + 日","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"日","role":"部件","label":"太陽"}]},"松":{"formula":"木 + 公","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"公","role":"聲符","label":"讀音"}]},"板":{"formula":"木 + 反","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"反","role":"聲符","label":"讀音"}]},"析":{"formula":"木 + 斤","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"斤","role":"部件","label":"斧頭"}]},"林":{"formula":"木 + 木","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"木","role":"部件","label":"樹木"}]},"果":{"formula":"田 + 木","components":[{"radical":"田","role":"部件","label":"田地"},{"radical":"木","role":"部件","label":"樹木"}]},"枝":{"formula":"木 + 支","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"支","role":"聲符","label":"讀音"}]},"枯":{"formula":"木 + 古","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"古","role":"部件","label":"古"}]},"架":{"formula":"加 + 木","components":[{"radical":"加","role":"聲符","label":"讀音"},{"radical":"木","role":"形符","label":"樹木"}]},"柄":{"formula":"木 + 丙","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"丙","role":"聲符","label":"讀音"}]},"柏":{"formula":"木 + 白","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"白","role":"聲符","label":"讀音"}]},"某":{"formula":"甘 + 木","components":[{"radical":"甘","role":"部件","label":"甘甜"},{"radical":"木","role":"部件","label":"樹木"}]},"柑":{"formula":"木 + 甘","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"甘","role":"部件","label":"甘甜"}]},"染":{"formula":"氿 + 木","components":[{"radical":"氿","role":"部件","label":"氿"},{"radical":"木","role":"部件","label":"樹木"}]},"柔":{"formula":"矛 + 木","components":[{"radical":"矛","role":"部件","label":"長矛"},{"radical":"木","role":"部件","label":"樹木"}]},"查":{"formula":"木 + 旦","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"旦","role":"部件","label":"旦"}]},"柯":{"formula":"木 + 可","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"可","role":"聲符","label":"讀音"}]},"柱":{"formula":"木 + 主","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"主","role":"聲符","label":"讀音"}]},"柳":{"formula":"木 + 卯","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"卯","role":"聲符","label":"讀音"}]},"柴":{"formula":"此 + 木","components":[{"radical":"此","role":"聲符","label":"讀音"},{"radical":"木","role":"形符","label":"樹木"}]},"柿":{"formula":"木 + 市","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"市","role":"聲符","label":"讀音"}]},"栓":{"formula":"木 + 全","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"全","role":"聲符","label":"讀音"}]},"校":{"formula":"木 + 交","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"交","role":"聲符","label":"讀音"}]},"株":{"formula":"木 + 朱","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"朱","role":"聲符","label":"讀音"}]},"核":{"formula":"木 + 亥","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"亥","role":"聲符","label":"讀音"}]},"根":{"formula":"木 + 艮","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"艮","role":"聲符","label":"讀音"}]},"格":{"formula":"木 + 各","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"各","role":"聲符","label":"讀音"}]},"栽":{"formula":"戈 + 木","components":[{"radical":"戈","role":"聲符","label":"讀音"},{"radical":"木","role":"形符","label":"樹木"}]},"桂":{"formula":"木 + 圭","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"圭","role":"聲符","label":"讀音"}]},"框":{"formula":"木 + 匡","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"匡","role":"聲符","label":"讀音"}]},"案":{"formula":"安 + 木","components":[{"radical":"安","role":"聲符","label":"讀音"},{"radical":"木","role":"形符","label":"樹木"}]},"桌":{"formula":"木 + 卜 + 日","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"卜","role":"部件","label":"占卜"},{"radical":"日","role":"部件","label":"太陽"}]},"桑":{"formula":"叒 + 木","components":[{"radical":"叒","role":"部件","label":"叒"},{"radical":"木","role":"部件","label":"樹木"}]},"桶":{"formula":"木 + 甬","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"甬","role":"聲符","label":"讀音"}]},"桿":{"formula":"木 + 旱","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"旱","role":"聲符","label":"讀音"}]},"梁":{"formula":"氵 + 刅 + 木","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"刅","role":"部件","label":"刅"},{"radical":"木","role":"部件","label":"樹木"}]},"梅":{"formula":"木 + 每","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"每","role":"聲符","label":"讀音"}]},"條":{"formula":"亻 + 丨 + 条","components":[{"radical":"亻","role":"部件","label":"人旁"},{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"条","role":"部件","label":"条"}]},"梢":{"formula":"木 + 肖","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"肖","role":"聲符","label":"讀音"}]},"梧":{"formula":"木 + 吾","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"吾","role":"聲符","label":"讀音"}]},"梯":{"formula":"木 + 弟","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"弟","role":"聲符","label":"讀音"}]},"械":{"formula":"木 + 戒","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"戒","role":"聲符","label":"讀音"}]},"棉":{"formula":"木 + 帛","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"帛","role":"部件","label":"帛"}]},"棒":{"formula":"木 + 奉","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"奉","role":"聲符","label":"讀音"}]},"棘":{"formula":"朿 + 朿","components":[{"radical":"朿","role":"形符","label":"朿"},{"radical":"朿","role":"形符","label":"朿"}]},"棚":{"formula":"木 + 朋","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"朋","role":"聲符","label":"讀音"}]},"棟":{"formula":"木 + 東","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"東","role":"聲符","label":"讀音"}]},"森":{"formula":"木 + 木 + 木","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"木","role":"部件","label":"樹木"},{"radical":"木","role":"部件","label":"樹木"}]},"棲":{"formula":"木 + 妻","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"妻","role":"聲符","label":"讀音"}]},"棵":{"formula":"木 + 果","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"果","role":"聲符","label":"讀音"}]},"植":{"formula":"木 + 直","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"直","role":"聲符","label":"讀音"}]},"椎":{"formula":"木 + 隹","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"隹","role":"聲符","label":"讀音"}]},"椹":{"formula":"木 + 甚","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"甚","role":"聲符","label":"讀音"}]},"楊":{"formula":"木 + 昜","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"昜","role":"聲符","label":"讀音"}]},"楚":{"formula":"林 + 疋","components":[{"radical":"林","role":"部件","label":"樹林"},{"radical":"疋","role":"部件","label":"量詞"}]},"楞":{"formula":"木 + 罒","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"罒","role":"聲符","label":"讀音"}]},"楠":{"formula":"木 + 南","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"南","role":"聲符","label":"讀音"}]},"楣":{"formula":"木 + 眉","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"眉","role":"聲符","label":"讀音"}]},"業":{"formula":"业 + 未","components":[{"radical":"业","role":"部件","label":"业"},{"radical":"未","role":"部件","label":"未來"}]},"極":{"formula":"木 + 亟","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"亟","role":"聲符","label":"讀音"}]},"楷":{"formula":"木 + 皆","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"皆","role":"部件","label":"皆"}]},"概":{"formula":"木 + 既","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"既","role":"聲符","label":"讀音"}]},"榜":{"formula":"木 + 旁","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"旁","role":"部件","label":"旁"}]},"榮":{"formula":"炏 + 冖 + 木","components":[{"radical":"炏","role":"部件","label":"炏"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"木","role":"部件","label":"樹木"}]},"構":{"formula":"木 + 冓","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"冓","role":"聲符","label":"讀音"}]},"槍":{"formula":"木 + 倉","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"倉","role":"聲符","label":"讀音"}]},"槓":{"formula":"木 + 貢","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"貢","role":"聲符","label":"讀音"}]},"槽":{"formula":"木 + 曹","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"曹","role":"聲符","label":"讀音"}]},"樁":{"formula":"木 + 舂","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"舂","role":"聲符","label":"讀音"}]},"樂":{"formula":"幺 + 白 + 幺 + 木","components":[{"radical":"幺","role":"部件","label":"細小"},{"radical":"白","role":"部件","label":"白色"},{"radical":"幺","role":"部件","label":"細小"},{"radical":"木","role":"部件","label":"樹木"}]},"樑":{"formula":"木 + 梁","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"梁","role":"部件","label":"梁"}]},"樓":{"formula":"木 + 婁","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"婁","role":"聲符","label":"讀音"}]},"標":{"formula":"木 + 票","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"票","role":"聲符","label":"讀音"}]},"樟":{"formula":"木 + 章","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"章","role":"聲符","label":"讀音"}]},"模":{"formula":"木 + 莫","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"莫","role":"聲符","label":"讀音"}]},"樣":{"formula":"木 + 羕","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"羕","role":"聲符","label":"讀音"}]},"樸":{"formula":"木 + 菐","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"菐","role":"聲符","label":"讀音"}]},"樹":{"formula":"木 + 尌","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"尌","role":"聲符","label":"讀音"}]},"橇":{"formula":"木 + 毳","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"毳","role":"聲符","label":"讀音"}]},"橋":{"formula":"木 + 喬","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"喬","role":"聲符","label":"讀音"}]},"橘":{"formula":"木 + 矞","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"矞","role":"聲符","label":"讀音"}]},"機":{"formula":"木 + 幾","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"幾","role":"部件","label":"幾"}]},"橡":{"formula":"木 + 象","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"象","role":"聲符","label":"讀音"}]},"橫":{"formula":"木 + 黃","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"黃","role":"聲符","label":"讀音"}]},"檢":{"formula":"木 + 僉","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"僉","role":"聲符","label":"讀音"}]},"檬":{"formula":"木 + 蒙","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"蒙","role":"聲符","label":"讀音"}]},"檸":{"formula":"木 + 寧","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"寧","role":"聲符","label":"讀音"}]},"檻":{"formula":"木 + 監","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"監","role":"聲符","label":"讀音"}]},"欄":{"formula":"木 + 闌","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"闌","role":"聲符","label":"讀音"}]},"權":{"formula":"木 + 雚","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"雚","role":"聲符","label":"讀音"}]},"欠":{"formula":"⺈ + 人","components":[{"radical":"⺈","role":"部件","label":"⺈"},{"radical":"人","role":"部件","label":"人"}]},"次":{"formula":"冫 + 欠","components":[{"radical":"冫","role":"部件","label":"冰旁"},{"radical":"欠","role":"部件","label":"呼吸"}]},"欣":{"formula":"斤 + 欠","components":[{"radical":"斤","role":"聲符","label":"讀音"},{"radical":"欠","role":"形符","label":"呼吸"}]},"欲":{"formula":"谷 + 欠","components":[{"radical":"谷","role":"聲符","label":"讀音"},{"radical":"欠","role":"形符","label":"呼吸"}]},"欵":{"formula":"匕 + 矢 + 欠","components":[{"radical":"匕","role":"部件","label":"湯匙"},{"radical":"矢","role":"部件","label":"箭"},{"radical":"欠","role":"部件","label":"呼吸"}]},"欸":{"formula":"矣 + 欠","components":[{"radical":"矣","role":"部件","label":"矣"},{"radical":"欠","role":"部件","label":"呼吸"}]},"欺":{"formula":"其 + 欠","components":[{"radical":"其","role":"聲符","label":"讀音"},{"radical":"欠","role":"形符","label":"呼吸"}]},"款":{"formula":"士 + 示 + 欠","components":[{"radical":"士","role":"部件","label":"未婚的男子"},{"radical":"示","role":"部件","label":"祭祀"},{"radical":"欠","role":"形符","label":"呼吸"}]},"歉":{"formula":"兼 + 欠","components":[{"radical":"兼","role":"聲符","label":"讀音"},{"radical":"欠","role":"形符","label":"呼吸"}]},"歌":{"formula":"哥 + 欠","components":[{"radical":"哥","role":"聲符","label":"讀音"},{"radical":"欠","role":"形符","label":"呼吸"}]},"歡":{"formula":"雚 + 欠","components":[{"radical":"雚","role":"聲符","label":"讀音"},{"radical":"欠","role":"形符","label":"呼吸"}]},"止":{"formula":"止","components":[{"radical":"止","role":"部件","label":"象形字（獨體）"}]},"正":{"formula":"一 + 止","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"止","role":"部件","label":"停止"}]},"此":{"formula":"止 + 匕","components":[{"radical":"止","role":"聲符","label":"讀音"},{"radical":"匕","role":"形符","label":"湯匙"}]},"步":{"formula":"止","components":[{"radical":"止","role":"部件","label":"停止"}]},"武":{"formula":"一 + 弋 + 止","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"弋","role":"部件","label":"射箭"},{"radical":"止","role":"部件","label":"停止"}]},"歪":{"formula":"不 + 正","components":[{"radical":"不","role":"部件","label":"不"},{"radical":"正","role":"部件","label":"正"}]},"歷":{"formula":"厤 + 止","components":[{"radical":"厤","role":"形符","label":"厤"},{"radical":"止","role":"聲符","label":"讀音"}]},"歸":{"formula":"㠯 + 止","components":[{"radical":"㠯","role":"聲符","label":"讀音"},{"radical":"止","role":"形符","label":"停止"}]},"歹":{"formula":"歹","components":[{"radical":"歹","role":"部件","label":"象形字（獨體）"}]},"死":{"formula":"歹 + 匕","components":[{"radical":"歹","role":"部件","label":"死亡"},{"radical":"匕","role":"部件","label":"湯匙"}]},"殃":{"formula":"歹 + 央","components":[{"radical":"歹","role":"形符","label":"死亡"},{"radical":"央","role":"聲符","label":"讀音"}]},"殆":{"formula":"歹 + 台","components":[{"radical":"歹","role":"形符","label":"死亡"},{"radical":"台","role":"聲符","label":"讀音"}]},"殊":{"formula":"歹 + 朱","components":[{"radical":"歹","role":"形符","label":"死亡"},{"radical":"朱","role":"聲符","label":"讀音"}]},"殖":{"formula":"歹 + 直","components":[{"radical":"歹","role":"形符","label":"死亡"},{"radical":"直","role":"聲符","label":"讀音"}]},"殘":{"formula":"歹 + 戔","components":[{"radical":"歹","role":"形符","label":"死亡"},{"radical":"戔","role":"聲符","label":"讀音"}]},"殲":{"formula":"歹 + 韱","components":[{"radical":"歹","role":"形符","label":"死亡"},{"radical":"韱","role":"聲符","label":"讀音"}]},"段":{"formula":"殳","components":[{"radical":"殳","role":"部件","label":"武器"}]},"殷":{"formula":"㐆 + 殳","components":[{"radical":"㐆","role":"部件","label":"㐆"},{"radical":"殳","role":"部件","label":"武器"}]},"殺":{"formula":"杀 + 殳","components":[{"radical":"杀","role":"聲符","label":"讀音"},{"radical":"殳","role":"形符","label":"武器"}]},"殿":{"formula":"尸 + 共 + 殳","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"共","role":"部件","label":"共同"},{"radical":"殳","role":"部件","label":"武器"}]},"毀":{"formula":"臼 + 土 + 殳","components":[{"radical":"臼","role":"部件","label":"中間下凹的舂"},{"radical":"土","role":"部件","label":"泥土"},{"radical":"殳","role":"部件","label":"武器"}]},"毅":{"formula":"豙 + 殳","components":[{"radical":"豙","role":"聲符","label":"讀音"},{"radical":"殳","role":"形符","label":"武器"}]},"母":{"formula":"丨 + 一 + 二 + 丶 + 丶 + 亅","components":[{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"一","role":"部件","label":"一"},{"radical":"二","role":"部件","label":"二"},{"radical":"丶","role":"部件","label":"點"},{"radical":"丶","role":"部件","label":"點"},{"radical":"亅","role":"部件","label":"倒掛的鉤"}]},"每":{"formula":"母","components":[{"radical":"母","role":"聲符","label":"讀音"}]},"毒":{"formula":"龶 + 母","components":[{"radical":"龶","role":"形符","label":"龶"},{"radical":"母","role":"聲符","label":"讀音"}]},"比":{"formula":"匕 + 匕","components":[{"radical":"匕","role":"部件","label":"湯匙"},{"radical":"匕","role":"部件","label":"湯匙"}]},"毛":{"formula":"丿 + 一 + 匕","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"一","role":"部件","label":"一"},{"radical":"匕","role":"部件","label":"湯匙"}]},"毫":{"formula":"毛","components":[{"radical":"毛","role":"形符","label":"毛髮"}]},"毯":{"formula":"毛 + 炎","components":[{"radical":"毛","role":"形符","label":"毛髮"},{"radical":"炎","role":"聲符","label":"讀音"}]},"氈":{"formula":"亶 + 毛","components":[{"radical":"亶","role":"聲符","label":"讀音"},{"radical":"毛","role":"形符","label":"毛髮"}]},"民":{"formula":"巳 + 戈","components":[{"radical":"巳","role":"部件","label":"巳"},{"radical":"戈","role":"部件","label":"武器"}]},"氛":{"formula":"气 + 分","components":[{"radical":"气","role":"形符","label":"氣體"},{"radical":"分","role":"聲符","label":"讀音"}]},"氣":{"formula":"气 + 米","components":[{"radical":"气","role":"部件","label":"氣體"},{"radical":"米","role":"部件","label":"米穀"}]},"氧":{"formula":"气 + 羊","components":[{"radical":"气","role":"形符","label":"氣體"},{"radical":"羊","role":"聲符","label":"讀音"}]},"氫":{"formula":"气 + 巠","components":[{"radical":"气","role":"形符","label":"氣體"},{"radical":"巠","role":"聲符","label":"讀音"}]},"水":{"formula":"水","components":[{"radical":"水","role":"部件","label":"象形字（獨體）"}]},"永":{"formula":"丶 + 一 + 水","components":[{"radical":"丶","role":"部件","label":"點"},{"radical":"一","role":"部件","label":"一"},{"radical":"水","role":"部件","label":"水"}]},"氾":{"formula":"氵 + 㔾","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"㔾","role":"聲符","label":"讀音"}]},"求":{"formula":"水 + 一 + 丶","components":[{"radical":"水","role":"部件","label":"水"},{"radical":"一","role":"部件","label":"一"},{"radical":"丶","role":"部件","label":"點"}]},"汗":{"formula":"氵 + 干","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"干","role":"聲符","label":"讀音"}]},"池":{"formula":"氵 + 也","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"也","role":"聲符","label":"讀音"}]},"污":{"formula":"氵 + 亏","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"亏","role":"聲符","label":"讀音"}]},"汰":{"formula":"氵 + 太","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"太","role":"聲符","label":"讀音"}]},"汲":{"formula":"氵 + 及","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"及","role":"聲符","label":"讀音"}]},"決":{"formula":"氵 + 夬","components":[{"radical":"氵","role":"聲符","label":"讀音"},{"radical":"夬","role":"形符","label":"夬"}]},"沁":{"formula":"氵 + 心","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"心","role":"聲符","label":"讀音"}]},"沃":{"formula":"氵 + 夭","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"夭","role":"聲符","label":"讀音"}]},"沈":{"formula":"氵 + 冘","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"冘","role":"聲符","label":"讀音"}]},"沉":{"formula":"氵 + 冗","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"冗","role":"部件","label":"冗"}]},"沒":{"formula":"氵 + 殳","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"殳","role":"聲符","label":"讀音"}]},"沙":{"formula":"氵 + 少","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"少","role":"聲符","label":"讀音"}]},"沫":{"formula":"氵 + 末","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"末","role":"聲符","label":"讀音"}]},"沮":{"formula":"氵 + 且","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"且","role":"聲符","label":"讀音"}]},"河":{"formula":"氵 + 可","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"可","role":"聲符","label":"讀音"}]},"沸":{"formula":"氵 + 弗","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"弗","role":"聲符","label":"讀音"}]},"油":{"formula":"氵 + 由","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"由","role":"聲符","label":"讀音"}]},"治":{"formula":"氵 + 台","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"台","role":"部件","label":"台"}]},"沼":{"formula":"氵 + 召","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"召","role":"聲符","label":"讀音"}]},"沿":{"formula":"氵 + 几 + 口","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"几","role":"部件","label":"小桌"},{"radical":"口","role":"部件","label":"嘴巴"}]},"泌":{"formula":"氵 + 必","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"必","role":"聲符","label":"讀音"}]},"法":{"formula":"氵 + 去","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"去","role":"部件","label":"去"}]},"泛":{"formula":"氵 + 乏","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"乏","role":"聲符","label":"讀音"}]},"泡":{"formula":"氵 + 包","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"包","role":"聲符","label":"讀音"}]},"波":{"formula":"氵 + 皮","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"皮","role":"聲符","label":"讀音"}]},"泣":{"formula":"氵 + 立","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"立","role":"聲符","label":"讀音"}]},"泥":{"formula":"氵 + 尼","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"尼","role":"聲符","label":"讀音"}]},"注":{"formula":"氵 + 主","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"主","role":"聲符","label":"讀音"}]},"泯":{"formula":"氵 + 民","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"民","role":"聲符","label":"讀音"}]},"泳":{"formula":"氵 + 永","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"永","role":"聲符","label":"讀音"}]},"洋":{"formula":"氵 + 羊","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"羊","role":"聲符","label":"讀音"}]},"洗":{"formula":"氵 + 先","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"先","role":"聲符","label":"讀音"}]},"洛":{"formula":"氵 + 各","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"各","role":"聲符","label":"讀音"}]},"洞":{"formula":"氵 + 同","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"同","role":"聲符","label":"讀音"}]},"津":{"formula":"氵 + 聿","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"聿","role":"聲符","label":"讀音"}]},"洪":{"formula":"氵 + 共","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"共","role":"部件","label":"共同"}]},"洲":{"formula":"氵 + 州","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"州","role":"部件","label":"州"}]},"活":{"formula":"氵 + 舌","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"舌","role":"聲符","label":"讀音"}]},"派":{"formula":"水 + 厂 + 氏","components":[{"radical":"水","role":"部件","label":"水"},{"radical":"厂","role":"部件","label":"山崖"},{"radical":"氏","role":"部件","label":"姓氏"}]},"流":{"formula":"氵 + 㐬","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"㐬","role":"聲符","label":"讀音"}]},"浩":{"formula":"氵 + 告","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"告","role":"聲符","label":"讀音"}]},"浪":{"formula":"氵 + 良","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"良","role":"聲符","label":"讀音"}]},"浮":{"formula":"氵 + 孚","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"孚","role":"聲符","label":"讀音"}]},"浴":{"formula":"氵 + 谷","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"谷","role":"聲符","label":"讀音"}]},"海":{"formula":"氵 + 每","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"每","role":"聲符","label":"讀音"}]},"浹":{"formula":"氵 + 夾","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"夾","role":"聲符","label":"讀音"}]},"消":{"formula":"氵 + 肖","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"肖","role":"聲符","label":"讀音"}]},"涉":{"formula":"氵 + 步","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"步","role":"部件","label":"步"}]},"涯":{"formula":"氵 + 厓","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"厓","role":"聲符","label":"讀音"}]},"液":{"formula":"氵 + 夜","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"夜","role":"聲符","label":"讀音"}]},"涵":{"formula":"氵 + 函","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"函","role":"聲符","label":"讀音"}]},"涼":{"formula":"氵 + 京","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"京","role":"聲符","label":"讀音"}]},"淆":{"formula":"氵 + 肴","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"肴","role":"聲符","label":"讀音"}]},"淋":{"formula":"氵 + 林","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"林","role":"聲符","label":"讀音"}]},"淒":{"formula":"氵 + 妻","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"妻","role":"聲符","label":"讀音"}]},"淘":{"formula":"氵 + 匋","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"匋","role":"聲符","label":"讀音"}]},"淚":{"formula":"氵 + 戾","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"戾","role":"聲符","label":"讀音"}]},"淡":{"formula":"氵 + 炎","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"炎","role":"聲符","label":"讀音"}]},"淨":{"formula":"氵 + 爭","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"爭","role":"聲符","label":"讀音"}]},"深":{"formula":"氵 + 罙","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"罙","role":"部件","label":"罙"}]},"淳":{"formula":"氵 + 享","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"享","role":"聲符","label":"讀音"}]},"淵":{"formula":"氵 + 片","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"片","role":"聲符","label":"讀音"}]},"混":{"formula":"氵 + 昆","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"昆","role":"聲符","label":"讀音"}]},"淹":{"formula":"氵 + 奄","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"奄","role":"聲符","label":"讀音"}]},"淺":{"formula":"氵 + 戔","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"戔","role":"聲符","label":"讀音"}]},"添":{"formula":"氵 + 忝","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"忝","role":"聲符","label":"讀音"}]},"清":{"formula":"氵 + 青","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"青","role":"聲符","label":"讀音"}]},"減":{"formula":"氵 + 咸","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"咸","role":"聲符","label":"讀音"}]},"渡":{"formula":"氵 + 度","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"度","role":"聲符","label":"讀音"}]},"渣":{"formula":"氵 + 查","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"查","role":"聲符","label":"讀音"}]},"測":{"formula":"氵 + 則","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"則","role":"聲符","label":"讀音"}]},"渭":{"formula":"氵 + 胃","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"胃","role":"聲符","label":"讀音"}]},"港":{"formula":"氵 + 巷","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"巷","role":"聲符","label":"讀音"}]},"渲":{"formula":"氵 + 宣","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"宣","role":"聲符","label":"讀音"}]},"渴":{"formula":"氵 + 曷","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"曷","role":"聲符","label":"讀音"}]},"游":{"formula":"氵 + 斿","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"斿","role":"部件","label":"斿"}]},"渺":{"formula":"氵 + 眇","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"眇","role":"聲符","label":"讀音"}]},"湊":{"formula":"氵 + 奏","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"奏","role":"聲符","label":"讀音"}]},"湖":{"formula":"氵 + 胡","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"胡","role":"聲符","label":"讀音"}]},"湛":{"formula":"氵 + 甚","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"甚","role":"部件","label":"甚"}]},"湧":{"formula":"氵 + 勈","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"勈","role":"聲符","label":"讀音"}]},"湯":{"formula":"氵 + 昜","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"昜","role":"聲符","label":"讀音"}]},"源":{"formula":"氵 + 原","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"原","role":"聲符","label":"讀音"}]},"準":{"formula":"淮 + 十","components":[{"radical":"淮","role":"部件","label":"淮"},{"radical":"十","role":"部件","label":"十"}]},"溝":{"formula":"氵 + 冓","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"冓","role":"聲符","label":"讀音"}]},"溪":{"formula":"氵 + 奚","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"奚","role":"聲符","label":"讀音"}]},"溫":{"formula":"氵 + 皿","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"皿","role":"聲符","label":"讀音"}]},"溶":{"formula":"氵 + 容","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"容","role":"聲符","label":"讀音"}]},"滅":{"formula":"氵 + 烕","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"烕","role":"部件","label":"烕"}]},"滋":{"formula":"氵 + 兹","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"兹","role":"聲符","label":"讀音"}]},"滑":{"formula":"氵 + 骨","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"骨","role":"聲符","label":"讀音"}]},"滯":{"formula":"氵 + 帶","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"帶","role":"聲符","label":"讀音"}]},"滴":{"formula":"氵 + 啇","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"啇","role":"聲符","label":"讀音"}]},"滷":{"formula":"氵 + 鹵","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"鹵","role":"部件","label":"鹵"}]},"滾":{"formula":"氵 + 袞","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"袞","role":"聲符","label":"讀音"}]},"滿":{"formula":"氵 + 㒼","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"㒼","role":"聲符","label":"讀音"}]},"漁":{"formula":"氵 + 魚","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"魚","role":"部件","label":"魚"}]},"漂":{"formula":"氵 + 票","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"票","role":"聲符","label":"讀音"}]},"漆":{"formula":"氵 + 桼","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"桼","role":"部件","label":"桼"}]},"漓":{"formula":"氵 + 离","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"离","role":"聲符","label":"讀音"}]},"演":{"formula":"氵 + 寅","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"寅","role":"聲符","label":"讀音"}]},"漠":{"formula":"氵 + 莫","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"莫","role":"聲符","label":"讀音"}]},"漢":{"formula":"氵 + 堇","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"堇","role":"部件","label":"堇"}]},"漫":{"formula":"氵 + 曼","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"曼","role":"聲符","label":"讀音"}]},"漸":{"formula":"氵 + 斬","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"斬","role":"聲符","label":"讀音"}]},"潔":{"formula":"氵 + 絜","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"絜","role":"聲符","label":"讀音"}]},"潛":{"formula":"氵 + 朁","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"朁","role":"聲符","label":"讀音"}]},"潤":{"formula":"氵 + 閏","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"閏","role":"聲符","label":"讀音"}]},"潦":{"formula":"氵 + 尞","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"尞","role":"聲符","label":"讀音"}]},"潭":{"formula":"氵 + 覃","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"覃","role":"聲符","label":"讀音"}]},"潮":{"formula":"氵 + 朝","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"朝","role":"聲符","label":"讀音"}]},"潰":{"formula":"氵 + 貴","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"貴","role":"聲符","label":"讀音"}]},"潸":{"formula":"氵 + 林 + 月","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"林","role":"部件","label":"樹林"},{"radical":"月","role":"部件","label":"月亮"}]},"澀":{"formula":"氵 + 歰","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"歰","role":"部件","label":"歰"}]},"澄":{"formula":"氵 + 登","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"登","role":"聲符","label":"讀音"}]},"澆":{"formula":"氵 + 堯","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"堯","role":"聲符","label":"讀音"}]},"澡":{"formula":"氵 + 喿","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"喿","role":"聲符","label":"讀音"}]},"澤":{"formula":"氵 + 睪","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"睪","role":"聲符","label":"讀音"}]},"澱":{"formula":"氵 + 殿","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"殿","role":"聲符","label":"讀音"}]},"澳":{"formula":"氵 + 奥","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"奥","role":"聲符","label":"讀音"}]},"激":{"formula":"氵 + 敫","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"敫","role":"聲符","label":"讀音"}]},"濃":{"formula":"氵 + 農","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"農","role":"聲符","label":"讀音"}]},"濕":{"formula":"氵 + 㬎","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"㬎","role":"聲符","label":"讀音"}]},"濟":{"formula":"氵 + 齊","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"齊","role":"聲符","label":"讀音"}]},"濫":{"formula":"氵 + 監","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"監","role":"聲符","label":"讀音"}]},"濱":{"formula":"氵 + 賓","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"賓","role":"聲符","label":"讀音"}]},"瀕":{"formula":"氵 + 頻","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"頻","role":"聲符","label":"讀音"}]},"瀚":{"formula":"氵 + 翰","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"翰","role":"聲符","label":"讀音"}]},"瀟":{"formula":"氵 + 蕭","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"蕭","role":"聲符","label":"讀音"}]},"灌":{"formula":"氵 + 雚","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"雚","role":"聲符","label":"讀音"}]},"灑":{"formula":"氵 + 麗","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"麗","role":"聲符","label":"讀音"}]},"灘":{"formula":"氵 + 難","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"難","role":"部件","label":"難"}]},"灣":{"formula":"氵 + 彎","components":[{"radical":"氵","role":"形符","label":"水旁"},{"radical":"彎","role":"聲符","label":"讀音"}]},"火":{"formula":"火","components":[{"radical":"火","role":"部件","label":"象形字（獨體）"}]},"灰":{"formula":"火","components":[{"radical":"火","role":"部件","label":"火"}]},"災":{"formula":"巛 + 火","components":[{"radical":"巛","role":"部件","label":"河流"},{"radical":"火","role":"部件","label":"火"}]},"炎":{"formula":"火 + 火","components":[{"radical":"火","role":"部件","label":"火"},{"radical":"火","role":"部件","label":"火"}]},"炒":{"formula":"火 + 少","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"少","role":"聲符","label":"讀音"}]},"炙":{"formula":"月 + 火","components":[{"radical":"月","role":"聲符","label":"讀音"},{"radical":"火","role":"形符","label":"火"}]},"炫":{"formula":"火 + 玄","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"玄","role":"聲符","label":"讀音"}]},"炮":{"formula":"火 + 包","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"包","role":"聲符","label":"讀音"}]},"炸":{"formula":"火 + 乍","components":[{"radical":"火","role":"部件","label":"火"},{"radical":"乍","role":"部件","label":"乍"}]},"為":{"formula":"爫 + 灬","components":[{"radical":"爫","role":"部件","label":"爫"},{"radical":"灬","role":"部件","label":"火底"}]},"烈":{"formula":"列 + 灬","components":[{"radical":"列","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"烏":{"formula":"烏","components":[{"radical":"烏","role":"部件","label":"象形字（獨體）"}]},"烘":{"formula":"火 + 共","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"共","role":"聲符","label":"讀音"}]},"烙":{"formula":"火 + 各","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"各","role":"聲符","label":"讀音"}]},"烤":{"formula":"火 + 考","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"考","role":"聲符","label":"讀音"}]},"烽":{"formula":"火 + 夆","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"夆","role":"聲符","label":"讀音"}]},"焉":{"formula":"正 + 灬","components":[{"radical":"正","role":"部件","label":"正"},{"radical":"灬","role":"部件","label":"火底"}]},"焚":{"formula":"林 + 火","components":[{"radical":"林","role":"部件","label":"樹林"},{"radical":"火","role":"部件","label":"火"}]},"焦":{"formula":"隹 + 灬","components":[{"radical":"隹","role":"部件","label":"鳥類"},{"radical":"灬","role":"部件","label":"火底"}]},"焰":{"formula":"火 + 臽","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"臽","role":"聲符","label":"讀音"}]},"然":{"formula":"肰 + 灬","components":[{"radical":"肰","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"煉":{"formula":"火 + 柬","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"柬","role":"聲符","label":"讀音"}]},"煎":{"formula":"前 + 灬","components":[{"radical":"前","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"煙":{"formula":"火 + 垔","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"垔","role":"聲符","label":"讀音"}]},"煞":{"formula":"刍 + 攴 + 火","components":[{"radical":"刍","role":"部件","label":"刍"},{"radical":"攴","role":"部件","label":"輕擊"},{"radical":"火","role":"部件","label":"火"}]},"煤":{"formula":"火 + 某","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"某","role":"聲符","label":"讀音"}]},"煥":{"formula":"火 + 奐","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"奐","role":"聲符","label":"讀音"}]},"照":{"formula":"昭 + 灬","components":[{"radical":"昭","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"煩":{"formula":"火 + 頁","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"頁","role":"聲符","label":"讀音"}]},"煮":{"formula":"者 + 灬","components":[{"radical":"者","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"煽":{"formula":"火 + 扇","components":[{"radical":"火","role":"部件","label":"火"},{"radical":"扇","role":"部件","label":"扇"}]},"熙":{"formula":"巸 + 灬","components":[{"radical":"巸","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"熟":{"formula":"孰 + 灬","components":[{"radical":"孰","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"熬":{"formula":"敖 + 灬","components":[{"radical":"敖","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"熱":{"formula":"埶 + 灬","components":[{"radical":"埶","role":"聲符","label":"讀音"},{"radical":"灬","role":"形符","label":"火底"}]},"燃":{"formula":"火 + 然","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"然","role":"聲符","label":"讀音"}]},"燈":{"formula":"火 + 登","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"登","role":"聲符","label":"讀音"}]},"燒":{"formula":"火 + 堯","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"堯","role":"聲符","label":"讀音"}]},"燥":{"formula":"火 + 喿","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"喿","role":"聲符","label":"讀音"}]},"燦":{"formula":"火 + 粲","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"粲","role":"聲符","label":"讀音"}]},"爆":{"formula":"火 + 暴","components":[{"radical":"火","role":"部件","label":"火"},{"radical":"暴","role":"部件","label":"暴"}]},"爍":{"formula":"火 + 樂","components":[{"radical":"火","role":"部件","label":"火"},{"radical":"樂","role":"部件","label":"樂"}]},"爛":{"formula":"火 + 闌","components":[{"radical":"火","role":"形符","label":"火"},{"radical":"闌","role":"聲符","label":"讀音"}]},"爪":{"formula":"爪","components":[{"radical":"爪","role":"部件","label":"象形字（獨體）"}]},"爬":{"formula":"爪 + 巴","components":[{"radical":"爪","role":"形符","label":"爪子"},{"radical":"巴","role":"聲符","label":"讀音"}]},"爭":{"formula":"爫 + 彐 + 亅","components":[{"radical":"爫","role":"部件","label":"爫"},{"radical":"彐","role":"部件","label":"豬頭"},{"radical":"亅","role":"部件","label":"倒掛的鉤"}]},"父":{"formula":"八 + 乂","components":[{"radical":"八","role":"部件","label":"八"},{"radical":"乂","role":"部件","label":"乂"}]},"爸":{"formula":"父 + 巴","components":[{"radical":"父","role":"形符","label":"父親"},{"radical":"巴","role":"聲符","label":"讀音"}]},"爺":{"formula":"父 + 耶","components":[{"radical":"父","role":"形符","label":"父親"},{"radical":"耶","role":"聲符","label":"讀音"}]},"爽":{"formula":"大 + 爻 + 爻","components":[{"radical":"大","role":"部件","label":"大"},{"radical":"爻","role":"部件","label":"(一)之讀音"},{"radical":"爻","role":"部件","label":"(一)之讀音"}]},"牆":{"formula":"爿 + 嗇","components":[{"radical":"爿","role":"形符","label":"床板"},{"radical":"嗇","role":"聲符","label":"讀音"}]},"片":{"formula":"片","components":[{"radical":"片","role":"部件","label":"象形字（獨體）"}]},"版":{"formula":"片 + 反","components":[{"radical":"片","role":"形符","label":"薄片"},{"radical":"反","role":"聲符","label":"讀音"}]},"牌":{"formula":"片 + 卑","components":[{"radical":"片","role":"形符","label":"薄片"},{"radical":"卑","role":"聲符","label":"讀音"}]},"牙":{"formula":"丅 + 一 + 亅 + 丿","components":[{"radical":"丅","role":"部件","label":"丅"},{"radical":"一","role":"部件","label":"一"},{"radical":"亅","role":"部件","label":"倒掛的鉤"},{"radical":"丿","role":"部件","label":"撇"}]},"牛":{"formula":"牛","components":[{"radical":"牛","role":"部件","label":"象形字（獨體）"}]},"牠":{"formula":"牛 + 也","components":[{"radical":"牛","role":"部件","label":"牛"},{"radical":"也","role":"部件","label":"也"}]},"牢":{"formula":"宀 + 牛","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"牛","role":"部件","label":"牛"}]},"物":{"formula":"牛 + 勿","components":[{"radical":"牛","role":"形符","label":"牛"},{"radical":"勿","role":"聲符","label":"讀音"}]},"牲":{"formula":"牛 + 生","components":[{"radical":"牛","role":"形符","label":"牛"},{"radical":"生","role":"聲符","label":"讀音"}]},"特":{"formula":"牛 + 寺","components":[{"radical":"牛","role":"形符","label":"牛"},{"radical":"寺","role":"聲符","label":"讀音"}]},"牽":{"formula":"玄 + 冖 + 牛","components":[{"radical":"玄","role":"部件","label":"黑色的"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"牛","role":"部件","label":"牛"}]},"犀":{"formula":"尾 + 牛","components":[{"radical":"尾","role":"部件","label":"尾"},{"radical":"牛","role":"部件","label":"牛"}]},"犧":{"formula":"牛 + 羲","components":[{"radical":"牛","role":"形符","label":"牛"},{"radical":"羲","role":"聲符","label":"讀音"}]},"犬":{"formula":"犬","components":[{"radical":"犬","role":"部件","label":"象形字（獨體）"}]},"犯":{"formula":"犭 + 㔾","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"㔾","role":"聲符","label":"讀音"}]},"狀":{"formula":"爿 + 犬","components":[{"radical":"爿","role":"聲符","label":"讀音"},{"radical":"犬","role":"形符","label":"狗"}]},"狂":{"formula":"犭 + 王","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"王","role":"聲符","label":"讀音"}]},"狄":{"formula":"犭 + 火","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"火","role":"聲符","label":"讀音"}]},"狐":{"formula":"犭 + 瓜","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"瓜","role":"聲符","label":"讀音"}]},"狗":{"formula":"犭 + 句","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"句","role":"聲符","label":"讀音"}]},"狠":{"formula":"犭 + 艮","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"艮","role":"聲符","label":"讀音"}]},"狩":{"formula":"犭 + 守","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"守","role":"聲符","label":"讀音"}]},"狹":{"formula":"犭 + 夾","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"夾","role":"聲符","label":"讀音"}]},"狼":{"formula":"犭 + 良","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"良","role":"聲符","label":"讀音"}]},"猛":{"formula":"犭 + 孟","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"孟","role":"聲符","label":"讀音"}]},"猜":{"formula":"犭 + 青","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"青","role":"聲符","label":"讀音"}]},"猩":{"formula":"犭 + 星","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"星","role":"聲符","label":"讀音"}]},"猴":{"formula":"犭 + 侯","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"侯","role":"聲符","label":"讀音"}]},"猶":{"formula":"犭 + 酋","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"酋","role":"聲符","label":"讀音"}]},"獅":{"formula":"犭 + 師","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"師","role":"聲符","label":"讀音"}]},"獎":{"formula":"將 + 犬","components":[{"radical":"將","role":"聲符","label":"讀音"},{"radical":"犬","role":"形符","label":"狗"}]},"獨":{"formula":"犭 + 蜀","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"蜀","role":"聲符","label":"讀音"}]},"獲":{"formula":"犭 + 蒦","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"蒦","role":"聲符","label":"讀音"}]},"獵":{"formula":"犭 + 巤","components":[{"radical":"犭","role":"形符","label":"犬旁"},{"radical":"巤","role":"聲符","label":"讀音"}]},"獸":{"formula":"嘼 + 犬","components":[{"radical":"嘼","role":"聲符","label":"讀音"},{"radical":"犬","role":"形符","label":"狗"}]},"獻":{"formula":"鬳 + 犬","components":[{"radical":"鬳","role":"聲符","label":"讀音"},{"radical":"犬","role":"形符","label":"狗"}]},"玄":{"formula":"亠 + 幺","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"幺","role":"部件","label":"細小"}]},"率":{"formula":"亠 + 幺 + 十","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"幺","role":"部件","label":"細小"},{"radical":"十","role":"部件","label":"十"}]},"玉":{"formula":"王 + 丶","components":[{"radical":"王","role":"部件","label":"王旁"},{"radical":"丶","role":"部件","label":"點"}]},"王":{"formula":"一 + 土","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"土","role":"部件","label":"泥土"}]},"玩":{"formula":"王 + 元","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"元","role":"聲符","label":"讀音"}]},"玫":{"formula":"王 + 攵","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"攵","role":"聲符","label":"讀音"}]},"玻":{"formula":"王 + 皮","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"皮","role":"聲符","label":"讀音"}]},"珈":{"formula":"王 + 加","components":[{"radical":"王","role":"部件","label":"王旁"},{"radical":"加","role":"部件","label":"加"}]},"珊":{"formula":"王 + 册","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"册","role":"聲符","label":"讀音"}]},"珍":{"formula":"王 + 彡","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"彡","role":"聲符","label":"讀音"}]},"珠":{"formula":"王 + 朱","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"朱","role":"聲符","label":"讀音"}]},"班":{"formula":"王 + 刂 + 王","components":[{"radical":"王","role":"部件","label":"王旁"},{"radical":"刂","role":"部件","label":"刀旁"},{"radical":"王","role":"部件","label":"王旁"}]},"現":{"formula":"王 + 見","components":[{"radical":"王","role":"部件","label":"王旁"},{"radical":"見","role":"部件","label":"看見"}]},"球":{"formula":"王 + 求","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"求","role":"聲符","label":"讀音"}]},"理":{"formula":"王 + 里","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"里","role":"聲符","label":"讀音"}]},"琢":{"formula":"王 + 豖","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"豖","role":"聲符","label":"讀音"}]},"琦":{"formula":"王 + 奇","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"奇","role":"聲符","label":"讀音"}]},"琪":{"formula":"王 + 其","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"其","role":"聲符","label":"讀音"}]},"琴":{"formula":"玨 + 今","components":[{"radical":"玨","role":"部件","label":"玨"},{"radical":"今","role":"部件","label":"今"}]},"瑕":{"formula":"王 + 叚","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"叚","role":"聲符","label":"讀音"}]},"瑚":{"formula":"王 + 胡","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"胡","role":"聲符","label":"讀音"}]},"瑜":{"formula":"王 + 俞","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"俞","role":"聲符","label":"讀音"}]},"瑟":{"formula":"玨 + 必","components":[{"radical":"玨","role":"形符","label":"玨"},{"radical":"必","role":"聲符","label":"讀音"}]},"瑪":{"formula":"王 + 馬","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"馬","role":"聲符","label":"讀音"}]},"瑰":{"formula":"王 + 鬼","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"鬼","role":"聲符","label":"讀音"}]},"璃":{"formula":"王 + 离","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"离","role":"聲符","label":"讀音"}]},"璞":{"formula":"王 + 菐","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"菐","role":"聲符","label":"讀音"}]},"環":{"formula":"王 + 睘","components":[{"radical":"王","role":"形符","label":"王旁"},{"radical":"睘","role":"聲符","label":"讀音"}]},"瓜":{"formula":"瓜","components":[{"radical":"瓜","role":"部件","label":"象形字（獨體）"}]},"瓦":{"formula":"瓦","components":[{"radical":"瓦","role":"部件","label":"象形字（獨體）"}]},"瓶":{"formula":"并 + 瓦","components":[{"radical":"并","role":"聲符","label":"讀音"},{"radical":"瓦","role":"形符","label":"陶瓦"}]},"甘":{"formula":"卄 + 二","components":[{"radical":"卄","role":"部件","label":"卄"},{"radical":"二","role":"部件","label":"二"}]},"甚":{"formula":"甘 + 匹","components":[{"radical":"甘","role":"部件","label":"甘甜"},{"radical":"匹","role":"部件","label":"匹"}]},"甜":{"formula":"舌 + 甘","components":[{"radical":"舌","role":"部件","label":"舌頭"},{"radical":"甘","role":"部件","label":"甘甜"}]},"生":{"formula":"一 + 土","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"土","role":"部件","label":"泥土"}]},"產":{"formula":"厂 + 生","components":[{"radical":"厂","role":"聲符","label":"讀音"},{"radical":"生","role":"形符","label":"生長"}]},"甦":{"formula":"更 + 生","components":[{"radical":"更","role":"部件","label":"更"},{"radical":"生","role":"部件","label":"生長"}]},"用":{"formula":"月 + 丨","components":[{"radical":"月","role":"部件","label":"月亮"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"甩":{"formula":"月 + 乚","components":[{"radical":"月","role":"部件","label":"月亮"},{"radical":"乚","role":"部件","label":"乚"}]},"甫":{"formula":"一 + 丶 + 用","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"丶","role":"部件","label":"點"},{"radical":"用","role":"部件","label":"使用"}]},"田":{"formula":"田","components":[{"radical":"田","role":"部件","label":"象形字（獨體）"}]},"由":{"formula":"田","components":[{"radical":"田","role":"部件","label":"田地"}]},"甲":{"formula":"囗 + 十","components":[{"radical":"囗","role":"部件","label":"口框"},{"radical":"十","role":"部件","label":"十"}]},"申":{"formula":"申","components":[{"radical":"申","role":"部件","label":"象形字（獨體）"}]},"男":{"formula":"田 + 力","components":[{"radical":"田","role":"部件","label":"田地"},{"radical":"力","role":"部件","label":"力量"}]},"界":{"formula":"田 + 介","components":[{"radical":"田","role":"形符","label":"田地"},{"radical":"介","role":"聲符","label":"讀音"}]},"畏":{"formula":"畏","components":[{"radical":"畏","role":"部件","label":"象形字（獨體）"}]},"畔":{"formula":"田 + 半","components":[{"radical":"田","role":"部件","label":"田地"},{"radical":"半","role":"部件","label":"半"}]},"留":{"formula":"卯 + 田","components":[{"radical":"卯","role":"部件","label":"卯"},{"radical":"田","role":"部件","label":"田地"}]},"畜":{"formula":"玄 + 田","components":[{"radical":"玄","role":"聲符","label":"讀音"},{"radical":"田","role":"形符","label":"田地"}]},"畢":{"formula":"卄 + 十","components":[{"radical":"卄","role":"聲符","label":"讀音"},{"radical":"十","role":"形符","label":"十"}]},"略":{"formula":"田 + 各","components":[{"radical":"田","role":"形符","label":"田地"},{"radical":"各","role":"聲符","label":"讀音"}]},"番":{"formula":"米 + 田","components":[{"radical":"米","role":"部件","label":"米穀"},{"radical":"田","role":"部件","label":"田地"}]},"畫":{"formula":"聿 + 田 + 一","components":[{"radical":"聿","role":"部件","label":"筆"},{"radical":"田","role":"部件","label":"田地"},{"radical":"一","role":"部件","label":"一"}]},"異":{"formula":"異","components":[{"radical":"異","role":"部件","label":"象形字（獨體）"}]},"當":{"formula":"尚 + 田","components":[{"radical":"尚","role":"聲符","label":"讀音"},{"radical":"田","role":"形符","label":"田地"}]},"疇":{"formula":"田 + 壽","components":[{"radical":"田","role":"形符","label":"田地"},{"radical":"壽","role":"聲符","label":"讀音"}]},"疊":{"formula":"畾 + 冝","components":[{"radical":"畾","role":"部件","label":"畾"},{"radical":"冝","role":"部件","label":"冝"}]},"疏":{"formula":"疋 + 㐬","components":[{"radical":"疋","role":"部件","label":"量詞"},{"radical":"㐬","role":"部件","label":"㐬"}]},"疑":{"formula":"匕 + 矢 + 疋","components":[{"radical":"匕","role":"部件","label":"湯匙"},{"radical":"矢","role":"部件","label":"箭"},{"radical":"疋","role":"部件","label":"量詞"}]},"疚":{"formula":"疒 + 久","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"久","role":"聲符","label":"讀音"}]},"疤":{"formula":"疒 + 巴","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"巴","role":"聲符","label":"讀音"}]},"疫":{"formula":"疒 + 殳","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"殳","role":"聲符","label":"讀音"}]},"疲":{"formula":"疒 + 皮","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"皮","role":"聲符","label":"讀音"}]},"疵":{"formula":"疒 + 此","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"此","role":"聲符","label":"讀音"}]},"疼":{"formula":"疒 + 冬","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"冬","role":"聲符","label":"讀音"}]},"疾":{"formula":"疒 + 矢","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"矢","role":"聲符","label":"讀音"}]},"病":{"formula":"疒 + 丙","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"丙","role":"聲符","label":"讀音"}]},"症":{"formula":"疒 + 正","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"正","role":"聲符","label":"讀音"}]},"痊":{"formula":"疒 + 全","components":[{"radical":"疒","role":"部件","label":"病旁"},{"radical":"全","role":"部件","label":"完全"}]},"痕":{"formula":"疒 + 艮","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"艮","role":"聲符","label":"讀音"}]},"痙":{"formula":"疒 + 巠","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"巠","role":"聲符","label":"讀音"}]},"痛":{"formula":"疒 + 甬","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"甬","role":"聲符","label":"讀音"}]},"痟":{"formula":"病 + 肖","components":[{"radical":"病","role":"部件","label":"病"},{"radical":"肖","role":"部件","label":"肖"}]},"痠":{"formula":"病 + 夋","components":[{"radical":"病","role":"部件","label":"病"},{"radical":"夋","role":"部件","label":"夋"}]},"痰":{"formula":"疒 + 炎","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"炎","role":"聲符","label":"讀音"}]},"痺":{"formula":"疒 + 卑","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"卑","role":"聲符","label":"讀音"}]},"瘁":{"formula":"疒 + 卒","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"卒","role":"聲符","label":"讀音"}]},"瘋":{"formula":"疒 + 風","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"風","role":"聲符","label":"讀音"}]},"瘓":{"formula":"疒 + 奐","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"奐","role":"聲符","label":"讀音"}]},"瘖":{"formula":"病 + 音","components":[{"radical":"病","role":"部件","label":"病"},{"radical":"音","role":"部件","label":"聲音"}]},"瘟":{"formula":"疒 + 昷","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"昷","role":"聲符","label":"讀音"}]},"瘦":{"formula":"疒 + 叟","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"叟","role":"聲符","label":"讀音"}]},"瘧":{"formula":"疒 + 虐","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"虐","role":"聲符","label":"讀音"}]},"療":{"formula":"疒 + 尞","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"尞","role":"聲符","label":"讀音"}]},"癇":{"formula":"疒 + 閒","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"閒","role":"聲符","label":"讀音"}]},"癌":{"formula":"疒 + 嵒","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"嵒","role":"聲符","label":"讀音"}]},"癒":{"formula":"疒 + 愈","components":[{"radical":"疒","role":"部件","label":"病旁"},{"radical":"愈","role":"部件","label":"愈"}]},"癢":{"formula":"疒 + 養","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"養","role":"聲符","label":"讀音"}]},"癮":{"formula":"疒 + 隱","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"隱","role":"聲符","label":"讀音"}]},"癱":{"formula":"疒 + 難","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"難","role":"聲符","label":"讀音"}]},"癲":{"formula":"疒 + 顛","components":[{"radical":"疒","role":"形符","label":"病旁"},{"radical":"顛","role":"聲符","label":"讀音"}]},"登":{"formula":"癶 + 豆","components":[{"radical":"癶","role":"形符","label":"足剌癶：兩個"},{"radical":"豆","role":"聲符","label":"讀音"}]},"發":{"formula":"癶 + 弓","components":[{"radical":"癶","role":"聲符","label":"讀音"},{"radical":"弓","role":"形符","label":"弓箭"}]},"白":{"formula":"日","components":[{"radical":"日","role":"部件","label":"太陽"}]},"百":{"formula":"一 + 白","components":[{"radical":"一","role":"形符","label":"一"},{"radical":"白","role":"聲符","label":"讀音"}]},"的":{"formula":"白 + 勺","components":[{"radical":"白","role":"部件","label":"白色"},{"radical":"勺","role":"部件","label":"勺"}]},"皆":{"formula":"比 + 白","components":[{"radical":"比","role":"部件","label":"比較"},{"radical":"白","role":"部件","label":"白色"}]},"皇":{"formula":"白 + 王","components":[{"radical":"白","role":"部件","label":"白色"},{"radical":"王","role":"部件","label":"王旁"}]},"皓":{"formula":"白 + 告","components":[{"radical":"白","role":"形符","label":"白色"},{"radical":"告","role":"聲符","label":"讀音"}]},"皮":{"formula":"皮","components":[{"radical":"皮","role":"部件","label":"象形字（獨體）"}]},"皺":{"formula":"芻 + 皮","components":[{"radical":"芻","role":"聲符","label":"讀音"},{"radical":"皮","role":"形符","label":"皮膚"}]},"盃":{"formula":"不 + 皿","components":[{"radical":"不","role":"聲符","label":"讀音"},{"radical":"皿","role":"形符","label":"器皿"}]},"盈":{"formula":"皿","components":[{"radical":"皿","role":"形符","label":"器皿"}]},"益":{"formula":"水 + 皿","components":[{"radical":"水","role":"部件","label":"水"},{"radical":"皿","role":"部件","label":"器皿"}]},"盛":{"formula":"成 + 皿","components":[{"radical":"成","role":"聲符","label":"讀音"},{"radical":"皿","role":"形符","label":"器皿"}]},"盟":{"formula":"明 + 皿","components":[{"radical":"明","role":"聲符","label":"讀音"},{"radical":"皿","role":"形符","label":"器皿"}]},"盡":{"formula":"聿 + 灬 + 皿","components":[{"radical":"聿","role":"部件","label":"筆"},{"radical":"灬","role":"部件","label":"火底"},{"radical":"皿","role":"部件","label":"器皿"}]},"監":{"formula":"臣 + 皿","components":[{"radical":"臣","role":"形符","label":"臣子"},{"radical":"皿","role":"聲符","label":"讀音"}]},"盤":{"formula":"般 + 皿","components":[{"radical":"般","role":"聲符","label":"讀音"},{"radical":"皿","role":"形符","label":"器皿"}]},"盧":{"formula":"虍","components":[{"radical":"虍","role":"聲符","label":"讀音"}]},"盪":{"formula":"湯 + 皿","components":[{"radical":"湯","role":"部件","label":"湯"},{"radical":"皿","role":"部件","label":"器皿"}]},"目":{"formula":"目","components":[{"radical":"目","role":"部件","label":"象形字（獨體）"}]},"盯":{"formula":"目 + 丁","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"丁","role":"聲符","label":"讀音"}]},"盲":{"formula":"亡 + 目","components":[{"radical":"亡","role":"部件","label":"亡"},{"radical":"目","role":"部件","label":"眼睛"}]},"直":{"formula":"十 + 目 + 一","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"目","role":"部件","label":"眼睛"},{"radical":"一","role":"部件","label":"一"}]},"相":{"formula":"木 + 目","components":[{"radical":"木","role":"部件","label":"樹木"},{"radical":"目","role":"部件","label":"眼睛"}]},"盼":{"formula":"目 + 分","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"分","role":"聲符","label":"讀音"}]},"盾":{"formula":"厂 + 十 + 目","components":[{"radical":"厂","role":"部件","label":"山崖"},{"radical":"十","role":"部件","label":"十"},{"radical":"目","role":"部件","label":"眼睛"}]},"省":{"formula":"少 + 目","components":[{"radical":"少","role":"聲符","label":"讀音"},{"radical":"目","role":"形符","label":"眼睛"}]},"眉":{"formula":"尸 + 目","components":[{"radical":"尸","role":"部件","label":"身體"},{"radical":"目","role":"部件","label":"眼睛"}]},"看":{"formula":"手 + 目","components":[{"radical":"手","role":"部件","label":"手"},{"radical":"目","role":"部件","label":"眼睛"}]},"真":{"formula":"直 + 几","components":[{"radical":"直","role":"部件","label":"直"},{"radical":"几","role":"部件","label":"小桌"}]},"眠":{"formula":"目 + 民","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"民","role":"聲符","label":"讀音"}]},"眶":{"formula":"目 + 匡","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"匡","role":"聲符","label":"讀音"}]},"眼":{"formula":"目 + 艮","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"艮","role":"聲符","label":"讀音"}]},"眾":{"formula":"罒 + 众","components":[{"radical":"罒","role":"聲符","label":"讀音"},{"radical":"众","role":"形符","label":"众"}]},"睛":{"formula":"目 + 青","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"青","role":"聲符","label":"讀音"}]},"睜":{"formula":"目 + 爭","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"爭","role":"聲符","label":"讀音"}]},"睞":{"formula":"目 + 來","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"來","role":"聲符","label":"讀音"}]},"睡":{"formula":"目 + 垂","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"垂","role":"聲符","label":"讀音"}]},"睭":{"formula":"目 + 周","components":[{"radical":"目","role":"部件","label":"眼睛"},{"radical":"周","role":"部件","label":"周"}]},"睹":{"formula":"目 + 者","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"者","role":"聲符","label":"讀音"}]},"睽":{"formula":"目 + 癸","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"癸","role":"聲符","label":"讀音"}]},"瞄":{"formula":"目 + 苗","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"苗","role":"聲符","label":"讀音"}]},"瞇":{"formula":"目 + 迷","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"迷","role":"聲符","label":"讀音"}]},"瞌":{"formula":"目 + 盍","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"盍","role":"聲符","label":"讀音"}]},"瞞":{"formula":"目 + 㒼","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"㒼","role":"聲符","label":"讀音"}]},"瞠":{"formula":"目 + 堂","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"堂","role":"聲符","label":"讀音"}]},"瞥":{"formula":"敝 + 目","components":[{"radical":"敝","role":"聲符","label":"讀音"},{"radical":"目","role":"形符","label":"眼睛"}]},"瞪":{"formula":"目 + 登","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"登","role":"聲符","label":"讀音"}]},"瞬":{"formula":"目 + 舜","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"舜","role":"聲符","label":"讀音"}]},"瞭":{"formula":"目 + 尞","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"尞","role":"聲符","label":"讀音"}]},"瞰":{"formula":"目 + 敢","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"敢","role":"聲符","label":"讀音"}]},"矗":{"formula":"直 + 直 + 直","components":[{"radical":"直","role":"部件","label":"直"},{"radical":"直","role":"部件","label":"直"},{"radical":"直","role":"部件","label":"直"}]},"矚":{"formula":"目 + 屬","components":[{"radical":"目","role":"形符","label":"眼睛"},{"radical":"屬","role":"聲符","label":"讀音"}]},"矛":{"formula":"矛","components":[{"radical":"矛","role":"部件","label":"象形字（獨體）"}]},"矢":{"formula":"矢","components":[{"radical":"矢","role":"部件","label":"象形字（獨體）"}]},"矣":{"formula":"厶 + 矢","components":[{"radical":"厶","role":"部件","label":"私"},{"radical":"矢","role":"部件","label":"箭"}]},"知":{"formula":"矢 + 口","components":[{"radical":"矢","role":"聲符","label":"讀音"},{"radical":"口","role":"形符","label":"嘴巴"}]},"短":{"formula":"矢 + 豆","components":[{"radical":"矢","role":"形符","label":"箭"},{"radical":"豆","role":"聲符","label":"讀音"}]},"矮":{"formula":"矢 + 委","components":[{"radical":"矢","role":"形符","label":"箭"},{"radical":"委","role":"聲符","label":"讀音"}]},"矯":{"formula":"矢 + 喬","components":[{"radical":"矢","role":"形符","label":"箭"},{"radical":"喬","role":"聲符","label":"讀音"}]},"石":{"formula":"厂 + 口","components":[{"radical":"厂","role":"部件","label":"山崖"},{"radical":"口","role":"部件","label":"嘴巴"}]},"砍":{"formula":"石 + 欠","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"欠","role":"聲符","label":"讀音"}]},"研":{"formula":"石 + 开","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"开","role":"聲符","label":"讀音"}]},"砲":{"formula":"石 + 包","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"包","role":"聲符","label":"讀音"}]},"破":{"formula":"石 + 皮","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"皮","role":"聲符","label":"讀音"}]},"砸":{"formula":"石 + 匝","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"匝","role":"聲符","label":"讀音"}]},"硬":{"formula":"石 + 更","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"更","role":"聲符","label":"讀音"}]},"硯":{"formula":"石 + 見","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"見","role":"聲符","label":"讀音"}]},"碌":{"formula":"石 + 录","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"录","role":"聲符","label":"讀音"}]},"碎":{"formula":"石 + 卒","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"卒","role":"聲符","label":"讀音"}]},"碑":{"formula":"石 + 卑","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"卑","role":"聲符","label":"讀音"}]},"碗":{"formula":"石 + 宛","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"宛","role":"聲符","label":"讀音"}]},"碟":{"formula":"石 + 枼","components":[{"radical":"石","role":"部件","label":"石頭"},{"radical":"枼","role":"部件","label":"枼"}]},"碧":{"formula":"珀 + 石","components":[{"radical":"珀","role":"部件","label":"珀"},{"radical":"石","role":"部件","label":"石頭"}]},"碩":{"formula":"石 + 頁","components":[{"radical":"石","role":"部件","label":"石頭"},{"radical":"頁","role":"部件","label":"頭部"}]},"碰":{"formula":"石 + 並","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"並","role":"聲符","label":"讀音"}]},"碳":{"formula":"石 + 炭","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"炭","role":"聲符","label":"讀音"}]},"確":{"formula":"石 + 隺","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"隺","role":"聲符","label":"讀音"}]},"碼":{"formula":"石 + 馬","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"馬","role":"聲符","label":"讀音"}]},"磁":{"formula":"石 + 兹","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"兹","role":"聲符","label":"讀音"}]},"磨":{"formula":"麻 + 石","components":[{"radical":"麻","role":"聲符","label":"讀音"},{"radical":"石","role":"形符","label":"石頭"}]},"磷":{"formula":"石 + 粦","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"粦","role":"聲符","label":"讀音"}]},"礎":{"formula":"石 + 楚","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"楚","role":"聲符","label":"讀音"}]},"礙":{"formula":"石 + 疑","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"疑","role":"聲符","label":"讀音"}]},"礦":{"formula":"石 + 廣","components":[{"radical":"石","role":"形符","label":"石頭"},{"radical":"廣","role":"聲符","label":"讀音"}]},"示":{"formula":"示","components":[{"radical":"示","role":"部件","label":"象形字（獨體）"}]},"社":{"formula":"礻 + 土","components":[{"radical":"礻","role":"部件","label":"示旁"},{"radical":"土","role":"部件","label":"泥土"}]},"祂":{"formula":"示 + 也","components":[{"radical":"示","role":"部件","label":"祭祀"},{"radical":"也","role":"部件","label":"也"}]},"祇":{"formula":"礻 + 氏","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"氏","role":"聲符","label":"讀音"}]},"祈":{"formula":"礻 + 斤","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"斤","role":"聲符","label":"讀音"}]},"祕":{"formula":"礻 + 必","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"必","role":"聲符","label":"讀音"}]},"祖":{"formula":"礻 + 且","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"且","role":"聲符","label":"讀音"}]},"祝":{"formula":"礻 + 兄","components":[{"radical":"礻","role":"部件","label":"示旁"},{"radical":"兄","role":"部件","label":"兄長"}]},"神":{"formula":"礻 + 申","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"申","role":"聲符","label":"讀音"}]},"祥":{"formula":"礻 + 羊","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"羊","role":"聲符","label":"讀音"}]},"票":{"formula":"覀 + 示","components":[{"radical":"覀","role":"部件","label":"覀"},{"radical":"示","role":"部件","label":"祭祀"}]},"禁":{"formula":"林 + 示","components":[{"radical":"林","role":"聲符","label":"讀音"},{"radical":"示","role":"形符","label":"祭祀"}]},"禍":{"formula":"礻 + 咼","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"咼","role":"聲符","label":"讀音"}]},"福":{"formula":"礻 + 畐","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"畐","role":"聲符","label":"讀音"}]},"禦":{"formula":"御 + 示","components":[{"radical":"御","role":"聲符","label":"讀音"},{"radical":"示","role":"形符","label":"祭祀"}]},"禮":{"formula":"礻 + 豊","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"豊","role":"聲符","label":"讀音"}]},"禱":{"formula":"礻 + 壽","components":[{"radical":"礻","role":"形符","label":"示旁"},{"radical":"壽","role":"聲符","label":"讀音"}]},"禾":{"formula":"禾","components":[{"radical":"禾","role":"部件","label":"象形字（獨體）"}]},"禿":{"formula":"禾 + 儿","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"儿","role":"部件","label":"同「人」"}]},"秀":{"formula":"禾 + 乃","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"乃","role":"部件","label":"乃"}]},"私":{"formula":"禾 + 厶","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"厶","role":"部件","label":"私"}]},"秋":{"formula":"禾 + 火","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"火","role":"部件","label":"火"}]},"科":{"formula":"禾 + 斗","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"斗","role":"部件","label":"量器"}]},"秒":{"formula":"禾 + 少","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"少","role":"聲符","label":"讀音"}]},"秘":{"formula":"禾 + 必","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"必","role":"聲符","label":"讀音"}]},"租":{"formula":"禾 + 且","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"且","role":"部件","label":"且"}]},"秩":{"formula":"禾 + 失","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"失","role":"聲符","label":"讀音"}]},"移":{"formula":"禾 + 多","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"多","role":"部件","label":"多"}]},"稀":{"formula":"禾 + 希","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"希","role":"聲符","label":"讀音"}]},"程":{"formula":"禾 + 呈","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"呈","role":"聲符","label":"讀音"}]},"稍":{"formula":"禾 + 肖","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"肖","role":"部件","label":"肖"}]},"稞":{"formula":"禾 + 果","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"果","role":"部件","label":"果"}]},"稟":{"formula":"亠 + 回 + 禾","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"回","role":"部件","label":"回"},{"radical":"禾","role":"部件","label":"穀物"}]},"稠":{"formula":"禾 + 周","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"周","role":"聲符","label":"讀音"}]},"種":{"formula":"禾 + 重","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"重","role":"聲符","label":"讀音"}]},"稱":{"formula":"禾 + 爯","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"爯","role":"部件","label":"爯"}]},"稻":{"formula":"禾 + 舀","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"舀","role":"聲符","label":"讀音"}]},"稼":{"formula":"禾 + 家","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"家","role":"聲符","label":"讀音"}]},"稽":{"formula":"禾 + 旨","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"旨","role":"聲符","label":"讀音"}]},"稿":{"formula":"禾 + 高","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"高","role":"聲符","label":"讀音"}]},"積":{"formula":"禾 + 責","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"責","role":"聲符","label":"讀音"}]},"穎":{"formula":"禾 + 匕 + 頁","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"匕","role":"部件","label":"匕首"},{"radical":"頁","role":"聲符","label":"頭部"}]},"穗":{"formula":"禾 + 惠","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"惠","role":"聲符","label":"讀音"}]},"穩":{"formula":"禾 + 㥯","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"㥯","role":"聲符","label":"讀音"}]},"穫":{"formula":"禾 + 蒦","components":[{"radical":"禾","role":"形符","label":"穀物"},{"radical":"蒦","role":"聲符","label":"讀音"}]},"穴":{"formula":"穴","components":[{"radical":"穴","role":"部件","label":"象形字（獨體）"}]},"究":{"formula":"穴 + 九","components":[{"radical":"穴","role":"形符","label":"洞穴"},{"radical":"九","role":"聲符","label":"讀音"}]},"空":{"formula":"穴 + 工","components":[{"radical":"穴","role":"形符","label":"洞穴"},{"radical":"工","role":"聲符","label":"讀音"}]},"穿":{"formula":"穴 + 牙","components":[{"radical":"穴","role":"聲符","label":"讀音"},{"radical":"牙","role":"形符","label":"牙齒"}]},"突":{"formula":"穴 + 犬","components":[{"radical":"穴","role":"部件","label":"洞穴"},{"radical":"犬","role":"部件","label":"狗"}]},"窄":{"formula":"穴 + 乍","components":[{"radical":"穴","role":"形符","label":"洞穴"},{"radical":"乍","role":"聲符","label":"讀音"}]},"窗":{"formula":"穴 + 囱","components":[{"radical":"穴","role":"形符","label":"洞穴"},{"radical":"囱","role":"聲符","label":"讀音"}]},"窘":{"formula":"穴 + 君","components":[{"radical":"穴","role":"形符","label":"洞穴"},{"radical":"君","role":"聲符","label":"讀音"}]},"窩":{"formula":"穴 + 咼","components":[{"radical":"穴","role":"形符","label":"洞穴"},{"radical":"咼","role":"聲符","label":"讀音"}]},"窮":{"formula":"穴 + 躬","components":[{"radical":"穴","role":"形符","label":"洞穴"},{"radical":"躬","role":"聲符","label":"讀音"}]},"窺":{"formula":"穴 + 規","components":[{"radical":"穴","role":"形符","label":"洞穴"},{"radical":"規","role":"聲符","label":"讀音"}]},"竄":{"formula":"穴 + 鼠","components":[{"radical":"穴","role":"部件","label":"洞穴"},{"radical":"鼠","role":"部件","label":"老鼠"}]},"竇":{"formula":"穴 + 賣","components":[{"radical":"穴","role":"部件","label":"洞穴"},{"radical":"賣","role":"部件","label":"賣"}]},"竊":{"formula":"穴 + 米 + 禼","components":[{"radical":"穴","role":"部件","label":"洞穴"},{"radical":"米","role":"部件","label":"米穀"},{"radical":"禼","role":"部件","label":"禼"}]},"立":{"formula":"立","components":[{"radical":"立","role":"部件","label":"象形字（獨體）"}]},"站":{"formula":"立 + 占","components":[{"radical":"立","role":"形符","label":"站立"},{"radical":"占","role":"聲符","label":"讀音"}]},"竟":{"formula":"音 + 儿","components":[{"radical":"音","role":"部件","label":"聲音"},{"radical":"儿","role":"部件","label":"同「人」"}]},"章":{"formula":"音 + 十","components":[{"radical":"音","role":"部件","label":"聲音"},{"radical":"十","role":"部件","label":"十"}]},"童":{"formula":"立 + 里","components":[{"radical":"立","role":"部件","label":"站立"},{"radical":"里","role":"部件","label":"距離"}]},"端":{"formula":"立 + 耑","components":[{"radical":"立","role":"形符","label":"站立"},{"radical":"耑","role":"聲符","label":"讀音"}]},"競":{"formula":"竞 + 竞","components":[{"radical":"竞","role":"部件","label":"竞"},{"radical":"竞","role":"部件","label":"竞"}]},"竹":{"formula":"竹","components":[{"radical":"竹","role":"部件","label":"象形字（獨體）"}]},"竿":{"formula":"⺮ + 干","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"干","role":"聲符","label":"讀音"}]},"笆":{"formula":"⺮ + 巴","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"巴","role":"聲符","label":"讀音"}]},"笑":{"formula":"⺮ + 夭","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"夭","role":"部件","label":"夭"}]},"符":{"formula":"⺮ + 付","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"付","role":"聲符","label":"讀音"}]},"笨":{"formula":"⺮ + 本","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"本","role":"聲符","label":"讀音"}]},"第":{"formula":"⺮ + 弟","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"弟","role":"部件","label":"弟"}]},"筆":{"formula":"⺮ + 聿","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"聿","role":"部件","label":"筆"}]},"等":{"formula":"⺮ + 寺","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"寺","role":"部件","label":"寺"}]},"筋":{"formula":"⺮ + 肋","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"肋","role":"部件","label":"肋"}]},"答":{"formula":"竹 + 合","components":[{"radical":"竹","role":"部件","label":"竹子"},{"radical":"合","role":"部件","label":"合"}]},"策":{"formula":"⺮ + 朿","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"朿","role":"聲符","label":"讀音"}]},"箍":{"formula":"⺮ + 㧜","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"㧜","role":"部件","label":"㧜"}]},"箔":{"formula":"⺮ + 泊","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"泊","role":"聲符","label":"讀音"}]},"算":{"formula":"⺮ + 具","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"具","role":"部件","label":"工具"}]},"管":{"formula":"⺮ + 官","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"官","role":"聲符","label":"讀音"}]},"箭":{"formula":"⺮ + 前","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"前","role":"聲符","label":"讀音"}]},"箱":{"formula":"⺮ + 相","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"相","role":"聲符","label":"讀音"}]},"節":{"formula":"⺮ + 即","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"即","role":"聲符","label":"讀音"}]},"範":{"formula":"⺮ + 㔾","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"㔾","role":"聲符","label":"讀音"}]},"篇":{"formula":"⺮ + 扁","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"扁","role":"部件","label":"扁"}]},"築":{"formula":"⺮ + 巩 + 木","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"巩","role":"部件","label":"巩"},{"radical":"木","role":"部件","label":"樹木"}]},"篩":{"formula":"⺮ + 師","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"師","role":"聲符","label":"讀音"}]},"簏":{"formula":"⺮ + 鹿","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"鹿","role":"聲符","label":"讀音"}]},"簡":{"formula":"⺮ + 間","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"間","role":"聲符","label":"讀音"}]},"簽":{"formula":"⺮ + 僉","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"僉","role":"聲符","label":"讀音"}]},"簾":{"formula":"⺮ + 廉","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"廉","role":"部件","label":"廉"}]},"籃":{"formula":"⺮ + 監","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"監","role":"聲符","label":"讀音"}]},"籌":{"formula":"⺮ + 壽","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"壽","role":"聲符","label":"讀音"}]},"籍":{"formula":"⺮ + 耤","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"耤","role":"聲符","label":"讀音"}]},"籠":{"formula":"⺮ + 龍","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"龍","role":"聲符","label":"讀音"}]},"籬":{"formula":"⺮ + 離","components":[{"radical":"⺮","role":"形符","label":"竹頭"},{"radical":"離","role":"聲符","label":"讀音"}]},"籲":{"formula":"⺮ + 龥","components":[{"radical":"⺮","role":"部件","label":"竹頭"},{"radical":"龥","role":"部件","label":"龥"}]},"米":{"formula":"米","components":[{"radical":"米","role":"部件","label":"象形字（獨體）"}]},"粉":{"formula":"米 + 分","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"分","role":"聲符","label":"讀音"}]},"粒":{"formula":"米 + 立","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"立","role":"聲符","label":"讀音"}]},"粗":{"formula":"米 + 且","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"且","role":"聲符","label":"讀音"}]},"粟":{"formula":"覀 + 米","components":[{"radical":"覀","role":"部件","label":"覀"},{"radical":"米","role":"部件","label":"米穀"}]},"粥":{"formula":"弓 + 米 + 弓","components":[{"radical":"弓","role":"部件","label":"弓箭"},{"radical":"米","role":"部件","label":"米穀"},{"radical":"弓","role":"部件","label":"弓箭"}]},"精":{"formula":"米 + 青","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"青","role":"聲符","label":"讀音"}]},"糊":{"formula":"米 + 胡","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"胡","role":"聲符","label":"讀音"}]},"糕":{"formula":"米 + 羔","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"羔","role":"聲符","label":"讀音"}]},"糖":{"formula":"米 + 唐","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"唐","role":"聲符","label":"讀音"}]},"糞":{"formula":"米 + 異","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"異","role":"聲符","label":"讀音"}]},"糟":{"formula":"米 + 曹","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"曹","role":"聲符","label":"讀音"}]},"糧":{"formula":"米 + 量","components":[{"radical":"米","role":"形符","label":"米穀"},{"radical":"量","role":"聲符","label":"讀音"}]},"系":{"formula":"糸","components":[{"radical":"糸","role":"形符","label":"絲線"}]},"糾":{"formula":"糹 + 丩","components":[{"radical":"糹","role":"部件","label":"絲線"},{"radical":"丩","role":"部件","label":"丩"}]},"紀":{"formula":"糹 + 己","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"己","role":"聲符","label":"讀音"}]},"約":{"formula":"糹 + 勺","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"勺","role":"聲符","label":"讀音"}]},"紅":{"formula":"糹 + 工","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"工","role":"聲符","label":"讀音"}]},"紋":{"formula":"糹 + 文","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"文","role":"聲符","label":"讀音"}]},"納":{"formula":"糹 + 内","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"内","role":"聲符","label":"讀音"}]},"紐":{"formula":"糹 + 丑","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"丑","role":"聲符","label":"讀音"}]},"紓":{"formula":"糹 + 予","components":[{"radical":"糹","role":"部件","label":"絲線"},{"radical":"予","role":"部件","label":"予"}]},"純":{"formula":"糹 + 屯","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"屯","role":"聲符","label":"讀音"}]},"紙":{"formula":"糹 + 氏","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"氏","role":"聲符","label":"讀音"}]},"級":{"formula":"糹 + 及","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"及","role":"聲符","label":"讀音"}]},"紛":{"formula":"糹 + 分","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"分","role":"聲符","label":"讀音"}]},"紜":{"formula":"糹 + 云","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"云","role":"聲符","label":"讀音"}]},"素":{"formula":"龶 + 糸","components":[{"radical":"龶","role":"部件","label":"龶"},{"radical":"糸","role":"部件","label":"絲線"}]},"索":{"formula":"十 + 冖 + 糸","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"糸","role":"部件","label":"絲線"}]},"紫":{"formula":"此 + 糸","components":[{"radical":"此","role":"聲符","label":"讀音"},{"radical":"糸","role":"形符","label":"絲線"}]},"紮":{"formula":"札 + 糸","components":[{"radical":"札","role":"聲符","label":"讀音"},{"radical":"糸","role":"形符","label":"絲線"}]},"累":{"formula":"田 + 糸","components":[{"radical":"田","role":"部件","label":"田地"},{"radical":"糸","role":"部件","label":"絲線"}]},"細":{"formula":"糹 + 田","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"田","role":"聲符","label":"讀音"}]},"紹":{"formula":"糹 + 召","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"召","role":"聲符","label":"讀音"}]},"終":{"formula":"糹 + 冬","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"冬","role":"聲符","label":"讀音"}]},"組":{"formula":"糹 + 且","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"且","role":"聲符","label":"讀音"}]},"絆":{"formula":"糹 + 半","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"半","role":"聲符","label":"讀音"}]},"結":{"formula":"糹 + 吉","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"吉","role":"聲符","label":"讀音"}]},"絕":{"formula":"糹 + 刀 + 巴","components":[{"radical":"糹","role":"部件","label":"絲線"},{"radical":"刀","role":"部件","label":"刀"},{"radical":"巴","role":"部件","label":"巴"}]},"絡":{"formula":"糹 + 各","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"各","role":"聲符","label":"讀音"}]},"給":{"formula":"糹 + 合","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"合","role":"聲符","label":"讀音"}]},"統":{"formula":"糹 + 充","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"充","role":"聲符","label":"讀音"}]},"絲":{"formula":"糹 + 糸","components":[{"radical":"糹","role":"部件","label":"絲線"},{"radical":"糸","role":"部件","label":"絲線"}]},"綁":{"formula":"糹 + 邦","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"邦","role":"聲符","label":"讀音"}]},"經":{"formula":"糹 + 巠","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"巠","role":"聲符","label":"讀音"}]},"綜":{"formula":"糹 + 宗","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"宗","role":"聲符","label":"讀音"}]},"綠":{"formula":"糹 + 彔","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"彔","role":"聲符","label":"讀音"}]},"綢":{"formula":"糹 + 周","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"周","role":"聲符","label":"讀音"}]},"維":{"formula":"糹 + 隹","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"隹","role":"聲符","label":"讀音"}]},"綱":{"formula":"糹 + 岡","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"岡","role":"聲符","label":"讀音"}]},"網":{"formula":"糹 + 罔","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"罔","role":"聲符","label":"讀音"}]},"綻":{"formula":"糹 + 定","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"定","role":"聲符","label":"讀音"}]},"綿":{"formula":"糹 + 帛","components":[{"radical":"糹","role":"部件","label":"絲線"},{"radical":"帛","role":"部件","label":"帛"}]},"緊":{"formula":"臤 + 糸","components":[{"radical":"臤","role":"聲符","label":"讀音"},{"radical":"糸","role":"形符","label":"絲線"}]},"緒":{"formula":"糹 + 者","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"者","role":"聲符","label":"讀音"}]},"線":{"formula":"糹 + 泉","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"泉","role":"聲符","label":"讀音"}]},"緝":{"formula":"糹 + 咠","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"咠","role":"聲符","label":"讀音"}]},"緣":{"formula":"糹 + 彖","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"彖","role":"聲符","label":"讀音"}]},"編":{"formula":"糹 + 扁","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"扁","role":"聲符","label":"讀音"}]},"緩":{"formula":"糹 + 爰","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"爰","role":"聲符","label":"讀音"}]},"緯":{"formula":"糹 + 韋","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"韋","role":"聲符","label":"讀音"}]},"練":{"formula":"糹 + 柬","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"柬","role":"聲符","label":"讀音"}]},"緻":{"formula":"糹 + 致","components":[{"radical":"糹","role":"部件","label":"絲線"},{"radical":"致","role":"部件","label":"致"}]},"縛":{"formula":"糹 + 尃","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"尃","role":"聲符","label":"讀音"}]},"縣":{"formula":"県 + 系","components":[{"radical":"県","role":"部件","label":"県"},{"radical":"系","role":"部件","label":"系"}]},"縫":{"formula":"糹 + 逢","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"逢","role":"聲符","label":"讀音"}]},"縮":{"formula":"糹 + 宿","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"宿","role":"聲符","label":"讀音"}]},"縱":{"formula":"糹 + 從","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"從","role":"聲符","label":"讀音"}]},"總":{"formula":"糹 + 悤","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"悤","role":"聲符","label":"讀音"}]},"績":{"formula":"糹 + 責","components":[{"radical":"糹","role":"部件","label":"絲線"},{"radical":"責","role":"部件","label":"責"}]},"繁":{"formula":"敏 + 糸","components":[{"radical":"敏","role":"聲符","label":"讀音"},{"radical":"糸","role":"形符","label":"絲線"}]},"繃":{"formula":"糹 + 崩","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"崩","role":"聲符","label":"讀音"}]},"繆":{"formula":"糹 + 翏","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"翏","role":"聲符","label":"讀音"}]},"織":{"formula":"糹 + 戠","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"戠","role":"聲符","label":"讀音"}]},"繞":{"formula":"糹 + 堯","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"堯","role":"聲符","label":"讀音"}]},"繩":{"formula":"糹 + 黽","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"黽","role":"聲符","label":"讀音"}]},"繪":{"formula":"糹 + 會","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"會","role":"聲符","label":"讀音"}]},"繫":{"formula":"毄 + 糸","components":[{"radical":"毄","role":"聲符","label":"讀音"},{"radical":"糸","role":"形符","label":"絲線"}]},"繭":{"formula":"艹 + 冂 + 糹 + 虫","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"冂","role":"部件","label":"邊界"},{"radical":"糹","role":"部件","label":"絲線"},{"radical":"虫","role":"部件","label":"蟲類"}]},"繼":{"formula":"糹 + 㡭","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"㡭","role":"聲符","label":"讀音"}]},"續":{"formula":"糹 + 賣","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"賣","role":"聲符","label":"讀音"}]},"纍":{"formula":"畾 + 糸","components":[{"radical":"畾","role":"部件","label":"畾"},{"radical":"糸","role":"部件","label":"絲線"}]},"纏":{"formula":"糹 + 廛","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"廛","role":"聲符","label":"讀音"}]},"纖":{"formula":"糹 + 韱","components":[{"radical":"糹","role":"形符","label":"絲線"},{"radical":"韱","role":"聲符","label":"讀音"}]},"缺":{"formula":"缶 + 夬","components":[{"radical":"缶","role":"形符","label":"陶器"},{"radical":"夬","role":"聲符","label":"讀音"}]},"罐":{"formula":"缶 + 雚","components":[{"radical":"缶","role":"形符","label":"陶器"},{"radical":"雚","role":"聲符","label":"讀音"}]},"罩":{"formula":"罒 + 卓","components":[{"radical":"罒","role":"形符","label":"網罟"},{"radical":"卓","role":"聲符","label":"讀音"}]},"罪":{"formula":"罒 + 非","components":[{"radical":"罒","role":"部件","label":"網罟"},{"radical":"非","role":"部件","label":"不是"}]},"置":{"formula":"罒 + 直","components":[{"radical":"罒","role":"形符","label":"網罟"},{"radical":"直","role":"聲符","label":"讀音"}]},"罰":{"formula":"罒 + 言 + 刂","components":[{"radical":"罒","role":"部件","label":"網罟"},{"radical":"言","role":"部件","label":"說話"},{"radical":"刂","role":"部件","label":"刀旁"}]},"署":{"formula":"罒 + 者","components":[{"radical":"罒","role":"形符","label":"網罟"},{"radical":"者","role":"聲符","label":"讀音"}]},"罵":{"formula":"罒 + 馬","components":[{"radical":"罒","role":"形符","label":"網罟"},{"radical":"馬","role":"聲符","label":"讀音"}]},"罷":{"formula":"罒 + 能","components":[{"radical":"罒","role":"部件","label":"網罟"},{"radical":"能","role":"部件","label":"能"}]},"罹":{"formula":"忄","components":[{"radical":"忄","role":"形符","label":"心旁"}]},"羅":{"formula":"罒 + 維","components":[{"radical":"罒","role":"部件","label":"網罟"},{"radical":"維","role":"部件","label":"維"}]},"羊":{"formula":"羊","components":[{"radical":"羊","role":"部件","label":"象形字（獨體）"}]},"美":{"formula":"羊 + 大","components":[{"radical":"羊","role":"部件","label":"羊"},{"radical":"大","role":"部件","label":"大"}]},"羞":{"formula":"羊 + 丑","components":[{"radical":"羊","role":"部件","label":"羊"},{"radical":"丑","role":"部件","label":"丑"}]},"群":{"formula":"君 + 羊","components":[{"radical":"君","role":"聲符","label":"讀音"},{"radical":"羊","role":"形符","label":"羊"}]},"羨":{"formula":"羊 + 㳄","components":[{"radical":"羊","role":"形符","label":"羊"},{"radical":"㳄","role":"聲符","label":"讀音"}]},"義":{"formula":"羊 + 我","components":[{"radical":"羊","role":"形符","label":"羊"},{"radical":"我","role":"聲符","label":"讀音"}]},"羽":{"formula":"羽","components":[{"radical":"羽","role":"部件","label":"象形字（獨體）"}]},"翅":{"formula":"支 + 羽","components":[{"radical":"支","role":"聲符","label":"讀音"},{"radical":"羽","role":"形符","label":"羽毛"}]},"習":{"formula":"羽 + 白","components":[{"radical":"羽","role":"部件","label":"羽毛"},{"radical":"白","role":"部件","label":"白色"}]},"翔":{"formula":"羊 + 羽","components":[{"radical":"羊","role":"聲符","label":"讀音"},{"radical":"羽","role":"形符","label":"羽毛"}]},"翩":{"formula":"扁 + 羽","components":[{"radical":"扁","role":"聲符","label":"讀音"},{"radical":"羽","role":"形符","label":"羽毛"}]},"翰":{"formula":"倝 + 羽","components":[{"radical":"倝","role":"聲符","label":"讀音"},{"radical":"羽","role":"形符","label":"羽毛"}]},"翻":{"formula":"番 + 羽","components":[{"radical":"番","role":"聲符","label":"讀音"},{"radical":"羽","role":"形符","label":"羽毛"}]},"翼":{"formula":"羽 + 異","components":[{"radical":"羽","role":"形符","label":"羽毛"},{"radical":"異","role":"聲符","label":"讀音"}]},"耀":{"formula":"光 + 翟","components":[{"radical":"光","role":"部件","label":"光亮"},{"radical":"翟","role":"部件","label":"翟"}]},"老":{"formula":"老","components":[{"radical":"老","role":"部件","label":"象形字（獨體）"}]},"考":{"formula":"耂 + 丂","components":[{"radical":"耂","role":"形符","label":"耂"},{"radical":"丂","role":"聲符","label":"讀音"}]},"者":{"formula":"土 + 丿 + 日","components":[{"radical":"土","role":"部件","label":"泥土"},{"radical":"丿","role":"部件","label":"撇"},{"radical":"日","role":"部件","label":"太陽"}]},"而":{"formula":"一 + 丶 + 冂 + 丨 + 丨","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"丶","role":"部件","label":"點"},{"radical":"冂","role":"部件","label":"邊界"},{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"丨","role":"部件","label":"上下貫通的樣"}]},"耍":{"formula":"而 + 女","components":[{"radical":"而","role":"部件","label":"兩頰上的毛"},{"radical":"女","role":"部件","label":"女旁"}]},"耐":{"formula":"而 + 寸","components":[{"radical":"而","role":"部件","label":"兩頰上的毛"},{"radical":"寸","role":"部件","label":"量詞"}]},"耕":{"formula":"耒 + 井","components":[{"radical":"耒","role":"形符","label":"古代木製耕具"},{"radical":"井","role":"聲符","label":"讀音"}]},"耗":{"formula":"耒 + 毛","components":[{"radical":"耒","role":"形符","label":"古代木製耕具"},{"radical":"毛","role":"聲符","label":"讀音"}]},"耳":{"formula":"耳","components":[{"radical":"耳","role":"部件","label":"象形字（獨體）"}]},"耶":{"formula":"耳 + 阝","components":[{"radical":"耳","role":"形符","label":"耳朵"},{"radical":"阝","role":"聲符","label":"讀音"}]},"聆":{"formula":"耳 + 令","components":[{"radical":"耳","role":"形符","label":"耳朵"},{"radical":"令","role":"聲符","label":"讀音"}]},"聊":{"formula":"耳 + 卯","components":[{"radical":"耳","role":"形符","label":"耳朵"},{"radical":"卯","role":"聲符","label":"讀音"}]},"聖":{"formula":"耳 + 口 + 王","components":[{"radical":"耳","role":"部件","label":"耳朵"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"王","role":"部件","label":"王旁"}]},"聚":{"formula":"取 + 乑","components":[{"radical":"取","role":"部件","label":"取"},{"radical":"乑","role":"部件","label":"乑"}]},"聞":{"formula":"門 + 耳","components":[{"radical":"門","role":"聲符","label":"讀音"},{"radical":"耳","role":"形符","label":"耳朵"}]},"聯":{"formula":"絲","components":[{"radical":"絲","role":"形符","label":"絲"}]},"聰":{"formula":"耳 + 悤","components":[{"radical":"耳","role":"形符","label":"耳朵"},{"radical":"悤","role":"聲符","label":"讀音"}]},"聲":{"formula":"殸 + 耳","components":[{"radical":"殸","role":"聲符","label":"讀音"},{"radical":"耳","role":"形符","label":"耳朵"}]},"聳":{"formula":"從 + 耳","components":[{"radical":"從","role":"聲符","label":"讀音"},{"radical":"耳","role":"形符","label":"耳朵"}]},"職":{"formula":"耳 + 戠","components":[{"radical":"耳","role":"形符","label":"耳朵"},{"radical":"戠","role":"聲符","label":"讀音"}]},"聽":{"formula":"耳 + 王 + 十 + 罒 + 一 + 心","components":[{"radical":"耳","role":"部件","label":"耳朵"},{"radical":"王","role":"部件","label":"王旁"},{"radical":"十","role":"部件","label":"十"},{"radical":"罒","role":"部件","label":"網罟"},{"radical":"一","role":"部件","label":"一"},{"radical":"心","role":"部件","label":"心理"}]},"肆":{"formula":"镸 + 聿","components":[{"radical":"镸","role":"部件","label":"镸"},{"radical":"聿","role":"部件","label":"筆"}]},"肉":{"formula":"肉","components":[{"radical":"肉","role":"部件","label":"象形字（獨體）"}]},"肌":{"formula":"⺼ + 几","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"几","role":"聲符","label":"讀音"}]},"肖":{"formula":"⺌ + ⺼","components":[{"radical":"⺌","role":"聲符","label":"讀音"},{"radical":"⺼","role":"形符","label":"身體"}]},"肚":{"formula":"⺼ + 土","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"土","role":"聲符","label":"讀音"}]},"股":{"formula":"⺼ + 殳","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"殳","role":"聲符","label":"讀音"}]},"肢":{"formula":"⺼ + 支","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"支","role":"聲符","label":"讀音"}]},"肥":{"formula":"⺼ + 巴","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"巴","role":"聲符","label":"讀音"}]},"肩":{"formula":"户 + ⺼","components":[{"radical":"户","role":"部件","label":"「戶」的異體"},{"radical":"⺼","role":"部件","label":"身體"}]},"肪":{"formula":"⺼ + 方","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"方","role":"聲符","label":"讀音"}]},"肯":{"formula":"止 + ⺼","components":[{"radical":"止","role":"部件","label":"停止"},{"radical":"⺼","role":"部件","label":"身體"}]},"育":{"formula":"亠 + 厶 + ⺼","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"厶","role":"部件","label":"私"},{"radical":"⺼","role":"部件","label":"身體"}]},"肺":{"formula":"⺼ + 巿","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"巿","role":"聲符","label":"讀音"}]},"胃":{"formula":"田 + ⺼","components":[{"radical":"田","role":"部件","label":"田地"},{"radical":"⺼","role":"部件","label":"身體"}]},"背":{"formula":"北 + ⺼","components":[{"radical":"北","role":"聲符","label":"讀音"},{"radical":"⺼","role":"形符","label":"身體"}]},"胎":{"formula":"⺼ + 台","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"台","role":"聲符","label":"讀音"}]},"胖":{"formula":"⺼ + 半","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"半","role":"聲符","label":"讀音"}]},"胞":{"formula":"⺼ + 包","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"包","role":"聲符","label":"讀音"}]},"胡":{"formula":"古 + ⺼","components":[{"radical":"古","role":"聲符","label":"讀音"},{"radical":"⺼","role":"形符","label":"身體"}]},"胸":{"formula":"⺼ + 匈","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"匈","role":"部件","label":"匈"}]},"胺":{"formula":"⺼ + 安","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"安","role":"聲符","label":"讀音"}]},"能":{"formula":"能","components":[{"radical":"能","role":"部件","label":"象形字（獨體）"}]},"脂":{"formula":"⺼ + 旨","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"旨","role":"聲符","label":"讀音"}]},"脅":{"formula":"劦 + ⺼","components":[{"radical":"劦","role":"部件","label":"劦"},{"radical":"⺼","role":"部件","label":"身體"}]},"脆":{"formula":"⺼ + 危","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"危","role":"部件","label":"危"}]},"脈":{"formula":"⺼ + 永","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"永","role":"部件","label":"永"}]},"脊":{"formula":"人 + ⺼","components":[{"radical":"人","role":"部件","label":"人"},{"radical":"⺼","role":"部件","label":"身體"}]},"脖":{"formula":"⺼ + 孛","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"孛","role":"聲符","label":"讀音"}]},"脫":{"formula":"⺼ + 兌","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"兌","role":"聲符","label":"讀音"}]},"脹":{"formula":"⺼ + 長","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"長","role":"聲符","label":"讀音"}]},"脾":{"formula":"⺼ + 卑","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"卑","role":"聲符","label":"讀音"}]},"腎":{"formula":"臤 + ⺼","components":[{"radical":"臤","role":"聲符","label":"讀音"},{"radical":"⺼","role":"形符","label":"身體"}]},"腐":{"formula":"付 + 肉","components":[{"radical":"付","role":"聲符","label":"讀音"},{"radical":"肉","role":"形符","label":"肉"}]},"腔":{"formula":"⺼ + 空","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"空","role":"聲符","label":"讀音"}]},"腥":{"formula":"⺼ + 星","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"星","role":"聲符","label":"讀音"}]},"腦":{"formula":"⺼ + 巛 + 囟","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"巛","role":"部件","label":"河流"},{"radical":"囟","role":"部件","label":"囟"}]},"腫":{"formula":"⺼ + 重","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"重","role":"部件","label":"重"}]},"腰":{"formula":"⺼ + 要","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"要","role":"聲符","label":"讀音"}]},"腳":{"formula":"⺼ + 卻","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"卻","role":"聲符","label":"讀音"}]},"腹":{"formula":"⺼ + 复","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"复","role":"聲符","label":"讀音"}]},"腿":{"formula":"⺼ + 退","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"退","role":"部件","label":"退"}]},"膀":{"formula":"⺼ + 旁","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"旁","role":"部件","label":"旁"}]},"膏":{"formula":"高 + ⺼","components":[{"radical":"高","role":"聲符","label":"讀音"},{"radical":"⺼","role":"形符","label":"身體"}]},"膚":{"formula":"⺼ + 虍","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"虍","role":"聲符","label":"讀音"}]},"膛":{"formula":"⺼ + 堂","components":[{"radical":"⺼","role":"部件","label":"身體"},{"radical":"堂","role":"部件","label":"堂"}]},"膜":{"formula":"⺼ + 莫","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"莫","role":"聲符","label":"讀音"}]},"膝":{"formula":"⺼ + 桼","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"桼","role":"聲符","label":"讀音"}]},"膠":{"formula":"⺼ + 翏","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"翏","role":"聲符","label":"讀音"}]},"膽":{"formula":"⺼ + 詹","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"詹","role":"聲符","label":"讀音"}]},"臀":{"formula":"殿 + ⺼","components":[{"radical":"殿","role":"聲符","label":"讀音"},{"radical":"⺼","role":"形符","label":"身體"}]},"臂":{"formula":"辟 + ⺼","components":[{"radical":"辟","role":"聲符","label":"讀音"},{"radical":"⺼","role":"形符","label":"身體"}]},"臉":{"formula":"⺼ + 僉","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"僉","role":"聲符","label":"讀音"}]},"臘":{"formula":"⺼ + 巤","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"巤","role":"聲符","label":"讀音"}]},"臟":{"formula":"⺼ + 藏","components":[{"radical":"⺼","role":"形符","label":"身體"},{"radical":"藏","role":"聲符","label":"讀音"}]},"臥":{"formula":"臣 + 人","components":[{"radical":"臣","role":"部件","label":"臣子"},{"radical":"人","role":"部件","label":"人"}]},"自":{"formula":"自","components":[{"radical":"自","role":"部件","label":"象形字（獨體）"}]},"至":{"formula":"一 + 厶 + 土","components":[{"radical":"一","role":"部件","label":"一"},{"radical":"厶","role":"部件","label":"私"},{"radical":"土","role":"部件","label":"泥土"}]},"致":{"formula":"至 + 攵","components":[{"radical":"至","role":"聲符","label":"讀音"},{"radical":"攵","role":"形符","label":"敲打"}]},"臺":{"formula":"吉 + 冖 + 至","components":[{"radical":"吉","role":"部件","label":"吉"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"至","role":"部件","label":"到達"}]},"舅":{"formula":"臼 + 男","components":[{"radical":"臼","role":"聲符","label":"讀音"},{"radical":"男","role":"形符","label":"男"}]},"舉":{"formula":"扌 + 舉","components":[{"radical":"扌","role":"形符","label":"手旁"},{"radical":"舉","role":"聲符","label":"讀音"}]},"舊":{"formula":"臼","components":[{"radical":"臼","role":"聲符","label":"讀音"}]},"舌":{"formula":"舌","components":[{"radical":"舌","role":"部件","label":"象形字（獨體）"}]},"舍":{"formula":"人 + 舌","components":[{"radical":"人","role":"形符","label":"人"},{"radical":"舌","role":"聲符","label":"讀音"}]},"舒":{"formula":"舍 + 予","components":[{"radical":"舍","role":"形符","label":"舍"},{"radical":"予","role":"聲符","label":"讀音"}]},"舞":{"formula":"無 + 舛","components":[{"radical":"無","role":"部件","label":"無"},{"radical":"舛","role":"部件","label":"相背"}]},"航":{"formula":"舟 + 亢","components":[{"radical":"舟","role":"形符","label":"船"},{"radical":"亢","role":"聲符","label":"讀音"}]},"般":{"formula":"舟 + 殳","components":[{"radical":"舟","role":"部件","label":"船"},{"radical":"殳","role":"部件","label":"武器"}]},"船":{"formula":"舟","components":[{"radical":"舟","role":"形符","label":"船"}]},"良":{"formula":"丶 + 艮","components":[{"radical":"丶","role":"部件","label":"點"},{"radical":"艮","role":"部件","label":"堅固"}]},"艱":{"formula":"堇 + 艮","components":[{"radical":"堇","role":"聲符","label":"讀音"},{"radical":"艮","role":"形符","label":"堅固"}]},"色":{"formula":"⺈ + 巴","components":[{"radical":"⺈","role":"部件","label":"⺈"},{"radical":"巴","role":"部件","label":"巴"}]},"艷":{"formula":"豐 + 色","components":[{"radical":"豐","role":"部件","label":"豐"},{"radical":"色","role":"部件","label":"顏色"}]},"艾":{"formula":"艹 + 乂","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"乂","role":"聲符","label":"讀音"}]},"芒":{"formula":"艹 + 亡","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"亡","role":"聲符","label":"讀音"}]},"芝":{"formula":"艹 + 之","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"之","role":"聲符","label":"讀音"}]},"芬":{"formula":"艹 + 分","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"分","role":"聲符","label":"讀音"}]},"芮":{"formula":"艹 + 内","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"内","role":"聲符","label":"讀音"}]},"花":{"formula":"艹 + 化","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"化","role":"部件","label":"變化"}]},"芳":{"formula":"艹 + 方","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"方","role":"聲符","label":"讀音"}]},"芸":{"formula":"艹 + 云","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"云","role":"聲符","label":"讀音"}]},"芻":{"formula":"勹 + 屮 + 勹 + 屮","components":[{"radical":"勹","role":"部件","label":"包裹"},{"radical":"屮","role":"部件","label":"初生的草木"},{"radical":"勹","role":"部件","label":"包裹"},{"radical":"屮","role":"部件","label":"初生的草木"}]},"芽":{"formula":"艹 + 牙","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"牙","role":"聲符","label":"讀音"}]},"苗":{"formula":"艹 + 田","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"田","role":"部件","label":"田地"}]},"苞":{"formula":"艹 + 包","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"包","role":"部件","label":"包"}]},"若":{"formula":"草 + 右","components":[{"radical":"草","role":"部件","label":"草"},{"radical":"右","role":"部件","label":"右"}]},"苦":{"formula":"艹 + 古","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"古","role":"聲符","label":"讀音"}]},"英":{"formula":"艹 + 央","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"央","role":"聲符","label":"讀音"}]},"茂":{"formula":"艹 + 戊","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"戊","role":"聲符","label":"讀音"}]},"茅":{"formula":"艹 + 矛","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"矛","role":"聲符","label":"讀音"}]},"茫":{"formula":"艹 + 汒","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"汒","role":"聲符","label":"讀音"}]},"茶":{"formula":"艹","components":[{"radical":"艹","role":"形符","label":"草頭"}]},"草":{"formula":"艹 + 早","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"早","role":"聲符","label":"讀音"}]},"荒":{"formula":"芒 + 川","components":[{"radical":"芒","role":"形符","label":"芒"},{"radical":"川","role":"聲符","label":"讀音"}]},"荷":{"formula":"艹 + 何","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"何","role":"聲符","label":"讀音"}]},"莉":{"formula":"艹 + 利","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"利","role":"聲符","label":"讀音"}]},"莊":{"formula":"艹 + 壯","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"壯","role":"聲符","label":"讀音"}]},"莎":{"formula":"艹 + 沙","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"沙","role":"聲符","label":"讀音"}]},"莖":{"formula":"艹 + 巠","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"巠","role":"聲符","label":"讀音"}]},"莫":{"formula":"草 + 日 + 大","components":[{"radical":"草","role":"部件","label":"草"},{"radical":"日","role":"部件","label":"太陽"},{"radical":"大","role":"部件","label":"大"}]},"莽":{"formula":"艹 + 犬 + 廾","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"犬","role":"部件","label":"狗"},{"radical":"廾","role":"部件","label":"「廿」的異體"}]},"菁":{"formula":"艹 + 青","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"青","role":"聲符","label":"讀音"}]},"菇":{"formula":"艹 + 姑","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"姑","role":"聲符","label":"讀音"}]},"菜":{"formula":"艹 + 采","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"采","role":"聲符","label":"讀音"}]},"菠":{"formula":"艹 + 波","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"波","role":"聲符","label":"讀音"}]},"華":{"formula":"艹 + 十","components":[{"radical":"艹","role":"聲符","label":"讀音"},{"radical":"十","role":"形符","label":"十"}]},"菲":{"formula":"艹 + 非","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"非","role":"聲符","label":"讀音"}]},"菸":{"formula":"艹 + 於","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"於","role":"聲符","label":"讀音"}]},"萊":{"formula":"艹 + 來","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"來","role":"聲符","label":"讀音"}]},"落":{"formula":"艹 + 洛","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"洛","role":"聲符","label":"讀音"}]},"葉":{"formula":"艹 + 枼","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"枼","role":"部件","label":"枼"}]},"著":{"formula":"艹 + 者","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"者","role":"聲符","label":"讀音"}]},"葫":{"formula":"艹 + 胡","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"胡","role":"聲符","label":"讀音"}]},"葬":{"formula":"艹 + 死 + 廾","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"死","role":"部件","label":"死"},{"radical":"廾","role":"部件","label":"「廿」的異體"}]},"蒂":{"formula":"艹 + 帝","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"帝","role":"聲符","label":"讀音"}]},"蒐":{"formula":"草 + 鬼","components":[{"radical":"草","role":"部件","label":"草"},{"radical":"鬼","role":"部件","label":"鬼神"}]},"蒙":{"formula":"艹 + 冡","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"冡","role":"聲符","label":"讀音"}]},"蒸":{"formula":"艹 + 烝","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"烝","role":"部件","label":"烝"}]},"蒼":{"formula":"艹 + 倉","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"倉","role":"聲符","label":"讀音"}]},"蓄":{"formula":"艹 + 畜","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"畜","role":"聲符","label":"讀音"}]},"蓋":{"formula":"艹 + 盍","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"盍","role":"聲符","label":"讀音"}]},"蓬":{"formula":"艹 + 逢","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"逢","role":"聲符","label":"讀音"}]},"蓮":{"formula":"艹 + 連","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"連","role":"聲符","label":"讀音"}]},"蔡":{"formula":"草 + 祭","components":[{"radical":"草","role":"部件","label":"草"},{"radical":"祭","role":"部件","label":"祭"}]},"蔣":{"formula":"艹 + 將","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"將","role":"聲符","label":"讀音"}]},"蔬":{"formula":"艹 + 疏","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"疏","role":"聲符","label":"讀音"}]},"蔭":{"formula":"艹 + 陰","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"陰","role":"部件","label":"陰"}]},"蔽":{"formula":"艹 + 敝","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"敝","role":"聲符","label":"讀音"}]},"蕉":{"formula":"艹 + 焦","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"焦","role":"聲符","label":"讀音"}]},"蕩":{"formula":"艹 + 湯","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"湯","role":"部件","label":"湯"}]},"蕪":{"formula":"艹 + 無","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"無","role":"聲符","label":"讀音"}]},"蕾":{"formula":"艹 + 雷","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"雷","role":"聲符","label":"讀音"}]},"薄":{"formula":"艹 + 溥","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"溥","role":"聲符","label":"讀音"}]},"薦":{"formula":"艹 + 廌","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"廌","role":"聲符","label":"讀音"}]},"薩":{"formula":"艹 + 隡","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"隡","role":"聲符","label":"讀音"}]},"薪":{"formula":"艹 + 新","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"新","role":"部件","label":"新"}]},"薯":{"formula":"艹 + 署","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"署","role":"聲符","label":"讀音"}]},"藉":{"formula":"艹 + 耤","components":[{"radical":"艹","role":"部件","label":"草頭"},{"radical":"耤","role":"部件","label":"耤"}]},"藍":{"formula":"艹 + 監","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"監","role":"聲符","label":"讀音"}]},"藏":{"formula":"艹 + 臧","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"臧","role":"聲符","label":"讀音"}]},"藝":{"formula":"艹 + 埶","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"埶","role":"聲符","label":"讀音"}]},"藥":{"formula":"艹 + 樂","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"樂","role":"聲符","label":"讀音"}]},"藹":{"formula":"艹 + 謁","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"謁","role":"聲符","label":"讀音"}]},"蘆":{"formula":"艹 + 盧","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"盧","role":"聲符","label":"讀音"}]},"蘋":{"formula":"艹 + 頻","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"頻","role":"聲符","label":"讀音"}]},"蘭":{"formula":"艹 + 闌","components":[{"radical":"艹","role":"形符","label":"草頭"},{"radical":"闌","role":"聲符","label":"讀音"}]},"虎":{"formula":"虍 + 几","components":[{"radical":"虍","role":"部件","label":"老虎身上的花"},{"radical":"几","role":"部件","label":"小桌"}]},"虔":{"formula":"虎 + 文","components":[{"radical":"虎","role":"部件","label":"虎"},{"radical":"文","role":"部件","label":"文字"}]},"處":{"formula":"虍 + 処","components":[{"radical":"虍","role":"聲符","label":"讀音"},{"radical":"処","role":"形符","label":"処"}]},"虛":{"formula":"虍 + 丱 + 一","components":[{"radical":"虍","role":"部件","label":"老虎身上的花"},{"radical":"丱","role":"部件","label":"丱"},{"radical":"一","role":"部件","label":"一"}]},"虜":{"formula":"虍 + 男","components":[{"radical":"虍","role":"聲符","label":"讀音"},{"radical":"男","role":"形符","label":"男"}]},"號":{"formula":"号 + 虎","components":[{"radical":"号","role":"部件","label":"号"},{"radical":"虎","role":"部件","label":"虎"}]},"虧":{"formula":"雐 + 亏","components":[{"radical":"雐","role":"部件","label":"雐"},{"radical":"亏","role":"部件","label":"亏"}]},"虹":{"formula":"虫 + 工","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"工","role":"聲符","label":"讀音"}]},"蚊":{"formula":"虫 + 文","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"文","role":"聲符","label":"讀音"}]},"蚋":{"formula":"虫 + 内","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"内","role":"聲符","label":"讀音"}]},"蛀":{"formula":"虫 + 主","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"主","role":"聲符","label":"讀音"}]},"蛇":{"formula":"虫 + 它","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"它","role":"聲符","label":"讀音"}]},"蛋":{"formula":"虫 + 延","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"延","role":"聲符","label":"讀音"}]},"蛙":{"formula":"虫 + 圭","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"圭","role":"聲符","label":"讀音"}]},"蛛":{"formula":"虫 + 朱","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"朱","role":"聲符","label":"讀音"}]},"蛭":{"formula":"虫 + 至","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"至","role":"聲符","label":"讀音"}]},"蛻":{"formula":"虫 + 兌","components":[{"radical":"虫","role":"部件","label":"蟲類"},{"radical":"兌","role":"部件","label":"兌"}]},"蛾":{"formula":"虫 + 我","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"我","role":"聲符","label":"讀音"}]},"蜂":{"formula":"虫 + 夆","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"夆","role":"聲符","label":"讀音"}]},"蜒":{"formula":"虫 + 延","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"延","role":"聲符","label":"讀音"}]},"蜓":{"formula":"虫 + 廷","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"廷","role":"聲符","label":"讀音"}]},"蜘":{"formula":"虫 + 知","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"知","role":"聲符","label":"讀音"}]},"蜜":{"formula":"宓 + 虫","components":[{"radical":"宓","role":"聲符","label":"讀音"},{"radical":"虫","role":"形符","label":"蟲類"}]},"蜻":{"formula":"虫 + 青","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"青","role":"聲符","label":"讀音"}]},"蜿":{"formula":"虫 + 宛","components":[{"radical":"虫","role":"部件","label":"蟲類"},{"radical":"宛","role":"部件","label":"宛"}]},"蝕":{"formula":"飠 + 虫","components":[{"radical":"飠","role":"部件","label":"食物"},{"radical":"虫","role":"部件","label":"蟲類"}]},"蝴":{"formula":"虫 + 胡","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"胡","role":"聲符","label":"讀音"}]},"蝶":{"formula":"虫 + 枼","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"枼","role":"聲符","label":"讀音"}]},"螂":{"formula":"虫 + 郎","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"郎","role":"聲符","label":"讀音"}]},"融":{"formula":"鬲 + 虫","components":[{"radical":"鬲","role":"形符","label":"一種古代的炊"},{"radical":"虫","role":"聲符","label":"讀音"}]},"螢":{"formula":"火 + 火 + 冖 + 虫","components":[{"radical":"火","role":"部件","label":"火"},{"radical":"火","role":"部件","label":"火"},{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"虫","role":"部件","label":"蟲類"}]},"螯":{"formula":"敖 + 虫","components":[{"radical":"敖","role":"聲符","label":"讀音"},{"radical":"虫","role":"形符","label":"蟲類"}]},"蟑":{"formula":"虫 + 章","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"章","role":"聲符","label":"讀音"}]},"蟒":{"formula":"虫 + 莽","components":[{"radical":"虫","role":"形符","label":"蟲類"},{"radical":"莽","role":"聲符","label":"讀音"}]},"蟲":{"formula":"虫 + 虫 + 虫","components":[{"radical":"虫","role":"部件","label":"蟲類"},{"radical":"虫","role":"部件","label":"蟲類"},{"radical":"虫","role":"部件","label":"蟲類"}]},"蟹":{"formula":"解 + 虫","components":[{"radical":"解","role":"聲符","label":"讀音"},{"radical":"虫","role":"形符","label":"蟲類"}]},"蠅":{"formula":"虫 + 黽","components":[{"radical":"虫","role":"部件","label":"蟲類"},{"radical":"黽","role":"部件","label":"黽"}]},"蠢":{"formula":"春 + 虫","components":[{"radical":"春","role":"聲符","label":"讀音"},{"radical":"虫","role":"形符","label":"蟲類"}]},"蠻":{"formula":"䜌 + 虫","components":[{"radical":"䜌","role":"聲符","label":"讀音"},{"radical":"虫","role":"形符","label":"蟲類"}]},"血":{"formula":"丿 + 皿","components":[{"radical":"丿","role":"部件","label":"撇"},{"radical":"皿","role":"部件","label":"器皿"}]},"行":{"formula":"彳 + 亍","components":[{"radical":"彳","role":"部件","label":"行旁"},{"radical":"亍","role":"部件","label":"亍"}]},"衍":{"formula":"行 + 氵","components":[{"radical":"行","role":"部件","label":"行走"},{"radical":"氵","role":"部件","label":"水旁"}]},"術":{"formula":"行 + 术","components":[{"radical":"行","role":"部件","label":"行走"},{"radical":"术","role":"部件","label":"术"}]},"街":{"formula":"行 + 圭","components":[{"radical":"行","role":"形符","label":"行走"},{"radical":"圭","role":"聲符","label":"讀音"}]},"衛":{"formula":"行 + 韋","components":[{"radical":"行","role":"形符","label":"行走"},{"radical":"韋","role":"聲符","label":"讀音"}]},"衝":{"formula":"行 + 重","components":[{"radical":"行","role":"形符","label":"行走"},{"radical":"重","role":"聲符","label":"讀音"}]},"衡":{"formula":"行 + 角 + 大","components":[{"radical":"行","role":"部件","label":"行走"},{"radical":"角","role":"部件","label":"角"},{"radical":"大","role":"部件","label":"大"}]},"衣":{"formula":"衣","components":[{"radical":"衣","role":"部件","label":"象形字（獨體）"}]},"表":{"formula":"毛 + 衣","components":[{"radical":"毛","role":"部件","label":"毛髮"},{"radical":"衣","role":"部件","label":"衣服"}]},"衫":{"formula":"衤 + 彡","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"彡","role":"聲符","label":"讀音"}]},"衰":{"formula":"衣 + 口 + 一","components":[{"radical":"衣","role":"部件","label":"衣服"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"一","role":"部件","label":"一"}]},"衷":{"formula":"衣 + 中","components":[{"radical":"衣","role":"部件","label":"衣服"},{"radical":"中","role":"部件","label":"中"}]},"袋":{"formula":"代 + 衣","components":[{"radical":"代","role":"聲符","label":"讀音"},{"radical":"衣","role":"形符","label":"衣服"}]},"袖":{"formula":"衤 + 由","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"由","role":"聲符","label":"讀音"}]},"被":{"formula":"衤 + 皮","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"皮","role":"聲符","label":"讀音"}]},"裁":{"formula":"十 + 戈 + 衣","components":[{"radical":"十","role":"部件","label":"十"},{"radical":"戈","role":"部件","label":"武器"},{"radical":"衣","role":"部件","label":"衣服"}]},"裂":{"formula":"列 + 衣","components":[{"radical":"列","role":"聲符","label":"讀音"},{"radical":"衣","role":"形符","label":"衣服"}]},"裔":{"formula":"衣 + 冏","components":[{"radical":"衣","role":"聲符","label":"讀音"},{"radical":"冏","role":"形符","label":"冏"}]},"裕":{"formula":"衤 + 谷","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"谷","role":"聲符","label":"讀音"}]},"裙":{"formula":"衤 + 君","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"君","role":"聲符","label":"讀音"}]},"補":{"formula":"衤 + 甫","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"甫","role":"聲符","label":"讀音"}]},"裝":{"formula":"壯 + 衣","components":[{"radical":"壯","role":"聲符","label":"讀音"},{"radical":"衣","role":"形符","label":"衣服"}]},"裡":{"formula":"衤 + 里","components":[{"radical":"衤","role":"部件","label":"衣旁"},{"radical":"里","role":"部件","label":"距離"}]},"裨":{"formula":"裨","components":[{"radical":"裨","role":"部件","label":"象形字（獨體）"}]},"裳":{"formula":"尚 + 衣","components":[{"radical":"尚","role":"聲符","label":"讀音"},{"radical":"衣","role":"形符","label":"衣服"}]},"裹":{"formula":"衣 + 果","components":[{"radical":"衣","role":"形符","label":"衣服"},{"radical":"果","role":"聲符","label":"讀音"}]},"製":{"formula":"制 + 衣","components":[{"radical":"制","role":"部件","label":"制"},{"radical":"衣","role":"部件","label":"衣服"}]},"複":{"formula":"衤 + 复","components":[{"radical":"衤","role":"部件","label":"衣旁"},{"radical":"复","role":"部件","label":"复"}]},"褓":{"formula":"衤 + 保","components":[{"radical":"衤","role":"部件","label":"衣旁"},{"radical":"保","role":"部件","label":"保"}]},"褪":{"formula":"衤 + 退","components":[{"radical":"衤","role":"部件","label":"衣旁"},{"radical":"退","role":"部件","label":"退"}]},"褲":{"formula":"衤 + 庫","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"庫","role":"聲符","label":"讀音"}]},"襁":{"formula":"衤 + 强","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"强","role":"聲符","label":"讀音"}]},"襯":{"formula":"衤 + 親","components":[{"radical":"衤","role":"形符","label":"衣旁"},{"radical":"親","role":"聲符","label":"讀音"}]},"襲":{"formula":"龍 + 衣","components":[{"radical":"龍","role":"形符","label":"龍"},{"radical":"衣","role":"聲符","label":"讀音"}]},"西":{"formula":"西","components":[{"radical":"西","role":"部件","label":"象形字（獨體）"}]},"要":{"formula":"覀 + 女","components":[{"radical":"覀","role":"部件","label":"覀"},{"radical":"女","role":"部件","label":"女旁"}]},"覆":{"formula":"覀 + 復","components":[{"radical":"覀","role":"形符","label":"覀"},{"radical":"復","role":"聲符","label":"讀音"}]},"見":{"formula":"目 + 儿","components":[{"radical":"目","role":"部件","label":"眼睛"},{"radical":"儿","role":"部件","label":"同「人」"}]},"規":{"formula":"夫 + 見","components":[{"radical":"夫","role":"聲符","label":"讀音"},{"radical":"見","role":"形符","label":"看見"}]},"覓":{"formula":"爫 + 見","components":[{"radical":"爫","role":"部件","label":"爫"},{"radical":"見","role":"部件","label":"看見"}]},"視":{"formula":"礻 + 見","components":[{"radical":"礻","role":"聲符","label":"讀音"},{"radical":"見","role":"形符","label":"看見"}]},"親":{"formula":"亲 + 見","components":[{"radical":"亲","role":"聲符","label":"讀音"},{"radical":"見","role":"形符","label":"看見"}]},"覽":{"formula":"監 + 見","components":[{"radical":"監","role":"聲符","label":"讀音"},{"radical":"見","role":"形符","label":"看見"}]},"觀":{"formula":"雚 + 見","components":[{"radical":"雚","role":"聲符","label":"讀音"},{"radical":"見","role":"形符","label":"看見"}]},"角":{"formula":"角","components":[{"radical":"角","role":"部件","label":"象形字（獨體）"}]},"解":{"formula":"角 + 刀 + 牛","components":[{"radical":"角","role":"部件","label":"角"},{"radical":"刀","role":"部件","label":"刀"},{"radical":"牛","role":"部件","label":"牛"}]},"觸":{"formula":"角 + 蜀","components":[{"radical":"角","role":"形符","label":"角"},{"radical":"蜀","role":"聲符","label":"讀音"}]},"言":{"formula":"亠 + 二 + 口","components":[{"radical":"亠","role":"部件","label":"二一四部首之"},{"radical":"二","role":"部件","label":"二"},{"radical":"口","role":"部件","label":"嘴巴"}]},"訂":{"formula":"言 + 丁","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"丁","role":"聲符","label":"讀音"}]},"計":{"formula":"言 + 十","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"十","role":"聲符","label":"讀音"}]},"訊":{"formula":"言 + 卂","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"卂","role":"聲符","label":"讀音"}]},"討":{"formula":"言 + 寸","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"寸","role":"部件","label":"量詞"}]},"訓":{"formula":"言 + 川","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"川","role":"聲符","label":"讀音"}]},"託":{"formula":"言 + 乇","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"乇","role":"部件","label":"乇"}]},"記":{"formula":"言 + 己","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"己","role":"部件","label":"天干的第六位"}]},"訝":{"formula":"言 + 牙","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"牙","role":"聲符","label":"讀音"}]},"訣":{"formula":"言 + 夬","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"夬","role":"部件","label":"夬"}]},"訪":{"formula":"言 + 方","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"方","role":"聲符","label":"讀音"}]},"設":{"formula":"言 + 殳","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"殳","role":"聲符","label":"讀音"}]},"許":{"formula":"言 + 午","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"午","role":"聲符","label":"讀音"}]},"訴":{"formula":"言 + 斥","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"斥","role":"部件","label":"斥"}]},"診":{"formula":"言 + 㐱","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"㐱","role":"聲符","label":"讀音"}]},"詐":{"formula":"言 + 乍","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"乍","role":"聲符","label":"讀音"}]},"評":{"formula":"言 + 平","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"平","role":"聲符","label":"讀音"}]},"詞":{"formula":"言 + 司","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"司","role":"聲符","label":"讀音"}]},"詠":{"formula":"言 + 永","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"永","role":"聲符","label":"讀音"}]},"詢":{"formula":"言 + 旬","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"旬","role":"聲符","label":"讀音"}]},"試":{"formula":"言 + 式","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"式","role":"聲符","label":"讀音"}]},"詩":{"formula":"言 + 寺","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"寺","role":"聲符","label":"讀音"}]},"詮":{"formula":"言 + 全","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"全","role":"聲符","label":"讀音"}]},"話":{"formula":"言 + 舌","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"舌","role":"部件","label":"舌頭"}]},"該":{"formula":"言 + 亥","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"亥","role":"聲符","label":"讀音"}]},"詳":{"formula":"言 + 羊","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"羊","role":"聲符","label":"讀音"}]},"詹":{"formula":"厂 + 言","components":[{"radical":"厂","role":"聲符","label":"讀音"},{"radical":"言","role":"形符","label":"說話"}]},"誇":{"formula":"言 + 夸","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"夸","role":"部件","label":"夸"}]},"誌":{"formula":"言 + 志","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"志","role":"聲符","label":"讀音"}]},"認":{"formula":"言 + 忍","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"忍","role":"聲符","label":"讀音"}]},"誘":{"formula":"言 + 秀","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"秀","role":"部件","label":"秀"}]},"語":{"formula":"言 + 吾","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"吾","role":"聲符","label":"讀音"}]},"誠":{"formula":"言 + 成","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"成","role":"聲符","label":"讀音"}]},"誤":{"formula":"言 + 吴","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"吴","role":"聲符","label":"讀音"}]},"誦":{"formula":"言 + 甬","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"甬","role":"聲符","label":"讀音"}]},"說":{"formula":"言 + 兌","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"兌","role":"聲符","label":"讀音"}]},"誰":{"formula":"言 + 隹","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"隹","role":"聲符","label":"讀音"}]},"課":{"formula":"言 + 果","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"果","role":"聲符","label":"讀音"}]},"調":{"formula":"言 + 周","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"周","role":"聲符","label":"讀音"}]},"談":{"formula":"言 + 炎","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"炎","role":"聲符","label":"讀音"}]},"請":{"formula":"言 + 青","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"青","role":"聲符","label":"讀音"}]},"諒":{"formula":"言 + 京","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"京","role":"聲符","label":"讀音"}]},"論":{"formula":"言 + 侖","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"侖","role":"部件","label":"侖"}]},"諧":{"formula":"言 + 皆","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"皆","role":"聲符","label":"讀音"}]},"諮":{"formula":"言 + 咨","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"咨","role":"部件","label":"咨"}]},"諷":{"formula":"言 + 風","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"風","role":"聲符","label":"讀音"}]},"諸":{"formula":"言 + 者","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"者","role":"聲符","label":"讀音"}]},"諺":{"formula":"言 + 彦","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"彦","role":"部件","label":"彦"}]},"諾":{"formula":"言 + 若","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"若","role":"聲符","label":"讀音"}]},"謀":{"formula":"言 + 某","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"某","role":"聲符","label":"讀音"}]},"謁":{"formula":"言 + 曷","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"曷","role":"聲符","label":"讀音"}]},"謂":{"formula":"言 + 胃","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"胃","role":"聲符","label":"讀音"}]},"謎":{"formula":"言 + 迷","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"迷","role":"部件","label":"迷"}]},"謙":{"formula":"言 + 兼","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"兼","role":"聲符","label":"讀音"}]},"講":{"formula":"言 + 冓","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"冓","role":"聲符","label":"讀音"}]},"謝":{"formula":"言 + 射","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"射","role":"聲符","label":"讀音"}]},"謠":{"formula":"言 + 䍃","components":[{"radical":"言","role":"聲符","label":"讀音"},{"radical":"䍃","role":"形符","label":"䍃"}]},"謹":{"formula":"言 + 堇","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"堇","role":"聲符","label":"讀音"}]},"證":{"formula":"言 + 登","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"登","role":"聲符","label":"讀音"}]},"識":{"formula":"言 + 戠","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"戠","role":"聲符","label":"讀音"}]},"譜":{"formula":"言 + 普","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"普","role":"聲符","label":"讀音"}]},"警":{"formula":"敬 + 言","components":[{"radical":"敬","role":"聲符","label":"讀音"},{"radical":"言","role":"形符","label":"說話"}]},"譬":{"formula":"辟 + 言","components":[{"radical":"辟","role":"聲符","label":"讀音"},{"radical":"言","role":"形符","label":"說話"}]},"譯":{"formula":"言 + 睪","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"睪","role":"部件","label":"睪"}]},"議":{"formula":"言 + 義","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"義","role":"聲符","label":"讀音"}]},"護":{"formula":"言 + 蒦","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"蒦","role":"聲符","label":"讀音"}]},"譽":{"formula":"與 + 言","components":[{"radical":"與","role":"聲符","label":"讀音"},{"radical":"言","role":"形符","label":"說話"}]},"讀":{"formula":"言 + 賣","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"賣","role":"部件","label":"賣"}]},"變":{"formula":"䜌 + 攵","components":[{"radical":"䜌","role":"部件","label":"䜌"},{"radical":"攵","role":"部件","label":"敲打"}]},"讓":{"formula":"言 + 襄","components":[{"radical":"言","role":"形符","label":"說話"},{"radical":"襄","role":"聲符","label":"讀音"}]},"讚":{"formula":"言 + 贊","components":[{"radical":"言","role":"部件","label":"說話"},{"radical":"贊","role":"部件","label":"贊"}]},"谷":{"formula":"八 + 人 + 口","components":[{"radical":"八","role":"部件","label":"八"},{"radical":"人","role":"部件","label":"人"},{"radical":"口","role":"部件","label":"嘴巴"}]},"谿":{"formula":"奚 + 谷","components":[{"radical":"奚","role":"聲符","label":"讀音"},{"radical":"谷","role":"形符","label":"山谷"}]},"豁":{"formula":"害 + 谷","components":[{"radical":"害","role":"聲符","label":"讀音"},{"radical":"谷","role":"形符","label":"山谷"}]},"豆":{"formula":"豆","components":[{"radical":"豆","role":"部件","label":"象形字（獨體）"}]},"豎":{"formula":"臤 + 豆","components":[{"radical":"臤","role":"形符","label":"臤"},{"radical":"豆","role":"聲符","label":"讀音"}]},"豐":{"formula":"山 + 丰 + 丰 + 豆","components":[{"radical":"山","role":"部件","label":"山"},{"radical":"丰","role":"部件","label":"丰"},{"radical":"丰","role":"部件","label":"丰"},{"radical":"豆","role":"部件","label":"豆子"}]},"豔":{"formula":"豐 + 盍","components":[{"radical":"豐","role":"聲符","label":"讀音"},{"radical":"盍","role":"形符","label":"盍"}]},"豚":{"formula":"豚","components":[{"radical":"豚","role":"部件","label":"象形字（獨體）"}]},"象":{"formula":"豕","components":[{"radical":"豕","role":"形符","label":"豬"}]},"豪":{"formula":"高 + 豕","components":[{"radical":"高","role":"聲符","label":"讀音"},{"radical":"豕","role":"形符","label":"豬"}]},"豫":{"formula":"予 + 象","components":[{"radical":"予","role":"聲符","label":"讀音"},{"radical":"象","role":"形符","label":"象"}]},"豬":{"formula":"豕 + 者","components":[{"radical":"豕","role":"形符","label":"豬"},{"radical":"者","role":"聲符","label":"讀音"}]},"豹":{"formula":"豸 + 勺","components":[{"radical":"豸","role":"形符","label":"爬蟲類的總稱"},{"radical":"勺","role":"聲符","label":"讀音"}]},"貂":{"formula":"豸 + 召","components":[{"radical":"豸","role":"形符","label":"爬蟲類的總稱"},{"radical":"召","role":"聲符","label":"讀音"}]},"貌":{"formula":"豸 + 皃","components":[{"radical":"豸","role":"部件","label":"爬蟲類的總稱"},{"radical":"皃","role":"部件","label":"皃"}]},"貓":{"formula":"豸 + 苗","components":[{"radical":"豸","role":"形符","label":"爬蟲類的總稱"},{"radical":"苗","role":"聲符","label":"讀音"}]},"貝":{"formula":"目 + 八","components":[{"radical":"目","role":"部件","label":"眼睛"},{"radical":"八","role":"部件","label":"八"}]},"負":{"formula":"⺈ + 貝","components":[{"radical":"⺈","role":"部件","label":"⺈"},{"radical":"貝","role":"部件","label":"錢財"}]},"財":{"formula":"貝 + 才","components":[{"radical":"貝","role":"形符","label":"錢財"},{"radical":"才","role":"聲符","label":"讀音"}]},"貢":{"formula":"工 + 貝","components":[{"radical":"工","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"貧":{"formula":"分 + 貝","components":[{"radical":"分","role":"部件","label":"分"},{"radical":"貝","role":"部件","label":"錢財"}]},"貨":{"formula":"化 + 貝","components":[{"radical":"化","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"販":{"formula":"貝 + 反","components":[{"radical":"貝","role":"形符","label":"錢財"},{"radical":"反","role":"聲符","label":"讀音"}]},"貪":{"formula":"今 + 貝","components":[{"radical":"今","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"貫":{"formula":"毌 + 貝","components":[{"radical":"毌","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"責":{"formula":"龶 + 貝","components":[{"radical":"龶","role":"部件","label":"龶"},{"radical":"貝","role":"部件","label":"錢財"}]},"貴":{"formula":"貝","components":[{"radical":"貝","role":"形符","label":"錢財"}]},"買":{"formula":"貝","components":[{"radical":"貝","role":"形符","label":"錢財"}]},"貸":{"formula":"代 + 貝","components":[{"radical":"代","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"費":{"formula":"弗 + 貝","components":[{"radical":"弗","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"貼":{"formula":"貝 + 占","components":[{"radical":"貝","role":"形符","label":"錢財"},{"radical":"占","role":"聲符","label":"讀音"}]},"賀":{"formula":"加 + 貝","components":[{"radical":"加","role":"部件","label":"加"},{"radical":"貝","role":"部件","label":"錢財"}]},"賁":{"formula":"卉 + 貝","components":[{"radical":"卉","role":"形符","label":"卉"},{"radical":"貝","role":"聲符","label":"讀音"}]},"賄":{"formula":"貝 + 有","components":[{"radical":"貝","role":"部件","label":"錢財"},{"radical":"有","role":"部件","label":"有"}]},"資":{"formula":"次 + 貝","components":[{"radical":"次","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"賈":{"formula":"覀 + 貝","components":[{"radical":"覀","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"賊":{"formula":"貝 + 戎","components":[{"radical":"貝","role":"聲符","label":"讀音"},{"radical":"戎","role":"形符","label":"戎"}]},"賓":{"formula":"宀 + 小 + 貝","components":[{"radical":"宀","role":"部件","label":"房頂"},{"radical":"小","role":"部件","label":"小"},{"radical":"貝","role":"部件","label":"錢財"}]},"賜":{"formula":"貝 + 易","components":[{"radical":"貝","role":"形符","label":"錢財"},{"radical":"易","role":"聲符","label":"讀音"}]},"賞":{"formula":"贝 + 尚","components":[{"radical":"贝","role":"形符","label":"shell"},{"radical":"尚","role":"聲符","label":"讀音"}]},"賣":{"formula":"貝 + 买","components":[{"radical":"貝","role":"形符","label":"錢財"},{"radical":"买","role":"聲符","label":"讀音"}]},"賤":{"formula":"貝 + 戔","components":[{"radical":"貝","role":"部件","label":"錢財"},{"radical":"戔","role":"部件","label":"戔"}]},"賦":{"formula":"貝 + 武","components":[{"radical":"貝","role":"部件","label":"錢財"},{"radical":"武","role":"部件","label":"武"}]},"質":{"formula":"斦 + 貝","components":[{"radical":"斦","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"賴":{"formula":"束 + 負","components":[{"radical":"束","role":"聲符","label":"讀音"},{"radical":"負","role":"形符","label":"負"}]},"賺":{"formula":"貝 + 兼","components":[{"radical":"貝","role":"形符","label":"錢財"},{"radical":"兼","role":"聲符","label":"讀音"}]},"購":{"formula":"貝 + 冓","components":[{"radical":"貝","role":"形符","label":"錢財"},{"radical":"冓","role":"聲符","label":"讀音"}]},"賽":{"formula":"宀 + 貝","components":[{"radical":"宀","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"贈":{"formula":"貝 + 曾","components":[{"radical":"貝","role":"形符","label":"錢財"},{"radical":"曾","role":"聲符","label":"讀音"}]},"贊":{"formula":"兟 + 貝","components":[{"radical":"兟","role":"聲符","label":"讀音"},{"radical":"貝","role":"形符","label":"錢財"}]},"贏":{"formula":"亡 + 口 + 月 + 貝 + 凡","components":[{"radical":"亡","role":"部件","label":"亡"},{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"月","role":"部件","label":"月亮"},{"radical":"貝","role":"形符","label":"錢財"},{"radical":"凡","role":"部件","label":"凡"}]},"贖":{"formula":"貝 + 賣","components":[{"radical":"貝","role":"部件","label":"錢財"},{"radical":"賣","role":"部件","label":"賣"}]},"赫":{"formula":"赤 + 赤","components":[{"radical":"赤","role":"部件","label":"紅色的"},{"radical":"赤","role":"部件","label":"紅色的"}]},"走":{"formula":"土 + 止","components":[{"radical":"土","role":"部件","label":"泥土"},{"radical":"止","role":"部件","label":"停止"}]},"赳":{"formula":"走 + 丩","components":[{"radical":"走","role":"形符","label":"行走"},{"radical":"丩","role":"聲符","label":"讀音"}]},"起":{"formula":"走 + 己","components":[{"radical":"走","role":"形符","label":"行走"},{"radical":"己","role":"聲符","label":"讀音"}]},"超":{"formula":"走 + 召","components":[{"radical":"走","role":"形符","label":"行走"},{"radical":"召","role":"聲符","label":"讀音"}]},"越":{"formula":"走 + 戉","components":[{"radical":"走","role":"形符","label":"行走"},{"radical":"戉","role":"聲符","label":"讀音"}]},"趕":{"formula":"走 + 旱","components":[{"radical":"走","role":"形符","label":"行走"},{"radical":"旱","role":"聲符","label":"讀音"}]},"趟":{"formula":"走 + 尚","components":[{"radical":"走","role":"形符","label":"行走"},{"radical":"尚","role":"聲符","label":"讀音"}]},"趣":{"formula":"走 + 取","components":[{"radical":"走","role":"形符","label":"行走"},{"radical":"取","role":"聲符","label":"讀音"}]},"趨":{"formula":"走 + 芻","components":[{"radical":"走","role":"形符","label":"行走"},{"radical":"芻","role":"聲符","label":"讀音"}]},"足":{"formula":"足","components":[{"radical":"足","role":"部件","label":"象形字（獨體）"}]},"趾":{"formula":"足 + 止","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"止","role":"聲符","label":"讀音"}]},"跌":{"formula":"足 + 失","components":[{"radical":"足","role":"部件","label":"足旁"},{"radical":"失","role":"部件","label":"失"}]},"跑":{"formula":"足 + 包","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"包","role":"聲符","label":"讀音"}]},"距":{"formula":"足 + 巨","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"巨","role":"聲符","label":"讀音"}]},"跟":{"formula":"足 + 艮","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"艮","role":"聲符","label":"讀音"}]},"跡":{"formula":"足 + 亦","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"亦","role":"聲符","label":"讀音"}]},"跤":{"formula":"足 + 交","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"交","role":"聲符","label":"讀音"}]},"跨":{"formula":"足 + 夸","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"夸","role":"聲符","label":"讀音"}]},"跪":{"formula":"足 + 危","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"危","role":"聲符","label":"讀音"}]},"路":{"formula":"足 + 各","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"各","role":"聲符","label":"讀音"}]},"跳":{"formula":"足 + 兆","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"兆","role":"聲符","label":"讀音"}]},"跺":{"formula":"足 + 朵","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"朵","role":"聲符","label":"讀音"}]},"踏":{"formula":"足 + 沓","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"沓","role":"聲符","label":"讀音"}]},"踐":{"formula":"足 + 戔","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"戔","role":"聲符","label":"讀音"}]},"踝":{"formula":"足 + 果","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"果","role":"聲符","label":"讀音"}]},"踢":{"formula":"足 + 易","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"易","role":"聲符","label":"讀音"}]},"踩":{"formula":"足 + 采","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"采","role":"聲符","label":"讀音"}]},"踴":{"formula":"足 + 勇","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"勇","role":"聲符","label":"讀音"}]},"蹂":{"formula":"足 + 柔","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"柔","role":"聲符","label":"讀音"}]},"蹄":{"formula":"足 + 帝","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"帝","role":"聲符","label":"讀音"}]},"蹈":{"formula":"足 + 舀","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"舀","role":"聲符","label":"讀音"}]},"蹋":{"formula":"足 + 日","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"日","role":"聲符","label":"讀音"}]},"蹟":{"formula":"足 + 責","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"責","role":"聲符","label":"讀音"}]},"蹤":{"formula":"足 + 從","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"從","role":"聲符","label":"讀音"}]},"蹲":{"formula":"足 + 尊","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"尊","role":"聲符","label":"讀音"}]},"蹶":{"formula":"足 + 厥","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"厥","role":"聲符","label":"讀音"}]},"躁":{"formula":"足 + 喿","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"喿","role":"聲符","label":"讀音"}]},"躍":{"formula":"足 + 翟","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"翟","role":"聲符","label":"讀音"}]},"躪":{"formula":"足 + 藺","components":[{"radical":"足","role":"形符","label":"足旁"},{"radical":"藺","role":"聲符","label":"讀音"}]},"身":{"formula":"身","components":[{"radical":"身","role":"部件","label":"象形字（獨體）"}]},"躲":{"formula":"身 + 朵","components":[{"radical":"身","role":"形符","label":"身體"},{"radical":"朵","role":"聲符","label":"讀音"}]},"躺":{"formula":"身 + 尚","components":[{"radical":"身","role":"形符","label":"身體"},{"radical":"尚","role":"聲符","label":"讀音"}]},"軀":{"formula":"身 + 區","components":[{"radical":"身","role":"形符","label":"身體"},{"radical":"區","role":"聲符","label":"讀音"}]},"車":{"formula":"車","components":[{"radical":"車","role":"部件","label":"象形字（獨體）"}]},"軍":{"formula":"冖 + 車","components":[{"radical":"冖","role":"部件","label":"覆蓋"},{"radical":"車","role":"部件","label":"車輛"}]},"軟":{"formula":"車 + 欠","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"欠","role":"聲符","label":"讀音"}]},"軸":{"formula":"車 + 由","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"由","role":"聲符","label":"讀音"}]},"較":{"formula":"車 + 交","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"交","role":"聲符","label":"讀音"}]},"載":{"formula":"哉 + 車","components":[{"radical":"哉","role":"聲符","label":"讀音"},{"radical":"車","role":"形符","label":"車輛"}]},"輔":{"formula":"車 + 甫","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"甫","role":"聲符","label":"讀音"}]},"輕":{"formula":"車 + 巠","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"巠","role":"聲符","label":"讀音"}]},"輩":{"formula":"非 + 車","components":[{"radical":"非","role":"聲符","label":"讀音"},{"radical":"車","role":"形符","label":"車輛"}]},"輪":{"formula":"車 + 侖","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"侖","role":"聲符","label":"讀音"}]},"輯":{"formula":"車 + 咠","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"咠","role":"聲符","label":"讀音"}]},"輸":{"formula":"車 + 俞","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"俞","role":"聲符","label":"讀音"}]},"輻":{"formula":"車 + 畐","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"畐","role":"聲符","label":"讀音"}]},"輾":{"formula":"車 + 展","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"展","role":"聲符","label":"讀音"}]},"輿":{"formula":"舁 + 車","components":[{"radical":"舁","role":"部件","label":"舁"},{"radical":"車","role":"部件","label":"車輛"}]},"轅":{"formula":"車 + 袁","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"袁","role":"聲符","label":"讀音"}]},"轉":{"formula":"車 + 專","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"專","role":"聲符","label":"讀音"}]},"轍":{"formula":"車 + 徹","components":[{"radical":"車","role":"形符","label":"車輛"},{"radical":"徹","role":"聲符","label":"讀音"}]},"轟":{"formula":"車 + 車 + 車","components":[{"radical":"車","role":"部件","label":"車輛"},{"radical":"車","role":"部件","label":"車輛"},{"radical":"車","role":"部件","label":"車輛"}]},"辛":{"formula":"辛","components":[{"radical":"辛","role":"部件","label":"象形字（獨體）"}]},"辜":{"formula":"古 + 辛","components":[{"radical":"古","role":"聲符","label":"讀音"},{"radical":"辛","role":"形符","label":"辛苦"}]},"辣":{"formula":"辛 + 束","components":[{"radical":"辛","role":"形符","label":"辛苦"},{"radical":"束","role":"聲符","label":"讀音"}]},"辦":{"formula":"辛 + 力","components":[{"radical":"辛","role":"聲符","label":"讀音"},{"radical":"力","role":"形符","label":"力量"}]},"辨":{"formula":"辛 + 刂 + 辛","components":[{"radical":"辛","role":"部件","label":"辛苦"},{"radical":"刂","role":"部件","label":"刀旁"},{"radical":"辛","role":"部件","label":"辛苦"}]},"辯":{"formula":"辛 + 言 + 辛","components":[{"radical":"辛","role":"部件","label":"辛苦"},{"radical":"言","role":"部件","label":"說話"},{"radical":"辛","role":"部件","label":"辛苦"}]},"農":{"formula":"農","components":[{"radical":"農","role":"部件","label":"象形字（獨體）"}]},"迅":{"formula":"辶 + 卂","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"卂","role":"部件","label":"卂"}]},"迎":{"formula":"辶 + 卬","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"卬","role":"聲符","label":"讀音"}]},"近":{"formula":"辶 + 斤","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"斤","role":"聲符","label":"讀音"}]},"返":{"formula":"辶 + 反","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"反","role":"部件","label":"反"}]},"迢":{"formula":"辶 + 召","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"召","role":"聲符","label":"讀音"}]},"迥":{"formula":"辶 + 冋","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"冋","role":"部件","label":"冋"}]},"迪":{"formula":"辶 + 由","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"由","role":"部件","label":"由"}]},"迫":{"formula":"辶 + 白","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"白","role":"聲符","label":"讀音"}]},"迭":{"formula":"辶 + 失","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"失","role":"聲符","label":"讀音"}]},"述":{"formula":"辶 + 术","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"术","role":"聲符","label":"讀音"}]},"迴":{"formula":"辶 + 回","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"回","role":"部件","label":"回"}]},"迷":{"formula":"辶 + 米","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"米","role":"聲符","label":"讀音"}]},"追":{"formula":"辶 + 㠯","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"㠯","role":"聲符","label":"讀音"}]},"退":{"formula":"辶 + 艮","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"艮","role":"聲符","label":"讀音"}]},"送":{"formula":"辶 + 关","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"关","role":"部件","label":"关"}]},"逃":{"formula":"辶 + 兆","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"兆","role":"聲符","label":"讀音"}]},"逆":{"formula":"辶 + 屰","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"屰","role":"部件","label":"屰"}]},"透":{"formula":"辶 + 秀","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"秀","role":"聲符","label":"讀音"}]},"逐":{"formula":"辶 + 豕","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"豕","role":"聲符","label":"讀音"}]},"途":{"formula":"辶 + 余","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"余","role":"聲符","label":"讀音"}]},"逕":{"formula":"辶 + 巠","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"巠","role":"聲符","label":"讀音"}]},"逗":{"formula":"辶 + 豆","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"豆","role":"聲符","label":"讀音"}]},"這":{"formula":"辶 + 言","components":[{"radical":"辶","role":"聲符","label":"讀音"},{"radical":"言","role":"形符","label":"說話"}]},"通":{"formula":"辶 + 甬","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"甬","role":"聲符","label":"讀音"}]},"逝":{"formula":"辶 + 折","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"折","role":"聲符","label":"讀音"}]},"速":{"formula":"辶 + 束","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"束","role":"聲符","label":"讀音"}]},"造":{"formula":"辶 + 告","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"告","role":"聲符","label":"讀音"}]},"逢":{"formula":"辶 + 夆","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"夆","role":"聲符","label":"讀音"}]},"連":{"formula":"辶 + 車","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"車","role":"部件","label":"車輛"}]},"週":{"formula":"辶 + 周","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"周","role":"部件","label":"周"}]},"進":{"formula":"辶 + 隹","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"隹","role":"聲符","label":"讀音"}]},"逸":{"formula":"辶 + 兔","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"兔","role":"部件","label":"兔"}]},"逼":{"formula":"辶 + 畐","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"畐","role":"聲符","label":"讀音"}]},"遂":{"formula":"辶 + 豕","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"豕","role":"聲符","label":"讀音"}]},"遇":{"formula":"辶 + 禺","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"禺","role":"聲符","label":"讀音"}]},"遊":{"formula":"辶 + 斿","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"斿","role":"聲符","label":"讀音"}]},"運":{"formula":"辶 + 軍","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"軍","role":"聲符","label":"讀音"}]},"遍":{"formula":"辶 + 扁","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"扁","role":"聲符","label":"讀音"}]},"過":{"formula":"辶 + 咼","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"咼","role":"聲符","label":"讀音"}]},"遐":{"formula":"辶 + 叚","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"叚","role":"聲符","label":"讀音"}]},"道":{"formula":"辶 + 首","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"首","role":"聲符","label":"讀音"}]},"達":{"formula":"辶 + 羍","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"羍","role":"聲符","label":"讀音"}]},"違":{"formula":"辶 + 韋","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"韋","role":"聲符","label":"讀音"}]},"遙":{"formula":"辶 + 䍃","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"䍃","role":"聲符","label":"讀音"}]},"遜":{"formula":"辶 + 孫","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"孫","role":"聲符","label":"讀音"}]},"遞":{"formula":"辶 + 虒","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"虒","role":"聲符","label":"讀音"}]},"遠":{"formula":"辶 + 袁","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"袁","role":"聲符","label":"讀音"}]},"適":{"formula":"辶 + 啇","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"啇","role":"聲符","label":"讀音"}]},"遭":{"formula":"辶 + 曹","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"曹","role":"聲符","label":"讀音"}]},"遮":{"formula":"辶 + 庶","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"庶","role":"聲符","label":"讀音"}]},"遲":{"formula":"辶 + 犀","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"犀","role":"聲符","label":"讀音"}]},"遵":{"formula":"辶 + 尊","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"尊","role":"部件","label":"尊"}]},"遷":{"formula":"辶 + 䙴","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"䙴","role":"聲符","label":"讀音"}]},"選":{"formula":"辶 + 巽","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"巽","role":"聲符","label":"讀音"}]},"遺":{"formula":"辶 + 貴","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"貴","role":"部件","label":"貴"}]},"遼":{"formula":"辶 + 尞","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"尞","role":"聲符","label":"讀音"}]},"避":{"formula":"辶 + 辟","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"辟","role":"聲符","label":"讀音"}]},"邀":{"formula":"辶 + 敫","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"敫","role":"聲符","label":"讀音"}]},"邁":{"formula":"辶 + 萬","components":[{"radical":"辶","role":"部件","label":"走旁"},{"radical":"萬","role":"部件","label":"萬"}]},"邇":{"formula":"辶 + 爾","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"爾","role":"聲符","label":"讀音"}]},"邊":{"formula":"辶 + 臱","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"臱","role":"聲符","label":"讀音"}]},"邏":{"formula":"辶 + 羅","components":[{"radical":"辶","role":"形符","label":"走旁"},{"radical":"羅","role":"聲符","label":"讀音"}]},"邑":{"formula":"口 + 巴","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"巴","role":"部件","label":"巴"}]},"那":{"formula":"月 + 邑","components":[{"radical":"月","role":"部件","label":"月亮"},{"radical":"邑","role":"部件","label":"城邑"}]},"邪":{"formula":"牙 + 邑","components":[{"radical":"牙","role":"部件","label":"牙齒"},{"radical":"邑","role":"部件","label":"城邑"}]},"邸":{"formula":"氐 + 阝","components":[{"radical":"氐","role":"聲符","label":"讀音"},{"radical":"阝","role":"形符","label":"耳旁"}]},"郁":{"formula":"有 + 阝","components":[{"radical":"有","role":"聲符","label":"讀音"},{"radical":"阝","role":"形符","label":"耳旁"}]},"郎":{"formula":"良 + 阝","components":[{"radical":"良","role":"部件","label":"良"},{"radical":"阝","role":"部件","label":"耳旁"}]},"郡":{"formula":"君 + 阝","components":[{"radical":"君","role":"聲符","label":"讀音"},{"radical":"阝","role":"形符","label":"耳旁"}]},"部":{"formula":"咅 + 阝","components":[{"radical":"咅","role":"聲符","label":"讀音"},{"radical":"阝","role":"形符","label":"耳旁"}]},"郭":{"formula":"享 + 阝","components":[{"radical":"享","role":"部件","label":"享"},{"radical":"阝","role":"部件","label":"耳旁"}]},"都":{"formula":"者 + 阝","components":[{"radical":"者","role":"聲符","label":"讀音"},{"radical":"阝","role":"形符","label":"耳旁"}]},"鄉":{"formula":"乡 + 郎","components":[{"radical":"乡","role":"部件","label":"乡"},{"radical":"郎","role":"部件","label":"郎"}]},"鄧":{"formula":"登 + 阝","components":[{"radical":"登","role":"聲符","label":"讀音"},{"radical":"阝","role":"形符","label":"耳旁"}]},"鄰":{"formula":"粦 + 阝","components":[{"radical":"粦","role":"聲符","label":"讀音"},{"radical":"阝","role":"形符","label":"耳旁"}]},"酌":{"formula":"酉 + 勺","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"勺","role":"聲符","label":"讀音"}]},"配":{"formula":"酉 + 己","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"己","role":"聲符","label":"讀音"}]},"酒":{"formula":"氵 + 酉","components":[{"radical":"氵","role":"部件","label":"水旁"},{"radical":"酉","role":"部件","label":"酒"}]},"酗":{"formula":"酉 + 凶","components":[{"radical":"酉","role":"部件","label":"酒"},{"radical":"凶","role":"部件","label":"凶"}]},"酪":{"formula":"酉 + 各","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"各","role":"聲符","label":"讀音"}]},"酬":{"formula":"酉 + 州","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"州","role":"聲符","label":"讀音"}]},"酷":{"formula":"酉 + 告","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"告","role":"聲符","label":"讀音"}]},"酸":{"formula":"酉 + 夋","components":[{"radical":"酉","role":"部件","label":"酒"},{"radical":"夋","role":"部件","label":"夋"}]},"醉":{"formula":"酉 + 卒","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"卒","role":"聲符","label":"讀音"}]},"醍":{"formula":"酉 + 是","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"是","role":"聲符","label":"讀音"}]},"醐":{"formula":"酉 + 胡","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"胡","role":"聲符","label":"讀音"}]},"醒":{"formula":"酉 + 星","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"星","role":"聲符","label":"讀音"}]},"醜":{"formula":"酉 + 鬼","components":[{"radical":"酉","role":"聲符","label":"讀音"},{"radical":"鬼","role":"形符","label":"鬼神"}]},"醫":{"formula":"殹 + 酉","components":[{"radical":"殹","role":"聲符","label":"讀音"},{"radical":"酉","role":"形符","label":"酒"}]},"醬":{"formula":"將 + 酉","components":[{"radical":"將","role":"聲符","label":"讀音"},{"radical":"酉","role":"形符","label":"酒"}]},"醺":{"formula":"酉 + 熏","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"熏","role":"聲符","label":"讀音"}]},"釀":{"formula":"酉 + 襄","components":[{"radical":"酉","role":"形符","label":"酒"},{"radical":"襄","role":"聲符","label":"讀音"}]},"采":{"formula":"爫 + 木","components":[{"radical":"爫","role":"部件","label":"爫"},{"radical":"木","role":"部件","label":"樹木"}]},"釋":{"formula":"釆 + 睪","components":[{"radical":"釆","role":"形符","label":"分別"},{"radical":"睪","role":"聲符","label":"讀音"}]},"里":{"formula":"田 + 土","components":[{"radical":"田","role":"部件","label":"田地"},{"radical":"土","role":"部件","label":"泥土"}]},"重":{"formula":"千 + 里","components":[{"radical":"千","role":"部件","label":"千"},{"radical":"里","role":"部件","label":"距離"}]},"野":{"formula":"里 + 予","components":[{"radical":"里","role":"形符","label":"距離"},{"radical":"予","role":"聲符","label":"讀音"}]},"量":{"formula":"旦 + 里","components":[{"radical":"旦","role":"聲符","label":"讀音"},{"radical":"里","role":"形符","label":"距離"}]},"釐":{"formula":"厘","components":[{"radical":"厘","role":"聲符","label":"讀音"}]},"金":{"formula":"金","components":[{"radical":"金","role":"部件","label":"象形字（獨體）"}]},"釘":{"formula":"釒 + 丁","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"丁","role":"部件","label":"丁"}]},"針":{"formula":"釒 + 十","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"十","role":"部件","label":"十"}]},"釣":{"formula":"釒 + 勺","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"勺","role":"部件","label":"勺"}]},"鈍":{"formula":"釒 + 屯","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"屯","role":"聲符","label":"讀音"}]},"鈎":{"formula":"釒 + 勾","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"勾","role":"部件","label":"勾"}]},"鈣":{"formula":"釒 + 丐","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"丐","role":"聲符","label":"讀音"}]},"鈴":{"formula":"釒 + 令","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"令","role":"聲符","label":"讀音"}]},"鈺":{"formula":"釒 + 玉","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"玉","role":"部件","label":"玉石"}]},"鉅":{"formula":"釒 + 巨","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"巨","role":"聲符","label":"讀音"}]},"鉛":{"formula":"釒 + 几","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"几","role":"聲符","label":"讀音"}]},"鉤":{"formula":"釒 + 句","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"句","role":"部件","label":"句"}]},"銀":{"formula":"釒 + 艮","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"艮","role":"聲符","label":"讀音"}]},"銅":{"formula":"釒 + 同","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"同","role":"聲符","label":"讀音"}]},"銳":{"formula":"釒 + 兌","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"兌","role":"聲符","label":"讀音"}]},"銷":{"formula":"釒 + 肖","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"肖","role":"聲符","label":"讀音"}]},"鋁":{"formula":"釒 + 吕","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"吕","role":"聲符","label":"讀音"}]},"鋒":{"formula":"釒 + 夆","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"夆","role":"聲符","label":"讀音"}]},"鋪":{"formula":"釒 + 甫","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"甫","role":"聲符","label":"讀音"}]},"錄":{"formula":"釒 + 彔","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"彔","role":"部件","label":"彔"}]},"錘":{"formula":"釒 + 垂","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"垂","role":"聲符","label":"讀音"}]},"錢":{"formula":"釒 + 戔","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"戔","role":"聲符","label":"讀音"}]},"錦":{"formula":"釒 + 帛","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"帛","role":"部件","label":"帛"}]},"錯":{"formula":"釒 + 昔","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"昔","role":"部件","label":"昔"}]},"鍊":{"formula":"釒 + 柬","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"柬","role":"聲符","label":"讀音"}]},"鍛":{"formula":"釒 + 段","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"段","role":"聲符","label":"讀音"}]},"鍥":{"formula":"釒 + 契","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"契","role":"部件","label":"契"}]},"鍵":{"formula":"釒 + 建","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"建","role":"聲符","label":"讀音"}]},"鎖":{"formula":"釒 + ⺌","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"⺌","role":"聲符","label":"讀音"}]},"鎮":{"formula":"釒 + 真","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"真","role":"聲符","label":"讀音"}]},"鏈":{"formula":"釒 + 連","components":[{"radical":"釒","role":"部件","label":"金屬"},{"radical":"連","role":"部件","label":"連"}]},"鏟":{"formula":"釒 + 産","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"産","role":"聲符","label":"讀音"}]},"鏡":{"formula":"釒 + 竟","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"竟","role":"聲符","label":"讀音"}]},"鐘":{"formula":"釒 + 童","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"童","role":"聲符","label":"讀音"}]},"鐮":{"formula":"釒 + 廉","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"廉","role":"聲符","label":"讀音"}]},"鐵":{"formula":"釒 + 戜","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"戜","role":"聲符","label":"讀音"}]},"鑑":{"formula":"釒 + 監","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"監","role":"聲符","label":"讀音"}]},"鑼":{"formula":"釒 + 羅","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"羅","role":"聲符","label":"讀音"}]},"鑽":{"formula":"釒 + 贊","components":[{"radical":"釒","role":"形符","label":"金屬"},{"radical":"贊","role":"聲符","label":"讀音"}]},"長":{"formula":"長","components":[{"radical":"長","role":"部件","label":"象形字（獨體）"}]},"門":{"formula":"門","components":[{"radical":"門","role":"部件","label":"象形字（獨體）"}]},"閃":{"formula":"門 + 人","components":[{"radical":"門","role":"部件","label":"門"},{"radical":"人","role":"部件","label":"人"}]},"閉":{"formula":"門 + 才","components":[{"radical":"門","role":"部件","label":"門"},{"radical":"才","role":"部件","label":"才"}]},"開":{"formula":"門 + 开","components":[{"radical":"門","role":"形符","label":"門"},{"radical":"开","role":"聲符","label":"讀音"}]},"閑":{"formula":"門 + 木","components":[{"radical":"門","role":"部件","label":"門"},{"radical":"木","role":"部件","label":"樹木"}]},"閒":{"formula":"門 + 月","components":[{"radical":"門","role":"部件","label":"門"},{"radical":"月","role":"部件","label":"月亮"}]},"間":{"formula":"門 + 日","components":[{"radical":"門","role":"部件","label":"門"},{"radical":"日","role":"部件","label":"太陽"}]},"閣":{"formula":"門 + 各","components":[{"radical":"門","role":"形符","label":"門"},{"radical":"各","role":"聲符","label":"讀音"}]},"閩":{"formula":"門 + 虫","components":[{"radical":"門","role":"聲符","label":"讀音"},{"radical":"虫","role":"形符","label":"蟲類"}]},"闆":{"formula":"門 + 品","components":[{"radical":"門","role":"部件","label":"門"},{"radical":"品","role":"部件","label":"品"}]},"闊":{"formula":"門 + 活","components":[{"radical":"門","role":"形符","label":"門"},{"radical":"活","role":"聲符","label":"讀音"}]},"關":{"formula":"門 + 丱","components":[{"radical":"門","role":"形符","label":"門"},{"radical":"丱","role":"聲符","label":"讀音"}]},"阱":{"formula":"阝 + 井","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"井","role":"部件","label":"井"}]},"防":{"formula":"阝 + 方","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"方","role":"聲符","label":"讀音"}]},"阻":{"formula":"阝 + 且","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"且","role":"聲符","label":"讀音"}]},"阿":{"formula":"阝 + 可","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"可","role":"聲符","label":"讀音"}]},"附":{"formula":"阝 + 付","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"付","role":"聲符","label":"讀音"}]},"际":{"formula":"阝 + 示","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"示","role":"聲符","label":"讀音"}]},"陋":{"formula":"阝","components":[{"radical":"阝","role":"形符","label":"耳旁"}]},"陌":{"formula":"阝 + 百","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"百","role":"部件","label":"百"}]},"降":{"formula":"阝 + 夅","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"夅","role":"聲符","label":"讀音"}]},"限":{"formula":"阝 + 艮","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"艮","role":"聲符","label":"讀音"}]},"陡":{"formula":"阝 + 走","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"走","role":"聲符","label":"讀音"}]},"院":{"formula":"阝 + 完","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"完","role":"聲符","label":"讀音"}]},"陣":{"formula":"阝 + 車","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"車","role":"部件","label":"車輛"}]},"除":{"formula":"阝 + 余","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"余","role":"部件","label":"余"}]},"陪":{"formula":"阝 + 咅","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"咅","role":"聲符","label":"讀音"}]},"陰":{"formula":"阝 + 侌","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"侌","role":"部件","label":"侌"}]},"陳":{"formula":"阝 + 東","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"東","role":"部件","label":"東"}]},"陷":{"formula":"阝 + 臽","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"臽","role":"部件","label":"臽"}]},"陸":{"formula":"阝 + 坴","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"坴","role":"聲符","label":"讀音"}]},"陽":{"formula":"阝 + 昜","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"昜","role":"部件","label":"昜"}]},"隊":{"formula":"阝 + 㒸","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"㒸","role":"聲符","label":"讀音"}]},"階":{"formula":"阝 + 皆","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"皆","role":"聲符","label":"讀音"}]},"隔":{"formula":"阝 + 鬲","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"鬲","role":"聲符","label":"讀音"}]},"際":{"formula":"阝 + 祭","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"祭","role":"聲符","label":"讀音"}]},"障":{"formula":"阝 + 章","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"章","role":"聲符","label":"讀音"}]},"隧":{"formula":"阝 + 遂","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"遂","role":"聲符","label":"讀音"}]},"隨":{"formula":"阝 + 遀","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"遀","role":"部件","label":"遀"}]},"險":{"formula":"阝 + 僉","components":[{"radical":"阝","role":"形符","label":"耳旁"},{"radical":"僉","role":"聲符","label":"讀音"}]},"隱":{"formula":"阝 + 㥯","components":[{"radical":"阝","role":"部件","label":"耳旁"},{"radical":"㥯","role":"部件","label":"㥯"}]},"隸":{"formula":"柰 + 隶","components":[{"radical":"柰","role":"形符","label":"柰"},{"radical":"隶","role":"聲符","label":"讀音"}]},"隻":{"formula":"隹 + 又","components":[{"radical":"隹","role":"聲符","label":"讀音"},{"radical":"又","role":"形符","label":"手"}]},"雀":{"formula":"小 + 隹","components":[{"radical":"小","role":"部件","label":"小"},{"radical":"隹","role":"部件","label":"鳥類"}]},"雄":{"formula":"厷 + 隹","components":[{"radical":"厷","role":"聲符","label":"讀音"},{"radical":"隹","role":"形符","label":"鳥類"}]},"雅":{"formula":"牙 + 隹","components":[{"radical":"牙","role":"聲符","label":"讀音"},{"radical":"隹","role":"形符","label":"鳥類"}]},"集":{"formula":"隹 + 木","components":[{"radical":"隹","role":"部件","label":"鳥類"},{"radical":"木","role":"部件","label":"樹木"}]},"雇":{"formula":"户 + 隹","components":[{"radical":"户","role":"聲符","label":"讀音"},{"radical":"隹","role":"形符","label":"鳥類"}]},"雌":{"formula":"此 + 隹","components":[{"radical":"此","role":"聲符","label":"讀音"},{"radical":"隹","role":"形符","label":"鳥類"}]},"雕":{"formula":"周 + 隹","components":[{"radical":"周","role":"聲符","label":"讀音"},{"radical":"隹","role":"形符","label":"鳥類"}]},"雖":{"formula":"隹","components":[{"radical":"隹","role":"聲符","label":"讀音"}]},"雙":{"formula":"雔 + 又","components":[{"radical":"雔","role":"部件","label":"雔"},{"radical":"又","role":"部件","label":"手"}]},"雛":{"formula":"芻 + 隹","components":[{"radical":"芻","role":"聲符","label":"讀音"},{"radical":"隹","role":"形符","label":"鳥類"}]},"雜":{"formula":"九 + 木 + 隹","components":[{"radical":"九","role":"部件","label":"九"},{"radical":"木","role":"部件","label":"樹木"},{"radical":"隹","role":"聲符","label":"短尾鳥"}]},"雞":{"formula":"奚 + 隹","components":[{"radical":"奚","role":"部件","label":"奚"},{"radical":"隹","role":"部件","label":"鳥類"}]},"離":{"formula":"离 + 隹","components":[{"radical":"离","role":"聲符","label":"讀音"},{"radical":"隹","role":"形符","label":"鳥類"}]},"難":{"formula":"堇 + 隹","components":[{"radical":"堇","role":"聲符","label":"讀音"},{"radical":"隹","role":"形符","label":"鳥類"}]},"雨":{"formula":"雨","components":[{"radical":"雨","role":"部件","label":"象形字（獨體）"}]},"雪":{"formula":"雨 + 彐","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"彐","role":"聲符","label":"讀音"}]},"雲":{"formula":"雨 + 云","components":[{"radical":"雨","role":"部件","label":"天氣"},{"radical":"云","role":"部件","label":"云"}]},"零":{"formula":"雨 + 令","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"令","role":"聲符","label":"讀音"}]},"雷":{"formula":"雨 + 田","components":[{"radical":"雨","role":"部件","label":"天氣"},{"radical":"田","role":"部件","label":"田地"}]},"雹":{"formula":"雨 + 包","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"包","role":"聲符","label":"讀音"}]},"電":{"formula":"雨 + 电","components":[{"radical":"雨","role":"部件","label":"天氣"},{"radical":"电","role":"部件","label":"电"}]},"需":{"formula":"雨 + 而","components":[{"radical":"雨","role":"部件","label":"天氣"},{"radical":"而","role":"部件","label":"兩頰上的毛"}]},"霄":{"formula":"雨 + 肖","components":[{"radical":"雨","role":"部件","label":"天氣"},{"radical":"肖","role":"部件","label":"肖"}]},"霆":{"formula":"雨 + 廷","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"廷","role":"聲符","label":"讀音"}]},"震":{"formula":"雨 + 辰","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"辰","role":"聲符","label":"讀音"}]},"霜":{"formula":"雨 + 相","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"相","role":"聲符","label":"讀音"}]},"霧":{"formula":"雨 + 務","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"務","role":"聲符","label":"讀音"}]},"露":{"formula":"雨 + 路","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"路","role":"聲符","label":"讀音"}]},"霸":{"formula":"雨 + 革 + 月","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"革","role":"部件","label":"皮革"},{"radical":"月","role":"部件","label":"月亮"}]},"霾":{"formula":"雨 + 貍","components":[{"radical":"雨","role":"形符","label":"天氣"},{"radical":"貍","role":"聲符","label":"讀音"}]},"青":{"formula":"丰 + 月","components":[{"radical":"丰","role":"部件","label":"丰"},{"radical":"月","role":"部件","label":"月亮"}]},"靜":{"formula":"青 + 爭","components":[{"radical":"青","role":"形符","label":"青色"},{"radical":"爭","role":"聲符","label":"讀音"}]},"非":{"formula":"三 + 丿 + 丨 + 三","components":[{"radical":"三","role":"部件","label":"三"},{"radical":"丿","role":"部件","label":"撇"},{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"三","role":"部件","label":"三"}]},"靠":{"formula":"告 + 非","components":[{"radical":"告","role":"聲符","label":"讀音"},{"radical":"非","role":"形符","label":"不是"}]},"面":{"formula":"面","components":[{"radical":"面","role":"部件","label":"象形字（獨體）"}]},"革":{"formula":"革","components":[{"radical":"革","role":"部件","label":"象形字（獨體）"}]},"鞋":{"formula":"革 + 圭","components":[{"radical":"革","role":"形符","label":"皮革"},{"radical":"圭","role":"聲符","label":"讀音"}]},"鞍":{"formula":"革 + 安","components":[{"radical":"革","role":"形符","label":"皮革"},{"radical":"安","role":"聲符","label":"讀音"}]},"鞏":{"formula":"巩 + 革","components":[{"radical":"巩","role":"部件","label":"巩"},{"radical":"革","role":"部件","label":"皮革"}]},"鞭":{"formula":"革 + 便","components":[{"radical":"革","role":"形符","label":"皮革"},{"radical":"便","role":"聲符","label":"讀音"}]},"韌":{"formula":"韋 + 刃","components":[{"radical":"韋","role":"形符","label":"韋"},{"radical":"刃","role":"聲符","label":"讀音"}]},"音":{"formula":"立 + 日","components":[{"radical":"立","role":"部件","label":"站立"},{"radical":"日","role":"部件","label":"太陽"}]},"韻":{"formula":"音 + 員","components":[{"radical":"音","role":"部件","label":"聲音"},{"radical":"員","role":"部件","label":"員"}]},"響":{"formula":"鄉 + 音","components":[{"radical":"鄉","role":"聲符","label":"讀音"},{"radical":"音","role":"形符","label":"聲音"}]},"頂":{"formula":"丁 + 頁","components":[{"radical":"丁","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"項":{"formula":"工 + 頁","components":[{"radical":"工","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"順":{"formula":"川 + 頁","components":[{"radical":"川","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"須":{"formula":"彡 + 頁","components":[{"radical":"彡","role":"部件","label":"花紋"},{"radical":"頁","role":"部件","label":"頭部"}]},"預":{"formula":"予 + 頁","components":[{"radical":"予","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"頑":{"formula":"元 + 頁","components":[{"radical":"元","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"頓":{"formula":"屯 + 頁","components":[{"radical":"屯","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"頗":{"formula":"皮 + 頁","components":[{"radical":"皮","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"領":{"formula":"令 + 頁","components":[{"radical":"令","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"頡":{"formula":"吉 + 頁","components":[{"radical":"吉","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"頭":{"formula":"豆 + 頁","components":[{"radical":"豆","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"頸":{"formula":"巠 + 頁","components":[{"radical":"巠","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"顆":{"formula":"果 + 頁","components":[{"radical":"果","role":"形符","label":"果"},{"radical":"頁","role":"聲符","label":"讀音"}]},"題":{"formula":"是 + 頁","components":[{"radical":"是","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"額":{"formula":"客 + 頁","components":[{"radical":"客","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"顏":{"formula":"彥 + 頁","components":[{"radical":"彥","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"願":{"formula":"原 + 頁","components":[{"radical":"原","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"顛":{"formula":"真 + 頁","components":[{"radical":"真","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"顧":{"formula":"雇 + 頁","components":[{"radical":"雇","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"顯":{"formula":"㬎 + 頁","components":[{"radical":"㬎","role":"聲符","label":"讀音"},{"radical":"頁","role":"形符","label":"頭部"}]},"颱":{"formula":"風 + 台","components":[{"radical":"風","role":"部件","label":"風"},{"radical":"台","role":"部件","label":"台"}]},"飄":{"formula":"票 + 風","components":[{"radical":"票","role":"聲符","label":"讀音"},{"radical":"風","role":"形符","label":"風"}]},"飆":{"formula":"猋 + 風","components":[{"radical":"猋","role":"部件","label":"猋"},{"radical":"風","role":"部件","label":"風"}]},"飛":{"formula":"飞 + 飞","components":[{"radical":"飞","role":"部件","label":"fly"},{"radical":"飞","role":"部件","label":"fly"}]},"食":{"formula":"食","components":[{"radical":"食","role":"部件","label":"象形字（獨體）"}]},"飢":{"formula":"飠 + 几","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"几","role":"聲符","label":"讀音"}]},"飯":{"formula":"飠 + 反","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"反","role":"聲符","label":"讀音"}]},"飲":{"formula":"飠 + 欠","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"欠","role":"聲符","label":"讀音"}]},"飽":{"formula":"飠 + 包","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"包","role":"聲符","label":"讀音"}]},"飾":{"formula":"飠 + 巾","components":[{"radical":"飠","role":"聲符","label":"讀音"},{"radical":"巾","role":"形符","label":"布"}]},"餅":{"formula":"飠 + 并","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"并","role":"聲符","label":"讀音"}]},"養":{"formula":"羊 + 食","components":[{"radical":"羊","role":"聲符","label":"讀音"},{"radical":"食","role":"形符","label":"食物"}]},"餌":{"formula":"飠 + 耳","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"耳","role":"聲符","label":"讀音"}]},"餐":{"formula":"食","components":[{"radical":"食","role":"形符","label":"食物"}]},"餒":{"formula":"飠 + 妥","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"妥","role":"聲符","label":"讀音"}]},"餓":{"formula":"飠 + 我","components":[{"radical":"飠","role":"部件","label":"食物"},{"radical":"我","role":"部件","label":"我"}]},"餘":{"formula":"飠 + 余","components":[{"radical":"飠","role":"部件","label":"食物"},{"radical":"余","role":"部件","label":"余"}]},"館":{"formula":"飠 + 官","components":[{"radical":"飠","role":"部件","label":"食物"},{"radical":"官","role":"部件","label":"官"}]},"餵":{"formula":"飠 + 畏","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"畏","role":"聲符","label":"讀音"}]},"饋":{"formula":"飠 + 貴","components":[{"radical":"飠","role":"部件","label":"食物"},{"radical":"貴","role":"部件","label":"貴"}]},"饑":{"formula":"飠 + 幾","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"幾","role":"聲符","label":"讀音"}]},"饒":{"formula":"飠 + 堯","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"堯","role":"聲符","label":"讀音"}]},"饞":{"formula":"飠 + 毚","components":[{"radical":"飠","role":"形符","label":"食物"},{"radical":"毚","role":"聲符","label":"讀音"}]},"首":{"formula":"丷 + 自","components":[{"radical":"丷","role":"部件","label":"丷"},{"radical":"自","role":"部件","label":"自己"}]},"香":{"formula":"禾 + 日","components":[{"radical":"禾","role":"部件","label":"穀物"},{"radical":"日","role":"部件","label":"太陽"}]},"馬":{"formula":"馬","components":[{"radical":"馬","role":"部件","label":"象形字（獨體）"}]},"馳":{"formula":"馬 + 也","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"也","role":"聲符","label":"讀音"}]},"駕":{"formula":"加 + 馬","components":[{"radical":"加","role":"聲符","label":"讀音"},{"radical":"馬","role":"形符","label":"馬"}]},"駛":{"formula":"馬 + 史","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"史","role":"聲符","label":"讀音"}]},"駝":{"formula":"馬 + 它","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"它","role":"聲符","label":"讀音"}]},"騎":{"formula":"馬 + 奇","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"奇","role":"聲符","label":"讀音"}]},"騙":{"formula":"馬 + 扁","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"扁","role":"聲符","label":"讀音"}]},"騰":{"formula":"朕 + 馬","components":[{"radical":"朕","role":"部件","label":"朕"},{"radical":"馬","role":"部件","label":"馬"}]},"騷":{"formula":"馬 + 蚤","components":[{"radical":"馬","role":"部件","label":"馬"},{"radical":"蚤","role":"部件","label":"蚤"}]},"驅":{"formula":"馬 + 區","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"區","role":"聲符","label":"讀音"}]},"驕":{"formula":"馬 + 喬","components":[{"radical":"馬","role":"部件","label":"馬"},{"radical":"喬","role":"部件","label":"喬"}]},"驗":{"formula":"馬 + 僉","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"僉","role":"聲符","label":"讀音"}]},"驚":{"formula":"敬 + 馬","components":[{"radical":"敬","role":"聲符","label":"讀音"},{"radical":"馬","role":"形符","label":"馬"}]},"驟":{"formula":"馬 + 聚","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"聚","role":"聲符","label":"讀音"}]},"驢":{"formula":"馬 + 盧","components":[{"radical":"馬","role":"形符","label":"馬"},{"radical":"盧","role":"聲符","label":"讀音"}]},"骨":{"formula":"冎 + ⺼","components":[{"radical":"冎","role":"部件","label":"冎"},{"radical":"⺼","role":"部件","label":"身體"}]},"骸":{"formula":"骨 + 亥","components":[{"radical":"骨","role":"形符","label":"骨頭"},{"radical":"亥","role":"聲符","label":"讀音"}]},"骼":{"formula":"骨 + 各","components":[{"radical":"骨","role":"形符","label":"骨頭"},{"radical":"各","role":"聲符","label":"讀音"}]},"髒":{"formula":"骨 + 葬","components":[{"radical":"骨","role":"形符","label":"骨頭"},{"radical":"葬","role":"聲符","label":"讀音"}]},"體":{"formula":"骨 + 豊","components":[{"radical":"骨","role":"形符","label":"骨頭"},{"radical":"豊","role":"聲符","label":"讀音"}]},"高":{"formula":"高","components":[{"radical":"高","role":"部件","label":"象形字（獨體）"}]},"髮":{"formula":"髟 + 犮","components":[{"radical":"髟","role":"形符","label":"形容毛髮垂披"},{"radical":"犮","role":"聲符","label":"讀音"}]},"鬆":{"formula":"木 + 公","components":[{"radical":"木","role":"形符","label":"樹木"},{"radical":"公","role":"聲符","label":"讀音"}]},"鬚":{"formula":"髟 + 須","components":[{"radical":"髟","role":"形符","label":"形容毛髮垂披"},{"radical":"須","role":"聲符","label":"讀音"}]},"鬥":{"formula":"丨 + 亅 + 王 + 王","components":[{"radical":"丨","role":"部件","label":"上下貫通的樣"},{"radical":"亅","role":"部件","label":"倒掛的鉤"},{"radical":"王","role":"部件","label":"王旁"},{"radical":"王","role":"部件","label":"王旁"}]},"鬧":{"formula":"鬥 + 市","components":[{"radical":"鬥","role":"部件","label":"相爭"},{"radical":"市","role":"部件","label":"市"}]},"鬱":{"formula":"林 + 缶","components":[{"radical":"林","role":"形符","label":"樹林"},{"radical":"缶","role":"聲符","label":"讀音"}]},"鬼":{"formula":"鬼","components":[{"radical":"鬼","role":"部件","label":"象形字（獨體）"}]},"魁":{"formula":"鬼 + 斗","components":[{"radical":"鬼","role":"部件","label":"鬼神"},{"radical":"斗","role":"部件","label":"量器"}]},"魂":{"formula":"云 + 鬼","components":[{"radical":"云","role":"聲符","label":"讀音"},{"radical":"鬼","role":"形符","label":"鬼神"}]},"魄":{"formula":"白 + 鬼","components":[{"radical":"白","role":"聲符","label":"讀音"},{"radical":"鬼","role":"形符","label":"鬼神"}]},"魅":{"formula":"鬼 + 未","components":[{"radical":"鬼","role":"部件","label":"鬼神"},{"radical":"未","role":"部件","label":"未來"}]},"魔":{"formula":"麻 + 鬼","components":[{"radical":"麻","role":"聲符","label":"讀音"},{"radical":"鬼","role":"形符","label":"鬼神"}]},"魚":{"formula":"魚","components":[{"radical":"魚","role":"部件","label":"象形字（獨體）"}]},"魯":{"formula":"魚 + 日","components":[{"radical":"魚","role":"部件","label":"魚"},{"radical":"日","role":"部件","label":"太陽"}]},"鮑":{"formula":"魚 + 包","components":[{"radical":"魚","role":"形符","label":"魚"},{"radical":"包","role":"聲符","label":"讀音"}]},"鮭":{"formula":"魚 + 圭","components":[{"radical":"魚","role":"形符","label":"魚"},{"radical":"圭","role":"聲符","label":"讀音"}]},"鮮":{"formula":"魚 + 羊","components":[{"radical":"魚","role":"形符","label":"魚"},{"radical":"羊","role":"聲符","label":"讀音"}]},"鯊":{"formula":"沙 + 魚","components":[{"radical":"沙","role":"聲符","label":"讀音"},{"radical":"魚","role":"形符","label":"魚"}]},"鯨":{"formula":"魚 + 京","components":[{"radical":"魚","role":"形符","label":"魚"},{"radical":"京","role":"聲符","label":"讀音"}]},"鰭":{"formula":"魚 + 耆","components":[{"radical":"魚","role":"形符","label":"魚"},{"radical":"耆","role":"聲符","label":"讀音"}]},"鳥":{"formula":"鳥","components":[{"radical":"鳥","role":"部件","label":"象形字（獨體）"}]},"鳳":{"formula":"鳥 + 凡","components":[{"radical":"鳥","role":"形符","label":"鳥類"},{"radical":"凡","role":"聲符","label":"讀音"}]},"鳴":{"formula":"口 + 鳥","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"鳥","role":"部件","label":"鳥類"}]},"鴉":{"formula":"牙 + 鳥","components":[{"radical":"牙","role":"聲符","label":"讀音"},{"radical":"鳥","role":"形符","label":"鳥類"}]},"鴕":{"formula":"鳥 + 它","components":[{"radical":"鳥","role":"形符","label":"鳥類"},{"radical":"它","role":"聲符","label":"讀音"}]},"鴨":{"formula":"甲 + 鳥","components":[{"radical":"甲","role":"聲符","label":"讀音"},{"radical":"鳥","role":"形符","label":"鳥類"}]},"鴿":{"formula":"合 + 鳥","components":[{"radical":"合","role":"聲符","label":"讀音"},{"radical":"鳥","role":"形符","label":"鳥類"}]},"鵒":{"formula":"谷 + 鳥","components":[{"radical":"谷","role":"聲符","label":"讀音"},{"radical":"鳥","role":"形符","label":"鳥類"}]},"鷲":{"formula":"就 + 鳥","components":[{"radical":"就","role":"聲符","label":"讀音"},{"radical":"鳥","role":"形符","label":"鳥類"}]},"鷹":{"formula":"䧹 + 鳥","components":[{"radical":"䧹","role":"聲符","label":"讀音"},{"radical":"鳥","role":"形符","label":"鳥類"}]},"鹹":{"formula":"鹵 + 咸","components":[{"radical":"鹵","role":"形符","label":"鹵"},{"radical":"咸","role":"聲符","label":"讀音"}]},"鹿":{"formula":"鹿","components":[{"radical":"鹿","role":"部件","label":"象形字（獨體）"}]},"麗":{"formula":"丽 + 鹿","components":[{"radical":"丽","role":"部件","label":"丽"},{"radical":"鹿","role":"部件","label":"鹿"}]},"麟":{"formula":"鹿 + 粦","components":[{"radical":"鹿","role":"形符","label":"鹿"},{"radical":"粦","role":"聲符","label":"讀音"}]},"麥":{"formula":"來 + 夂","components":[{"radical":"來","role":"部件","label":"來"},{"radical":"夂","role":"部件","label":"行走"}]},"麵":{"formula":"麥 + 面","components":[{"radical":"麥","role":"聲符","label":"讀音"},{"radical":"面","role":"形符","label":"臉面"}]},"麻":{"formula":"广 + 林","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"林","role":"部件","label":"樹林"}]},"麼":{"formula":"麻 + 幺","components":[{"radical":"麻","role":"聲符","label":"讀音"},{"radical":"幺","role":"形符","label":"細小"}]},"黃":{"formula":"黃","components":[{"radical":"黃","role":"部件","label":"象形字（獨體）"}]},"黎":{"formula":"黍 + 勹 + 丿","components":[{"radical":"黍","role":"部件","label":"植物名"},{"radical":"勹","role":"部件","label":"包裹"},{"radical":"丿","role":"部件","label":"撇"}]},"黏":{"formula":"黍 + 占","components":[{"radical":"黍","role":"形符","label":"植物名"},{"radical":"占","role":"聲符","label":"讀音"}]},"黑":{"formula":"口 + 土 + 灬","components":[{"radical":"口","role":"部件","label":"嘴巴"},{"radical":"土","role":"部件","label":"泥土"},{"radical":"灬","role":"部件","label":"火底"}]},"默":{"formula":"默","components":[{"radical":"默","role":"部件","label":"象形字（獨體）"}]},"點":{"formula":"黑 + 占","components":[{"radical":"黑","role":"形符","label":"黑色"},{"radical":"占","role":"聲符","label":"讀音"}]},"黯":{"formula":"黑 + 音","components":[{"radical":"黑","role":"形符","label":"黑色"},{"radical":"音","role":"聲符","label":"讀音"}]},"鼓":{"formula":"壴 + 支","components":[{"radical":"壴","role":"形符","label":"壴"},{"radical":"支","role":"聲符","label":"讀音"}]},"鼠":{"formula":"鼠","components":[{"radical":"鼠","role":"部件","label":"象形字（獨體）"}]},"鼩":{"formula":"鼠 + 句","components":[{"radical":"鼠","role":"形符","label":"老鼠"},{"radical":"句","role":"聲符","label":"讀音"}]},"鼻":{"formula":"自 + 畀","components":[{"radical":"自","role":"形符","label":"自己"},{"radical":"畀","role":"聲符","label":"讀音"}]},"鼾":{"formula":"鼻 + 干","components":[{"radical":"鼻","role":"形符","label":"動物的呼吸器"},{"radical":"干","role":"聲符","label":"讀音"}]},"齊":{"formula":"齊","components":[{"radical":"齊","role":"部件","label":"象形字（獨體）"}]},"齒":{"formula":"齒","components":[{"radical":"齒","role":"部件","label":"象形字（獨體）"}]},"齡":{"formula":"齒 + 令","components":[{"radical":"齒","role":"形符","label":"牙齒"},{"radical":"令","role":"聲符","label":"讀音"}]},"龍":{"formula":"龍","components":[{"radical":"龍","role":"部件","label":"象形字（獨體）"}]},"龐":{"formula":"广 + 龍","components":[{"radical":"广","role":"部件","label":"房屋"},{"radical":"龍","role":"部件","label":"龍"}]}}
+{
+  "丈": {
+    "formula": "一 + 乂",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "乂",
+        "role": "部件",
+        "label": "乂"
+      }
+    ]
+  },
+  "丙": {
+    "formula": "一 + 人 + 冂",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      }
+    ]
+  },
+  "並": {
+    "formula": "丷 + 亚",
+    "components": [
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "亚",
+        "role": "部件",
+        "label": "亚"
+      }
+    ]
+  },
+  "串": {
+    "formula": "口 + 口 + 丨",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      }
+    ]
+  },
+  "久": {
+    "formula": "丿 + 入",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "入",
+        "role": "部件",
+        "label": "入"
+      }
+    ]
+  },
+  "乍": {
+    "formula": "丿 + 丅 + 二",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "丅",
+        "role": "部件",
+        "label": "丅"
+      },
+      {
+        "radical": "二",
+        "role": "部件",
+        "label": "二"
+      }
+    ]
+  },
+  "乎": {
+    "formula": "丿 + 丷 + 一 + 亅",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "亅",
+        "role": "部件",
+        "label": "亅"
+      }
+    ]
+  },
+  "乏": {
+    "formula": "丿 + 之",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "之",
+        "role": "部件",
+        "label": "之"
+      }
+    ]
+  },
+  "乖": {
+    "formula": "千 + 北",
+    "components": [
+      {
+        "radical": "千",
+        "role": "部件",
+        "label": "千"
+      },
+      {
+        "radical": "北",
+        "role": "部件",
+        "label": "北"
+      }
+    ]
+  },
+  "乘": {
+    "formula": "禾 + 北",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "北",
+        "role": "部件",
+        "label": "北"
+      }
+    ]
+  },
+  "乞": {
+    "formula": "丿 + 一 + 乙",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "乙",
+        "role": "部件",
+        "label": "乙"
+      }
+    ]
+  },
+  "乩": {
+    "formula": "占 + 乚",
+    "components": [
+      {
+        "radical": "占",
+        "role": "形符",
+        "label": "占"
+      },
+      {
+        "radical": "乚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "乳": {
+    "formula": "孚 + 乚",
+    "components": [
+      {
+        "radical": "孚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "乚",
+        "role": "形符",
+        "label": "乚"
+      }
+    ]
+  },
+  "乾": {
+    "formula": "龺 + 乞",
+    "components": [
+      {
+        "radical": "龺",
+        "role": "部件",
+        "label": "龺"
+      },
+      {
+        "radical": "乞",
+        "role": "部件",
+        "label": "乞"
+      }
+    ]
+  },
+  "亂": {
+    "formula": "爫 + 冂 + 厶 + 又 + 乚",
+    "components": [
+      {
+        "radical": "爫",
+        "role": "部件",
+        "label": "爫"
+      },
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      },
+      {
+        "radical": "乚",
+        "role": "部件",
+        "label": "乚"
+      }
+    ]
+  },
+  "予": {
+    "formula": "龴 + 乛 + 亅",
+    "components": [
+      {
+        "radical": "龴",
+        "role": "部件",
+        "label": "龴"
+      },
+      {
+        "radical": "乛",
+        "role": "部件",
+        "label": "乛"
+      },
+      {
+        "radical": "亅",
+        "role": "部件",
+        "label": "亅"
+      }
+    ]
+  },
+  "事": {
+    "formula": "一 + 口 + 聿",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "聿",
+        "role": "部件",
+        "label": "筆"
+      }
+    ]
+  },
+  "于": {
+    "formula": "二 + 亅",
+    "components": [
+      {
+        "radical": "二",
+        "role": "部件",
+        "label": "二"
+      },
+      {
+        "radical": "亅",
+        "role": "部件",
+        "label": "亅"
+      }
+    ]
+  },
+  "些": {
+    "formula": "此 + 二",
+    "components": [
+      {
+        "radical": "此",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "二",
+        "role": "形符",
+        "label": "二"
+      }
+    ]
+  },
+  "交": {
+    "formula": "六 + 乂",
+    "components": [
+      {
+        "radical": "六",
+        "role": "部件",
+        "label": "六"
+      },
+      {
+        "radical": "乂",
+        "role": "部件",
+        "label": "乂"
+      }
+    ]
+  },
+  "享": {
+    "formula": "亠 + 口 + 子",
+    "components": [
+      {
+        "radical": "亠",
+        "role": "部件",
+        "label": "亠"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "什": {
+    "formula": "亻 + 十",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "仁": {
+    "formula": "亻 + 二",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "二",
+        "role": "部件",
+        "label": "二"
+      }
+    ]
+  },
+  "仃": {
+    "formula": "亻 + 丁",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "丁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "仆": {
+    "formula": "亻 + 卜",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "卜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "仍": {
+    "formula": "亻 + 乃",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "乃",
+        "role": "形符",
+        "label": "乃"
+      }
+    ]
+  },
+  "仔": {
+    "formula": "亻 + 子",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "他": {
+    "formula": "亻 + 也",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "也",
+        "role": "部件",
+        "label": "也"
+      }
+    ]
+  },
+  "付": {
+    "formula": "亻 + 寸",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "代": {
+    "formula": "亻 + 弋",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "弋",
+        "role": "部件",
+        "label": "弋"
+      }
+    ]
+  },
+  "以": {
+    "formula": "□ + 丶 + 人",
+    "components": [
+      {
+        "radical": "□",
+        "role": "部件",
+        "label": "□"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "仰": {
+    "formula": "亻 + 卬",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "卬",
+        "role": "部件",
+        "label": "卬"
+      }
+    ]
+  },
+  "仲": {
+    "formula": "亻 + 中",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "中",
+        "role": "部件",
+        "label": "中"
+      }
+    ]
+  },
+  "件": {
+    "formula": "亻 + 牛",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "牛",
+        "role": "部件",
+        "label": "牛"
+      }
+    ]
+  },
+  "任": {
+    "formula": "亻 + 壬",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "壬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "份": {
+    "formula": "亻 + 分",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "分",
+        "role": "部件",
+        "label": "分"
+      }
+    ]
+  },
+  "仿": {
+    "formula": "亻 + 方",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "企": {
+    "formula": "人 + 止",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "止",
+        "role": "部件",
+        "label": "止"
+      }
+    ]
+  },
+  "伍": {
+    "formula": "亻 + 五",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "五",
+        "role": "部件",
+        "label": "五"
+      }
+    ]
+  },
+  "伏": {
+    "formula": "亻 + 犬",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "犬",
+        "role": "部件",
+        "label": "狗"
+      }
+    ]
+  },
+  "伐": {
+    "formula": "亻 + 戈",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      }
+    ]
+  },
+  "休": {
+    "formula": "亻 + 木",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "伙": {
+    "formula": "亻 + 火",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "火",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "伯": {
+    "formula": "亻 + 白",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "白",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "估": {
+    "formula": "亻 + 古",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "古",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "伴": {
+    "formula": "亻 + 半",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "半",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "伶": {
+    "formula": "亻 + 令",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "令",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "伸": {
+    "formula": "亻 + 申",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "申",
+        "role": "部件",
+        "label": "申"
+      }
+    ]
+  },
+  "似": {
+    "formula": "亻 + 以",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "以",
+        "role": "部件",
+        "label": "以"
+      }
+    ]
+  },
+  "但": {
+    "formula": "亻 + 旦",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "旦",
+        "role": "聲符",
+        "label": "旦"
+      }
+    ]
+  },
+  "佈": {
+    "formula": "亻 + 布",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "布",
+        "role": "部件",
+        "label": "布"
+      }
+    ]
+  },
+  "位": {
+    "formula": "亻 + 立",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "立",
+        "role": "部件",
+        "label": "立"
+      }
+    ]
+  },
+  "低": {
+    "formula": "亻 + 氐",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "氐",
+        "role": "聲符",
+        "label": "氐"
+      }
+    ]
+  },
+  "住": {
+    "formula": "亻 + 主",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "主",
+        "role": "部件",
+        "label": "主"
+      }
+    ]
+  },
+  "佑": {
+    "formula": "亻 + 右",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "右",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "佔": {
+    "formula": "亻 + 占",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "占",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "何": {
+    "formula": "人 + 可",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "可",
+        "role": "部件",
+        "label": "可"
+      }
+    ]
+  },
+  "佛": {
+    "formula": "亻 + 弗",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "弗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "作": {
+    "formula": "亻 + 乍",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "乍",
+        "role": "部件",
+        "label": "乍"
+      }
+    ]
+  },
+  "你": {
+    "formula": "亻 + 尔",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "尔",
+        "role": "部件",
+        "label": "尔"
+      }
+    ]
+  },
+  "佩": {
+    "formula": "亻 + 凡 + 巾",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "凡",
+        "role": "部件",
+        "label": "凡"
+      },
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      }
+    ]
+  },
+  "佳": {
+    "formula": "亻 + 圭",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "佼": {
+    "formula": "亻 + 交",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "交",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "使": {
+    "formula": "亻 + 吏",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "吏",
+        "role": "部件",
+        "label": "吏"
+      }
+    ]
+  },
+  "來": {
+    "formula": "木 + 从",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "从",
+        "role": "部件",
+        "label": "从"
+      }
+    ]
+  },
+  "侈": {
+    "formula": "亻 + 多",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "多",
+        "role": "部件",
+        "label": "多"
+      }
+    ]
+  },
+  "例": {
+    "formula": "亻 + 列",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "列",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "供": {
+    "formula": "亻 + 共",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "共",
+        "role": "部件",
+        "label": "共"
+      }
+    ]
+  },
+  "依": {
+    "formula": "亻 + 衣",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "衣",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "侵": {
+    "formula": "人 + 彐 + 冖 + 又",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "彐",
+        "role": "部件",
+        "label": "彐"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "侶": {
+    "formula": "亻 + 呂",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "呂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "侷": {
+    "formula": "亻 + 局",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "局",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "便": {
+    "formula": "人 + 更",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "更",
+        "role": "部件",
+        "label": "更"
+      }
+    ]
+  },
+  "係": {
+    "formula": "亻 + 系",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "系",
+        "role": "部件",
+        "label": "系"
+      }
+    ]
+  },
+  "促": {
+    "formula": "亻 + 足",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "足",
+        "role": "部件",
+        "label": "足旁"
+      }
+    ]
+  },
+  "俊": {
+    "formula": "亻 + 夋",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "夋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "俐": {
+    "formula": "亻 + 利",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "利",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "俗": {
+    "formula": "亻 + 谷",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "谷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "保": {
+    "formula": "亻 + 呆",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "呆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "俠": {
+    "formula": "亻 + 夾",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "夾",
+        "role": "部件",
+        "label": "夾"
+      }
+    ]
+  },
+  "信": {
+    "formula": "人 + 言",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      }
+    ]
+  },
+  "修": {
+    "formula": "攸 + 彡",
+    "components": [
+      {
+        "radical": "攸",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "彡",
+        "role": "形符",
+        "label": "彡"
+      }
+    ]
+  },
+  "俱": {
+    "formula": "亻 + 具",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "具",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "倆": {
+    "formula": "亻 + 兩",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "兩",
+        "role": "部件",
+        "label": "兩"
+      }
+    ]
+  },
+  "倉": {
+    "formula": "人 + 户 + 口",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "户",
+        "role": "部件",
+        "label": "户"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "個": {
+    "formula": "亻 + 固",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "固",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "倍": {
+    "formula": "人 + 咅",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "咅",
+        "role": "部件",
+        "label": "咅"
+      }
+    ]
+  },
+  "們": {
+    "formula": "亻 + 門",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "門",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "倒": {
+    "formula": "亻 + 到",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "到",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "倖": {
+    "formula": "亻 + 幸",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "幸",
+        "role": "部件",
+        "label": "幸"
+      }
+    ]
+  },
+  "倘": {
+    "formula": "亻 + 尚",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "候": {
+    "formula": "亻 + 矦",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "矦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "倚": {
+    "formula": "亻 + 奇",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "奇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "借": {
+    "formula": "亻 + 昔",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "昔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "倡": {
+    "formula": "亻 + 昌",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "昌",
+        "role": "部件",
+        "label": "昌"
+      }
+    ]
+  },
+  "倦": {
+    "formula": "亻 + 卷",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "卷",
+        "role": "部件",
+        "label": "卷"
+      }
+    ]
+  },
+  "倫": {
+    "formula": "亻 + 侖",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "侖",
+        "role": "部件",
+        "label": "侖"
+      }
+    ]
+  },
+  "倬": {
+    "formula": "亻 + 卓",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "卓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "值": {
+    "formula": "亻 + 直",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "直",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "假": {
+    "formula": "亻 + 叚",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "叚",
+        "role": "部件",
+        "label": "叚"
+      }
+    ]
+  },
+  "偉": {
+    "formula": "亻 + 韋",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "韋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "偏": {
+    "formula": "亻 + 扁",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "扁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "偕": {
+    "formula": "亻 + 皆",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "皆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "做": {
+    "formula": "亻 + 故",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "故",
+        "role": "部件",
+        "label": "故"
+      }
+    ]
+  },
+  "停": {
+    "formula": "亻 + 亭",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "亭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "健": {
+    "formula": "亻 + 建",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "建",
+        "role": "部件",
+        "label": "建"
+      }
+    ]
+  },
+  "側": {
+    "formula": "亻 + 則",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "則",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "偵": {
+    "formula": "亻 + 貞",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "貞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "偶": {
+    "formula": "亻 + 禺",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "禺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "偷": {
+    "formula": "亻 + 俞",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "俞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "偽": {
+    "formula": "亻 + 為",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "為",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "傑": {
+    "formula": "亻 + 桀",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "桀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "傲": {
+    "formula": "亻 + 敖",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "敖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "傳": {
+    "formula": "亻 + 專",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "專",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "債": {
+    "formula": "亻 + 責",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "責",
+        "role": "部件",
+        "label": "責"
+      }
+    ]
+  },
+  "傾": {
+    "formula": "亻 + 頃",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "頃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "僅": {
+    "formula": "亻 + 堇",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "堇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "像": {
+    "formula": "亻 + 象",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "象",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "僕": {
+    "formula": "亻 + 菐",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "菐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "僥": {
+    "formula": "亻 + 堯",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "堯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "僧": {
+    "formula": "亻 + 曾",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "曾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "僭": {
+    "formula": "亻 + 朁",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "朁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "僱": {
+    "formula": "亻 + 雇",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "雇",
+        "role": "部件",
+        "label": "雇"
+      }
+    ]
+  },
+  "僵": {
+    "formula": "亻 + 畺",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "畺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "價": {
+    "formula": "亻 + 賈",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "賈",
+        "role": "部件",
+        "label": "賈"
+      }
+    ]
+  },
+  "僻": {
+    "formula": "亻 + 辟",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "辟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "儀": {
+    "formula": "亻 + 義",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "義",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "億": {
+    "formula": "亻 + 意",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "意",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "儒": {
+    "formula": "亻 + 需",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "需",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "儘": {
+    "formula": "亻 + 盡",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "盡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "償": {
+    "formula": "亻 + 賞",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "賞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "優": {
+    "formula": "亻 + 憂",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "憂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "儲": {
+    "formula": "亻 + 諸",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "諸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "儼": {
+    "formula": "亻 + 嚴",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "形符",
+        "label": "人旁"
+      },
+      {
+        "radical": "嚴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "兄": {
+    "formula": "口 + 儿",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "儿",
+        "role": "部件",
+        "label": "儿"
+      }
+    ]
+  },
+  "充": {
+    "formula": "亠 + 允",
+    "components": [
+      {
+        "radical": "亠",
+        "role": "部件",
+        "label": "亠"
+      },
+      {
+        "radical": "允",
+        "role": "部件",
+        "label": "允"
+      }
+    ]
+  },
+  "兇": {
+    "formula": "凶 + 儿",
+    "components": [
+      {
+        "radical": "凶",
+        "role": "部件",
+        "label": "凶"
+      },
+      {
+        "radical": "儿",
+        "role": "部件",
+        "label": "儿"
+      }
+    ]
+  },
+  "先": {
+    "formula": "土 + 儿",
+    "components": [
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
+      {
+        "radical": "儿",
+        "role": "部件",
+        "label": "儿"
+      }
+    ]
+  },
+  "光": {
+    "formula": "⺌ + 兀",
+    "components": [
+      {
+        "radical": "⺌",
+        "role": "部件",
+        "label": "⺌"
+      },
+      {
+        "radical": "兀",
+        "role": "部件",
+        "label": "兀"
+      }
+    ]
+  },
+  "克": {
+    "formula": "十 + 兄",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "兄",
+        "role": "部件",
+        "label": "兄"
+      }
+    ]
+  },
+  "免": {
+    "formula": "刀 + 口 + 丨 + 儿",
+    "components": [
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      },
+      {
+        "radical": "儿",
+        "role": "部件",
+        "label": "儿"
+      }
+    ]
+  },
+  "兒": {
+    "formula": "儿 + 儿",
+    "components": [
+      {
+        "radical": "儿",
+        "role": "形符",
+        "label": "儿"
+      },
+      {
+        "radical": "儿",
+        "role": "形符",
+        "label": "儿"
+      }
+    ]
+  },
+  "入": {
+    "formula": "乁 + 丿",
+    "components": [
+      {
+        "radical": "乁",
+        "role": "部件",
+        "label": "乁"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "內": {
+    "formula": "冂 + 入",
+    "components": [
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "入",
+        "role": "部件",
+        "label": "入"
+      }
+    ]
+  },
+  "全": {
+    "formula": "入 + 玉",
+    "components": [
+      {
+        "radical": "入",
+        "role": "部件",
+        "label": "入"
+      },
+      {
+        "radical": "玉",
+        "role": "部件",
+        "label": "玉"
+      }
+    ]
+  },
+  "兩": {
+    "formula": "一 + 巾 + 入 + 入",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      },
+      {
+        "radical": "入",
+        "role": "部件",
+        "label": "入"
+      },
+      {
+        "radical": "入",
+        "role": "部件",
+        "label": "入"
+      }
+    ]
+  },
+  "公": {
+    "formula": "八 + 厶",
+    "components": [
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      },
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      }
+    ]
+  },
+  "共": {
+    "formula": "廾 + 一 + 八",
+    "components": [
+      {
+        "radical": "廾",
+        "role": "部件",
+        "label": "廾"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      }
+    ]
+  },
+  "兵": {
+    "formula": "丘 + 八",
+    "components": [
+      {
+        "radical": "丘",
+        "role": "部件",
+        "label": "丘"
+      },
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      }
+    ]
+  },
+  "其": {
+    "formula": "甘 + 一 + 八",
+    "components": [
+      {
+        "radical": "甘",
+        "role": "部件",
+        "label": "甘"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      }
+    ]
+  },
+  "具": {
+    "formula": "目 + 一 + 八",
+    "components": [
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      }
+    ]
+  },
+  "典": {
+    "formula": "曲 + 八",
+    "components": [
+      {
+        "radical": "曲",
+        "role": "部件",
+        "label": "曲"
+      },
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      }
+    ]
+  },
+  "兼": {
+    "formula": "丷 + 彐 + 禾 + 禾",
+    "components": [
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "彐",
+        "role": "部件",
+        "label": "彐"
+      },
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      }
+    ]
+  },
+  "冉": {
+    "formula": "冂 + 十 + 一",
+    "components": [
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "冊": {
+    "formula": "冂 + 卄",
+    "components": [
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "卄",
+        "role": "部件",
+        "label": "卄"
+      }
+    ]
+  },
+  "冒": {
+    "formula": "目 + 冃",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "冃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "冠": {
+    "formula": "冖 + 元 + 寸",
+    "components": [
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "元",
+        "role": "部件",
+        "label": "元"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "冤": {
+    "formula": "冖 + 兔",
+    "components": [
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "兔",
+        "role": "部件",
+        "label": "兔"
+      }
+    ]
+  },
+  "冥": {
+    "formula": "冖 + 日 + 六",
+    "components": [
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "六",
+        "role": "部件",
+        "label": "六"
+      }
+    ]
+  },
+  "冬": {
+    "formula": "夂 + ⺀",
+    "components": [
+      {
+        "radical": "夂",
+        "role": "部件",
+        "label": "夂"
+      },
+      {
+        "radical": "⺀",
+        "role": "部件",
+        "label": "⺀"
+      }
+    ]
+  },
+  "冰": {
+    "formula": "冫 + 水",
+    "components": [
+      {
+        "radical": "冫",
+        "role": "部件",
+        "label": "冰旁"
+      },
+      {
+        "radical": "水",
+        "role": "部件",
+        "label": "水"
+      }
+    ]
+  },
+  "冷": {
+    "formula": "冫 + 令",
+    "components": [
+      {
+        "radical": "冫",
+        "role": "形符",
+        "label": "冰旁"
+      },
+      {
+        "radical": "令",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "准": {
+    "formula": "冫 + 隹",
+    "components": [
+      {
+        "radical": "冫",
+        "role": "形符",
+        "label": "冰旁"
+      },
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "凌": {
+    "formula": "冫 + 夌",
+    "components": [
+      {
+        "radical": "冫",
+        "role": "形符",
+        "label": "冰旁"
+      },
+      {
+        "radical": "夌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "凍": {
+    "formula": "冫 + 東",
+    "components": [
+      {
+        "radical": "冫",
+        "role": "形符",
+        "label": "冰旁"
+      },
+      {
+        "radical": "東",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "凝": {
+    "formula": "冫 + 疑",
+    "components": [
+      {
+        "radical": "冫",
+        "role": "形符",
+        "label": "冰旁"
+      },
+      {
+        "radical": "疑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "凡": {
+    "formula": "几 + 丶",
+    "components": [
+      {
+        "radical": "几",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      }
+    ]
+  },
+  "凶": {
+    "formula": "凵 + 乂",
+    "components": [
+      {
+        "radical": "凵",
+        "role": "部件",
+        "label": "凵"
+      },
+      {
+        "radical": "乂",
+        "role": "部件",
+        "label": "乂"
+      }
+    ]
+  },
+  "出": {
+    "formula": "屮 + 凵",
+    "components": [
+      {
+        "radical": "屮",
+        "role": "部件",
+        "label": "屮"
+      },
+      {
+        "radical": "凵",
+        "role": "部件",
+        "label": "凵"
+      }
+    ]
+  },
+  "刃": {
+    "formula": "刀 + 丶",
+    "components": [
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      }
+    ]
+  },
+  "分": {
+    "formula": "八 + 刀",
+    "components": [
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      },
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      }
+    ]
+  },
+  "切": {
+    "formula": "七 + 刀",
+    "components": [
+      {
+        "radical": "七",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刀",
+        "role": "形符",
+        "label": "刀"
+      }
+    ]
+  },
+  "刈": {
+    "formula": "乂 + 刂",
+    "components": [
+      {
+        "radical": "乂",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "刑": {
+    "formula": "开 + 刂",
+    "components": [
+      {
+        "radical": "开",
+        "role": "部件",
+        "label": "开"
+      },
+      {
+        "radical": "刂",
+        "role": "部件",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "列": {
+    "formula": "歹 + 刂",
+    "components": [
+      {
+        "radical": "歹",
+        "role": "部件",
+        "label": "歹"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "初": {
+    "formula": "衤 + 刀",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "部件",
+        "label": "衣旁"
+      },
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      }
+    ]
+  },
+  "判": {
+    "formula": "半 + 刂",
+    "components": [
+      {
+        "radical": "半",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "別": {
+    "formula": "另 + 刂",
+    "components": [
+      {
+        "radical": "另",
+        "role": "部件",
+        "label": "另"
+      },
+      {
+        "radical": "刂",
+        "role": "部件",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "利": {
+    "formula": "禾 + 刂",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "刂",
+        "role": "部件",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "刮": {
+    "formula": "舌 + 刂",
+    "components": [
+      {
+        "radical": "舌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "到": {
+    "formula": "至 + 刂",
+    "components": [
+      {
+        "radical": "至",
+        "role": "形符",
+        "label": "至"
+      },
+      {
+        "radical": "刂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "制": {
+    "formula": "巾 + 刂",
+    "components": [
+      {
+        "radical": "巾",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "刷": {
+    "formula": "尸 + 巾 + 刂",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      },
+      {
+        "radical": "刂",
+        "role": "部件",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "刺": {
+    "formula": "朿 + 刂",
+    "components": [
+      {
+        "radical": "朿",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "刻": {
+    "formula": "亥 + 刂",
+    "components": [
+      {
+        "radical": "亥",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "則": {
+    "formula": "貝 + 刂",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      },
+      {
+        "radical": "刂",
+        "role": "部件",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "削": {
+    "formula": "肖 + 刂",
+    "components": [
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "剌": {
+    "formula": "束 + 刂",
+    "components": [
+      {
+        "radical": "束",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "前": {
+    "formula": "丷 + 一 + 肉 + 刀",
+    "components": [
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "肉",
+        "role": "部件",
+        "label": "肉"
+      },
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      }
+    ]
+  },
+  "剎": {
+    "formula": "杀 + 刂",
+    "components": [
+      {
+        "radical": "杀",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "剖": {
+    "formula": "咅 + 刂",
+    "components": [
+      {
+        "radical": "咅",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "剛": {
+    "formula": "岡 + 刂",
+    "components": [
+      {
+        "radical": "岡",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "剝": {
+    "formula": "彔 + 刂",
+    "components": [
+      {
+        "radical": "彔",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "剩": {
+    "formula": "乘 + 刂",
+    "components": [
+      {
+        "radical": "乘",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "剪": {
+    "formula": "前 + 刀",
+    "components": [
+      {
+        "radical": "前",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刀",
+        "role": "形符",
+        "label": "刀"
+      }
+    ]
+  },
+  "副": {
+    "formula": "畐 + 刂",
+    "components": [
+      {
+        "radical": "畐",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "割": {
+    "formula": "害 + 刂",
+    "components": [
+      {
+        "radical": "害",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "創": {
+    "formula": "倉 + 刂",
+    "components": [
+      {
+        "radical": "倉",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "劃": {
+    "formula": "畫 + 刂",
+    "components": [
+      {
+        "radical": "畫",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "劇": {
+    "formula": "豦 + 刂",
+    "components": [
+      {
+        "radical": "豦",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "劈": {
+    "formula": "辟 + 刀",
+    "components": [
+      {
+        "radical": "辟",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刀",
+        "role": "形符",
+        "label": "刀"
+      }
+    ]
+  },
+  "劉": {
+    "formula": "卯 + 刂",
+    "components": [
+      {
+        "radical": "卯",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "劍": {
+    "formula": "僉 + 刂",
+    "components": [
+      {
+        "radical": "僉",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "劑": {
+    "formula": "齊 + 刂",
+    "components": [
+      {
+        "radical": "齊",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "刂",
+        "role": "形符",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "功": {
+    "formula": "工 + 力",
+    "components": [
+      {
+        "radical": "工",
+        "role": "部件",
+        "label": "工"
+      },
+      {
+        "radical": "力",
+        "role": "部件",
+        "label": "力量"
+      }
+    ]
+  },
+  "加": {
+    "formula": "力 + 口",
+    "components": [
+      {
+        "radical": "力",
+        "role": "部件",
+        "label": "力量"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "劣": {
+    "formula": "少 + 力",
+    "components": [
+      {
+        "radical": "少",
+        "role": "形符",
+        "label": "少"
+      },
+      {
+        "radical": "力",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "助": {
+    "formula": "且 + 力",
+    "components": [
+      {
+        "radical": "且",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "努": {
+    "formula": "奴 + 力",
+    "components": [
+      {
+        "radical": "奴",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "劫": {
+    "formula": "去 + 力",
+    "components": [
+      {
+        "radical": "去",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勃": {
+    "formula": "孛 + 力",
+    "components": [
+      {
+        "radical": "孛",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勇": {
+    "formula": "甬 + 力",
+    "components": [
+      {
+        "radical": "甬",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勉": {
+    "formula": "免 + 力",
+    "components": [
+      {
+        "radical": "免",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勒": {
+    "formula": "革 + 力",
+    "components": [
+      {
+        "radical": "革",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "動": {
+    "formula": "重 + 力",
+    "components": [
+      {
+        "radical": "重",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "務": {
+    "formula": "矛 + 务",
+    "components": [
+      {
+        "radical": "矛",
+        "role": "形符",
+        "label": "矛"
+      },
+      {
+        "radical": "务",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "勝": {
+    "formula": "月 + 劵",
+    "components": [
+      {
+        "radical": "月",
+        "role": "形符",
+        "label": "月亮"
+      },
+      {
+        "radical": "劵",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "勞": {
+    "formula": "炏 + 冖 + 力",
+    "components": [
+      {
+        "radical": "炏",
+        "role": "部件",
+        "label": "炏"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "力",
+        "role": "部件",
+        "label": "力量"
+      }
+    ]
+  },
+  "勢": {
+    "formula": "埶 + 力",
+    "components": [
+      {
+        "radical": "埶",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勤": {
+    "formula": "堇 + 力",
+    "components": [
+      {
+        "radical": "堇",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勳": {
+    "formula": "熏 + 力",
+    "components": [
+      {
+        "radical": "熏",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勵": {
+    "formula": "厲 + 力",
+    "components": [
+      {
+        "radical": "厲",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勸": {
+    "formula": "雚 + 力",
+    "components": [
+      {
+        "radical": "雚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "勾": {
+    "formula": "勹 + 厶",
+    "components": [
+      {
+        "radical": "勹",
+        "role": "部件",
+        "label": "勹"
+      },
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      }
+    ]
+  },
+  "勿": {
+    "formula": "勹 + 丿 + 丿",
+    "components": [
+      {
+        "radical": "勹",
+        "role": "部件",
+        "label": "勹"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "包": {
+    "formula": "勹 + 巳",
+    "components": [
+      {
+        "radical": "勹",
+        "role": "部件",
+        "label": "勹"
+      },
+      {
+        "radical": "巳",
+        "role": "部件",
+        "label": "巳"
+      }
+    ]
+  },
+  "匏": {
+    "formula": "夸 + 包",
+    "components": [
+      {
+        "radical": "夸",
+        "role": "形符",
+        "label": "夸"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "化": {
+    "formula": "人 + 匕",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      }
+    ]
+  },
+  "匠": {
+    "formula": "匚 + 斤",
+    "components": [
+      {
+        "radical": "匚",
+        "role": "部件",
+        "label": "匚"
+      },
+      {
+        "radical": "斤",
+        "role": "部件",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "匪": {
+    "formula": "匚 + 非",
+    "components": [
+      {
+        "radical": "匚",
+        "role": "形符",
+        "label": "匚"
+      },
+      {
+        "radical": "非",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "區": {
+    "formula": "匸 + 品",
+    "components": [
+      {
+        "radical": "匸",
+        "role": "部件",
+        "label": "匸"
+      },
+      {
+        "radical": "品",
+        "role": "部件",
+        "label": "品"
+      }
+    ]
+  },
+  "升": {
+    "formula": "千 + 丨",
+    "components": [
+      {
+        "radical": "千",
+        "role": "部件",
+        "label": "千"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      }
+    ]
+  },
+  "午": {
+    "formula": "丿 + 干",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "干",
+        "role": "部件",
+        "label": "干"
+      }
+    ]
+  },
+  "半": {
+    "formula": "丷 + 牛",
+    "components": [
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "牛",
+        "role": "部件",
+        "label": "牛"
+      }
+    ]
+  },
+  "卑": {
+    "formula": "白 + 十",
+    "components": [
+      {
+        "radical": "白",
+        "role": "部件",
+        "label": "白色"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "卓": {
+    "formula": "⺊ + 早",
+    "components": [
+      {
+        "radical": "⺊",
+        "role": "部件",
+        "label": "⺊"
+      },
+      {
+        "radical": "早",
+        "role": "部件",
+        "label": "早"
+      }
+    ]
+  },
+  "協": {
+    "formula": "十 + 劦",
+    "components": [
+      {
+        "radical": "十",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "劦",
+        "role": "形符",
+        "label": "劦"
+      }
+    ]
+  },
+  "博": {
+    "formula": "十 + 尃",
+    "components": [
+      {
+        "radical": "十",
+        "role": "形符",
+        "label": "十"
+      },
+      {
+        "radical": "尃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "占": {
+    "formula": "⺊ + 口",
+    "components": [
+      {
+        "radical": "⺊",
+        "role": "部件",
+        "label": "⺊"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "卡": {
+    "formula": "上 + 卜",
+    "components": [
+      {
+        "radical": "上",
+        "role": "部件",
+        "label": "上"
+      },
+      {
+        "radical": "卜",
+        "role": "部件",
+        "label": "卜"
+      }
+    ]
+  },
+  "卦": {
+    "formula": "圭 + 卜",
+    "components": [
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "卜",
+        "role": "形符",
+        "label": "卜"
+      }
+    ]
+  },
+  "卯": {
+    "formula": "卬 + 丿",
+    "components": [
+      {
+        "radical": "卬",
+        "role": "部件",
+        "label": "卬"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "危": {
+    "formula": "厃 + 㔾",
+    "components": [
+      {
+        "radical": "厃",
+        "role": "部件",
+        "label": "厃"
+      },
+      {
+        "radical": "㔾",
+        "role": "部件",
+        "label": "㔾"
+      }
+    ]
+  },
+  "卸": {
+    "formula": "止 + 卩",
+    "components": [
+      {
+        "radical": "止",
+        "role": "形符",
+        "label": "止"
+      },
+      {
+        "radical": "卩",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "卻": {
+    "formula": "谷 + 卩",
+    "components": [
+      {
+        "radical": "谷",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "卩",
+        "role": "形符",
+        "label": "卩"
+      }
+    ]
+  },
+  "厄": {
+    "formula": "厂 + 㔾",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "部件",
+        "label": "山崖"
+      },
+      {
+        "radical": "㔾",
+        "role": "部件",
+        "label": "㔾"
+      }
+    ]
+  },
+  "厚": {
+    "formula": "厂 + 日 + 子",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "部件",
+        "label": "山崖"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "原": {
+    "formula": "厂 + 泉",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "形符",
+        "label": "山崖"
+      },
+      {
+        "radical": "泉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "厭": {
+    "formula": "厂 + 猒",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "形符",
+        "label": "山崖"
+      },
+      {
+        "radical": "猒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "去": {
+    "formula": "土 + 厶",
+    "components": [
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      }
+    ]
+  },
+  "參": {
+    "formula": "⺶ + 大 + 彡",
+    "components": [
+      {
+        "radical": "⺶",
+        "role": "部件",
+        "label": "羊頭"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "彡",
+        "role": "聲符",
+        "label": "紋飾"
+      }
+    ]
+  },
+  "叉": {
+    "formula": "又 + 丶",
+    "components": [
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      }
+    ]
+  },
+  "及": {
+    "formula": "乃 + 乀",
+    "components": [
+      {
+        "radical": "乃",
+        "role": "部件",
+        "label": "乃"
+      },
+      {
+        "radical": "乀",
+        "role": "部件",
+        "label": "乀"
+      }
+    ]
+  },
+  "反": {
+    "formula": "厂 + 又",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "部件",
+        "label": "山崖"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "取": {
+    "formula": "耳 + 又",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "部件",
+        "label": "耳朵"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "受": {
+    "formula": "爫 + 冖 + 又",
+    "components": [
+      {
+        "radical": "爫",
+        "role": "部件",
+        "label": "爫"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "古": {
+    "formula": "十 + 口",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "句": {
+    "formula": "勹 + 口",
+    "components": [
+      {
+        "radical": "勹",
+        "role": "部件",
+        "label": "勹"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "另": {
+    "formula": "口 + 力",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "力",
+        "role": "部件",
+        "label": "力量"
+      }
+    ]
+  },
+  "叨": {
+    "formula": "口 + 刀",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "刀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "只": {
+    "formula": "口 + 八",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      }
+    ]
+  },
+  "叫": {
+    "formula": "口 + 丩",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "丩",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "叮": {
+    "formula": "口 + 丁",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "丁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "可": {
+    "formula": "丁 + 口",
+    "components": [
+      {
+        "radical": "丁",
+        "role": "形符",
+        "label": "丁"
+      },
+      {
+        "radical": "口",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "台": {
+    "formula": "厶 + 口",
+    "components": [
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "史": {
+    "formula": "口 + 乂",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "乂",
+        "role": "部件",
+        "label": "乂"
+      }
+    ]
+  },
+  "右": {
+    "formula": "一 + 丿 + 口",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "叼": {
+    "formula": "口 + 刁",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "刁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "吃": {
+    "formula": "口 + 乞",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "乞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "各": {
+    "formula": "夂 + 口",
+    "components": [
+      {
+        "radical": "夂",
+        "role": "部件",
+        "label": "夂"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "合": {
+    "formula": "人 + 一 + 口",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "吉": {
+    "formula": "士 + 口",
+    "components": [
+      {
+        "radical": "士",
+        "role": "部件",
+        "label": "士"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "吊": {
+    "formula": "口 + 巾",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      }
+    ]
+  },
+  "同": {
+    "formula": "凡 + 口",
+    "components": [
+      {
+        "radical": "凡",
+        "role": "部件",
+        "label": "凡"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "名": {
+    "formula": "夕 + 口",
+    "components": [
+      {
+        "radical": "夕",
+        "role": "部件",
+        "label": "夕"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "后": {
+    "formula": "厂 + 一 + 口",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "部件",
+        "label": "山崖"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "吐": {
+    "formula": "口 + 土",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "土",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "向": {
+    "formula": "丶 + 冂 + 口",
+    "components": [
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      },
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "吔": {
+    "formula": "口 + 也",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "也",
+        "role": "部件",
+        "label": "也"
+      }
+    ]
+  },
+  "吝": {
+    "formula": "文 + 口",
+    "components": [
+      {
+        "radical": "文",
+        "role": "部件",
+        "label": "文"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "吞": {
+    "formula": "天 + 口",
+    "components": [
+      {
+        "radical": "天",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "吟": {
+    "formula": "口 + 今",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "今",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "否": {
+    "formula": "不 + 口",
+    "components": [
+      {
+        "radical": "不",
+        "role": "形符",
+        "label": "不"
+      },
+      {
+        "radical": "口",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "吧": {
+    "formula": "口 + 巴",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "巴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "含": {
+    "formula": "今 + 口",
+    "components": [
+      {
+        "radical": "今",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "吮": {
+    "formula": "口 + 允",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "允",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "吵": {
+    "formula": "口 + 少",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "少",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "吸": {
+    "formula": "口 + 及",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "及",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "吻": {
+    "formula": "口 + 勿",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "勿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "吼": {
+    "formula": "口 + 孔",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "孔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "吾": {
+    "formula": "五 + 口",
+    "components": [
+      {
+        "radical": "五",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "呀": {
+    "formula": "口 + 牙",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "牙",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "呃": {
+    "formula": "口 + 厄",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "厄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "呆": {
+    "formula": "口 + 木",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "呈": {
+    "formula": "口 + 王",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      }
+    ]
+  },
+  "告": {
+    "formula": "牛 + 口",
+    "components": [
+      {
+        "radical": "牛",
+        "role": "部件",
+        "label": "牛"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "呎": {
+    "formula": "口 + 尺",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "尺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "呢": {
+    "formula": "口 + 尼",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "尼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "周": {
+    "formula": "冂 + 土 + 口",
+    "components": [
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "味": {
+    "formula": "口 + 未",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "未",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "呵": {
+    "formula": "口 + 可",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "可",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "呼": {
+    "formula": "口 + 乎",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "乎",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "命": {
+    "formula": "令 + 口",
+    "components": [
+      {
+        "radical": "令",
+        "role": "部件",
+        "label": "令"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "咀": {
+    "formula": "口 + 且",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "且",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "和": {
+    "formula": "禾 + 口",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "咎": {
+    "formula": "处 + 口",
+    "components": [
+      {
+        "radical": "处",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "咒": {
+    "formula": "口 + 口 + 几",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "几",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "咕": {
+    "formula": "口 + 古",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "古",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "咖": {
+    "formula": "口 + 加",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "加",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "咚": {
+    "formula": "口 + 冬",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "冬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "咦": {
+    "formula": "口 + 夷",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "夷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "咪": {
+    "formula": "口 + 米",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "米",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "咬": {
+    "formula": "口 + 交",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "交",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "咳": {
+    "formula": "口 + 亥",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "亥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "咸": {
+    "formula": "戊 + 一 + 口",
+    "components": [
+      {
+        "radical": "戊",
+        "role": "部件",
+        "label": "戊"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "咽": {
+    "formula": "口 + 因",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "因",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "哀": {
+    "formula": "衣 + 口",
+    "components": [
+      {
+        "radical": "衣",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "品": {
+    "formula": "口 + 口 + 口",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "哄": {
+    "formula": "口 + 共",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "共",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "哆": {
+    "formula": "口 + 多",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "多",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "哇": {
+    "formula": "口 + 圭",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "哈": {
+    "formula": "口 + 合",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "合",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "員": {
+    "formula": "口 + 貝",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "哥": {
+    "formula": "可 + 可",
+    "components": [
+      {
+        "radical": "可",
+        "role": "部件",
+        "label": "可"
+      },
+      {
+        "radical": "可",
+        "role": "部件",
+        "label": "可"
+      }
+    ]
+  },
+  "哦": {
+    "formula": "口 + 我",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "我",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "哨": {
+    "formula": "口 + 肖",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "哪": {
+    "formula": "口 + 那",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "那",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "哭": {
+    "formula": "口 + 口 + 犬",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "犬",
+        "role": "部件",
+        "label": "狗"
+      }
+    ]
+  },
+  "哲": {
+    "formula": "折 + 口",
+    "components": [
+      {
+        "radical": "折",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "哺": {
+    "formula": "口 + 甫",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "甫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "哼": {
+    "formula": "口 + 亨",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "亨",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "唇": {
+    "formula": "辰 + 口",
+    "components": [
+      {
+        "radical": "辰",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "唉": {
+    "formula": "口 + 矣",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "矣",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "唚": {
+    "formula": "口 + 彐",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "彐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "售": {
+    "formula": "隹 + 口",
+    "components": [
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "唯": {
+    "formula": "口 + 隹",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      }
+    ]
+  },
+  "唱": {
+    "formula": "口 + 昌",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "昌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "唸": {
+    "formula": "口 + 念",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "念",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "唾": {
+    "formula": "口 + 垂",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "垂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "啃": {
+    "formula": "口 + 肯",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "肯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "啄": {
+    "formula": "口 + 豖",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "豖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "商": {
+    "formula": "冏 + 章",
+    "components": [
+      {
+        "radical": "冏",
+        "role": "形符",
+        "label": "冏"
+      },
+      {
+        "radical": "章",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "啊": {
+    "formula": "口 + 阿",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "阿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "問": {
+    "formula": "門 + 口",
+    "components": [
+      {
+        "radical": "門",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "啜": {
+    "formula": "口 + 叕",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "叕",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "啞": {
+    "formula": "口 + 亞",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "亞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "啟": {
+    "formula": "启 + 攵",
+    "components": [
+      {
+        "radical": "启",
+        "role": "部件",
+        "label": "启"
+      },
+      {
+        "radical": "攵",
+        "role": "部件",
+        "label": "攵"
+      }
+    ]
+  },
+  "啡": {
+    "formula": "口 + 非",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "非",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "啤": {
+    "formula": "口 + 卑",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "卑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "啦": {
+    "formula": "口 + 拉",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "拉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "啼": {
+    "formula": "口 + 帝",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "帝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喀": {
+    "formula": "口 + 客",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "客",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "善": {
+    "formula": "羊 + 丷 + 一 + 口",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "部件",
+        "label": "羊"
+      },
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "喉": {
+    "formula": "口 + 侯",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "侯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喊": {
+    "formula": "口 + 咸",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "咸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喑": {
+    "formula": "口 + 音",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "音",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喔": {
+    "formula": "口 + 屋",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "屋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喘": {
+    "formula": "口 + 耑",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "耑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喚": {
+    "formula": "口 + 奐",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "奐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喜": {
+    "formula": "壴 + 口",
+    "components": [
+      {
+        "radical": "壴",
+        "role": "部件",
+        "label": "壴"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "喝": {
+    "formula": "口 + 曷",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "曷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喬": {
+    "formula": "夭 + 高",
+    "components": [
+      {
+        "radical": "夭",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "高",
+        "role": "形符",
+        "label": "高"
+      }
+    ]
+  },
+  "喲": {
+    "formula": "口 + 約",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "約",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喳": {
+    "formula": "口 + 查",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "查",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "喻": {
+    "formula": "口 + 俞",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "俞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嗎": {
+    "formula": "口 + 馬",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "馬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嗚": {
+    "formula": "口 + 烏",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "烏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嗜": {
+    "formula": "口 + 耆",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "耆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嗡": {
+    "formula": "口 + 翁",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "翁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嗯": {
+    "formula": "口 + 恩",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "恩",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嗶": {
+    "formula": "口 + 畢",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "畢",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嗷": {
+    "formula": "口 + 敖",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "敖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘀": {
+    "formula": "口 + 啇",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "啇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘆": {
+    "formula": "口 + 堇",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "堇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘔": {
+    "formula": "口 + 區",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "區",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘗": {
+    "formula": "尚 + 旨",
+    "components": [
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "旨",
+        "role": "形符",
+        "label": "旨"
+      }
+    ]
+  },
+  "嘛": {
+    "formula": "口 + 麻",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "麻",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘮": {
+    "formula": "口 + 勞",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "勞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘯": {
+    "formula": "口 + 肅",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "肅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘰": {
+    "formula": "口 + 幾",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "幾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘲": {
+    "formula": "口 + 朝",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "朝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘴": {
+    "formula": "口 + 觜",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "觜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嘿": {
+    "formula": "口 + 黑",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "黑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "噁": {
+    "formula": "惡 + 惡",
+    "components": [
+      {
+        "radical": "惡",
+        "role": "形符",
+        "label": "惡"
+      },
+      {
+        "radical": "惡",
+        "role": "形符",
+        "label": "惡"
+      }
+    ]
+  },
+  "噎": {
+    "formula": "口 + 壹",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "壹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "噗": {
+    "formula": "口 + 菐",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "菐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "器": {
+    "formula": "口 + 口 + 犬 + 口 + 口",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "犬",
+        "role": "部件",
+        "label": "狗"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "噩": {
+    "formula": "王 + 口 + 口 + 口 + 口",
+    "components": [
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "噬": {
+    "formula": "口 + 筮",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "筮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "噴": {
+    "formula": "口 + 賁",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "賁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "噸": {
+    "formula": "口 + 頓",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "頓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嚇": {
+    "formula": "口 + 赫",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "赫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嚕": {
+    "formula": "口 + 魯",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "魯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嚥": {
+    "formula": "口 + 燕",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "燕",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嚨": {
+    "formula": "口 + 龍",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "龍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嚼": {
+    "formula": "口 + 爵",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "爵",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "囉": {
+    "formula": "口 + 羅",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "羅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "囊": {
+    "formula": "口 + 襄",
+    "components": [
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      },
+      {
+        "radical": "襄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "囚": {
+    "formula": "囗 + 人",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "部件",
+        "label": "口框"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "回": {
+    "formula": "囗 + 口",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "部件",
+        "label": "口框"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "因": {
+    "formula": "囗 + 大",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "部件",
+        "label": "口框"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "困": {
+    "formula": "囗 + 木",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "部件",
+        "label": "口框"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "固": {
+    "formula": "囗 + 古",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "形符",
+        "label": "口框"
+      },
+      {
+        "radical": "古",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "圈": {
+    "formula": "囗 + 卷",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "形符",
+        "label": "口框"
+      },
+      {
+        "radical": "卷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "國": {
+    "formula": "囗 + 或",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "部件",
+        "label": "口框"
+      },
+      {
+        "radical": "或",
+        "role": "部件",
+        "label": "或"
+      }
+    ]
+  },
+  "圍": {
+    "formula": "囗 + 韋",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "形符",
+        "label": "口框"
+      },
+      {
+        "radical": "韋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "園": {
+    "formula": "囗 + 袁",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "形符",
+        "label": "口框"
+      },
+      {
+        "radical": "袁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "圓": {
+    "formula": "囗 + 員",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "形符",
+        "label": "口框"
+      },
+      {
+        "radical": "員",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "圖": {
+    "formula": "囗 + 啚",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "部件",
+        "label": "口框"
+      },
+      {
+        "radical": "啚",
+        "role": "部件",
+        "label": "啚"
+      }
+    ]
+  },
+  "團": {
+    "formula": "囗 + 專",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "部件",
+        "label": "口框"
+      },
+      {
+        "radical": "專",
+        "role": "部件",
+        "label": "專"
+      }
+    ]
+  },
+  "在": {
+    "formula": "才 + 土",
+    "components": [
+      {
+        "radical": "才",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "地": {
+    "formula": "土 + 也",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "也",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "圾": {
+    "formula": "土 + 及",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "及",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "址": {
+    "formula": "土 + 止",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "止",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "均": {
+    "formula": "土 + 匀",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "匀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "坐": {
+    "formula": "从 + 土",
+    "components": [
+      {
+        "radical": "从",
+        "role": "部件",
+        "label": "从"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "坡": {
+    "formula": "土 + 皮",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "皮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "坦": {
+    "formula": "土 + 旦",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "旦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "坳": {
+    "formula": "土 + 幼",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "幼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "垃": {
+    "formula": "土 + 立",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "立",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "型": {
+    "formula": "刑 + 土",
+    "components": [
+      {
+        "radical": "刑",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "垮": {
+    "formula": "土 + 夸",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "夸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "埃": {
+    "formula": "土 + 矣",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "矣",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "埋": {
+    "formula": "土 + 里",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "里",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "城": {
+    "formula": "土 + 成",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "成",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "域": {
+    "formula": "土 + 或",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "或",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "執": {
+    "formula": "幸 + 丸",
+    "components": [
+      {
+        "radical": "幸",
+        "role": "部件",
+        "label": "幸"
+      },
+      {
+        "radical": "丸",
+        "role": "部件",
+        "label": "丸"
+      }
+    ]
+  },
+  "培": {
+    "formula": "土 + 咅",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "咅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "基": {
+    "formula": "其 + 土",
+    "components": [
+      {
+        "radical": "其",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "埼": {
+    "formula": "土 + 奇",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "奇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "堂": {
+    "formula": "尚 + 土",
+    "components": [
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "堅": {
+    "formula": "臤 + 土",
+    "components": [
+      {
+        "radical": "臤",
+        "role": "部件",
+        "label": "臤"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "堆": {
+    "formula": "土 + 隹",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "堡": {
+    "formula": "保 + 土",
+    "components": [
+      {
+        "radical": "保",
+        "role": "部件",
+        "label": "保"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "報": {
+    "formula": "幸 + 卩 + 又",
+    "components": [
+      {
+        "radical": "幸",
+        "role": "部件",
+        "label": "幸"
+      },
+      {
+        "radical": "卩",
+        "role": "部件",
+        "label": "卩"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "場": {
+    "formula": "土 + 昜",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "昜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "堵": {
+    "formula": "土 + 者",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "塊": {
+    "formula": "土 + 鬼",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "鬼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "塌": {
+    "formula": "土 + 日 + 羽",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "羽",
+        "role": "部件",
+        "label": "羽毛"
+      }
+    ]
+  },
+  "塑": {
+    "formula": "朔 + 土",
+    "components": [
+      {
+        "radical": "朔",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "塔": {
+    "formula": "土 + 荅",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "荅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "塗": {
+    "formula": "氵 + 余",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "余",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "塘": {
+    "formula": "土 + 唐",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "唐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "塞": {
+    "formula": "宀 + 二 + 土",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "二",
+        "role": "部件",
+        "label": "二"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "塢": {
+    "formula": "土 + 烏",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "烏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "填": {
+    "formula": "土 + 真",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "真",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "塵": {
+    "formula": "鹿 + 土",
+    "components": [
+      {
+        "radical": "鹿",
+        "role": "部件",
+        "label": "鹿"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "境": {
+    "formula": "土 + 竟",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "竟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "墓": {
+    "formula": "莫 + 土",
+    "components": [
+      {
+        "radical": "莫",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "墜": {
+    "formula": "隊 + 土",
+    "components": [
+      {
+        "radical": "隊",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "增": {
+    "formula": "土 + 曾",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "曾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "墨": {
+    "formula": "黑 + 土",
+    "components": [
+      {
+        "radical": "黑",
+        "role": "部件",
+        "label": "黑"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "墮": {
+    "formula": "隋 + 土",
+    "components": [
+      {
+        "radical": "隋",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "墳": {
+    "formula": "土 + 賁",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "賁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "墾": {
+    "formula": "貇 + 土",
+    "components": [
+      {
+        "radical": "貇",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "壁": {
+    "formula": "辟 + 土",
+    "components": [
+      {
+        "radical": "辟",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "壇": {
+    "formula": "土 + 亶",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "亶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "壓": {
+    "formula": "厭 + 土",
+    "components": [
+      {
+        "radical": "厭",
+        "role": "部件",
+        "label": "厭"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "壘": {
+    "formula": "畾 + 土",
+    "components": [
+      {
+        "radical": "畾",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      }
+    ]
+  },
+  "壞": {
+    "formula": "土 + 褱",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "褱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "壤": {
+    "formula": "土 + 襄",
+    "components": [
+      {
+        "radical": "土",
+        "role": "形符",
+        "label": "土"
+      },
+      {
+        "radical": "襄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "壯": {
+    "formula": "爿 + 士",
+    "components": [
+      {
+        "radical": "爿",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "士",
+        "role": "形符",
+        "label": "士"
+      }
+    ]
+  },
+  "壽": {
+    "formula": "士 + 乛 + 工 + 一 + 吋",
+    "components": [
+      {
+        "radical": "士",
+        "role": "部件",
+        "label": "士"
+      },
+      {
+        "radical": "乛",
+        "role": "部件",
+        "label": "乛"
+      },
+      {
+        "radical": "工",
+        "role": "部件",
+        "label": "工"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "吋",
+        "role": "部件",
+        "label": "吋"
+      }
+    ]
+  },
+  "夏": {
+    "formula": "一 + 自 + 夕",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "自",
+        "role": "部件",
+        "label": "自己"
+      },
+      {
+        "radical": "夕",
+        "role": "部件",
+        "label": "夕"
+      }
+    ]
+  },
+  "外": {
+    "formula": "夕 + 卜",
+    "components": [
+      {
+        "radical": "夕",
+        "role": "部件",
+        "label": "夕"
+      },
+      {
+        "radical": "卜",
+        "role": "部件",
+        "label": "卜"
+      }
+    ]
+  },
+  "多": {
+    "formula": "夕 + 夕",
+    "components": [
+      {
+        "radical": "夕",
+        "role": "部件",
+        "label": "夕"
+      },
+      {
+        "radical": "夕",
+        "role": "部件",
+        "label": "夕"
+      }
+    ]
+  },
+  "夜": {
+    "formula": "亠 + 亻 + 夕",
+    "components": [
+      {
+        "radical": "亠",
+        "role": "部件",
+        "label": "亠"
+      },
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "夕",
+        "role": "部件",
+        "label": "夕"
+      }
+    ]
+  },
+  "夠": {
+    "formula": "多 + 句",
+    "components": [
+      {
+        "radical": "多",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "句",
+        "role": "形符",
+        "label": "句"
+      }
+    ]
+  },
+  "夢": {
+    "formula": "艹 + 罒 + 冖 + 夕",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "夕",
+        "role": "部件",
+        "label": "夕"
+      }
+    ]
+  },
+  "夥": {
+    "formula": "果 + 多",
+    "components": [
+      {
+        "radical": "果",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "多",
+        "role": "形符",
+        "label": "多"
+      }
+    ]
+  },
+  "天": {
+    "formula": "一 + 大",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "太": {
+    "formula": "大 + 丶",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      }
+    ]
+  },
+  "夫": {
+    "formula": "一 + 大",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "央": {
+    "formula": "冂 + 大",
+    "components": [
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "失": {
+    "formula": "丿 + 夫",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "夫",
+        "role": "部件",
+        "label": "夫"
+      }
+    ]
+  },
+  "夷": {
+    "formula": "大 + 弓",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "弓",
+        "role": "部件",
+        "label": "弓箭"
+      }
+    ]
+  },
+  "奇": {
+    "formula": "大 + 可",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "可",
+        "role": "部件",
+        "label": "可"
+      }
+    ]
+  },
+  "奈": {
+    "formula": "大 + 示",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "示",
+        "role": "部件",
+        "label": "祭祀"
+      }
+    ]
+  },
+  "奉": {
+    "formula": "手 + 乀 + 一 + 十",
+    "components": [
+      {
+        "radical": "手",
+        "role": "部件",
+        "label": "手"
+      },
+      {
+        "radical": "乀",
+        "role": "部件",
+        "label": "乀"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "奎": {
+    "formula": "大 + 圭",
+    "components": [
+      {
+        "radical": "大",
+        "role": "形符",
+        "label": "大"
+      },
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "契": {
+    "formula": "丰 + 刀 + 大",
+    "components": [
+      {
+        "radical": "丰",
+        "role": "部件",
+        "label": "丰"
+      },
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "奔": {
+    "formula": "大 + 卉",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "卉",
+        "role": "部件",
+        "label": "卉"
+      }
+    ]
+  },
+  "套": {
+    "formula": "大 + 镸",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "镸",
+        "role": "部件",
+        "label": "镸"
+      }
+    ]
+  },
+  "奠": {
+    "formula": "酋 + 大",
+    "components": [
+      {
+        "radical": "酋",
+        "role": "部件",
+        "label": "酋"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "奢": {
+    "formula": "大 + 者",
+    "components": [
+      {
+        "radical": "大",
+        "role": "形符",
+        "label": "大"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "奧": {
+    "formula": "釆 + 大",
+    "components": [
+      {
+        "radical": "釆",
+        "role": "部件",
+        "label": "釆"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "奪": {
+    "formula": "大 + 隹 + 寸",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "奮": {
+    "formula": "大 + 隹 + 田",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      },
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      }
+    ]
+  },
+  "奶": {
+    "formula": "女 + 乃",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "乃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "她": {
+    "formula": "女 + 也",
+    "components": [
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      },
+      {
+        "radical": "也",
+        "role": "部件",
+        "label": "也"
+      }
+    ]
+  },
+  "好": {
+    "formula": "女 + 子",
+    "components": [
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "如": {
+    "formula": "女 + 口",
+    "components": [
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "妄": {
+    "formula": "亡 + 女",
+    "components": [
+      {
+        "radical": "亡",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      }
+    ]
+  },
+  "妒": {
+    "formula": "女 + 户",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "户",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "妙": {
+    "formula": "女 + 少",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "少",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "妝": {
+    "formula": "爿 + 女",
+    "components": [
+      {
+        "radical": "爿",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      }
+    ]
+  },
+  "妤": {
+    "formula": "女 + 予",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "予",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "妥": {
+    "formula": "爫 + 女",
+    "components": [
+      {
+        "radical": "爫",
+        "role": "部件",
+        "label": "爫"
+      },
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      }
+    ]
+  },
+  "妳": {
+    "formula": "女 + 尔",
+    "components": [
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      },
+      {
+        "radical": "尔",
+        "role": "部件",
+        "label": "尔"
+      }
+    ]
+  },
+  "妹": {
+    "formula": "女 + 未",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "未",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "妻": {
+    "formula": "十 + 彐 + 女",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "彐",
+        "role": "部件",
+        "label": "彐"
+      },
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      }
+    ]
+  },
+  "姆": {
+    "formula": "女 + 母",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "母",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "姊": {
+    "formula": "女 + 丿 + ㇉ + 丨 + 丿",
+    "components": [
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "㇉",
+        "role": "部件",
+        "label": "㇉"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "始": {
+    "formula": "女 + 台",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "台",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "姐": {
+    "formula": "女 + 且",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "且",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "姓": {
+    "formula": "女 + 生",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "生",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "委": {
+    "formula": "禾 + 女",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      }
+    ]
+  },
+  "姨": {
+    "formula": "女 + 夷",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "夷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "姿": {
+    "formula": "次 + 女",
+    "components": [
+      {
+        "radical": "次",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      }
+    ]
+  },
+  "威": {
+    "formula": "戌 + 女",
+    "components": [
+      {
+        "radical": "戌",
+        "role": "部件",
+        "label": "戌"
+      },
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      }
+    ]
+  },
+  "娘": {
+    "formula": "女 + 良",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "良",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "娥": {
+    "formula": "女 + 我",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "我",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "婚": {
+    "formula": "女 + 昏",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "昏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "婞": {
+    "formula": "女 + 幸",
+    "components": [
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      },
+      {
+        "radical": "幸",
+        "role": "部件",
+        "label": "幸"
+      }
+    ]
+  },
+  "婦": {
+    "formula": "女 + 帚",
+    "components": [
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      },
+      {
+        "radical": "帚",
+        "role": "部件",
+        "label": "帚"
+      }
+    ]
+  },
+  "媒": {
+    "formula": "女 + 某",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "某",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "媚": {
+    "formula": "女 + 眉",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "眉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "媽": {
+    "formula": "女 + 馬",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "馬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嫁": {
+    "formula": "女 + 家",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "家",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嫉": {
+    "formula": "女 + 疾",
+    "components": [
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      },
+      {
+        "radical": "疾",
+        "role": "部件",
+        "label": "疾"
+      }
+    ]
+  },
+  "嫌": {
+    "formula": "女 + 兼",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "兼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嫦": {
+    "formula": "女 + 常",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "常",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嬉": {
+    "formula": "女 + 喜",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "喜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嬌": {
+    "formula": "女 + 喬",
+    "components": [
+      {
+        "radical": "女",
+        "role": "形符",
+        "label": "女旁"
+      },
+      {
+        "radical": "喬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "孔": {
+    "formula": "子 + 乚",
+    "components": [
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      },
+      {
+        "radical": "乚",
+        "role": "部件",
+        "label": "乚"
+      }
+    ]
+  },
+  "孕": {
+    "formula": "乃 + 子",
+    "components": [
+      {
+        "radical": "乃",
+        "role": "部件",
+        "label": "乃"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "字": {
+    "formula": "宀 + 子",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "存": {
+    "formula": "才 + 子",
+    "components": [
+      {
+        "radical": "才",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "子",
+        "role": "形符",
+        "label": "孩子"
+      }
+    ]
+  },
+  "孝": {
+    "formula": "耂 + 子",
+    "components": [
+      {
+        "radical": "耂",
+        "role": "部件",
+        "label": "耂"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "孟": {
+    "formula": "子 + 皿",
+    "components": [
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      },
+      {
+        "radical": "皿",
+        "role": "部件",
+        "label": "器皿"
+      }
+    ]
+  },
+  "季": {
+    "formula": "禾 + 子",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "孤": {
+    "formula": "子 + 瓜",
+    "components": [
+      {
+        "radical": "子",
+        "role": "形符",
+        "label": "孩子"
+      },
+      {
+        "radical": "瓜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "学": {
+    "formula": "⺍ + 冖 + 子",
+    "components": [
+      {
+        "radical": "⺍",
+        "role": "部件",
+        "label": "⺍"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "孩": {
+    "formula": "子 + 亥",
+    "components": [
+      {
+        "radical": "子",
+        "role": "形符",
+        "label": "孩子"
+      },
+      {
+        "radical": "亥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "孫": {
+    "formula": "子 + 系",
+    "components": [
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      },
+      {
+        "radical": "系",
+        "role": "部件",
+        "label": "系"
+      }
+    ]
+  },
+  "孳": {
+    "formula": "兹 + 子",
+    "components": [
+      {
+        "radical": "兹",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "子",
+        "role": "形符",
+        "label": "孩子"
+      }
+    ]
+  },
+  "孵": {
+    "formula": "卵 + 孚",
+    "components": [
+      {
+        "radical": "卵",
+        "role": "部件",
+        "label": "卵"
+      },
+      {
+        "radical": "孚",
+        "role": "部件",
+        "label": "孚"
+      }
+    ]
+  },
+  "學": {
+    "formula": "冖 + 子",
+    "components": [
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "子",
+        "role": "部件",
+        "label": "孩子"
+      }
+    ]
+  },
+  "孽": {
+    "formula": "薛 + 子",
+    "components": [
+      {
+        "radical": "薛",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "子",
+        "role": "形符",
+        "label": "孩子"
+      }
+    ]
+  },
+  "它": {
+    "formula": "宀 + 匕",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      }
+    ]
+  },
+  "宇": {
+    "formula": "宀 + 于",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "于",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "守": {
+    "formula": "宀 + 寸",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "安": {
+    "formula": "宀 + 女",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      }
+    ]
+  },
+  "完": {
+    "formula": "宀 + 元",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "元",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "宏": {
+    "formula": "宀 + 厷",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "厷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "宗": {
+    "formula": "宀 + 示",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "示",
+        "role": "部件",
+        "label": "祭祀"
+      }
+    ]
+  },
+  "官": {
+    "formula": "宀 + 㠯",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "㠯",
+        "role": "部件",
+        "label": "㠯"
+      }
+    ]
+  },
+  "宙": {
+    "formula": "宀 + 由",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "由",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "定": {
+    "formula": "宀 + 疋",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "疋",
+        "role": "部件",
+        "label": "疋"
+      }
+    ]
+  },
+  "宛": {
+    "formula": "宀 + 夗",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "夗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "宜": {
+    "formula": "宀 + 且",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "且",
+        "role": "部件",
+        "label": "且"
+      }
+    ]
+  },
+  "客": {
+    "formula": "宀 + 各",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "各",
+        "role": "部件",
+        "label": "各"
+      }
+    ]
+  },
+  "室": {
+    "formula": "宀 + 至",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "至",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "宰": {
+    "formula": "宀 + 辛",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "辛",
+        "role": "部件",
+        "label": "辛"
+      }
+    ]
+  },
+  "害": {
+    "formula": "宀 + 丰 + 口",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "丰",
+        "role": "部件",
+        "label": "丰"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "宴": {
+    "formula": "宀 + 妟",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "妟",
+        "role": "部件",
+        "label": "妟"
+      }
+    ]
+  },
+  "宵": {
+    "formula": "宀 + 肖",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "家": {
+    "formula": "宀 + 豕",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "豕",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "容": {
+    "formula": "宀 + 谷",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "谷",
+        "role": "聲符",
+        "label": "山谷"
+      }
+    ]
+  },
+  "宿": {
+    "formula": "宀 + 佰",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "佰",
+        "role": "部件",
+        "label": "佰"
+      }
+    ]
+  },
+  "寂": {
+    "formula": "宀 + 叔",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "叔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "寄": {
+    "formula": "宀 + 奇",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "奇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "密": {
+    "formula": "宓 + 山",
+    "components": [
+      {
+        "radical": "宓",
+        "role": "部件",
+        "label": "宓"
+      },
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      }
+    ]
+  },
+  "富": {
+    "formula": "宀 + 畐",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "畐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "寐": {
+    "formula": "宀 + 爿 + 未",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "爿",
+        "role": "部件",
+        "label": "爿"
+      },
+      {
+        "radical": "未",
+        "role": "部件",
+        "label": "未"
+      }
+    ]
+  },
+  "寒": {
+    "formula": "宀 + 井 + 大 + 冰",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "井",
+        "role": "部件",
+        "label": "井"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "冰",
+        "role": "部件",
+        "label": "冰"
+      }
+    ]
+  },
+  "寓": {
+    "formula": "宀 + 禺",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "禺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "寞": {
+    "formula": "宀 + 莫",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "莫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "察": {
+    "formula": "宀 + 祭",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "祭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "寡": {
+    "formula": "宀 + 直 + 分",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "直",
+        "role": "部件",
+        "label": "直"
+      },
+      {
+        "radical": "分",
+        "role": "部件",
+        "label": "分"
+      }
+    ]
+  },
+  "寢": {
+    "formula": "宀 + 爿 + 彐 + 冖 + 又",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "爿",
+        "role": "部件",
+        "label": "爿"
+      },
+      {
+        "radical": "彐",
+        "role": "部件",
+        "label": "彐"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "實": {
+    "formula": "宀 + 貫",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貫",
+        "role": "形符",
+        "label": "貫"
+      }
+    ]
+  },
+  "寧": {
+    "formula": "心 + 丁",
+    "components": [
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      },
+      {
+        "radical": "丁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "審": {
+    "formula": "宀 + 番",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "番",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "寬": {
+    "formula": "宀 + 苋",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "苋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "寵": {
+    "formula": "宀 + 龍",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "形符",
+        "label": "房頂"
+      },
+      {
+        "radical": "龍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "寶": {
+    "formula": "宀 + 珤 + 貝",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "珤",
+        "role": "部件",
+        "label": "珤"
+      },
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      }
+    ]
+  },
+  "封": {
+    "formula": "圭 + 寸",
+    "components": [
+      {
+        "radical": "圭",
+        "role": "部件",
+        "label": "圭"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "將": {
+    "formula": "爿 + 夕 + 寸",
+    "components": [
+      {
+        "radical": "爿",
+        "role": "部件",
+        "label": "爿"
+      },
+      {
+        "radical": "夕",
+        "role": "部件",
+        "label": "夕"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "專": {
+    "formula": "叀 + 寸",
+    "components": [
+      {
+        "radical": "叀",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "寸",
+        "role": "形符",
+        "label": "寸"
+      }
+    ]
+  },
+  "尊": {
+    "formula": "酋 + 寸",
+    "components": [
+      {
+        "radical": "酋",
+        "role": "部件",
+        "label": "酋"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "尋": {
+    "formula": "彐 + 工 + 口 + 寸",
+    "components": [
+      {
+        "radical": "彐",
+        "role": "部件",
+        "label": "彐"
+      },
+      {
+        "radical": "工",
+        "role": "部件",
+        "label": "工"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "對": {
+    "formula": "业 + 羊 + 寸",
+    "components": [
+      {
+        "radical": "业",
+        "role": "部件",
+        "label": "业"
+      },
+      {
+        "radical": "羊",
+        "role": "部件",
+        "label": "羊"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "導": {
+    "formula": "道 + 寸",
+    "components": [
+      {
+        "radical": "道",
+        "role": "部件",
+        "label": "道"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "尔": {
+    "formula": "刀 + 小",
+    "components": [
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      },
+      {
+        "radical": "小",
+        "role": "部件",
+        "label": "小"
+      }
+    ]
+  },
+  "尖": {
+    "formula": "小 + 大",
+    "components": [
+      {
+        "radical": "小",
+        "role": "部件",
+        "label": "小"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "尚": {
+    "formula": "小 + 冂 + 口",
+    "components": [
+      {
+        "radical": "小",
+        "role": "部件",
+        "label": "小"
+      },
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "就": {
+    "formula": "京 + 尤",
+    "components": [
+      {
+        "radical": "京",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "尤",
+        "role": "形符",
+        "label": "尤"
+      }
+    ]
+  },
+  "尺": {
+    "formula": "尸 + 乚",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "乚",
+        "role": "部件",
+        "label": "乚"
+      }
+    ]
+  },
+  "尼": {
+    "formula": "尸 + 匕",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      }
+    ]
+  },
+  "尾": {
+    "formula": "尸 + 毛",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "毛",
+        "role": "部件",
+        "label": "毛"
+      }
+    ]
+  },
+  "尿": {
+    "formula": "尸 + 水",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "水",
+        "role": "部件",
+        "label": "水"
+      }
+    ]
+  },
+  "局": {
+    "formula": "尺 + 口",
+    "components": [
+      {
+        "radical": "尺",
+        "role": "部件",
+        "label": "尺"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "居": {
+    "formula": "户 + 古",
+    "components": [
+      {
+        "radical": "户",
+        "role": "形符",
+        "label": "户"
+      },
+      {
+        "radical": "古",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "屈": {
+    "formula": "尸 + 出",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "形符",
+        "label": "尸"
+      },
+      {
+        "radical": "出",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "屋": {
+    "formula": "尸 + 至",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "至",
+        "role": "部件",
+        "label": "至"
+      }
+    ]
+  },
+  "屍": {
+    "formula": "尸 + 死",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "死",
+        "role": "部件",
+        "label": "死"
+      }
+    ]
+  },
+  "屎": {
+    "formula": "尸 + 米",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "米",
+        "role": "部件",
+        "label": "米"
+      }
+    ]
+  },
+  "屏": {
+    "formula": "户 + 并",
+    "components": [
+      {
+        "radical": "户",
+        "role": "形符",
+        "label": "户"
+      },
+      {
+        "radical": "并",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "屑": {
+    "formula": "尸 + 肖",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "形符",
+        "label": "尸"
+      },
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "展": {
+    "formula": "尸 + 衣",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "衣",
+        "role": "部件",
+        "label": "衣服"
+      }
+    ]
+  },
+  "屢": {
+    "formula": "尸 + 婁",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "形符",
+        "label": "尸"
+      },
+      {
+        "radical": "婁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "層": {
+    "formula": "尸 + 曾",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "形符",
+        "label": "尸"
+      },
+      {
+        "radical": "曾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "屬": {
+    "formula": "尸 + 禹",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "形符",
+        "label": "尸"
+      },
+      {
+        "radical": "禹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "岌": {
+    "formula": "山 + 及",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "及",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "岐": {
+    "formula": "山 + 支",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "支",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "岩": {
+    "formula": "山 + 石",
+    "components": [
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      },
+      {
+        "radical": "石",
+        "role": "部件",
+        "label": "石頭"
+      }
+    ]
+  },
+  "岸": {
+    "formula": "山 + 厂 + 干",
+    "components": [
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      },
+      {
+        "radical": "厂",
+        "role": "部件",
+        "label": "山崖"
+      },
+      {
+        "radical": "干",
+        "role": "部件",
+        "label": "干"
+      }
+    ]
+  },
+  "峭": {
+    "formula": "山 + 肖",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "峰": {
+    "formula": "山 + 夆",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "夆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "島": {
+    "formula": "烏 + 山",
+    "components": [
+      {
+        "radical": "烏",
+        "role": "部件",
+        "label": "烏"
+      },
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      }
+    ]
+  },
+  "峻": {
+    "formula": "山 + 夋",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "夋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "峽": {
+    "formula": "山 + 夾",
+    "components": [
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      },
+      {
+        "radical": "夾",
+        "role": "部件",
+        "label": "夾"
+      }
+    ]
+  },
+  "崇": {
+    "formula": "山 + 宗",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "宗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "崎": {
+    "formula": "山 + 奇",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "奇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "崑": {
+    "formula": "山 + 昆",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "昆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "崩": {
+    "formula": "山 + 朋",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "朋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嵎": {
+    "formula": "山 + 禺",
+    "components": [
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      },
+      {
+        "radical": "禺",
+        "role": "部件",
+        "label": "禺"
+      }
+    ]
+  },
+  "嶄": {
+    "formula": "山 + 斬",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "斬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嶇": {
+    "formula": "山 + 區",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "區",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嶺": {
+    "formula": "山 + 令",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "令",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "嶼": {
+    "formula": "山 + 與",
+    "components": [
+      {
+        "radical": "山",
+        "role": "形符",
+        "label": "山"
+      },
+      {
+        "radical": "與",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "川": {
+    "formula": "丿 + 丨 + 丨",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      }
+    ]
+  },
+  "巡": {
+    "formula": "辶 + 巛",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "巛",
+        "role": "部件",
+        "label": "巛"
+      }
+    ]
+  },
+  "巢": {
+    "formula": "巛 + 果",
+    "components": [
+      {
+        "radical": "巛",
+        "role": "部件",
+        "label": "巛"
+      },
+      {
+        "radical": "果",
+        "role": "部件",
+        "label": "果"
+      }
+    ]
+  },
+  "巧": {
+    "formula": "工 + 丂",
+    "components": [
+      {
+        "radical": "工",
+        "role": "形符",
+        "label": "工"
+      },
+      {
+        "radical": "丂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "差": {
+    "formula": "羊 + 工",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "部件",
+        "label": "羊"
+      },
+      {
+        "radical": "工",
+        "role": "部件",
+        "label": "工"
+      }
+    ]
+  },
+  "已": {
+    "formula": "㇆ + 一 + 乚",
+    "components": [
+      {
+        "radical": "㇆",
+        "role": "部件",
+        "label": "㇆"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "乚",
+        "role": "部件",
+        "label": "乚"
+      }
+    ]
+  },
+  "巴": {
+    "formula": "巳 + 丨",
+    "components": [
+      {
+        "radical": "巳",
+        "role": "部件",
+        "label": "巳"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      }
+    ]
+  },
+  "巷": {
+    "formula": "共 + 己",
+    "components": [
+      {
+        "radical": "共",
+        "role": "部件",
+        "label": "共"
+      },
+      {
+        "radical": "己",
+        "role": "部件",
+        "label": "己"
+      }
+    ]
+  },
+  "市": {
+    "formula": "亠 + 巾",
+    "components": [
+      {
+        "radical": "亠",
+        "role": "部件",
+        "label": "亠"
+      },
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      }
+    ]
+  },
+  "帆": {
+    "formula": "巾 + 凡",
+    "components": [
+      {
+        "radical": "巾",
+        "role": "形符",
+        "label": "巾"
+      },
+      {
+        "radical": "凡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "希": {
+    "formula": "乂 + 布",
+    "components": [
+      {
+        "radical": "乂",
+        "role": "部件",
+        "label": "乂"
+      },
+      {
+        "radical": "布",
+        "role": "部件",
+        "label": "布"
+      }
+    ]
+  },
+  "帕": {
+    "formula": "巾 + 白",
+    "components": [
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      },
+      {
+        "radical": "白",
+        "role": "部件",
+        "label": "白色"
+      }
+    ]
+  },
+  "師": {
+    "formula": "丿 + 㠯 + 帀",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "㠯",
+        "role": "部件",
+        "label": "㠯"
+      },
+      {
+        "radical": "帀",
+        "role": "部件",
+        "label": "帀"
+      }
+    ]
+  },
+  "席": {
+    "formula": "广 + 廿 + 巾",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "廿",
+        "role": "部件",
+        "label": "廿"
+      },
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      }
+    ]
+  },
+  "帳": {
+    "formula": "巾 + 長",
+    "components": [
+      {
+        "radical": "巾",
+        "role": "形符",
+        "label": "巾"
+      },
+      {
+        "radical": "長",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "帶": {
+    "formula": "卌 + 冖 + 巾",
+    "components": [
+      {
+        "radical": "卌",
+        "role": "部件",
+        "label": "卌"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      }
+    ]
+  },
+  "常": {
+    "formula": "尚 + 巾",
+    "components": [
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "巾",
+        "role": "形符",
+        "label": "巾"
+      }
+    ]
+  },
+  "帽": {
+    "formula": "巾 + 冒",
+    "components": [
+      {
+        "radical": "巾",
+        "role": "形符",
+        "label": "巾"
+      },
+      {
+        "radical": "冒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "幅": {
+    "formula": "巾 + 畐",
+    "components": [
+      {
+        "radical": "巾",
+        "role": "部件",
+        "label": "巾"
+      },
+      {
+        "radical": "畐",
+        "role": "部件",
+        "label": "畐"
+      }
+    ]
+  },
+  "幕": {
+    "formula": "莫 + 巾",
+    "components": [
+      {
+        "radical": "莫",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "巾",
+        "role": "形符",
+        "label": "巾"
+      }
+    ]
+  },
+  "幟": {
+    "formula": "巾 + 戠",
+    "components": [
+      {
+        "radical": "巾",
+        "role": "形符",
+        "label": "巾"
+      },
+      {
+        "radical": "戠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "幣": {
+    "formula": "敝 + 巾",
+    "components": [
+      {
+        "radical": "敝",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "巾",
+        "role": "形符",
+        "label": "巾"
+      }
+    ]
+  },
+  "幫": {
+    "formula": "封 + 帛",
+    "components": [
+      {
+        "radical": "封",
+        "role": "部件",
+        "label": "封"
+      },
+      {
+        "radical": "帛",
+        "role": "部件",
+        "label": "帛"
+      }
+    ]
+  },
+  "并": {
+    "formula": "丷 + 开",
+    "components": [
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "开",
+        "role": "部件",
+        "label": "开"
+      }
+    ]
+  },
+  "幸": {
+    "formula": "土 + 丷 + 干",
+    "components": [
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "干",
+        "role": "部件",
+        "label": "干"
+      }
+    ]
+  },
+  "幼": {
+    "formula": "幺 + 力",
+    "components": [
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "力",
+        "role": "部件",
+        "label": "力量"
+      }
+    ]
+  },
+  "幽": {
+    "formula": "山 + 幺 + 幺",
+    "components": [
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      }
+    ]
+  },
+  "庇": {
+    "formula": "广 + 比",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "比",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "床": {
+    "formula": "广 + 木",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "序": {
+    "formula": "广 + 予",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "予",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "底": {
+    "formula": "广 + 氐",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "氐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "店": {
+    "formula": "广 + 占",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "占",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "庚": {
+    "formula": "广 + 彐 + 人",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "彐",
+        "role": "部件",
+        "label": "彐"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "府": {
+    "formula": "广 + 付",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "付",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "度": {
+    "formula": "广 + 廿 + 又",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "廿",
+        "role": "部件",
+        "label": "廿"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "座": {
+    "formula": "广 + 坐",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "坐",
+        "role": "部件",
+        "label": "坐"
+      }
+    ]
+  },
+  "庫": {
+    "formula": "广 + 車",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "車",
+        "role": "部件",
+        "label": "車"
+      }
+    ]
+  },
+  "庭": {
+    "formula": "广 + 廷",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "廷",
+        "role": "部件",
+        "label": "廷"
+      }
+    ]
+  },
+  "康": {
+    "formula": "广 + 隶",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "隶",
+        "role": "部件",
+        "label": "隶"
+      }
+    ]
+  },
+  "廁": {
+    "formula": "广 + 則",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "則",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "廂": {
+    "formula": "广 + 相",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "相",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "廉": {
+    "formula": "广 + 兼",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "兼",
+        "role": "部件",
+        "label": "兼"
+      }
+    ]
+  },
+  "廚": {
+    "formula": "厂 + 豆",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "形符",
+        "label": "山崖"
+      },
+      {
+        "radical": "豆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "廝": {
+    "formula": "广 + 斯",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "斯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "廟": {
+    "formula": "广 + 朝",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "朝",
+        "role": "部件",
+        "label": "朝"
+      }
+    ]
+  },
+  "廠": {
+    "formula": "广 + 敞",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "敞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "廣": {
+    "formula": "广 + 黄",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "黄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "廳": {
+    "formula": "广 + 聽",
+    "components": [
+      {
+        "radical": "广",
+        "role": "形符",
+        "label": "广"
+      },
+      {
+        "radical": "聽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "延": {
+    "formula": "丿 + 㢟",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "㢟",
+        "role": "部件",
+        "label": "㢟"
+      }
+    ]
+  },
+  "建": {
+    "formula": "廴 + 聿",
+    "components": [
+      {
+        "radical": "廴",
+        "role": "形符",
+        "label": "延"
+      },
+      {
+        "radical": "聿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "弄": {
+    "formula": "玉 + 廾",
+    "components": [
+      {
+        "radical": "玉",
+        "role": "部件",
+        "label": "玉"
+      },
+      {
+        "radical": "廾",
+        "role": "部件",
+        "label": "廾"
+      }
+    ]
+  },
+  "弊": {
+    "formula": "敝 + 廾",
+    "components": [
+      {
+        "radical": "敝",
+        "role": "部件",
+        "label": "敝"
+      },
+      {
+        "radical": "廾",
+        "role": "部件",
+        "label": "廾"
+      }
+    ]
+  },
+  "式": {
+    "formula": "弋 + 工",
+    "components": [
+      {
+        "radical": "弋",
+        "role": "部件",
+        "label": "弋"
+      },
+      {
+        "radical": "工",
+        "role": "部件",
+        "label": "工"
+      }
+    ]
+  },
+  "引": {
+    "formula": "弓 + 丨",
+    "components": [
+      {
+        "radical": "弓",
+        "role": "部件",
+        "label": "弓箭"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      }
+    ]
+  },
+  "弗": {
+    "formula": "弓 + 丨 + 丨",
+    "components": [
+      {
+        "radical": "弓",
+        "role": "部件",
+        "label": "弓箭"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      }
+    ]
+  },
+  "弟": {
+    "formula": "丷 + 弔 + 丿",
+    "components": [
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "弔",
+        "role": "部件",
+        "label": "弔"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "弱": {
+    "formula": "弓 + 冫 + 弓 + 冫",
+    "components": [
+      {
+        "radical": "弓",
+        "role": "部件",
+        "label": "弓箭"
+      },
+      {
+        "radical": "冫",
+        "role": "部件",
+        "label": "冰旁"
+      },
+      {
+        "radical": "弓",
+        "role": "部件",
+        "label": "弓箭"
+      },
+      {
+        "radical": "冫",
+        "role": "部件",
+        "label": "冰旁"
+      }
+    ]
+  },
+  "張": {
+    "formula": "弓 + 長",
+    "components": [
+      {
+        "radical": "弓",
+        "role": "形符",
+        "label": "弓箭"
+      },
+      {
+        "radical": "長",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "強": {
+    "formula": "弓 + 虫",
+    "components": [
+      {
+        "radical": "弓",
+        "role": "形符",
+        "label": "弓箭"
+      },
+      {
+        "radical": "虫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "彈": {
+    "formula": "弓 + 單",
+    "components": [
+      {
+        "radical": "弓",
+        "role": "形符",
+        "label": "弓箭"
+      },
+      {
+        "radical": "單",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "彌": {
+    "formula": "弓 + 爾",
+    "components": [
+      {
+        "radical": "弓",
+        "role": "形符",
+        "label": "弓箭"
+      },
+      {
+        "radical": "爾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "彎": {
+    "formula": "䜌 + 弓",
+    "components": [
+      {
+        "radical": "䜌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "弓",
+        "role": "形符",
+        "label": "弓箭"
+      }
+    ]
+  },
+  "彙": {
+    "formula": "彑 + 冖 + 果",
+    "components": [
+      {
+        "radical": "彑",
+        "role": "部件",
+        "label": "彑"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "果",
+        "role": "部件",
+        "label": "果"
+      }
+    ]
+  },
+  "形": {
+    "formula": "开 + 彡",
+    "components": [
+      {
+        "radical": "开",
+        "role": "部件",
+        "label": "开"
+      },
+      {
+        "radical": "彡",
+        "role": "部件",
+        "label": "彡"
+      }
+    ]
+  },
+  "彥": {
+    "formula": "文 + 彡",
+    "components": [
+      {
+        "radical": "文",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "彡",
+        "role": "形符",
+        "label": "彡"
+      }
+    ]
+  },
+  "彩": {
+    "formula": "采 + 彡",
+    "components": [
+      {
+        "radical": "采",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "彡",
+        "role": "形符",
+        "label": "彡"
+      }
+    ]
+  },
+  "彪": {
+    "formula": "虎 + 彡",
+    "components": [
+      {
+        "radical": "虎",
+        "role": "部件",
+        "label": "虎"
+      },
+      {
+        "radical": "彡",
+        "role": "部件",
+        "label": "彡"
+      }
+    ]
+  },
+  "彰": {
+    "formula": "章 + 彡",
+    "components": [
+      {
+        "radical": "章",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "彡",
+        "role": "形符",
+        "label": "彡"
+      }
+    ]
+  },
+  "影": {
+    "formula": "景 + 彡",
+    "components": [
+      {
+        "radical": "景",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "彡",
+        "role": "形符",
+        "label": "彡"
+      }
+    ]
+  },
+  "彷": {
+    "formula": "彳 + 方",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "役": {
+    "formula": "彳 + 殳",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "殳",
+        "role": "部件",
+        "label": "殳"
+      }
+    ]
+  },
+  "彼": {
+    "formula": "彳 + 皮",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "皮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "彿": {
+    "formula": "彳 + 弗",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "弗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "往": {
+    "formula": "彳 + 王",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "王",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "待": {
+    "formula": "彳 + 寺",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "寺",
+        "role": "部件",
+        "label": "寺"
+      }
+    ]
+  },
+  "很": {
+    "formula": "彳 + 艮",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "徉": {
+    "formula": "彳 + 羊",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "律": {
+    "formula": "彳 + 聿",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "聿",
+        "role": "部件",
+        "label": "筆"
+      }
+    ]
+  },
+  "後": {
+    "formula": "彳 + 幺 + 夂",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "夂",
+        "role": "部件",
+        "label": "夂"
+      }
+    ]
+  },
+  "徐": {
+    "formula": "彳 + 余",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "余",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "徑": {
+    "formula": "彳 + 巠",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "巠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "徒": {
+    "formula": "彳 + 走",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "走",
+        "role": "部件",
+        "label": "走"
+      }
+    ]
+  },
+  "得": {
+    "formula": "彳 + 旦 + 寸",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "旦",
+        "role": "部件",
+        "label": "旦"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "徜": {
+    "formula": "彳 + 尚",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "從": {
+    "formula": "彳 + 从",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "从",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "復": {
+    "formula": "彳 + 复",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "复",
+        "role": "部件",
+        "label": "复"
+      }
+    ]
+  },
+  "循": {
+    "formula": "彳 + 盾",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "盾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "微": {
+    "formula": "彳 + 山 + 兀 + 攴",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      },
+      {
+        "radical": "兀",
+        "role": "部件",
+        "label": "兀"
+      },
+      {
+        "radical": "攴",
+        "role": "部件",
+        "label": "攴"
+      }
+    ]
+  },
+  "徵": {
+    "formula": "彳 + 正",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "正",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "德": {
+    "formula": "彳 + 十 + 罒 + 心",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "形符",
+        "label": "行旁"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "徹": {
+    "formula": "切 + 彳",
+    "components": [
+      {
+        "radical": "切",
+        "role": "形符",
+        "label": "切"
+      },
+      {
+        "radical": "彳",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "必": {
+    "formula": "心 + 丿",
+    "components": [
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "忌": {
+    "formula": "己 + 心",
+    "components": [
+      {
+        "radical": "己",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "忍": {
+    "formula": "刃 + 心",
+    "components": [
+      {
+        "radical": "刃",
+        "role": "部件",
+        "label": "刃"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "志": {
+    "formula": "士 + 心",
+    "components": [
+      {
+        "radical": "士",
+        "role": "部件",
+        "label": "士"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "忘": {
+    "formula": "亡 + 心",
+    "components": [
+      {
+        "radical": "亡",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "忙": {
+    "formula": "忄 + 亡",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "部件",
+        "label": "心旁"
+      },
+      {
+        "radical": "亡",
+        "role": "部件",
+        "label": "亡"
+      }
+    ]
+  },
+  "忠": {
+    "formula": "中 + 心",
+    "components": [
+      {
+        "radical": "中",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "忡": {
+    "formula": "忄 + 中",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "中",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "忪": {
+    "formula": "忄 + 公",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "公",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "快": {
+    "formula": "忄 + 夬",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "部件",
+        "label": "心旁"
+      },
+      {
+        "radical": "夬",
+        "role": "部件",
+        "label": "夬"
+      }
+    ]
+  },
+  "忱": {
+    "formula": "忄 + 冘",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "冘",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "念": {
+    "formula": "今 + 心",
+    "components": [
+      {
+        "radical": "今",
+        "role": "部件",
+        "label": "今"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "忽": {
+    "formula": "勿 + 心",
+    "components": [
+      {
+        "radical": "勿",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "怎": {
+    "formula": "乍 + 心",
+    "components": [
+      {
+        "radical": "乍",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "怒": {
+    "formula": "奴 + 心",
+    "components": [
+      {
+        "radical": "奴",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "怕": {
+    "formula": "忄 + 白",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "白",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "怖": {
+    "formula": "忄 + 布",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "布",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "思": {
+    "formula": "田 + 心",
+    "components": [
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "怠": {
+    "formula": "台 + 心",
+    "components": [
+      {
+        "radical": "台",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "怡": {
+    "formula": "忄 + 台",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "台",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "急": {
+    "formula": "刍 + 心",
+    "components": [
+      {
+        "radical": "刍",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "性": {
+    "formula": "忄 + 生",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "生",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "怨": {
+    "formula": "夗 + 心",
+    "components": [
+      {
+        "radical": "夗",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "怪": {
+    "formula": "心 + 圣",
+    "components": [
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      },
+      {
+        "radical": "圣",
+        "role": "部件",
+        "label": "圣"
+      }
+    ]
+  },
+  "恆": {
+    "formula": "忄 + 亙",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "部件",
+        "label": "心旁"
+      },
+      {
+        "radical": "亙",
+        "role": "部件",
+        "label": "亙"
+      }
+    ]
+  },
+  "恐": {
+    "formula": "巩 + 心",
+    "components": [
+      {
+        "radical": "巩",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "恕": {
+    "formula": "如 + 心",
+    "components": [
+      {
+        "radical": "如",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "恙": {
+    "formula": "羊 + 心",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "恢": {
+    "formula": "忄 + 灰",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "灰",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "恤": {
+    "formula": "忄 + 血",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "血",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "恨": {
+    "formula": "忄 + 艮",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "恩": {
+    "formula": "因 + 心",
+    "components": [
+      {
+        "radical": "因",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "恭": {
+    "formula": "共 + ⺗",
+    "components": [
+      {
+        "radical": "共",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺗",
+        "role": "形符",
+        "label": "⺗"
+      }
+    ]
+  },
+  "息": {
+    "formula": "自 + 心",
+    "components": [
+      {
+        "radical": "自",
+        "role": "部件",
+        "label": "自己"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "恰": {
+    "formula": "忄 + 合",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "合",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "悄": {
+    "formula": "忄 + 肖",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "悅": {
+    "formula": "忄 + 兌",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "兌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "悉": {
+    "formula": "釆 + 心",
+    "components": [
+      {
+        "radical": "釆",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "悍": {
+    "formula": "忄 + 旱",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "旱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "悔": {
+    "formula": "忄 + 每",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "每",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "悖": {
+    "formula": "忄 + 孛",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "孛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "悚": {
+    "formula": "忄 + 束",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "束",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "悠": {
+    "formula": "攸 + 心",
+    "components": [
+      {
+        "radical": "攸",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "患": {
+    "formula": "串 + 心",
+    "components": [
+      {
+        "radical": "串",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "您": {
+    "formula": "你 + 心",
+    "components": [
+      {
+        "radical": "你",
+        "role": "部件",
+        "label": "你"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "悲": {
+    "formula": "非 + 心",
+    "components": [
+      {
+        "radical": "非",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "悶": {
+    "formula": "門 + 心",
+    "components": [
+      {
+        "radical": "門",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "悸": {
+    "formula": "忄 + 季",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "季",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "情": {
+    "formula": "忄 + 青",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "惋": {
+    "formula": "忄 + 宛",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "宛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "惑": {
+    "formula": "或 + 心",
+    "components": [
+      {
+        "radical": "或",
+        "role": "部件",
+        "label": "或"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "惕": {
+    "formula": "忄 + 易",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "易",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "惜": {
+    "formula": "忄 + 昔",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "部件",
+        "label": "心旁"
+      },
+      {
+        "radical": "昔",
+        "role": "部件",
+        "label": "昔"
+      }
+    ]
+  },
+  "惡": {
+    "formula": "亞 + 心",
+    "components": [
+      {
+        "radical": "亞",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "惰": {
+    "formula": "忄 + 左",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "左",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "惱": {
+    "formula": "忄 + 囟",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "囟",
+        "role": "聲符",
+        "label": "腦頂"
+      }
+    ]
+  },
+  "想": {
+    "formula": "相 + 心",
+    "components": [
+      {
+        "radical": "相",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "惹": {
+    "formula": "若 + 心",
+    "components": [
+      {
+        "radical": "若",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "惺": {
+    "formula": "忄 + 星",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "部件",
+        "label": "心旁"
+      },
+      {
+        "radical": "星",
+        "role": "部件",
+        "label": "星"
+      }
+    ]
+  },
+  "愁": {
+    "formula": "秋 + 心",
+    "components": [
+      {
+        "radical": "秋",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "愈": {
+    "formula": "俞 + 心",
+    "components": [
+      {
+        "radical": "俞",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "意": {
+    "formula": "音 + 心",
+    "components": [
+      {
+        "radical": "音",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "愚": {
+    "formula": "禺 + 心",
+    "components": [
+      {
+        "radical": "禺",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "愛": {
+    "formula": "爫 + 冖 + 心 + 夂",
+    "components": [
+      {
+        "radical": "爫",
+        "role": "部件",
+        "label": "爫"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      },
+      {
+        "radical": "夂",
+        "role": "部件",
+        "label": "夂"
+      }
+    ]
+  },
+  "感": {
+    "formula": "咸 + 心",
+    "components": [
+      {
+        "radical": "咸",
+        "role": "部件",
+        "label": "咸"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "愧": {
+    "formula": "忄 + 鬼",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "鬼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "慈": {
+    "formula": "兹 + 心",
+    "components": [
+      {
+        "radical": "兹",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "態": {
+    "formula": "能 + 心",
+    "components": [
+      {
+        "radical": "能",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "慌": {
+    "formula": "忄 + 荒",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "荒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "慎": {
+    "formula": "忄 + 真",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "真",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "慕": {
+    "formula": "莫 + ⺗",
+    "components": [
+      {
+        "radical": "莫",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺗",
+        "role": "形符",
+        "label": "⺗"
+      }
+    ]
+  },
+  "慘": {
+    "formula": "忄 + 參",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "參",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "慢": {
+    "formula": "忄 + 曼",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "曼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "慣": {
+    "formula": "忄 + 貫",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "貫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "慧": {
+    "formula": "彗 + 心",
+    "components": [
+      {
+        "radical": "彗",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "慨": {
+    "formula": "忄 + 既",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "既",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "慮": {
+    "formula": "虍 + 思",
+    "components": [
+      {
+        "radical": "虍",
+        "role": "部件",
+        "label": "虍"
+      },
+      {
+        "radical": "思",
+        "role": "部件",
+        "label": "思"
+      }
+    ]
+  },
+  "慰": {
+    "formula": "尉 + 心",
+    "components": [
+      {
+        "radical": "尉",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "慶": {
+    "formula": "鹿 + 心 + 夂",
+    "components": [
+      {
+        "radical": "鹿",
+        "role": "部件",
+        "label": "鹿"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      },
+      {
+        "radical": "夂",
+        "role": "部件",
+        "label": "夂"
+      }
+    ]
+  },
+  "慾": {
+    "formula": "欲 + 心",
+    "components": [
+      {
+        "radical": "欲",
+        "role": "部件",
+        "label": "欲"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "憂": {
+    "formula": "忄 + 頁",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "頁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "憊": {
+    "formula": "備 + 心",
+    "components": [
+      {
+        "radical": "備",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "憐": {
+    "formula": "忄 + 粦",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "粦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "憑": {
+    "formula": "馮 + 心",
+    "components": [
+      {
+        "radical": "馮",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "憚": {
+    "formula": "忄 + 單",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "單",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "憤": {
+    "formula": "忄 + 賁",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "賁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "憶": {
+    "formula": "忄 + 意",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "意",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "憾": {
+    "formula": "忄 + 感",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "感",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "懂": {
+    "formula": "忄 + 董",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "董",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "懇": {
+    "formula": "貇 + 心",
+    "components": [
+      {
+        "radical": "貇",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "懈": {
+    "formula": "忄 + 解",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "解",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "應": {
+    "formula": "倠 + 心",
+    "components": [
+      {
+        "radical": "倠",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "懊": {
+    "formula": "忄 + 奥",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "奥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "懟": {
+    "formula": "對 + 心",
+    "components": [
+      {
+        "radical": "對",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "懲": {
+    "formula": "徴 + 心",
+    "components": [
+      {
+        "radical": "徴",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "懶": {
+    "formula": "忄 + 賴",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "賴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "懷": {
+    "formula": "忄 + 褱",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "褱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "懸": {
+    "formula": "縣 + 心",
+    "components": [
+      {
+        "radical": "縣",
+        "role": "部件",
+        "label": "縣"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "懼": {
+    "formula": "忄 + 瞿",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "瞿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "懾": {
+    "formula": "忄 + 聶",
+    "components": [
+      {
+        "radical": "忄",
+        "role": "形符",
+        "label": "心旁"
+      },
+      {
+        "radical": "聶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "戀": {
+    "formula": "䜌 + 心",
+    "components": [
+      {
+        "radical": "䜌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "心",
+        "role": "形符",
+        "label": "心"
+      }
+    ]
+  },
+  "戊": {
+    "formula": "丿 + 戈",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      }
+    ]
+  },
+  "成": {
+    "formula": "戊 + ㇆",
+    "components": [
+      {
+        "radical": "戊",
+        "role": "部件",
+        "label": "戊"
+      },
+      {
+        "radical": "㇆",
+        "role": "部件",
+        "label": "㇆"
+      }
+    ]
+  },
+  "我": {
+    "formula": "扌 + 戈",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      }
+    ]
+  },
+  "戒": {
+    "formula": "戈 + 廾",
+    "components": [
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      },
+      {
+        "radical": "廾",
+        "role": "部件",
+        "label": "廾"
+      }
+    ]
+  },
+  "或": {
+    "formula": "戈 + 口 + 一",
+    "components": [
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "战": {
+    "formula": "占 + 戈",
+    "components": [
+      {
+        "radical": "占",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "戈",
+        "role": "形符",
+        "label": "戈"
+      }
+    ]
+  },
+  "戚": {
+    "formula": "戊 + 尗",
+    "components": [
+      {
+        "radical": "戊",
+        "role": "部件",
+        "label": "戊"
+      },
+      {
+        "radical": "尗",
+        "role": "部件",
+        "label": "尗"
+      }
+    ]
+  },
+  "截": {
+    "formula": "十 + 隹 + 戈",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      },
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      }
+    ]
+  },
+  "戰": {
+    "formula": "單 + 戈",
+    "components": [
+      {
+        "radical": "單",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "戈",
+        "role": "形符",
+        "label": "戈"
+      }
+    ]
+  },
+  "戴": {
+    "formula": "十 + 戈 + 異",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      },
+      {
+        "radical": "異",
+        "role": "部件",
+        "label": "異"
+      }
+    ]
+  },
+  "房": {
+    "formula": "户 + 方",
+    "components": [
+      {
+        "radical": "户",
+        "role": "形符",
+        "label": "户"
+      },
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "所": {
+    "formula": "户 + 斤",
+    "components": [
+      {
+        "radical": "户",
+        "role": "部件",
+        "label": "户"
+      },
+      {
+        "radical": "斤",
+        "role": "部件",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "扇": {
+    "formula": "户 + 羽",
+    "components": [
+      {
+        "radical": "户",
+        "role": "部件",
+        "label": "户"
+      },
+      {
+        "radical": "羽",
+        "role": "部件",
+        "label": "羽"
+      }
+    ]
+  },
+  "打": {
+    "formula": "扌 + 丁",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "丁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "扔": {
+    "formula": "扌 + 乃",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "乃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "托": {
+    "formula": "扌 + 乇",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "乇",
+        "role": "部件",
+        "label": "乇"
+      }
+    ]
+  },
+  "扛": {
+    "formula": "扌 + 工",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "工",
+        "role": "部件",
+        "label": "工"
+      }
+    ]
+  },
+  "扣": {
+    "formula": "扌 + 口",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "口",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "扭": {
+    "formula": "扌 + 丑",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "丑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "扮": {
+    "formula": "扌 + 分",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "分",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "扯": {
+    "formula": "扌 + 止",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "止",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "扳": {
+    "formula": "扌 + 反",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "反",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "扶": {
+    "formula": "扌 + 夫",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "夫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "批": {
+    "formula": "扌 + 比",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "比",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "找": {
+    "formula": "扌 + 戈",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      }
+    ]
+  },
+  "承": {
+    "formula": "了 + 三",
+    "components": [
+      {
+        "radical": "了",
+        "role": "部件",
+        "label": "了"
+      },
+      {
+        "radical": "三",
+        "role": "部件",
+        "label": "三"
+      }
+    ]
+  },
+  "技": {
+    "formula": "扌 + 支",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "支",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抉": {
+    "formula": "扌 + 夬",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "夬",
+        "role": "部件",
+        "label": "夬"
+      }
+    ]
+  },
+  "把": {
+    "formula": "扌 + 巴",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "巴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抑": {
+    "formula": "扌 + 卬",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "卬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抓": {
+    "formula": "扌 + 爪",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "爪",
+        "role": "部件",
+        "label": "爪"
+      }
+    ]
+  },
+  "投": {
+    "formula": "扌 + 殳",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "殳",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抖": {
+    "formula": "扌 + 斗",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "斗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抗": {
+    "formula": "扌 + 亢",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "亢",
+        "role": "部件",
+        "label": "亢"
+      }
+    ]
+  },
+  "折": {
+    "formula": "扌 + 斤",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "斤",
+        "role": "部件",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "披": {
+    "formula": "扌 + 皮",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "皮",
+        "role": "部件",
+        "label": "皮"
+      }
+    ]
+  },
+  "抬": {
+    "formula": "扌 + 台",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "台",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抱": {
+    "formula": "扌 + 包",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "包",
+        "role": "部件",
+        "label": "包"
+      }
+    ]
+  },
+  "抵": {
+    "formula": "扌 + 氐",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "氐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抹": {
+    "formula": "扌 + 末",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "末",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抽": {
+    "formula": "扌 + 由",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "由",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "抿": {
+    "formula": "扌 + 民",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "民",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拆": {
+    "formula": "扌 + 斥",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "斥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拇": {
+    "formula": "扌 + 母",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "母",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拉": {
+    "formula": "扌 + 立",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "立",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拋": {
+    "formula": "扌 + 九 + 力",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "九",
+        "role": "部件",
+        "label": "九"
+      },
+      {
+        "radical": "力",
+        "role": "部件",
+        "label": "力量"
+      }
+    ]
+  },
+  "拍": {
+    "formula": "扌 + 白",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "白",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拐": {
+    "formula": "扌 + 另",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "另",
+        "role": "部件",
+        "label": "另"
+      }
+    ]
+  },
+  "拒": {
+    "formula": "扌 + 巨",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "巨",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拔": {
+    "formula": "扌 + 犮",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "犮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拖": {
+    "formula": "扌 + 它",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "它",
+        "role": "聲符",
+        "label": "它"
+      }
+    ]
+  },
+  "拗": {
+    "formula": "扌 + 幼",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "幼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拚": {
+    "formula": "扌 + 弁",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "弁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "招": {
+    "formula": "扌 + 召",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "召",
+        "role": "部件",
+        "label": "召"
+      }
+    ]
+  },
+  "拜": {
+    "formula": "手 + 手",
+    "components": [
+      {
+        "radical": "手",
+        "role": "部件",
+        "label": "手"
+      },
+      {
+        "radical": "手",
+        "role": "部件",
+        "label": "手"
+      }
+    ]
+  },
+  "括": {
+    "formula": "扌 + 舌",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "舌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拭": {
+    "formula": "扌 + 式",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "式",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拯": {
+    "formula": "扌 + 丞",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "丞",
+        "role": "部件",
+        "label": "丞"
+      }
+    ]
+  },
+  "拳": {
+    "formula": "龹 + 手",
+    "components": [
+      {
+        "radical": "龹",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "手",
+        "role": "形符",
+        "label": "手"
+      }
+    ]
+  },
+  "拼": {
+    "formula": "扌 + 并",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "并",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "拾": {
+    "formula": "扌 + 合",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "合",
+        "role": "部件",
+        "label": "合"
+      }
+    ]
+  },
+  "拿": {
+    "formula": "合 + 手",
+    "components": [
+      {
+        "radical": "合",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "手",
+        "role": "形符",
+        "label": "手"
+      }
+    ]
+  },
+  "持": {
+    "formula": "扌 + 寺",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "寺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "指": {
+    "formula": "扌 + 旨",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "旨",
+        "role": "部件",
+        "label": "旨"
+      }
+    ]
+  },
+  "按": {
+    "formula": "扌 + 安",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "安",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "挑": {
+    "formula": "扌 + 兆",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "兆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "挖": {
+    "formula": "扌 + 穵",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "穵",
+        "role": "部件",
+        "label": "穵"
+      }
+    ]
+  },
+  "挪": {
+    "formula": "扌 + 那",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "那",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "挫": {
+    "formula": "扌 + 坐",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "坐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "振": {
+    "formula": "扌 + 辰",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "辰",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "挺": {
+    "formula": "扌 + 廷",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "廷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "挽": {
+    "formula": "扌 + 免",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "免",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "捉": {
+    "formula": "扌 + 足",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "足",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "捏": {
+    "formula": "扌 + 圼",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "圼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "捐": {
+    "formula": "扌 + 肙",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "肙",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "捕": {
+    "formula": "扌 + 甫",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "甫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "捧": {
+    "formula": "扌 + 奉",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "奉",
+        "role": "部件",
+        "label": "奉"
+      }
+    ]
+  },
+  "捨": {
+    "formula": "扌 + 舍",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "舍",
+        "role": "形符",
+        "label": "舍"
+      }
+    ]
+  },
+  "捲": {
+    "formula": "扌 + 卷",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "卷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "捶": {
+    "formula": "扌 + 垂",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "垂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "捷": {
+    "formula": "扌 + 疌",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "疌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "掃": {
+    "formula": "扌 + 帚",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "帚",
+        "role": "部件",
+        "label": "帚"
+      }
+    ]
+  },
+  "授": {
+    "formula": "扌 + 受",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "受",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "掉": {
+    "formula": "扌 + 卓",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "卓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "掌": {
+    "formula": "尚 + 手",
+    "components": [
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "手",
+        "role": "形符",
+        "label": "手"
+      }
+    ]
+  },
+  "掏": {
+    "formula": "扌 + 匋",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "匋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "掐": {
+    "formula": "扌 + 臽",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "臽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "排": {
+    "formula": "扌 + 非",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "非",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "掘": {
+    "formula": "扌 + 屈",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "屈",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "掛": {
+    "formula": "扌 + 卦",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "卦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "採": {
+    "formula": "扌 + 采",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "采",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "探": {
+    "formula": "扌 + 穴 + 木",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "穴",
+        "role": "部件",
+        "label": "穴"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "接": {
+    "formula": "扌 + 妾",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "妾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "控": {
+    "formula": "扌 + 空",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "空",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "推": {
+    "formula": "扌 + 隹",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "掩": {
+    "formula": "扌 + 奄",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "奄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "措": {
+    "formula": "扌 + 昔",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "昔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "描": {
+    "formula": "扌 + 苗",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "苗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "提": {
+    "formula": "扌 + 是",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "是",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "插": {
+    "formula": "扌 + 臿",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "臿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "揚": {
+    "formula": "扌 + 昜",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "昜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "換": {
+    "formula": "扌 + 奐",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "奐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "握": {
+    "formula": "扌 + 屋",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "屋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "揪": {
+    "formula": "扌 + 秋",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "秋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "揭": {
+    "formula": "扌 + 曷",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "曷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "揮": {
+    "formula": "扌 + 軍",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "軍",
+        "role": "部件",
+        "label": "軍"
+      }
+    ]
+  },
+  "援": {
+    "formula": "扌 + 爰",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "爰",
+        "role": "部件",
+        "label": "爰"
+      }
+    ]
+  },
+  "損": {
+    "formula": "扌 + 員",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "員",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搏": {
+    "formula": "扌 + 尃",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "尃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搐": {
+    "formula": "扌 + 畜",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "畜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搓": {
+    "formula": "扌 + 差",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "差",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搖": {
+    "formula": "扌 + 䍃",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "䍃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搗": {
+    "formula": "扌 + 島",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "島",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搜": {
+    "formula": "扌 + 叟",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "叟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搞": {
+    "formula": "扌 + 高",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "高",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搬": {
+    "formula": "扌 + 般",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "般",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搭": {
+    "formula": "扌 + 荅",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "荅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "搶": {
+    "formula": "扌 + 倉",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "倉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "摔": {
+    "formula": "扌 + 率",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "率",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "摘": {
+    "formula": "扌 + 啇",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "啇",
+        "role": "部件",
+        "label": "啇"
+      }
+    ]
+  },
+  "摧": {
+    "formula": "扌 + 崔",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "崔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "摩": {
+    "formula": "麻 + 手",
+    "components": [
+      {
+        "radical": "麻",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "手",
+        "role": "形符",
+        "label": "手"
+      }
+    ]
+  },
+  "摯": {
+    "formula": "執 + 手",
+    "components": [
+      {
+        "radical": "執",
+        "role": "部件",
+        "label": "執"
+      },
+      {
+        "radical": "手",
+        "role": "部件",
+        "label": "手"
+      }
+    ]
+  },
+  "摸": {
+    "formula": "扌 + 莫",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "莫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "撇": {
+    "formula": "扌 + 敝",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "敝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "撐": {
+    "formula": "扌 + 牚",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "牚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "撒": {
+    "formula": "扌 + 散",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "散",
+        "role": "部件",
+        "label": "散"
+      }
+    ]
+  },
+  "撓": {
+    "formula": "扌 + 堯",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "堯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "撞": {
+    "formula": "扌 + 童",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "童",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "撩": {
+    "formula": "扌 + 尞",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "尞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "撫": {
+    "formula": "扌 + 無",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "無",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "播": {
+    "formula": "扌 + 番",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "番",
+        "role": "部件",
+        "label": "番"
+      }
+    ]
+  },
+  "撰": {
+    "formula": "扌 + 巽",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "巽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "撲": {
+    "formula": "扌 + 菐",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "菐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "撿": {
+    "formula": "扌 + 僉",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "僉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擁": {
+    "formula": "扌 + 雍",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "雍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擂": {
+    "formula": "扌 + 雷",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "雷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擅": {
+    "formula": "扌 + 亶",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "亶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擇": {
+    "formula": "扌 + 睪",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "睪",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擊": {
+    "formula": "毄 + 手",
+    "components": [
+      {
+        "radical": "毄",
+        "role": "部件",
+        "label": "毄"
+      },
+      {
+        "radical": "手",
+        "role": "部件",
+        "label": "手"
+      }
+    ]
+  },
+  "擋": {
+    "formula": "扌 + 當",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "部件",
+        "label": "手旁"
+      },
+      {
+        "radical": "當",
+        "role": "部件",
+        "label": "當"
+      }
+    ]
+  },
+  "操": {
+    "formula": "扌 + 喿",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "喿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擔": {
+    "formula": "扌 + 詹",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "詹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "據": {
+    "formula": "扌 + 豦",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "豦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擠": {
+    "formula": "扌 + 齊",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "齊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擦": {
+    "formula": "扌 + 察",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "察",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擬": {
+    "formula": "扌 + 疑",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "疑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擱": {
+    "formula": "扌 + 閣",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "閣",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擴": {
+    "formula": "扌 + 廣",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "廣",
+        "role": "形符",
+        "label": "廣"
+      }
+    ]
+  },
+  "擺": {
+    "formula": "扌 + 罷",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "罷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擻": {
+    "formula": "扌 + 數",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "數",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "擾": {
+    "formula": "扌 + 憂",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "憂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "攀": {
+    "formula": "樊 + 手",
+    "components": [
+      {
+        "radical": "樊",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "手",
+        "role": "形符",
+        "label": "手"
+      }
+    ]
+  },
+  "攏": {
+    "formula": "扌 + 龍",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "龍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "攙": {
+    "formula": "扌 + 毚",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "毚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "攜": {
+    "formula": "扌 + 巂",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "巂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "攝": {
+    "formula": "扌 + 聶",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "聶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "攣": {
+    "formula": "䜌 + 手",
+    "components": [
+      {
+        "radical": "䜌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "手",
+        "role": "形符",
+        "label": "手"
+      }
+    ]
+  },
+  "攤": {
+    "formula": "扌 + 難",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "難",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "攫": {
+    "formula": "扌 + 矍",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "矍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "支": {
+    "formula": "十 + 又",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "收": {
+    "formula": "丩 + 攵",
+    "components": [
+      {
+        "radical": "丩",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "改": {
+    "formula": "己 + 攵",
+    "components": [
+      {
+        "radical": "己",
+        "role": "部件",
+        "label": "己"
+      },
+      {
+        "radical": "攵",
+        "role": "部件",
+        "label": "攵"
+      }
+    ]
+  },
+  "攻": {
+    "formula": "工 + 攵",
+    "components": [
+      {
+        "radical": "工",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "放": {
+    "formula": "方 + 攵",
+    "components": [
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "政": {
+    "formula": "正 + 攵",
+    "components": [
+      {
+        "radical": "正",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "故": {
+    "formula": "古 + 攵",
+    "components": [
+      {
+        "radical": "古",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "效": {
+    "formula": "交 + 攵",
+    "components": [
+      {
+        "radical": "交",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "敏": {
+    "formula": "每 + 攵",
+    "components": [
+      {
+        "radical": "每",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "救": {
+    "formula": "求 + 攵",
+    "components": [
+      {
+        "radical": "求",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "敗": {
+    "formula": "貝 + 攵",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "敘": {
+    "formula": "余 + 攵",
+    "components": [
+      {
+        "radical": "余",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "教": {
+    "formula": "孝 + 攵",
+    "components": [
+      {
+        "radical": "孝",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "敢": {
+    "formula": "耳 + 攵",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "部件",
+        "label": "耳朵"
+      },
+      {
+        "radical": "攵",
+        "role": "部件",
+        "label": "攵"
+      }
+    ]
+  },
+  "散": {
+    "formula": "⺼ + 攵",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "攵",
+        "role": "部件",
+        "label": "攵"
+      }
+    ]
+  },
+  "敦": {
+    "formula": "享 + 攵",
+    "components": [
+      {
+        "radical": "享",
+        "role": "形符",
+        "label": "享"
+      },
+      {
+        "radical": "攵",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "敬": {
+    "formula": "茍 + 攴",
+    "components": [
+      {
+        "radical": "茍",
+        "role": "部件",
+        "label": "茍"
+      },
+      {
+        "radical": "攴",
+        "role": "部件",
+        "label": "攴"
+      }
+    ]
+  },
+  "敲": {
+    "formula": "高 + 攴",
+    "components": [
+      {
+        "radical": "高",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攴",
+        "role": "形符",
+        "label": "攴"
+      }
+    ]
+  },
+  "整": {
+    "formula": "敕 + 正",
+    "components": [
+      {
+        "radical": "敕",
+        "role": "形符",
+        "label": "敕"
+      },
+      {
+        "radical": "正",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "敵": {
+    "formula": "啇 + 攵",
+    "components": [
+      {
+        "radical": "啇",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "數": {
+    "formula": "婁 + 攵",
+    "components": [
+      {
+        "radical": "婁",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "斃": {
+    "formula": "敝 + 死",
+    "components": [
+      {
+        "radical": "敝",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "死",
+        "role": "形符",
+        "label": "死"
+      }
+    ]
+  },
+  "斐": {
+    "formula": "非 + 文",
+    "components": [
+      {
+        "radical": "非",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "文",
+        "role": "形符",
+        "label": "文"
+      }
+    ]
+  },
+  "料": {
+    "formula": "米 + 斗",
+    "components": [
+      {
+        "radical": "米",
+        "role": "部件",
+        "label": "米"
+      },
+      {
+        "radical": "斗",
+        "role": "部件",
+        "label": "斗"
+      }
+    ]
+  },
+  "斜": {
+    "formula": "余 + 斗",
+    "components": [
+      {
+        "radical": "余",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "斗",
+        "role": "形符",
+        "label": "斗"
+      }
+    ]
+  },
+  "斥": {
+    "formula": "斤 + 丶",
+    "components": [
+      {
+        "radical": "斤",
+        "role": "部件",
+        "label": "斧頭"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      }
+    ]
+  },
+  "斧": {
+    "formula": "父 + 斤",
+    "components": [
+      {
+        "radical": "父",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "斤",
+        "role": "形符",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "斬": {
+    "formula": "車 + 斤",
+    "components": [
+      {
+        "radical": "車",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "斤",
+        "role": "形符",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "斯": {
+    "formula": "其 + 斤",
+    "components": [
+      {
+        "radical": "其",
+        "role": "部件",
+        "label": "其"
+      },
+      {
+        "radical": "斤",
+        "role": "部件",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "新": {
+    "formula": "亲 + 斤",
+    "components": [
+      {
+        "radical": "亲",
+        "role": "部件",
+        "label": "亲"
+      },
+      {
+        "radical": "斤",
+        "role": "部件",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "斷": {
+    "formula": "幺 + 幺 + 一 + 幺 + 幺 + 斤",
+    "components": [
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "斤",
+        "role": "部件",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "施": {
+    "formula": "方 + 丿 + 一 + 也",
+    "components": [
+      {
+        "radical": "方",
+        "role": "部件",
+        "label": "方"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "也",
+        "role": "部件",
+        "label": "也"
+      }
+    ]
+  },
+  "旁": {
+    "formula": "立 + 方",
+    "components": [
+      {
+        "radical": "立",
+        "role": "形符",
+        "label": "立"
+      },
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "旅": {
+    "formula": "方 + 氏",
+    "components": [
+      {
+        "radical": "方",
+        "role": "部件",
+        "label": "方"
+      },
+      {
+        "radical": "氏",
+        "role": "部件",
+        "label": "氏"
+      }
+    ]
+  },
+  "旋": {
+    "formula": "方 + 疋",
+    "components": [
+      {
+        "radical": "方",
+        "role": "部件",
+        "label": "方"
+      },
+      {
+        "radical": "疋",
+        "role": "部件",
+        "label": "疋"
+      }
+    ]
+  },
+  "族": {
+    "formula": "方 + 矢",
+    "components": [
+      {
+        "radical": "方",
+        "role": "部件",
+        "label": "方"
+      },
+      {
+        "radical": "矢",
+        "role": "部件",
+        "label": "箭"
+      }
+    ]
+  },
+  "旗": {
+    "formula": "方 + 其",
+    "components": [
+      {
+        "radical": "方",
+        "role": "形符",
+        "label": "方"
+      },
+      {
+        "radical": "其",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "旦": {
+    "formula": "日 + 一",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "旨": {
+    "formula": "匕 + 日",
+    "components": [
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "早": {
+    "formula": "日 + 十",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "旱": {
+    "formula": "日 + 干",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "干",
+        "role": "部件",
+        "label": "干"
+      }
+    ]
+  },
+  "昂": {
+    "formula": "日 + 卬",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "卬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "昆": {
+    "formula": "日 + 比",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "比",
+        "role": "部件",
+        "label": "比"
+      }
+    ]
+  },
+  "昇": {
+    "formula": "日 + 升",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "升",
+        "role": "部件",
+        "label": "升"
+      }
+    ]
+  },
+  "昌": {
+    "formula": "日 + 曰",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "曰",
+        "role": "部件",
+        "label": "說"
+      }
+    ]
+  },
+  "明": {
+    "formula": "日 + 月",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      }
+    ]
+  },
+  "昏": {
+    "formula": "氏 + 日",
+    "components": [
+      {
+        "radical": "氏",
+        "role": "部件",
+        "label": "氏"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "易": {
+    "formula": "日 + 勿",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "勿",
+        "role": "部件",
+        "label": "勿"
+      }
+    ]
+  },
+  "星": {
+    "formula": "日 + 生",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "生",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "映": {
+    "formula": "日 + 央",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "央",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "春": {
+    "formula": "三 + 人 + 日",
+    "components": [
+      {
+        "radical": "三",
+        "role": "部件",
+        "label": "三"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      }
+    ]
+  },
+  "昨": {
+    "formula": "日 + 乍",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "乍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "是": {
+    "formula": "日 + 疋",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "疋",
+        "role": "部件",
+        "label": "疋"
+      }
+    ]
+  },
+  "昱": {
+    "formula": "日 + 立",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "立",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "時": {
+    "formula": "日 + 寺",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "寺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "晉": {
+    "formula": "一 + 厶 + 厶 + 一 + 日",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      },
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "晒": {
+    "formula": "日 + 西",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "西",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "晚": {
+    "formula": "日 + 免",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "免",
+        "role": "部件",
+        "label": "免"
+      }
+    ]
+  },
+  "晨": {
+    "formula": "日 + 辰",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "辰",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "普": {
+    "formula": "並 + 日",
+    "components": [
+      {
+        "radical": "並",
+        "role": "部件",
+        "label": "並"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "景": {
+    "formula": "日 + 京",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "京",
+        "role": "部件",
+        "label": "京"
+      }
+    ]
+  },
+  "晰": {
+    "formula": "日 + 析",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "析",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "晴": {
+    "formula": "日 + 青",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "智": {
+    "formula": "知 + 日",
+    "components": [
+      {
+        "radical": "知",
+        "role": "部件",
+        "label": "知"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "暇": {
+    "formula": "日 + 叚",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "叚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "暈": {
+    "formula": "日 + 軍",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "軍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "暑": {
+    "formula": "日 + 者",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "暖": {
+    "formula": "日 + 爰",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "爰",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "暗": {
+    "formula": "日 + 音",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "音",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "暢": {
+    "formula": "申 + 昜",
+    "components": [
+      {
+        "radical": "申",
+        "role": "形符",
+        "label": "申"
+      },
+      {
+        "radical": "昜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "暨": {
+    "formula": "既 + 旦",
+    "components": [
+      {
+        "radical": "既",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "旦",
+        "role": "形符",
+        "label": "旦"
+      }
+    ]
+  },
+  "暫": {
+    "formula": "斬 + 日",
+    "components": [
+      {
+        "radical": "斬",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      }
+    ]
+  },
+  "暴": {
+    "formula": "日 + 共 + 水",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "共",
+        "role": "部件",
+        "label": "共"
+      },
+      {
+        "radical": "水",
+        "role": "部件",
+        "label": "水"
+      }
+    ]
+  },
+  "曆": {
+    "formula": "厤 + 日",
+    "components": [
+      {
+        "radical": "厤",
+        "role": "形符",
+        "label": "厤"
+      },
+      {
+        "radical": "日",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "曙": {
+    "formula": "日 + 署",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "署",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "曝": {
+    "formula": "日 + 暴",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "暴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "曠": {
+    "formula": "日 + 廣",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "廣",
+        "role": "部件",
+        "label": "廣"
+      }
+    ]
+  },
+  "曬": {
+    "formula": "日 + 麗",
+    "components": [
+      {
+        "radical": "日",
+        "role": "形符",
+        "label": "太陽"
+      },
+      {
+        "radical": "麗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "曰": {
+    "formula": "口 + 一",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "曳": {
+    "formula": "曰 + 乁 + 丿",
+    "components": [
+      {
+        "radical": "曰",
+        "role": "部件",
+        "label": "說"
+      },
+      {
+        "radical": "乁",
+        "role": "部件",
+        "label": "乁"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "更": {
+    "formula": "一 + 日 + 人",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "書": {
+    "formula": "聿 + 曰",
+    "components": [
+      {
+        "radical": "聿",
+        "role": "部件",
+        "label": "筆"
+      },
+      {
+        "radical": "曰",
+        "role": "部件",
+        "label": "說"
+      }
+    ]
+  },
+  "曼": {
+    "formula": "日 + 罒 + 又",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "曾": {
+    "formula": "丷 + 日",
+    "components": [
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "替": {
+    "formula": "夫 + 夫 + 日",
+    "components": [
+      {
+        "radical": "夫",
+        "role": "部件",
+        "label": "夫"
+      },
+      {
+        "radical": "夫",
+        "role": "部件",
+        "label": "夫"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "最": {
+    "formula": "日 + 取",
+    "components": [
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "取",
+        "role": "部件",
+        "label": "取"
+      }
+    ]
+  },
+  "會": {
+    "formula": "亼 + 日",
+    "components": [
+      {
+        "radical": "亼",
+        "role": "部件",
+        "label": "亼"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "朋": {
+    "formula": "月 + 月",
+    "components": [
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      }
+    ]
+  },
+  "服": {
+    "formula": "月 + 卩 + 又",
+    "components": [
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      },
+      {
+        "radical": "卩",
+        "role": "部件",
+        "label": "卩"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "朗": {
+    "formula": "良 + 月",
+    "components": [
+      {
+        "radical": "良",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "月",
+        "role": "形符",
+        "label": "月亮"
+      }
+    ]
+  },
+  "望": {
+    "formula": "亡 + 月 + 王",
+    "components": [
+      {
+        "radical": "亡",
+        "role": "部件",
+        "label": "亡"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      },
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      }
+    ]
+  },
+  "朝": {
+    "formula": "龺 + 月",
+    "components": [
+      {
+        "radical": "龺",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "月",
+        "role": "形符",
+        "label": "月亮"
+      }
+    ]
+  },
+  "期": {
+    "formula": "其 + 月",
+    "components": [
+      {
+        "radical": "其",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "月",
+        "role": "形符",
+        "label": "月亮"
+      }
+    ]
+  },
+  "未": {
+    "formula": "一 + 木",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "末": {
+    "formula": "木 + 一",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "本": {
+    "formula": "木 + 一",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "札": {
+    "formula": "木 + 乚",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "乚",
+        "role": "部件",
+        "label": "乚"
+      }
+    ]
+  },
+  "朵": {
+    "formula": "几 + 木",
+    "components": [
+      {
+        "radical": "几",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "朽": {
+    "formula": "木 + 丂",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "丂",
+        "role": "部件",
+        "label": "丂"
+      }
+    ]
+  },
+  "杉": {
+    "formula": "木 + 彡",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "彡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "李": {
+    "formula": "木 + 子",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "子",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "杏": {
+    "formula": "木 + 口",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "材": {
+    "formula": "木 + 才",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "才",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "村": {
+    "formula": "木 + 寸",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "寸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "杜": {
+    "formula": "木 + 土",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "土",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "束": {
+    "formula": "木 + 口",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "杯": {
+    "formula": "木 + 不",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "不",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "東": {
+    "formula": "木 + 日",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "杳": {
+    "formula": "木 + 日",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "松": {
+    "formula": "木 + 公",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "公",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "板": {
+    "formula": "木 + 反",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "反",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "析": {
+    "formula": "木 + 斤",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "斤",
+        "role": "部件",
+        "label": "斧頭"
+      }
+    ]
+  },
+  "林": {
+    "formula": "木 + 木",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "果": {
+    "formula": "田 + 木",
+    "components": [
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "枝": {
+    "formula": "木 + 支",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "支",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "枯": {
+    "formula": "木 + 古",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "古",
+        "role": "部件",
+        "label": "古"
+      }
+    ]
+  },
+  "架": {
+    "formula": "加 + 木",
+    "components": [
+      {
+        "radical": "加",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      }
+    ]
+  },
+  "柄": {
+    "formula": "木 + 丙",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "丙",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "柏": {
+    "formula": "木 + 白",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "白",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "某": {
+    "formula": "甘 + 木",
+    "components": [
+      {
+        "radical": "甘",
+        "role": "部件",
+        "label": "甘"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "柑": {
+    "formula": "木 + 甘",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "甘",
+        "role": "部件",
+        "label": "甘"
+      }
+    ]
+  },
+  "染": {
+    "formula": "氿 + 木",
+    "components": [
+      {
+        "radical": "氿",
+        "role": "部件",
+        "label": "氿"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "柔": {
+    "formula": "矛 + 木",
+    "components": [
+      {
+        "radical": "矛",
+        "role": "部件",
+        "label": "矛"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "查": {
+    "formula": "木 + 旦",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "旦",
+        "role": "部件",
+        "label": "旦"
+      }
+    ]
+  },
+  "柯": {
+    "formula": "木 + 可",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "可",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "柱": {
+    "formula": "木 + 主",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "主",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "柳": {
+    "formula": "木 + 卯",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "卯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "柴": {
+    "formula": "此 + 木",
+    "components": [
+      {
+        "radical": "此",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      }
+    ]
+  },
+  "柿": {
+    "formula": "木 + 市",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "市",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "栓": {
+    "formula": "木 + 全",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "全",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "校": {
+    "formula": "木 + 交",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "交",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "株": {
+    "formula": "木 + 朱",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "朱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "核": {
+    "formula": "木 + 亥",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "亥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "根": {
+    "formula": "木 + 艮",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "格": {
+    "formula": "木 + 各",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "栽": {
+    "formula": "戈 + 木",
+    "components": [
+      {
+        "radical": "戈",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      }
+    ]
+  },
+  "桂": {
+    "formula": "木 + 圭",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "框": {
+    "formula": "木 + 匡",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "匡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "案": {
+    "formula": "安 + 木",
+    "components": [
+      {
+        "radical": "安",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      }
+    ]
+  },
+  "桌": {
+    "formula": "木 + 卜 + 日",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "卜",
+        "role": "部件",
+        "label": "卜"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "桑": {
+    "formula": "叒 + 木",
+    "components": [
+      {
+        "radical": "叒",
+        "role": "部件",
+        "label": "叒"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "桶": {
+    "formula": "木 + 甬",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "甬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "桿": {
+    "formula": "木 + 旱",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "旱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "梁": {
+    "formula": "氵 + 刅 + 木",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "刅",
+        "role": "部件",
+        "label": "刅"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "梅": {
+    "formula": "木 + 每",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "每",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "條": {
+    "formula": "亻 + 丨 + 条",
+    "components": [
+      {
+        "radical": "亻",
+        "role": "部件",
+        "label": "人旁"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      },
+      {
+        "radical": "条",
+        "role": "部件",
+        "label": "条"
+      }
+    ]
+  },
+  "梢": {
+    "formula": "木 + 肖",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "梧": {
+    "formula": "木 + 吾",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "吾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "梯": {
+    "formula": "木 + 弟",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "弟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "械": {
+    "formula": "木 + 戒",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "戒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "棉": {
+    "formula": "木 + 帛",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "帛",
+        "role": "部件",
+        "label": "帛"
+      }
+    ]
+  },
+  "棒": {
+    "formula": "木 + 奉",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "奉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "棘": {
+    "formula": "朿 + 朿",
+    "components": [
+      {
+        "radical": "朿",
+        "role": "形符",
+        "label": "朿"
+      },
+      {
+        "radical": "朿",
+        "role": "形符",
+        "label": "朿"
+      }
+    ]
+  },
+  "棚": {
+    "formula": "木 + 朋",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "朋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "棟": {
+    "formula": "木 + 東",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "東",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "森": {
+    "formula": "木 + 木 + 木",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "棲": {
+    "formula": "木 + 妻",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "妻",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "棵": {
+    "formula": "木 + 果",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "果",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "植": {
+    "formula": "木 + 直",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "直",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "椎": {
+    "formula": "木 + 隹",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "椹": {
+    "formula": "木 + 甚",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "甚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "楊": {
+    "formula": "木 + 昜",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "昜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "楚": {
+    "formula": "林 + 疋",
+    "components": [
+      {
+        "radical": "林",
+        "role": "部件",
+        "label": "樹林"
+      },
+      {
+        "radical": "疋",
+        "role": "部件",
+        "label": "疋"
+      }
+    ]
+  },
+  "楞": {
+    "formula": "木 + 罒",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "罒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "楠": {
+    "formula": "木 + 南",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "南",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "楣": {
+    "formula": "木 + 眉",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "眉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "業": {
+    "formula": "业 + 未",
+    "components": [
+      {
+        "radical": "业",
+        "role": "部件",
+        "label": "业"
+      },
+      {
+        "radical": "未",
+        "role": "部件",
+        "label": "未"
+      }
+    ]
+  },
+  "極": {
+    "formula": "木 + 亟",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "亟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "楷": {
+    "formula": "木 + 皆",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "皆",
+        "role": "部件",
+        "label": "皆"
+      }
+    ]
+  },
+  "概": {
+    "formula": "木 + 既",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "既",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "榜": {
+    "formula": "木 + 旁",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "旁",
+        "role": "部件",
+        "label": "旁"
+      }
+    ]
+  },
+  "榮": {
+    "formula": "炏 + 冖 + 木",
+    "components": [
+      {
+        "radical": "炏",
+        "role": "部件",
+        "label": "炏"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "構": {
+    "formula": "木 + 冓",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "冓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "槍": {
+    "formula": "木 + 倉",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "倉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "槓": {
+    "formula": "木 + 貢",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "貢",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "槽": {
+    "formula": "木 + 曹",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "曹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "樁": {
+    "formula": "木 + 舂",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "舂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "樂": {
+    "formula": "幺 + 白 + 幺 + 木",
+    "components": [
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "白",
+        "role": "部件",
+        "label": "白色"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "樑": {
+    "formula": "木 + 梁",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "梁",
+        "role": "部件",
+        "label": "梁"
+      }
+    ]
+  },
+  "樓": {
+    "formula": "木 + 婁",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "婁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "標": {
+    "formula": "木 + 票",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "票",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "樟": {
+    "formula": "木 + 章",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "章",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "模": {
+    "formula": "木 + 莫",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "莫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "樣": {
+    "formula": "木 + 羕",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "羕",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "樸": {
+    "formula": "木 + 菐",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "菐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "樹": {
+    "formula": "木 + 尌",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "尌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "橇": {
+    "formula": "木 + 毳",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "毳",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "橋": {
+    "formula": "木 + 喬",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "喬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "橘": {
+    "formula": "木 + 矞",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "矞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "機": {
+    "formula": "木 + 幾",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "幾",
+        "role": "部件",
+        "label": "幾"
+      }
+    ]
+  },
+  "橡": {
+    "formula": "木 + 象",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "象",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "橫": {
+    "formula": "木 + 黃",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "黃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "檢": {
+    "formula": "木 + 僉",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "僉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "檬": {
+    "formula": "木 + 蒙",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "蒙",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "檸": {
+    "formula": "木 + 寧",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "寧",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "檻": {
+    "formula": "木 + 監",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "監",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "欄": {
+    "formula": "木 + 闌",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "闌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "權": {
+    "formula": "木 + 雚",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "雚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "欠": {
+    "formula": "⺈ + 人",
+    "components": [
+      {
+        "radical": "⺈",
+        "role": "部件",
+        "label": "⺈"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "次": {
+    "formula": "冫 + 欠",
+    "components": [
+      {
+        "radical": "冫",
+        "role": "部件",
+        "label": "冰旁"
+      },
+      {
+        "radical": "欠",
+        "role": "部件",
+        "label": "欠"
+      }
+    ]
+  },
+  "欣": {
+    "formula": "斤 + 欠",
+    "components": [
+      {
+        "radical": "斤",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "欠",
+        "role": "形符",
+        "label": "欠"
+      }
+    ]
+  },
+  "欲": {
+    "formula": "谷 + 欠",
+    "components": [
+      {
+        "radical": "谷",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "欠",
+        "role": "形符",
+        "label": "欠"
+      }
+    ]
+  },
+  "欵": {
+    "formula": "匕 + 矢 + 欠",
+    "components": [
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      },
+      {
+        "radical": "矢",
+        "role": "部件",
+        "label": "箭"
+      },
+      {
+        "radical": "欠",
+        "role": "部件",
+        "label": "欠"
+      }
+    ]
+  },
+  "欸": {
+    "formula": "矣 + 欠",
+    "components": [
+      {
+        "radical": "矣",
+        "role": "部件",
+        "label": "矣"
+      },
+      {
+        "radical": "欠",
+        "role": "部件",
+        "label": "欠"
+      }
+    ]
+  },
+  "欺": {
+    "formula": "其 + 欠",
+    "components": [
+      {
+        "radical": "其",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "欠",
+        "role": "形符",
+        "label": "欠"
+      }
+    ]
+  },
+  "款": {
+    "formula": "士 + 示 + 欠",
+    "components": [
+      {
+        "radical": "士",
+        "role": "部件",
+        "label": "士"
+      },
+      {
+        "radical": "示",
+        "role": "部件",
+        "label": "祭祀"
+      },
+      {
+        "radical": "欠",
+        "role": "形符",
+        "label": "欠"
+      }
+    ]
+  },
+  "歉": {
+    "formula": "兼 + 欠",
+    "components": [
+      {
+        "radical": "兼",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "欠",
+        "role": "形符",
+        "label": "欠"
+      }
+    ]
+  },
+  "歌": {
+    "formula": "哥 + 欠",
+    "components": [
+      {
+        "radical": "哥",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "欠",
+        "role": "形符",
+        "label": "欠"
+      }
+    ]
+  },
+  "歡": {
+    "formula": "雚 + 欠",
+    "components": [
+      {
+        "radical": "雚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "欠",
+        "role": "形符",
+        "label": "欠"
+      }
+    ]
+  },
+  "正": {
+    "formula": "一 + 止",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "止",
+        "role": "部件",
+        "label": "止"
+      }
+    ]
+  },
+  "此": {
+    "formula": "止 + 匕",
+    "components": [
+      {
+        "radical": "止",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "匕",
+        "role": "形符",
+        "label": "湯匙"
+      }
+    ]
+  },
+  "武": {
+    "formula": "一 + 弋 + 止",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "弋",
+        "role": "部件",
+        "label": "弋"
+      },
+      {
+        "radical": "止",
+        "role": "部件",
+        "label": "止"
+      }
+    ]
+  },
+  "歪": {
+    "formula": "不 + 正",
+    "components": [
+      {
+        "radical": "不",
+        "role": "部件",
+        "label": "不"
+      },
+      {
+        "radical": "正",
+        "role": "部件",
+        "label": "正"
+      }
+    ]
+  },
+  "歷": {
+    "formula": "厤 + 止",
+    "components": [
+      {
+        "radical": "厤",
+        "role": "形符",
+        "label": "厤"
+      },
+      {
+        "radical": "止",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "歸": {
+    "formula": "㠯 + 止",
+    "components": [
+      {
+        "radical": "㠯",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "止",
+        "role": "形符",
+        "label": "止"
+      }
+    ]
+  },
+  "死": {
+    "formula": "歹 + 匕",
+    "components": [
+      {
+        "radical": "歹",
+        "role": "部件",
+        "label": "歹"
+      },
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      }
+    ]
+  },
+  "殃": {
+    "formula": "歹 + 央",
+    "components": [
+      {
+        "radical": "歹",
+        "role": "形符",
+        "label": "歹"
+      },
+      {
+        "radical": "央",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "殆": {
+    "formula": "歹 + 台",
+    "components": [
+      {
+        "radical": "歹",
+        "role": "形符",
+        "label": "歹"
+      },
+      {
+        "radical": "台",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "殊": {
+    "formula": "歹 + 朱",
+    "components": [
+      {
+        "radical": "歹",
+        "role": "形符",
+        "label": "歹"
+      },
+      {
+        "radical": "朱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "殖": {
+    "formula": "歹 + 直",
+    "components": [
+      {
+        "radical": "歹",
+        "role": "形符",
+        "label": "歹"
+      },
+      {
+        "radical": "直",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "殘": {
+    "formula": "歹 + 戔",
+    "components": [
+      {
+        "radical": "歹",
+        "role": "形符",
+        "label": "歹"
+      },
+      {
+        "radical": "戔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "殲": {
+    "formula": "歹 + 韱",
+    "components": [
+      {
+        "radical": "歹",
+        "role": "形符",
+        "label": "歹"
+      },
+      {
+        "radical": "韱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "殷": {
+    "formula": "㐆 + 殳",
+    "components": [
+      {
+        "radical": "㐆",
+        "role": "部件",
+        "label": "㐆"
+      },
+      {
+        "radical": "殳",
+        "role": "部件",
+        "label": "殳"
+      }
+    ]
+  },
+  "殺": {
+    "formula": "杀 + 殳",
+    "components": [
+      {
+        "radical": "杀",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "殳",
+        "role": "形符",
+        "label": "殳"
+      }
+    ]
+  },
+  "殿": {
+    "formula": "尸 + 共 + 殳",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "共",
+        "role": "部件",
+        "label": "共"
+      },
+      {
+        "radical": "殳",
+        "role": "部件",
+        "label": "殳"
+      }
+    ]
+  },
+  "毀": {
+    "formula": "臼 + 土 + 殳",
+    "components": [
+      {
+        "radical": "臼",
+        "role": "部件",
+        "label": "臼"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
+      {
+        "radical": "殳",
+        "role": "部件",
+        "label": "殳"
+      }
+    ]
+  },
+  "毅": {
+    "formula": "豙 + 殳",
+    "components": [
+      {
+        "radical": "豙",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "殳",
+        "role": "形符",
+        "label": "殳"
+      }
+    ]
+  },
+  "母": {
+    "formula": "丨 + 一 + 二 + 丶 + 丶 + 亅",
+    "components": [
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "二",
+        "role": "部件",
+        "label": "二"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      },
+      {
+        "radical": "亅",
+        "role": "部件",
+        "label": "亅"
+      }
+    ]
+  },
+  "毒": {
+    "formula": "龶 + 母",
+    "components": [
+      {
+        "radical": "龶",
+        "role": "形符",
+        "label": "龶"
+      },
+      {
+        "radical": "母",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "比": {
+    "formula": "匕 + 匕",
+    "components": [
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      },
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      }
+    ]
+  },
+  "毯": {
+    "formula": "毛 + 炎",
+    "components": [
+      {
+        "radical": "毛",
+        "role": "形符",
+        "label": "毛"
+      },
+      {
+        "radical": "炎",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "氈": {
+    "formula": "亶 + 毛",
+    "components": [
+      {
+        "radical": "亶",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "毛",
+        "role": "形符",
+        "label": "毛"
+      }
+    ]
+  },
+  "民": {
+    "formula": "巳 + 戈",
+    "components": [
+      {
+        "radical": "巳",
+        "role": "部件",
+        "label": "巳"
+      },
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      }
+    ]
+  },
+  "氛": {
+    "formula": "气 + 分",
+    "components": [
+      {
+        "radical": "气",
+        "role": "形符",
+        "label": "气"
+      },
+      {
+        "radical": "分",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "氣": {
+    "formula": "气 + 米",
+    "components": [
+      {
+        "radical": "气",
+        "role": "部件",
+        "label": "气"
+      },
+      {
+        "radical": "米",
+        "role": "部件",
+        "label": "米"
+      }
+    ]
+  },
+  "氧": {
+    "formula": "气 + 羊",
+    "components": [
+      {
+        "radical": "气",
+        "role": "形符",
+        "label": "气"
+      },
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "氫": {
+    "formula": "气 + 巠",
+    "components": [
+      {
+        "radical": "气",
+        "role": "形符",
+        "label": "气"
+      },
+      {
+        "radical": "巠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "永": {
+    "formula": "丶 + 一 + 水",
+    "components": [
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "水",
+        "role": "部件",
+        "label": "水"
+      }
+    ]
+  },
+  "氾": {
+    "formula": "氵 + 㔾",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "㔾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "求": {
+    "formula": "水 + 一 + 丶",
+    "components": [
+      {
+        "radical": "水",
+        "role": "部件",
+        "label": "水"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      }
+    ]
+  },
+  "汗": {
+    "formula": "氵 + 干",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "干",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "池": {
+    "formula": "氵 + 也",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "也",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "污": {
+    "formula": "氵 + 亏",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "亏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "汰": {
+    "formula": "氵 + 太",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "太",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "汲": {
+    "formula": "氵 + 及",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "及",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "決": {
+    "formula": "氵 + 夬",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "夬",
+        "role": "形符",
+        "label": "夬"
+      }
+    ]
+  },
+  "沁": {
+    "formula": "氵 + 心",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "心",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "沃": {
+    "formula": "氵 + 夭",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "夭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "沈": {
+    "formula": "氵 + 冘",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "冘",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "沉": {
+    "formula": "氵 + 冗",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "冗",
+        "role": "部件",
+        "label": "冗"
+      }
+    ]
+  },
+  "沒": {
+    "formula": "氵 + 殳",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "殳",
+        "role": "聲符",
+        "label": "殳"
+      }
+    ]
+  },
+  "沙": {
+    "formula": "氵 + 少",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "少",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "沫": {
+    "formula": "氵 + 末",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "末",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "沮": {
+    "formula": "氵 + 且",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "且",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "河": {
+    "formula": "氵 + 可",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "可",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "沸": {
+    "formula": "氵 + 弗",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "弗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "油": {
+    "formula": "氵 + 由",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "由",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "治": {
+    "formula": "氵 + 台",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "台",
+        "role": "部件",
+        "label": "台"
+      }
+    ]
+  },
+  "沼": {
+    "formula": "氵 + 召",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "召",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "沿": {
+    "formula": "氵 + 几 + 口",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "几",
+        "role": "部件",
+        "label": "几"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "泌": {
+    "formula": "氵 + 必",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "必",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "法": {
+    "formula": "氵 + 去",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "去",
+        "role": "部件",
+        "label": "去"
+      }
+    ]
+  },
+  "泛": {
+    "formula": "氵 + 乏",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "乏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "泡": {
+    "formula": "氵 + 包",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "波": {
+    "formula": "氵 + 皮",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "皮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "泣": {
+    "formula": "氵 + 立",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "立",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "泥": {
+    "formula": "氵 + 尼",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "尼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "注": {
+    "formula": "氵 + 主",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "主",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "泯": {
+    "formula": "氵 + 民",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "民",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "泳": {
+    "formula": "氵 + 永",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "永",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "洋": {
+    "formula": "氵 + 羊",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "洗": {
+    "formula": "氵 + 先",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "先",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "洛": {
+    "formula": "氵 + 各",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "洞": {
+    "formula": "氵 + 同",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "同",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "津": {
+    "formula": "氵 + 聿",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "聿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "洪": {
+    "formula": "氵 + 共",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "共",
+        "role": "部件",
+        "label": "共"
+      }
+    ]
+  },
+  "洲": {
+    "formula": "氵 + 州",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "州",
+        "role": "部件",
+        "label": "州"
+      }
+    ]
+  },
+  "活": {
+    "formula": "氵 + 舌",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "舌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "派": {
+    "formula": "水 + 厂 + 氏",
+    "components": [
+      {
+        "radical": "水",
+        "role": "部件",
+        "label": "水"
+      },
+      {
+        "radical": "厂",
+        "role": "部件",
+        "label": "山崖"
+      },
+      {
+        "radical": "氏",
+        "role": "部件",
+        "label": "氏"
+      }
+    ]
+  },
+  "流": {
+    "formula": "氵 + 㐬",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "㐬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "浩": {
+    "formula": "氵 + 告",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "告",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "浪": {
+    "formula": "氵 + 良",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "良",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "浮": {
+    "formula": "氵 + 孚",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "孚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "浴": {
+    "formula": "氵 + 谷",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "谷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "海": {
+    "formula": "氵 + 每",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "每",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "浹": {
+    "formula": "氵 + 夾",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "夾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "消": {
+    "formula": "氵 + 肖",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "涉": {
+    "formula": "氵 + 步",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "步",
+        "role": "部件",
+        "label": "步"
+      }
+    ]
+  },
+  "涯": {
+    "formula": "氵 + 厓",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "厓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "液": {
+    "formula": "氵 + 夜",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "夜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "涵": {
+    "formula": "氵 + 函",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "函",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "涼": {
+    "formula": "氵 + 京",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "京",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淆": {
+    "formula": "氵 + 肴",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "肴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淋": {
+    "formula": "氵 + 林",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "林",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淒": {
+    "formula": "氵 + 妻",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "妻",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淘": {
+    "formula": "氵 + 匋",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "匋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淚": {
+    "formula": "氵 + 戾",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "戾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淡": {
+    "formula": "氵 + 炎",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "炎",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淨": {
+    "formula": "氵 + 爭",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "爭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "深": {
+    "formula": "氵 + 罙",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "罙",
+        "role": "部件",
+        "label": "罙"
+      }
+    ]
+  },
+  "淳": {
+    "formula": "氵 + 享",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "享",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淵": {
+    "formula": "氵 + 片",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "片",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "混": {
+    "formula": "氵 + 昆",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "昆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淹": {
+    "formula": "氵 + 奄",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "奄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "淺": {
+    "formula": "氵 + 戔",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "戔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "添": {
+    "formula": "氵 + 忝",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "忝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "清": {
+    "formula": "氵 + 青",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "減": {
+    "formula": "氵 + 咸",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "咸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "渡": {
+    "formula": "氵 + 度",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "度",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "渣": {
+    "formula": "氵 + 查",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "查",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "測": {
+    "formula": "氵 + 則",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "則",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "渭": {
+    "formula": "氵 + 胃",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "胃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "港": {
+    "formula": "氵 + 巷",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "巷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "渲": {
+    "formula": "氵 + 宣",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "宣",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "渴": {
+    "formula": "氵 + 曷",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "曷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "游": {
+    "formula": "氵 + 斿",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "斿",
+        "role": "部件",
+        "label": "斿"
+      }
+    ]
+  },
+  "渺": {
+    "formula": "氵 + 眇",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "眇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "湊": {
+    "formula": "氵 + 奏",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "奏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "湖": {
+    "formula": "氵 + 胡",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "胡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "湛": {
+    "formula": "氵 + 甚",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "甚",
+        "role": "部件",
+        "label": "甚"
+      }
+    ]
+  },
+  "湧": {
+    "formula": "氵 + 勈",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "勈",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "湯": {
+    "formula": "氵 + 昜",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "昜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "源": {
+    "formula": "氵 + 原",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "原",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "準": {
+    "formula": "淮 + 十",
+    "components": [
+      {
+        "radical": "淮",
+        "role": "部件",
+        "label": "淮"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "溝": {
+    "formula": "氵 + 冓",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "冓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "溪": {
+    "formula": "氵 + 奚",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "奚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "溫": {
+    "formula": "氵 + 皿",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "皿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "溶": {
+    "formula": "氵 + 容",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "容",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "滅": {
+    "formula": "氵 + 烕",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "烕",
+        "role": "部件",
+        "label": "烕"
+      }
+    ]
+  },
+  "滋": {
+    "formula": "氵 + 兹",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "兹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "滑": {
+    "formula": "氵 + 骨",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "骨",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "滯": {
+    "formula": "氵 + 帶",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "帶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "滴": {
+    "formula": "氵 + 啇",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "啇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "滷": {
+    "formula": "氵 + 鹵",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "鹵",
+        "role": "部件",
+        "label": "鹵"
+      }
+    ]
+  },
+  "滾": {
+    "formula": "氵 + 袞",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "袞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "滿": {
+    "formula": "氵 + 㒼",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "㒼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "漁": {
+    "formula": "氵 + 魚",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "魚",
+        "role": "部件",
+        "label": "魚"
+      }
+    ]
+  },
+  "漂": {
+    "formula": "氵 + 票",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "票",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "漆": {
+    "formula": "氵 + 桼",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "桼",
+        "role": "部件",
+        "label": "桼"
+      }
+    ]
+  },
+  "漓": {
+    "formula": "氵 + 离",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "离",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "演": {
+    "formula": "氵 + 寅",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "寅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "漠": {
+    "formula": "氵 + 莫",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "莫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "漢": {
+    "formula": "氵 + 堇",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "堇",
+        "role": "部件",
+        "label": "堇"
+      }
+    ]
+  },
+  "漫": {
+    "formula": "氵 + 曼",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "曼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "漸": {
+    "formula": "氵 + 斬",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "斬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "潔": {
+    "formula": "氵 + 絜",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "絜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "潛": {
+    "formula": "氵 + 朁",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "朁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "潤": {
+    "formula": "氵 + 閏",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "閏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "潦": {
+    "formula": "氵 + 尞",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "尞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "潭": {
+    "formula": "氵 + 覃",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "覃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "潮": {
+    "formula": "氵 + 朝",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "朝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "潰": {
+    "formula": "氵 + 貴",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "貴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "潸": {
+    "formula": "氵 + 林 + 月",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "林",
+        "role": "部件",
+        "label": "樹林"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      }
+    ]
+  },
+  "澀": {
+    "formula": "氵 + 歰",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "歰",
+        "role": "部件",
+        "label": "歰"
+      }
+    ]
+  },
+  "澄": {
+    "formula": "氵 + 登",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "登",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "澆": {
+    "formula": "氵 + 堯",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "堯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "澡": {
+    "formula": "氵 + 喿",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "喿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "澤": {
+    "formula": "氵 + 睪",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "睪",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "澱": {
+    "formula": "氵 + 殿",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "殿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "澳": {
+    "formula": "氵 + 奥",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "奥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "激": {
+    "formula": "氵 + 敫",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "敫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "濃": {
+    "formula": "氵 + 農",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "農",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "濕": {
+    "formula": "氵 + 㬎",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "㬎",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "濟": {
+    "formula": "氵 + 齊",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "齊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "濫": {
+    "formula": "氵 + 監",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "監",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "濱": {
+    "formula": "氵 + 賓",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "賓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瀕": {
+    "formula": "氵 + 頻",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "頻",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瀚": {
+    "formula": "氵 + 翰",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "翰",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瀟": {
+    "formula": "氵 + 蕭",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "蕭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "灌": {
+    "formula": "氵 + 雚",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "雚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "灑": {
+    "formula": "氵 + 麗",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "麗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "灘": {
+    "formula": "氵 + 難",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "難",
+        "role": "部件",
+        "label": "難"
+      }
+    ]
+  },
+  "灣": {
+    "formula": "氵 + 彎",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "形符",
+        "label": "水旁"
+      },
+      {
+        "radical": "彎",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "災": {
+    "formula": "巛 + 火",
+    "components": [
+      {
+        "radical": "巛",
+        "role": "部件",
+        "label": "巛"
+      },
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      }
+    ]
+  },
+  "炎": {
+    "formula": "火 + 火",
+    "components": [
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      },
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      }
+    ]
+  },
+  "炒": {
+    "formula": "火 + 少",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "少",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "炙": {
+    "formula": "月 + 火",
+    "components": [
+      {
+        "radical": "月",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      }
+    ]
+  },
+  "炫": {
+    "formula": "火 + 玄",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "玄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "炮": {
+    "formula": "火 + 包",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "炸": {
+    "formula": "火 + 乍",
+    "components": [
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      },
+      {
+        "radical": "乍",
+        "role": "部件",
+        "label": "乍"
+      }
+    ]
+  },
+  "為": {
+    "formula": "爫 + 灬",
+    "components": [
+      {
+        "radical": "爫",
+        "role": "部件",
+        "label": "爫"
+      },
+      {
+        "radical": "灬",
+        "role": "部件",
+        "label": "火底"
+      }
+    ]
+  },
+  "烈": {
+    "formula": "列 + 灬",
+    "components": [
+      {
+        "radical": "列",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "烘": {
+    "formula": "火 + 共",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "共",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "烙": {
+    "formula": "火 + 各",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "烤": {
+    "formula": "火 + 考",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "考",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "烽": {
+    "formula": "火 + 夆",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "夆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "焉": {
+    "formula": "正 + 灬",
+    "components": [
+      {
+        "radical": "正",
+        "role": "部件",
+        "label": "正"
+      },
+      {
+        "radical": "灬",
+        "role": "部件",
+        "label": "火底"
+      }
+    ]
+  },
+  "焚": {
+    "formula": "林 + 火",
+    "components": [
+      {
+        "radical": "林",
+        "role": "部件",
+        "label": "樹林"
+      },
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      }
+    ]
+  },
+  "焦": {
+    "formula": "隹 + 灬",
+    "components": [
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      },
+      {
+        "radical": "灬",
+        "role": "部件",
+        "label": "火底"
+      }
+    ]
+  },
+  "焰": {
+    "formula": "火 + 臽",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "臽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "然": {
+    "formula": "肰 + 灬",
+    "components": [
+      {
+        "radical": "肰",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "煉": {
+    "formula": "火 + 柬",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "柬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "煎": {
+    "formula": "前 + 灬",
+    "components": [
+      {
+        "radical": "前",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "煙": {
+    "formula": "火 + 垔",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "垔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "煞": {
+    "formula": "刍 + 攴 + 火",
+    "components": [
+      {
+        "radical": "刍",
+        "role": "部件",
+        "label": "刍"
+      },
+      {
+        "radical": "攴",
+        "role": "部件",
+        "label": "攴"
+      },
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      }
+    ]
+  },
+  "煤": {
+    "formula": "火 + 某",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "某",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "煥": {
+    "formula": "火 + 奐",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "奐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "照": {
+    "formula": "昭 + 灬",
+    "components": [
+      {
+        "radical": "昭",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "煩": {
+    "formula": "火 + 頁",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "頁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "煮": {
+    "formula": "者 + 灬",
+    "components": [
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "煽": {
+    "formula": "火 + 扇",
+    "components": [
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      },
+      {
+        "radical": "扇",
+        "role": "部件",
+        "label": "扇"
+      }
+    ]
+  },
+  "熙": {
+    "formula": "巸 + 灬",
+    "components": [
+      {
+        "radical": "巸",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "熟": {
+    "formula": "孰 + 灬",
+    "components": [
+      {
+        "radical": "孰",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "熬": {
+    "formula": "敖 + 灬",
+    "components": [
+      {
+        "radical": "敖",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "熱": {
+    "formula": "埶 + 灬",
+    "components": [
+      {
+        "radical": "埶",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "灬",
+        "role": "形符",
+        "label": "火底"
+      }
+    ]
+  },
+  "燃": {
+    "formula": "火 + 然",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "然",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "燈": {
+    "formula": "火 + 登",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "登",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "燒": {
+    "formula": "火 + 堯",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "堯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "燥": {
+    "formula": "火 + 喿",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "喿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "燦": {
+    "formula": "火 + 粲",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "粲",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "爆": {
+    "formula": "火 + 暴",
+    "components": [
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      },
+      {
+        "radical": "暴",
+        "role": "部件",
+        "label": "暴"
+      }
+    ]
+  },
+  "爍": {
+    "formula": "火 + 樂",
+    "components": [
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      },
+      {
+        "radical": "樂",
+        "role": "部件",
+        "label": "樂"
+      }
+    ]
+  },
+  "爛": {
+    "formula": "火 + 闌",
+    "components": [
+      {
+        "radical": "火",
+        "role": "形符",
+        "label": "火"
+      },
+      {
+        "radical": "闌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "爬": {
+    "formula": "爪 + 巴",
+    "components": [
+      {
+        "radical": "爪",
+        "role": "形符",
+        "label": "爪"
+      },
+      {
+        "radical": "巴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "爭": {
+    "formula": "爫 + 彐 + 亅",
+    "components": [
+      {
+        "radical": "爫",
+        "role": "部件",
+        "label": "爫"
+      },
+      {
+        "radical": "彐",
+        "role": "部件",
+        "label": "彐"
+      },
+      {
+        "radical": "亅",
+        "role": "部件",
+        "label": "亅"
+      }
+    ]
+  },
+  "父": {
+    "formula": "八 + 乂",
+    "components": [
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      },
+      {
+        "radical": "乂",
+        "role": "部件",
+        "label": "乂"
+      }
+    ]
+  },
+  "爸": {
+    "formula": "父 + 巴",
+    "components": [
+      {
+        "radical": "父",
+        "role": "形符",
+        "label": "父"
+      },
+      {
+        "radical": "巴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "爺": {
+    "formula": "父 + 耶",
+    "components": [
+      {
+        "radical": "父",
+        "role": "形符",
+        "label": "父"
+      },
+      {
+        "radical": "耶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "爽": {
+    "formula": "大 + 爻 + 爻",
+    "components": [
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      },
+      {
+        "radical": "爻",
+        "role": "部件",
+        "label": "爻"
+      },
+      {
+        "radical": "爻",
+        "role": "部件",
+        "label": "爻"
+      }
+    ]
+  },
+  "牆": {
+    "formula": "爿 + 嗇",
+    "components": [
+      {
+        "radical": "爿",
+        "role": "形符",
+        "label": "爿"
+      },
+      {
+        "radical": "嗇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "版": {
+    "formula": "片 + 反",
+    "components": [
+      {
+        "radical": "片",
+        "role": "形符",
+        "label": "片"
+      },
+      {
+        "radical": "反",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "牌": {
+    "formula": "片 + 卑",
+    "components": [
+      {
+        "radical": "片",
+        "role": "形符",
+        "label": "片"
+      },
+      {
+        "radical": "卑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "牙": {
+    "formula": "丅 + 一 + 亅 + 丿",
+    "components": [
+      {
+        "radical": "丅",
+        "role": "部件",
+        "label": "丅"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "亅",
+        "role": "部件",
+        "label": "亅"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "牠": {
+    "formula": "牛 + 也",
+    "components": [
+      {
+        "radical": "牛",
+        "role": "部件",
+        "label": "牛"
+      },
+      {
+        "radical": "也",
+        "role": "部件",
+        "label": "也"
+      }
+    ]
+  },
+  "牢": {
+    "formula": "宀 + 牛",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "牛",
+        "role": "部件",
+        "label": "牛"
+      }
+    ]
+  },
+  "物": {
+    "formula": "牛 + 勿",
+    "components": [
+      {
+        "radical": "牛",
+        "role": "形符",
+        "label": "牛"
+      },
+      {
+        "radical": "勿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "牲": {
+    "formula": "牛 + 生",
+    "components": [
+      {
+        "radical": "牛",
+        "role": "形符",
+        "label": "牛"
+      },
+      {
+        "radical": "生",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "特": {
+    "formula": "牛 + 寺",
+    "components": [
+      {
+        "radical": "牛",
+        "role": "形符",
+        "label": "牛"
+      },
+      {
+        "radical": "寺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "牽": {
+    "formula": "玄 + 冖 + 牛",
+    "components": [
+      {
+        "radical": "玄",
+        "role": "部件",
+        "label": "玄"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "牛",
+        "role": "部件",
+        "label": "牛"
+      }
+    ]
+  },
+  "犀": {
+    "formula": "尾 + 牛",
+    "components": [
+      {
+        "radical": "尾",
+        "role": "部件",
+        "label": "尾"
+      },
+      {
+        "radical": "牛",
+        "role": "部件",
+        "label": "牛"
+      }
+    ]
+  },
+  "犧": {
+    "formula": "牛 + 羲",
+    "components": [
+      {
+        "radical": "牛",
+        "role": "形符",
+        "label": "牛"
+      },
+      {
+        "radical": "羲",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "犯": {
+    "formula": "犭 + 㔾",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "㔾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "狀": {
+    "formula": "爿 + 犬",
+    "components": [
+      {
+        "radical": "爿",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "犬",
+        "role": "形符",
+        "label": "狗"
+      }
+    ]
+  },
+  "狂": {
+    "formula": "犭 + 王",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "王",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "狄": {
+    "formula": "犭 + 火",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "火",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "狐": {
+    "formula": "犭 + 瓜",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "瓜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "狗": {
+    "formula": "犭 + 句",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "句",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "狠": {
+    "formula": "犭 + 艮",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "狩": {
+    "formula": "犭 + 守",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "守",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "狹": {
+    "formula": "犭 + 夾",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "夾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "狼": {
+    "formula": "犭 + 良",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "良",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "猛": {
+    "formula": "犭 + 孟",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "孟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "猜": {
+    "formula": "犭 + 青",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "猩": {
+    "formula": "犭 + 星",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "星",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "猴": {
+    "formula": "犭 + 侯",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "侯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "猶": {
+    "formula": "犭 + 酋",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "酋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "獅": {
+    "formula": "犭 + 師",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "師",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "獎": {
+    "formula": "將 + 犬",
+    "components": [
+      {
+        "radical": "將",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "犬",
+        "role": "形符",
+        "label": "狗"
+      }
+    ]
+  },
+  "獨": {
+    "formula": "犭 + 蜀",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "蜀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "獲": {
+    "formula": "犭 + 蒦",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "蒦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "獵": {
+    "formula": "犭 + 巤",
+    "components": [
+      {
+        "radical": "犭",
+        "role": "形符",
+        "label": "犬旁"
+      },
+      {
+        "radical": "巤",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "獸": {
+    "formula": "嘼 + 犬",
+    "components": [
+      {
+        "radical": "嘼",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "犬",
+        "role": "形符",
+        "label": "狗"
+      }
+    ]
+  },
+  "獻": {
+    "formula": "鬳 + 犬",
+    "components": [
+      {
+        "radical": "鬳",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "犬",
+        "role": "形符",
+        "label": "狗"
+      }
+    ]
+  },
+  "玄": {
+    "formula": "亠 + 幺",
+    "components": [
+      {
+        "radical": "亠",
+        "role": "部件",
+        "label": "亠"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      }
+    ]
+  },
+  "率": {
+    "formula": "亠 + 幺 + 十",
+    "components": [
+      {
+        "radical": "亠",
+        "role": "部件",
+        "label": "亠"
+      },
+      {
+        "radical": "幺",
+        "role": "部件",
+        "label": "幺"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "玉": {
+    "formula": "王 + 丶",
+    "components": [
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      }
+    ]
+  },
+  "王": {
+    "formula": "一 + 土",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "玩": {
+    "formula": "王 + 元",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "元",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "玫": {
+    "formula": "王 + 攵",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "攵",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "玻": {
+    "formula": "王 + 皮",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "皮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "珈": {
+    "formula": "王 + 加",
+    "components": [
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      },
+      {
+        "radical": "加",
+        "role": "部件",
+        "label": "加"
+      }
+    ]
+  },
+  "珊": {
+    "formula": "王 + 册",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "册",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "珍": {
+    "formula": "王 + 彡",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "彡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "珠": {
+    "formula": "王 + 朱",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "朱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "班": {
+    "formula": "王 + 刂 + 王",
+    "components": [
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      },
+      {
+        "radical": "刂",
+        "role": "部件",
+        "label": "刀旁"
+      },
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      }
+    ]
+  },
+  "現": {
+    "formula": "王 + 見",
+    "components": [
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      },
+      {
+        "radical": "見",
+        "role": "部件",
+        "label": "看見"
+      }
+    ]
+  },
+  "球": {
+    "formula": "王 + 求",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "求",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "理": {
+    "formula": "王 + 里",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "里",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "琢": {
+    "formula": "王 + 豖",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "豖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "琦": {
+    "formula": "王 + 奇",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "奇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "琪": {
+    "formula": "王 + 其",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "其",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "琴": {
+    "formula": "玨 + 今",
+    "components": [
+      {
+        "radical": "玨",
+        "role": "部件",
+        "label": "玨"
+      },
+      {
+        "radical": "今",
+        "role": "部件",
+        "label": "今"
+      }
+    ]
+  },
+  "瑕": {
+    "formula": "王 + 叚",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "叚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瑚": {
+    "formula": "王 + 胡",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "胡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瑜": {
+    "formula": "王 + 俞",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "俞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瑟": {
+    "formula": "玨 + 必",
+    "components": [
+      {
+        "radical": "玨",
+        "role": "形符",
+        "label": "玨"
+      },
+      {
+        "radical": "必",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瑪": {
+    "formula": "王 + 馬",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "馬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瑰": {
+    "formula": "王 + 鬼",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "鬼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "璃": {
+    "formula": "王 + 离",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "离",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "璞": {
+    "formula": "王 + 菐",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "菐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "環": {
+    "formula": "王 + 睘",
+    "components": [
+      {
+        "radical": "王",
+        "role": "形符",
+        "label": "王旁"
+      },
+      {
+        "radical": "睘",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瓶": {
+    "formula": "并 + 瓦",
+    "components": [
+      {
+        "radical": "并",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "瓦",
+        "role": "形符",
+        "label": "瓦"
+      }
+    ]
+  },
+  "甘": {
+    "formula": "卄 + 二",
+    "components": [
+      {
+        "radical": "卄",
+        "role": "部件",
+        "label": "卄"
+      },
+      {
+        "radical": "二",
+        "role": "部件",
+        "label": "二"
+      }
+    ]
+  },
+  "甚": {
+    "formula": "甘 + 匹",
+    "components": [
+      {
+        "radical": "甘",
+        "role": "部件",
+        "label": "甘"
+      },
+      {
+        "radical": "匹",
+        "role": "部件",
+        "label": "匹"
+      }
+    ]
+  },
+  "甜": {
+    "formula": "舌 + 甘",
+    "components": [
+      {
+        "radical": "舌",
+        "role": "部件",
+        "label": "舌頭"
+      },
+      {
+        "radical": "甘",
+        "role": "部件",
+        "label": "甘"
+      }
+    ]
+  },
+  "生": {
+    "formula": "一 + 土",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "產": {
+    "formula": "厂 + 生",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "生",
+        "role": "形符",
+        "label": "生"
+      }
+    ]
+  },
+  "甦": {
+    "formula": "更 + 生",
+    "components": [
+      {
+        "radical": "更",
+        "role": "部件",
+        "label": "更"
+      },
+      {
+        "radical": "生",
+        "role": "部件",
+        "label": "生"
+      }
+    ]
+  },
+  "用": {
+    "formula": "月 + 丨",
+    "components": [
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      }
+    ]
+  },
+  "甩": {
+    "formula": "月 + 乚",
+    "components": [
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      },
+      {
+        "radical": "乚",
+        "role": "部件",
+        "label": "乚"
+      }
+    ]
+  },
+  "甫": {
+    "formula": "一 + 丶 + 用",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      },
+      {
+        "radical": "用",
+        "role": "部件",
+        "label": "用"
+      }
+    ]
+  },
+  "甲": {
+    "formula": "囗 + 十",
+    "components": [
+      {
+        "radical": "囗",
+        "role": "部件",
+        "label": "口框"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "男": {
+    "formula": "田 + 力",
+    "components": [
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      },
+      {
+        "radical": "力",
+        "role": "部件",
+        "label": "力量"
+      }
+    ]
+  },
+  "界": {
+    "formula": "田 + 介",
+    "components": [
+      {
+        "radical": "田",
+        "role": "形符",
+        "label": "田地"
+      },
+      {
+        "radical": "介",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "畔": {
+    "formula": "田 + 半",
+    "components": [
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      },
+      {
+        "radical": "半",
+        "role": "部件",
+        "label": "半"
+      }
+    ]
+  },
+  "留": {
+    "formula": "卯 + 田",
+    "components": [
+      {
+        "radical": "卯",
+        "role": "部件",
+        "label": "卯"
+      },
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      }
+    ]
+  },
+  "畜": {
+    "formula": "玄 + 田",
+    "components": [
+      {
+        "radical": "玄",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "田",
+        "role": "形符",
+        "label": "田地"
+      }
+    ]
+  },
+  "畢": {
+    "formula": "卄 + 十",
+    "components": [
+      {
+        "radical": "卄",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "十",
+        "role": "形符",
+        "label": "十"
+      }
+    ]
+  },
+  "略": {
+    "formula": "田 + 各",
+    "components": [
+      {
+        "radical": "田",
+        "role": "形符",
+        "label": "田地"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "番": {
+    "formula": "米 + 田",
+    "components": [
+      {
+        "radical": "米",
+        "role": "部件",
+        "label": "米"
+      },
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      }
+    ]
+  },
+  "畫": {
+    "formula": "聿 + 田 + 一",
+    "components": [
+      {
+        "radical": "聿",
+        "role": "部件",
+        "label": "筆"
+      },
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "當": {
+    "formula": "尚 + 田",
+    "components": [
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "田",
+        "role": "形符",
+        "label": "田地"
+      }
+    ]
+  },
+  "疇": {
+    "formula": "田 + 壽",
+    "components": [
+      {
+        "radical": "田",
+        "role": "形符",
+        "label": "田地"
+      },
+      {
+        "radical": "壽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "疊": {
+    "formula": "畾 + 冝",
+    "components": [
+      {
+        "radical": "畾",
+        "role": "部件",
+        "label": "畾"
+      },
+      {
+        "radical": "冝",
+        "role": "部件",
+        "label": "冝"
+      }
+    ]
+  },
+  "疏": {
+    "formula": "疋 + 㐬",
+    "components": [
+      {
+        "radical": "疋",
+        "role": "部件",
+        "label": "疋"
+      },
+      {
+        "radical": "㐬",
+        "role": "部件",
+        "label": "㐬"
+      }
+    ]
+  },
+  "疑": {
+    "formula": "匕 + 矢 + 疋",
+    "components": [
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "湯匙"
+      },
+      {
+        "radical": "矢",
+        "role": "部件",
+        "label": "箭"
+      },
+      {
+        "radical": "疋",
+        "role": "部件",
+        "label": "疋"
+      }
+    ]
+  },
+  "疚": {
+    "formula": "疒 + 久",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "久",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "疤": {
+    "formula": "疒 + 巴",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "巴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "疫": {
+    "formula": "疒 + 殳",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "殳",
+        "role": "聲符",
+        "label": "殳"
+      }
+    ]
+  },
+  "疲": {
+    "formula": "疒 + 皮",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "皮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "疵": {
+    "formula": "疒 + 此",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "此",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "疼": {
+    "formula": "疒 + 冬",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "冬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "疾": {
+    "formula": "疒 + 矢",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "矢",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "病": {
+    "formula": "疒 + 丙",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "丙",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "症": {
+    "formula": "疒 + 正",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "正",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "痊": {
+    "formula": "疒 + 全",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "部件",
+        "label": "病旁"
+      },
+      {
+        "radical": "全",
+        "role": "部件",
+        "label": "全"
+      }
+    ]
+  },
+  "痕": {
+    "formula": "疒 + 艮",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "痙": {
+    "formula": "疒 + 巠",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "巠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "痛": {
+    "formula": "疒 + 甬",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "甬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "痟": {
+    "formula": "病 + 肖",
+    "components": [
+      {
+        "radical": "病",
+        "role": "部件",
+        "label": "病"
+      },
+      {
+        "radical": "肖",
+        "role": "部件",
+        "label": "肖"
+      }
+    ]
+  },
+  "痠": {
+    "formula": "病 + 夋",
+    "components": [
+      {
+        "radical": "病",
+        "role": "部件",
+        "label": "病"
+      },
+      {
+        "radical": "夋",
+        "role": "部件",
+        "label": "夋"
+      }
+    ]
+  },
+  "痰": {
+    "formula": "疒 + 炎",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "炎",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "痺": {
+    "formula": "疒 + 卑",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "卑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瘁": {
+    "formula": "疒 + 卒",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "卒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瘋": {
+    "formula": "疒 + 風",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "風",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瘓": {
+    "formula": "疒 + 奐",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "奐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瘖": {
+    "formula": "病 + 音",
+    "components": [
+      {
+        "radical": "病",
+        "role": "部件",
+        "label": "病"
+      },
+      {
+        "radical": "音",
+        "role": "部件",
+        "label": "音"
+      }
+    ]
+  },
+  "瘟": {
+    "formula": "疒 + 昷",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "昷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瘦": {
+    "formula": "疒 + 叟",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "叟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瘧": {
+    "formula": "疒 + 虐",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "虐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "療": {
+    "formula": "疒 + 尞",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "尞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "癇": {
+    "formula": "疒 + 閒",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "閒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "癌": {
+    "formula": "疒 + 嵒",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "嵒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "癒": {
+    "formula": "疒 + 愈",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "部件",
+        "label": "病旁"
+      },
+      {
+        "radical": "愈",
+        "role": "部件",
+        "label": "愈"
+      }
+    ]
+  },
+  "癢": {
+    "formula": "疒 + 養",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "養",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "癮": {
+    "formula": "疒 + 隱",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "隱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "癱": {
+    "formula": "疒 + 難",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "難",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "癲": {
+    "formula": "疒 + 顛",
+    "components": [
+      {
+        "radical": "疒",
+        "role": "形符",
+        "label": "病旁"
+      },
+      {
+        "radical": "顛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "登": {
+    "formula": "癶 + 豆",
+    "components": [
+      {
+        "radical": "癶",
+        "role": "形符",
+        "label": "癶"
+      },
+      {
+        "radical": "豆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "發": {
+    "formula": "癶 + 弓",
+    "components": [
+      {
+        "radical": "癶",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "弓",
+        "role": "形符",
+        "label": "弓箭"
+      }
+    ]
+  },
+  "的": {
+    "formula": "白 + 勺",
+    "components": [
+      {
+        "radical": "白",
+        "role": "部件",
+        "label": "白色"
+      },
+      {
+        "radical": "勺",
+        "role": "部件",
+        "label": "勺"
+      }
+    ]
+  },
+  "皆": {
+    "formula": "比 + 白",
+    "components": [
+      {
+        "radical": "比",
+        "role": "部件",
+        "label": "比"
+      },
+      {
+        "radical": "白",
+        "role": "部件",
+        "label": "白色"
+      }
+    ]
+  },
+  "皇": {
+    "formula": "白 + 王",
+    "components": [
+      {
+        "radical": "白",
+        "role": "部件",
+        "label": "白色"
+      },
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      }
+    ]
+  },
+  "皓": {
+    "formula": "白 + 告",
+    "components": [
+      {
+        "radical": "白",
+        "role": "形符",
+        "label": "白色"
+      },
+      {
+        "radical": "告",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "皺": {
+    "formula": "芻 + 皮",
+    "components": [
+      {
+        "radical": "芻",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "皮",
+        "role": "形符",
+        "label": "皮"
+      }
+    ]
+  },
+  "盃": {
+    "formula": "不 + 皿",
+    "components": [
+      {
+        "radical": "不",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "皿",
+        "role": "形符",
+        "label": "器皿"
+      }
+    ]
+  },
+  "益": {
+    "formula": "水 + 皿",
+    "components": [
+      {
+        "radical": "水",
+        "role": "部件",
+        "label": "水"
+      },
+      {
+        "radical": "皿",
+        "role": "部件",
+        "label": "器皿"
+      }
+    ]
+  },
+  "盛": {
+    "formula": "成 + 皿",
+    "components": [
+      {
+        "radical": "成",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "皿",
+        "role": "形符",
+        "label": "器皿"
+      }
+    ]
+  },
+  "盟": {
+    "formula": "明 + 皿",
+    "components": [
+      {
+        "radical": "明",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "皿",
+        "role": "形符",
+        "label": "器皿"
+      }
+    ]
+  },
+  "盡": {
+    "formula": "聿 + 灬 + 皿",
+    "components": [
+      {
+        "radical": "聿",
+        "role": "部件",
+        "label": "筆"
+      },
+      {
+        "radical": "灬",
+        "role": "部件",
+        "label": "火底"
+      },
+      {
+        "radical": "皿",
+        "role": "部件",
+        "label": "器皿"
+      }
+    ]
+  },
+  "監": {
+    "formula": "臣 + 皿",
+    "components": [
+      {
+        "radical": "臣",
+        "role": "形符",
+        "label": "臣"
+      },
+      {
+        "radical": "皿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "盤": {
+    "formula": "般 + 皿",
+    "components": [
+      {
+        "radical": "般",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "皿",
+        "role": "形符",
+        "label": "器皿"
+      }
+    ]
+  },
+  "盪": {
+    "formula": "湯 + 皿",
+    "components": [
+      {
+        "radical": "湯",
+        "role": "部件",
+        "label": "湯"
+      },
+      {
+        "radical": "皿",
+        "role": "部件",
+        "label": "器皿"
+      }
+    ]
+  },
+  "盯": {
+    "formula": "目 + 丁",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "丁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "盲": {
+    "formula": "亡 + 目",
+    "components": [
+      {
+        "radical": "亡",
+        "role": "部件",
+        "label": "亡"
+      },
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      }
+    ]
+  },
+  "直": {
+    "formula": "十 + 目 + 一",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "相": {
+    "formula": "木 + 目",
+    "components": [
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      }
+    ]
+  },
+  "盼": {
+    "formula": "目 + 分",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "分",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "盾": {
+    "formula": "厂 + 十 + 目",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "部件",
+        "label": "山崖"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      }
+    ]
+  },
+  "省": {
+    "formula": "少 + 目",
+    "components": [
+      {
+        "radical": "少",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      }
+    ]
+  },
+  "眉": {
+    "formula": "尸 + 目",
+    "components": [
+      {
+        "radical": "尸",
+        "role": "部件",
+        "label": "尸"
+      },
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      }
+    ]
+  },
+  "看": {
+    "formula": "手 + 目",
+    "components": [
+      {
+        "radical": "手",
+        "role": "部件",
+        "label": "手"
+      },
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      }
+    ]
+  },
+  "真": {
+    "formula": "直 + 几",
+    "components": [
+      {
+        "radical": "直",
+        "role": "部件",
+        "label": "直"
+      },
+      {
+        "radical": "几",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "眠": {
+    "formula": "目 + 民",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "民",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "眶": {
+    "formula": "目 + 匡",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "匡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "眼": {
+    "formula": "目 + 艮",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "眾": {
+    "formula": "罒 + 众",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "众",
+        "role": "形符",
+        "label": "众"
+      }
+    ]
+  },
+  "睛": {
+    "formula": "目 + 青",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "睜": {
+    "formula": "目 + 爭",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "爭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "睞": {
+    "formula": "目 + 來",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "來",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "睡": {
+    "formula": "目 + 垂",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "垂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "睭": {
+    "formula": "目 + 周",
+    "components": [
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      },
+      {
+        "radical": "周",
+        "role": "部件",
+        "label": "周"
+      }
+    ]
+  },
+  "睹": {
+    "formula": "目 + 者",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "睽": {
+    "formula": "目 + 癸",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "癸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞄": {
+    "formula": "目 + 苗",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "苗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞇": {
+    "formula": "目 + 迷",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "迷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞌": {
+    "formula": "目 + 盍",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "盍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞞": {
+    "formula": "目 + 㒼",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "㒼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞠": {
+    "formula": "目 + 堂",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "堂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞥": {
+    "formula": "敝 + 目",
+    "components": [
+      {
+        "radical": "敝",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      }
+    ]
+  },
+  "瞪": {
+    "formula": "目 + 登",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "登",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞬": {
+    "formula": "目 + 舜",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "舜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞭": {
+    "formula": "目 + 尞",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "尞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "瞰": {
+    "formula": "目 + 敢",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "敢",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "矗": {
+    "formula": "直 + 直 + 直",
+    "components": [
+      {
+        "radical": "直",
+        "role": "部件",
+        "label": "直"
+      },
+      {
+        "radical": "直",
+        "role": "部件",
+        "label": "直"
+      },
+      {
+        "radical": "直",
+        "role": "部件",
+        "label": "直"
+      }
+    ]
+  },
+  "矚": {
+    "formula": "目 + 屬",
+    "components": [
+      {
+        "radical": "目",
+        "role": "形符",
+        "label": "眼睛"
+      },
+      {
+        "radical": "屬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "矣": {
+    "formula": "厶 + 矢",
+    "components": [
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      },
+      {
+        "radical": "矢",
+        "role": "部件",
+        "label": "箭"
+      }
+    ]
+  },
+  "知": {
+    "formula": "矢 + 口",
+    "components": [
+      {
+        "radical": "矢",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "口",
+        "role": "形符",
+        "label": "口"
+      }
+    ]
+  },
+  "短": {
+    "formula": "矢 + 豆",
+    "components": [
+      {
+        "radical": "矢",
+        "role": "形符",
+        "label": "箭"
+      },
+      {
+        "radical": "豆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "矮": {
+    "formula": "矢 + 委",
+    "components": [
+      {
+        "radical": "矢",
+        "role": "形符",
+        "label": "箭"
+      },
+      {
+        "radical": "委",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "矯": {
+    "formula": "矢 + 喬",
+    "components": [
+      {
+        "radical": "矢",
+        "role": "形符",
+        "label": "箭"
+      },
+      {
+        "radical": "喬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "砍": {
+    "formula": "石 + 欠",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "欠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "研": {
+    "formula": "石 + 开",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "开",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "砲": {
+    "formula": "石 + 包",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "破": {
+    "formula": "石 + 皮",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "皮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "砸": {
+    "formula": "石 + 匝",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "匝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "硬": {
+    "formula": "石 + 更",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "更",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "硯": {
+    "formula": "石 + 見",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "見",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "碌": {
+    "formula": "石 + 录",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "录",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "碎": {
+    "formula": "石 + 卒",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "卒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "碑": {
+    "formula": "石 + 卑",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "卑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "碗": {
+    "formula": "石 + 宛",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "宛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "碟": {
+    "formula": "石 + 枼",
+    "components": [
+      {
+        "radical": "石",
+        "role": "部件",
+        "label": "石頭"
+      },
+      {
+        "radical": "枼",
+        "role": "部件",
+        "label": "枼"
+      }
+    ]
+  },
+  "碧": {
+    "formula": "珀 + 石",
+    "components": [
+      {
+        "radical": "珀",
+        "role": "部件",
+        "label": "珀"
+      },
+      {
+        "radical": "石",
+        "role": "部件",
+        "label": "石頭"
+      }
+    ]
+  },
+  "碩": {
+    "formula": "石 + 頁",
+    "components": [
+      {
+        "radical": "石",
+        "role": "部件",
+        "label": "石頭"
+      },
+      {
+        "radical": "頁",
+        "role": "部件",
+        "label": "頭部"
+      }
+    ]
+  },
+  "碰": {
+    "formula": "石 + 並",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "並",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "碳": {
+    "formula": "石 + 炭",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "炭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "確": {
+    "formula": "石 + 隺",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "隺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "碼": {
+    "formula": "石 + 馬",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "馬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "磁": {
+    "formula": "石 + 兹",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "兹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "磨": {
+    "formula": "麻 + 石",
+    "components": [
+      {
+        "radical": "麻",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      }
+    ]
+  },
+  "磷": {
+    "formula": "石 + 粦",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "粦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "礎": {
+    "formula": "石 + 楚",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "楚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "礙": {
+    "formula": "石 + 疑",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "疑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "礦": {
+    "formula": "石 + 廣",
+    "components": [
+      {
+        "radical": "石",
+        "role": "形符",
+        "label": "石頭"
+      },
+      {
+        "radical": "廣",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "社": {
+    "formula": "礻 + 土",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "部件",
+        "label": "示旁"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "祂": {
+    "formula": "示 + 也",
+    "components": [
+      {
+        "radical": "示",
+        "role": "部件",
+        "label": "祭祀"
+      },
+      {
+        "radical": "也",
+        "role": "部件",
+        "label": "也"
+      }
+    ]
+  },
+  "祇": {
+    "formula": "礻 + 氏",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "氏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "祈": {
+    "formula": "礻 + 斤",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "斤",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "祕": {
+    "formula": "礻 + 必",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "必",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "祖": {
+    "formula": "礻 + 且",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "且",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "祝": {
+    "formula": "礻 + 兄",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "部件",
+        "label": "示旁"
+      },
+      {
+        "radical": "兄",
+        "role": "部件",
+        "label": "兄"
+      }
+    ]
+  },
+  "神": {
+    "formula": "礻 + 申",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "申",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "祥": {
+    "formula": "礻 + 羊",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "票": {
+    "formula": "覀 + 示",
+    "components": [
+      {
+        "radical": "覀",
+        "role": "部件",
+        "label": "覀"
+      },
+      {
+        "radical": "示",
+        "role": "部件",
+        "label": "祭祀"
+      }
+    ]
+  },
+  "禁": {
+    "formula": "林 + 示",
+    "components": [
+      {
+        "radical": "林",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "示",
+        "role": "形符",
+        "label": "祭祀"
+      }
+    ]
+  },
+  "禍": {
+    "formula": "礻 + 咼",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "咼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "福": {
+    "formula": "礻 + 畐",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "畐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "禦": {
+    "formula": "御 + 示",
+    "components": [
+      {
+        "radical": "御",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "示",
+        "role": "形符",
+        "label": "祭祀"
+      }
+    ]
+  },
+  "禮": {
+    "formula": "礻 + 豊",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "豊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "禱": {
+    "formula": "礻 + 壽",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "形符",
+        "label": "示旁"
+      },
+      {
+        "radical": "壽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "禿": {
+    "formula": "禾 + 儿",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "儿",
+        "role": "部件",
+        "label": "儿"
+      }
+    ]
+  },
+  "秀": {
+    "formula": "禾 + 乃",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "乃",
+        "role": "部件",
+        "label": "乃"
+      }
+    ]
+  },
+  "私": {
+    "formula": "禾 + 厶",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      }
+    ]
+  },
+  "秋": {
+    "formula": "禾 + 火",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      }
+    ]
+  },
+  "科": {
+    "formula": "禾 + 斗",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "斗",
+        "role": "部件",
+        "label": "斗"
+      }
+    ]
+  },
+  "秒": {
+    "formula": "禾 + 少",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "少",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "秘": {
+    "formula": "禾 + 必",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "必",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "租": {
+    "formula": "禾 + 且",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "且",
+        "role": "部件",
+        "label": "且"
+      }
+    ]
+  },
+  "秩": {
+    "formula": "禾 + 失",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "失",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "移": {
+    "formula": "禾 + 多",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "多",
+        "role": "部件",
+        "label": "多"
+      }
+    ]
+  },
+  "稀": {
+    "formula": "禾 + 希",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "希",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "程": {
+    "formula": "禾 + 呈",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "呈",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "稍": {
+    "formula": "禾 + 肖",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "肖",
+        "role": "部件",
+        "label": "肖"
+      }
+    ]
+  },
+  "稞": {
+    "formula": "禾 + 果",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "果",
+        "role": "部件",
+        "label": "果"
+      }
+    ]
+  },
+  "稟": {
+    "formula": "亠 + 回 + 禾",
+    "components": [
+      {
+        "radical": "亠",
+        "role": "部件",
+        "label": "亠"
+      },
+      {
+        "radical": "回",
+        "role": "部件",
+        "label": "回"
+      },
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      }
+    ]
+  },
+  "稠": {
+    "formula": "禾 + 周",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "周",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "種": {
+    "formula": "禾 + 重",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "重",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "稱": {
+    "formula": "禾 + 爯",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "爯",
+        "role": "部件",
+        "label": "爯"
+      }
+    ]
+  },
+  "稻": {
+    "formula": "禾 + 舀",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "舀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "稼": {
+    "formula": "禾 + 家",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "家",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "稽": {
+    "formula": "禾 + 旨",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "旨",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "稿": {
+    "formula": "禾 + 高",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "高",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "積": {
+    "formula": "禾 + 責",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "責",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "穎": {
+    "formula": "禾 + 匕 + 頁",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "匕",
+        "role": "部件",
+        "label": "匕首"
+      },
+      {
+        "radical": "頁",
+        "role": "聲符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "穗": {
+    "formula": "禾 + 惠",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "惠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "穩": {
+    "formula": "禾 + 㥯",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "㥯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "穫": {
+    "formula": "禾 + 蒦",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "形符",
+        "label": "穀物"
+      },
+      {
+        "radical": "蒦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "究": {
+    "formula": "穴 + 九",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "形符",
+        "label": "穴"
+      },
+      {
+        "radical": "九",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "空": {
+    "formula": "穴 + 工",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "形符",
+        "label": "穴"
+      },
+      {
+        "radical": "工",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "穿": {
+    "formula": "穴 + 牙",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "牙",
+        "role": "形符",
+        "label": "牙齒"
+      }
+    ]
+  },
+  "突": {
+    "formula": "穴 + 犬",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "部件",
+        "label": "穴"
+      },
+      {
+        "radical": "犬",
+        "role": "部件",
+        "label": "狗"
+      }
+    ]
+  },
+  "窄": {
+    "formula": "穴 + 乍",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "形符",
+        "label": "穴"
+      },
+      {
+        "radical": "乍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "窗": {
+    "formula": "穴 + 囱",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "形符",
+        "label": "穴"
+      },
+      {
+        "radical": "囱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "窘": {
+    "formula": "穴 + 君",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "形符",
+        "label": "穴"
+      },
+      {
+        "radical": "君",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "窩": {
+    "formula": "穴 + 咼",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "形符",
+        "label": "穴"
+      },
+      {
+        "radical": "咼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "窮": {
+    "formula": "穴 + 躬",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "形符",
+        "label": "穴"
+      },
+      {
+        "radical": "躬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "窺": {
+    "formula": "穴 + 規",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "形符",
+        "label": "穴"
+      },
+      {
+        "radical": "規",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "竄": {
+    "formula": "穴 + 鼠",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "部件",
+        "label": "穴"
+      },
+      {
+        "radical": "鼠",
+        "role": "部件",
+        "label": "鼠"
+      }
+    ]
+  },
+  "竇": {
+    "formula": "穴 + 賣",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "部件",
+        "label": "穴"
+      },
+      {
+        "radical": "賣",
+        "role": "部件",
+        "label": "賣"
+      }
+    ]
+  },
+  "竊": {
+    "formula": "穴 + 米 + 禼",
+    "components": [
+      {
+        "radical": "穴",
+        "role": "部件",
+        "label": "穴"
+      },
+      {
+        "radical": "米",
+        "role": "部件",
+        "label": "米"
+      },
+      {
+        "radical": "禼",
+        "role": "部件",
+        "label": "禼"
+      }
+    ]
+  },
+  "站": {
+    "formula": "立 + 占",
+    "components": [
+      {
+        "radical": "立",
+        "role": "形符",
+        "label": "立"
+      },
+      {
+        "radical": "占",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "竟": {
+    "formula": "音 + 儿",
+    "components": [
+      {
+        "radical": "音",
+        "role": "部件",
+        "label": "音"
+      },
+      {
+        "radical": "儿",
+        "role": "部件",
+        "label": "儿"
+      }
+    ]
+  },
+  "章": {
+    "formula": "音 + 十",
+    "components": [
+      {
+        "radical": "音",
+        "role": "部件",
+        "label": "音"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "童": {
+    "formula": "立 + 里",
+    "components": [
+      {
+        "radical": "立",
+        "role": "部件",
+        "label": "立"
+      },
+      {
+        "radical": "里",
+        "role": "部件",
+        "label": "里"
+      }
+    ]
+  },
+  "端": {
+    "formula": "立 + 耑",
+    "components": [
+      {
+        "radical": "立",
+        "role": "形符",
+        "label": "立"
+      },
+      {
+        "radical": "耑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "競": {
+    "formula": "竞 + 竞",
+    "components": [
+      {
+        "radical": "竞",
+        "role": "部件",
+        "label": "竞"
+      },
+      {
+        "radical": "竞",
+        "role": "部件",
+        "label": "竞"
+      }
+    ]
+  },
+  "竿": {
+    "formula": "⺮ + 干",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "干",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "笆": {
+    "formula": "⺮ + 巴",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "巴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "笑": {
+    "formula": "⺮ + 夭",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "夭",
+        "role": "部件",
+        "label": "夭"
+      }
+    ]
+  },
+  "符": {
+    "formula": "⺮ + 付",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "付",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "笨": {
+    "formula": "⺮ + 本",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "本",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "第": {
+    "formula": "⺮ + 弟",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "弟",
+        "role": "部件",
+        "label": "弟"
+      }
+    ]
+  },
+  "筆": {
+    "formula": "⺮ + 聿",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "聿",
+        "role": "部件",
+        "label": "筆"
+      }
+    ]
+  },
+  "等": {
+    "formula": "⺮ + 寺",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "寺",
+        "role": "部件",
+        "label": "寺"
+      }
+    ]
+  },
+  "筋": {
+    "formula": "⺮ + 肋",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "肋",
+        "role": "部件",
+        "label": "肋"
+      }
+    ]
+  },
+  "答": {
+    "formula": "竹 + 合",
+    "components": [
+      {
+        "radical": "竹",
+        "role": "部件",
+        "label": "竹子"
+      },
+      {
+        "radical": "合",
+        "role": "部件",
+        "label": "合"
+      }
+    ]
+  },
+  "策": {
+    "formula": "⺮ + 朿",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "朿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "箍": {
+    "formula": "⺮ + 㧜",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "㧜",
+        "role": "部件",
+        "label": "㧜"
+      }
+    ]
+  },
+  "箔": {
+    "formula": "⺮ + 泊",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "泊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "算": {
+    "formula": "⺮ + 具",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "具",
+        "role": "部件",
+        "label": "具"
+      }
+    ]
+  },
+  "管": {
+    "formula": "⺮ + 官",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "官",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "箭": {
+    "formula": "⺮ + 前",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "前",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "箱": {
+    "formula": "⺮ + 相",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "相",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "節": {
+    "formula": "⺮ + 即",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "即",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "範": {
+    "formula": "⺮ + 㔾",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "㔾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "篇": {
+    "formula": "⺮ + 扁",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "扁",
+        "role": "部件",
+        "label": "扁"
+      }
+    ]
+  },
+  "築": {
+    "formula": "⺮ + 巩 + 木",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "巩",
+        "role": "部件",
+        "label": "巩"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "篩": {
+    "formula": "⺮ + 師",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "師",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "簏": {
+    "formula": "⺮ + 鹿",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "鹿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "簡": {
+    "formula": "⺮ + 間",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "間",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "簽": {
+    "formula": "⺮ + 僉",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "僉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "簾": {
+    "formula": "⺮ + 廉",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "廉",
+        "role": "部件",
+        "label": "廉"
+      }
+    ]
+  },
+  "籃": {
+    "formula": "⺮ + 監",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "監",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "籌": {
+    "formula": "⺮ + 壽",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "壽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "籍": {
+    "formula": "⺮ + 耤",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "耤",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "籠": {
+    "formula": "⺮ + 龍",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "龍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "籬": {
+    "formula": "⺮ + 離",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "形符",
+        "label": "竹頭"
+      },
+      {
+        "radical": "離",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "籲": {
+    "formula": "⺮ + 龥",
+    "components": [
+      {
+        "radical": "⺮",
+        "role": "部件",
+        "label": "竹頭"
+      },
+      {
+        "radical": "龥",
+        "role": "部件",
+        "label": "龥"
+      }
+    ]
+  },
+  "粉": {
+    "formula": "米 + 分",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "分",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "粒": {
+    "formula": "米 + 立",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "立",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "粗": {
+    "formula": "米 + 且",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "且",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "粟": {
+    "formula": "覀 + 米",
+    "components": [
+      {
+        "radical": "覀",
+        "role": "部件",
+        "label": "覀"
+      },
+      {
+        "radical": "米",
+        "role": "部件",
+        "label": "米"
+      }
+    ]
+  },
+  "粥": {
+    "formula": "弓 + 米 + 弓",
+    "components": [
+      {
+        "radical": "弓",
+        "role": "部件",
+        "label": "弓箭"
+      },
+      {
+        "radical": "米",
+        "role": "部件",
+        "label": "米"
+      },
+      {
+        "radical": "弓",
+        "role": "部件",
+        "label": "弓箭"
+      }
+    ]
+  },
+  "精": {
+    "formula": "米 + 青",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "糊": {
+    "formula": "米 + 胡",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "胡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "糕": {
+    "formula": "米 + 羔",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "羔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "糖": {
+    "formula": "米 + 唐",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "唐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "糞": {
+    "formula": "米 + 異",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "異",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "糟": {
+    "formula": "米 + 曹",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "曹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "糧": {
+    "formula": "米 + 量",
+    "components": [
+      {
+        "radical": "米",
+        "role": "形符",
+        "label": "米"
+      },
+      {
+        "radical": "量",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "糾": {
+    "formula": "糹 + 丩",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "部件",
+        "label": "糹"
+      },
+      {
+        "radical": "丩",
+        "role": "部件",
+        "label": "丩"
+      }
+    ]
+  },
+  "紀": {
+    "formula": "糹 + 己",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "己",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "約": {
+    "formula": "糹 + 勺",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "絲線"
+      },
+      {
+        "radical": "勺",
+        "role": "聲符",
+        "label": "勺"
+      }
+    ]
+  },
+  "紅": {
+    "formula": "糹 + 工",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "工",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "紋": {
+    "formula": "糹 + 文",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "文",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "納": {
+    "formula": "糹 + 内",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "内",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "紐": {
+    "formula": "糹 + 丑",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "丑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "紓": {
+    "formula": "糹 + 予",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "部件",
+        "label": "糹"
+      },
+      {
+        "radical": "予",
+        "role": "部件",
+        "label": "予"
+      }
+    ]
+  },
+  "純": {
+    "formula": "糹 + 屯",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "屯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "紙": {
+    "formula": "糹 + 氏",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "氏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "級": {
+    "formula": "糹 + 及",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "及",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "紛": {
+    "formula": "糹 + 分",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "分",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "紜": {
+    "formula": "糹 + 云",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "云",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "素": {
+    "formula": "龶 + 糸",
+    "components": [
+      {
+        "radical": "龶",
+        "role": "部件",
+        "label": "龶"
+      },
+      {
+        "radical": "糸",
+        "role": "部件",
+        "label": "絲線"
+      }
+    ]
+  },
+  "索": {
+    "formula": "十 + 冖 + 糸",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "糸",
+        "role": "部件",
+        "label": "絲線"
+      }
+    ]
+  },
+  "紫": {
+    "formula": "此 + 糸",
+    "components": [
+      {
+        "radical": "此",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "糸",
+        "role": "形符",
+        "label": "絲線"
+      }
+    ]
+  },
+  "紮": {
+    "formula": "札 + 糸",
+    "components": [
+      {
+        "radical": "札",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "糸",
+        "role": "形符",
+        "label": "絲線"
+      }
+    ]
+  },
+  "累": {
+    "formula": "田 + 糸",
+    "components": [
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      },
+      {
+        "radical": "糸",
+        "role": "部件",
+        "label": "絲線"
+      }
+    ]
+  },
+  "細": {
+    "formula": "糹 + 田",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "田",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "紹": {
+    "formula": "糹 + 召",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "召",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "終": {
+    "formula": "糹 + 冬",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "冬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "組": {
+    "formula": "糹 + 且",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "且",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "絆": {
+    "formula": "糹 + 半",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "半",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "結": {
+    "formula": "糹 + 吉",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "吉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "絕": {
+    "formula": "糹 + 刀 + 巴",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "部件",
+        "label": "糹"
+      },
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      },
+      {
+        "radical": "巴",
+        "role": "部件",
+        "label": "巴"
+      }
+    ]
+  },
+  "絡": {
+    "formula": "糹 + 各",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "給": {
+    "formula": "糹 + 合",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "合",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "統": {
+    "formula": "糹 + 充",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "充",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "絲": {
+    "formula": "糹 + 糸",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "部件",
+        "label": "糹"
+      },
+      {
+        "radical": "糸",
+        "role": "部件",
+        "label": "絲線"
+      }
+    ]
+  },
+  "綁": {
+    "formula": "糹 + 邦",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "邦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "經": {
+    "formula": "糹 + 巠",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "巠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "綜": {
+    "formula": "糹 + 宗",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "宗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "綠": {
+    "formula": "糹 + 彔",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "彔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "綢": {
+    "formula": "糹 + 周",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "周",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "維": {
+    "formula": "糹 + 隹",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "綱": {
+    "formula": "糹 + 岡",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "岡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "網": {
+    "formula": "糹 + 罔",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "罔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "綻": {
+    "formula": "糹 + 定",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "定",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "綿": {
+    "formula": "糹 + 帛",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "部件",
+        "label": "糹"
+      },
+      {
+        "radical": "帛",
+        "role": "部件",
+        "label": "帛"
+      }
+    ]
+  },
+  "緊": {
+    "formula": "臤 + 糸",
+    "components": [
+      {
+        "radical": "臤",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "糸",
+        "role": "形符",
+        "label": "絲線"
+      }
+    ]
+  },
+  "緒": {
+    "formula": "糹 + 者",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "線": {
+    "formula": "糹 + 泉",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "泉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "緝": {
+    "formula": "糹 + 咠",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "咠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "緣": {
+    "formula": "糹 + 彖",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "彖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "編": {
+    "formula": "糹 + 扁",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "扁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "緩": {
+    "formula": "糹 + 爰",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "爰",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "緯": {
+    "formula": "糹 + 韋",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "韋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "練": {
+    "formula": "糹 + 柬",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "柬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "緻": {
+    "formula": "糹 + 致",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "部件",
+        "label": "糹"
+      },
+      {
+        "radical": "致",
+        "role": "部件",
+        "label": "致"
+      }
+    ]
+  },
+  "縛": {
+    "formula": "糹 + 尃",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "尃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "縣": {
+    "formula": "県 + 系",
+    "components": [
+      {
+        "radical": "県",
+        "role": "部件",
+        "label": "県"
+      },
+      {
+        "radical": "系",
+        "role": "部件",
+        "label": "系"
+      }
+    ]
+  },
+  "縫": {
+    "formula": "糹 + 逢",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "逢",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "縮": {
+    "formula": "糹 + 宿",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "宿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "縱": {
+    "formula": "糹 + 從",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "從",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "總": {
+    "formula": "糹 + 悤",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "悤",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "績": {
+    "formula": "糹 + 責",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "部件",
+        "label": "糹"
+      },
+      {
+        "radical": "責",
+        "role": "部件",
+        "label": "責"
+      }
+    ]
+  },
+  "繁": {
+    "formula": "敏 + 糸",
+    "components": [
+      {
+        "radical": "敏",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "糸",
+        "role": "形符",
+        "label": "絲線"
+      }
+    ]
+  },
+  "繃": {
+    "formula": "糹 + 崩",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "崩",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "繆": {
+    "formula": "糹 + 翏",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "翏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "織": {
+    "formula": "糹 + 戠",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "戠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "繞": {
+    "formula": "糹 + 堯",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "堯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "繩": {
+    "formula": "糹 + 黽",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "黽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "繪": {
+    "formula": "糹 + 會",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "會",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "繫": {
+    "formula": "毄 + 糸",
+    "components": [
+      {
+        "radical": "毄",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "糸",
+        "role": "形符",
+        "label": "絲線"
+      }
+    ]
+  },
+  "繭": {
+    "formula": "艹 + 冂 + 糹 + 虫",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "糹",
+        "role": "部件",
+        "label": "糹"
+      },
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      }
+    ]
+  },
+  "繼": {
+    "formula": "糹 + 㡭",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "㡭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "續": {
+    "formula": "糹 + 賣",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "賣",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "纍": {
+    "formula": "畾 + 糸",
+    "components": [
+      {
+        "radical": "畾",
+        "role": "部件",
+        "label": "畾"
+      },
+      {
+        "radical": "糸",
+        "role": "部件",
+        "label": "絲線"
+      }
+    ]
+  },
+  "纏": {
+    "formula": "糹 + 廛",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "廛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "纖": {
+    "formula": "糹 + 韱",
+    "components": [
+      {
+        "radical": "糹",
+        "role": "形符",
+        "label": "糹"
+      },
+      {
+        "radical": "韱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "缺": {
+    "formula": "缶 + 夬",
+    "components": [
+      {
+        "radical": "缶",
+        "role": "形符",
+        "label": "缶"
+      },
+      {
+        "radical": "夬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "罐": {
+    "formula": "缶 + 雚",
+    "components": [
+      {
+        "radical": "缶",
+        "role": "形符",
+        "label": "缶"
+      },
+      {
+        "radical": "雚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "罩": {
+    "formula": "罒 + 卓",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "形符",
+        "label": "網罟"
+      },
+      {
+        "radical": "卓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "罪": {
+    "formula": "罒 + 非",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "非",
+        "role": "部件",
+        "label": "非"
+      }
+    ]
+  },
+  "置": {
+    "formula": "罒 + 直",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "形符",
+        "label": "網罟"
+      },
+      {
+        "radical": "直",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "罰": {
+    "formula": "罒 + 言 + 刂",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "刂",
+        "role": "部件",
+        "label": "刀旁"
+      }
+    ]
+  },
+  "署": {
+    "formula": "罒 + 者",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "形符",
+        "label": "網罟"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "罵": {
+    "formula": "罒 + 馬",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "形符",
+        "label": "網罟"
+      },
+      {
+        "radical": "馬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "罷": {
+    "formula": "罒 + 能",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "能",
+        "role": "部件",
+        "label": "能"
+      }
+    ]
+  },
+  "羅": {
+    "formula": "罒 + 維",
+    "components": [
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "維",
+        "role": "部件",
+        "label": "維"
+      }
+    ]
+  },
+  "美": {
+    "formula": "羊 + 大",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "部件",
+        "label": "羊"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "羞": {
+    "formula": "羊 + 丑",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "部件",
+        "label": "羊"
+      },
+      {
+        "radical": "丑",
+        "role": "部件",
+        "label": "丑"
+      }
+    ]
+  },
+  "群": {
+    "formula": "君 + 羊",
+    "components": [
+      {
+        "radical": "君",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "羊",
+        "role": "形符",
+        "label": "羊"
+      }
+    ]
+  },
+  "羨": {
+    "formula": "羊 + 㳄",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "形符",
+        "label": "羊"
+      },
+      {
+        "radical": "㳄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "義": {
+    "formula": "羊 + 我",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "形符",
+        "label": "羊"
+      },
+      {
+        "radical": "我",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "翅": {
+    "formula": "支 + 羽",
+    "components": [
+      {
+        "radical": "支",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "羽",
+        "role": "形符",
+        "label": "羽"
+      }
+    ]
+  },
+  "習": {
+    "formula": "羽 + 白",
+    "components": [
+      {
+        "radical": "羽",
+        "role": "部件",
+        "label": "羽"
+      },
+      {
+        "radical": "白",
+        "role": "部件",
+        "label": "白色"
+      }
+    ]
+  },
+  "翔": {
+    "formula": "羊 + 羽",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "羽",
+        "role": "形符",
+        "label": "羽"
+      }
+    ]
+  },
+  "翩": {
+    "formula": "扁 + 羽",
+    "components": [
+      {
+        "radical": "扁",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "羽",
+        "role": "形符",
+        "label": "羽"
+      }
+    ]
+  },
+  "翰": {
+    "formula": "倝 + 羽",
+    "components": [
+      {
+        "radical": "倝",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "羽",
+        "role": "形符",
+        "label": "羽"
+      }
+    ]
+  },
+  "翻": {
+    "formula": "番 + 羽",
+    "components": [
+      {
+        "radical": "番",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "羽",
+        "role": "形符",
+        "label": "羽"
+      }
+    ]
+  },
+  "翼": {
+    "formula": "羽 + 異",
+    "components": [
+      {
+        "radical": "羽",
+        "role": "形符",
+        "label": "羽"
+      },
+      {
+        "radical": "異",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "耀": {
+    "formula": "光 + 翟",
+    "components": [
+      {
+        "radical": "光",
+        "role": "部件",
+        "label": "光"
+      },
+      {
+        "radical": "翟",
+        "role": "部件",
+        "label": "翟"
+      }
+    ]
+  },
+  "考": {
+    "formula": "耂 + 丂",
+    "components": [
+      {
+        "radical": "耂",
+        "role": "形符",
+        "label": "耂"
+      },
+      {
+        "radical": "丂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "者": {
+    "formula": "土 + 丿 + 日",
+    "components": [
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "而": {
+    "formula": "一 + 丶 + 冂 + 丨 + 丨",
+    "components": [
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      },
+      {
+        "radical": "冂",
+        "role": "部件",
+        "label": "冂"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      },
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      }
+    ]
+  },
+  "耍": {
+    "formula": "而 + 女",
+    "components": [
+      {
+        "radical": "而",
+        "role": "部件",
+        "label": "而"
+      },
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      }
+    ]
+  },
+  "耐": {
+    "formula": "而 + 寸",
+    "components": [
+      {
+        "radical": "而",
+        "role": "部件",
+        "label": "而"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "耕": {
+    "formula": "耒 + 井",
+    "components": [
+      {
+        "radical": "耒",
+        "role": "形符",
+        "label": "耒"
+      },
+      {
+        "radical": "井",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "耗": {
+    "formula": "耒 + 毛",
+    "components": [
+      {
+        "radical": "耒",
+        "role": "形符",
+        "label": "耒"
+      },
+      {
+        "radical": "毛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "耶": {
+    "formula": "耳 + 阝",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "形符",
+        "label": "耳朵"
+      },
+      {
+        "radical": "阝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "聆": {
+    "formula": "耳 + 令",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "形符",
+        "label": "耳朵"
+      },
+      {
+        "radical": "令",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "聊": {
+    "formula": "耳 + 卯",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "形符",
+        "label": "耳朵"
+      },
+      {
+        "radical": "卯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "聖": {
+    "formula": "耳 + 口 + 王",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "部件",
+        "label": "耳朵"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      }
+    ]
+  },
+  "聚": {
+    "formula": "取 + 乑",
+    "components": [
+      {
+        "radical": "取",
+        "role": "部件",
+        "label": "取"
+      },
+      {
+        "radical": "乑",
+        "role": "部件",
+        "label": "乑"
+      }
+    ]
+  },
+  "聞": {
+    "formula": "門 + 耳",
+    "components": [
+      {
+        "radical": "門",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "耳",
+        "role": "形符",
+        "label": "耳朵"
+      }
+    ]
+  },
+  "聰": {
+    "formula": "耳 + 悤",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "形符",
+        "label": "耳朵"
+      },
+      {
+        "radical": "悤",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "聲": {
+    "formula": "殸 + 耳",
+    "components": [
+      {
+        "radical": "殸",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "耳",
+        "role": "形符",
+        "label": "耳朵"
+      }
+    ]
+  },
+  "聳": {
+    "formula": "從 + 耳",
+    "components": [
+      {
+        "radical": "從",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "耳",
+        "role": "形符",
+        "label": "耳朵"
+      }
+    ]
+  },
+  "職": {
+    "formula": "耳 + 戠",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "形符",
+        "label": "耳朵"
+      },
+      {
+        "radical": "戠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "聽": {
+    "formula": "耳 + 王 + 十 + 罒 + 一 + 心",
+    "components": [
+      {
+        "radical": "耳",
+        "role": "部件",
+        "label": "耳朵"
+      },
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "罒",
+        "role": "部件",
+        "label": "網罟"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      },
+      {
+        "radical": "心",
+        "role": "部件",
+        "label": "心"
+      }
+    ]
+  },
+  "肆": {
+    "formula": "镸 + 聿",
+    "components": [
+      {
+        "radical": "镸",
+        "role": "部件",
+        "label": "镸"
+      },
+      {
+        "radical": "聿",
+        "role": "部件",
+        "label": "筆"
+      }
+    ]
+  },
+  "肌": {
+    "formula": "⺼ + 几",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "几",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "肖": {
+    "formula": "⺌ + ⺼",
+    "components": [
+      {
+        "radical": "⺌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      }
+    ]
+  },
+  "肚": {
+    "formula": "⺼ + 土",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "土",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "股": {
+    "formula": "⺼ + 殳",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "殳",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "肢": {
+    "formula": "⺼ + 支",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "支",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "肥": {
+    "formula": "⺼ + 巴",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "巴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "肩": {
+    "formula": "户 + ⺼",
+    "components": [
+      {
+        "radical": "户",
+        "role": "部件",
+        "label": "户"
+      },
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      }
+    ]
+  },
+  "肪": {
+    "formula": "⺼ + 方",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "肯": {
+    "formula": "止 + ⺼",
+    "components": [
+      {
+        "radical": "止",
+        "role": "部件",
+        "label": "止"
+      },
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      }
+    ]
+  },
+  "育": {
+    "formula": "亠 + 厶 + ⺼",
+    "components": [
+      {
+        "radical": "亠",
+        "role": "部件",
+        "label": "亠"
+      },
+      {
+        "radical": "厶",
+        "role": "部件",
+        "label": "厶"
+      },
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      }
+    ]
+  },
+  "肺": {
+    "formula": "⺼ + 巿",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "巿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "胃": {
+    "formula": "田 + ⺼",
+    "components": [
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      },
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      }
+    ]
+  },
+  "背": {
+    "formula": "北 + ⺼",
+    "components": [
+      {
+        "radical": "北",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      }
+    ]
+  },
+  "胎": {
+    "formula": "⺼ + 台",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "台",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "胖": {
+    "formula": "⺼ + 半",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "半",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "胞": {
+    "formula": "⺼ + 包",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "胡": {
+    "formula": "古 + ⺼",
+    "components": [
+      {
+        "radical": "古",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      }
+    ]
+  },
+  "胸": {
+    "formula": "⺼ + 匈",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "匈",
+        "role": "部件",
+        "label": "匈"
+      }
+    ]
+  },
+  "胺": {
+    "formula": "⺼ + 安",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "安",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "脂": {
+    "formula": "⺼ + 旨",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "旨",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "脅": {
+    "formula": "劦 + ⺼",
+    "components": [
+      {
+        "radical": "劦",
+        "role": "部件",
+        "label": "劦"
+      },
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      }
+    ]
+  },
+  "脆": {
+    "formula": "⺼ + 危",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "危",
+        "role": "部件",
+        "label": "危"
+      }
+    ]
+  },
+  "脈": {
+    "formula": "⺼ + 永",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "永",
+        "role": "部件",
+        "label": "永"
+      }
+    ]
+  },
+  "脊": {
+    "formula": "人 + ⺼",
+    "components": [
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      }
+    ]
+  },
+  "脖": {
+    "formula": "⺼ + 孛",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "孛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "脫": {
+    "formula": "⺼ + 兌",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "兌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "脹": {
+    "formula": "⺼ + 長",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "長",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "脾": {
+    "formula": "⺼ + 卑",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "卑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "腎": {
+    "formula": "臤 + ⺼",
+    "components": [
+      {
+        "radical": "臤",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      }
+    ]
+  },
+  "腐": {
+    "formula": "付 + 肉",
+    "components": [
+      {
+        "radical": "付",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "肉",
+        "role": "形符",
+        "label": "肉"
+      }
+    ]
+  },
+  "腔": {
+    "formula": "⺼ + 空",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "空",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "腥": {
+    "formula": "⺼ + 星",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "星",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "腦": {
+    "formula": "⺼ + 巛 + 囟",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "巛",
+        "role": "部件",
+        "label": "巛"
+      },
+      {
+        "radical": "囟",
+        "role": "部件",
+        "label": "囟"
+      }
+    ]
+  },
+  "腫": {
+    "formula": "⺼ + 重",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "重",
+        "role": "部件",
+        "label": "重"
+      }
+    ]
+  },
+  "腰": {
+    "formula": "⺼ + 要",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "要",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "腳": {
+    "formula": "⺼ + 卻",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "卻",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "腹": {
+    "formula": "⺼ + 复",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "复",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "腿": {
+    "formula": "⺼ + 退",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "退",
+        "role": "部件",
+        "label": "退"
+      }
+    ]
+  },
+  "膀": {
+    "formula": "⺼ + 旁",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "旁",
+        "role": "部件",
+        "label": "旁"
+      }
+    ]
+  },
+  "膏": {
+    "formula": "高 + ⺼",
+    "components": [
+      {
+        "radical": "高",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      }
+    ]
+  },
+  "膚": {
+    "formula": "⺼ + 虍",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "虍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "膛": {
+    "formula": "⺼ + 堂",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "部件",
+        "label": "⺼"
+      },
+      {
+        "radical": "堂",
+        "role": "部件",
+        "label": "堂"
+      }
+    ]
+  },
+  "膜": {
+    "formula": "⺼ + 莫",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "莫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "膝": {
+    "formula": "⺼ + 桼",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "桼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "膠": {
+    "formula": "⺼ + 翏",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "翏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "膽": {
+    "formula": "⺼ + 詹",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "詹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "臀": {
+    "formula": "殿 + ⺼",
+    "components": [
+      {
+        "radical": "殿",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      }
+    ]
+  },
+  "臂": {
+    "formula": "辟 + ⺼",
+    "components": [
+      {
+        "radical": "辟",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      }
+    ]
+  },
+  "臉": {
+    "formula": "⺼ + 僉",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "僉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "臘": {
+    "formula": "⺼ + 巤",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "巤",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "臟": {
+    "formula": "⺼ + 藏",
+    "components": [
+      {
+        "radical": "⺼",
+        "role": "形符",
+        "label": "⺼"
+      },
+      {
+        "radical": "藏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "臥": {
+    "formula": "臣 + 人",
+    "components": [
+      {
+        "radical": "臣",
+        "role": "部件",
+        "label": "臣"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "致": {
+    "formula": "至 + 攵",
+    "components": [
+      {
+        "radical": "至",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "攵",
+        "role": "形符",
+        "label": "攵"
+      }
+    ]
+  },
+  "臺": {
+    "formula": "吉 + 冖 + 至",
+    "components": [
+      {
+        "radical": "吉",
+        "role": "部件",
+        "label": "吉"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "至",
+        "role": "部件",
+        "label": "至"
+      }
+    ]
+  },
+  "舅": {
+    "formula": "臼 + 男",
+    "components": [
+      {
+        "radical": "臼",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "男",
+        "role": "形符",
+        "label": "男"
+      }
+    ]
+  },
+  "舉": {
+    "formula": "扌 + 舉",
+    "components": [
+      {
+        "radical": "扌",
+        "role": "形符",
+        "label": "手旁"
+      },
+      {
+        "radical": "舉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "舍": {
+    "formula": "人 + 舌",
+    "components": [
+      {
+        "radical": "人",
+        "role": "形符",
+        "label": "人"
+      },
+      {
+        "radical": "舌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "舒": {
+    "formula": "舍 + 予",
+    "components": [
+      {
+        "radical": "舍",
+        "role": "形符",
+        "label": "舍"
+      },
+      {
+        "radical": "予",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "舞": {
+    "formula": "無 + 舛",
+    "components": [
+      {
+        "radical": "無",
+        "role": "部件",
+        "label": "無"
+      },
+      {
+        "radical": "舛",
+        "role": "部件",
+        "label": "舛"
+      }
+    ]
+  },
+  "航": {
+    "formula": "舟 + 亢",
+    "components": [
+      {
+        "radical": "舟",
+        "role": "形符",
+        "label": "舟"
+      },
+      {
+        "radical": "亢",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "般": {
+    "formula": "舟 + 殳",
+    "components": [
+      {
+        "radical": "舟",
+        "role": "部件",
+        "label": "舟"
+      },
+      {
+        "radical": "殳",
+        "role": "部件",
+        "label": "殳"
+      }
+    ]
+  },
+  "良": {
+    "formula": "丶 + 艮",
+    "components": [
+      {
+        "radical": "丶",
+        "role": "部件",
+        "label": "丶"
+      },
+      {
+        "radical": "艮",
+        "role": "部件",
+        "label": "艮"
+      }
+    ]
+  },
+  "艱": {
+    "formula": "堇 + 艮",
+    "components": [
+      {
+        "radical": "堇",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "艮",
+        "role": "形符",
+        "label": "艮"
+      }
+    ]
+  },
+  "艷": {
+    "formula": "豐 + 色",
+    "components": [
+      {
+        "radical": "豐",
+        "role": "部件",
+        "label": "豐"
+      },
+      {
+        "radical": "色",
+        "role": "部件",
+        "label": "色"
+      }
+    ]
+  },
+  "艾": {
+    "formula": "艹 + 乂",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "乂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "芒": {
+    "formula": "艹 + 亡",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "亡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "芝": {
+    "formula": "艹 + 之",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "之",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "芬": {
+    "formula": "艹 + 分",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "分",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "芮": {
+    "formula": "艹 + 内",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "内",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "花": {
+    "formula": "艹 + 化",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "化",
+        "role": "部件",
+        "label": "變化"
+      }
+    ]
+  },
+  "芳": {
+    "formula": "艹 + 方",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "芸": {
+    "formula": "艹 + 云",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "云",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "芻": {
+    "formula": "勹 + 屮 + 勹 + 屮",
+    "components": [
+      {
+        "radical": "勹",
+        "role": "部件",
+        "label": "勹"
+      },
+      {
+        "radical": "屮",
+        "role": "部件",
+        "label": "屮"
+      },
+      {
+        "radical": "勹",
+        "role": "部件",
+        "label": "勹"
+      },
+      {
+        "radical": "屮",
+        "role": "部件",
+        "label": "屮"
+      }
+    ]
+  },
+  "芽": {
+    "formula": "艹 + 牙",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "牙",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "苗": {
+    "formula": "艹 + 田",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      }
+    ]
+  },
+  "苞": {
+    "formula": "艹 + 包",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "包",
+        "role": "部件",
+        "label": "包"
+      }
+    ]
+  },
+  "若": {
+    "formula": "草 + 右",
+    "components": [
+      {
+        "radical": "草",
+        "role": "部件",
+        "label": "草"
+      },
+      {
+        "radical": "右",
+        "role": "部件",
+        "label": "右"
+      }
+    ]
+  },
+  "苦": {
+    "formula": "艹 + 古",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "古",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "英": {
+    "formula": "艹 + 央",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "央",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "茂": {
+    "formula": "艹 + 戊",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "戊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "茅": {
+    "formula": "艹 + 矛",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "矛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "茫": {
+    "formula": "艹 + 汒",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "汒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "草": {
+    "formula": "艹 + 早",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "早",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "荒": {
+    "formula": "芒 + 川",
+    "components": [
+      {
+        "radical": "芒",
+        "role": "形符",
+        "label": "芒"
+      },
+      {
+        "radical": "川",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "荷": {
+    "formula": "艹 + 何",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "何",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "莉": {
+    "formula": "艹 + 利",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "利",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "莊": {
+    "formula": "艹 + 壯",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "壯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "莎": {
+    "formula": "艹 + 沙",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "沙",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "莖": {
+    "formula": "艹 + 巠",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "巠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "莫": {
+    "formula": "草 + 日 + 大",
+    "components": [
+      {
+        "radical": "草",
+        "role": "部件",
+        "label": "草"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "莽": {
+    "formula": "艹 + 犬 + 廾",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "犬",
+        "role": "部件",
+        "label": "狗"
+      },
+      {
+        "radical": "廾",
+        "role": "部件",
+        "label": "廾"
+      }
+    ]
+  },
+  "菁": {
+    "formula": "艹 + 青",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "菇": {
+    "formula": "艹 + 姑",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "姑",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "菜": {
+    "formula": "艹 + 采",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "采",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "菠": {
+    "formula": "艹 + 波",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "波",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "華": {
+    "formula": "艹 + 十",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "十",
+        "role": "形符",
+        "label": "十"
+      }
+    ]
+  },
+  "菲": {
+    "formula": "艹 + 非",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "非",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "菸": {
+    "formula": "艹 + 於",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "於",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "萊": {
+    "formula": "艹 + 來",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "來",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "落": {
+    "formula": "艹 + 洛",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "洛",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "葉": {
+    "formula": "艹 + 枼",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "枼",
+        "role": "部件",
+        "label": "枼"
+      }
+    ]
+  },
+  "著": {
+    "formula": "艹 + 者",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "葫": {
+    "formula": "艹 + 胡",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "胡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "葬": {
+    "formula": "艹 + 死 + 廾",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "死",
+        "role": "部件",
+        "label": "死"
+      },
+      {
+        "radical": "廾",
+        "role": "部件",
+        "label": "廾"
+      }
+    ]
+  },
+  "蒂": {
+    "formula": "艹 + 帝",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "帝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蒐": {
+    "formula": "草 + 鬼",
+    "components": [
+      {
+        "radical": "草",
+        "role": "部件",
+        "label": "草"
+      },
+      {
+        "radical": "鬼",
+        "role": "部件",
+        "label": "鬼"
+      }
+    ]
+  },
+  "蒙": {
+    "formula": "艹 + 冡",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "冡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蒸": {
+    "formula": "艹 + 烝",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "烝",
+        "role": "部件",
+        "label": "烝"
+      }
+    ]
+  },
+  "蒼": {
+    "formula": "艹 + 倉",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "倉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蓄": {
+    "formula": "艹 + 畜",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "畜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蓋": {
+    "formula": "艹 + 盍",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "盍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蓬": {
+    "formula": "艹 + 逢",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "逢",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蓮": {
+    "formula": "艹 + 連",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "連",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蔡": {
+    "formula": "草 + 祭",
+    "components": [
+      {
+        "radical": "草",
+        "role": "部件",
+        "label": "草"
+      },
+      {
+        "radical": "祭",
+        "role": "部件",
+        "label": "祭"
+      }
+    ]
+  },
+  "蔣": {
+    "formula": "艹 + 將",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "將",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蔬": {
+    "formula": "艹 + 疏",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "疏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蔭": {
+    "formula": "艹 + 陰",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "陰",
+        "role": "部件",
+        "label": "陰"
+      }
+    ]
+  },
+  "蔽": {
+    "formula": "艹 + 敝",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "敝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蕉": {
+    "formula": "艹 + 焦",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "焦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蕩": {
+    "formula": "艹 + 湯",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "湯",
+        "role": "部件",
+        "label": "湯"
+      }
+    ]
+  },
+  "蕪": {
+    "formula": "艹 + 無",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "無",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蕾": {
+    "formula": "艹 + 雷",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "雷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "薄": {
+    "formula": "艹 + 溥",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "溥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "薦": {
+    "formula": "艹 + 廌",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "廌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "薩": {
+    "formula": "艹 + 隡",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "隡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "薪": {
+    "formula": "艹 + 新",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "新",
+        "role": "部件",
+        "label": "新"
+      }
+    ]
+  },
+  "薯": {
+    "formula": "艹 + 署",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "署",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "藉": {
+    "formula": "艹 + 耤",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "部件",
+        "label": "草頭"
+      },
+      {
+        "radical": "耤",
+        "role": "部件",
+        "label": "耤"
+      }
+    ]
+  },
+  "藍": {
+    "formula": "艹 + 監",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "監",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "藏": {
+    "formula": "艹 + 臧",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "臧",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "藝": {
+    "formula": "艹 + 埶",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "埶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "藥": {
+    "formula": "艹 + 樂",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "樂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "藹": {
+    "formula": "艹 + 謁",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "謁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蘆": {
+    "formula": "艹 + 盧",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "盧",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蘋": {
+    "formula": "艹 + 頻",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "頻",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蘭": {
+    "formula": "艹 + 闌",
+    "components": [
+      {
+        "radical": "艹",
+        "role": "形符",
+        "label": "草頭"
+      },
+      {
+        "radical": "闌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "虎": {
+    "formula": "虍 + 几",
+    "components": [
+      {
+        "radical": "虍",
+        "role": "部件",
+        "label": "虍"
+      },
+      {
+        "radical": "几",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "虔": {
+    "formula": "虎 + 文",
+    "components": [
+      {
+        "radical": "虎",
+        "role": "部件",
+        "label": "虎"
+      },
+      {
+        "radical": "文",
+        "role": "部件",
+        "label": "文"
+      }
+    ]
+  },
+  "處": {
+    "formula": "虍 + 処",
+    "components": [
+      {
+        "radical": "虍",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "処",
+        "role": "形符",
+        "label": "処"
+      }
+    ]
+  },
+  "虛": {
+    "formula": "虍 + 丱 + 一",
+    "components": [
+      {
+        "radical": "虍",
+        "role": "部件",
+        "label": "虍"
+      },
+      {
+        "radical": "丱",
+        "role": "部件",
+        "label": "丱"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "虜": {
+    "formula": "虍 + 男",
+    "components": [
+      {
+        "radical": "虍",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "男",
+        "role": "形符",
+        "label": "男"
+      }
+    ]
+  },
+  "號": {
+    "formula": "号 + 虎",
+    "components": [
+      {
+        "radical": "号",
+        "role": "部件",
+        "label": "号"
+      },
+      {
+        "radical": "虎",
+        "role": "部件",
+        "label": "虎"
+      }
+    ]
+  },
+  "虧": {
+    "formula": "雐 + 亏",
+    "components": [
+      {
+        "radical": "雐",
+        "role": "部件",
+        "label": "雐"
+      },
+      {
+        "radical": "亏",
+        "role": "部件",
+        "label": "亏"
+      }
+    ]
+  },
+  "虹": {
+    "formula": "虫 + 工",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "工",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蚊": {
+    "formula": "虫 + 文",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "文",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蚋": {
+    "formula": "虫 + 内",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "内",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蛀": {
+    "formula": "虫 + 主",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "主",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蛇": {
+    "formula": "虫 + 它",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "它",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蛋": {
+    "formula": "虫 + 延",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "延",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蛙": {
+    "formula": "虫 + 圭",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蛛": {
+    "formula": "虫 + 朱",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "朱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蛭": {
+    "formula": "虫 + 至",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "至",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蛻": {
+    "formula": "虫 + 兌",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      },
+      {
+        "radical": "兌",
+        "role": "部件",
+        "label": "兌"
+      }
+    ]
+  },
+  "蛾": {
+    "formula": "虫 + 我",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "我",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蜂": {
+    "formula": "虫 + 夆",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "夆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蜒": {
+    "formula": "虫 + 延",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "延",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蜓": {
+    "formula": "虫 + 廷",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "廷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蜘": {
+    "formula": "虫 + 知",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "知",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蜜": {
+    "formula": "宓 + 虫",
+    "components": [
+      {
+        "radical": "宓",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      }
+    ]
+  },
+  "蜻": {
+    "formula": "虫 + 青",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蜿": {
+    "formula": "虫 + 宛",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      },
+      {
+        "radical": "宛",
+        "role": "部件",
+        "label": "宛"
+      }
+    ]
+  },
+  "蝕": {
+    "formula": "飠 + 虫",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "部件",
+        "label": "飠"
+      },
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      }
+    ]
+  },
+  "蝴": {
+    "formula": "虫 + 胡",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "胡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蝶": {
+    "formula": "虫 + 枼",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "枼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "螂": {
+    "formula": "虫 + 郎",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "郎",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "融": {
+    "formula": "鬲 + 虫",
+    "components": [
+      {
+        "radical": "鬲",
+        "role": "形符",
+        "label": "鬲"
+      },
+      {
+        "radical": "虫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "螢": {
+    "formula": "火 + 火 + 冖 + 虫",
+    "components": [
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      },
+      {
+        "radical": "火",
+        "role": "部件",
+        "label": "火"
+      },
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      }
+    ]
+  },
+  "螯": {
+    "formula": "敖 + 虫",
+    "components": [
+      {
+        "radical": "敖",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      }
+    ]
+  },
+  "蟑": {
+    "formula": "虫 + 章",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "章",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蟒": {
+    "formula": "虫 + 莽",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      },
+      {
+        "radical": "莽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蟲": {
+    "formula": "虫 + 虫 + 虫",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      },
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      },
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      }
+    ]
+  },
+  "蟹": {
+    "formula": "解 + 虫",
+    "components": [
+      {
+        "radical": "解",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      }
+    ]
+  },
+  "蠅": {
+    "formula": "虫 + 黽",
+    "components": [
+      {
+        "radical": "虫",
+        "role": "部件",
+        "label": "蟲"
+      },
+      {
+        "radical": "黽",
+        "role": "部件",
+        "label": "黽"
+      }
+    ]
+  },
+  "蠢": {
+    "formula": "春 + 虫",
+    "components": [
+      {
+        "radical": "春",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      }
+    ]
+  },
+  "蠻": {
+    "formula": "䜌 + 虫",
+    "components": [
+      {
+        "radical": "䜌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      }
+    ]
+  },
+  "血": {
+    "formula": "丿 + 皿",
+    "components": [
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      },
+      {
+        "radical": "皿",
+        "role": "部件",
+        "label": "器皿"
+      }
+    ]
+  },
+  "行": {
+    "formula": "彳 + 亍",
+    "components": [
+      {
+        "radical": "彳",
+        "role": "部件",
+        "label": "行旁"
+      },
+      {
+        "radical": "亍",
+        "role": "部件",
+        "label": "亍"
+      }
+    ]
+  },
+  "衍": {
+    "formula": "行 + 氵",
+    "components": [
+      {
+        "radical": "行",
+        "role": "部件",
+        "label": "行走"
+      },
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      }
+    ]
+  },
+  "術": {
+    "formula": "行 + 术",
+    "components": [
+      {
+        "radical": "行",
+        "role": "部件",
+        "label": "行走"
+      },
+      {
+        "radical": "术",
+        "role": "部件",
+        "label": "术"
+      }
+    ]
+  },
+  "街": {
+    "formula": "行 + 圭",
+    "components": [
+      {
+        "radical": "行",
+        "role": "形符",
+        "label": "行走"
+      },
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "衛": {
+    "formula": "行 + 韋",
+    "components": [
+      {
+        "radical": "行",
+        "role": "形符",
+        "label": "行走"
+      },
+      {
+        "radical": "韋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "衝": {
+    "formula": "行 + 重",
+    "components": [
+      {
+        "radical": "行",
+        "role": "形符",
+        "label": "行走"
+      },
+      {
+        "radical": "重",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "衡": {
+    "formula": "行 + 角 + 大",
+    "components": [
+      {
+        "radical": "行",
+        "role": "部件",
+        "label": "行走"
+      },
+      {
+        "radical": "角",
+        "role": "部件",
+        "label": "角"
+      },
+      {
+        "radical": "大",
+        "role": "部件",
+        "label": "大"
+      }
+    ]
+  },
+  "表": {
+    "formula": "毛 + 衣",
+    "components": [
+      {
+        "radical": "毛",
+        "role": "部件",
+        "label": "毛"
+      },
+      {
+        "radical": "衣",
+        "role": "部件",
+        "label": "衣服"
+      }
+    ]
+  },
+  "衫": {
+    "formula": "衤 + 彡",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "彡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "衰": {
+    "formula": "衣 + 口 + 一",
+    "components": [
+      {
+        "radical": "衣",
+        "role": "部件",
+        "label": "衣服"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "一",
+        "role": "部件",
+        "label": "一"
+      }
+    ]
+  },
+  "衷": {
+    "formula": "衣 + 中",
+    "components": [
+      {
+        "radical": "衣",
+        "role": "部件",
+        "label": "衣服"
+      },
+      {
+        "radical": "中",
+        "role": "部件",
+        "label": "中"
+      }
+    ]
+  },
+  "袋": {
+    "formula": "代 + 衣",
+    "components": [
+      {
+        "radical": "代",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "衣",
+        "role": "形符",
+        "label": "衣服"
+      }
+    ]
+  },
+  "袖": {
+    "formula": "衤 + 由",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "由",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "被": {
+    "formula": "衤 + 皮",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "皮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "裁": {
+    "formula": "十 + 戈 + 衣",
+    "components": [
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      },
+      {
+        "radical": "戈",
+        "role": "部件",
+        "label": "戈"
+      },
+      {
+        "radical": "衣",
+        "role": "部件",
+        "label": "衣服"
+      }
+    ]
+  },
+  "裂": {
+    "formula": "列 + 衣",
+    "components": [
+      {
+        "radical": "列",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "衣",
+        "role": "形符",
+        "label": "衣服"
+      }
+    ]
+  },
+  "裔": {
+    "formula": "衣 + 冏",
+    "components": [
+      {
+        "radical": "衣",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "冏",
+        "role": "形符",
+        "label": "冏"
+      }
+    ]
+  },
+  "裕": {
+    "formula": "衤 + 谷",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "谷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "裙": {
+    "formula": "衤 + 君",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "君",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "補": {
+    "formula": "衤 + 甫",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "甫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "裝": {
+    "formula": "壯 + 衣",
+    "components": [
+      {
+        "radical": "壯",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "衣",
+        "role": "形符",
+        "label": "衣服"
+      }
+    ]
+  },
+  "裡": {
+    "formula": "衤 + 里",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "部件",
+        "label": "衣旁"
+      },
+      {
+        "radical": "里",
+        "role": "部件",
+        "label": "里"
+      }
+    ]
+  },
+  "裳": {
+    "formula": "尚 + 衣",
+    "components": [
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "衣",
+        "role": "形符",
+        "label": "衣服"
+      }
+    ]
+  },
+  "裹": {
+    "formula": "衣 + 果",
+    "components": [
+      {
+        "radical": "衣",
+        "role": "形符",
+        "label": "衣服"
+      },
+      {
+        "radical": "果",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "製": {
+    "formula": "制 + 衣",
+    "components": [
+      {
+        "radical": "制",
+        "role": "部件",
+        "label": "制"
+      },
+      {
+        "radical": "衣",
+        "role": "部件",
+        "label": "衣服"
+      }
+    ]
+  },
+  "複": {
+    "formula": "衤 + 复",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "部件",
+        "label": "衣旁"
+      },
+      {
+        "radical": "复",
+        "role": "部件",
+        "label": "复"
+      }
+    ]
+  },
+  "褓": {
+    "formula": "衤 + 保",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "部件",
+        "label": "衣旁"
+      },
+      {
+        "radical": "保",
+        "role": "部件",
+        "label": "保"
+      }
+    ]
+  },
+  "褪": {
+    "formula": "衤 + 退",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "部件",
+        "label": "衣旁"
+      },
+      {
+        "radical": "退",
+        "role": "部件",
+        "label": "退"
+      }
+    ]
+  },
+  "褲": {
+    "formula": "衤 + 庫",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "庫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "襁": {
+    "formula": "衤 + 强",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "强",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "襯": {
+    "formula": "衤 + 親",
+    "components": [
+      {
+        "radical": "衤",
+        "role": "形符",
+        "label": "衣旁"
+      },
+      {
+        "radical": "親",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "襲": {
+    "formula": "龍 + 衣",
+    "components": [
+      {
+        "radical": "龍",
+        "role": "形符",
+        "label": "龍"
+      },
+      {
+        "radical": "衣",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "要": {
+    "formula": "覀 + 女",
+    "components": [
+      {
+        "radical": "覀",
+        "role": "部件",
+        "label": "覀"
+      },
+      {
+        "radical": "女",
+        "role": "部件",
+        "label": "女旁"
+      }
+    ]
+  },
+  "覆": {
+    "formula": "覀 + 復",
+    "components": [
+      {
+        "radical": "覀",
+        "role": "形符",
+        "label": "覀"
+      },
+      {
+        "radical": "復",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "規": {
+    "formula": "夫 + 見",
+    "components": [
+      {
+        "radical": "夫",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "見",
+        "role": "形符",
+        "label": "看見"
+      }
+    ]
+  },
+  "覓": {
+    "formula": "爫 + 見",
+    "components": [
+      {
+        "radical": "爫",
+        "role": "部件",
+        "label": "爫"
+      },
+      {
+        "radical": "見",
+        "role": "部件",
+        "label": "看見"
+      }
+    ]
+  },
+  "視": {
+    "formula": "礻 + 見",
+    "components": [
+      {
+        "radical": "礻",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "見",
+        "role": "形符",
+        "label": "看見"
+      }
+    ]
+  },
+  "親": {
+    "formula": "亲 + 見",
+    "components": [
+      {
+        "radical": "亲",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "見",
+        "role": "形符",
+        "label": "看見"
+      }
+    ]
+  },
+  "覽": {
+    "formula": "監 + 見",
+    "components": [
+      {
+        "radical": "監",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "見",
+        "role": "形符",
+        "label": "看見"
+      }
+    ]
+  },
+  "觀": {
+    "formula": "雚 + 見",
+    "components": [
+      {
+        "radical": "雚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "見",
+        "role": "形符",
+        "label": "看見"
+      }
+    ]
+  },
+  "解": {
+    "formula": "角 + 刀 + 牛",
+    "components": [
+      {
+        "radical": "角",
+        "role": "部件",
+        "label": "角"
+      },
+      {
+        "radical": "刀",
+        "role": "部件",
+        "label": "刀"
+      },
+      {
+        "radical": "牛",
+        "role": "部件",
+        "label": "牛"
+      }
+    ]
+  },
+  "觸": {
+    "formula": "角 + 蜀",
+    "components": [
+      {
+        "radical": "角",
+        "role": "形符",
+        "label": "角"
+      },
+      {
+        "radical": "蜀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "訂": {
+    "formula": "言 + 丁",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "丁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "計": {
+    "formula": "言 + 十",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "十",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "訊": {
+    "formula": "言 + 卂",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "卂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "討": {
+    "formula": "言 + 寸",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "寸",
+        "role": "部件",
+        "label": "寸"
+      }
+    ]
+  },
+  "訓": {
+    "formula": "言 + 川",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "川",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "託": {
+    "formula": "言 + 乇",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "乇",
+        "role": "部件",
+        "label": "乇"
+      }
+    ]
+  },
+  "記": {
+    "formula": "言 + 己",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "己",
+        "role": "部件",
+        "label": "己"
+      }
+    ]
+  },
+  "訝": {
+    "formula": "言 + 牙",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "牙",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "訣": {
+    "formula": "言 + 夬",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "夬",
+        "role": "部件",
+        "label": "夬"
+      }
+    ]
+  },
+  "訪": {
+    "formula": "言 + 方",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "設": {
+    "formula": "言 + 殳",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "殳",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "許": {
+    "formula": "言 + 午",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "午",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "訴": {
+    "formula": "言 + 斥",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "斥",
+        "role": "部件",
+        "label": "斥"
+      }
+    ]
+  },
+  "診": {
+    "formula": "言 + 㐱",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "㐱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "詐": {
+    "formula": "言 + 乍",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "乍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "評": {
+    "formula": "言 + 平",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "平",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "詞": {
+    "formula": "言 + 司",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "司",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "詠": {
+    "formula": "言 + 永",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "永",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "詢": {
+    "formula": "言 + 旬",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "旬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "試": {
+    "formula": "言 + 式",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "式",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "詩": {
+    "formula": "言 + 寺",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "寺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "詮": {
+    "formula": "言 + 全",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "全",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "話": {
+    "formula": "言 + 舌",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "舌",
+        "role": "部件",
+        "label": "舌頭"
+      }
+    ]
+  },
+  "該": {
+    "formula": "言 + 亥",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "亥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "詳": {
+    "formula": "言 + 羊",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "詹": {
+    "formula": "厂 + 言",
+    "components": [
+      {
+        "radical": "厂",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      }
+    ]
+  },
+  "誇": {
+    "formula": "言 + 夸",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "夸",
+        "role": "部件",
+        "label": "夸"
+      }
+    ]
+  },
+  "誌": {
+    "formula": "言 + 志",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "志",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "認": {
+    "formula": "言 + 忍",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "忍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "誘": {
+    "formula": "言 + 秀",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "秀",
+        "role": "部件",
+        "label": "秀"
+      }
+    ]
+  },
+  "語": {
+    "formula": "言 + 吾",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "吾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "誠": {
+    "formula": "言 + 成",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "成",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "誤": {
+    "formula": "言 + 吴",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "吴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "誦": {
+    "formula": "言 + 甬",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "甬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "說": {
+    "formula": "言 + 兌",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "兌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "誰": {
+    "formula": "言 + 隹",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "課": {
+    "formula": "言 + 果",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "果",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "調": {
+    "formula": "言 + 周",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "周",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "談": {
+    "formula": "言 + 炎",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "炎",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "請": {
+    "formula": "言 + 青",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "青",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "諒": {
+    "formula": "言 + 京",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "京",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "論": {
+    "formula": "言 + 侖",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "侖",
+        "role": "部件",
+        "label": "侖"
+      }
+    ]
+  },
+  "諧": {
+    "formula": "言 + 皆",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "皆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "諮": {
+    "formula": "言 + 咨",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "咨",
+        "role": "部件",
+        "label": "咨"
+      }
+    ]
+  },
+  "諷": {
+    "formula": "言 + 風",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "風",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "諸": {
+    "formula": "言 + 者",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "諺": {
+    "formula": "言 + 彦",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "彦",
+        "role": "部件",
+        "label": "彦"
+      }
+    ]
+  },
+  "諾": {
+    "formula": "言 + 若",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "若",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "謀": {
+    "formula": "言 + 某",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "某",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "謁": {
+    "formula": "言 + 曷",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "曷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "謂": {
+    "formula": "言 + 胃",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "胃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "謎": {
+    "formula": "言 + 迷",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "迷",
+        "role": "部件",
+        "label": "迷"
+      }
+    ]
+  },
+  "謙": {
+    "formula": "言 + 兼",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "兼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "講": {
+    "formula": "言 + 冓",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "冓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "謝": {
+    "formula": "言 + 射",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "射",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "謠": {
+    "formula": "言 + 䍃",
+    "components": [
+      {
+        "radical": "言",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "䍃",
+        "role": "形符",
+        "label": "䍃"
+      }
+    ]
+  },
+  "謹": {
+    "formula": "言 + 堇",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "堇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "證": {
+    "formula": "言 + 登",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "登",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "識": {
+    "formula": "言 + 戠",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "戠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "譜": {
+    "formula": "言 + 普",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "普",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "警": {
+    "formula": "敬 + 言",
+    "components": [
+      {
+        "radical": "敬",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      }
+    ]
+  },
+  "譬": {
+    "formula": "辟 + 言",
+    "components": [
+      {
+        "radical": "辟",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      }
+    ]
+  },
+  "譯": {
+    "formula": "言 + 睪",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "睪",
+        "role": "部件",
+        "label": "睪"
+      }
+    ]
+  },
+  "議": {
+    "formula": "言 + 義",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "義",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "護": {
+    "formula": "言 + 蒦",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "蒦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "譽": {
+    "formula": "與 + 言",
+    "components": [
+      {
+        "radical": "與",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      }
+    ]
+  },
+  "讀": {
+    "formula": "言 + 賣",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "賣",
+        "role": "部件",
+        "label": "賣"
+      }
+    ]
+  },
+  "變": {
+    "formula": "䜌 + 攵",
+    "components": [
+      {
+        "radical": "䜌",
+        "role": "部件",
+        "label": "䜌"
+      },
+      {
+        "radical": "攵",
+        "role": "部件",
+        "label": "攵"
+      }
+    ]
+  },
+  "讓": {
+    "formula": "言 + 襄",
+    "components": [
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      },
+      {
+        "radical": "襄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "讚": {
+    "formula": "言 + 贊",
+    "components": [
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "贊",
+        "role": "部件",
+        "label": "贊"
+      }
+    ]
+  },
+  "谷": {
+    "formula": "八 + 人 + 口",
+    "components": [
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      }
+    ]
+  },
+  "谿": {
+    "formula": "奚 + 谷",
+    "components": [
+      {
+        "radical": "奚",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "谷",
+        "role": "形符",
+        "label": "谷"
+      }
+    ]
+  },
+  "豁": {
+    "formula": "害 + 谷",
+    "components": [
+      {
+        "radical": "害",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "谷",
+        "role": "形符",
+        "label": "谷"
+      }
+    ]
+  },
+  "豎": {
+    "formula": "臤 + 豆",
+    "components": [
+      {
+        "radical": "臤",
+        "role": "形符",
+        "label": "臤"
+      },
+      {
+        "radical": "豆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "豐": {
+    "formula": "山 + 丰 + 丰 + 豆",
+    "components": [
+      {
+        "radical": "山",
+        "role": "部件",
+        "label": "山"
+      },
+      {
+        "radical": "丰",
+        "role": "部件",
+        "label": "丰"
+      },
+      {
+        "radical": "丰",
+        "role": "部件",
+        "label": "丰"
+      },
+      {
+        "radical": "豆",
+        "role": "部件",
+        "label": "豆"
+      }
+    ]
+  },
+  "豔": {
+    "formula": "豐 + 盍",
+    "components": [
+      {
+        "radical": "豐",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "盍",
+        "role": "形符",
+        "label": "盍"
+      }
+    ]
+  },
+  "豪": {
+    "formula": "高 + 豕",
+    "components": [
+      {
+        "radical": "高",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "豕",
+        "role": "形符",
+        "label": "豬"
+      }
+    ]
+  },
+  "豫": {
+    "formula": "予 + 象",
+    "components": [
+      {
+        "radical": "予",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "象",
+        "role": "形符",
+        "label": "象"
+      }
+    ]
+  },
+  "豬": {
+    "formula": "豕 + 者",
+    "components": [
+      {
+        "radical": "豕",
+        "role": "形符",
+        "label": "豬"
+      },
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "豹": {
+    "formula": "豸 + 勺",
+    "components": [
+      {
+        "radical": "豸",
+        "role": "形符",
+        "label": "豸"
+      },
+      {
+        "radical": "勺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "貂": {
+    "formula": "豸 + 召",
+    "components": [
+      {
+        "radical": "豸",
+        "role": "形符",
+        "label": "豸"
+      },
+      {
+        "radical": "召",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "貌": {
+    "formula": "豸 + 皃",
+    "components": [
+      {
+        "radical": "豸",
+        "role": "部件",
+        "label": "豸"
+      },
+      {
+        "radical": "皃",
+        "role": "部件",
+        "label": "皃"
+      }
+    ]
+  },
+  "貓": {
+    "formula": "豸 + 苗",
+    "components": [
+      {
+        "radical": "豸",
+        "role": "形符",
+        "label": "豸"
+      },
+      {
+        "radical": "苗",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "貝": {
+    "formula": "目 + 八",
+    "components": [
+      {
+        "radical": "目",
+        "role": "部件",
+        "label": "眼睛"
+      },
+      {
+        "radical": "八",
+        "role": "部件",
+        "label": "八"
+      }
+    ]
+  },
+  "負": {
+    "formula": "⺈ + 貝",
+    "components": [
+      {
+        "radical": "⺈",
+        "role": "部件",
+        "label": "⺈"
+      },
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      }
+    ]
+  },
+  "財": {
+    "formula": "貝 + 才",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "才",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "貢": {
+    "formula": "工 + 貝",
+    "components": [
+      {
+        "radical": "工",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "貧": {
+    "formula": "分 + 貝",
+    "components": [
+      {
+        "radical": "分",
+        "role": "部件",
+        "label": "分"
+      },
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      }
+    ]
+  },
+  "貨": {
+    "formula": "化 + 貝",
+    "components": [
+      {
+        "radical": "化",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "販": {
+    "formula": "貝 + 反",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "反",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "貪": {
+    "formula": "今 + 貝",
+    "components": [
+      {
+        "radical": "今",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "貫": {
+    "formula": "毌 + 貝",
+    "components": [
+      {
+        "radical": "毌",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "責": {
+    "formula": "龶 + 貝",
+    "components": [
+      {
+        "radical": "龶",
+        "role": "部件",
+        "label": "龶"
+      },
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      }
+    ]
+  },
+  "貸": {
+    "formula": "代 + 貝",
+    "components": [
+      {
+        "radical": "代",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "費": {
+    "formula": "弗 + 貝",
+    "components": [
+      {
+        "radical": "弗",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "貼": {
+    "formula": "貝 + 占",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "占",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "賀": {
+    "formula": "加 + 貝",
+    "components": [
+      {
+        "radical": "加",
+        "role": "部件",
+        "label": "加"
+      },
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      }
+    ]
+  },
+  "賁": {
+    "formula": "卉 + 貝",
+    "components": [
+      {
+        "radical": "卉",
+        "role": "形符",
+        "label": "卉"
+      },
+      {
+        "radical": "貝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "賄": {
+    "formula": "貝 + 有",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      },
+      {
+        "radical": "有",
+        "role": "部件",
+        "label": "有"
+      }
+    ]
+  },
+  "資": {
+    "formula": "次 + 貝",
+    "components": [
+      {
+        "radical": "次",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "賈": {
+    "formula": "覀 + 貝",
+    "components": [
+      {
+        "radical": "覀",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "賊": {
+    "formula": "貝 + 戎",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "戎",
+        "role": "形符",
+        "label": "戎"
+      }
+    ]
+  },
+  "賓": {
+    "formula": "宀 + 小 + 貝",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "部件",
+        "label": "房頂"
+      },
+      {
+        "radical": "小",
+        "role": "部件",
+        "label": "小"
+      },
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      }
+    ]
+  },
+  "賜": {
+    "formula": "貝 + 易",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "易",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "賞": {
+    "formula": "贝 + 尚",
+    "components": [
+      {
+        "radical": "贝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "賣": {
+    "formula": "貝 + 买",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "买",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "賤": {
+    "formula": "貝 + 戔",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      },
+      {
+        "radical": "戔",
+        "role": "部件",
+        "label": "戔"
+      }
+    ]
+  },
+  "賦": {
+    "formula": "貝 + 武",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      },
+      {
+        "radical": "武",
+        "role": "部件",
+        "label": "武"
+      }
+    ]
+  },
+  "質": {
+    "formula": "斦 + 貝",
+    "components": [
+      {
+        "radical": "斦",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "賴": {
+    "formula": "束 + 負",
+    "components": [
+      {
+        "radical": "束",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "負",
+        "role": "形符",
+        "label": "負"
+      }
+    ]
+  },
+  "賺": {
+    "formula": "貝 + 兼",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "兼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "購": {
+    "formula": "貝 + 冓",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "冓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "賽": {
+    "formula": "宀 + 貝",
+    "components": [
+      {
+        "radical": "宀",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "贈": {
+    "formula": "貝 + 曾",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "曾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "贊": {
+    "formula": "兟 + 貝",
+    "components": [
+      {
+        "radical": "兟",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      }
+    ]
+  },
+  "贏": {
+    "formula": "亡 + 口 + 月 + 貝 + 凡",
+    "components": [
+      {
+        "radical": "亡",
+        "role": "部件",
+        "label": "亡"
+      },
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      },
+      {
+        "radical": "貝",
+        "role": "形符",
+        "label": "貝"
+      },
+      {
+        "radical": "凡",
+        "role": "部件",
+        "label": "凡"
+      }
+    ]
+  },
+  "贖": {
+    "formula": "貝 + 賣",
+    "components": [
+      {
+        "radical": "貝",
+        "role": "部件",
+        "label": "貝"
+      },
+      {
+        "radical": "賣",
+        "role": "部件",
+        "label": "賣"
+      }
+    ]
+  },
+  "赫": {
+    "formula": "赤 + 赤",
+    "components": [
+      {
+        "radical": "赤",
+        "role": "部件",
+        "label": "赤"
+      },
+      {
+        "radical": "赤",
+        "role": "部件",
+        "label": "赤"
+      }
+    ]
+  },
+  "走": {
+    "formula": "土 + 止",
+    "components": [
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
+      {
+        "radical": "止",
+        "role": "部件",
+        "label": "止"
+      }
+    ]
+  },
+  "赳": {
+    "formula": "走 + 丩",
+    "components": [
+      {
+        "radical": "走",
+        "role": "形符",
+        "label": "走"
+      },
+      {
+        "radical": "丩",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "起": {
+    "formula": "走 + 己",
+    "components": [
+      {
+        "radical": "走",
+        "role": "形符",
+        "label": "走"
+      },
+      {
+        "radical": "己",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "超": {
+    "formula": "走 + 召",
+    "components": [
+      {
+        "radical": "走",
+        "role": "形符",
+        "label": "走"
+      },
+      {
+        "radical": "召",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "越": {
+    "formula": "走 + 戉",
+    "components": [
+      {
+        "radical": "走",
+        "role": "形符",
+        "label": "走"
+      },
+      {
+        "radical": "戉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "趕": {
+    "formula": "走 + 旱",
+    "components": [
+      {
+        "radical": "走",
+        "role": "形符",
+        "label": "走"
+      },
+      {
+        "radical": "旱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "趟": {
+    "formula": "走 + 尚",
+    "components": [
+      {
+        "radical": "走",
+        "role": "形符",
+        "label": "走"
+      },
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "趣": {
+    "formula": "走 + 取",
+    "components": [
+      {
+        "radical": "走",
+        "role": "形符",
+        "label": "走"
+      },
+      {
+        "radical": "取",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "趨": {
+    "formula": "走 + 芻",
+    "components": [
+      {
+        "radical": "走",
+        "role": "形符",
+        "label": "走"
+      },
+      {
+        "radical": "芻",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "趾": {
+    "formula": "足 + 止",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "止",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "跌": {
+    "formula": "足 + 失",
+    "components": [
+      {
+        "radical": "足",
+        "role": "部件",
+        "label": "足旁"
+      },
+      {
+        "radical": "失",
+        "role": "部件",
+        "label": "失"
+      }
+    ]
+  },
+  "跑": {
+    "formula": "足 + 包",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "距": {
+    "formula": "足 + 巨",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "巨",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "跟": {
+    "formula": "足 + 艮",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "跡": {
+    "formula": "足 + 亦",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "亦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "跤": {
+    "formula": "足 + 交",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "交",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "跨": {
+    "formula": "足 + 夸",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "夸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "跪": {
+    "formula": "足 + 危",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "危",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "路": {
+    "formula": "足 + 各",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "跳": {
+    "formula": "足 + 兆",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "兆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "跺": {
+    "formula": "足 + 朵",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "朵",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "踏": {
+    "formula": "足 + 沓",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "沓",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "踐": {
+    "formula": "足 + 戔",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "戔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "踝": {
+    "formula": "足 + 果",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "果",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "踢": {
+    "formula": "足 + 易",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "易",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "踩": {
+    "formula": "足 + 采",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "采",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "踴": {
+    "formula": "足 + 勇",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "勇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蹂": {
+    "formula": "足 + 柔",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "柔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蹄": {
+    "formula": "足 + 帝",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "帝",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蹈": {
+    "formula": "足 + 舀",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "舀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蹋": {
+    "formula": "足 + 日",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "日",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蹟": {
+    "formula": "足 + 責",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "責",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蹤": {
+    "formula": "足 + 從",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "從",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蹲": {
+    "formula": "足 + 尊",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "尊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "蹶": {
+    "formula": "足 + 厥",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "厥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "躁": {
+    "formula": "足 + 喿",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "喿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "躍": {
+    "formula": "足 + 翟",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "翟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "躪": {
+    "formula": "足 + 藺",
+    "components": [
+      {
+        "radical": "足",
+        "role": "形符",
+        "label": "足旁"
+      },
+      {
+        "radical": "藺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "躲": {
+    "formula": "身 + 朵",
+    "components": [
+      {
+        "radical": "身",
+        "role": "形符",
+        "label": "身體"
+      },
+      {
+        "radical": "朵",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "躺": {
+    "formula": "身 + 尚",
+    "components": [
+      {
+        "radical": "身",
+        "role": "形符",
+        "label": "身體"
+      },
+      {
+        "radical": "尚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "軀": {
+    "formula": "身 + 區",
+    "components": [
+      {
+        "radical": "身",
+        "role": "形符",
+        "label": "身體"
+      },
+      {
+        "radical": "區",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "軍": {
+    "formula": "冖 + 車",
+    "components": [
+      {
+        "radical": "冖",
+        "role": "部件",
+        "label": "冖"
+      },
+      {
+        "radical": "車",
+        "role": "部件",
+        "label": "車"
+      }
+    ]
+  },
+  "軟": {
+    "formula": "車 + 欠",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "欠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "軸": {
+    "formula": "車 + 由",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "由",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "較": {
+    "formula": "車 + 交",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "交",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "載": {
+    "formula": "哉 + 車",
+    "components": [
+      {
+        "radical": "哉",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      }
+    ]
+  },
+  "輔": {
+    "formula": "車 + 甫",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "甫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "輕": {
+    "formula": "車 + 巠",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "巠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "輩": {
+    "formula": "非 + 車",
+    "components": [
+      {
+        "radical": "非",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      }
+    ]
+  },
+  "輪": {
+    "formula": "車 + 侖",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "侖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "輯": {
+    "formula": "車 + 咠",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "咠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "輸": {
+    "formula": "車 + 俞",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "俞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "輻": {
+    "formula": "車 + 畐",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "畐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "輾": {
+    "formula": "車 + 展",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "展",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "輿": {
+    "formula": "舁 + 車",
+    "components": [
+      {
+        "radical": "舁",
+        "role": "部件",
+        "label": "舁"
+      },
+      {
+        "radical": "車",
+        "role": "部件",
+        "label": "車"
+      }
+    ]
+  },
+  "轅": {
+    "formula": "車 + 袁",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "袁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "轉": {
+    "formula": "車 + 專",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "專",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "轍": {
+    "formula": "車 + 徹",
+    "components": [
+      {
+        "radical": "車",
+        "role": "形符",
+        "label": "車"
+      },
+      {
+        "radical": "徹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "轟": {
+    "formula": "車 + 車 + 車",
+    "components": [
+      {
+        "radical": "車",
+        "role": "部件",
+        "label": "車"
+      },
+      {
+        "radical": "車",
+        "role": "部件",
+        "label": "車"
+      },
+      {
+        "radical": "車",
+        "role": "部件",
+        "label": "車"
+      }
+    ]
+  },
+  "辜": {
+    "formula": "古 + 辛",
+    "components": [
+      {
+        "radical": "古",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "辛",
+        "role": "形符",
+        "label": "辛"
+      }
+    ]
+  },
+  "辣": {
+    "formula": "辛 + 束",
+    "components": [
+      {
+        "radical": "辛",
+        "role": "形符",
+        "label": "辛"
+      },
+      {
+        "radical": "束",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "辦": {
+    "formula": "辛 + 力",
+    "components": [
+      {
+        "radical": "辛",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "力",
+        "role": "形符",
+        "label": "力量"
+      }
+    ]
+  },
+  "辨": {
+    "formula": "辛 + 刂 + 辛",
+    "components": [
+      {
+        "radical": "辛",
+        "role": "部件",
+        "label": "辛"
+      },
+      {
+        "radical": "刂",
+        "role": "部件",
+        "label": "刀旁"
+      },
+      {
+        "radical": "辛",
+        "role": "部件",
+        "label": "辛"
+      }
+    ]
+  },
+  "辯": {
+    "formula": "辛 + 言 + 辛",
+    "components": [
+      {
+        "radical": "辛",
+        "role": "部件",
+        "label": "辛"
+      },
+      {
+        "radical": "言",
+        "role": "部件",
+        "label": "說話"
+      },
+      {
+        "radical": "辛",
+        "role": "部件",
+        "label": "辛"
+      }
+    ]
+  },
+  "迅": {
+    "formula": "辶 + 卂",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "卂",
+        "role": "部件",
+        "label": "卂"
+      }
+    ]
+  },
+  "迎": {
+    "formula": "辶 + 卬",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "卬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "近": {
+    "formula": "辶 + 斤",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "斤",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "返": {
+    "formula": "辶 + 反",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "反",
+        "role": "部件",
+        "label": "反"
+      }
+    ]
+  },
+  "迢": {
+    "formula": "辶 + 召",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "召",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "迥": {
+    "formula": "辶 + 冋",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "冋",
+        "role": "部件",
+        "label": "冋"
+      }
+    ]
+  },
+  "迪": {
+    "formula": "辶 + 由",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "由",
+        "role": "部件",
+        "label": "由"
+      }
+    ]
+  },
+  "迫": {
+    "formula": "辶 + 白",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "白",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "迭": {
+    "formula": "辶 + 失",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "失",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "述": {
+    "formula": "辶 + 术",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "术",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "迴": {
+    "formula": "辶 + 回",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "回",
+        "role": "部件",
+        "label": "回"
+      }
+    ]
+  },
+  "迷": {
+    "formula": "辶 + 米",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "米",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "追": {
+    "formula": "辶 + 㠯",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "㠯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "退": {
+    "formula": "辶 + 艮",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "送": {
+    "formula": "辶 + 关",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "关",
+        "role": "部件",
+        "label": "关"
+      }
+    ]
+  },
+  "逃": {
+    "formula": "辶 + 兆",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "兆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "逆": {
+    "formula": "辶 + 屰",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "屰",
+        "role": "部件",
+        "label": "屰"
+      }
+    ]
+  },
+  "透": {
+    "formula": "辶 + 秀",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "秀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "逐": {
+    "formula": "辶 + 豕",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "豕",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "途": {
+    "formula": "辶 + 余",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "余",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "逕": {
+    "formula": "辶 + 巠",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "巠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "逗": {
+    "formula": "辶 + 豆",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "豆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "這": {
+    "formula": "辶 + 言",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "言",
+        "role": "形符",
+        "label": "說話"
+      }
+    ]
+  },
+  "通": {
+    "formula": "辶 + 甬",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "甬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "逝": {
+    "formula": "辶 + 折",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "折",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "速": {
+    "formula": "辶 + 束",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "束",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "造": {
+    "formula": "辶 + 告",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "告",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "逢": {
+    "formula": "辶 + 夆",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "夆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "連": {
+    "formula": "辶 + 車",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "車",
+        "role": "部件",
+        "label": "車"
+      }
+    ]
+  },
+  "週": {
+    "formula": "辶 + 周",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "周",
+        "role": "部件",
+        "label": "周"
+      }
+    ]
+  },
+  "進": {
+    "formula": "辶 + 隹",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "逸": {
+    "formula": "辶 + 兔",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "兔",
+        "role": "部件",
+        "label": "兔"
+      }
+    ]
+  },
+  "逼": {
+    "formula": "辶 + 畐",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "畐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遂": {
+    "formula": "辶 + 豕",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "豕",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遇": {
+    "formula": "辶 + 禺",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "禺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遊": {
+    "formula": "辶 + 斿",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "斿",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "運": {
+    "formula": "辶 + 軍",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "軍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遍": {
+    "formula": "辶 + 扁",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "扁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "過": {
+    "formula": "辶 + 咼",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "咼",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遐": {
+    "formula": "辶 + 叚",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "叚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "道": {
+    "formula": "辶 + 首",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "首",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "達": {
+    "formula": "辶 + 羍",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "羍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "違": {
+    "formula": "辶 + 韋",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "韋",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遙": {
+    "formula": "辶 + 䍃",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "䍃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遜": {
+    "formula": "辶 + 孫",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "孫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遞": {
+    "formula": "辶 + 虒",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "虒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遠": {
+    "formula": "辶 + 袁",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "袁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "適": {
+    "formula": "辶 + 啇",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "啇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遭": {
+    "formula": "辶 + 曹",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "曹",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遮": {
+    "formula": "辶 + 庶",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "庶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遲": {
+    "formula": "辶 + 犀",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "犀",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遵": {
+    "formula": "辶 + 尊",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "尊",
+        "role": "部件",
+        "label": "尊"
+      }
+    ]
+  },
+  "遷": {
+    "formula": "辶 + 䙴",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "䙴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "選": {
+    "formula": "辶 + 巽",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "巽",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "遺": {
+    "formula": "辶 + 貴",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "貴",
+        "role": "部件",
+        "label": "貴"
+      }
+    ]
+  },
+  "遼": {
+    "formula": "辶 + 尞",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "尞",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "避": {
+    "formula": "辶 + 辟",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "辟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "邀": {
+    "formula": "辶 + 敫",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "敫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "邁": {
+    "formula": "辶 + 萬",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "部件",
+        "label": "走旁"
+      },
+      {
+        "radical": "萬",
+        "role": "部件",
+        "label": "萬"
+      }
+    ]
+  },
+  "邇": {
+    "formula": "辶 + 爾",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "爾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "邊": {
+    "formula": "辶 + 臱",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "臱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "邏": {
+    "formula": "辶 + 羅",
+    "components": [
+      {
+        "radical": "辶",
+        "role": "形符",
+        "label": "走旁"
+      },
+      {
+        "radical": "羅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "邑": {
+    "formula": "口 + 巴",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "巴",
+        "role": "部件",
+        "label": "巴"
+      }
+    ]
+  },
+  "那": {
+    "formula": "月 + 邑",
+    "components": [
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      },
+      {
+        "radical": "邑",
+        "role": "部件",
+        "label": "城邑"
+      }
+    ]
+  },
+  "邪": {
+    "formula": "牙 + 邑",
+    "components": [
+      {
+        "radical": "牙",
+        "role": "部件",
+        "label": "牙齒"
+      },
+      {
+        "radical": "邑",
+        "role": "部件",
+        "label": "城邑"
+      }
+    ]
+  },
+  "邸": {
+    "formula": "氐 + 阝",
+    "components": [
+      {
+        "radical": "氐",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "郁": {
+    "formula": "有 + 阝",
+    "components": [
+      {
+        "radical": "有",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "郎": {
+    "formula": "良 + 阝",
+    "components": [
+      {
+        "radical": "良",
+        "role": "部件",
+        "label": "良"
+      },
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "郡": {
+    "formula": "君 + 阝",
+    "components": [
+      {
+        "radical": "君",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "部": {
+    "formula": "咅 + 阝",
+    "components": [
+      {
+        "radical": "咅",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "郭": {
+    "formula": "享 + 阝",
+    "components": [
+      {
+        "radical": "享",
+        "role": "部件",
+        "label": "享"
+      },
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "都": {
+    "formula": "者 + 阝",
+    "components": [
+      {
+        "radical": "者",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "鄉": {
+    "formula": "乡 + 郎",
+    "components": [
+      {
+        "radical": "乡",
+        "role": "部件",
+        "label": "乡"
+      },
+      {
+        "radical": "郎",
+        "role": "部件",
+        "label": "郎"
+      }
+    ]
+  },
+  "鄧": {
+    "formula": "登 + 阝",
+    "components": [
+      {
+        "radical": "登",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "鄰": {
+    "formula": "粦 + 阝",
+    "components": [
+      {
+        "radical": "粦",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      }
+    ]
+  },
+  "酌": {
+    "formula": "酉 + 勺",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "勺",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "配": {
+    "formula": "酉 + 己",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "己",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "酒": {
+    "formula": "氵 + 酉",
+    "components": [
+      {
+        "radical": "氵",
+        "role": "部件",
+        "label": "水旁"
+      },
+      {
+        "radical": "酉",
+        "role": "部件",
+        "label": "酉"
+      }
+    ]
+  },
+  "酗": {
+    "formula": "酉 + 凶",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "部件",
+        "label": "酉"
+      },
+      {
+        "radical": "凶",
+        "role": "部件",
+        "label": "凶"
+      }
+    ]
+  },
+  "酪": {
+    "formula": "酉 + 各",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "酬": {
+    "formula": "酉 + 州",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "州",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "酷": {
+    "formula": "酉 + 告",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "告",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "酸": {
+    "formula": "酉 + 夋",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "部件",
+        "label": "酉"
+      },
+      {
+        "radical": "夋",
+        "role": "部件",
+        "label": "夋"
+      }
+    ]
+  },
+  "醉": {
+    "formula": "酉 + 卒",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "卒",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "醍": {
+    "formula": "酉 + 是",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "是",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "醐": {
+    "formula": "酉 + 胡",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "胡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "醒": {
+    "formula": "酉 + 星",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "星",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "醜": {
+    "formula": "酉 + 鬼",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鬼",
+        "role": "形符",
+        "label": "鬼"
+      }
+    ]
+  },
+  "醫": {
+    "formula": "殹 + 酉",
+    "components": [
+      {
+        "radical": "殹",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      }
+    ]
+  },
+  "醬": {
+    "formula": "將 + 酉",
+    "components": [
+      {
+        "radical": "將",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      }
+    ]
+  },
+  "醺": {
+    "formula": "酉 + 熏",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "熏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "釀": {
+    "formula": "酉 + 襄",
+    "components": [
+      {
+        "radical": "酉",
+        "role": "形符",
+        "label": "酉"
+      },
+      {
+        "radical": "襄",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "采": {
+    "formula": "爫 + 木",
+    "components": [
+      {
+        "radical": "爫",
+        "role": "部件",
+        "label": "爫"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "釋": {
+    "formula": "釆 + 睪",
+    "components": [
+      {
+        "radical": "釆",
+        "role": "形符",
+        "label": "釆"
+      },
+      {
+        "radical": "睪",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "里": {
+    "formula": "田 + 土",
+    "components": [
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      }
+    ]
+  },
+  "重": {
+    "formula": "千 + 里",
+    "components": [
+      {
+        "radical": "千",
+        "role": "部件",
+        "label": "千"
+      },
+      {
+        "radical": "里",
+        "role": "部件",
+        "label": "里"
+      }
+    ]
+  },
+  "野": {
+    "formula": "里 + 予",
+    "components": [
+      {
+        "radical": "里",
+        "role": "形符",
+        "label": "里"
+      },
+      {
+        "radical": "予",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "量": {
+    "formula": "旦 + 里",
+    "components": [
+      {
+        "radical": "旦",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "里",
+        "role": "形符",
+        "label": "里"
+      }
+    ]
+  },
+  "釘": {
+    "formula": "釒 + 丁",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "丁",
+        "role": "部件",
+        "label": "丁"
+      }
+    ]
+  },
+  "針": {
+    "formula": "釒 + 十",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "十",
+        "role": "部件",
+        "label": "十"
+      }
+    ]
+  },
+  "釣": {
+    "formula": "釒 + 勺",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "勺",
+        "role": "部件",
+        "label": "勺"
+      }
+    ]
+  },
+  "鈍": {
+    "formula": "釒 + 屯",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "屯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鈎": {
+    "formula": "釒 + 勾",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "勾",
+        "role": "部件",
+        "label": "勾"
+      }
+    ]
+  },
+  "鈣": {
+    "formula": "釒 + 丐",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "丐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鈴": {
+    "formula": "釒 + 令",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "令",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鈺": {
+    "formula": "釒 + 玉",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "玉",
+        "role": "部件",
+        "label": "玉"
+      }
+    ]
+  },
+  "鉅": {
+    "formula": "釒 + 巨",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "巨",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鉛": {
+    "formula": "釒 + 几",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "几",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鉤": {
+    "formula": "釒 + 句",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "句",
+        "role": "部件",
+        "label": "句"
+      }
+    ]
+  },
+  "銀": {
+    "formula": "釒 + 艮",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "銅": {
+    "formula": "釒 + 同",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "同",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "銳": {
+    "formula": "釒 + 兌",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "兌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "銷": {
+    "formula": "釒 + 肖",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "肖",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鋁": {
+    "formula": "釒 + 吕",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "吕",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鋒": {
+    "formula": "釒 + 夆",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "夆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鋪": {
+    "formula": "釒 + 甫",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "甫",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "錄": {
+    "formula": "釒 + 彔",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "彔",
+        "role": "部件",
+        "label": "彔"
+      }
+    ]
+  },
+  "錘": {
+    "formula": "釒 + 垂",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "垂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "錢": {
+    "formula": "釒 + 戔",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "戔",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "錦": {
+    "formula": "釒 + 帛",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "帛",
+        "role": "部件",
+        "label": "帛"
+      }
+    ]
+  },
+  "錯": {
+    "formula": "釒 + 昔",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "昔",
+        "role": "部件",
+        "label": "昔"
+      }
+    ]
+  },
+  "鍊": {
+    "formula": "釒 + 柬",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "柬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鍛": {
+    "formula": "釒 + 段",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "段",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鍥": {
+    "formula": "釒 + 契",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "契",
+        "role": "部件",
+        "label": "契"
+      }
+    ]
+  },
+  "鍵": {
+    "formula": "釒 + 建",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "建",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鎖": {
+    "formula": "釒 + ⺌",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "⺌",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鎮": {
+    "formula": "釒 + 真",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "真",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鏈": {
+    "formula": "釒 + 連",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "部件",
+        "label": "釒"
+      },
+      {
+        "radical": "連",
+        "role": "部件",
+        "label": "連"
+      }
+    ]
+  },
+  "鏟": {
+    "formula": "釒 + 産",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "産",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鏡": {
+    "formula": "釒 + 竟",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "竟",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鐘": {
+    "formula": "釒 + 童",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "童",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鐮": {
+    "formula": "釒 + 廉",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "廉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鐵": {
+    "formula": "釒 + 戜",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "戜",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鑑": {
+    "formula": "釒 + 監",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "監",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鑼": {
+    "formula": "釒 + 羅",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "羅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鑽": {
+    "formula": "釒 + 贊",
+    "components": [
+      {
+        "radical": "釒",
+        "role": "形符",
+        "label": "釒"
+      },
+      {
+        "radical": "贊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "閃": {
+    "formula": "門 + 人",
+    "components": [
+      {
+        "radical": "門",
+        "role": "部件",
+        "label": "門"
+      },
+      {
+        "radical": "人",
+        "role": "部件",
+        "label": "人"
+      }
+    ]
+  },
+  "閉": {
+    "formula": "門 + 才",
+    "components": [
+      {
+        "radical": "門",
+        "role": "部件",
+        "label": "門"
+      },
+      {
+        "radical": "才",
+        "role": "部件",
+        "label": "才"
+      }
+    ]
+  },
+  "開": {
+    "formula": "門 + 开",
+    "components": [
+      {
+        "radical": "門",
+        "role": "形符",
+        "label": "門"
+      },
+      {
+        "radical": "开",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "閑": {
+    "formula": "門 + 木",
+    "components": [
+      {
+        "radical": "門",
+        "role": "部件",
+        "label": "門"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "閒": {
+    "formula": "門 + 月",
+    "components": [
+      {
+        "radical": "門",
+        "role": "部件",
+        "label": "門"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      }
+    ]
+  },
+  "間": {
+    "formula": "門 + 日",
+    "components": [
+      {
+        "radical": "門",
+        "role": "部件",
+        "label": "門"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "閣": {
+    "formula": "門 + 各",
+    "components": [
+      {
+        "radical": "門",
+        "role": "形符",
+        "label": "門"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "閩": {
+    "formula": "門 + 虫",
+    "components": [
+      {
+        "radical": "門",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "虫",
+        "role": "形符",
+        "label": "蟲"
+      }
+    ]
+  },
+  "闆": {
+    "formula": "門 + 品",
+    "components": [
+      {
+        "radical": "門",
+        "role": "部件",
+        "label": "門"
+      },
+      {
+        "radical": "品",
+        "role": "部件",
+        "label": "品"
+      }
+    ]
+  },
+  "闊": {
+    "formula": "門 + 活",
+    "components": [
+      {
+        "radical": "門",
+        "role": "形符",
+        "label": "門"
+      },
+      {
+        "radical": "活",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "關": {
+    "formula": "門 + 丱",
+    "components": [
+      {
+        "radical": "門",
+        "role": "形符",
+        "label": "門"
+      },
+      {
+        "radical": "丱",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "阱": {
+    "formula": "阝 + 井",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "井",
+        "role": "部件",
+        "label": "井"
+      }
+    ]
+  },
+  "防": {
+    "formula": "阝 + 方",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "方",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "阻": {
+    "formula": "阝 + 且",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "且",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "阿": {
+    "formula": "阝 + 可",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "可",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "附": {
+    "formula": "阝 + 付",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "付",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "际": {
+    "formula": "阝 + 示",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "示",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "陌": {
+    "formula": "阝 + 百",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "百",
+        "role": "部件",
+        "label": "百"
+      }
+    ]
+  },
+  "降": {
+    "formula": "阝 + 夅",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "夅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "限": {
+    "formula": "阝 + 艮",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "艮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "陡": {
+    "formula": "阝 + 走",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "走",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "院": {
+    "formula": "阝 + 完",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "完",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "陣": {
+    "formula": "阝 + 車",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "車",
+        "role": "部件",
+        "label": "車"
+      }
+    ]
+  },
+  "除": {
+    "formula": "阝 + 余",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "余",
+        "role": "部件",
+        "label": "余"
+      }
+    ]
+  },
+  "陪": {
+    "formula": "阝 + 咅",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "咅",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "陰": {
+    "formula": "阝 + 侌",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "侌",
+        "role": "部件",
+        "label": "侌"
+      }
+    ]
+  },
+  "陳": {
+    "formula": "阝 + 東",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "東",
+        "role": "部件",
+        "label": "東"
+      }
+    ]
+  },
+  "陷": {
+    "formula": "阝 + 臽",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "臽",
+        "role": "部件",
+        "label": "臽"
+      }
+    ]
+  },
+  "陸": {
+    "formula": "阝 + 坴",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "坴",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "陽": {
+    "formula": "阝 + 昜",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "昜",
+        "role": "部件",
+        "label": "昜"
+      }
+    ]
+  },
+  "隊": {
+    "formula": "阝 + 㒸",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "㒸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "階": {
+    "formula": "阝 + 皆",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "皆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "隔": {
+    "formula": "阝 + 鬲",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "鬲",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "際": {
+    "formula": "阝 + 祭",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "祭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "障": {
+    "formula": "阝 + 章",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "章",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "隧": {
+    "formula": "阝 + 遂",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "遂",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "隨": {
+    "formula": "阝 + 遀",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "遀",
+        "role": "部件",
+        "label": "遀"
+      }
+    ]
+  },
+  "險": {
+    "formula": "阝 + 僉",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "形符",
+        "label": "耳旁"
+      },
+      {
+        "radical": "僉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "隱": {
+    "formula": "阝 + 㥯",
+    "components": [
+      {
+        "radical": "阝",
+        "role": "部件",
+        "label": "耳旁"
+      },
+      {
+        "radical": "㥯",
+        "role": "部件",
+        "label": "㥯"
+      }
+    ]
+  },
+  "隸": {
+    "formula": "柰 + 隶",
+    "components": [
+      {
+        "radical": "柰",
+        "role": "形符",
+        "label": "柰"
+      },
+      {
+        "radical": "隶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "隻": {
+    "formula": "隹 + 又",
+    "components": [
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "又",
+        "role": "形符",
+        "label": "又"
+      }
+    ]
+  },
+  "雀": {
+    "formula": "小 + 隹",
+    "components": [
+      {
+        "radical": "小",
+        "role": "部件",
+        "label": "小"
+      },
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      }
+    ]
+  },
+  "雄": {
+    "formula": "厷 + 隹",
+    "components": [
+      {
+        "radical": "厷",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "隹",
+        "role": "形符",
+        "label": "隹"
+      }
+    ]
+  },
+  "雅": {
+    "formula": "牙 + 隹",
+    "components": [
+      {
+        "radical": "牙",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "隹",
+        "role": "形符",
+        "label": "隹"
+      }
+    ]
+  },
+  "集": {
+    "formula": "隹 + 木",
+    "components": [
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      }
+    ]
+  },
+  "雇": {
+    "formula": "户 + 隹",
+    "components": [
+      {
+        "radical": "户",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "隹",
+        "role": "形符",
+        "label": "隹"
+      }
+    ]
+  },
+  "雌": {
+    "formula": "此 + 隹",
+    "components": [
+      {
+        "radical": "此",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "隹",
+        "role": "形符",
+        "label": "隹"
+      }
+    ]
+  },
+  "雕": {
+    "formula": "周 + 隹",
+    "components": [
+      {
+        "radical": "周",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "隹",
+        "role": "形符",
+        "label": "隹"
+      }
+    ]
+  },
+  "雙": {
+    "formula": "雔 + 又",
+    "components": [
+      {
+        "radical": "雔",
+        "role": "部件",
+        "label": "雔"
+      },
+      {
+        "radical": "又",
+        "role": "部件",
+        "label": "又"
+      }
+    ]
+  },
+  "雛": {
+    "formula": "芻 + 隹",
+    "components": [
+      {
+        "radical": "芻",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "隹",
+        "role": "形符",
+        "label": "隹"
+      }
+    ]
+  },
+  "雜": {
+    "formula": "九 + 木 + 隹",
+    "components": [
+      {
+        "radical": "九",
+        "role": "部件",
+        "label": "九"
+      },
+      {
+        "radical": "木",
+        "role": "部件",
+        "label": "木"
+      },
+      {
+        "radical": "隹",
+        "role": "聲符",
+        "label": "短尾鳥"
+      }
+    ]
+  },
+  "雞": {
+    "formula": "奚 + 隹",
+    "components": [
+      {
+        "radical": "奚",
+        "role": "部件",
+        "label": "奚"
+      },
+      {
+        "radical": "隹",
+        "role": "部件",
+        "label": "隹"
+      }
+    ]
+  },
+  "離": {
+    "formula": "离 + 隹",
+    "components": [
+      {
+        "radical": "离",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "隹",
+        "role": "形符",
+        "label": "隹"
+      }
+    ]
+  },
+  "難": {
+    "formula": "堇 + 隹",
+    "components": [
+      {
+        "radical": "堇",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "隹",
+        "role": "形符",
+        "label": "隹"
+      }
+    ]
+  },
+  "雪": {
+    "formula": "雨 + 彐",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "彐",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "雲": {
+    "formula": "雨 + 云",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "部件",
+        "label": "雨"
+      },
+      {
+        "radical": "云",
+        "role": "部件",
+        "label": "云"
+      }
+    ]
+  },
+  "零": {
+    "formula": "雨 + 令",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "令",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "雷": {
+    "formula": "雨 + 田",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "部件",
+        "label": "雨"
+      },
+      {
+        "radical": "田",
+        "role": "部件",
+        "label": "田地"
+      }
+    ]
+  },
+  "雹": {
+    "formula": "雨 + 包",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "電": {
+    "formula": "雨 + 电",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "部件",
+        "label": "雨"
+      },
+      {
+        "radical": "电",
+        "role": "部件",
+        "label": "电"
+      }
+    ]
+  },
+  "需": {
+    "formula": "雨 + 而",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "部件",
+        "label": "雨"
+      },
+      {
+        "radical": "而",
+        "role": "部件",
+        "label": "而"
+      }
+    ]
+  },
+  "霄": {
+    "formula": "雨 + 肖",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "部件",
+        "label": "雨"
+      },
+      {
+        "radical": "肖",
+        "role": "部件",
+        "label": "肖"
+      }
+    ]
+  },
+  "霆": {
+    "formula": "雨 + 廷",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "廷",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "震": {
+    "formula": "雨 + 辰",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "辰",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "霜": {
+    "formula": "雨 + 相",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "相",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "霧": {
+    "formula": "雨 + 務",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "務",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "露": {
+    "formula": "雨 + 路",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "路",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "霸": {
+    "formula": "雨 + 革 + 月",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "革",
+        "role": "部件",
+        "label": "皮革"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      }
+    ]
+  },
+  "霾": {
+    "formula": "雨 + 貍",
+    "components": [
+      {
+        "radical": "雨",
+        "role": "形符",
+        "label": "雨"
+      },
+      {
+        "radical": "貍",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "青": {
+    "formula": "丰 + 月",
+    "components": [
+      {
+        "radical": "丰",
+        "role": "部件",
+        "label": "丰"
+      },
+      {
+        "radical": "月",
+        "role": "部件",
+        "label": "月亮"
+      }
+    ]
+  },
+  "靜": {
+    "formula": "青 + 爭",
+    "components": [
+      {
+        "radical": "青",
+        "role": "形符",
+        "label": "青"
+      },
+      {
+        "radical": "爭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "靠": {
+    "formula": "告 + 非",
+    "components": [
+      {
+        "radical": "告",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "非",
+        "role": "形符",
+        "label": "非"
+      }
+    ]
+  },
+  "鞋": {
+    "formula": "革 + 圭",
+    "components": [
+      {
+        "radical": "革",
+        "role": "形符",
+        "label": "皮革"
+      },
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鞍": {
+    "formula": "革 + 安",
+    "components": [
+      {
+        "radical": "革",
+        "role": "形符",
+        "label": "皮革"
+      },
+      {
+        "radical": "安",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鞏": {
+    "formula": "巩 + 革",
+    "components": [
+      {
+        "radical": "巩",
+        "role": "部件",
+        "label": "巩"
+      },
+      {
+        "radical": "革",
+        "role": "部件",
+        "label": "皮革"
+      }
+    ]
+  },
+  "鞭": {
+    "formula": "革 + 便",
+    "components": [
+      {
+        "radical": "革",
+        "role": "形符",
+        "label": "皮革"
+      },
+      {
+        "radical": "便",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "韌": {
+    "formula": "韋 + 刃",
+    "components": [
+      {
+        "radical": "韋",
+        "role": "形符",
+        "label": "韋"
+      },
+      {
+        "radical": "刃",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "音": {
+    "formula": "立 + 日",
+    "components": [
+      {
+        "radical": "立",
+        "role": "部件",
+        "label": "立"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "韻": {
+    "formula": "音 + 員",
+    "components": [
+      {
+        "radical": "音",
+        "role": "部件",
+        "label": "音"
+      },
+      {
+        "radical": "員",
+        "role": "部件",
+        "label": "員"
+      }
+    ]
+  },
+  "響": {
+    "formula": "鄉 + 音",
+    "components": [
+      {
+        "radical": "鄉",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "音",
+        "role": "形符",
+        "label": "音"
+      }
+    ]
+  },
+  "頂": {
+    "formula": "丁 + 頁",
+    "components": [
+      {
+        "radical": "丁",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "項": {
+    "formula": "工 + 頁",
+    "components": [
+      {
+        "radical": "工",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "順": {
+    "formula": "川 + 頁",
+    "components": [
+      {
+        "radical": "川",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "須": {
+    "formula": "彡 + 頁",
+    "components": [
+      {
+        "radical": "彡",
+        "role": "部件",
+        "label": "彡"
+      },
+      {
+        "radical": "頁",
+        "role": "部件",
+        "label": "頭部"
+      }
+    ]
+  },
+  "預": {
+    "formula": "予 + 頁",
+    "components": [
+      {
+        "radical": "予",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "頑": {
+    "formula": "元 + 頁",
+    "components": [
+      {
+        "radical": "元",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "頓": {
+    "formula": "屯 + 頁",
+    "components": [
+      {
+        "radical": "屯",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "頗": {
+    "formula": "皮 + 頁",
+    "components": [
+      {
+        "radical": "皮",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "領": {
+    "formula": "令 + 頁",
+    "components": [
+      {
+        "radical": "令",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "頡": {
+    "formula": "吉 + 頁",
+    "components": [
+      {
+        "radical": "吉",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "頭": {
+    "formula": "豆 + 頁",
+    "components": [
+      {
+        "radical": "豆",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "頸": {
+    "formula": "巠 + 頁",
+    "components": [
+      {
+        "radical": "巠",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "顆": {
+    "formula": "果 + 頁",
+    "components": [
+      {
+        "radical": "果",
+        "role": "形符",
+        "label": "果"
+      },
+      {
+        "radical": "頁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "題": {
+    "formula": "是 + 頁",
+    "components": [
+      {
+        "radical": "是",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "額": {
+    "formula": "客 + 頁",
+    "components": [
+      {
+        "radical": "客",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "顏": {
+    "formula": "彥 + 頁",
+    "components": [
+      {
+        "radical": "彥",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "願": {
+    "formula": "原 + 頁",
+    "components": [
+      {
+        "radical": "原",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "顛": {
+    "formula": "真 + 頁",
+    "components": [
+      {
+        "radical": "真",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "顧": {
+    "formula": "雇 + 頁",
+    "components": [
+      {
+        "radical": "雇",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "顯": {
+    "formula": "㬎 + 頁",
+    "components": [
+      {
+        "radical": "㬎",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "頁",
+        "role": "形符",
+        "label": "頭部"
+      }
+    ]
+  },
+  "颱": {
+    "formula": "風 + 台",
+    "components": [
+      {
+        "radical": "風",
+        "role": "部件",
+        "label": "風"
+      },
+      {
+        "radical": "台",
+        "role": "部件",
+        "label": "台"
+      }
+    ]
+  },
+  "飄": {
+    "formula": "票 + 風",
+    "components": [
+      {
+        "radical": "票",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "風",
+        "role": "形符",
+        "label": "風"
+      }
+    ]
+  },
+  "飆": {
+    "formula": "猋 + 風",
+    "components": [
+      {
+        "radical": "猋",
+        "role": "部件",
+        "label": "猋"
+      },
+      {
+        "radical": "風",
+        "role": "部件",
+        "label": "風"
+      }
+    ]
+  },
+  "飛": {
+    "formula": "飞 + 飞",
+    "components": [
+      {
+        "radical": "飞",
+        "role": "部件",
+        "label": "飞"
+      },
+      {
+        "radical": "飞",
+        "role": "部件",
+        "label": "飞"
+      }
+    ]
+  },
+  "飢": {
+    "formula": "飠 + 几",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "几",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "飯": {
+    "formula": "飠 + 反",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "反",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "飲": {
+    "formula": "飠 + 欠",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "欠",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "飽": {
+    "formula": "飠 + 包",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "飾": {
+    "formula": "飠 + 巾",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "巾",
+        "role": "形符",
+        "label": "巾"
+      }
+    ]
+  },
+  "餅": {
+    "formula": "飠 + 并",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "并",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "養": {
+    "formula": "羊 + 食",
+    "components": [
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "食",
+        "role": "形符",
+        "label": "食"
+      }
+    ]
+  },
+  "餌": {
+    "formula": "飠 + 耳",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "耳",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "餒": {
+    "formula": "飠 + 妥",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "妥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "餓": {
+    "formula": "飠 + 我",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "部件",
+        "label": "飠"
+      },
+      {
+        "radical": "我",
+        "role": "部件",
+        "label": "我"
+      }
+    ]
+  },
+  "餘": {
+    "formula": "飠 + 余",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "部件",
+        "label": "飠"
+      },
+      {
+        "radical": "余",
+        "role": "部件",
+        "label": "余"
+      }
+    ]
+  },
+  "館": {
+    "formula": "飠 + 官",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "部件",
+        "label": "飠"
+      },
+      {
+        "radical": "官",
+        "role": "部件",
+        "label": "官"
+      }
+    ]
+  },
+  "餵": {
+    "formula": "飠 + 畏",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "畏",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "饋": {
+    "formula": "飠 + 貴",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "部件",
+        "label": "飠"
+      },
+      {
+        "radical": "貴",
+        "role": "部件",
+        "label": "貴"
+      }
+    ]
+  },
+  "饑": {
+    "formula": "飠 + 幾",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "幾",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "饒": {
+    "formula": "飠 + 堯",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "堯",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "饞": {
+    "formula": "飠 + 毚",
+    "components": [
+      {
+        "radical": "飠",
+        "role": "形符",
+        "label": "飠"
+      },
+      {
+        "radical": "毚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "首": {
+    "formula": "丷 + 自",
+    "components": [
+      {
+        "radical": "丷",
+        "role": "部件",
+        "label": "丷"
+      },
+      {
+        "radical": "自",
+        "role": "部件",
+        "label": "自己"
+      }
+    ]
+  },
+  "香": {
+    "formula": "禾 + 日",
+    "components": [
+      {
+        "radical": "禾",
+        "role": "部件",
+        "label": "穀物"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "馳": {
+    "formula": "馬 + 也",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "也",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "駕": {
+    "formula": "加 + 馬",
+    "components": [
+      {
+        "radical": "加",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      }
+    ]
+  },
+  "駛": {
+    "formula": "馬 + 史",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "史",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "駝": {
+    "formula": "馬 + 它",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "它",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "騎": {
+    "formula": "馬 + 奇",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "奇",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "騙": {
+    "formula": "馬 + 扁",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "扁",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "騰": {
+    "formula": "朕 + 馬",
+    "components": [
+      {
+        "radical": "朕",
+        "role": "部件",
+        "label": "朕"
+      },
+      {
+        "radical": "馬",
+        "role": "部件",
+        "label": "馬"
+      }
+    ]
+  },
+  "騷": {
+    "formula": "馬 + 蚤",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "部件",
+        "label": "馬"
+      },
+      {
+        "radical": "蚤",
+        "role": "部件",
+        "label": "蚤"
+      }
+    ]
+  },
+  "驅": {
+    "formula": "馬 + 區",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "區",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "驕": {
+    "formula": "馬 + 喬",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "部件",
+        "label": "馬"
+      },
+      {
+        "radical": "喬",
+        "role": "部件",
+        "label": "喬"
+      }
+    ]
+  },
+  "驗": {
+    "formula": "馬 + 僉",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "僉",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "驚": {
+    "formula": "敬 + 馬",
+    "components": [
+      {
+        "radical": "敬",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      }
+    ]
+  },
+  "驟": {
+    "formula": "馬 + 聚",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "聚",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "驢": {
+    "formula": "馬 + 盧",
+    "components": [
+      {
+        "radical": "馬",
+        "role": "形符",
+        "label": "馬"
+      },
+      {
+        "radical": "盧",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "骸": {
+    "formula": "骨 + 亥",
+    "components": [
+      {
+        "radical": "骨",
+        "role": "形符",
+        "label": "骨頭"
+      },
+      {
+        "radical": "亥",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "骼": {
+    "formula": "骨 + 各",
+    "components": [
+      {
+        "radical": "骨",
+        "role": "形符",
+        "label": "骨頭"
+      },
+      {
+        "radical": "各",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "髒": {
+    "formula": "骨 + 葬",
+    "components": [
+      {
+        "radical": "骨",
+        "role": "形符",
+        "label": "骨頭"
+      },
+      {
+        "radical": "葬",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "體": {
+    "formula": "骨 + 豊",
+    "components": [
+      {
+        "radical": "骨",
+        "role": "形符",
+        "label": "骨頭"
+      },
+      {
+        "radical": "豊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "髮": {
+    "formula": "髟 + 犮",
+    "components": [
+      {
+        "radical": "髟",
+        "role": "形符",
+        "label": "髟"
+      },
+      {
+        "radical": "犮",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鬆": {
+    "formula": "木 + 公",
+    "components": [
+      {
+        "radical": "木",
+        "role": "形符",
+        "label": "木"
+      },
+      {
+        "radical": "公",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鬚": {
+    "formula": "髟 + 須",
+    "components": [
+      {
+        "radical": "髟",
+        "role": "形符",
+        "label": "髟"
+      },
+      {
+        "radical": "須",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鬥": {
+    "formula": "丨 + 亅 + 王 + 王",
+    "components": [
+      {
+        "radical": "丨",
+        "role": "部件",
+        "label": "丨"
+      },
+      {
+        "radical": "亅",
+        "role": "部件",
+        "label": "亅"
+      },
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      },
+      {
+        "radical": "王",
+        "role": "部件",
+        "label": "王旁"
+      }
+    ]
+  },
+  "鬧": {
+    "formula": "鬥 + 市",
+    "components": [
+      {
+        "radical": "鬥",
+        "role": "部件",
+        "label": "鬥"
+      },
+      {
+        "radical": "市",
+        "role": "部件",
+        "label": "市"
+      }
+    ]
+  },
+  "鬱": {
+    "formula": "林 + 缶",
+    "components": [
+      {
+        "radical": "林",
+        "role": "形符",
+        "label": "樹林"
+      },
+      {
+        "radical": "缶",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "魁": {
+    "formula": "鬼 + 斗",
+    "components": [
+      {
+        "radical": "鬼",
+        "role": "部件",
+        "label": "鬼"
+      },
+      {
+        "radical": "斗",
+        "role": "部件",
+        "label": "斗"
+      }
+    ]
+  },
+  "魂": {
+    "formula": "云 + 鬼",
+    "components": [
+      {
+        "radical": "云",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鬼",
+        "role": "形符",
+        "label": "鬼"
+      }
+    ]
+  },
+  "魄": {
+    "formula": "白 + 鬼",
+    "components": [
+      {
+        "radical": "白",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鬼",
+        "role": "形符",
+        "label": "鬼"
+      }
+    ]
+  },
+  "魅": {
+    "formula": "鬼 + 未",
+    "components": [
+      {
+        "radical": "鬼",
+        "role": "部件",
+        "label": "鬼"
+      },
+      {
+        "radical": "未",
+        "role": "部件",
+        "label": "未"
+      }
+    ]
+  },
+  "魔": {
+    "formula": "麻 + 鬼",
+    "components": [
+      {
+        "radical": "麻",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鬼",
+        "role": "形符",
+        "label": "鬼"
+      }
+    ]
+  },
+  "魯": {
+    "formula": "魚 + 日",
+    "components": [
+      {
+        "radical": "魚",
+        "role": "部件",
+        "label": "魚"
+      },
+      {
+        "radical": "日",
+        "role": "部件",
+        "label": "太陽"
+      }
+    ]
+  },
+  "鮑": {
+    "formula": "魚 + 包",
+    "components": [
+      {
+        "radical": "魚",
+        "role": "形符",
+        "label": "魚"
+      },
+      {
+        "radical": "包",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鮭": {
+    "formula": "魚 + 圭",
+    "components": [
+      {
+        "radical": "魚",
+        "role": "形符",
+        "label": "魚"
+      },
+      {
+        "radical": "圭",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鮮": {
+    "formula": "魚 + 羊",
+    "components": [
+      {
+        "radical": "魚",
+        "role": "形符",
+        "label": "魚"
+      },
+      {
+        "radical": "羊",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鯊": {
+    "formula": "沙 + 魚",
+    "components": [
+      {
+        "radical": "沙",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "魚",
+        "role": "形符",
+        "label": "魚"
+      }
+    ]
+  },
+  "鯨": {
+    "formula": "魚 + 京",
+    "components": [
+      {
+        "radical": "魚",
+        "role": "形符",
+        "label": "魚"
+      },
+      {
+        "radical": "京",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鰭": {
+    "formula": "魚 + 耆",
+    "components": [
+      {
+        "radical": "魚",
+        "role": "形符",
+        "label": "魚"
+      },
+      {
+        "radical": "耆",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鳳": {
+    "formula": "鳥 + 凡",
+    "components": [
+      {
+        "radical": "鳥",
+        "role": "形符",
+        "label": "鳥類"
+      },
+      {
+        "radical": "凡",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鳴": {
+    "formula": "口 + 鳥",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "鳥",
+        "role": "部件",
+        "label": "鳥類"
+      }
+    ]
+  },
+  "鴉": {
+    "formula": "牙 + 鳥",
+    "components": [
+      {
+        "radical": "牙",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鳥",
+        "role": "形符",
+        "label": "鳥類"
+      }
+    ]
+  },
+  "鴕": {
+    "formula": "鳥 + 它",
+    "components": [
+      {
+        "radical": "鳥",
+        "role": "形符",
+        "label": "鳥類"
+      },
+      {
+        "radical": "它",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鴨": {
+    "formula": "甲 + 鳥",
+    "components": [
+      {
+        "radical": "甲",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鳥",
+        "role": "形符",
+        "label": "鳥類"
+      }
+    ]
+  },
+  "鴿": {
+    "formula": "合 + 鳥",
+    "components": [
+      {
+        "radical": "合",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鳥",
+        "role": "形符",
+        "label": "鳥類"
+      }
+    ]
+  },
+  "鵒": {
+    "formula": "谷 + 鳥",
+    "components": [
+      {
+        "radical": "谷",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鳥",
+        "role": "形符",
+        "label": "鳥類"
+      }
+    ]
+  },
+  "鷲": {
+    "formula": "就 + 鳥",
+    "components": [
+      {
+        "radical": "就",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鳥",
+        "role": "形符",
+        "label": "鳥類"
+      }
+    ]
+  },
+  "鷹": {
+    "formula": "䧹 + 鳥",
+    "components": [
+      {
+        "radical": "䧹",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "鳥",
+        "role": "形符",
+        "label": "鳥類"
+      }
+    ]
+  },
+  "鹹": {
+    "formula": "鹵 + 咸",
+    "components": [
+      {
+        "radical": "鹵",
+        "role": "形符",
+        "label": "鹵"
+      },
+      {
+        "radical": "咸",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "麗": {
+    "formula": "丽 + 鹿",
+    "components": [
+      {
+        "radical": "丽",
+        "role": "部件",
+        "label": "丽"
+      },
+      {
+        "radical": "鹿",
+        "role": "部件",
+        "label": "鹿"
+      }
+    ]
+  },
+  "麟": {
+    "formula": "鹿 + 粦",
+    "components": [
+      {
+        "radical": "鹿",
+        "role": "形符",
+        "label": "鹿"
+      },
+      {
+        "radical": "粦",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "麥": {
+    "formula": "來 + 夂",
+    "components": [
+      {
+        "radical": "來",
+        "role": "部件",
+        "label": "來"
+      },
+      {
+        "radical": "夂",
+        "role": "部件",
+        "label": "夂"
+      }
+    ]
+  },
+  "麵": {
+    "formula": "麥 + 面",
+    "components": [
+      {
+        "radical": "麥",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "面",
+        "role": "形符",
+        "label": "面"
+      }
+    ]
+  },
+  "麻": {
+    "formula": "广 + 林",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "林",
+        "role": "部件",
+        "label": "樹林"
+      }
+    ]
+  },
+  "麼": {
+    "formula": "麻 + 幺",
+    "components": [
+      {
+        "radical": "麻",
+        "role": "聲符",
+        "label": "讀音"
+      },
+      {
+        "radical": "幺",
+        "role": "形符",
+        "label": "幺"
+      }
+    ]
+  },
+  "黎": {
+    "formula": "黍 + 勹 + 丿",
+    "components": [
+      {
+        "radical": "黍",
+        "role": "部件",
+        "label": "黍"
+      },
+      {
+        "radical": "勹",
+        "role": "部件",
+        "label": "勹"
+      },
+      {
+        "radical": "丿",
+        "role": "部件",
+        "label": "丿"
+      }
+    ]
+  },
+  "黏": {
+    "formula": "黍 + 占",
+    "components": [
+      {
+        "radical": "黍",
+        "role": "形符",
+        "label": "黍"
+      },
+      {
+        "radical": "占",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "黑": {
+    "formula": "口 + 土 + 灬",
+    "components": [
+      {
+        "radical": "口",
+        "role": "部件",
+        "label": "口"
+      },
+      {
+        "radical": "土",
+        "role": "部件",
+        "label": "土"
+      },
+      {
+        "radical": "灬",
+        "role": "部件",
+        "label": "火底"
+      }
+    ]
+  },
+  "點": {
+    "formula": "黑 + 占",
+    "components": [
+      {
+        "radical": "黑",
+        "role": "形符",
+        "label": "黑"
+      },
+      {
+        "radical": "占",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "黯": {
+    "formula": "黑 + 音",
+    "components": [
+      {
+        "radical": "黑",
+        "role": "形符",
+        "label": "黑"
+      },
+      {
+        "radical": "音",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鼓": {
+    "formula": "壴 + 支",
+    "components": [
+      {
+        "radical": "壴",
+        "role": "形符",
+        "label": "壴"
+      },
+      {
+        "radical": "支",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鼩": {
+    "formula": "鼠 + 句",
+    "components": [
+      {
+        "radical": "鼠",
+        "role": "形符",
+        "label": "鼠"
+      },
+      {
+        "radical": "句",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "鼾": {
+    "formula": "鼻 + 干",
+    "components": [
+      {
+        "radical": "鼻",
+        "role": "形符",
+        "label": "鼻"
+      },
+      {
+        "radical": "干",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "齡": {
+    "formula": "齒 + 令",
+    "components": [
+      {
+        "radical": "齒",
+        "role": "形符",
+        "label": "齒"
+      },
+      {
+        "radical": "令",
+        "role": "聲符",
+        "label": "讀音"
+      }
+    ]
+  },
+  "龐": {
+    "formula": "广 + 龍",
+    "components": [
+      {
+        "radical": "广",
+        "role": "部件",
+        "label": "广"
+      },
+      {
+        "radical": "龍",
+        "role": "部件",
+        "label": "龍"
+      }
+    ]
+  }
+}

--- a/scripts/build-decomposition-data.py
+++ b/scripts/build-decomposition-data.py
@@ -42,6 +42,55 @@ IDS_ORDER_PRESERVED = set("⿰⿱⿲⿳⿴⿵⿶⿷⿸⿹⿺⿻")  # All operato
 
 
 # ---------------------------------------------------------------------------
+# INDEPENDENT_CHARS — 獨體字清單
+# Characters that CANNOT be further decomposed into meaningful sub-components.
+# These are 象形字 (pictographic) or structurally indivisible characters.
+# When a char is in this set, it is EXCLUDED from decompositions-generated.json
+# so the frontend RadicalDecomposition component can show a friendly message.
+#
+# Sources:
+#   - Traditional Kangxi radicals that are themselves indivisible
+#   - Common 象形字 used in elementary education
+#   - Characters where makemeahanzi/chaizi produce meaningless 1-component splits
+# ---------------------------------------------------------------------------
+INDEPENDENT_CHARS: set[str] = {
+    # Basic numerals / simple forms
+    "一", "二", "三", "四", "五", "六", "七", "八", "九", "十",
+    "百", "千", "萬",
+    # Common independent pictographs (象形字)
+    "人", "大", "小", "上", "下", "中",
+    "山", "水", "火", "日", "月", "木", "金", "土",
+    "口", "手", "目", "耳", "足", "身", "心",
+    "牛", "羊", "犬", "馬", "魚", "鳥", "鹿",
+    "田", "禾", "米", "竹",
+    # Common independent characters in lesson texts
+    "不", "龍", "也", "了", "又", "之",
+    "乃", "才", "己", "巳", "乙",
+    "丁", "丸", "丰", "九", "力", "女", "子", "寸",
+    "工", "干", "弓", "斤", "方", "毛", "片",
+    "立", "羊", "耳", "舌", "自", "至", "臣", "色",
+    "角", "言", "豆", "身", "車", "辛",
+    "長", "門", "雨", "非", "面", "革", "骨", "高",
+    "魚", "鳥", "鹿", "齒",
+    # Kangxi radicals that are themselves pictographic and indivisible
+    "刀", "力", "又", "土", "士", "夕", "大", "女", "子",
+    "山", "工", "己", "巾", "干", "弓", "心", "戈", "戶", "手",
+    "文", "斗", "月", "木", "止", "歹", "水", "火", "爪",
+    "片", "牛", "犬", "瓜", "瓦", "田", "目", "矛", "矢", "石",
+    "禾", "穴", "立", "竹", "米", "羊", "羽", "老", "耳", "肉",
+    "舌", "衣", "見", "角", "言", "豆", "豕", "身", "車",
+    "辛", "金", "長", "門", "雨", "面", "革", "骨", "高", "魚",
+    "鳥", "鹿", "鼠", "鼻", "齒", "龍",
+    # Additional pictographs commonly mis-decomposed
+    "丁", "丐", "且", "世", "丘", "丰", "丸", "主", "乙",
+    "云", "井", "亞", "京", "亮", "元", "兔", "再", "北",
+    "匹", "南", "卵", "喪", "垂", "宣", "射", "少",
+    "岡", "巫", "帝", "平", "幹", "幾", "西",
+    "烏", "申", "畏", "異", "皮", "示",
+    "能", "農", "食", "鬼", "黃", "默", "齊",
+}
+
+# ---------------------------------------------------------------------------
 # MANUAL_CORRECTIONS — override known-bad decompositions
 # Add entries here for characters where makemeahanzi/chaizi give wrong results.
 # Priority: always applied before any automatic source.
@@ -687,10 +736,16 @@ def main() -> None:
         "pictographic": 0,
         "chaizi_fallback": 0,
         "no_data": 0,
+        "independent": 0,
     }
 
     manual_count = 0
     for char in sorted(lesson_chars):
+        # Step -1: Skip 獨體字 (independent chars that cannot be decomposed)
+        if char in INDEPENDENT_CHARS:
+            stats["independent"] += 1
+            continue
+
         # Step 0: Apply manual corrections (highest priority)
         if char in MANUAL_CORRECTIONS:
             result[char] = MANUAL_CORRECTIONS[char]
@@ -702,6 +757,13 @@ def main() -> None:
         if entry:
             decomp = build_from_makemeahanzi(entry)
             if decomp:
+                # Skip trivial single-component decompositions that are meaningless:
+                # e.g. 不 -> [一], 乃 -> [丿] — these are stroke-level breakdowns,
+                # not teachable 部件 decompositions.
+                comps = decomp.get("components", [])
+                if len(comps) == 1:
+                    stats["independent"] += 1
+                    continue
                 etype = entry.get("etymology", {}).get("type", "ideographic")
                 if etype == "pictophonetic":
                     stats["pictophonetic"] += 1
@@ -717,6 +779,10 @@ def main() -> None:
         # Fallback to chaizi
         decomp = build_from_chaizi(char, chaizi)
         if decomp:
+            comps = decomp.get("components", [])
+            if len(comps) == 1:
+                stats["independent"] += 1
+                continue
             stats["chaizi_fallback"] += 1
             result[char] = decomp
             continue
@@ -767,6 +833,7 @@ def main() -> None:
     print(f"  ideographic   : {stats['ideographic']}")
     print(f"  pictographic  : {stats['pictographic']}")
     print(f"  chaizi fallback: {stats['chaizi_fallback']}")
+    print(f"  independent (skipped): {stats['independent']}")
     print(f"  no data        : {stats['no_data']}")
 
     # Write output JSON (just the decomposition map)


### PR DESCRIPTION
Fixes #813

## Summary

- Add `INDEPENDENT_CHARS` set in `scripts/build-decomposition-data.py` — 100+ pictographic/indivisible characters (不, 龍, 山, 水, 日, 月, etc.) that should never be decomposed
- Add safety filter: any auto-generated single-component decomposition is also excluded (catches edge cases not in the explicit list)
- Frontend `RadicalDecomposition.tsx`: when `getDecomposition()` returns `null`, show an educational panel — "此字為獨體字，無法再拆解" — instead of silently rendering nothing
- Regenerated `decompositions-generated.json`: 2528 entries (was 2734), 208 independent chars correctly skipped, 0 single-component entries remain

## Verification

- `不` is NOT in decompositions-generated.json (was showing 不=一)
- `龍` is NOT in decompositions-generated.json (was showing 龍=龍)
- `npm run build` passes (built in 5.40s)
- 0 single-component decompositions remain in output JSON

## Test plan

- [ ] Open any lesson that contains 不 or 龍 in the 部件拆解 tab
- [ ] Verify 不 shows "此字為獨體字，無法再拆解" instead of "不 = 一"
- [ ] Verify 龍 shows "此字為獨體字，無法再拆解" instead of "龍 = 龍"
- [ ] Verify a compound character like 明 still shows its decomposition (日 + 月)