### PR TITLE
fix: 造句練習改用 vocabulary 生字，修正 cache 命中率 (#910)

### DIFF
--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -491,7 +491,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
       <>
         {/* Character tab nav — shown inline above content */}
         {practicedChars.length > 1 && (
-          <div className="bg-white border border-gray-100 rounded-xl px-3 py-2 flex gap-2 overflow-x-auto">
+          <div className="bg-white border border-gray-100 rounded-xl px-3 py-2 flex flex-wrap gap-2">
             {practicedChars.map((ch, i) => {
               const done = completedChars.has(ch);
               const active = i === currentCharIndex;

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -207,6 +207,22 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     return optional.slice(0, 12);
   }, [story.content, attempt?.mispronouncedWords]);
 
+  // Vocabulary chars for sentence practice — extracted from story.vocabulary words
+  // These match the cache keys in example_sentence_cache.json (Issue #910)
+  const vocabChars = useMemo(() => {
+    const seen = new Set<string>();
+    const chars: string[] = [];
+    for (const item of story.vocabulary ?? []) {
+      for (const ch of item.word) {
+        if (/[\u4e00-\u9fa5]/.test(ch) && !seen.has(ch)) {
+          chars.push(ch);
+          seen.add(ch);
+        }
+      }
+    }
+    return chars;
+  }, [story.vocabulary]);
+
   // Pronunciation tab: all characters are candidates (no stroke-data filter needed)
   const pronunciationChars = useMemo(() => {
     const suggested = (attempt?.mispronouncedWords ?? []).filter(ch => /[\u4e00-\u9fa5]/.test(ch));
@@ -476,7 +492,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           {/* Sentence practice — inline tab panel */}
           {activeTab === 'sentence' && (
             <SentencePractice
-              practicedChars={displayChars.length > 0 ? displayChars : Array.from(practicedChars)}
+              practicedChars={vocabChars.length > 0 ? vocabChars : displayChars}
               storyTitle={story.title}
               onFinish={() => handleFinish({ practicedChars: Array.from(practicedChars), totalChars: displayChars.length })}
               onBack={() => setActiveTab('stroke')}


### PR DESCRIPTION
## Summary

- 造句練習（SentencePractice）原本從 `story.content` 取前 12 個字，與 `example_sentence_cache.json` 的 vocabulary 生字 key 完全不匹配，導致 1490 筆預生成快取從未被使用，每次都呼叫 AI
- 新增 `vocabChars` memo 從 `story.vocabulary` 拆出去重的 CJK 字，傳給 SentencePractice
- 造句字 tab 容器改 `flex-wrap` 防止字數多時溢出

## Test plan

- [ ] 進入 `/learn/5/vocab` → 造句 tab，確認練習字為 vocabulary 生字（家、常、便、飯…）而非課文前幾個字（一、個、夢、想…）
- [ ] 確認 AI 例句標籤顯示「預先生成」而非「AI 即時生成」（需 staging 後端有 cache）
- [ ] 確認筆順練習 tab 不受影響（仍使用 displayChars）
- [ ] 確認字數較多時 tab 按鈕正確換行，不會溢出容器

Closes #910

<img width="746" height="707" alt="image" src="https://github.com/user-attachments/assets/5dd362f6-65fd-4a0f-afe4-ad5c3efa9596" />
