### PR TITLE
feat(api): add source field to sentence example API response (Fixes #836)

### DIFF
--- a/backend/app/routes/learning/learning_vocab.py
+++ b/backend/app/routes/learning/learning_vocab.py
@@ -35,6 +35,7 @@ class ExampleSentenceItem(BaseModel):
 
 class ExampleSentencesResponse(BaseModel):
     sentences: list[ExampleSentenceItem]
+    source: str = Field(default="ai", description="'pregenerated' if from cache/JSON, 'ai' if generated in real-time")
 
 
 class ValidateSentenceRequest(BaseModel):
@@ -69,9 +70,10 @@ async def get_example_sentences(
     cached = get_cached(story_title=payload.story_title, character=payload.character)
     if cached is not None:
         logger.debug(
-            "Example sentence cache hit: char=%s story=%s",
+            "Example sentence cache hit: char=%s story=%s source=%s",
             payload.character,
             payload.story_title,
+            cached.get("source", "ai"),
         )
         def _to_item(s: object) -> ExampleSentenceItem:
             # Pre-generated cache stores plain strings; AI-generated cache stores dicts.
@@ -79,8 +81,13 @@ async def get_example_sentences(
                 return ExampleSentenceItem(sentence=s, explanation="")
             return ExampleSentenceItem(**s)
 
+        # Determine source: explicitly-tagged pregenerated entries keep "pregenerated";
+        # all other cache hits (AI results stored after first call) are treated as "pregenerated"
+        # because they return instantly without an AI call.
+        cache_source = cached.get("source", "pregenerated")
         return ExampleSentencesResponse(
             sentences=[_to_item(s) for s in cached.get("sentences", [])],
+            source=cache_source,
         )
 
     # 2. Cache miss — call AI
@@ -130,6 +137,7 @@ async def get_example_sentences(
 
     return ExampleSentencesResponse(
         sentences=[ExampleSentenceItem(**s) for s in result.get("sentences", [])],
+        source="ai",
     )
 
 

--- a/backend/tests/test_sentence_practice.py
+++ b/backend/tests/test_sentence_practice.py
@@ -98,19 +98,33 @@ def client(db_session):
 # ---------------------------------------------------------------------------
 
 def _create_student_and_login(client: TestClient) -> str:
-    """Register a student and return JWT token."""
+    """Create a user directly in the DB (bypasses self-reg restriction and email verification).
+
+    Students cannot self-register since issue #457 — they're created by teachers.
+    We insert the user directly into the test DB with email_verified=True.
+    The sentence practice endpoint only requires a valid authenticated user, not a specific role.
+    """
     import uuid
-    email = f"student_{uuid.uuid4().hex[:8]}@test.com"
+    from app.auth.password import hash_password
+    from app.models.user import User as UserModel
+
+    unique = uuid.uuid4().hex[:8]
+    email = f"testuser_{unique}@example.com"
     password = "TestPass123!"
 
-    res = client.post("/api/auth/register", json={
-        "email": email,
-        "password": password,
-        "name": "Test Student",
-        "role": "student",
-        "copyright_confirmed": True,
-    })
-    assert res.status_code in (200, 201), f"Register failed: {res.text}"
+    db = TestingSessionLocal()
+    try:
+        user = UserModel(
+            email=email,
+            password_hash=hash_password(password),
+            name=f"Test User {unique}",
+            email_verified=True,
+            is_active=True,
+        )
+        db.add(user)
+        db.commit()
+    finally:
+        db.close()
 
     login_res = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_res.status_code == 200, f"Login failed: {login_res.text}"
@@ -132,7 +146,7 @@ class TestExampleSentences:
             ]
         }
         with patch(
-            "app.routes.learning.generate_example_sentences",
+            "app.routes.learning.learning_vocab.generate_example_sentences",
             new=AsyncMock(return_value=mock_result),
         ):
             res = client.post(
@@ -151,7 +165,7 @@ class TestExampleSentences:
     def test_example_sentences_requires_auth(self, client: TestClient):
         """Without auth token, endpoint returns 401 or 403."""
         with patch(
-            "app.routes.learning.generate_example_sentences",
+            "app.routes.learning.learning_vocab.generate_example_sentences",
             new=AsyncMock(return_value={"sentences": []}),
         ):
             res = client.post(
@@ -174,7 +188,7 @@ class TestExampleSentences:
         """Returns 503 when AI service times out."""
         token = _create_student_and_login(client)
         with patch(
-            "app.routes.learning.generate_example_sentences",
+            "app.routes.learning.learning_vocab.generate_example_sentences",
             new=AsyncMock(side_effect=TimeoutError("AI timeout")),
         ):
             res = client.post(
@@ -183,6 +197,93 @@ class TestExampleSentences:
                 headers={"Authorization": f"Bearer {token}"},
             )
         assert res.status_code == 503
+
+    def test_example_sentences_ai_path_returns_source_ai(self, client: TestClient):
+        """When AI generates sentences in real-time, response includes source='ai'. (Issue #836)"""
+        import app.services.example_sentence_cache as cache_module
+        from app.services.example_sentence_cache import _reset
+
+        token = _create_student_and_login(client)
+        mock_result = {
+            "sentences": [
+                {"sentence": "河流源源不絕地流著。", "explanation": "源：水流的起點"},
+                {"sentence": "這個想法來源於大自然。", "explanation": "源：事物的根本"},
+            ]
+        }
+        # Use a unique story title to guarantee cache miss
+        unique_story = "測試課文_issue836_ai"
+        with patch(
+            "app.routes.learning.learning_vocab.get_cached",
+            return_value=None,
+        ), patch(
+            "app.routes.learning.learning_vocab.generate_example_sentences",
+            new=AsyncMock(return_value=mock_result),
+        ), patch(
+            "app.routes.learning.learning_vocab.set_cached",
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/example-sentences",
+                json={"character": "源", "story_title": unique_story},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 200
+        data = res.json()
+        assert "source" in data, "Response must include 'source' field (Issue #836)"
+        assert data["source"] == "ai", f"Expected source='ai' for real-time generation, got '{data['source']}'"
+
+    def test_example_sentences_pregenerated_cache_returns_source_pregenerated(self, client: TestClient):
+        """When served from pregenerated cache, response includes source='pregenerated'. (Issue #836)"""
+        token = _create_student_and_login(client)
+        cached_data = {
+            "sentences": [
+                {"sentence": "這條河的來源是高山。", "explanation": "來源：事物的起點"},
+                {"sentence": "她的靈感來源於童年記憶。", "explanation": "來源：根本"},
+            ],
+            "source": "pregenerated",
+        }
+        with patch(
+            "app.routes.learning.learning_vocab.get_cached",
+            return_value=cached_data,
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/example-sentences",
+                json={"character": "源", "story_title": "測試課文_pregenerated"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 200
+        data = res.json()
+        assert "source" in data, "Response must include 'source' field (Issue #836)"
+        assert data["source"] == "pregenerated", (
+            f"Expected source='pregenerated' for cached entry, got '{data['source']}'"
+        )
+
+    def test_example_sentences_ai_cached_returns_source_pregenerated(self, client: TestClient):
+        """When served from AI-result cache (no source tag), response includes source='pregenerated'.
+        AI-cached results also return instantly, so they use 'pregenerated' semantics. (Issue #836)"""
+        token = _create_student_and_login(client)
+        # AI cache entries don't have a 'source' key — they're stored by set_cached
+        cached_data = {
+            "sentences": [
+                {"sentence": "泉水是山裡清澈的水源。", "explanation": "水源：水的來源"},
+                {"sentence": "她努力工作是收入的主要來源。", "explanation": "來源：事物根本"},
+            ],
+            # No 'source' key — simulates a cached AI result stored by set_cached
+        }
+        with patch(
+            "app.routes.learning.learning_vocab.get_cached",
+            return_value=cached_data,
+        ):
+            res = client.post(
+                "/api/learning/sentence-practice/example-sentences",
+                json={"character": "源", "story_title": "測試課文_ai_cached"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert res.status_code == 200
+        data = res.json()
+        assert "source" in data, "Response must include 'source' field (Issue #836)"
+        assert data["source"] == "pregenerated", (
+            f"Expected source='pregenerated' for cached AI result (returns instantly), got '{data['source']}'"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +300,7 @@ class TestValidateSentence:
             "suggestion": "",
         }
         with patch(
-            "app.routes.learning.validate_student_sentence",
+            "app.routes.learning.learning_vocab.validate_student_sentence",
             new=AsyncMock(return_value=mock_result),
         ):
             res = client.post(
@@ -221,7 +322,7 @@ class TestValidateSentence:
         """Returns is_correct=False without calling AI when char not in sentence."""
         token = _create_student_and_login(client)
         with patch(
-            "app.routes.learning.validate_student_sentence",
+            "app.routes.learning.learning_vocab.validate_student_sentence",
             new=AsyncMock(return_value={"is_correct": True, "feedback": "", "suggestion": ""}),
         ) as mock_ai:
             res = client.post(
@@ -250,7 +351,7 @@ class TestValidateSentence:
             "suggestion": "試試：「這杯水很清涼。」",
         }
         with patch(
-            "app.routes.learning.validate_student_sentence",
+            "app.routes.learning.learning_vocab.validate_student_sentence",
             new=AsyncMock(return_value=mock_result),
         ):
             res = client.post(
@@ -298,7 +399,7 @@ class TestValidateSentence:
         """Returns 503 when AI service encounters an error."""
         token = _create_student_and_login(client)
         with patch(
-            "app.routes.learning.validate_student_sentence",
+            "app.routes.learning.learning_vocab.validate_student_sentence",
             new=AsyncMock(side_effect=Exception("AI error")),
         ):
             res = client.post(

--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -16,6 +16,8 @@ interface ExampleSentence {
   explanation: string;
 }
 
+type ExampleSentenceSource = 'pregenerated' | 'ai';
+
 type SentenceStatus = 'idle' | 'loading' | 'correct' | 'incorrect';
 
 interface SentenceEntry {
@@ -29,6 +31,7 @@ interface CharacterPracticeState {
   exampleSentences: ExampleSentence[] | null;
   examplesLoading: boolean;
   examplesError: string;
+  examplesSource: ExampleSentenceSource | null;
   sentences: [SentenceEntry, SentenceEntry];
   allCorrect: boolean;
 }
@@ -42,6 +45,7 @@ function makeCharState(): CharacterPracticeState {
     exampleSentences: null,
     examplesLoading: false,
     examplesError: '',
+    examplesSource: null,
     sentences: [makeSentenceEntry(), makeSentenceEntry()],
     allCorrect: false,
   };
@@ -49,11 +53,16 @@ function makeCharState(): CharacterPracticeState {
 
 // ── API helpers ───────────────────────────────────────────────────────────
 
+interface ExampleSentencesApiResponse {
+  sentences: ExampleSentence[];
+  source: ExampleSentenceSource;
+}
+
 async function fetchExampleSentences(
   character: string,
   storyTitle: string,
   token: string | null,
-): Promise<ExampleSentence[]> {
+): Promise<ExampleSentencesApiResponse> {
   const res = await fetch(`${API_BASE}/api/learning/sentence-practice/example-sentences`, {
     method: 'POST',
     headers: {
@@ -64,7 +73,10 @@ async function fetchExampleSentences(
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = await res.json();
-  return data.sentences as ExampleSentence[];
+  return {
+    sentences: data.sentences as ExampleSentence[],
+    source: (data.source ?? 'ai') as ExampleSentenceSource,
+  };
 }
 
 async function validateSentence(
@@ -163,10 +175,15 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
     }));
 
     try {
-      const examples = await fetchExampleSentences(currentChar, storyTitle, token);
+      const { sentences: examples, source } = await fetchExampleSentences(currentChar, storyTitle, token);
       setCharStates(prev => ({
         ...prev,
-        [currentChar]: { ...prev[currentChar], examplesLoading: false, exampleSentences: examples },
+        [currentChar]: {
+          ...prev[currentChar],
+          examplesLoading: false,
+          exampleSentences: examples,
+          examplesSource: source,
+        },
       }));
     } catch {
       // Remove from ref so the retry button can re-attempt
@@ -325,6 +342,16 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
           <div className="bg-white rounded-2xl border border-gray-200 p-4">
             <div className="flex items-center gap-2 mb-3">
               <span className="text-xs font-bold text-gray-500 uppercase tracking-wider">AI 例句示範</span>
+              {!currentState.examplesLoading && currentState.examplesSource && (
+                <span className={[
+                  'text-[10px] font-medium px-1.5 py-0.5 rounded',
+                  currentState.examplesSource === 'pregenerated'
+                    ? 'bg-blue-50 text-blue-500'
+                    : 'bg-purple-50 text-purple-500',
+                ].join(' ')}>
+                  {currentState.examplesSource === 'pregenerated' ? '預先生成' : 'AI 即時生成'}
+                </span>
+              )}
             </div>
 
             {currentState.examplesLoading && (


### PR DESCRIPTION
Fixes #836

## Summary

- Added `source` field to `ExampleSentencesResponse` schema — values: `'pregenerated'` | `'ai'`
- Cache hits (both pregenerated JSON entries and stored AI results) return `source='pregenerated'` since they resolve instantly without calling Gemini
- Real-time Gemini generation returns `source='ai'`
- Frontend `SentencePractice.tsx` now tracks `examplesSource` in `CharacterPracticeState` and shows a small badge (`'預先生成'` / `'AI 即時生成'`) in the example sentences panel header after load

## Changes

- `backend/app/routes/learning/learning_vocab.py` — added `source` field to response model and both return paths
- `frontend/src/components/reading-steps/SentencePractice.tsx` — added `ExampleSentenceSource` type, `examplesSource` state field, source badge in UI
- `backend/tests/test_sentence_practice.py` — 3 new tests for `source` field; also fixed pre-existing issues: corrected mock patch paths (routes were refactored into submodules) and fixed `_create_student_and_login` helper (student self-registration blocked since #457)

## Test plan

- [x] `cd backend && python -m pytest tests/test_sentence_practice.py::TestExampleSentences -v` — 7/7 pass
- [x] `cd backend && python -m pytest tests/test_example_sentence_cache.py -v` — 27/27 pass
- [x] `cd frontend && npm run build` — clean build, no TypeScript errors
- [ ] Verify PR Preview deploys and badge appears correctly on sentence practice step