### PR TITLE
fix(annotation): #829 — remove non-functional 不懂/重要 header buttons

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -78,9 +78,6 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     }
   });
 
-  // Active mark tool
-  const [activeTool, setActiveTool] = useState<AnnotationType>('unknown');
-
   // Floating toolbar state
   const [toolbar, setToolbar] = useState<{
     visible: boolean;
@@ -372,28 +369,6 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
         <span className="text-xs text-amber-700 font-bold">閱讀標記</span>
 
         <div className="flex-1" />
-
-        {/* Tool selector */}
-        <div className="flex items-center gap-2" role="group" aria-label="標記類型">
-          {(Object.entries(TYPE_CONFIG) as Array<[AnnotationType, typeof TYPE_CONFIG[AnnotationType]]>).map(
-            ([type, cfg]) => (
-              <button
-                key={type}
-                type="button"
-                onClick={() => setActiveTool(type)}
-                aria-pressed={activeTool === type}
-                className={`flex items-center gap-1 px-3 py-1.5 rounded-lg text-sm font-bold border transition-all ${
-                  activeTool === type
-                    ? `${cfg.activeClass} border-current`
-                    : 'bg-white border-gray-300 text-gray-600 hover:bg-gray-50'
-                }`}
-              >
-                <span aria-hidden="true">{cfg.icon}</span>
-                {cfg.label}
-              </button>
-            )
-          )}
-        </div>
 
         {/* Undo */}
         <button


### PR DESCRIPTION
## Summary

- Traced `activeTool` state: set by header 不懂/重要 buttons via `setActiveTool()`, but **never read anywhere** — `applyAnnotation(type)` receives the type directly from the floating toolbar, not from `activeTool`
- Removed the dead header button group (the `role="group"` 標記類型 section) and the unused `activeTool` state — 25 lines of dead code deleted
- **復原** and **清除全部** are fully functional (verified by tracing `undo()` and `clearAll()` call paths) — kept unchanged
- The floating toolbar that appears on text selection correctly offers both ❓ 不懂 and 💛 重要, so annotation type selection still works — just via the correct mechanism

## Root Cause

The header buttons pre-dated or were disconnected from the floating-toolbar selection flow. `applyAnnotation(type: AnnotationType)` was designed to receive the type at call-time from the floating toolbar, making a separate header mode-selector redundant and disconnected.

## Issue #862 Note

Issue #862 asked for the header buttons to be made sticky on scroll. Since the buttons are non-functional dead code, removing them resolves the question — no sticky fix needed.

## Test plan

- [ ] Open any lesson, go to 閱讀標記 step
- [ ] Confirm the header now shows only story title › 閱讀標記 + 復原 + 清除全部 (no 不懂/重要 header buttons)
- [ ] Select any text in the passage → floating toolbar should appear with ❓ 不懂 and 💛 重要 buttons
- [ ] Apply 不懂 annotation → text gets red underline decoration
- [ ] Apply 重要 annotation → text gets yellow highlight
- [ ] Click an annotated span → annotation is removed
- [ ] 復原 button restores previous state
- [ ] 清除全部 removes all annotations

Closes #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)