### PR TITLE
fix(vocab): #854 — pin activeTab on stroke practice entry/exit

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -247,10 +247,20 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     setPracticingChar(ch);
     // Only 'stroke' launches WriteCharacter; all other modes (including
     // 'radical', 'sentence', etc.) are tab-based inline panels, not a
-    // full-screen phase. Guard here so an unexpected activeTab value can
-    // never send the user to PronunciationPractice by accident.
-    const targetPhase = mode === 'stroke' ? 'practice' : mode === 'pronunciation' ? 'pronunciation' : 'practice';
-    setPhase(targetPhase);
+    // full-screen phase. Guard: any mode that isn't 'stroke' or 'pronunciation'
+    // falls through to 'practice' (WriteCharacter) as the safe default.
+    // Also pin activeTab so returning from WriteCharacter always lands on the
+    // correct tab (fixes #854: clicking stroke-tab card returned to 部件 tab).
+    if (mode === 'stroke') {
+      setActiveTab('stroke');
+      setPhase('practice');
+    } else if (mode === 'pronunciation') {
+      setActiveTab('pronunciation');
+      setPhase('pronunciation');
+    } else {
+      setActiveTab('stroke');
+      setPhase('practice');
+    }
     setJustCompleted('');
   };
 
@@ -258,15 +268,20 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     const ch = practicingChar;
     setPracticedChars(prev => new Set(prev).add(ch));
     setJustCompleted(ch);
+    // Always return to the stroke tab after completing WriteCharacter (#854)
+    setActiveTab('stroke');
     setPhase('grid');
   };
 
   const handlePronunciationComplete = () => {
     setPronoucedChars(prev => new Set(prev).add(practicingChar));
+    setActiveTab('pronunciation');
     setPhase('grid');
   };
 
   const handlePracticeBack = () => {
+    // Return to the stroke tab after backing out of WriteCharacter (#854)
+    setActiveTab('stroke');
     setPhase('grid');
   };
 


### PR DESCRIPTION
## Summary

Fixes #854: Clicking a character card in the 筆順練習 tab didn't enter WriteCharacter — user was returned to 部件 tab instead.

**Root cause**: `handlePractice`, `handlePracticeComplete`, and `handlePracticeBack` never explicitly set `activeTab` during phase transitions. Since `activeTab` defaults to `'radical'` on component mount, any scenario where the state drifted (stale closure, React batching, or component remount) would cause the user to land back on the 部件學習 tab instead of the stroke tab.

**Fix**: Pin `activeTab` atomically alongside every phase transition:
- `handlePractice(ch, 'stroke')` → `setActiveTab('stroke')` + `setPhase('practice')`  
- `handlePracticeComplete` → `setActiveTab('stroke')` + `setPhase('grid')`  
- `handlePracticeBack` → `setActiveTab('stroke')` + `setPhase('grid')`  
- `handlePronunciationComplete` → `setActiveTab('pronunciation')` + `setPhase('grid')`

This makes the tab/phase pair always consistent, so the user reliably reaches WriteCharacter and returns to the correct tab regardless of any intermediate state drift.

## Files changed

- `frontend/src/components/reading-steps/VocabPractice.tsx` — `handlePractice`, `handlePracticeComplete`, `handlePronunciationComplete`, `handlePracticeBack`

## Test plan

- [ ] Open VocabPractice (生字練習) for any story
- [ ] Default tab is 部件學習 — verify RadicalDecomposition rows show
- [ ] Click 筆順練習 tab → character grid appears
- [ ] Click any character card → WriteCharacter (筆順練習) renders full screen
- [ ] Press Back in WriteCharacter → returns to 筆順練習 tab (NOT 部件 tab)
- [ ] Complete WriteCharacter → returns to 筆順練習 tab with completion flash
- [ ] Click 造句練習 tab → SentencePractice inline panel appears
- [ ] `npm run build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)