### PR TITLE
fix: #885 — TTS onerror on all utterances, remove debug button, fix preview URL

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -110,16 +110,13 @@ jobs:
       - name: Get backend preview URL
         id: backend-url
         run: |
-          # Try to get the PR-specific backend, fall back to staging, then production
+          # Try to get the PR-specific backend, fall back to staging (hardcoded stable URL), then production
           URL=$(gcloud run services describe ${{ env.BACKEND_SERVICE }} \
             --region ${{ env.REGION }} \
             --project ${{ env.PROJECT_ID }} \
             --format='value(status.url)' 2>/dev/null || echo "")
           if [ -z "$URL" ]; then
-            URL=$(gcloud run services describe lingoleap-backend-staging \
-              --region ${{ env.REGION }} \
-              --project ${{ env.PROJECT_ID }} \
-              --format='value(status.url)' 2>/dev/null || echo "")
+            URL="https://lingoleap-backend-staging-958347263320.asia-east1.run.app"
           fi
           if [ -z "$URL" ]; then
             URL="https://lingoleap-backend-958347263320.asia-east1.run.app"

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -143,7 +143,10 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
       });
       utterances[0].onstart = () => setIsTtsSpeaking(true);
       utterances[utterances.length - 1].onend = () => { setIsTtsSpeaking(false); setIsTtsPaused(false); };
-      utterances[utterances.length - 1].onerror = () => { setIsTtsSpeaking(false); setIsTtsPaused(false); };
+      // Add onerror to every utterance so isTtsSpeaking resets if any intermediate sentence fails
+      utterances.forEach(u => {
+        u.onerror = () => { window.speechSynthesis.cancel(); setIsTtsSpeaking(false); setIsTtsPaused(false); };
+      });
       utterances.forEach(u => window.speechSynthesis.speak(u));
     };
 

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -1291,32 +1291,6 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                           )}
                           {isTtsSpeaking && idx === currentLineIndex ? '停止' : 'AI 朗讀'}
                         </button>
-                        {/* A/B test: Web Speech API button for comparison */}
-                        <button
-                          onClick={() => {
-                            const text = story.content[idx];
-                            if (!text) return;
-                            if (window.speechSynthesis.speaking) {
-                              window.speechSynthesis.cancel();
-                              return;
-                            }
-                            const utt = new SpeechSynthesisUtterance(text);
-                            utt.lang = 'zh-TW';
-                            utt.rate = 0.9;
-                            const voices = window.speechSynthesis.getVoices();
-                            const best = voices.find(v => v.name.includes('Google') && v.name.includes('Taiwan'))
-                              || voices.find(v => v.lang === 'zh-TW');
-                            if (best) utt.voice = best;
-                            window.speechSynthesis.speak(utt);
-                          }}
-                          disabled={idx === currentLineIndex && (isSessionActive || isPreparing)}
-                          className={`px-4 py-2 rounded-lg text-sm font-bold flex items-center gap-1.5 transition-all bg-amber-50 hover:bg-amber-100 text-amber-700 border border-amber-200 ${
-                            idx === currentLineIndex && (isSessionActive || isPreparing) ? 'opacity-40 cursor-not-allowed' : ''
-                          }`}
-                        >
-                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" /></svg>
-                          瀏覽器朗讀
-                        </button>
                         {/* Start / Submit / Retry — context-dependent */}
                         {idx === currentLineIndex ? (
                           // Current paragraph: show session controls


### PR DESCRIPTION
## Summary

- **FullReading.tsx**: Add `onerror` to every `SpeechSynthesisUtterance` in `speakFullStory`. Previously only the last utterance had `onerror`, so if any intermediate sentence failed, `isTtsSpeaking` would stay `true` forever and the TTS controls would be stuck.
- **LiveTutor.tsx**: Remove the debug 瀏覽器朗讀 button (Web Speech API A/B test, lines 1294–1319). Production doesn't need this comparison button.
- **preview-deploy.yml**: Hardcode the staging backend URL as the fallback instead of using `gcloud run services describe lingoleap-backend-staging`, which can fail with permission errors or timeouts. Mirrors the same fix applied in #879 for `staging-deploy.yml`.

## Test plan

- [ ] Open a story → go to FullReading → click 系統朗讀 → verify TTS plays and controls work
- [ ] Verify 瀏覽器朗讀 button is no longer visible on LiveTutor paragraphs
- [ ] Open a PR → verify preview-deploy workflow completes without gcloud describe errors for staging fallback

Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)