### PR TITLE
fix: 造句例句、課文重點表 rate limit 改為僅限 cache miss 請求 (#911)

### DIFF
--- a/backend/app/auth/rate_limiter.py
+++ b/backend/app/auth/rate_limiter.py
@@ -98,7 +98,7 @@ general_rate_limiter = InMemoryRateLimiter()
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _get_client_key(request: Request) -> str:
+def get_client_key(request: Request) -> str:
     """Return a stable key for the current request client.
 
     Uses the authenticated user ID when available (from a previously decoded
@@ -133,7 +133,7 @@ def make_ai_rate_limit_dependency(max_requests: int = 10, window_seconds: int = 
             ...
     """
     def _dependency(request: Request) -> None:
-        key = f"ai:{_get_client_key(request)}"
+        key = f"ai:{get_client_key(request)}"
         if not ai_rate_limiter.check(key, max_requests, window_seconds):
             raise HTTPException(
                 status_code=429,

--- a/backend/app/routes/learning/learning_vocab.py
+++ b/backend/app/routes/learning/learning_vocab.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from ...auth.dependencies import get_current_user
-from ...auth.rate_limiter import ai_limit_5_per_min, ai_limit_10_per_min, ai_rate_limiter
+from ...auth.rate_limiter import ai_limit_5_per_min, ai_limit_10_per_min, ai_rate_limiter, get_client_key
 from ...database import get_db
 from ...models.user import User
 from ...services.ai_service import generate_example_sentences, validate_student_sentence
@@ -91,8 +91,7 @@ async def get_example_sentences(
         )
 
     # 2. Cache miss — enforce rate limit before calling AI (Issue #911)
-    user_id = getattr(request.state, "user_id", None)
-    rl_key = f"ai:user:{user_id}" if user_id else f"ai:ip:{request.client.host if request.client else 'unknown'}"
+    rl_key = f"ai:{get_client_key(request)}"
     if not ai_rate_limiter.check(rl_key, max_requests=10, window_seconds=60):
         raise HTTPException(status_code=429, detail="AI endpoint rate limit exceeded. Please wait before retrying.")
     start_time = time.monotonic()

--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -4,14 +4,14 @@ No database dependency for platform content.
 """
 
 import time
-from fastapi import APIRouter, Query, HTTPException, Depends
+from fastapi import APIRouter, Query, HTTPException, Depends, Request
 from sqlalchemy.orm import Session
 
 from ..database import get_db
 from ..models.user import User
 from ..models.school import ClassroomStudent, ClassroomText
 from ..auth.dependencies import get_optional_user, get_current_user
-from ..auth.rate_limiter import ai_limit_5_per_min
+from ..auth.rate_limiter import ai_rate_limiter, get_client_key
 from ..services.lesson_loader import search_lessons, get_lesson_by_id, get_available_grades
 from ..services.ai_service import generate_story_structure
 from ..services.ai_usage_tracker import last_usage, log_ai_usage
@@ -147,11 +147,9 @@ def get_story(story_id: str):
 
 # ── ⑤ 文章重點表 AI endpoint (#615) ──────────────────────────────────────────
 
-@router.get(
-    "/stories/{story_id}/structure",
-    dependencies=[Depends(ai_limit_5_per_min)],
-)
+@router.get("/stories/{story_id}/structure")
 async def get_story_structure(
+    request: Request,
     story_id: str,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -161,7 +159,7 @@ async def get_story_structure(
     Returns a list of rows with label/value (and optional sub_rows).
     Genre-aware: 記敘文 / 說明文 / 議論文 each get different templates.
 
-    Requires authentication. Rate-limited to 5 req/min per user.
+    Requires authentication. Rate-limited to 5 req/min per user (cache miss only).
     Responses are cached in-memory for 24 h to avoid redundant Gemini calls.
     """
     normalized = story_id.lstrip("Ll")
@@ -173,9 +171,15 @@ async def get_story_structure(
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
 
+    # Cache hit — return immediately without consuming rate limit quota
     cached = _get_cached_structure(story_id)
     if cached is not None:
         return cached
+
+    # Cache miss — enforce rate limit before calling AI
+    rl_key = f"ai:{get_client_key(request)}"
+    if not ai_rate_limiter.check(rl_key, max_requests=5, window_seconds=60):
+        raise HTTPException(status_code=429, detail="AI endpoint rate limit exceeded. Please wait before retrying.")
 
     story_text = story.get("full_text") or "\n".join(story.get("paragraphs", []))
     start_time = time.monotonic()


### PR DESCRIPTION
## Summary

- `/api/learning/sentence-practice/example-sentences` 的 rate limiter 原本設在 route decorator，所有請求（含 cache hit）都消耗額度，導致學生快速切換生字時觸發 429
- 將 rate limit 從 decorator 移到 cache miss 的 AI 呼叫路徑內，cache hit 不再受限

## Test plan

- [ ] 快速切換超過 10 個生字，cache hit 請求不會被 429 擋住
- [ ] Cache miss 時仍受 10 次/分鐘限制，超過會回 429
- [ ] validate endpoint 的 rate limit 不受影響
- [ ] 既有 13 個 test_sentence_practice 測試全部通過

Closes #911