### PR TITLE
fix(security): add input sanitization to all user-input API endpoints

### DIFF
--- a/backend/app/routes/admin_stories.py
+++ b/backend/app/routes/admin_stories.py
@@ -20,6 +20,7 @@ from ..schemas.story import (
     VocabItemSchema,
 )
 from ..services import lesson_loader
+from ..services.input_sanitizer import sanitize_ai_input
 
 router = APIRouter(tags=["admin-stories"])
 
@@ -39,22 +40,25 @@ def _lesson_path(lesson_number: int) -> Path:
     return _LESSONS_DIR / f"L{lesson_number}.yml"
 
 
-def _build_yaml_dict(data: StoryCreateRequest) -> dict:
+def _build_yaml_dict(data: StoryCreateRequest, user_id: str | None = None) -> dict:
     """Convert a StoryCreateRequest to the YAML dict format used on disk."""
-    full_text = "\n".join(data.paragraphs)
+    # Sanitize text fields — story content is used in AI prompts
+    safe_title, _ = sanitize_ai_input(data.title, user_id=user_id)
+    safe_paragraphs = [sanitize_ai_input(p, user_id=user_id)[0] for p in data.paragraphs]
+    full_text = "\n".join(safe_paragraphs)
     char_count = len(full_text.replace("\n", "").replace(" ", ""))
 
     doc: dict = {
         "lesson_number": data.lesson_number,
         "grade": data.grade,
         "grade_code": data.grade_code,
-        "title": data.title,
+        "title": safe_title,
         "genre": data.genre,
         "text_type": data.text_type,
         "reading_strategy": data.reading_strategy or "無",
         "story_text": full_text,
-        "paragraphs": data.paragraphs,
-        "paragraph_count": len(data.paragraphs),
+        "paragraphs": safe_paragraphs,
+        "paragraph_count": len(safe_paragraphs),
         "char_count": char_count,
     }
     if data.vocabulary:
@@ -192,7 +196,7 @@ def create_story(body: StoryCreateRequest):
             detail=f"Story with lesson_number {body.lesson_number} already exists",
         )
 
-    doc = _build_yaml_dict(body)
+    doc = _build_yaml_dict(body, user_id=None)
     with open(yaml_path, "w", encoding="utf-8") as f:
         yaml.dump(doc, f, allow_unicode=True, default_flow_style=False, sort_keys=False)
 
@@ -218,9 +222,10 @@ def update_story(lesson_number: int, body: StoryUpdateRequest):
     with open(yaml_path, "r", encoding="utf-8") as f:
         doc = yaml.safe_load(f)
 
-    # Apply partial updates
+    # Apply partial updates (sanitize text fields that feed into AI prompts)
     if body.title is not None:
-        doc["title"] = body.title
+        safe_title, _ = sanitize_ai_input(body.title)
+        doc["title"] = safe_title
     if body.grade is not None:
         doc["grade"] = body.grade
     if body.grade_code is not None:
@@ -234,9 +239,10 @@ def update_story(lesson_number: int, body: StoryUpdateRequest):
     if body.source_file is not None:
         doc["source_file"] = body.source_file
     if body.paragraphs is not None:
-        doc["paragraphs"] = body.paragraphs
-        doc["paragraph_count"] = len(body.paragraphs)
-        full_text = "\n".join(body.paragraphs)
+        safe_paragraphs = [sanitize_ai_input(p)[0] for p in body.paragraphs]
+        doc["paragraphs"] = safe_paragraphs
+        doc["paragraph_count"] = len(safe_paragraphs)
+        full_text = "\n".join(safe_paragraphs)
         doc["story_text"] = full_text
         doc["char_count"] = len(full_text.replace("\n", "").replace(" ", ""))
     if body.vocabulary is not None:

--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -37,6 +37,7 @@ from ..schemas.assignment import (
     DEFAULT_TARGET_ACCURACY,
 )
 from ..services.assignment_copy_strategy import resolve_text_for_assignment
+from ..services.input_sanitizer import sanitize_ai_input
 from ..services.lesson_loader import get_lesson_by_id
 from ..services.notification_service import send_assignment_submitted_notification
 from .classrooms import _get_classroom_or_404, _require_owner_or_admin
@@ -370,6 +371,12 @@ def create_assignment(
             detail="classroom_id in request body must match classroom_id in path",
         )
 
+    # Sanitize teacher-provided text fields
+    safe_title, _ = sanitize_ai_input(payload.title, user_id=str(current_user.id)) if payload.title else (payload.title, False)
+    safe_description = payload.description
+    if safe_description:
+        safe_description, _ = sanitize_ai_input(safe_description, user_id=str(current_user.id))
+
     classroom = _get_classroom_or_404(classroom_id, db)
     _require_owner_or_admin(classroom, current_user, db)
 
@@ -403,8 +410,8 @@ def create_assignment(
         teacher_id=current_user.id,
         story_id=resolved_story_id,
         text_id=resolved_text_id,
-        title=payload.title,
-        description=payload.description,
+        title=safe_title,
+        description=safe_description,
         assignment_type=payload.assignment_type,
         due_date=payload.due_date,
         # Reading goals (Issue #84)
@@ -548,6 +555,12 @@ def update_assignment(
     _require_assignment_owner_or_admin(assignment, current_user, db)
 
     update_data = payload.model_dump(exclude_unset=True)
+    # Sanitize text fields in update payload
+    for text_field in ("title", "description"):
+        if text_field in update_data and update_data[text_field]:
+            update_data[text_field], _ = sanitize_ai_input(
+                update_data[text_field], user_id=str(current_user.id)
+            )
     for field, value in update_data.items():
         setattr(assignment, field, value)
 
@@ -594,7 +607,8 @@ def grade_submission(
         submission.score = payload.score
     # Persist per-student feedback (Issue #424); None keeps existing value unchanged
     if payload.teacher_feedback is not None:
-        submission.teacher_feedback = payload.teacher_feedback
+        safe_feedback, _ = sanitize_ai_input(payload.teacher_feedback, user_id=str(current_user.id))
+        submission.teacher_feedback = safe_feedback
     submission.status = "graded"
 
     db.commit()

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -28,6 +28,7 @@ from ..schemas.auth import (
     VerifyEmailRequest,
     VerifyEmailResponse,
 )
+from ..services.input_sanitizer import sanitize_ai_input
 from ..utils.password_validator import validate_password_strength
 from ..schemas.user import UserResponse
 
@@ -116,6 +117,9 @@ def register(req: RegisterRequest, request: Request, db: Session = Depends(get_d
     if not rate_limiter.check(f"register:{client_ip}", max_requests=5, window_seconds=60):
         raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
 
+    # Sanitize user-provided name to prevent injection in downstream AI contexts
+    safe_name, _ = sanitize_ai_input(req.name, user_id=req.email) if req.name else (req.name, False)
+
     # Block student self-registration. Students are created by teachers only.
     if req.role is not None and req.role.lower() == "student":
         raise HTTPException(
@@ -148,7 +152,7 @@ def register(req: RegisterRequest, request: Request, db: Session = Depends(get_d
     user = User(
         email=req.email,
         password_hash=hash_password(req.password),
-        name=req.name,
+        name=safe_name,
         email_verified=auto_verified,
         email_verification_token=verification_token,
     )

--- a/backend/app/routes/classrooms/classroom_batch.py
+++ b/backend/app/routes/classrooms/classroom_batch.py
@@ -17,6 +17,7 @@ from ...schemas.classroom import (
     BatchStudentError,
     CreatedStudentInfo,
 )
+from ...services.input_sanitizer import sanitize_ai_input
 from .helpers import (
     check_email_domain,
     get_classroom_or_404,
@@ -66,6 +67,8 @@ def batch_create_students(
     for item in payload.students:
         try:
             savepoint = db.begin_nested()
+            # Sanitize student name — displayed in reports and potentially used in AI contexts
+            safe_name, _ = sanitize_ai_input(item.name, user_id=str(current_user.id))
             username = f"{classroom.join_code}{item.seat_number}"
             email = f"{username.lower()}@student.lingoleap.local"
 
@@ -90,7 +93,7 @@ def batch_create_students(
                 email=email,
                 username=username.upper(),
                 password_hash=hash_password(password),
-                name=item.name,
+                name=safe_name,
                 is_active=True,
             )
             db.add(user)

--- a/backend/app/routes/classrooms/classroom_crud.py
+++ b/backend/app/routes/classrooms/classroom_crud.py
@@ -19,6 +19,7 @@ from ...schemas.classroom import (
     StudentEnrolledClassroom,
     StudentEnrolledClassroomsResponse,
 )
+from ...services.input_sanitizer import sanitize_ai_input
 from .helpers import (
     classroom_to_detail_response,
     classroom_to_response,
@@ -62,9 +63,12 @@ def create_classroom(
             raise HTTPException(status_code=404, detail="Teacher user not found")
         effective_teacher_id = payload.teacher_id
 
+    # Sanitize teacher-provided name
+    safe_name, _ = sanitize_ai_input(payload.name, user_id=str(current_user.id))
+
     join_code = generate_join_code(db)
     classroom = Classroom(
-        name=payload.name,
+        name=safe_name,
         school_id=payload.school_id,
         teacher_id=effective_teacher_id,
         grade=payload.grade,
@@ -244,6 +248,11 @@ def update_classroom(
     require_owner_or_admin(classroom, current_user, db)
 
     update_data = payload.model_dump(exclude_unset=True)
+    # Sanitize text fields in update payload
+    if "name" in update_data and update_data["name"]:
+        update_data["name"], _ = sanitize_ai_input(
+            update_data["name"], user_id=str(current_user.id)
+        )
     for field, value in update_data.items():
         setattr(classroom, field, value)
 

--- a/backend/app/routes/feedback.py
+++ b/backend/app/routes/feedback.py
@@ -21,6 +21,7 @@ from ..schemas.feedback import (
     FeedbackResponse,
     FeedbackStatusUpdateRequest,
 )
+from ..services.input_sanitizer import sanitize_ai_input
 
 router = APIRouter(tags=["feedback"])
 logger = logging.getLogger(__name__)
@@ -47,11 +48,17 @@ def submit_feedback(
     db: Session = Depends(get_db),
 ) -> FeedbackResponse:
     """Submit feedback from any authenticated user."""
+    # Sanitize user-provided text fields
+    safe_title, _ = sanitize_ai_input(body.title, user_id=str(current_user.id))
+    safe_description = body.description
+    if safe_description:
+        safe_description, _ = sanitize_ai_input(safe_description, user_id=str(current_user.id))
+
     feedback = Feedback(
         user_id=current_user.id,
         category=body.category,
-        title=body.title,
-        description=body.description,
+        title=safe_title,
+        description=safe_description,
         page_url=body.page_url,
         status="open",
     )

--- a/backend/app/routes/learning/learning_comprehension.py
+++ b/backend/app/routes/learning/learning_comprehension.py
@@ -17,6 +17,7 @@ from ...models.teacher_instruction import TeacherInstruction
 from ...models.user import User
 from ...services.ai_service import generate_socratic_question
 from ...services.ai_usage_tracker import last_usage, log_ai_usage
+from ...services.input_sanitizer import sanitize_ai_input
 from ...services.socratic_agent import socratic_agent
 from ._helpers import ConversationTurn
 
@@ -56,14 +57,18 @@ async def get_comprehension_question(
     the next AI question. Call this after each student answer (and on initial
     load with an empty conversation to get the first question).
     """
+    # Sanitize user-provided text before sending to AI
+    safe_story_title, _ = sanitize_ai_input(payload.story_title, user_id=str(current_user.id))
+    safe_story_text, _ = sanitize_ai_input(payload.story_text, user_id=str(current_user.id))
+
     start_time = time.monotonic()
     ai_success = True
     ai_error_type = None
     try:
         conversation = [t.model_dump() for t in payload.conversation]
         question = await generate_socratic_question(
-            story_title=payload.story_title,
-            story_text=payload.story_text,
+            story_title=safe_story_title,
+            story_text=safe_story_text,
             conversation=conversation,
         )
     except Exception as e:
@@ -174,6 +179,13 @@ async def comprehension_chat(
     the response includes resumed=true and conversation_history so the frontend can
     display the prior conversation without a Gemini call.
     """
+    # Sanitize user-provided text before sending to AI
+    safe_story_title, _ = sanitize_ai_input(payload.story_title, user_id=str(current_user.id))
+    safe_story_text, _ = sanitize_ai_input(payload.story_text, user_id=str(current_user.id))
+    safe_student_answer = payload.student_answer
+    if safe_student_answer is not None:
+        safe_student_answer, _ = sanitize_ai_input(safe_student_answer, user_id=str(current_user.id))
+
     is_resumed = False
     conversation_history: list[ConversationHistoryItem] = []
     start_time = time.monotonic()
@@ -195,7 +207,7 @@ async def comprehension_chat(
             raise HTTPException(status_code=403, detail="Session not found")
 
     try:
-        if payload.student_answer is None:
+        if safe_student_answer is None:
             # Fetch active teacher instructions for this student (Issue #90)
             teacher_instructions_content: list[str] = []
             try:
@@ -213,8 +225,8 @@ async def comprehension_chat(
 
             result, is_resumed = await socratic_agent.start_session(
                 session_id=payload.session_id,
-                story_title=payload.story_title,
-                story_text=payload.story_text,
+                story_title=safe_story_title,
+                story_text=safe_story_text,
                 mispronounced_words=payload.mispronounced_words,
                 accuracy=payload.accuracy,
                 cpm=payload.cpm,
@@ -248,7 +260,7 @@ async def comprehension_chat(
         else:
             result = await socratic_agent.process_answer(
                 session_id=payload.session_id,
-                student_answer=payload.student_answer,
+                student_answer=safe_student_answer,
             )
     except ValueError as e:
         ai_success = False
@@ -273,7 +285,7 @@ async def comprehension_chat(
                 db=db,
                 socratic_session_id=payload.session_id,
                 learning_session_id=payload.db_session_id,
-                student_answer=payload.student_answer,
+                student_answer=safe_student_answer,
                 result=result,
             )
         except Exception as e:

--- a/backend/app/routes/learning/learning_comprehension_score.py
+++ b/backend/app/routes/learning/learning_comprehension_score.py
@@ -19,6 +19,7 @@ from ...models.user import User
 from ...schemas.session import ComprehensionScoreResponse
 from ...services.ai_service import evaluate_comprehension
 from ...services.ai_usage_tracker import last_usage, log_ai_usage
+from ...services.input_sanitizer import sanitize_ai_input
 from ._helpers import ConversationTurn
 
 router = APIRouter()
@@ -129,14 +130,23 @@ async def score_comprehension(
             feedback=feedback,
         )
 
+    # Sanitize user-provided text before sending to AI
+    safe_story_title, _ = sanitize_ai_input(payload.story_title, user_id=str(current_user.id))
+    safe_story_text, _ = sanitize_ai_input(payload.story_text, user_id=str(current_user.id))
+
     # Build story context
     story_context = {
-        "title": payload.story_title,
-        "summary": payload.story_text[:500],  # Use first 500 chars as summary
+        "title": safe_story_title,
+        "summary": safe_story_text[:500],  # Use first 500 chars as summary
     }
 
-    # Build dialogue turns list
-    dialogue_turns = [t.model_dump() for t in payload.dialogue_turns]
+    # Build dialogue turns list — sanitize student turns
+    dialogue_turns = []
+    for t in payload.dialogue_turns:
+        turn = t.model_dump()
+        if turn.get("role") == "student" and turn.get("text"):
+            turn["text"], _ = sanitize_ai_input(turn["text"], user_id=str(current_user.id))
+        dialogue_turns.append(turn)
 
     start_time = time.monotonic()
     try:

--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -16,6 +16,7 @@ from ...models.session import LearningSession
 from ...models.user import User
 from ...services.ai_service import generate_reading_analysis, GeminiContentFilterError, CONTENT_FILTER_FRIENDLY_MSG
 from ...services.ai_usage_tracker import last_usage, log_ai_usage
+from ...services.input_sanitizer import sanitize_ai_input
 from ...services.reading_evaluation_service import evaluate_reading_with_ai
 
 router = APIRouter()
@@ -143,6 +144,9 @@ async def get_ai_analysis(
     if session.student_id != current_user.id:
         raise HTTPException(status_code=403, detail="Not your session")
 
+    # Sanitize user-provided text before sending to AI
+    safe_story_title, _ = sanitize_ai_input(payload.story_title, user_id=str(current_user.id))
+
     cached_resp = _try_return_cached_ai_analysis(session.ai_analysis, payload)
     if cached_resp is not None:
         return cached_resp
@@ -158,7 +162,7 @@ async def get_ai_analysis(
     ai_error_type = None
     try:
         analysis = await generate_reading_analysis({
-            "story_title": payload.story_title,
+            "story_title": safe_story_title,
             "accuracy": payload.accuracy,
             "cpm": payload.cpm,
             "error_chars": payload.error_chars,
@@ -200,7 +204,7 @@ async def get_ai_analysis(
         endpoint=f"/learning/sessions/{session_id}/ai-analysis",
         step="analysis",
         student_id=current_user.id,
-        story_title=payload.story_title,
+        story_title=safe_story_title,
         session_id=session_id,
         input_tokens=usage.input_tokens if usage else 0,
         output_tokens=usage.output_tokens if usage else 0,
@@ -240,12 +244,15 @@ async def get_ai_analysis_standalone(
 
     Rate limited: 5 requests per minute per user/IP.
     """
+    # Sanitize user-provided text before sending to AI
+    safe_story_title, _ = sanitize_ai_input(payload.story_title, user_id=str(current_user.id))
+
     start_time = time.monotonic()
     ai_success = True
     ai_error_type = None
     try:
         analysis = await generate_reading_analysis({
-            "story_title": payload.story_title,
+            "story_title": safe_story_title,
             "accuracy": payload.accuracy,
             "cpm": payload.cpm,
             "error_chars": payload.error_chars,
@@ -286,7 +293,7 @@ async def get_ai_analysis_standalone(
         endpoint="/learning/ai-analysis",
         step="analysis",
         student_id=current_user.id,
-        story_title=payload.story_title,
+        story_title=safe_story_title,
         input_tokens=usage.input_tokens if usage else 0,
         output_tokens=usage.output_tokens if usage else 0,
         model=usage.model if usage else "gemini-2.5-flash",
@@ -362,11 +369,14 @@ async def evaluate_reading_endpoint(
     db: Session = Depends(get_db),
 ):
     """Stateless AI reading evaluation. Rate limited: 10 requests per minute."""
+    # Sanitize user-provided spoken text before sending to AI
+    safe_spoken_text, _ = sanitize_ai_input(payload.spoken_text, user_id=str(current_user.id))
+
     logger.info(
         "Reading eval request: user=%d target_len=%d spoken_len=%d",
         current_user.id,
         len(payload.target_text),
-        len(payload.spoken_text),
+        len(safe_spoken_text),
         extra={
             "event": "reading_eval_request",
             "user_id": current_user.id,
@@ -376,7 +386,7 @@ async def evaluate_reading_endpoint(
 
     start_time = time.monotonic()
     result = await evaluate_reading_with_ai(
-        spoken_text=payload.spoken_text,
+        spoken_text=safe_spoken_text,
         target_text=payload.target_text,
         duration_ms=payload.duration_ms,
     )

--- a/backend/app/routes/learning/learning_vocab.py
+++ b/backend/app/routes/learning/learning_vocab.py
@@ -15,6 +15,7 @@ from ...models.user import User
 from ...services.ai_service import generate_example_sentences, validate_student_sentence
 from ...services.ai_usage_tracker import last_usage, log_ai_usage
 from ...services.example_sentence_cache import get_cached, set_cached
+from ...services.input_sanitizer import sanitize_ai_input
 from ...services.listening_service import evaluate_retelling
 
 router = APIRouter()
@@ -157,8 +158,12 @@ async def validate_sentence(
     and uses the target character appropriately (Issue #109).
     Rate limited: 10 requests per minute per user/IP.
     """
+    # Sanitize student input before sending to AI
+    safe_sentence, _ = sanitize_ai_input(payload.student_sentence, user_id=str(current_user.id))
+    safe_story_title, _ = sanitize_ai_input(payload.story_title, user_id=str(current_user.id))
+
     # Basic check: target character must appear in the sentence
-    if payload.character not in payload.student_sentence:
+    if payload.character not in safe_sentence:
         return ValidateSentenceResponse(
             is_correct=False,
             feedback="你的句子裡沒有包含目標生字喔！",
@@ -169,8 +174,8 @@ async def validate_sentence(
     try:
         result = await validate_student_sentence(
             character=payload.character,
-            student_sentence=payload.student_sentence,
-            story_title=payload.story_title,
+            student_sentence=safe_sentence,
+            story_title=safe_story_title,
         )
     except TimeoutError:
         raise HTTPException(status_code=503, detail="AI service timeout")
@@ -242,12 +247,16 @@ async def evaluate_listening_retelling(
 
     Returns a score (0-100), covered/missed key points, and feedback.
     """
+    # Sanitize student retelling before sending to AI
+    safe_retelling, _ = sanitize_ai_input(payload.student_retelling, user_id=str(current_user.id))
+    safe_story_title_listen, _ = sanitize_ai_input(payload.story_title, user_id=str(current_user.id))
+
     start_time = time.monotonic()
     try:
         result = await evaluate_retelling(
             original_text=payload.original_text,
-            student_retelling=payload.student_retelling,
-            story_title=payload.story_title,
+            student_retelling=safe_retelling,
+            story_title=safe_story_title_listen,
         )
     except TimeoutError:
         raise HTTPException(status_code=503, detail="AI service timeout")

--- a/backend/app/routes/organizations.py
+++ b/backend/app/routes/organizations.py
@@ -29,6 +29,7 @@ from ..schemas.organization import (
     SchoolStatItem,
 )
 from ..schemas.school import SchoolResponse
+from ..services.input_sanitizer import sanitize_ai_input
 
 router = APIRouter(tags=["organizations"])
 logger = logging.getLogger(__name__)
@@ -87,6 +88,15 @@ def create_organization(
     db: Session = Depends(get_db),
 ):
     """Create a new organization."""
+    # Sanitize admin-provided text fields
+    safe_name, _ = sanitize_ai_input(payload.name, user_id=str(current_user.id))
+    safe_display_name = payload.display_name
+    if safe_display_name:
+        safe_display_name, _ = sanitize_ai_input(safe_display_name, user_id=str(current_user.id))
+    safe_description = payload.description
+    if safe_description:
+        safe_description, _ = sanitize_ai_input(safe_description, user_id=str(current_user.id))
+
     if payload.tax_id:
         existing = db.query(Organization).filter(
             Organization.tax_id == payload.tax_id,
@@ -95,10 +105,10 @@ def create_organization(
         if existing:
             raise HTTPException(status_code=409, detail="統一編號已被其他機構使用")
     org = Organization(
-        name=payload.name,
-        display_name=payload.display_name,
+        name=safe_name,
+        display_name=safe_display_name,
         teacher_limit=payload.teacher_limit,
-        description=payload.description,
+        description=safe_description,
         tax_id=payload.tax_id,
         contact_email=payload.contact_email,
         contact_phone=payload.contact_phone,
@@ -211,6 +221,12 @@ def update_organization(
             raise HTTPException(status_code=409, detail="統一編號已被其他機構使用")
 
     update_data = payload.model_dump(exclude_unset=True)
+    # Sanitize text fields in update payload
+    for text_field in ("name", "display_name", "description", "address"):
+        if text_field in update_data and update_data[text_field]:
+            update_data[text_field], _ = sanitize_ai_input(
+                update_data[text_field], user_id=str(current_user.id)
+            )
     for field, value in update_data.items():
         setattr(org, field, value)
 

--- a/backend/app/routes/schools.py
+++ b/backend/app/routes/schools.py
@@ -18,6 +18,7 @@ from ..schemas.school import (
     SchoolUpdateRequest,
 )
 from ..schemas.user_admin import SchoolMemberResponse
+from ..services.input_sanitizer import sanitize_ai_input
 
 router = APIRouter(tags=["schools"])
 logger = logging.getLogger(__name__)
@@ -87,9 +88,12 @@ def create_school(
         if org is None:
             raise HTTPException(status_code=404, detail="Organization not found")
 
+    # Sanitize admin-provided text fields
+    safe_name, _ = sanitize_ai_input(payload.name, user_id=str(current_user.id))
+
     join_code = _generate_school_join_code(db)
     school = School(
-        name=payload.name,
+        name=safe_name,
         organization_id=payload.organization_id,
         address=payload.address,
         phone=payload.phone,
@@ -153,6 +157,12 @@ def update_school(
         raise HTTPException(status_code=403, detail="Not authorized for this school")
 
     update_data = payload.model_dump(exclude_unset=True)
+    # Sanitize text fields in update payload
+    for text_field in ("name", "address"):
+        if text_field in update_data and update_data[text_field]:
+            update_data[text_field], _ = sanitize_ai_input(
+                update_data[text_field], user_id=str(current_user.id)
+            )
     for field, value in update_data.items():
         setattr(school, field, value)
 

--- a/backend/app/routes/teacher/teacher_instructions.py
+++ b/backend/app/routes/teacher/teacher_instructions.py
@@ -17,6 +17,7 @@ from ...schemas.teacher_instruction import (
     InstructionResponse,
     InstructionUpdate,
 )
+from ...services.input_sanitizer import sanitize_ai_input
 from ..classrooms import _get_classroom_or_404, _require_owner_or_admin
 
 router = APIRouter(tags=["teacher"])
@@ -61,12 +62,15 @@ def create_student_instruction(
             detail="Student not found in this classroom",
         )
 
+    # Sanitize instruction content — this text is injected into AI prompts
+    safe_content, _ = sanitize_ai_input(payload.content, user_id=str(current_user.id))
+
     instruction = TeacherInstruction(
         teacher_id=current_user.id,
         student_id=student_id,
         classroom_id=payload.classroom_id,
         instruction_type=payload.instruction_type,
-        content=payload.content,
+        content=safe_content,
     )
     db.add(instruction)
     db.commit()
@@ -195,6 +199,11 @@ def update_instruction(
         )
 
     update_data = payload.model_dump(exclude_unset=True)
+    # Sanitize content field — injected into AI prompts
+    if "content" in update_data and update_data["content"]:
+        update_data["content"], _ = sanitize_ai_input(
+            update_data["content"], user_id=str(current_user.id)
+        )
     for field, value in update_data.items():
         setattr(instruction, field, value)
 

--- a/backend/app/routes/teacher/teacher_story_tags.py
+++ b/backend/app/routes/teacher/teacher_story_tags.py
@@ -8,6 +8,7 @@ from ...auth.dependencies import get_current_user
 from ...database import get_db
 from ...models.story_tag import StoryTag
 from ...models.user import User
+from ...services.input_sanitizer import sanitize_ai_input
 from .teacher_schemas import StoryTagResponse, StoryTagUpsertRequest
 
 router = APIRouter(tags=["teacher"])
@@ -106,7 +107,13 @@ def upsert_story_tag(
     ):
         tag.difficulty_level = body.difficulty_level
     if body.custom_tags is not None:
-        tag.custom_tags = [t.strip() for t in body.custom_tags if t.strip()]
+        sanitized_tags = []
+        for t in body.custom_tags:
+            stripped = t.strip()
+            if stripped:
+                safe_tag, _ = sanitize_ai_input(stripped, user_id=str(current_user.id))
+                sanitized_tags.append(safe_tag)
+        tag.custom_tags = sanitized_tags
 
     db.commit()
     db.refresh(tag)

--- a/backend/app/routes/teacher/teacher_students.py
+++ b/backend/app/routes/teacher/teacher_students.py
@@ -14,6 +14,7 @@ from ...models.session import DialogueTurn, LearningSession
 from ...models.student_tag import StudentTag
 from ...models.user import User
 from ...services.audit_logger import AuditAction, audit_log_endpoint
+from ...services.input_sanitizer import sanitize_ai_input
 from ...services.lesson_loader import get_lesson_by_id
 from ...services.stuck_detection_service import build_recommendations, detect_stuck_points
 from .teacher_schemas import (
@@ -219,6 +220,8 @@ def add_student_tag(
     tag_name = payload.tag_name.strip()
     if not tag_name:
         raise HTTPException(status_code=422, detail="tag_name must not be blank")
+    # Sanitize tag name to prevent injection
+    tag_name, _ = sanitize_ai_input(tag_name, user_id=str(current_user.id))
     if len(tag_name) > 50:
         raise HTTPException(status_code=422, detail="tag_name must be 50 characters or fewer")
 

--- a/backend/app/routes/teacher/teacher_texts.py
+++ b/backend/app/routes/teacher/teacher_texts.py
@@ -9,6 +9,7 @@ from ...auth.dependencies import get_current_user
 from ...database import get_db
 from ...models.text import Text, TextStatus, VisibilityLevel
 from ...models.user import User
+from ...services.input_sanitizer import sanitize_ai_input
 from .teacher_schemas import (
     TeacherTextCreateRequest,
     TeacherTextDetail,
@@ -129,20 +130,27 @@ def create_my_text(
     db: Session = Depends(get_db),
 ):
     """Create a new custom text owned by the authenticated teacher."""
-    full_text = "\n".join(body.paragraphs)
+    # Sanitize teacher-provided text — these are used in AI prompts
+    safe_title, _ = sanitize_ai_input(body.title, user_id=str(current_user.id))
+    safe_paragraphs = []
+    for p in body.paragraphs:
+        safe_p, _ = sanitize_ai_input(p, user_id=str(current_user.id))
+        safe_paragraphs.append(safe_p)
+
+    full_text = "\n".join(safe_paragraphs)
     char_count = len(full_text.replace("\n", "").replace(" ", ""))
     grade_code = _GRADE_CODE_MAP.get(body.grade, f"G{body.grade}")
     category = _GENRE_TO_CATEGORY.get(body.genre, "Daily")
 
     text = Text(
-        title=body.title,
+        title=safe_title,
         grade=body.grade,
         grade_code=grade_code,
         genre=body.genre,
         text_type=body.text_type,
         category=category,
         reading_strategy=body.reading_strategy,
-        paragraphs=body.paragraphs,
+        paragraphs=safe_paragraphs,
         full_text=full_text,
         char_count=char_count,
         vocabulary=body.vocabulary,
@@ -171,7 +179,7 @@ def update_my_text(
     text = _get_text_or_404(text_id, current_user.id, db)
 
     if body.title is not None:
-        text.title = body.title
+        text.title, _ = sanitize_ai_input(body.title, user_id=str(current_user.id))
     if body.grade is not None:
         text.grade = body.grade
         text.grade_code = _GRADE_CODE_MAP.get(body.grade, f"G{body.grade}")
@@ -183,8 +191,12 @@ def update_my_text(
     if body.reading_strategy is not None:
         text.reading_strategy = body.reading_strategy
     if body.paragraphs is not None:
-        text.paragraphs = body.paragraphs
-        full_text = "\n".join(body.paragraphs)
+        safe_paragraphs = []
+        for p in body.paragraphs:
+            safe_p, _ = sanitize_ai_input(p, user_id=str(current_user.id))
+            safe_paragraphs.append(safe_p)
+        text.paragraphs = safe_paragraphs
+        full_text = "\n".join(safe_paragraphs)
         text.full_text = full_text
         text.char_count = len(full_text.replace("\n", "").replace(" ", ""))
     if body.vocabulary is not None:


### PR DESCRIPTION
## Summary
- Adds `sanitize_ai_input()` calls to **16 route files** covering all endpoints that accept user-generated text input
- Previously only 6 service-level calls used the sanitizer out of 178 total endpoints
- High-risk AI-bound endpoints (comprehension chat, sentence validation, reading evaluation, listening retelling) now sanitize text before it reaches Gemini
- Medium-risk stored-text endpoints (assignments, feedback, teacher instructions, classrooms, organizations, schools, admin stories, teacher texts) sanitize to prevent injection payloads from persisting in DB and later flowing into AI contexts

### Endpoints covered by category:
| Category | Files | Endpoints |
|----------|-------|-----------|
| Student AI input | learning_comprehension, learning_comprehension_score, learning_vocab, learning_reading | comprehension chat, sentence validation, listening evaluation, reading evaluation, AI analysis |
| Registration | auth | register (name field) |
| Teacher content | teacher_instructions, teacher_texts, teacher_story_tags, teacher_students | instruction CRUD, custom text CRUD, story tags, student tags |
| Assignment system | assignments | create/update assignment, grade submission feedback |
| Feedback | feedback | submit feedback |
| Classroom mgmt | classroom_crud, classroom_batch | create/update classroom, batch student creation |
| Admin | organizations, schools, admin_stories | org/school/story CRUD |

## Test plan
- [ ] Verify all 16 modified files pass syntax check: `cd backend && python -c "import ast; ast.parse(open('app/main.py').read()); print('OK')"`
- [ ] Test comprehension chat with normal input — should work as before
- [ ] Test comprehension chat with injection attempt (e.g., "ignore all previous instructions") — should be filtered
- [ ] Test teacher text creation with normal Chinese text — should persist correctly
- [ ] Test registration with normal name — should work as before
- [ ] Verify no existing tests break

🤖 Generated with [Claude Code](https://claude.com/claude-code)