### PR TITLE
refactor: sidebar to top nav + library simplification

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -1,6 +1,5 @@
-import React, { useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { AppView, Story, LearningSession } from '../types';
-import { useIsMobile } from '../hooks/useIsMobile';
 import { ACTIVE_STEPS, STEP_CATEGORY_COLORS } from '../config/stepConfig';
 
 interface StepperNavProps {
@@ -71,43 +70,12 @@ function getStepStatus(
   return isCompleted ? 'completed' : 'idle';
 }
 
-function getMiniSummary(stepDef: StepDef, session: LearningSession | null): string | null {
-  if (!session) return null;
-  switch (stepDef.view) {
-    case AppView.TUTOR: {
-      const a = session.readingAttempt;
-      return a ? `${a.accuracy}% \u00B7 ${a.cpm} CPM` : null;
-    }
-    case AppView.VOCAB: {
-      const v = session.vocabResult;
-      return v ? `${v.practicedChars.length}/${v.totalChars} \u5B57` : null;
-    }
-    case AppView.COMPREHENSION: {
-      const c = session.comprehensionResult;
-      return c ? `${c.understoodCount}/${c.requiredCount} \u984C` : null;
-    }
-    case AppView.DICTATION: {
-      const d = session.dictationResult;
-      return d ? `${d.correctCount}/${d.totalWords} \u5C0D` : null;
-    }
-    case AppView.FULL_READING: {
-      const f = session.fullReadingResult;
-      return f ? `${Math.round(f.matchRate * 100)}%` : null;
-    }
-    default:
-      return null;
-  }
-}
-
 // -- Step badge sub-component --
 const StepBadge: React.FC<{
   step: number;
   status: StepStatus;
   category?: 'reading' | 'comprehension' | 'practice' | 'report';
-  size?: 'sm' | 'md';
-}> = ({ step, status, category, size = 'md' }) => {
-  const sizeClasses = size === 'sm' ? 'w-6 h-6 text-xs' : 'w-8 h-8 text-sm';
-
+}> = ({ step, status, category }) => {
   const categoryColors = category ? STEP_CATEGORY_COLORS[category] : null;
 
   const styleMap: Record<StepStatus, string> = {
@@ -119,10 +87,10 @@ const StepBadge: React.FC<{
 
   return (
     <span
-      className={`${sizeClasses} rounded-full flex items-center justify-center font-bold shrink-0 ${styleMap[status]}`}
+      className={`w-6 h-6 text-xs rounded-full flex items-center justify-center font-bold shrink-0 ${styleMap[status]}`}
     >
       {status === 'completed' ? (
-        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
+        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
           <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
         </svg>
       ) : (
@@ -132,228 +100,83 @@ const StepBadge: React.FC<{
   );
 };
 
-// ── Desktop vertical sidebar ──────────────────────────────────────────────
-
-const DesktopSidebar: React.FC<StepperNavProps> = ({
-  currentView,
-  session,
-  selectedStory,
-  onNavigate,
-}) => {
-  return (
-    <nav
-      aria-label="學習步驟導覽"
-      className="hidden md:flex flex-col font-ui w-52 shrink-0 bg-white border-r border-gray-200 overflow-y-auto py-4 gap-1.5"
-    >
-      {/* Story title */}
-      {selectedStory && (
-        <div className="px-4 pb-3 border-b border-gray-100 mb-1">
-          <p className="text-[11px] text-gray-400 uppercase tracking-wider font-semibold mb-0.5">目前課文</p>
-          <p className="text-xs font-semibold text-gray-700 line-clamp-2 leading-snug">
-            {selectedStory.title}
-          </p>
-        </div>
-      )}
-
-      {/* Step list */}
-      {steps.map((stepDef) => {
-        const status = getStepStatus(stepDef, currentView, session, selectedStory);
-        const summary = status === 'completed' ? getMiniSummary(stepDef, session) : null;
-        const isActive = status === 'active';
-        const isDisabled = status === 'disabled';
-
-        return (
-          <button
-            key={stepDef.view}
-            onClick={() => !isDisabled && onNavigate(stepDef.view)}
-            disabled={isDisabled}
-            aria-current={isActive ? 'step' : undefined}
-            aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${isActive ? '目前' : isDisabled ? '未解鎖' : status === 'completed' ? '已完成' : '未完成'}）`}
-            className={`mx-2 flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
-              isActive
-                ? `${STEP_CATEGORY_COLORS[stepDef.category].activeBg} ${STEP_CATEGORY_COLORS[stepDef.category].text}`
-                : isDisabled
-                ? 'text-gray-300 cursor-not-allowed'
-                : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-            }`}
-          >
-            <StepBadge step={stepDef.step} status={status} category={stepDef.category} size="md" />
-            <span className="flex flex-col min-w-0">
-              <span className={`text-sm leading-tight ${isActive ? 'font-semibold' : 'font-medium'}`}>
-                {stepDef.label}
-              </span>
-              {summary && (
-                <span className="text-[11px] text-emerald-600 font-normal mt-0.5">{summary}</span>
-              )}
-            </span>
-          </button>
-        );
-      })}
-    </nav>
-  );
-};
-
-// ── Mobile compact bar + bottom sheet overlay ─────────────────────────────
-
-const MobileStepBar: React.FC<StepperNavProps> = ({
-  currentView,
-  session,
-  selectedStory,
-  onNavigate,
-}) => {
-  const [open, setOpen] = useState(false);
-
-  const currentStepDef = steps.find((s) => s.view === currentView);
-  const currentStatus = currentStepDef
-    ? getStepStatus(currentStepDef, currentView, session, selectedStory)
-    : 'idle';
-
-  const handleNavigate = (view: AppView) => {
-    onNavigate(view);
-    setOpen(false);
-  };
-
-  return (
-    <>
-      {/* Compact top bar — mobile only */}
-      <div className="flex items-center gap-3 px-4 py-2 font-ui bg-white border-b border-gray-200 shrink-0">
-        <div className="flex items-center gap-2 flex-1 min-w-0">
-          {currentStepDef ? (
-            <>
-              <StepBadge step={currentStepDef.step} status={currentStatus} category={currentStepDef.category} size="sm" />
-              <span className="text-sm font-semibold text-gray-800 truncate">
-                {currentStepDef.label}
-              </span>
-              <span className="text-xs text-gray-400 shrink-0">
-                {currentStepDef.step} / {steps.length}
-              </span>
-            </>
-          ) : (
-            <span className="text-sm text-gray-500">選擇步驟</span>
-          )}
-        </div>
-
-        <button
-          onClick={() => setOpen(true)}
-          aria-label="展開所有步驟"
-          aria-expanded={open}
-          aria-haspopup="dialog"
-          className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-        >
-          <svg className="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
-      </div>
-
-      {/* Bottom sheet overlay */}
-      {open && (
-        <>
-          <div
-            className="fixed inset-0 z-40 bg-black/40"
-            onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
-          <div
-            role="dialog"
-            aria-label="學習步驟清單"
-            aria-modal="true"
-            className="fixed inset-x-0 bottom-0 z-50 bg-white rounded-t-2xl shadow-2xl max-h-[80vh] flex flex-col"
-          >
-            {/* Sheet handle */}
-            <div className="flex justify-center pt-3 pb-1">
-              <div className="w-10 h-1 rounded-full bg-gray-300" />
-            </div>
-
-            {/* Sheet header */}
-            <div className="flex items-center justify-between px-5 py-3 border-b border-gray-100">
-              <div>
-                <h2 className="text-base font-semibold text-gray-900">學習步驟</h2>
-                {selectedStory && (
-                  <p className="text-xs text-gray-500 mt-0.5 truncate max-w-xs">{selectedStory.title}</p>
-                )}
-              </div>
-              <button
-                onClick={() => setOpen(false)}
-                aria-label="關閉"
-                className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
-              >
-                <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-
-            {/* Step list */}
-            <nav
-              aria-label="學習步驟導覽"
-              className="overflow-y-auto py-3 px-3 flex flex-col gap-1.5 font-ui"
-            >
-              {steps.map((stepDef) => {
-                const status = getStepStatus(stepDef, currentView, session, selectedStory);
-                const summary = status === 'completed' ? getMiniSummary(stepDef, session) : null;
-                const isActive = status === 'active';
-                const isDisabled = status === 'disabled';
-
-                return (
-                  <button
-                    key={stepDef.view}
-                    onClick={() => !isDisabled && handleNavigate(stepDef.view)}
-                    disabled={isDisabled}
-                    aria-current={isActive ? 'step' : undefined}
-                    className={`flex items-center gap-3 px-4 py-3 rounded-xl transition-colors text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                      isActive
-                        ? `${STEP_CATEGORY_COLORS[stepDef.category].activeBg} ${STEP_CATEGORY_COLORS[stepDef.category].text}`
-                        : isDisabled
-                        ? 'text-gray-300 cursor-not-allowed'
-                        : 'text-gray-700 hover:bg-gray-50'
-                    }`}
-                  >
-                    <StepBadge step={stepDef.step} status={status} category={stepDef.category} size="sm" />
-                    <span className="flex flex-col">
-                      <span className={`text-base leading-snug ${isActive ? 'font-semibold' : 'font-medium'}`}>
-                        {stepDef.label}
-                      </span>
-                      {summary && (
-                        <span className="text-xs text-emerald-600 font-normal mt-0.5">{summary}</span>
-                      )}
-                    </span>
-                    {isActive && (
-                      <span className="ml-auto text-xs font-medium bg-accent/10 text-accent px-2 py-0.5 rounded-full shrink-0">
-                        目前
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
-            </nav>
-          </div>
-        </>
-      )}
-    </>
-  );
-};
-
-// ── Main export ───────────────────────────────────────────────────────────
+// ── Horizontal top nav (shared for desktop & mobile) ─────────────────────
 
 /**
- * StepperNav — vertical sidebar on desktop, compact bar + bottom sheet on mobile.
+ * StepperNav — horizontal top navigation bar.
  *
- * Desktop (md+): fixed-width left column (208px / w-52) with numbered step rows.
- * Mobile (<md): slim top bar showing current step + hamburger; tapping opens a
- * bottom sheet with the full step list.
+ * Desktop (md+): horizontal row of step pills with labels.
+ * Mobile (<md): horizontally scrollable compact step indicators.
  *
- * This component is rendered OUTSIDE the header. It lives as a sibling to the
- * main learning content area (see LearningAppShell in AppShell.tsx).
+ * Auto-scrolls the active step into view on mount and when the step changes.
  */
-const StepperNav: React.FC<StepperNavProps> = (props) => {
-  const isMobile = useIsMobile();
+const StepperNav: React.FC<StepperNavProps> = ({
+  currentView,
+  session,
+  selectedStory,
+  onNavigate,
+}) => {
+  const scrollRef = useRef<HTMLElement>(null);
 
-  if (isMobile) {
-    return <MobileStepBar {...props} />;
-  }
+  // Auto-scroll the active step into view
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const activeEl = container.querySelector('[aria-current="step"]');
+    if (activeEl) {
+      activeEl.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  }, [currentView]);
 
-  return <DesktopSidebar {...props} />;
+  return (
+    <nav
+      ref={scrollRef}
+      aria-label="學習步驟導覽"
+      className="font-ui bg-white border-b border-gray-200 shrink-0 overflow-x-auto scrollbar-hide"
+    >
+      <div className="flex items-center gap-1 px-3 py-2 min-w-max">
+        {/* Story title pill — desktop only */}
+        {selectedStory && (
+          <div className="hidden md:flex items-center mr-2 pr-3 border-r border-gray-200">
+            <p className="text-xs font-semibold text-gray-500 truncate max-w-[120px]" title={selectedStory.title}>
+              {selectedStory.title}
+            </p>
+          </div>
+        )}
+
+        {/* Step pills */}
+        {steps.map((stepDef) => {
+          const status = getStepStatus(stepDef, currentView, session, selectedStory);
+          const isActive = status === 'active';
+          const isDisabled = status === 'disabled';
+          const categoryColors = STEP_CATEGORY_COLORS[stepDef.category];
+
+          return (
+            <button
+              key={stepDef.view}
+              onClick={() => !isDisabled && onNavigate(stepDef.view)}
+              disabled={isDisabled}
+              aria-current={isActive ? 'step' : undefined}
+              aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${isActive ? '目前' : isDisabled ? '未解鎖' : status === 'completed' ? '已完成' : '未完成'}）`}
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
+                isActive
+                  ? `${categoryColors.activeBg} ${categoryColors.text}`
+                  : isDisabled
+                  ? 'text-gray-300 cursor-not-allowed'
+                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+              }`}
+            >
+              <StepBadge step={stepDef.step} status={status} category={stepDef.category} />
+              {/* Show label on desktop, hide on mobile to save space */}
+              <span className={`hidden md:inline text-xs leading-tight ${isActive ? 'font-semibold' : 'font-medium'}`}>
+                {stepDef.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
 };
 
 export default StepperNav;

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -2,8 +2,8 @@
  * AppShell — the authenticated app chrome (header + sidebar + main area).
  *
  * LearningAppShell — thin wrapper that puts LearningLayout inside AppShell,
- * used for all /learn/:storyId/* routes. It also renders the StepperNav as a
- * vertical left sidebar alongside the learning content (moved out of the header).
+ * used for all /learn/:storyId/* routes. It renders the StepperNav as a
+ * horizontal top navigation bar above the learning content.
  */
 import React, { useState, useEffect, useCallback, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -110,11 +110,10 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
 };
 
 /**
- * Inner content for the learning flow: StepperNav sidebar + LearningLayout.
+ * Inner content for the learning flow: StepperNav top bar + LearningLayout.
  * Rendered inside AppShell's <main> element.
  *
- * Desktop: flex-row — [StepperNav 208px] + [LearningLayout fills rest]
- * Mobile: flex-col — [StepperNav compact bar] stacked above [LearningLayout]
+ * Layout: flex-col — [StepperNav horizontal bar] stacked above [LearningLayout full-width]
  */
 const LearningContent: React.FC = () => {
   const navigate = useNavigate();
@@ -144,8 +143,8 @@ const LearningContent: React.FC = () => {
   };
 
   return (
-    <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
-      {/* Vertical step sidebar (desktop) / compact bar (mobile) */}
+    <div className="flex-1 flex flex-col overflow-hidden">
+      {/* Horizontal step nav bar at the top */}
       <StepperNav
         currentView={currentView}
         session={navSession}
@@ -153,11 +152,9 @@ const LearningContent: React.FC = () => {
         onNavigate={handleStepperNavigate}
       />
 
-      {/* Learning step content — flex flex-col so child step components receive a flex
-          context and their flex-1 / h-full classes are bounded. overflow-hidden keeps the
-          height capped to the viewport so steps with internal scroll containers (e.g.
-          ReadingAnnotation's containerRef, VocabPractice's main-content div) scroll
-          correctly without the outer wrapper scrolling instead (#815, #824). */}
+      {/* Learning step content — full width below the top nav.
+          overflow-y-auto keeps the height capped to the viewport so steps with
+          internal scroll containers scroll correctly (#815, #824). */}
       <div className="flex-1 flex flex-col overflow-y-auto pb-14 md:pb-0">
         <LearningLayout />
       </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -115,6 +115,18 @@
   }
 }
 
+/* ── Scrollbar utility ── */
+
+@layer utilities {
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* ── Custom animations for interactive learning components ── */
 
 @keyframes shake {

--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -3,13 +3,13 @@
  * file but too domain-specific to live in App.tsx.
  *
  * - HomePage       — role-based redirect to teacher/student/library
- * - LibraryPage    — student library with recent practice + recommendations + full list
+ * - LibraryPage    — student library with story browsing
  * - WritePage      — standalone character writing practice
  * - ClassroomDetailPage  — resolves :id param and renders ClassroomDetail
  * - TeacherDashboardPage — thin wrapper around TeacherDashboard
  * - OnboardingWrapper    — first-time student onboarding overlay
  */
-import React, { Suspense, useState, useEffect, useCallback } from 'react';
+import React, { Suspense, useState } from 'react';
 import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { lazy } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
@@ -19,8 +19,6 @@ import { PARENT_PORTAL_ENABLED } from '../../config/featureFlags';
 import StoryLibrary from '../student/StoryLibrary';
 import WriteCharacter from '../../components/stroke-order/WriteCharacter';
 import SessionResumePrompt from '../../components/SessionResumePrompt';
-import RecommendedStories from '../../components/student/RecommendedStories';
-import { fetchLearningSessions, type LearningSummary } from '../../services/learningApi';
 import { Story } from '../../types';
 
 // Lazy-loaded — only needed when route is active
@@ -48,66 +46,16 @@ export const HomePage: React.FC = () => {
   return <Navigate to={homeMap[activeView] ?? '/student'} replace />;
 };
 
-interface RecentPracticeItem {
-  id: number;
-  storySlug: string | null;
-  title: string;
-  status: string;
-  startedAt: string;
-  completedAt: string | null;
-}
-
-function mapSessionToRecentItem(session: LearningSummary): RecentPracticeItem {
-  return {
-    id: session.id,
-    storySlug: session.story_slug,
-    title: session.story_title ?? session.story_slug ?? '未知課文',
-    status: session.status,
-    startedAt: session.started_at,
-    completedAt: session.completed_at,
-  };
-}
-
-/** Library page — wraps StoryLibrary with resume prompt, recommendations, and recent practice list. */
+/** Library page — clean story browsing with session resume prompt. */
 export const LibraryPage: React.FC = () => {
-  const { token } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const classroomId = searchParams.get('classroom');
   const classroomIdNum = classroomId ? parseInt(classroomId, 10) : null;
   const [showResumePrompt, setShowResumePrompt] = useState(true);
-  const [recentPractice, setRecentPractice] = useState<RecentPracticeItem[]>([]);
-  const [isLoadingRecent, setIsLoadingRecent] = useState(true);
-  const [recentError, setRecentError] = useState<string | null>(null);
 
   const handleSelectStory = (story: Story) => {
     navigate(`/learn/${story.id}/intro`);
-  };
-
-  const loadRecentPractice = useCallback(async () => {
-    if (!token) return;
-    try {
-      setIsLoadingRecent(true);
-      setRecentError(null);
-      const { items } = await fetchLearningSessions(token, { limit: 5 });
-      setRecentPractice(items.map(mapSessionToRecentItem));
-    } catch (err) {
-      setRecentError(err instanceof Error ? err.message : '載入最近練習失敗');
-    } finally {
-      setIsLoadingRecent(false);
-    }
-  }, [token]);
-
-  useEffect(() => {
-    void loadRecentPractice();
-  }, [loadRecentPractice]);
-
-  const formatDate = (iso: string | null): string => {
-    if (!iso) return '';
-    return new Date(iso).toLocaleDateString('zh-TW', {
-      month: 'short',
-      day: 'numeric',
-    });
   };
 
   return (
@@ -115,53 +63,7 @@ export const LibraryPage: React.FC = () => {
       {showResumePrompt && (
         <SessionResumePrompt onDismiss={() => setShowResumePrompt(false)} />
       )}
-      <div className="mt-4 min-h-[200px]">
-        <RecommendedStories />
-      </div>
-      <section className="mt-6">
-        <h2 className="text-lg font-bold text-gray-900 mb-2">最近練習</h2>
-        {isLoadingRecent && (
-          <div className="space-y-2">
-            {Array.from({ length: 3 }).map((_, idx) => (
-              <div key={idx} className="h-10 rounded-lg bg-gray-100 animate-pulse" />
-            ))}
-          </div>
-        )}
-        {!isLoadingRecent && recentError && (
-          <p className="text-sm text-red-500">{recentError}</p>
-        )}
-        {!isLoadingRecent && !recentError && recentPractice.length === 0 && (
-          <p className="text-sm text-gray-500">還沒有練習紀錄，先從下方課文開始吧！</p>
-        )}
-        {!isLoadingRecent && !recentError && recentPractice.length > 0 && (
-          <ul className="divide-y divide-gray-100 rounded-xl border border-gray-100 bg-white">
-            {recentPractice.map((item) => (
-              <li key={item.id} className="flex items-center justify-between px-4 py-3">
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-gray-900 truncate">{item.title}</p>
-                  <p className="text-xs text-gray-500">
-                    {item.completedAt
-                      ? `完成：${formatDate(item.completedAt)}`
-                      : `開始：${formatDate(item.startedAt)}`}
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() =>
-                    item.storySlug
-                      ? navigate(`/learn/${item.storySlug}/report`)
-                      : navigate(`/history`)
-                  }
-                  className="text-xs font-medium text-accent hover:text-accent-hover"
-                >
-                  查看記錄
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-      <div className="mt-8">
+      <div className="mt-4">
         <StoryLibrary onStartReading={handleSelectStory} classroomId={classroomIdNum} />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **StepperNav**: Converted from vertical left sidebar to horizontal top navigation bar. Desktop shows step badges + labels in a row; mobile uses horizontally scrollable compact indicators with auto-scroll to active step
- **Layout**: Learning content is now full-width below the top nav instead of sharing horizontal space with a sidebar
- **Library page**: Removed AI 推薦 (RecommendedStories) and 最近練習 (recent practice list) sections for a cleaner browsing experience

## Test plan
- [ ] Desktop: verify step nav appears as a horizontal bar above learning content
- [ ] Mobile: verify steps are horizontally scrollable, active step scrolls into view
- [ ] Step completion states (active/completed/disabled/idle) display correctly
- [ ] Clicking steps navigates to the correct learning step
- [ ] Library page shows only session resume prompt + story grid (no recommendations or recent practice)
- [ ] Build passes (`npm run build`)

Closes #932

🤖 Generated with [Claude Code](https://claude.com/claude-code)