### PR TITLE
fix(layout): #824 — fix scroll regression across multiple steps

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -153,11 +153,12 @@ const LearningContent: React.FC = () => {
         onNavigate={handleStepperNavigate}
       />
 
-      {/* Learning step content — overflow-hidden so each step manages its own scroll.
-          ReadingAnnotation, LiveTutor, and other steps use h-full + internal overflow-y-auto
-          and require a height-bounded parent; overflow-y-auto here would let them expand
-          unboundedly and make their internal containerRef never scroll (#815). */}
-      <div className="flex-1 overflow-hidden pb-14 md:pb-0">
+      {/* Learning step content — flex flex-col so child step components receive a flex
+          context and their flex-1 / h-full classes are bounded. overflow-hidden keeps the
+          height capped to the viewport so steps with internal scroll containers (e.g.
+          ReadingAnnotation's containerRef, VocabPractice's main-content div) scroll
+          correctly without the outer wrapper scrolling instead (#815, #824). */}
+      <div className="flex-1 flex flex-col overflow-hidden pb-14 md:pb-0">
         <LearningLayout />
       </div>
     </div>

--- a/frontend/src/components/reading-steps/VocabApplication.tsx
+++ b/frontend/src/components/reading-steps/VocabApplication.tsx
@@ -397,7 +397,7 @@ const VocabApplication: React.FC<VocabApplicationProps> = ({
 
   return (
     <div
-      className="flex flex-col min-h-full bg-white"
+      className="flex-1 flex flex-col bg-white"
       style={fontSizePx ? { fontSize: fontSizePx } : undefined}
     >
       <StepHeader

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -703,7 +703,7 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
   };
 
   return (
-    <div className="flex flex-col min-h-full bg-amber-50">
+    <div className="flex-1 flex flex-col bg-amber-50">
       <StepHeader
         title="語詞定義配對"
         subtitle={phase === 'summary' ? '作答結果' : modeSubtitles[mode]}

--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -575,7 +575,7 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
   const gridTotalPx = size * cellSizePx;
 
   return (
-    <div className="flex flex-col gap-4 px-2 py-4 select-none">
+    <div className="flex-1 overflow-y-auto flex flex-col gap-4 px-2 py-4 select-none">
       {/* Header */}
       <div className="px-2">
         <h2 className="text-lg font-black text-gray-800">語詞複習</h2>

--- a/frontend/src/pages/learning/ReportPage.tsx
+++ b/frontend/src/pages/learning/ReportPage.tsx
@@ -110,7 +110,7 @@ const ReportPage: React.FC = () => {
   }, []);
 
   return (
-    <div className="p-8 max-w-4xl mx-auto w-full">
+    <div className="flex-1 overflow-y-auto p-8 max-w-4xl mx-auto w-full">
       <AssessmentReport
         session={session}
         story={selectedStory}


### PR DESCRIPTION
## Problem

PR #819 changed the `LearningContent` step wrapper from `overflow-y-auto` to `overflow-hidden` to fix ReadingAnnotation's panel click scroll. This introduced scroll regressions in three areas:

1. **VocabDefinitionMatch (語詞定義配對)** — root used `flex flex-col min-h-full`. In an `overflow-hidden` flex container, `min-h-full` resolves to 0. The inner `flex-1 overflow-auto` had no height to scroll within.
2. **VocabApplication (語詞應用)** — same `min-h-full` problem.
3. **VocabWordSearch (語詞複習) and ReportPage (報告)** — these rely on their own content growing and had no `flex-1` or `overflow-y-auto` on root. Content was clipped by `overflow-hidden`.

## Root Cause

The wrapper div was a flex ITEM but NOT a flex CONTAINER. So `flex-1` on child step components had no flex context — they were laid out as block elements. Steps without `flex-1` were clipped with no way to scroll.

## Fix (5 files)

| File | Change |
|------|--------|
| `AppShell.tsx` | Add `flex flex-col` to the step wrapper so `flex-1` on child steps is bounded by the wrapper height |
| `VocabDefinitionMatch.tsx` | `flex flex-col min-h-full` → `flex-1 flex flex-col` |
| `VocabApplication.tsx` | `flex flex-col min-h-full` → `flex-1 flex flex-col` |
| `VocabWordSearch.tsx` | Add `flex-1 overflow-y-auto` to root |
| `ReportPage.tsx` | Add `flex-1 overflow-y-auto` to wrapper div |

ReadingAnnotation's `containerRef` scroll continues to work because its root (`flex-1 flex flex-col h-full overflow-hidden`) still receives a bounded height via `flex-1` in the now-flex wrapper.

## Test Checklist

- [ ] ReadingAnnotation: panel click scrolls to text
- [ ] VocabPractice 部件 tab: can scroll down
- [ ] VocabDefinitionMatch: can scroll down
- [ ] VocabWordSearch: grid scrollable
- [ ] AssessmentReport: full report scrollable
- [ ] All other steps: no layout regression

Closes #824