### PR TITLE
fix(decompositions): 開.門→門戶, 聲符/形符 labels 補全 (Fixes #825)

### DIFF
--- a/frontend/src/data/decompositions-generated.json
+++ b/frontend/src/data/decompositions-generated.json
@@ -5,12 +5,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "乂",
         "role": "部件",
-        "label": "乂"
+        "label": "交叉"
       }
     ]
   },
@@ -20,7 +20,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "人",
@@ -30,7 +30,7 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       }
     ]
   },
@@ -40,7 +40,7 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "亚",
@@ -55,12 +55,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "丨",
@@ -100,7 +100,7 @@
       {
         "radical": "二",
         "role": "部件",
-        "label": "二"
+        "label": "兩橫"
       }
     ]
   },
@@ -115,12 +115,12 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "亅",
@@ -185,7 +185,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "乙",
@@ -200,7 +200,7 @@
       {
         "radical": "占",
         "role": "形符",
-        "label": "占"
+        "label": "占卜"
       },
       {
         "radical": "乚",
@@ -220,7 +220,7 @@
       {
         "radical": "乚",
         "role": "形符",
-        "label": "乚"
+        "label": "隱曲"
       }
     ]
   },
@@ -245,27 +245,27 @@
       {
         "radical": "爫",
         "role": "部件",
-        "label": "爫"
+        "label": "爪部"
       },
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       },
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       },
       {
         "radical": "乚",
         "role": "部件",
-        "label": "乚"
+        "label": "隱曲"
       }
     ]
   },
@@ -295,12 +295,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "聿",
@@ -315,7 +315,7 @@
       {
         "radical": "二",
         "role": "部件",
-        "label": "二"
+        "label": "兩橫"
       },
       {
         "radical": "亅",
@@ -335,7 +335,7 @@
       {
         "radical": "二",
         "role": "形符",
-        "label": "二"
+        "label": "兩橫"
       }
     ]
   },
@@ -350,7 +350,7 @@
       {
         "radical": "乂",
         "role": "部件",
-        "label": "乂"
+        "label": "交叉"
       }
     ]
   },
@@ -360,12 +360,12 @@
       {
         "radical": "亠",
         "role": "部件",
-        "label": "亠"
+        "label": "頭部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "子",
@@ -385,7 +385,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -400,7 +400,7 @@
       {
         "radical": "二",
         "role": "部件",
-        "label": "二"
+        "label": "兩橫"
       }
     ]
   },
@@ -445,7 +445,7 @@
       {
         "radical": "乃",
         "role": "形符",
-        "label": "乃"
+        "label": "乃是"
       }
     ]
   },
@@ -490,7 +490,7 @@
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -505,7 +505,7 @@
       {
         "radical": "弋",
         "role": "部件",
-        "label": "弋"
+        "label": "弋射"
       }
     ]
   },
@@ -570,7 +570,7 @@
       {
         "radical": "牛",
         "role": "部件",
-        "label": "牛"
+        "label": "牛隻"
       }
     ]
   },
@@ -630,7 +630,7 @@
       {
         "radical": "止",
         "role": "部件",
-        "label": "止"
+        "label": "停止"
       }
     ]
   },
@@ -675,7 +675,7 @@
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       }
     ]
   },
@@ -690,7 +690,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -780,7 +780,7 @@
       {
         "radical": "申",
         "role": "部件",
-        "label": "申"
+        "label": "申述"
       }
     ]
   },
@@ -840,7 +840,7 @@
       {
         "radical": "立",
         "role": "部件",
-        "label": "立"
+        "label": "站立"
       }
     ]
   },
@@ -980,7 +980,7 @@
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -1035,7 +1035,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "从",
@@ -1055,7 +1055,7 @@
       {
         "radical": "多",
         "role": "部件",
-        "label": "多"
+        "label": "多數"
       }
     ]
   },
@@ -1115,7 +1115,7 @@
       {
         "radical": "彐",
         "role": "部件",
-        "label": "彐"
+        "label": "彐形"
       },
       {
         "radical": "冖",
@@ -1125,7 +1125,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -1170,7 +1170,7 @@
       {
         "radical": "更",
         "role": "部件",
-        "label": "更"
+        "label": "更改"
       }
     ]
   },
@@ -1305,7 +1305,7 @@
       {
         "radical": "彡",
         "role": "形符",
-        "label": "彡"
+        "label": "花紋"
       }
     ]
   },
@@ -1350,12 +1350,12 @@
       {
         "radical": "户",
         "role": "部件",
-        "label": "户"
+        "label": "門戶"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -2100,12 +2100,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "儿",
         "role": "部件",
-        "label": "儿"
+        "label": "人腳"
       }
     ]
   },
@@ -2115,7 +2115,7 @@
       {
         "radical": "亠",
         "role": "部件",
-        "label": "亠"
+        "label": "頭部"
       },
       {
         "radical": "允",
@@ -2135,7 +2135,7 @@
       {
         "radical": "儿",
         "role": "部件",
-        "label": "儿"
+        "label": "人腳"
       }
     ]
   },
@@ -2145,12 +2145,12 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "儿",
         "role": "部件",
-        "label": "儿"
+        "label": "人腳"
       }
     ]
   },
@@ -2175,7 +2175,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "兄",
@@ -2190,12 +2190,12 @@
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "丨",
@@ -2205,7 +2205,7 @@
       {
         "radical": "儿",
         "role": "部件",
-        "label": "儿"
+        "label": "人腳"
       }
     ]
   },
@@ -2215,12 +2215,12 @@
       {
         "radical": "儿",
         "role": "形符",
-        "label": "儿"
+        "label": "人腳"
       },
       {
         "radical": "儿",
         "role": "形符",
-        "label": "儿"
+        "label": "人腳"
       }
     ]
   },
@@ -2245,7 +2245,7 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "入",
@@ -2265,7 +2265,7 @@
       {
         "radical": "玉",
         "role": "部件",
-        "label": "玉"
+        "label": "玉石"
       }
     ]
   },
@@ -2275,12 +2275,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       },
       {
         "radical": "入",
@@ -2305,7 +2305,7 @@
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       }
     ]
   },
@@ -2320,7 +2320,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "八",
@@ -2350,12 +2350,12 @@
       {
         "radical": "甘",
         "role": "部件",
-        "label": "甘"
+        "label": "甜味"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "八",
@@ -2375,7 +2375,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "八",
@@ -2405,12 +2405,12 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "彐",
         "role": "部件",
-        "label": "彐"
+        "label": "彐形"
       },
       {
         "radical": "禾",
@@ -2430,17 +2430,17 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -2450,7 +2450,7 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "卄",
@@ -2490,7 +2490,7 @@
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -2535,7 +2535,7 @@
       {
         "radical": "夂",
         "role": "部件",
-        "label": "夂"
+        "label": "往下"
       },
       {
         "radical": "⺀",
@@ -2655,12 +2655,12 @@
       {
         "radical": "凵",
         "role": "部件",
-        "label": "凵"
+        "label": "容器"
       },
       {
         "radical": "乂",
         "role": "部件",
-        "label": "乂"
+        "label": "交叉"
       }
     ]
   },
@@ -2675,7 +2675,7 @@
       {
         "radical": "凵",
         "role": "部件",
-        "label": "凵"
+        "label": "容器"
       }
     ]
   },
@@ -2685,7 +2685,7 @@
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       },
       {
         "radical": "丶",
@@ -2705,7 +2705,7 @@
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       }
     ]
   },
@@ -2720,7 +2720,7 @@
       {
         "radical": "刀",
         "role": "形符",
-        "label": "刀"
+        "label": "刀具"
       }
     ]
   },
@@ -2760,7 +2760,7 @@
       {
         "radical": "歹",
         "role": "部件",
-        "label": "歹"
+        "label": "死亡"
       },
       {
         "radical": "刂",
@@ -2780,7 +2780,7 @@
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       }
     ]
   },
@@ -2850,7 +2850,7 @@
       {
         "radical": "至",
         "role": "形符",
-        "label": "至"
+        "label": "到達"
       },
       {
         "radical": "刂",
@@ -2880,12 +2880,12 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       },
       {
         "radical": "刂",
@@ -2930,7 +2930,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "刂",
@@ -2975,22 +2975,22 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "肉",
         "role": "部件",
-        "label": "肉"
+        "label": "肉形"
       },
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       }
     ]
   },
@@ -3080,7 +3080,7 @@
       {
         "radical": "刀",
         "role": "形符",
-        "label": "刀"
+        "label": "刀具"
       }
     ]
   },
@@ -3170,7 +3170,7 @@
       {
         "radical": "刀",
         "role": "形符",
-        "label": "刀"
+        "label": "刀具"
       }
     ]
   },
@@ -3225,7 +3225,7 @@
       {
         "radical": "工",
         "role": "部件",
-        "label": "工"
+        "label": "工作"
       },
       {
         "radical": "力",
@@ -3245,7 +3245,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -3255,7 +3255,7 @@
       {
         "radical": "少",
         "role": "形符",
-        "label": "少"
+        "label": "少量"
       },
       {
         "radical": "力",
@@ -3390,7 +3390,7 @@
       {
         "radical": "矛",
         "role": "形符",
-        "label": "矛"
+        "label": "矛形"
       },
       {
         "radical": "务",
@@ -3515,12 +3515,12 @@
       {
         "radical": "勹",
         "role": "部件",
-        "label": "勹"
+        "label": "包圍"
       },
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       }
     ]
   },
@@ -3530,7 +3530,7 @@
       {
         "radical": "勹",
         "role": "部件",
-        "label": "勹"
+        "label": "包圍"
       },
       {
         "radical": "丿",
@@ -3550,7 +3550,7 @@
       {
         "radical": "勹",
         "role": "部件",
-        "label": "勹"
+        "label": "包圍"
       },
       {
         "radical": "巳",
@@ -3565,7 +3565,7 @@
       {
         "radical": "夸",
         "role": "形符",
-        "label": "夸"
+        "label": "誇張"
       },
       {
         "radical": "包",
@@ -3595,7 +3595,7 @@
       {
         "radical": "匚",
         "role": "部件",
-        "label": "匚"
+        "label": "方框"
       },
       {
         "radical": "斤",
@@ -3610,7 +3610,7 @@
       {
         "radical": "匚",
         "role": "形符",
-        "label": "匚"
+        "label": "方框"
       },
       {
         "radical": "非",
@@ -3660,7 +3660,7 @@
       {
         "radical": "干",
         "role": "部件",
-        "label": "干"
+        "label": "干犯"
       }
     ]
   },
@@ -3670,12 +3670,12 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "牛",
         "role": "部件",
-        "label": "牛"
+        "label": "牛隻"
       }
     ]
   },
@@ -3690,7 +3690,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -3720,7 +3720,7 @@
       {
         "radical": "劦",
         "role": "形符",
-        "label": "劦"
+        "label": "合力"
       }
     ]
   },
@@ -3730,7 +3730,7 @@
       {
         "radical": "十",
         "role": "形符",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "尃",
@@ -3750,7 +3750,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -3765,7 +3765,7 @@
       {
         "radical": "卜",
         "role": "部件",
-        "label": "卜"
+        "label": "占卜"
       }
     ]
   },
@@ -3780,7 +3780,7 @@
       {
         "radical": "卜",
         "role": "形符",
-        "label": "卜"
+        "label": "占卜"
       }
     ]
   },
@@ -3820,7 +3820,7 @@
       {
         "radical": "止",
         "role": "形符",
-        "label": "止"
+        "label": "停止"
       },
       {
         "radical": "卩",
@@ -3840,7 +3840,7 @@
       {
         "radical": "卩",
         "role": "形符",
-        "label": "卩"
+        "label": "跪坐"
       }
     ]
   },
@@ -3915,12 +3915,12 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       }
     ]
   },
@@ -3935,7 +3935,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "彡",
@@ -3950,7 +3950,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       },
       {
         "radical": "丶",
@@ -3965,7 +3965,7 @@
       {
         "radical": "乃",
         "role": "部件",
-        "label": "乃"
+        "label": "乃是"
       },
       {
         "radical": "乀",
@@ -3985,7 +3985,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -4000,7 +4000,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -4010,7 +4010,7 @@
       {
         "radical": "爫",
         "role": "部件",
-        "label": "爫"
+        "label": "爪部"
       },
       {
         "radical": "冖",
@@ -4020,7 +4020,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -4030,12 +4030,12 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4045,12 +4045,12 @@
       {
         "radical": "勹",
         "role": "部件",
-        "label": "勹"
+        "label": "包圍"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4060,7 +4060,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "力",
@@ -4075,7 +4075,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "刀",
@@ -4090,7 +4090,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "八",
@@ -4105,7 +4105,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "丩",
@@ -4120,7 +4120,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "丁",
@@ -4135,7 +4135,7 @@
       {
         "radical": "丁",
         "role": "形符",
-        "label": "丁"
+        "label": "成丁"
       },
       {
         "radical": "口",
@@ -4150,12 +4150,12 @@
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4165,12 +4165,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "乂",
         "role": "部件",
-        "label": "乂"
+        "label": "交叉"
       }
     ]
   },
@@ -4180,7 +4180,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "丿",
@@ -4190,7 +4190,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4200,7 +4200,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "刁",
@@ -4215,7 +4215,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "乞",
@@ -4230,12 +4230,12 @@
       {
         "radical": "夂",
         "role": "部件",
-        "label": "夂"
+        "label": "往下"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4250,12 +4250,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4265,12 +4265,12 @@
       {
         "radical": "士",
         "role": "部件",
-        "label": "士"
+        "label": "士人"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4280,12 +4280,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -4300,7 +4300,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4310,12 +4310,12 @@
       {
         "radical": "夕",
         "role": "部件",
-        "label": "夕"
+        "label": "傍晚"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4330,12 +4330,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4345,7 +4345,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "土",
@@ -4365,12 +4365,12 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4380,7 +4380,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "也",
@@ -4395,12 +4395,12 @@
       {
         "radical": "文",
         "role": "部件",
-        "label": "文"
+        "label": "文化"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4415,7 +4415,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4425,7 +4425,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "今",
@@ -4440,7 +4440,7 @@
       {
         "radical": "不",
         "role": "形符",
-        "label": "不"
+        "label": "否定"
       },
       {
         "radical": "口",
@@ -4455,7 +4455,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "巴",
@@ -4475,7 +4475,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4485,7 +4485,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "允",
@@ -4500,7 +4500,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "少",
@@ -4515,7 +4515,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "及",
@@ -4530,7 +4530,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "勿",
@@ -4545,7 +4545,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "孔",
@@ -4565,7 +4565,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4575,7 +4575,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "牙",
@@ -4590,7 +4590,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "厄",
@@ -4605,12 +4605,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -4620,7 +4620,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "王",
@@ -4635,12 +4635,12 @@
       {
         "radical": "牛",
         "role": "部件",
-        "label": "牛"
+        "label": "牛隻"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4650,7 +4650,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "尺",
@@ -4665,7 +4665,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "尼",
@@ -4680,17 +4680,17 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4700,7 +4700,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "未",
@@ -4715,7 +4715,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "可",
@@ -4730,7 +4730,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "乎",
@@ -4745,12 +4745,12 @@
       {
         "radical": "令",
         "role": "部件",
-        "label": "令"
+        "label": "命令"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4760,7 +4760,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "且",
@@ -4780,7 +4780,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4795,7 +4795,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4805,12 +4805,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "几",
@@ -4825,7 +4825,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "古",
@@ -4840,7 +4840,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "加",
@@ -4855,7 +4855,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "冬",
@@ -4870,7 +4870,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "夷",
@@ -4885,7 +4885,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "米",
@@ -4900,7 +4900,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "交",
@@ -4915,7 +4915,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "亥",
@@ -4935,12 +4935,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4950,7 +4950,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "因",
@@ -4970,7 +4970,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -4980,17 +4980,17 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -5000,7 +5000,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "共",
@@ -5015,7 +5015,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "多",
@@ -5030,7 +5030,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "圭",
@@ -5045,7 +5045,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "合",
@@ -5060,12 +5060,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -5090,7 +5090,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "我",
@@ -5105,7 +5105,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "肖",
@@ -5120,7 +5120,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "那",
@@ -5135,12 +5135,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "犬",
@@ -5160,7 +5160,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -5170,7 +5170,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "甫",
@@ -5185,7 +5185,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "亨",
@@ -5205,7 +5205,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -5215,7 +5215,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "矣",
@@ -5230,7 +5230,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "彐",
@@ -5245,12 +5245,12 @@
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -5260,12 +5260,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -5275,7 +5275,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "昌",
@@ -5290,7 +5290,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "念",
@@ -5305,7 +5305,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "垂",
@@ -5320,7 +5320,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "肯",
@@ -5335,7 +5335,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "豖",
@@ -5350,7 +5350,7 @@
       {
         "radical": "冏",
         "role": "形符",
-        "label": "冏"
+        "label": "光明"
       },
       {
         "radical": "章",
@@ -5365,7 +5365,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "阿",
@@ -5385,7 +5385,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -5395,7 +5395,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "叕",
@@ -5410,7 +5410,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "亞",
@@ -5430,7 +5430,7 @@
       {
         "radical": "攵",
         "role": "部件",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -5440,7 +5440,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "非",
@@ -5455,7 +5455,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "卑",
@@ -5470,7 +5470,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "拉",
@@ -5485,7 +5485,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "帝",
@@ -5500,7 +5500,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "客",
@@ -5515,22 +5515,22 @@
       {
         "radical": "羊",
         "role": "部件",
-        "label": "羊"
+        "label": "羊形"
       },
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -5540,7 +5540,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "侯",
@@ -5555,7 +5555,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "咸",
@@ -5570,7 +5570,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "音",
@@ -5585,7 +5585,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "屋",
@@ -5600,7 +5600,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "耑",
@@ -5615,7 +5615,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "奐",
@@ -5635,7 +5635,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -5645,7 +5645,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "曷",
@@ -5665,7 +5665,7 @@
       {
         "radical": "高",
         "role": "形符",
-        "label": "高"
+        "label": "高聳"
       }
     ]
   },
@@ -5675,7 +5675,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "約",
@@ -5690,7 +5690,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "查",
@@ -5705,7 +5705,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "俞",
@@ -5720,7 +5720,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "馬",
@@ -5735,7 +5735,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "烏",
@@ -5750,7 +5750,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "耆",
@@ -5765,7 +5765,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "翁",
@@ -5780,7 +5780,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "恩",
@@ -5795,7 +5795,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "畢",
@@ -5810,7 +5810,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "敖",
@@ -5825,7 +5825,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "啇",
@@ -5840,7 +5840,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "堇",
@@ -5855,7 +5855,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "區",
@@ -5875,7 +5875,7 @@
       {
         "radical": "旨",
         "role": "形符",
-        "label": "旨"
+        "label": "旨意"
       }
     ]
   },
@@ -5885,7 +5885,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "麻",
@@ -5900,7 +5900,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "勞",
@@ -5915,7 +5915,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "肅",
@@ -5930,7 +5930,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "幾",
@@ -5945,7 +5945,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "朝",
@@ -5960,7 +5960,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "觜",
@@ -5975,7 +5975,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "黑",
@@ -5990,12 +5990,12 @@
       {
         "radical": "惡",
         "role": "形符",
-        "label": "惡"
+        "label": "惡意"
       },
       {
         "radical": "惡",
         "role": "形符",
-        "label": "惡"
+        "label": "惡意"
       }
     ]
   },
@@ -6005,7 +6005,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "壹",
@@ -6020,7 +6020,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "菐",
@@ -6035,12 +6035,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "犬",
@@ -6050,12 +6050,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -6070,22 +6070,22 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -6095,7 +6095,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "筮",
@@ -6110,7 +6110,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "賁",
@@ -6125,7 +6125,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "頓",
@@ -6140,7 +6140,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "赫",
@@ -6155,7 +6155,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "魯",
@@ -6170,7 +6170,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "燕",
@@ -6185,7 +6185,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "龍",
@@ -6200,7 +6200,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "爵",
@@ -6215,7 +6215,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "羅",
@@ -6230,7 +6230,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "襄",
@@ -6265,7 +6265,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -6280,7 +6280,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -6295,7 +6295,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -6340,7 +6340,7 @@
       {
         "radical": "或",
         "role": "部件",
-        "label": "或"
+        "label": "或許"
       }
     ]
   },
@@ -6430,7 +6430,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6440,7 +6440,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "也",
@@ -6455,7 +6455,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "及",
@@ -6470,7 +6470,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "止",
@@ -6485,7 +6485,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "匀",
@@ -6505,7 +6505,7 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6515,7 +6515,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "皮",
@@ -6530,7 +6530,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "旦",
@@ -6545,7 +6545,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "幼",
@@ -6560,7 +6560,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "立",
@@ -6580,7 +6580,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6590,7 +6590,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "夸",
@@ -6605,7 +6605,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "矣",
@@ -6620,7 +6620,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "里",
@@ -6635,7 +6635,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "成",
@@ -6650,7 +6650,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "或",
@@ -6680,7 +6680,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "咅",
@@ -6700,7 +6700,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6710,7 +6710,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "奇",
@@ -6730,7 +6730,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6745,7 +6745,7 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6755,7 +6755,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "隹",
@@ -6775,7 +6775,7 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6790,12 +6790,12 @@
       {
         "radical": "卩",
         "role": "部件",
-        "label": "卩"
+        "label": "跪坐"
       },
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -6805,7 +6805,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "昜",
@@ -6820,7 +6820,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "者",
@@ -6835,7 +6835,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "鬼",
@@ -6850,7 +6850,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "日",
@@ -6875,7 +6875,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6885,7 +6885,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "荅",
@@ -6915,7 +6915,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "唐",
@@ -6935,12 +6935,12 @@
       {
         "radical": "二",
         "role": "部件",
-        "label": "二"
+        "label": "兩橫"
       },
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6950,7 +6950,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "烏",
@@ -6965,7 +6965,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "真",
@@ -6985,7 +6985,7 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -6995,7 +6995,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "竟",
@@ -7015,7 +7015,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -7030,7 +7030,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -7040,7 +7040,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "曾",
@@ -7055,12 +7055,12 @@
       {
         "radical": "黑",
         "role": "部件",
-        "label": "黑"
+        "label": "黑色"
       },
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -7075,7 +7075,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -7085,7 +7085,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "賁",
@@ -7105,7 +7105,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -7120,7 +7120,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -7130,7 +7130,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "亶",
@@ -7150,7 +7150,7 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -7165,7 +7165,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -7175,7 +7175,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "褱",
@@ -7190,7 +7190,7 @@
       {
         "radical": "土",
         "role": "形符",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "襄",
@@ -7210,7 +7210,7 @@
       {
         "radical": "士",
         "role": "形符",
-        "label": "士"
+        "label": "士人"
       }
     ]
   },
@@ -7220,7 +7220,7 @@
       {
         "radical": "士",
         "role": "部件",
-        "label": "士"
+        "label": "士人"
       },
       {
         "radical": "乛",
@@ -7230,12 +7230,12 @@
       {
         "radical": "工",
         "role": "部件",
-        "label": "工"
+        "label": "工作"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "吋",
@@ -7250,7 +7250,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "自",
@@ -7260,7 +7260,7 @@
       {
         "radical": "夕",
         "role": "部件",
-        "label": "夕"
+        "label": "傍晚"
       }
     ]
   },
@@ -7270,12 +7270,12 @@
       {
         "radical": "夕",
         "role": "部件",
-        "label": "夕"
+        "label": "傍晚"
       },
       {
         "radical": "卜",
         "role": "部件",
-        "label": "卜"
+        "label": "占卜"
       }
     ]
   },
@@ -7285,12 +7285,12 @@
       {
         "radical": "夕",
         "role": "部件",
-        "label": "夕"
+        "label": "傍晚"
       },
       {
         "radical": "夕",
         "role": "部件",
-        "label": "夕"
+        "label": "傍晚"
       }
     ]
   },
@@ -7300,7 +7300,7 @@
       {
         "radical": "亠",
         "role": "部件",
-        "label": "亠"
+        "label": "頭部"
       },
       {
         "radical": "亻",
@@ -7310,7 +7310,7 @@
       {
         "radical": "夕",
         "role": "部件",
-        "label": "夕"
+        "label": "傍晚"
       }
     ]
   },
@@ -7325,7 +7325,7 @@
       {
         "radical": "句",
         "role": "形符",
-        "label": "句"
+        "label": "句子"
       }
     ]
   },
@@ -7350,7 +7350,7 @@
       {
         "radical": "夕",
         "role": "部件",
-        "label": "夕"
+        "label": "傍晚"
       }
     ]
   },
@@ -7365,7 +7365,7 @@
       {
         "radical": "多",
         "role": "形符",
-        "label": "多"
+        "label": "多數"
       }
     ]
   },
@@ -7375,12 +7375,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -7390,7 +7390,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "丶",
@@ -7405,12 +7405,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -7420,12 +7420,12 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -7440,7 +7440,7 @@
       {
         "radical": "夫",
         "role": "部件",
-        "label": "夫"
+        "label": "成人"
       }
     ]
   },
@@ -7450,7 +7450,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "弓",
@@ -7465,7 +7465,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "可",
@@ -7480,7 +7480,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "示",
@@ -7495,7 +7495,7 @@
       {
         "radical": "手",
         "role": "部件",
-        "label": "手"
+        "label": "手部"
       },
       {
         "radical": "乀",
@@ -7505,12 +7505,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -7520,7 +7520,7 @@
       {
         "radical": "大",
         "role": "形符",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "圭",
@@ -7540,12 +7540,12 @@
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       },
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -7555,7 +7555,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "卉",
@@ -7570,7 +7570,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "镸",
@@ -7590,7 +7590,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -7600,7 +7600,7 @@
       {
         "radical": "大",
         "role": "形符",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "者",
@@ -7615,12 +7615,12 @@
       {
         "radical": "釆",
         "role": "部件",
-        "label": "釆"
+        "label": "辨別"
       },
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -7630,17 +7630,17 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       },
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -7650,12 +7650,12 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       },
       {
         "radical": "田",
@@ -7720,7 +7720,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -7805,7 +7805,7 @@
       {
         "radical": "爫",
         "role": "部件",
-        "label": "爫"
+        "label": "爪部"
       },
       {
         "radical": "女",
@@ -7850,12 +7850,12 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "彐",
         "role": "部件",
-        "label": "彐"
+        "label": "彐形"
       },
       {
         "radical": "女",
@@ -8235,7 +8235,7 @@
       {
         "radical": "乚",
         "role": "部件",
-        "label": "乚"
+        "label": "隱曲"
       }
     ]
   },
@@ -8245,7 +8245,7 @@
       {
         "radical": "乃",
         "role": "部件",
-        "label": "乃"
+        "label": "乃是"
       },
       {
         "radical": "子",
@@ -8495,7 +8495,7 @@
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -8645,7 +8645,7 @@
       {
         "radical": "各",
         "role": "部件",
-        "label": "各"
+        "label": "各自"
       }
     ]
   },
@@ -8675,7 +8675,7 @@
       {
         "radical": "辛",
         "role": "部件",
-        "label": "辛"
+        "label": "辛苦"
       }
     ]
   },
@@ -8695,7 +8695,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -8815,7 +8815,7 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       }
     ]
   },
@@ -8845,7 +8845,7 @@
       {
         "radical": "爿",
         "role": "部件",
-        "label": "爿"
+        "label": "片形"
       },
       {
         "radical": "未",
@@ -8870,12 +8870,12 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "冰",
         "role": "部件",
-        "label": "冰"
+        "label": "冰水"
       }
     ]
   },
@@ -8955,12 +8955,12 @@
       {
         "radical": "爿",
         "role": "部件",
-        "label": "爿"
+        "label": "片形"
       },
       {
         "radical": "彐",
         "role": "部件",
-        "label": "彐"
+        "label": "彐形"
       },
       {
         "radical": "冖",
@@ -8970,7 +8970,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -8985,7 +8985,7 @@
       {
         "radical": "貫",
         "role": "形符",
-        "label": "貫"
+        "label": "貫通"
       }
     ]
   },
@@ -8995,7 +8995,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       },
       {
         "radical": "丁",
@@ -9065,7 +9065,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -9080,7 +9080,7 @@
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -9090,17 +9090,17 @@
       {
         "radical": "爿",
         "role": "部件",
-        "label": "爿"
+        "label": "片形"
       },
       {
         "radical": "夕",
         "role": "部件",
-        "label": "夕"
+        "label": "傍晚"
       },
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -9115,7 +9115,7 @@
       {
         "radical": "寸",
         "role": "形符",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -9130,7 +9130,7 @@
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -9140,22 +9140,22 @@
       {
         "radical": "彐",
         "role": "部件",
-        "label": "彐"
+        "label": "彐形"
       },
       {
         "radical": "工",
         "role": "部件",
-        "label": "工"
+        "label": "工作"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -9170,12 +9170,12 @@
       {
         "radical": "羊",
         "role": "部件",
-        "label": "羊"
+        "label": "羊形"
       },
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -9190,7 +9190,7 @@
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -9200,12 +9200,12 @@
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       },
       {
         "radical": "小",
         "role": "部件",
-        "label": "小"
+        "label": "細小"
       }
     ]
   },
@@ -9215,12 +9215,12 @@
       {
         "radical": "小",
         "role": "部件",
-        "label": "小"
+        "label": "細小"
       },
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -9230,17 +9230,17 @@
       {
         "radical": "小",
         "role": "部件",
-        "label": "小"
+        "label": "細小"
       },
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -9255,7 +9255,7 @@
       {
         "radical": "尤",
         "role": "形符",
-        "label": "尤"
+        "label": "特別"
       }
     ]
   },
@@ -9265,12 +9265,12 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "乚",
         "role": "部件",
-        "label": "乚"
+        "label": "隱曲"
       }
     ]
   },
@@ -9280,7 +9280,7 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "匕",
@@ -9295,12 +9295,12 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "毛",
         "role": "部件",
-        "label": "毛"
+        "label": "毛羽"
       }
     ]
   },
@@ -9310,7 +9310,7 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "水",
@@ -9330,7 +9330,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -9340,7 +9340,7 @@
       {
         "radical": "户",
         "role": "形符",
-        "label": "户"
+        "label": "門戶"
       },
       {
         "radical": "古",
@@ -9355,7 +9355,7 @@
       {
         "radical": "尸",
         "role": "形符",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "出",
@@ -9370,12 +9370,12 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "至",
         "role": "部件",
-        "label": "至"
+        "label": "到達"
       }
     ]
   },
@@ -9385,12 +9385,12 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "死",
         "role": "部件",
-        "label": "死"
+        "label": "死亡"
       }
     ]
   },
@@ -9400,12 +9400,12 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "米",
         "role": "部件",
-        "label": "米"
+        "label": "米糧"
       }
     ]
   },
@@ -9415,7 +9415,7 @@
       {
         "radical": "户",
         "role": "形符",
-        "label": "户"
+        "label": "門戶"
       },
       {
         "radical": "并",
@@ -9430,7 +9430,7 @@
       {
         "radical": "尸",
         "role": "形符",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "肖",
@@ -9445,7 +9445,7 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "衣",
@@ -9460,7 +9460,7 @@
       {
         "radical": "尸",
         "role": "形符",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "婁",
@@ -9475,7 +9475,7 @@
       {
         "radical": "尸",
         "role": "形符",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "曾",
@@ -9490,7 +9490,7 @@
       {
         "radical": "尸",
         "role": "形符",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "禹",
@@ -9505,7 +9505,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "及",
@@ -9520,7 +9520,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "支",
@@ -9535,7 +9535,7 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "石",
@@ -9550,7 +9550,7 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "厂",
@@ -9560,7 +9560,7 @@
       {
         "radical": "干",
         "role": "部件",
-        "label": "干"
+        "label": "干犯"
       }
     ]
   },
@@ -9570,7 +9570,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "肖",
@@ -9585,7 +9585,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "夆",
@@ -9605,7 +9605,7 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       }
     ]
   },
@@ -9615,7 +9615,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "夋",
@@ -9630,7 +9630,7 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "夾",
@@ -9645,7 +9645,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "宗",
@@ -9660,7 +9660,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "奇",
@@ -9675,7 +9675,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "昆",
@@ -9690,7 +9690,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "朋",
@@ -9705,7 +9705,7 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "禺",
@@ -9720,7 +9720,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "斬",
@@ -9735,7 +9735,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "區",
@@ -9750,7 +9750,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "令",
@@ -9765,7 +9765,7 @@
       {
         "radical": "山",
         "role": "形符",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "與",
@@ -9820,7 +9820,7 @@
       {
         "radical": "果",
         "role": "部件",
-        "label": "果"
+        "label": "果實"
       }
     ]
   },
@@ -9830,7 +9830,7 @@
       {
         "radical": "工",
         "role": "形符",
-        "label": "工"
+        "label": "工作"
       },
       {
         "radical": "丂",
@@ -9845,12 +9845,12 @@
       {
         "radical": "羊",
         "role": "部件",
-        "label": "羊"
+        "label": "羊形"
       },
       {
         "radical": "工",
         "role": "部件",
-        "label": "工"
+        "label": "工作"
       }
     ]
   },
@@ -9865,12 +9865,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "乚",
         "role": "部件",
-        "label": "乚"
+        "label": "隱曲"
       }
     ]
   },
@@ -9900,7 +9900,7 @@
       {
         "radical": "己",
         "role": "部件",
-        "label": "己"
+        "label": "自己"
       }
     ]
   },
@@ -9910,12 +9910,12 @@
       {
         "radical": "亠",
         "role": "部件",
-        "label": "亠"
+        "label": "頭部"
       },
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -9925,7 +9925,7 @@
       {
         "radical": "巾",
         "role": "形符",
-        "label": "巾"
+        "label": "布巾"
       },
       {
         "radical": "凡",
@@ -9940,7 +9940,7 @@
       {
         "radical": "乂",
         "role": "部件",
-        "label": "乂"
+        "label": "交叉"
       },
       {
         "radical": "布",
@@ -9955,7 +9955,7 @@
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       },
       {
         "radical": "白",
@@ -9990,7 +9990,7 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "廿",
@@ -10000,7 +10000,7 @@
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -10010,7 +10010,7 @@
       {
         "radical": "巾",
         "role": "形符",
-        "label": "巾"
+        "label": "布巾"
       },
       {
         "radical": "長",
@@ -10035,7 +10035,7 @@
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -10050,7 +10050,7 @@
       {
         "radical": "巾",
         "role": "形符",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -10060,7 +10060,7 @@
       {
         "radical": "巾",
         "role": "形符",
-        "label": "巾"
+        "label": "布巾"
       },
       {
         "radical": "冒",
@@ -10075,7 +10075,7 @@
       {
         "radical": "巾",
         "role": "部件",
-        "label": "巾"
+        "label": "布巾"
       },
       {
         "radical": "畐",
@@ -10095,7 +10095,7 @@
       {
         "radical": "巾",
         "role": "形符",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -10105,7 +10105,7 @@
       {
         "radical": "巾",
         "role": "形符",
-        "label": "巾"
+        "label": "布巾"
       },
       {
         "radical": "戠",
@@ -10125,7 +10125,7 @@
       {
         "radical": "巾",
         "role": "形符",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -10150,7 +10150,7 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "开",
@@ -10165,17 +10165,17 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "干",
         "role": "部件",
-        "label": "干"
+        "label": "干犯"
       }
     ]
   },
@@ -10185,7 +10185,7 @@
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "力",
@@ -10200,17 +10200,17 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       }
     ]
   },
@@ -10220,7 +10220,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "比",
@@ -10235,12 +10235,12 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -10250,7 +10250,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "予",
@@ -10265,7 +10265,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "氐",
@@ -10280,7 +10280,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "占",
@@ -10295,12 +10295,12 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "彐",
         "role": "部件",
-        "label": "彐"
+        "label": "彐形"
       },
       {
         "radical": "人",
@@ -10315,7 +10315,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "付",
@@ -10330,7 +10330,7 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "廿",
@@ -10340,7 +10340,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -10350,12 +10350,12 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "坐",
         "role": "部件",
-        "label": "坐"
+        "label": "坐下"
       }
     ]
   },
@@ -10365,12 +10365,12 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "車",
         "role": "部件",
-        "label": "車"
+        "label": "車形"
       }
     ]
   },
@@ -10380,7 +10380,7 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "廷",
@@ -10395,7 +10395,7 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "隶",
@@ -10410,7 +10410,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "則",
@@ -10425,7 +10425,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "相",
@@ -10440,12 +10440,12 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "兼",
         "role": "部件",
-        "label": "兼"
+        "label": "兼顧"
       }
     ]
   },
@@ -10470,7 +10470,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "斯",
@@ -10485,7 +10485,7 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "朝",
@@ -10500,7 +10500,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "敞",
@@ -10515,7 +10515,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "黄",
@@ -10530,7 +10530,7 @@
       {
         "radical": "广",
         "role": "形符",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "聽",
@@ -10575,7 +10575,7 @@
       {
         "radical": "玉",
         "role": "部件",
-        "label": "玉"
+        "label": "玉石"
       },
       {
         "radical": "廾",
@@ -10605,12 +10605,12 @@
       {
         "radical": "弋",
         "role": "部件",
-        "label": "弋"
+        "label": "弋射"
       },
       {
         "radical": "工",
         "role": "部件",
-        "label": "工"
+        "label": "工作"
       }
     ]
   },
@@ -10655,7 +10655,7 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "弔",
@@ -10785,7 +10785,7 @@
       {
         "radical": "果",
         "role": "部件",
-        "label": "果"
+        "label": "果實"
       }
     ]
   },
@@ -10800,7 +10800,7 @@
       {
         "radical": "彡",
         "role": "部件",
-        "label": "彡"
+        "label": "花紋"
       }
     ]
   },
@@ -10815,7 +10815,7 @@
       {
         "radical": "彡",
         "role": "形符",
-        "label": "彡"
+        "label": "花紋"
       }
     ]
   },
@@ -10830,7 +10830,7 @@
       {
         "radical": "彡",
         "role": "形符",
-        "label": "彡"
+        "label": "花紋"
       }
     ]
   },
@@ -10845,7 +10845,7 @@
       {
         "radical": "彡",
         "role": "部件",
-        "label": "彡"
+        "label": "花紋"
       }
     ]
   },
@@ -10860,7 +10860,7 @@
       {
         "radical": "彡",
         "role": "形符",
-        "label": "彡"
+        "label": "花紋"
       }
     ]
   },
@@ -10875,7 +10875,7 @@
       {
         "radical": "彡",
         "role": "形符",
-        "label": "彡"
+        "label": "花紋"
       }
     ]
   },
@@ -10905,7 +10905,7 @@
       {
         "radical": "殳",
         "role": "部件",
-        "label": "殳"
+        "label": "器具"
       }
     ]
   },
@@ -11025,12 +11025,12 @@
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "夂",
         "role": "部件",
-        "label": "夂"
+        "label": "往下"
       }
     ]
   },
@@ -11075,7 +11075,7 @@
       {
         "radical": "走",
         "role": "部件",
-        "label": "走"
+        "label": "奔走"
       }
     ]
   },
@@ -11095,7 +11095,7 @@
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -11170,7 +11170,7 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "兀",
@@ -11180,7 +11180,7 @@
       {
         "radical": "攴",
         "role": "部件",
-        "label": "攴"
+        "label": "攻打"
       }
     ]
   },
@@ -11210,7 +11210,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "罒",
@@ -11220,7 +11220,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11230,7 +11230,7 @@
       {
         "radical": "切",
         "role": "形符",
-        "label": "切"
+        "label": "切割"
       },
       {
         "radical": "彳",
@@ -11245,7 +11245,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       },
       {
         "radical": "丿",
@@ -11265,7 +11265,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11280,7 +11280,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11290,12 +11290,12 @@
       {
         "radical": "士",
         "role": "部件",
-        "label": "士"
+        "label": "士人"
       },
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11310,7 +11310,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11340,7 +11340,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11415,7 +11415,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11430,7 +11430,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11445,7 +11445,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11460,7 +11460,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11505,7 +11505,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11520,7 +11520,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11550,7 +11550,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11580,7 +11580,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11590,7 +11590,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       },
       {
         "radical": "圣",
@@ -11625,7 +11625,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11640,7 +11640,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11655,7 +11655,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11715,7 +11715,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11730,7 +11730,7 @@
       {
         "radical": "⺗",
         "role": "形符",
-        "label": "⺗"
+        "label": "心旁"
       }
     ]
   },
@@ -11745,7 +11745,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11805,7 +11805,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11880,7 +11880,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11895,7 +11895,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11910,7 +11910,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11925,7 +11925,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11940,7 +11940,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -11995,12 +11995,12 @@
       {
         "radical": "或",
         "role": "部件",
-        "label": "或"
+        "label": "或許"
       },
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12045,7 +12045,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12090,7 +12090,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12105,7 +12105,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12135,7 +12135,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12150,7 +12150,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12165,7 +12165,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12180,7 +12180,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12190,7 +12190,7 @@
       {
         "radical": "爫",
         "role": "部件",
-        "label": "爫"
+        "label": "爪部"
       },
       {
         "radical": "冖",
@@ -12200,12 +12200,12 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       },
       {
         "radical": "夂",
         "role": "部件",
-        "label": "夂"
+        "label": "往下"
       }
     ]
   },
@@ -12220,7 +12220,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12250,7 +12250,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12265,7 +12265,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12310,7 +12310,7 @@
       {
         "radical": "⺗",
         "role": "形符",
-        "label": "⺗"
+        "label": "心旁"
       }
     ]
   },
@@ -12370,7 +12370,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12395,7 +12395,7 @@
       {
         "radical": "虍",
         "role": "部件",
-        "label": "虍"
+        "label": "虎紋"
       },
       {
         "radical": "思",
@@ -12415,7 +12415,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12430,12 +12430,12 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       },
       {
         "radical": "夂",
         "role": "部件",
-        "label": "夂"
+        "label": "往下"
       }
     ]
   },
@@ -12450,7 +12450,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12480,7 +12480,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12510,7 +12510,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12600,7 +12600,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12630,7 +12630,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12660,7 +12660,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12675,7 +12675,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12720,7 +12720,7 @@
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12765,7 +12765,7 @@
       {
         "radical": "心",
         "role": "形符",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -12780,7 +12780,7 @@
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       }
     ]
   },
@@ -12810,7 +12810,7 @@
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       }
     ]
   },
@@ -12820,7 +12820,7 @@
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       },
       {
         "radical": "廾",
@@ -12835,17 +12835,17 @@
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -12860,7 +12860,7 @@
       {
         "radical": "戈",
         "role": "形符",
-        "label": "戈"
+        "label": "武器"
       }
     ]
   },
@@ -12885,17 +12885,17 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       },
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       }
     ]
   },
@@ -12910,7 +12910,7 @@
       {
         "radical": "戈",
         "role": "形符",
-        "label": "戈"
+        "label": "武器"
       }
     ]
   },
@@ -12920,17 +12920,17 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       },
       {
         "radical": "異",
         "role": "部件",
-        "label": "異"
+        "label": "差異"
       }
     ]
   },
@@ -12940,7 +12940,7 @@
       {
         "radical": "户",
         "role": "形符",
-        "label": "户"
+        "label": "門戶"
       },
       {
         "radical": "方",
@@ -12955,7 +12955,7 @@
       {
         "radical": "户",
         "role": "部件",
-        "label": "户"
+        "label": "門戶"
       },
       {
         "radical": "斤",
@@ -12970,12 +12970,12 @@
       {
         "radical": "户",
         "role": "部件",
-        "label": "户"
+        "label": "門戶"
       },
       {
         "radical": "羽",
         "role": "部件",
-        "label": "羽"
+        "label": "羽毛"
       }
     ]
   },
@@ -13035,7 +13035,7 @@
       {
         "radical": "工",
         "role": "部件",
-        "label": "工"
+        "label": "工作"
       }
     ]
   },
@@ -13155,7 +13155,7 @@
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       }
     ]
   },
@@ -13170,7 +13170,7 @@
       {
         "radical": "三",
         "role": "部件",
-        "label": "三"
+        "label": "三橫"
       }
     ]
   },
@@ -13245,7 +13245,7 @@
       {
         "radical": "爪",
         "role": "部件",
-        "label": "爪"
+        "label": "爪形"
       }
     ]
   },
@@ -13320,7 +13320,7 @@
       {
         "radical": "皮",
         "role": "部件",
-        "label": "皮"
+        "label": "皮膚"
       }
     ]
   },
@@ -13350,7 +13350,7 @@
       {
         "radical": "包",
         "role": "部件",
-        "label": "包"
+        "label": "包裹"
       }
     ]
   },
@@ -13605,12 +13605,12 @@
       {
         "radical": "手",
         "role": "部件",
-        "label": "手"
+        "label": "手部"
       },
       {
         "radical": "手",
         "role": "部件",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -13670,7 +13670,7 @@
       {
         "radical": "手",
         "role": "形符",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -13700,7 +13700,7 @@
       {
         "radical": "合",
         "role": "部件",
-        "label": "合"
+        "label": "合計"
       }
     ]
   },
@@ -13715,7 +13715,7 @@
       {
         "radical": "手",
         "role": "形符",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -13745,7 +13745,7 @@
       {
         "radical": "旨",
         "role": "部件",
-        "label": "旨"
+        "label": "旨意"
       }
     ]
   },
@@ -13955,7 +13955,7 @@
       {
         "radical": "舍",
         "role": "形符",
-        "label": "舍"
+        "label": "房舍"
       }
     ]
   },
@@ -14060,7 +14060,7 @@
       {
         "radical": "手",
         "role": "形符",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -14165,12 +14165,12 @@
       {
         "radical": "穴",
         "role": "部件",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -14620,7 +14620,7 @@
       {
         "radical": "手",
         "role": "形符",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -14635,7 +14635,7 @@
       {
         "radical": "手",
         "role": "部件",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -14890,7 +14890,7 @@
       {
         "radical": "手",
         "role": "部件",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -15025,7 +15025,7 @@
       {
         "radical": "廣",
         "role": "形符",
-        "label": "廣"
+        "label": "廣大"
       }
     ]
   },
@@ -15085,7 +15085,7 @@
       {
         "radical": "手",
         "role": "形符",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -15160,7 +15160,7 @@
       {
         "radical": "手",
         "role": "形符",
-        "label": "手"
+        "label": "手部"
       }
     ]
   },
@@ -15200,12 +15200,12 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -15220,7 +15220,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15230,12 +15230,12 @@
       {
         "radical": "己",
         "role": "部件",
-        "label": "己"
+        "label": "自己"
       },
       {
         "radical": "攵",
         "role": "部件",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15250,7 +15250,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15265,7 +15265,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15280,7 +15280,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15295,7 +15295,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15310,7 +15310,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15325,7 +15325,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15340,7 +15340,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15355,7 +15355,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15370,7 +15370,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15385,7 +15385,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15400,7 +15400,7 @@
       {
         "radical": "攵",
         "role": "部件",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15415,7 +15415,7 @@
       {
         "radical": "攵",
         "role": "部件",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15425,7 +15425,7 @@
       {
         "radical": "享",
         "role": "形符",
-        "label": "享"
+        "label": "享用"
       },
       {
         "radical": "攵",
@@ -15445,7 +15445,7 @@
       {
         "radical": "攴",
         "role": "部件",
-        "label": "攴"
+        "label": "攻打"
       }
     ]
   },
@@ -15460,7 +15460,7 @@
       {
         "radical": "攴",
         "role": "形符",
-        "label": "攴"
+        "label": "攻打"
       }
     ]
   },
@@ -15470,7 +15470,7 @@
       {
         "radical": "敕",
         "role": "形符",
-        "label": "敕"
+        "label": "命令"
       },
       {
         "radical": "正",
@@ -15490,7 +15490,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15505,7 +15505,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -15520,7 +15520,7 @@
       {
         "radical": "死",
         "role": "形符",
-        "label": "死"
+        "label": "死亡"
       }
     ]
   },
@@ -15535,7 +15535,7 @@
       {
         "radical": "文",
         "role": "形符",
-        "label": "文"
+        "label": "文化"
       }
     ]
   },
@@ -15545,12 +15545,12 @@
       {
         "radical": "米",
         "role": "部件",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "斗",
         "role": "部件",
-        "label": "斗"
+        "label": "量器"
       }
     ]
   },
@@ -15565,7 +15565,7 @@
       {
         "radical": "斗",
         "role": "形符",
-        "label": "斗"
+        "label": "量器"
       }
     ]
   },
@@ -15620,7 +15620,7 @@
       {
         "radical": "其",
         "role": "部件",
-        "label": "其"
+        "label": "其他"
       },
       {
         "radical": "斤",
@@ -15650,27 +15650,27 @@
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "斤",
@@ -15685,7 +15685,7 @@
       {
         "radical": "方",
         "role": "部件",
-        "label": "方"
+        "label": "方形"
       },
       {
         "radical": "丿",
@@ -15695,7 +15695,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "也",
@@ -15710,7 +15710,7 @@
       {
         "radical": "立",
         "role": "形符",
-        "label": "立"
+        "label": "站立"
       },
       {
         "radical": "方",
@@ -15725,12 +15725,12 @@
       {
         "radical": "方",
         "role": "部件",
-        "label": "方"
+        "label": "方形"
       },
       {
         "radical": "氏",
         "role": "部件",
-        "label": "氏"
+        "label": "族氏"
       }
     ]
   },
@@ -15740,7 +15740,7 @@
       {
         "radical": "方",
         "role": "部件",
-        "label": "方"
+        "label": "方形"
       },
       {
         "radical": "疋",
@@ -15755,7 +15755,7 @@
       {
         "radical": "方",
         "role": "部件",
-        "label": "方"
+        "label": "方形"
       },
       {
         "radical": "矢",
@@ -15770,7 +15770,7 @@
       {
         "radical": "方",
         "role": "形符",
-        "label": "方"
+        "label": "方形"
       },
       {
         "radical": "其",
@@ -15790,7 +15790,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -15820,7 +15820,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -15835,7 +15835,7 @@
       {
         "radical": "干",
         "role": "部件",
-        "label": "干"
+        "label": "干犯"
       }
     ]
   },
@@ -15865,7 +15865,7 @@
       {
         "radical": "比",
         "role": "部件",
-        "label": "比"
+        "label": "比較"
       }
     ]
   },
@@ -15920,7 +15920,7 @@
       {
         "radical": "氏",
         "role": "部件",
-        "label": "氏"
+        "label": "族氏"
       },
       {
         "radical": "日",
@@ -15980,7 +15980,7 @@
       {
         "radical": "三",
         "role": "部件",
-        "label": "三"
+        "label": "三橫"
       },
       {
         "radical": "人",
@@ -16060,22 +16060,22 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       },
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "日",
@@ -16195,7 +16195,7 @@
       {
         "radical": "知",
         "role": "部件",
-        "label": "知"
+        "label": "知識"
       },
       {
         "radical": "日",
@@ -16285,7 +16285,7 @@
       {
         "radical": "申",
         "role": "形符",
-        "label": "申"
+        "label": "申述"
       },
       {
         "radical": "昜",
@@ -16400,7 +16400,7 @@
       {
         "radical": "廣",
         "role": "部件",
-        "label": "廣"
+        "label": "廣大"
       }
     ]
   },
@@ -16425,12 +16425,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -16460,7 +16460,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "日",
@@ -16505,7 +16505,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -16515,7 +16515,7 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "日",
@@ -16530,12 +16530,12 @@
       {
         "radical": "夫",
         "role": "部件",
-        "label": "夫"
+        "label": "成人"
       },
       {
         "radical": "夫",
         "role": "部件",
-        "label": "夫"
+        "label": "成人"
       },
       {
         "radical": "日",
@@ -16565,7 +16565,7 @@
       {
         "radical": "亼",
         "role": "部件",
-        "label": "亼"
+        "label": "集合"
       },
       {
         "radical": "日",
@@ -16600,12 +16600,12 @@
       {
         "radical": "卩",
         "role": "部件",
-        "label": "卩"
+        "label": "跪坐"
       },
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -16680,12 +16680,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -16695,12 +16695,12 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -16710,12 +16710,12 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -16725,12 +16725,12 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "乚",
         "role": "部件",
-        "label": "乚"
+        "label": "隱曲"
       }
     ]
   },
@@ -16745,7 +16745,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -16755,7 +16755,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "丂",
@@ -16770,7 +16770,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "彡",
@@ -16785,7 +16785,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "子",
@@ -16800,12 +16800,12 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -16815,7 +16815,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "才",
@@ -16830,7 +16830,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "寸",
@@ -16845,7 +16845,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "土",
@@ -16860,12 +16860,12 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -16875,7 +16875,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "不",
@@ -16890,7 +16890,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "日",
@@ -16905,7 +16905,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "日",
@@ -16920,7 +16920,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "公",
@@ -16935,7 +16935,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "反",
@@ -16950,7 +16950,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "斤",
@@ -16965,12 +16965,12 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -16985,7 +16985,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -16995,7 +16995,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "支",
@@ -17010,7 +17010,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "古",
@@ -17030,7 +17030,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17040,7 +17040,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "丙",
@@ -17055,7 +17055,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "白",
@@ -17070,12 +17070,12 @@
       {
         "radical": "甘",
         "role": "部件",
-        "label": "甘"
+        "label": "甜味"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17085,12 +17085,12 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "甘",
         "role": "部件",
-        "label": "甘"
+        "label": "甜味"
       }
     ]
   },
@@ -17105,7 +17105,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17115,12 +17115,12 @@
       {
         "radical": "矛",
         "role": "部件",
-        "label": "矛"
+        "label": "矛形"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17130,7 +17130,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "旦",
@@ -17145,7 +17145,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "可",
@@ -17160,7 +17160,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "主",
@@ -17175,7 +17175,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "卯",
@@ -17195,7 +17195,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17205,7 +17205,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "市",
@@ -17220,7 +17220,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "全",
@@ -17235,7 +17235,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "交",
@@ -17250,7 +17250,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "朱",
@@ -17265,7 +17265,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "亥",
@@ -17280,7 +17280,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "艮",
@@ -17295,7 +17295,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "各",
@@ -17315,7 +17315,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17325,7 +17325,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "圭",
@@ -17340,7 +17340,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "匡",
@@ -17360,7 +17360,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17370,12 +17370,12 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "卜",
         "role": "部件",
-        "label": "卜"
+        "label": "占卜"
       },
       {
         "radical": "日",
@@ -17395,7 +17395,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17405,7 +17405,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "甬",
@@ -17420,7 +17420,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "旱",
@@ -17445,7 +17445,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17455,7 +17455,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "每",
@@ -17490,7 +17490,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "肖",
@@ -17505,7 +17505,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "吾",
@@ -17520,7 +17520,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "弟",
@@ -17535,7 +17535,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "戒",
@@ -17550,7 +17550,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "帛",
@@ -17565,7 +17565,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "奉",
@@ -17595,7 +17595,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "朋",
@@ -17610,7 +17610,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "東",
@@ -17625,17 +17625,17 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17645,7 +17645,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "妻",
@@ -17660,7 +17660,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "果",
@@ -17675,7 +17675,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "直",
@@ -17690,7 +17690,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "隹",
@@ -17705,7 +17705,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "甚",
@@ -17720,7 +17720,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "昜",
@@ -17750,7 +17750,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "罒",
@@ -17765,7 +17765,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "南",
@@ -17780,7 +17780,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "眉",
@@ -17810,7 +17810,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "亟",
@@ -17825,7 +17825,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "皆",
@@ -17840,7 +17840,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "既",
@@ -17855,7 +17855,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "旁",
@@ -17880,7 +17880,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17890,7 +17890,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "冓",
@@ -17905,7 +17905,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "倉",
@@ -17920,7 +17920,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "貢",
@@ -17935,7 +17935,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "曹",
@@ -17950,7 +17950,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "舂",
@@ -17965,7 +17965,7 @@
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "白",
@@ -17975,12 +17975,12 @@
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -17990,7 +17990,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "梁",
@@ -18005,7 +18005,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "婁",
@@ -18020,7 +18020,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "票",
@@ -18035,7 +18035,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "章",
@@ -18050,7 +18050,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "莫",
@@ -18065,7 +18065,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "羕",
@@ -18080,7 +18080,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "菐",
@@ -18095,7 +18095,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "尌",
@@ -18110,7 +18110,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "毳",
@@ -18125,7 +18125,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "喬",
@@ -18140,7 +18140,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "矞",
@@ -18155,7 +18155,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "幾",
@@ -18170,7 +18170,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "象",
@@ -18185,7 +18185,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "黃",
@@ -18200,7 +18200,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "僉",
@@ -18215,7 +18215,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "蒙",
@@ -18230,7 +18230,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "寧",
@@ -18245,7 +18245,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "監",
@@ -18260,7 +18260,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "闌",
@@ -18275,7 +18275,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "雚",
@@ -18310,7 +18310,7 @@
       {
         "radical": "欠",
         "role": "部件",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18325,7 +18325,7 @@
       {
         "radical": "欠",
         "role": "形符",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18340,7 +18340,7 @@
       {
         "radical": "欠",
         "role": "形符",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18360,7 +18360,7 @@
       {
         "radical": "欠",
         "role": "部件",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18375,7 +18375,7 @@
       {
         "radical": "欠",
         "role": "部件",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18390,7 +18390,7 @@
       {
         "radical": "欠",
         "role": "形符",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18400,7 +18400,7 @@
       {
         "radical": "士",
         "role": "部件",
-        "label": "士"
+        "label": "士人"
       },
       {
         "radical": "示",
@@ -18410,7 +18410,7 @@
       {
         "radical": "欠",
         "role": "形符",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18425,7 +18425,7 @@
       {
         "radical": "欠",
         "role": "形符",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18440,7 +18440,7 @@
       {
         "radical": "欠",
         "role": "形符",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18455,7 +18455,7 @@
       {
         "radical": "欠",
         "role": "形符",
-        "label": "欠"
+        "label": "欠缺"
       }
     ]
   },
@@ -18465,12 +18465,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "止",
         "role": "部件",
-        "label": "止"
+        "label": "停止"
       }
     ]
   },
@@ -18495,17 +18495,17 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "弋",
         "role": "部件",
-        "label": "弋"
+        "label": "弋射"
       },
       {
         "radical": "止",
         "role": "部件",
-        "label": "止"
+        "label": "停止"
       }
     ]
   },
@@ -18515,12 +18515,12 @@
       {
         "radical": "不",
         "role": "部件",
-        "label": "不"
+        "label": "否定"
       },
       {
         "radical": "正",
         "role": "部件",
-        "label": "正"
+        "label": "正確"
       }
     ]
   },
@@ -18550,7 +18550,7 @@
       {
         "radical": "止",
         "role": "形符",
-        "label": "止"
+        "label": "停止"
       }
     ]
   },
@@ -18560,7 +18560,7 @@
       {
         "radical": "歹",
         "role": "部件",
-        "label": "歹"
+        "label": "死亡"
       },
       {
         "radical": "匕",
@@ -18575,7 +18575,7 @@
       {
         "radical": "歹",
         "role": "形符",
-        "label": "歹"
+        "label": "死亡"
       },
       {
         "radical": "央",
@@ -18590,7 +18590,7 @@
       {
         "radical": "歹",
         "role": "形符",
-        "label": "歹"
+        "label": "死亡"
       },
       {
         "radical": "台",
@@ -18605,7 +18605,7 @@
       {
         "radical": "歹",
         "role": "形符",
-        "label": "歹"
+        "label": "死亡"
       },
       {
         "radical": "朱",
@@ -18620,7 +18620,7 @@
       {
         "radical": "歹",
         "role": "形符",
-        "label": "歹"
+        "label": "死亡"
       },
       {
         "radical": "直",
@@ -18635,7 +18635,7 @@
       {
         "radical": "歹",
         "role": "形符",
-        "label": "歹"
+        "label": "死亡"
       },
       {
         "radical": "戔",
@@ -18650,7 +18650,7 @@
       {
         "radical": "歹",
         "role": "形符",
-        "label": "歹"
+        "label": "死亡"
       },
       {
         "radical": "韱",
@@ -18670,7 +18670,7 @@
       {
         "radical": "殳",
         "role": "部件",
-        "label": "殳"
+        "label": "器具"
       }
     ]
   },
@@ -18685,7 +18685,7 @@
       {
         "radical": "殳",
         "role": "形符",
-        "label": "殳"
+        "label": "器具"
       }
     ]
   },
@@ -18695,7 +18695,7 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "共",
@@ -18705,7 +18705,7 @@
       {
         "radical": "殳",
         "role": "部件",
-        "label": "殳"
+        "label": "器具"
       }
     ]
   },
@@ -18715,17 +18715,17 @@
       {
         "radical": "臼",
         "role": "部件",
-        "label": "臼"
+        "label": "臼形"
       },
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "殳",
         "role": "部件",
-        "label": "殳"
+        "label": "器具"
       }
     ]
   },
@@ -18740,7 +18740,7 @@
       {
         "radical": "殳",
         "role": "形符",
-        "label": "殳"
+        "label": "器具"
       }
     ]
   },
@@ -18755,12 +18755,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "二",
         "role": "部件",
-        "label": "二"
+        "label": "兩橫"
       },
       {
         "radical": "丶",
@@ -18815,7 +18815,7 @@
       {
         "radical": "毛",
         "role": "形符",
-        "label": "毛"
+        "label": "毛羽"
       },
       {
         "radical": "炎",
@@ -18835,7 +18835,7 @@
       {
         "radical": "毛",
         "role": "形符",
-        "label": "毛"
+        "label": "毛羽"
       }
     ]
   },
@@ -18850,7 +18850,7 @@
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       }
     ]
   },
@@ -18860,7 +18860,7 @@
       {
         "radical": "气",
         "role": "形符",
-        "label": "气"
+        "label": "氣體"
       },
       {
         "radical": "分",
@@ -18875,12 +18875,12 @@
       {
         "radical": "气",
         "role": "部件",
-        "label": "气"
+        "label": "氣體"
       },
       {
         "radical": "米",
         "role": "部件",
-        "label": "米"
+        "label": "米糧"
       }
     ]
   },
@@ -18890,7 +18890,7 @@
       {
         "radical": "气",
         "role": "形符",
-        "label": "气"
+        "label": "氣體"
       },
       {
         "radical": "羊",
@@ -18905,7 +18905,7 @@
       {
         "radical": "气",
         "role": "形符",
-        "label": "气"
+        "label": "氣體"
       },
       {
         "radical": "巠",
@@ -18925,7 +18925,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "水",
@@ -18960,7 +18960,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "丶",
@@ -19265,12 +19265,12 @@
       {
         "radical": "几",
         "role": "部件",
-        "label": "几"
+        "label": "几桌"
       },
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -19560,7 +19560,7 @@
       {
         "radical": "氏",
         "role": "部件",
-        "label": "氏"
+        "label": "族氏"
       }
     ]
   },
@@ -20235,7 +20235,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -20385,7 +20385,7 @@
       {
         "radical": "鹵",
         "role": "部件",
-        "label": "鹵"
+        "label": "鹽鹵"
       }
     ]
   },
@@ -20430,7 +20430,7 @@
       {
         "radical": "魚",
         "role": "部件",
-        "label": "魚"
+        "label": "魚類"
       }
     ]
   },
@@ -20990,7 +20990,7 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       }
     ]
   },
@@ -21000,12 +21000,12 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       }
     ]
   },
@@ -21015,7 +21015,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "少",
@@ -21035,7 +21035,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       }
     ]
   },
@@ -21045,7 +21045,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "玄",
@@ -21060,7 +21060,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "包",
@@ -21075,7 +21075,7 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "乍",
@@ -21090,7 +21090,7 @@
       {
         "radical": "爫",
         "role": "部件",
-        "label": "爫"
+        "label": "爪部"
       },
       {
         "radical": "灬",
@@ -21120,7 +21120,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "共",
@@ -21135,7 +21135,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "各",
@@ -21150,7 +21150,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "考",
@@ -21165,7 +21165,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "夆",
@@ -21180,7 +21180,7 @@
       {
         "radical": "正",
         "role": "部件",
-        "label": "正"
+        "label": "正確"
       },
       {
         "radical": "灬",
@@ -21200,7 +21200,7 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       }
     ]
   },
@@ -21210,7 +21210,7 @@
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       },
       {
         "radical": "灬",
@@ -21225,7 +21225,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "臽",
@@ -21255,7 +21255,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "柬",
@@ -21285,7 +21285,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "垔",
@@ -21305,12 +21305,12 @@
       {
         "radical": "攴",
         "role": "部件",
-        "label": "攴"
+        "label": "攻打"
       },
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       }
     ]
   },
@@ -21320,7 +21320,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "某",
@@ -21335,7 +21335,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "奐",
@@ -21365,7 +21365,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "頁",
@@ -21395,7 +21395,7 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "扇",
@@ -21470,7 +21470,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "然",
@@ -21485,7 +21485,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "登",
@@ -21500,7 +21500,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "堯",
@@ -21515,7 +21515,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "喿",
@@ -21530,7 +21530,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "粲",
@@ -21545,7 +21545,7 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "暴",
@@ -21560,12 +21560,12 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "樂",
         "role": "部件",
-        "label": "樂"
+        "label": "音樂"
       }
     ]
   },
@@ -21575,7 +21575,7 @@
       {
         "radical": "火",
         "role": "形符",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "闌",
@@ -21590,7 +21590,7 @@
       {
         "radical": "爪",
         "role": "形符",
-        "label": "爪"
+        "label": "爪形"
       },
       {
         "radical": "巴",
@@ -21605,12 +21605,12 @@
       {
         "radical": "爫",
         "role": "部件",
-        "label": "爫"
+        "label": "爪部"
       },
       {
         "radical": "彐",
         "role": "部件",
-        "label": "彐"
+        "label": "彐形"
       },
       {
         "radical": "亅",
@@ -21630,7 +21630,7 @@
       {
         "radical": "乂",
         "role": "部件",
-        "label": "乂"
+        "label": "交叉"
       }
     ]
   },
@@ -21640,7 +21640,7 @@
       {
         "radical": "父",
         "role": "形符",
-        "label": "父"
+        "label": "父輩"
       },
       {
         "radical": "巴",
@@ -21655,7 +21655,7 @@
       {
         "radical": "父",
         "role": "形符",
-        "label": "父"
+        "label": "父輩"
       },
       {
         "radical": "耶",
@@ -21670,17 +21670,17 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       },
       {
         "radical": "爻",
         "role": "部件",
-        "label": "爻"
+        "label": "交叉"
       },
       {
         "radical": "爻",
         "role": "部件",
-        "label": "爻"
+        "label": "交叉"
       }
     ]
   },
@@ -21690,7 +21690,7 @@
       {
         "radical": "爿",
         "role": "形符",
-        "label": "爿"
+        "label": "片形"
       },
       {
         "radical": "嗇",
@@ -21705,7 +21705,7 @@
       {
         "radical": "片",
         "role": "形符",
-        "label": "片"
+        "label": "片狀"
       },
       {
         "radical": "反",
@@ -21720,7 +21720,7 @@
       {
         "radical": "片",
         "role": "形符",
-        "label": "片"
+        "label": "片狀"
       },
       {
         "radical": "卑",
@@ -21740,7 +21740,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "亅",
@@ -21760,7 +21760,7 @@
       {
         "radical": "牛",
         "role": "部件",
-        "label": "牛"
+        "label": "牛隻"
       },
       {
         "radical": "也",
@@ -21780,7 +21780,7 @@
       {
         "radical": "牛",
         "role": "部件",
-        "label": "牛"
+        "label": "牛隻"
       }
     ]
   },
@@ -21790,7 +21790,7 @@
       {
         "radical": "牛",
         "role": "形符",
-        "label": "牛"
+        "label": "牛隻"
       },
       {
         "radical": "勿",
@@ -21805,7 +21805,7 @@
       {
         "radical": "牛",
         "role": "形符",
-        "label": "牛"
+        "label": "牛隻"
       },
       {
         "radical": "生",
@@ -21820,7 +21820,7 @@
       {
         "radical": "牛",
         "role": "形符",
-        "label": "牛"
+        "label": "牛隻"
       },
       {
         "radical": "寺",
@@ -21835,7 +21835,7 @@
       {
         "radical": "玄",
         "role": "部件",
-        "label": "玄"
+        "label": "深奧"
       },
       {
         "radical": "冖",
@@ -21845,7 +21845,7 @@
       {
         "radical": "牛",
         "role": "部件",
-        "label": "牛"
+        "label": "牛隻"
       }
     ]
   },
@@ -21860,7 +21860,7 @@
       {
         "radical": "牛",
         "role": "部件",
-        "label": "牛"
+        "label": "牛隻"
       }
     ]
   },
@@ -21870,7 +21870,7 @@
       {
         "radical": "牛",
         "role": "形符",
-        "label": "牛"
+        "label": "牛隻"
       },
       {
         "radical": "羲",
@@ -22215,12 +22215,12 @@
       {
         "radical": "亠",
         "role": "部件",
-        "label": "亠"
+        "label": "頭部"
       },
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       }
     ]
   },
@@ -22230,17 +22230,17 @@
       {
         "radical": "亠",
         "role": "部件",
-        "label": "亠"
+        "label": "頭部"
       },
       {
         "radical": "幺",
         "role": "部件",
-        "label": "幺"
+        "label": "細小"
       },
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -22265,12 +22265,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -22650,7 +22650,7 @@
       {
         "radical": "瓦",
         "role": "形符",
-        "label": "瓦"
+        "label": "瓦片"
       }
     ]
   },
@@ -22665,7 +22665,7 @@
       {
         "radical": "二",
         "role": "部件",
-        "label": "二"
+        "label": "兩橫"
       }
     ]
   },
@@ -22675,12 +22675,12 @@
       {
         "radical": "甘",
         "role": "部件",
-        "label": "甘"
+        "label": "甜味"
       },
       {
         "radical": "匹",
         "role": "部件",
-        "label": "匹"
+        "label": "匹配"
       }
     ]
   },
@@ -22695,7 +22695,7 @@
       {
         "radical": "甘",
         "role": "部件",
-        "label": "甘"
+        "label": "甜味"
       }
     ]
   },
@@ -22705,12 +22705,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -22725,7 +22725,7 @@
       {
         "radical": "生",
         "role": "形符",
-        "label": "生"
+        "label": "生長"
       }
     ]
   },
@@ -22735,12 +22735,12 @@
       {
         "radical": "更",
         "role": "部件",
-        "label": "更"
+        "label": "更改"
       },
       {
         "radical": "生",
         "role": "部件",
-        "label": "生"
+        "label": "生長"
       }
     ]
   },
@@ -22770,7 +22770,7 @@
       {
         "radical": "乚",
         "role": "部件",
-        "label": "乚"
+        "label": "隱曲"
       }
     ]
   },
@@ -22780,7 +22780,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "丶",
@@ -22790,7 +22790,7 @@
       {
         "radical": "用",
         "role": "部件",
-        "label": "用"
+        "label": "使用"
       }
     ]
   },
@@ -22805,7 +22805,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -22895,7 +22895,7 @@
       {
         "radical": "十",
         "role": "形符",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -22920,7 +22920,7 @@
       {
         "radical": "米",
         "role": "部件",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "田",
@@ -22945,7 +22945,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -23340,7 +23340,7 @@
       {
         "radical": "音",
         "role": "部件",
-        "label": "音"
+        "label": "聲音"
       }
     ]
   },
@@ -23560,7 +23560,7 @@
       {
         "radical": "比",
         "role": "部件",
-        "label": "比"
+        "label": "比較"
       },
       {
         "radical": "白",
@@ -23610,7 +23610,7 @@
       {
         "radical": "皮",
         "role": "形符",
-        "label": "皮"
+        "label": "皮膚"
       }
     ]
   },
@@ -23700,7 +23700,7 @@
       {
         "radical": "臣",
         "role": "形符",
-        "label": "臣"
+        "label": "臣服"
       },
       {
         "radical": "皿",
@@ -23775,7 +23775,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "目",
@@ -23785,7 +23785,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -23795,7 +23795,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "目",
@@ -23830,7 +23830,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "目",
@@ -23860,7 +23860,7 @@
       {
         "radical": "尸",
         "role": "部件",
-        "label": "尸"
+        "label": "屍形"
       },
       {
         "radical": "目",
@@ -23875,7 +23875,7 @@
       {
         "radical": "手",
         "role": "部件",
-        "label": "手"
+        "label": "手部"
       },
       {
         "radical": "目",
@@ -24030,7 +24030,7 @@
       {
         "radical": "周",
         "role": "部件",
-        "label": "周"
+        "label": "周圍"
       }
     ]
   },
@@ -24255,7 +24255,7 @@
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       },
       {
         "radical": "矢",
@@ -24275,7 +24275,7 @@
       {
         "radical": "口",
         "role": "形符",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -24695,7 +24695,7 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -24935,7 +24935,7 @@
       {
         "radical": "儿",
         "role": "部件",
-        "label": "儿"
+        "label": "人腳"
       }
     ]
   },
@@ -24950,7 +24950,7 @@
       {
         "radical": "乃",
         "role": "部件",
-        "label": "乃"
+        "label": "乃是"
       }
     ]
   },
@@ -24965,7 +24965,7 @@
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       }
     ]
   },
@@ -24980,7 +24980,7 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       }
     ]
   },
@@ -24995,7 +24995,7 @@
       {
         "radical": "斗",
         "role": "部件",
-        "label": "斗"
+        "label": "量器"
       }
     ]
   },
@@ -25070,7 +25070,7 @@
       {
         "radical": "多",
         "role": "部件",
-        "label": "多"
+        "label": "多數"
       }
     ]
   },
@@ -25130,7 +25130,7 @@
       {
         "radical": "果",
         "role": "部件",
-        "label": "果"
+        "label": "果實"
       }
     ]
   },
@@ -25140,7 +25140,7 @@
       {
         "radical": "亠",
         "role": "部件",
-        "label": "亠"
+        "label": "頭部"
       },
       {
         "radical": "回",
@@ -25345,7 +25345,7 @@
       {
         "radical": "穴",
         "role": "形符",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "九",
@@ -25360,7 +25360,7 @@
       {
         "radical": "穴",
         "role": "形符",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "工",
@@ -25390,7 +25390,7 @@
       {
         "radical": "穴",
         "role": "部件",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "犬",
@@ -25405,7 +25405,7 @@
       {
         "radical": "穴",
         "role": "形符",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "乍",
@@ -25420,7 +25420,7 @@
       {
         "radical": "穴",
         "role": "形符",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "囱",
@@ -25435,7 +25435,7 @@
       {
         "radical": "穴",
         "role": "形符",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "君",
@@ -25450,7 +25450,7 @@
       {
         "radical": "穴",
         "role": "形符",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "咼",
@@ -25465,7 +25465,7 @@
       {
         "radical": "穴",
         "role": "形符",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "躬",
@@ -25480,7 +25480,7 @@
       {
         "radical": "穴",
         "role": "形符",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "規",
@@ -25495,12 +25495,12 @@
       {
         "radical": "穴",
         "role": "部件",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "鼠",
         "role": "部件",
-        "label": "鼠"
+        "label": "鼠類"
       }
     ]
   },
@@ -25510,7 +25510,7 @@
       {
         "radical": "穴",
         "role": "部件",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "賣",
@@ -25525,12 +25525,12 @@
       {
         "radical": "穴",
         "role": "部件",
-        "label": "穴"
+        "label": "洞穴"
       },
       {
         "radical": "米",
         "role": "部件",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "禼",
@@ -25545,7 +25545,7 @@
       {
         "radical": "立",
         "role": "形符",
-        "label": "立"
+        "label": "站立"
       },
       {
         "radical": "占",
@@ -25560,12 +25560,12 @@
       {
         "radical": "音",
         "role": "部件",
-        "label": "音"
+        "label": "聲音"
       },
       {
         "radical": "儿",
         "role": "部件",
-        "label": "儿"
+        "label": "人腳"
       }
     ]
   },
@@ -25575,12 +25575,12 @@
       {
         "radical": "音",
         "role": "部件",
-        "label": "音"
+        "label": "聲音"
       },
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -25590,12 +25590,12 @@
       {
         "radical": "立",
         "role": "部件",
-        "label": "立"
+        "label": "站立"
       },
       {
         "radical": "里",
         "role": "部件",
-        "label": "里"
+        "label": "鄉里"
       }
     ]
   },
@@ -25605,7 +25605,7 @@
       {
         "radical": "立",
         "role": "形符",
-        "label": "立"
+        "label": "站立"
       },
       {
         "radical": "耑",
@@ -25775,7 +25775,7 @@
       {
         "radical": "合",
         "role": "部件",
-        "label": "合"
+        "label": "合計"
       }
     ]
   },
@@ -25835,7 +25835,7 @@
       {
         "radical": "具",
         "role": "部件",
-        "label": "具"
+        "label": "器具"
       }
     ]
   },
@@ -25945,7 +25945,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -26120,7 +26120,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "分",
@@ -26135,7 +26135,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "立",
@@ -26150,7 +26150,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "且",
@@ -26170,7 +26170,7 @@
       {
         "radical": "米",
         "role": "部件",
-        "label": "米"
+        "label": "米糧"
       }
     ]
   },
@@ -26185,7 +26185,7 @@
       {
         "radical": "米",
         "role": "部件",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "弓",
@@ -26200,7 +26200,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "青",
@@ -26215,7 +26215,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "胡",
@@ -26230,7 +26230,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "羔",
@@ -26245,7 +26245,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "唐",
@@ -26260,7 +26260,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "異",
@@ -26275,7 +26275,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "曹",
@@ -26290,7 +26290,7 @@
       {
         "radical": "米",
         "role": "形符",
-        "label": "米"
+        "label": "米糧"
       },
       {
         "radical": "量",
@@ -26305,7 +26305,7 @@
       {
         "radical": "糹",
         "role": "部件",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "丩",
@@ -26320,7 +26320,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "己",
@@ -26350,7 +26350,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "工",
@@ -26365,7 +26365,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "文",
@@ -26380,7 +26380,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "内",
@@ -26395,7 +26395,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "丑",
@@ -26410,7 +26410,7 @@
       {
         "radical": "糹",
         "role": "部件",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "予",
@@ -26425,7 +26425,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "屯",
@@ -26440,7 +26440,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "氏",
@@ -26455,7 +26455,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "及",
@@ -26470,7 +26470,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "分",
@@ -26485,7 +26485,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "云",
@@ -26515,7 +26515,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "冖",
@@ -26580,7 +26580,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "田",
@@ -26595,7 +26595,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "召",
@@ -26610,7 +26610,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "冬",
@@ -26625,7 +26625,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "且",
@@ -26640,7 +26640,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "半",
@@ -26655,7 +26655,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "吉",
@@ -26670,12 +26670,12 @@
       {
         "radical": "糹",
         "role": "部件",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       },
       {
         "radical": "巴",
@@ -26690,7 +26690,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "各",
@@ -26705,7 +26705,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "合",
@@ -26720,7 +26720,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "充",
@@ -26735,7 +26735,7 @@
       {
         "radical": "糹",
         "role": "部件",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "糸",
@@ -26750,7 +26750,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "邦",
@@ -26765,7 +26765,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "巠",
@@ -26780,7 +26780,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "宗",
@@ -26795,7 +26795,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "彔",
@@ -26810,7 +26810,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "周",
@@ -26825,7 +26825,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "隹",
@@ -26840,7 +26840,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "岡",
@@ -26855,7 +26855,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "罔",
@@ -26870,7 +26870,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "定",
@@ -26885,7 +26885,7 @@
       {
         "radical": "糹",
         "role": "部件",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "帛",
@@ -26915,7 +26915,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "者",
@@ -26930,7 +26930,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "泉",
@@ -26945,7 +26945,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "咠",
@@ -26960,7 +26960,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "彖",
@@ -26975,7 +26975,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "扁",
@@ -26990,7 +26990,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "爰",
@@ -27005,7 +27005,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "韋",
@@ -27020,7 +27020,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "柬",
@@ -27035,7 +27035,7 @@
       {
         "radical": "糹",
         "role": "部件",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "致",
@@ -27050,7 +27050,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "尃",
@@ -27080,7 +27080,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "逢",
@@ -27095,7 +27095,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "宿",
@@ -27110,7 +27110,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "從",
@@ -27125,7 +27125,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "悤",
@@ -27140,7 +27140,7 @@
       {
         "radical": "糹",
         "role": "部件",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "責",
@@ -27170,7 +27170,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "崩",
@@ -27185,7 +27185,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "翏",
@@ -27200,7 +27200,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "戠",
@@ -27215,7 +27215,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "堯",
@@ -27230,7 +27230,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "黽",
@@ -27245,7 +27245,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "會",
@@ -27280,12 +27280,12 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "糹",
         "role": "部件",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "虫",
@@ -27300,7 +27300,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "㡭",
@@ -27315,7 +27315,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "賣",
@@ -27345,7 +27345,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "廛",
@@ -27360,7 +27360,7 @@
       {
         "radical": "糹",
         "role": "形符",
-        "label": "糹"
+        "label": "絲旁"
       },
       {
         "radical": "韱",
@@ -27375,7 +27375,7 @@
       {
         "radical": "缶",
         "role": "形符",
-        "label": "缶"
+        "label": "陶器"
       },
       {
         "radical": "夬",
@@ -27390,7 +27390,7 @@
       {
         "radical": "缶",
         "role": "形符",
-        "label": "缶"
+        "label": "陶器"
       },
       {
         "radical": "雚",
@@ -27425,7 +27425,7 @@
       {
         "radical": "非",
         "role": "部件",
-        "label": "非"
+        "label": "相違"
       }
     ]
   },
@@ -27505,7 +27505,7 @@
       {
         "radical": "能",
         "role": "部件",
-        "label": "能"
+        "label": "能力"
       }
     ]
   },
@@ -27530,12 +27530,12 @@
       {
         "radical": "羊",
         "role": "部件",
-        "label": "羊"
+        "label": "羊形"
       },
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -27545,7 +27545,7 @@
       {
         "radical": "羊",
         "role": "部件",
-        "label": "羊"
+        "label": "羊形"
       },
       {
         "radical": "丑",
@@ -27565,7 +27565,7 @@
       {
         "radical": "羊",
         "role": "形符",
-        "label": "羊"
+        "label": "羊形"
       }
     ]
   },
@@ -27575,7 +27575,7 @@
       {
         "radical": "羊",
         "role": "形符",
-        "label": "羊"
+        "label": "羊形"
       },
       {
         "radical": "㳄",
@@ -27590,7 +27590,7 @@
       {
         "radical": "羊",
         "role": "形符",
-        "label": "羊"
+        "label": "羊形"
       },
       {
         "radical": "我",
@@ -27610,7 +27610,7 @@
       {
         "radical": "羽",
         "role": "形符",
-        "label": "羽"
+        "label": "羽毛"
       }
     ]
   },
@@ -27620,7 +27620,7 @@
       {
         "radical": "羽",
         "role": "部件",
-        "label": "羽"
+        "label": "羽毛"
       },
       {
         "radical": "白",
@@ -27640,7 +27640,7 @@
       {
         "radical": "羽",
         "role": "形符",
-        "label": "羽"
+        "label": "羽毛"
       }
     ]
   },
@@ -27655,7 +27655,7 @@
       {
         "radical": "羽",
         "role": "形符",
-        "label": "羽"
+        "label": "羽毛"
       }
     ]
   },
@@ -27670,7 +27670,7 @@
       {
         "radical": "羽",
         "role": "形符",
-        "label": "羽"
+        "label": "羽毛"
       }
     ]
   },
@@ -27685,7 +27685,7 @@
       {
         "radical": "羽",
         "role": "形符",
-        "label": "羽"
+        "label": "羽毛"
       }
     ]
   },
@@ -27695,7 +27695,7 @@
       {
         "radical": "羽",
         "role": "形符",
-        "label": "羽"
+        "label": "羽毛"
       },
       {
         "radical": "異",
@@ -27740,7 +27740,7 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "丿",
@@ -27760,7 +27760,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "丶",
@@ -27770,7 +27770,7 @@
       {
         "radical": "冂",
         "role": "部件",
-        "label": "冂"
+        "label": "開口"
       },
       {
         "radical": "丨",
@@ -27790,7 +27790,7 @@
       {
         "radical": "而",
         "role": "部件",
-        "label": "而"
+        "label": "連接"
       },
       {
         "radical": "女",
@@ -27805,12 +27805,12 @@
       {
         "radical": "而",
         "role": "部件",
-        "label": "而"
+        "label": "連接"
       },
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -27820,7 +27820,7 @@
       {
         "radical": "耒",
         "role": "形符",
-        "label": "耒"
+        "label": "農具"
       },
       {
         "radical": "井",
@@ -27835,7 +27835,7 @@
       {
         "radical": "耒",
         "role": "形符",
-        "label": "耒"
+        "label": "農具"
       },
       {
         "radical": "毛",
@@ -27900,7 +27900,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "王",
@@ -28015,7 +28015,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "罒",
@@ -28025,12 +28025,12 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       },
       {
         "radical": "心",
         "role": "部件",
-        "label": "心"
+        "label": "心思"
       }
     ]
   },
@@ -28145,7 +28145,7 @@
       {
         "radical": "户",
         "role": "部件",
-        "label": "户"
+        "label": "門戶"
       },
       {
         "radical": "⺼",
@@ -28175,7 +28175,7 @@
       {
         "radical": "止",
         "role": "部件",
-        "label": "止"
+        "label": "停止"
       },
       {
         "radical": "⺼",
@@ -28190,12 +28190,12 @@
       {
         "radical": "亠",
         "role": "部件",
-        "label": "亠"
+        "label": "頭部"
       },
       {
         "radical": "厶",
         "role": "部件",
-        "label": "厶"
+        "label": "私"
       },
       {
         "radical": "⺼",
@@ -28360,7 +28360,7 @@
       {
         "radical": "劦",
         "role": "部件",
-        "label": "劦"
+        "label": "合力"
       },
       {
         "radical": "⺼",
@@ -28500,7 +28500,7 @@
       {
         "radical": "肉",
         "role": "形符",
-        "label": "肉"
+        "label": "肉形"
       }
     ]
   },
@@ -28565,7 +28565,7 @@
       {
         "radical": "重",
         "role": "部件",
-        "label": "重"
+        "label": "重量"
       }
     ]
   },
@@ -28685,7 +28685,7 @@
       {
         "radical": "堂",
         "role": "部件",
-        "label": "堂"
+        "label": "廳堂"
       }
     ]
   },
@@ -28830,7 +28830,7 @@
       {
         "radical": "臣",
         "role": "部件",
-        "label": "臣"
+        "label": "臣服"
       },
       {
         "radical": "人",
@@ -28850,7 +28850,7 @@
       {
         "radical": "攵",
         "role": "形符",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -28860,7 +28860,7 @@
       {
         "radical": "吉",
         "role": "部件",
-        "label": "吉"
+        "label": "吉祥"
       },
       {
         "radical": "冖",
@@ -28870,7 +28870,7 @@
       {
         "radical": "至",
         "role": "部件",
-        "label": "至"
+        "label": "到達"
       }
     ]
   },
@@ -28925,7 +28925,7 @@
       {
         "radical": "舍",
         "role": "形符",
-        "label": "舍"
+        "label": "房舍"
       },
       {
         "radical": "予",
@@ -28945,7 +28945,7 @@
       {
         "radical": "舛",
         "role": "部件",
-        "label": "舛"
+        "label": "相違"
       }
     ]
   },
@@ -28955,7 +28955,7 @@
       {
         "radical": "舟",
         "role": "形符",
-        "label": "舟"
+        "label": "船形"
       },
       {
         "radical": "亢",
@@ -28970,12 +28970,12 @@
       {
         "radical": "舟",
         "role": "部件",
-        "label": "舟"
+        "label": "船形"
       },
       {
         "radical": "殳",
         "role": "部件",
-        "label": "殳"
+        "label": "器具"
       }
     ]
   },
@@ -28990,7 +28990,7 @@
       {
         "radical": "艮",
         "role": "部件",
-        "label": "艮"
+        "label": "停止"
       }
     ]
   },
@@ -29005,7 +29005,7 @@
       {
         "radical": "艮",
         "role": "形符",
-        "label": "艮"
+        "label": "停止"
       }
     ]
   },
@@ -29015,12 +29015,12 @@
       {
         "radical": "豐",
         "role": "部件",
-        "label": "豐"
+        "label": "豐盛"
       },
       {
         "radical": "色",
         "role": "部件",
-        "label": "色"
+        "label": "顏色"
       }
     ]
   },
@@ -29150,7 +29150,7 @@
       {
         "radical": "勹",
         "role": "部件",
-        "label": "勹"
+        "label": "包圍"
       },
       {
         "radical": "屮",
@@ -29160,7 +29160,7 @@
       {
         "radical": "勹",
         "role": "部件",
-        "label": "勹"
+        "label": "包圍"
       },
       {
         "radical": "屮",
@@ -29210,7 +29210,7 @@
       {
         "radical": "包",
         "role": "部件",
-        "label": "包"
+        "label": "包裹"
       }
     ]
   },
@@ -29220,7 +29220,7 @@
       {
         "radical": "草",
         "role": "部件",
-        "label": "草"
+        "label": "草本"
       },
       {
         "radical": "右",
@@ -29415,7 +29415,7 @@
       {
         "radical": "草",
         "role": "部件",
-        "label": "草"
+        "label": "草本"
       },
       {
         "radical": "日",
@@ -29425,7 +29425,7 @@
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -29520,7 +29520,7 @@
       {
         "radical": "十",
         "role": "形符",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -29640,7 +29640,7 @@
       {
         "radical": "死",
         "role": "部件",
-        "label": "死"
+        "label": "死亡"
       },
       {
         "radical": "廾",
@@ -29670,12 +29670,12 @@
       {
         "radical": "草",
         "role": "部件",
-        "label": "草"
+        "label": "草本"
       },
       {
         "radical": "鬼",
         "role": "部件",
-        "label": "鬼"
+        "label": "鬼怪"
       }
     ]
   },
@@ -29790,7 +29790,7 @@
       {
         "radical": "草",
         "role": "部件",
-        "label": "草"
+        "label": "草本"
       },
       {
         "radical": "祭",
@@ -30135,7 +30135,7 @@
       {
         "radical": "虍",
         "role": "部件",
-        "label": "虍"
+        "label": "虎紋"
       },
       {
         "radical": "几",
@@ -30155,7 +30155,7 @@
       {
         "radical": "文",
         "role": "部件",
-        "label": "文"
+        "label": "文化"
       }
     ]
   },
@@ -30180,7 +30180,7 @@
       {
         "radical": "虍",
         "role": "部件",
-        "label": "虍"
+        "label": "虎紋"
       },
       {
         "radical": "丱",
@@ -30190,7 +30190,7 @@
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -30385,7 +30385,7 @@
       {
         "radical": "兌",
         "role": "部件",
-        "label": "兌"
+        "label": "兌換"
       }
     ]
   },
@@ -30515,7 +30515,7 @@
       {
         "radical": "飠",
         "role": "部件",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "虫",
@@ -30575,7 +30575,7 @@
       {
         "radical": "鬲",
         "role": "形符",
-        "label": "鬲"
+        "label": "鼎器"
       },
       {
         "radical": "虫",
@@ -30590,12 +30590,12 @@
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "火",
         "role": "部件",
-        "label": "火"
+        "label": "火焰"
       },
       {
         "radical": "冖",
@@ -30700,7 +30700,7 @@
       {
         "radical": "黽",
         "role": "部件",
-        "label": "黽"
+        "label": "蛙類"
       }
     ]
   },
@@ -30850,12 +30850,12 @@
       {
         "radical": "角",
         "role": "部件",
-        "label": "角"
+        "label": "角形"
       },
       {
         "radical": "大",
         "role": "部件",
-        "label": "大"
+        "label": "大人"
       }
     ]
   },
@@ -30865,7 +30865,7 @@
       {
         "radical": "毛",
         "role": "部件",
-        "label": "毛"
+        "label": "毛羽"
       },
       {
         "radical": "衣",
@@ -30900,12 +30900,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "一",
         "role": "部件",
-        "label": "一"
+        "label": "橫畫"
       }
     ]
   },
@@ -30975,12 +30975,12 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       },
       {
         "radical": "戈",
         "role": "部件",
-        "label": "戈"
+        "label": "武器"
       },
       {
         "radical": "衣",
@@ -31015,7 +31015,7 @@
       {
         "radical": "冏",
         "role": "形符",
-        "label": "冏"
+        "label": "光明"
       }
     ]
   },
@@ -31090,7 +31090,7 @@
       {
         "radical": "里",
         "role": "部件",
-        "label": "里"
+        "label": "鄉里"
       }
     ]
   },
@@ -31295,7 +31295,7 @@
       {
         "radical": "爫",
         "role": "部件",
-        "label": "爫"
+        "label": "爪部"
       },
       {
         "radical": "見",
@@ -31370,17 +31370,17 @@
       {
         "radical": "角",
         "role": "部件",
-        "label": "角"
+        "label": "角形"
       },
       {
         "radical": "刀",
         "role": "部件",
-        "label": "刀"
+        "label": "刀具"
       },
       {
         "radical": "牛",
         "role": "部件",
-        "label": "牛"
+        "label": "牛隻"
       }
     ]
   },
@@ -31390,7 +31390,7 @@
       {
         "radical": "角",
         "role": "形符",
-        "label": "角"
+        "label": "角形"
       },
       {
         "radical": "蜀",
@@ -31455,7 +31455,7 @@
       {
         "radical": "寸",
         "role": "部件",
-        "label": "寸"
+        "label": "寸量"
       }
     ]
   },
@@ -31500,7 +31500,7 @@
       {
         "radical": "己",
         "role": "部件",
-        "label": "己"
+        "label": "自己"
       }
     ]
   },
@@ -31800,7 +31800,7 @@
       {
         "radical": "夸",
         "role": "部件",
-        "label": "夸"
+        "label": "誇張"
       }
     ]
   },
@@ -32415,7 +32415,7 @@
       {
         "radical": "攵",
         "role": "部件",
-        "label": "攵"
+        "label": "動作旁"
       }
     ]
   },
@@ -32465,7 +32465,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       }
     ]
   },
@@ -32480,7 +32480,7 @@
       {
         "radical": "谷",
         "role": "形符",
-        "label": "谷"
+        "label": "谷地"
       }
     ]
   },
@@ -32495,7 +32495,7 @@
       {
         "radical": "谷",
         "role": "形符",
-        "label": "谷"
+        "label": "谷地"
       }
     ]
   },
@@ -32520,7 +32520,7 @@
       {
         "radical": "山",
         "role": "部件",
-        "label": "山"
+        "label": "山岳"
       },
       {
         "radical": "丰",
@@ -32535,7 +32535,7 @@
       {
         "radical": "豆",
         "role": "部件",
-        "label": "豆"
+        "label": "豆形"
       }
     ]
   },
@@ -32685,7 +32685,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32695,7 +32695,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "才",
@@ -32715,7 +32715,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32730,7 +32730,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32745,7 +32745,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32755,7 +32755,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "反",
@@ -32775,7 +32775,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32790,7 +32790,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32805,7 +32805,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32820,7 +32820,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32835,7 +32835,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32845,7 +32845,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "占",
@@ -32865,7 +32865,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32890,7 +32890,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "有",
@@ -32910,7 +32910,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32925,7 +32925,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32955,12 +32955,12 @@
       {
         "radical": "小",
         "role": "部件",
-        "label": "小"
+        "label": "細小"
       },
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -32970,7 +32970,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "易",
@@ -33000,7 +33000,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "买",
@@ -33015,7 +33015,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "戔",
@@ -33030,12 +33030,12 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "武",
         "role": "部件",
-        "label": "武"
+        "label": "武力"
       }
     ]
   },
@@ -33050,7 +33050,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -33075,7 +33075,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "兼",
@@ -33090,7 +33090,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "冓",
@@ -33110,7 +33110,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -33120,7 +33120,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "曾",
@@ -33140,7 +33140,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       }
     ]
   },
@@ -33155,7 +33155,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "月",
@@ -33165,7 +33165,7 @@
       {
         "radical": "貝",
         "role": "形符",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "凡",
@@ -33180,7 +33180,7 @@
       {
         "radical": "貝",
         "role": "部件",
-        "label": "貝"
+        "label": "貝幣"
       },
       {
         "radical": "賣",
@@ -33195,12 +33195,12 @@
       {
         "radical": "赤",
         "role": "部件",
-        "label": "赤"
+        "label": "紅色"
       },
       {
         "radical": "赤",
         "role": "部件",
-        "label": "赤"
+        "label": "紅色"
       }
     ]
   },
@@ -33210,12 +33210,12 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "止",
         "role": "部件",
-        "label": "止"
+        "label": "停止"
       }
     ]
   },
@@ -33225,7 +33225,7 @@
       {
         "radical": "走",
         "role": "形符",
-        "label": "走"
+        "label": "奔走"
       },
       {
         "radical": "丩",
@@ -33240,7 +33240,7 @@
       {
         "radical": "走",
         "role": "形符",
-        "label": "走"
+        "label": "奔走"
       },
       {
         "radical": "己",
@@ -33255,7 +33255,7 @@
       {
         "radical": "走",
         "role": "形符",
-        "label": "走"
+        "label": "奔走"
       },
       {
         "radical": "召",
@@ -33270,7 +33270,7 @@
       {
         "radical": "走",
         "role": "形符",
-        "label": "走"
+        "label": "奔走"
       },
       {
         "radical": "戉",
@@ -33285,7 +33285,7 @@
       {
         "radical": "走",
         "role": "形符",
-        "label": "走"
+        "label": "奔走"
       },
       {
         "radical": "旱",
@@ -33300,7 +33300,7 @@
       {
         "radical": "走",
         "role": "形符",
-        "label": "走"
+        "label": "奔走"
       },
       {
         "radical": "尚",
@@ -33315,7 +33315,7 @@
       {
         "radical": "走",
         "role": "形符",
-        "label": "走"
+        "label": "奔走"
       },
       {
         "radical": "取",
@@ -33330,7 +33330,7 @@
       {
         "radical": "走",
         "role": "形符",
-        "label": "走"
+        "label": "奔走"
       },
       {
         "radical": "芻",
@@ -33830,7 +33830,7 @@
       {
         "radical": "車",
         "role": "部件",
-        "label": "車"
+        "label": "車形"
       }
     ]
   },
@@ -33840,7 +33840,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "欠",
@@ -33855,7 +33855,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "由",
@@ -33870,7 +33870,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "交",
@@ -33890,7 +33890,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       }
     ]
   },
@@ -33900,7 +33900,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "甫",
@@ -33915,7 +33915,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "巠",
@@ -33935,7 +33935,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       }
     ]
   },
@@ -33945,7 +33945,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "侖",
@@ -33960,7 +33960,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "咠",
@@ -33975,7 +33975,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "俞",
@@ -33990,7 +33990,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "畐",
@@ -34005,7 +34005,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "展",
@@ -34025,7 +34025,7 @@
       {
         "radical": "車",
         "role": "部件",
-        "label": "車"
+        "label": "車形"
       }
     ]
   },
@@ -34035,7 +34035,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "袁",
@@ -34050,7 +34050,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "專",
@@ -34065,7 +34065,7 @@
       {
         "radical": "車",
         "role": "形符",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "徹",
@@ -34080,17 +34080,17 @@
       {
         "radical": "車",
         "role": "部件",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "車",
         "role": "部件",
-        "label": "車"
+        "label": "車形"
       },
       {
         "radical": "車",
         "role": "部件",
-        "label": "車"
+        "label": "車形"
       }
     ]
   },
@@ -34105,7 +34105,7 @@
       {
         "radical": "辛",
         "role": "形符",
-        "label": "辛"
+        "label": "辛苦"
       }
     ]
   },
@@ -34115,7 +34115,7 @@
       {
         "radical": "辛",
         "role": "形符",
-        "label": "辛"
+        "label": "辛苦"
       },
       {
         "radical": "束",
@@ -34145,7 +34145,7 @@
       {
         "radical": "辛",
         "role": "部件",
-        "label": "辛"
+        "label": "辛苦"
       },
       {
         "radical": "刂",
@@ -34155,7 +34155,7 @@
       {
         "radical": "辛",
         "role": "部件",
-        "label": "辛"
+        "label": "辛苦"
       }
     ]
   },
@@ -34165,7 +34165,7 @@
       {
         "radical": "辛",
         "role": "部件",
-        "label": "辛"
+        "label": "辛苦"
       },
       {
         "radical": "言",
@@ -34175,7 +34175,7 @@
       {
         "radical": "辛",
         "role": "部件",
-        "label": "辛"
+        "label": "辛苦"
       }
     ]
   },
@@ -34235,7 +34235,7 @@
       {
         "radical": "反",
         "role": "部件",
-        "label": "反"
+        "label": "反向"
       }
     ]
   },
@@ -34280,7 +34280,7 @@
       {
         "radical": "由",
         "role": "部件",
-        "label": "由"
+        "label": "由來"
       }
     ]
   },
@@ -34610,7 +34610,7 @@
       {
         "radical": "車",
         "role": "部件",
-        "label": "車"
+        "label": "車形"
       }
     ]
   },
@@ -34625,7 +34625,7 @@
       {
         "radical": "周",
         "role": "部件",
-        "label": "周"
+        "label": "周圍"
       }
     ]
   },
@@ -35115,7 +35115,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "巴",
@@ -35190,7 +35190,7 @@
       {
         "radical": "良",
         "role": "部件",
-        "label": "良"
+        "label": "良好"
       },
       {
         "radical": "阝",
@@ -35235,7 +35235,7 @@
       {
         "radical": "享",
         "role": "部件",
-        "label": "享"
+        "label": "享用"
       },
       {
         "radical": "阝",
@@ -35310,7 +35310,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "勺",
@@ -35325,7 +35325,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "己",
@@ -35345,7 +35345,7 @@
       {
         "radical": "酉",
         "role": "部件",
-        "label": "酉"
+        "label": "酒器"
       }
     ]
   },
@@ -35355,7 +35355,7 @@
       {
         "radical": "酉",
         "role": "部件",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "凶",
@@ -35370,7 +35370,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "各",
@@ -35385,7 +35385,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "州",
@@ -35400,7 +35400,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "告",
@@ -35415,7 +35415,7 @@
       {
         "radical": "酉",
         "role": "部件",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "夋",
@@ -35430,7 +35430,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "卒",
@@ -35445,7 +35445,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "是",
@@ -35460,7 +35460,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "胡",
@@ -35475,7 +35475,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "星",
@@ -35495,7 +35495,7 @@
       {
         "radical": "鬼",
         "role": "形符",
-        "label": "鬼"
+        "label": "鬼怪"
       }
     ]
   },
@@ -35510,7 +35510,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       }
     ]
   },
@@ -35525,7 +35525,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       }
     ]
   },
@@ -35535,7 +35535,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "熏",
@@ -35550,7 +35550,7 @@
       {
         "radical": "酉",
         "role": "形符",
-        "label": "酉"
+        "label": "酒器"
       },
       {
         "radical": "襄",
@@ -35565,12 +35565,12 @@
       {
         "radical": "爫",
         "role": "部件",
-        "label": "爫"
+        "label": "爪部"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -35580,7 +35580,7 @@
       {
         "radical": "釆",
         "role": "形符",
-        "label": "釆"
+        "label": "辨別"
       },
       {
         "radical": "睪",
@@ -35600,7 +35600,7 @@
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       }
     ]
   },
@@ -35615,7 +35615,7 @@
       {
         "radical": "里",
         "role": "部件",
-        "label": "里"
+        "label": "鄉里"
       }
     ]
   },
@@ -35625,7 +35625,7 @@
       {
         "radical": "里",
         "role": "形符",
-        "label": "里"
+        "label": "鄉里"
       },
       {
         "radical": "予",
@@ -35645,7 +35645,7 @@
       {
         "radical": "里",
         "role": "形符",
-        "label": "里"
+        "label": "鄉里"
       }
     ]
   },
@@ -35660,7 +35660,7 @@
       {
         "radical": "丁",
         "role": "部件",
-        "label": "丁"
+        "label": "成丁"
       }
     ]
   },
@@ -35675,7 +35675,7 @@
       {
         "radical": "十",
         "role": "部件",
-        "label": "十"
+        "label": "十字"
       }
     ]
   },
@@ -35765,7 +35765,7 @@
       {
         "radical": "玉",
         "role": "部件",
-        "label": "玉"
+        "label": "玉石"
       }
     ]
   },
@@ -35810,7 +35810,7 @@
       {
         "radical": "句",
         "role": "部件",
-        "label": "句"
+        "label": "句子"
       }
     ]
   },
@@ -36225,7 +36225,7 @@
       {
         "radical": "門",
         "role": "部件",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "人",
@@ -36240,7 +36240,7 @@
       {
         "radical": "門",
         "role": "部件",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "才",
@@ -36255,7 +36255,7 @@
       {
         "radical": "門",
         "role": "形符",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "开",
@@ -36270,12 +36270,12 @@
       {
         "radical": "門",
         "role": "部件",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -36285,7 +36285,7 @@
       {
         "radical": "門",
         "role": "部件",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "月",
@@ -36300,7 +36300,7 @@
       {
         "radical": "門",
         "role": "部件",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "日",
@@ -36315,7 +36315,7 @@
       {
         "radical": "門",
         "role": "形符",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "各",
@@ -36345,7 +36345,7 @@
       {
         "radical": "門",
         "role": "部件",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "品",
@@ -36360,7 +36360,7 @@
       {
         "radical": "門",
         "role": "形符",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "活",
@@ -36375,7 +36375,7 @@
       {
         "radical": "門",
         "role": "形符",
-        "label": "門"
+        "label": "門戶"
       },
       {
         "radical": "丱",
@@ -36560,7 +36560,7 @@
       {
         "radical": "車",
         "role": "部件",
-        "label": "車"
+        "label": "車形"
       }
     ]
   },
@@ -36830,7 +36830,7 @@
       {
         "radical": "又",
         "role": "形符",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -36840,12 +36840,12 @@
       {
         "radical": "小",
         "role": "部件",
-        "label": "小"
+        "label": "細小"
       },
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -36860,7 +36860,7 @@
       {
         "radical": "隹",
         "role": "形符",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -36875,7 +36875,7 @@
       {
         "radical": "隹",
         "role": "形符",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -36885,12 +36885,12 @@
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       },
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       }
     ]
   },
@@ -36905,7 +36905,7 @@
       {
         "radical": "隹",
         "role": "形符",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -36920,7 +36920,7 @@
       {
         "radical": "隹",
         "role": "形符",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -36935,7 +36935,7 @@
       {
         "radical": "隹",
         "role": "形符",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -36950,7 +36950,7 @@
       {
         "radical": "又",
         "role": "部件",
-        "label": "又"
+        "label": "右手"
       }
     ]
   },
@@ -36965,7 +36965,7 @@
       {
         "radical": "隹",
         "role": "形符",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -36980,7 +36980,7 @@
       {
         "radical": "木",
         "role": "部件",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "隹",
@@ -37000,7 +37000,7 @@
       {
         "radical": "隹",
         "role": "部件",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -37015,7 +37015,7 @@
       {
         "radical": "隹",
         "role": "形符",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -37030,7 +37030,7 @@
       {
         "radical": "隹",
         "role": "形符",
-        "label": "隹"
+        "label": "鳥形"
       }
     ]
   },
@@ -37040,7 +37040,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "彐",
@@ -37055,7 +37055,7 @@
       {
         "radical": "雨",
         "role": "部件",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "云",
@@ -37070,7 +37070,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "令",
@@ -37085,7 +37085,7 @@
       {
         "radical": "雨",
         "role": "部件",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "田",
@@ -37100,7 +37100,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "包",
@@ -37115,7 +37115,7 @@
       {
         "radical": "雨",
         "role": "部件",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "电",
@@ -37130,12 +37130,12 @@
       {
         "radical": "雨",
         "role": "部件",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "而",
         "role": "部件",
-        "label": "而"
+        "label": "連接"
       }
     ]
   },
@@ -37145,7 +37145,7 @@
       {
         "radical": "雨",
         "role": "部件",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "肖",
@@ -37160,7 +37160,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "廷",
@@ -37175,7 +37175,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "辰",
@@ -37190,7 +37190,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "相",
@@ -37205,7 +37205,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "務",
@@ -37220,7 +37220,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "路",
@@ -37235,7 +37235,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "革",
@@ -37255,7 +37255,7 @@
       {
         "radical": "雨",
         "role": "形符",
-        "label": "雨"
+        "label": "雨水"
       },
       {
         "radical": "貍",
@@ -37285,7 +37285,7 @@
       {
         "radical": "青",
         "role": "形符",
-        "label": "青"
+        "label": "青色"
       },
       {
         "radical": "爭",
@@ -37305,7 +37305,7 @@
       {
         "radical": "非",
         "role": "形符",
-        "label": "非"
+        "label": "相違"
       }
     ]
   },
@@ -37375,7 +37375,7 @@
       {
         "radical": "韋",
         "role": "形符",
-        "label": "韋"
+        "label": "柔皮"
       },
       {
         "radical": "刃",
@@ -37390,7 +37390,7 @@
       {
         "radical": "立",
         "role": "部件",
-        "label": "立"
+        "label": "站立"
       },
       {
         "radical": "日",
@@ -37405,7 +37405,7 @@
       {
         "radical": "音",
         "role": "部件",
-        "label": "音"
+        "label": "聲音"
       },
       {
         "radical": "員",
@@ -37425,7 +37425,7 @@
       {
         "radical": "音",
         "role": "形符",
-        "label": "音"
+        "label": "聲音"
       }
     ]
   },
@@ -37480,7 +37480,7 @@
       {
         "radical": "彡",
         "role": "部件",
-        "label": "彡"
+        "label": "花紋"
       },
       {
         "radical": "頁",
@@ -37615,7 +37615,7 @@
       {
         "radical": "果",
         "role": "形符",
-        "label": "果"
+        "label": "果實"
       },
       {
         "radical": "頁",
@@ -37735,7 +37735,7 @@
       {
         "radical": "風",
         "role": "部件",
-        "label": "風"
+        "label": "風形"
       },
       {
         "radical": "台",
@@ -37755,7 +37755,7 @@
       {
         "radical": "風",
         "role": "形符",
-        "label": "風"
+        "label": "風形"
       }
     ]
   },
@@ -37770,7 +37770,7 @@
       {
         "radical": "風",
         "role": "部件",
-        "label": "風"
+        "label": "風形"
       }
     ]
   },
@@ -37795,7 +37795,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "几",
@@ -37810,7 +37810,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "反",
@@ -37825,7 +37825,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "欠",
@@ -37840,7 +37840,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "包",
@@ -37860,7 +37860,7 @@
       {
         "radical": "巾",
         "role": "形符",
-        "label": "巾"
+        "label": "布巾"
       }
     ]
   },
@@ -37870,7 +37870,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "并",
@@ -37890,7 +37890,7 @@
       {
         "radical": "食",
         "role": "形符",
-        "label": "食"
+        "label": "食物"
       }
     ]
   },
@@ -37900,7 +37900,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "耳",
@@ -37915,7 +37915,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "妥",
@@ -37930,12 +37930,12 @@
       {
         "radical": "飠",
         "role": "部件",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "我",
         "role": "部件",
-        "label": "我"
+        "label": "自我"
       }
     ]
   },
@@ -37945,7 +37945,7 @@
       {
         "radical": "飠",
         "role": "部件",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "余",
@@ -37960,12 +37960,12 @@
       {
         "radical": "飠",
         "role": "部件",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "官",
         "role": "部件",
-        "label": "官"
+        "label": "官職"
       }
     ]
   },
@@ -37975,7 +37975,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "畏",
@@ -37990,7 +37990,7 @@
       {
         "radical": "飠",
         "role": "部件",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "貴",
@@ -38005,7 +38005,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "幾",
@@ -38020,7 +38020,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "堯",
@@ -38035,7 +38035,7 @@
       {
         "radical": "飠",
         "role": "形符",
-        "label": "飠"
+        "label": "食旁"
       },
       {
         "radical": "毚",
@@ -38050,7 +38050,7 @@
       {
         "radical": "丷",
         "role": "部件",
-        "label": "丷"
+        "label": "撇捺"
       },
       {
         "radical": "自",
@@ -38080,7 +38080,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "也",
@@ -38100,7 +38100,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       }
     ]
   },
@@ -38110,7 +38110,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "史",
@@ -38125,7 +38125,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "它",
@@ -38140,7 +38140,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "奇",
@@ -38155,7 +38155,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "扁",
@@ -38175,7 +38175,7 @@
       {
         "radical": "馬",
         "role": "部件",
-        "label": "馬"
+        "label": "馬匹"
       }
     ]
   },
@@ -38185,7 +38185,7 @@
       {
         "radical": "馬",
         "role": "部件",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "蚤",
@@ -38200,7 +38200,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "區",
@@ -38215,7 +38215,7 @@
       {
         "radical": "馬",
         "role": "部件",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "喬",
@@ -38230,7 +38230,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "僉",
@@ -38250,7 +38250,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       }
     ]
   },
@@ -38260,7 +38260,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "聚",
@@ -38275,7 +38275,7 @@
       {
         "radical": "馬",
         "role": "形符",
-        "label": "馬"
+        "label": "馬匹"
       },
       {
         "radical": "盧",
@@ -38365,7 +38365,7 @@
       {
         "radical": "木",
         "role": "形符",
-        "label": "木"
+        "label": "木材"
       },
       {
         "radical": "公",
@@ -38420,7 +38420,7 @@
       {
         "radical": "鬥",
         "role": "部件",
-        "label": "鬥"
+        "label": "爭鬥"
       },
       {
         "radical": "市",
@@ -38450,12 +38450,12 @@
       {
         "radical": "鬼",
         "role": "部件",
-        "label": "鬼"
+        "label": "鬼怪"
       },
       {
         "radical": "斗",
         "role": "部件",
-        "label": "斗"
+        "label": "量器"
       }
     ]
   },
@@ -38470,7 +38470,7 @@
       {
         "radical": "鬼",
         "role": "形符",
-        "label": "鬼"
+        "label": "鬼怪"
       }
     ]
   },
@@ -38485,7 +38485,7 @@
       {
         "radical": "鬼",
         "role": "形符",
-        "label": "鬼"
+        "label": "鬼怪"
       }
     ]
   },
@@ -38495,7 +38495,7 @@
       {
         "radical": "鬼",
         "role": "部件",
-        "label": "鬼"
+        "label": "鬼怪"
       },
       {
         "radical": "未",
@@ -38515,7 +38515,7 @@
       {
         "radical": "鬼",
         "role": "形符",
-        "label": "鬼"
+        "label": "鬼怪"
       }
     ]
   },
@@ -38525,7 +38525,7 @@
       {
         "radical": "魚",
         "role": "部件",
-        "label": "魚"
+        "label": "魚類"
       },
       {
         "radical": "日",
@@ -38540,7 +38540,7 @@
       {
         "radical": "魚",
         "role": "形符",
-        "label": "魚"
+        "label": "魚類"
       },
       {
         "radical": "包",
@@ -38555,7 +38555,7 @@
       {
         "radical": "魚",
         "role": "形符",
-        "label": "魚"
+        "label": "魚類"
       },
       {
         "radical": "圭",
@@ -38570,7 +38570,7 @@
       {
         "radical": "魚",
         "role": "形符",
-        "label": "魚"
+        "label": "魚類"
       },
       {
         "radical": "羊",
@@ -38590,7 +38590,7 @@
       {
         "radical": "魚",
         "role": "形符",
-        "label": "魚"
+        "label": "魚類"
       }
     ]
   },
@@ -38600,7 +38600,7 @@
       {
         "radical": "魚",
         "role": "形符",
-        "label": "魚"
+        "label": "魚類"
       },
       {
         "radical": "京",
@@ -38615,7 +38615,7 @@
       {
         "radical": "魚",
         "role": "形符",
-        "label": "魚"
+        "label": "魚類"
       },
       {
         "radical": "耆",
@@ -38645,7 +38645,7 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "鳥",
@@ -38765,7 +38765,7 @@
       {
         "radical": "鹵",
         "role": "形符",
-        "label": "鹵"
+        "label": "鹽鹵"
       },
       {
         "radical": "咸",
@@ -38815,7 +38815,7 @@
       {
         "radical": "夂",
         "role": "部件",
-        "label": "夂"
+        "label": "往下"
       }
     ]
   },
@@ -38830,7 +38830,7 @@
       {
         "radical": "面",
         "role": "形符",
-        "label": "面"
+        "label": "臉面"
       }
     ]
   },
@@ -38840,7 +38840,7 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "林",
@@ -38860,7 +38860,7 @@
       {
         "radical": "幺",
         "role": "形符",
-        "label": "幺"
+        "label": "細小"
       }
     ]
   },
@@ -38870,12 +38870,12 @@
       {
         "radical": "黍",
         "role": "部件",
-        "label": "黍"
+        "label": "黍米"
       },
       {
         "radical": "勹",
         "role": "部件",
-        "label": "勹"
+        "label": "包圍"
       },
       {
         "radical": "丿",
@@ -38890,7 +38890,7 @@
       {
         "radical": "黍",
         "role": "形符",
-        "label": "黍"
+        "label": "黍米"
       },
       {
         "radical": "占",
@@ -38905,12 +38905,12 @@
       {
         "radical": "口",
         "role": "部件",
-        "label": "口"
+        "label": "口部"
       },
       {
         "radical": "土",
         "role": "部件",
-        "label": "土"
+        "label": "土地"
       },
       {
         "radical": "灬",
@@ -38925,7 +38925,7 @@
       {
         "radical": "黑",
         "role": "形符",
-        "label": "黑"
+        "label": "黑色"
       },
       {
         "radical": "占",
@@ -38940,7 +38940,7 @@
       {
         "radical": "黑",
         "role": "形符",
-        "label": "黑"
+        "label": "黑色"
       },
       {
         "radical": "音",
@@ -38970,7 +38970,7 @@
       {
         "radical": "鼠",
         "role": "形符",
-        "label": "鼠"
+        "label": "鼠類"
       },
       {
         "radical": "句",
@@ -38985,7 +38985,7 @@
       {
         "radical": "鼻",
         "role": "形符",
-        "label": "鼻"
+        "label": "鼻子"
       },
       {
         "radical": "干",
@@ -39000,7 +39000,7 @@
       {
         "radical": "齒",
         "role": "形符",
-        "label": "齒"
+        "label": "牙齒"
       },
       {
         "radical": "令",
@@ -39015,7 +39015,7 @@
       {
         "radical": "广",
         "role": "部件",
-        "label": "广"
+        "label": "廣廈"
       },
       {
         "radical": "龍",


### PR DESCRIPTION
Fixes #825

## Summary
- 開 的 門(形符) label 從 "門" 改為 "門戶" — 不再只是重複部件字
- 開 的 开(聲符) label 確認為 "讀音" （staging 已正確）
- 修正 625 個 形符 label 與部件字相同的情況，補上有意義的描述（如「門→門戶」「人→人形」「刀→刀具」）
- 修正 700 個 部件 label 與部件字相同的情況，補上有意義的描述
- 總計 1325 個 label 改善，覆蓋 2528 個漢字

## Test plan
- [ ] 開 拆解顯示：門(形符, 門戶) + 开(聲符, 讀音)
- [ ] 其他含「門」部件的字（如 間、閉、開、關）也顯示「門戶」
- [ ] 含「刀」形符的字（切、到、剪）顯示「刀具」而非「刀」
- [ ] `npm run build` 通過（已驗證）
- [ ] 無空白 label 的 聲符