### PR TITLE
fix(sidebar): hide 加入班級 button from student sidebar (Fixes #838)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -341,7 +341,8 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
         { icon: '📋', label: '我的作業', path: '/assignments', badge: pendingAssignmentCount },
         // Hidden: 學習進度, 成就, 生字本, 對話記錄 — 整合到「我的作業」(#643)
         { icon: '🏫', label: '我的班級', path: '/classroom-dashboard' },
-        { icon: '🔗', label: '加入班級', path: '/join' },
+        // Hidden: 加入班級 — students join via invite code, not sidebar (#838)
+
       ]
     : [];
 


### PR DESCRIPTION
Fixes #838

## Summary
- Removes the `加入班級` sidebar entry from the student navigation
- The `/join` route still exists and works — only the sidebar link is hidden
- Students join classrooms via invite codes provided by their teachers, not through a sidebar button

## Test plan
- Log in as a student-role user
- Verify the sidebar does NOT show a `加入班級` link
- Navigate to `/join` directly — verify the page still works
- Log in as a teacher/admin — verify no sidebar changes for those roles