### PR TITLE
fix(vocab): React hooks order crash on stroke tab card click

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -295,6 +295,19 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     setRadicalChar(prev => (prev === ch ? null : ch));
   };
 
+  // ── Derived state (must stay BEFORE conditional returns to satisfy Rules of Hooks) ──
+  const strokeDone = displayChars.length > 0 && displayChars.every(ch => practicedChars.has(ch));
+  const pronounceDone = displayChars.length > 0 && displayChars.every(ch => pronouncedChars.has(ch));
+  const allDone = strokeDone && pronounceDone;
+
+  const currentChars = activeTab === 'stroke' ? displayChars : activeTab === 'pronunciation' ? pronunciationChars : [];
+  const currentPracticedSet = activeTab === 'stroke' ? practicedChars : activeTab === 'pronunciation' ? pronouncedChars : new Set<string>();
+  const currentDone = activeTab === 'stroke' ? strokeDone : activeTab === 'pronunciation' ? pronounceDone : false;
+
+  // Characters for which we have radical decomposition data (re-filter after generated data loads)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const charsWithRadical = useMemo(() => displayChars.filter(ch => getDecomposition(ch) !== null), [displayChars, decompReady]);
+
   /* ── Pronunciation practice phase ── */
   if (phase === 'pronunciation') {
     const zhuyinStr = zhuyinActive ? processZhuyin(practicingChar) : undefined;
@@ -331,18 +344,6 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   }
 
   /* ── Grid phase: character selection ── */
-  const strokeDone = displayChars.length > 0 && displayChars.every(ch => practicedChars.has(ch));
-  const pronounceDone = displayChars.length > 0 && displayChars.every(ch => pronouncedChars.has(ch));
-  const allDone = strokeDone && pronounceDone;
-
-  const currentChars = activeTab === 'stroke' ? displayChars : activeTab === 'pronunciation' ? pronunciationChars : [];
-  const currentPracticedSet = activeTab === 'stroke' ? practicedChars : activeTab === 'pronunciation' ? pronouncedChars : new Set<string>();
-  const currentDone = activeTab === 'stroke' ? strokeDone : activeTab === 'pronunciation' ? pronounceDone : false;
-  // 'zhuyin', 'fillinblank', and 'sentence' tabs are handled separately; these vars only matter for stroke/pronunciation
-
-  // Characters for which we have radical decomposition data (re-filter after generated data loads)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const charsWithRadical = useMemo(() => displayChars.filter(ch => getDecomposition(ch) !== null), [displayChars, decompReady]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Move `useMemo` (charsWithRadical) and derived state variables before conditional early returns in VocabPractice
- Fixes React error #300 ("Rendered fewer hooks than expected") that crashed the component when clicking a character card on the stroke tab

## Root cause
`charsWithRadical` useMemo was at line 345, AFTER conditional returns at lines 299-330. When phase changed from 'grid' to 'practice', the early return skipped the useMemo, causing hook count mismatch.

## Test plan
- [x] Local: click stroke tab card → WriteCharacter loads without crash
- [x] Local: back from WriteCharacter → returns to stroke tab
- [ ] Staging: repeat above tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)