### PR TITLE
fix: 閱讀標記按鈕修正 (fix #904)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -217,12 +217,14 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       return;
     }
 
-    const containerRect = containerRef.current?.getBoundingClientRect();
-    if (!containerRect) return;
+    const container = containerRef.current;
+    const containerRect = container?.getBoundingClientRect();
+    if (!container || !containerRect) return;
 
-    // Position toolbar above the selection
-    const x = info.rect.left + info.rect.width / 2 - containerRect.left;
-    const y = info.rect.top - containerRect.top - 8; // 8px gap above
+    // Convert viewport coords to scroll-content coords so the toolbar stays
+    // attached to the selected text even in long, scrolled paragraphs.
+    const x = info.rect.left + info.rect.width / 2 - containerRect.left + container.scrollLeft;
+    const y = info.rect.top - containerRect.top - 8 + container.scrollTop;
 
     setToolbar({
       visible: true,


### PR DESCRIPTION
在 ReadingAnnotation.tsx:193 調整了浮動工具列座標計算。
原本是用視窗座標直接換算容器內座標，沒有把可捲動容器的 scrollTop/scrollLeft 算進去。
現在會加上容器捲動位移，所以文章往下滑後，按鈕仍會貼著你當下選取的文字。