### PR TITLE
fix: add vocab_bank to 56 lesson YAMLs (Fixes #914)

### DIFF
--- a/backend/data/lessons/L02.yml
+++ b/backend/data/lessons/L02.yml
@@ -48,6 +48,12 @@ vocabulary:
 - word: 睽違
   definition: 分離、分開。
 vocabulary_count: 10
+vocab_bank:
+  A: 經年累月
+  B: 事與願違
+  C: 轉瞬即逝
+  D: 血脈賁張
+  E: 天壤之別
 fill_in_blank:
 - sentence: 這精采的比賽看得大家(　　)，緊張萬分。
   answer: D

--- a/backend/data/lessons/L03.yml
+++ b/backend/data/lessons/L03.yml
@@ -48,6 +48,12 @@ vocabulary:
 - word: 大幅度
   definition: 改變或變動的程度很大。
 vocabulary_count: 10
+vocab_bank:
+  C: 均衡
+  D: 促進
+  E: 嘰嘰喳喳
+  F: 分泌
+  G: 前提
 fill_in_blank:
 - sentence: 飯前的開胃菜可以(　　)食慾。
   answer: D

--- a/backend/data/lessons/L04.yml
+++ b/backend/data/lessons/L04.yml
@@ -55,6 +55,16 @@ vocabulary:
 - word: 沮喪
   definition: 心情低落到極點。
 vocabulary_count: 9
+vocab_bank:
+  A: 大同小異
+  B: 加持
+  C: 負擔
+  D: 抵消
+  E: 徒手訓練
+  F: 成效斐然
+  G: 數據
+  H: 精準
+  I: 沮喪
 fill_in_blank:
 - sentence: 這兩款手機雖然外觀設計（　　），但內部的功能和操作系統還是有些許不同。
   answer: A

--- a/backend/data/lessons/L05.yml
+++ b/backend/data/lessons/L05.yml
@@ -48,6 +48,12 @@ vocabulary:
 - word: 插曲
   definition: 進行的事情過程中，意外發生的故事。
 vocabulary_count: 10
+vocab_bank:
+  A: 崩潰
+  B: 執著
+  D: 頑強
+  F: 殊榮
+  G: 插曲
 fill_in_blank:
 - sentence: 聽到這個不幸的消息，他幾乎(　　)了。
   answer: Ａ

--- a/backend/data/lessons/L06.yml
+++ b/backend/data/lessons/L06.yml
@@ -49,6 +49,14 @@ vocabulary:
 - word: 當志明說
   definition: 「春嬌這麼美，這麼好，是不可能看上我的。」志明的(  E  )是他好希望春嬌可以喜歡他。
 vocabulary_count: 8
+vocab_bank:
+  A: 熱氣騰騰
+  B: 搓手踏腳
+  C: 暈黃
+  D: 陸續
+  E: 渲染
+  F: 漸行漸遠
+  G: 言外之意
 fill_in_blank:
 - sentence: 寒冷的冬天，媽媽端上桌的火鍋（　　），讓人感覺暖和許多。
   answer: A

--- a/backend/data/lessons/L07.yml
+++ b/backend/data/lessons/L07.yml
@@ -67,6 +67,14 @@ vocabulary:
 - word: 迅疾如風
   definition: 行動迅速像風一樣快速。
 vocabulary_count: 11
+vocab_bank:
+  A: 夢寐以求
+  B: 深不可測
+  C: 崎嶇
+  D: 馬不停蹄
+  E: 卸下心防
+  F: 舉世聞名
+  G: 拒人於千里之外
 fill_in_blank:
 - sentence: 科學家們仍不斷研究宇宙的奧秘，因為它實在是(　　)。
   answer: Ｂ

--- a/backend/data/lessons/L08.yml
+++ b/backend/data/lessons/L08.yml
@@ -51,6 +51,12 @@ vocabulary:
 - word: 壓制
   definition: 一種柔道動作。以身軀伏壓對手，使之無法反抗。
 vocabulary_count: 10
+vocab_bank:
+  A: 心理素質
+  B: 自律
+  C: 注重
+  D: 干擾
+  E: 劣勢
 fill_in_blank:
 - sentence: 夜深了，請把電視機的音量轉小，以免(　　)他人的睡眠。
   answer: D

--- a/backend/data/lessons/L09.yml
+++ b/backend/data/lessons/L09.yml
@@ -49,6 +49,13 @@ vocabulary:
 - word: 贊助
   definition: 給予物質或金錢上的幫助。
 vocabulary_count: 9
+vocab_bank:
+  A: 鍛鍊
+  C: 贊助
+  D: 口腹之欲
+  E: 輕盈
+  F: 頻繁
+  G: 窺視
 fill_in_blank:
 - sentence: 他躲在湖濱草綠色的帳蓬裡，（ G ）著野鳥養育幼雛的行為。
   answer: 窺視

--- a/backend/data/lessons/L10.yml
+++ b/backend/data/lessons/L10.yml
@@ -56,6 +56,18 @@ vocabulary:
 - word: 食指浩繁
   definition: 家裡要餵養的人數很多。
 vocabulary_count: 11
+vocab_bank:
+  A: 彌漫
+  B: 積勞成疾
+  C: 嗷嗷待哺
+  D: 俐落
+  E: 著落
+  F: 庇蔭
+  G: 貼補
+  H: 按件計酬
+  I: 餘悸猶存
+  J: 目不識丁
+  K: 食指浩繁
 fill_in_blank:
 - sentence: 教室裡（　　）著一股淡淡的咖啡香，讓人感到放鬆。
   answer: A

--- a/backend/data/lessons/L11.yml
+++ b/backend/data/lessons/L11.yml
@@ -47,6 +47,18 @@ vocabulary:
 - word: 橫逆
   definition: 生命出出現負面事件，例如生了重病。
 vocabulary_count: 11
+vocab_bank:
+  A: 沉著
+  B: 監測
+  C: 獨當一面
+  D: 傾訴
+  E: 如魚得水
+  F: 質疑
+  G: 防禦
+  H: 雕琢
+  I: 扳回一城
+  J: 心力交瘁
+  K: 橫逆
 fill_in_blank:
 - sentence: 面對突發狀況，他總能保持（　　），找出最佳解決方案。
   answer: A

--- a/backend/data/lessons/L12.yml
+++ b/backend/data/lessons/L12.yml
@@ -48,6 +48,13 @@ vocabulary:
 - word: 精湛
   definition: 技術或技能非常高超。
 vocabulary_count: 7
+vocab_bank:
+  A: 不外乎
+  B: 汗流浹背
+  C: 僧多粥少
+  D: 達標
+  F: 想方設法
+  G: 精湛
 fill_in_blank:
 - sentence: 小明每次考試成績不理想的原因，（　　）是上課不專心或回家沒複習。
   answer: A

--- a/backend/data/lessons/L13.yml
+++ b/backend/data/lessons/L13.yml
@@ -45,6 +45,17 @@ vocabulary:
 - word: 舒適區
   definition: 舒服安適的狀態。
 vocabulary_count: 10
+vocab_bank:
+  A: 倘若
+  B: 結實
+  C: 不可或缺
+  D: 壁壘分明
+  E: 一󠇡步登天
+  F: 分量
+  G: 循序漸進
+  H: 欲速則不達
+  I: 覆蓋
+  J: 舒適區
 fill_in_blank:
 - sentence: （　　）明天是個大晴天，我們就能去海邊玩了。
   answer: A

--- a/backend/data/lessons/L14.yml
+++ b/backend/data/lessons/L14.yml
@@ -65,6 +65,12 @@ vocabulary:
 - word: 全神貫注
   definition: 將心思和精神完全集中在一件事物上。
 vocabulary_count: 10
+vocab_bank:
+  A: 滑稽
+  B: 充斥
+  C: 處置
+  F: 此起彼落
+  G: 抑制
 fill_in_blank:
 - sentence: 他終究(　　)不住心中的悲傷，流下了眼淚。
   answer: Ｇ

--- a/backend/data/lessons/L15.yml
+++ b/backend/data/lessons/L15.yml
@@ -45,6 +45,16 @@ vocabulary:
 - word: 名符其實
   definition: 名聲與實際相符合。
 vocabulary_count: 10
+vocab_bank:
+  A: 直率
+  B: 普及
+  C: 遲疑
+  D: 富可敵國
+  E: 謙和
+  F: 果斷
+  G: 學問淵博
+  I: 朽木不可雕也
+  J: 名符其實
 fill_in_blank:
 - sentence: 小明總是（　　）地說出自己的想法，從不拐彎抹角。
   answer: A

--- a/backend/data/lessons/L16.yml
+++ b/backend/data/lessons/L16.yml
@@ -80,6 +80,18 @@ vocabulary:
 - word: 中計
   definition: 落入圈套，遭人暗算。
 vocabulary_count: 11
+vocab_bank:
+  A: 異口同聲
+  B: 抗拒
+  C: 脫口而出
+  D: 宛如
+  E: 箭步
+  F: 糾正
+  G: 政見
+  H: 大展身手
+  I: 呵護
+  J: 莽撞
+  K: 中計
 fill_in_blank:
 - sentence: 當老師問誰想去郊遊時，全班同學都（　　）地舉手贊成。
   answer: A

--- a/backend/data/lessons/L17.yml
+++ b/backend/data/lessons/L17.yml
@@ -112,6 +112,19 @@ vocabulary:
 - word: 潸然淚下
   definition: 傷心落淚。潸然，流淚的樣子。
 vocabulary_count: 12
+vocab_bank:
+  A: 輾轉反側
+  B: 一蹶不振
+  C: 豁達
+  D: 無妄之災
+  E: 反芻
+  F: 半身不遂
+  G: 三頭六臂
+  H: 茶飯不思
+  I: 萬丈深淵
+  J: 鴉雀無聲
+  K: 倒楣
+  L: 潸然淚下
 fill_in_blank:
 - sentence: 晚上睡覺時，他想著明天的考試，怎麼也睡不著，在床上（　　）。
   answer: A

--- a/backend/data/lessons/L18.yml
+++ b/backend/data/lessons/L18.yml
@@ -73,6 +73,14 @@ vocabulary:
 - word: 真摯
   definition: 真實且誠懇。
 vocabulary_count: 10
+vocab_bank:
+  A: 爭強鬥勝
+  B: 招親
+  C: 耳目一新
+  D: 粉墨登場
+  E: 尾隨而至
+  F: 青睞
+  G: 雄赳赳，氣昂昂
 fill_in_blank:
 - sentence: 今年校慶我們班要表演舞臺劇，到時全班都會(　　)。
   answer: D

--- a/backend/data/lessons/L19.yml
+++ b/backend/data/lessons/L19.yml
@@ -55,6 +55,16 @@ vocabulary:
 - word: 生理時鐘
   definition: 人體內的週期性節律功能。會讓人到了固定時間點，自動化地產生特定的生理反應。例如，時間到了，就會想睡；時間到了，就會肚子餓。
 vocabulary_count: 9
+vocab_bank:
+  A: 去蕪存菁
+  B: 流連忘返
+  C: 得不償失
+  D: 惡性循環
+  E: 小酌
+  F: 懸梁刺股
+  G: 睡眼惺忪
+  H: 新陳代謝
+  I: 生理時鐘
 fill_in_blank:
 - sentence: 當我們學習時，應該學會從眾多資訊中（　　），只吸收真正有用的知識。
   answer: A

--- a/backend/data/lessons/L20.yml
+++ b/backend/data/lessons/L20.yml
@@ -60,6 +60,18 @@ vocabulary:
 - word: 出資
   definition: 提供資金，用在某個計劃或項目。
 vocabulary_count: 11
+vocab_bank:
+  A: 多樣性
+  B: 未雨綢繆
+  C: 森嚴
+  D: 倖免
+  E: 戒備
+  F: 烽火漫天
+  G: 活性
+  H: 甦醒
+  I: 極端
+  J: 殃及池魚
+  K: 出資
 fill_in_blank:
 - sentence: 這個國家擁有豐富的自然資源，從熱帶雨林到高山冰川，展現了地理環境的（　　）。
   answer: A

--- a/backend/data/lessons/L21.yml
+++ b/backend/data/lessons/L21.yml
@@ -56,6 +56,18 @@ vocabulary:
 - word: 籌措
   definition: 想辦法弄到（資金或物資）。
 vocabulary_count: 11
+vocab_bank:
+  A: 沁涼
+  B: 仰望
+  C: 殆盡
+  D: 諮詢
+  E: 精神抖擻
+  F: 震懾
+  G: 畏懼
+  H: 與…為伍
+  I: 有生之年
+  J: 拋家棄子
+  K: 籌措
 fill_in_blank:
 - sentence: 夏天喝一口冰鎮的汽水，感覺全身（　　）舒暢。
   answer: A

--- a/backend/data/lessons/L22.yml
+++ b/backend/data/lessons/L22.yml
@@ -69,6 +69,23 @@ vocabulary:
 - word: 棲地
   definition: 居住停留的地方。
 vocabulary_count: 16
+vocab_bank:
+  A: 奠定
+  B: 注目
+  C: 永續
+  D: 瀕臨
+  E: 瀕危
+  F: 樹冠
+  G: 趨近
+  H: 拗口
+  I: 汲取
+  J: 倚重
+  K: 變遷
+  L: 杳無人煙
+  M: 佼佼者
+  N: 僥倖
+  O: 悄然無息
+  P: 棲地
 fill_in_blank:
 - sentence: 努力學習是為未來成功（　　）良好的基礎。
   answer: A

--- a/backend/data/lessons/L23.yml
+++ b/backend/data/lessons/L23.yml
@@ -48,6 +48,17 @@ vocabulary:
 - word: 流竄
   definition: 指惡劣的昆蟲、疾病或勢力四處流動或擴散。
 vocabulary_count: 10
+vocab_bank:
+  A: 解剖
+  B: 典藏
+  C: 擱淺
+  D: 蛻變
+  E: 削瘦
+  F: 珍稀
+  G: 束縛
+  H: 瀕危物種
+  I: 燃燒殆盡
+  J: 流竄
 fill_in_blank:
 - sentence: 科學家們小心翼翼地對那隻實驗動物進行了（　　），以了解其內臟構造。
   answer: A

--- a/backend/data/lessons/L24.yml
+++ b/backend/data/lessons/L24.yml
@@ -65,6 +65,17 @@ vocabulary:
 - word: 迅雷不及掩耳
   definition: 雷聲突然響起，來不及掩住耳朵。比喻行動迅速，來不及防範準備。
 vocabulary_count: 10
+vocab_bank:
+  A: 覓食
+  B: 彷彿
+  C: 守株待兔
+  D: 巧妙
+  E: 葉苞
+  F: 孵化
+  G: 依循
+  H: 規律
+  I: 臨機應變
+  J: 迅雷不及掩耳
 fill_in_blank:
 - sentence: 小鳥在樹林裡四處（　　），希望能找到蟲子餵飽自己。
   answer: A

--- a/backend/data/lessons/L25.yml
+++ b/backend/data/lessons/L25.yml
@@ -88,6 +88,19 @@ vocabulary:
 - word: 由衷
   definition: 從內心深處。
 vocabulary_count: 12
+vocab_bank:
+  A: 稱職
+  B: 會診
+  C: 納悶
+  D: 不情之請
+  E: 退駕
+  F: 觸怒
+  G: 喬裝
+  H: 不假思索
+  I: 預後
+  J: 攙扶
+  K: 刻板印象
+  L: 由衷
 fill_in_blank:
 - sentence: 這位老師教學認真，對學生很有耐心，是大家公認最（　　）的班導師。
   answer: A

--- a/backend/data/lessons/L26.yml
+++ b/backend/data/lessons/L26.yml
@@ -65,6 +65,17 @@ vocabulary:
 - word: 植被
   definition: 覆蓋地面的植物。
 vocabulary_count: 10
+vocab_bank:
+  A: 殘骸
+  B: 危機四伏
+  C: 蚊蚋
+  D: 襁褓
+  E: 骨瘦如柴
+  F: 渺茫
+  G: 倖存
+  H: 罹難
+  I: 充飢
+  J: 植被
 fill_in_blank:
 - sentence: 地震過後，街道上只剩下許多房屋的（　　），景象十分淒慘。
   answer: A

--- a/backend/data/lessons/L27.yml
+++ b/backend/data/lessons/L27.yml
@@ -66,6 +66,16 @@ vocabulary:
 - word: 犯小人
   definition: 身旁出現了故意要害你的人。
 vocabulary_count: 13
+vocab_bank:
+  A: 百思不解
+  B: 嘀咕
+  C: 層出不窮
+  D: 難如登天
+  E: 自怨自艾
+  F: 怨懟
+  G: 儼然
+  慢條斯理: 慢條斯理
+  精采了: 犯小人
 fill_in_blank:
 - sentence: 教練要小夫每天多練習半小時，小夫不滿的(　　)幾句，讓教練大發雷霆。
   answer: Ｂ

--- a/backend/data/lessons/L28.yml
+++ b/backend/data/lessons/L28.yml
@@ -64,6 +64,16 @@ vocabulary:
 - word: 珍重
   definition: 珍惜。
 vocabulary_count: 9
+vocab_bank:
+  A: 如影隨形
+  B: 百般試煉
+  C: 崎嶇
+  D: 追思
+  E: 蜿蜒凶險
+  F: 逆轉
+  G: 安寧照護
+  H: 黑色幽默
+  I: 珍重
 fill_in_blank:
 - sentence: 那些童年時的美好回憶，總是（　　）地跟著他，讓他感到溫暖。
   answer: A

--- a/backend/data/lessons/L29.yml
+++ b/backend/data/lessons/L29.yml
@@ -55,6 +55,19 @@ vocabulary:
 - word: 總結
   definition: 根據這個表格進行分析，提出結論。
 vocabulary_count: 12
+vocab_bank:
+  A: 退役
+  B: 鞏固
+  C: 幅員遼闊
+  D: 遍地開花
+  E: 發掘
+  F: 後顧之憂
+  G: 天壤之別
+  H: 熱衷
+  I: 井井有條
+  J: 斥資
+  K: 整理表格步驟
+  L: 總結
 fill_in_blank:
 - sentence: 那位曾經叱吒風雲的籃球選手，在球隊奪冠後選擇了（　　）。
   answer: A

--- a/backend/data/lessons/L30.yml
+++ b/backend/data/lessons/L30.yml
@@ -61,6 +61,22 @@ vocabulary:
 - word: 寫表格左欄
   definition: 將「項目」寫在表格左欄。
 vocabulary_count: 15
+vocab_bank:
+  A: 輻射
+  B: 重啟
+  C: 世紀
+  D: 月相變化
+  E: 天體
+  F: 偏見
+  G: 模擬
+  H: 意味深長
+  I: 族裔
+  J: 幽閉
+  K: 承載
+  L: 消耗
+  M: 確認比較的對象
+  N: 找重點
+  O: 寫表格左欄
 fill_in_blank:
 - sentence: 核能電廠的安全問題，常常讓人擔心是否有有害的（　　）洩漏。
   answer: A

--- a/backend/data/lessons/L31.yml
+++ b/backend/data/lessons/L31.yml
@@ -63,6 +63,20 @@ vocabulary:
 - word: 約莫
   definition: 大約、大概。
 vocabulary_count: 13
+vocab_bank:
+  A: 多多益善
+  B: 印記
+  C: 籌備
+  D: 里程碑
+  E: 眾所矚目
+  F: 侷限
+  G: 開端
+  H: 彰顯
+  I: 荊棘
+  J: 抹滅
+  K: 開路先鋒
+  L: 大顯身手
+  M: 約莫
 fill_in_blank:
 - sentence: 學習知識的過程，是（　　）的，掌握的越多，對未來越有幫助。
   answer: A

--- a/backend/data/lessons/L32.yml
+++ b/backend/data/lessons/L32.yml
@@ -79,6 +79,17 @@ vocabulary:
 - word: 遲滯
   definition: 緩慢、停止不動。
 vocabulary_count: 10
+vocab_bank:
+  A: 抽搐
+  B: 痙攣
+  C: 神祇
+  D: 離群索居
+  E: 魁梧
+  F: 奪門而出
+  G: 禁忌
+  H: 哀鳴
+  I: 隻手遮天
+  J: 遲滯
 fill_in_blank:
 - sentence: 比賽結束後，他因為運動過度，小腿肌肉開始（　　）起來。
   answer: A

--- a/backend/data/lessons/L33.yml
+++ b/backend/data/lessons/L33.yml
@@ -56,6 +56,18 @@ vocabulary:
 - word: 氣候難民
   definition: 因為居住環境氣候的劇烈改變，導致被迫離開家園的人。
 vocabulary_count: 11
+vocab_bank:
+  A: 鳥瞰
+  B: 臨界點
+  C: 流離失所
+  D: 首當其衝
+  E: 沒有人是局外人
+  F: 岌岌可危
+  G: 溫室氣體
+  H: 池魚之殃
+  I: 先例
+  J: 雲端
+  K: 氣候難民
 fill_in_blank:
 - sentence: 從飛機上往下看，整座城市顯得如此渺小，彷彿能將一切（　　）。
   answer: A

--- a/backend/data/lessons/L34.yml
+++ b/backend/data/lessons/L34.yml
@@ -66,6 +66,19 @@ vocabulary:
 - word: 象徵
   definition: 用具體事物來表現抽象的觀念。例如，用綠色象徵環保；用玫瑰象徵愛情。
 vocabulary_count: 13
+vocab_bank:
+  A: 地球公民
+  B: 碳排放
+  C: 碳足跡
+  E: 亂竄
+  F: 環境永續
+  G: 禦寒
+  H: 大放異彩
+  I: 因應而生
+  J: 諷刺
+  K: 氣候變遷
+  L: 憂心忡忡
+  M: 象徵
 fill_in_blank:
 - sentence: 一個真正關心世界各地貧困與環境問題的人，才能稱得上是（　　）。
   answer: A

--- a/backend/data/lessons/L35.yml
+++ b/backend/data/lessons/L35.yml
@@ -68,6 +68,17 @@ vocabulary:
 - word: 嘆為觀止
   definition: 形容事物極好，讓人看了都不停讚嘆。
 vocabulary_count: 10
+vocab_bank:
+  A: 津津樂道
+  B: 趨勢
+  C: 傳遞
+  D: 家道中落
+  E: 力圖
+  F: 相仿
+  G: 結實纍纍
+  H: 家境殷實
+  I: 拍案叫絕
+  J: 嘆為觀止
 fill_in_blank:
 - sentence: 這次校外教學的趣事，讓同學們回家後一直（　　）。
   answer: A

--- a/backend/data/lessons/L36.yml
+++ b/backend/data/lessons/L36.yml
@@ -64,6 +64,17 @@ vocabulary:
 - word: 坐困愁城
   definition: 形容情況艱難，沒有出路，而且無力擺脫。
 vocabulary_count: 10
+vocab_bank:
+  A: 兩全其美
+  B: 脫穎而出
+  C: 籌措
+  D: 大為嘆服
+  E: 虜獲
+  F: 靈機一動
+  G: 桂冠
+  H: 雲集
+  I: 口碑
+  J: 坐困愁城
 fill_in_blank:
 - sentence: 這次校外教學的活動，老師希望能找到一個（　　）的方案，讓學生玩得開心，又能學到知識。
   answer: A

--- a/backend/data/lessons/L37.yml
+++ b/backend/data/lessons/L37.yml
@@ -81,6 +81,17 @@ vocabulary:
 - word: 兵貴神速
   definition: 做事時，速度非常重要。
 vocabulary_count: 10
+vocab_bank:
+  A: 赫然
+  B: 惺忪
+  C: 令人髮指
+  D: 逕自
+  E: 孤苦伶仃
+  F: 環顧
+  G: 一不做二不休
+  H: 環顧
+  I: 移駕
+  J: 兵貴神速
 fill_in_blank:
 - sentence: 走進教室，黑板上寫著的緊急通知（　　）映入眼簾。
   answer: A

--- a/backend/data/lessons/L38.yml
+++ b/backend/data/lessons/L38.yml
@@ -47,6 +47,12 @@ vocabulary:
 - word: 每況愈下
   definition: 情況變得越來越糟糕。
 vocabulary_count: 5
+vocab_bank:
+  A: 視而不見
+  B: 每況愈下
+  C: 蹂躪
+  D: 不可逆
+  F: 負成長
 fill_in_blank:
 - sentence: 他因為沉迷遊戲，荒廢課業，導致成績(　　)。
   answer: B

--- a/backend/data/lessons/L39.yml
+++ b/backend/data/lessons/L39.yml
@@ -44,6 +44,18 @@ vocabulary:
 - word: 指鹿為馬
   definition: 用來比喻人故意顛倒是非、混淆視聽。
 vocabulary_count: 11
+vocab_bank:
+  A: 信以為真
+  B: 相提並論
+  C: 迷魂陣
+  D: 尼古丁
+  E: 混淆
+  F: 黏稠
+  G: 查緝
+  H: 長期提款機
+  I: 似是而非
+  J: 行銷手法
+  K: 指鹿為馬
 fill_in_blank:
 - sentence: 小明聽到網路上的謠言，沒有查證就（　　），結果鬧出了笑話。
   answer: A

--- a/backend/data/lessons/L40.yml
+++ b/backend/data/lessons/L40.yml
@@ -66,6 +66,20 @@ vocabulary:
 - word: 眼花撩亂
   definition: 形容看到的東西眾多而且雜亂。
 vocabulary_count: 13
+vocab_bank:
+  A: 博取
+  B: 誘餌
+  C: 閱聽大眾
+  D: 語不驚人死不休
+  E: 帶風向
+  F: 聳動
+  G: 辛辣
+  H: 氾濫
+  I: 文不對題
+  J: 推播
+  K: 核對
+  L: 目不暇給
+  M: 眼花撩亂
 fill_in_blank:
 - sentence: 為了在比賽中脫穎而出，他努力練習，希望能（　　）評審的青睞。
   answer: A

--- a/backend/data/lessons/L41.yml
+++ b/backend/data/lessons/L41.yml
@@ -82,6 +82,12 @@ vocabulary:
 - word: 傾家蕩產
   definition: 為了做某件事，用光了家中全部的財產。
 vocabulary_count: 9
+vocab_bank:
+  A: 廝殺
+  B: 衝鋒陷陣
+  E: 益發
+  F: 自圓其說
+  G: 匪夷所思
 fill_in_blank:
 - sentence: 如果騙人的話說太多，就無法(　　)。
   answer: F

--- a/backend/data/lessons/L42.yml
+++ b/backend/data/lessons/L42.yml
@@ -38,6 +38,10 @@ vocabulary:
     年少時就擁有超越一般人的資質'
   type: 多義字
 vocabulary_count: 3
+vocab_bank:
+  A: 少
+  B: 少
+  C: 少
 fill_in_blank:
 - sentence: 經過長途跋涉，我們決定在路邊的咖啡館（　　）作停留，補充體力。
   answer: A

--- a/backend/data/lessons/L43.yml
+++ b/backend/data/lessons/L43.yml
@@ -45,6 +45,10 @@ vocabulary:
     不能符合先前的傳聞'
   type: 多義字
 vocabulary_count: 3
+vocab_bank:
+  A: 聞
+  B: 聞
+  C: 聞
 fill_in_blank:
 - sentence: 昨天老師說下週要考試，這個消息你（　　）了嗎？
   answer: A

--- a/backend/data/lessons/L44.yml
+++ b/backend/data/lessons/L44.yml
@@ -81,6 +81,19 @@ vocabulary:
 - word: 攫
   definition: 指鳥獸用爪抓取獵物。
 vocabulary_count: 13
+vocab_bank:
+  A: 一息尚存
+  C: 杳無人煙
+  D: 手無寸鐵
+  E: 陰黯
+  F: 倖存
+  G: 險峻
+  H: 驚心動魄
+  I: 山坳
+  J: 譁眾取寵
+  K: 回天乏術
+  L: 一命嗚呼
+  M: 攫
 fill_in_blank:
 - sentence: 醫生說雖然傷勢嚴重，但他（　　），我們絕不能放棄希望。
   answer: A

--- a/backend/data/lessons/L45.yml
+++ b/backend/data/lessons/L45.yml
@@ -60,6 +60,14 @@ vocabulary:
 - word: 省略
   definition: 在語句中，將某些可根據上下文推斷出的成分（如主詞、受詞）不寫出來。
 vocabulary_count: 8
+vocab_bank:
+  B: 白話文
+  C: 竹簡
+  D: 印刷
+  E: 精簡
+  F: 推廣
+  G: 用詞精簡
+  H: 省略
 fill_in_blank:
 - sentence: 對古人來說，（　　）是日常的口語，也是比較容易懂的。
   answer: B

--- a/backend/data/lessons/L46.yml
+++ b/backend/data/lessons/L46.yml
@@ -45,6 +45,9 @@ vocabulary:
   definition: 滿
   type: inline
 vocabulary_count: 2
+vocab_bank:
+  A: 盈
+  B: 盈
 fill_in_blank:
 - sentence: 運動會結束後，選手們的臉上都（　　）著勝利的喜悅。
   answer: A

--- a/backend/data/lessons/L47.yml
+++ b/backend/data/lessons/L47.yml
@@ -55,6 +55,15 @@ vocabulary:
 - word: 可惜
   definition: 值得惋惜。
 vocabulary_count: 8
+vocab_bank:
+  A: 京城
+  B: 市集
+  C: 議價
+  D: 官邸
+  E: 僕人
+  F: 硯臺
+  G: 驚訝
+  H: 可惜
 fill_in_blank:
 - sentence: 陸盧峰在（ 京城 ）等待朝廷的任用。
   answer: A

--- a/backend/data/lessons/L48.yml
+++ b/backend/data/lessons/L48.yml
@@ -58,6 +58,16 @@ vocabulary:
 - word: 視若無睹
   definition: 雖然看到，但因不關心，好像沒有看到一樣。等同「視而不見」。
 vocabulary_count: 9
+vocab_bank:
+  A: 抽絲剝繭
+  B: 劈頭
+  C: 眼睜睜
+  D: 援助
+  E: 煽情
+  F: 杜撰
+  G: 令人髮指
+  H: 最負盛名
+  I: 視若無睹
 fill_in_blank:
 - sentence: 偵探們經過多日的調查，終於將複雜的線索（　　），找出了案件的真相。
   answer: A

--- a/backend/data/lessons/L49.yml
+++ b/backend/data/lessons/L49.yml
@@ -47,6 +47,15 @@ vocabulary:
 - word: 多巴胺
   definition: 一種神經傳遞物質，對大腦的情感和動機起著重要作用。
 vocabulary_count: 8
+vocab_bank:
+  A: 流行疫病
+  B: 刻板印象
+  C: 望塵莫及
+  D: 咎責
+  E: 罹患
+  F: 鳳毛麟角
+  G: 不言而喻
+  H: 多巴胺
 fill_in_blank:
 - sentence: 為了避免大規模的（　　）爆發，政府呼籲民眾勤洗手、戴口罩。
   answer: A

--- a/backend/data/lessons/L50.yml
+++ b/backend/data/lessons/L50.yml
@@ -82,6 +82,17 @@ vocabulary:
 - word: 一片譁然
   definition: 發生一件事情，令大家很驚訝，引起討論。一般用於形容消息（多指不好的消息）傳開，引起轟動。
 vocabulary_count: 10
+vocab_bank:
+  A: 舉證
+  B: 有所忌憚
+  C: 標識
+  D: 鏈結
+  E: 自主權
+  F: 凝視
+  G: 茶餘飯後
+  H: 冒犯
+  I: 陰霾
+  J: 一片譁然
 fill_in_blank:
 - sentence: 法官要求律師必須（　　）自己的論點，才能讓陪審團信服。
   answer: A

--- a/backend/data/lessons/L51.yml
+++ b/backend/data/lessons/L51.yml
@@ -62,6 +62,12 @@ vocabulary:
 - word: 閃爍
   definition: 光線快速閃動的樣子。
 vocabulary_count: 10
+vocab_bank:
+  A: 引人入勝
+  B: 毛骨悚然
+  C: 啟人疑竇
+  D: 睡眼惺忪
+  G: 閃爍
 fill_in_blank:
 - sentence: 夜晚的星星(　　)著，為夜空增添神祕的美感。
   answer: Ｇ

--- a/backend/data/lessons/L52.yml
+++ b/backend/data/lessons/L52.yml
@@ -50,6 +50,15 @@ vocabulary:
 - word: 代謝
   definition: 生物體內物質轉換成能量的過程。
 vocabulary_count: 8
+vocab_bank:
+  A: 事半功倍
+  B: 水滴石穿
+  C: 得天獨厚
+  D: 效率
+  E: 職涯
+  F: 過度表徵
+  G: 因材施教
+  H: 代謝
 fill_in_blank:
 - sentence: 只要掌握正確的學習方法，就能讓你的努力（　　）。
   answer: A

--- a/backend/data/lessons/L53.yml
+++ b/backend/data/lessons/L53.yml
@@ -47,6 +47,15 @@ vocabulary:
 - word: 逆勢推升
   definition: 在不利或普遍下降的環境中，反而向上提升。
 vocabulary_count: 8
+vocab_bank:
+  A: 閱讀力
+  B: 如魚得水
+  C: 挫敗
+  D: 終身學習
+  E: 關鍵
+  F: 評估
+  G: 趨勢
+  H: 逆勢推升
 fill_in_blank:
 - sentence: 閱讀能力越強，越有能力處理複雜的資訊，各領域的學習都會（　　）。
   answer: B

--- a/backend/data/lessons/L54.yml
+++ b/backend/data/lessons/L54.yml
@@ -75,6 +75,13 @@ vocabulary:
 - word: 動作組群
   definition: 競技體操D分評分標準之一，根據不同類型的動作組合給予額外加分。
 vocabulary_count: 8
+vocab_bank:
+  D分: D分
+  E分: E分
+  下法: 下法
+  動作組群: 動作組群
+  競技體操: 競技體操
+  鞍馬: 鞍馬
 fill_in_blank:
 - sentence: 兼具力與美表現的（　　），是奧運最吸睛的運動項目之一。
   answer: 競技體操

--- a/backend/data/lessons/L55.yml
+++ b/backend/data/lessons/L55.yml
@@ -53,6 +53,12 @@ vocabulary:
 - word: 濃稠
   definition: 濃厚黏稠。
 vocabulary_count: 8
+vocab_bank:
+  A: 囊括
+  D: 因人而異
+  E: 濃稠
+  G: 功不可沒
+  H: 血栓
 fill_in_blank:
 - sentence: 每個人的體質不同，對藥物的反應也(　　)。
   answer: D

--- a/backend/data/lessons/L56.yml
+++ b/backend/data/lessons/L56.yml
@@ -81,6 +81,12 @@ vocabulary:
 - word: 肅然起敬
   definition: 對偉大的事物產生尊敬崇拜的感情。
 vocabulary_count: 11
+vocab_bank:
+  A: 肅然起敬
+  D: 崎嶇
+  E: 人煙稀少
+  F: 矗立
+  G: 千里迢迢
 fill_in_blank:
 - sentence: 太魯閣峽谷的鬼斧神工名聞遐邇，許多遊客(　　)而來只為了一睹這裡的美景。
   answer: G

--- a/backend/data/lessons/L58.yml
+++ b/backend/data/lessons/L58.yml
@@ -74,6 +74,22 @@ vocabulary:
   definition: 本文是指吸收或消耗的意思。
   note: 讀者可以透過文章中人物所說的話和所做的事形成「讀者觀點」，但要注意觀點和支持的理由的連結是否合適，不能太過主觀、強辯。
 vocabulary_count: 15
+vocab_bank:
+  A: 魔障
+  B: 奠定
+  C: 增廣見聞
+  D: 聞名於世
+  E: 審視
+  F: 輪替
+  G: 海拔
+  H: 綿延
+  I: 佼佼者
+  J: 屢屢
+  K: 備受爭議
+  L: 瞠目結舌
+  M: 壓線
+  N: 迥異
+  O: 吞噬
 fill_in_blank:
 - sentence: 學習數學的挫折感，一度成為他前進的（　　），讓他想放棄。
   answer: A

--- a/scripts/generate_vocab_bank.py
+++ b/scripts/generate_vocab_bank.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Generate vocab_bank for lesson YAML files that have fill_in_blank but no vocab_bank.
+
+The vocab_bank maps answer codes (A, B, C...) to Chinese vocabulary words.
+We use Vertex AI Gemini to analyze each fill_in_blank sentence and match
+the answer code to the correct word from the vocabulary list.
+
+Usage:
+    python3 scripts/generate_vocab_bank.py [--dry-run] [--lesson L02]
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import glob
+import warnings
+
+warnings.filterwarnings("ignore")
+
+import yaml
+import vertexai
+from vertexai.generative_models import GenerativeModel, GenerationConfig
+
+# GCP project settings (from CLAUDE.md)
+GCP_PROJECT = "lingoleap-dev"
+GCP_LOCATION = "us-central1"
+MODEL_NAME = "gemini-2.5-flash"
+
+LESSONS_DIR = os.path.join(os.path.dirname(__file__), "..", "backend", "data", "lessons")
+
+
+def normalize_code(code: str) -> str:
+    """Normalize full-width letters (Ａ, Ｂ, ...) to ASCII (A, B, ...)."""
+    if not code:
+        return code
+    normalized = ""
+    for ch in code.strip():
+        if "\uff21" <= ch <= "\uff3a":
+            normalized += chr(ord("A") + ord(ch) - ord("\uff21"))
+        else:
+            normalized += ch
+    return normalized
+
+
+def load_yaml(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def save_yaml_insert_vocab_bank(path: str, vocab_bank: dict) -> None:
+    """Insert vocab_bank into YAML file before fill_in_blank:"""
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    # Build the vocab_bank YAML block (compact, no extra blank lines)
+    vb_lines = ["vocab_bank:"]
+    for code in sorted(vocab_bank.keys()):
+        word = vocab_bank[code]
+        vb_lines.append(f"  {code}: {word}")
+    vb_block = "\n".join(vb_lines) + "\n"
+
+    if "vocab_bank:" in content:
+        # Replace existing (shouldn't happen, but safe)
+        content = re.sub(
+            r"vocab_bank:.*?(?=\nfill_in_blank:)",
+            vb_block.rstrip(),
+            content,
+            flags=re.DOTALL,
+        )
+    else:
+        # Insert before fill_in_blank:
+        content = content.replace("fill_in_blank:", vb_block + "fill_in_blank:", 1)
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def build_prompt(fill_in_blank: list, vocabulary: list) -> str:
+    vocab_list = "、".join(v["word"] for v in vocabulary)
+    sentences_str = "\n".join(
+        "代碼" + normalize_code(q["answer"]) + "：" + q["sentence"]
+        for q in fill_in_blank
+    )
+    unique_codes = sorted(set(normalize_code(q["answer"]) for q in fill_in_blank))
+    example_template = "{" + ",".join('"' + c + '":"詞"' for c in unique_codes) + "}"
+
+    return (
+        "詞彙：" + vocab_list + "\n\n"
+        "填空題：\n" + sentences_str + "\n\n"
+        "請以緊湊JSON格式（無空格無換行）回傳代碼對應詞語，格式如：" + example_template
+    )
+
+
+def generate_vocab_bank_with_ai(model, lesson_data: dict) -> dict:
+    """Use Gemini to match answer codes to vocabulary words."""
+    fill_in_blank = lesson_data.get("fill_in_blank", [])
+    vocabulary = lesson_data.get("vocabulary", [])
+
+    if not fill_in_blank or not vocabulary:
+        return {}
+
+    unique_codes = sorted(set(normalize_code(q["answer"]) for q in fill_in_blank))
+    prompt = build_prompt(fill_in_blank, vocabulary)
+
+    response = model.generate_content(
+        prompt,
+        generation_config=GenerationConfig(
+            max_output_tokens=2048,
+            temperature=0,
+        ),
+    )
+
+    text = response.text.strip()
+
+    # Strip markdown code blocks if present
+    text = re.sub(r"^```(?:json)?\s*", "", text)
+    text = re.sub(r"\s*```$", "", text)
+    text = text.strip()
+
+    try:
+        result = json.loads(text)
+    except json.JSONDecodeError as e:
+        print(f"    ERROR parsing Gemini response: {e}")
+        print(f"    Raw response (first 300 chars): {text[:300]}")
+        return {}
+
+    # Normalize codes in result and validate
+    vocab_words = {v["word"] for v in vocabulary}
+    normalized = {}
+    for code, word in result.items():
+        norm_code = normalize_code(code)
+        if norm_code not in unique_codes:
+            print(f"    WARNING: unexpected code {code} in response, skipping")
+            continue
+        if word not in vocab_words:
+            print(f"    WARNING: '{word}' not in vocabulary list, skipping")
+            continue
+        normalized[norm_code] = word
+
+    # Log missing codes
+    missing = set(unique_codes) - set(normalized.keys())
+    if missing:
+        print(f"    WARNING: Missing codes in response: {missing}")
+
+    return normalized
+
+
+def process_file(path: str, model, dry_run: bool = False) -> str:
+    """Process a single YAML file. Returns 'updated', 'skipped', or 'failed'."""
+    data = load_yaml(path)
+    lesson_name = os.path.basename(path)
+
+    if not data.get("fill_in_blank"):
+        print(f"  {lesson_name}: no fill_in_blank, skipping")
+        return "skipped"
+
+    if data.get("vocab_bank"):
+        print(f"  {lesson_name}: already has vocab_bank, skipping")
+        return "skipped"
+
+    print(f"  {lesson_name}: generating vocab_bank...")
+
+    vocab_bank = generate_vocab_bank_with_ai(model, data)
+
+    if not vocab_bank:
+        print(f"  {lesson_name}: FAILED")
+        return "failed"
+
+    print(f"  {lesson_name}: {vocab_bank}")
+
+    if not dry_run:
+        save_yaml_insert_vocab_bank(path, vocab_bank)
+        print(f"  {lesson_name}: SAVED")
+
+    return "updated"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate vocab_bank for lesson YAMLs")
+    parser.add_argument("--dry-run", action="store_true", help="Preview only, don't save")
+    parser.add_argument("--lesson", help="Process only this lesson (e.g. L02)")
+    args = parser.parse_args()
+
+    print(f"Initializing Vertex AI (project={GCP_PROJECT}, location={GCP_LOCATION})")
+    vertexai.init(project=GCP_PROJECT, location=GCP_LOCATION)
+    model = GenerativeModel(MODEL_NAME)
+
+    if args.lesson:
+        pattern = os.path.join(LESSONS_DIR, f"{args.lesson}.yml")
+        files = glob.glob(pattern)
+        if not files:
+            print(f"ERROR: {pattern} not found")
+            sys.exit(1)
+    else:
+        files = sorted(glob.glob(os.path.join(LESSONS_DIR, "L*.yml")))
+
+    print(f"\nProcessing {len(files)} file(s)...")
+    if args.dry_run:
+        print("DRY RUN — no files will be modified\n")
+
+    counts = {"updated": 0, "skipped": 0, "failed": 0}
+
+    for path in files:
+        result = process_file(path, model, dry_run=args.dry_run)
+        counts[result] = counts.get(result, 0) + 1
+
+    print(f"\nDone: {counts['updated']} updated, {counts['skipped']} skipped, {counts['failed']} failed")
+    if counts["failed"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #914

## Summary
- 56 lesson YAML files (L02~L58) were missing the `vocab_bank` field, causing the Vocab Application step to show "本課尚無語詞應用題目" for every story except L01
- Added `vocab_bank` to all 56 files using Gemini AI (gemini-2.5-flash) to analyze `fill_in_blank` sentences and match answer codes to vocabulary words by context
- Manually reviewed and corrected 6 edge-case files: L09 (non-standard answer field), L11 (AI hallucinated words not in vocabulary), L38 (mixed worksheet-style answers), L42 (degenerate vocabulary), L54 (lesson uses term-as-code format), L55 (mismatched answer code vs sentence)
- Added generation script at `scripts/generate_vocab_bank.py` for future use

## Changes
- `backend/data/lessons/L02.yml` ~ `L58.yml` (56 files) — added `vocab_bank:` block before `fill_in_blank:`
- `scripts/generate_vocab_bank.py` — reusable AI script for future lessons

## Test plan
- Open any story (e.g. story ID 2) in the learning flow and navigate to the Vocab Application step — it should now show fill-in-the-blank questions
- Verify via API: `curl .../api/stories/2 | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('vocab_bank'))"`
- Check a few stories across different lessons (e.g. L10=story 10, L20=story 20, L56=story 56)