### PR TITLE
fix: complete CSV import — drag-drop, warnings, credential download (Fixes #538)

### DIFF
--- a/frontend/src/pages/teacher/CsvUploadModal.tsx
+++ b/frontend/src/pages/teacher/CsvUploadModal.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   downloadCsvTemplate,
   uploadCsvStudents,
@@ -39,6 +39,36 @@ function parseCsvPreview(text: string): ParsedRow[] {
   });
 }
 
+function countCsvDataRows(text: string): number {
+  const lines = text.split(/\r?\n/).filter((l) => l.trim());
+  const firstLower = lines[0]?.toLowerCase() ?? '';
+  const hasHeader = firstLower.includes('name') || firstLower.includes('姓名') || firstLower.includes('seat');
+  return hasHeader ? lines.length - 1 : lines.length;
+}
+
+/**
+ * Download the created students' credentials as a CSV file.
+ * This gives teachers a portable record of the one-time passwords.
+ */
+function downloadCredentialsCsv(students: CsvUploadResult['created']): void {
+  const BOM = '\uFEFF';
+  const header = '姓名,座號,帳號,初始密碼\n';
+  const rows = students
+    .map((s) => `${s.name},${s.seat_number},${s.username},${s.password}`)
+    .join('\n');
+  const csvContent = BOM + header + rows;
+
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'student-credentials.csv';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
 const CsvUploadModal: React.FC<CsvUploadModalProps> = ({
   token,
   classroomId,
@@ -53,28 +83,54 @@ const CsvUploadModal: React.FC<CsvUploadModalProps> = ({
   const [isUploading, setIsUploading] = useState(false);
   const [uploadResult, setUploadResult] = useState<CsvUploadResult | null>(null);
   const [error, setError] = useState('');
+  const [isDragOver, setIsDragOver] = useState(false);
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  const processFile = useCallback((file: File) => {
     setError('');
     setSelectedFile(file);
 
-    // Parse preview
     const reader = new FileReader();
     reader.onload = (evt) => {
       const text = evt.target?.result as string;
       const preview = parseCsvPreview(text);
-      // Count total data rows
-      const lines = text.split(/\r?\n/).filter((l) => l.trim());
-      const firstLower = lines[0]?.toLowerCase() ?? '';
-      const hasHeader = firstLower.includes('name') || firstLower.includes('姓名') || firstLower.includes('seat');
-      setTotalRows(hasHeader ? lines.length - 1 : lines.length);
+      setTotalRows(countCsvDataRows(text));
       setPreviewRows(preview);
       setPhase('preview');
     };
     reader.readAsText(file, 'utf-8');
+  }, []);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    processFile(file);
   };
+
+  // ── Drag-and-drop handlers ────────────────────────────────────────────────
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDragOver(false);
+
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    processFile(file);
+  };
+
+  // ── Upload ────────────────────────────────────────────────────────────────
 
   const handleUpload = async () => {
     if (!selectedFile) return;
@@ -99,6 +155,7 @@ const CsvUploadModal: React.FC<CsvUploadModalProps> = ({
     setTotalRows(0);
     setUploadResult(null);
     setError('');
+    setIsDragOver(false);
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
@@ -151,16 +208,34 @@ const CsvUploadModal: React.FC<CsvUploadModalProps> = ({
                 下載範本 CSV
               </button>
 
-              {/* File input */}
-              <div>
+              {/* Drag-and-drop zone */}
+              <div
+                role="region"
+                aria-label="拖曳 CSV 檔案至此或點擊選擇"
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                className={`rounded-xl transition-colors ${
+                  isDragOver
+                    ? 'border-2 border-accent ring-2 ring-accent/30 bg-accent/5'
+                    : 'border-2 border-dashed border-gray-300 hover:border-accent'
+                }`}
+              >
                 <label
                   htmlFor="csv-file-input"
-                  className="block w-full cursor-pointer border-2 border-dashed border-gray-300 hover:border-accent rounded-xl p-6 text-center transition-colors"
+                  className="block w-full cursor-pointer p-6 text-center"
                 >
-                  <svg className="mx-auto w-8 h-8 text-gray-400 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg
+                    className={`mx-auto w-8 h-8 mb-2 ${isDragOver ? 'text-accent' : 'text-gray-400'}`}
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
                   </svg>
-                  <p className="text-sm font-medium text-gray-700">點擊或拖曳 CSV 檔案至此</p>
+                  <p className="text-sm font-medium text-gray-700">
+                    {isDragOver ? '放開以上傳' : '點擊或拖曳 CSV 檔案至此'}
+                  </p>
                   <p className="text-xs text-gray-400 mt-1">支援 .csv 格式，UTF-8 或 UTF-8 BOM 編碼</p>
                 </label>
                 <input
@@ -241,6 +316,18 @@ const CsvUploadModal: React.FC<CsvUploadModalProps> = ({
                   <p className={`text-xs mt-0.5 ${uploadResult.skipped_count > 0 ? 'text-amber-600' : 'text-gray-400'}`}>跳過</p>
                 </div>
               </div>
+
+              {/* Warnings */}
+              {uploadResult.warnings && uploadResult.warnings.length > 0 && (
+                <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-3">
+                  <p className="text-xs font-medium text-blue-700 mb-1">注意事項：</p>
+                  <ul className="space-y-0.5">
+                    {uploadResult.warnings.map((w, i) => (
+                      <li key={i} className="text-xs text-blue-700">{w}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
 
               {/* Credentials table */}
               {uploadResult.created.length > 0 && (
@@ -325,6 +412,14 @@ const CsvUploadModal: React.FC<CsvUploadModalProps> = ({
                   className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
                 >
                   重試
+                </button>
+              )}
+              {uploadResult && uploadResult.created.length > 0 && (
+                <button
+                  onClick={() => downloadCredentialsCsv(uploadResult.created)}
+                  className="px-4 py-2 rounded-lg border border-blue-300 text-blue-700 text-sm font-medium hover:bg-blue-50 transition-colors cursor-pointer"
+                >
+                  下載帳號 CSV
                 </button>
               )}
               <button

--- a/frontend/src/pages/teacher/__tests__/CsvUploadModal.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/CsvUploadModal.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Tests for CsvUploadModal — covers the gaps identified in issue #538:
+ * 1. drag-and-drop file handling
+ * 2. warnings display from backend response
+ * 3. credential CSV download after import
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CsvUploadModal from '../CsvUploadModal';
+import * as classroomApi from '../../../services/classroomApi';
+
+vi.mock('../../../services/classroomApi', () => ({
+  uploadCsvStudents: vi.fn(),
+  downloadCsvTemplate: vi.fn(),
+}));
+
+const DEFAULT_PROPS = {
+  token: 'test-token',
+  classroomId: 1,
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+};
+
+function makeCsvFile(content = 'name,seat_number\n王小明,01\n李小美,02\n') {
+  return new File([content], 'students.csv', { type: 'text/csv' });
+}
+
+describe('CsvUploadModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Test 1: drag-and-drop ─────────────────────────────────────────────────
+
+  describe('drag-and-drop file handling', () => {
+    it('accepts a file dropped onto the dropzone', async () => {
+      render(<CsvUploadModal {...DEFAULT_PROPS} />);
+
+      const dropzone = screen.getByRole('region', { name: /拖曳/i });
+      const file = makeCsvFile();
+
+      fireEvent.dragOver(dropzone, {
+        dataTransfer: { files: [file], types: ['Files'] },
+      });
+      fireEvent.drop(dropzone, {
+        dataTransfer: { files: [file] },
+      });
+
+      // After drop, should move to preview phase
+      await waitFor(() => {
+        expect(screen.getByText(/預覽/)).toBeInTheDocument();
+      });
+    });
+
+    it('applies drag-active styling when a file is dragged over', async () => {
+      render(<CsvUploadModal {...DEFAULT_PROPS} />);
+
+      const dropzone = screen.getByRole('region', { name: /拖曳/i });
+      fireEvent.dragOver(dropzone, {
+        dataTransfer: { files: [], types: ['Files'] },
+      });
+
+      expect(dropzone.className).toMatch(/border-accent|drag-active|ring/i);
+    });
+
+    it('removes drag-active styling when drag leaves', async () => {
+      render(<CsvUploadModal {...DEFAULT_PROPS} />);
+
+      const dropzone = screen.getByRole('region', { name: /拖曳/i });
+      fireEvent.dragOver(dropzone, {
+        dataTransfer: { files: [], types: ['Files'] },
+      });
+      fireEvent.dragLeave(dropzone);
+
+      // Should not have drag-active border after leave
+      expect(dropzone.className).not.toMatch(/ring-accent|border-accent.*ring/);
+    });
+  });
+
+  // ── Test 2: warnings display ──────────────────────────────────────────────
+
+  describe('warnings from backend', () => {
+    it('displays warnings returned by the upload API', async () => {
+      const mockResult = {
+        created_count: 2,
+        skipped_count: 0,
+        errors: [],
+        created: [
+          { name: '王小明', seat_number: '01', username: 'ABC01', password: 'XY12ZW34', user_id: 1 },
+          { name: '李小美', seat_number: '02', username: 'ABC02', password: 'YZ45QR67', user_id: 2 },
+        ],
+        warnings: ['學校未設定網域，使用預設 lingoleap.local 網域'],
+      };
+      vi.mocked(classroomApi.uploadCsvStudents).mockResolvedValue(mockResult);
+
+      render(<CsvUploadModal {...DEFAULT_PROPS} />);
+
+      // Simulate file selection to get to preview
+      const input = document.getElementById('csv-file-input') as HTMLInputElement;
+      const file = makeCsvFile();
+      await userEvent.upload(input, file);
+
+      // Click upload
+      const uploadBtn = await screen.findByRole('button', { name: /確認匯入/i });
+      await userEvent.click(uploadBtn);
+
+      // Should show warning
+      await waitFor(() => {
+        expect(screen.getByText(/學校未設定網域/)).toBeInTheDocument();
+      });
+    });
+
+    it('does not show warnings section when there are no warnings', async () => {
+      const mockResult = {
+        created_count: 1,
+        skipped_count: 0,
+        errors: [],
+        created: [
+          { name: '王小明', seat_number: '01', username: 'ABC01', password: 'XY12ZW34', user_id: 1 },
+        ],
+        warnings: [],
+      };
+      vi.mocked(classroomApi.uploadCsvStudents).mockResolvedValue(mockResult);
+
+      render(<CsvUploadModal {...DEFAULT_PROPS} />);
+
+      const input = document.getElementById('csv-file-input') as HTMLInputElement;
+      const file = makeCsvFile('王小明,01\n');
+      await userEvent.upload(input, file);
+
+      const uploadBtn = await screen.findByRole('button', { name: /確認匯入/i });
+      await userEvent.click(uploadBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText('1')).toBeInTheDocument(); // created_count
+      });
+
+      expect(screen.queryByText(/警告/)).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Test 3: credential download ───────────────────────────────────────────
+
+  describe('credential CSV download', () => {
+    it('shows a download button on the result phase when students were created', async () => {
+      const mockResult = {
+        created_count: 2,
+        skipped_count: 0,
+        errors: [],
+        created: [
+          { name: '王小明', seat_number: '01', username: 'ABC01', password: 'XY12ZW34', user_id: 1 },
+          { name: '李小美', seat_number: '02', username: 'ABC02', password: 'YZ45QR67', user_id: 2 },
+        ],
+        warnings: [],
+      };
+      vi.mocked(classroomApi.uploadCsvStudents).mockResolvedValue(mockResult);
+
+      render(<CsvUploadModal {...DEFAULT_PROPS} />);
+
+      const input = document.getElementById('csv-file-input') as HTMLInputElement;
+      const file = makeCsvFile();
+      await userEvent.upload(input, file);
+
+      const uploadBtn = await screen.findByRole('button', { name: /確認匯入/i });
+      await userEvent.click(uploadBtn);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /下載帳號/i })).toBeInTheDocument();
+      });
+    });
+
+    it('does not show download button when no students were created', async () => {
+      const mockResult = {
+        created_count: 0,
+        skipped_count: 1,
+        errors: [{ name: '王小明', seat_number: '01', error: '已存在' }],
+        created: [],
+        warnings: [],
+      };
+      vi.mocked(classroomApi.uploadCsvStudents).mockResolvedValue(mockResult);
+
+      render(<CsvUploadModal {...DEFAULT_PROPS} />);
+
+      const input = document.getElementById('csv-file-input') as HTMLInputElement;
+      const file = makeCsvFile('王小明,01\n');
+      await userEvent.upload(input, file);
+
+      const uploadBtn = await screen.findByRole('button', { name: /確認匯入/i });
+      await userEvent.click(uploadBtn);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('button', { name: /下載帳號/i })).not.toBeInTheDocument();
+      });
+    });
+
+    it('triggers CSV download when the download button is clicked', async () => {
+      const mockResult = {
+        created_count: 1,
+        skipped_count: 0,
+        errors: [],
+        created: [
+          { name: '王小明', seat_number: '01', username: 'ABC01', password: 'XY12ZW34', user_id: 1 },
+        ],
+        warnings: [],
+      };
+      vi.mocked(classroomApi.uploadCsvStudents).mockResolvedValue(mockResult);
+
+      // Mock URL.createObjectURL
+      const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+      const mockRevokeObjectURL = vi.fn();
+      Object.defineProperty(global.URL, 'createObjectURL', { value: mockCreateObjectURL, writable: true });
+      Object.defineProperty(global.URL, 'revokeObjectURL', { value: mockRevokeObjectURL, writable: true });
+
+      // Mock anchor click
+      const mockAnchorClick = vi.fn();
+      const originalCreateElement = document.createElement.bind(document);
+      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'a') {
+          const anchor = originalCreateElement(tag) as HTMLAnchorElement;
+          anchor.click = mockAnchorClick;
+          return anchor;
+        }
+        return originalCreateElement(tag);
+      });
+
+      render(<CsvUploadModal {...DEFAULT_PROPS} />);
+
+      const input = document.getElementById('csv-file-input') as HTMLInputElement;
+      const file = makeCsvFile('王小明,01\n');
+      await userEvent.upload(input, file);
+
+      const uploadBtn = await screen.findByRole('button', { name: /確認匯入/i });
+      await userEvent.click(uploadBtn);
+
+      const downloadBtn = await screen.findByRole('button', { name: /下載帳號/i });
+      await userEvent.click(downloadBtn);
+
+      expect(mockCreateObjectURL).toHaveBeenCalled();
+      expect(mockAnchorClick).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/services/classroomApi.ts
+++ b/frontend/src/services/classroomApi.ts
@@ -265,6 +265,7 @@ export interface CsvUploadResult {
     password: string;
     user_id: number;
   }[];
+  warnings: string[];
 }
 
 export async function uploadCsvStudents(


### PR DESCRIPTION
Fixes #538

## Summary

- **Drag-and-drop upload**: Wired up `onDragOver`, `onDragLeave`, `onDrop` handlers on the dropzone. The UI already showed a drag-drop affordance but it was not functional — clicking was the only way to pick a file.
- **Warnings display**: Backend `CsvUploadResponse` includes a `warnings` list (e.g. when school domain is not configured), but the frontend `CsvUploadResult` type was missing the `warnings` field and the modal never rendered warnings. Now both are fixed.
- **Credential CSV download**: After a successful import, teachers see the one-time passwords in a table but had no way to save them. Added a "下載帳號 CSV" button in the result phase that generates a BOM-encoded CSV with name, seat_number, username, and password columns.

## Changes

| File | Change |
|------|--------|
| `frontend/src/services/classroomApi.ts` | Add `warnings: string[]` to `CsvUploadResult` |
| `frontend/src/pages/teacher/CsvUploadModal.tsx` | Implement drag-drop, warnings display, credential download |
| `frontend/src/pages/teacher/__tests__/CsvUploadModal.test.tsx` | 8 new Vitest tests (all pass) |

## Test plan

- [ ] Open teacher dashboard → classroom detail → 學生名單 tab
- [ ] Click "匯入 CSV" to open modal
- [ ] Drag a `.csv` file onto the dropzone — should advance to preview phase
- [ ] Click "確認匯入" — result shows created count
- [ ] Click "下載帳號 CSV" — downloads a CSV with student credentials
- [ ] If backend returns warnings, they appear in a blue notice box
- [ ] Unit tests: `npx vitest run src/pages/teacher/__tests__/CsvUploadModal.test.tsx` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)