### PR TITLE
fix: reduce font sizes and tighten layout on assignments pages (Fixes #839)

### DIFF
--- a/frontend/src/pages/student/MyAssignments.tsx
+++ b/frontend/src/pages/student/MyAssignments.tsx
@@ -280,12 +280,12 @@ const MyAssignments: React.FC = () => {
   };
 
   return (
-    <div className="flex-1 overflow-y-auto p-6 sm:p-8">
-      <div className="max-w-2xl mx-auto space-y-6">
+    <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+      <div className="max-w-2xl mx-auto space-y-4">
         {/* Page title */}
         <div>
-          <h1 className="text-xl font-bold text-gray-900">我的作業</h1>
-          <p className="text-sm text-gray-500 mt-1">完成老師指派的學習任務</p>
+          <h1 className="text-base font-bold text-gray-900">我的作業</h1>
+          <p className="text-xs text-gray-500 mt-0.5">完成老師指派的學習任務</p>
         </div>
 
         {/* Filter tabs */}
@@ -295,7 +295,7 @@ const MyAssignments: React.FC = () => {
               <button
                 key={tab.key}
                 onClick={() => setActiveFilter(tab.key)}
-                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
+                className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer ${
                   activeFilter === tab.key
                     ? 'border-accent text-accent'
                     : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'

--- a/frontend/src/pages/student/StudentClassroomDashboard.tsx
+++ b/frontend/src/pages/student/StudentClassroomDashboard.tsx
@@ -174,7 +174,7 @@ const ClassroomCard: React.FC<ClassroomCardProps> = ({
       </div>
 
       {/* Assignment summary stats */}
-      <div className="px-5 pt-4 pb-2 flex gap-4 text-sm">
+      <div className="px-5 pt-3 pb-2 flex gap-4 text-xs">
         <span className="text-amber-700 font-semibold">
           {pending.length} 待完成
         </span>
@@ -292,11 +292,11 @@ const StudentClassroomDashboard: React.FC = () => {
   if (loading) {
     return (
       <div className="flex-1 overflow-y-auto">
-        <div className="max-w-3xl mx-auto p-6 space-y-6">
+        <div className="max-w-3xl mx-auto p-4 sm:p-6 space-y-4">
           <LoadingIndicator />
           <div>
-            <Skeleton className="h-8 w-36 rounded" />
-            <Skeleton className="h-4 w-52 rounded mt-2" />
+            <Skeleton className="h-5 w-36 rounded" />
+            <Skeleton className="h-3 w-52 rounded mt-1.5" />
           </div>
           <div className="space-y-5">
             {Array.from({ length: 2 }).map((_, index) => (
@@ -310,11 +310,11 @@ const StudentClassroomDashboard: React.FC = () => {
 
   return (
     <div className="flex-1 overflow-y-auto">
-      <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <div className="max-w-3xl mx-auto p-4 sm:p-6 space-y-4">
         {/* Page header */}
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">我的班級</h1>
-          <p className="text-sm text-gray-500 mt-1">查看你加入的班級、老師和作業</p>
+          <h1 className="text-base font-bold text-gray-900">我的班級</h1>
+          <p className="text-xs text-gray-500 mt-0.5">查看你加入的班級、老師和作業</p>
         </div>
 
         {error && (


### PR DESCRIPTION
Fixes #839

## Summary
- `MyAssignments.tsx`: page title `text-xl` → `text-base`, subtitle `text-sm` → `text-xs`, outer padding reduced from `p-6 sm:p-8` to `p-4 sm:p-6`, section spacing `space-y-6` → `space-y-4`, filter tabs `text-sm px-4 py-2` → `text-xs px-3 py-1.5`
- `StudentClassroomDashboard.tsx`: page title `text-2xl` → `text-base`, subtitle `text-sm` → `text-xs`, padding and spacing tightened to match, assignment stats `text-sm` → `text-xs`, loading skeleton heights aligned

## Test plan
- [ ] Open `/assignments` — cards should be compact with smaller title and tabs
- [ ] Open the classroom dashboard — "我的班級" title should be smaller, stats should be `text-xs`
- [ ] `npm run build` passes (verified locally)