### PR TITLE
fix(vocab): #865 — replace reload() with state reset in VocabWordSearch

### DIFF
--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -259,10 +259,14 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
     [story.vocabulary]
   );
 
+  const [redoKey, setRedoKey] = useState(0);
+
   const { grid, placedWords, size } = useMemo(() => {
     if (vocabWords.length === 0) return { grid: [], placedWords: [], size: 0 };
     return generateGrid(vocabWords);
-  }, [vocabWords]);
+  // redoKey forces grid regeneration when student clicks 重新練習
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vocabWords, redoKey]);
 
   const wordKeysMap = useMemo(() => {
     const map = new Map<string, Set<string>>();
@@ -499,11 +503,20 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
     );
   }
 
-  // #847: handleRedo available for both the completion banner and restart button
+  // #847: handleRedo — reset all game state without reloading the page (#865)
   const handleRedo = () => {
-    // #816: only clear localStorage when student explicitly requests restart
+    // Clear localStorage so completion state is gone
     try { localStorage.removeItem(storageKey); } catch {}
-    window.location.reload();
+    // Reset all game state in-place; incrementing redoKey regenerates the grid via useMemo
+    setFoundWords(new Set());
+    setHighlightedCells(new Set());
+    setDragCells(new Set());
+    setDragStart(null);
+    setFlashCells(new Set());
+    setFinished(false);
+    setFinishedElapsed(0);
+    setJustFound(null);
+    setRedoKey((k) => k + 1);
   };
 
   // Ensure minimum 44px touch targets per design guidelines; use larger cells for readability


### PR DESCRIPTION
## Summary
- Replace `window.location.reload()` with proper React state reset
- Add `redoKey` state to trigger grid regeneration via `useMemo` dependency
- No more full page flash or session data loss on retry

## Found by
Comprehensive review 2026-03-31

Closes #865