### PR TITLE
test: fix 150+ test failures after REQUIRE_EMAIL_VERIFICATION flag (#460)

### DIFF
--- a/backend/tests/test_admin_api.py
+++ b/backend/tests/test_admin_api.py
@@ -145,8 +145,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_ai_analysis.py
+++ b/backend/tests/test_ai_analysis.py
@@ -145,12 +145,13 @@ def _register_user(client, suffix: str | None = None) -> dict:
         "name": name,
     })
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
+    verification_token = resp.json().get("verification_token")
 
-    resp = client.post("/api/auth/verify-email", json={
-        "token": verification_token,
-    })
-    assert resp.status_code == 200, resp.text
+    if verification_token:
+        resp = client.post("/api/auth/verify-email", json={
+            "token": verification_token,
+        })
+        assert resp.status_code == 200, resp.text
 
     resp = client.post("/api/auth/login", json={
         "email": email,

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -143,10 +143,10 @@ def _register_user(client, suffix: str) -> dict:
     })
     assert resp.status_code == 201
     # Verify email using the dev-mode token returned in the response
-    verification_token = resp.json()["verification_token"]
-    assert verification_token is not None
-    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
-    assert verify_resp.status_code == 200
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+        assert verify_resp.status_code == 200
     # Login to get a JWT token
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_resp.status_code == 200

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -601,8 +601,9 @@ class TestAutoSchoolCreation:
         assert resp.status_code == 201
 
         # Verify email and login to get a JWT (issue #460)
-        verification_token = resp.json()["verification_token"]
-        client.get(f"/api/auth/verify-email?token={verification_token}")
+        verification_token = resp.json().get("verification_token")
+        if verification_token:
+            client.get(f"/api/auth/verify-email?token={verification_token}")
         login_resp = client.post("/api/auth/login", json={"email": email, "password": "StrongPass1!"})
         token = login_resp.json()["access_token"]
         user_id = int(decode_token(token)["sub"])
@@ -1476,7 +1477,7 @@ class TestEmailVerificationFlow:
         data = self._register(client)
         # Get a new token via resend
         resend_resp = client.post("/api/auth/resend-verification", json={"email": data["email"]})
-        new_token = resend_resp.json()["verification_token"]
+        new_token = resend_resp.json().get("verification_token")
         # Verify with new token
         client.get(f"/api/auth/verify-email?token={new_token}")
         # Login should now work
@@ -1823,8 +1824,9 @@ class TestHasClassroomLoginResponse:
             "email": email, "password": "StrongPass1!", "name": "HC Teacher",
         })
         assert reg.status_code == 201
-        vtoken = reg.json()["verification_token"]
-        client.get(f"/api/auth/verify-email?token={vtoken}")
+        vtoken = reg.json().get("verification_token")
+        if vtoken:
+            client.get(f"/api/auth/verify-email?token={vtoken}")
         teacher_token = client.post("/api/auth/login", json={
             "email": email, "password": "StrongPass1!",
         }).json()["access_token"]
@@ -1914,8 +1916,9 @@ class TestHasClassroomLoginResponse:
             "name": "Plain User",
         })
         assert reg.status_code == 201
-        vtoken = reg.json()["verification_token"]
-        client.get(f"/api/auth/verify-email?token={vtoken}")
+        vtoken = reg.json().get("verification_token")
+        if vtoken:
+            client.get(f"/api/auth/verify-email?token={vtoken}")
 
         resp = client.post("/api/auth/login", json={
             "email": f"plain@{domain}",

--- a/backend/tests/test_background_jobs.py
+++ b/backend/tests/test_background_jobs.py
@@ -109,8 +109,9 @@ def _register_user(client, suffix: str) -> dict:
         json={"email": email, "password": password, "name": f"{suffix.title()} {unique}"},
     )
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_classroom_join_and_batch.py
+++ b/backend/tests/test_classroom_join_and_batch.py
@@ -140,8 +140,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_classroom_texts_api.py
+++ b/backend/tests/test_classroom_texts_api.py
@@ -135,8 +135,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_classrooms_api.py
+++ b/backend/tests/test_classrooms_api.py
@@ -148,8 +148,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     # Get user ID from /users/me

--- a/backend/tests/test_co_teaching_api.py
+++ b/backend/tests/test_co_teaching_api.py
@@ -98,9 +98,9 @@ def _register(client, name, email, password="Password123!"):
     assert r.status_code in (200, 201), r.text
     # Dev mode returns verification_token directly; verify it before login
     verification_token = r.json().get("verification_token")
-    assert verification_token is not None, "Expected verification_token in dev mode response"
-    verify_r = client.get(f"/api/auth/verify-email?token={verification_token}")
-    assert verify_r.status_code == 200, verify_r.text
+    if verification_token:
+        verify_r = client.get(f"/api/auth/verify-email?token={verification_token}")
+        assert verify_r.status_code == 200, verify_r.text
     # Login to get access_token
     login_r = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_r.status_code == 200, login_r.text

--- a/backend/tests/test_comprehension_score.py
+++ b/backend/tests/test_comprehension_score.py
@@ -138,10 +138,10 @@ def _register_user(client, suffix: str | None = None) -> dict:
     assert resp.status_code == 201, resp.text
 
     # Verify email using the dev-mode verification_token
-    verification_token = resp.json()["verification_token"]
-    assert verification_token is not None
-    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
-    assert verify_resp.status_code == 200, verify_resp.text
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+        assert verify_resp.status_code == 200, verify_resp.text
 
     # Login to get a JWT access token
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})

--- a/backend/tests/test_copyright.py
+++ b/backend/tests/test_copyright.py
@@ -136,8 +136,9 @@ def _register_and_login(client) -> str:
         "name": f"Teacher {unique}",
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     return login_resp.json()["access_token"]
 

--- a/backend/tests/test_csv_upload.py
+++ b/backend/tests/test_csv_upload.py
@@ -135,8 +135,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_email_domain_validation.py
+++ b/backend/tests/test_email_domain_validation.py
@@ -173,8 +173,9 @@ def _register_teacher(client, email_prefix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_email_verification_flag.py
+++ b/backend/tests/test_email_verification_flag.py
@@ -257,7 +257,7 @@ class TestEmailVerificationFlagOn:
 
         # Resend and get new token
         resend_resp = client.post("/api/auth/resend-verification", json={"email": data["email"]})
-        new_token = resend_resp.json()["verification_token"]
+        new_token = resend_resp.json().get("verification_token")
 
         # Verify with new token
         client.get(f"/api/auth/verify-email?token={new_token}")

--- a/backend/tests/test_error_correction.py
+++ b/backend/tests/test_error_correction.py
@@ -125,9 +125,9 @@ def _register_user(client, suffix: str | None = None) -> dict:
     assert resp.status_code == 201, resp.text
     # Dev mode returns a verification_token to bypass email confirmation
     verification_token = resp.json().get("verification_token")
-    assert verification_token is not None, "Expected dev-mode verification_token"
-    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
-    assert verify_resp.status_code == 200, verify_resp.text
+    if verification_token:
+        verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+        assert verify_resp.status_code == 200, verify_resp.text
     # Now login to obtain a JWT
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_resp.status_code == 200, login_resp.text

--- a/backend/tests/test_error_heatmap.py
+++ b/backend/tests/test_error_heatmap.py
@@ -141,9 +141,9 @@ def _register_user(client, suffix: str) -> dict:
     assert resp.status_code == 201, resp.text
 
     verification_token = resp.json().get("verification_token")
-    assert verification_token is not None, "Expected dev-mode verification_token"
-    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
-    assert verify_resp.status_code == 200, verify_resp.text
+    if verification_token:
+        verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+        assert verify_resp.status_code == 200, verify_resp.text
 
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_resp.status_code == 200, login_resp.text

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -112,8 +112,9 @@ def _register_and_login(client, suffix: str, role_name: str | None = None) -> tu
         "name": f"{suffix} user",
     })
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_r = client.post("/api/auth/login", json={"email": email, "password": "Test1234!"})
     token = login_r.json()["access_token"]
 

--- a/backend/tests/test_heatmap.py
+++ b/backend/tests/test_heatmap.py
@@ -140,8 +140,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_learning_path_service.py
+++ b/backend/tests/test_learning_path_service.py
@@ -118,8 +118,9 @@ def _register_user(client: TestClient, suffix: str | None = None) -> dict:
         "name": name,
     })
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_resp.status_code == 200, login_resp.text
     token = login_resp.json()["access_token"]

--- a/backend/tests/test_learning_sessions_api.py
+++ b/backend/tests/test_learning_sessions_api.py
@@ -122,8 +122,9 @@ def _register_user(client, suffix: str | None = None) -> dict:
         "name": name,
     })
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     return {
         "email": email,

--- a/backend/tests/test_listening.py
+++ b/backend/tests/test_listening.py
@@ -109,8 +109,9 @@ def _register_and_login(client: TestClient) -> str:
         json={"email": email, "password": password, "name": "Listen Tester"},
     )
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     return login_resp.json()["access_token"]
 

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -116,8 +116,9 @@ def registered_student(client):
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     return {"email": email, "password": password, "name": name, "token": token}
@@ -191,8 +192,9 @@ class TestCompleteOnboardingEndpoint:
             "name": f"Persist User {unique}",
         })
         assert reg_resp.status_code == 201
-        vt = reg_resp.json()["verification_token"]
-        client.get(f"/api/auth/verify-email?token={vt}")
+        vt = reg_resp.json().get("verification_token")
+        if vt:
+            client.get(f"/api/auth/verify-email?token={vt}")
         token = client.post("/api/auth/login", json={"email": persist_email, "password": persist_pass}).json()["access_token"]
 
         # Initially False
@@ -234,8 +236,9 @@ class TestCompleteOnboardingEndpoint:
             "name": f"Idempotent User {unique}",
         })
         assert reg_resp.status_code == 201
-        vt = reg_resp.json()["verification_token"]
-        client.get(f"/api/auth/verify-email?token={vt}")
+        vt = reg_resp.json().get("verification_token")
+        if vt:
+            client.get(f"/api/auth/verify-email?token={vt}")
         token = client.post("/api/auth/login", json={"email": idem_email, "password": idem_pass}).json()["access_token"]
 
         # Call twice
@@ -269,8 +272,9 @@ class TestOnboardingFlow:
             "name": f"Flow User {unique}",
         })
         assert reg_resp.status_code == 201
-        vt = reg_resp.json()["verification_token"]
-        client.get(f"/api/auth/verify-email?token={vt}")
+        vt = reg_resp.json().get("verification_token")
+        if vt:
+            client.get(f"/api/auth/verify-email?token={vt}")
         token = client.post("/api/auth/login", json={"email": flow_email, "password": flow_pass}).json()["access_token"]
 
         # Step 2: Verify onboarding_completed is False after registration

--- a/backend/tests/test_org_dashboard.py
+++ b/backend/tests/test_org_dashboard.py
@@ -125,8 +125,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": f"{suffix.title()} {unique}",
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_org_fields.py
+++ b/backend/tests/test_org_fields.py
@@ -116,8 +116,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": f"{suffix.title()} {unique}",
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_organizations_api.py
+++ b/backend/tests/test_organizations_api.py
@@ -116,8 +116,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": f"{suffix.title()} {unique}",
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_parent_portal.py
+++ b/backend/tests/test_parent_portal.py
@@ -105,8 +105,9 @@ def _register(client, prefix: str) -> tuple[int, str]:
     password = "Test1234!"
     r = client.post("/api/auth/register", json={"email": email, "password": password, "name": prefix})
     assert r.status_code == 201, r.text
-    verification_token = r.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = r.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_r = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_r.json()["access_token"]
     me = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_password_validation.py
+++ b/backend/tests/test_password_validation.py
@@ -87,8 +87,9 @@ def register_and_verify(client: TestClient, email: str, password: str, name: str
     """Register a user and verify their email so they can log in."""
     resp = client.post("/api/auth/register", json={"email": email, "password": password, "name": name})
     assert resp.status_code == 201
-    token = resp.json()["verification_token"]
-    client.post("/api/auth/verify-email", json={"token": token})
+    token = resp.json().get("verification_token")
+    if token:
+        client.post("/api/auth/verify-email", json={"token": token})
     return resp
 
 

--- a/backend/tests/test_points_system.py
+++ b/backend/tests/test_points_system.py
@@ -113,8 +113,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_report_export.py
+++ b/backend/tests/test_report_export.py
@@ -139,8 +139,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_roles_api.py
+++ b/backend/tests/test_roles_api.py
@@ -118,8 +118,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": f"{suffix.title()} {unique}",
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_schools_api.py
+++ b/backend/tests/test_schools_api.py
@@ -137,8 +137,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": f"{suffix.title()} {unique}",
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_security_fixes.py
+++ b/backend/tests/test_security_fixes.py
@@ -111,8 +111,9 @@ def _register_and_login(client) -> str:
         "name": f"Security Test {unique}",
     })
     assert resp.status_code == 201, f"Register failed: {resp.text}"
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     return login_resp.json()["access_token"]
 

--- a/backend/tests/test_semesters.py
+++ b/backend/tests/test_semesters.py
@@ -155,10 +155,10 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    assert verification_token is not None
-    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
-    assert verify_resp.status_code == 200
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
+        assert verify_resp.status_code == 200
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_resp.status_code == 200
     token = login_resp.json()["access_token"]

--- a/backend/tests/test_session_resume.py
+++ b/backend/tests/test_session_resume.py
@@ -118,8 +118,9 @@ def _register_user(client, suffix: str | None = None) -> dict:
         "name": name,
     })
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     return {
         "email": email,

--- a/backend/tests/test_step_progress_api.py
+++ b/backend/tests/test_step_progress_api.py
@@ -105,8 +105,9 @@ def _register_and_login(client, suffix: str | None = None) -> dict:
         json={"email": email, "password": password, "name": f"SP660 {unique}"},
     )
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     assert login_resp.status_code == 200, login_resp.text
     return {"email": email, "token": login_resp.json()["access_token"]}

--- a/backend/tests/test_student_progress.py
+++ b/backend/tests/test_student_progress.py
@@ -117,8 +117,9 @@ def _register_user(client, suffix=None):
         "copyright_confirmed": True,
     })
     assert resp.status_code == 201, resp.text
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me = client.get("/api/users/me", headers={"Authorization": f"Bearer {token}"})

--- a/backend/tests/test_student_tags.py
+++ b/backend/tests/test_student_tags.py
@@ -104,8 +104,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_teacher_analytics.py
+++ b/backend/tests/test_teacher_analytics.py
@@ -136,8 +136,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=_auth(token))

--- a/backend/tests/test_teacher_api.py
+++ b/backend/tests/test_teacher_api.py
@@ -140,8 +140,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_teacher_instructions.py
+++ b/backend/tests/test_teacher_instructions.py
@@ -139,8 +139,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": name,
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))

--- a/backend/tests/test_terms.py
+++ b/backend/tests/test_terms.py
@@ -107,8 +107,9 @@ def _register_and_get_token(client: TestClient, email: str, name: str = "Test Us
         json={"email": email, "password": password, "name": name},
     )
     assert resp.status_code == 201, f"Register failed: {resp.json()}"
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     return login_resp.json()["access_token"]
 

--- a/backend/tests/test_text_cleanup.py
+++ b/backend/tests/test_text_cleanup.py
@@ -151,8 +151,9 @@ def _register_user(client, suffix: str) -> dict:
         "name": f"{suffix.title()} {unique}",
     })
     assert resp.status_code == 201
-    verification_token = resp.json()["verification_token"]
-    client.get(f"/api/auth/verify-email?token={verification_token}")
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
     login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
     token = login_resp.json()["access_token"]
     me_resp = client.get("/api/users/me", headers=auth_header(token))


### PR DESCRIPTION
## Summary

- PR #922 added `REQUIRE_EMAIL_VERIFICATION` flag (default `False`). When `False`, registration auto-verifies and returns `verification_token=None`
- This broke 42 test files (150+ individual assertions) that did `resp.json()["verification_token"]` and asserted non-None
- Fix: changed all test helpers to use `.get("verification_token")` and wrapped verify endpoint calls with `if token:` guard
- No production code changed — tests-only fix

## Files changed

42 test files updated. Pattern applied uniformly:

```python
# Before (breaks when flag=False)
verification_token = resp.json()["verification_token"]
assert verification_token is not None
verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
assert verify_resp.status_code == 200

# After (works with flag True or False)
verification_token = resp.json().get("verification_token")
if verification_token:
    verify_resp = client.get(f"/api/auth/verify-email?token={verification_token}")
    assert verify_resp.status_code == 200
```

## Test plan

- [x] `test_semesters.py` — 163 tests pass
- [x] `test_assignments.py` — all pass
- [x] `test_comprehension_score.py` — all pass
- [x] `test_error_correction.py` — all pass
- [x] `test_co_teaching_api.py` — all pass
- [x] Full suite: 1640+ pass, only pre-existing failures remain (unrelated to this PR)
- [x] Pre-existing failures confirmed on `staging` before this change: `test_dialogue_history.py` (Pydantic schema bug), `test_roles_api.py::TestNoAutoAssignOnRegister` (business logic), `test_rate_limiting.py` (missing constant), `test_tts_service.py` (GCS credentials), `test_sentence_practice.py`

🤖 Generated with Claude Code