### PR TITLE
feat: repeated reading + progress curves (#909)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -16,3 +16,4 @@ from .gamification import StudentXPLog, StudentBadge, StudentStreak  # noqa: F40
 from .story_tag import StoryTag  # noqa: F401
 from .semester import Semester  # noqa: F401
 from .ai_usage import AIUsageLog  # noqa: F401
+from .reading_history import ReadingHistory, ReadingTarget  # noqa: F401

--- a/backend/app/models/reading_history.py
+++ b/backend/app/models/reading_history.py
@@ -1,0 +1,53 @@
+"""Reading History model for tracking repeated reading attempts.
+
+Each record represents one reading attempt (either paragraph-level from LiveTutor
+or full-text from FullReading). Supports progress curves and CPM target tracking.
+
+Issue #909: 重複朗讀 + 進步曲線
+"""
+from datetime import datetime
+from sqlalchemy import String, Integer, Float, ForeignKey, DateTime, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from .base import Base
+
+
+class ReadingHistory(Base):
+    """One reading attempt for a student on a specific lesson/paragraph."""
+    __tablename__ = "reading_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
+    lesson_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    # NULL = full reading; 0-based index = specific paragraph in LiveTutor
+    paragraph_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # reading_type: "paragraph" (LiveTutor) or "full" (FullReading)
+    reading_type: Mapped[str] = mapped_column(String(20), nullable=False, default="full")
+    cpm: Mapped[float] = mapped_column(Float, nullable=False)
+    accuracy: Mapped[float] = mapped_column(Float, nullable=False)
+    duration_seconds: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    student: Mapped["User"] = relationship("User")  # type: ignore[name-defined]
+
+
+class ReadingTarget(Base):
+    """Teacher-set CPM target for a specific lesson (optional).
+
+    If no target exists, the system uses a grade-based default.
+    """
+    __tablename__ = "reading_targets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    teacher_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
+    lesson_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    target_cpm: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    teacher: Mapped["User"] = relationship("User")  # type: ignore[name-defined]

--- a/backend/app/routes/learning/__init__.py
+++ b/backend/app/routes/learning/__init__.py
@@ -33,6 +33,7 @@ from .learning_dashboard import router as dashboard_router
 from .learning_dashboard import DashboardResponse, get_student_dashboard  # noqa: F401
 from .learning_vocab import router as vocab_router
 from .learning_exit_ticket import router as exit_ticket_router
+from .learning_reading_history import router as reading_history_router
 
 router = APIRouter(tags=["learning"])
 
@@ -47,5 +48,6 @@ router.include_router(recommendations_router)
 router.include_router(dashboard_router)
 router.include_router(vocab_router)
 router.include_router(exit_ticket_router)
+router.include_router(reading_history_router)
 
 __all__ = ["router"]

--- a/backend/app/routes/learning/learning_reading_history.py
+++ b/backend/app/routes/learning/learning_reading_history.py
@@ -1,0 +1,298 @@
+"""Reading history routes — repeated reading progress tracking.
+
+POST /api/reading-history          — save a reading attempt
+GET  /api/reading-history/{student_id}/{lesson_id} — get reading history for a student+lesson
+GET  /api/reading-history/{student_id}/{lesson_id}/summary — get summary stats
+
+Issue #909: 重複朗讀 + 進步曲線
+"""
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+
+from ...auth.dependencies import get_current_user
+from ...database import get_db
+from ...models.reading_history import ReadingHistory, ReadingTarget
+from ...models.user import User
+from ._helpers import verify_student_access
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Grade-based default CPM targets (characters per minute)
+# Based on 曾世杰教授研究 — grade 3-4: 80, grade 5-6: 100, grade 7+: 120
+DEFAULT_CPM_TARGETS = {
+    3: 80,
+    4: 80,
+    5: 100,
+    6: 100,
+    7: 120,
+    8: 120,
+    9: 120,
+}
+FALLBACK_CPM_TARGET = 90
+
+
+# ── Request / Response schemas ────────────────────────────────────────────────
+
+class ReadingHistoryCreate(BaseModel):
+    lesson_id: str
+    paragraph_index: Optional[int] = None
+    reading_type: str = "full"  # "paragraph" or "full"
+    cpm: float = Field(ge=0)
+    accuracy: float = Field(ge=0, le=100)
+    duration_seconds: float = Field(gt=0)
+
+
+class ReadingHistoryItem(BaseModel):
+    id: int
+    student_id: int
+    lesson_id: str
+    paragraph_index: Optional[int]
+    reading_type: str
+    cpm: float
+    accuracy: float
+    duration_seconds: float
+    created_at: str
+
+    class Config:
+        from_attributes = True
+
+
+class ReadingHistoryResponse(BaseModel):
+    history: list[ReadingHistoryItem]
+    target_cpm: float
+    target_source: str  # "teacher" or "default"
+
+
+class ReadingProgressSummary(BaseModel):
+    total_attempts: int
+    best_cpm: float
+    latest_cpm: float
+    best_accuracy: float
+    latest_accuracy: float
+    cpm_improvement_pct: float  # % improvement from first to latest
+    target_cpm: float
+    target_reached: bool
+    encouragement: str
+
+
+# ── POST /api/reading-history ─────────────────────────────────────────────────
+
+@router.post("/reading-history", response_model=ReadingHistoryItem)
+async def save_reading_history(
+    payload: ReadingHistoryCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Save a reading attempt for the current user."""
+    record = ReadingHistory(
+        student_id=current_user.id,
+        lesson_id=payload.lesson_id,
+        paragraph_index=payload.paragraph_index,
+        reading_type=payload.reading_type,
+        cpm=payload.cpm,
+        accuracy=payload.accuracy,
+        duration_seconds=payload.duration_seconds,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+
+    # Check if student hit teacher's target — notify if so
+    _check_target_reached(current_user.id, payload.lesson_id, payload.cpm, db)
+
+    return ReadingHistoryItem(
+        id=record.id,
+        student_id=record.student_id,
+        lesson_id=record.lesson_id,
+        paragraph_index=record.paragraph_index,
+        reading_type=record.reading_type,
+        cpm=record.cpm,
+        accuracy=record.accuracy,
+        duration_seconds=record.duration_seconds,
+        created_at=record.created_at.isoformat(),
+    )
+
+
+# ── GET /api/reading-history/{student_id}/{lesson_id} ─────────────────────────
+
+@router.get("/reading-history/{student_id}/{lesson_id}", response_model=ReadingHistoryResponse)
+async def get_reading_history(
+    student_id: int,
+    lesson_id: str,
+    reading_type: Optional[str] = Query(None, description="Filter by reading_type: 'paragraph' or 'full'"),
+    paragraph_index: Optional[int] = Query(None, description="Filter by paragraph_index (for LiveTutor)"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get reading history for a student on a specific lesson."""
+    verify_student_access(student_id, current_user, db)
+
+    query = (
+        db.query(ReadingHistory)
+        .filter(
+            ReadingHistory.student_id == student_id,
+            ReadingHistory.lesson_id == lesson_id,
+        )
+    )
+    if reading_type:
+        query = query.filter(ReadingHistory.reading_type == reading_type)
+    if paragraph_index is not None:
+        query = query.filter(ReadingHistory.paragraph_index == paragraph_index)
+
+    records = query.order_by(ReadingHistory.created_at.asc()).all()
+
+    target_cpm, target_source = _get_target_cpm(student_id, lesson_id, db)
+
+    return ReadingHistoryResponse(
+        history=[
+            ReadingHistoryItem(
+                id=r.id,
+                student_id=r.student_id,
+                lesson_id=r.lesson_id,
+                paragraph_index=r.paragraph_index,
+                reading_type=r.reading_type,
+                cpm=r.cpm,
+                accuracy=r.accuracy,
+                duration_seconds=r.duration_seconds,
+                created_at=r.created_at.isoformat(),
+            )
+            for r in records
+        ],
+        target_cpm=target_cpm,
+        target_source=target_source,
+    )
+
+
+# ── GET /api/reading-history/{student_id}/{lesson_id}/summary ─────────────────
+
+@router.get("/reading-history/{student_id}/{lesson_id}/summary", response_model=ReadingProgressSummary)
+async def get_reading_summary(
+    student_id: int,
+    lesson_id: str,
+    reading_type: Optional[str] = Query("full"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get summary stats and encouragement for a student's reading progress."""
+    verify_student_access(student_id, current_user, db)
+
+    query = (
+        db.query(ReadingHistory)
+        .filter(
+            ReadingHistory.student_id == student_id,
+            ReadingHistory.lesson_id == lesson_id,
+        )
+    )
+    if reading_type:
+        query = query.filter(ReadingHistory.reading_type == reading_type)
+
+    records = query.order_by(ReadingHistory.created_at.asc()).all()
+
+    if not records:
+        target_cpm, _ = _get_target_cpm(student_id, lesson_id, db)
+        return ReadingProgressSummary(
+            total_attempts=0,
+            best_cpm=0,
+            latest_cpm=0,
+            best_accuracy=0,
+            latest_accuracy=0,
+            cpm_improvement_pct=0,
+            target_cpm=target_cpm,
+            target_reached=False,
+            encouragement="開始你的第一次朗讀吧！",
+        )
+
+    best_cpm = max(r.cpm for r in records)
+    latest_cpm = records[-1].cpm
+    best_accuracy = max(r.accuracy for r in records)
+    latest_accuracy = records[-1].accuracy
+    first_cpm = records[0].cpm
+    improvement = ((latest_cpm - first_cpm) / first_cpm * 100) if first_cpm > 0 else 0
+
+    target_cpm, _ = _get_target_cpm(student_id, lesson_id, db)
+    target_reached = best_cpm >= target_cpm
+
+    encouragement = _generate_encouragement(records, improvement, target_reached, target_cpm)
+
+    return ReadingProgressSummary(
+        total_attempts=len(records),
+        best_cpm=round(best_cpm, 1),
+        latest_cpm=round(latest_cpm, 1),
+        best_accuracy=round(best_accuracy, 1),
+        latest_accuracy=round(latest_accuracy, 1),
+        cpm_improvement_pct=round(improvement, 1),
+        target_cpm=target_cpm,
+        target_reached=target_reached,
+        encouragement=encouragement,
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _get_target_cpm(student_id: int, lesson_id: str, db: Session) -> tuple[float, str]:
+    """Get the CPM target for a student+lesson. Teacher-set takes priority."""
+    teacher_target = (
+        db.query(ReadingTarget)
+        .filter(ReadingTarget.lesson_id == lesson_id)
+        .order_by(desc(ReadingTarget.updated_at))
+        .first()
+    )
+    if teacher_target:
+        return teacher_target.target_cpm, "teacher"
+
+    return FALLBACK_CPM_TARGET, "default"
+
+
+def _check_target_reached(student_id: int, lesson_id: str, cpm: float, db: Session) -> None:
+    """Check if the student just reached the target. Log it for teacher notification."""
+    target_cpm, _ = _get_target_cpm(student_id, lesson_id, db)
+    if cpm >= target_cpm:
+        # Check if this is the FIRST time reaching the target
+        previous_hits = (
+            db.query(ReadingHistory)
+            .filter(
+                ReadingHistory.student_id == student_id,
+                ReadingHistory.lesson_id == lesson_id,
+                ReadingHistory.cpm >= target_cpm,
+            )
+            .count()
+        )
+        if previous_hits <= 1:  # Just this one (already committed)
+            logger.info(
+                "Student %d reached CPM target %.0f for lesson %s (actual: %.0f)",
+                student_id, target_cpm, lesson_id, cpm,
+            )
+            # Future: push notification to teacher via WebSocket or notification table
+
+
+def _generate_encouragement(
+    records: list[ReadingHistory],
+    improvement_pct: float,
+    target_reached: bool,
+    target_cpm: float,
+) -> str:
+    """Generate a motivational message based on progress."""
+    n = len(records)
+
+    if target_reached:
+        return f"太棒了！你已經達到目標速度 {target_cpm:.0f} 字/分鐘！繼續保持"
+
+    if n == 1:
+        return "好的開始！再讀一次，看看能不能更快更準確"
+
+    if improvement_pct > 20:
+        return f"進步驚人！速度提升了 {improvement_pct:.0f}%，繼續加油"
+    elif improvement_pct > 10:
+        return f"穩定進步中！速度提升了 {improvement_pct:.0f}%，再讀一次會更好"
+    elif improvement_pct > 0:
+        return f"你的速度提升了 {improvement_pct:.0f}%！再讀一次會更好"
+    elif improvement_pct > -5:
+        return "保持得很好！多練習幾次，速度會越來越快"
+    else:
+        return "別擔心，每個人都有起伏，再試一次吧"

--- a/backend/app/routes/teacher/__init__.py
+++ b/backend/app/routes/teacher/__init__.py
@@ -15,6 +15,7 @@ from .teacher_reports import router as reports_router
 from .teacher_story_tags import router as story_tags_router
 from .teacher_students import router as students_router
 from .teacher_texts import router as texts_router
+from .teacher_reading_progress import router as reading_progress_router
 
 router = APIRouter()
 
@@ -28,5 +29,6 @@ router.include_router(reports_router)
 router.include_router(instructions_router)
 router.include_router(texts_router)
 router.include_router(story_tags_router)
+router.include_router(reading_progress_router)
 
 __all__ = ["router"]

--- a/backend/app/routes/teacher/teacher_reading_progress.py
+++ b/backend/app/routes/teacher/teacher_reading_progress.py
@@ -1,0 +1,189 @@
+"""Teacher reading progress routes — view student reading curves and set CPM targets.
+
+GET  /api/teacher/students/{student_id}/reading-progress/{lesson_id}
+PUT  /api/teacher/reading-targets/{lesson_id}
+
+Issue #909: 重複朗讀 + 進步曲線（教師端）
+"""
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import desc
+from sqlalchemy.orm import Session
+
+from ...auth.dependencies import get_current_user
+from ...database import get_db
+from ...models.reading_history import ReadingHistory, ReadingTarget
+from ...models.school import Classroom, ClassroomStudent
+from ...models.user import User
+
+router = APIRouter(tags=["teacher"])
+logger = logging.getLogger(__name__)
+
+
+def _require_teacher_access_to_student(teacher_id: int, student_id: int, db: Session) -> None:
+    """Raise 403 if teacher doesn't own a classroom containing this student."""
+    enrollment = (
+        db.query(ClassroomStudent)
+        .join(Classroom, ClassroomStudent.classroom_id == Classroom.id)
+        .filter(
+            ClassroomStudent.student_id == student_id,
+            Classroom.teacher_id == teacher_id,
+        )
+        .first()
+    )
+    if not enrollment:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+class ReadingAttemptItem(BaseModel):
+    id: int
+    cpm: float
+    accuracy: float
+    duration_seconds: float
+    reading_type: str
+    paragraph_index: Optional[int]
+    created_at: str
+
+
+class StudentReadingProgressResponse(BaseModel):
+    student_id: int
+    student_name: str
+    lesson_id: str
+    attempts: list[ReadingAttemptItem]
+    target_cpm: float
+    target_source: str
+    total_attempts: int
+    best_cpm: float
+    latest_cpm: float
+    target_reached: bool
+
+
+class SetReadingTargetRequest(BaseModel):
+    target_cpm: float = Field(gt=0, le=500)
+
+
+class ReadingTargetResponse(BaseModel):
+    lesson_id: str
+    target_cpm: float
+    teacher_id: int
+    updated_at: str
+
+
+# ── GET /api/teacher/students/{student_id}/reading-progress/{lesson_id} ───────
+
+@router.get(
+    "/teacher/students/{student_id}/reading-progress/{lesson_id}",
+    response_model=StudentReadingProgressResponse,
+)
+async def get_student_reading_progress(
+    student_id: int,
+    lesson_id: str,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get a student's reading progress curve for a specific lesson (teacher view)."""
+    _require_teacher_access_to_student(current_user.id, student_id, db)
+
+    student = db.query(User).filter(User.id == student_id).first()
+    if not student:
+        raise HTTPException(status_code=404, detail="Student not found")
+
+    records = (
+        db.query(ReadingHistory)
+        .filter(
+            ReadingHistory.student_id == student_id,
+            ReadingHistory.lesson_id == lesson_id,
+        )
+        .order_by(ReadingHistory.created_at.asc())
+        .all()
+    )
+
+    # Get target
+    teacher_target = (
+        db.query(ReadingTarget)
+        .filter(
+            ReadingTarget.lesson_id == lesson_id,
+            ReadingTarget.teacher_id == current_user.id,
+        )
+        .first()
+    )
+    if teacher_target:
+        target_cpm = teacher_target.target_cpm
+        target_source = "teacher"
+    else:
+        target_cpm = 90.0
+        target_source = "default"
+
+    best_cpm = max((r.cpm for r in records), default=0)
+    latest_cpm = records[-1].cpm if records else 0
+
+    return StudentReadingProgressResponse(
+        student_id=student_id,
+        student_name=student.name or student.email,
+        lesson_id=lesson_id,
+        attempts=[
+            ReadingAttemptItem(
+                id=r.id,
+                cpm=r.cpm,
+                accuracy=r.accuracy,
+                duration_seconds=r.duration_seconds,
+                reading_type=r.reading_type,
+                paragraph_index=r.paragraph_index,
+                created_at=r.created_at.isoformat(),
+            )
+            for r in records
+        ],
+        target_cpm=target_cpm,
+        target_source=target_source,
+        total_attempts=len(records),
+        best_cpm=round(best_cpm, 1),
+        latest_cpm=round(latest_cpm, 1),
+        target_reached=best_cpm >= target_cpm,
+    )
+
+
+# ── PUT /api/teacher/reading-targets/{lesson_id} ─────────────────────────────
+
+@router.put("/teacher/reading-targets/{lesson_id}", response_model=ReadingTargetResponse)
+async def set_reading_target(
+    lesson_id: str,
+    payload: SetReadingTargetRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Set or update the CPM target for a lesson (teacher only)."""
+    existing = (
+        db.query(ReadingTarget)
+        .filter(
+            ReadingTarget.lesson_id == lesson_id,
+            ReadingTarget.teacher_id == current_user.id,
+        )
+        .first()
+    )
+
+    if existing:
+        existing.target_cpm = payload.target_cpm
+        db.commit()
+        db.refresh(existing)
+        target = existing
+    else:
+        target = ReadingTarget(
+            teacher_id=current_user.id,
+            lesson_id=lesson_id,
+            target_cpm=payload.target_cpm,
+        )
+        db.add(target)
+        db.commit()
+        db.refresh(target)
+
+    return ReadingTargetResponse(
+        lesson_id=target.lesson_id,
+        target_cpm=target.target_cpm,
+        teacher_id=target.teacher_id,
+        updated_at=target.updated_at.isoformat(),
+    )

--- a/frontend/src/components/reading-progress/ReadingProgressChart.tsx
+++ b/frontend/src/components/reading-progress/ReadingProgressChart.tsx
@@ -1,0 +1,281 @@
+/**
+ * ReadingProgressChart — Line chart showing CPM and accuracy progress over attempts.
+ *
+ * Uses recharts. Shows:
+ * - CPM line (primary, blue)
+ * - Accuracy line (secondary, green)
+ * - Target CPM reference line (dashed red)
+ * - Encouragement message
+ *
+ * Issue #909: 重複朗讀 + 進步曲線
+ */
+import React, { useEffect, useState } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  getReadingHistory,
+  getReadingSummary,
+  type ReadingHistoryItem,
+  type ReadingProgressSummary,
+} from '../../services/readingHistoryApi';
+
+interface ReadingProgressChartProps {
+  studentId: number;
+  lessonId: string;
+  readingType?: 'full' | 'paragraph';
+  paragraphIndex?: number;
+  /** Compact mode hides the summary text below the chart */
+  compact?: boolean;
+  /** Called when summary data loads (parent can use encouragement message) */
+  onSummaryLoad?: (summary: ReadingProgressSummary) => void;
+}
+
+interface ChartDataPoint {
+  attempt: number;
+  cpm: number;
+  accuracy: number;
+  date: string;
+}
+
+const ReadingProgressChart: React.FC<ReadingProgressChartProps> = ({
+  studentId,
+  lessonId,
+  readingType = 'full',
+  paragraphIndex,
+  compact = false,
+  onSummaryLoad,
+}) => {
+  const { token } = useAuth();
+  const [data, setData] = useState<ChartDataPoint[]>([]);
+  const [targetCpm, setTargetCpm] = useState(90);
+  const [summary, setSummary] = useState<ReadingProgressSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!token || !studentId || !lessonId) return;
+
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const [historyRes, summaryRes] = await Promise.all([
+          getReadingHistory(studentId, lessonId, token, readingType, paragraphIndex),
+          getReadingSummary(studentId, lessonId, token, readingType),
+        ]);
+
+        if (cancelled) return;
+
+        const points: ChartDataPoint[] = historyRes.history.map(
+          (item: ReadingHistoryItem, idx: number) => ({
+            attempt: idx + 1,
+            cpm: Math.round(item.cpm),
+            accuracy: Math.round(item.accuracy),
+            date: new Date(item.created_at).toLocaleDateString('zh-TW', {
+              month: 'short',
+              day: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            }),
+          }),
+        );
+
+        setData(points);
+        setTargetCpm(historyRes.target_cpm);
+        setSummary(summaryRes);
+        onSummaryLoad?.(summaryRes);
+      } catch (err) {
+        console.error('Failed to load reading progress:', err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+    return () => { cancelled = true; };
+  }, [studentId, lessonId, token, readingType, paragraphIndex, onSummaryLoad]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8 text-gray-400">
+        <svg className="animate-spin h-5 w-5 mr-2" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+        載入中...
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="text-center py-6 text-gray-500">
+        <p className="text-lg">還沒有朗讀紀錄</p>
+        <p className="text-sm mt-1">完成朗讀後，進步曲線會顯示在這裡</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Chart */}
+      <div className="bg-white rounded-xl border border-gray-200 p-4">
+        <h3 className="text-sm font-semibold text-gray-700 mb-3">
+          朗讀進步曲線
+          {data.length > 1 && summary && (
+            <span className={`ml-2 text-xs font-normal ${
+              summary.cpm_improvement_pct > 0 ? 'text-green-600' : 'text-gray-500'
+            }`}>
+              {summary.cpm_improvement_pct > 0 ? '▲' : summary.cpm_improvement_pct < 0 ? '▼' : ''}
+              {Math.abs(summary.cpm_improvement_pct).toFixed(0)}% 速度變化
+            </span>
+          )}
+        </h3>
+
+        <ResponsiveContainer width="100%" height={compact ? 180 : 240}>
+          <LineChart data={data} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis
+              dataKey="attempt"
+              label={{ value: '第 N 次', position: 'insideBottomRight', offset: -5, fontSize: 12 }}
+              tick={{ fontSize: 12 }}
+            />
+            <YAxis
+              yAxisId="cpm"
+              label={{ value: '字/分鐘', angle: -90, position: 'insideLeft', fontSize: 12 }}
+              tick={{ fontSize: 11 }}
+            />
+            <YAxis
+              yAxisId="accuracy"
+              orientation="right"
+              domain={[0, 100]}
+              label={{ value: '準確率%', angle: 90, position: 'insideRight', fontSize: 12 }}
+              tick={{ fontSize: 11 }}
+            />
+            <Tooltip
+              formatter={(value: number, name: string) => {
+                if (name === 'cpm') return [`${value} 字/分鐘`, '閱讀速度'];
+                return [`${value}%`, '準確率'];
+              }}
+              labelFormatter={(label: number) => `第 ${label} 次朗讀`}
+              contentStyle={{ fontSize: 13, borderRadius: 8 }}
+            />
+            <Legend
+              formatter={(value: string) => (value === 'cpm' ? '閱讀速度' : '準確率')}
+              wrapperStyle={{ fontSize: 12 }}
+            />
+
+            {/* Target CPM reference line */}
+            <ReferenceLine
+              yAxisId="cpm"
+              y={targetCpm}
+              stroke="#ef4444"
+              strokeDasharray="6 3"
+              label={{
+                value: `目標 ${targetCpm}`,
+                position: 'right',
+                fill: '#ef4444',
+                fontSize: 11,
+              }}
+            />
+
+            {/* CPM line */}
+            <Line
+              yAxisId="cpm"
+              type="monotone"
+              dataKey="cpm"
+              stroke="#3b82f6"
+              strokeWidth={2.5}
+              dot={{ r: 4, fill: '#3b82f6' }}
+              activeDot={{ r: 6 }}
+              name="cpm"
+            />
+
+            {/* Accuracy line */}
+            <Line
+              yAxisId="accuracy"
+              type="monotone"
+              dataKey="accuracy"
+              stroke="#22c55e"
+              strokeWidth={2}
+              dot={{ r: 3, fill: '#22c55e' }}
+              strokeDasharray="4 2"
+              name="accuracy"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Summary stats */}
+      {!compact && summary && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <StatCard label="朗讀次數" value={String(summary.total_attempts)} />
+          <StatCard
+            label="最佳速度"
+            value={`${summary.best_cpm} 字/分`}
+            highlight={summary.target_reached}
+          />
+          <StatCard
+            label="最新速度"
+            value={`${summary.latest_cpm} 字/分`}
+          />
+          <StatCard
+            label="最佳準確率"
+            value={`${summary.best_accuracy}%`}
+          />
+        </div>
+      )}
+
+      {/* Encouragement */}
+      {summary && (
+        <div className={`rounded-lg px-4 py-3 text-sm ${
+          summary.target_reached
+            ? 'bg-green-50 text-green-700 border border-green-200'
+            : 'bg-blue-50 text-blue-700 border border-blue-200'
+        }`}>
+          {summary.target_reached && <span className="mr-1">🎉</span>}
+          {summary.encouragement}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function StatCard({
+  label,
+  value,
+  highlight = false,
+}: {
+  label: string;
+  value: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-lg px-3 py-2 text-center border ${
+        highlight
+          ? 'bg-green-50 border-green-200'
+          : 'bg-gray-50 border-gray-200'
+      }`}
+    >
+      <div className="text-xs text-gray-500">{label}</div>
+      <div className={`text-base font-semibold mt-0.5 ${
+        highlight ? 'text-green-700' : 'text-gray-800'
+      }`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export default ReadingProgressChart;

--- a/frontend/src/components/reading-progress/RereadPanel.tsx
+++ b/frontend/src/components/reading-progress/RereadPanel.tsx
@@ -1,0 +1,125 @@
+/**
+ * RereadPanel — "再讀一次" encouragement panel shown after LiveTutor or FullReading.
+ *
+ * Shows the progress chart + a prominent "再讀一次" button.
+ * Also saves the just-completed reading to history.
+ *
+ * Issue #909: 重複朗讀 + 進步曲線
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import ReadingProgressChart from './ReadingProgressChart';
+import { useAuth } from '../../contexts/AuthContext';
+import { saveReadingHistory, type ReadingProgressSummary } from '../../services/readingHistoryApi';
+
+interface RereadPanelProps {
+  lessonId: string;
+  studentId: number;
+  /** Reading metrics from the just-completed reading */
+  cpm: number;
+  accuracy: number;
+  durationSeconds: number;
+  readingType: 'full' | 'paragraph';
+  paragraphIndex?: number;
+  /** Called when user clicks "再讀一次" */
+  onReread: () => void;
+  /** Called when user clicks "繼續" to move to next step */
+  onContinue: () => void;
+}
+
+const RereadPanel: React.FC<RereadPanelProps> = ({
+  lessonId,
+  studentId,
+  cpm,
+  accuracy,
+  durationSeconds,
+  readingType,
+  paragraphIndex,
+  onReread,
+  onContinue,
+}) => {
+  const { token } = useAuth();
+  const savedRef = useRef(false);
+  const [encouragement, setEncouragement] = useState('');
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Save the reading attempt on mount (once)
+  useEffect(() => {
+    if (savedRef.current || !token) return;
+    savedRef.current = true;
+
+    saveReadingHistory(
+      {
+        lesson_id: lessonId,
+        paragraph_index: paragraphIndex ?? null,
+        reading_type: readingType,
+        cpm,
+        accuracy,
+        duration_seconds: durationSeconds,
+      },
+      token,
+    )
+      .then(() => {
+        // Trigger chart refresh after save
+        setRefreshKey(k => k + 1);
+      })
+      .catch((err) => {
+        console.error('Failed to save reading history:', err);
+      });
+  }, [token, lessonId, paragraphIndex, readingType, cpm, accuracy, durationSeconds]);
+
+  const handleSummaryLoad = (summary: ReadingProgressSummary) => {
+    setEncouragement(summary.encouragement);
+  };
+
+  return (
+    <div className="space-y-4 animate-in fade-in duration-500">
+      {/* Current reading results */}
+      <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl border border-blue-200 p-4">
+        <h3 className="text-sm font-semibold text-blue-800 mb-3">本次朗讀成績</h3>
+        <div className="grid grid-cols-3 gap-4 text-center">
+          <div>
+            <div className="text-2xl font-bold text-blue-700">{Math.round(cpm)}</div>
+            <div className="text-xs text-blue-600 mt-0.5">字/分鐘</div>
+          </div>
+          <div>
+            <div className="text-2xl font-bold text-green-700">{Math.round(accuracy)}%</div>
+            <div className="text-xs text-green-600 mt-0.5">準確率</div>
+          </div>
+          <div>
+            <div className="text-2xl font-bold text-purple-700">{Math.round(durationSeconds)}</div>
+            <div className="text-xs text-purple-600 mt-0.5">秒</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Progress chart */}
+      <ReadingProgressChart
+        key={refreshKey}
+        studentId={studentId}
+        lessonId={lessonId}
+        readingType={readingType}
+        paragraphIndex={paragraphIndex}
+        compact
+        onSummaryLoad={handleSummaryLoad}
+      />
+
+      {/* Action buttons */}
+      <div className="flex gap-3">
+        <button
+          onClick={onReread}
+          className="flex-1 py-3 px-6 bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600 text-white font-semibold rounded-xl shadow-md hover:shadow-lg transition-all duration-200 text-base"
+        >
+          🔄 再讀一次
+        </button>
+        <button
+          onClick={onContinue}
+          className="flex-none py-3 px-6 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-xl border border-gray-300 transition-all duration-200 text-sm"
+        >
+          繼續 →
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default RereadPanel;

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -8,8 +8,9 @@ import { useIsMobile } from '../../hooks/useIsMobile';
 import { useAudioRecorder } from '../../hooks/useAudioRecorder';
 import { useResizablePanel } from '../../hooks/useResizablePanel';
 import { getReadingHistory, type ReadingHistoryPoint } from '../../services/learningApi';
+import { saveReadingHistory } from '../../services/readingHistoryApi';
 import { useAuth } from '../../contexts/AuthContext';
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine, ResponsiveContainer } from 'recharts';
 
 /* ------------------------------------------------------------------ */
 
@@ -55,10 +56,33 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
 
   /* ---- Reading history for progress curve ---- */
   const [readingHistory, setReadingHistory] = useState<ReadingHistoryPoint[]>([]);
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
   useEffect(() => {
     if (!token || !story.id) return;
     getReadingHistory(token, String(story.id)).then(setReadingHistory).catch(() => {});
-  }, [token, story.id]);
+  }, [token, story.id, historyRefreshKey]);
+
+  /* ---- Save reading attempt to dedicated reading_history table (#909) ---- */
+  const savedResultRef = useRef(false);
+  useEffect(() => {
+    if (!result || savedResultRef.current || !token) return;
+    savedResultRef.current = true;
+    const durationSec = (result.durationMs || 0) / 1000;
+    if (durationSec > 0) {
+      saveReadingHistory(
+        {
+          lesson_id: String(story.id),
+          reading_type: 'full',
+          cpm: result.cpm || 0,
+          accuracy: Math.round((result.matchRate || 0) * 100),
+          duration_seconds: durationSec,
+        },
+        token,
+      )
+        .then(() => setHistoryRefreshKey(k => k + 1))
+        .catch((err) => console.error('Failed to save reading history:', err));
+    }
+  }, [result, token, story.id]);
 
   /* ---- Audio recorder (for student playback review) ---- */
   const audioRecorder = useAudioRecorder(120);
@@ -379,10 +403,23 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
               )}
 
               {/* Reading progress curve (#909) */}
-              {readingHistory.length >= 2 && (
+              {readingHistory.length >= 1 && (
                 <div className="bg-white border border-gray-200 rounded-xl px-3 py-2.5">
-                  <p className="text-xs text-gray-500 mb-2 uppercase tracking-widest">朗讀進步曲線</p>
-                  <ResponsiveContainer width="100%" height={120}>
+                  <p className="text-xs text-gray-500 mb-2 uppercase tracking-widest">
+                    朗讀進步曲線
+                    {readingHistory.length >= 2 && (() => {
+                      const first = readingHistory[0]?.cpm;
+                      const last = readingHistory[readingHistory.length - 1]?.cpm;
+                      if (first && last && first > 0) {
+                        const pct = Math.round(((last - first) / first) * 100);
+                        return pct > 0
+                          ? <span className="ml-1 text-green-600">▲{pct}%</span>
+                          : pct < 0 ? <span className="ml-1 text-red-500">▼{Math.abs(pct)}%</span> : null;
+                      }
+                      return null;
+                    })()}
+                  </p>
+                  <ResponsiveContainer width="100%" height={140}>
                     <LineChart data={readingHistory.map((h, i) => ({
                       attempt: `第${i + 1}次`,
                       cpm: h.cpm,
@@ -396,8 +433,9 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
                           name === 'cpm' ? '語速' : '準確度',
                         ]}
                       />
-                      <Line yAxisId="cpm" type="monotone" dataKey="cpm" stroke="#4A3FA3" strokeWidth={2} dot={{ r: 3 }} name="cpm" />
-                      <Line yAxisId="cpm" type="monotone" dataKey="accuracy" stroke="#10b981" strokeWidth={2} dot={{ r: 3 }} name="accuracy" />
+                      <ReferenceLine yAxisId="cpm" y={90} stroke="#ef4444" strokeDasharray="6 3" label={{ value: '目標 90', position: 'right', fill: '#ef4444', fontSize: 9 }} />
+                      <Line yAxisId="cpm" type="monotone" dataKey="cpm" stroke="#3b82f6" strokeWidth={2.5} dot={{ r: 3, fill: '#3b82f6' }} name="cpm" />
+                      <Line yAxisId="cpm" type="monotone" dataKey="accuracy" stroke="#22c55e" strokeWidth={2} dot={{ r: 3, fill: '#22c55e' }} strokeDasharray="4 2" name="accuracy" />
                     </LineChart>
                   </ResponsiveContainer>
                   <p className="text-[10px] text-gray-400 text-center mt-1">
@@ -416,11 +454,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, rightPanelWidth, onPan
           {result ? (
             <div className="space-y-2">
               <button
-                onClick={() => { try { localStorage.removeItem(storageKey); } catch {} setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); }}
-                aria-label="重新開始全文朗讀"
-                className="w-full py-2.5 rounded-full text-sm font-bold border border-gray-300 bg-transparent hover:bg-gray-50 text-gray-800 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+                onClick={() => { try { localStorage.removeItem(storageKey); } catch {} savedResultRef.current = false; setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); }}
+                aria-label="再讀一次全文朗讀"
+                className="w-full py-2.5 rounded-full text-sm font-bold bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-600 hover:to-indigo-600 text-white shadow-md transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
               >
-                再試一次
+                🔄 再讀一次
               </button>
               <button
                 onClick={() => { try { localStorage.removeItem(storageKey); } catch {} onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript, cpm: result.cpm, durationMs: result.durationMs, errorBreakdown: result.errorBreakdown }); }}

--- a/frontend/src/components/reading-steps/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/LiveTutor.tsx
@@ -16,6 +16,7 @@ import {
   type LocalEvalResult,
 } from '../../utils/localEval';
 import { cancelTts } from '../../services/ttsApi';
+import { saveReadingHistory } from '../../services/readingHistoryApi';
 import {
   TIER1_POOL,
   TIER2_POOL,
@@ -429,8 +430,30 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   /*  Core: evaluate the student's reading and respond                */
   /* ================================================================ */
 
+  /* ---- Helper: save paragraph reading to history (#909) ---- */
+  const saveParagraphReading = useCallback((lineIdx: number, result: LineResult) => {
+    if (!token) return;
+    const durationSec = result.durationMs / 1000;
+    if (durationSec <= 0) return;
+    saveReadingHistory(
+      {
+        lesson_id: String(story.id),
+        paragraph_index: lineIdx,
+        reading_type: 'paragraph',
+        cpm: result.cpm,
+        accuracy: Math.round(result.matchRate * 100),
+        duration_seconds: durationSec,
+      },
+      token,
+    ).catch((err) => console.error('Failed to save paragraph reading history:', err));
+  }, [token, story.id]);
+
   /* ---- Helper: advance or finish after a successful paragraph ---- */
   const advanceParagraph = useCallback((lineIdx: number, allLineResults: LineResult[]) => {
+    // Save per-paragraph reading to history (#909)
+    const currentResult = allLineResults.find(r => r.lineIndex === lineIdx);
+    if (currentResult) saveParagraphReading(lineIdx, currentResult);
+
     const isLastLine = lineIdx >= story.content.length - 1;
     if (!isLastLine) {
       if (isAdvancingRef.current) return;
@@ -474,7 +497,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         });
       }, 2000);
     }
-  }, [story, onFinish, onParagraphComplete]);
+  }, [story, onFinish, onParagraphComplete, saveParagraphReading]);
 
   /* ---- Hybrid evaluation: local first, Gemini only on FAIL ---- */
   const evaluateAndRespond = useCallback(async (rawTranscript: string, rawStt: string, durationMs: number, lineIdx: number) => {

--- a/frontend/src/services/readingHistoryApi.ts
+++ b/frontend/src/services/readingHistoryApi.ts
@@ -1,0 +1,106 @@
+/**
+ * readingHistoryApi.ts — Reading history and progress tracking APIs.
+ *
+ * Issue #909: 重複朗讀 + 進步曲線
+ */
+
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ReadingHistoryItem {
+  id: number;
+  student_id: number;
+  lesson_id: string;
+  paragraph_index: number | null;
+  reading_type: string;
+  cpm: number;
+  accuracy: number;
+  duration_seconds: number;
+  created_at: string;
+}
+
+export interface ReadingHistoryResponse {
+  history: ReadingHistoryItem[];
+  target_cpm: number;
+  target_source: string;
+}
+
+export interface ReadingProgressSummary {
+  total_attempts: number;
+  best_cpm: number;
+  latest_cpm: number;
+  best_accuracy: number;
+  latest_accuracy: number;
+  cpm_improvement_pct: number;
+  target_cpm: number;
+  target_reached: boolean;
+  encouragement: string;
+}
+
+// ── Save a reading attempt ───────────────────────────────────────────────────
+
+export async function saveReadingHistory(
+  payload: {
+    lesson_id: string;
+    paragraph_index?: number | null;
+    reading_type: 'paragraph' | 'full';
+    cpm: number;
+    accuracy: number;
+    duration_seconds: number;
+  },
+  token: string,
+): Promise<ReadingHistoryItem> {
+  const res = await fetch(`${API_BASE}/api/reading-history`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`saveReadingHistory failed: ${res.status}`);
+  return res.json();
+}
+
+// ── Get reading history ──────────────────────────────────────────────────────
+
+export async function getReadingHistory(
+  studentId: number,
+  lessonId: string,
+  token: string,
+  readingType?: string,
+  paragraphIndex?: number,
+): Promise<ReadingHistoryResponse> {
+  const params = new URLSearchParams();
+  if (readingType) params.set('reading_type', readingType);
+  if (paragraphIndex !== undefined) params.set('paragraph_index', String(paragraphIndex));
+  const qs = params.toString() ? `?${params.toString()}` : '';
+
+  const res = await fetch(
+    `${API_BASE}/api/reading-history/${studentId}/${lessonId}${qs}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  if (!res.ok) throw new Error(`getReadingHistory failed: ${res.status}`);
+  return res.json();
+}
+
+// ── Get reading summary ──────────────────────────────────────────────────────
+
+export async function getReadingSummary(
+  studentId: number,
+  lessonId: string,
+  token: string,
+  readingType: string = 'full',
+): Promise<ReadingProgressSummary> {
+  const res = await fetch(
+    `${API_BASE}/api/reading-history/${studentId}/${lessonId}/summary?reading_type=${readingType}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  if (!res.ok) throw new Error(`getReadingSummary failed: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- Full-stack implementation of **repeated reading practice** with progress tracking, based on 曾世杰教授研究 methodology
- New `ReadingHistory` + `ReadingTarget` DB models for per-attempt CPM/accuracy tracking with teacher-set targets
- Backend APIs: save reading attempts, query history, get progress summary with encouragement messages, teacher reading progress view, set CPM targets
- Frontend: `ReadingProgressChart` (recharts line chart with CPM + accuracy + target reference line), `RereadPanel` (completion stats + "再讀一次" button), enhanced FullReading/LiveTutor with automatic history saving

## Test plan
- [ ] FullReading: complete a reading, verify "再讀一次" button appears prominently
- [ ] FullReading: re-read same text, verify progress chart shows multiple attempts with CPM trend
- [ ] LiveTutor: complete paragraphs, verify per-paragraph reading history is saved
- [ ] Teacher: verify reading progress endpoint returns student reading curves
- [ ] Teacher: set CPM target for a lesson, verify target line appears on student chart
- [ ] Verify frontend build passes (`cd frontend && npm run build`)
- [ ] Verify backend syntax (`python3 -c "import ast; ast.parse(open('app/main.py').read())"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)