### PR TITLE
fix(steps): persist completion state across 6 steps (Fixes #817)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -435,11 +435,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     }
   };
 
-  // Clear session and start over from scratch (Issue #632)
+  // Keep completion record — only clear on explicit redo (Issue #817)
   const handleFinish = useCallback(() => {
-    try { localStorage.removeItem(storageKey); } catch {}
     onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length });
-  }, [storageKey, onFinish, understoodCount, requiredCount, isSessionComplete, conversation.length]);
+  }, [onFinish, understoodCount, requiredCount, isSessionComplete, conversation.length]);
 
   const handleRestart = useCallback(async () => {
     try { localStorage.removeItem(storageKey); } catch {}

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -430,7 +430,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
                 再試一次
               </button>
               <button
-                onClick={() => { try { localStorage.removeItem(storageKey); } catch {} onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript, cpm: result.cpm, durationMs: result.durationMs, errorBreakdown: result.errorBreakdown }); }}
+                onClick={() => { /* Keep completion record — only clear on explicit redo */ onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript, cpm: result.cpm, durationMs: result.durationMs, errorBreakdown: result.errorBreakdown }); }}
                 aria-label="完成全文朗讀，查看學習報告"
                 className="w-full py-3 rounded-xl text-base font-bold bg-emerald-600 hover:bg-emerald-500 text-white transition-all flex items-center justify-center gap-2 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-1"
               >

--- a/frontend/src/components/reading-steps/KnowledgeStation.tsx
+++ b/frontend/src/components/reading-steps/KnowledgeStation.tsx
@@ -20,7 +20,7 @@ const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish }) 
   }, [storageKey]);
 
   const handleFinish = () => {
-    try { localStorage.removeItem(storageKey); } catch {}
+    // Keep completion record — only clear on explicit redo
     onFinish();
   };
 

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -1111,8 +1111,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   const handleFinish = () => {
     stopSession();
-    // Clear localStorage — progress is complete, will be sent to backend
-    try { localStorage.removeItem(storageKey); } catch {}
+    // Keep completion record — only clear on explicit redo
     const avgMatchRate =
       lineResults.length > 0
         ? lineResults.reduce((s, r) => s + r.matchRate, 0) / lineResults.length : 0;

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -692,12 +692,10 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
   }, [vocab]);
 
   const handleFinish = useCallback(() => {
-    try {
-      localStorage.removeItem(storageModeKey);
-    } catch {}
+    // Keep completion record — only clear on explicit redo
     const correctCount = summaryAnswers.filter((a) => a.correct).length;
     onFinish({ matchedCount: correctCount, totalCount: vocab.length });
-  }, [onFinish, summaryAnswers, vocab.length, storageModeKey]);
+  }, [onFinish, summaryAnswers, vocab.length]);
 
   const modeSubtitles: Record<InteractionMode, string> = {
     'multiple-choice': '看定義，選出對應的語詞',

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -266,7 +266,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   };
 
   const handleFinish = (result: VocabResult) => {
-    try { localStorage.removeItem(storageKey); } catch {}
+    // Keep completion record — only clear on explicit redo
     onFinish(result);
   };
 


### PR DESCRIPTION
Fixes #817

## Summary
- Remove `localStorage.removeItem(storageKey)` from `handleFinish` in 6 step components
- Completion state now persists when user re-enters a completed step
- `removeItem` is retained only in explicit redo/retry handlers (「再試一次」, `handleRestart`, etc.)

## Files changed
- `LiveTutor.tsx` — removed removeItem from handleFinish
- `FullReading.tsx` — removed removeItem from the "查看報告" onClick (redo button keeps it)
- `VocabPractice.tsx` — removed removeItem from handleFinish
- `VocabDefinitionMatch.tsx` — removed removeItem from handleFinish, removed unused `storageModeKey` dep
- `ComprehensionChat.tsx` — removed removeItem from handleFinish (handleRestart keeps it)
- `KnowledgeStation.tsx` — removed removeItem from handleFinish

## Reference pattern
Follows `VocabApplication.tsx` (#758): `handleFinish` does NOT call removeItem, only `handleRedoFromDone` does.

## Test plan
- [ ] Complete any of the 6 steps, then navigate away and return — should show completed state
- [ ] Use the redo/retry button — should clear state and restart
- [ ] `npm run build` passes (verified locally)