### PR TITLE
fix: #889 — Chinese status strings in FullReading + fix indexOf for duplicate text in ReadingAnnotation

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -305,7 +305,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           <span>共 {story.content.length} 段 · {story.title}</span>
           <div className="flex-1" />
           <span className={isSessionActive ? 'text-green-500 font-bold' : isPreparing ? 'text-yellow-500 font-bold' : 'text-gray-300'}>
-            {isSessionActive ? '• LISTENING' : isPreparing ? '• PREPARING' : '• IDLE'}
+            {isSessionActive ? '• 聆聽中' : isPreparing ? '• 準備中' : '• 待命'}
           </span>
         </div>
       </div>
@@ -355,7 +355,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {/* Live transcript */}
           {isSessionActive && streamingTranscript && (
             <div className="flex flex-col gap-1">
-              <span className="text-xs font-bold text-accent-light uppercase animate-pulse">LISTENING...</span>
+              <span className="text-xs font-bold text-accent-light uppercase animate-pulse">聆聽中...</span>
               <div className="bg-accent/20 border border-accent/30 rounded-xl px-3 py-2.5 text-base text-gray-800 leading-relaxed">
                 {streamingTranscript}
               </div>
@@ -364,7 +364,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
           {isSessionActive && !streamingTranscript && (
             <div className="flex flex-col gap-1">
-              <span className="text-xs font-bold text-green-500 uppercase animate-pulse">LISTENING</span>
+              <span className="text-xs font-bold text-green-500 uppercase animate-pulse">聆聽中</span>
               <div className="bg-green-900/20 border border-green-700/30 rounded-xl px-3 py-2.5 text-base text-gray-600 leading-relaxed">
                 請朗讀左側課文，從頭到尾…
               </div>

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -154,17 +154,28 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     const paraEl = startEl; // same element
 
     // Compute char offsets relative to the original paragraph text.
-    // Uses the selected text to find its position in the raw paragraph string,
-    // avoiding DOM text node offset issues caused by annotation spans.
+    // Walk text nodes with a TreeWalker to get the actual character offset from
+    // the Range, so duplicate text in the same paragraph is handled correctly.
     const selectedText = range.toString();
     if (!selectedText.trim()) return null;
 
-    const rawParagraph = story.content[paragraphIndex];
-    const selStart = rawParagraph.indexOf(selectedText);
-    if (selStart < 0) return null; // selected text not found in paragraph
+    // Walk all text nodes inside the paragraph to find where range.startContainer
+    // sits and accumulate the character offset up to range.startOffset.
+    let charStart = 0;
+    let found = false;
+    const walker = document.createTreeWalker(paraEl, NodeFilter.SHOW_TEXT);
+    let node: Text | null;
+    while ((node = walker.nextNode() as Text | null)) {
+      if (node === range.startContainer) {
+        charStart += range.startOffset;
+        found = true;
+        break;
+      }
+      charStart += node.textContent?.length ?? 0;
+    }
+    if (!found) return null;
 
-    const charStart = selStart;
-    const charEnd = selStart + selectedText.length;
+    const charEnd = charStart + selectedText.length;
 
     if (charStart >= charEnd) return null;
 


### PR DESCRIPTION
## Summary

- **FullReading**: Replace English status labels (`LISTENING`, `PREPARING`, `IDLE`) shown in the status bar and live transcript area with Chinese equivalents (`聆聽中`, `準備中`, `待命`) — 3 occurrences across the component
- **ReadingAnnotation**: Replace `rawParagraph.indexOf(selectedText)` in `getSelectionInfo()` with a `TreeWalker`-based character offset calculation using `range.startContainer` — fixes the bug where selecting a word that appears more than once in a paragraph always snapped to the first occurrence

## Files Changed

- `frontend/src/components/reading-steps/FullReading.tsx`
- `frontend/src/components/reading-steps/ReadingAnnotation.tsx`

## Test plan

- [ ] Open FullReading step → start recording → confirm status bar shows `• 聆聽中` (not `LISTENING`)
- [ ] Before recording → confirm status bar shows `• 待命` (not `IDLE`)
- [ ] Click "開始朗讀" → brief preparing state should show `• 準備中` (not `PREPARING`)
- [ ] Live transcript label should show `聆聽中...` (not `LISTENING...`)
- [ ] Open ReadingAnnotation → find a paragraph with a repeated word/phrase → select the **second** occurrence → confirm the annotation lands on the second occurrence, not the first

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)