### PR TITLE
fix(vocab): #864 — null guard for attempt.mispronouncedWords

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -229,7 +229,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
   // Pronunciation tab: all characters are candidates (no stroke-data filter needed)
   const pronunciationChars = useMemo(() => {
-    const suggested = attempt.mispronouncedWords.filter(ch => /[\u4e00-\u9fa5]/.test(ch));
+    const suggested = (attempt?.mispronouncedWords ?? []).filter(ch => /[\u4e00-\u9fa5]/.test(ch));
     if (suggested.length > 0) return suggested.slice(0, 12);
     const seen = new Set<string>();
     const optional: string[] = [];
@@ -242,7 +242,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
       }
     }
     return optional.slice(0, 12);
-  }, [story.content, attempt.mispronouncedWords]);
+  }, [story.content, attempt?.mispronouncedWords]);
 
   const handlePractice = (ch: string, mode: PracticeMode = 'stroke') => {
     setPracticingChar(ch);
@@ -278,7 +278,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
   /* ── Confirm phase: ask student whether to start vocab practice ── */
   if (phase === 'confirm') {
-    const suggestedCount = attempt.mispronouncedWords.filter(hasStrokeData).length;
+    const suggestedCount = (attempt?.mispronouncedWords ?? []).filter(hasStrokeData).length;
     const totalVocabCount = displayChars.length;
     const charCount = suggestedCount > 0 ? suggestedCount : totalVocabCount;
 


### PR DESCRIPTION
## Summary
- Add optional chaining on `attempt?.mispronouncedWords` at lines 232 and 245
- Add null guard `(attempt?.mispronouncedWords ?? [])` at line 281 (confirm phase)
- Prevents TypeError crash when `attempt` is null

## Found by
Comprehensive review 2026-03-31

Closes #864