### PR TITLE
fix(design): #882 — standardize CTA colors, min text-xs, bg-amber-50, replace hardcoded hex

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -298,7 +298,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
         </div>
 
         {/* Status bar */}
-        <div className="h-7 bg-white border-t border-gray-200 flex items-center px-4 text-[10px] text-gray-500 uppercase shrink-0">
+        <div className="h-7 bg-white border-t border-gray-200 flex items-center px-4 text-xs text-gray-500 uppercase shrink-0">
           <span>共 {story.content.length} 段 · {story.title}</span>
           <div className="flex-1" />
           <span className={isSessionActive ? 'text-green-500 font-bold' : isPreparing ? 'text-yellow-500 font-bold' : 'text-gray-300'}>
@@ -328,7 +328,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       >
         {/* Header */}
         <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4">
-          <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">全文朗讀</span>
+          <span className="text-xs font-black text-accent-light uppercase tracking-widest">全文朗讀</span>
         </div>
 
         {/* Content */}
@@ -352,7 +352,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {/* Live transcript */}
           {isSessionActive && streamingTranscript && (
             <div className="flex flex-col gap-1">
-              <span className="text-[9px] font-bold text-accent-light uppercase animate-pulse">LISTENING...</span>
+              <span className="text-xs font-bold text-accent-light uppercase animate-pulse">LISTENING...</span>
               <div className="bg-accent/20 border border-accent/30 rounded-xl px-3 py-2.5 text-base text-gray-800 leading-relaxed">
                 {streamingTranscript}
               </div>
@@ -361,7 +361,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
           {isSessionActive && !streamingTranscript && (
             <div className="flex flex-col gap-1">
-              <span className="text-[9px] font-bold text-green-500 uppercase animate-pulse">LISTENING</span>
+              <span className="text-xs font-bold text-green-500 uppercase animate-pulse">LISTENING</span>
               <div className="bg-green-900/20 border border-green-700/30 rounded-xl px-3 py-2.5 text-base text-gray-600 leading-relaxed">
                 請朗讀左側課文，從頭到尾…
               </div>
@@ -390,14 +390,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
               {streamingTranscript && (
                 <div className="bg-white border border-gray-200 rounded-xl px-3 py-2.5">
-                  <p className="text-[10px] text-gray-500 mb-1 uppercase tracking-widest">你說的</p>
+                  <p className="text-xs text-gray-500 mb-1 uppercase tracking-widest">你說的</p>
                   <p className="text-xs text-gray-600 leading-relaxed line-clamp-6">{streamingTranscript}</p>
                 </div>
               )}
 
               {result.diffTokens && result.diffTokens.length > 0 && (
                 <div className="bg-white border border-gray-200 rounded-xl px-3 py-2.5">
-                  <p className="text-[10px] text-gray-500 mb-2 uppercase tracking-widest">逐字比對</p>
+                  <p className="text-xs text-gray-500 mb-2 uppercase tracking-widest">逐字比對</p>
                   <DiffDisplay tokens={result.diffTokens} showLegend className="text-lg" />
                 </div>
               )}
@@ -405,7 +405,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
               {/* Audio playback — let student re-listen to their reading */}
               {audioRecorder.audioUrl && (
                 <div className="bg-white border border-gray-200 rounded-xl px-3 py-2.5">
-                  <p className="text-[10px] text-gray-500 mb-2 uppercase tracking-widest">重聽錄音</p>
+                  <p className="text-xs text-gray-500 mb-2 uppercase tracking-widest">重聽錄音</p>
                   <audio src={audioRecorder.audioUrl} controls className="w-full h-9" aria-label="播放您的朗讀錄音" />
                 </div>
               )}
@@ -415,7 +415,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
         {/* Controls */}
         <div className="shrink-0 p-3 bg-white border-t border-gray-200 space-y-2">
-          {micError && <div className="text-[10px] text-rose-400 px-1 pb-1">{micError}</div>}
+          {micError && <div className="text-xs text-rose-400 px-1 pb-1">{micError}</div>}
 
           {result ? (
             <div className="space-y-2">

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -1243,7 +1243,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                       </span>
                     )}
                     {status === 'locked' && (
-                      <span className="ml-auto text-[10px] text-gray-400">完成前一段後解鎖</span>
+                      <span className="ml-auto text-xs text-gray-400">完成前一段後解鎖</span>
                     )}
                     {/* Inline action buttons — system read + start/submit/retry */}
                     {status !== 'locked' && !isAdvancing && (
@@ -1522,9 +1522,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       >
         {/* Header */}
         <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4 gap-2">
-          <span className="text-[10px] font-black text-accent-light uppercase tracking-widest">朗讀回饋</span>
+          <span className="text-xs font-black text-accent-light uppercase tracking-widest">朗讀回饋</span>
           <div className="flex-1" />
-          <span className={`text-[10px] font-bold ${isSessionActive ? 'text-green-500' : isPreparing ? 'text-yellow-500' : 'text-gray-300'}`}>
+          <span className={`text-xs font-bold ${isSessionActive ? 'text-green-500' : isPreparing ? 'text-yellow-500' : 'text-gray-300'}`}>
             {isSessionActive ? '● 聆聽中' : isPreparing ? '● 準備中' : '● 待機'}
           </span>
         </div>
@@ -1534,7 +1534,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
           {/* Progress info */}
           <div className="bg-white rounded-xl border border-gray-200 p-3 space-y-1">
-            <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">朗讀進度</p>
+            <p className="text-xs font-bold text-gray-400 uppercase tracking-widest">朗讀進度</p>
             <p className="text-sm font-bold text-gray-700">
               第 {currentLineIndex + 1} 段 / 共 {story.content.length} 段
             </p>
@@ -1547,7 +1547,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           {/* Live transcript — shown while recording */}
           {isSessionActive && (
             <div className="space-y-1">
-              <p className="text-[9px] font-bold text-accent-light uppercase tracking-widest animate-pulse">即時辨識</p>
+              <p className="text-xs font-bold text-accent-light uppercase tracking-widest animate-pulse">即時辨識</p>
               <div className="bg-accent/10 border border-accent/20 rounded-xl px-3 py-2.5 text-sm text-gray-800 leading-relaxed min-h-[2.5rem]">
                 {streamingUserInput || <span className="text-gray-400">請開始朗讀…</span>}
               </div>
@@ -1558,9 +1558,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
           {!isSessionActive && rightPanelDiffTokens && (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <p className="text-[9px] font-bold text-gray-400 uppercase tracking-widest">逐字比對</p>
+                <p className="text-xs font-bold text-gray-400 uppercase tracking-widest">逐字比對</p>
                 {paragraphSummary?.geminiPending && (
-                  <span className="text-[9px] text-blue-400 font-bold animate-pulse">AI 精算中…</span>
+                  <span className="text-xs text-blue-400 font-bold animate-pulse">AI 精算中…</span>
                 )}
               </div>
               <div className="bg-white border border-gray-200 rounded-xl px-3 py-3">

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -534,7 +534,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
         <button
           type="button"
           onClick={() => onFinish(summary)}
-          className="px-8 py-3 rounded-xl font-bold text-base bg-amber-600 hover:bg-amber-700 text-white shadow-lg transition-all active:scale-95 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2"
+          className="px-8 py-3 rounded-xl font-bold text-base bg-accent hover:bg-accent-hover text-white shadow-lg transition-all active:scale-95 flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
         >
           完成標記
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">

--- a/frontend/src/components/reading-steps/VocabApplication.tsx
+++ b/frontend/src/components/reading-steps/VocabApplication.tsx
@@ -196,7 +196,7 @@ function CompletionScreen({
         {wrongCount > 0 && (
           <button
             onClick={onRetryWrong}
-            className="rounded-xl border-2 border-[#5B4FC4] bg-white px-8 py-3 text-base font-bold text-[#5B4FC4] hover:bg-[#5B4FC4]/5 active:scale-95 transition-all shadow-sm min-h-[52px]"
+            className="rounded-xl border-2 border-accent bg-white px-8 py-3 text-base font-bold text-accent hover:bg-accent/5 active:scale-95 transition-all shadow-sm min-h-[52px]"
           >
             練習錯題（{wrongCount} 題）
           </button>
@@ -209,7 +209,7 @@ function CompletionScreen({
         </button>
         <button
           onClick={onFinish}
-          className="rounded-lg bg-emerald-500 px-10 py-3 text-white font-semibold hover:bg-emerald-600 transition-colors text-lg min-h-[52px]"
+          className="rounded-xl bg-accent px-10 py-3 text-white font-semibold hover:bg-accent-hover transition-colors text-lg min-h-[52px]"
         >
           繼續下一步 →
         </button>
@@ -397,7 +397,7 @@ const VocabApplication: React.FC<VocabApplicationProps> = ({
 
   return (
     <div
-      className="flex-1 flex flex-col bg-white"
+      className="flex-1 flex flex-col bg-amber-50"
       style={fontSizePx ? { fontSize: fontSizePx } : undefined}
     >
       <StepHeader

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -208,7 +208,7 @@ function SummaryScreen({
         {!allCorrect && (
           <button
             onClick={onRetryWrong}
-            className="rounded-xl border-2 border-[#5B4FC4] text-[#5B4FC4] px-6 py-3 font-bold hover:bg-[#5B4FC4] hover:text-white transition-all active:scale-95"
+            className="rounded-xl border-2 border-accent text-accent px-6 py-3 font-bold hover:bg-accent hover:text-white transition-all active:scale-95"
           >
             只重做錯題（{wrongAnswers.length} 題）
           </button>
@@ -221,7 +221,7 @@ function SummaryScreen({
         </button>
         <button
           onClick={onFinish}
-          className="rounded-xl bg-[#5B4FC4] px-8 py-3 text-white font-bold hover:bg-[#4a3fb0] transition-all active:scale-95 shadow-md"
+          className="rounded-xl bg-accent px-8 py-3 text-white font-bold hover:bg-accent-hover transition-all active:scale-95 shadow-md"
         >
           繼續下一步 →
         </button>
@@ -254,7 +254,7 @@ function ModeSwitcher({
           onClick={() => onChange(id)}
           className={`flex-1 flex items-center justify-center gap-1 py-2 px-2 rounded-lg text-sm font-semibold transition-all duration-200 ${
             current === id
-              ? 'bg-white text-[#5B4FC4] shadow-sm'
+              ? 'bg-white text-accent shadow-sm'
               : 'text-gray-500 hover:text-gray-700'
           }`}
         >
@@ -331,8 +331,8 @@ function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: MultipleChoi
       </div>
 
       {/* Definition card */}
-      <div className="bg-white border-2 border-[#5B4FC4] rounded-2xl p-6 mb-6 shadow-sm">
-        <p className="text-xs font-semibold text-[#5B4FC4] uppercase tracking-wider mb-2">
+      <div className="bg-white border-2 border-accent rounded-2xl p-6 mb-6 shadow-sm">
+        <p className="text-xs font-semibold text-accent uppercase tracking-wider mb-2">
           定義
         </p>
         <p className="text-lg text-gray-800 leading-relaxed">{item?.definition}</p>
@@ -346,7 +346,7 @@ function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: MultipleChoi
         {options.map((vocabIdx) => (
           <button
             key={vocabIdx}
-            className="rounded-xl border-2 px-4 py-4 text-center font-bold text-xl transition-all duration-200 select-none bg-white border-gray-200 text-gray-800 hover:border-[#5B4FC4] hover:bg-purple-50 hover:shadow-sm active:scale-95 cursor-pointer disabled:opacity-50"
+            className="rounded-xl border-2 px-4 py-4 text-center font-bold text-xl transition-all duration-200 select-none bg-white border-gray-200 text-gray-800 hover:border-accent hover:bg-purple-50 hover:shadow-sm active:scale-95 cursor-pointer disabled:opacity-50"
             onClick={() => handleChoice(vocabIdx)}
             disabled={pendingAdvance}
           >
@@ -488,11 +488,11 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
           let cls =
             'rounded-xl border-2 px-5 py-3 text-center font-bold text-xl select-none transition-all duration-200 ';
           if (isDragging) {
-            cls += 'border-[#5B4FC4] bg-purple-100 text-purple-900 shadow-xl scale-105 opacity-80 cursor-grabbing';
+            cls += 'border-accent bg-purple-100 text-purple-900 shadow-xl scale-105 opacity-80 cursor-grabbing';
           } else if (isTouchSelected) {
-            cls += 'border-[#5B4FC4] bg-purple-100 text-purple-900 shadow-md scale-105 cursor-pointer';
+            cls += 'border-accent bg-purple-100 text-purple-900 shadow-md scale-105 cursor-pointer';
           } else {
-            cls += 'border-gray-200 bg-white text-gray-800 hover:border-[#5B4FC4] hover:bg-purple-50 hover:shadow-sm active:scale-95 cursor-grab';
+            cls += 'border-gray-200 bg-white text-gray-800 hover:border-accent hover:bg-purple-50 hover:shadow-sm active:scale-95 cursor-grab';
           }
 
           return (
@@ -511,7 +511,7 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
         })}
       </div>
       {touchSelected !== null && (
-        <p className="text-center text-xs text-[#5B4FC4] mt-2 font-medium">
+        <p className="text-center text-xs text-accent mt-2 font-medium">
           已選「{vocab[touchSelected]?.word}」— 點選下方欄位放入
         </p>
       )}
@@ -533,11 +533,11 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
     } else if (isWrong) {
       cls += 'bg-red-50 border-red-400 animate-shake';
     } else if (isOver) {
-      cls += 'bg-purple-50 border-[#5B4FC4] scale-[1.01] shadow-md';
+      cls += 'bg-purple-50 border-accent scale-[1.01] shadow-md';
     } else if (placedVocabIdx !== null) {
       cls += 'bg-amber-50 border-amber-400';
     } else {
-      cls += 'bg-white border-dashed border-gray-300 hover:border-[#5B4FC4]';
+      cls += 'bg-white border-dashed border-gray-300 hover:border-accent';
     }
 
     return (

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -38,8 +38,8 @@ function ProgressBar({ done, total }: ProgressBarProps) {
     <div className="w-full px-6 py-2 bg-white border-b border-gray-100">
       <div className="max-w-2xl mx-auto">
         <div className="flex justify-between items-center mb-1">
-          <span className="text-[10px] font-medium text-gray-500" aria-hidden="true">練習進度</span>
-          <span className="text-[10px] font-bold text-gray-700" aria-hidden="true">{done} / {total} 字</span>
+          <span className="text-xs font-medium text-gray-500" aria-hidden="true">練習進度</span>
+          <span className="text-xs font-bold text-gray-700" aria-hidden="true">{done} / {total} 字</span>
         </div>
         <div
           role="progressbar"
@@ -131,7 +131,7 @@ function CharCard({ label, isSuggested, isPracticed, animDelay, onClick }: CharC
         </span>
       )}
 
-      <span className="text-[9px] mt-1 opacity-50 font-medium">
+      <span className="text-xs mt-1 opacity-50 font-medium">
         {isPracticed ? '已完成' : '點我練習'}
       </span>
     </button>
@@ -341,7 +341,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           {story.filename} — 生字練習
         </div>
         <div className="flex-1" />
-        <span className="text-[10px] text-gray-500">
+        <span className="text-xs text-gray-500">
           {activeTab === 'radical'
             ? `部件 ${charsWithRadical.length} 字`
             : activeTab === 'stroke'
@@ -530,7 +530,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                         </span>
                       )}
 
-                      <span className="text-[9px] mt-1 opacity-60">
+                      <span className="text-xs mt-1 opacity-60">
                         {isPracticed ? '已練習' : '點我練習'}
                       </span>
                     </button>
@@ -545,7 +545,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           {/* 教育部國語辭典 panel removed per product decision 2026-03-27 */}
 
           {/* Legend */}
-          <div className="flex items-center gap-4 text-[10px] text-gray-400 flex-wrap">
+          <div className="flex items-center gap-4 text-xs text-gray-400 flex-wrap">
             {needPracticeSet.size > 0 && (
               <>
                 <div className="flex items-center gap-1.5">
@@ -565,7 +565,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
           {/* Usage hint */}
           {currentChars.length > 0 && (
-            <p className="text-[10px] text-gray-400 text-center">
+            <p className="text-xs text-gray-400 text-center">
               點一下字卡即可練習{activeTab === 'stroke' ? '筆順' : '發音'}
             </p>
           )}

--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -671,13 +671,13 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
                   className={
                     'flex items-center gap-2 px-4 py-3 rounded-xl border-2 transition-all duration-300 min-h-[52px] ' +
                     (found
-                      ? 'bg-[#5B4FC4]/10 border-[#5B4FC4]/40'
+                      ? 'bg-accent/10 border-accent/40'
                       : 'bg-white border-gray-200')
                   }
                 >
                   {found ? (
                     <svg
-                      className="w-5 h-5 text-[#5B4FC4] flex-shrink-0"
+                      className="w-5 h-5 text-accent flex-shrink-0"
                       fill="currentColor"
                       viewBox="0 0 20 20"
                       aria-label="已找到"
@@ -694,7 +694,7 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
                   <span
                     className={
                       'text-lg font-black ' +
-                      (found ? 'text-[#5B4FC4] line-through' : 'text-gray-800')
+                      (found ? 'text-accent line-through' : 'text-gray-800')
                     }
                   >
                     {pw.word}


### PR DESCRIPTION
## Summary
- **CTA button colors**: Standardized all primary action buttons (`bg-amber-600`, `bg-[#5B4FC4]`, `bg-emerald-500`) to `bg-accent hover:bg-accent-hover` across ReadingAnnotation, VocabDefinitionMatch, and VocabApplication
- **Minimum font size**: Replaced `text-[9px]` and `text-[10px]` with `text-xs` (12px) in VocabPractice, LiveTutor, and FullReading for child legibility
- **VocabApplication background**: Changed root container from `bg-white` to `bg-amber-50` to match all other step components
- **Hardcoded hex removal**: Replaced all 12+ instances of `#5B4FC4` with `accent` CSS variable tokens in VocabDefinitionMatch and VocabWordSearch

Closes #882

## Test plan
- [ ] Verify ReadingAnnotation "完成標記" button uses accent color
- [ ] Verify VocabDefinitionMatch buttons and borders use accent tokens (no purple hex)
- [ ] Verify VocabApplication "繼續下一步" button is accent (not emerald)
- [ ] Verify VocabApplication has amber-50 background (not white)
- [ ] Verify VocabWordSearch found-word styling uses accent tokens
- [ ] Verify VocabPractice card labels are readable (12px min)
- [ ] Verify LiveTutor status labels are readable (12px min)
- [ ] Verify FullReading status bar labels are readable (12px min)
- [ ] Confirm no semantic colors were changed (green=correct, red=wrong stay intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)