### PR TITLE
fix(vocab): #832 — guard handlePractice mode + restore example sentence cache

### DIFF
--- a/backend/app/routes/learning/learning_vocab.py
+++ b/backend/app/routes/learning/learning_vocab.py
@@ -70,8 +70,14 @@ async def get_example_sentences(
             payload.character,
             payload.story_title,
         )
+        def _to_item(s: object) -> ExampleSentenceItem:
+            # Pre-generated cache stores plain strings; AI-generated cache stores dicts.
+            if isinstance(s, str):
+                return ExampleSentenceItem(sentence=s, explanation="")
+            return ExampleSentenceItem(**s)
+
         return ExampleSentencesResponse(
-            sentences=[ExampleSentenceItem(**s) for s in cached.get("sentences", [])],
+            sentences=[_to_item(s) for s in cached.get("sentences", [])],
         )
 
     # 2. Cache miss — call AI

--- a/backend/data/example_sentence_cache.json
+++ b/backend/data/example_sentence_cache.json
@@ -1,8942 +1,13412 @@
 {
   "#MeToo運動與我們的權利:一": {
-    "sentences": [],
+    "sentences": [
+      "這一場運動改變了整個社會對性騷擾的認知",
+      "每一個勇敢站出來的人都值得被尊重與傾聽",
+      "一旦沉默被打破，正義的力量就會開始匯聚"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:主": {
-    "sentences": [],
+    "sentences": [
+      "每個人都是自己身體的主人，有權拒絕任何不當接觸",
+      "主動揭發不法行為需要極大的勇氣與決心",
+      "這場運動的主軸在於喚醒社會對受害者的同理心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:冒": {
-    "sentences": [],
+    "sentences": [
+      "冒著被報復的風險，她仍然選擇說出真相",
+      "許多受害者不敢冒險發聲，因為害怕失去工作",
+      "社會應該保護那些冒著壓力挺身而出的人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:凝": {
-    "sentences": [],
+    "sentences": [
+      "她凝視著鏡頭，堅定地說出自己的遭遇",
+      "社會的目光逐漸凝聚在這個長期被忽略的議題上",
+      "凝重的氣氛籠罩著整個聽證會現場"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:後": {
-    "sentences": [],
+    "sentences": [
+      "事件曝光後，越來越多受害者開始願意發聲",
+      "在漫長的沉默之後，真相終於浮出水面",
+      "後續的法律改革讓加害者更難逃脫制裁"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:忌": {
-    "sentences": [],
+    "sentences": [
+      "加害者利用權勢讓受害者心生忌憚而不敢聲張",
+      "面對不公不義的事情，我們不該有所忌諱",
+      "肆無忌憚地濫用權力終究會受到法律的制裁"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:憚": {
-    "sentences": [],
+    "sentences": [
+      "她無所畏憚地站上法庭，為自己爭取正義",
+      "權勢者肆無忌憚的行為終於被攤在陽光下",
+      "不要因為憚於權威就放棄捍衛自己的權利"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:所": {
-    "sentences": [],
+    "sentences": [
+      "每個人所擁有的基本人權都不應該被侵犯",
+      "她所經歷的一切成為推動社會改革的關鍵力量",
+      "受害者所承受的心理創傷需要長時間的療癒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:有": {
-    "sentences": [],
+    "sentences": [
+      "所有人都有權利在安全的環境中工作與生活",
+      "有些傷害即使過了很久仍然會影響一個人的身心",
+      "只有建立完善的申訴管道才能有效保護受害者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:標": {
-    "sentences": [],
+    "sentences": [
+      "這場運動的標誌性口號傳遍了世界各個角落",
+      "社群媒體上的標籤讓更多人看見了這個議題",
+      "她成為推動性別平權的標竿人物"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:權": {
-    "sentences": [],
+    "sentences": [
+      "每個人都擁有不被騷擾的基本權利",
+      "權力的不對等往往是職場性騷擾發生的根本原因",
+      "人權的維護需要整個社會共同努力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:然": {
-    "sentences": [],
+    "sentences": [
+      "然而改變不會一夕之間發生，需要持續的努力",
+      "她毅然決定站出來揭發長期以來的不公對待",
+      "雖然過程艱辛，但這場運動確實帶來了深遠的影響"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:片": {
-    "sentences": [],
+    "sentences": [
+      "那些片段的記憶至今仍讓她感到不安與恐懼",
+      "社群上的短片記錄了這場運動的每一個重要時刻",
+      "不要只看到片面的報導就急著下結論"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:犯": {
-    "sentences": [],
+    "sentences": [
+      "侵犯他人身體自主權的行為必須受到法律制裁",
+      "犯罪者不應因為社會地位高就被輕判或姑息",
+      "任何人都不該成為性犯罪的受害者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:結": {
-    "sentences": [],
+    "sentences": [
+      "受害者們團結起來，共同對抗不公正的體制",
+      "這場運動的結果促成了多項法律的修訂與完善",
+      "社會各界結合力量推動了反性騷擾的立法改革"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:自": {
-    "sentences": [],
+    "sentences": [
+      "每個人都有保護自己身體自主權的權利",
+      "她鼓起勇氣，自願站出來為其他受害者發聲",
+      "自我保護的意識應該從小就開始培養"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:舉": {
-    "sentences": [],
+    "sentences": [
+      "她勇敢地舉報了職場中的不當行為",
+      "這一舉動鼓勵了無數沉默的受害者",
+      "舉世矚目的這場運動改變了人們對性別議題的看法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:茶": {
-    "sentences": [],
+    "sentences": [
+      "茶餘飯後的閒聊中也開始討論性別平權的話題",
+      "她端起茶杯，平靜地述說那段不堪的往事",
+      "這個議題不該只是茶餘飯後的談資，而是需要行動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:視": {
-    "sentences": [],
+    "sentences": [
+      "我們不該漠視身邊正在發生的不公義的事",
+      "社會長期忽視受害者的聲音，是這場運動爆發的原因",
+      "正視問題的存在是解決問題的第一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:譁": {
-    "sentences": [],
+    "sentences": [
+      "喧譁的網路輿論中，我們更需要冷靜地傾聽真相",
+      "這場運動不是一時的譁眾取寵，而是真實的社會訴求",
+      "不要被譁然的言論帶偏，應該關注事件的核心本質"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:證": {
-    "sentences": [],
+    "sentences": [
+      "受害者提出的證據讓整個案件有了突破性的進展",
+      "蒐集證據的過程對受害者來說是一段痛苦的回憶",
+      "法庭上的證詞揭露了權勢者長期濫權的真相"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:識": {
-    "sentences": [],
+    "sentences": [
+      "提升全民對性別平權的意識是教育的重要課題",
+      "我們應該具備辨識不當行為的基本知識和能力",
+      "認識自己的權利是保護自己的第一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:鏈": {
-    "sentences": [],
+    "sentences": [
+      "受害者的勇敢發聲形成了一條改變社會的連鏈效應",
+      "權力的鏈條一旦被打破，加害者就無處遁形",
+      "證據鏈的完整性對於案件的審理至關重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:陰": {
-    "sentences": [],
+    "sentences": [
+      "陰暗角落裡發生的事不該被永遠掩蓋",
+      "走出陰影需要時間，也需要社會的支持與包容",
+      "她終於從那段陰霾中走出來，重新面對生活"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:霾": {
-    "sentences": [],
+    "sentences": [
+      "長期的霾害讓她幾乎失去了對生活的信心",
+      "走出心中的陰霾是一段漫長而艱辛的旅程",
+      "這場運動像一陣風，吹散了籠罩在受害者心頭的霾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:飯": {
-    "sentences": [],
+    "sentences": [
+      "茶餘飯後人們開始更認真地看待性別平等的議題",
+      "吃飯時同事們討論起最近的社會運動",
+      "飯桌上的對話反映出社會意識正在悄悄改變"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "#MeToo運動與我們的權利:餘": {
-    "sentences": [],
+    "sentences": [
+      "茶餘飯後的話題逐漸從八卦轉向了社會正義",
+      "事件的餘波持續影響著社會的各個層面",
+      "工作之餘她積極投入反性騷擾的倡議活動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:倖": {
-    "sentences": [],
+    "sentences": [
+      "倖存的種子在極端環境下依然保有發芽的能力",
+      "末日種子庫讓作物在災難後仍有倖存的機會",
+      "那些倖免於難的稀有植物被妥善保存了起來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:備": {
-    "sentences": [],
+    "sentences": [
+      "科學家為了應對未來的災難做好了萬全的準備",
+      "種子庫裡儲備了來自世界各地的珍貴植物種子",
+      "防災準備不只是口號，更需要實際的行動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:免": {
-    "sentences": [],
+    "sentences": [
+      "末日種子庫的目的是讓糧食作物免於滅絕的危機",
+      "為了避免物種消失，科學家收集了大量的種子",
+      "免於飢荒的威脅是全人類共同的願望"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:出": {
-    "sentences": [],
+    "sentences": [
+      "科學家從世界各地找出最珍貴的種子加以保存",
+      "一旦災難發生，這些種子就能拿出來重新種植",
+      "種子庫的設計出自於對未來氣候變遷的擔憂"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:及": {
-    "sentences": [],
+    "sentences": [
+      "及時保存種子才能在災難來臨時挽救糧食危機",
+      "種子庫收藏的品種涵及全球各大洲的重要作物",
+      "趁著物種還沒消失，我們必須及早採取行動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:嚴": {
-    "sentences": [],
+    "sentences": [
+      "嚴寒的北極氣候正好適合長期保存種子",
+      "嚴格的溫度控制確保種子能維持數百年的活性",
+      "面對嚴峻的糧食危機，種子庫是最後的防線"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:多": {
-    "sentences": [],
+    "sentences": [
+      "種子庫裡收藏了多達上百萬種不同的植物種子",
+      "許多國家紛紛送來自己最珍貴的農作物種子",
+      "多樣化的作物品種是糧食安全的重要基礎"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:天": {
-    "sentences": [],
+    "sentences": [
+      "天災人禍隨時都可能威脅到全球的糧食供應",
+      "種子庫建在天寒地凍的北極，自然形成冷藏環境",
+      "老天爺的考驗讓人類更懂得珍惜大自然的資源"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:性": {
-    "sentences": [],
+    "sentences": [
+      "保存種子的多樣性對未來的農業發展非常重要",
+      "種子的活性必須定期檢測以確保品質",
+      "生物多樣性一旦消失就很難再恢復了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:戒": {
-    "sentences": [],
+    "sentences": [
+      "末日種子庫提醒我們要時刻戒備自然災害的威脅",
+      "我們應該引以為戒，不再過度開發自然資源",
+      "警戒意識讓人類在面對危機時能更快做出反應"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:未": {
-    "sentences": [],
+    "sentences": [
+      "未來的氣候變遷可能導致更多農作物品種消失",
+      "種子庫是為了應對那些未知的災難而建造的",
+      "未雨綢繆的態度是保護地球最好的方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:森": {
-    "sentences": [],
+    "sentences": [
+      "森林大火可能在一夕之間摧毀大片的植被",
+      "陰森的末日場景提醒我們保護環境的重要性",
+      "森林裡的許多珍稀植物已經被收錄進種子庫中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:極": {
-    "sentences": [],
+    "sentences": [
+      "種子庫建在北極圈內，利用極地的天然低溫保存",
+      "極端氣候造成的農業損失已經越來越嚴重了",
+      "科學家不辭辛勞到極地建造這座種子保險庫"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:樣": {
-    "sentences": [],
+    "sentences": [
+      "種子庫保存的樣本來自世界各地的農業研究機構",
+      "各式各樣的農作物種子都被妥善收藏在庫中",
+      "每一種樣本都代表著人類飲食文化的一部分"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:殃": {
-    "sentences": [],
+    "sentences": [
+      "戰爭帶來的災殃讓許多國家的農業遭受重創",
+      "城門失火殃及池魚，氣候變遷影響了所有物種",
+      "天災造成的禍殃促使人類開始認真保存珍貴種子"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:池": {
-    "sentences": [],
+    "sentences": [
+      "城門失火殃及池魚，一場戰爭毀了整個地區的農業",
+      "種子庫就像一座安全的蓄水池，儲存著未來的希望",
+      "池塘裡的水生植物種子也被納入保存的範圍中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:活": {
-    "sentences": [],
+    "sentences": [
+      "這些冷凍保存的種子在解凍後仍然能夠存活發芽",
+      "保持種子的活力是種子庫最重要的任務之一",
+      "活下去的希望就藏在這些小小的種子裡面"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:漫": {
-    "sentences": [],
+    "sentences": [
+      "漫長的冰河時期曾經讓許多物種走向滅絕",
+      "漫天風雪中，種子庫靜靜地守護著人類的未來",
+      "在漫無邊際的冰原上，這座種子庫顯得格外重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:火": {
-    "sentences": [],
+    "sentences": [
+      "戰火摧毀了敘利亞的種子庫，幸好備份保存在北極",
+      "森林大火是威脅植物多樣性的主要災害之一",
+      "烽火連天的年代裡，糧食安全更顯得重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:烽": {
-    "sentences": [],
+    "sentences": [
+      "烽火四起的地區最需要種子庫的備援保護",
+      "古代用烽火傳遞警報，現代則用科技保護種子",
+      "戰爭的烽煙散去後，人們靠著備份種子重建農業"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:甦": {
-    "sentences": [],
+    "sentences": [
+      "沉睡多年的種子經過適當處理後竟然復甦發芽了",
+      "大地回春萬物甦醒，正如種子在適當條件下重生",
+      "種子庫讓瀕臨消失的品種有機會甦醒過來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:端": {
-    "sentences": [],
+    "sentences": [
+      "極端天氣越來越頻繁，糧食安全問題日益嚴峻",
+      "種子庫的一端連接著現在，另一端延伸到遙遠的未來",
+      "科學家從多方面端詳每一顆種子的保存狀態"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:綢": {
-    "sentences": [],
+    "sentences": [
+      "未雨綢繆的精神讓人類在危機來臨前做好了準備",
+      "科學家綢繆已久，終於建成了這座末日種子庫",
+      "綢繆的計畫需要各國政府通力合作才能實現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:繆": {
-    "sentences": [],
+    "sentences": [
+      "未雨綢繆是建造末日種子庫的核心理念",
+      "提前綢繆讓我們在面對災難時不至於束手無策",
+      "這份深謀遠繆的計畫保護了全球的糧食安全"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:資": {
-    "sentences": [],
+    "sentences": [
+      "建造種子庫需要大量的資金和各國的共同支持",
+      "珍貴的種子資源是全人類最寶貴的財產之一",
+      "許多國家投入資源來維護這座全球共享的種子庫"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:醒": {
-    "sentences": [],
+    "sentences": [
+      "這座種子庫提醒我們要時刻保持危機意識",
+      "科學家不斷提醒世人氣候變遷的嚴重後果",
+      "覺醒的人類終於開始為下一代的糧食安全做準備"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:雨": {
-    "sentences": [],
+    "sentences": [
+      "未雨綢繆的態度讓種子庫在災難前就已經建好了",
+      "暴雨洪水可能沖毀農田，但種子庫裡的備份安然無恙",
+      "風雨無阻，科學家持續收集世界各地的珍貴種子"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-末日種子庫:魚": {
-    "sentences": [],
+    "sentences": [
+      "城門失火殃及池魚，環境的破壞影響了所有生物",
+      "除了農作物，魚類和水生植物的基因也需要保存",
+      "小小的種子就像水中的魚，在適當環境下就能活過來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:人": {
-    "sentences": [],
+    "sentences": [
+      "植物獵人深入叢林只為了尋找珍稀的植物品種",
+      "這些人冒著生命危險在野外採集瀕危植物",
+      "人類對自然的好奇心驅使探險家走遍世界各地"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:佼": {
-    "sentences": [],
+    "sentences": [
+      "他是植物學界的佼佼者，發現了許多新品種",
+      "佼佼者總是比別人付出更多的努力和汗水",
+      "在眾多探險家中，他的成就可說是出類拔萃的佼佼者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:倖": {
-    "sentences": [],
+    "sentences": [
+      "倖存下來的珍稀植物需要人類的保護才能延續",
+      "他們僥倖逃過了暴風雨，繼續進行採集任務",
+      "那棵倖免於砍伐的千年老樹成了重要的研究對象"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:倚": {
-    "sentences": [],
+    "sentences": [
+      "探險家倚靠著大樹休息，觀察四周的植物生態",
+      "他倚賴多年的野外經驗才能在叢林中安全行動",
+      "老樹倚著山壁生長，姿態優美又充滿生命力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:僥": {
-    "sentences": [],
+    "sentences": [
+      "靠僥倖在野外生存是非常危險的事情",
+      "植物獵人不能存有僥倖心理，必須做足準備",
+      "他僥倖避開了毒蛇的攻擊，繼續前進"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:冠": {
-    "sentences": [],
+    "sentences": [
+      "那棵大樹的樹冠遮天蔽日，底下長滿了稀有蕨類",
+      "他被譽為植物獵人之冠，一生發現了上百種新品種",
+      "森林的樹冠層是許多珍稀植物生長的重要棲地"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:危": {
-    "sentences": [],
+    "sentences": [
+      "許多珍貴的植物正面臨瀕臨絕種的危機",
+      "危險的地形擋不住植物獵人探索的決心",
+      "瀕危植物的保護工作刻不容緩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:取": {
-    "sentences": [],
+    "sentences": [
+      "植物獵人小心翼翼地採取珍貴的種子帶回研究",
+      "他從懸崖邊取得了一株極為罕見的蘭花",
+      "採取正確的保存方式才能讓種子維持活力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:口": {
-    "sentences": [],
+    "sentences": [
+      "峽谷的入口處長滿了從未見過的奇特植物",
+      "他口中描述的那片原始森林令人心生嚮往",
+      "山洞口的苔蘚已經生長了數百年之久"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:地": {
-    "sentences": [],
+    "sentences": [
+      "這片土地上生長著許多獨特的植物品種",
+      "植物獵人到世界各地尋找珍稀的植物",
+      "棲息地遭到破壞是植物瀕危的主要原因"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:奠": {
-    "sentences": [],
+    "sentences": [
+      "他的研究奠定了現代植物分類學的重要基礎",
+      "植物獵人的採集工作為植物園的建立奠下根基",
+      "這次探險奠定了他在植物學界不可動搖的地位"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:定": {
-    "sentences": [],
+    "sentences": [
+      "他下定決心要找到那株傳說中的珍稀蘭花",
+      "確定植物的品種需要仔細觀察葉片和花朵的特徵",
+      "堅定的意志讓他在惡劣環境中也不輕言放棄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:息": {
-    "sentences": [],
+    "sentences": [
+      "探險家在溪邊休息片刻，記錄沿途發現的植物",
+      "森林中傳來鳥兒的叫聲和蟲鳴，生生不息",
+      "植物的生息環境一旦被破壞就很難恢復"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:悄": {
-    "sentences": [],
+    "sentences": [
+      "他悄悄地靠近那株罕見的蘭花，深怕驚擾到它",
+      "森林裡的變化悄然發生，許多物種正在消失",
+      "植物獵人悄無聲息地穿越叢林進行採集工作"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:拗": {
-    "sentences": [],
+    "sentences": [
+      "他個性執拗，堅持要親自攀上懸崖採集那株植物",
+      "拗不過同伴的勸說，他只好暫時放棄那條危險的路線",
+      "那棵樹的枝幹被風吹得彎曲拗折卻依然存活"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:杳": {
-    "sentences": [],
+    "sentences": [
+      "杳無人煙的深山裡反而保存著最珍貴的植物",
+      "那位探險家進入叢林後便杳無音訊令人擔憂",
+      "杳無蹤跡的珍稀品種或許還藏在某個未知的角落"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:棲": {
-    "sentences": [],
+    "sentences": [
+      "許多珍稀植物的棲息地正在因人類活動而縮減",
+      "鳥類棲息在樹冠層與各種附生植物共同生活",
+      "保護植物的棲地就是保護整個生態系統的關鍵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:樹": {
-    "sentences": [],
+    "sentences": [
+      "那棵千年老樹的枝幹上長滿了珍貴的附生植物",
+      "植物獵人爬上高大的樹幹尋找隱藏在樹冠的蘭花",
+      "一棵樹就像一個小型的生態系統，養活了無數生命"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:永": {
-    "sentences": [],
+    "sentences": [
+      "植物獵人希望這些珍稀品種能永遠被保存下來",
+      "永續經營的理念是現代保育工作的核心精神",
+      "他永遠記得第一次在野外發現新品種時的感動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:汲": {
-    "sentences": [],
+    "sentences": [
+      "植物從土壤中汲取養分和水分才能健康成長",
+      "他不斷汲取前輩探險家的經驗來充實自己",
+      "植物的根系深入地底汲取珍貴的水源維持生命"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:注": {
-    "sentences": [],
+    "sentences": [
+      "他全神貫注地觀察那朵花的構造並仔細記錄",
+      "植物獵人把畢生的心血注入珍稀植物的保育工作",
+      "注意觀察葉片的紋路是辨識植物品種的關鍵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:瀕": {
-    "sentences": [],
+    "sentences": [
+      "瀕臨絕種的植物急需人類的保護和復育",
+      "這片森林裡的許多物種已經瀕危，情況令人憂心",
+      "瀕危植物名錄上的品種數量每年都在增加"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:無": {
-    "sentences": [],
+    "sentences": [
+      "杳無人煙的山區往往隱藏著最珍貴的植物資源",
+      "他在無人到達的懸崖上發現了一株全新的品種",
+      "無數植物獵人前仆後繼地投入珍稀物種的採集工作"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:然": {
-    "sentences": [],
+    "sentences": [
+      "他突然在岩縫中發現了一株從未被記錄過的植物",
+      "大自然的奧妙讓每一位植物獵人都感到由衷的敬畏",
+      "原始森林中自然生長的植物遠比人工培育的更加多樣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:煙": {
-    "sentences": [],
+    "sentences": [
+      "杳無人煙的深山是許多珍稀植物最後的避難所",
+      "炊煙升起的村落旁，他發現了一片野生的藥用植物",
+      "煙霧瀰漫的雲霧森林是許多附生蘭花的天堂"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:目": {
-    "sentences": [],
+    "sentences": [
+      "他的目光被一株從未見過的奇特植物深深吸引住了",
+      "這次探險的目標是採集三種瀕危的蕨類植物標本",
+      "植物獵人目不轉睛地觀察著眼前罕見的花朵構造"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:續": {
-    "sentences": [],
+    "sentences": [
+      "持續的保育工作讓許多瀕危植物族群逐漸恢復",
+      "他繼續深入叢林，尋找更多未被發現的植物品種",
+      "永續經營的理念需要一代又一代的人共同努力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:者": {
-    "sentences": [],
+    "sentences": [
+      "植物獵人是最早關注生物多樣性的先驅者之一",
+      "研究者花了好幾年才確認這是一個全新的植物品種",
+      "這些勇敢的探險者為植物學的發展做出了巨大貢獻"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:臨": {
-    "sentences": [],
+    "sentences": [
+      "面臨棲地消失的危機，許多珍稀植物急需被保護",
+      "植物獵人親臨現場才能真正了解植物的生長環境",
+      "瀕臨滅絕的物種提醒我們生態保育刻不容緩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:變": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷讓許多植物的分布範圍產生了巨大變化",
+      "環境的劇變迫使一些植物不得不向更高海拔遷移",
+      "植物獵人必須隨時應變，調整探險計畫"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:趨": {
-    "sentences": [],
+    "sentences": [
+      "全球暖化的趨勢讓高山植物的生存空間越來越小",
+      "保育意識日益增強是近年來令人欣慰的趨勢",
+      "植物的分布逐漸趨向更高海拔的區域"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:近": {
-    "sentences": [],
+    "sentences": [
+      "他小心翼翼地靠近那株珍稀的蘭花仔細觀察",
+      "近年來越來越多人投入植物保育的行列",
+      "附近的村民幫助植物獵人找到了通往秘境的小路"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:遷": {
-    "sentences": [],
+    "sentences": [
+      "棲地的破壞迫使許多植物的分布範圍不斷遷移",
+      "植物無法像動物一樣快速遷徙來適應環境變化",
+      "人類的大規模遷居活動嚴重影響了原生植物的生態"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "-植物獵人:重": {
-    "sentences": [],
+    "sentences": [
+      "保護瀕危植物是一項重要且刻不容緩的工作",
+      "他重新踏上旅程，前往更偏遠的山區採集標本",
+      "植物多樣性對維持生態平衡有著舉足輕重的地位"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "不量田:盈": {
-    "sentences": [],
+    "sentences": [
+      "農夫觀察田中水位的盈虧來決定灌溉的時機",
+      "他不需要丈量，只看水面是否盈滿便知收成好壞",
+      "古人的智慧在於懂得從自然的盈虛變化中順勢而為"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:下": {
-    "sentences": [],
+    "sentences": [
+      "出生率持續下降是許多國家正在面對的嚴峻問題",
+      "在少子化的趨勢下，社會結構將發生重大的變化",
+      "人口負成長的問題已經擺在我們眼前，不容再拖延下去"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:不": {
-    "sentences": [],
+    "sentences": [
+      "少子化的危機並不是突然發生的，而是長期累積的結果",
+      "不願正視問題的態度只會讓人口危機變得更加嚴重",
+      "這頭灰犀牛不是看不見，而是大家選擇視而不見"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:可": {
-    "sentences": [],
+    "sentences": [
+      "人口負成長可能導致勞動力不足和經濟發展停滯",
+      "這個問題不可再被忽視，必須立刻採取對策",
+      "少子化的衝擊可以預見，但很少有人認真準備"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:愈": {
-    "sentences": [],
+    "sentences": [
+      "少子化的問題愈來愈嚴重，已經影響到國家的發展",
+      "人口結構的失衡只會愈演愈烈，不會自動好轉",
+      "愈是拖延面對問題，將來付出的代價就愈大"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:成": {
-    "sentences": [],
+    "sentences": [
+      "人口負成長已經成為許多已開發國家最大的隱憂",
+      "造成少子化的原因包括高房價和育兒成本的上升",
+      "如何達成人口結構的平衡是政府最迫切的課題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:每": {
-    "sentences": [],
+    "sentences": [
+      "每一年出生人數都在減少，這個趨勢令人非常擔憂",
+      "每個家庭對於是否生育都有自己的考量和難處",
+      "幾乎每個已開發國家都在面對人口老化的挑戰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:況": {
-    "sentences": [],
+    "sentences": [
+      "目前的人口狀況顯示，勞動力缺口將持續擴大",
+      "每況愈下的出生率讓政府不得不重新思考政策方向",
+      "少子化的情況如果持續惡化，社會福利將難以維持"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:而": {
-    "sentences": [],
+    "sentences": [
+      "人口問題看似遙遠，而實際上已經影響到我們的生活",
+      "少子化的衝擊不是一朝一夕形成的，而是數十年的累積",
+      "然而面對這頭灰犀牛，多數人仍然選擇漠視它的存在"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:見": {
-    "sentences": [],
+    "sentences": [
+      "灰犀牛的特徵就是明明看得見卻沒有人願意正視",
+      "可以預見的是，人口持續減少將衝擊國家的經濟發展",
+      "你看見了這個問題嗎？還是選擇假裝它不存在呢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:視": {
-    "sentences": [],
+    "sentences": [
+      "我們不能再漠視人口負成長帶來的嚴重後果了",
+      "忽視少子化的問題就像看到灰犀牛卻不躲開一樣危險",
+      "正視人口結構的變化才能提前做好應對的準備"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:負": {
-    "sentences": [],
+    "sentences": [
+      "人口負成長意味著死亡人數已經超過了出生人數",
+      "負面的人口趨勢將對社會的各個層面產生深遠影響",
+      "背負著沉重壓力的年輕世代越來越不想生小孩了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:蹂": {
-    "sentences": [],
+    "sentences": [
+      "少子化的浪潮正在蹂躪許多國家的社會結構和經濟",
+      "被現實蹂躪的年輕人已經對未來失去了信心",
+      "灰犀牛般的危機一旦衝來，將蹂躪一切毫無準備的社會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:躪": {
-    "sentences": [],
+    "sentences": [
+      "經濟壓力和高房價蹂躪著年輕家庭的生活品質",
+      "少子化的衝擊會像灰犀牛蹂躪草原般地摧殘整個社會",
+      "如果繼續放任不管，人口危機將無情地蹂躪整個國家"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:逆": {
-    "sentences": [],
+    "sentences": [
+      "想要逆轉人口負成長的趨勢需要全方位的政策支持",
+      "逆境中更需要有遠見的領導者來面對這項嚴峻的挑戰",
+      "我們不能逆轉時間，但可以從現在開始改變未來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "你看見時代的灰犀牛了嗎談人口負成長:長": {
-    "sentences": [],
+    "sentences": [
+      "人口負成長已經是台灣不可忽視的重要國安議題了",
+      "經濟的長期停滯與人口結構的改變有著密切的關聯",
+      "漫長的政策改革需要社會各界共同耐心地努力推動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:仆": {
-    "sentences": [],
+    "sentences": [
+      "前仆後繼的信眾不顧一切地追隨著教主的指示",
+      "他仆倒在地，卻仍對教主的話語深信不疑",
+      "看到前人仆倒的教訓，我們應該更加謹慎地判斷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:傾": {
-    "sentences": [],
+    "sentences": [
+      "信眾傾盡家產也要追隨教主，令家人十分擔心",
+      "他傾聽教主的每一句話，毫無保留地相信",
+      "盲目的信仰讓人傾家蕩產卻還甘之如飴"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:其": {
-    "sentences": [],
+    "sentences": [
+      "其實很多信眾在加入之前都是理性的普通人",
+      "教主利用信眾的虔誠來達成其不可告人的目的",
+      "其中的道理值得每一個人深思與警惕"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:前": {
-    "sentences": [],
+    "sentences": [
+      "前仆後繼的追隨者讓教主的勢力不斷壯大",
+      "在加入教團之前，他從未想過自己會如此盲從",
+      "前車之鑑告訴我們盲目崇拜會帶來多大的危害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:北": {
-    "sentences": [],
+    "sentences": [
+      "教團的影響力從南到北擴展到了全國各個角落",
+      "南轅北轍的價值觀讓他與家人產生了嚴重的衝突",
+      "教主帶著信眾北上集會，聲勢浩大引起社會關注"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:匪": {
-    "sentences": [],
+    "sentences": [
+      "匪夷所思的教義竟然能讓這麼多人深信不疑",
+      "這些行為看起來匪夷所思，但信眾卻覺得理所當然",
+      "他的所作所為令人覺得匪夷所思又難以理解"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:南": {
-    "sentences": [],
+    "sentences": [
+      "南轅北轍的想法讓他和朋友之間的距離越來越遠",
+      "教團從南部發跡，逐漸擴展到全國各地",
+      "他一路從南方趕來參加教主的講道大會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:圓": {
-    "sentences": [],
+    "sentences": [
+      "教主巧妙地用話術自圓其說，讓信眾無法反駁",
+      "看似圓滿的說法背後其實漏洞百出",
+      "他試圖用各種理由把教主的謊言圓回來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:夷": {
-    "sentences": [],
+    "sentences": [
+      "匪夷所思的儀式讓外人看了都感到不可思議",
+      "這種夷然自若的態度讓旁觀者更加困惑不解",
+      "教主的行為在常人看來簡直是匪夷所思"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:孽": {
-    "sentences": [],
+    "sentences": [
+      "盲目的崇拜造成了無法挽回的罪孽和家庭破碎",
+      "教主利用信眾的虔誠來造孽，終究會受到報應",
+      "這些冤孽般的悲劇不斷在不同的邪教中重複上演"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:家": {
-    "sentences": [],
+    "sentences": [
+      "許多信眾為了追隨教主甚至拋棄了自己的家庭",
+      "傾家蕩產的故事在這個教團中屢見不鮮",
+      "一個家庭的崩解往往從一個成員的盲目信仰開始"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:廝": {
-    "sentences": [],
+    "sentences": [
+      "信眾之間互相廝混，形成了一個封閉的小社會",
+      "他們在教團裡廝守多年，已經與外界完全脫節",
+      "教團內部的人彼此廝殺爭權，信仰早已變了質"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:後": {
-    "sentences": [],
+    "sentences": [
+      "前仆後繼的追隨者讓這個教團持續擴張壯大",
+      "事後回想起來，他才意識到自己被洗腦了多久",
+      "後來的調查揭露了教主背後不為人知的真面目"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:思": {
-    "sentences": [],
+    "sentences": [
+      "信眾失去了獨立思考的能力，只會盲目服從",
+      "靜下心來仔細思考，就會發現教主的話漏洞百出",
+      "不經思索就相信別人的話是一件非常危險的事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:所": {
-    "sentences": [],
+    "sentences": [
+      "教主所說的每一句話都被信眾奉為絕對的真理",
+      "他所失去的不只是金錢，還有寶貴的親情和友誼",
+      "匪夷所思的行為在教團內部卻被視為理所當然"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:殺": {
-    "sentences": [],
+    "sentences": [
+      "教團內部的權力鬥爭最終演變成了互相殘殺",
+      "自相殘殺的悲劇讓社會大眾對邪教更加警惕",
+      "他在衝鋒陷陣中殺出一條路，終於逃離了教團"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:產": {
-    "sentences": [],
+    "sentences": [
+      "許多信眾傾家蕩產後才醒悟自己被騙了",
+      "教主靠著信眾的奉獻累積了大量的財產",
+      "失去所有家產的信眾最終只能流落街頭"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:發": {
-    "sentences": [],
+    "sentences": [
+      "事件爆發後，社會大眾才驚覺教團的危害有多大",
+      "教主善於激發信眾的情緒，讓他們失去理智",
+      "這個案件的發展引起了全國上下的高度關注"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:益": {
-    "sentences": [],
+    "sentences": [
+      "教主打著公益的旗號實際上卻在中飽私囊",
+      "受益的永遠只有教主本人，信眾只是被利用的工具",
+      "加入教團對他毫無益處，反而讓他失去了一切"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:繼": {
-    "sentences": [],
+    "sentences": [
+      "前仆後繼的信眾讓教團的規模不斷擴大",
+      "即使前人已經受害，後面的人仍繼續加入",
+      "他繼續留在教團裡，已經無法分辨是非對錯了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:罪": {
-    "sentences": [],
+    "sentences": [
+      "教主犯下的罪行終於被司法機關揭露並起訴",
+      "盲目的信仰所造成的罪孽讓整個社會付出了代價",
+      "他為自己過去的盲從感到深深的罪惡感"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:自": {
-    "sentences": [],
+    "sentences": [
+      "教主自稱擁有超凡的能力，吸引了大批追隨者",
+      "失去自主判斷能力的信眾就像被操控的傀儡一樣",
+      "自欺欺人的謊言遲早會被戳破，真相終會大白"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:蕩": {
-    "sentences": [],
+    "sentences": [
+      "傾家蕩產的信眾最後才發現教主根本是個騙子",
+      "他把所有積蓄都蕩盡了，只換來一場空虛的夢",
+      "教主奢靡蕩漾的生活全靠信眾的血汗錢在支撐"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:衝": {
-    "sentences": [],
+    "sentences": [
+      "衝鋒陷陣的信眾為教主賣命，卻不知自己是棋子",
+      "理性與情感的衝突讓他在離開與留下之間掙扎",
+      "他終於衝破了心理的枷鎖，鼓起勇氣離開教團"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:說": {
-    "sentences": [],
+    "sentences": [
+      "教主能說善道，輕易就能把黑的說成白的",
+      "信眾之間口耳相傳教主的種種神蹟傳說",
+      "他的說法聽起來頭頭是道，實際上卻經不起檢驗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:轅": {
-    "sentences": [],
+    "sentences": [
+      "教主的行為與他宣揚的教義南轅北轍令人諷刺",
+      "南轅北轍的言行不一最終讓信眾開始產生了懷疑",
+      "他發現教主嘴上說的和實際做的完全是南轅北轍"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:轍": {
-    "sentences": [],
+    "sentences": [
+      "前人的覆轍應該成為後人的警惕而非重蹈覆轍",
+      "南轅北轍的結局讓所有被蒙蔽的信眾徹底清醒",
+      "走過同樣轍痕的人才能真正體會那種被欺騙的痛苦"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:鋒": {
-    "sentences": [],
+    "sentences": [
+      "衝鋒陷陣的信眾到頭來只是教主手中的一顆棋子",
+      "他在教團中總是站在最前鋒，替教主擋下所有質疑",
+      "鋒芒畢露的新信眾很快就被教主收為核心幹部"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:陣": {
-    "sentences": [],
+    "sentences": [
+      "衝鋒陷陣的狂熱信眾讓社會大眾感到不安和恐懼",
+      "教主在講道時突然一陣沉默，讓全場信眾屏息以待",
+      "一陣喧囂過後，教團的真面目終於被揭開了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "信眾與教主:陷": {
-    "sentences": [],
+    "sentences": [
+      "他陷入了教團的泥沼裡，怎麼也掙脫不了",
+      "衝鋒陷陣的結果往往是信眾受害而教主得利",
+      "陷入盲從的人很難靠自己的力量走出來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:一": {
-    "sentences": [],
+    "sentences": [
+      "這一則流傳已久的故事究竟是真實事件還是假新聞",
+      "一個孩子鞭打老虎救弟弟的傳說在民間廣為流傳",
+      "一旦仔細考證就會發現這個故事有許多不合理之處"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:乏": {
-    "sentences": [],
+    "sentences": [
+      "這個故事缺乏可靠的歷史文獻來佐證其真實性",
+      "不乏有人對這則傳說深信不疑且不願接受質疑",
+      "乏味的考證工作卻是辨別真假新聞最重要的一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:人": {
-    "sentences": [],
+    "sentences": [
+      "古代的人比現代人更容易相信這類充滿神蹟的故事",
+      "旁人對這個故事的態度往往取決於他們的知識背景",
+      "許多人不加思索就把這則傳聞當作真實的歷史事件"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:倖": {
-    "sentences": [],
+    "sentences": [
+      "弟弟倖免於虎口是故事中最戲劇化的轉折",
+      "倖存的當事人卻從未留下任何親筆的文字記錄",
+      "這種僥倖的結局在現實中發生的機率微乎其微"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:動": {
-    "sentences": [],
+    "sentences": [
+      "這個動人的故事激發了人們對手足之情的深刻共鳴",
+      "不要被故事的感動沖昏頭腦而忘了查證事實的真相",
+      "輕易就被消息牽動情緒是現代人最需要警惕的弱點"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:取": {
-    "sentences": [],
+    "sentences": [
+      "故事取材自民間傳說經過多次轉述已經面目全非了",
+      "我們應該取得可靠的證據之後再決定是否相信一則報導",
+      "斷章取義的引用方式讓這個故事變得更加離譜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:叫": {
-    "sentences": [],
+    "sentences": [
+      "弟弟的叫喊聲引來了哥哥奮不顧身地前來營救",
+      "他大聲叫喊試圖嚇退老虎的說法在生物學上站不住腳",
+      "故事中驚恐的叫聲讓讀者的情緒跟著緊張起來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:呼": {
-    "sentences": [],
+    "sentences": [
+      "弟弟呼救的聲音據說傳遍了整個山谷引來救援",
+      "我們不該被故事的情緒渲染所呼攏而喪失了判斷力",
+      "呼籲大眾培養媒體素養是現代教育的重要課題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:命": {
-    "sentences": [],
+    "sentences": [
+      "故事中哥哥拼了命也要把弟弟從虎口中搶回來",
+      "性命交關的情境讓這則故事具有強大的感染力",
+      "用命來搏鬥的情節在傳說中被渲染得越來越誇張"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:嗚": {
-    "sentences": [],
+    "sentences": [
+      "傳說中弟弟嗚咽求救的場面讓人聽了心生不忍",
+      "嗚呼哀哉的感嘆詞讓古文中的描述更加戲劇化",
+      "他嗚嗚地哭著說出了事情的真相令聽者動容"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:回": {
-    "sentences": [],
+    "sentences": [
+      "回過頭來仔細想想這個故事確實有很多疑點",
+      "把故事追溯回最早的文獻版本才能找到真相的線索",
+      "這則傳說在民間流傳了好幾回，每次都添油加醋"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:坳": {
-    "sentences": [],
+    "sentences": [
+      "山坳裡的小路據說就是故事發生的地點",
+      "傳聞中兄弟倆在偏僻的山坳處遭遇了猛虎",
+      "地形險峻的山坳讓這個故事的場景更添幾分驚險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:天": {
-    "sentences": [],
+    "sentences": [
+      "天底下真的會有小孩能打跑老虎這麼離奇的事嗎",
+      "驚天動地的故事往往經過了許多次的渲染和加工",
+      "老天爺保佑的說法在古代是常見的解釋方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:存": {
-    "sentences": [],
+    "sentences": [
+      "這個故事之所以流傳至今是因為人們心中存有善念",
+      "現存的文獻記載中有多個不同版本的鞭虎故事",
+      "保存下來的古籍中對這件事的描述並不一致"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:寵": {
-    "sentences": [],
+    "sentences": [
+      "故事中弟弟是家中最受寵愛的小兒子",
+      "不要被寵幸的感覺蒙蔽了理性的判斷能力",
+      "受寵若驚的弟弟被哥哥從虎口救回深感感激"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:寸": {
-    "sentences": [],
+    "sentences": [
+      "一寸光陰一寸金，查證事實需要花費不少時間和精力",
+      "面對猛虎步步進逼，兄弟倆已經退無寸步了",
+      "他寸步不離地守在弟弟身邊直到危險完全解除"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:尚": {
-    "sentences": [],
+    "sentences": [
+      "古代崇尚孝悌的風氣讓這類故事特別容易流傳",
+      "尚且不論故事的真假，它傳達的手足之情確實感人",
+      "高尚的品德故事在古代被大量記錄用來教化百姓"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:山": {
-    "sentences": [],
+    "sentences": [
+      "山林中遇到猛獸在古代確實是常見的危險情況",
+      "故事發生在深山裡，偏僻的環境增添了戲劇張力",
+      "他們兄弟倆在上山砍柴時意外遭遇了老虎的襲擊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:峻": {
-    "sentences": [],
+    "sentences": [
+      "嚴峻的考驗面前，哥哥展現了超乎常人的勇氣",
+      "故事中描述的山勢險峻讓整個場景更加驚心動魄",
+      "峻峭的山壁擋住了兄弟倆的退路令情勢更加危急"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:心": {
-    "sentences": [],
+    "sentences": [
+      "用心考證才能分辨歷史故事與民間傳說之間的差異",
+      "這個故事的核心是兄弟之間真摯的手足之心",
+      "驚心動魄的場面描寫讓讀者彷彿身歷其境"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:息": {
-    "sentences": [],
+    "sentences": [
+      "消息在民間口耳相傳的過程中不斷被添油加醋",
+      "仔細查閱文獻記載後才發現其中有不少可疑的訊息",
+      "他屏住呼吸等待老虎離去，直到危險完全平息"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:手": {
-    "sentences": [],
+    "sentences": [
+      "赤手空拳對抗猛虎的情節在邏輯上令人存疑",
+      "故事中哥哥手持樹枝鞭打老虎的畫面被傳頌千年",
+      "高手一出手就能看出破綻——這個故事並不合理"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:攫": {
-    "sentences": [],
+    "sentences": [
+      "老虎攫住弟弟的描述讓整個故事充滿了緊張氣氛",
+      "猛虎攫取獵物的力量豈是一個小孩能夠對抗的",
+      "被攫走的弟弟在傳說中竟然毫髮無傷令人質疑"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:杳": {
-    "sentences": [],
+    "sentences": [
+      "事件的真正目擊者杳無音訊，只剩下輾轉的傳聞",
+      "杳無實據的故事卻被後人當成真實的歷史來記載",
+      "當事人杳然不見蹤影讓這個故事更加撲朔迷離"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:無": {
-    "sentences": [],
+    "sentences": [
+      "赤手空拳的孩子面對猛虎幾乎是毫無勝算的",
+      "無從考證的傳說在流傳過程中變得越來越離譜",
+      "查無實據的故事不應該被當作真實的歷史來教導"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:煙": {
-    "sentences": [],
+    "sentences": [
+      "杳無人煙的深山野嶺是這類傳說最常出現的場景",
+      "故事像一縷煙霧般虛無飄渺，難以捉摸其真實面貌",
+      "硝煙散去後真相才慢慢浮出水面"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:眾": {
-    "sentences": [],
+    "sentences": [
+      "眾人對這個故事的看法分歧很大，各執一詞",
+      "聽眾被精彩的情節吸引住了，很少有人質疑其真假",
+      "在眾說紛紜之中，我們更需要冷靜地尋找事實"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:號": {
-    "sentences": [],
+    "sentences": [
+      "哥哥放聲號哭的描述為故事增添了強烈的情感色彩",
+      "據說當時的號叫聲響徹了整座山谷驚退了猛虎",
+      "這個故事號稱是真人真事，但證據卻明顯不足"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:術": {
-    "sentences": [],
+    "sentences": [
+      "用鞭打的技術嚇退猛虎在實際操作上幾乎不可能",
+      "分辨真假新聞是現代人必須具備的重要技術之一",
+      "古代的話術讓許多不可信的故事被傳頌了數百年"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:譁": {
-    "sentences": [],
+    "sentences": [
+      "譁眾取寵的故事往往比平淡的真相更容易傳播",
+      "不要被喧譁的輿論帶著走而失去了自己的判斷力",
+      "這個故事的譁然效果正是它能夠流傳千年的關鍵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:鐵": {
-    "sentences": [],
+    "sentences": [
+      "鐵一般的證據才能證明這個故事的真偽",
+      "沒有鐵證如山的文獻支持，這個故事只能算是傳說",
+      "他鐵了心要查明這則流傳百年的故事到底是不是真的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:陰": {
-    "sentences": [],
+    "sentences": [
+      "陰暗的森林中潛伏著危機，正是老虎出沒的地方",
+      "陰錯陽差之下，這個故事被後人當成了真實的歷史",
+      "山林中陰森的氣氛為這個故事營造了驚悚的背景"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:險": {
-    "sentences": [],
+    "sentences": [
+      "險象環生的情節讓這個故事格外引人入勝",
+      "冒險犯難的行為在古代常被拿來當作道德教材",
+      "危險的處境中展現的勇氣是這個故事最打動人心之處"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:驚": {
-    "sentences": [],
+    "sentences": [
+      "驚心動魄的故事讓讀者不自覺地被牽著情緒走",
+      "聽到這個故事的人無不感到驚訝和難以置信",
+      "驚慌失措之下做出的反應往往不是最理智的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:魄": {
-    "sentences": [],
+    "sentences": [
+      "驚心動魄的鞭虎情節是這個故事最吸引人的部分",
+      "故事雖然精彩得令人魂飛魄散，但真實性仍待考證",
+      "他被嚇得魂飛魄散，好一陣子才回過神來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "假新聞？鞭虎救弟記:黯": {
-    "sentences": [],
+    "sentences": [
+      "黯然失色的真相往往敵不過精彩動人的傳說",
+      "他想到弟弟差點喪命，心中不禁黯然神傷",
+      "在華麗的傳說面前，平凡的歷史記錄顯得黯淡無光"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:不": {
-    "sentences": [],
+    "sentences": [
+      "不懂的地方就要主動發問，這是孔子教導的精神",
+      "學習不能只靠死背，還要真正理解其中的道理",
+      "不恥下問是孔子最推崇的學習態度之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:也": {
-    "sentences": [],
+    "sentences": [
+      "學而時習之，不也是一件快樂的事嗎？這句話流傳了兩千多年",
+      "孔子也曾經歷過困難的時期，但他從未放棄教學",
+      "這位酷老師的智慧放到現代也一樣受用"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:其": {
-    "sentences": [],
+    "sentences": [
+      "孔子的教學方式在當時可說是獨樹一格，其影響深遠",
+      "其實孔子並不是一個嚴肅死板的老夫子",
+      "他對學生的關愛與期許，其用心良苦令人感動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:博": {
-    "sentences": [],
+    "sentences": [
+      "孔子博學多聞，各種知識都能信手拈來教導學生",
+      "博覽群書是成為一位好老師的基本條件之一",
+      "他博大精深的學問讓學生們都非常景仰和佩服"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:及": {
-    "sentences": [],
+    "sentences": [
+      "孔子的教育理念影響了後世，至今及於全世界",
+      "學習要趁早，等到長大才後悔就來不及了",
+      "他的教誨涉及做人處事的方方面面"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:可": {
-    "sentences": [],
+    "sentences": [
+      "孔子認為每個人都可以透過學習變成更好的人",
+      "知之為知之，不知為不知，是知也——可見誠實多重要",
+      "這位兩千五百歲的老師到現在還是很酷，可見其魅力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:名": {
-    "sentences": [],
+    "sentences": [
+      "孔子是全世界最有名的老師之一，影響了無數的人",
+      "他的名言至今仍被寫在教室的牆壁上激勵著學生",
+      "名師出高徒，孔子教出了許多傑出的弟子"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:和": {
-    "sentences": [],
+    "sentences": [
+      "孔子主張人和人之間應該和睦相處互相尊重",
+      "和藹可親的態度讓孔子深受學生們的愛戴",
+      "他用溫和的方式引導學生思考而不是強迫灌輸"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:問": {
-    "sentences": [],
+    "sentences": [
+      "孔子鼓勵學生要勇敢地提出問題和表達想法",
+      "不恥下問的精神是孔子教育理念中非常重要的一環",
+      "好的問題比標準答案更能啟發一個人的思考"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:國": {
-    "sentences": [],
+    "sentences": [
+      "孔子周遊列國傳播他的教育理念和治國思想",
+      "他的思想影響了整個國家的文化和價值觀念",
+      "中國被稱為禮儀之邦，與孔子的教導有很大的關係"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:如": {
-    "sentences": [],
+    "sentences": [
+      "如果孔子活在現代，他應該會是最受歡迎的老師",
+      "學如不及，猶恐失之——孔子鼓勵學生不斷追求進步",
+      "他的教學方式就如同朋友聊天一樣輕鬆自在"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:學": {
-    "sentences": [],
+    "sentences": [
+      "學而不思則罔，思而不學則殆，這是孔子的名言",
+      "孔子認為學習是一輩子的事情，永遠不嫌晚",
+      "好的學習態度比聰明的腦袋更加重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:富": {
-    "sentences": [],
+    "sentences": [
+      "孔子認為精神的富足比物質的富裕更加重要",
+      "他雖然生活不富裕，卻擁有最豐富的知識和智慧",
+      "豐富的學識和高尚的品德讓孔子受到後世的尊崇"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:實": {
-    "sentences": [],
+    "sentences": [
+      "孔子強調做人做事都要腳踏實地不能只說不做",
+      "實事求是的態度是孔子教導學生的核心精神",
+      "他的教學內容紮實又實用，難怪能流傳兩千多年"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:對": {
-    "sentences": [],
+    "sentences": [
+      "對待每一位學生，孔子都能因材施教給予不同指導",
+      "面對困難的問題，孔子總是耐心地引導學生思考",
+      "他對教育的熱忱即使過了兩千五百年依然令人敬佩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:應": {
-    "sentences": [],
+    "sentences": [
+      "孔子認為學習應該要學以致用而不只是紙上談兵",
+      "面對不同的學生，他總能靈活應變調整教學方式",
+      "做人應該要言行一致，這是孔子反覆強調的道理"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:敵": {
-    "sentences": [],
+    "sentences": [
+      "孔子的智慧無人能敵，至今仍深深影響著全世界",
+      "他的學問廣博精深，在當時幾乎是所向無敵的",
+      "好的老師能把敵對的關係化解為互相學習的夥伴"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:斷": {
-    "sentences": [],
+    "sentences": [
+      "孔子從不武斷地否定學生的想法，而是耐心引導",
+      "不斷學習和反省是孔子一生奉行的原則",
+      "判斷事情不能只看表面，這是孔子教給我們的智慧"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:普": {
-    "sentences": [],
+    "sentences": [
+      "孔子的教育理念具有普世的價值，不分國界和時代",
+      "他是最早提出普及教育理念的思想家之一",
+      "普通人也能成為有學問的人——這是孔子最了不起的主張"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:木": {
-    "sentences": [],
+    "sentences": [
+      "朽木不可雕也——孔子偶爾也會對懶惰的學生生氣",
+      "就算是一塊木頭，用心雕刻也能成為精美的藝術品",
+      "木訥寡言的學生在孔子的引導下也變得善於表達"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:朽": {
-    "sentences": [],
+    "sentences": [
+      "朽木不可雕也是孔子對不認真學生的批評",
+      "不朽的思想讓孔子的影響力延續了兩千五百年",
+      "即使是看似朽壞的木材也有可能被巧手化為藝術品"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:果": {
-    "sentences": [],
+    "sentences": [
+      "如果每個老師都像孔子那樣用心，學生一定更愛學習",
+      "學習的成果需要經過長時間的努力才能慢慢顯現",
+      "果然好的教育方法經得起兩千多年的時間考驗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:流": {
-    "sentences": [],
+    "sentences": [
+      "孔子的思想像河流一樣源遠流長影響了無數的世代",
+      "他的教育理念流傳到了日本、韓國等許多國家",
+      "知識的交流和分享是孔子最重視的事情之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:淵": {
-    "sentences": [],
+    "sentences": [
+      "孔子學識淵博，弟子們都以能跟隨他學習為榮",
+      "學問就像深淵一樣深不見底，需要不斷地探索",
+      "淵博的知識讓這位老師在兩千五百年後仍受人景仰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:率": {
-    "sentences": [],
+    "sentences": [
+      "孔子以身作則率先示範什麼是正確的做人態度",
+      "他率真的性格讓學生們覺得這位老師特別親切",
+      "直率地說出自己的想法是孔子鼓勵學生做的事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:疑": {
-    "sentences": [],
+    "sentences": [
+      "孔子認為有疑問就要勇敢地提出來尋求解答",
+      "學而不疑等於沒有真正在思考問題的本質",
+      "面對可疑的說法不輕易相信，這是孔子教我們的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:直": {
-    "sentences": [],
+    "sentences": [
+      "孔子是一個正直的人，從不為了利益而說違心的話",
+      "直來直往的個性讓學生們覺得孔子很真誠",
+      "他直接指出學生的錯誤，但方式溫和不傷人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:符": {
-    "sentences": [],
+    "sentences": [
+      "言行相符是孔子衡量一個人品德的重要標準",
+      "他的教學理念與現代教育的趨勢不謀而合完全符合",
+      "名符其實的好老師，連兩千五百年後的學生都佩服"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:謙": {
-    "sentences": [],
+    "sentences": [
+      "孔子為人謙虛，從不自誇自己有多大的學問",
+      "謙虛受教的態度是孔子認為最好的學習品質",
+      "這位謙和的老師用行動證明了什麼叫以身作則"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:遲": {
-    "sentences": [],
+    "sentences": [
+      "學習永遠不嫌遲，這是孔子給所有人的鼓勵",
+      "遲到的學生也不會被孔子責罵，而是被溫柔地提醒",
+      "與其遲疑不前，不如勇敢踏出學習的第一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "兩千五百歲的酷老師:雕": {
-    "sentences": [],
+    "sentences": [
+      "朽木不可雕也——但孔子相信大多數人都是可教之材",
+      "精心雕琢的品德需要長時間的教育和自我修養",
+      "老師就像雕刻家一樣，用心把學生培養成更好的人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:一": {
-    "sentences": [],
+    "sentences": [
+      "一步一步慢慢來，不要急著馬上練出六塊肌",
+      "做任何運動都要一口氣吸好再開始動作",
+      "每天運動一小時，身體就會慢慢變強壯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:不": {
-    "sentences": [],
+    "sentences": [
+      "不運動光靠節食是練不出健康好身材的",
+      "只吃炸雞不運動的話身體一定會越來越不好",
+      "不要小看每天的運動習慣，它會改變你的生活"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:倘": {
-    "sentences": [],
+    "sentences": [
+      "倘若每天都堅持運動，身體一定會有明顯改變",
+      "倘使只靠吃東西就能健康，那誰還需要運動呢",
+      "倘若偷懶不練習，之前的努力就白費了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:分": {
-    "sentences": [],
+    "sentences": [
+      "每天只要花三十分鐘運動就能維持基本體能",
+      "分辨健康的飲食和垃圾食物是很重要的能力",
+      "合理分配運動和休息的時間才能達到最好效果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:則": {
-    "sentences": [],
+    "sentences": [
+      "想要練出六塊肌，就必須遵守正確的運動原則",
+      "飲食均衡是維持健康的基本法則之一",
+      "運動的第一個原則就是不要操之過急"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:區": {
-    "sentences": [],
+    "sentences": [
+      "腹部的肌肉可以區分成好幾個不同的部位",
+      "區別炸雞和健康食物是開始健康飲食的第一步",
+      "運動場上劃分了不同的區域給同學們使用"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:可": {
-    "sentences": [],
+    "sentences": [
+      "只要持之以恆，每個人都可以擁有健康的體魄",
+      "炸雞偶爾吃可以，但不能天天吃當正餐",
+      "六塊肌不是一天就可以練成的需要長期努力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:壁": {
-    "sentences": [],
+    "sentences": [
+      "做仰臥起坐時腹部的肌肉會像牆壁一樣緊繃",
+      "他靠在牆壁上做深蹲動作來鍛鍊腿部肌肉",
+      "銅牆鐵壁般的腹肌需要長時間的鍛鍊才能養成"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:壘": {
-    "sentences": [],
+    "sentences": [
+      "堡壘般結實的身體需要長期運動才能打造出來",
+      "他在壘球場上奔跑，每天都在鍛鍊體能",
+      "一點一滴地壘積訓練量才能看到明顯的效果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:天": {
-    "sentences": [],
+    "sentences": [
+      "每天堅持做運動是維持健康最簡單的方法",
+      "天氣好的時候到戶外運動比待在家裡好多了",
+      "天天吃炸雞卻想要六塊肌根本是天方夜譚"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:實": {
-    "sentences": [],
+    "sentences": [
+      "腳踏實地地鍛鍊才是練出好身材的唯一方法",
+      "其實只要飲食均衡加上適量運動就能很健康",
+      "真正實用的運動方式不需要花大錢買器材"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:序": {
-    "sentences": [],
+    "sentences": [
+      "運動要按照正確的順序來，先暖身再開始訓練",
+      "循序漸進是所有運動教練都會強調的基本觀念",
+      "有秩序地安排訓練計畫才能避免受傷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:循": {
-    "sentences": [],
+    "sentences": [
+      "循序漸進地增加運動量才不會讓身體受傷",
+      "遵循教練的指導來運動會更安全也更有效率",
+      "他循著正確的步驟一步步鍛鍊出結實的肌肉"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:或": {
-    "sentences": [],
+    "sentences": [
+      "你可以選擇跑步或游泳來鍛鍊自己的體能",
+      "或許每天少吃一塊炸雞就能讓身體更健康一些",
+      "或站或蹲都可以做簡單的肌力訓練活動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:明": {
-    "sentences": [],
+    "sentences": [
+      "明白了運動的好處之後他開始每天慢跑三十分鐘",
+      "說明正確的運動姿勢才能避免受傷的風險",
+      "明天開始運動不如今天就開始行動比較實際"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:欲": {
-    "sentences": [],
+    "sentences": [
+      "欲速則不達，運動訓練急不來要循序漸進",
+      "他有著鍛鍊出好身材的強烈欲望每天都努力運動",
+      "他求勝心切卻忘了欲速則不達的道理"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:步": {
-    "sentences": [],
+    "sentences": [
+      "每天走一萬步是最簡單的日常運動方式",
+      "一步一步慢慢進步比一口氣練太多更安全",
+      "跑步是鍛鍊心肺功能最有效的運動之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:漸": {
-    "sentences": [],
+    "sentences": [
+      "漸漸地他的體力變好了，爬樓梯也不喘了",
+      "循序漸進的訓練方式才能讓肌肉穩定成長",
+      "改變飲食習慣需要漸進式地調整而非一步到位"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:登": {
-    "sentences": [],
+    "sentences": [
+      "他成功登上了山頂，靠的是平時鍛鍊的好體力",
+      "登山是一種能鍛鍊全身肌肉的戶外運動",
+      "想要登上健康的頂峰就必須持之以恆地運動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:結": {
-    "sentences": [],
+    "sentences": [
+      "結實的肌肉不是一天就能練出來的",
+      "他和朋友結伴一起運動互相鼓勵效果更好",
+      "總結來說運動和飲食要搭配才能達到最好效果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:缺": {
-    "sentences": [],
+    "sentences": [
+      "缺乏運動是現代人健康出問題的主要原因",
+      "均衡的營養不能缺少蛋白質和蔬菜水果",
+      "他唯一缺少的就是持之以恆的運動習慣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:舒": {
-    "sentences": [],
+    "sentences": [
+      "運動完做伸展操讓全身的肌肉好好舒展開來",
+      "舒服的運動節奏比拚命操練更容易持續下去",
+      "每天花十分鐘舒緩身體就能減少很多痠痛"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:若": {
-    "sentences": [],
+    "sentences": [
+      "若是每天都吃六塊炸雞一定會越來越不健康",
+      "假若能堅持運動三個月你一定會看到明顯的改變",
+      "若不注意飲食，再怎麼運動也練不出六塊肌"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:蓋": {
-    "sentences": [],
+    "sentences": [
+      "棉被蓋好睡飽覺和運動一樣都是保持健康的關鍵",
+      "體能訓練涵蓋了肌力、心肺和柔軟度三大面向",
+      "他蓋上水壺蓋子休息一下再繼續下一組訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:覆": {
-    "sentences": [],
+    "sentences": [
+      "反覆練習基本動作是打好運動基礎的不二法門",
+      "翻來覆去睡不著的時候不如起來做點簡單的伸展",
+      "他不斷重覆同樣的動作直到姿勢完全正確為止"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:速": {
-    "sentences": [],
+    "sentences": [
+      "欲速則不達，運動訓練要慢慢來才不會受傷",
+      "快速減肥的方式很傷身體，不如慢慢調整比較好",
+      "他用適當的速度慢跑讓身體慢慢適應運動的節奏"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:進": {
-    "sentences": [],
+    "sentences": [
+      "進步的感覺讓他更有動力繼續堅持每天的鍛鍊",
+      "循序漸進地增加訓練量才是最安全的方式",
+      "他鼓起勇氣走進健身房開始了第一次的訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:達": {
-    "sentences": [],
+    "sentences": [
+      "欲速則不達的道理在運動訓練上特別適用",
+      "要達到理想的體態需要長期且有紀律的練習",
+      "他終於達成了每天運動三十分鐘的小目標"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:適": {
-    "sentences": [],
+    "sentences": [
+      "適當的運動量比過度訓練更有助於身體健康",
+      "選擇適合自己的運動方式才能持續堅持下去",
+      "適度地享受美食搭配運動就是最好的生活方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "六塊肌六塊雞:量": {
-    "sentences": [],
+    "sentences": [
+      "適量的運動加上均衡的飲食是健康的不二法門",
+      "運動量要根據自己的體力來調整不要勉強",
+      "他每天測量體重來追蹤自己的運動成效"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:不": {
-    "sentences": [],
+    "sentences": [
+      "不要被誇張的標題吸引而忘了查證內容的真實性",
+      "標題黨的文章往往名不副實讓人大失所望",
+      "不經思考就轉發聳動的新聞是非常不負責任的行為"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:亂": {
-    "sentences": [],
+    "sentences": [
+      "網路上的假消息氾濫成災，讓真假資訊混亂不堪",
+      "不要亂點來路不明的連結以免上了誘餌式標題的當",
+      "胡亂轉發未經查證的消息等於在幫忙散播假新聞"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:人": {
-    "sentences": [],
+    "sentences": [
+      "誘餌式標題專門針對人們的好奇心和恐懼來設計",
+      "很多人明知是標題黨卻還是忍不住點進去看",
+      "每個人都應該培養辨識假新聞的媒體素養能力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:休": {
-    "sentences": [],
+    "sentences": [
+      "假新聞的製造者從不休息，持續產出大量的聳動標題",
+      "他們利用人們茶餘飯後的休閒時間散播誘餌式內容",
+      "目不暇給的資訊讓人完全沒有喘息休息的時間"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:動": {
-    "sentences": [],
+    "sentences": [
+      "聳動的標題會讓人不自覺地想要點進去一探究竟",
+      "不要被情緒牽動而衝動地轉發未經查證的文章",
+      "社群媒體的演算法偏好能帶動高點閱率的內容"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:博": {
-    "sentences": [],
+    "sentences": [
+      "誘餌式標題的目的就是博取讀者的眼球和點擊量",
+      "博君一笑的標題背後可能隱藏著不實的資訊內容",
+      "廣博的知識背景能幫助你更快辨識出虛假的報導"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:取": {
-    "sentences": [],
+    "sentences": [
+      "標題黨利用誇張的用詞來騙取讀者的點擊和關注",
+      "不要輕易被聳動的文字所吸引而被騙取了信任",
+      "斷章取義是誘餌式標題最常使用的手法之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:向": {
-    "sentences": [],
+    "sentences": [
+      "我們應該向可靠的新聞來源求證而不是相信標題黨",
+      "一味地向流量低頭只會讓媒體品質每況愈下",
+      "面向大眾傳播的訊息更應該經過嚴格的查證程序"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:大": {
-    "sentences": [],
+    "sentences": [
+      "誘餌式標題最愛用誇大其詞的方式吸引讀者注意",
+      "大量的假新聞正在侵蝕人們對媒體的信任感",
+      "點擊量再大也不能代表內容的品質和可信度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:對": {
-    "sentences": [],
+    "sentences": [
+      "面對誘餌式標題最好的方式就是先查證再決定是否相信",
+      "對於來路不明的資訊我們應該保持懷疑的態度",
+      "他對那些聳動標題的免疫力越來越強不再輕易上當"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:帶": {
-    "sentences": [],
+    "sentences": [
+      "帶有情緒煽動性的標題往往是誘餌式手法的典型特徵",
+      "這類標題會帶著讀者的情緒走讓人失去理性判斷",
+      "手機上不斷跳出帶有聳動標題的通知讓人無法忽視"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:推": {
-    "sentences": [],
+    "sentences": [
+      "社群媒體的推播機制讓誘餌式標題傳播得更快更廣",
+      "不要隨便推薦或轉發未經查證的聳動新聞給朋友",
+      "演算法會自動推送高點閱率的內容不管它是真是假"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:撩": {
-    "sentences": [],
+    "sentences": [
+      "誘餌式標題故意撩撥讀者的情緒讓人忍不住點進去",
+      "他被那個聳動的標題撩起了好奇心結果發現是假消息",
+      "刻意撩動人心的文字是標題黨最擅長使用的伎倆"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:播": {
-    "sentences": [],
+    "sentences": [
+      "假新聞透過社群媒體的傳播速度遠超過真實報導",
+      "散播未經查證的消息等於在幫假新聞免費打廣告",
+      "媒體有責任播報經過查證的真實消息而非譁眾取寵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:文": {
-    "sentences": [],
+    "sentences": [
+      "點進去之後才發現文章的內容和標題根本毫無關聯",
+      "好的新聞文章應該標題與內容一致不誇大不誤導",
+      "一篇有價值的文章不需要靠聳動的標題來吸引讀者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:暇": {
-    "sentences": [],
+    "sentences": [
+      "資訊爆炸的時代讓人目不暇給難以分辨真偽",
+      "忙碌的現代人沒有閒暇逐一查證每則新聞的真假",
+      "即使再忙也不該以無暇查證為藉口隨意轉發假消息"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:核": {
-    "sentences": [],
+    "sentences": [
+      "查核消息來源是避免上當受騙最有效的方法",
+      "事實查核機構的存在就是為了幫大眾過濾假新聞",
+      "核實標題的真實性只需要花幾分鐘的時間而已"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:死": {
-    "sentences": [],
+    "sentences": [
+      "標題用「嚇死人」這種誇張用語就是典型的誘餌手法",
+      "死守查證原則的人比較不容易被假新聞所欺騙",
+      "那些「不看會死」的標題十之八九都是標題黨"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:氾": {
-    "sentences": [],
+    "sentences": [
+      "假消息在網路上氾濫成災嚴重影響了社會的信任感",
+      "資訊氾濫的時代更需要培養獨立思考的判斷能力",
+      "當不實資訊氾濫失控時，受害的是每一個人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:濫": {
-    "sentences": [],
+    "sentences": [
+      "濫用聳動標題的媒體正在一步步摧毀新聞的公信力",
+      "網路上泛濫的假新聞讓人越來越難以信任媒體報導",
+      "粗製濫造的標題黨文章只會降低整體的閱讀品質"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:目": {
-    "sentences": [],
+    "sentences": [
+      "聳動的標題讓人目不轉睛卻往往只是一場空歡喜",
+      "他的目光被那個驚悚的標題吸引住了差點就上當了",
+      "目前已有許多查核機構在幫助民眾辨識假新聞"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:眼": {
-    "sentences": [],
+    "sentences": [
+      "不要被花俏的標題閃花了眼而忽略了內容的品質",
+      "訓練自己的眼光才能在資訊洪流中看出哪些是假的",
+      "擦亮眼睛仔細辨別是面對誘餌標題最好的態度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:眾": {
-    "sentences": [],
+    "sentences": [
+      "譁眾取寵的標題或許能短暫吸引目光卻會失去信任",
+      "大眾的媒體素養提升之後標題黨的效果就會大打折扣",
+      "群眾的情緒很容易被設計過的標題所操控和利用"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:給": {
-    "sentences": [],
+    "sentences": [
+      "目不暇給的資訊讓人沒有時間靜下心來查證真相",
+      "不要給假新聞任何傳播的機會，看到就檢舉",
+      "他給自己訂了一個規則：看到聳動標題先查證再說"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:聳": {
-    "sentences": [],
+    "sentences": [
+      "聳動的標題是為了刺激讀者的情緒而精心設計的",
+      "越是聳人聽聞的消息就越需要小心求證其真實性",
+      "他對那些危言聳聽的假新聞已經完全免疫了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:聽": {
-    "sentences": [],
+    "sentences": [
+      "聽到未經證實的消息時不要急著轉發而是先查證",
+      "聳人聽聞的標題往往是吸引點閱的廉價手段",
+      "仔細聽完整篇報導再做判斷比只看標題要可靠多了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:花": {
-    "sentences": [],
+    "sentences": [
+      "花俏的標題背後可能只是空洞的內容和不實的資訊",
+      "他花了一點時間查證之後發現那則新聞是假的",
+      "眼花撩亂的標題讓人很難在短時間內分辨真假"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:誘": {
-    "sentences": [],
+    "sentences": [
+      "誘餌式標題利用人類天生的好奇心來騙取點擊量",
+      "不要被精心設計的話術誘導而喪失了理性的判斷",
+      "誘人上鉤的文字陷阱在網路上隨處可見"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:語": {
-    "sentences": [],
+    "sentences": [
+      "誇張的語氣和用詞是辨識誘餌式標題的重要線索",
+      "使用煽動性語言的標題十之八九是在騙取你的點擊",
+      "理性的語調和客觀的內容才是優質新聞的標準"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:辛": {
-    "sentences": [],
+    "sentences": [
+      "辛苦蒐集的證據才能戳破那些精心包裝的假新聞",
+      "辛辣的用詞雖然吸睛卻往往偏離了事實的真相",
+      "事實查核人員辛勤地為大眾過濾不實的資訊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:辣": {
-    "sentences": [],
+    "sentences": [
+      "辛辣的標題讓人一時衝動點下去卻只換來失望",
+      "毒辣的假新聞製造者利用人們的恐懼來牟取利益",
+      "辣味十足的標題可能只是一個精心設計的流量陷阱"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:閱": {
-    "sentences": [],
+    "sentences": [
+      "提升閱讀素養才能在資訊洪流中明辨是非真偽",
+      "閱讀完整的報導比只看標題能獲得更準確的資訊",
+      "他養成了閱讀全文再做判斷的好習慣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:題": {
-    "sentences": [],
+    "sentences": [
+      "誘餌式標題的特徵就是用誇張的文字吸引你的注意",
+      "標題和內容不符是辨識假新聞最簡單的方法之一",
+      "好的新聞標題應該準確地反映文章的核心內容"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:風": {
-    "sentences": [],
+    "sentences": [
+      "跟風轉發假新聞只會讓不實資訊傳播得更快更廣",
+      "網路上歪風邪氣的標題黨文化需要每個人共同抵制",
+      "一股查核事實的新風氣正在社群媒體上慢慢形成"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:餌": {
-    "sentences": [],
+    "sentences": [
+      "標題就是誘餌，而你的點擊就是他們想要釣的魚",
+      "不要咬下那個精心設計的餌，先想想它是否合理",
+      "一旦你咬了餌，演算法就會推送更多類似的聳動內容"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "別上「誘餌式標題」的鉤:驚": {
-    "sentences": [],
+    "sentences": [
+      "驚悚的標題是標題黨最常用的手法讓人忍不住好奇",
+      "別被嚇人的文字驚嚇到而失去了冷靜判斷的能力",
+      "看到令人驚訝的標題時第一反應應該是懷疑而非相信"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:一": {
-    "sentences": [],
+    "sentences": [
+      "一到求偶季節，雄性動物就會使出渾身解數吸引伴侶",
+      "每一種動物談情說愛的方式都非常獨特有趣",
+      "一場精彩的求偶表演正在森林裡熱鬧地上演"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:丰": {
-    "sentences": [],
+    "sentences": [
+      "孔雀展開丰姿綽約的尾巴來吸引母孔雀的目光",
+      "丰采迷人的羽毛是雄鳥吸引伴侶的重要武器",
+      "丰富多彩的求偶儀式是大自然最有趣的現象之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:勝": {
-    "sentences": [],
+    "sentences": [
+      "最終勝出的雄性才有機會贏得母鳥的芳心",
+      "求偶競爭中不一定是最強壯的獲勝，有時靠的是才藝",
+      "美麗的羽毛勝過一切言語成為最有效的求愛訊號"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:場": {
-    "sentences": [],
+    "sentences": [
+      "求偶的場地就像一個動物們展現魅力的大舞台",
+      "這場精彩的求偶表演讓觀察者看得目不轉睛",
+      "在森林的一處空地上，一場求愛大戲正在上演"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:墨": {
-    "sentences": [],
+    "sentences": [
+      "墨魚會改變身上的顏色來向對方表達愛意",
+      "如同潑墨畫般美麗的尾羽是雄孔雀最大的驕傲",
+      "烏賊噴出墨汁是為了在求偶時吸引異性的注意"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:嬌": {
-    "sentences": [],
+    "sentences": [
+      "雌鳥嬌羞地站在樹枝上看著雄鳥賣力地跳舞",
+      "嬌小的雌蟲發出的氣味能吸引遠方的雄蟲前來",
+      "嬌嫩的花朵也像動物一樣用色彩吸引傳粉者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:客": {
-    "sentences": [],
+    "sentences": [
+      "不速之客闖入了求偶場地打斷了正在進行的表演",
+      "雄性動物扮演著熱情的追求客爭取雌性的青睞",
+      "訪客觀察動物求偶時要保持安靜避免驚擾牠們"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:尾": {
-    "sentences": [],
+    "sentences": [
+      "孔雀張開華麗的尾巴展示自己的健康和基因優勢",
+      "尾巴越長越漂亮的雄鳥越容易受到母鳥的喜愛",
+      "松鼠搖動蓬鬆的尾巴也是吸引異性的一種方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:強": {
-    "sentences": [],
+    "sentences": [
+      "求偶季節裡雄性動物會展現自己最強壯的一面",
+      "強壯的雄鹿用巨大的鹿角和對手決鬥爭奪配偶",
+      "在動物世界中不一定是最強的獲勝，有時巧妙更重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:招": {
-    "sentences": [],
+    "sentences": [
+      "每種動物都有自己獨特的求偶招式讓人大開眼界",
+      "雄鳥使出各種招數只為了博得雌鳥的一眼青睞",
+      "花招百出的求偶行為是動物界最精彩的表演"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:摯": {
-    "sentences": [],
+    "sentences": [
+      "動物之間真摯的感情讓人看了也忍不住感動",
+      "雄企鵝送石頭給母企鵝表達最真摯的愛意",
+      "許多動物的伴侶關係比人類想像的還要忠誠真摯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:新": {
-    "sentences": [],
+    "sentences": [
+      "科學家不斷發現動物談情說愛的全新方式令人驚奇",
+      "新的研究顯示許多動物的求偶行為比想像中更複雜",
+      "每一個新發現都讓我們更了解動物的情感世界"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:昂": {
-    "sentences": [],
+    "sentences": [
+      "雄雞昂首闊步在母雞面前展現自己威武的姿態",
+      "雄鹿昂起頭顱用壯觀的鹿角向對手發出挑戰",
+      "高昂的鳴叫聲迴盪在森林中吸引遠方的異性"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:氣": {
-    "sentences": [],
+    "sentences": [
+      "蝴蝶靠氣味來找到遠方的伴侶進行交配",
+      "雄性動物散發的氣息是吸引雌性的化學訊號",
+      "求偶時雄鳥會鼓起胸膛讓自己看起來更有氣勢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:爭": {
-    "sentences": [],
+    "sentences": [
+      "雄性動物為了爭奪交配權經常展開激烈的競爭",
+      "爭風吃醋的場面在動物界可說是家常便飯",
+      "求偶的競爭雖然激烈但通常不會造成嚴重傷害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:登": {
-    "sentences": [],
+    "sentences": [
+      "雄鳥登上最高的樹枝放聲歌唱來吸引母鳥注意",
+      "登場亮相的那一刻，雄孔雀開屏的畫面美極了",
+      "他登上小丘觀察動物們精彩的求偶表演"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:目": {
-    "sentences": [],
+    "sentences": [
+      "雌鳥會用挑剔的目光審視每一位求偶者的表現",
+      "令人目不暇給的求偶舞蹈是自然界的精彩節目",
+      "目睹動物求偶的過程會讓你對大自然更加著迷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:真": {
-    "sentences": [],
+    "sentences": [
+      "動物的求偶行為展現了大自然中最真實的情感表達",
+      "真正打動雌性的不只是外表還有求偶的誠意",
+      "這些真摯的動物情感讓研究者深受感動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:睞": {
-    "sentences": [],
+    "sentences": [
+      "華麗的尾羽讓雄孔雀輕易就能獲得母孔雀的青睞",
+      "能歌善舞的雄鳥更容易受到異性的青睞和喜愛",
+      "用歌聲博得青睞是許多鳥類最常使用的求偶方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:粉": {
-    "sentences": [],
+    "sentences": [
+      "蝴蝶翅膀上的鱗粉在陽光下閃閃發光吸引著異性",
+      "粉嫩的花朵和鮮豔的羽毛都是自然界求偶的信號",
+      "雄鳥身上色彩繽粉的羽毛是吸引雌鳥的關鍵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:而": {
-    "sentences": [],
+    "sentences": [
+      "有些動物靠外表吸引伴侶，而有些則靠聲音取勝",
+      "求偶失敗的雄鳥不會氣餒，而是繼續努力嘗試",
+      "有趣的是動物界反而是雄性需要打扮得更漂亮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:耳": {
-    "sentences": [],
+    "sentences": [
+      "動聽的歌聲傳入母鳥的耳中讓牠心生好感",
+      "耳熟能詳的蟬鳴其實就是雄蟬的求偶歌聲",
+      "動物用各種聲音訊號來傳達愛意刺激對方的耳朵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:至": {
-    "sentences": [],
+    "sentences": [
+      "甚至有些動物會跳舞或蓋房子來追求心儀的對象",
+      "從螢火蟲至鯨魚，幾乎每一種動物都有求偶行為",
+      "至今科學家仍在發現更多動物談情說愛的新方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:親": {
-    "sentences": [],
+    "sentences": [
+      "動物之間的親密行為充滿了溫馨和令人感動的畫面",
+      "企鵝夫妻互相親暱地磨蹭脖子是牠們表達愛意的方式",
+      "親眼目睹動物求偶的人都會被大自然的奧妙所折服"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:赳": {
-    "sentences": [],
+    "sentences": [
+      "雄赳赳的公雞在母雞面前走來走去展現自己的風采",
+      "赳赳武夫般的雄鹿用鹿角決鬥來爭奪配偶的權利",
+      "雄性動物赳赳昂昂的模樣是為了讓自己看起來更強壯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:采": {
-    "sentences": [],
+    "sentences": [
+      "孔雀開屏時展現出的丰采讓所有觀察者都嘆為觀止",
+      "風采迷人的雄鳥輕輕鬆鬆就能贏得母鳥的芳心",
+      "雄鳥華麗的羽毛就像是大自然賦予牠的獨特采色"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:隨": {
-    "sentences": [],
+    "sentences": [
+      "隨著求偶季節到來，森林裡到處充滿了美妙的歌聲",
+      "母鳥會跟隨最有魅力的雄鳥一起築巢繁殖後代",
+      "隨機應變的求偶策略讓一些看似弱小的雄性也能成功"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:雄": {
-    "sentences": [],
+    "sentences": [
+      "雄性動物為了吸引異性會使出各種令人驚嘆的招式",
+      "威風凜凜的雄獅用吼聲宣告自己的地盤和地位",
+      "雄偉壯觀的鹿角是雄鹿在求偶季節最大的驕傲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:青": {
-    "sentences": [],
+    "sentences": [
+      "雄鳥努力展現魅力只為了博得雌鳥的青睞",
+      "青春洋溢的求偶舞蹈是大自然中最有活力的表演",
+      "色彩鮮艷如青金石般的羽毛讓雄鳥更加引人注目"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "動物談情說愛的方式:鬥": {
-    "sentences": [],
+    "sentences": [
+      "雄鹿之間的角鬥是為了爭奪和雌鹿交配的權利",
+      "鬥志高昂的雄性動物在求偶季節會變得特別活躍",
+      "激烈的戰鬥過後，勝利者才能贏得伴侶的青睞"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:之": {
-    "sentences": [],
+    "sentences": [
+      "十秒之內要跑完一百公尺真的很不容易",
+      "成功之前他經歷了很多辛苦的訓練",
+      "勝利的背後之所以感人是因為付出了很多"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:事": {
-    "sentences": [],
+    "sentences": [
+      "練習跑步這件事他從來不會偷懶",
+      "做任何事情都要全力以赴才會有好結果",
+      "比賽的事讓他又期待又緊張"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:刃": {
-    "sentences": [],
+    "sentences": [
+      "他把身體鍛鍊得像刀刃一樣銳利有力",
+      "站在起跑線上他感覺自己如同出鞘的刀刃",
+      "經過日復一日的磨練他終於練成了利刃般的速度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:別": {
-    "sentences": [],
+    "sentences": [
+      "他的努力和別人很不一樣每天都比別人多練兩小時",
+      "特別辛苦的訓練讓他變得比以前更加強壯",
+      "跟朋友告別後他又回到跑道上繼續練習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:即": {
-    "sentences": [],
+    "sentences": [
+      "比賽即將開始他的心跳變得好快",
+      "即使下雨他也不會停止練習跑步",
+      "教練說要隨時準備好因為機會隨即就會到來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:喪": {
-    "sentences": [],
+    "sentences": [
+      "他曾經因為比賽失敗感到非常沮喪",
+      "沮喪的心情沒有打倒他反而讓他更加努力",
+      "不要因為一次挫折就喪失了繼續努力的信心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:垮": {
-    "sentences": [],
+    "sentences": [
+      "再大的壓力也不能讓他的信心垮掉",
+      "身體要是沒照顧好就可能在比賽中垮下來",
+      "他不讓任何困難把自己打垮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:壤": {
-    "sentences": [],
+    "sentences": [
+      "天壤之別的成績背後是完全不同的努力程度",
+      "好的訓練環境就像肥沃的土壤能培養出冠軍",
+      "從失敗到成功之間有著天壤之別的辛苦過程"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:天": {
-    "sentences": [],
+    "sentences": [
+      "每天清晨他都會準時到跑道上練習",
+      "天還沒亮他就已經開始做暖身運動了",
+      "好天氣讓他練習起來更有精神"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:孤": {
-    "sentences": [],
+    "sentences": [
+      "訓練的路上他常常感到孤獨因為只有自己在跑",
+      "他孤單地在跑道上一圈又一圈地練習",
+      "即使孤軍奮戰他也從來沒有想過放棄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:寂": {
-    "sentences": [],
+    "sentences": [
+      "寂靜的清晨只有他一個人在跑道上練跑",
+      "寂寞的訓練時光讓他學會了和自己相處",
+      "比賽結束後場上一片寂靜接著就是如雷掌聲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:年": {
-    "sentences": [],
+    "sentences": [
+      "好幾年的辛苦訓練才換來十秒的精彩表現",
+      "他從小學三年級就開始練習跑步了",
+      "一年又一年的堅持讓他越跑越快"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:張": {
-    "sentences": [],
+    "sentences": [
+      "比賽前他緊張得手心都是汗",
+      "緊張的心情隨著鳴槍聲一起消失了",
+      "雖然很緊張但他告訴自己要相信平時的訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:感": {
-    "sentences": [],
+    "sentences": [
+      "他對教練充滿感謝因為教練從不放棄他",
+      "勝利的感覺比什麼都還要美好",
+      "感動的淚水在衝過終點線的那一刻流了下來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:擊": {
-    "sentences": [],
+    "sentences": [
+      "他像閃電一樣衝擊終點線贏得了冠軍",
+      "受到挫折的打擊反而讓他更有動力練習",
+      "最後的衝擊讓全場觀眾都驚呼連連為他歡呼"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:月": {
-    "sentences": [],
+    "sentences": [
+      "好幾個月的密集訓練讓他的速度大幅進步",
+      "每個月他都會記錄自己的跑步成績",
+      "日月如梭轉眼間比賽的日子就到了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:沮": {
-    "sentences": [],
+    "sentences": [
+      "受傷的時候他很沮喪覺得自己可能趕不上比賽",
+      "沮喪的時候教練會鼓勵他不要放棄",
+      "就算再沮喪他也會擦乾眼淚繼續練習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:睽": {
-    "sentences": [],
+    "sentences": [
+      "眾目睽睽之下他站上了起跑線準備比賽",
+      "在大家睽睽注視下他跑出了最好的成績",
+      "萬眾睽睽的比賽讓他既興奮又緊張"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:瞬": {
-    "sentences": [],
+    "sentences": [
+      "短短十秒的瞬間凝聚了他好幾年的努力",
+      "衝過終點線的那一瞬間全世界彷彿靜止了",
+      "一瞬間的爆發力背後是無數次的練習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:累": {
-    "sentences": [],
+    "sentences": [
+      "訓練很累但他知道每一滴汗水都不會白費",
+      "日積月累的努力終於在比賽中得到了回報",
+      "再累他也要堅持完成每天的訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:經": {
-    "sentences": [],
+    "sentences": [
+      "他經歷了很多挫折才走到今天這個位置",
+      "經過無數次的練習他終於突破了自己的紀錄",
+      "曾經失敗的經驗變成了他最寶貴的財富"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:而": {
-    "sentences": [],
+    "sentences": [
+      "他摔倒了又站起來而且跑得比之前更快",
+      "努力不一定馬上看到成果但堅持而不放棄就會成功",
+      "十秒很短而背後的付出卻是好幾年的汗水"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:脈": {
-    "sentences": [],
+    "sentences": [
+      "他能感覺到自己的脈搏隨著起跑聲加速跳動",
+      "血脈賁張的那一刻他全力衝向終點",
+      "跑步時感受到脈搏的跳動讓他知道自己還活著"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:與": {
-    "sentences": [],
+    "sentences": [
+      "他與對手之間的差距只有零點幾秒",
+      "參與比賽的經驗讓他學到了很多寶貴的東西",
+      "家人與教練的支持是他堅持下去的動力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:血": {
-    "sentences": [],
+    "sentences": [
+      "流了很多血汗才換來這十秒的好成績",
+      "他跑到全身熱血沸騰衝過了終點線",
+      "血脈賁張的比賽讓觀眾看得熱血沸騰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:解": {
-    "sentences": [],
+    "sentences": [
+      "了解十秒背後的故事才知道運動員有多辛苦",
+      "他用行動來化解大家對他的質疑",
+      "分解動作的練習幫助他跑得更快更穩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:賁": {
-    "sentences": [],
+    "sentences": [
+      "血脈賁張的比賽讓觀眾席上的人都站了起來",
+      "賁張的情緒在鳴槍的那一刻全部釋放出來",
+      "他感覺全身血脈賁張充滿了無窮的力量"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:轉": {
-    "sentences": [],
+    "sentences": [
+      "轉個彎之後他看到了終點線就在前方",
+      "人生的轉折點就是他決定開始認真練跑的那一天",
+      "他的成績出現了大幅的轉變讓所有人刮目相看"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:迎": {
-    "sentences": [],
+    "sentences": [
+      "他張開雙臂迎接終點線那一刻的到來",
+      "迎面而來的風讓他跑得更有精神",
+      "朋友和家人在終點線迎接他的歸來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:逝": {
-    "sentences": [],
+    "sentences": [
+      "十秒一閃即逝但那份感動會永遠留在心中",
+      "時間飛逝轉眼間他已經從小選手變成了冠軍",
+      "稍縱即逝的機會讓他更加珍惜每一次比賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:違": {
-    "sentences": [],
+    "sentences": [
+      "他從不違背對教練的承諾每天都準時到場練習",
+      "長時間的久違之後他終於重新回到了跑道上",
+      "違反規則的行為會讓所有努力都白費"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "十秒的背後:願": {
-    "sentences": [],
+    "sentences": [
+      "他最大的願望就是在比賽中跑進十秒以內",
+      "心甘情願地付出汗水才能在比賽中發光發熱",
+      "如願以償的那一刻他忍不住流下了眼淚"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:中": {
-    "sentences": [],
+    "sentences": [
+      "在這場票選活動中，候選人正在台上發表精彩的政見",
+      "在這場票選活動中，每個角色都使出了渾身解數",
+      "投票結果揭曉的那一刻，教室中響起了熱烈的掌聲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:出": {
-    "sentences": [],
+    "sentences": [
+      "每位候選人都使出渾身解數爭取同學們的支持",
+      "脫穎而出的角色就能成為這次票選的人氣王",
+      "出乎意料的結果讓許多同學都感到非常驚喜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:口": {
-    "sentences": [],
+    "sentences": [
+      "他異口同聲地和大家一起喊出支持的口號",
+      "候選人的口才好到讓台下的同學都忍不住鼓掌",
+      "投票結果出口之後大家才知道誰是最受歡迎的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:同": {
-    "sentences": [],
+    "sentences": [
+      "同學們對於誰應該當選有著各自不同的看法",
+      "他們異口同聲地支持自己最喜歡的卡通角色",
+      "相同的票數讓兩位候選人必須進行最後的決選"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:呵": {
-    "sentences": [],
+    "sentences": [
+      "他呵護著自己精心製作的競選海報不讓它被弄壞",
+      "同學們笑呵呵地看著台上搞笑的政見發表內容",
+      "一呵而就的演說詞讓大家對這位候選人刮目相看"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:大": {
-    "sentences": [],
+    "sentences": [
+      "大家一起投票選出心目中最喜歡的卡通人氣王",
+      "這場政見發表會的規模比想像中還要盛大熱鬧",
+      "他大聲地念出自己的政見讓全班同學都能聽見"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:如": {
-    "sentences": [],
+    "sentences": [
+      "他如願以償地當選了這次的卡通人氣王",
+      "如果你是評審，你會投票給哪一位卡通角色呢",
+      "結果如同大家預料的一樣，最受歡迎的角色獲勝了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:宛": {
-    "sentences": [],
+    "sentences": [
+      "他上台時的架勢宛如真正的候選人一般充滿自信",
+      "那場政見發表會宛如一場精彩的表演秀",
+      "她的演說宛如真正的政治家讓同學們佩服不已"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:展": {
-    "sentences": [],
+    "sentences": [
+      "候選人在台上展示自己的政見並說明執行計畫",
+      "這次活動讓同學們有機會展現自己的表達能力",
+      "發展出自己的風格是贏得選票的重要關鍵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:手": {
-    "sentences": [],
+    "sentences": [
+      "這場票選競爭激烈，每位對手都很有實力",
+      "他親手製作了精美的海報來宣傳自己的政見",
+      "高手雲集的比賽讓這場活動更加精彩好看"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:抗": {
-    "sentences": [],
+    "sentences": [
+      "兩位人氣角色互相抗衡讓票數非常接近",
+      "他勇敢地站出來對抗不公平的投票方式",
+      "抗議無效票的同學認為應該重新進行計票"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:拒": {
-    "sentences": [],
+    "sentences": [
+      "他拒絕用不正當的方式拉票堅持公平競爭",
+      "拒絕接受賄選是維護選舉公正的基本態度",
+      "她拒絕了同學要她退出比賽的請求繼續參選"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:撞": {
-    "sentences": [],
+    "sentences": [
+      "兩個人的政見正面撞上了讓場面變得很刺激",
+      "他不小心撞翻了投票箱讓大家都嚇了一跳",
+      "不同意見的衝撞反而讓討論變得更加精彩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:政": {
-    "sentences": [],
+    "sentences": [
+      "政見發表會上每位候選人都有三分鐘的發言時間",
+      "他的政見內容很有創意獲得了同學們的熱烈支持",
+      "好的政見要能說服大家並且讓人願意投票支持"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:正": {
-    "sentences": [],
+    "sentences": [
+      "正式投票開始前每位同學都拿到了一張選票",
+      "他堂堂正正地參加比賽沒有用任何不光彩的手段",
+      "正確的態度比輸贏更加重要這是老師想教我們的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:步": {
-    "sentences": [],
+    "sentences": [
+      "他一步一步走上講台準備發表自己的精彩政見",
+      "投票的步驟很簡單但每一票都代表著同學的選擇",
+      "邁出勇敢的第一步站上台發表政見需要很大的勇氣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:異": {
-    "sentences": [],
+    "sentences": [
+      "異口同聲的歡呼代表這位候選人非常受歡迎",
+      "同學們對投票結果的反應各異有人歡喜有人失望",
+      "他提出了異於常人的創意政見讓全班眼睛一亮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:箭": {
-    "sentences": [],
+    "sentences": [
+      "他像離弦的箭一樣衝上台搶先發表自己的政見",
+      "一箭雙雕的政見同時解決了兩個問題贏得了掌聲",
+      "同學丟出的提問像箭一樣又快又尖考驗著候選人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:糾": {
-    "sentences": [],
+    "sentences": [
+      "糾正不公平的投票程序是每位參與者的責任",
+      "兩位候選人互相糾纏爭論誰的政見比較好",
+      "他糾結了好久才決定把票投給哪一位候選人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:而": {
-    "sentences": [],
+    "sentences": [
+      "他雖然落選了但還是微笑而且大方地恭喜對方",
+      "有些同學憑感覺投票而不是根據政見內容來決定",
+      "努力準備過的政見會被看見而隨便應付的會被淘汰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:聲": {
-    "sentences": [],
+    "sentences": [
+      "台下響起了如雷的掌聲為最後的當選者歡呼",
+      "他的聲音又大又清楚讓全班都能聽得一清二楚",
+      "歡呼聲中夾雜著失望的嘆息選舉結果總是幾家歡樂"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:脫": {
-    "sentences": [],
+    "sentences": [
+      "他從眾多候選人中脫穎而出成為這次的人氣王",
+      "脫離了緊張的情緒後他才開始享受比賽的樂趣",
+      "最後脫穎而出的角色是大家最意想不到的那一位"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:莽": {
-    "sentences": [],
+    "sentences": [
+      "魯莽的行為會讓你在選舉中失去同學們的信任",
+      "他不想做一個莽撞的候選人所以事先做了很多準備",
+      "草莽英雄般的登場讓全場同學都笑了出來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:見": {
-    "sentences": [],
+    "sentences": [
+      "政見發表是讓候選人展現自己想法的重要環節",
+      "他的見解獨到讓許多原本猶豫的同學決定支持他",
+      "聽完所有政見之後同學們才做出最後的投票決定"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:計": {
-    "sentences": [],
+    "sentences": [
+      "他精心設計了一份有趣又有深度的政見內容",
+      "計票的過程讓大家都屏住呼吸期待最後結果",
+      "好的競選計畫需要提前準備不能臨時抱佛腳"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:護": {
-    "sentences": [],
+    "sentences": [
+      "他在政見中承諾要維護班上每一位同學的權益",
+      "保護公平競爭的精神是這次活動最重要的目的",
+      "大家一起愛護這個充滿歡笑的票選活動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "卡通人氣王票選政見發表會:身": {
-    "sentences": [],
+    "sentences": [
+      "他親身上台體驗了一次當候選人的感覺很特別",
+      "挺身而出參加選舉需要很大的勇氣和自信",
+      "他全身充滿了自信一步步走向講台開始發表政見"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:之": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯是全世界海拔最低的國家之一面臨被海水淹沒的危機",
+      "氣候變遷之下，這個小島國正在一點一點地消失",
+      "這是攸關國家存亡之際的重大議題不容任何人忽視"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:人": {
-    "sentences": [],
+    "sentences": [
+      "島上的人們面對海平面上升感到無比的焦慮和無助",
+      "許多人還不知道吐瓦魯這個國家正在慢慢消失",
+      "當地人世世代代居住在這座島上卻可能很快被迫離開"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:例": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯就是氣候變遷影響最嚴重的典型案例之一",
+      "以吐瓦魯為例就能看出海平面上升帶來的巨大威脅",
+      "這個案例讓全世界開始正視氣候難民的問題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:候": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷是造成吐瓦魯面臨滅頂之災的根本原因",
+      "極端氣候事件的頻率越來越高讓島民苦不堪言",
+      "時候到了全世界都必須認真面對氣候變遷的問題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:先": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯可能成為全世界最先因氣候變遷而消失的國家",
+      "首先受到衝擊的就是這些低海拔的太平洋島國",
+      "他們搶先發出了求救信號希望國際社會伸出援手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:其": {
-    "sentences": [],
+    "sentences": [
+      "其實吐瓦魯的碳排放量幾乎為零卻承受最大的後果",
+      "其中最令人擔憂的是海水入侵已經汙染了地下水源",
+      "氣候變遷的影響遍及全球，其嚴重性不容小覷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:危": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯正面臨國土被海水淹沒的生存危機",
+      "危在旦夕的處境讓島民不得不開始考慮遷移計畫",
+      "岌岌可危的島國向全世界發出了最後的呼救信號"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:可": {
-    "sentences": [],
+    "sentences": [
+      "如果不採取行動吐瓦魯可能在數十年內完全消失",
+      "這個悲劇是可以避免的只要各國願意共同減少碳排放",
+      "可以想見未來會有更多島嶼國家面臨同樣的命運"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:外": {
-    "sentences": [],
+    "sentences": [
+      "除了海平面上升之外，鹹水入侵也威脅著島上的農業",
+      "外界對吐瓦魯的處境知之甚少讓人感到遺憾",
+      "在這座島嶼的外海上潮水正以驚人的速度不斷上漲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:失": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯面臨失去國土的危機這在人類歷史上前所未有",
+      "流失的土地再也無法恢復讓島民感到深深的絕望",
+      "一旦失去了家園他們將成為世界上第一批氣候難民"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:室": {
-    "sentences": [],
+    "sentences": [
+      "溫室效應導致全球暖化是海平面上升的主要原因",
+      "聯合國的會議室裡各國代表正在討論氣候變遷的對策",
+      "教室裡老師用吐瓦魯的故事讓學生了解環保的重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:局": {
-    "sentences": [],
+    "sentences": [
+      "目前的局勢對吐瓦魯非常不利海平面持續在上升中",
+      "全球暖化的大局之下小島國的聲音往往被忽略",
+      "困局之中吐瓦魯仍然積極在國際場合為自己發聲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:岌": {
-    "sentences": [],
+    "sentences": [
+      "岌岌可危的國土讓吐瓦魯的未來充滿了不確定性",
+      "島上的基礎設施在海水侵蝕下變得岌岌可危",
+      "岌岌可危的處境迫使政府開始認真討論全國遷移計畫"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:所": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯所面臨的危機是全人類共同造成的後果",
+      "島民所擁有的一切可能在未來幾十年內被海水吞沒",
+      "他們所居住的這片土地正在以肉眼可見的速度縮小"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:是": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯是全世界最脆弱的國家之一面積僅有二十六平方公里",
+      "這不只是一個小國的問題而是全人類應該共同面對的危機",
+      "事實是如果各國不合作減碳這個國家將會永遠消失"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:有": {
-    "sentences": [],
+    "sentences": [
+      "島上所有的居民都在擔心自己的家園還能撐多久",
+      "有些家庭已經被迫遷移到地勢較高的區域居住",
+      "吐瓦魯擁有的時間已經不多了國際社會必須加緊行動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:殃": {
-    "sentences": [],
+    "sentences": [
+      "工業大國的碳排放殃及了無辜的太平洋島國居民",
+      "城門失火殃及池魚吐瓦魯就是氣候變遷的無辜受害者",
+      "全球暖化帶來的災殃正在一步步吞噬這個美麗的島國"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:民": {
-    "sentences": [],
+    "sentences": [
+      "島上的居民正在為保護自己的家園做最後的努力",
+      "吐瓦魯的人民雖然人數不多但他們的聲音值得被聽見",
+      "氣候難民的問題將成為未來國際社會最棘手的議題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:氣": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷讓海平面不斷上升威脅著低窪島國的存亡",
+      "溫室氣體的排放是造成全球暖化的主要元凶之一",
+      "大氣中的二氧化碳濃度越高全球暖化就越嚴重"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:池": {
-    "sentences": [],
+    "sentences": [
+      "城門失火殃及池魚吐瓦魯因為他國的碳排放而受害",
+      "海水倒灌讓島上原本的淡水池變成了鹹水無法飲用",
+      "一個小小的水池就能反映出海平面上升帶來的影響"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:沒": {
-    "sentences": [],
+    "sentences": [
+      "海平面持續上升吐瓦魯正面臨被完全淹沒的命運",
+      "如果全球暖化不受控制這個國家將在未來數十年內消沒",
+      "他們最害怕的就是有一天醒來發現家園已經被海水淹沒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:流": {
-    "sentences": [],
+    "sentences": [
+      "海水倒流入侵內陸嚴重影響了島上的農業生產",
+      "氣候難民的流離失所是未來世界必須面對的問題",
+      "洋流的變化加速了海平面上升對吐瓦魯的衝擊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:溫": {
-    "sentences": [],
+    "sentences": [
+      "全球平均溫度持續升高是海平面上升的直接原因",
+      "溫室效應讓地球越來越熱冰川加速融化",
+      "即使只升溫一度對吐瓦魯這樣的低窪島國也是致命的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:界": {
-    "sentences": [],
+    "sentences": [
+      "全世界都應該共同承擔氣候變遷帶來的責任",
+      "國界無法阻擋氣候變遷的影響每個國家都會受波及",
+      "科學界不斷警告如果不減碳後果將不堪設想"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:當": {
-    "sentences": [],
+    "sentences": [
+      "當海水漲到家門口時島民才真正感受到危機的急迫",
+      "面對氣候變遷我們每個人都應當負起一份責任",
+      "當這個國家消失的時候全世界都應該感到愧疚"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:瞰": {
-    "sentences": [],
+    "sentences": [
+      "從高空鳥瞰吐瓦魯只是汪洋中一個小小的珊瑚環礁",
+      "俯瞰這座島國你會發現它的面積小得令人心疼",
+      "衛星圖像讓我們能從空中鳥瞰海平面上升的實際影響"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:端": {
-    "sentences": [],
+    "sentences": [
+      "極端氣候事件越來越頻繁加速了吐瓦魯的消失",
+      "海平面上升只是冰山一端背後是整個氣候系統的失衡",
+      "站在島嶼的最東端就能感受到海水逐漸逼近的壓迫感"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:臨": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯面臨的不只是國土消失更是一個民族文化的消亡",
+      "瀕臨消失的島國向全世界發出了最後的求救訊號",
+      "他們正面臨著必須離開世代居住的家園的殘酷現實"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:衝": {
-    "sentences": [],
+    "sentences": [
+      "海浪的衝擊讓島上的防波堤越來越脆弱",
+      "首當其衝的就是這些海拔僅有幾公尺的太平洋島國",
+      "氣候變遷帶來的衝擊對小島國的影響最為嚴重"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:離": {
-    "sentences": [],
+    "sentences": [
+      "被迫離開家園是吐瓦魯居民最不願面對的選擇",
+      "距離吐瓦魯最近的大陸也有數千公里之遙",
+      "離鄉背井的痛苦是氣候難民最難以承受的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:難": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯的居民可能成為世界上第一批氣候難民",
+      "面對這場難以逆轉的危機國際社會必須團結一致",
+      "困難重重的處境讓這個小國的未來充滿了未知"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:雲": {
-    "sentences": [],
+    "sentences": [
+      "烏雲密布的天空彷彿也在為這個島國的命運感到哀傷",
+      "雲層中累積的熱量正在加速全球暖化的進程",
+      "撥雲見日的那天或許就是全世界開始認真減碳的時候"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:首": {
-    "sentences": [],
+    "sentences": [
+      "吐瓦魯首當其衝成為全球暖化最直接的受害者",
+      "這個國家的首都在大潮時幾乎整片被海水淹沒",
+      "首先我們必須了解為什麼一個國家會因為氣候而消失"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:體": {
-    "sentences": [],
+    "sentences": [
+      "整體而言吐瓦魯的處境反映了全球氣候危機的嚴重性",
+      "國際社會的共同體認知是減碳行動刻不容緩",
+      "體會到島民的痛苦才能真正理解氣候正義的意義"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:魚": {
-    "sentences": [],
+    "sentences": [
+      "城門失火殃及池魚吐瓦魯正是氣候變遷的池中之魚",
+      "海水溫度的改變也影響了島民賴以捕魚維生的生計",
+      "島上居民靠捕魚維生但海洋環境的變化讓漁獲越來越少"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:鳥": {
-    "sentences": [],
+    "sentences": [
+      "從空中鳥瞰這座島國你會發現它脆弱得令人心疼",
+      "許多候鳥的棲息地也因為海平面上升而逐漸消失",
+      "鳥類是觀察環境變化最敏感的指標之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "吐瓦魯：逐漸被淹沒的島國:點": {
-    "sentences": [],
+    "sentences": [
+      "海平面只要上升一點點對吐瓦魯來說就是致命的打擊",
+      "這一點點的溫度變化卻足以改變一個國家的命運",
+      "從這個切入點來看氣候變遷不再只是遙遠的數據"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:之": {
-    "sentences": [],
+    "sentences": [
+      "成為頂尖選手之前他每天都要練習好幾個小時",
+      "成功之路沒有捷徑只有不斷地努力和堅持",
+      "他之所以能站上國際舞台靠的是日復一日的苦練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:助": {
-    "sentences": [],
+    "sentences": [
+      "教練的幫助讓他在技術上有了很大的進步",
+      "營養師的協助讓他的飲食搭配更加均衡健康",
+      "隊友的互相幫助讓整個團隊的氣氛非常融洽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:口": {
-    "sentences": [],
+    "sentences": [
+      "口渴的時候他只喝白開水不碰含糖飲料",
+      "他的口頭禪就是「今天也要全力以赴」",
+      "教練在場邊大聲喊口令指揮他的腳步移動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:懈": {
-    "sentences": [],
+    "sentences": [
+      "堅持不懈的態度是他成為頂尖選手的關鍵",
+      "即使身體疲累他也從不鬆懈每天的訓練計畫",
+      "不敢稍有懈怠因為對手隨時都在進步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:拜": {
-    "sentences": [],
+    "sentences": [
+      "他拜了一位經驗豐富的教練學習高階技巧",
+      "許多年輕選手都把他當作偶像來崇拜",
+      "每次比賽前他都會虔誠地拜拜祈求好表現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:會": {
-    "sentences": [],
+    "sentences": [
+      "他學會了在壓力下保持冷靜發揮最好的實力",
+      "每一場比賽都是學習和成長的寶貴機會",
+      "體會到堅持的力量之後他更加認真地訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:欲": {
-    "sentences": [],
+    "sentences": [
+      "想要成為頂尖選手就不能有欲速則不達的心態",
+      "他對勝利的欲望促使自己每天都比別人更加努力",
+      "求勝欲望讓他在每一場比賽中都全力以赴不留遺憾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:潛": {
-    "sentences": [],
+    "sentences": [
+      "他潛心鑽研每一個技術動作追求完美的表現",
+      "潛力被發掘之後教練開始對他進行更嚴格的訓練",
+      "每天的訓練就像潛入深水一樣需要專注和耐心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:盈": {
-    "sentences": [],
+    "sentences": [
+      "他的生活充滿了滿滿的正能量笑容盈盈",
+      "汗水盈滿了他的額頭但他依然堅持完成訓練",
+      "日積月累的努力讓他的技術水準日益充盈"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:窺": {
-    "sentences": [],
+    "sentences": [
+      "從他的一天就能窺見頂尖選手生活的不容易",
+      "外人很難窺見這些光鮮成績背後的辛酸血淚",
+      "透過紀錄片我們得以一窺冠軍選手的日常"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:繁": {
-    "sentences": [],
+    "sentences": [
+      "頻繁的比賽行程讓他幾乎沒有休息的時間",
+      "繁重的訓練計畫需要強大的意志力才能堅持下去",
+      "繁忙的一天從清晨五點的體能訓練開始"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:能": {
-    "sentences": [],
+    "sentences": [
+      "頂尖選手的體能是經過多年鍛鍊才培養出來的",
+      "他相信只要努力不懈就一定能達成自己的目標",
+      "良好的技能加上穩定的心態是致勝的關鍵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:腹": {
-    "sentences": [],
+    "sentences": [
+      "空腹訓練會影響表現所以他一定先吃早餐再練球",
+      "他的滿腹經綸都來自多年比賽累積的實戰經驗",
+      "鍛鍊核心腹部肌群是他每天必做的基本訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:視": {
-    "sentences": [],
+    "sentences": [
+      "他把每一場比賽都視為提升自己的寶貴機會",
+      "電視轉播讓更多人看見了他在球場上的精彩表現",
+      "忽視身體發出的警訊可能會導致嚴重的運動傷害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:贊": {
-    "sentences": [],
+    "sentences": [
+      "教練對他的進步贊不絕口給了他更多的信心和動力",
+      "贊助商看到了他的潛力決定支持他的運動生涯",
+      "他的堅持精神值得所有人贊許和學習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:輕": {
-    "sentences": [],
+    "sentences": [
+      "不要輕視每一次的基本功練習因為它是實力的根基",
+      "輕鬆的態度面對壓力是他在比賽中穩定發揮的祕訣",
+      "年輕的他已經展現出超越同齡選手的成熟技術"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:鍊": {
-    "sentences": [],
+    "sentences": [
+      "日復一日的鍛鍊讓他的體能達到了巔峰狀態",
+      "每一次的鍊習都是在為未來的大賽做最好的準備",
+      "千錘百鍊的精神造就了一位世界級的羽球好手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:鍛": {
-    "sentences": [],
+    "sentences": [
+      "鍛鍊身體是每位運動員每天最重要的功課",
+      "他從小就開始鍛鍊體能為未來的運動生涯打基礎",
+      "鍛造一位頂尖選手需要時間、汗水和堅定的意志"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:頻": {
-    "sentences": [],
+    "sentences": [
+      "頻繁的出國比賽讓他累積了豐富的實戰經驗",
+      "他頻頻在國際賽事中取得好成績為國爭光",
+      "高頻率的訓練是維持競技水準不可或缺的條件"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "周天成的一天-頂尖選手的養成:鬆": {
-    "sentences": [],
+    "sentences": [
+      "訓練結束後他會做伸展運動讓肌肉好好放鬆",
+      "輕鬆的心情反而讓他在比賽中發揮得更好",
+      "不能有一絲鬆懈因為對手隨時都在追趕"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:不": {
-    "sentences": [],
+    "sentences": [
+      "至今仍有許多關於巨石陣的謎團不曾被解開令人好奇",
+      "不同學者對摩艾石像的建造目的提出了截然不同的假說",
+      "這些巨石為何被搬運到此處至今不得而知"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:人": {
-    "sentences": [],
+    "sentences": [
+      "古代的人是如何在沒有機械的條件下搬運這些巨石的",
+      "無人能夠確切解釋摩艾石像面朝內陸的真正原因",
+      "這些謎團吸引了無數的研究人員投入畢生的心血"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:休": {
-    "sentences": [],
+    "sentences": [
+      "關於巨石陣用途的爭論從未休止，各方說法莫衷一是",
+      "研究者不眠不休地考察遺址試圖找到建造的真相",
+      "歷經數千年的風霜這些巨石依然矗立不休"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:假": {
-    "sentences": [],
+    "sentences": [
+      "有人假設巨石陣是古代的天文觀測站但尚無定論",
+      "各種假說百花齊放卻沒有一個能完全解釋所有現象",
+      "真假難辨的傳說讓這些遺跡更添幾分神祕色彩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:偶": {
-    "sentences": [],
+    "sentences": [
+      "偶然的考古發現有時能為千年未解之謎提供關鍵線索",
+      "摩艾石像的造型並非偶然而是經過精心設計的",
+      "偶爾回顧這些古老的謎團能讓我們對人類文明充滿敬畏"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:光": {
-    "sentences": [],
+    "sentences": [
+      "陽光穿過巨石陣的縫隙在夏至那天形成完美的光影",
+      "時光流逝了數千年這些巨石依然沉默地守護著祕密",
+      "月光下的摩艾石像群呈現出一種莊嚴肅穆的氣氛"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:千": {
-    "sentences": [],
+    "sentences": [
+      "數千年前的古人究竟是如何完成這些偉大工程的",
+      "千百年來無數的探險家和學者都試圖解開這個謎",
+      "千里迢迢運送巨石的過程至今仍是考古學的未解之謎"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:少": {
-    "sentences": [],
+    "sentences": [
+      "目前為止能確定的證據少之又少讓研究進展緩慢",
+      "不少學者認為巨石陣與古代的宗教祭祀儀式有關",
+      "至少有九百座摩艾石像散布在復活節島的各個角落"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:崎": {
-    "sentences": [],
+    "sentences": [
+      "復活節島崎嶇的地形讓巨石的運送變得更加困難",
+      "千里迢迢穿越崎嶇的路途只為了解開這個千年之謎",
+      "崎嶇不平的地表上矗立著一排排令人驚嘆的石像"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:嶇": {
-    "sentences": [],
+    "sentences": [
+      "崎嶇的山路擋不住古代工匠搬運巨石的決心",
+      "考古學家在嶇嶔的岩石間發現了可能的建造工具遺跡",
+      "穿越崎嶇的地形搬運數噸重的石頭至今無人能完全復現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:布": {
-    "sentences": [],
+    "sentences": [
+      "摩艾石像散布在復活節島上彷彿沉默的守衛者",
+      "巨石陣的石塊呈環形分布其排列方式暗藏天文密碼",
+      "遺跡的分布範圍之廣讓考古學家感到相當驚訝"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:敬": {
-    "sentences": [],
+    "sentences": [
+      "這些古老的遺跡讓每一位造訪者都心生敬畏之情",
+      "我們應該對古代文明的智慧與工藝表達由衷的敬意",
+      "帶著敬畏的心情研究這些遺跡才能真正理解其意義"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:星": {
-    "sentences": [],
+    "sentences": [
+      "有學者推測巨石陣可能被用來觀測星象和預測季節",
+      "星辰的運行軌跡或許就是古人建造巨石陣的密碼",
+      "繁星之下的巨石陣展現出一種超越時空的神祕力量"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:有": {
-    "sentences": [],
+    "sentences": [
+      "有些假說認為巨石陣是古代王族的墓地或祭祀場所",
+      "現有的考古證據仍然不足以完全解開這些千年謎團",
+      "只有持續的考古挖掘才有可能找到最終的答案"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:滿": {
-    "sentences": [],
+    "sentences": [
+      "復活節島上佈滿了數百座神祕的摩艾石像令人震撼",
+      "這些未解之謎充滿了讓人想要探索的強烈吸引力",
+      "研究者心中滿是疑問每一個發現都帶來更多的謎團"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:無": {
-    "sentences": [],
+    "sentences": [
+      "無人能確切解釋這些巨石是如何被搬運到現在的位置",
+      "杳無人煙的荒野中這些石像靜靜地佇立了數千年",
+      "無數的理論被提出又被推翻真相依然撲朔迷離"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:然": {
-    "sentences": [],
+    "sentences": [
+      "然而即使有了先進的科技這些謎團依然沒有被完全破解",
+      "巨石陣依然矗立在英格蘭的草原上等待著答案的揭曉",
+      "自然的力量加上人類的智慧共同造就了這些不朽的奇蹟"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:煙": {
-    "sentences": [],
+    "sentences": [
+      "杳無人煙的復活節島上這些石像靜默地守護著千年祕密",
+      "歷史的煙塵掩蓋了真相讓後人只能憑藉蛛絲馬跡推測",
+      "硝煙散盡之後這些古老的遺跡依然屹立不搖"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:爭": {
-    "sentences": [],
+    "sentences": [
+      "關於巨石陣建造目的的爭論已經持續了好幾個世紀",
+      "學術界對摩艾石像的起源和功能爭議不休尚無定論",
+      "這場學術上的爭辯激發了更多人投入相關的研究工作"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:獨": {
-    "sentences": [],
+    "sentences": [
+      "每一座摩艾石像都有獨特的面部特徵絕非批量複製",
+      "獨特的巨石排列方式暗示著古人擁有高度的天文知識",
+      "獨自站在巨石陣中央你會感受到一股超越時空的力量"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:眾": {
-    "sentences": [],
+    "sentences": [
+      "眾多的假說讓真相變得更加撲朔迷離難以判斷",
+      "眾說紛紜之中我們更需要依靠科學的方法尋找答案",
+      "在眾多的未解之謎中巨石陣和摩艾石像最為人知"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:矗": {
-    "sentences": [],
+    "sentences": [
+      "巨石陣矗立在英格蘭的索爾茲伯里平原上已有五千年",
+      "數百座摩艾石像矗立在復活節島的海岸邊蔚為壯觀",
+      "矗立千年的巨石見證了人類文明的興衰更替"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:稀": {
-    "sentences": [],
+    "sentences": [
+      "如此大規模的巨石建築在全世界都是極為稀有的存在",
+      "稀少的考古證據讓研究者必須從有限的線索中拼湊真相",
+      "稀世罕見的摩艾石像每年吸引數十萬遊客前來朝聖"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:立": {
-    "sentences": [],
+    "sentences": [
+      "這些巨石是如何被豎立起來的至今仍然是一個謎",
+      "屹立數千年不倒的巨石陣展現了古代工程的驚人成就",
+      "獨立思考的精神正是解開未解之謎最需要的素質"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:紛": {
-    "sentences": [],
+    "sentences": [
+      "紛紜的假說讓巨石陣和摩艾石像的真相更加撲朔迷離",
+      "眾說紛紛之中唯有考古證據才能帶我們接近真相",
+      "學者們紛紛提出自己的見解試圖為這些謎團找到解答"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:紜": {
-    "sentences": [],
+    "sentences": [
+      "眾說紛紜的局面正好說明了這個謎團的複雜程度",
+      "紛紜的理論中每一個都有其合理之處也有不足之處",
+      "面對紛紜的說法保持開放的心態才是正確的態度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:肅": {
-    "sentences": [],
+    "sentences": [
+      "摩艾石像莊嚴肅穆的表情讓人不由得心生敬畏",
+      "站在巨石陣前你會感受到一股肅然起敬的神聖氛圍",
+      "肅穆的氣氛籠罩著這片古老的遺跡令人不敢喧嘩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:製": {
-    "sentences": [],
+    "sentences": [
+      "這些石像是用什麼工具製造出來的至今仍是未解之謎",
+      "古代工匠製作石像的精湛技術讓現代人嘆為觀止",
+      "複製古人的建造方法是研究者嘗試解謎的途徑之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:複": {
-    "sentences": [],
+    "sentences": [
+      "複雜的建造過程需要大量的人力和精密的組織協調",
+      "試圖複製古人搬運巨石的實驗至今尚未完全成功",
+      "這些遺跡的複雜程度遠超過我們對古代文明的想像"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:設": {
-    "sentences": [],
+    "sentences": [
+      "有人假設巨石陣是用來舉行宗教儀式的神聖場所",
+      "各種假設都有支持者也有反對者真相仍然成謎",
+      "設身處地想想古人是如何在沒有機械的情況下完成的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:說": {
-    "sentences": [],
+    "sentences": [
+      "關於巨石陣的傳說數不勝數有的浪漫有的離奇",
+      "眾說紛紜的局面讓這些未解之謎更增添了神祕感",
+      "有一種說法認為摩艾石像代表的是島民已故的祖先"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:論": {
-    "sentences": [],
+    "sentences": [
+      "無論哪一種理論都無法完美解釋這些巨石建築的全貌",
+      "學者們的討論和辯論推動了考古研究不斷向前邁進",
+      "結論尚未定案但每一次的新發現都讓我們離真相更近"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:起": {
-    "sentences": [],
+    "sentences": [
+      "這些巨石是如何被豎起來的至今仍然眾說紛紜",
+      "追溯起源才能真正理解古代文明建造這些遺跡的動機",
+      "一起探索這些千年未解之謎是最令人興奮的知識冒險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:迢": {
-    "sentences": [],
+    "sentences": [
+      "千里迢迢將數噸重的巨石搬運到這裡究竟是為了什麼",
+      "迢迢的路途擋不住古人完成這項偉大工程的決心",
+      "迢遠的距離讓巨石的來源之謎更加令人費解不已"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-未解之謎-巨石陣+摩艾石像:里": {
-    "sentences": [],
+    "sentences": [
+      "巨石陣的石材來源地距離遺址有數百里之遙令人驚嘆",
+      "千里迢迢運送巨石的壯舉在古代是難以想像的工程",
+      "方圓數里內散布著各種大小不一的摩艾石像"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:世": {
-    "sentences": [],
+    "sentences": [
+      "他打破了世界紀錄成為馬拉松歷史上最偉大的跑者之一",
+      "這雙跑鞋的問世引發了關於科技與競技公平性的激烈討論",
+      "世人對於科技輔助破紀錄的看法分歧甚大莫衷一是"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:佼": {
-    "sentences": [],
+    "sentences": [
+      "他是馬拉松界的佼佼者多次打破世界紀錄",
+      "佼佼者之所以能脫穎而出靠的不只是裝備而是苦練",
+      "在眾多頂尖選手中他的表現堪稱佼佼者中的佼佼者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:備": {
-    "sentences": [],
+    "sentences": [
+      "充分的體能準備和先進的跑鞋科技共同促成了破紀錄",
+      "裝備的進步讓選手具備了挑戰人體極限的更多可能",
+      "準備充分的選手加上頂尖的跑鞋裝備才能創造奇蹟"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:受": {
-    "sentences": [],
+    "sentences": [
+      "這項爭議受到了全球體育界和科學界的高度關注",
+      "選手的身體承受著巨大的負荷才能完成馬拉松的挑戰",
+      "新型跑鞋受到了許多頂尖選手的青睞和採用"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:名": {
-    "sentences": [],
+    "sentences": [
+      "他以驚人的成績名揚四海成為馬拉松界的傳奇人物",
+      "名列前茅的選手幾乎都穿著同一品牌的碳板跑鞋",
+      "莫名其妙的成績飛躍讓人不禁質疑跑鞋的作用"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:吞": {
-    "sentences": [],
+    "sentences": [
+      "他以驚人的配速吞噬著賽道上的每一公里",
+      "被吞噬的舊紀錄提醒我們人類潛能的邊界正在被重新定義",
+      "時間彷彿被他吞進了步伐裡以不可思議的速度消逝"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:噬": {
-    "sentences": [],
+    "sentences": [
+      "新科技像猛獸一般噬咬著傳統競技的公平性根基",
+      "被噬去的紀錄背後是科技與人體能力的複雜交互作用",
+      "時間的流逝在他的腳下被一步步噬盡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:增": {
-    "sentences": [],
+    "sentences": [
+      "碳板跑鞋據研究能增加百分之四的跑步效率",
+      "科技的進步增添了破紀錄的可能但也引發了公平性的質疑",
+      "不斷增長的訓練量和科技輔助共同推動了成績的提升"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:壓": {
-    "sentences": [],
+    "sentences": [
+      "頂尖選手承受著巨大的心理壓力在每場比賽中突破極限",
+      "碳板跑鞋的壓縮泡棉能有效吸收地面的衝擊力",
+      "沉重的輿論壓力讓打破紀錄的選手不得不回應公平性質疑"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:奠": {
-    "sentences": [],
+    "sentences": [
+      "長期的科學訓練奠定了他挑戰世界紀錄的堅實基礎",
+      "這項研究奠定了運動科技與競技表現之間關聯的學術基礎",
+      "前人的努力奠下了後來者不斷突破極限的基石"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:定": {
-    "sentences": [],
+    "sentences": [
+      "科技在競技運動中的角色尚未被明確定義和規範",
+      "堅定的意志力加上先進的裝備才能創造出偉大的紀錄",
+      "國際田聯決定針對跑鞋科技制定更嚴格的規範標準"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:審": {
-    "sentences": [],
+    "sentences": [
+      "審視跑鞋科技對成績的影響是體育界必須面對的課題",
+      "國際田聯仔細審查了碳板跑鞋是否違反了競賽公平原則",
+      "審慎地評估科技與公平的平衡點是未來運動規則的關鍵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:屢": {
-    "sentences": [],
+    "sentences": [
+      "他屢次打破世界紀錄讓人不禁好奇他的極限在哪裡",
+      "屢創佳績的背後是日復一日不間斷的高強度訓練",
+      "碳板跑鞋問世後馬拉松紀錄屢屢被刷新引發熱議"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:廣": {
-    "sentences": [],
+    "sentences": [
+      "這場關於科技與公平的討論在全球範圍內廣泛展開",
+      "廣大的跑步愛好者對碳板跑鞋的看法兩極分化",
+      "他廣泛涉獵運動科學的知識將其應用在訓練之中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:延": {
-    "sentences": [],
+    "sentences": [
+      "科技的進步讓選手的運動壽命得到了一定程度的延長",
+      "關於跑鞋公平性的爭議延續至今仍然沒有定論",
+      "他延續了前輩的精神不斷挑戰人類體能的極限"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:拔": {
-    "sentences": [],
+    "sentences": [
+      "他在激烈的競爭中脫穎而出展現了出類拔萃的實力",
+      "海拔較高的訓練環境能提升選手的心肺耐力",
+      "選拔賽中的優異表現讓他獲得了代表國家參賽的資格"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:於": {
-    "sentences": [],
+    "sentences": [
+      "關於跑鞋科技是否有助於破紀錄的爭論至今方興未艾",
+      "他的成功不僅僅歸功於裝備更在於多年如一日的苦練",
+      "對於科技與競技公平的平衡各方至今尚無共識"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:替": {
-    "sentences": [],
+    "sentences": [
+      "新型跑鞋是否能替代選手本身的實力成為破紀錄的關鍵",
+      "科技無法完全替代人體的努力兩者缺一不可",
+      "隨著科技的進步舊的訓練方法逐漸被新的理念所替代"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:海": {
-    "sentences": [],
+    "sentences": [
+      "高海拔的訓練環境能有效提升選手的血紅素濃度",
+      "他名揚四海的成績讓全世界都認識了這位馬拉松王者",
+      "來自東非高原的選手如同大海般源源不斷地湧現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:爭": {
-    "sentences": [],
+    "sentences": [
+      "關於跑鞋是否影響公平競爭的爭論在體育界持續升溫",
+      "爭議的核心在於科技進步是否扭曲了運動競技的本質",
+      "他在賽場上奮力爭先用實力證明自己配得上這個紀錄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:異": {
-    "sentences": [],
+    "sentences": [
+      "迥異的訓練方法和科技裝備讓不同時代的紀錄難以比較",
+      "異軍突起的新型跑鞋徹底改變了馬拉松運動的競爭格局",
+      "對此議題持異議的學者認為科技進步本來就是運動的一部分"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:目": {
-    "sentences": [],
+    "sentences": [
+      "他的目標是突破兩小時大關成為史上最快的馬拉松選手",
+      "瞠目結舌的成績讓全世界都為之震驚和讚嘆",
+      "目前的爭議焦點在於如何界定科技輔助的合理範圍"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:瞠": {
-    "sentences": [],
+    "sentences": [
+      "他的成績讓所有競爭對手都瞠目結舌難以置信",
+      "令人瞠目的速度提升讓學界開始認真研究跑鞋的影響",
+      "瞠目結舌的紀錄背後是科技與人類意志的完美結合"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:結": {
-    "sentences": [],
+    "sentences": [
+      "科學訓練和先進裝備的結合創造了前所未有的馬拉松成績",
+      "這場辯論的結論將深刻影響未來運動競技的規則制定",
+      "他用汗水和毅力凝結出了一個又一個令人驚嘆的世界紀錄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:綿": {
-    "sentences": [],
+    "sentences": [
+      "綿延不斷的訓練日程是每位馬拉松選手的日常寫照",
+      "他以綿密的配速策略在最後十公里反超了所有對手",
+      "綿長的賽道考驗的不只是體力更是意志力和戰術智慧"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:線": {
-    "sentences": [],
+    "sentences": [
+      "衝過終點線的那一刻他打破了人類認為不可能的紀錄",
+      "起跑線上所有選手都穿著最新款的碳板跑鞋蓄勢待發",
+      "底線在哪裡——科技輔助與競技公平之間的那條線越來越模糊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:者": {
-    "sentences": [],
+    "sentences": [
+      "這位馬拉松王者用行動證明了人類體能的無限可能",
+      "研究者發現碳板跑鞋確實能顯著提升跑步的能量回饋效率",
+      "支持者認為科技進步本來就是人類追求更快更遠的一部分"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:聞": {
-    "sentences": [],
+    "sentences": [
+      "他的破紀錄新聞轟動了全球體育界引發了廣泛的討論",
+      "聞名世界的馬拉松選手背後都有一套嚴謹的科學訓練體系",
+      "這則消息讓許多人聞之震驚並重新思考科技在運動中的角色"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:舌": {
-    "sentences": [],
+    "sentences": [
+      "關於跑鞋科技的爭論讓雙方都唇槍舌劍互不相讓",
+      "他以不可思議的成績讓所有質疑者都瞠目結舌啞口無言",
+      "舌戰群雄的辯論會上正反雙方都提出了有力的論據"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:見": {
-    "sentences": [],
+    "sentences": [
+      "可以預見的是科技對運動競技的影響只會越來越深遠",
+      "各方對於跑鞋規範的意見分歧至今仍未達成共識",
+      "他用實際成績讓所有的偏見和質疑都不攻自破"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:視": {
-    "sentences": [],
+    "sentences": [
+      "我們不能漠視科技進步對競技運動帶來的深刻影響",
+      "他被視為這個時代最偉大的馬拉松選手之一",
+      "正視科技與公平的張力是體育界無法迴避的重要課題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:議": {
-    "sentences": [],
+    "sentences": [
+      "關於碳板跑鞋的爭議推動了國際田聯修訂裝備規範",
+      "這個議題涉及科技進步與運動公平之間的根本張力",
+      "會議上各國代表就跑鞋規範進行了激烈的辯論和協商"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:輪": {
-    "sentences": [],
+    "sentences": [
+      "一輪又一輪的紀錄被打破讓人類不斷重新定義極限",
+      "新一輪的科技軍備競賽正在跑鞋產業中悄然展開",
+      "他在最後一輪衝刺中爆發出驚人的速度一舉破紀錄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:迥": {
-    "sentences": [],
+    "sentences": [
+      "迥然不同的觀點讓這場辯論更加精彩和深入",
+      "新舊跑鞋的性能表現迥異差距大到令人難以置信",
+      "他的訓練理念與傳統方法迥然不同卻取得了驚人效果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:障": {
-    "sentences": [],
+    "sentences": [
+      "突破兩小時的心理障礙是馬拉松運動的歷史性時刻",
+      "跑鞋科技是否構成了不公平的競爭障礙仍有待釐清",
+      "排除一切障礙之後他終於站上了夢寐以求的世界舞台"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素:魔": {
-    "sentences": [],
+    "sentences": [
+      "兩小時的魔咒曾被認為是人類永遠無法突破的馬拉松障壁",
+      "破除心魔比打敗對手更加困難但他做到了",
+      "魔鬼般的訓練強度造就了他超越凡人的驚人耐力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:伏": {
-    "sentences": [],
+    "sentences": [
+      "救援人員埋伏在附近等待最佳的救援時機",
+      "他趴伏在地上躲避危險的碎片和落石",
+      "這次救援行動中潛伏著許多不可預知的風險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:倖": {
-    "sentences": [],
+    "sentences": [
+      "倖存者被發現時雖然虛弱但意識還很清楚",
+      "能夠倖免於難真的是一個奇蹟讓所有人感動",
+      "他是這場災難中唯一的倖存者讓人既慶幸又心疼"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:充": {
-    "sentences": [],
+    "sentences": [
+      "充滿希望的救援行動讓所有人都打起了精神",
+      "他們帶了充足的食物和水準備展開長時間的搜救",
+      "充當臨時醫護的志工們日夜不停地照顧傷患"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:危": {
-    "sentences": [],
+    "sentences": [
+      "危在旦夕的傷者急需醫療救助不能再拖延了",
+      "危險的環境中救援人員依然勇敢地衝了進去",
+      "他們在危急的時刻做出了正確的判斷拯救了生命"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:四": {
-    "sentences": [],
+    "sentences": [
+      "四面楚歌的處境中他們依然沒有放棄希望",
+      "救援人員從四面八方趕來支援這次的行動",
+      "他被困在四周都是廢墟的空間裡等待救援"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:如": {
-    "sentences": [],
+    "sentences": [
+      "如果再晚一步他可能就撐不下去了",
+      "救援隊的表現如同奇蹟一般讓所有人讚嘆不已",
+      "如此艱困的環境中竟然還能找到生還者太不可思議了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:存": {
-    "sentences": [],
+    "sentences": [
+      "他靠著頑強的求生意志在廢墟中存活了好幾天",
+      "生存的渴望讓他在最艱困的時刻也不曾放棄",
+      "倖存下來的他對生命有了更深刻的感恩和珍惜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:柴": {
-    "sentences": [],
+    "sentences": [
+      "他們用撿來的柴火取暖度過了最寒冷的夜晚",
+      "骨瘦如柴的倖存者被發現時讓救援人員紅了眼眶",
+      "他收集枯柴生火為受困的夥伴煮了一碗熱湯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:植": {
-    "sentences": [],
+    "sentences": [
+      "醫療團隊為傷者進行了緊急的植皮手術挽救了生命",
+      "他像一棵深深扎根的植物般堅強地活了下來",
+      "救援人員在心中種植下了永不放棄的信念"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:機": {
-    "sentences": [],
+    "sentences": [
+      "直升機在上空盤旋尋找可能的倖存者位置",
+      "把握每一個救援的時機是這次行動成功的關鍵",
+      "危機之中人們展現出了令人感動的互助精神"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:殘": {
-    "sentences": [],
+    "sentences": [
+      "殘破的建築裡傳來了微弱的求救聲讓人振奮",
+      "殘酷的環境沒有擊倒他的求生意志反而讓他更堅強",
+      "他拖著殘弱的身軀一步步爬向有光的方向"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:渺": {
-    "sentences": [],
+    "sentences": [
+      "渺茫的生還機會在救援隊的努力下變成了奇蹟",
+      "在渺小的縫隙中他看到了一絲光線燃起了希望",
+      "生還的希望雖然渺茫但救援隊從未放棄搜索"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:瘦": {
-    "sentences": [],
+    "sentences": [
+      "骨瘦如柴的倖存者被救出時全場的人都哭了",
+      "他瘦弱的身體裡藏著一顆無比堅強的心",
+      "雖然瘦了很多但他活下來了這就是最大的奇蹟"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:罹": {
-    "sentences": [],
+    "sentences": [
+      "罹難者的家屬在等待消息的過程中焦急萬分",
+      "他不幸罹患了嚴重的傷寒但在救援後順利康復",
+      "這場災難中罹難的人數比預期少得多全靠及時救援"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:茫": {
-    "sentences": [],
+    "sentences": [
+      "茫茫的廢墟中找到生還者簡直像大海撈針一樣困難",
+      "面對茫然未知的處境他選擇相信救援一定會來",
+      "茫茫大海中那一絲微弱的信號引導救援隊找到了他"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:蚊": {
-    "sentences": [],
+    "sentences": [
+      "叢林中的蚊蟲讓救援行動變得更加困難和辛苦",
+      "他被蚊子叮得滿身是包但完全顧不了那麼多",
+      "防蚊措施是野外救援行動中不可忽視的重要準備"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:蚋": {
-    "sentences": [],
+    "sentences": [
+      "密林中的蚋蟲成群結隊地攻擊救援人員的皮膚",
+      "蚊蚋的叮咬雖然惱人但擋不住救援隊前進的決心",
+      "他在蚋蟲肆虐的環境中堅持搜索每一個可能的角落"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:被": {
-    "sentences": [],
+    "sentences": [
+      "被困在廢墟下的他聽到了救援隊的聲音激動得大哭",
+      "被救出來的那一刻他緊緊抱住了第一個看到的人",
+      "他雖然被嚴重的傷勢折磨卻始終保持著清醒的意識"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:褓": {
-    "sentences": [],
+    "sentences": [
+      "襁褓中的嬰兒被救援人員從廢墟中安全地抱了出來",
+      "他像照顧襁褓嬰兒一樣細心地照料每一位傷患",
+      "這個從襁褓中被救出的孩子成為了這次奇蹟行動的象徵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:襁": {
-    "sentences": [],
+    "sentences": [
+      "襁褓中的嬰兒竟然在廢墟中存活了三天令人驚嘆",
+      "救援人員小心翼翼地把襁褓中的嬰兒交到母親手中",
+      "從襁褓裡傳出的哭聲讓所有人都激動得流下了眼淚"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:難": {
-    "sentences": [],
+    "sentences": [
+      "這次的救難行動被稱為奇蹟讓全國上下感動不已",
+      "災難發生後救援隊在最短時間內趕到了現場",
+      "劫後餘生的倖存者說這是他經歷過最大的災難"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:飢": {
-    "sentences": [],
+    "sentences": [
+      "飢餓和口渴是受困者面臨的最大生存威脅",
+      "他忍受著飢寒交迫的折磨等待救援的到來",
+      "飢腸轆轆的倖存者拿到食物時感動得說不出話來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:骨": {
-    "sentences": [],
+    "sentences": [
+      "骨瘦如柴的他被救出時讓所有救援人員都紅了眼眶",
+      "他的骨頭雖然受了傷但頑強的意志讓他撐了下來",
+      "救援犬靈敏的嗅覺幫助搜救隊找到了埋在瓦礫下的骸骨"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奇蹟行動:骸": {
-    "sentences": [],
+    "sentences": [
+      "廢墟下的殘骸中竟然傳來了微弱的呼救聲令人振奮",
+      "搜救犬在一堆骸瓦中找到了仍有生命跡象的倖存者",
+      "清理殘骸的過程中每一個發現都牽動著所有人的心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:侷": {
-    "sentences": [],
+    "sentences": [
+      "性別刻板印象侷限了女性參與運動的機會",
+      "不要讓傳統觀念侷住你追求夢想的腳步",
+      "她不願被偏見侷限，勇敢挑戰奧運舞台"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:備": {
-    "sentences": [],
+    "sentences": [
+      "選手們為了奧運比賽做了充分的準備",
+      "她具備了優秀運動員所需要的一切條件",
+      "完善的訓練設備讓選手們能夠安心備戰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:先": {
-    "sentences": [],
+    "sentences": [
+      "她是第一位參加奧運的女性先驅",
+      "先有平等的機會，才能展現真正的實力",
+      "這位女選手率先打破了性別的藩籬"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:印": {
-    "sentences": [],
+    "sentences": [
+      "性別刻板印象影響了人們對女性運動員的看法",
+      "她用實力打破了社會對女性的負面印象",
+      "這面金牌深深烙印在每位觀眾的心中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:善": {
-    "sentences": [],
+    "sentences": [
+      "改善運動場上的性別不平等需要大家共同努力",
+      "她善於利用自己的影響力為女性發聲",
+      "完善的制度才能保障每位選手的權益"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:多": {
-    "sentences": [],
+    "sentences": [
+      "越來越多的女性運動員在奧運中嶄露頭角",
+      "多元化的參賽項目讓更多人有機會圓夢",
+      "許多國家投入了更多資源培養女性選手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:大": {
-    "sentences": [],
+    "sentences": [
+      "這是一個偉大的里程碑，象徵著性別平等的進步",
+      "她在奧運的舞台上展現出巨大的勇氣和決心",
+      "這項改革對推動性別平等有重大的意義"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:彰": {
-    "sentences": [],
+    "sentences": [
+      "她的成就彰顯了女性在運動場上的無限潛力",
+      "這面獎牌彰顯出平等參賽的重要價值",
+      "奧運精神彰顯了公平競爭的核心理念"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:所": {
-    "sentences": [],
+    "sentences": [
+      "所有選手不分性別都應該獲得平等的機會",
+      "她所付出的努力終於在奧運場上得到回報",
+      "這正是所有人期待已久的歷史性時刻"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:手": {
-    "sentences": [],
+    "sentences": [
+      "這位女選手是奧運史上最傑出的運動好手",
+      "她一路披荊斬棘，成為世界頂尖的高手",
+      "選手之間的競爭讓比賽更加精彩激烈"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:抹": {
-    "sentences": [],
+    "sentences": [
+      "誰也無法抹滅她在奧運史上的光輝紀錄",
+      "她用行動抹去了人們對女性運動員的偏見",
+      "這段歷史不容任何人輕易抹殺"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:棘": {
-    "sentences": [],
+    "sentences": [
+      "推動性別平等這條路充滿了荊棘與挑戰",
+      "她不畏荊棘，一步步走向奧運的舞台",
+      "即使前方荊棘密布，她也從未想過放棄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:滅": {
-    "sentences": [],
+    "sentences": [
+      "歧視不會自動消滅，需要每個人的努力",
+      "她的精神永遠不會被時間磨滅",
+      "這些不合理的規定終於被廢滅了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:益": {
-    "sentences": [],
+    "sentences": [
+      "性別平等的推動讓所有人都能從中受益",
+      "女性參與奧運的人數日益增加",
+      "這項改革帶來了許多意想不到的利益"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:目": {
-    "sentences": [],
+    "sentences": [
+      "她的成就令全世界刮目相看",
+      "推動性別平等是當前最重要的目標之一",
+      "奧運新增的比賽項目讓更多女性有機會參賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:眾": {
-    "sentences": [],
+    "sentences": [
+      "她在眾人面前展現了驚人的實力",
+      "眾多女性運動員的努力終於得到了認可",
+      "觀眾們為這位選手的表現歡呼喝采"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:矚": {
-    "sentences": [],
+    "sentences": [
+      "這場比賽是全球矚目的焦點",
+      "她的故事吸引了舉世矚目的關注",
+      "這項歷史性的決定令人矚目"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:碑": {
-    "sentences": [],
+    "sentences": [
+      "她的成就成為奧運史上的一座里程碑",
+      "這面金牌是性別平等運動的豐碑",
+      "每一次突破都是邁向平等的紀念碑"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:程": {
-    "sentences": [],
+    "sentences": [
+      "性別平等的歷程漫長而艱辛",
+      "她的奮鬥歷程激勵了無數年輕女性",
+      "這段旅程雖然辛苦，但每一步都值得"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:端": {
-    "sentences": [],
+    "sentences": [
+      "性別歧視是一種極端不公平的現象",
+      "她站在跑道的起端，準備迎接人生最重要的比賽",
+      "這只是推動平等的開端，未來還有很長的路"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:籌": {
-    "sentences": [],
+    "sentences": [
+      "為了這場比賽，團隊運籌帷幄了整整四年",
+      "她從小就開始為奧運夢想籌備",
+      "主辦單位精心籌劃了一場公平的賽事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:約": {
-    "sentences": [],
+    "sentences": [
+      "國際奧委會制定了新的公約來保障性別平等",
+      "她和教練約定好要全力以赴",
+      "這項約定改變了奧運的歷史"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:荊": {
-    "sentences": [],
+    "sentences": [
+      "她披荊斬棘，終於站上了奧運的頒獎台",
+      "推動平等的道路上佈滿了荊棘",
+      "即使滿路荊棘，她依然勇往直前"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:莫": {
-    "sentences": [],
+    "sentences": [
+      "莫讓性別成為阻礙夢想的藉口",
+      "她的成就舉世莫不讚嘆",
+      "莫忘那些為平等奮鬥的先驅們"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:記": {
-    "sentences": [],
+    "sentences": [
+      "歷史會記住每一位為平等奮鬥的人",
+      "她的名字被永遠記錄在奧運的史冊中",
+      "這是一個值得被記住的偉大時刻"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:路": {
-    "sentences": [],
+    "sentences": [
+      "性別平等這條路還有很長要走",
+      "她一路走來，從未向困難低頭",
+      "這條通往夢想的路充滿了挑戰與希望"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:身": {
-    "sentences": [],
+    "sentences": [
+      "她以身作則，鼓勵更多女性參與運動",
+      "身為女性運動員，她承受了許多壓力",
+      "她全身心投入訓練，只為站上奧運舞台"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:里": {
-    "sentences": [],
+    "sentences": [
+      "這是邁向平等的重要里程碑",
+      "她跑完了人生中最重要的那一里路",
+      "千里之行始於足下，平等之路亦然"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:鋒": {
-    "sentences": [],
+    "sentences": [
+      "她是推動性別平等的先鋒人物",
+      "這位選手鋒芒畢露，令對手刮目相看",
+      "衝鋒陷陣的勇氣讓她贏得了眾人的尊敬"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:開": {
-    "sentences": [],
+    "sentences": [
+      "奧運終於向所有性別的選手敞開了大門",
+      "她的成功為後來的女性運動員開闢了道路",
+      "這場改革開啟了運動史上嶄新的一頁"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:限": {
-    "sentences": [],
+    "sentences": [
+      "不要讓性別限制了你的可能性",
+      "她突破了社會對女性的種種限制",
+      "打破侷限之後，她看到了更寬廣的世界"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運性別平等這條路:顯": {
-    "sentences": [],
+    "sentences": [
+      "她的努力成果顯而易見",
+      "數據明顯顯示女性選手的參賽比例逐年上升",
+      "這項成就顯示了平等政策的重要性"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:不": {
-    "sentences": [],
+    "sentences": [
+      "她不怕辛苦，每天堅持練習",
+      "比賽結果不如預期，但她從不放棄",
+      "銀牌並不代表失敗，而是另一種成功"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:制": {
-    "sentences": [],
+    "sentences": [
+      "她學會了控制自己的情緒和節奏",
+      "嚴格的自律讓她能夠克制衝動",
+      "教練制定了一套完整的訓練計畫"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:劣": {
-    "sentences": [],
+    "sentences": [
+      "即使條件惡劣，她仍然堅持訓練",
+      "她在劣勢中找到了反敗為勝的方法",
+      "惡劣的天氣無法阻擋她練習的決心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:勢": {
-    "sentences": [],
+    "sentences": [
+      "她靠著自律扭轉了比賽的劣勢",
+      "這股氣勢讓對手感到壓力",
+      "她的優勢在於堅強的意志力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:壓": {
-    "sentences": [],
+    "sentences": [
+      "比賽的壓力讓她更加專注",
+      "她頂住壓力，發揮出最好的表現",
+      "面對壓力時，深呼吸能幫助放鬆"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:大": {
-    "sentences": [],
+    "sentences": [
+      "她付出了巨大的努力才拿到銀牌",
+      "強大的意志力是她成功的關鍵",
+      "這次比賽對她有很大的意義"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:將": {
-    "sentences": [],
+    "sentences": [
+      "她即將參加人生中最重要的比賽",
+      "教練把她當作未來的大將培養",
+      "將來她一定能站上更高的舞台"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:就": {
-    "sentences": [],
+    "sentences": [
+      "成就來自於日復一日的努力",
+      "她的銀牌就是自律鍛鍊的最佳證明",
+      "只要堅持下去，就能看到進步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:干": {
-    "sentences": [],
+    "sentences": [
+      "她從不讓外界的雜音干擾自己",
+      "干擾越多，她就越要保持專注",
+      "這件事和別人無干，是她自己的選擇"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:律": {
-    "sentences": [],
+    "sentences": [
+      "嚴格的自律是她每天的功課",
+      "她規律地進行訓練，從不偷懶",
+      "自律讓她在比賽中保持最佳狀態"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:得": {
-    "sentences": [],
+    "sentences": [
+      "她覺得銀牌也是很棒的成績",
+      "要得到好成績，必須付出加倍努力",
+      "這面獎牌得來不易"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:心": {
-    "sentences": [],
+    "sentences": [
+      "她用心準備每一場比賽",
+      "堅定的信心讓她表現出色",
+      "練習時要專心，才能進步得快"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:按": {
-    "sentences": [],
+    "sentences": [
+      "她按照計畫一步步完成訓練",
+      "教練按部就班地指導她的技巧",
+      "按時休息也是鍛鍊的一部分"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:擾": {
-    "sentences": [],
+    "sentences": [
+      "她不讓任何事情干擾自己的訓練",
+      "外界的噪音曾經困擾過她",
+      "排除干擾後，她的表現進步了許多"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:斬": {
-    "sentences": [],
+    "sentences": [
+      "她在比賽中過關斬將",
+      "她斬獲了一面寶貴的銀牌",
+      "披荊斬棘的精神讓她越來越強"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:注": {
-    "sentences": [],
+    "sentences": [
+      "她全神貫注地練習每一個動作",
+      "專注力是她在比賽中的最大武器",
+      "她把所有心力都注入了訓練中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:滿": {
-    "sentences": [],
+    "sentences": [
+      "她對自己的銀牌成績感到滿意",
+      "滿滿的汗水換來了今天的榮耀",
+      "她的心中充滿了對運動的熱愛"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:班": {
-    "sentences": [],
+    "sentences": [
+      "她按部就班地完成每天的訓練",
+      "班上的同學都為她感到驕傲",
+      "她是訓練班裡最認真的選手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:理": {
-    "sentences": [],
+    "sentences": [
+      "自我管理是成為好選手的基本功",
+      "她學會合理分配練習和休息時間",
+      "心理素質和體能一樣重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:素": {
-    "sentences": [],
+    "sentences": [
+      "良好的心理素質幫助她穩定發揮",
+      "她的基本素養非常紮實",
+      "優秀的身體素質是長期訓練的結果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:自": {
-    "sentences": [],
+    "sentences": [
+      "自律是她成功的秘訣",
+      "她靠自己的努力贏得了這面銀牌",
+      "自我鍛鍊讓她變得更加堅強"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:貫": {
-    "sentences": [],
+    "sentences": [
+      "她一貫保持規律的訓練節奏",
+      "全神貫注是她比賽時的狀態",
+      "這種堅持始終如一貫穿了她的運動生涯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:質": {
-    "sentences": [],
+    "sentences": [
+      "她的身體素質經過長期鍛鍊已非常好",
+      "優秀的心理質素幫她度過難關",
+      "她用實質的努力證明了自己的實力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:過": {
-    "sentences": [],
+    "sentences": [
+      "她經過無數次練習才有今天的成果",
+      "過程雖然辛苦，但結果很值得",
+      "她曾經超越過許多比她年長的選手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:部": {
-    "sentences": [],
+    "sentences": [
+      "她按部就班地完成每個訓練步驟",
+      "教練安排了全部的訓練課程",
+      "身體的每個部位都需要鍛鍊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:重": {
-    "sentences": [],
+    "sentences": [
+      "她非常重視每一次練習的機會",
+      "銀牌的重量代表著她所有的努力",
+      "自律在訓練中佔有很重要的地位"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:閒": {
-    "sentences": [],
+    "sentences": [
+      "她利用空閒時間加強體能訓練",
+      "即使是休閒時間，她也在研究比賽影片",
+      "她從不讓自己閒下來，總是在進步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "奧運銀牌的自我鍛鍊:關": {
-    "sentences": [],
+    "sentences": [
+      "自律是通往成功的關鍵",
+      "過了這一關，她就能站上奧運舞台",
+      "她很關心隊友的訓練狀況"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:世": {
-    "sentences": [],
+    "sentences": [
+      "她是世界上第一位登月的女性太空人",
+      "這項成就震驚了全世界",
+      "新世代的女性正在改寫太空探索的歷史"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:偏": {
-    "sentences": [],
+    "sentences": [
+      "社會對女性太空人存在許多偏見",
+      "她用實力打破了人們的偏頗看法",
+      "不要偏離目標，堅持走自己的路"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:化": {
-    "sentences": [],
+    "sentences": [
+      "太空科技的進化讓登月任務更加安全",
+      "她的成功象徵著性別觀念的轉化",
+      "月球表面的變化一直是科學家研究的重點"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:味": {
-    "sentences": [],
+    "sentences": [
+      "太空中的食物據說沒什麼味道",
+      "這項挑戰意味著人類探索太空的新里程碑",
+      "她細細品味著踏上月球的那一刻"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:啟": {
-    "sentences": [],
+    "sentences": [
+      "她的故事啟發了無數年輕女性投入科學領域",
+      "這次登月任務開啟了太空探索的新篇章",
+      "太空人的經歷啟迪了人們對宇宙的好奇心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:天": {
-    "sentences": [],
+    "sentences": [
+      "她從小就夢想有一天能飛上太空",
+      "太空中看不到藍天白雲的景象",
+      "天文學的知識幫助她理解月球的環境"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:寫": {
-    "sentences": [],
+    "sentences": [
+      "她在月球上寫下了人類歷史新的一頁",
+      "科學家們記錄並寫下了所有的觀測數據",
+      "她的名字被寫入了太空探索的史冊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:射": {
-    "sentences": [],
+    "sentences": [
+      "火箭發射的那一刻，全場屏息以待",
+      "輻射是太空人在月球上面臨的重大威脅",
+      "她注視著發射台，心中充滿了期待"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:對": {
-    "sentences": [],
+    "sentences": [
+      "她面對困難時從不退縮",
+      "這次任務對人類太空探索有深遠的影響",
+      "她對登月充滿了堅定的信念"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:左": {
-    "sentences": [],
+    "sentences": [
+      "火箭發射後向左轉了一個小角度進入軌道",
+      "她從左手邊的窗戶看到了地球的全貌",
+      "太空站左側裝設了新型的太陽能板"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:幽": {
-    "sentences": [],
+    "sentences": [
+      "月球表面是一片幽靜而神秘的世界",
+      "太空的幽暗中閃爍著無數星辰",
+      "她在幽靜的太空艙中回顧著自己的旅程"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:意": {
-    "sentences": [],
+    "sentences": [
+      "她登月的決心和意志力令人敬佩",
+      "這項任務的意義遠超過一次太空飛行",
+      "出乎意料的是，月球上的景色比想像中更壯觀"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:找": {
-    "sentences": [],
+    "sentences": [
+      "科學家在月球上找到了水冰存在的證據",
+      "她從小就在找尋前往太空的方法",
+      "這次任務的目標是找出月球的資源分布"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:承": {
-    "sentences": [],
+    "sentences": [
+      "她承擔了這項艱鉅的太空任務",
+      "傳承太空探索的精神是每一代人的責任",
+      "她承諾會為更多女性打開通往太空的大門"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:擬": {
-    "sentences": [],
+    "sentences": [
+      "團隊模擬了月球上的各種突發狀況",
+      "她在虛擬環境中反覆演練登月流程",
+      "計畫擬定之後，所有人都全力以赴"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:族": {
-    "sentences": [],
+    "sentences": [
+      "她是少數族裔中第一位登月的太空人",
+      "人類這個種族終於再次踏上了月球",
+      "不同族群的科學家共同完成了這項壯舉"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:月": {
-    "sentences": [],
+    "sentences": [
+      "月球是人類太空探索的重要目標",
+      "她在月球表面留下了自己的腳印",
+      "月光下的訓練基地顯得格外寧靜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:格": {
-    "sentences": [],
+    "sentences": [
+      "嚴格的體能測試篩選出最優秀的太空人",
+      "她的堅毅性格讓她通過了所有考驗",
+      "合格的太空人需要具備多方面的能力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:模": {
-    "sentences": [],
+    "sentences": [
+      "她是年輕女性學習科學的最佳模範",
+      "團隊建造了月球表面的模型來進行訓練",
+      "模擬實驗幫助她熟悉了月球上的環境"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:欄": {
-    "sentences": [],
+    "sentences": [
+      "這則新聞登上了各大媒體的頭版專欄",
+      "她跨越了性別的欄杆，成功踏上月球",
+      "太空站的安全欄確保太空人的行動安全"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:比": {
-    "sentences": [],
+    "sentences": [
+      "和過去相比，現在有更多女性加入太空計畫",
+      "她的表現比其他候選人都更加出色",
+      "這次登月任務的規模比以往任何一次都大"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:消": {
-    "sentences": [],
+    "sentences": [
+      "太空中的輻射會消耗太空人的體力",
+      "她消除了人們對女性無法登月的疑慮",
+      "這個好消息很快傳遍了全世界"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:深": {
-    "sentences": [],
+    "sentences": [
+      "她對太空探索有著深厚的熱情",
+      "月球上的隕石坑非常深",
+      "這次經歷深深地改變了她對宇宙的看法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:的": {
-    "sentences": [],
+    "sentences": [
+      "她是第一位踏上月球的女性太空人",
+      "登月成功的那一刻讓所有人歡呼",
+      "她的勇氣和決心激勵了全世界的人們"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:相": {
-    "sentences": [],
+    "sentences": [
+      "她相信有一天女性也能征服太空",
+      "月球的真相比我們想像的還要複雜",
+      "太空人們互相支持，共同完成了這項任務"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:確": {
-    "sentences": [],
+    "sentences": [
+      "她確定自己從小的夢想就是成為太空人",
+      "精確的計算是太空任務成功的關鍵",
+      "她確實是最適合這項任務的人選"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:紀": {
-    "sentences": [],
+    "sentences": [
+      "這是二十一世紀最重要的太空成就之一",
+      "她創下了女性登月的歷史紀錄",
+      "新世紀的太空探索正在蓬勃發展"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:耗": {
-    "sentences": [],
+    "sentences": [
+      "太空任務消耗了大量的人力和物力",
+      "長時間的太空飛行非常耗費體力",
+      "這項研究耗時多年才終於有了突破"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:表": {
-    "sentences": [],
+    "sentences": [
+      "她在記者會上發表了登月後的感想",
+      "這次任務代表了人類探索精神的延續",
+      "她的表現令所有人刮目相看"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:裔": {
-    "sentences": [],
+    "sentences": [
+      "她是亞裔美國人中第一位登月的太空人",
+      "不同族裔的科學家齊心協力完成了任務",
+      "她的祖裔來自一個重視教育的家庭"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:見": {
-    "sentences": [],
+    "sentences": [
+      "她親眼見到了月球壯麗的景色",
+      "這次登月讓人類對宇宙有了新的見解",
+      "可以預見未來會有更多女性探索太空"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:認": {
-    "sentences": [],
+    "sentences": [
+      "她被公認為最優秀的女性太空人之一",
+      "世界各國都認同她的傑出貢獻",
+      "她認真地完成了每一項太空任務"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:變": {
-    "sentences": [],
+    "sentences": [
+      "太空環境的變化對人體有很大的影響",
+      "她的成功改變了社會對女性的刻板印象",
+      "月球表面的地形在數十億年間不斷變化"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:象": {
-    "sentences": [],
+    "sentences": [
+      "她打破了人們對太空人的傳統印象",
+      "月球上的景象讓她終生難忘",
+      "這次登月的成功現象引起了全球熱議"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:較": {
-    "sentences": [],
+    "sentences": [
+      "與男性太空人相比較，她的表現毫不遜色",
+      "這次任務比較複雜，需要更精密的規劃",
+      "她在體能測試中取得了較高的分數"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:載": {
-    "sentences": [],
+    "sentences": [
+      "太空船載著她飛向了月球",
+      "這段歷史被詳細記載在太空探索的檔案中",
+      "她滿載著全人類的希望踏上了月球"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:輻": {
-    "sentences": [],
+    "sentences": [
+      "太空中的輻射是太空人健康的最大威脅",
+      "月球表面缺乏大氣層保護，輻射量很高",
+      "科學家正在研發更好的輻射防護裝備"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:重": {
-    "sentences": [],
+    "sentences": [
+      "月球的重力只有地球的六分之一",
+      "這項任務的重要性不言而喻",
+      "她肩負著重大的使命踏上了月球"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:長": {
-    "sentences": [],
+    "sentences": [
+      "從地球到月球的旅程非常漫長",
+      "她是太空站的首位女性站長",
+      "長期的訓練讓她具備了登月的能力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:閉": {
-    "sentences": [],
+    "sentences": [
+      "太空人在密閉的太空艙中生活了好幾天",
+      "她在封閉的環境中依然保持冷靜",
+      "閉上眼睛，她彷彿又回到了月球上"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:體": {
-    "sentences": [],
+    "sentences": [
+      "太空中的無重力狀態對人體影響很大",
+      "她的身體素質通過了嚴格的檢測",
+      "這次登月是一次全體團隊合作的成果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "女性太空人登月:點": {
-    "sentences": [],
+    "sentences": [
+      "月球的著陸地點經過了精密的計算",
+      "她的成功為太空探索增添了新的亮點",
+      "出發的時間點精確到了毫秒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:典": {
-    "sentences": [],
+    "sentences": [
+      "藍鯨是海洋生物中的經典代表",
+      "這個故事成為海洋保育的典範",
+      "字典裡找不到比悲傷更能形容這件事的詞"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:削": {
-    "sentences": [],
+    "sentences": [
+      "人類的活動削弱了藍鯨的生存空間",
+      "汙染像刀一樣削減了海洋生物的數量",
+      "過度捕撈嚴重剝削了海洋的資源"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:剖": {
-    "sentences": [],
+    "sentences": [
+      "科學家解剖小藍鯨後發現了驚人的真相",
+      "他們仔細剖析了藍鯨死亡的原因",
+      "深入剖開問題的核心才能找到解決方法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:危": {
-    "sentences": [],
+    "sentences": [
+      "藍鯨已經是瀕臨滅絕的危險物種",
+      "小藍鯨的死亡敲響了生態危機的警鐘",
+      "海洋汙染對所有生物都構成了嚴重的危害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:擱": {
-    "sentences": [],
+    "sentences": [
+      "小藍鯨擱淺在沙灘上奄奄一息",
+      "這個議題不能再被擱置不管了",
+      "牠被海浪沖上岸，擱在淺灘上動彈不得"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:束": {
-    "sentences": [],
+    "sentences": [
+      "小藍鯨的生命就這樣束然而止",
+      "塑膠繩索束縛了牠的身體",
+      "這個悲傷的故事還沒有結束"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:殆": {
-    "sentences": [],
+    "sentences": [
+      "藍鯨的數量已經瀕臨殆盡",
+      "海洋中的魚群被捕撈殆盡",
+      "如果不加以保護，牠們將會滅亡殆盡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:流": {
-    "sentences": [],
+    "sentences": [
+      "海洋中的洋流帶來了大量的塑膠垃圾",
+      "小藍鯨隨著潮流漂到了岸邊",
+      "眼淚不自覺地流了下來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:淺": {
-    "sentences": [],
+    "sentences": [
+      "小藍鯨擱淺在海灘上令人心疼",
+      "淺海區域的汙染特別嚴重",
+      "這個問題絕對不是淺顯易懂那麼簡單"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:瀕": {
-    "sentences": [],
+    "sentences": [
+      "藍鯨是瀕臨絕種的珍貴動物",
+      "許多海洋生物正瀕臨滅絕的危機",
+      "牠瀕死的眼神讓在場的人都紅了眼眶"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:燃": {
-    "sentences": [],
+    "sentences": [
+      "這個故事燃起了人們保護海洋的決心",
+      "小藍鯨的死燃燒了大眾的憤怒",
+      "保育的熱情在每個人心中燃燒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:燒": {
-    "sentences": [],
+    "sentences": [
+      "焚燒垃圾產生的廢氣也會汙染海洋",
+      "這件事像一把火燒在每個人的心裡",
+      "人們燃燒著想要改變現狀的熱情"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:物": {
-    "sentences": [],
+    "sentences": [
+      "塑膠廢棄物是海洋動物的致命殺手",
+      "藍鯨是地球上體型最大的動物",
+      "保護野生動物是每個人的責任"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:珍": {
-    "sentences": [],
+    "sentences": [
+      "藍鯨是非常珍貴的海洋生物",
+      "我們應該珍惜地球上每一個生命",
+      "這些珍稀的物種需要我們的保護"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:瘦": {
-    "sentences": [],
+    "sentences": [
+      "擱淺的小藍鯨身體已經非常消瘦",
+      "牠瘦弱的身軀讓救援人員十分心疼",
+      "海洋汙染讓許多動物變得瘦弱不堪"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:盡": {
-    "sentences": [],
+    "sentences": [
+      "人類不應該將海洋資源消耗殆盡",
+      "救援人員盡了最大的努力想救活牠",
+      "小藍鯨用盡了最後一口氣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:稀": {
-    "sentences": [],
+    "sentences": [
+      "藍鯨是世界上最稀有的動物之一",
+      "這種珍稀物種的數量越來越少",
+      "稀少的藍鯨每一隻都非常珍貴"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:種": {
-    "sentences": [],
+    "sentences": [
+      "藍鯨這個物種正面臨滅絕的危機",
+      "保護瀕危種群是人類的共同責任",
+      "每一個物種的消失都是生態的損失"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:竄": {
-    "sentences": [],
+    "sentences": [
+      "汙染物在海洋中四處流竄",
+      "受驚的魚群在水中四處竄逃",
+      "有毒物質竄入了藍鯨的食物鏈中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:縛": {
-    "sentences": [],
+    "sentences": [
+      "漁網和塑膠繩束縛住了小藍鯨的身體",
+      "牠被垃圾纏繞束縛無法自由游動",
+      "解開這些束縛才能讓海洋生物重獲自由"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:藏": {
-    "sentences": [],
+    "sentences": [
+      "海洋深處藏著許多我們不知道的祕密",
+      "小藍鯨的胃裡藏著大量的塑膠碎片",
+      "這個悲傷的事實無法被隱藏"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:蛻": {
-    "sentences": [],
+    "sentences": [
+      "小藍鯨的死讓社會蛻變出更強的環保意識",
+      "每一次覺醒都像是一次蛻變",
+      "海洋保育運動正在經歷一次重大蛻變"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:解": {
-    "sentences": [],
+    "sentences": [
+      "科學家試圖了解小藍鯨死亡的原因",
+      "解剖結果讓所有人都沉默了",
+      "只有徹底了解問題才能找到解決辦法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "小藍鯨之死:變": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷嚴重影響了藍鯨的棲息地",
+      "我們必須改變對待海洋的方式",
+      "小藍鯨的死成為了改變的開始"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:事": {
-    "sentences": [],
+    "sentences": [
+      "基因研究是當代生物科學最重要的事業之一",
+      "每個人的天賦其實從出生就已注定，這並非偶然之事",
+      "從事基因研究的科學家們揭開了遺傳的神秘面紗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:代": {
-    "sentences": [],
+    "sentences": [
+      "基因一代一代地傳遞著生命的密碼",
+      "現代科學已經能夠解讀基因中蘊含的訊息",
+      "每一代人都從父母那裡繼承了獨特的遺傳特徵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:倍": {
-    "sentences": [],
+    "sentences": [
+      "後天的努力可以讓天賦發揮出加倍的效果",
+      "科學家投入了數倍的心血才完成基因圖譜的解析",
+      "事半功倍的關鍵在於找到自己的天賦所在"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:功": {
-    "sentences": [],
+    "sentences": [
+      "基因賦予的天賦需要後天努力才能成功",
+      "許多偉大的成就都是天賦與勤奮共同的功勞",
+      "功夫不負有心人，善用天賦終能有所成就"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:半": {
-    "sentences": [],
+    "sentences": [
+      "天賦只佔成功的一半，另一半靠的是努力",
+      "事半功倍的學習來自於了解自己的基因優勢",
+      "半數以上的人格特質都與遺傳基因有關"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:厚": {
-    "sentences": [],
+    "sentences": [
+      "深厚的基因研究基礎推動了醫學的突破性進展",
+      "她對基因科學懷抱著深厚的熱情與使命感",
+      "每個人都承載著祖先留下的豐厚遺傳資產"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:因": {
-    "sentences": [],
+    "sentences": [
+      "基因是決定我們外貌和體質的重要因素",
+      "因為有了基因研究，許多遺傳疾病得以被預防",
+      "原因很簡單，每個人的基因組合都是獨一無二的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:天": {
-    "sentences": [],
+    "sentences": [
+      "天賦是基因贈予我們的一份特別禮物",
+      "先天的遺傳條件與後天的環境同樣重要",
+      "天生的才能需要適當的培養才能綻放光芒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:度": {
-    "sentences": [],
+    "sentences": [
+      "每個人對壓力的承受度與基因密切相關",
+      "科學家從不同角度探索基因對行為的影響程度",
+      "基因在某種程度上決定了我們的性格傾向"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:得": {
-    "sentences": [],
+    "sentences": [
+      "得天獨厚的基因讓她在運動方面表現出眾",
+      "研究顯示後天環境與基因的交互作用不可忽視，值得深入探討",
+      "她從基因研究中獲得了對自身天賦的全新認識"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:徵": {
-    "sentences": [],
+    "sentences": [
+      "每個人的遺傳特徵都是基因表達的結果",
+      "科學家透過觀察外在特徵來推測基因的功能",
+      "這些生理特徵的差異源自於基因組合的多樣性"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:效": {
-    "sentences": [],
+    "sentences": [
+      "基因療法的療效讓醫學界看到了新的希望",
+      "有效地運用天賦才能達到事半功倍的效果",
+      "後天努力能顯著提升基因天賦的實際成效"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:教": {
-    "sentences": [],
+    "sentences": [
+      "因材施教的理念與基因研究的發現不謀而合",
+      "教育應該幫助每個孩子發掘自己獨特的基因天賦",
+      "這項研究對教學方法的改革提供了重要的啟示"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:施": {
-    "sentences": [],
+    "sentences": [
+      "科學家正在實施一項大規模的基因研究計畫",
+      "因材施教意味著依據每個人的天賦來設計學習方式",
+      "基因療法的實施為遺傳疾病患者帶來了曙光"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:材": {
-    "sentences": [],
+    "sentences": [
+      "每個人都是獨特的材料，基因決定了我們的基本特質",
+      "因材施教的關鍵在於理解每個學生的先天優勢",
+      "基因研究為個人化教材的開發提供了科學依據"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:水": {
-    "sentences": [],
+    "sentences": [
+      "水滴石穿的道理說明了持續努力的重要性",
+      "基因如同水源，滋養著我們與生俱來的潛能",
+      "即使天賦如涓涓細水，持之以恆也能匯成江河"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:涯": {
-    "sentences": [],
+    "sentences": [
+      "基因研究可能改變一個人的職業生涯規劃",
+      "了解自己的基因天賦有助於規劃更適合的人生涯途",
+      "在學術生涯中，她致力於解開基因與天賦之間的關聯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:滴": {
-    "sentences": [],
+    "sentences": [
+      "水滴石穿的毅力能讓任何天賦都開花結果",
+      "每一滴汗水都在為基因賦予的天賦增添光彩",
+      "基因的影響是一點一滴累積而成的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:獨": {
-    "sentences": [],
+    "sentences": [
+      "每個人的基因組合都是獨一無二的特別禮物",
+      "得天獨厚的條件需要配合後天的努力才有意義",
+      "她獨立完成了這項突破性的基因研究"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:率": {
-    "sentences": [],
+    "sentences": [
+      "基因突變的機率雖然微小，卻可能帶來重大影響",
+      "效率最高的學習方式往往與個人的基因天賦相呼應",
+      "遺傳疾病的發生率因族群不同而有顯著差異"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:石": {
-    "sentences": [],
+    "sentences": [
+      "水滴石穿，再微小的天賦也能被磨練成璀璨的鑽石",
+      "基因就像一塊璞石，需要後天的雕琢才能發光",
+      "科學家如同在岩石中尋找寶藏般地研究基因密碼"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:穿": {
-    "sentences": [],
+    "sentences": [
+      "水滴石穿的精神告訴我們，堅持終能成就非凡",
+      "她穿越了重重困難，終於在基因研究上取得突破",
+      "看穿基因的奧秘需要長年累月的專注與投入"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:職": {
-    "sentences": [],
+    "sentences": [
+      "了解自己的基因天賦有助於選擇最適合的職業",
+      "她以基因研究作為終身的職志",
+      "在職場上發揮天賦的人往往能獲得更大的成就感"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:表": {
-    "sentences": [],
+    "sentences": [
+      "基因的表達方式決定了每個人外在的生理特徵",
+      "她在國際期刊上發表了關於基因與天賦的最新研究",
+      "表面上看不出來的差異其實都藏在基因密碼之中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:謝": {
-    "sentences": [],
+    "sentences": [
+      "感謝基因賦予我們每個人獨特的天賦與潛能",
+      "新陳代謝的速率也受到遺傳基因的顯著影響",
+      "她在獲獎時感謝了所有支持基因研究的人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從基因來的特別禮物:過": {
-    "sentences": [],
+    "sentences": [
+      "透過基因研究，我們更加了解人類遺傳的奧秘",
+      "經過數十年的努力，科學家終於解開了基因之謎",
+      "不要錯過任何發掘自己基因天賦的機會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從天才跌為凡人的神童:聞": {
-    "sentences": [],
+    "sentences": [
+      "神童的名聲曾經轟動一時，聞名全國",
+      "聽聞他從天才跌落凡塵的消息，令人不勝唏噓",
+      "這段從天才到凡人的經歷，成為人們茶餘飯後的見聞"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:丁": {
-    "sentences": [],
+    "sentences": [
+      "他小時候是個不起眼的小人丁",
+      "人丁稀少的村莊裡，他努力求學",
+      "家中人丁雖少，但他從不感到孤單"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:不": {
-    "sentences": [],
+    "sentences": [
+      "他不怕吃苦，努力讀書改變命運",
+      "童年的困難並不能阻擋他學習",
+      "他從不放棄任何學習的機會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:件": {
-    "sentences": [],
+    "sentences": [
+      "在工廠裡，他每天要處理上百件物品",
+      "成為教授這件事他從小就立下志願",
+      "一件又一件的挫折沒有打倒他"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:俐": {
-    "sentences": [],
+    "sentences": [
+      "他從小就聰明伶俐，學什麼都很快",
+      "伶俐的頭腦幫助他快速學會新知識",
+      "老師誇他口齒伶俐，表達能力很好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:勞": {
-    "sentences": [],
+    "sentences": [
+      "童年的辛勞讓他更珍惜讀書的機會",
+      "他用勞動換來的錢買書來念",
+      "勤勞的態度是他成功的重要原因"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:哺": {
-    "sentences": [],
+    "sentences": [
+      "母親含辛茹苦地哺育他長大",
+      "嗷嗷待哺的弟妹讓他不得不去工作",
+      "他感謝母親的哺育之恩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:嗷": {
-    "sentences": [],
+    "sentences": [
+      "家裡嗷嗷待哺的孩子太多了",
+      "弟弟妹妹嗷嗷待哺，他只好去工廠打工",
+      "嗷嗷待哺的童年讓他提早懂事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:存": {
-    "sentences": [],
+    "sentences": [
+      "他把每一分工錢都存起來交學費",
+      "生存的壓力讓他比同齡人更成熟",
+      "他心中一直存著一個讀書的夢想"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:庇": {
-    "sentences": [],
+    "sentences": [
+      "學校成為他遮風避雨的庇護所",
+      "老師的庇護讓他有安心讀書的環境",
+      "他在書本的庇蔭下找到了希望"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:彌": {
-    "sentences": [],
+    "sentences": [
+      "他用努力彌補了童年缺少教育的遺憾",
+      "彌足珍貴的學習機會他一刻也不浪費",
+      "老師的鼓勵彌補了他內心的不安"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:待": {
-    "sentences": [],
+    "sentences": [
+      "他期待有一天能夠走進大學的校門",
+      "嗷嗷待哺的童年讓他更加堅強",
+      "等待機會的同時，他從未停止學習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:悸": {
-    "sentences": [],
+    "sentences": [
+      "回想童年的辛苦，他仍然心有餘悸",
+      "站上大學講台的那一刻，他激動得心悸",
+      "每次想起工廠裡的日子就令人悸動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:成": {
-    "sentences": [],
+    "sentences": [
+      "他從童工成長為大學教授",
+      "成功不是靠運氣，而是靠努力",
+      "他終於完成了從工廠到講堂的轉變"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:指": {
-    "sentences": [],
+    "sentences": [
+      "老師的指導改變了他的一生",
+      "他指著課本上的字一個一個認真學",
+      "教授的指引讓許多學生找到方向"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:按": {
-    "sentences": [],
+    "sentences": [
+      "他按照計畫一步步完成學業",
+      "按部就班地學習讓他打好了基礎",
+      "他按時到工廠上工從不遲到"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:浩": {
-    "sentences": [],
+    "sentences": [
+      "浩瀚的書海讓他忘記了生活的辛苦",
+      "圖書館裡浩如煙海的書籍讓他著迷",
+      "他在浩大的知識世界中找到了方向"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:漫": {
-    "sentences": [],
+    "sentences": [
+      "從童工到教授是一條漫長的路",
+      "漫漫求學路上，他從不孤單",
+      "他在漫長的歲月中慢慢累積知識"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:猶": {
-    "sentences": [],
+    "sentences": [
+      "回想過去的艱辛，他猶如隔世",
+      "他毫不猶豫地選擇了繼續讀書",
+      "童年的記憶猶新，激勵著他前進"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:疾": {
-    "sentences": [],
+    "sentences": [
+      "他疾步走向夢想，從不停歇",
+      "即使身體有疾病他也堅持學習",
+      "他以疾風般的速度完成了大學學業"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:目": {
-    "sentences": [],
+    "sentences": [
+      "他的目標很明確，就是要成為教授",
+      "目不轉睛地看著課本認真學習",
+      "親眼目睹他的蛻變讓人感動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:積": {
-    "sentences": [],
+    "sentences": [
+      "他日積月累地充實自己的知識",
+      "長年累積的努力終於有了回報",
+      "積少成多，他存夠了上大學的學費"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:繁": {
-    "sentences": [],
+    "sentences": [
+      "工廠裡繁重的工作讓他疲憊不堪",
+      "繁忙的生活中他仍擠出時間讀書",
+      "繁星點點的夜晚，他在燈下苦讀"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:落": {
-    "sentences": [],
+    "sentences": [
+      "他從不因出身低落而自卑",
+      "即使跌落谷底，他也能重新站起來",
+      "村落裡的人都以他為榮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:著": {
-    "sentences": [],
+    "sentences": [
+      "他著迷於書本中的知識世界",
+      "穿著破舊衣服的他在教室裡格外認真",
+      "他執著地追求自己的教授夢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:蔭": {
-    "sentences": [],
+    "sentences": [
+      "老師的庇蔭讓他安心讀書",
+      "大樹的綠蔭下，他捧著書本靜靜閱讀",
+      "前人種樹後人乘涼，他受惠於師長的蔭庇"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:補": {
-    "sentences": [],
+    "sentences": [
+      "他利用晚上時間補習功課",
+      "努力補足了童年缺少的教育",
+      "互相幫補讓他和同學一起進步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:計": {
-    "sentences": [],
+    "sentences": [
+      "他計畫好了每一步的求學之路",
+      "生計的壓力讓他不得不一邊工作一邊讀書",
+      "不計辛苦只為了實現心中的夢想"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:識": {
-    "sentences": [],
+    "sentences": [
+      "知識改變了他的命運",
+      "他認識到教育是脫離困境的唯一道路",
+      "豐富的學識讓他成為受人敬重的教授"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:貼": {
-    "sentences": [],
+    "sentences": [
+      "同學們體貼地幫助他補習功課",
+      "他把獎學金的通知單貼在牆上",
+      "貼心的老師常常留下來指導他"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:酬": {
-    "sentences": [],
+    "sentences": [
+      "他的努力終於獲得了豐厚的報酬",
+      "微薄的工酬讓他的生活非常拮据",
+      "天道酬勤，他從童工成為了教授"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:食": {
-    "sentences": [],
+    "sentences": [
+      "他常常為了買書而省下吃飯的食物",
+      "嗷嗷待哺的弟妹需要食物",
+      "豐衣足食是他童年最大的願望"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "從童工到大學教授之路:餘": {
-    "sentences": [],
+    "sentences": [
+      "工作之餘他把所有時間用來讀書",
+      "家裡沒有多餘的錢讓他上學",
+      "他利用業餘時間自學各種知識"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:一": {
-    "sentences": [],
+    "sentences": [
+      "一件小事也可能影響一個人的心理",
+      "一步一步慢慢走出困境",
+      "心理問題不是一天造成的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:丈": {
-    "sentences": [],
+    "sentences": [
+      "丈夫的支持對心理健康很重要",
+      "大丈夫能屈能伸，不怕暫時的挫折",
+      "好男兒要有丈夫般的氣概，不被困難嚇倒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:三": {
-    "sentences": [],
+    "sentences": [
+      "三思而後行才不容易犯錯",
+      "她花了三年時間才走出心理陰影",
+      "事不過三，要學會適時尋求幫助"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:下": {
-    "sentences": [],
+    "sentences": [
+      "心情低落的時候不要把情緒往肚子裡吞下去",
+      "放下心中的負擔會讓自己輕鬆許多",
+      "遇到困難時停下來想一想再做決定"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:不": {
-    "sentences": [],
+    "sentences": [
+      "心理出狀況不一定是壞事導致的",
+      "不要害怕向別人尋求幫助",
+      "壓力大的時候不要硬撐"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:之": {
-    "sentences": [],
+    "sentences": [
+      "生活中的壓力是心理問題的原因之一",
+      "好事壞事都是人生經歷的一部分之外",
+      "失之東隅收之桑榆，壞事不一定都是壞的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:倒": {
-    "sentences": [],
+    "sentences": [
+      "跌倒了不要怕，站起來就好",
+      "壞事不一定會把人打倒",
+      "她被困難擊倒後又勇敢地站了起來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:側": {
-    "sentences": [],
+    "sentences": [
+      "身邊的人在你身側給你溫暖的陪伴",
+      "從另一個側面來看，壞事也能帶來成長",
+      "側耳傾聽朋友的煩惱是最好的支持"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:六": {
-    "sentences": [],
+    "sentences": [
+      "六神無主的時候，找個人聊聊天",
+      "她花了六個月的時間走出低潮",
+      "每六個人中就有一個曾有心理困擾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:半": {
-    "sentences": [],
+    "sentences": [
+      "事情往往不是非黑即白，而是一半一半",
+      "半夜睡不著的人可能心裡有煩惱",
+      "遇到困難時，已經撐過一半了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:反": {
-    "sentences": [],
+    "sentences": [
+      "反過來想，壞事有時也能帶來好的改變",
+      "她反覆思考後決定尋求心理諮商",
+      "事情的反面往往藏著意想不到的收穫"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:妄": {
-    "sentences": [],
+    "sentences": [
+      "不要妄自菲薄，每個人都有自己的價值",
+      "妄下結論只會讓問題更嚴重",
+      "胡思亂想和妄念會影響心理健康"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:思": {
-    "sentences": [],
+    "sentences": [
+      "遇到困難時要靜下心來好好思考",
+      "反覆思索問題的根源才能找到答案",
+      "她深思熟慮後決定向專家求助"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:振": {
-    "sentences": [],
+    "sentences": [
+      "朋友的鼓勵讓她重新振作起來",
+      "振奮精神，面對人生的每一個挑戰",
+      "一蹶不振只會讓情況越來越糟"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:楣": {
-    "sentences": [],
+    "sentences": [
+      "倒楣的事不一定會導致心理問題",
+      "她覺得自己最近特別倒楣",
+      "連續倒楣讓她開始懷疑自己"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:淚": {
-    "sentences": [],
+    "sentences": [
+      "她忍不住潸然淚下",
+      "有時候流淚反而是一種釋放壓力的方式",
+      "擦乾眼淚之後，她變得更堅強了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:深": {
-    "sentences": [],
+    "sentences": [
+      "深呼吸可以幫助緩解緊張的情緒",
+      "她深深地感受到朋友的關心",
+      "深入了解自己的心理狀態很重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:淵": {
-    "sentences": [],
+    "sentences": [
+      "她曾經掉入情緒的深淵",
+      "臨淵而退需要很大的勇氣",
+      "走出心理的深淵後，她看到了陽光"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:潸": {
-    "sentences": [],
+    "sentences": [
+      "她潸然淚下，終於釋放了內心的壓力",
+      "回想過去的經歷，她不禁潸然落淚",
+      "潸潸的淚水洗去了心中的陰霾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:災": {
-    "sentences": [],
+    "sentences": [
+      "天災人禍都可能造成心理創傷",
+      "災難過後的心理重建同樣重要",
+      "不幸的遭遇不一定是災難"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:無": {
-    "sentences": [],
+    "sentences": [
+      "感到無助的時候要記得求助",
+      "心理健康和身體健康同樣不可或缺，無法忽視",
+      "她無論遇到什麼困難都不輕易放棄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:然": {
-    "sentences": [],
+    "sentences": [
+      "壞事的發生雖然讓人難過，但不是絕路",
+      "她潸然淚下，釋放了心中的壓力",
+      "坦然面對問題是解決的第一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:聲": {
-    "sentences": [],
+    "sentences": [
+      "她不聲不響地承受著心裡的痛苦",
+      "一聲關心的問候就能溫暖人心",
+      "鴉雀無聲的夜裡，她終於說出了心事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:臂": {
-    "sentences": [],
+    "sentences": [
+      "朋友伸出了溫暖的臂膀安慰她",
+      "她需要一個可以依靠的臂彎",
+      "張開雙臂擁抱那些需要幫助的人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:芻": {
-    "sentences": [],
+    "sentences": [
+      "她的建議只是拋磚引玉的芻議",
+      "這些芻蕘之見或許能幫助你思考",
+      "他虛心接受每一個人的芻言"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:茶": {
-    "sentences": [],
+    "sentences": [
+      "心情不好時，泡杯茶靜靜坐著想一想",
+      "她和朋友喝茶聊天紓解壓力",
+      "粗茶淡飯的日子也能過得快樂"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:萬": {
-    "sentences": [],
+    "sentences": [
+      "萬一遇到心理問題不要害怕求助",
+      "千萬不要一個人默默承受痛苦",
+      "她下定了萬全的決心面對挑戰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:豁": {
-    "sentences": [],
+    "sentences": [
+      "豁達的心態能幫助我們面對困難",
+      "她豁然開朗地想通了許多事情",
+      "豁出去反而讓她找到了新的方向"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:蹶": {
-    "sentences": [],
+    "sentences": [
+      "她一蹶不振了好長一段時間",
+      "跌倒後不要一蹶不振，要勇敢站起來",
+      "失敗讓他一蹶不振，朋友的關心讓他重新振作"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:身": {
-    "sentences": [],
+    "sentences": [
+      "身心健康比什麼都重要",
+      "她全身心地投入了心理諮商的課程",
+      "照顧好自己的身體和心理同樣重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:輾": {
-    "sentences": [],
+    "sentences": [
+      "她輾轉難眠，心裡想著許多事情",
+      "他在床上輾轉反側睡不著覺",
+      "輾轉求醫後她終於找到了好的心理師"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:轉": {
-    "sentences": [],
+    "sentences": [
+      "心念一轉，壞事也能變成好事",
+      "轉換心情最好的方法是去運動",
+      "她的人生在那一刻出現了轉折"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:遂": {
-    "sentences": [],
+    "sentences": [
+      "事情不會總是盡如人意，不遂心願也是常態",
+      "他的願望沒有得遂",
+      "不遂己意時要學會調整心態"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:達": {
-    "sentences": [],
+    "sentences": [
+      "她用豁達的態度面對人生的起伏",
+      "表達自己的感受是心理健康的第一步",
+      "通達事理的人不容易被壞事擊倒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:雀": {
-    "sentences": [],
+    "sentences": [
+      "她高興得像隻小雀一樣跳來跳去",
+      "鴉雀無聲的教室裡她說出了心事",
+      "歡呼雀躍的背後也可能藏著壓力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:頭": {
-    "sentences": [],
+    "sentences": [
+      "遇到困難不要低頭，要勇敢面對",
+      "她終於抬起頭來面對心裡的問題",
+      "回頭看看，那些壞事其實讓她成長了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:飯": {
-    "sentences": [],
+    "sentences": [
+      "她心情不好的時候連飯都吃不下",
+      "吃飽飯才有力氣面對困難",
+      "粗茶淡飯也能讓人感到滿足"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "心理出狀況，是壞事導致的嗎?:鴉": {
-    "sentences": [],
+    "sentences": [
+      "教室裡鴉雀無聲地聽她說故事",
+      "鴉雀無聲的環境有助於靜心思考",
+      "烏鴉雖然黑但也有牠的美麗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "愛讀書的顧寧人:少": {
-    "sentences": [],
+    "sentences": [
+      "他從少年時代就對讀書充滿了熱情，手不釋卷",
+      "書讀得多，見識自然不少，這正是顧寧人的寫照",
+      "青少年時期養成的閱讀習慣讓他受益終身"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:不": {
-    "sentences": [],
+    "sentences": [
+      "他不管多辛苦都要練習棒球",
+      "遇到挫折不要放棄你的夢想",
+      "不斷練習才能打出漂亮的全壘打"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:乎": {
-    "sentences": [],
+    "sentences": [
+      "他在乎的不是輸贏而是努力的過程",
+      "幾乎每天放學後他都去練習棒球",
+      "他不在乎別人怎麼看，只管追夢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:作": {
-    "sentences": [],
+    "sentences": [
+      "他把打棒球當作人生最重要的事",
+      "團隊合作是棒球比賽的關鍵",
+      "他的努力終於發揮了作用"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:僧": {
-    "sentences": [],
+    "sentences": [
+      "球隊裡僧多粥少，競爭很激烈",
+      "僧多粥少的球隊讓他更努力爭取上場機會",
+      "僧多粥少讓他更努力爭取上場機會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:合": {
-    "sentences": [],
+    "sentences": [
+      "棒球是一項需要團隊合作的運動",
+      "他的表現完全符合教練的期待",
+      "配合默契的隊友讓比賽更順利"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:外": {
-    "sentences": [],
+    "sentences": [
+      "他在外野守備的表現非常出色",
+      "意料之外的好球讓他開心極了",
+      "除了練球之外他還要認真念書"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:多": {
-    "sentences": [],
+    "sentences": [
+      "多練習幾次揮棒就能進步",
+      "他花了很多時間在練習上",
+      "棒球帶給他許多快樂的回憶"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:少": {
-    "sentences": [],
+    "sentences": [
+      "他從少年時期就愛上了棒球",
+      "球隊裡僧多粥少，他更努力表現",
+      "小小少年懷抱著一個大大的棒球夢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:想": {
-    "sentences": [],
+    "sentences": [
+      "他的夢想是成為職業棒球選手",
+      "想要成功就必須比別人更努力",
+      "每次想到棒球他的眼睛就發亮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:方": {
-    "sentences": [],
+    "sentences": [
+      "教練教他正確的打擊方法",
+      "他想方設法讓自己的技術進步",
+      "方向對了就不怕路途遙遠"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:標": {
-    "sentences": [],
+    "sentences": [
+      "他的目標是打進全國大賽",
+      "標準的投球姿勢需要反覆練習",
+      "他朝著目標一步步前進"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:汗": {
-    "sentences": [],
+    "sentences": [
+      "他每天練到汗流浹背",
+      "一滴汗水一分收穫",
+      "球場上的汗水是他追夢的證明"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:法": {
-    "sentences": [],
+    "sentences": [
+      "他想盡辦法讓自己的球技進步",
+      "教練的方法讓他快速成長",
+      "沒有捷徑可走，唯一的方法就是練習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:流": {
-    "sentences": [],
+    "sentences": [
+      "他練球練到汗流浹背",
+      "球場上的淚水和汗水一起流下",
+      "他的棒球技術已達到一流水準"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:浹": {
-    "sentences": [],
+    "sentences": [
+      "每次練習都讓他汗流浹背",
+      "汗流浹背的訓練讓他越來越強",
+      "即使汗流浹背他也甘之如飴"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:湛": {
-    "sentences": [],
+    "sentences": [
+      "他精湛的球技讓教練刮目相看",
+      "精湛的打擊技術需要長期練習",
+      "他的表現堪稱精湛"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:無": {
-    "sentences": [],
+    "sentences": [
+      "他追逐夢想的決心無人能擋",
+      "無論颳風下雨他都堅持練球",
+      "無數次的揮棒終於換來好成績"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:粥": {
-    "sentences": [],
+    "sentences": [
+      "球隊裡僧多粥少競爭激烈",
+      "早上喝碗粥就去球場練習了",
+      "僧多粥少的環境讓他學會競爭"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:精": {
-    "sentences": [],
+    "sentences": [
+      "他精湛的守備讓全場觀眾驚呼",
+      "精神專注是打好球的重要條件",
+      "他把精力全部投入棒球訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:背": {
-    "sentences": [],
+    "sentences": [
+      "他練到汗流浹背才肯休息",
+      "背後默默支持他的家人很重要",
+      "他背負著全隊的期待站上打擊區"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:設": {
-    "sentences": [],
+    "sentences": [
+      "教練為他設計了專屬的訓練計畫",
+      "他設定了明確的棒球目標",
+      "球場的設備雖然簡陋但他不介意"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:達": {
-    "sentences": [],
+    "sentences": [
+      "他終於達成了心中的棒球夢",
+      "到達夢想的那一天他激動落淚",
+      "他是個樂觀豁達的棒球少年"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "我有一個棒球夢:間": {
-    "sentences": [],
+    "sentences": [
+      "他把所有空間時間都用來練球",
+      "球場是他課間最喜歡去的地方",
+      "他在短短幾年間進步神速"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:不": {
-    "sentences": [],
+    "sentences": [
+      "不要羨慕別人的機會，先做好手邊的事",
+      "他不抱怨條件不好，反而更加努力",
+      "不管處境如何，都要把事情做到最好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:人": {
-    "sentences": [],
+    "sentences": [
+      "每個人手上都有一塊屬於自己的餅",
+      "做人要懂得珍惜眼前擁有的東西",
+      "人生沒有完美的劇本，只有認真的演員"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:儼": {
-    "sentences": [],
+    "sentences": [
+      "他儼然成為了同學中最認真的那個人",
+      "她做事的態度儼如一位小大人",
+      "工作時他儼然換了一個人似的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:出": {
-    "sentences": [],
+    "sentences": [
+      "他想出了一個讓餅更好吃的方法",
+      "只要肯努力就能闖出一片天",
+      "他走出了自怨自艾的低潮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:咕": {
-    "sentences": [],
+    "sentences": [
+      "肚子咕嚕咕嚕叫個不停",
+      "他嘀嘀咕咕地抱怨了半天",
+      "咕噥了幾句之後他還是認真做事了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:嘀": {
-    "sentences": [],
+    "sentences": [
+      "他嘀嘀咕咕地覺得不公平",
+      "別再嘀咕了，把手上的事做好吧",
+      "她嘀咕了幾聲就開始動手做了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:嘴": {
-    "sentences": [],
+    "sentences": [
+      "與其動嘴抱怨不如動手改變",
+      "嘴上說不想做，手卻很誠實",
+      "他嘴角帶著微笑把餅吃得津津有味"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:天": {
-    "sentences": [],
+    "sentences": [
+      "天無絕人之路，總會有辦法的",
+      "他每天都認真地做好分內的事",
+      "天底下沒有白吃的午餐"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:如": {
-    "sentences": [],
+    "sentences": [
+      "與其羨慕別人，不如把自己做好",
+      "他如夢初醒般開始珍惜眼前的一切",
+      "醍醐灌頂如同當頭棒喝讓他清醒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:小": {
-    "sentences": [],
+    "sentences": [
+      "小事做好了，大事自然跟著來",
+      "不要小看手上這塊小小的餅",
+      "從小處著手才能成就大事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:層": {
-    "sentences": [],
+    "sentences": [
+      "他把餅做出了好幾層的口感",
+      "更上一層樓需要不斷地努力",
+      "層層疊疊的努力堆出了甜美的成果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:思": {
-    "sentences": [],
+    "sentences": [
+      "他開始反思自己的態度是不是有問題",
+      "與其胡思亂想不如踏實行動",
+      "她深思之後決定改變面對事情的方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:怨": {
-    "sentences": [],
+    "sentences": [
+      "抱怨解決不了任何問題",
+      "他不再自怨自艾而是積極面對",
+      "怨天尤人只會浪費寶貴的時間"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:慢": {
-    "sentences": [],
+    "sentences": [
+      "慢慢來比較快，把事情做好最重要",
+      "他慢慢地品嚐手上這塊餅的味道",
+      "不要著急，慢工出細活"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:懟": {
-    "sentences": [],
+    "sentences": [
+      "他心裡懟著一股不服輸的勁",
+      "懟了好久終於找到突破口",
+      "這股懟勁讓他把餅做得比誰都好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:技": {
-    "sentences": [],
+    "sentences": [
+      "把一件事做到極致就是最好的技術",
+      "他靠著精湛的技藝把餅做得很香",
+      "掌握技巧之後，事情變得容易多了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:撒": {
-    "sentences": [],
+    "sentences": [
+      "她在餅上撒了一些芝麻增加風味",
+      "不要把機會像撒沙子一樣浪費掉",
+      "他撒下了努力的種子等待收穫"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:故": {
-    "sentences": [],
+    "sentences": [
+      "他故意用不同的方式來做這件事",
+      "這個故事告訴我們要珍惜手上的東西",
+      "無緣無故地抱怨是沒有用的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:斯": {
-    "sentences": [],
+    "sentences": [
+      "他斯斯文文地把餅吃得很優雅",
+      "醍醐灌頂如斯，讓他徹底改變想法",
+      "慢條斯理地做事反而更有效率"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:施": {
-    "sentences": [],
+    "sentences": [
+      "他開始施展自己的才華把事情做好",
+      "施比受更有福，用心對待每件事",
+      "把手上的資源善加施用就能有好結果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:條": {
-    "sentences": [],
+    "sentences": [
+      "他列出了好幾條改進的方法",
+      "有條有理地做事效率更高",
+      "慢條斯理的態度讓他把事情做得更好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:灌": {
-    "sentences": [],
+    "sentences": [
+      "老師的話如醍醐灌頂讓他醒悟了",
+      "他把全部心力都灌注在這件事上",
+      "這番道理像灌了蜜一樣甜進心裡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:然": {
-    "sentences": [],
+    "sentences": [
+      "他豁然開朗地理解了這個道理",
+      "自然而然地他開始享受手上的工作",
+      "突然間他明白了珍惜的意義"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:犯": {
-    "sentences": [],
+    "sentences": [
+      "他不再犯同樣的錯誤",
+      "犯錯不可怕，怕的是不改正",
+      "他差點犯了好高騖遠的毛病"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:理": {
-    "sentences": [],
+    "sentences": [
+      "他明白了一個簡單的道理",
+      "道理很簡單，做好眼前的事就對了",
+      "這個道理讓他重新整理了自己的心態"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:登": {
-    "sentences": [],
+    "sentences": [
+      "他想要更上一層樓登上更高的地方",
+      "登高必自卑，從基礎做起最實在",
+      "把餅做好就是通往成功的登天梯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:百": {
-    "sentences": [],
+    "sentences": [
+      "百分之百的努力才能換來最好的結果",
+      "他嘗試了上百種方法來改善自己",
+      "百尺竿頭更進一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:窮": {
-    "sentences": [],
+    "sentences": [
+      "窮則變變則通，辦法總是有的",
+      "他不因條件窮困而放棄努力",
+      "山窮水盡疑無路柳暗花明又一村"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:自": {
-    "sentences": [],
+    "sentences": [
+      "他學會了自我調整心態",
+      "自怨自艾解決不了問題",
+      "自己手上的餅要自己想辦法做好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:艾": {
-    "sentences": [],
+    "sentences": [
+      "自怨自艾只會讓自己更不開心",
+      "他不再自怨自艾而是積極行動",
+      "方興未艾的鬥志讓他把事情做好了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:解": {
-    "sentences": [],
+    "sentences": [
+      "他終於解開了心中的結",
+      "了解自己的處境才能找到出路",
+      "抱怨不能解決問題，行動才可以"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:賴": {
-    "sentences": [],
+    "sentences": [
+      "成功不是靠運氣而是靠自己，不能依賴別人",
+      "他不再耍賴推卸責任",
+      "只有依賴自己的雙手才能把餅做香"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:醍": {
-    "sentences": [],
+    "sentences": [
+      "老師的一番話讓他如獲醍醐灌頂",
+      "醍醐灌頂的感覺讓他瞬間清醒",
+      "這個故事帶給他醍醐般的啟發"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:醐": {
-    "sentences": [],
+    "sentences": [
+      "醍醐灌頂的道理改變了他的想法",
+      "這番話如同醍醐灌頂般透徹",
+      "品嚐過醍醐的滋味就不再抱怨了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:重": {
-    "sentences": [],
+    "sentences": [
+      "他重新審視了手上擁有的東西",
+      "做事要注重品質而不只是速度",
+      "他開始重視每一個小小的機會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:難": {
-    "sentences": [],
+    "sentences": [
+      "再難吃的餅也能想辦法做得美味",
+      "困難是成長的養分",
+      "難關總會過去，把眼前的事做好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:頂": {
-    "sentences": [],
+    "sentences": [
+      "醍醐灌頂讓他徹底改變了態度",
+      "他站在山頂上看到了不一樣的風景",
+      "登峰造極的秘訣就是把每件事做到頂"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "把手上的餅吃香一點:饞": {
-    "sentences": [],
+    "sentences": [
+      "他把餅做得香噴噴的讓人好饞",
+      "看著別人的東西嘴饞不如做好自己的",
+      "饞嘴的他決定把自己的餅做得更好吃"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:一": {
-    "sentences": [],
+    "sentences": [
+      "她一心一意地追求拳擊的夢想",
+      "每一拳都用盡了全部力量",
+      "一步一腳印走出屬於自己的路"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:交": {
-    "sentences": [],
+    "sentences": [
+      "她和對手在擂台上激烈交鋒",
+      "教練把畢生所學都交給了她",
+      "比賽中她和對手交換了好幾拳"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:傾": {
-    "sentences": [],
+    "sentences": [
+      "她傾盡全力打出了決勝的一拳",
+      "教練傾囊相授所有的拳擊技巧",
+      "她對拳擊的熱情讓人為之傾倒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:力": {
-    "sentences": [],
+    "sentences": [
+      "她用盡全力揮出了漂亮的一拳",
+      "拳擊需要力量也需要智慧",
+      "努力訓練是她成功的最大動力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:回": {
-    "sentences": [],
+    "sentences": [
+      "她在決賽中成功回擊了對手",
+      "回想起辛苦的訓練過程她很感動",
+      "每一回合她都全神貫注"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:城": {
-    "sentences": [],
+    "sentences": [
+      "她是拳擊場上眾志成城的鬥士",
+      "滿城的觀眾都為她歡呼",
+      "她在擂台上築起了一座堅固的城"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:如": {
-    "sentences": [],
+    "sentences": [
+      "她如願以償站上了國際比賽的舞台",
+      "比賽時她的出拳快如閃電",
+      "一切如她所願拿到了好成績"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:得": {
-    "sentences": [],
+    "sentences": [
+      "她覺得所有的辛苦都值得了",
+      "要成為好選手就得付出加倍努力",
+      "她的努力讓她獲得了寶貴的獎牌"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:心": {
-    "sentences": [],
+    "sentences": [
+      "她用心練習每一個動作",
+      "堅定的決心讓她克服了許多困難",
+      "她一心想成為最好的拳擊手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:扳": {
-    "sentences": [],
+    "sentences": [
+      "她在比賽中成功扳回了一局",
+      "扳回劣勢的那一刻觀眾歡聲雷動",
+      "教練教她如何在落後時扳回局面"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:橫": {
-    "sentences": [],
+    "sentences": [
+      "她橫掃了所有的對手贏得冠軍",
+      "練習中她遇到了很多橫衝直撞的挑戰",
+      "她有一股不服輸的橫勁"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:水": {
-    "sentences": [],
+    "sentences": [
+      "她的實力已達到國際水準",
+      "比賽時她的汗水灑滿了擂台",
+      "練習時她喝了好多水補充體力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:沉": {
-    "sentences": [],
+    "sentences": [
+      "她沉著冷靜地面對每一場比賽",
+      "沉重的壓力讓她學會堅強",
+      "她沉浸在拳擊的世界裡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:測": {
-    "sentences": [],
+    "sentences": [
+      "她的出拳速度讓對手難以預測",
+      "教練用儀器測量她的反應速度",
+      "變幻莫測的戰術讓對手措手不及"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:獨": {
-    "sentences": [],
+    "sentences": [
+      "她獨自一人在練習室苦練",
+      "擂台上她獨當一面表現出色",
+      "獨立堅強的個性讓她不怕挑戰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:琢": {
-    "sentences": [],
+    "sentences": [
+      "她不斷琢磨自己的拳擊技術",
+      "精雕細琢的訓練讓她越來越厲害",
+      "教練幫她琢磨出最好的打法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:當": {
-    "sentences": [],
+    "sentences": [
+      "她當上了國家隊的代表選手",
+      "面對強敵她也能獨當一面",
+      "她把拳擊當作自己最重要的事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:疑": {
-    "sentences": [],
+    "sentences": [
+      "她用實力消除了所有人的質疑",
+      "毋庸置疑她是最努力的選手",
+      "一開始很多人對她的能力抱持懷疑"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:瘁": {
-    "sentences": [],
+    "sentences": [
+      "她為了拳擊夢想鞠躬盡瘁",
+      "日夜操勞讓她身體有些憔瘁",
+      "即使精疲力瘁她也不肯停下來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:監": {
-    "sentences": [],
+    "sentences": [
+      "教練在旁邊監督她的每一次訓練",
+      "國家隊的訓練受到嚴格的監管",
+      "監考官般嚴格的教練讓她進步飛速"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:禦": {
-    "sentences": [],
+    "sentences": [
+      "她學會了如何防禦對手的攻擊",
+      "完美的防禦讓她在比賽中立於不敗",
+      "她的防禦動作既快速又精準"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:著": {
-    "sentences": [],
+    "sentences": [
+      "她著迷於拳擊帶來的挑戰",
+      "穿著拳擊手套的她充滿自信",
+      "她執著地追求拳擊的最高榮譽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:訴": {
-    "sentences": [],
+    "sentences": [
+      "她用金牌告訴大家她做到了",
+      "她向教練傾訴了心中的壓力",
+      "她的故事訴說著努力的意義"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:質": {
-    "sentences": [],
+    "sentences": [
+      "她用出色的表現回應所有的質疑",
+      "優秀的身體素質是拳擊手的基本",
+      "本質上她是一個不服輸的人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:逆": {
-    "sentences": [],
+    "sentences": [
+      "她在逆境中展現了驚人的韌性",
+      "逆風而行讓她變得更加堅強",
+      "她成功逆轉了比賽的劣勢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:防": {
-    "sentences": [],
+    "sentences": [
+      "她的防守技術讓對手無從下手",
+      "進攻和防禦都是拳擊的重要技巧",
+      "她的防備滴水不漏"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:雕": {
-    "sentences": [],
+    "sentences": [
+      "精雕細琢的訓練讓她技術更精湛",
+      "教練像雕刻家一樣打磨她的技術",
+      "她把每個動作都雕琢到完美"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:面": {
-    "sentences": [],
+    "sentences": [
+      "她勇敢地面對每一位強勁的對手",
+      "她正面迎擊每一位強勁的對手",
+      "全面的訓練讓她成為全方位的選手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "拳力出擊-陳念琴:魚": {
-    "sentences": [],
+    "sentences": [
+      "她如魚得水般在擂台上揮灑自如",
+      "練習中她像一條靈活的魚",
+      "城門失火殃及池魚的道理她很明白"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:不": {
-    "sentences": [],
+    "sentences": [
+      "科學家至今仍不確定昆蟲有沒有思考能力",
+      "不可思議的是螞蟻能夠合作搬運食物",
+      "昆蟲的行為模式不一定代表牠們在思考"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:依": {
-    "sentences": [],
+    "sentences": [
+      "昆蟲的行為可能只是依靠本能反應",
+      "蝴蝶依循固定的路線遷徙",
+      "牠們依賴觸角來感知周圍的環境"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:兔": {
-    "sentences": [],
+    "sentences": [
+      "守株待兔的故事和昆蟲的本能行為有點像",
+      "蜘蛛就像守株待兔一樣等待獵物上門",
+      "螳螂捕蟬和兔死狗烹都是自然界的法則"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:化": {
-    "sentences": [],
+    "sentences": [
+      "昆蟲經過千萬年的演化發展出驚人的能力",
+      "毛毛蟲蛻變化為蝴蝶是大自然的奇蹟",
+      "牠們的行為是長期進化的結果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:及": {
-    "sentences": [],
+    "sentences": [
+      "來不及思考就已經做出反應的昆蟲很神奇",
+      "昆蟲的反應速度快到人類望塵莫及",
+      "研究涉及了許多不同種類的昆蟲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:妙": {
-    "sentences": [],
+    "sentences": [
+      "昆蟲的行為有許多奇妙之處",
+      "大自然的巧妙設計讓人讚嘆",
+      "螞蟻分工合作的方式真是太精妙了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:孵": {
-    "sentences": [],
+    "sentences": [
+      "蝴蝶的卵需要一段時間才能孵化",
+      "母蟲會找安全的地方孵育下一代",
+      "孵化後的幼蟲開始了牠的生命旅程"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:守": {
-    "sentences": [],
+    "sentences": [
+      "蜘蛛守在網上等待獵物靠近",
+      "守株待兔的行為在昆蟲界很常見",
+      "有些昆蟲會守護自己的巢穴"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:巧": {
-    "sentences": [],
+    "sentences": [
+      "昆蟲築巢的技巧讓科學家嘆為觀止",
+      "蜜蜂建造蜂巢的結構非常巧妙",
+      "這些看似巧合的行為可能只是本能"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:彷": {
-    "sentences": [],
+    "sentences": [
+      "昆蟲的行為彷彿經過精心設計",
+      "牠們彷佛知道什麼時候該遷徙",
+      "蟻群的運作彷如一個有組織的社會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:彿": {
-    "sentences": [],
+    "sentences": [
+      "螞蟻的分工合作彷彿有人在指揮",
+      "蝴蝶彷彿知道花朵在哪裡",
+      "牠們的行為彷彿是經過思考才做出來的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:待": {
-    "sentences": [],
+    "sentences": [
+      "蜘蛛守株待兔般等待獵物上門",
+      "科學家期待能解開昆蟲智慧之謎",
+      "有些昆蟲會等待最佳時機才行動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:律": {
-    "sentences": [],
+    "sentences": [
+      "昆蟲的行為似乎遵循著某種規律",
+      "大自然有它自己運作的定律",
+      "螞蟻覓食的路線有固定的規律"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:循": {
-    "sentences": [],
+    "sentences": [
+      "蜜蜂循著花香找到了花朵",
+      "昆蟲遵循本能做出各種行為",
+      "牠們循環往復地完成生命的使命"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:應": {
-    "sentences": [],
+    "sentences": [
+      "昆蟲的反應速度快得令人驚訝",
+      "牠們對環境變化的應變能力很強",
+      "這些行為可能只是本能的反應"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:掩": {
-    "sentences": [],
+    "sentences": [
+      "有些昆蟲會掩藏自己躲避天敵",
+      "枯葉蝶用翅膀掩蓋住自己的身體",
+      "掩耳盜鈴的行為在昆蟲界並不存在"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:株": {
-    "sentences": [],
+    "sentences": [
+      "守株待兔的蜘蛛耐心地等著獵物",
+      "牠停在一株植物上一動也不動",
+      "昆蟲和植株之間有密切的關係"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:機": {
-    "sentences": [],
+    "sentences": [
+      "昆蟲會等待最佳時機才出手捕食",
+      "蜜蜂的飛行機制讓科學家非常好奇",
+      "隨機應變的能力是不是代表牠們在思考"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:耳": {
-    "sentences": [],
+    "sentences": [
+      "掩耳盜鈴的行為昆蟲不會做",
+      "蟋蟀的耳朵長在前腳上真神奇",
+      "迅雷不及掩耳的速度讓獵物逃不掉"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:臨": {
-    "sentences": [],
+    "sentences": [
+      "面臨危險時昆蟲會做出快速反應",
+      "臨機應變的能力讓牠們存活了下來",
+      "牠們面臨天敵時的反應非常迅速"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:苞": {
-    "sentences": [],
+    "sentences": [
+      "毛毛蟲躲在花苞裡等待蛻變",
+      "含苞待放的花朵吸引了許多昆蟲",
+      "牠藏在苞片裡躲避天敵的攻擊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:葉": {
-    "sentences": [],
+    "sentences": [
+      "枯葉蝶的翅膀看起來就像一片樹葉",
+      "昆蟲利用葉子來偽裝自己",
+      "毛毛蟲在嫩葉上大口吃著食物"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:規": {
-    "sentences": [],
+    "sentences": [
+      "螞蟻的行為似乎有一套固定的規則",
+      "蜜蜂的舞蹈遵循著嚴格的規律",
+      "牠們的行為是否有規劃讓人好奇"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:覓": {
-    "sentences": [],
+    "sentences": [
+      "螞蟻出門覓食的路線非常有效率",
+      "蜜蜂在花叢中覓食花蜜",
+      "昆蟲覓食的行為是本能還是思考的結果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:變": {
-    "sentences": [],
+    "sentences": [
+      "毛毛蟲蛻變為蝴蝶是大自然的奇蹟",
+      "昆蟲的行為會隨著環境變化而改變",
+      "牠們能快速應變來躲避危險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:迅": {
-    "sentences": [],
+    "sentences": [
+      "蜻蜓捕捉獵物的動作非常迅速",
+      "昆蟲迅速的反應讓天敵措手不及",
+      "迅雷不及掩耳的速度是牠的看家本領"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:雷": {
-    "sentences": [],
+    "sentences": [
+      "蟬鳴的聲音有時候大得像打雷",
+      "迅雷不及掩耳的速度讓人驚嘆",
+      "螳螂出手時快如迅雷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "昆蟲會思考嗎？:食": {
-    "sentences": [],
+    "sentences": [
+      "螞蟻會合作搬運比自己大的食物",
+      "昆蟲覓食的行為讓科學家很感興趣",
+      "牠們尋找食物的方式非常聰明"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:一": {
-    "sentences": [],
+    "sentences": [
+      "他一心想要做出全世界最好吃的果醬",
+      "一罐小小的果醬改變了他的人生",
+      "這是一段從零到一的創業故事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:全": {
-    "sentences": [],
+    "sentences": [
+      "他全心全意投入果醬的研發",
+      "全力以赴的態度讓他的果醬脫穎而出",
+      "他對品質的要求近乎完全的執著"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:兩": {
-    "sentences": [],
+    "sentences": [
+      "他在學業和做果醬之間取得了兩全其美",
+      "兩年的努力讓他的果醬品牌聞名遐邇",
+      "他用兩隻手親手熬煮每一罐果醬"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:其": {
-    "sentences": [],
+    "sentences": [
+      "他的果醬之所以好吃其實有獨到的祕訣",
+      "其他人都覺得不可能，但他做到了",
+      "他把其中的困難都當作學習的機會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:冠": {
-    "sentences": [],
+    "sentences": [
+      "他的果醬在比賽中勇奪冠軍",
+      "冠軍的頭銜讓更多人認識了他的品牌",
+      "這位年輕的果醬冠軍令人刮目相看"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:出": {
-    "sentences": [],
+    "sentences": [
+      "他做出了令人讚不絕口的手工果醬",
+      "出乎所有人的意料，這個男孩成功了",
+      "他想出了許多獨特的果醬口味"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:動": {
-    "sentences": [],
+    "sentences": [
+      "他的創業故事感動了很多人",
+      "他主動學習各種製作果醬的技術",
+      "行動力是他成功的關鍵因素"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:口": {
-    "sentences": [],
+    "sentences": [
+      "他的果醬入口即化讓人讚不絕口",
+      "好口碑讓他的果醬供不應求",
+      "大家口耳相傳他的果醬有多好吃"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:嘆": {
-    "sentences": [],
+    "sentences": [
+      "評審品嚐後驚嘆不已",
+      "他的果醬讓人嘆為觀止",
+      "令人讚嘆的手藝來自於不斷的練習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:困": {
-    "sentences": [],
+    "sentences": [
+      "他不被眼前的困難打倒",
+      "困境反而激發了他更多的創意",
+      "他從困難中找到了做果醬的靈感"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:坐": {
-    "sentences": [],
+    "sentences": [
+      "他不會坐等機會上門，而是主動出擊",
+      "坐而言不如起而行是他的座右銘",
+      "他坐在廚房裡反覆試做新口味"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:城": {
-    "sentences": [],
+    "sentences": [
+      "他的果醬品牌在城市裡打響了名聲",
+      "滿城的人都在討論這位果醬男孩",
+      "他帶著果醬走遍了好幾座城市"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:大": {
-    "sentences": [],
+    "sentences": [
+      "他把小小的果醬做成了大大的事業",
+      "他的勇氣和創意讓大家非常佩服",
+      "大膽嘗試讓他找到了成功的配方"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:愁": {
-    "sentences": [],
+    "sentences": [
+      "他從不為失敗發愁而是繼續嘗試",
+      "銷路不好的時候他也曾經發愁",
+      "化解憂愁最好的方法就是動手做事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:措": {
-    "sentences": [],
+    "sentences": [
+      "他面對困難從不手足無措",
+      "一開始他也曾不知所措",
+      "有了方向之後他不再感到無措"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:服": {
-    "sentences": [],
+    "sentences": [
+      "他的果醬讓所有評審都心服口服",
+      "他用實力說服了不看好他的人",
+      "令人信服的品質是成功的根本"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:桂": {
-    "sentences": [],
+    "sentences": [
+      "他的果醬奪得了比賽的桂冠",
+      "蟾宮折桂般的榮耀讓他興奮不已",
+      "桂花口味的果醬是他的招牌之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:機": {
-    "sentences": [],
+    "sentences": [
+      "他抓住了每一個展示果醬的機會",
+      "危機就是轉機，困難讓他更有創意",
+      "靈機一動他想到了新的果醬配方"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:為": {
-    "sentences": [],
+    "sentences": [
+      "他為了做出最好的果醬付出了很多",
+      "果醬成為了他人生中最重要的事業",
+      "他的故事證明年輕人也能大有作為"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:獲": {
-    "sentences": [],
+    "sentences": [
+      "他獲得了果醬比賽的最高榮譽",
+      "獲獎的喜悅讓所有的辛苦都值得",
+      "他在比賽中斬獲了好幾個獎項"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:碑": {
-    "sentences": [],
+    "sentences": [
+      "他的成功成為年輕創業家的里程碑",
+      "好口碑讓他的果醬名聲遠播",
+      "他為自己的品牌樹立了良好的口碑"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:穎": {
-    "sentences": [],
+    "sentences": [
+      "他新穎的果醬口味讓評審眼前一亮",
+      "他的創意在眾多參賽者中脫穎而出",
+      "穎悟的他很快就掌握了製作的訣竅"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:籌": {
-    "sentences": [],
+    "sentences": [
+      "他精心籌備了每一次的果醬展售會",
+      "運籌帷幄的能力讓他的事業蒸蒸日上",
+      "為了比賽他籌劃了好幾個月"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:美": {
-    "sentences": [],
+    "sentences": [
+      "他追求完美的態度體現在每一罐果醬中",
+      "果醬的色澤和味道都十分美好",
+      "他在學業和事業之間取得了兩全其美"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:而": {
-    "sentences": [],
+    "sentences": [
+      "他年紀雖小而志氣卻很大",
+      "脫穎而出的他成為了大家學習的榜樣",
+      "他鍥而不捨地改良每一個配方"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:脫": {
-    "sentences": [],
+    "sentences": [
+      "他的果醬在眾多品牌中脫穎而出",
+      "他擺脫了困境走向成功的道路",
+      "這位男孩的表現完全超脫了年齡的限制"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:虜": {
-    "sentences": [],
+    "sentences": [
+      "他的果醬俘虜了所有人的味蕾",
+      "香甜的滋味俘虜了評審的心",
+      "一口就被俘虜是大家共同的評價"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:集": {
-    "sentences": [],
+    "sentences": [
+      "他收集了世界各地的水果來做果醬",
+      "他把所有的經驗集結成一本食譜",
+      "市集上他的果醬攤位總是最受歡迎"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:雲": {
-    "sentences": [],
+    "sentences": [
+      "他的名聲如白雲般飄散到各地",
+      "風起雲湧的創業路上他從不退縮",
+      "他在國際比賽中叱吒風雲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "果醬男孩:靈": {
-    "sentences": [],
+    "sentences": [
+      "一次偶然的靈感讓他創造出招牌口味",
+      "他的果醬配方彷彿有魔法般的靈妙",
+      "靈活的創意是他成功的秘密武器"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:之": {
-    "sentences": [],
+    "sentences": [
+      "保護森林是他畢生的志業之一",
+      "森林之中藏著無數珍貴的生命",
+      "他是森林之中最勇敢的守護者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:仰": {
-    "sentences": [],
+    "sentences": [
+      "他仰望著高聳的大樹感到無比敬畏",
+      "人們對這位守護者充滿了敬仰之情",
+      "仰望星空的夜晚他守護著整片森林"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:伍": {
-    "sentences": [],
+    "sentences": [
+      "他加入了森林巡護的行伍之中",
+      "守護隊伍裡每個人都盡心盡力",
+      "他和同伴們組成了一支強大的隊伍"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:子": {
-    "sentences": [],
+    "sentences": [
+      "他把森林裡的每棵樹都當作自己的孩子",
+      "種子發芽的那一刻讓他非常感動",
+      "他一輩子都在守護這片林子"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:家": {
-    "sentences": [],
+    "sentences": [
+      "森林就是許多動物的家",
+      "他把守護森林當作安家立命的志業",
+      "大家一起努力才能保護好我們的家園"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:年": {
-    "sentences": [],
+    "sentences": [
+      "他花了好多年的時間守護這片森林",
+      "年復一年的巡護工作從未間斷",
+      "多年來他對森林的熱愛始終如一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:懼": {
-    "sentences": [],
+    "sentences": [
+      "他無所畏懼地面對森林中的各種危險",
+      "恐懼無法阻止他守護森林的決心",
+      "面對盜獵者他毫無懼色"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:懾": {
-    "sentences": [],
+    "sentences": [
+      "他的勇氣震懾了那些破壞森林的人",
+      "盜伐者被他的堅定態度所懾服",
+      "他的守護精神令人敬畏震懾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:抖": {
-    "sentences": [],
+    "sentences": [
+      "寒冷的夜裡他在森林中凍得發抖",
+      "即使害怕得發抖他也堅守崗位",
+      "風吹得樹葉沙沙地顫抖"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:拋": {
-    "sentences": [],
+    "sentences": [
+      "他拋下了城市的舒適生活來守護森林",
+      "他把個人的安危拋在腦後",
+      "拋開一切顧慮全心投入守護工作"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:措": {
-    "sentences": [],
+    "sentences": [
+      "面對森林大火他臨危不亂沉著應對措施",
+      "他採取了有效的措施保護森林",
+      "手足無措的新人在他的帶領下穩定下來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:擻": {
-    "sentences": [],
+    "sentences": [
+      "他每天精神抖擻地巡邏森林",
+      "抖擻精神迎接每一天的挑戰",
+      "他總是精神抖擻地出現在崗位上"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:有": {
-    "sentences": [],
+    "sentences": [
+      "森林裡有許多珍貴的動植物",
+      "有了他的守護，森林才能安全",
+      "他擁有一顆熱愛大自然的心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:望": {
-    "sentences": [],
+    "sentences": [
+      "他望著翠綠的森林心中充滿希望",
+      "守護森林是他從小的願望",
+      "眺望遠方的山林讓他感到平靜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:棄": {
-    "sentences": [],
+    "sentences": [
+      "他從不放棄守護森林的使命",
+      "即使條件再艱苦他也不會丟棄崗位",
+      "他丟棄了城市生活選擇了山林"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:殆": {
-    "sentences": [],
+    "sentences": [
+      "森林裡的珍稀動物幾乎消耗殆盡",
+      "如果沒有他的守護，樹木恐怕會被砍伐殆盡",
+      "他不知疲倦地巡護直到精力殆盡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:沁": {
-    "sentences": [],
+    "sentences": [
+      "森林裡沁涼的空氣讓人精神舒暢",
+      "芬多精的香氣沁人心脾",
+      "沁入心底的感動讓他更加堅定"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:涼": {
-    "sentences": [],
+    "sentences": [
+      "森林裡涼爽的微風讓人心曠神怡",
+      "夏天的森林比城市涼快許多",
+      "樹蔭下的涼意讓巡護工作不那麼辛苦"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:為": {
-    "sentences": [],
+    "sentences": [
+      "他以守護森林為畢生的志業",
+      "為了保護這片林地他日夜巡邏",
+      "他的行為感動了所有人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:生": {
-    "sentences": [],
+    "sentences": [
+      "森林是許多生物賴以生存的家園",
+      "他把一生都奉獻給了森林保育",
+      "新生的嫩芽象徵著森林的希望"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:畏": {
-    "sentences": [],
+    "sentences": [
+      "他不畏艱難地守護著這片森林",
+      "對大自然的敬畏讓他更加謹慎",
+      "他的勇氣讓盜獵者望而生畏"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:盡": {
-    "sentences": [],
+    "sentences": [
+      "他盡心盡力地保護每一棵大樹",
+      "即使精疲力盡他也不肯離開",
+      "他對森林的付出可說是鞠躬盡瘁"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:神": {
-    "sentences": [],
+    "sentences": [
+      "他是森林的守護神",
+      "精神抖擻的他每天準時出發巡邏",
+      "這片森林因為有他而充滿了生機和神采"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:籌": {
-    "sentences": [],
+    "sentences": [
+      "他精心運籌帷幄地規劃巡護路線",
+      "為了保護森林他籌備了許多方案",
+      "他籌劃了一場森林保育的宣導活動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:精": {
-    "sentences": [],
+    "sentences": [
+      "他精神抖擻地巡視每一個角落",
+      "精心維護的森林生態越來越好",
+      "他對工作的精益求精令人敬佩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:與": {
-    "sentences": [],
+    "sentences": [
+      "他與森林裡的動物和平共處",
+      "守護自然與保護生態是他的使命",
+      "他與同伴們並肩作戰守護森林"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:詢": {
-    "sentences": [],
+    "sentences": [
+      "遊客向他詢問森林的知識",
+      "他諮詢專家如何更好地保護生態",
+      "大家遇到問題都會來詢問他的意見"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:諮": {
-    "sentences": [],
+    "sentences": [
+      "他諮詢了生態專家的建議",
+      "經過諮詢後他決定種植更多原生樹種",
+      "諮商師也像守護者一樣關心每個人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "森林大軍的守護者:震": {
-    "sentences": [],
+    "sentences": [
+      "他的故事震撼了每一位聽眾",
+      "地震後他第一時間衝進森林確認安全",
+      "他的奉獻精神令人震動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:之": {
-    "sentences": [],
+    "sentences": [
+      "澳洲奪金的祕密之所以成功在於全面的科學訓練",
+      "這是體育史上最令人驚嘆的逆襲故事之一",
+      "金牌的背後隱藏著不為人知的訓練之道"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:井": {
-    "sentences": [],
+    "sentences": [
+      "他們有條不紊地進行訓練，井然有序",
+      "井底之蛙看不到外面的世界，澳洲卻放眼全球",
+      "科學訓練讓選手們不再是坐井觀天的門外漢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:別": {
-    "sentences": [],
+    "sentences": [
+      "澳洲的訓練方式和其他國家截然不同，別具一格",
+      "他們特別注重運動科學的應用",
+      "告別傳統方法後，成績大幅提升"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:員": {
-    "sentences": [],
+    "sentences": [
+      "每一位隊員都接受了最先進的科學訓練",
+      "研究人員深入分析了選手的身體數據",
+      "教練團的成員來自各個專業領域"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:固": {
-    "sentences": [],
+    "sentences": [
+      "他們鞏固了訓練體系讓成績持續進步",
+      "這套方法穩固了澳洲在奧運的競爭地位",
+      "基礎打得牢固才能在比賽中發揮實力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:地": {
-    "sentences": [],
+    "sentences": [
+      "訓練基地遍佈澳洲各地",
+      "他們腳踏實地地執行每一項訓練計畫",
+      "這片土地孕育了無數優秀的奧運選手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:壤": {
-    "sentences": [],
+    "sentences": [
+      "良好的訓練環境和科學方法是成功的土壤",
+      "天壤之別的成績來自於方法的革新",
+      "這片孕育冠軍的土壤是經過精心培養的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:天": {
-    "sentences": [],
+    "sentences": [
+      "澳洲選手並非天生就強，而是靠科學訓練",
+      "天時地利人和是他們成功的要素",
+      "得天獨厚的自然環境讓戶外訓練更加有效"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:幅": {
-    "sentences": [],
+    "sentences": [
+      "澳洲的奧運獎牌數出現了大幅度的成長",
+      "他們的進步幅度讓全世界刮目相看",
+      "訓練計畫的調整帶來了顯著的提升幅度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:役": {
-    "sentences": [],
+    "sentences": [
+      "每一場奧運比賽都是一次重要的戰役",
+      "這場金牌之役讓澳洲名揚國際",
+      "退役選手也參與了科學訓練計畫的研發"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:後": {
-    "sentences": [],
+    "sentences": [
+      "金牌背後隱藏著不為人知的努力和祕密",
+      "落後的成績激發了他們改革的決心",
+      "他們後來居上的關鍵就是科學化訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:憂": {
-    "sentences": [],
+    "sentences": [
+      "教練團憂心落後的成績，於是大膽推動改革",
+      "他們不再為成績不佳而憂心忡忡",
+      "未雨綢繆的憂患意識讓他們保持了競爭優勢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:掘": {
-    "sentences": [],
+    "sentences": [
+      "他們深入挖掘每一位選手的最大潛力",
+      "科學家發掘了許多提升表現的關鍵因素",
+      "透過數據分析他們挖掘出了致勝的祕密"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:整": {
-    "sentences": [],
+    "sentences": [
+      "他們對訓練體系進行了全面的整頓和改革",
+      "整合各領域的專業知識是成功的關鍵",
+      "教練團整理了大量的比賽數據來優化策略"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:斥": {
-    "sentences": [],
+    "sentences": [
+      "澳洲政府斥資建設了先進的訓練中心",
+      "他們不惜斥巨資引進最新的運動科技",
+      "過去的失敗曾讓他們飽受外界的指斥"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:有": {
-    "sentences": [],
+    "sentences": [
+      "他們擁有全世界最先進的運動科學研究團隊",
+      "只有科學化的訓練才能帶來持續的進步",
+      "這個祕密讓他們在奧運中佔有一席之地"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:格": {
-    "sentences": [],
+    "sentences": [
+      "嚴格的選拔標準確保了隊伍的競爭力",
+      "他們對每一個訓練環節都有嚴格的品質要求",
+      "合格的選手必須通過多項科學檢測"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:條": {
-    "sentences": [],
+    "sentences": [
+      "他們列出了多項科學訓練的條件和標準",
+      "有條不紊的計畫讓訓練更有效率",
+      "每一條訓練準則都經過科學驗證"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:步": {
-    "sentences": [],
+    "sentences": [
+      "一步一步的改革讓澳洲成為奧運強國",
+      "他們的進步速度讓其他國家望塵莫及",
+      "每一步的科學訓練都經過精密計算"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:熱": {
-    "sentences": [],
+    "sentences": [
+      "澳洲人民對奧運金牌充滿了熱情",
+      "選手們的熱血拚搏感動了全國觀眾",
+      "這股追求卓越的熱忱是成功的動力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:理": {
-    "sentences": [],
+    "sentences": [
+      "科學原理被大量應用在運動訓練中",
+      "合理的訓練安排讓選手的表現更加穩定",
+      "他們用數據和邏輯來管理每一項訓練"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:發": {
-    "sentences": [],
+    "sentences": [
+      "科學家們發現了提升運動表現的關鍵因素",
+      "他們研發了許多創新的訓練器材",
+      "這項計畫的啟發來自於一次慘敗的教訓"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:結": {
-    "sentences": [],
+    "sentences": [
+      "團隊團結一致是贏得金牌的重要因素",
+      "科學訓練結合了多個領域的專業知識",
+      "總結過去的經驗教訓讓他們不斷進步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:總": {
-    "sentences": [],
+    "sentences": [
+      "總結來說，科學訓練是澳洲成功的核心祕密",
+      "教練團總是在尋找更好的訓練方法",
+      "他們總共投入了數十年的時間來建立這套體系"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:花": {
-    "sentences": [],
+    "sentences": [
+      "他們花費了大量的時間和資源在科學研究上",
+      "這朵金牌之花是無數人辛勤灌溉的結果",
+      "眼花繚亂的訓練方法背後都有科學根據"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:表": {
-    "sentences": [],
+    "sentences": [
+      "選手的表現透過科學數據來精確追蹤",
+      "這份研究報告發表後引起了國際體壇的關注",
+      "他們在奧運獎牌榜上的表現令人驚艷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:衷": {
-    "sentences": [],
+    "sentences": [
+      "教練們由衷地感謝科學團隊的貢獻",
+      "他們對體育的初衷從未改變",
+      "衷心祝賀每一位站上頒獎台的選手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:資": {
-    "sentences": [],
+    "sentences": [
+      "政府投入大量資源支持運動科學研究",
+      "豐沛的資金讓訓練設備不斷升級",
+      "這筆投資為澳洲帶來了豐碩的金牌回報"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:退": {
-    "sentences": [],
+    "sentences": [
+      "他們從不退縮，即使面對強大的對手",
+      "退役選手將經驗傳承給下一代",
+      "面對失敗他們選擇反省而非退卻"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:遍": {
-    "sentences": [],
+    "sentences": [
+      "他們走遍世界各地學習最先進的訓練方法",
+      "科學訓練的理念已經遍及澳洲各個運動項目",
+      "普遍的科學意識提升了整體競技水準"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:遼": {
-    "sentences": [],
+    "sentences": [
+      "澳洲遼闊的國土提供了多樣的訓練環境",
+      "遼闊的視野讓他們看得比別人更遠",
+      "他們的目標如同遼闊的天空般沒有極限"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:開": {
-    "sentences": [],
+    "sentences": [
+      "他們開創了運動科學訓練的新紀元",
+      "打開了通往金牌的祕密之門",
+      "展開全新的訓練計畫後成績突飛猛進"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:闊": {
-    "sentences": [],
+    "sentences": [
+      "寬闊的視野讓澳洲在奧運中脫穎而出",
+      "遼闊的訓練場地是他們得天獨厚的優勢",
+      "開闊的心胸讓他們願意學習各國的長處"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:鞏": {
-    "sentences": [],
+    "sentences": [
+      "科學訓練鞏固了澳洲在奧運的地位",
+      "他們不斷鞏固自己的訓練體系",
+      "堅實的基礎鞏固了選手們的信心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:顧": {
-    "sentences": [],
+    "sentences": [
+      "回顧過去的失敗，他們找到了前進的方向",
+      "教練團毫無顧忌地推動了大膽的改革",
+      "他們顧及了每一位選手的身心狀態"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "澳洲奧運金牌的X機密:驟": {
-    "sentences": [],
+    "sentences": [
+      "改革的步驟經過了縝密的規劃",
+      "突如其來的暴風驟雨擋不住訓練的腳步",
+      "他們按照既定的步驟穩步推進計畫"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:一": {
-    "sentences": [],
+    "sentences": [
+      "他是一位獨一無二的科學神探",
+      "一絲不苟的態度讓他從不放過任何線索",
+      "這位神探用一個指紋就破解了整起案件"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:不": {
-    "sentences": [],
+    "sentences": [
+      "他絕不放過任何可疑的蛛絲馬跡",
+      "科學鑑識的結果不容任何人質疑",
+      "不畏強權是這位神探最可貴的品質"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:二": {
-    "sentences": [],
+    "sentences": [
+      "他是獨一無二的科學鑑識專家",
+      "二話不說他就開始著手調查案件",
+      "他用科學方法讓真相不容置疑，沒有第二種解讀"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:人": {
-    "sentences": [],
+    "sentences": [
+      "他是一位令所有罪犯聞風喪膽的神探，人稱科學之眼",
+      "科學鑑識還給了無辜的人清白",
+      "每個人都有權利受到公正的對待"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:仃": {
-    "sentences": [],
+    "sentences": [
+      "調查工作從不曾有片刻停仃",
+      "他在案發現場仃立良久仔細觀察",
+      "任何困難都無法讓他的腳步停仃"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:令": {
-    "sentences": [],
+    "sentences": [
+      "他的推理能力令所有人嘆為觀止",
+      "一道命令就能啟動整個鑑識團隊",
+      "令人信服的科學證據讓真相大白"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:休": {
-    "sentences": [],
+    "sentences": [
+      "不查出真相他絕不善罷甘休",
+      "他廢寢忘食地工作直到休息時間才停下",
+      "喋喋不休地追問讓嫌犯露出了破綻"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:伶": {
-    "sentences": [],
+    "sentences": [
+      "他伶俐的頭腦讓案件迎刃而解",
+      "口齒伶俐的他在法庭上條理分明地陳述證據",
+      "孤苦伶仃的受害者因為他而獲得了正義"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:做": {
-    "sentences": [],
+    "sentences": [
+      "他做任何事都講求科學根據",
+      "做為一名神探，他的觀察力異常敏銳",
+      "他所做的每一件事都是為了伸張正義"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:兵": {
-    "sentences": [],
+    "sentences": [
+      "他像一名精銳的偵查兵追蹤每一條線索",
+      "短兵相接的法庭攻防中他從容不迫",
+      "科學證據是他手中最強大的兵器"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:孤": {
-    "sentences": [],
+    "sentences": [
+      "他有時孤身一人深入調查危險的案件",
+      "孤掌難鳴，他也需要團隊的支持",
+      "即使孤立無援他也堅持追查真相"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:忪": {
-    "sentences": [],
+    "sentences": [
+      "他通宵辦案後睡眼惺忪卻仍不放棄",
+      "即使惺忪疲憊他也要把證據看完",
+      "案件突破的那一刻讓他忘記了睡眼惺忪的疲憊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:惺": {
-    "sentences": [],
+    "sentences": [
+      "他睡眼惺忪地翻開了案件資料",
+      "惺惺相惜的同事們一起並肩作戰",
+      "即使惺忪也不影響他敏銳的判斷力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:指": {
-    "sentences": [],
+    "sentences": [
+      "一枚指紋就讓他找到了真正的兇手",
+      "他指出了案件中所有不合理的地方",
+      "科學鑑識中指紋比對是最基本的技術"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:然": {
-    "sentences": [],
+    "sentences": [
+      "他泰然自若地面對每一起複雜的案件",
+      "顯然科學方法比直覺推理更加可靠",
+      "真相昭然若揭讓所有人恍然大悟"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:環": {
-    "sentences": [],
+    "sentences": [
+      "他仔細檢查案發現場的每一個環節",
+      "環環相扣的證據鏈讓案件水落石出",
+      "周遭環境中的微小線索都逃不過他的眼睛"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:神": {
-    "sentences": [],
+    "sentences": [
+      "他被稱為科學鑑識領域的神探",
+      "神乎其技的推理能力讓人嘆服",
+      "他全神貫注地分析每一項科學證據"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:移": {
-    "sentences": [],
+    "sentences": [
+      "任何威脅都無法動搖他對正義的信念，絲毫不移",
+      "他小心翼翼地移動證物避免破壞現場",
+      "轉移注意力的伎倆騙不了這位神探"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:自": {
-    "sentences": [],
+    "sentences": [
+      "他自信地用科學證據伸張了正義",
+      "真相不會自己浮現，需要用科學方法去挖掘",
+      "他泰然自若的態度讓團隊充滿信心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:苦": {
-    "sentences": [],
+    "sentences": [
+      "他苦心鑽研科學鑑識技術多年",
+      "辛苦的調查工作最終換來了正義的伸張",
+      "不辭辛苦地追查真相是他的專業精神"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:貴": {
-    "sentences": [],
+    "sentences": [
+      "科學證據是伸張正義最可貴的武器",
+      "珍貴的鑑識資料被他妥善保存",
+      "他可貴的堅持讓無數冤案得以平反"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:赫": {
-    "sentences": [],
+    "sentences": [
+      "他的名聲赫赫有名，令罪犯聞之色變",
+      "他在科學鑑識領域的成就顯赫非凡",
+      "赫然發現的新證據讓案情出現了重大轉折"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:逕": {
-    "sentences": [],
+    "sentences": [
+      "他逕自走進案發現場開始進行科學鑑識",
+      "罪犯想要逕行逃離卻被證據攔住了去路",
+      "他毫不猶豫地逕直提出了自己的結論"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:速": {
-    "sentences": [],
+    "sentences": [
+      "他迅速地在現場採集了所有的科學證據",
+      "破案的速度令所有人驚嘆不已",
+      "快速而準確的鑑識是他的拿手絕活"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:顧": {
-    "sentences": [],
+    "sentences": [
+      "他不顧個人安危也要查明案件的真相",
+      "回顧這些年的辦案經歷讓他感慨萬千",
+      "他毫無顧忌地揭露了隱藏在背後的真相"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:駕": {
-    "sentences": [],
+    "sentences": [
+      "他駕輕就熟地運用各種科學鑑識技術",
+      "他駕馭證據的能力讓法官和陪審團信服",
+      "凌駕於一切之上的是對真相的執著追求"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "用科學方法伸張正義的神探:髮": {
-    "sentences": [],
+    "sentences": [
+      "他從一根毛髮就能鑑定出嫌犯的身分",
+      "千鈞一髮之際他找到了關鍵的科學證據",
+      "間不容髮的緊張時刻考驗著他的冷靜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:人": {
-    "sentences": [],
+    "sentences": [
+      "盲目相信書本上的記載可能會冤枉無辜的人",
+      "每個人都應該培養獨立思考和批判的能力",
+      "殺人案的真相需要靠理性思辨而非盲從來釐清"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:令": {
-    "sentences": [],
+    "sentences": [
+      "令人深思的是，權威的記載未必都是正確的",
+      "這起案件令所有人開始反思盲信的危害",
+      "令人震驚的判決結果揭示了盡信書的危險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:剝": {
-    "sentences": [],
+    "sentences": [
+      "層層剝開事實的表象才能看到隱藏在背後的真相",
+      "盲目相信權威等於被剝奪了獨立思考的能力",
+      "他抽絲剝繭般地還原了案件的完整面貌"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:劈": {
-    "sentences": [],
+    "sentences": [
+      "他以劈頭蓋臉的氣勢質疑了書中的錯誤記載",
+      "一道真相如閃電般劈開了長久以來的迷霧",
+      "他開門見山劈頭就指出了文獻中的致命矛盾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:助": {
-    "sentences": [],
+    "sentences": [
+      "批判性思維有助於我們辨別資訊的真偽",
+      "盲目的信任對查明案件真相毫無助益",
+      "獨立思考才能幫助我們做出正確的判斷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:名": {
-    "sentences": [],
+    "sentences": [
+      "不能僅憑書中的名人記載就斷定事實的全貌",
+      "莫名其妙的判決往往來自於不加質疑的盲信",
+      "這位學者因為勇於質疑權威而聲名遠播"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:情": {
-    "sentences": [],
+    "sentences": [
+      "案件的真實情況遠比書中描述的更加複雜",
+      "不帶感情色彩的理性分析才能還原事實真相",
+      "煽情的敘述容易蒙蔽人們的判斷力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:抽": {
-    "sentences": [],
+    "sentences": [
+      "他抽絲剝繭地分析了案件中每一個疑點",
+      "從龐雜的文獻中抽取關鍵訊息需要敏銳的判斷力",
+      "抽離個人偏見才能客觀地審視書中的記載"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:指": {
-    "sentences": [],
+    "sentences": [
+      "他一針見血地指出了書中記載的重大謬誤",
+      "這位學者明確指出了盡信書的危害性",
+      "當所有人指向同一個結論時更需要保持警覺"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:援": {
-    "sentences": [],
+    "sentences": [
+      "他援引了大量佐證來推翻書中錯誤的記載",
+      "引經據典地援用權威固然重要但不可盲從",
+      "這個案例為反對盲信提供了最有力的援助"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:撰": {
-    "sentences": [],
+    "sentences": [
+      "撰寫文章的人也可能帶有主觀偏見",
+      "他撰文質疑了歷史文獻中對案件的片面記述",
+      "即使是知名學者撰寫的作品也需要批判性審視"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:最": {
-    "sentences": [],
+    "sentences": [
+      "最危險的事莫過於不經思考就全盤接受書中的說法",
+      "這起案件是盡信書導致冤案的最典型範例",
+      "最重要的是培養獨立思考而非盲目服從的習慣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:杜": {
-    "sentences": [],
+    "sentences": [
+      "盲目引用未經查證的文獻無異於向壁虛構和杜撰",
+      "杜絕冤案的根本之道在於鼓勵批判性思考",
+      "他決心杜絕因盲信書本而導致的司法不公"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:無": {
-    "sentences": [],
+    "sentences": [
+      "盡信書不如無書，關鍵在於獨立思考的能力",
+      "無條件相信權威是最危險的思維陷阱",
+      "真相不會無緣無故地從書頁中自動浮現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:煽": {
-    "sentences": [],
+    "sentences": [
+      "煽動性的文字容易誤導讀者做出錯誤的判斷",
+      "那些煽情的描述與案件的客觀事實大相逕庭",
+      "不被煽惑性的言論左右是理性思考的基本功"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:盛": {
-    "sentences": [],
+    "sentences": [
+      "盛名之下其實難副，權威的記載也可能存在謬誤",
+      "在資訊盛行的時代批判性思維顯得更加重要",
+      "即使是盛極一時的學說也需要接受質疑和檢驗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:眼": {
-    "sentences": [],
+    "sentences": [
+      "他用自己的雙眼重新審視了案件的所有證據",
+      "盲目相信書本等於閉著眼睛走路",
+      "睜大眼睛看清事實比讀一百本書更重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:睜": {
-    "sentences": [],
+    "sentences": [
+      "他睜大眼睛仔細審視每一項證據和記載",
+      "眼睜睜看著無辜的人被冤枉讓他決心追查真相",
+      "睜眼看世界需要的是質疑的勇氣而非盲從的習慣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:睹": {
-    "sentences": [],
+    "sentences": [
+      "目睹冤案的發生讓他深刻體會到盡信書的危害",
+      "有目共睹的事實卻被書中的記載所扭曲",
+      "親眼目睹真相後他再也無法盲目相信書本"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:絲": {
-    "sentences": [],
+    "sentences": [
+      "他抽絲剝繭般地拆解了書中每一個可疑的論述",
+      "一絲不苟的考證態度讓真相終於浮出水面",
+      "絲毫不差的邏輯推理推翻了書中的錯誤結論"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:繭": {
-    "sentences": [],
+    "sentences": [
+      "他抽絲剝繭地還原了案件被掩蓋的真相",
+      "像蠶破繭而出一樣，真相終於掙脫了謊言的束縛",
+      "從文獻的層層包繭中挖掘事實需要極大的耐心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:若": {
-    "sentences": [],
+    "sentences": [
+      "若不加以質疑，書本中的謬誤將一直被當作真理",
+      "旁若無人地堅持追查真相是他最令人敬佩的特質",
+      "倘若每個人都盲信書本，正義將永遠無法伸張"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:視": {
-    "sentences": [],
+    "sentences": [
+      "我們不能漠視書本記載中潛藏的偏見與謬誤",
+      "重新審視這起殺人案讓我們學到了批判思考的重要",
+      "盲目地視書本為絕對真理是最危險的知識態度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:負": {
-    "sentences": [],
+    "sentences": [
+      "讀者有責任負起批判思考的義務而非全盤接受",
+      "盲信書本的後果讓整個司法系統背負了冤案的罪名",
+      "他不負眾望地揭開了塵封多年的案件真相"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:頭": {
-    "sentences": [],
+    "sentences": [
+      "他從頭到尾重新檢視了所有文獻中的記載",
+      "劈頭就質疑權威需要莫大的知識底蘊和勇氣",
+      "回過頭來看，盡信書的教訓值得每個人深思"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "盡信書不如無書：從一件殺人案@談起:髮": {
-    "sentences": [],
+    "sentences": [
+      "他從嫌犯的一根毛髮中提取了關鍵的科學證據",
+      "千鈞一髮之際他找到了推翻錯誤記載的決定性證據",
+      "令人髮指的冤案本可因批判性思考而避免發生"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:中": {
-    "sentences": [],
+    "sentences": [
+      "他在紀錄片中捕捉到許多珍貴的自然畫面",
+      "這部影片正中觀眾的內心深處，引發廣泛討論",
+      "攝影師在人群中發現了一個令人動容的故事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:仿": {
-    "sentences": [],
+    "sentences": [
+      "他仿照紀錄片導演的手法來拍攝校園生活",
+      "他仿效紀錄片導演的手法帶觀眾親臨現場",
+      "模仿別人的視角看世界，反而發現了新的可能"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:傳": {
-    "sentences": [],
+    "sentences": [
+      "這部紀錄片透過網路傳播，感動了無數觀眾",
+      "攝影師將傳統文化的面貌用鏡頭忠實記錄下來",
+      "他把觀察到的故事傳遞給更多需要被看見的人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:力": {
-    "sentences": [],
+    "sentences": [
+      "用心觀察的力量，能讓平凡的事物變得不平凡",
+      "這部影片展現了影像記錄的強大說服力",
+      "他竭盡全力想要呈現最真實的社會面貌"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:勢": {
-    "sentences": [],
+    "sentences": [
+      "紀錄片的影響力正以不可擋的趨勢席捲全球",
+      "觀察者必須順應情勢的變化來調整拍攝角度",
+      "這股關注社會議題的風潮勢不可擋"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:叫": {
-    "sentences": [],
+    "sentences": [
+      "他大聲叫喊，希望更多人關注這個被忽視的議題",
+      "這部紀錄片的結局令人拍案叫絕，久久無法忘懷",
+      "導演用影像替那些無法發聲的人叫屈"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:嘆": {
-    "sentences": [],
+    "sentences": [
+      "觀眾看完影片後不禁發出一聲長嘆",
+      "他感嘆這些珍貴的畫面差一點就無法被記錄下來",
+      "人們讚嘆攝影師捕捉瞬間的精湛技巧"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:圖": {
-    "sentences": [],
+    "sentences": [
+      "攝影師試圖用鏡頭還原事件的真實面貌",
+      "這張照片的構圖精妙，把觀察的細節完美呈現",
+      "他企圖透過紀錄片改變社會對弱勢的偏見"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:境": {
-    "sentences": [],
+    "sentences": [
+      "身處不同的環境，觀察到的世界也截然不同",
+      "攝影師深入偏遠地區，記錄當地的生活境況",
+      "這部片讓觀眾彷彿身歷其境，感受現場的氛圍"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:家": {
-    "sentences": [],
+    "sentences": [
+      "這位攝影家用一生的時間記錄社會的變遷",
+      "每個家庭都有值得被看見和記錄的故事",
+      "他是國際知名的紀錄片大家，作品屢獲大獎"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:實": {
-    "sentences": [],
+    "sentences": [
+      "紀錄片最重要的價值在於真實呈現事物的面貌",
+      "他用鏡頭記錄下的每一幕都是確實發生過的故事",
+      "實際走進現場觀察，才能拍出有溫度的作品"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:拍": {
-    "sentences": [],
+    "sentences": [
+      "他拍下的這張照片後來成為經典的新聞影像",
+      "攝影師不停地拍攝，只為了捕捉最真實的瞬間",
+      "導演花了三年時間拍攝這部關於海洋的紀錄片"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:案": {
-    "sentences": [],
+    "sentences": [
+      "這個拍攝方案經過反覆討論才最終確定下來",
+      "他拍案叫絕，決定親自前往現場進行深度報導",
+      "紀錄片揭露的這個案件震驚了整個社會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:樂": {
-    "sentences": [],
+    "sentences": [
+      "他樂於用鏡頭記錄生活中被忽略的美好角落",
+      "觀眾在紀錄片中找到了觀察世界的樂趣",
+      "音樂搭配影像的節奏，讓觀眾更投入其中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:止": {
-    "sentences": [],
+    "sentences": [
+      "看到令人震撼的畫面，他忍不住停下腳步駐足不止",
+      "這部紀錄片的影響力至今仍未停止擴散",
+      "觀察不應止於表面，還要深入探索背後的故事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:殷": {
-    "sentences": [],
+    "sentences": [
+      "他殷切期盼這部紀錄片能喚起社會大眾的關注",
+      "攝影師以殷實的態度記錄每一個珍貴的片段",
+      "導演殷殷叮囑團隊務必忠實呈現受訪者的心聲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:津": {
-    "sentences": [],
+    "sentences": [
+      "觀眾聽他描述拍攝過程，聽得津津有味",
+      "這段影像記錄了港口津渡繁忙的日常景象",
+      "他津津樂道地分享每一次觀察旅程中的發現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:為": {
-    "sentences": [],
+    "sentences": [
+      "他認為用心觀察是拍出好紀錄片的第一步",
+      "這部作品之所以感人，是因為導演真心為弱勢發聲",
+      "觀察與記錄可以成為改變社會的力量"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:相": {
-    "sentences": [],
+    "sentences": [
+      "透過鏡頭，他終於看見了事情的真相",
+      "攝影師與被拍攝者之間需要建立互相信任的關係",
+      "表面的現象與真相往往大相逕庭"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:結": {
-    "sentences": [],
+    "sentences": [
+      "他將多年的觀察結果整理成一部完整的紀錄片",
+      "這個故事的結局出乎所有觀眾的預料",
+      "攝影師和當地居民結下了深厚的情誼"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:絕": {
-    "sentences": [],
+    "sentences": [
+      "這部紀錄片拍得精彩絕倫，獲得國際影展大獎",
+      "他絕不放棄任何一個值得被記錄的故事",
+      "攝影師在與世隔絕的山區待了整整一年"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:纍": {
-    "sentences": [],
+    "sentences": [
+      "長期拍攝紀錄片的工作讓他感到身心俱疲纍纍",
+      "這些年的觀察成果纍積起來，終於完成了這部鉅作",
+      "他不辭辛勞、碩果纍纍，記錄了許多珍貴影像"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:落": {
-    "sentences": [],
+    "sentences": [
+      "鏡頭記錄下夕陽緩緩落入地平線的美麗瞬間",
+      "他走遍偏遠村落，拍下被世界遺忘的角落",
+      "影片的結落讓觀眾陷入深深的反思之中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:觀": {
-    "sentences": [],
+    "sentences": [
+      "他從獨特的觀點切入，拍出與眾不同的紀錄片",
+      "觀察力是每一位紀錄片工作者最重要的能力",
+      "這場觀影活動吸引了數百位對社會議題關心的民眾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:趨": {
-    "sentences": [],
+    "sentences": [
+      "越來越多人開始關注紀錄片，這是一個可喜的趨勢",
+      "他趨前一步仔細觀察，發現了被忽略的重要細節",
+      "社會大眾對真實記錄的需求正在逐漸趨於增長"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:道": {
-    "sentences": [],
+    "sentences": [
+      "他用鏡頭為無法發聲的人報道真實的遭遇",
+      "他用鏡頭為無法發聲的人報道真實的遭遇",
+      "觀察之道在於用心感受，而非僅用眼睛看"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "看到了嗎，然後呢:遞": {
-    "sentences": [],
+    "sentences": [
+      "攝影師透過影像傳遞溫暖與希望給每位觀眾",
+      "他將觀察到的故事一一遞送到世界各地的影展",
+      "紀錄片把被遺忘的聲音遞達到更多人的耳中"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:不": {
-    "sentences": [],
+    "sentences": [
+      "睡眠不足會影響白天的學習效率",
+      "如果不養成規律的作息，身體容易出問題",
+      "他不知不覺就在沙發上睡著了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:代": {
-    "sentences": [],
+    "sentences": [
+      "充足的睡眠無法用任何東西來替代",
+      "現代人因為手機而越來越晚睡覺",
+      "這一代的學生普遍有睡眠不足的困擾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:償": {
-    "sentences": [],
+    "sentences": [
+      "平日缺少的睡眠很難在週末一次補償回來",
+      "長期熬夜對身體造成的傷害是難以彌償的",
+      "他試圖用假日補償不足的睡眠時間"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:刺": {
-    "sentences": [],
+    "sentences": [
+      "咖啡因會刺激神經，讓人不容易入睡",
+      "強烈的光線刺激眼睛，會干擾睡眠品質",
+      "睡前避免接收太多刺激性的資訊比較好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:去": {
-    "sentences": [],
+    "sentences": [
+      "把煩惱拋到腦後去，才能安心入睡",
+      "他去看了醫生，才知道自己有失眠的問題",
+      "每天的疲勞在一夜好眠之後就消去大半"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:失": {
-    "sentences": [],
+    "sentences": [
+      "長期失眠會對身體健康造成嚴重影響",
+      "他因為壓力太大而失去了安穩入睡的能力",
+      "睡眠品質一旦失調，白天精神就會很差"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:存": {
-    "sentences": [],
+    "sentences": [
+      "規律的作息習慣值得好好保存下來",
+      "睡眠幫助大腦儲存白天學到的新知識",
+      "良好的睡眠品質是健康生活不可或缺的存在"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:小": {
-    "sentences": [],
+    "sentences": [
+      "小學生每天需要至少九個小時的睡眠",
+      "午休時小睡二十分鐘就能恢復不少精神",
+      "即使是小小的作息改變也能改善睡眠品質"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:得": {
-    "sentences": [],
+    "sentences": [
+      "養成早睡早起的習慣，才能獲得充足的休息",
+      "他覺得睡前聽輕音樂可以幫助自己放鬆",
+      "經過一夜好眠，他得到了滿滿的精神和活力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:循": {
-    "sentences": [],
+    "sentences": [
+      "人體的生理時鐘會遵循固定的節律運作",
+      "良好的睡眠需要循序漸進地調整作息",
+      "身體會依循日夜的變化自動調節睡眠"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:忘": {
-    "sentences": [],
+    "sentences": [
+      "別忘了在睡前把手機放到房間外面去",
+      "他忘記設鬧鐘，結果隔天差點遲到",
+      "充足的睡眠能幫助我們記住學過的內容而不遺忘"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:忪": {
-    "sentences": [],
+    "sentences": [
+      "他睡眠不足，早上起來一臉睡眼惺忪的樣子",
+      "惺忪的雙眼說明他昨晚又熬夜了",
+      "她揉著惺忪的眼睛，慢慢從床上坐起來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:性": {
-    "sentences": [],
+    "sentences": [
+      "養成規律睡眠的習慣具有長期性的好處",
+      "睡眠對記憶力的影響具有關鍵性的作用",
+      "慢性失眠需要尋求專業醫師的協助"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:惡": {
-    "sentences": [],
+    "sentences": [
+      "睡眠不足容易讓人做惡夢，影響休息品質",
+      "惡劣的睡眠環境會讓人怎麼睡都睡不好",
+      "他發現改善睡前習慣後，惡夢明顯減少了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:惺": {
-    "sentences": [],
+    "sentences": [
+      "他一臉惺忪地走進教室，顯然沒睡飽",
+      "惺忪的眼神透露出他昨晚熬夜趕作業",
+      "早起時惺惺作態假裝精神好是沒有用的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:懸": {
-    "sentences": [],
+    "sentences": [
+      "睡前把懸在心上的煩惱寫下來會比較好入睡",
+      "他帶著懸而未決的問題入眠，夢裡竟然想到答案",
+      "懸殊的作息時間差異讓他的身體很難適應"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:新": {
-    "sentences": [],
+    "sentences": [
+      "研究發現睡眠能讓大腦更新和修復自己",
+      "嶄新的一天從一夜好眠開始才會有好精神",
+      "科學家提出了關於睡眠功能的全新理論"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:時": {
-    "sentences": [],
+    "sentences": [
+      "睡覺的時間長短會影響隔天的精神狀態",
+      "現在是時候改掉熬夜滑手機的壞習慣了",
+      "他每天固定時間上床，慢慢養成了規律作息"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:梁": {
-    "sentences": [],
+    "sentences": [
+      "他躺在床上做了一個像黃梁一夢般奇妙的夢境",
+      "枕著橫梁下方睡覺據說會影響睡眠品質",
+      "夢裡他好像走過一座長長的橋梁到達彼岸"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:流": {
-    "sentences": [],
+    "sentences": [
+      "睡前做瑜伽讓全身的血液循環更加流暢",
+      "充足的睡眠是目前最流行的健康養生方式",
+      "淚水不知不覺從眼角流下，原來是在做夢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:理": {
-    "sentences": [],
+    "sentences": [
+      "睡眠是大腦整理白天所學知識的重要時間",
+      "合理安排作息時間才能擁有高品質的睡眠",
+      "他去看心理醫生，尋找失眠背後的真正原因"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:環": {
-    "sentences": [],
+    "sentences": [
+      "安靜舒適的睡眠環境對入睡非常重要",
+      "生活作息和睡眠品質之間形成了一個循環",
+      "改善臥室環境是提升睡眠品質的第一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:生": {
-    "sentences": [],
+    "sentences": [
+      "學生如果睡眠充足，學習表現會更好",
+      "良好的睡眠習慣能讓人充滿生機和活力",
+      "研究發現睡眠不足會衍生出許多健康問題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:眼": {
-    "sentences": [],
+    "sentences": [
+      "他揉了揉眼睛，從一場深沉的睡夢中醒來",
+      "睡前滑手機會讓眼睛受到藍光的刺激",
+      "閉上眼睛深呼吸，慢慢地就能進入夢鄉"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:睡": {
-    "sentences": [],
+    "sentences": [
+      "每天至少要睡滿八個小時才算充足",
+      "他昨晚睡得很好，今天精神特別飽滿",
+      "午休小睡一下，下午上課就不會打瞌睡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:股": {
-    "sentences": [],
+    "sentences": [
+      "一股暖意從被窩裡升起，讓他很快入睡",
+      "他感到一股強烈的睡意襲來，眼皮越來越重",
+      "那股疲倦感讓他倒頭就睡著了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:菁": {
-    "sentences": [],
+    "sentences": [
+      "睡眠是保持頭腦清醒和菁英表現的關鍵",
+      "他是班上的菁英，因為每天都有充足的睡眠",
+      "菁華時段的睡眠品質比其他時段更為重要"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:蕪": {
-    "sentences": [],
+    "sentences": [
+      "雜亂蕪雜的思緒是導致失眠的常見原因",
+      "他在睡前清理蕪雜的想法讓心情平靜下來",
+      "去蕪存菁地整理一天的思緒後才比較好入睡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:謝": {
-    "sentences": [],
+    "sentences": [
+      "他感謝醫生幫助自己解決了長期失眠的問題",
+      "睡眠讓身體的新陳代謝能夠正常運作",
+      "充足的休息讓人容光煥發，大家都稱謝好眠"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:返": {
-    "sentences": [],
+    "sentences": [
+      "經過一夜好眠，他的精力彷彿返回到最佳狀態",
+      "他返家後洗了個熱水澡，很快就睡著了",
+      "生理時鐘會隨著日出日落而反覆循返"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:連": {
-    "sentences": [],
+    "sentences": [
+      "他連續好幾天失眠，白天上課都無法專心",
+      "充足的睡眠和良好的飲食之間有密切的連結",
+      "連著下了三天雨，他每天都睡得特別香甜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:酌": {
-    "sentences": [],
+    "sentences": [
+      "睡前適量飲水要斟酌，喝太多會半夜起來",
+      "他開始斟酌調整自己的就寢時間",
+      "醫生建議他酌量減少咖啡的攝取量"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:鐘": {
-    "sentences": [],
+    "sentences": [
+      "他每天設定鬧鐘提醒自己準時上床睡覺",
+      "生理時鐘一旦被打亂就很難再調整回來",
+      "午休只需要短短二十分鐘就能恢復精神"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "祝你好眠:陳": {
-    "sentences": [],
+    "sentences": [
+      "新陳代謝在睡眠期間會特別活躍地運作",
+      "他向醫生陳述了自己長期失眠的困擾",
+      "房間裡陳舊的空氣也會影響睡眠品質"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:出": {
-    "sentences": [],
+    "sentences": [
+      "科學家創造出一個令人恐懼的生命體",
+      "怪物從實驗室裡走出來，嚇壞了所有的人",
+      "他鼓起勇氣走出黑暗的房間面對未知的世界"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:哀": {
-    "sentences": [],
+    "sentences": [
+      "怪物發出一聲悲哀的嘶吼，令人不忍直視",
+      "他的遭遇令人感到無比哀傷和同情",
+      "科學家在哀痛中反省自己的所作所為"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:天": {
-    "sentences": [],
+    "sentences": [
+      "他夜以繼日在實驗室裡工作，不見天日",
+      "天色漸暗，怪物獨自徘徊在荒涼的曠野中",
+      "這個實驗的結果出乎所有人的意料之外，簡直是天大的意外"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:奪": {
-    "sentences": [],
+    "sentences": [
+      "科學家企圖奪取上天創造生命的權力",
+      "怪物的出現奪走了科學家原本平靜的生活",
+      "他不願讓恐懼奪去自己面對真相的勇氣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:居": {
-    "sentences": [],
+    "sentences": [
+      "怪物被迫離開人群，獨自居住在荒山野嶺",
+      "科學家居然成功讓一具屍體重新獲得生命",
+      "他居無定所地四處流浪，無人願意收留"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:忌": {
-    "sentences": [],
+    "sentences": [
+      "村民們對怪物充滿了猜忌和恐懼的情緒",
+      "科學家忌憚自己創造出來的生物會失去控制",
+      "人們心中的偏見和猜忌才是真正可怕的怪物"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:手": {
-    "sentences": [],
+    "sentences": [
+      "科學家親手創造了一個他自己都害怕的生命",
+      "怪物伸出一雙巨大的手，想要觸碰溫暖的火光",
+      "他束手無策地看著自己的實驗走向失控"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:抽": {
-    "sentences": [],
+    "sentences": [
+      "怪物的身體突然劇烈抽動，彷彿被電流貫穿",
+      "他抽出那封藏在抽屜深處的實驗筆記",
+      "科學家抽絲剝繭地研究如何賦予生命"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:搐": {
-    "sentences": [],
+    "sentences": [
+      "怪物的臉部肌肉不停地抽搐，表情猙獰而痛苦",
+      "他全身搐動著，像是剛從死亡中被喚醒",
+      "那張因抽搐而扭曲的面容讓所有人都嚇得後退"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:攣": {
-    "sentences": [],
+    "sentences": [
+      "怪物的雙手因痙攣而無法正常伸展開來",
+      "他痛苦地蜷縮著，全身肌肉不停地痙攣",
+      "科學家看著實驗體四肢攣縮的樣子感到深深的不安"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:梧": {
-    "sentences": [],
+    "sentences": [
+      "怪物躲在一棵高大的梧桐樹後面偷偷觀察人類",
+      "梧桐葉在秋風中飄落，怪物孤獨地站在樹下",
+      "他在梧桐樹蔭下回憶起自己被創造的那個夜晚"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:滯": {
-    "sentences": [],
+    "sentences": [
+      "怪物的動作僵硬遲滯，像是一具剛被喚醒的軀殼",
+      "科學家的研究陷入了停滯不前的困境之中",
+      "他的表情呆滯，眼神裡卻透出一絲渴望被理解的光芒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:痙": {
-    "sentences": [],
+    "sentences": [
+      "怪物全身痙攣地從實驗台上緩緩坐起來",
+      "電流通過身體時引發了劇烈的痙攣反應",
+      "他看著怪物痙攣的模樣，才意識到自己犯了大錯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:祇": {
-    "sentences": [],
+    "sentences": [
+      "他祇想要被人接納，卻始終被世界所拒絕",
+      "科學家祇顧著實驗的成功，忽略了倫理的底線",
+      "怪物祇是渴望一個溫暖的擁抱，僅此而已"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:神": {
-    "sentences": [],
+    "sentences": [
+      "科學家以為自己擁有了造物神一般的力量",
+      "怪物的出現讓整個村莊的人都精神緊繃",
+      "他面容憔悴、精神恍惚地從實驗室走出來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:禁": {
-    "sentences": [],
+    "sentences": [
+      "村民們嚴禁任何人靠近怪物出沒的區域",
+      "他不禁反思：科學的力量是否該有個界限",
+      "科學家被關進監禁室，為自己的行為付出代價"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:索": {
-    "sentences": [],
+    "sentences": [
+      "怪物在黑暗中獨自摸索著前行的方向",
+      "科學家不斷探索生命的奧祕，最終走向了極端",
+      "他索性放棄隱藏，坦然面對世人的目光"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:群": {
-    "sentences": [],
+    "sentences": [
+      "怪物被人群追趕，只好逃向無人的荒野",
+      "他渴望融入人群，卻因為外貌而屢遭排斥",
+      "一群憤怒的村民拿著火把朝怪物的藏身處逼近"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:而": {
-    "sentences": [],
+    "sentences": [
+      "他外表駭人而內心善良，卻沒有人願意了解",
+      "科學家因好奇而開始實驗，卻因恐懼而後悔",
+      "怪物不請自來而闖入了人類的世界"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:遮": {
-    "sentences": [],
+    "sentences": [
+      "怪物用破布遮住自己的臉，不敢讓人看見",
+      "烏雲遮蔽了月光，整座實驗室陷入一片漆黑",
+      "他試圖用謊言遮掩自己創造怪物的真相"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:遲": {
-    "sentences": [],
+    "sentences": [
+      "怪物遲緩地移動著沉重的身軀走向門口",
+      "科學家遲遲不敢面對自己創造出來的生命",
+      "他遲疑了一下，最終還是決定打開那扇門"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:門": {
-    "sentences": [],
+    "sentences": [
+      "怪物用力推開門，踏出了他生命中的第一步",
+      "科學家把自己關在實驗室的門後日夜不休地工作",
+      "那扇門的背後隱藏著一個震驚世界的祕密"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:隻": {
-    "sentences": [],
+    "sentences": [
+      "怪物孤身隻影地走在月光下的小路上",
+      "他形單影隻地站在山頂，俯瞰著拒絕他的世界",
+      "只剩隻身一人的怪物發出了絕望的怒吼"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:離": {
-    "sentences": [],
+    "sentences": [
+      "怪物被迫遠離人群，獨自在荒野中生存",
+      "科學家的家人紛紛離開他，不願與他為伍",
+      "他離開了實驗室，卻永遠無法逃離內心的恐懼"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:魁": {
-    "sentences": [],
+    "sentences": [
+      "怪物身形魁梧高大，所到之處人人驚恐逃散",
+      "他魁偉的身軀擋住了整個走廊的去路",
+      "科學家看著這個自己創造的魁梧生命體，心中百感交集"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "科學怪人:鳴": {
-    "sentences": [],
+    "sentences": [
+      "怪物發出低沉的悲鳴，在空曠的山谷中迴盪",
+      "遠處傳來雷鳴般的巨響，實驗終於成功了",
+      "他的哀鳴聲令科學家內心充滿了愧疚"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:便": {
-    "sentences": [],
+    "sentences": [
+      "即便身體很累，他還是堅持跑完全程",
+      "他隨便做了暖身操就開始跑步了",
+      "方便的運動鞋讓他跑起來更輕鬆"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:可": {
-    "sentences": [],
+    "sentences": [
+      "他相信自己可以跑到終點",
+      "雖然生了病，但他的毅力不可小看",
+      "這場馬拉松可以說是他人生最大的挑戰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:喻": {
-    "sentences": [],
+    "sentences": [
+      "他的故事家喻戶曉，大家都很佩服他",
+      "老師用跑步比喻人生要堅持到底",
+      "這位跑者的精神不言而喻"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:執": {
-    "sentences": [],
+    "sentences": [
+      "他執意要跑完這場馬拉松，誰也攔不住",
+      "教練很執著地要求選手每天練跑",
+      "他固執地相信自己能戰勝病魔"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:家": {
-    "sentences": [],
+    "sentences": [
+      "他是一位了不起的運動家",
+      "全家人都到終點等他回來",
+      "大家都為這位勇敢的跑者加油"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:屆": {
-    "sentences": [],
+    "sentences": [
+      "這是他第三屆參加馬拉松比賽",
+      "本屆馬拉松有一千多人報名參加",
+      "他每一屆都會來跑這場比賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:崩": {
-    "sentences": [],
+    "sentences": [
+      "跑到一半他差點體力崩潰倒下來",
+      "他的身體快要崩塌了，但意志力撐住他",
+      "觀眾看他跌倒又爬起來，感動得快崩潰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:常": {
-    "sentences": [],
+    "sentences": [
+      "他每天照常練習跑步，風雨無阻",
+      "生病之後他比平常更努力地鍛鍊",
+      "他平常就有跑步的好習慣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:強": {
-    "sentences": [],
+    "sentences": [
+      "他是一個非常堅強的跑者",
+      "再強的困難都擋不住他的決心",
+      "他用跑步證明自己比病魔更強大"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:快": {
-    "sentences": [],
+    "sentences": [
+      "他跑得很快，像風一樣衝過去",
+      "快要到終點了，大家都替他加油",
+      "他很快就適應了長距離跑步的節奏"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:插": {
-    "sentences": [],
+    "sentences": [
+      "他把國旗插在終點線旁邊",
+      "一段小插曲讓比賽變得更感人",
+      "他在腰帶上插了一面小旗子"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:曲": {
-    "sentences": [],
+    "sentences": [
+      "他的人生就像一首動人的樂曲",
+      "跑步途中遇到彎曲的山路很辛苦",
+      "雖然過程曲折，他最終還是完成了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:榮": {
-    "sentences": [],
+    "sentences": [
+      "他跑完全程，臉上充滿了光榮的笑容",
+      "這份榮耀屬於每一位堅持到底的跑者",
+      "老師說完成比賽本身就是一種榮譽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:歷": {
-    "sentences": [],
+    "sentences": [
+      "他經歷了很多困難才跑到終點",
+      "這次馬拉松是他人生中最難忘的經歷",
+      "他的病歷上寫著需要更多的運動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:殊": {
-    "sentences": [],
+    "sentences": [
+      "他是一位很特殊的跑者，帶病參賽",
+      "這場比賽有特殊的意義，是為公益而跑",
+      "他和別人不一樣，有著殊死奮鬥的精神"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:淋": {
-    "sentences": [],
+    "sentences": [
+      "雨水淋在身上，他還是繼續往前跑",
+      "汗水淋漓地跑完全程，他覺得好暢快",
+      "被大雨淋濕了也不放棄比賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:漓": {
-    "sentences": [],
+    "sentences": [
+      "他跑得大汗淋漓，全身都濕透了",
+      "汗水淋漓的他站在終點線前微笑",
+      "跑完之後他淋漓盡致地享受了勝利"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:潰": {
-    "sentences": [],
+    "sentences": [
+      "他差一點體力潰散倒在地上",
+      "身體快崩潰了，但他的心沒有放棄",
+      "觀眾擔心他會體力潰敗，紛紛為他打氣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:無": {
-    "sentences": [],
+    "sentences": [
+      "他無論如何都要跑完這場比賽",
+      "即使前方看似無盡的路，他也不害怕",
+      "他跑步的精神讓大家無不感動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:痛": {
-    "sentences": [],
+    "sentences": [
+      "腳上的水泡很痛，但他咬牙撐過去",
+      "他忍著身體的疼痛繼續向前奔跑",
+      "痛苦的訓練讓他變得更加堅強"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:癌": {
-    "sentences": [],
+    "sentences": [
+      "他被診斷出癌症，但沒有放棄跑步",
+      "即使罹患癌症，他仍然參加馬拉松",
+      "癌症沒有打敗他，反而讓他更勇敢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:罹": {
-    "sentences": [],
+    "sentences": [
+      "他罹患重病後仍然堅持每天跑步",
+      "罹病之後他更珍惜每一次跑步的機會",
+      "即使罹癌，他也不願意停下腳步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:著": {
-    "sentences": [],
+    "sentences": [
+      "他穿著跑鞋站在起跑線上深呼吸",
+      "沿著這條路一直跑就能到達終點",
+      "他堅持著自己的信念，一步一步向前"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:言": {
-    "sentences": [],
+    "sentences": [
+      "他的行動比任何言語都更有說服力",
+      "他從不多言，只用跑步來表達自己的決心",
+      "不需要太多言語，他用跑步來表達決心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:頑": {
-    "sentences": [],
+    "sentences": [
+      "他頑強地對抗病魔，從不輕易認輸",
+      "這位跑者有著頑固不放棄的個性",
+      "頑強的意志力讓他跑完了全程"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "穿越極限的跑者:飯": {
-    "sentences": [],
+    "sentences": [
+      "跑完步之後他吃了一大碗飯補充體力",
+      "每天吃飽飯才有力氣好好練習跑步",
+      "媽媽煮了一碗熱騰騰的飯等他回來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:之": {
-    "sentences": [],
+    "sentences": [
+      "這碗麵之所以好吃是因為用心做的",
+      "他是村子裡最有名的麵攤之一",
+      "成功之路就像煮麵一樣需要耐心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:外": {
-    "sentences": [],
+    "sentences": [
+      "除了麵條之外，湯頭也非常重要",
+      "他的手藝好到連外地人都來吃",
+      "意料之外的是這碗麵特別好吃"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:志": {
-    "sentences": [],
+    "sentences": [
+      "他立下志願要做出最好吃的麵",
+      "做麵師傅的志氣讓他每天努力練習",
+      "有了堅定的志向才能堅持做下去"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:意": {
-    "sentences": [],
+    "sentences": [
+      "這碗麵裡裝滿了師傅的心意",
+      "他滿意地看著客人把麵吃光光",
+      "做麵需要專心一意才不會失敗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:手": {
-    "sentences": [],
+    "sentences": [
+      "他用雙手搓出一條條細細的麵條",
+      "這碗手工麵是師傅的拿手好菜",
+      "新手剛開始學做麵一定會手忙腳亂"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:搓": {
-    "sentences": [],
+    "sentences": [
+      "他把麵團搓成又細又長的麵條",
+      "搓麵條需要很大的力氣和耐心",
+      "師傅教他怎麼把麵團搓得均勻"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:明": {
-    "sentences": [],
+    "sentences": [
+      "他明白做好一碗麵需要很多練習",
+      "明天他還會繼續練習搓麵條",
+      "師傅說明了煮麵的每一個步驟"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:暈": {
-    "sentences": [],
+    "sentences": [
+      "他揉了太久的麵團，揉到頭都暈了",
+      "暈黃的燈光照著小小的麵攤",
+      "忙了一整天他累得有點頭暈"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:染": {
-    "sentences": [],
+    "sentences": [
+      "麵攤裡飄出的香味染滿了整條街",
+      "他被師傅的熱情感染也開始學做麵",
+      "這碗麵的味道渲染了他童年的記憶"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:氣": {
-    "sentences": [],
+    "sentences": [
+      "他有勇氣堅持把第一百碗麵做好",
+      "麵攤裡熱氣騰騰的香味讓人好餓",
+      "他鼓起勇氣第一次自己煮麵給客人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:渲": {
-    "sentences": [],
+    "sentences": [
+      "那碗麵的香味渲染了整個小巷子",
+      "他用渲染的方式描述那碗麵有多好吃",
+      "夕陽的光線渲染了麵攤溫馨的氣氛"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:漸": {
-    "sentences": [],
+    "sentences": [
+      "他的手藝漸漸進步，麵越做越好吃",
+      "客人漸漸變多了，麵攤生意好起來",
+      "他逐漸明白做麵不只是一份工作"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:熱": {
-    "sentences": [],
+    "sentences": [
+      "一碗熱騰騰的麵端上桌，香味四溢",
+      "他對做麵的熱情從來沒有減少過",
+      "大熱天裡他還是堅持站在灶前煮麵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:當": {
-    "sentences": [],
+    "sentences": [
+      "他當初決定學做麵是為了幫助家裡",
+      "當他端出第一百碗麵時忍不住流淚",
+      "做麵當然不容易，但他從不後悔"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:續": {
-    "sentences": [],
+    "sentences": [
+      "他會繼續努力做出更好吃的麵",
+      "連續做了一百碗麵讓他的手都酸了",
+      "師傅持續不斷地改良麵條的做法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:腳": {
-    "sentences": [],
+    "sentences": [
+      "他站了一整天，腳都快站不住了",
+      "腳踏實地做好每一碗麵才是正確的",
+      "他邁開腳步走向麵攤開始新的一天"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:行": {
-    "sentences": [],
+    "sentences": [
+      "做麵這一行需要很多的耐心和毅力",
+      "他用行動證明自己可以做出好吃的麵",
+      "師傅說只要堅持就一定行得通"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:言": {
-    "sentences": [],
+    "sentences": [
+      "他說到做到，言而有信地完成承諾",
+      "不需要多餘的言語，一碗好麵說明一切",
+      "師傅的一番話言猶在耳令他難以忘懷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:說": {
-    "sentences": [],
+    "sentences": [
+      "大家都說他做的麵是全村最好吃的",
+      "師傅常說做麵要用心才會有好味道",
+      "他笑著說第一百碗麵終於完成了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:踏": {
-    "sentences": [],
+    "sentences": [
+      "他踏進麵攤開始了新的一天",
+      "腳踏實地學做麵是成功的第一步",
+      "他一步一步踏著穩健的步伐向前走"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:遠": {
-    "sentences": [],
+    "sentences": [
+      "遠方的客人也特地來品嘗他的手工麵",
+      "他的夢想不遠了，只差最後幾碗麵",
+      "師傅的教導讓他受益深遠永生難忘"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:陸": {
-    "sentences": [],
+    "sentences": [
+      "客人陸續走進麵攤來點餐了",
+      "他陸陸續續學會了各種不同的麵食",
+      "消息傳開後客人陸續從各地趕來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:騰": {
-    "sentences": [],
+    "sentences": [
+      "那碗麵熱氣騰騰地端了上來",
+      "他心裡充滿了沸騰的喜悅和感動",
+      "成功的喜悅讓他整個人歡騰起來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "第一百碗麵:黃": {
-    "sentences": [],
+    "sentences": [
+      "昏黃的燈光下他還在練習搓麵條",
+      "麵條炸到金黃色就可以起鍋了",
+      "黃昏時分麵攤開始準備營業了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:凶": {
-    "sentences": [],
+    "sentences": [
+      "外面的暴風雨很凶，但父親仍然出門了",
+      "外面的暴風雨很凶猛，但父親仍然出門了",
+      "那條蜿蜒的山路看起來險象環生十分凶險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:如": {
-    "sentences": [],
+    "sentences": [
+      "他如往常一樣繫上那條紅色的領帶出門上班",
+      "回憶中的父親如同一座溫暖的山讓人安心",
+      "這條領帶就如同父親留給他最珍貴的禮物"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:安": {
-    "sentences": [],
+    "sentences": [
+      "看到父親繫著紅領帶的樣子讓他感到無比安心",
+      "他把領帶收在抽屜裡，安安靜靜地保存著",
+      "母親不安地等著父親平安回家"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:寧": {
-    "sentences": [],
+    "sentences": [
+      "他寧可一直保留這條領帶也不願意丟掉",
+      "父親離開後家裡再也沒有以前那種安寧的感覺",
+      "他寧靜地坐在窗邊，手裡握著那條紅領帶"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:崎": {
-    "sentences": [],
+    "sentences": [
+      "父親每天走過崎嶇的山路去上班養活全家",
+      "人生的道路崎嶇不平，但父親從不抱怨",
+      "那條崎嶇的小路上留下了父親無數的腳印"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:嶇": {
-    "sentences": [],
+    "sentences": [
+      "山路崎嶇難行，但父親每天都準時出門",
+      "即使前方的路再怎麼崎嶇他也要走下去",
+      "父親在崎嶇的路上跌倒又爬起來的身影讓他難忘"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:幽": {
-    "sentences": [],
+    "sentences": [
+      "他在幽暗的房間裡輕輕撫摸那條紅領帶",
+      "幽靜的夜晚裡他想起父親溫暖的笑容",
+      "那段幽深的回憶讓他忍不住紅了眼眶"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:形": {
-    "sentences": [],
+    "sentences": [
+      "那條紅領帶是父親留下最具體的形象代表",
+      "父親的身形在記憶中漸漸變得模糊了",
+      "他看著鏡中繫著領帶的自己覺得好像父親的形影"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:影": {
-    "sentences": [],
+    "sentences": [
+      "父親的背影漸漸消失在蜿蜒的山路盡頭",
+      "他的影子被夕陽拉得好長好長",
+      "那條紅領帶就像父親的影子一直陪伴著他"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:思": {
-    "sentences": [],
+    "sentences": [
+      "他一看到紅領帶就會想起父親忍不住思念",
+      "對父親的思念隨著時間越來越深刻",
+      "他陷入沉思回憶父親繫領帶時的溫柔模樣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:煉": {
-    "sentences": [],
+    "sentences": [
+      "歲月的磨煉讓他從男孩成長為堅強的大人",
+      "那些艱苦的日子像烈火一樣淬煉了他的心志",
+      "經過生活的千錘百煉他終於理解了父親的堅持"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:照": {
-    "sentences": [],
+    "sentences": [
+      "他拿出一張父親繫著紅領帶的舊照片",
+      "父親溫暖的笑容像陽光一樣照亮他的心",
+      "按照父親的習慣他也開始每天繫上領帶出門"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:珍": {
-    "sentences": [],
+    "sentences": [
+      "他把父親的紅領帶當作最珍貴的寶物保存",
+      "珍惜眼前的家人是父親教會他最重要的事",
+      "這條領帶雖然舊了但他珍而重之地收藏著"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:百": {
-    "sentences": [],
+    "sentences": [
+      "他百感交集地撫摸著那條褪色的紅領帶",
+      "即使過了一百年他也不會忘記父親的溫暖",
+      "千辛萬苦百般挫折都無法動搖父親的堅持"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:般": {
-    "sentences": [],
+    "sentences": [
+      "父親的愛像陽光一般溫暖而無處不在",
+      "他小心翼翼般地把紅領帶摺好放進盒子裡",
+      "這一般深沉的思念讓他常常在夜裡流淚"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:色": {
-    "sentences": [],
+    "sentences": [
+      "那條領帶鮮紅的顏色讓他一眼就認出來",
+      "歲月讓領帶的色澤漸漸褪去卻更顯珍貴",
+      "紅色的領帶在灰暗的衣櫃裡格外顯眼"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:蜒": {
-    "sentences": [],
+    "sentences": [
+      "那條蜿蜒的小路通往父親每天工作的地方",
+      "河流蜿蜒地流過村莊就像時間靜靜地流逝",
+      "他沿著蜿蜒的山路走著彷彿看見父親的身影"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:蜿": {
-    "sentences": [],
+    "sentences": [
+      "蜿蜒的山路上留著父親多年來往返的足跡",
+      "記憶像蜿蜒的河流一樣悠長而深遠",
+      "他走在蜿蜒的小徑上回想起和父親散步的時光"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:試": {
-    "sentences": [],
+    "sentences": [
+      "他試著繫上父親的紅領帶但手一直在發抖",
+      "他嘗試用父親教他的方式打一個漂亮的結",
+      "他試探性地打開了那個裝著領帶的舊盒子"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:護": {
-    "sentences": [],
+    "sentences": [
+      "父親總是默默地守護著整個家庭的幸福",
+      "那條紅領帶像護身符一樣給他勇氣和力量",
+      "他發誓要像父親一樣保護好自己的家人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:轉": {
-    "sentences": [],
+    "sentences": [
+      "他轉身離開時口袋裡放著父親的紅領帶",
+      "人生的轉折讓他更加珍惜家人在身邊的時光",
+      "他轉過頭看了最後一眼父親離去的背影"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:追": {
-    "sentences": [],
+    "sentences": [
+      "他追著父親的背影跑卻怎麼也追不上",
+      "長大後他才明白那些追不回的時光多麼珍貴",
+      "他追尋著父親的腳步也成為了一個好父親"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:逆": {
-    "sentences": [],
+    "sentences": [
+      "他逆著寒風走在父親曾經走過的那條路上",
+      "即使逆境重重父親也從未對家人露出疲態",
+      "他逆光站著手裡緊握著那條紅色的領帶"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:重": {
-    "sentences": [],
+    "sentences": [
+      "這條紅領帶對他來說有著非常重大的意義",
+      "他重新繫上領帶彷彿又感受到父親的溫度",
+      "父親在他心中的分量比什麼都還要重"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:隨": {
-    "sentences": [],
+    "sentences": [
+      "他隨身攜帶那條紅領帶像帶著父親的祝福",
+      "隨著年紀增長他越來越能體會父親的心意",
+      "他隨手拿起領帶思緒就飄回了童年的時光"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:險": {
-    "sentences": [],
+    "sentences": [
+      "父親冒著風險走過險峻的山路去工作",
+      "人生中的危險和挑戰讓他更懂得珍惜親情",
+      "那段險象環生的路程是父親每天必經之途"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:黑": {
-    "sentences": [],
+    "sentences": [
+      "他在漆黑的夜裡緊握著父親留下的紅領帶",
+      "黑暗中他想起父親說的話便不再害怕了",
+      "即使天色漆黑父親也從未遲到過"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "紅領帶:默": {
-    "sentences": [],
+    "sentences": [
+      "父親總是沉默地付出從不求任何回報",
+      "他默默地把紅領帶收進口袋轉身離開",
+      "那份默默無言的父愛是他一輩子最大的支撐"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:不": {
-    "sentences": [],
+    "sentences": [
+      "他不太相信求神問卜但還是跟著阿嬤去了",
+      "廟裡的神明不分貴賤都願意傾聽信徒的煩惱",
+      "阿嬤說心不誠就不靈驗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:之": {
-    "sentences": [],
+    "sentences": [
+      "這座廟是這一帶香火最旺盛的廟宇之一",
+      "求神問卜之前要先把心靜下來才行",
+      "信仰之道在於心誠而不在於形式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:假": {
-    "sentences": [],
+    "sentences": [
+      "他假裝很虔誠的樣子跟著大家一起拜拜",
+      "假日的廟宇總是擠滿了來參拜的信徒",
+      "不管是真心還是假意神明都看在眼裡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:刻": {
-    "sentences": [],
+    "sentences": [
+      "廟門上刻著精美的龍鳳圖案栩栩如生",
+      "他深刻體會到民間信仰對老一輩的重要性",
+      "這座廟的每一根柱子上都刻滿了故事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:印": {
-    "sentences": [],
+    "sentences": [
+      "廟裡蓋了一個紅色的平安印章給他帶回家",
+      "這次的廟宇之旅在他心中留下了深刻的印象",
+      "阿嬤把神明的護身符印在隨身的布袋上"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:喬": {
-    "sentences": [],
+    "sentences": [
+      "他和朋友喬好時間一起去廟裡拜拜祈福",
+      "喬裝打扮的神明繞境隊伍讓小朋友又怕又愛",
+      "大家喬了半天才決定要問神明哪個問題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:後": {
-    "sentences": [],
+    "sentences": [
+      "拜完神明之後他覺得心裡踏實了不少",
+      "他在廟裡求完籤之後去找廟祝解籤",
+      "排在他後面的阿伯也是來問健康的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:怒": {
-    "sentences": [],
+    "sentences": [
+      "據說神明會對不誠實的人發怒降下懲罰",
+      "他氣得怒目圓睜因為有人在廟裡大聲喧嘩",
+      "阿嬤說神明不會隨便生氣發怒的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:思": {
-    "sentences": [],
+    "sentences": [
+      "他仔細思考著要問神明什麼問題比較好",
+      "廟裡安靜的氣氛讓人不由自主地陷入沉思",
+      "他在神明面前反思自己最近做錯的事情"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:悶": {
-    "sentences": [],
+    "sentences": [
+      "他心裡有個悶了很久的疑問想請神明解惑",
+      "廟裡燒了太多香煙得他覺得好悶好不舒服",
+      "他悶悶不樂地來到廟裡向神明傾訴心事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:情": {
-    "sentences": [],
+    "sentences": [
+      "他帶著虔誠的心情走進廟裡向神明祈求",
+      "阿嬤和廟祝的交情很好常常一起泡茶聊天",
+      "他動了真情跪在神明面前說出心中的煩惱"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:扶": {
-    "sentences": [],
+    "sentences": [
+      "他扶著年邁的阿嬤慢慢走進廟裡去拜拜",
+      "神明保佑扶持信徒度過生活中的難關",
+      "阿嬤扶著香爐旁的欄杆虔誠地祈禱"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:攙": {
-    "sentences": [],
+    "sentences": [
+      "他攙扶著行動不便的老奶奶走上廟前的階梯",
+      "孫子攙著阿嬤的手小心翼翼地走過廟門口",
+      "信徒們互相攙扶著在擁擠的廟會中前行"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:會": {
-    "sentences": [],
+    "sentences": [
+      "廟會的時候整條街都擠滿了熱鬧的人潮",
+      "他第一次參加這種給神明會診的有趣活動",
+      "大家會在特定的日子聚集到廟裡一起祈福"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:板": {
-    "sentences": [],
+    "sentences": [
+      "廟裡的老師傅正在刻一塊新的木板匾額",
+      "他表情嚴肅一板一眼地照著規矩上香",
+      "神明桌前那塊木板上寫著廟宇的歷史"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:由": {
-    "sentences": [],
+    "sentences": [
+      "他自由自在地逛著廟會享受熱鬧的氣氛",
+      "信仰是每個人由心而發不能勉強別人",
+      "理由很簡單因為阿嬤相信神明會保佑全家"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:稱": {
-    "sentences": [],
+    "sentences": [
+      "這座廟被當地人稱為最靈驗的廟宇",
+      "大家稱讚廟祝解籤解得非常準確",
+      "據說這位神明號稱有求必應非常靈驗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:納": {
-    "sentences": [],
+    "sentences": [
+      "他慢慢接納了阿嬤對信仰的虔誠態度",
+      "廟裡的功德箱收納了信徒們的善心捐款",
+      "他心裡納悶為什麼那麼多人相信求神問卜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:索": {
-    "sentences": [],
+    "sentences": [
+      "他在廟裡探索了許多有趣的民俗文化故事",
+      "阿嬤拉著繩索敲響了廟前那口古老的大鐘",
+      "他好奇地索取了一份廟宇的介紹手冊來看"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:職": {
-    "sentences": [],
+    "sentences": [
+      "廟祝的職責是幫信徒解籤和維護廟宇環境",
+      "他盡職地幫忙阿嬤準備拜拜需要用的供品",
+      "每位神明都有各自的職掌和守護的範圍"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:衷": {
-    "sentences": [],
+    "sentences": [
+      "他由衷地感謝神明保佑家人平安健康",
+      "阿嬤發自內心的虔誠是最衷心的祈禱",
+      "他終於說出了心中深藏已久的肺腑衷言"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:裝": {
-    "sentences": [],
+    "sentences": [
+      "廟裡的神明穿著華麗的裝扮威風凜凜",
+      "他裝作不在意但其實偷偷許了一個願望",
+      "繞境的隊伍裝飾得五彩繽紛非常好看"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:觸": {
-    "sentences": [],
+    "sentences": [
+      "他伸手觸摸廟門上精緻的石雕感到很驚奇",
+      "這次的廟宇之旅觸動了他對傳統文化的興趣",
+      "接觸民間信仰之後他對阿嬤更加理解了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:診": {
-    "sentences": [],
+    "sentences": [
+      "給神明發會診單這個故事讓他覺得很有趣",
+      "他像去看醫生一樣帶著問題來找神明診斷",
+      "這種替神明會診的民俗活動讓外國人嘖嘖稱奇"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:請": {
-    "sentences": [],
+    "sentences": [
+      "他恭敬地請神明指點迷津解答心中的疑惑",
+      "阿嬤請廟祝幫忙看看這支籤是什麼意思",
+      "他們邀請了附近的居民一起來參加廟會活動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:象": {
-    "sentences": [],
+    "sentences": [
+      "廟門口的石獅子是這座廟最具代表性的象徵",
+      "他對廟宇文化的印象從此完全改觀了",
+      "熱鬧的廟會呈現出台灣民間信仰的多元面象"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:退": {
-    "sentences": [],
+    "sentences": [
+      "他恭敬地向神明行禮之後慢慢退出大殿",
+      "人潮退去之後廟裡又恢復了平日的寧靜",
+      "他退後一步仔細欣賞廟宇屋頂的剪黏藝術"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:預": {
-    "sentences": [],
+    "sentences": [
+      "據說神明可以預知未來給信徒指引方向",
+      "他預先準備好要問神明的三個問題",
+      "阿嬤預料到今天廟裡會很多人所以早早出門"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "給神明發會診單:駕": {
-    "sentences": [],
+    "sentences": [
+      "廟會時神明出巡駕臨各個街道接受信徒參拜",
+      "他駕著車載阿嬤到隔壁鎮上最有名的廟去拜拜",
+      "傳說中神明會駕雲而來保佑善良的人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:亂": {
-    "sentences": [],
+    "sentences": [
+      "過度開發讓原本美麗的自然環境變得雜亂不堪",
+      "如果再不重視環保，氣候變化將更加混亂失控",
+      "賽事結束後場地被垃圾弄得一片凌亂"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:候": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷是當今全球最嚴峻的環境議題之一",
+      "這場綠色賽事選在氣候宜人的季節舉辦",
+      "我們正在等候一個更環保的運動賽事時代到來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:公": {
-    "sentences": [],
+    "sentences": [
+      "這場賽事以公開透明的方式公布碳排放數據",
+      "他認為環境保護是每一個公民應盡的責任",
+      "主辦單位在公園裡舉辦了一場零碳排的路跑活動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:刺": {
-    "sentences": [],
+    "sentences": [
+      "全球暖化的速度之快令環保人士感到刺痛和焦慮",
+      "這份環境報告用諷刺的語氣批評了高碳排的賽事",
+      "冷空氣刺骨的寒意提醒人們氣候正在劇烈變化"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:因": {
-    "sentences": [],
+    "sentences": [
+      "碳排放過多是導致全球暖化的主要原因之一",
+      "因為重視環保，這場賽事採用了全面綠色措施",
+      "環境惡化的根本原因在於人類過度消耗自然資源"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:地": {
-    "sentences": [],
+    "sentences": [
+      "賽事場地採用可回收材料搭建，減少對環境的衝擊",
+      "這塊土地因為過度開發而失去了原有的生態面貌",
+      "世界各地的運動賽事都開始關注環保和永續議題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:境": {
-    "sentences": [],
+    "sentences": [
+      "保護環境是舉辦綠色賽事最核心的理念",
+      "如果不改變現狀，未來的生存環境將令人堪憂",
+      "賽事主辦方致力於打造一個對環境友善的競賽境域"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:大": {
-    "sentences": [],
+    "sentences": [
+      "這場大型賽事成功將碳排放量降低了百分之四十",
+      "大量使用一次性用品是運動賽事最大的環保問題",
+      "大自然正在用極端氣候向人類發出嚴重的警告"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:寒": {
-    "sentences": [],
+    "sentences": [
+      "極端氣候讓冬天變得更加寒冷而夏天更加炎熱",
+      "寒流來襲的頻率增加，正是氣候變遷的具體徵兆",
+      "他在寒風中參加了這場以環保為主題的冬季路跑"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:彩": {
-    "sentences": [],
+    "sentences": [
+      "這場綠色賽事的開幕典禮精彩紛呈令人印象深刻",
+      "五彩繽紛的環保旗幟在賽場上隨風飄揚",
+      "他用多彩的方式呈現環保理念，吸引更多人關注"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:徵": {
-    "sentences": [],
+    "sentences": [
+      "極端天氣頻繁發生是氣候變遷的明顯特徵",
+      "主辦單位公開徵求民眾對綠色賽事的改善建議",
+      "冰川消融是全球暖化最具象徵性的環境警訊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:心": {
-    "sentences": [],
+    "sentences": [
+      "他用心規劃每一個環節，確保賽事真正落實環保",
+      "環保不只是口號，而是需要發自內心的實際行動",
+      "人們開始憂心忡忡地關注氣候變遷對未來的影響"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:忡": {
-    "sentences": [],
+    "sentences": [
+      "科學家憂心忡忡地警告全球暖化正在加速惡化",
+      "面對不斷升高的碳排放數據，環保團體忡忡不安",
+      "他憂心忡忡地看著年年創新高的全球平均溫度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:憂": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷的速度令全球科學家深感憂慮和擔心",
+      "他憂心未來的運動賽事會因極端氣候而無法舉辦",
+      "環保團體對碳排放持續增加的趨勢表達了深深的憂慮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:應": {
-    "sentences": [],
+    "sentences": [
+      "每個人都應該為減少碳排放盡一份自己的責任",
+      "賽事主辦方積極回應環保團體提出的各項建議",
+      "面對氣候變遷我們必須採取相應的行動來因應"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:排": {
-    "sentences": [],
+    "sentences": [
+      "減少碳排放是這場綠色賽事最重要的核心目標",
+      "主辦單位安排了專人負責監測賽事的碳排放量",
+      "如果不積極減排，地球的溫度將持續升高"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:提": {
-    "sentences": [],
+    "sentences": [
+      "他在會議上提出了多項降低賽事碳足跡的方案",
+      "這場綠色賽事提醒我們環保需要從日常做起",
+      "專家提議未來所有大型賽事都應該通過環保認證"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:放": {
-    "sentences": [],
+    "sentences": [
+      "工廠排放的廢氣是造成空氣污染的主要來源之一",
+      "他呼籲所有選手在賽後將垃圾放進回收桶",
+      "碳排放量的增加讓地球的溫度持續升高"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:案": {
-    "sentences": [],
+    "sentences": [
+      "主辦單位提出了一套完整的綠色賽事執行方案",
+      "這個減碳方案如果成功將成為未來賽事的典範",
+      "他研擬了一份詳細的環保備案以應對各種突發狀況"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:民": {
-    "sentences": [],
+    "sentences": [
+      "每一位市民都有責任為減緩氣候變遷貢獻心力",
+      "民眾對這場綠色賽事的參與度遠超主辦方的預期",
+      "環保意識的提升需要全體公民共同努力才能實現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:氣": {
-    "sentences": [],
+    "sentences": [
+      "溫室氣體的大量排放導致全球氣溫不斷攀升",
+      "極端氣候事件的增加已經不是未來式而是現在式",
+      "這場賽事的氣氛既熱烈又充滿了對環保的熱忱"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:永": {
-    "sentences": [],
+    "sentences": [
+      "永續發展是舉辦綠色賽事必須堅持的核心價值",
+      "我們希望地球的美麗環境能夠永遠被保存下來",
+      "環保不是一時的口號而是需要永久堅持的行動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:球": {
-    "sentences": [],
+    "sentences": [
+      "地球的生態正因為人類活動而面臨前所未有的危機",
+      "這場全球矚目的綠色賽事吸引了各國選手參加",
+      "足球和籃球等運動賽事也開始關注環保永續議題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:環": {
-    "sentences": [],
+    "sentences": [
+      "環保意識應該融入每一場運動賽事的規劃之中",
+      "良好的環境是舉辦優質賽事不可或缺的基礎條件",
+      "他希望透過這場賽事讓更多人加入環境保護的行列"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:生": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷對地球上所有生物的生存都造成了威脅",
+      "這場綠色賽事為永續發展注入了新的生命力",
+      "生態環境一旦被破壞就很難在短時間內恢復"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:異": {
-    "sentences": [],
+    "sentences": [
+      "今年的氣候異常現象讓許多戶外賽事被迫延期",
+      "這場賽事的差異化環保設計讓所有人眼前一亮",
+      "這場賽事的環保設計讓人感到新奇特異"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:碳": {
-    "sentences": [],
+    "sentences": [
+      "降低碳排放量是全球對抗氣候變遷的首要任務",
+      "這場賽事承諾達成碳中和成為業界的標竿",
+      "每個人都可以從日常生活開始減少自己的碳足跡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:禦": {
-    "sentences": [],
+    "sentences": [
+      "人類必須團結一致才能抵禦氣候變遷帶來的衝擊",
+      "環保措施就像一道防線幫助我們抵禦環境惡化",
+      "我們需要更強大的力量來防禦極端氣候的侵襲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:竄": {
-    "sentences": [],
+    "sentences": [
+      "全球氣溫不斷竄升已經達到歷史新高的水準",
+      "森林大火在乾燥的季節裡四處流竄威脅著生態",
+      "碳排放數據持續攀竄讓環保團體非常焦慮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:續": {
-    "sentences": [],
+    "sentences": [
+      "永續經營的理念已經成為舉辦賽事的基本要求",
+      "他持續推動綠色賽事的概念希望能影響更多人",
+      "如果不採取行動氣候將繼續惡化下去"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:而": {
-    "sentences": [],
+    "sentences": [
+      "環保不僅是責任而且是我們對下一代的承諾",
+      "他不畏困難而堅持推動這場零碳排的綠色賽事",
+      "氣候變遷看似遙遠然而它的影響已經近在眼前"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:諷": {
-    "sentences": [],
+    "sentences": [
+      "環保團體諷刺那些只喊口號卻不實際行動的企業",
+      "他用諷刺的語調批評了高碳排賽事的虛偽宣傳",
+      "諷刺的是號稱環保的賽事竟然製造了大量垃圾"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:變": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷正在改變全球運動賽事的舉辦方式",
+      "如果我們不做出改變地球的未來將岌岌可危",
+      "這場賽事的改變證明環保和精彩可以同時並存"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:象": {
-    "sentences": [],
+    "sentences": [
+      "北極熊棲息地的消失是全球暖化最令人痛心的現象",
+      "極端氣象事件的頻繁發生提醒人們環保刻不容緩",
+      "這場綠色賽事樹立了環保運動的新典範和新形象"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:足": {
-    "sentences": [],
+    "sentences": [
+      "每個人的碳足跡都會對地球環境產生一定的影響",
+      "這場賽事在環保方面的成績足以讓所有人感到驕傲",
+      "減少碳足跡是每一位地球公民都應該努力的方向"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:跡": {
-    "sentences": [],
+    "sentences": [
+      "他希望這場綠色賽事能為環保運動留下深遠的足跡",
+      "人類活動的痕跡正在地球上留下越來越多的傷疤",
+      "減少碳足跡需要從每一個生活細節開始做起"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "綠色賽事:遷": {
-    "sentences": [],
+    "sentences": [
+      "氣候變遷迫使許多動物不得不遷徙到新的棲息地",
+      "全球暖化導致的環境變遷已經影響到糧食的生產",
+      "他搬遷到鄉下生活就是為了減少自己的碳排放"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:丁": {
-    "sentences": [],
+    "sentences": [
+      "尼古丁是電子煙中讓人上癮的主要有害成分",
+      "即使是一丁點的尼古丁也會對青少年的腦部造成傷害",
+      "他在課堂上學到了關於尼古丁危害的重要知識"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:並": {
-    "sentences": [],
+    "sentences": [
+      "電子煙並不像廣告說的那樣安全無害",
+      "他並沒有被網紅的實驗說服，而是查閱了科學文獻",
+      "偽科學的說法並不能經得起嚴格的科學驗證"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:以": {
-    "sentences": [],
+    "sentences": [
+      "網紅以不嚴謹的實驗來誤導觀眾相信電子煙無害",
+      "他以批判的態度審視每一則關於電子煙的廣告宣傳",
+      "我們不應該以網路上的片面資訊作為判斷的依據"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:似": {
-    "sentences": [],
+    "sentences": [
+      "這個看似科學的實驗其實充滿了邏輯上的漏洞",
+      "網紅用似是而非的論點讓觀眾誤以為電子煙安全",
+      "類似的偽科學手法在社群媒體上屢見不鮮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:信": {
-    "sentences": [],
+    "sentences": [
+      "不要輕易相信網路上未經證實的健康資訊",
+      "他對網紅的電子煙實驗半信半疑於是自己查資料",
+      "盲目相信偽科學的說法可能會對健康造成嚴重危害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:古": {
-    "sentences": [],
+    "sentences": [
+      "尼古丁這個名字來自古老的菸草植物學名",
+      "自古以來人們就知道菸草對身體有害",
+      "他引用古今中外的科學研究來反駁偽科學的論點"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:尼": {
-    "sentences": [],
+    "sentences": [
+      "尼古丁會讓人產生強烈的依賴性而難以戒除",
+      "電子煙裡的尼古丁含量其實並不比傳統香菸少",
+      "他在報告中詳細說明了尼古丁對青少年大腦的危害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:手": {
-    "sentences": [],
+    "sentences": [
+      "網紅用巧妙的行銷手法讓觀眾對電子煙產生好感",
+      "他親手設計了一份問卷調查同學對電子煙的認知",
+      "識破偽科學的關鍵在於掌握科學思考的方法和手段"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:指": {
-    "sentences": [],
+    "sentences": [
+      "專家指出網紅的實驗缺乏科學上的嚴謹性",
+      "他用手指著螢幕上的數據向同學解釋實驗的漏洞",
+      "這份報告明確指出電子煙對呼吸系統的潛在危害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:提": {
-    "sentences": [],
+    "sentences": [
+      "老師提醒同學們要用批判的態度看待網路上的資訊",
+      "他提出了好幾個問題質疑網紅實驗的可信度",
+      "這個議題提升了同學們對偽科學的警覺和辨識能力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:是": {
-    "sentences": [],
+    "sentences": [
+      "電子煙是否真的無害，需要嚴謹的科學研究來證實",
+      "事實是電子煙同樣含有多種對人體有害的化學物質",
+      "他認為是時候讓更多人了解偽科學背後的真相了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:期": {
-    "sentences": [],
+    "sentences": [
+      "長期吸食電子煙對肺部造成的傷害不容小覷",
+      "這篇研究追蹤了電子煙使用者長期的健康數據",
+      "這篇研究追蹤了電子煙使用者長期的健康數據"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:查": {
-    "sentences": [],
+    "sentences": [
+      "他主動上網查詢了電子煙相關的醫學研究報告",
+      "經過仔細調查才發現網紅的實驗根本不符合科學",
+      "衛生單位正在徹查違法販售電子煙給青少年的商家"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:機": {
-    "sentences": [],
+    "sentences": [
+      "商人利用社群媒體的傳播機制來推銷電子煙產品",
+      "他抓住機會在課堂上分享了辨識偽科學的方法",
+      "智慧型手機成為偽科學訊息快速擴散的主要媒介"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:款": {
-    "sentences": [],
+    "sentences": [
+      "市面上有各種款式和口味的電子煙吸引年輕族群",
+      "違法販售電子煙給未成年人將面臨高額的罰款",
+      "這款電子煙的包裝設計顯然是針對青少年族群"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:法": {
-    "sentences": [],
+    "sentences": [
+      "網紅的實驗方法完全不符合正規的科學研究標準",
+      "目前法律明確禁止販售電子煙給未成年的青少年",
+      "科學方法的核心在於可重複驗證和同儕審查"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:淆": {
-    "sentences": [],
+    "sentences": [
+      "網紅刻意混淆視聽讓觀眾分不清科學和偽科學",
+      "偽科學常常用似是而非的數據來混淆大眾的判斷",
+      "他提醒同學不要被混淆不清的資訊所誤導"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:混": {
-    "sentences": [],
+    "sentences": [
+      "電子煙的煙霧中混合了多種有害的化學物質",
+      "網紅把行銷話術和科學實驗混在一起誤導觀眾",
+      "他學會了分辨真正的科學研究和混水摸魚的偽科學"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:為": {
-    "sentences": [],
+    "sentences": [
+      "他認為每個人都應該學會分辨科學和偽科學的差別",
+      "網紅之所以推廣電子煙是因為背後有商業利益驅動",
+      "批判思考能力將成為未來最重要的素養之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:相": {
-    "sentences": [],
+    "sentences": [
+      "真相是電子煙並不如廣告所宣稱的那樣安全無害",
+      "他仔細觀察之後發現網紅的實驗和事實真相不符",
+      "不要只看表面的相似就認定兩件事情是一樣的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:真": {
-    "sentences": [],
+    "sentences": [
+      "分辨資訊的真假是現代公民必備的重要能力",
+      "他認真地查閱了多篇醫學期刊確認電子煙的危害",
+      "真正的科學研究需要經過嚴格的實驗和同儕審查"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:稠": {
-    "sentences": [],
+    "sentences": [
+      "電子煙產生的濃稠煙霧中含有許多有害的微粒子",
+      "他用黏稠的液體模擬電子煙對肺部組織造成的影響",
+      "那些看起來稠密的煙霧其實暗藏著健康的危機"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:緝": {
-    "sentences": [],
+    "sentences": [
+      "警方正在追緝非法販售電子煙給青少年的地下商家",
+      "衛生單位加強查緝校園周邊違法販售電子煙的行為",
+      "他希望有關單位能更積極地緝查偽科學的行銷手法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:而": {
-    "sentences": [],
+    "sentences": [
+      "電子煙看起來很酷炫然而對健康的危害卻很嚴重",
+      "他不因為網紅的推薦而盲目相信電子煙是安全的",
+      "批判思考讓我們不會因表面現象而做出錯誤判斷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:行": {
-    "sentences": [],
+    "sentences": [
+      "網紅利用自身的影響力來進行電子煙的商業行銷",
+      "他身體力行地在校園裡推廣拒絕電子煙的理念",
+      "這種偽科學的行銷手法在網路上非常流行"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:論": {
-    "sentences": [],
+    "sentences": [
+      "科學論文需要經過嚴格的同儕審查才能發表",
+      "網紅的結論完全站不住腳經不起科學方法的檢驗",
+      "他在班上發表了一篇關於電子煙危害的論述報告"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:迷": {
-    "sentences": [],
+    "sentences": [
+      "許多青少年被電子煙的花俏外觀所迷惑而嘗試",
+      "他希望同學們不要迷信網紅說的每一句話",
+      "偽科學就像一座迷宮讓人在錯誤的資訊中迷失"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:銷": {
-    "sentences": [],
+    "sentences": [
+      "電子煙的行銷策略精準地瞄準了年輕的消費族群",
+      "他分析了網紅推銷電子煙時使用的各種話術技巧",
+      "這種利用偽科學來促銷產品的手法應該被嚴格禁止"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:長": {
-    "sentences": [],
+    "sentences": [
+      "長期接觸電子煙的煙霧會對呼吸系統造成永久傷害",
+      "師長們擔心電子煙在校園裡的蔓延速度越來越快",
+      "他花了很長的時間研究才終於看穿偽科學的伎倆"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:陣": {
-    "sentences": [],
+    "sentences": [
+      "一陣濃煙從電子煙中噴出瀰漫了整個房間",
+      "一陣偽科學的資訊轟炸讓我們需要保持冷靜",
+      "面對偽科學的資訊陣陣轟炸我們需要保持冷靜"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:非": {
-    "sentences": [],
+    "sentences": [
+      "電子煙並非無害這一點已經被多項研究所證實",
+      "他是非分明一眼就看出網紅的實驗有問題",
+      "偽科學的論點經常把似是而非的說法包裝成事實"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:馬": {
-    "sentences": [],
+    "sentences": [
+      "他馬上就發現網紅的實驗數據有很大的問題",
+      "指鹿為馬的偽科學手法在網路時代特別容易傳播",
+      "他一馬當先站出來提醒同學們不要被偽科學所騙"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:魂": {
-    "sentences": [],
+    "sentences": [
+      "電子煙行銷廣告勾魂攝魄般地吸引著好奇的青少年",
+      "他被偽科學的精美包裝差點迷了魂幸好及時清醒",
+      "網紅用引人入勝的內容讓觀眾像失了魂一樣買單"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:鹿": {
-    "sentences": [],
+    "sentences": [
+      "指鹿為馬正是偽科學最常使用的混淆視聽手法",
+      "他在報告中用指鹿為馬來比喻網紅顛倒是非的行為",
+      "偽科學把有害的東西說成無害就像古人指鹿為馬"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "網紅的電子煙實驗：偽科學的陷阱:黏": {
-    "sentences": [],
+    "sentences": [
+      "電子煙中的黏稠液體含有對肺部有害的化學成分",
+      "這些偽科學的論點像口香糖一樣黏住了人們的思維",
+      "他發現電子煙產生的殘留物質會黏附在肺部組織上"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:不": {
-    "sentences": [],
+    "sentences": [
+      "雖然輸了比賽，他不放棄的精神讓人佩服",
+      "他不怕失敗，每次都全力以赴",
+      "不管結果如何，他都不會難過太久"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:凝": {
-    "sentences": [],
+    "sentences": [
+      "他凝視著計分板上的數字，深吸一口氣",
+      "全場觀眾凝神注目看著他的表現",
+      "他凝聚所有的力量準備最後一擊"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:力": {
-    "sentences": [],
+    "sentences": [
+      "他用盡全力打完了每一場比賽",
+      "這場比賽考驗的不只是體力還有意志力",
+      "他的努力讓所有人都為他鼓掌加油"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:勢": {
-    "sentences": [],
+    "sentences": [
+      "對手的氣勢很強但他不害怕",
+      "雖然比分落後但他的氣勢不輸任何人",
+      "他以不放棄的姿勢迎接每一次挑戰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:喝": {
-    "sentences": [],
+    "sentences": [
+      "觀眾為他大聲喝采替他加油打氣",
+      "對手的表現也很好值得喝采一番",
+      "他喝了一口水繼續站回場上比賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:嘆": {
-    "sentences": [],
+    "sentences": [
+      "大家感嘆他雖然輸了卻贏得了尊重",
+      "教練嘆了一口氣然後拍拍他的肩膀",
+      "觀眾讚嘆他永不放棄的運動精神"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:均": {
-    "sentences": [],
+    "sentences": [
+      "他的實力和對手旗鼓相當平均分配",
+      "分數分布很平均，比賽非常精彩",
+      "均衡的訓練讓他在場上表現更穩定"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:寞": {
-    "sentences": [],
+    "sentences": [
+      "輸了比賽之後他感到一陣寂寞和失落",
+      "他獨自坐在場邊忍受著落寞的心情",
+      "寂寞的他在夜晚偷偷練習不被人看見"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:已": {
-    "sentences": [],
+    "sentences": [
+      "比賽結束了但他的精神已深深感動大家",
+      "他已經盡了最大的努力所以不後悔",
+      "大家已經把他當作真正的贏家了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:捶": {
-    "sentences": [],
+    "sentences": [
+      "他輸了之後用力捶了一下地板很不甘心",
+      "他捶著自己的胸口告訴自己下次會更好",
+      "教練看他捶桌子便走過來安慰他"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:摸": {
-    "sentences": [],
+    "sentences": [
+      "教練摸摸他的頭說你已經很棒了",
+      "他摸著獎牌的背面笑了笑繼續努力",
+      "他摸索著找到了最適合自己的打法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:敵": {
-    "sentences": [],
+    "sentences": [
+      "他最大的敵人不是對手而是自己",
+      "即使面對強敵他也毫不退縮",
+      "對手是值得尊敬的敵手不是仇人"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:洗": {
-    "sentences": [],
+    "sentences": [
+      "比賽結束他洗了把臉振作精神",
+      "經過這場比賽他洗去了之前的挫敗感",
+      "他用汗水洗去了大家對他的懷疑"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:爭": {
-    "sentences": [],
+    "sentences": [
+      "他不和別人爭輸贏只和自己比進步",
+      "比賽場上的競爭讓他變得更加強大",
+      "他爭取每一分不輕易放棄任何機會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:疑": {
-    "sentences": [],
+    "sentences": [
+      "有些人懷疑他能不能撐到最後",
+      "他毫不遲疑地接受了這場艱難的挑戰",
+      "所有的質疑都被他場上的表現打破了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:症": {
-    "sentences": [],
+    "sentences": [
+      "他克服了賽前緊張的症狀勇敢上場",
+      "輸球之後他出現了輕微的失落症狀",
+      "輸球之後他出現了一點失落症狀但很快就振作了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:目": {
-    "sentences": [],
+    "sentences": [
+      "全場的目光都集中在他身上",
+      "他的目標不是贏而是做到最好的自己",
+      "這場比賽讓人目不轉睛看到最後"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:眼": {
-    "sentences": [],
+    "sentences": [
+      "他眼眶泛紅但嘴角帶著微笑",
+      "觀眾眼睛一眨也不眨地看著他",
+      "教練眼中閃爍著驕傲的光芒"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:睛": {
-    "sentences": [],
+    "sentences": [
+      "他擦乾眼睛裡的淚水重新站起來",
+      "他睜大眼睛緊盯著飛過來的球",
+      "她的眼睛閃著感動的光看著他比賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:緒": {
-    "sentences": [],
+    "sentences": [
+      "輸了比賽他的情緒很低落但很快就恢復了",
+      "他學會了控制自己在比賽中的情緒",
+      "所有的負面情緒都在觀眾的掌聲中消散了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:聚": {
-    "sentences": [],
+    "sentences": [
+      "隊友們聚在一起為他打氣加油",
+      "他把所有的力量聚集起來迎接最後一球",
+      "大家聚精會神地看著這場精彩的比賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:胸": {
-    "sentences": [],
+    "sentences": [
+      "他挺起胸膛走上場接受觀眾的掌聲",
+      "雖然輸了但他的胸懷讓人非常佩服",
+      "教練拍了拍他的胸口說你很勇敢"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:腦": {
-    "sentences": [],
+    "sentences": [
+      "他用腦袋想出了一個聰明的戰術",
+      "他的腦海裡只有一個念頭就是不放棄",
+      "比賽需要用腦也需要用心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:落": {
-    "sentences": [],
+    "sentences": [
+      "雖然比分落後他還是拚命追趕",
+      "他的心情一度很低落但很快就振作了",
+      "太陽落下之前他完成了最後的練習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:著": {
-    "sentences": [],
+    "sentences": [
+      "他穿著汗濕的球衣站在場上微笑",
+      "他堅持著自己的信念打完每一場比賽",
+      "他緊緊握著球拍等待下一次機會"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:虎": {
-    "sentences": [],
+    "sentences": [
+      "他在場上生龍活虎讓對手難以招架",
+      "他虎虎生風地揮出了漂亮的一擊",
+      "兩隊打得龍爭虎鬥非常精彩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:讚": {
-    "sentences": [],
+    "sentences": [
+      "觀眾紛紛讚美他永不放棄的精神",
+      "連對手都忍不住稱讚他的表現很棒",
+      "他贏得了全場觀眾最熱烈的讚美"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:足": {
-    "sentences": [],
+    "sentences": [
+      "他對自己的表現感到心滿意足",
+      "雖然輸了但他已經心滿意足了",
+      "他用雙腳踢出了一記令人滿足的好球"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:轉": {
-    "sentences": [],
+    "sentences": [
+      "他轉身對觀眾鞠了一個躬表示感謝",
+      "比賽的情勢在最後一刻出現了逆轉",
+      "他轉敗為勝的故事讓所有人都感動了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:采": {
-    "sentences": [],
+    "sentences": [
+      "全場觀眾為他的精神喝采歡呼",
+      "他神采奕奕地走上場接受大家的掌聲",
+      "贏得喝采比贏得獎盃更讓人感到光彩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:雜": {
-    "sentences": [],
+    "sentences": [
+      "他的心情很複雜又開心又有點失落",
+      "比賽中出現了一些雜音但他不受影響",
+      "他排除了心中的雜念專心面對比賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:難": {
-    "sentences": [],
+    "sentences": [
+      "這場比賽對他來說是很大的困難挑戰",
+      "雖然很艱難但他咬牙撐到了最後",
+      "困難的比賽反而讓他學到更多東西"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:頓": {
-    "sentences": [],
+    "sentences": [
+      "他停頓了一下然後繼續奮力向前衝",
+      "他吃了一頓豐盛的晚餐犒賞自己",
+      "他突然頓悟了輸贏不是最重要的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:頭": {
-    "sentences": [],
+    "sentences": [
+      "他抬起頭微笑著接受觀眾的鼓勵",
+      "教練點了點頭對他的表現很滿意",
+      "他從頭到尾都沒有想過要放棄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:鬥": {
-    "sentences": [],
+    "sentences": [
+      "他在場上奮力鬥志昂揚地比賽",
+      "這場精彩的比賽讓人看到真正的戰鬥精神",
+      "他的鬥志讓對手也不敢掉以輕心"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:鷹": {
-    "sentences": [],
+    "sentences": [
+      "他像一隻老鷹一樣眼神銳利地盯著球",
+      "他有著雄鷹般的堅毅目光從不退縮",
+      "像鷹一樣專注讓他在場上表現出色"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "贏得喝采的輸家:龍": {
-    "sentences": [],
+    "sentences": [
+      "兩隊打得龍爭虎鬥比賽非常精彩",
+      "他在場上生龍活虎衝勁十足",
+      "觀眾看得精神抖擻像是看了一場龍虎大戰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:估": {
-    "sentences": [],
+    "sentences": [
+      "醫生先評估傷勢的嚴重程度再決定治療方式",
+      "他低估了運動傷害的嚴重性結果拖延了復原",
+      "正確估計自己的身體狀況才能避免受傷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:僵": {
-    "sentences": [],
+    "sentences": [
+      "受傷之後肌肉變得僵硬需要慢慢地復健",
+      "他的手臂因為扭傷而變得又痛又僵",
+      "不做暖身運動身體會很僵硬容易受傷"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:充": {
-    "sentences": [],
+    "sentences": [
+      "運動前要補充足夠的水分才能預防抽筋",
+      "充分的暖身是預防運動傷害最重要的步驟",
+      "他補充了足夠的營養讓受傷的部位恢復更快"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:全": {
-    "sentences": [],
+    "sentences": [
+      "運動時注意安全才能避免不必要的傷害",
+      "他全身上下都做了完整的暖身操才開始運動",
+      "安全第一是從事任何運動都必須牢記的原則"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:制": {
-    "sentences": [],
+    "sentences": [
+      "他學會了如何控制運動的強度來避免受傷",
+      "受傷之後要限制活動量讓身體有時間恢復",
+      "教練制定了一套科學的訓練計畫預防運動傷害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:哄": {
-    "sentences": [],
+    "sentences": [
+      "有人哄騙他說受傷了不用看醫生會自己好",
+      "同學們七嘴八舌地安慰他，好像在哄小孩",
+      "他用幽默的方式逗得大家哄堂大笑忘了傷痛"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:堂": {
-    "sentences": [],
+    "sentences": [
+      "他在課堂上學到了處理運動傷害的基本知識",
+      "同學們聽了他搞笑的受傷故事笑得哄堂大笑",
+      "學校禮堂裡正在舉辦運動傷害防治的宣導活動"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:壓": {
-    "sentences": [],
+    "sentences": [
+      "受傷之後要先用冰敷和加壓來減少腫脹",
+      "他壓住受傷的部位防止繼續流血",
+      "壓力太大的訓練方式反而容易造成運動傷害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:大": {
-    "sentences": [],
+    "sentences": [
+      "這次的扭傷不算太嚴重但也不能大意",
+      "他大聲喊痛引來了旁邊同學的關心",
+      "運動傷害如果不處理好可能會變成大問題"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:彼": {
-    "sentences": [],
+    "sentences": [
+      "選手們彼此提醒做好暖身避免運動傷害",
+      "受傷和康復彼此交替是運動員的日常生活",
+      "隊友們彼此照顧在有人受傷時互相幫忙"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:抑": {
-    "sentences": [],
+    "sentences": [
+      "冰敷可以抑制受傷部位的腫脹和發炎反應",
+      "他壓抑著疼痛堅持把比賽打完才去看醫生",
+      "適當的休息能有效抑制運動傷害的惡化"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:斥": {
-    "sentences": [],
+    "sentences": [
+      "教練斥責他受傷了還不去看醫生太逞強了",
+      "他被醫生斥責不應該帶傷繼續訓練",
+      "教練嚴厲地斥退了帶傷硬撐的選手要他先休息"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:此": {
-    "sentences": [],
+    "sentences": [
+      "從此以後他每次運動前都會認真做暖身操",
+      "因此正確的急救知識對每個人都很重要",
+      "如此嚴重的傷害需要好幾個月才能完全康復"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:注": {
-    "sentences": [],
+    "sentences": [
+      "運動時要注意姿勢才能減少受傷的風險",
+      "他全神貫注地聽醫生解釋復健的方法",
+      "注意身體發出的警訊是預防傷害的第一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:滑": {
-    "sentences": [],
+    "sentences": [
+      "他在濕滑的地面上摔倒扭傷了腳踝",
+      "溜滑梯的時候他不小心滑倒擦傷了手臂",
+      "光滑的地板是造成運動傷害的常見原因"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:硬": {
-    "sentences": [],
+    "sentences": [
+      "肌肉太僵硬的時候運動很容易拉傷",
+      "他硬撐著繼續練習結果傷勢更加嚴重了",
+      "不要硬撐要適時休息才能避免更嚴重的傷害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:神": {
-    "sentences": [],
+    "sentences": [
+      "他提起精神努力做復健希望早日回到球場",
+      "受傷之後他的精神狀態比身體恢復得更慢",
+      "教練鼓勵他保持好的精神面對漫長的復健過程"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:稽": {
-    "sentences": [],
+    "sentences": [
+      "他用滑稽的方式形容自己受傷的經過逗大家笑",
+      "同學覺得他受傷的姿勢看起來很滑稽忍不住笑了",
+      "那個滑稽的跌倒畫面讓全班笑得停不下來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:笑": {
-    "sentences": [],
+    "sentences": [
+      "他用自嘲的笑話讓大家不要太擔心他的傷勢",
+      "雖然受傷了但他還是笑著說沒關係很快就好",
+      "同學們邊笑邊幫他處理傷口氣氛很溫馨"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:置": {
-    "sentences": [],
+    "sentences": [
+      "正確處置運動傷害可以加速身體的復原速度",
+      "他把冰袋放置在腫脹的腳踝上消炎止痛",
+      "急救箱要放在容易取得的位置以備不時之需"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:落": {
-    "sentences": [],
+    "sentences": [
+      "他從高處落地時沒站穩結果扭傷了腳踝",
+      "受傷之後他的心情有些低落但很快就振作了",
+      "籃球從高處落下砸到了他的手指讓他痛了好久"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:處": {
-    "sentences": [],
+    "sentences": [
+      "受傷的地方要小心處理才不會留下後遺症",
+      "他到處尋找冰塊來冰敷受傷的部位",
+      "身體各處都要做好暖身才能避免運動傷害"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:評": {
-    "sentences": [],
+    "sentences": [
+      "醫生評估過後認為他的傷勢不需要開刀",
+      "教練評價他處理傷害的方式非常正確冷靜",
+      "經過專業評估他大約需要兩週就能康復"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:貫": {
-    "sentences": [],
+    "sentences": [
+      "他一貫堅持運動前先做足暖身操的好習慣",
+      "正確的急救觀念應該貫穿整個運動訓練過程",
+      "他始終如一貫徹教練教的傷害預防方法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:起": {
-    "sentences": [],
+    "sentences": [
+      "他跌倒之後馬上爬起來繼續完成比賽",
+      "受傷之後他更加注意起身前做好暖身運動",
+      "受傷之後他更加重視起身暖身運動這件事"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動傷害，怎麼辦:迫": {
-    "sentences": [],
+    "sentences": [
+      "傷勢迫使他不得不暫停訓練休息一段時間",
+      "他被迫放棄這次的比賽先把傷養好",
+      "時間緊迫但他還是堅持先做完暖身操再上場"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:加": {
-    "sentences": [],
+    "sentences": [
+      "他每天增加一點運動量讓身體慢慢進步",
+      "加油！教練在旁邊為他打氣加油",
+      "參加運動比賽讓他學到很多新東西"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:同": {
-    "sentences": [],
+    "sentences": [
+      "同學們一起討論運動科學的有趣知識",
+      "不同的運動需要不同的訓練方法",
+      "他和同伴一起練習效果比一個人好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:喪": {
-    "sentences": [],
+    "sentences": [
+      "他輸了比賽之後有點沮喪不想練習",
+      "不要因為一次失敗就喪失了信心",
+      "他很快從喪氣的情緒中振作起來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:大": {
-    "sentences": [],
+    "sentences": [
+      "這個科學發現對運動訓練有很大的幫助",
+      "他長大以後想成為一位運動科學家",
+      "運動的時候需要用到很大的力氣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:小": {
-    "sentences": [],
+    "sentences": [
+      "即使是小小的進步也值得開心慶祝",
+      "他從小就對運動科學非常有興趣",
+      "小細節的改變也能帶來大大的進步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:徒": {
-    "sentences": [],
+    "sentences": [
+      "光靠蠻力是徒勞無功的要用科學方法",
+      "他是教練的得意門徒學得又快又好",
+      "如果不用對的方法訓練一切都是徒然"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:成": {
-    "sentences": [],
+    "sentences": [
+      "科學訓練幫助他完成了許多目標",
+      "他的努力終於有了成果感覺好開心",
+      "好的練習習慣會讓你成為更棒的選手"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:手": {
-    "sentences": [],
+    "sentences": [
+      "他是隊上的好手每次比賽都表現優秀",
+      "運動科學家動手做實驗來研究訓練方法",
+      "新手剛開始練習難免會遇到困難"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:抵": {
-    "sentences": [],
+    "sentences": [
+      "科學的訓練方法可以抵消錯誤姿勢帶來的傷害",
+      "他的努力足以抵得上別人兩倍的練習量",
+      "正確的暖身運動能幫助身體抵抗受傷的風險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:持": {
-    "sentences": [],
+    "sentences": [
+      "持續不斷的練習是進步的唯一方法",
+      "他堅持每天按照科學方法來訓練",
+      "教練支持他用新的方式來練習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:擔": {
-    "sentences": [],
+    "sentences": [
+      "教練擔心他練習太多會受傷",
+      "不要擔心只要用對方法就會進步",
+      "他不再擔心比賽因為他已經準備好了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:據": {
-    "sentences": [],
+    "sentences": [
+      "科學家根據數據來改善運動的訓練方式",
+      "他記錄每天的練習數據來追蹤進步",
+      "根據研究顯示規律運動對身體非常好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:效": {
-    "sentences": [],
+    "sentences": [
+      "科學訓練讓他的練習更有效率",
+      "有效的方法可以讓進步的速度更快",
+      "這個訓練方式的效果非常明顯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:數": {
-    "sentences": [],
+    "sentences": [
+      "他用數據來記錄自己每天跑步的成績",
+      "經過無數次的練習他終於有了突破",
+      "科學家分析大量數據找到最好的訓練方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:斐": {
-    "sentences": [],
+    "sentences": [
+      "他的運動表現有了斐然的進步讓大家刮目相看",
+      "透過科學訓練他取得了非常亮眼的成績斐然",
+      "他的努力成果斐然讓教練感到很欣慰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:沮": {
-    "sentences": [],
+    "sentences": [
+      "失敗讓他有點沮喪但教練鼓勵他繼續加油",
+      "他不因為一次沮喪就放棄運動夢想",
+      "沮喪的時候想一想自己為什麼開始練習"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:消": {
-    "sentences": [],
+    "sentences": [
+      "運動可以幫助消除壓力和緊張的情緒",
+      "他的疲勞在休息之後就消失了大半",
+      "聽到好消息之後他的沮喪心情也跟著消散"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:準": {
-    "sentences": [],
+    "sentences": [
+      "他準備好要用科學方法來提升自己的表現",
+      "教練的要求很嚴格每個動作都要做到標準",
+      "精準的訓練計畫讓他的進步速度加快了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:然": {
-    "sentences": [],
+    "sentences": [
+      "他果然進步了科學訓練真的有用",
+      "雖然過程辛苦但他依然堅持下去",
+      "他自然而然地養成了每天運動的習慣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:異": {
-    "sentences": [],
+    "sentences": [
+      "他的表現和以前相比有了明顯的差異",
+      "每個人的身體條件不同訓練方式也有差異",
+      "科學訓練讓他有了異於常人的優秀表現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:精": {
-    "sentences": [],
+    "sentences": [
+      "他精準地完成了教練要求的每一個動作",
+      "精確的數據分析讓訓練變得更有效率",
+      "他練習得非常精熟每個動作都很到位"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:練": {
-    "sentences": [],
+    "sentences": [
+      "他每天認真練習跑步一點也不偷懶",
+      "練習的時候要注意正確的姿勢才有效",
+      "經過反覆練習他終於掌握了這個技巧"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:訓": {
-    "sentences": [],
+    "sentences": [
+      "科學的訓練方法讓他的體能大幅提升",
+      "教練按照科學方式設計了一套訓練課表",
+      "嚴格的訓練過程雖然辛苦但成果很好"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "運動科學:負": {
-    "sentences": [],
+    "sentences": [
+      "他不想辜負教練和隊友對他的期待",
+      "身體的負擔太大反而會造成運動傷害",
+      "他背負著大家的期望全力以赴比賽"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:促": {
-    "sentences": [],
+    "sentences": [
+      "運動可以促進生長激素的分泌",
+      "早睡能促使身體快速長高",
+      "牛奶裡的營養促進骨骼的成長"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:分": {
-    "sentences": [],
+    "sentences": [
+      "生長激素會在睡覺時大量分泌出來",
+      "他每天分配時間運動和讀書",
+      "充分的營養是長高的重要條件"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:前": {
-    "sentences": [],
+    "sentences": [
+      "睡覺前不要吃太多東西比較好",
+      "他比以前長高了好多公分",
+      "在長高之前要先養成好的生活習慣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:取": {
-    "sentences": [],
+    "sentences": [
+      "多攝取含鈣的食物對長高有幫助",
+      "他聽取醫生的建議改善了飲食習慣",
+      "想要長高就要攝取均衡的營養"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:含": {
-    "sentences": [],
+    "sentences": [
+      "牛奶裡含有豐富的鈣質幫助骨骼成長",
+      "含有蛋白質的食物對長高很有幫助",
+      "蔬菜裡含有許多長高需要的營養素"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:喳": {
-    "sentences": [],
+    "sentences": [
+      "同學們嘰嘰喳喳地討論誰長得最高",
+      "下課時大家喳喳地聊著長高的方法",
+      "他們吱吱喳喳地比較各自的身高"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:嘰": {
-    "sentences": [],
+    "sentences": [
+      "小朋友嘰嘰喳喳地討論長高的祕密",
+      "大家嘰嘰呱呱地分享長高的方法",
+      "他們嘰嘰喳喳地量身高看誰最高"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:均": {
-    "sentences": [],
+    "sentences": [
+      "均衡的飲食是長高最重要的基礎",
+      "他每天都吃得很均衡讓身體健康長高",
+      "營養要攝取均勻才能幫助身體成長"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:大": {
-    "sentences": [],
+    "sentences": [
+      "他希望快點長大變得又高又壯",
+      "長大以後他想成為一位籃球選手",
+      "多曬太陽對身體長大有很大的幫助"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:富": {
-    "sentences": [],
+    "sentences": [
+      "牛奶含有豐富的鈣質對長高很有幫助",
+      "他家的餐桌上總是擺滿了豐富的蔬菜水果",
+      "富含蛋白質的食物能幫助肌肉和骨骼成長"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:幅": {
-    "sentences": [],
+    "sentences": [
+      "他這學期的身高有了大幅度的成長",
+      "他的身高幅度增加讓同學們都很驚訝",
+      "量身高的時候他發現自己長高了一大幅"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:度": {
-    "sentences": [],
+    "sentences": [
+      "他每個月量一次身高來追蹤成長的速度",
+      "適度的運動可以幫助身體順利長高",
+      "長高的程度和營養攝取有很大的關係"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:思": {
-    "sentences": [],
+    "sentences": [
+      "他一直在思考要怎麼做才能長得更高",
+      "他對長高的祕密感到非常好奇不禁深思",
+      "他反思自己的生活習慣才發現影響長高的關鍵"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:提": {
-    "sentences": [],
+    "sentences": [
+      "醫生提醒他要多運動才能幫助長高",
+      "他提早上床睡覺讓身體有更多成長的時間",
+      "提高睡眠品質是促進長高的好方法"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:據": {
-    "sentences": [],
+    "sentences": [
+      "根據醫學研究睡眠是長高最重要的因素",
+      "他根據醫生的建議調整了作息和飲食",
+      "據說跳繩是幫助長高最有效的運動之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:攝": {
-    "sentences": [],
+    "sentences": [
+      "攝取足夠的鈣質是長高的基本條件",
+      "他每天攝取均衡的營養幫助身體成長",
+      "多攝取含有維生素D的食物有助於骨骼發育"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:根": {
-    "sentences": [],
+    "sentences": [
+      "他從根本改變飲食習慣讓身體更健康",
+      "長高的根基在於良好的生活習慣",
+      "根據科學研究遺傳和營養都會影響身高"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:泌": {
-    "sentences": [],
+    "sentences": [
+      "生長激素會在深度睡眠時大量分泌",
+      "激素的分泌和睡眠品質有密切的關係",
+      "運動能促進體內荷爾蒙的正常分泌"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:衡": {
-    "sentences": [],
+    "sentences": [
+      "均衡的營養對身體的成長發育非常重要",
+      "他學會了平衡飲食和運動來幫助長高",
+      "飲食營養失去平衡會影響長高的速度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:迷": {
-    "sentences": [],
+    "sentences": [
+      "他非常著迷於研究長高的各種方法",
+      "很多人對長高的偏方深信不疑很入迷",
+      "他迷上了打籃球因為聽說打球會長高"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "長高的祕密:進": {
-    "sentences": [],
+    "sentences": [
+      "他的身高最近進步了不少讓他很開心",
+      "多運動可以促進身體的新陳代謝",
+      "他每天進步一點點慢慢地就長高了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:乍": {
-    "sentences": [],
+    "sentences": [
+      "乍看之下那個黑影確實像是幽靈但其實只是光影效果",
+      "他乍聞鬼故事時嚇了一跳但冷靜下來就不怕了",
+      "乍然遇到無法解釋的現象時人們往往傾向超自然的解讀"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:人": {
-    "sentences": [],
+    "sentences": [
+      "很多人對靈異現象感到好奇卻忽略了科學的解釋",
+      "有些人聲稱看見鬼魂但科學家認為那是腦部的錯覺",
+      "人類的大腦傾向於在隨機事物中尋找有意義的模式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:入": {
-    "sentences": [],
+    "sentences": [
+      "他深入研究靈異事件之後發現大多數都有科學解釋",
+      "進入黑暗的空間時人的感官會變得異常敏銳容易產生幻覺",
+      "科學家投入大量時間探索那些看似超自然的現象背後的真相"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:凶": {
-    "sentences": [],
+    "sentences": [
+      "所謂的凶宅往往可以用環境因素來解釋那些奇怪的聲響",
+      "人們害怕凶兆其實是因為大腦的恐懼迴路被不當觸發了",
+      "傳說中的凶險之地經過科學調查後發現只是結構老舊的建築"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:勝": {
-    "sentences": [],
+    "sentences": [
+      "科學的解釋力勝過任何未經驗證的超自然說法",
+      "好奇心勝過恐懼讓他決定用科學方法探究靈異傳聞",
+      "他不勝唏噓地感嘆許多人寧願相信鬼神也不接受科學"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:啞": {
-    "sentences": [],
+    "sentences": [
+      "聽到科學家的解釋之後原本信誓旦旦的人都啞口無言了",
+      "他被突如其來的怪聲嚇得啞然失聲好一會才回過神來",
+      "面對鐵證如山的科學數據那些靈異說法的支持者瞬間啞然"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:啟": {
-    "sentences": [],
+    "sentences": [
+      "科學啟發人們用理性的態度去看待所謂的靈異事件",
+      "這本書啟迪讀者重新思考超自然現象背後的心理學機制",
+      "他受到老師的啟蒙開始用科學方法去驗證靈異傳說的真假"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:喑": {
-    "sentences": [],
+    "sentences": [
+      "喑啞的聲音從老舊的管線中傳出被誤認為是幽靈的哀號",
+      "那棟大樓裡喑沉的氛圍其實是低頻聲波造成的心理效應",
+      "他在喑暗的走廊中聽見怪聲後來發現是風穿過縫隙的共鳴"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:引": {
-    "sentences": [],
+    "sentences": [
+      "科學家引用大量的實驗數據來反駁靈異現象的存在",
+      "磁場異常會引發人腦產生幻覺讓人誤以為看見了鬼影",
+      "這個話題引起了同學們對科學與迷信之間界限的熱烈討論"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:忪": {
-    "sentences": [],
+    "sentences": [
+      "他被半夜的怪聲嚇得睡眼惺忪地跳起來查看",
+      "惺忪的意識在恍惚之間更容易把正常的聲響誤判為靈異事件",
+      "她睡眼惺忪時看見窗簾飄動以為是幽靈結果只是風吹的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:悚": {
-    "sentences": [],
+    "sentences": [
+      "那段影片看起來很毛骨悚然但科學家找到了合理的解釋",
+      "恐怖故事之所以令人悚然是因為大腦的杏仁核被過度激活了",
+      "他讀完那本關於靈異科學的書覺得既驚悚又啟發"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:惡": {
-    "sentences": [],
+    "sentences": [
+      "所謂的惡靈附身在醫學上其實是特定的神經或精神疾病",
+      "夢中的惡魔形象通常反映了我們白天未處理的焦慮和恐懼",
+      "他對惡意散播靈異謠言的行為感到非常不以為然"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:惺": {
-    "sentences": [],
+    "sentences": [
+      "半夢半醒之間惺忪的意識最容易產生超自然的幻覺體驗",
+      "他在惺忪狀態下看見床邊有個人影嚇壞了但那只是衣架",
+      "惺惺作態地假裝通靈的人其實是利用了人們恐懼的心理"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:期": {
-    "sentences": [],
+    "sentences": [
+      "科學家長期追蹤靈異事件最終都找到了合理的自然解釋",
+      "他期望透過科學教育讓更多人不再被靈異傳聞所迷惑",
+      "週期性出現的怪聲其實是老舊管線熱脹冷縮造成的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:極": {
-    "sentences": [],
+    "sentences": [
+      "極度恐懼會讓大腦產生幻覺誤以為看到了超自然的存在",
+      "他極力用科學的方法解釋那些令人費解的靈異現象",
+      "科學家窮極畢生精力研究人類為什麼傾向相信靈異事件"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:毛": {
-    "sentences": [],
+    "sentences": [
+      "這個故事聽起來令人毛骨悚然但其實有合理的解釋",
+      "他嚇得汗毛直豎後來才發現那只是樹枝的影子",
+      "科學可以解開那些讓人寒毛直立的靈異謎團"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:無": {
-    "sentences": [],
+    "sentences": [
+      "科學家的調查證實那棟所謂的鬼屋其實無任何異常之處",
+      "面對無法解釋的現象保持開放但存疑的態度才是正確的",
+      "他無懼地走進傳說中的靈異地點用儀器進行科學測量"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:然": {
-    "sentences": [],
+    "sentences": [
+      "看似超自然的現象往往可以用自然科學來合理解釋",
+      "他恍然大悟原來那些靈異故事都有科學根據可以破解",
+      "雖然科學尚未解釋所有現象但這並不代表超自然就必然存在"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:爍": {
-    "sentences": [],
+    "sentences": [
+      "閃爍不定的燈光讓人以為有幽靈出沒但其實是電路老舊",
+      "星光閃爍的夜晚他決定用科學儀器來調查靈異傳聞的真相",
+      "那些爍爍發光的不明現象最終被證實是螢火蟲的生物發光"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:疑": {
-    "sentences": [],
+    "sentences": [
+      "他對靈異現象始終抱持合理懷疑的科學態度",
+      "科學的精神就是對任何未經驗證的說法保持質疑",
+      "那些可疑的靈異影片經過分析後發現都是人為剪輯的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:瘓": {
-    "sentences": [],
+    "sentences": [
+      "睡眠癱瘓症會讓人動彈不得並產生看見鬼的幻覺",
+      "他經歷了一次睡眠癱瘓才理解為什麼有人聲稱被鬼壓床",
+      "癱瘓的恐懼感加上幻覺讓許多人把睡眠障礙誤認為靈異事件"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:癱": {
-    "sentences": [],
+    "sentences": [
+      "睡眠癱瘓時全身無法動彈會讓人以為是超自然力量的作用",
+      "他了解到鬼壓床其實就是睡眠癱瘓的醫學症狀之後就不怕了",
+      "癱軟無力的身體加上清醒的意識營造出極度恐怖的主觀體驗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:眼": {
-    "sentences": [],
+    "sentences": [
+      "親眼所見不一定為真因為大腦隨時都在建構我們的視覺經驗",
+      "他用自己的眼睛觀察用科學的方法分析那些靈異現象",
+      "眼見為憑這句話在科學上並不完全正確因為人的感官會出錯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:睡": {
-    "sentences": [],
+    "sentences": [
+      "睡眠障礙是許多靈異體驗最常見的科學解釋之一",
+      "他在半睡半醒之間產生了幻覺以為房間裡有個黑影",
+      "充足的睡眠可以減少因意識模糊而產生的超自然錯覺"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:窮": {
-    "sentences": [],
+    "sentences": [
+      "科學家窮盡各種方法試圖找出靈異現象背後的自然成因",
+      "他對靈異事件的好奇心似乎永無窮盡但始終用科學方法求解",
+      "人類對未知的探索是無窮無盡的而科學是最可靠的工具"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:竇": {
-    "sentences": [],
+    "sentences": [
+      "他的好奇心被這個靈異故事激發了滿腹疑竇決定一探究竟",
+      "那些疑竇重重的超自然事件經過科學調查後都水落石出了",
+      "他心中充滿疑竇於是決定親自到傳說中的鬼屋進行科學實驗"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:聲": {
-    "sentences": [],
+    "sentences": [
+      "黑夜裡的怪聲其實是老房子因溫差而發出的結構聲響",
+      "他循著聲音的來源追蹤最終發現那只是動物在天花板上活動",
+      "聲波的頻率如果低於人耳可聽範圍就可能引發不安和恐懼感"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:見": {
-    "sentences": [],
+    "sentences": [
+      "他親眼所見的靈異現象後來被證實只是光線折射造成的幻覺",
+      "許多人聲稱見過鬼魂但科學家認為那是腦部在特定狀態下的產物",
+      "眼見不一定為憑這個觀念是理解靈異科學的第一步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:週": {
-    "sentences": [],
+    "sentences": [
+      "他花了好幾週的時間收集資料才完成這份靈異科學的報告",
+      "每週都有新的科學研究發表來解釋各種看似超自然的現象",
+      "那棟大樓每隔幾週就傳出靈異事件但科學家發現了規律的成因"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:閃": {
-    "sentences": [],
+    "sentences": [
+      "閃爍的光影在黑暗中容易被大腦誤判為移動的人形物體",
+      "他看見一道閃光劃過房間後來發現只是車燈從窗戶反射進來的",
+      "雷電閃過的瞬間他看見了一個人影但那只是自己映在玻璃上的倒影"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "靈異與科學:骨": {
-    "sentences": [],
+    "sentences": [
+      "這個故事令人毛骨悚然但科學的解釋讓一切都合情合理了",
+      "科學家發現所謂的靈異聲響只是老房子骨架在熱脹冷縮",
+      "科學家發現所謂的靈異聲響只是老房子的骨架在熱脹冷縮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:不": {
-    "sentences": [],
+    "sentences": [
+      "近視一旦形成就不容易恢復所以預防遠比治療重要",
+      "如果不增加戶外活動的時間近視的比例只會越來越高",
+      "他不再長時間盯著螢幕而是多到戶外走走保護眼睛"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:刻": {
-    "sentences": [],
+    "sentences": [
+      "保護眼睛刻不容緩尤其是正在發育中的青少年",
+      "他深刻體會到預防近視需要從日常生活的小習慣做起",
+      "每一刻都在滑手機的習慣正悄悄地侵蝕著我們的視力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:印": {
-    "sentences": [],
+    "sentences": [
+      "戶外活動能預防近視這個觀念已經深深印在他的腦海中",
+      "研究數據給人留下了深刻的印象顯示戶外時間與視力成正比",
+      "老師把預防近視的要點印成傳單發給每一位同學帶回家"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:及": {
-    "sentences": [],
+    "sentences": [
+      "預防近視要趁早來不及等到視力惡化才開始注意",
+      "這項研究涉及數千名青少年追蹤了他們長達五年的視力變化",
+      "他及時調整了用眼習慣成功阻止了近視度數繼續加深"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:咎": {
-    "sentences": [],
+    "sentences": [
+      "近視率居高不下歸咎於青少年過度使用電子產品的習慣",
+      "他把自己近視加深的原因歸咎於長時間在室內讀書缺乏戶外活動",
+      "近視的成因難辭其咎的不只是基因還有環境因素和用眼習慣"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:喻": {
-    "sentences": [],
+    "sentences": [
+      "戶外活動對預防近視的重要性家喻戶曉但實踐的人卻不多",
+      "他用比喻的方式解釋眼球就像相機需要適當的光線才能正常運作",
+      "近視預防的道理不言而喻但真正付諸行動的家庭仍然是少數"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:塵": {
-    "sentences": [],
+    "sentences": [
+      "他走出灰塵瀰漫的室內到戶外呼吸新鮮空氣順便保護眼睛",
+      "不要讓近視的陰影像塵埃一樣悄悄地蒙蔽了你的視力",
+      "科學研究如同撥開迷霧和塵埃讓我們看清近視預防的真相"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:多": {
-    "sentences": [],
+    "sentences": [
+      "多花時間在戶外活動是預防近視最簡單有效的方法",
+      "越來越多的研究證實戶外光線對保護視力有顯著的幫助",
+      "他建議同學們多到操場活動不要整天待在教室裡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:巴": {
-    "sentences": [],
+    "sentences": [
+      "他眼巴巴地看著窗外希望下課後能趕快到戶外去活動",
+      "多巴胺的分泌與戶外光照有關而多巴胺能抑制眼球過度生長",
+      "他巴不得每天都有更多的戶外課讓眼睛好好休息"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:患": {
-    "sentences": [],
+    "sentences": [
+      "近視患者的年齡層正在逐年下降這個趨勢令人擔憂",
+      "預防勝於治療與其等到罹患近視不如提早做好視力保護",
+      "他是高度近視的患者深知保護眼睛的重要性"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:望": {
-    "sentences": [],
+    "sentences": [
+      "他希望透過推廣戶外活動來降低校園裡的近視率",
+      "他望著遠方的綠色山巒讓疲勞的眼睛得到充分的放鬆",
+      "家長們殷切期望孩子能遠離近視擁有健康的視力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:板": {
-    "sentences": [],
+    "sentences": [
+      "他不再像木板人一樣整天坐在電腦前而是多出去走走",
+      "老師在黑板上寫下了預防近視的幾個重要原則",
+      "刻板的室內學習模式正在加劇青少年近視的嚴重程度"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:毛": {
-    "sentences": [],
+    "sentences": [
+      "他發現自己開始瞇眼看黑板覺得毛毛的趕緊去檢查視力",
+      "九牛一毛的戶外時間根本不足以抵消長時間用眼的傷害",
+      "鳳毛麟角的學生能在畢業時仍保持正常視力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:流": {
-    "sentences": [],
+    "sentences": [
+      "最新的研究潮流顯示戶外活動是預防近視最有效的方法",
+      "近視在青少年之間的流行程度已經到了不容忽視的地步",
+      "他跟上科學的主流觀點開始增加每天的戶外活動時間"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:疫": {
-    "sentences": [],
+    "sentences": [
+      "近視在亞洲地區的蔓延速度幾乎可以用疫情來形容",
+      "預防近視就像防疫一樣需要全社會共同參與和重視",
+      "他把近視比喻為一場看不見的疫病正在悄悄侵襲年輕世代"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:病": {
-    "sentences": [],
+    "sentences": [
+      "近視雖然不是傳染病但它的蔓延速度卻令人警覺",
+      "高度近視可能引發多種眼部病變甚至導致失明的風險",
+      "預防近視就是在預防未來可能發生的嚴重眼部疾病"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:罹": {
-    "sentences": [],
+    "sentences": [
+      "罹患高度近視的風險會隨著用眼時間增加而顯著上升",
+      "他不希望自己的孩子也罹患近視所以每天帶他到戶外玩耍",
+      "研究顯示每天戶外活動超過兩小時可以降低罹患近視的機率"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:而": {
-    "sentences": [],
+    "sentences": [
+      "戶外活動不僅有益身體健康而且能有效預防近視",
+      "他不是因為愛玩而到戶外去而是為了保護自己寶貴的視力",
+      "近視的成因並非單一因素而是遺傳和環境共同作用的結果"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:胺": {
-    "sentences": [],
+    "sentences": [
+      "陽光能促進視網膜分泌多巴胺進而抑制眼球的過度增長",
+      "多巴胺在預防近視的機制中扮演著關鍵的角色",
+      "他在報告中詳細解釋了多巴胺如何保護眼球不會過度發育"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:莫": {
-    "sentences": [],
+    "sentences": [
+      "預防近視莫過於增加戶外活動這個方法既簡單又有效",
+      "他莫名其妙地近視加深了後來才發現是因為缺乏戶外活動",
+      "對於如何預防近視科學界的共識莫衷一是但戶外活動是公認有效的"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:行": {
-    "sentences": [],
+    "sentences": [
+      "增加戶外活動是目前公認最可行的近視預防策略",
+      "他身體力行每天放學後到公園跑步保護自己的眼睛",
+      "預防近視不能只說不做而是要付諸實際的行動才有效"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:角": {
-    "sentences": [],
+    "sentences": [
+      "從預防醫學的角度來看戶外活動對保護視力至關重要",
+      "他從各個角度分析了近視成因後認為戶外活動最為關鍵",
+      "眼角膜的健康和充足的自然光照之間有著密切的關聯"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:言": {
-    "sentences": [],
+    "sentences": [
+      "一言以蔽之多到戶外活動就是預防近視最好的方法",
+      "他引用了多位眼科專家的言論來支持戶外活動預防近視的觀點",
+      "預防近視的重要性已經不需要再多言大家都應該身體力行"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:象": {
-    "sentences": [],
+    "sentences": [
+      "近視人口的快速增加是一個不容忽視的社會現象",
+      "他用生動的比喻來描繪近視如同氣象災害般襲擊年輕世代",
+      "研究數據呈現的現象很明確戶外時間越多近視風險越低"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:責": {
-    "sentences": [],
+    "sentences": [
+      "保護孩子的視力是家長和學校共同的責任",
+      "他自責沒有早點帶孩子增加戶外活動導致近視加深",
+      "每個人都有責任維護自己的視力健康不能只依賴醫療"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:鳳": {
-    "sentences": [],
+    "sentences": [
+      "在高度近視盛行的年代視力正常的學生鳳毛麟角",
+      "鳳毛麟角般珍貴的好視力需要從小就開始細心保護",
+      "他感嘆現在視力正常的孩子真是鳳毛麟角越來越少了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "預防近視？多點戶外活動就對了！:麟": {
-    "sentences": [],
+    "sentences": [
+      "擁有健康視力的青少年如今已是鳳毛麟角般的稀有",
+      "他用鳳毛麟角來形容班上沒有近視的同學有多麼少見",
+      "麟角鳳毛般珍貴的好視力一旦失去就很難再恢復了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:不": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練的效果因人而異並不是所有運動員都適合",
+      "他發現高海拔的稀薄空氣讓呼吸變得不那麼順暢",
+      "科學家提醒不能盲目進行高地訓練必須在專業指導下進行"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:人": {
-    "sentences": [],
+    "sentences": [
+      "每個人對高海拔環境的適應能力都有所不同",
+      "很多人好奇高地訓練是否真的能提升運動表現",
+      "很多人好奇高地訓練是否真的能提升運動表現"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:住": {
-    "sentences": [],
+    "sentences": [
+      "長期居住在高海拔地區的人血液中紅血球含量較高",
+      "他住在山上訓練了六週身體逐漸適應了稀薄的空氣",
+      "高原上的居民已經適應了居住在低氧環境中的生理挑戰"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:凝": {
-    "sentences": [],
+    "sentences": [
+      "血液在高海拔環境中變得更加濃稠增加了凝結的風險",
+      "他凝神注視著自己的血液報告試圖理解高地訓練的效果",
+      "血液凝固的速度在高海拔環境中會受到不同因素的影響"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:功": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練如果方法正確可以有效提升運動員的功能表現",
+      "他功成名就的背後是在高海拔環境中無數次艱苦的訓練",
+      "科學研究證實高地訓練對提升心肺功能確實有顯著的功效"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:可": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練可以刺激身體產生更多的紅血球來攜帶氧氣",
+      "這項研究結果可以作為運動員是否適合高地訓練的參考依據",
+      "適度的高海拔訓練可能為運動表現帶來顯著的正面提升"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:囊": {
-    "sentences": [],
+    "sentences": [
+      "紅血球就像一個個小囊袋負責在血液中運輸氧氣分子",
+      "他把高地訓練的所有知識都收進了自己的知識錦囊之中",
+      "血液中的紅血球囊括了輸送氧氣到全身各處的重要功能"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:因": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練之所以有效是因為低氧環境刺激了紅血球增生",
+      "基因差異是不同人對高海拔適應能力差別很大的主要原因",
+      "他分析了各種因素之後認為高地訓練對耐力型選手最有幫助"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:堵": {
-    "sentences": [],
+    "sentences": [
+      "血液如果變得太過濃稠可能會堵塞血管造成健康風險",
+      "他擔心過度的高地訓練會讓血液黏稠到堵住細小的微血管",
+      "科學家警告血栓堵塞血管是高地訓練最需要警惕的潛在風險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:括": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練的好處包括提升紅血球數量和增強心肺功能",
+      "他的訓練計畫涵括了高海拔適應低海拔競賽等多個階段",
+      "研究項目包括了血液指標心率變化和運動表現等多項數據"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:栓": {
-    "sentences": [],
+    "sentences": [
+      "血液過於濃稠可能形成血栓這是高地訓練的潛在風險",
+      "科學家持續監測運動員的血液指標以預防血栓的形成",
+      "他在高地訓練期間被要求定期檢查以排除血栓的危險"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:沒": {
-    "sentences": [],
+    "sentences": [
+      "他還沒有嘗試過高地訓練但對其背後的科學原理很感興趣",
+      "如果沒有充分的準備就貿然進行高地訓練可能會適得其反",
+      "研究發現並沒有單一的訓練方法能保證對所有運動員都有效"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:濃": {
-    "sentences": [],
+    "sentences": [
+      "高海拔環境會促使血液變得更加濃稠以適應低氧的條件",
+      "血液濃度的增加是身體適應高地環境最明顯的生理反應",
+      "他發現自己在高地訓練後血液變濃了紅血球數量也增加了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:現": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練對運動員回到平地後的比賽表現有顯著的提升效果",
+      "研究發現高海拔訓練能讓運動員在賽場上展現出更好的耐力",
+      "他的運動表現在經過六週的高地訓練之後出現了明顯的進步"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:異": {
-    "sentences": [],
+    "sentences": [
+      "個體差異決定了高地訓練對每位運動員的效果各有不同",
+      "他觀察到高海拔訓練的效果在不同運動項目之間存在顯著差異",
+      "科學家對高地訓練效果的差異性進行了深入的基因層面研究"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:稀": {
-    "sentences": [],
+    "sentences": [
+      "高海拔地區空氣稀薄迫使身體產生更多紅血球來補償氧氣",
+      "稀薄的空氣讓呼吸變得困難但同時也觸發了身體的適應機制",
+      "他在稀薄的高原空氣中進行訓練感受到了身體逐漸適應的過程"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:稠": {
-    "sentences": [],
+    "sentences": [
+      "血液在高海拔環境中變得更加黏稠這既是適應也是風險",
+      "過於稠密的血液雖然能攜帶更多氧氣但也增加了血管阻塞的危險",
+      "他的血液報告顯示經過高地訓練後血液稠度確實有所增加"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:而": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練看似簡單然而其中的生理機制卻非常複雜",
+      "他不僅在高海拔環境中訓練而且嚴格監控自己的血液指標",
+      "適度的高地訓練有益於運動表現然而過度訓練反而有害健康"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:薄": {
-    "sentences": [],
+    "sentences": [
+      "高海拔地區的空氣比平地稀薄氧氣含量也明顯較低",
+      "薄薄的空氣中他感到每一次呼吸都比在平地時更加費力",
+      "在空氣稀薄的環境中訓練能有效刺激身體的攜氧能力"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:血": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練能促進血液中紅血球的增生提升攜氧效率",
+      "他抽血檢查後發現紅血球數量在高地訓練後顯著增加了",
+      "血液攜氧能力的提升是高地訓練最核心的生理適應機制"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "高地訓練有助於運動表現嗎？:象": {
-    "sentences": [],
+    "sentences": [
+      "高地訓練引發的生理現象包括紅血球增加和心肺功能提升",
+      "他仔細觀察了身體在高海拔環境中出現的各種適應現象",
+      "血液變稠是高地訓練後最典型的生理現象之一"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:下": {
-    "sentences": [],
+    "sentences": [
+      "她在大樹下觀察黑猩猩的一舉一動",
+      "她決心在困難的條件下繼續研究黑猩猩",
+      "她放下一切到非洲的叢林裡守護黑猩猩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:不": {
-    "sentences": [],
+    "sentences": [
+      "她不畏艱難獨自在叢林裡研究黑猩猩",
+      "黑猩猩不會說話但她讀懂了牠們的情感",
+      "保護黑猩猩的工作一刻也不能停歇"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:世": {
-    "sentences": [],
+    "sentences": [
+      "她讓全世界認識了黑猩猩的聰明和情感",
+      "她是世界上最了解黑猩猩行為的科學家",
+      "她畢生致力於讓世人重視動物保育"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:之": {
-    "sentences": [],
+    "sentences": [
+      "她是黑猩猩研究領域中最傑出的學者之一",
+      "保護動物之路漫長但她從未想過放棄",
+      "她之所以堅持是因為深愛著這些動物"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:人": {
-    "sentences": [],
+    "sentences": [
+      "她是一位令人敬佩的動物保育先驅",
+      "很少有人像她一樣願意在叢林裡住這麼久",
+      "她相信人類和黑猩猩可以和平共處"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:以": {
-    "sentences": [],
+    "sentences": [
+      "她以無比的耐心贏得了黑猩猩的信任",
+      "她可以坐在樹下觀察黑猩猩好幾個小時",
+      "她以自己的行動證明了動物也有豐富的情感"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:停": {
-    "sentences": [],
+    "sentences": [
+      "她從來沒有停止過對黑猩猩的研究和保護",
+      "她停下腳步靜靜地觀察黑猩猩的互動行為",
+      "即使年紀大了她也不會停止為動物發聲"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:千": {
-    "sentences": [],
+    "sentences": [
+      "她走過千山萬水只為了守護黑猩猩的家園",
+      "千辛萬苦的研究過程最終獲得了全世界的肯定",
+      "她的故事激勵了成千上萬的人投入動物保育"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:卸": {
-    "sentences": [],
+    "sentences": [
+      "她卸下了城市生活的舒適投身非洲的叢林",
+      "黑猩猩在她面前卸下防備展現最真實的一面",
+      "她毫不推卸地扛起了保護黑猩猩的重大責任"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:可": {
-    "sentences": [],
+    "sentences": [
+      "她的研究成果證明黑猩猩也可以使用工具",
+      "她堅信每個人都可以為動物保育盡一份心力",
+      "她的故事可以激勵更多年輕人關心自然生態"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:名": {
-    "sentences": [],
+    "sentences": [
+      "她是全球最知名的黑猩猩行為研究專家",
+      "她為每隻觀察到的黑猩猩取了一個名字",
+      "她的名字和黑猩猩保育永遠連在一起"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:囊": {
-    "sentences": [],
+    "sentences": [
+      "她把所有的知識和經驗都裝進了錦囊之中",
+      "她傾囊相授把研究黑猩猩的方法教給年輕人",
+      "她的背囊裡裝著筆記本和觀察工具"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:外": {
-    "sentences": [],
+    "sentences": [
+      "她到國外的非洲叢林展開了黑猩猩的研究",
+      "在野外觀察黑猩猩需要極大的耐心和毅力",
+      "除了研究之外她也積極推動動物保育教育"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:夢": {
-    "sentences": [],
+    "sentences": [
+      "她從小就夢想著到非洲去和動物生活在一起",
+      "她的夢想是讓所有黑猩猩都能在安全的環境中生活",
+      "實現夢想的過程中她遇到了許多困難但從不放棄"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:如": {
-    "sentences": [],
+    "sentences": [
+      "她如同黑猩猩的守護天使保護牠們的棲息地",
+      "如果沒有她的努力黑猩猩的處境可能更加危險",
+      "她把黑猩猩視如自己的家人一樣細心照顧"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:寐": {
-    "sentences": [],
+    "sentences": [
+      "她夢寐以求的就是看到黑猩猩在安全的環境中生活",
+      "為了研究她經常夜不成寐地記錄觀察數據",
+      "她日思夜寐地思考著如何更好地保護黑猩猩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:崎": {
-    "sentences": [],
+    "sentences": [
+      "她走過崎嶇的山路深入叢林尋找黑猩猩的蹤跡",
+      "非洲叢林裡崎嶇不平的地形讓研究工作充滿挑戰",
+      "即使道路崎嶇她也堅持每天去觀察黑猩猩"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:嶇": {
-    "sentences": [],
+    "sentences": [
+      "叢林中崎嶇的小路是她每天必經的研究路線",
+      "她不怕崎嶇的道路因為前方有她深愛的黑猩猩",
+      "走過無數崎嶇的路她終於發現了黑猩猩的巢穴"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:心": {
-    "sentences": [],
+    "sentences": [
+      "她用一顆真心贏得了黑猩猩群體的信任",
+      "保護動物需要發自內心的熱愛和長期的堅持",
+      "她全心全意地投入黑猩猩的保育工作"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:慮": {
-    "sentences": [],
+    "sentences": [
+      "她憂慮黑猩猩的棲息地正因為人類開發而不斷縮小",
+      "深思熟慮之後她決定把一生奉獻給動物保育事業",
+      "她的顧慮是對的盜獵問題確實越來越嚴重了"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:拒": {
-    "sentences": [],
+    "sentences": [
+      "她拒絕了舒適的城市生活選擇留在叢林研究",
+      "黑猩猩一開始拒絕讓她靠近但她耐心等待",
+      "她堅決拒絕任何傷害黑猩猩的研究方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:掛": {
-    "sentences": [],
+    "sentences": [
+      "她心裡時時刻刻掛念著叢林裡的黑猩猩",
+      "牆上掛著她和黑猩猩在一起的珍貴照片",
+      "她始終牽掛著黑猩猩的安全和健康"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:於": {
-    "sentences": [],
+    "sentences": [
+      "她的研究成果有助於人類更加了解黑猩猩的行為",
+      "她終於在叢林中找到了黑猩猩的活動範圍",
+      "她致力於推動全球對黑猩猩保育的重視"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:求": {
-    "sentences": [],
+    "sentences": [
+      "她追求的不是名利而是黑猩猩的幸福和安全",
+      "她請求各國政府加強保護黑猩猩的棲息地",
+      "她對知識的渴求讓她成為最優秀的研究者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:深": {
-    "sentences": [],
+    "sentences": [
+      "她深入非洲叢林展開了長達數十年的研究",
+      "她和黑猩猩之間建立了深厚的信任和情感",
+      "她深深相信每一個生命都值得被尊重和保護"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:測": {
-    "sentences": [],
+    "sentences": [
+      "她仔細觀測黑猩猩的行為模式並詳細記錄",
+      "研究人員用儀器測量叢林中的環境變化",
+      "她無法預測會遇到什麼困難但她從不退縮"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:疾": {
-    "sentences": [],
+    "sentences": [
+      "她大聲疾呼要求全世界重視黑猩猩的保育問題",
+      "叢林中的疾病威脅著黑猩猩族群的生存安全",
+      "她眼疾手快地記錄下黑猩猩使用工具的珍貴畫面"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:聞": {
-    "sentences": [],
+    "sentences": [
+      "她的研究發現轟動了整個科學界成為重大新聞",
+      "聽聞她的故事之後許多人也開始關心動物保育",
+      "她的事蹟聞名全球激勵了無數的年輕研究者"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:舉": {
-    "sentences": [],
+    "sentences": [
+      "她的一舉一動都小心翼翼以免嚇到黑猩猩",
+      "她舉出許多例子證明黑猩猩有豐富的情感世界",
+      "保育工作的每一個舉措都需要謹慎而長遠的規劃"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:行": {
-    "sentences": [],
+    "sentences": [
+      "她用實際行動證明了一個人也能改變世界",
+      "她的善行感動了全球數百萬關心動物的人",
+      "她獨自前行走進叢林開始了一段偉大的旅程"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:蹄": {
-    "sentences": [],
+    "sentences": [
+      "她聽見遠處傳來動物的蹄聲知道有大型動物靠近",
+      "馬不停蹄地奔走各國只為了替黑猩猩爭取保護",
+      "她走過草原上留下的動物蹄印追蹤著野生動物的足跡"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:迅": {
-    "sentences": [],
+    "sentences": [
+      "她迅速記錄下黑猩猩使用工具的難得畫面",
+      "消息迅速傳開全世界都在討論她的重大發現",
+      "她迅速採取行動阻止盜獵者進入保護區"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:迷": {
-    "sentences": [],
+    "sentences": [
+      "她從小就對動物著迷夢想著有一天能親眼見到黑猩猩",
+      "黑猩猩複雜的社會行為深深地迷住了每一位研究者",
+      "她被非洲叢林的神祕魅力所迷戀決定留下來"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:里": {
-    "sentences": [],
+    "sentences": [
+      "她跋涉了好幾千里路才抵達黑猩猩的棲息地",
+      "那片叢林位於非洲內陸距離最近的城鎮好幾百里",
+      "她在方圓數十里的叢林中建立了研究觀察站"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:防": {
-    "sentences": [],
+    "sentences": [
+      "她積極推動立法來防止黑猩猩遭到非法獵捕",
+      "保護區設立了防線阻止盜獵者進入黑猩猩的領地",
+      "預防棲息地被破壞是保護黑猩猩最重要的工作"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:霧": {
-    "sentences": [],
+    "sentences": [
+      "清晨的薄霧中她靜靜地等待黑猩猩出現",
+      "她穿過霧氣瀰漫的叢林尋找黑猩猩的蹤影",
+      "即使在濃霧中看不清楚她也堅持每天出門觀察"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:風": {
-    "sentences": [],
+    "sentences": [
+      "她不畏風雨每天準時出現在觀察點記錄黑猩猩",
+      "她的研究在科學界掀起了一陣新的風潮",
+      "叢林裡的風把她和黑猩猩的故事吹向了全世界"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   },
   "黑猩猩的守護者:馬": {
-    "sentences": [],
+    "sentences": [
+      "她馬上就被黑猩猩聰明的行為深深吸引了",
+      "她馬不停蹄地在世界各地宣傳動物保育理念",
+      "騎馬穿越草原是她前往研究地點最常見的方式"
+    ],
     "source": "pregenerated",
-    "cached_at": "",
-    "_placeholder": true
+    "cached_at": "2026-03-30T00:00:00Z"
   }
 }

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -245,7 +245,12 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
   const handlePractice = (ch: string, mode: PracticeMode = 'stroke') => {
     setPracticingChar(ch);
-    setPhase(mode === 'stroke' ? 'practice' : 'pronunciation');
+    // Only 'stroke' launches WriteCharacter; all other modes (including
+    // 'radical', 'sentence', etc.) are tab-based inline panels, not a
+    // full-screen phase. Guard here so an unexpected activeTab value can
+    // never send the user to PronunciationPractice by accident.
+    const targetPhase = mode === 'stroke' ? 'practice' : mode === 'pronunciation' ? 'pronunciation' : 'practice';
+    setPhase(targetPhase);
     setJustCompleted('');
   };
 
@@ -499,7 +504,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                 return (
                   <div key={ch} className="flex flex-col gap-1">
                     <button
-                      onClick={() => handlePractice(ch, activeTab)}
+                      onClick={() => handlePractice(ch, activeTab === 'stroke' ? 'stroke' : 'pronunciation')}
                       className={[
                         `relative flex flex-col items-center justify-center w-full ${zhuyinActive ? 'aspect-[3/6]' : 'aspect-square'} rounded-2xl border transition-all active:scale-95 animate-card-in`,
                         isPracticed


### PR DESCRIPTION
## Summary

- **Frontend**: `handlePractice(ch, activeTab)` — character card in the 筆順 tab passes `activeTab` directly as the mode. If `activeTab` is ever not `'stroke'` or `'pronunciation'` (e.g. due to stale state or future refactor), the old code falls through to `setPhase('pronunciation')` unexpectedly. Fixed: explicit ternary guards + character card onClick now maps `activeTab === 'stroke'` to `'stroke'` and any other value to `'pronunciation'`.
- **Backend cache**: All 1490 pre-generated example sentences in `example_sentence_cache.json` were placeholder-only (`"sentences": []`) after merge conflicts in PR #792. This caused every sentence-practice request to hit the AI instead of the cache. Restored correct entries from commit `d8faeb7`.
- **Backend route**: Pre-generation script stored sentences as plain strings (`["句子1", "句子2"]`) but the route used `ExampleSentenceItem(**s)` expecting dicts. Added a `_to_item()` helper to handle both formats without crashing.

## Root causes

1. `handlePractice` default case was `'pronunciation'` phase — any non-stroke/non-pronunciation mode would launch PronunciationPractice instead of WriteCharacter
2. All 1490 pre-generated cache entries were empty placeholders after merge conflict resolution
3. Route didn't handle the plain-string format the pre-generation script uses

## Test plan

- [ ] Go to 生字練習 step for any story
- [ ] Click 筆順練習 tab — character grid should appear
- [ ] Click a character card — WriteCharacter (筆順動畫) should launch
- [ ] Complete a character — should return to grid with green checkmark
- [ ] Click 造句練習 tab — SentencePractice inline should appear, AI examples should load fast from cache (not spinner for 2+ sec)
- [ ] Verify no 500 errors in backend logs for `/api/learning/sentence-practice/example-sentences`

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)