### PR TITLE
fix(vocab): #854 — pin activeTab on practice entry/exit so stroke tab never loses focus

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -247,10 +247,20 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     setPracticingChar(ch);
     // Only 'stroke' launches WriteCharacter; all other modes (including
     // 'radical', 'sentence', etc.) are tab-based inline panels, not a
-    // full-screen phase. Guard here so an unexpected activeTab value can
-    // never send the user to PronunciationPractice by accident.
-    const targetPhase = mode === 'stroke' ? 'practice' : mode === 'pronunciation' ? 'pronunciation' : 'practice';
-    setPhase(targetPhase);
+    // full-screen phase. Guard: any mode that isn't 'stroke' or 'pronunciation'
+    // falls through to 'practice' (WriteCharacter) as the safe default.
+    // Also pin activeTab so returning from WriteCharacter always lands on the
+    // correct tab (fixes #854: clicking stroke-tab card returned to 部件 tab).
+    if (mode === 'stroke') {
+      setActiveTab('stroke');
+      setPhase('practice');
+    } else if (mode === 'pronunciation') {
+      setActiveTab('pronunciation');
+      setPhase('pronunciation');
+    } else {
+      setActiveTab('stroke');
+      setPhase('practice');
+    }
     setJustCompleted('');
   };
 
@@ -258,15 +268,20 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     const ch = practicingChar;
     setPracticedChars(prev => new Set(prev).add(ch));
     setJustCompleted(ch);
+    // Always return to the stroke tab after completing WriteCharacter (#854)
+    setActiveTab('stroke');
     setPhase('grid');
   };
 
   const handlePronunciationComplete = () => {
     setPronoucedChars(prev => new Set(prev).add(practicingChar));
+    setActiveTab('pronunciation');
     setPhase('grid');
   };
 
   const handlePracticeBack = () => {
+    // Return to the stroke tab after backing out of WriteCharacter (#854)
+    setActiveTab('stroke');
     setPhase('grid');
   };
 


### PR DESCRIPTION
## Summary
- Pin `activeTab` when entering/exiting WriteCharacter so the stroke tab never loses focus
- Fixes #854: clicking a character card on the stroke tab would switch to the 部件 tab instead of entering WriteCharacter

## Test plan
- [ ] On staging, go to 生字練習 step
- [ ] Click 筆順練習 tab, then click a character card
- [ ] Verify WriteCharacter opens (not 部件拆解)
- [ ] Complete or back out of WriteCharacter
- [ ] Verify you return to 筆順練習 tab (not 部件學習)

🤖 Generated with [Claude Code](https://claude.com/claude-code)