### PR TITLE
fix: 閱讀標記 — 側邊 panel 收集標記詞語 BUG 修復 (fix: 862)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -32,6 +32,11 @@ interface ReadingAnnotationProps {
   fontSizePx?: number;
 }
 
+interface AnnotationWithText {
+  annotation: Annotation;
+  text: string;
+}
+
 // ── Config ─────────────────────────────────────────────────────────────────
 
 const STORAGE_KEY = (storyId: string) => `annotations_${storyId}`;
@@ -93,6 +98,8 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const annotationElementRefs = useRef(new Map<string, HTMLSpanElement>());
+  const [focusedAnnotationId, setFocusedAnnotationId] = useState<string | null>(null);
 
   // ── Zhuyin ─────────────────────────────────────────────────────────────
 
@@ -118,6 +125,23 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     unknownCount: annotations.filter((a) => a.type === 'unknown').length,
     importantCount: annotations.filter((a) => a.type === 'important').length,
   }), [annotations]);
+
+  const annotationsForPanel = useMemo<AnnotationWithText[]>(() => {
+    return [...annotations]
+      .sort((a, b) => {
+        if (a.paragraphIndex !== b.paragraphIndex) {
+          return a.paragraphIndex - b.paragraphIndex;
+        }
+        return a.charStart - b.charStart;
+      })
+      .map((annotation) => {
+        const paragraph = story.content[annotation.paragraphIndex] ?? '';
+        return {
+          annotation,
+          text: paragraph.slice(annotation.charStart, annotation.charEnd),
+        };
+      });
+  }, [annotations, story.content]);
 
   // ── Selection helpers ──────────────────────────────────────────────────
 
@@ -271,7 +295,12 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       setUndoStack((stack) => [...stack.slice(-19), prev]);
       return prev.filter((a) => a.id !== id);
     });
-  }, []);
+
+    if (focusedAnnotationId === id) {
+      setFocusedAnnotationId(null);
+    }
+    annotationElementRefs.current.delete(id);
+  }, [focusedAnnotationId]);
 
   // ── Undo ──────────────────────────────────────────────────────────────
 
@@ -289,7 +318,27 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   const clearAll = useCallback(() => {
     setUndoStack((stack) => [...stack.slice(-19), annotations]);
     setAnnotations([]);
+    setFocusedAnnotationId(null);
+    annotationElementRefs.current.clear();
   }, [annotations]);
+
+  const jumpToAnnotation = useCallback((annotationId: string) => {
+    const targetElement = annotationElementRefs.current.get(annotationId);
+    if (!targetElement) return;
+
+    targetElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setFocusedAnnotationId(annotationId);
+  }, []);
+
+  useEffect(() => {
+    if (!focusedAnnotationId) return;
+
+    const timer = window.setTimeout(() => {
+      setFocusedAnnotationId((current) => (current === focusedAnnotationId ? null : current));
+    }, 2200);
+
+    return () => window.clearTimeout(timer);
+  }, [focusedAnnotationId]);
 
   // ── Render paragraph with annotation spans ─────────────────────────────
 
@@ -346,11 +395,19 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       return (
         <span
           key={seg.annotation.id}
-          className={`cursor-pointer ${cfg.className}`}
+          ref={(element) => {
+            if (element) {
+              annotationElementRefs.current.set(seg.annotation.id, element);
+            } else {
+              annotationElementRefs.current.delete(seg.annotation.id);
+            }
+          }}
+          className={`cursor-pointer transition-all duration-300 ${cfg.className} ${focusedAnnotationId === seg.annotation.id ? 'ring-4 ring-lime-300 ring-offset-2 shadow-[0_0_0_4px_rgba(190,242,100,0.35)]' : ''}`}
           title={`${cfg.icon} ${cfg.label} (點擊移除)`}
           onClick={() => removeAnnotation(seg.annotation!.id)}
           role="mark"
           aria-label={`${cfg.label}標記：${chars}`}
+          data-annotation-id={seg.annotation.id}
         >
           {chars}
         </span>
@@ -418,73 +475,112 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       </div>
 
       {/* ── Main text area ─────────────────────────────────────────────── */}
-      <div
-        ref={containerRef}
-        className="flex-1 overflow-y-auto relative"
-        onMouseUp={handleMouseUp}
-        onTouchEnd={handleTouchEnd}
-        style={{ WebkitUserSelect: 'text', userSelect: 'text' } as React.CSSProperties}
-      >
-        <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
-          {story.content.map((rawPara, paraIdx) => {
-            const displayText = zhuyinParagraphs?.[paraIdx] ?? rawPara;
-            return (
-              <p
-                key={paraIdx}
-                data-para-idx={paraIdx}
-                className="text-gray-900 leading-loose"
-                style={{
-                  fontSize: `${fontSizePx}px`,
-                  lineHeight: zhuyinActive ? '3.8rem' : '2.8rem',
-                  letterSpacing: zhuyinActive ? '0.35em' : '0.05em',
+      <div className="flex-1 min-h-0 flex overflow-hidden">
+        <div
+          ref={containerRef}
+          className="flex-1 overflow-y-auto relative"
+          onMouseUp={handleMouseUp}
+          onTouchEnd={handleTouchEnd}
+          style={{ WebkitUserSelect: 'text', userSelect: 'text' } as React.CSSProperties}
+        >
+          <div className="max-w-3xl mx-auto px-6 py-8 space-y-6">
+            {story.content.map((rawPara, paraIdx) => {
+              const displayText = zhuyinParagraphs?.[paraIdx] ?? rawPara;
+              return (
+                <p
+                  key={paraIdx}
+                  data-para-idx={paraIdx}
+                  className="text-gray-900 leading-loose"
+                  style={{
+                    fontSize: `${fontSizePx}px`,
+                    lineHeight: zhuyinActive ? '3.8rem' : '2.8rem',
+                    letterSpacing: zhuyinActive ? '0.35em' : '0.05em',
+                  }}
+                >
+                  {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}
+                </p>
+              );
+            })}
+          </div>
+
+          {/* ── Floating toolbar — larger for touch ──────────────────────── */}
+          {toolbar.visible && (
+            <div
+              ref={toolbarRef}
+              role="toolbar"
+              aria-label="標記選取文字"
+              className="absolute z-50 flex items-center gap-2 bg-white border-2 border-amber-300 rounded-2xl shadow-2xl px-3 py-2 -translate-x-1/2 -translate-y-full"
+              style={{ left: toolbar.x, top: toolbar.y }}
+            >
+              {(Object.entries(TYPE_CONFIG) as Array<[AnnotationType, typeof TYPE_CONFIG[AnnotationType]]>).map(
+                ([type, cfg]) => (
+                  <button
+                    key={type}
+                    type="button"
+                    onPointerDown={(e) => {
+                      // Use pointerdown so we act before selection is cleared
+                      e.preventDefault();
+                      applyAnnotation(type);
+                    }}
+                    className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-black border-2 transition-all min-h-[44px] active:scale-95 ${cfg.activeClass}`}
+                  >
+                    <span aria-hidden="true">{cfg.icon}</span>
+                    {cfg.label}
+                  </button>
+                )
+              )}
+              <button
+                type="button"
+                onPointerDown={(e) => {
+                  e.preventDefault();
+                  window.getSelection()?.removeAllRanges();
+                  hideToolbar();
                 }}
+                className="ml-1 px-3 py-2 rounded-xl text-base text-gray-400 hover:text-gray-700 border-2 border-gray-200 hover:bg-gray-50 transition-all min-h-[44px]"
+                aria-label="取消"
               >
-                {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}
-              </p>
-            );
-          })}
+                ✕
+              </button>
+            </div>
+          )}
         </div>
 
-        {/* ── Floating toolbar — larger for touch ──────────────────────── */}
-        {toolbar.visible && (
-          <div
-            ref={toolbarRef}
-            role="toolbar"
-            aria-label="標記選取文字"
-            className="absolute z-50 flex items-center gap-2 bg-white border-2 border-amber-300 rounded-2xl shadow-2xl px-3 py-2 -translate-x-1/2 -translate-y-full"
-            style={{ left: toolbar.x, top: toolbar.y }}
-          >
-            {(Object.entries(TYPE_CONFIG) as Array<[AnnotationType, typeof TYPE_CONFIG[AnnotationType]]>).map(
-              ([type, cfg]) => (
-                <button
-                  key={type}
-                  type="button"
-                  onPointerDown={(e) => {
-                    // Use pointerdown so we act before selection is cleared
-                    e.preventDefault();
-                    applyAnnotation(type);
-                  }}
-                  className={`flex items-center gap-1.5 px-4 py-2 rounded-xl text-base font-black border-2 transition-all min-h-[44px] active:scale-95 ${cfg.activeClass}`}
-                >
-                  <span aria-hidden="true">{cfg.icon}</span>
-                  {cfg.label}
-                </button>
-              )
-            )}
-            <button
-              type="button"
-              onPointerDown={(e) => {
-                e.preventDefault();
-                window.getSelection()?.removeAllRanges();
-                hideToolbar();
-              }}
-              className="ml-1 px-3 py-2 rounded-xl text-base text-gray-400 hover:text-gray-700 border-2 border-gray-200 hover:bg-gray-50 transition-all min-h-[44px]"
-              aria-label="取消"
-            >
-              ✕
-            </button>
+        <aside className="w-52 sm:w-60 md:w-72 border-l border-amber-200 bg-white overflow-y-auto">
+          <div className="sticky top-0 bg-amber-50 border-b border-amber-200 px-4 py-3">
+            <h3 className="text-sm font-black text-amber-900">我的記號</h3>
+            <p className="text-xs text-amber-700 mt-1">點擊詞語可跳到課文對應位置</p>
           </div>
-        )}
+          <div className="px-3 py-3 space-y-2">
+            {annotationsForPanel.length === 0 ? (
+              <p className="text-xs text-gray-400 px-1 py-2">尚未標記詞語</p>
+            ) : (
+              annotationsForPanel.map(({ annotation, text }, index) => {
+                const cfg = TYPE_CONFIG[annotation.type];
+                const displayText = text.trim() || '（空白選取）';
+                return (
+                  <button
+                    key={annotation.id}
+                    type="button"
+                    onClick={() => jumpToAnnotation(annotation.id)}
+                    className={`w-full text-left px-3 py-2 rounded-xl border transition-all hover:shadow-sm ${focusedAnnotationId === annotation.id
+                      ? 'border-lime-300 bg-lime-50 shadow-[0_0_0_3px_rgba(163,230,53,0.25)]'
+                      : 'border-gray-200 bg-white hover:bg-amber-50'}
+                    `}
+                    aria-label={`跳轉到${cfg.label}標記：${displayText}`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-bold text-gray-500">#{index + 1}</span>
+                      <span className={`text-[11px] px-1.5 py-0.5 rounded-full border ${annotation.type === 'unknown' ? 'bg-red-50 text-red-700 border-red-200' : 'bg-yellow-50 text-yellow-900 border-yellow-200'}`}>
+                        {cfg.icon} {cfg.label}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm font-bold text-gray-800 break-all">{displayText}</p>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </aside>
       </div>
 
       {/* ── Summary bar + finish button ────────────────────────────────── */}

--- a/frontend/src/components/reading-steps/__tests__/ReadingAnnotation.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/ReadingAnnotation.test.tsx
@@ -48,10 +48,15 @@ const mockStory: Story = {
 
 describe('ReadingAnnotation', () => {
   const onFinish = vi.fn();
+  const scrollIntoViewMock = vi.fn();
 
   beforeEach(() => {
     localStorageMock.clear();
     vi.clearAllMocks();
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
   });
 
   afterEach(() => {
@@ -72,17 +77,14 @@ describe('ReadingAnnotation', () => {
 
   it('shows mark tool buttons in toolbar', () => {
     render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
-    // Both mark types should be in the top toolbar
-    const unknownBtns = screen.getAllByText('不懂');
-    const importantBtns = screen.getAllByText('重要');
+    const unknownBtns = screen.getAllByText(/不懂/);
+    const importantBtns = screen.getAllByText(/重要/);
     expect(unknownBtns.length).toBeGreaterThan(0);
     expect(importantBtns.length).toBeGreaterThan(0);
   });
 
   it('initially shows 0 marks in summary', () => {
     render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
-    expect(screen.getByText(/已標記/)).toBeTruthy();
-    expect(screen.getByText('0')).toBeTruthy();
     expect(screen.getByText(/還沒有標記/)).toBeTruthy();
   });
 
@@ -168,7 +170,40 @@ describe('ReadingAnnotation', () => {
     });
 
     // Count should be 0 now
-    expect(screen.getByText('0', { selector: 'strong' })).toBeTruthy();
     expect(screen.getByText(/還沒有標記/)).toBeTruthy();
+  });
+
+  it('shows marked words in right side panel as vertical list', () => {
+    const seeded = [
+      { id: 'ann-1', paragraphIndex: 0, charStart: 0, charEnd: 2, type: 'unknown' },
+      { id: 'ann-2', paragraphIndex: 1, charStart: 0, charEnd: 3, type: 'important' },
+    ];
+    localStorageMock.setItem(`annotations_test-story-001`, JSON.stringify(seeded));
+
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+
+    expect(screen.getByText('我的記號')).toBeTruthy();
+    expect(screen.getByLabelText(/跳轉到不懂標記：第一/)).toBeTruthy();
+    expect(screen.getByLabelText(/跳轉到重要標記：第二段/)).toBeTruthy();
+  });
+
+  it('jumps to selected marked word and highlights it when clicking side panel', async () => {
+    const seeded = [
+      { id: 'ann-jump', paragraphIndex: 0, charStart: 0, charEnd: 2, type: 'important' },
+    ];
+    localStorageMock.setItem(`annotations_test-story-001`, JSON.stringify(seeded));
+
+    render(<ReadingAnnotation story={mockStory} onFinish={onFinish} />);
+
+    const jumpButton = screen.getByLabelText(/跳轉到重要標記：第一/);
+
+    await act(async () => {
+      fireEvent.click(jumpButton);
+    });
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+
+    const mark = screen.getByRole('mark', { name: /重要標記：第一/ });
+    expect(mark.className).toContain('ring-4');
   });
 });


### PR DESCRIPTION
## 問題說明

在 [issue718](https://github.com/Youngger9765/chinese-literacy-platform/issues/718)中，開發了閱讀標記的功能。選擇課文後，第一步是畫標記，然後會把標記放到右側，功能都可以 work，但是當我卷下去時，點擊右側的詞語，他卻無法 scroll 到對的位置，也無法閃爍顯示？並且往下選取字詞的時候，`重要`或`不懂`的按鈕會在上方，沒有跟著使用者一起卷下來。

## 檢核目標

- [x] 修復詞語超連結傳送
- [x] 修復`重要`或`不懂`按鈕的跟隨位置