### PR TITLE
feat: student classroom gate — block dashboard when no classroom (Fixes #457)

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -11,7 +11,7 @@ from ..auth.rate_limiter import InMemoryRateLimiter
 from ..config import settings
 from ..database import get_db
 from ..models.user import User, UserRole, Role
-from ..models.school import School
+from ..models.school import School, ClassroomStudent
 from ..schemas.auth import (
     ChangePasswordRequest,
     ForgotPasswordRequest,
@@ -54,6 +54,27 @@ def _has_active_role(db: Session, user_id: int, role_name: str) -> bool:
         .first()
         is not None
     )
+
+
+def _compute_has_classroom(db: Session, user_id: int) -> bool:
+    """Return True if user is not a student OR if they belong to at least one classroom.
+
+    Issue #457: students who are not yet enrolled in any classroom should see a
+    friendly waiting screen on the frontend instead of the full dashboard.
+    Teachers, admins, and all other roles always return True (not gated).
+    """
+    is_student = _has_active_role(db, user_id, "student")
+    if not is_student:
+        # Non-students (teachers, admins, parents, etc.) are never gated
+        return True
+
+    # Student — check if enrolled in at least one classroom
+    enrolled = (
+        db.query(ClassroomStudent)
+        .filter(ClassroomStudent.student_id == user_id)
+        .first()
+    )
+    return enrolled is not None
 
 
 def _ensure_parent_login_allowed(user: User, db: Session) -> None:
@@ -264,8 +285,16 @@ def login(req: LoginRequest, request: Request, db: Session = Depends(get_db)):
     if user.student_profile and not user.student_profile.password_changed:
         must_change = True
 
+    # Issue #457: determine whether this user has at least one classroom.
+    # Only applies to students — teachers and admins always get True.
+    has_classroom = _compute_has_classroom(db, user.id)
+
     token = create_access_token(user.id)
-    return TokenResponse(access_token=token, must_change_password=must_change)
+    return TokenResponse(
+        access_token=token,
+        must_change_password=must_change,
+        has_classroom=has_classroom,
+    )
 
 
 @router.post("/complete-onboarding")

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -26,6 +26,9 @@ class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     must_change_password: bool = False
+    # Issue #457: True for teachers/admins and students enrolled in at least one classroom.
+    # False only for students with no classroom enrollment — shows a waiting screen on frontend.
+    has_classroom: bool = True
 
 
 class RegisterResponse(BaseModel):

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1704,3 +1704,176 @@ class TestEmailDomainValidation:
             "name": "Pioneer Teacher",
         })
         assert resp.status_code == 201
+
+
+# ===========================================================================
+# Integration tests — has_classroom field in login response (issue #457)
+# ===========================================================================
+
+
+class TestHasClassroomLoginResponse:
+    """Tests for issue #457: login response includes has_classroom flag.
+
+    Students not yet enrolled in any classroom should get has_classroom=False.
+    Teachers and other non-student roles always get has_classroom=True.
+    """
+
+    def _create_student_directly(self, name: str) -> dict:
+        """Create a student directly in DB (simulates teacher-created account).
+
+        Returns dict with email, password.
+        """
+        from app.models.user import User as UserModel, UserRole as UserRoleModel, Role as RoleModel
+        from app.auth.password import hash_password as _hash
+        import uuid as _uuid
+
+        email = f"student_{_uuid.uuid4().hex[:8]}@school.edu.tw"
+        password = "StudentPass1!"
+
+        db = TestingSessionLocal()
+        try:
+            student = UserModel(
+                email=email,
+                password_hash=_hash(password),
+                name=name,
+                email_verified=True,  # batch-created students skip email verification
+            )
+            db.add(student)
+            db.flush()
+
+            # Assign student role
+            role = db.query(RoleModel).filter(RoleModel.name == "student").first()
+            assert role is not None, "student role must be seeded"
+            db.add(UserRoleModel(user_id=student.id, role_id=role.id, scope_type="school"))
+            db.commit()
+            return {"email": email, "password": password, "user_id": student.id}
+        finally:
+            db.close()
+
+    def _enroll_student_in_classroom(self, student_id: int, classroom_id: int) -> None:
+        """Directly enroll a student in a classroom via DB."""
+        from app.models.school import ClassroomStudent
+
+        db = TestingSessionLocal()
+        try:
+            cs = ClassroomStudent(classroom_id=classroom_id, student_id=student_id)
+            db.add(cs)
+            db.commit()
+        finally:
+            db.close()
+
+    def _create_teacher_and_classroom(self, client) -> dict:
+        """Register a teacher (with email verification), then create a classroom.
+
+        Returns dict with teacher_token, classroom_id.
+        """
+        import uuid as _uuid
+
+        unique = _uuid.uuid4().hex[:6]
+        domain = f"hctest-{unique}.edu.tw"
+        email = f"teacher@{domain}"
+
+        reg = client.post("/api/auth/register", json={
+            "email": email, "password": "StrongPass1!", "name": "HC Teacher",
+        })
+        assert reg.status_code == 201
+        vtoken = reg.json()["verification_token"]
+        client.get(f"/api/auth/verify-email?token={vtoken}")
+        teacher_token = client.post("/api/auth/login", json={
+            "email": email, "password": "StrongPass1!",
+        }).json()["access_token"]
+
+        # Create a classroom
+        from app.models.school import School, Classroom
+        db = TestingSessionLocal()
+        try:
+            school = db.query(School).filter(School.domain == domain).first()
+            assert school is not None
+            # Get teacher user_id from token
+            from app.auth.jwt import decode_token
+            teacher_id = int(decode_token(teacher_token)["sub"])
+            classroom = Classroom(
+                school_id=school.id,
+                teacher_id=teacher_id,
+                name="Test Class",
+                grade=3,
+            )
+            db.add(classroom)
+            db.commit()
+            db.refresh(classroom)
+            return {"teacher_token": teacher_token, "classroom_id": classroom.id}
+        finally:
+            db.close()
+
+    # -----------------------------------------------------------------------
+    # Test: login response contains has_classroom field
+    # -----------------------------------------------------------------------
+
+    def test_login_response_has_has_classroom_field(self, client, registered_user):
+        """Login response must include has_classroom field (issue #457)."""
+        resp = client.post("/api/auth/login", json={
+            "email": registered_user["email"],
+            "password": registered_user["password"],
+        })
+        assert resp.status_code == 200
+        assert "has_classroom" in resp.json(), (
+            "Login response must include has_classroom field for student classroom gate"
+        )
+
+    def test_teacher_login_has_classroom_true(self, client, registered_user):
+        """Teachers always get has_classroom=True (they are not subject to the gate)."""
+        resp = client.post("/api/auth/login", json={
+            "email": registered_user["email"],
+            "password": registered_user["password"],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["has_classroom"] is True
+
+    def test_student_with_no_classroom_gets_has_classroom_false(self, client):
+        """Student with no classroom enrollment should get has_classroom=False."""
+        student = self._create_student_directly("No Classroom Student")
+        resp = client.post("/api/auth/login", json={
+            "email": student["email"],
+            "password": student["password"],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["has_classroom"] is False, (
+            "Student not enrolled in any classroom should get has_classroom=False"
+        )
+
+    def test_student_enrolled_in_classroom_gets_has_classroom_true(self, client):
+        """Student who IS enrolled in a classroom should get has_classroom=True."""
+        student = self._create_student_directly("Enrolled Student")
+        tc = self._create_teacher_and_classroom(client)
+        self._enroll_student_in_classroom(student["user_id"], tc["classroom_id"])
+
+        resp = client.post("/api/auth/login", json={
+            "email": student["email"],
+            "password": student["password"],
+        })
+        assert resp.status_code == 200
+        assert resp.json()["has_classroom"] is True, (
+            "Student enrolled in a classroom should get has_classroom=True"
+        )
+
+    def test_student_without_student_role_gets_has_classroom_true(self, client):
+        """A user with no student role (regular teacher account) gets has_classroom=True."""
+        # registered_user is a teacher — no student role assigned
+        import uuid as _uuid
+        unique = _uuid.uuid4().hex[:6]
+        domain = f"norole-{unique}.edu.tw"
+        reg = client.post("/api/auth/register", json={
+            "email": f"plain@{domain}",
+            "password": "StrongPass1!",
+            "name": "Plain User",
+        })
+        assert reg.status_code == 201
+        vtoken = reg.json()["verification_token"]
+        client.get(f"/api/auth/verify-email?token={vtoken}")
+
+        resp = client.post("/api/auth/login", json={
+            "email": f"plain@{domain}",
+            "password": "StrongPass1!",
+        })
+        assert resp.status_code == 200
+        assert resp.json()["has_classroom"] is True

--- a/frontend/src/pages/student/StudentHome.tsx
+++ b/frontend/src/pages/student/StudentHome.tsx
@@ -9,6 +9,10 @@
  * - RecommendedStories
  * - SessionResumePrompt (resume incomplete session)
  *
+ * Issue #457: Students not yet added to any classroom see a friendly waiting
+ * screen instead of the full dashboard. All dashboard content is blocked until
+ * a teacher enrolls the student.
+ *
  * Route: /student
  */
 
@@ -133,6 +137,51 @@ const ClassroomContextCard: React.FC<ClassroomContextCardProps> = ({
 };
 
 // ---------------------------------------------------------------------------
+// NoClassroomWaitingScreen — shown to students not yet added to any classroom
+// Issue #457
+// ---------------------------------------------------------------------------
+
+interface NoClassroomWaitingScreenProps {
+  firstName: string;
+}
+
+const NoClassroomWaitingScreen: React.FC<NoClassroomWaitingScreenProps> = ({ firstName }) => (
+  <div className="flex-1 flex items-center justify-center min-h-[60vh]">
+    <div className="max-w-md w-full mx-auto p-6 text-center space-y-6">
+      {/* Avatar */}
+      <div
+        className="w-20 h-20 rounded-full bg-amber-100 flex items-center justify-center mx-auto"
+        aria-hidden="true"
+      >
+        <span className="text-4xl">🏫</span>
+      </div>
+
+      {/* Greeting */}
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">你好，{firstName}！</h1>
+        <p className="text-base text-gray-600 mt-2">
+          你的老師還沒有把你加入班級
+        </p>
+      </div>
+
+      {/* Instruction card */}
+      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-5 text-left space-y-3">
+        <p className="text-sm font-semibold text-amber-900">下一步怎麼做？</p>
+        <ol className="space-y-2 text-sm text-amber-800 list-decimal list-inside">
+          <li>請聯繫你的老師</li>
+          <li>請老師把你加入班級</li>
+          <li>加入後重新登入，即可開始學習</li>
+        </ol>
+      </div>
+
+      <p className="text-xs text-gray-400">
+        加入班級後重新整理頁面即可繼續
+      </p>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
@@ -166,6 +215,13 @@ const StudentHome: React.FC = () => {
   const handleSelectClassroom = (classroomId: number) => {
     navigate(`/library?classroom=${classroomId}`);
   };
+
+  // Issue #457: block the full dashboard for students not yet added to any classroom.
+  // Only gate after classrooms have been fetched so we don't flash the waiting screen
+  // for students who ARE enrolled (while the API call is in-flight).
+  if (classroomsLoaded && classrooms.length === 0) {
+    return <NoClassroomWaitingScreen firstName={firstName} />;
+  }
 
   return (
     <div className="flex-1 overflow-y-auto">

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -52,6 +52,8 @@ export interface AuthTokenResponse {
   access_token: string;
   token_type: string;
   must_change_password?: boolean;
+  /** Issue #457: false for students not yet enrolled in any classroom. */
+  has_classroom?: boolean;
 }
 
 export class AuthError extends Error {


### PR DESCRIPTION
Fixes #457

## Summary

- **Backend**: Added `has_classroom: bool` field to `TokenResponse`. For users with an active `student` role, checks `ClassroomStudent` table — returns `false` if no enrollment exists. Teachers, admins, and all other roles always get `true`.
- **Frontend**: `StudentHome` now shows a friendly waiting screen ("你的老師還沒有把你加入班級，請聯繫你的老師") when classroom API returns an empty list after loading, instead of rendering the full dashboard.
- **Type safety**: `AuthTokenResponse` interface updated with `has_classroom` field.
- **No DB migration needed** — reads existing `classroom_students` table.

## Test plan

- [ ] Log in as a student account that has NOT been added to any classroom → should see waiting screen, not dashboard
- [ ] Log in as a student account that HAS been added to a classroom → should see normal dashboard (or auto-navigate to library)
- [ ] Log in as a teacher → should see teacher dashboard, unaffected
- [ ] Run backend tests: `cd backend && python -m pytest tests/test_auth_api.py::TestHasClassroomLoginResponse -v` → all 5 pass