### PR TITLE
feat: 課文理解改學習單模式（移除 AI 對話）

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -1,12 +1,20 @@
+/**
+ * ComprehensionChat — 課文理解（學習單模式）(#929)
+ *
+ * 2026-04-03 會議決議：移除 AI 對話 tab，改為左邊課文 + 右邊選擇題的學習單模式
+ * AI 功能改為獨立浮動小助手（FloatingAIHelper）
+ *
+ * Layout:
+ *   Desktop: left=scrollable lesson text, right=MCQ/structure tabs
+ *   Mobile:  tab switcher between story / MCQ / structure
+ */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Story, ReadingAttempt, ComprehensionResult } from '../../types';
-import { sendComprehensionChat, restartComprehensionSession, ChatResponse, SessionExpiredError } from '../../services/learningApi';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import StoryStructureTable from './StoryStructureTable';
 import MultipleChoiceExercise from './MultipleChoiceExercise';
-import { useAuth } from '../../contexts/AuthContext';
-import { speakText as cloudSpeakText, cancelTts } from '../../services/ttsApi';
+import FloatingAIHelper from './FloatingAIHelper';
 
 interface ComprehensionChatProps {
   story: Story;
@@ -20,16 +28,10 @@ interface ComprehensionChatProps {
   onProgressChange?: (stepData: Record<string, unknown>, immediate?: boolean) => void;
 }
 
-type ChatMessage =
-  | { role: 'ai'; text: string }
-  | { role: 'student'; text: string }
-  | { role: 'feedback'; text: string; understood: boolean };
-
-// ── Per-tab completion tracking (Issue #846) ────────────────────────────────
+// Per-tab completion tracking (adapted from #846)
 interface TabCompletion {
-  chatDone: boolean;       // Completed 5-question Socratic dialogue
-  structureVisited: boolean; // Opened the key points table (visited = completed)
-  mcqDone: boolean;        // Answered all MCQ questions
+  structureVisited: boolean;
+  mcqDone: boolean;
 }
 
 const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
@@ -43,250 +45,58 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   initialProgress,
   onProgressChange,
 }) => {
-  const { token } = useAuth();
-
-  // ── localStorage persistence ────────────────────────────────────────
-  const storageKey = `comprehension_progress_${story.id}`;
   const completionKey = `comprehension_completion_${story.id}`;
 
-  type SavedComprehension = {
-    conversation: ChatMessage[];
-    understoodCount: number;
-    requiredCount: number;
-    isSessionComplete: boolean;
-  };
-  const loadSaved = (): SavedComprehension | null => {
-    try {
-      const raw = localStorage.getItem(storageKey);
-      if (!raw) return null;
-      return JSON.parse(raw);
-    } catch { return null; }
-  };
-
-  // Load per-tab completion state from localStorage (#846)
   const loadCompletion = (): TabCompletion => {
     try {
       const raw = localStorage.getItem(completionKey);
-      if (!raw) return { chatDone: false, structureVisited: false, mcqDone: false };
-      return { chatDone: false, structureVisited: false, mcqDone: false, ...JSON.parse(raw) };
-    } catch { return { chatDone: false, structureVisited: false, mcqDone: false }; }
+      if (!raw) return { structureVisited: false, mcqDone: false };
+      return { structureVisited: false, mcqDone: false, ...JSON.parse(raw) };
+    } catch { return { structureVisited: false, mcqDone: false }; }
   };
 
-  const savedRef = useRef(loadSaved());
-
-  const persistedConversation = useMemo(() => {
-    const raw = initialProgress?.conversation;
-    return Array.isArray(raw) ? (raw as ChatMessage[]) : null;
-  }, [initialProgress]);
-  const persistedUnderstoodCount = useMemo(() => {
-    const raw = initialProgress?.understoodCount;
-    return typeof raw === 'number' ? raw : null;
-  }, [initialProgress]);
-  const persistedRequiredCount = useMemo(() => {
-    const raw = initialProgress?.requiredCount;
-    return typeof raw === 'number' ? raw : null;
-  }, [initialProgress]);
-  const persistedSessionComplete = useMemo(() => {
-    const raw = initialProgress?.isSessionComplete;
-    return typeof raw === 'boolean' ? raw : null;
-  }, [initialProgress]);
-  const persistedActiveTab = useMemo(() => {
-    const raw = initialProgress?.activeTab;
-    return raw === 'story' || raw === 'chat' || raw === 'structure' || raw === 'mcq'
-      ? raw
-      : null;
-  }, [initialProgress]);
   const persistedTabCompletion = useMemo(() => {
     const raw = initialProgress?.tabCompletion;
     if (!raw || typeof raw !== 'object') return null;
     return raw as TabCompletion;
   }, [initialProgress]);
 
-  const [conversation, setConversation] = useState<ChatMessage[]>(
-    () => persistedConversation ?? savedRef.current?.conversation ?? [],
-  );
-  const [inputText, setInputText] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [voiceError, setVoiceError] = useState<string | null>(null);
-  const [isVoicePreparing, setIsVoicePreparing] = useState(false);
-  const [isListening, setIsListening] = useState(false);
+  const persistedActiveTab = useMemo(() => {
+    const raw = initialProgress?.activeTab;
+    return raw === 'story' || raw === 'mcq' || raw === 'structure' ? raw : null;
+  }, [initialProgress]);
 
-  // Per-tab completion state (#846)
+  const persistedMcqScore = useMemo(() => {
+    const raw = initialProgress?.mcqScore;
+    return typeof raw === 'number' ? raw : null;
+  }, [initialProgress]);
+
+  const persistedMcqTotal = useMemo(() => {
+    const raw = initialProgress?.mcqTotal;
+    return typeof raw === 'number' ? raw : null;
+  }, [initialProgress]);
+
   const [tabCompletion, setTabCompletion] = useState<TabCompletion>(
     () => persistedTabCompletion ?? loadCompletion(),
   );
+  const [mcqScore, setMcqScore] = useState<number>(persistedMcqScore ?? 0);
+  const [mcqTotal, setMcqTotal] = useState<number>(persistedMcqTotal ?? 0);
 
-  // Mobile responsive
   const isMobile = useIsMobile();
-  const [activeTab, setActiveTab] = useState<'story' | 'chat' | 'structure' | 'mcq'>(
-    persistedActiveTab ?? 'chat',
-  );
+  const hasMcq = !!(story.multipleChoice && story.multipleChoice.length > 0);
 
-  // Server-driven session state
-  // Use a stable key derived from dbSessionId so refreshes don't generate a new UUID
-  // and waste a Gemini call. Anonymous users (no dbSessionId) fall back to a random UUID.
-  const [sessionId] = useState(() =>
-    dbSessionId ? `db-${dbSessionId}` : crypto.randomUUID()
+  // Default to MCQ tab if available, otherwise structure
+  const [activeTab, setActiveTab] = useState<'story' | 'mcq' | 'structure'>(
+    persistedActiveTab ?? (hasMcq ? 'mcq' : 'structure'),
   );
-  const [understoodCount, setUnderstoodCount] = useState(
-    () => persistedUnderstoodCount ?? savedRef.current?.understoodCount ?? 0,
-  );
-  const [requiredCount, setRequiredCount] = useState(
-    () => persistedRequiredCount ?? savedRef.current?.requiredCount ?? 3,
-  );
-  const [isSessionComplete, setIsSessionComplete] = useState(
-    () => persistedSessionComplete ?? savedRef.current?.isSessionComplete ?? false,
-  );
-  const [highlightedParagraph, setHighlightedParagraph] = useState<number | null>(null);
-  const [offlineMode, setOfflineMode] = useState(false);
-  const [mockQuestionIndex, setMockQuestionIndex] = useState(0);
-
-  const chatEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const recognitionRef = useRef<any>(null);
-  const isSubmittingRef = useRef(false);
-  const isListeningRef = useRef(false);
-  const isComposingRef = useRef(false);
-  const currentTranscriptRef = useRef('');
-  const accumulatedTranscriptRef = useRef('');
-
-  // Text-to-speech helper — uses Cloud TTS Neural2 with Web Speech API fallback
-  const speakText = useCallback((text: string) => {
-    cloudSpeakText(text).catch(() => {/* silently ignore — fallback handled inside */});
-  }, []);
-  const initializedRef = useRef(false);
-  const isDraggingRef = useRef(false);
-  const storyScrollRef = useRef<number>(0);
-  const storyPanelRef = useRef<HTMLDivElement>(null);
-  const dragStartXRef = useRef(0);
-  const dragStartWidthRef = useRef(384);
 
   const { zhuyinActive, processZhuyin, processLines: zhuyinProcessLines } = useZhuyin();
 
-  const mockQuestions = useMemo(() => {
-    const source = story.content.filter((line) => line.trim().length > 0);
-    const q1 = '這篇課文主要在說什麼？請用你自己的話說說看。';
-    const q2 = source[0]
-      ? `回到第一段「${source[0].slice(0, 14)}...」，你覺得作者最想表達什麼？`
-      : '課文中哪一段讓你印象最深？為什麼？';
-    const q3 = '如果你是故事中的主角，你會怎麼做？請說出理由。';
-    return [q1, q2, q3];
-  }, [story.content]);
+  // Resizable right panel (desktop)
+  const isDraggingRef = useRef(false);
+  const dragStartXRef = useRef(0);
+  const dragStartWidthRef = useRef(384);
 
-  const switchToOfflineMode = useCallback((message?: string) => {
-    setOfflineMode(true);
-    setMockQuestionIndex(0);
-    setUnderstoodCount(0);
-    setRequiredCount(mockQuestions.length);
-    setIsSessionComplete(false);
-    setHighlightedParagraph(null);
-    setConversation([{ role: 'ai', text: mockQuestions[0] }]);
-    setError(message ?? '已切換為離線測試模式（不需連線 GCP）。');
-  }, [mockQuestions]);
-
-  // Cleanup speech resources when leaving this step
-  useEffect(() => {
-    return () => {
-      isListeningRef.current = false;
-      if (recognitionRef.current) {
-        try {
-          recognitionRef.current.abort();
-        } catch (_) {
-          // noop
-        }
-        recognitionRef.current = null;
-      }
-      cancelTts();
-    };
-  }, []);
-
-  const zhuyinLines = useMemo(() => {
-    if (!zhuyinActive) return null;
-    return zhuyinProcessLines(story.content);
-  }, [story.content, zhuyinActive, zhuyinProcessLines]);
-
-  // Scroll to bottom whenever conversation updates
-  useEffect(() => {
-    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [conversation, isLoading]);
-
-  const paragraphRefs = useRef<(HTMLDivElement | null)[]>([]);
-
-  // Helper to apply server response to local state
-  const applyServerState = useCallback((result: ChatResponse) => {
-    setUnderstoodCount(result.understood_count);
-    setRequiredCount(result.required_count);
-    setIsSessionComplete(result.is_complete);
-
-    // Highlight referenced paragraph on wrong answer
-    if (result.understood === false && result.referenced_paragraph != null) {
-      setHighlightedParagraph(result.referenced_paragraph - 1);
-      // On mobile, auto-switch to story tab when highlighting
-      if (isMobile) {
-        setActiveTab('story');
-      }
-      // Auto-scroll to highlighted paragraph
-      setTimeout(() => {
-        paragraphRefs.current[result.referenced_paragraph! - 1]?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center',
-        });
-      }, 100);
-    } else {
-      setHighlightedParagraph(null);
-    }
-  }, [isMobile]);
-
-  // Fetch the first question from the server (no student answer).
-  // When the backend detects an existing session (resumed=true), it returns
-  // conversation_history so the frontend can restore the prior conversation
-  // without a Gemini call.
-  const fetchFirstQuestion = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const storyText = story.content.join('\n');
-      const result = await sendComprehensionChat({
-        sessionId,
-        storyTitle: story.title,
-        storyText,
-        studentAnswer: null,
-        // Pass reading results from LiveTutor (Issue #17)
-        // Filter out 0/empty values to avoid backend validation errors (Issue #48)
-        mispronouncedWords: attempt.mispronouncedWords?.length ? attempt.mispronouncedWords : undefined,
-        accuracy: attempt.accuracy || undefined,
-        cpm: attempt.cpm || undefined,
-        // Persist turns and enable session restore on refresh (Issue #632)
-        dbSessionId: dbSessionId,
-        // Genre-aware Socratic (#615)
-        genre: story.genre,
-        readingStrategy: story.readingStrategy,
-        token: token ?? undefined,
-      });
-
-      if (result.resumed && result.conversation_history && result.conversation_history.length > 0) {
-        // Restore prior conversation — no loading animation shown
-        const restored: ChatMessage[] = result.conversation_history.map(h => {
-          if (h.role === 'feedback') {
-            return { role: 'feedback' as const, text: h.text, understood: h.understood ?? false };
-          }
-          return { role: h.role as 'ai' | 'student', text: h.text };
-        });
-        setConversation(restored);
-      } else {
-        setConversation([{ role: 'ai', text: result.question }]);
-      }
-      applyServerState(result);
-    } catch {
-      switchToOfflineMode('無法連線到伺服器，已啟用離線測試模式。');
-    } finally {
-      setIsLoading(false);
-      setTimeout(() => inputRef.current?.focus(), 100);
-    }
-  }, [story.content, story.title, sessionId, dbSessionId, attempt, applyServerState, switchToOfflineMode, token]);
-
-  // Resizable right panel (mouse + touch)
   useEffect(() => {
     const onMouseMove = (e: MouseEvent) => {
       if (!isDraggingRef.current) return;
@@ -333,581 +143,89 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     e.preventDefault();
   };
 
-  // Fetch the first question on mount
-  useEffect(() => {
-    if (initializedRef.current) return;
-    initializedRef.current = true;
-    fetchFirstQuestion();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const zhuyinLines = useMemo(() => {
+    if (!zhuyinActive) return null;
+    return zhuyinProcessLines(story.content);
+  }, [story.content, zhuyinActive, zhuyinProcessLines]);
 
-  // ── Save conversation progress to localStorage ──────────────────────
-  useEffect(() => {
-    if (conversation.length === 0) return;
-    try {
-      localStorage.setItem(storageKey, JSON.stringify({
-        conversation,
-        understoodCount,
-        requiredCount,
-        isSessionComplete,
-      }));
-    } catch {}
-  }, [conversation, understoodCount, requiredCount, isSessionComplete, storageKey]);
-
-  // Persist comprehension process to DB step_progress so students can resume
-  // with prior dialogue and tab state after leaving the assignment.
-  useEffect(() => {
-    if (!onProgressChange) return;
-    onProgressChange(
-      {
-        conversation,
-        understoodCount,
-        requiredCount,
-        isSessionComplete,
-        tabCompletion,
-        activeTab,
-      },
-      false,
-    );
-  }, [
-    onProgressChange,
-    conversation,
-    understoodCount,
-    requiredCount,
-    isSessionComplete,
-    tabCompletion,
-    activeTab,
-  ]);
-
-  // ── Save per-tab completion to localStorage (#846) ──────────────────
-  useEffect(() => {
-    try {
-      localStorage.setItem(completionKey, JSON.stringify(tabCompletion));
-    } catch {}
-  }, [tabCompletion, completionKey]);
-
-  // Mark chatDone when Socratic dialogue completes (#846)
-  useEffect(() => {
-    if (isSessionComplete && !tabCompletion.chatDone) {
-      setTabCompletion(prev => ({ ...prev, chatDone: true }));
-    }
-  }, [isSessionComplete, tabCompletion.chatDone]);
-
-  // Mark structureVisited when user switches to structure tab (#846)
-  // "有打開就算完成"
-  const handleTabChange = useCallback((tab: 'story' | 'chat' | 'structure' | 'mcq') => {
+  // Tab change handler
+  const handleTabChange = useCallback((tab: 'story' | 'mcq' | 'structure') => {
     setActiveTab(tab);
     if (tab === 'structure' && !tabCompletion.structureVisited) {
       setTabCompletion(prev => ({ ...prev, structureVisited: true }));
     }
   }, [tabCompletion.structureVisited]);
 
-  const handleSubmit = useCallback(async (overrideText?: string) => {
-    const text = (overrideText ?? inputText).trim();
-    if (!text || isLoading || isSessionComplete || isSubmittingRef.current) return;
-
-    isSubmittingRef.current = true;
-
-    if (isListeningRef.current && recognitionRef.current) {
-      isListeningRef.current = false;
-      setIsListening(false);
-      setIsVoicePreparing(false);
-      try {
-        recognitionRef.current.abort();
-      } catch (_) {
-        // noop
-      }
-      recognitionRef.current = null;
-    }
-
-    const studentTurn: ChatMessage = { role: 'student', text };
-    setConversation(prev => [...prev, studentTurn]);
-    setInputText('');
-    currentTranscriptRef.current = '';
-    accumulatedTranscriptRef.current = '';
-    setIsLoading(true);
-    setError(null);
-    setHighlightedParagraph(null);
-
-    // Offline fallback mode for local testing without backend/GCP availability.
-    if (offlineMode) {
-      const isUnderstood = text.length >= 6;
-      const nextUnderstoodCount = understoodCount + (isUnderstood ? 1 : 0);
-      const nextQuestionIdx = mockQuestionIndex + 1;
-      const shouldComplete = nextQuestionIdx >= mockQuestions.length;
-
-      const newMessages: ChatMessage[] = [
-        {
-          role: 'feedback',
-          text: isUnderstood
-            ? '很好，你有抓到重點。'
-            : '再多說一點原因或細節，會更完整。',
-          understood: isUnderstood,
-        },
-      ];
-
-      if (!shouldComplete) {
-        newMessages.push({ role: 'ai', text: mockQuestions[nextQuestionIdx] });
-      }
-
-      setConversation(prev => [...prev, ...newMessages]);
-      setUnderstoodCount(nextUnderstoodCount);
-      setMockQuestionIndex(nextQuestionIdx);
-      setIsSessionComplete(shouldComplete);
-
-      isSubmittingRef.current = false;
-      setIsLoading(false);
-      setTimeout(() => inputRef.current?.focus(), 100);
-      return;
-    }
-
-    try {
-      const storyText = story.content.join('\n');
-      const result = await sendComprehensionChat({
-        sessionId,
-        storyTitle: story.title,
-        storyText,
-        studentAnswer: text,
-        dbSessionId: dbSessionId,
-        genre: story.genre,
-        readingStrategy: story.readingStrategy,
-        token: token ?? undefined,
-      });
-
-      applyServerState(result);
-
-      const newMessages: ChatMessage[] = [];
-
-      // Add feedback if present
-      if (result.feedback && result.understood !== null) {
-        newMessages.push({
-          role: 'feedback',
-          text: result.feedback,
-          understood: result.understood,
-        });
-      }
-
-      // Add next AI question if session is not complete
-      if (!result.is_complete) {
-        newMessages.push({ role: 'ai', text: result.question });
-      }
-
-      setConversation(prev => [...prev, ...newMessages]);
-    } catch (err) {
-      if (err instanceof SessionExpiredError) {
-        // Session expired after backend redeploy — auto-rebuild
-        setConversation([]);
-        setInputText(text); // Preserve their answer for re-submit
-        await fetchFirstQuestion();
-        setError('對話已重新開始，請再送出一次你的回答。');
-      } else {
-        switchToOfflineMode('伺服器暫時不可用，已切換為離線測試模式。');
-      }
-    } finally {
-      isSubmittingRef.current = false;
-      setIsLoading(false);
-      setTimeout(() => inputRef.current?.focus(), 100);
-    }
-  }, [applyServerState, fetchFirstQuestion, inputText, isLoading, isSessionComplete, mockQuestionIndex, mockQuestions, offlineMode, sessionId, story.content, story.title, switchToOfflineMode, understoodCount]);
-
-  const handleRetry = () => {
-    setError(null);
-    if (conversation.length === 0) {
-      fetchFirstQuestion();
-    } else {
-      // Find the last student message to re-submit
-      const lastStudentTurn = [...conversation].reverse().find(t => t.role === 'student');
-      if (lastStudentTurn) {
-        // Remove the last student turn and re-submit
-        setConversation(prev => prev.slice(0, prev.length - 1));
-        setInputText(lastStudentTurn.text);
-      } else {
-        fetchFirstQuestion();
-      }
-    }
-  };
-
-  // Keep completion record — only clear on explicit redo (Issue #817)
-  const handleFinish = useCallback(() => {
-    onProgressChange?.(
-      {
-        conversation,
-        understoodCount,
-        requiredCount,
-        isSessionComplete,
-        tabCompletion,
-        activeTab,
-      },
-      true,
-    );
-    onFinish({ understoodCount, requiredCount, isComplete: isSessionComplete, conversationLength: conversation.length });
-  }, [
-    onProgressChange,
-    conversation,
-    understoodCount,
-    requiredCount,
-    isSessionComplete,
-    tabCompletion,
-    activeTab,
-    onFinish,
-  ]);
-
-  const handleRestart = useCallback(async () => {
-    try { localStorage.removeItem(storageKey); } catch {}
-    // Reset chatDone on restart so tab checkmark reflects current session (#846)
-    setTabCompletion(prev => ({ ...prev, chatDone: false }));
-    setConversation([]);
-    setUnderstoodCount(0);
-    setIsSessionComplete(false);
-    setHighlightedParagraph(null);
-    setError(null);
-    initializedRef.current = false;
-    // Tell backend to clear memory + DB turns so next fetchFirstQuestion starts fresh
-    await restartComprehensionSession({
-      sessionId,
-      dbSessionId: dbSessionId,
-      token: token ?? undefined,
-    }).catch(() => { /* non-fatal */ });
-    fetchFirstQuestion();
-  }, [sessionId, dbSessionId, token, fetchFirstQuestion, storageKey]);
-
-  // MCQ completion handler — marks mcqDone (#846)
+  // MCQ completion handler
   const handleMcqComplete = useCallback((score: number, total: number) => {
     setTabCompletion(prev => ({ ...prev, mcqDone: true }));
-    setActiveTab('chat');
+    setMcqScore(score);
+    setMcqTotal(total);
   }, []);
 
-  // "重新練習" for structure tab (#846)
+  // Redo handlers
   const handleStructureRedo = useCallback(() => {
     setTabCompletion(prev => ({ ...prev, structureVisited: false }));
-    // Re-mark as visited immediately since user is still on the tab
     setTimeout(() => {
       setTabCompletion(prev => ({ ...prev, structureVisited: true }));
     }, 0);
   }, []);
 
-  // "重新練習" for MCQ tab (#846)
   const handleMcqRedo = useCallback(() => {
     setTabCompletion(prev => ({ ...prev, mcqDone: false }));
+    setMcqScore(0);
+    setMcqTotal(0);
   }, []);
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const nativeEvent = e.nativeEvent as KeyboardEvent;
-    const isImeComposing = isComposingRef.current || e.isComposing || nativeEvent.isComposing || nativeEvent.keyCode === 229;
+  // Check if worksheet is complete (MCQ done or no MCQ available)
+  const isWorksheetComplete = hasMcq ? tabCompletion.mcqDone : tabCompletion.structureVisited;
 
-    // Enter sends; Shift+Enter inserts newline. Guard IME composition to avoid accidental send when confirming Chinese candidates.
-    if (e.key === 'Enter' && !e.shiftKey && !isImeComposing) {
-      e.preventDefault();
-      handleSubmit();
-    }
-  };
+  // Persist progress to DB
+  useEffect(() => {
+    if (!onProgressChange) return;
+    onProgressChange(
+      {
+        tabCompletion,
+        activeTab,
+        mcqScore,
+        mcqTotal,
+        isWorksheetComplete,
+      },
+      false,
+    );
+  }, [onProgressChange, tabCompletion, activeTab, mcqScore, mcqTotal, isWorksheetComplete]);
 
-  const stopVoiceInput = useCallback(() => {
-    isListeningRef.current = false;
-    setIsListening(false);
-    setIsVoicePreparing(false);
-    if (recognitionRef.current) {
-      try {
-        recognitionRef.current.abort();
-      } catch (_) {
-        // noop
-      }
-      recognitionRef.current = null;
-    }
-  }, []);
-
-  const startVoiceInput = useCallback(() => {
-    if (isLoading || isSessionComplete || isListeningRef.current) return;
-
-    setVoiceError(null);
-    setIsVoicePreparing(true);
-
-    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
-    if (!SpeechRecognition) {
-      setIsVoicePreparing(false);
-      setVoiceError('您的瀏覽器不支援語音辨識，請使用 Chrome 瀏覽器。');
-      return;
-    }
-
-    const recognition = new SpeechRecognition();
-    recognition.lang = 'cmn-Hant-TW';
-    recognition.continuous = true;
-    recognition.interimResults = true;
-
-    recognition.onstart = () => {
-      setIsVoicePreparing(false);
-      isListeningRef.current = true;
-      setIsListening(true);
-    };
-
-    recognition.onresult = (event: any) => {
-      let finalTranscript = '';
-      let interimTranscript = '';
-      for (let i = event.resultIndex; i < event.results.length; i++) {
-        const part = event.results[i][0].transcript;
-        if (event.results[i].isFinal) {
-          finalTranscript += part;
-        } else {
-          interimTranscript += part;
-        }
-      }
-
-      if (finalTranscript) {
-        accumulatedTranscriptRef.current += finalTranscript;
-      }
-
-      const merged = accumulatedTranscriptRef.current + interimTranscript;
-      currentTranscriptRef.current = merged;
-      setInputText(merged);
-    };
-
-    recognition.onerror = (event: any) => {
-      setIsVoicePreparing(false);
-      if (event.error === 'not-allowed') {
-        setVoiceError('請允許麥克風權限後再試一次。');
-      } else if (event.error === 'audio-capture') {
-        setVoiceError('找不到麥克風，請確認麥克風已連接後再試一次。');
-      }
-      isListeningRef.current = false;
-      setIsListening(false);
-    };
-
-    recognition.onend = () => {
-      if (isListeningRef.current) {
-        try {
-          recognition.start();
-        } catch (_) {
-          isListeningRef.current = false;
-          setIsListening(false);
-          setIsVoicePreparing(false);
-        }
-      } else {
-        setIsListening(false);
-        setIsVoicePreparing(false);
-        recognitionRef.current = null;
-      }
-    };
-
-    recognitionRef.current = recognition;
-    currentTranscriptRef.current = inputText;
-    accumulatedTranscriptRef.current = inputText;
-
+  // Persist tab completion to localStorage
+  useEffect(() => {
     try {
-      recognition.start();
-    } catch (_) {
-      setIsVoicePreparing(false);
-      setVoiceError('語音辨識啟動失敗，請稍後再試。');
-      recognitionRef.current = null;
-    }
-  }, [inputText, isLoading, isSessionComplete]);
+      localStorage.setItem(completionKey, JSON.stringify(tabCompletion));
+    } catch {}
+  }, [tabCompletion, completionKey]);
 
-  // Extract chat content to reuse in both mobile and desktop layouts
-  const renderChatMessages = () => (
-    <>
-      {/* Intro message */}
-      <div className="flex gap-2.5 pt-1">
-        <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
-          <span className="text-white text-[10px] font-bold">AI</span>
-        </div>
-        <div className="flex-1">
-          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3">
-            <p className={`text-lg text-accent-hover leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>
-              {processZhuyin(`你剛才讀完了《${story.title}》，做得很棒！讓我們來聊聊課文的內容吧。`)}
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => speakText(`你剛才讀完了《${story.title}》，做得很棒！讓我們來聊聊課文的內容吧。`)}
-            className="mt-1 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700"
-          >
-            <span>🔊</span>
-            <span>播放</span>
-          </button>
-        </div>
-      </div>
+  // Finish handler
+  const handleFinish = useCallback(() => {
+    onProgressChange?.(
+      {
+        tabCompletion,
+        activeTab,
+        mcqScore,
+        mcqTotal,
+        isWorksheetComplete: true,
+      },
+      true,
+    );
+    onFinish({
+      understoodCount: mcqScore,
+      requiredCount: mcqTotal || 1,
+      isComplete: true,
+      conversationLength: 0,
+    });
+  }, [onProgressChange, tabCompletion, activeTab, mcqScore, mcqTotal, onFinish]);
 
-      {/* Conversation turns */}
-      {conversation.map((turn, i) => {
-        // Feedback message
-        if (turn.role === 'feedback') {
-          return (
-            <div key={i} className={`mx-10 rounded-xl px-3.5 py-2 text-sm border ${
-              turn.understood
-                ? 'bg-emerald-50 border-emerald-300 text-emerald-800'
-                : 'bg-amber-50 border-amber-300 text-amber-800'
-            }`}>
-              <span className="mr-1.5">{turn.understood ? '✓' : '💡'}</span>
-              {processZhuyin(turn.text)}
-            </div>
-          );
-        }
+  const storyText = useMemo(() => story.content.join('\n'), [story.content]);
 
-        // AI or student message
-        return (
-          <div key={i} className={`flex gap-2.5 ${turn.role === 'student' ? 'flex-row-reverse' : ''}`}>
-            {turn.role === 'ai' ? (
-              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
-                <span className="text-white text-[10px] font-bold">AI</span>
-              </div>
-            ) : (
-              <div className="flex-shrink-0 w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center">
-                <svg className="w-3.5 h-3.5 text-gray-900" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                </svg>
-              </div>
-            )}
-            <div className={`max-w-[85%] flex flex-col ${turn.role === 'student' ? 'items-end' : ''}`}>
-              <div className={[
-                'rounded-2xl px-4 py-3',
-                turn.role === 'ai'
-                  ? 'bg-accent-bg border border-accent-bg-subtle rounded-tl-sm text-accent-hover'
-                  : 'bg-accent rounded-tr-sm text-white',
-              ].join(' ')}>
-                <p className={`text-lg leading-[1.8] ${zhuyinActive ? 'tracking-[0.3em]' : ''}`}>{processZhuyin(turn.text)}</p>
-              </div>
-              {(turn.role === 'ai' || turn.role === 'student') && (
-                <button
-                  type="button"
-                  onClick={() => speakText(turn.text)}
-                  className="mt-1 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 self-start"
-                >
-                  <span>🔊</span>
-                  <span>播放</span>
-                </button>
-              )}
-            </div>
-          </div>
-        );
-      })}
-
-      {/* Loading indicator */}
-      {isLoading && (
-        <div className="flex gap-2.5">
-          <div className="flex-shrink-0 w-7 h-7 rounded-full bg-accent flex items-center justify-center">
-            <span className="text-white text-[10px] font-bold">AI</span>
-          </div>
-          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-4 py-3 flex items-center gap-1.5">
-            <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:0ms]" />
-            <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:150ms]" />
-            <span className="w-1.5 h-1.5 bg-accent-light rounded-full animate-bounce [animation-delay:300ms]" />
-          </div>
-        </div>
-      )}
-
-      {/* Error */}
-      {error && (
-        <div className="bg-red-900/30 border border-red-700/40 rounded-xl px-3.5 py-2.5 text-sm text-red-600">
-          {error}
-          <button
-            onClick={handleRetry}
-            className="ml-2 underline hover:no-underline"
-          >
-            重試
-          </button>
-        </div>
-      )}
-
-      {/* Completion message */}
-      {isSessionComplete && !isLoading && (
-        <div className="bg-emerald-50 border border-emerald-300 rounded-2xl p-4 text-center">
-          <p className="text-emerald-800 font-bold text-sm">太棒了！你展現了很好的理解力！</p>
-          <p className="text-emerald-700 text-xs mt-1">你對課文的理解很好，繼續下一步吧！</p>
-        </div>
-      )}
-
-      <div ref={chatEndRef} />
-    </>
-  );
-
-  const renderInputArea = () => (
-    <div className="shrink-0 bg-white border-t border-gray-200 p-3">
-      {isSessionComplete ? (
-        <div className="flex items-center justify-between gap-2">
-          <button
-            onClick={onBack}
-            className="px-3 py-3 rounded-xl text-base text-gray-500 hover:text-gray-900 transition-colors"
-          >
-            ← 回到朗讀
-          </button>
-          <button
-            onClick={handleRestart}
-            className="px-3 py-3 rounded-xl text-sm text-gray-500 hover:text-gray-900 transition-colors"
-            title="重新開始對話"
-          >
-            重新練習
-          </button>
-          <button
-            onClick={handleFinish}
-            className="flex-1 py-2.5 rounded-full font-bold text-sm bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2"
-          >
-            繼續，生字練習
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-            </svg>
-          </button>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <div className="flex gap-2 items-end">
-            <textarea
-              ref={inputRef}
-              value={inputText}
-              onChange={e => setInputText(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onCompositionStart={() => {
-                isComposingRef.current = true;
-              }}
-              onCompositionEnd={() => {
-                isComposingRef.current = false;
-              }}
-              placeholder="輸入你的回答……（Enter 送出，Shift+Enter 換行）"
-              rows={2}
-              disabled={isLoading || isSessionComplete}
-              className="flex-1 bg-white border border-gray-200 rounded-xl px-3 py-2 text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none disabled:opacity-50"
-            />
-            <button
-              type="button"
-              onClick={() => (isListening ? stopVoiceInput() : startVoiceInput())}
-              disabled={isLoading || isSessionComplete || isVoicePreparing}
-              className={`flex-shrink-0 w-11 h-11 rounded-xl text-white flex items-center justify-center transition-all active:scale-95 disabled:bg-gray-300 disabled:text-gray-400 ${
-                isListening ? 'bg-rose-500 hover:bg-rose-400' : 'bg-emerald-600 hover:bg-emerald-500'
-              }`}
-              title={isListening ? '停止語音輸入' : '啟動語音輸入'}
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 14a3 3 0 003-3V7a3 3 0 10-6 0v4a3 3 0 003 3z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 11a7 7 0 01-14 0m7 7v3m-4 0h8" />
-              </svg>
-            </button>
-            <button
-              onClick={() => handleSubmit()}
-              disabled={!inputText.trim() || isLoading || isSessionComplete}
-              className="flex-shrink-0 w-11 h-11 rounded-xl bg-accent hover:bg-accent-hover disabled:bg-gray-300 disabled:text-gray-400 text-white flex items-center justify-center transition-all active:scale-95"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-                  d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-              </svg>
-            </button>
-          </div>
-          <div className="flex gap-2 items-center justify-between text-xs">
-            <span className={isListening ? 'text-emerald-600' : 'text-gray-500'}>
-              {isVoicePreparing ? '麥克風啟動中…' : isListening ? '語音輸入中，完成後請按送出。' : '可直接鍵盤輸入，或按麥克風開始語音輸入。'}
-            </span>
-          </div>
-          {voiceError && (
-            <div className="text-xs text-red-600">{voiceError}</div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-
-  // ── #844: Prominent centered tab bar component ───────────────────────
-  // Used both in mobile and desktop (as overlay / standalone)
-  const hasMcq = !!(story.multipleChoice && story.multipleChoice.length > 0);
-
-  const renderProminentTabBar = (includeStory = false) => (
+  // ── Tab bar component ──────────────────────────────────────────────
+  const renderTabBar = (includeStory = false) => (
     <div className="flex items-center justify-center gap-1 px-3 py-2 bg-white border-b border-gray-200">
       <div className="flex bg-gray-100 rounded-xl p-1 gap-1">
         {includeStory && (
@@ -925,38 +243,6 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             課文
           </button>
         )}
-        <button
-          type="button"
-          role="tab"
-          aria-selected={activeTab === 'chat'}
-          onClick={() => handleTabChange('chat')}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold transition-all ${
-            activeTab === 'chat'
-              ? 'bg-white text-accent shadow-sm'
-              : 'text-gray-500 hover:text-gray-700'
-          }`}
-        >
-          AI 對話
-          {tabCompletion.chatDone && (
-            <span className="text-emerald-500 text-xs leading-none">✓</span>
-          )}
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={activeTab === 'structure'}
-          onClick={() => handleTabChange('structure')}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold transition-all ${
-            activeTab === 'structure'
-              ? 'bg-white text-accent shadow-sm'
-              : 'text-gray-500 hover:text-gray-700'
-          }`}
-        >
-          重點表
-          {tabCompletion.structureVisited && (
-            <span className="text-emerald-500 text-xs leading-none">✓</span>
-          )}
-        </button>
         {hasMcq && (
           <button
             type="button"
@@ -975,17 +261,30 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             )}
           </button>
         )}
-      </div>
-      <div className="ml-2">
-        {/* ZhuyinToggle moved to global Header (#863) */}
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'structure'}
+          onClick={() => handleTabChange('structure')}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold transition-all ${
+            activeTab === 'structure'
+              ? 'bg-white text-accent shadow-sm'
+              : 'text-gray-500 hover:text-gray-700'
+          }`}
+        >
+          重點表
+          {tabCompletion.structureVisited && (
+            <span className="text-emerald-500 text-xs leading-none">✓</span>
+          )}
+        </button>
       </div>
     </div>
   );
 
-  // Shared story panel for desktop — renders the same regardless of active tab
+  // ── Story panel (desktop left side) ────────────────────────────────
   const renderDesktopStoryPanel = () => (
     <div className="flex-1 flex flex-col bg-amber-50 min-w-0">
-      {/* Tab bar — story filename header */}
+      {/* Tab header */}
       <div className="h-9 bg-white border-b border-gray-200 flex items-center px-2 gap-2 shrink-0">
         <div className="h-full px-4 flex items-center bg-amber-50 border-t-2 border-accent border-x border-gray-200 text-xs text-gray-800 gap-2">
           {story.filename}
@@ -993,18 +292,13 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         <div className="flex-1" />
       </div>
 
-      {/* Story content — all paragraphs visible for reference */}
+      {/* Story content */}
       <div className="flex-1 p-8 lg:p-16 overflow-y-auto custom-scrollbar">
         <div className="max-w-3xl mx-auto space-y-20">
           {story.content.map((line, idx) => (
             <div
               key={idx}
-              ref={el => { paragraphRefs.current[idx] = el; }}
-              className={`rounded-2xl px-6 py-12 border transition-all ${
-                highlightedParagraph === idx
-                  ? 'border-amber-500/60 bg-amber-900/10 shadow-[0_0_15px_rgba(245,158,11,0.1)]'
-                  : 'border-transparent hover:border-gray-200 hover:bg-white/40'
-              }`}
+              className="rounded-2xl px-6 py-12 border border-transparent hover:border-gray-200 hover:bg-white/40 transition-all"
             >
               <p className={`text-2xl lg:text-3xl text-gray-900 leading-[3.5rem] lg:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                 {zhuyinLines ? zhuyinLines[idx] : line}
@@ -1021,7 +315,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     </div>
   );
 
-  // Desktop right panel content — switches based on active tab
+  // ── Right panel content (desktop) ──────────────────────────────────
   const renderDesktopRightPanel = () => {
     if (activeTab === 'structure') {
       return (
@@ -1046,17 +340,19 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       );
     }
 
-    if (activeTab === 'mcq' && hasMcq) {
-      return (
-        <div className="flex-shrink-0 bg-white flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
-          <div className="shrink-0 bg-white border-b border-gray-200 flex items-center justify-center gap-2 px-3 py-1.5">
-            <span className="text-xs text-gray-500">閱讀理解選擇題</span>
-          </div>
-          <div className="flex-1 min-h-0 overflow-y-auto p-4 custom-scrollbar bg-gray-50">
-            {tabCompletion.mcqDone ? (
+    // Default: MCQ panel
+    return (
+      <div className="flex-shrink-0 bg-white flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
+        <div className="shrink-0 bg-white border-b border-gray-200 flex items-center justify-center gap-2 px-3 py-1.5">
+          <span className="text-xs text-gray-500">閱讀理解選擇題</span>
+        </div>
+        <div className="flex-1 min-h-0 overflow-y-auto p-4 custom-scrollbar bg-gray-50">
+          {hasMcq ? (
+            tabCompletion.mcqDone ? (
               <div className="flex flex-col items-center justify-center p-8 gap-4">
-                <div className="text-4xl">✓</div>
+                <div className="text-4xl text-emerald-500">✓</div>
                 <p className="text-emerald-700 font-semibold text-sm">選擇題已完成</p>
+                <p className="text-gray-500 text-xs">答對 {mcqScore} / {mcqTotal} 題</p>
                 <button
                   onClick={handleMcqRedo}
                   className="px-4 py-2 rounded-lg bg-gray-100 text-gray-600 text-sm hover:bg-gray-200 transition-colors"
@@ -1069,33 +365,40 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 questions={story.multipleChoice!}
                 onComplete={handleMcqComplete}
               />
-            )}
+            )
+          ) : (
+            <div className="flex flex-col items-center justify-center p-8 gap-3 text-gray-400">
+              <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5"
+                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <p className="text-sm">此課文尚未有選擇題</p>
+              <p className="text-xs">可以切換到「重點表」查看文章重點</p>
+            </div>
+          )}
+        </div>
+        {/* Bottom action bar */}
+        {isWorksheetComplete && (
+          <div className="shrink-0 bg-white border-t border-gray-200 p-3">
+            <div className="flex items-center justify-between gap-2">
+              <button
+                onClick={onBack}
+                className="px-3 py-2.5 rounded-xl text-sm text-gray-500 hover:text-gray-900 transition-colors"
+              >
+                ← 上一步
+              </button>
+              <button
+                onClick={handleFinish}
+                className="flex-1 py-2.5 rounded-full font-bold text-sm bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2"
+              >
+                繼續下一步
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                </svg>
+              </button>
+            </div>
           </div>
-        </div>
-      );
-    }
-
-    // Default: AI chat panel
-    return (
-      <div className="flex-shrink-0 bg-white flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
-        {/* Progress + skip bar */}
-        <div className="shrink-0 bg-white border-b border-gray-200 flex items-center justify-center gap-2 px-3 py-1.5">
-          <span className="text-xs text-gray-500">AI 對話 {understoodCount}/{requiredCount}</span>
-          <button
-            onClick={handleFinish}
-            className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-          >
-            跳過
-          </button>
-        </div>
-
-        {/* Chat messages */}
-        <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-gray-50">
-          {renderChatMessages()}
-        </div>
-
-        {/* Input area */}
-        {renderInputArea()}
+        )}
       </div>
     );
   };
@@ -1110,24 +413,18 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       }}
     >
       {isMobile ? (
-        /* MOBILE: Tab-based layout — prominent centered pill tabs */
+        /* MOBILE: Tab-based layout */
         <>
-          {renderProminentTabBar(true)}
+          {renderTabBar(true)}
 
           {activeTab === 'story' ? (
-            /* Story panel - full height */
             <div className="flex-1 flex flex-col bg-amber-50 min-h-0">
-              <div ref={storyPanelRef} className="flex-1 p-4 overflow-y-auto custom-scrollbar">
+              <div className="flex-1 p-4 overflow-y-auto custom-scrollbar">
                 <div className="max-w-3xl mx-auto space-y-12">
                   {story.content.map((line, idx) => (
                     <div
                       key={idx}
-                      ref={el => { paragraphRefs.current[idx] = el; }}
-                      className={`rounded-2xl px-4 py-8 border transition-all ${
-                        highlightedParagraph === idx
-                          ? 'border-amber-500/60 bg-amber-900/10 shadow-[0_0_15px_rgba(245,158,11,0.1)]'
-                          : 'border-transparent hover:border-gray-200 hover:bg-white/40'
-                      }`}
+                      className="rounded-2xl px-4 py-8 border border-transparent hover:border-gray-200 hover:bg-white/40 transition-all"
                     >
                       <p className={`text-2xl text-gray-900 leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
                         {zhuyinLines ? zhuyinLines[idx] : line}
@@ -1136,81 +433,117 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                   ))}
                 </div>
               </div>
+              {/* Skip button on story tab for mobile */}
+              <div className="shrink-0 bg-white border-t border-gray-200 p-3 flex items-center justify-center gap-3">
+                <button
+                  onClick={() => handleTabChange(hasMcq ? 'mcq' : 'structure')}
+                  className="py-2.5 px-6 rounded-full font-bold text-sm bg-accent hover:bg-accent-hover text-white shadow transition-all active:scale-95"
+                >
+                  開始作答 →
+                </button>
+              </div>
             </div>
           ) : activeTab === 'structure' ? (
-            /* 文章重點表 panel */
-            <div className="flex-1 overflow-y-auto p-4 bg-gray-50">
-              <StoryStructureTable storyId={story.id} />
-              {tabCompletion.structureVisited && (
-                <div className="mt-4 text-center">
-                  <button
-                    onClick={handleStructureRedo}
-                    className="text-xs text-gray-400 hover:text-gray-600 underline"
-                  >
-                    重新練習
-                  </button>
+            <div className="flex-1 flex flex-col min-h-0">
+              <div className="flex-1 overflow-y-auto p-4 bg-gray-50">
+                <StoryStructureTable storyId={story.id} />
+                {tabCompletion.structureVisited && (
+                  <div className="mt-4 text-center">
+                    <button
+                      onClick={handleStructureRedo}
+                      className="text-xs text-gray-400 hover:text-gray-600 underline"
+                    >
+                      重新練習
+                    </button>
+                  </div>
+                )}
+              </div>
+              {isWorksheetComplete && (
+                <div className="shrink-0 bg-white border-t border-gray-200 p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <button
+                      onClick={onBack}
+                      className="px-3 py-2.5 rounded-xl text-sm text-gray-500 hover:text-gray-900 transition-colors"
+                    >
+                      ← 上一步
+                    </button>
+                    <button
+                      onClick={handleFinish}
+                      className="flex-1 py-2.5 rounded-full font-bold text-sm bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2"
+                    >
+                      繼續下一步
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                      </svg>
+                    </button>
+                  </div>
                 </div>
-              )}
-            </div>
-          ) : activeTab === 'mcq' && hasMcq ? (
-            /* 閱讀理解選擇題 panel */
-            <div className="flex-1 overflow-y-auto p-4 bg-gray-50">
-              {tabCompletion.mcqDone ? (
-                <div className="flex flex-col items-center justify-center p-8 gap-4">
-                  <div className="text-4xl">✓</div>
-                  <p className="text-emerald-700 font-semibold text-sm">選擇題已完成</p>
-                  <button
-                    onClick={handleMcqRedo}
-                    className="px-4 py-2 rounded-lg bg-gray-100 text-gray-600 text-sm hover:bg-gray-200 transition-colors"
-                  >
-                    重新練習
-                  </button>
-                </div>
-              ) : (
-                <MultipleChoiceExercise
-                  questions={story.multipleChoice!}
-                  onComplete={handleMcqComplete}
-                />
               )}
             </div>
           ) : (
-            /* Chat panel - full height with input */
+            /* MCQ panel */
             <div className="flex-1 flex flex-col min-h-0">
-              {/* Panel header with progress */}
-              <div className="h-9 shrink-0 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
-                <span className="text-[10px] font-bold text-accent-light uppercase tracking-widest">
-                  AI Tutor
-                </span>
-                <div className="flex-1" />
-                <span className="text-[10px] text-gray-600">
-                  {understoodCount} / {requiredCount} 理解
-                </span>
-                <button onClick={handleFinish} className="text-[10px] text-gray-600 hover:text-gray-400 transition-colors">
-                  跳過
-                </button>
+              <div className="flex-1 overflow-y-auto p-4 bg-gray-50">
+                {hasMcq ? (
+                  tabCompletion.mcqDone ? (
+                    <div className="flex flex-col items-center justify-center p-8 gap-4">
+                      <div className="text-4xl text-emerald-500">✓</div>
+                      <p className="text-emerald-700 font-semibold text-sm">選擇題已完成</p>
+                      <p className="text-gray-500 text-xs">答對 {mcqScore} / {mcqTotal} 題</p>
+                      <button
+                        onClick={handleMcqRedo}
+                        className="px-4 py-2 rounded-lg bg-gray-100 text-gray-600 text-sm hover:bg-gray-200 transition-colors"
+                      >
+                        重新練習
+                      </button>
+                    </div>
+                  ) : (
+                    <MultipleChoiceExercise
+                      questions={story.multipleChoice!}
+                      onComplete={handleMcqComplete}
+                    />
+                  )
+                ) : (
+                  <div className="flex flex-col items-center justify-center p-8 gap-3 text-gray-400">
+                    <p className="text-sm">此課文尚未有選擇題</p>
+                    <p className="text-xs">可以切換到「重點表」查看文章重點</p>
+                  </div>
+                )}
               </div>
-
-              {/* Chat messages */}
-              <div className="flex-1 min-h-0 overflow-y-auto p-4 space-y-5 custom-scrollbar bg-gray-50">
-                {renderChatMessages()}
-              </div>
-
-              {/* Input area */}
-              {renderInputArea()}
+              {isWorksheetComplete && (
+                <div className="shrink-0 bg-white border-t border-gray-200 p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <button
+                      onClick={onBack}
+                      className="px-3 py-2.5 rounded-xl text-sm text-gray-500 hover:text-gray-900 transition-colors"
+                    >
+                      ← 上一步
+                    </button>
+                    <button
+                      onClick={handleFinish}
+                      className="flex-1 py-2.5 rounded-full font-bold text-sm bg-emerald-600 hover:bg-emerald-500 text-white shadow transition-all active:scale-95 flex items-center justify-center gap-2"
+                    >
+                      繼續下一步
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </>
       ) : (
-        /* DESKTOP: consistent dual-pane layout — story left + tab content right (#808) */
+        /* DESKTOP: dual-pane layout — story left + worksheet right */
         <>
-          {/* Prominent centered tab bar — always visible on desktop */}
+          {/* Tab bar */}
           <div className="shrink-0 z-10">
-            {renderProminentTabBar(false)}
+            {renderTabBar(false)}
           </div>
 
-          {/* Dual-pane area: story left + active tab content right */}
+          {/* Dual-pane area */}
           <div className="flex flex-row flex-1 min-h-0">
-            {/* LEFT: Story text panel — always visible for reference */}
             {renderDesktopStoryPanel()}
 
             {/* Resizable divider */}
@@ -1220,10 +553,28 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               className="w-1 flex-shrink-0 bg-gray-200 hover:bg-accent cursor-col-resize transition-colors"
             />
 
-            {/* RIGHT: Tab content panel — chat / structure / MCQ */}
             {renderDesktopRightPanel()}
           </div>
         </>
+      )}
+
+      {/* Floating AI helper — replaces the removed AI dialogue tab */}
+      <FloatingAIHelper
+        storyTitle={story.title}
+        storyText={storyText}
+        dbSessionId={dbSessionId}
+      />
+
+      {/* Skip/finish button when worksheet not yet complete */}
+      {!isWorksheetComplete && !isMobile && (
+        <div className="absolute bottom-4 left-4 z-20">
+          <button
+            onClick={handleFinish}
+            className="text-xs text-gray-400 hover:text-gray-600 bg-white/80 backdrop-blur rounded-lg px-3 py-1.5 border border-gray-200 transition-colors"
+          >
+            跳過此步驟
+          </button>
+        </div>
       )}
 
       <style>{`

--- a/frontend/src/components/reading-steps/FloatingAIHelper.tsx
+++ b/frontend/src/components/reading-steps/FloatingAIHelper.tsx
@@ -1,0 +1,200 @@
+/**
+ * FloatingAIHelper — Floating AI chat assistant button + popup window (#929)
+ *
+ * Replaces the removed AI dialogue tab from ComprehensionChat.
+ * Students can ask questions about the lesson text via this floating helper.
+ * Uses the existing /api/comprehension/chat endpoint for AI responses.
+ */
+import React, { useCallback, useRef, useState, useEffect } from 'react';
+import { sendComprehensionChat, SessionExpiredError } from '../../services/learningApi';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface FloatingAIHelperProps {
+  storyTitle: string;
+  storyText: string;
+  dbSessionId?: number;
+}
+
+type HelperMessage =
+  | { role: 'ai'; text: string }
+  | { role: 'student'; text: string };
+
+const FloatingAIHelper: React.FC<FloatingAIHelperProps> = ({
+  storyTitle,
+  storyText,
+  dbSessionId,
+}) => {
+  const { token } = useAuth();
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState<HelperMessage[]>([]);
+  const [inputText, setInputText] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [sessionId] = useState(() =>
+    dbSessionId ? `helper-${dbSessionId}` : `helper-${crypto.randomUUID()}`
+  );
+  const chatEndRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const isComposingRef = useRef(false);
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, isLoading]);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [isOpen]);
+
+  const handleSend = useCallback(async () => {
+    const text = inputText.trim();
+    if (!text || isLoading) return;
+
+    const studentMsg: HelperMessage = { role: 'student', text };
+    setMessages(prev => [...prev, studentMsg]);
+    setInputText('');
+    setIsLoading(true);
+
+    try {
+      const result = await sendComprehensionChat({
+        sessionId,
+        storyTitle,
+        storyText,
+        studentAnswer: text,
+        dbSessionId,
+        token: token ?? undefined,
+      });
+
+      const aiText = result.feedback || result.question || '我不太確定怎麼回答，請再試一次';
+      setMessages(prev => [...prev, { role: 'ai', text: aiText }]);
+    } catch (err) {
+      const fallback = err instanceof SessionExpiredError
+        ? '對話已過期，請重新提問'
+        : '暫時無法回應，請稍後再試';
+      setMessages(prev => [...prev, { role: 'ai', text: fallback }]);
+    } finally {
+      setIsLoading(false);
+      setTimeout(() => inputRef.current?.focus(), 100);
+    }
+  }, [inputText, isLoading, sessionId, storyTitle, storyText, dbSessionId, token]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const nativeEvent = e.nativeEvent as KeyboardEvent;
+    const isImeComposing = isComposingRef.current || e.isComposing || nativeEvent.isComposing || nativeEvent.keyCode === 229;
+    if (e.key === 'Enter' && !e.shiftKey && !isImeComposing) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <>
+      {/* Floating button */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(prev => !prev)}
+        className={`fixed bottom-6 right-6 z-50 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-all hover:scale-105 active:scale-95 ${
+          isOpen ? 'bg-gray-500 hover:bg-gray-600' : 'bg-accent hover:bg-accent-hover'
+        }`}
+        title={isOpen ? '關閉 AI 小助手' : '打開 AI 小助手'}
+      >
+        {isOpen ? (
+          <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        ) : (
+          <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+              d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+          </svg>
+        )}
+      </button>
+
+      {/* Chat popup */}
+      {isOpen && (
+        <div className="fixed bottom-24 right-6 z-50 w-80 sm:w-96 max-h-[28rem] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden">
+          {/* Header */}
+          <div className="shrink-0 bg-accent px-4 py-3 flex items-center gap-2">
+            <div className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center">
+              <span className="text-white text-[10px] font-bold">AI</span>
+            </div>
+            <span className="text-white text-sm font-semibold">AI 小助手</span>
+            <span className="text-white/70 text-xs ml-auto">有問題就問我</span>
+          </div>
+
+          {/* Messages */}
+          <div className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3 bg-gray-50">
+            {messages.length === 0 && (
+              <div className="text-center text-gray-400 text-xs py-8">
+                <p>對課文有疑問嗎？</p>
+                <p className="mt-1">輸入你的問題，AI 會幫你解答</p>
+              </div>
+            )}
+
+            {messages.map((msg, i) => (
+              <div key={i} className={`flex gap-2 ${msg.role === 'student' ? 'flex-row-reverse' : ''}`}>
+                {msg.role === 'ai' && (
+                  <div className="flex-shrink-0 w-6 h-6 rounded-full bg-accent flex items-center justify-center">
+                    <span className="text-white text-[8px] font-bold">AI</span>
+                  </div>
+                )}
+                <div className={`max-w-[80%] rounded-xl px-3 py-2 text-sm ${
+                  msg.role === 'ai'
+                    ? 'bg-white border border-gray-200 text-gray-800'
+                    : 'bg-accent text-white'
+                }`}>
+                  {msg.text}
+                </div>
+              </div>
+            ))}
+
+            {isLoading && (
+              <div className="flex gap-2">
+                <div className="flex-shrink-0 w-6 h-6 rounded-full bg-accent flex items-center justify-center">
+                  <span className="text-white text-[8px] font-bold">AI</span>
+                </div>
+                <div className="bg-white border border-gray-200 rounded-xl px-3 py-2 flex items-center gap-1">
+                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
+                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
+                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
+                </div>
+              </div>
+            )}
+
+            <div ref={chatEndRef} />
+          </div>
+
+          {/* Input */}
+          <div className="shrink-0 border-t border-gray-200 p-2 flex gap-2 items-end bg-white">
+            <textarea
+              ref={inputRef}
+              value={inputText}
+              onChange={e => setInputText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              onCompositionStart={() => { isComposingRef.current = true; }}
+              onCompositionEnd={() => { isComposingRef.current = false; }}
+              placeholder="輸入問題…"
+              rows={1}
+              disabled={isLoading}
+              className="flex-1 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none disabled:opacity-50"
+            />
+            <button
+              onClick={handleSend}
+              disabled={!inputText.trim() || isLoading}
+              className="flex-shrink-0 w-9 h-9 rounded-lg bg-accent hover:bg-accent-hover disabled:bg-gray-300 text-white flex items-center justify-center transition-all active:scale-95"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+                  d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default FloatingAIHelper;


### PR DESCRIPTION
## Summary

Closes #929

- **ComprehensionChat -> Worksheet Mode**: 左邊課文 + 右邊選擇題，移除 AI 對話 tab
- **Floating AI Helper**: 右下角浮動按鈕，點開後可與 AI 對話（取代被移除的 AI 對話 tab）
- **Responsive**: Desktop 雙欄 split pane / Mobile tab 切換
- 保留重點表 tab、MCQ 完成追蹤、進度儲存

## Changes

| File | Change |
|------|--------|
| `ComprehensionChat.tsx` | 重寫為學習單模式：移除 Socratic AI 對話、語音輸入、離線模式等，改為 MCQ + 重點表雙 tab |
| `FloatingAIHelper.tsx` | 新增浮動 AI 小助手元件，使用既有 `/api/comprehension/chat` endpoint |

## Test plan

- [ ] Desktop: 課文理解步驟顯示左邊課文 + 右邊選擇題
- [ ] Desktop: 選擇題可正常作答，完成後顯示分數
- [ ] Desktop: 重點表 tab 可正常切換
- [ ] Mobile: Tab 切換（課文/選擇題/重點表）正常
- [ ] 右下角浮動按鈕可打開 AI 小助手
- [ ] AI 小助手可正常發送問題並收到回應
- [ ] 完成選擇題後出現「繼續下一步」按鈕
- [ ] 跳過按鈕正常運作
- [ ] `npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)