### PR TITLE
feat: 閱讀策略練習 Phase 1 — ordering/trait_inference/guided_steps (Fixes #943)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -142,6 +142,7 @@ def get_story(story_id: str):
         reading_benchmark=story["reading_benchmark"],
         text_type=story["text_type"],
         source_file=story["source_file"],
+        strategy_exercise=story.get("strategy_exercise"),
     )
 
 

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -50,6 +50,7 @@ class StoryDetail(StoryListItem):
     reading_benchmark: Optional[ReadingBenchmarkSchema] = None
     text_type: str = "單"
     source_file: Optional[str] = None
+    strategy_exercise: Optional[dict] = None  # 閱讀策略練習 (#943)
 
 
 class StoryListResponse(BaseModel):

--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -81,6 +81,7 @@ def _load_lessons() -> list[dict]:
             "knowledge_video_url": data.get("knowledge_video_url"),
             "reading_benchmark": data.get("reading_benchmark"),
             "source_file": data.get("source_file"),
+            "strategy_exercise": data.get("strategy_exercise"),
             "intro": _build_intro(data),
         }
         lessons.append(lesson)

--- a/backend/data/lessons/L02.yml
+++ b/backend/data/lessons/L02.yml
@@ -117,6 +117,19 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G4-2-L2十秒的背後.docx
 flags: []
+strategy_exercise:
+  type: ordering
+  strategy_name: 順敘法
+  instruction: 順敘法是按照事情的發生順序來講故事。先找到描述時間的詞，再依發生的先後順序排列。
+  items:
+    - text: 楊俊瀚從小學開始練短跑
+      correct_order: 1
+    - text: 在全大運跑出十秒二二破大會紀錄
+      correct_order: 2
+    - text: 二〇一八年亞運一百公尺與金牌擦身而過
+      correct_order: 3
+    - text: 期許自己代表台灣站上奧運舞台
+      correct_order: 4
 story_structure:
 - label: 主角
   value: 楊俊瀚

--- a/backend/data/lessons/L08.yml
+++ b/backend/data/lessons/L08.yml
@@ -120,6 +120,24 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G5-2-L8奧運銀牌的自我鍛鍊.docx
 flags: []
+strategy_exercise:
+  type: trait_inference
+  strategy_name: 推論人物特質
+  instruction: 推論人物特質，我們可以從一個人說的話、做的事來推論。
+  character: 楊勇緯
+  clues:
+    - text: 每天清晨提早三、四十分鐘到校練習
+      source: 做的事
+    - text: 我的目標是金牌！
+      source: 說的話
+    - text: 面對失敗不氣餒，把失敗當成成長養分
+      source: 態度
+  trait_options:
+    - 自律
+    - 勇敢
+    - 固執
+    - 懶散
+  correct_trait: 自律
 story_structure:
 - label: 主角
   value: 楊勇緯

--- a/backend/data/lessons/L16.yml
+++ b/backend/data/lessons/L16.yml
@@ -167,6 +167,28 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-3-L16卡通人氣王票選政見發表會.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 推論文章主旨
+  instruction: 推論文章主旨的方法：摘取文章的大意＋找出關鍵語句。
+  steps:
+    - prompt: 寫出本課大意（用一到兩句話說明課文在講什麼）
+      type: free_text
+    - prompt: 以下文章結尾的句子，哪一句最可能成為關鍵語句？
+      type: select
+      options:
+        - 票選活動進入最後階段，主持人為發表會做總結
+        - 謝謝大家發表了自己的觀點，謝謝大家專心聆聽彼此的意見
+        - 誰會成為第一名的卡通人氣王？我們就投票來決定囉
+      answer: 1
+    - prompt: 下列哪一個選項敘述符合本課主旨？
+      type: select
+      options:
+        - 少數服從多數，最優秀的人就是你自己
+        - 每個人都可以有不同的觀點，我們應該彼此尊重
+        - 只要我喜歡，有什麼不可以
+        - 人可以犯錯，但是不可犯同一個錯
+      answer: 1
 story_structure:
 - label: 主旨
   value: 第一次閱讀課文時，請在不太了解的字、詞或句做記號，如： ？

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -3,10 +3,11 @@
  *
  * 2026-04-03 會議決議：移除 AI 對話 tab，改為左邊課文 + 右邊選擇題的學習單模式
  * AI 功能改為獨立浮動小助手（FloatingAIHelper）
+ * 2026-04-04 (#943): 新增「閱讀策略」第三 tab
  *
  * Layout:
- *   Desktop: left=scrollable lesson text, right=MCQ/structure tabs
- *   Mobile:  tab switcher between story / MCQ / structure
+ *   Desktop: left=scrollable lesson text, right=MCQ/structure/strategy tabs
+ *   Mobile:  tab switcher between story / MCQ / structure / strategy
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Story, ReadingAttempt, ComprehensionResult } from '../../types';
@@ -15,6 +16,7 @@ import { useIsMobile } from '../../hooks/useIsMobile';
 import StoryStructureTable from './StoryStructureTable';
 import MultipleChoiceExercise from './MultipleChoiceExercise';
 import FloatingAIHelper from './FloatingAIHelper';
+import StrategyExercise from './StrategyExercise';
 
 interface ComprehensionChatProps {
   story: Story;
@@ -32,6 +34,7 @@ interface ComprehensionChatProps {
 interface TabCompletion {
   structureVisited: boolean;
   mcqDone: boolean;
+  strategyDone: boolean;
 }
 
 const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
@@ -50,9 +53,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   const loadCompletion = (): TabCompletion => {
     try {
       const raw = localStorage.getItem(completionKey);
-      if (!raw) return { structureVisited: false, mcqDone: false };
-      return { structureVisited: false, mcqDone: false, ...JSON.parse(raw) };
-    } catch { return { structureVisited: false, mcqDone: false }; }
+      if (!raw) return { structureVisited: false, mcqDone: false, strategyDone: false };
+      return { structureVisited: false, mcqDone: false, strategyDone: false, ...JSON.parse(raw) };
+    } catch { return { structureVisited: false, mcqDone: false, strategyDone: false }; }
   };
 
   const persistedTabCompletion = useMemo(() => {
@@ -63,7 +66,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
   const persistedActiveTab = useMemo(() => {
     const raw = initialProgress?.activeTab;
-    return raw === 'story' || raw === 'mcq' || raw === 'structure' ? raw : null;
+    return raw === 'story' || raw === 'mcq' || raw === 'structure' || raw === 'strategy' ? raw : null;
   }, [initialProgress]);
 
   const persistedMcqScore = useMemo(() => {
@@ -84,9 +87,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
   const isMobile = useIsMobile();
   const hasMcq = !!(story.multipleChoice && story.multipleChoice.length > 0);
+  const hasStrategy = !!story.strategyExercise;
 
   // Default to MCQ tab if available, otherwise structure
-  const [activeTab, setActiveTab] = useState<'story' | 'mcq' | 'structure'>(
+  const [activeTab, setActiveTab] = useState<'story' | 'mcq' | 'structure' | 'strategy'>(
     persistedActiveTab ?? (hasMcq ? 'mcq' : 'structure'),
   );
 
@@ -149,7 +153,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   }, [story.content, zhuyinActive, zhuyinProcessLines]);
 
   // Tab change handler
-  const handleTabChange = useCallback((tab: 'story' | 'mcq' | 'structure') => {
+  const handleTabChange = useCallback((tab: 'story' | 'mcq' | 'structure' | 'strategy') => {
     setActiveTab(tab);
     if (tab === 'structure' && !tabCompletion.structureVisited) {
       setTabCompletion(prev => ({ ...prev, structureVisited: true }));
@@ -177,7 +181,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     setMcqTotal(0);
   }, []);
 
+  const handleStrategyComplete = useCallback(() => {
+    setTabCompletion(prev => ({ ...prev, strategyDone: true }));
+  }, []);
+
   // Check if worksheet is complete (MCQ done or no MCQ available)
+  // Strategy tab completion is bonus — doesn't gate the "continue" button
   const isWorksheetComplete = hasMcq ? tabCompletion.mcqDone : tabCompletion.structureVisited;
 
   // Persist progress to DB
@@ -277,6 +286,24 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             <span className="text-emerald-500 text-xs leading-none">✓</span>
           )}
         </button>
+        {hasStrategy && (
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'strategy'}
+            onClick={() => handleTabChange('strategy')}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-semibold transition-all ${
+              activeTab === 'strategy'
+                ? 'bg-white text-accent shadow-sm'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            閱讀策略
+            {tabCompletion.strategyDone && (
+              <span className="text-emerald-500 text-xs leading-none">✓</span>
+            )}
+          </button>
+        )}
       </div>
     </div>
   );
@@ -335,6 +362,22 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 </button>
               </div>
             )}
+          </div>
+        </div>
+      );
+    }
+
+    if (activeTab === 'strategy' && hasStrategy && story.strategyExercise) {
+      return (
+        <div className="flex-shrink-0 bg-white flex flex-col h-full min-h-0" style={{ width: rightPanelWidth }}>
+          <div className="shrink-0 bg-white border-b border-gray-200 flex items-center justify-center gap-2 px-3 py-1.5">
+            <span className="text-xs text-gray-500">閱讀策略練習</span>
+          </div>
+          <div className="flex-1 min-h-0 overflow-y-auto p-4 custom-scrollbar bg-gray-50">
+            <StrategyExercise
+              exercise={story.strategyExercise}
+              onComplete={handleStrategyComplete}
+            />
           </div>
         </div>
       );
@@ -479,6 +522,16 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                   </div>
                 </div>
               )}
+            </div>
+          ) : activeTab === 'strategy' && hasStrategy && story.strategyExercise ? (
+            /* Strategy exercise panel (mobile) */
+            <div className="flex-1 flex flex-col min-h-0">
+              <div className="flex-1 overflow-y-auto p-4 bg-gray-50">
+                <StrategyExercise
+                  exercise={story.strategyExercise}
+                  onComplete={handleStrategyComplete}
+                />
+              </div>
             </div>
           ) : (
             /* MCQ panel */

--- a/frontend/src/components/reading-steps/StrategyExercise.tsx
+++ b/frontend/src/components/reading-steps/StrategyExercise.tsx
@@ -1,0 +1,524 @@
+/**
+ * StrategyExercise — 閱讀策略練習 (#943)
+ *
+ * Renders one of three exercise types based on `exercise.type`:
+ *   - ordering      : drag-and-drop (HTML5 native) to sort items in correct order
+ *   - trait_inference: show clues, pick correct character trait from options
+ *   - guided_steps  : multi-step exercise with free_text and select steps
+ *
+ * Designed to feel like part of the existing worksheet (matches MCQ / StoryStructure UI).
+ */
+import React, { useCallback, useRef, useState } from 'react';
+import { StrategyExercise as StrategyExerciseType, StrategyExerciseOrderingItem } from '../../types';
+
+interface Props {
+  exercise: StrategyExerciseType;
+  onComplete?: () => void;
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────────────
+
+function StrategyHeader({ name, instruction }: { name: string; instruction: string }) {
+  return (
+    <div className="mb-5">
+      <div className="inline-block px-3 py-1 rounded-full bg-violet-100 text-violet-700 text-xs font-semibold mb-3">
+        閱讀策略：{name}
+      </div>
+      <p className="text-sm text-gray-600 leading-relaxed bg-violet-50 rounded-xl px-4 py-3 border border-violet-100">
+        {instruction}
+      </p>
+    </div>
+  );
+}
+
+// ── Ordering Exercise ───────────────────────────────────────────────────────
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+interface OrderingItem extends StrategyExerciseOrderingItem {
+  id: string;
+}
+
+function OrderingExercise({
+  exercise,
+  onComplete,
+}: {
+  exercise: StrategyExerciseType;
+  onComplete?: () => void;
+}) {
+  const items = exercise.items ?? [];
+
+  const [orderedItems, setOrderedItems] = useState<OrderingItem[]>(() =>
+    shuffle(items.map((it, i) => ({ ...it, id: `item-${i}` }))),
+  );
+  const [submitted, setSubmitted] = useState(false);
+  const [isCorrect, setIsCorrect] = useState(false);
+
+  // Drag state
+  const dragIndexRef = useRef<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  const handleDragStart = (e: React.DragEvent, index: number) => {
+    dragIndexRef.current = index;
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverIndex(index);
+  };
+
+  const handleDrop = (e: React.DragEvent, dropIndex: number) => {
+    e.preventDefault();
+    const dragIndex = dragIndexRef.current;
+    if (dragIndex === null || dragIndex === dropIndex) {
+      setDragOverIndex(null);
+      return;
+    }
+    const next = [...orderedItems];
+    const [removed] = next.splice(dragIndex, 1);
+    next.splice(dropIndex, 0, removed);
+    setOrderedItems(next);
+    dragIndexRef.current = null;
+    setDragOverIndex(null);
+  };
+
+  const handleDragEnd = () => {
+    dragIndexRef.current = null;
+    setDragOverIndex(null);
+  };
+
+  const handleSubmit = () => {
+    const correct = orderedItems.every((item, idx) => item.correct_order === idx + 1);
+    setIsCorrect(correct);
+    setSubmitted(true);
+    if (correct) onComplete?.();
+  };
+
+  const handleReset = () => {
+    setOrderedItems(shuffle(items.map((it, i) => ({ ...it, id: `item-${i}` }))));
+    setSubmitted(false);
+    setIsCorrect(false);
+  };
+
+  return (
+    <div>
+      <StrategyHeader name={exercise.strategy_name} instruction={exercise.instruction} />
+
+      <p className="text-xs text-gray-500 mb-3">拖曳下方事件，依照故事發生的先後順序排列：</p>
+
+      <div className="space-y-2 mb-5">
+        {orderedItems.map((item, index) => {
+          const itemCorrect = submitted && item.correct_order === index + 1;
+          const itemWrong = submitted && item.correct_order !== index + 1;
+          return (
+            <div
+              key={item.id}
+              draggable={!submitted}
+              onDragStart={(e) => handleDragStart(e, index)}
+              onDragOver={(e) => handleDragOver(e, index)}
+              onDrop={(e) => handleDrop(e, index)}
+              onDragEnd={handleDragEnd}
+              className={[
+                'flex items-center gap-3 px-4 py-3 rounded-xl border-2 transition-all select-none',
+                submitted
+                  ? itemCorrect
+                    ? 'bg-emerald-50 border-emerald-300'
+                    : itemWrong
+                    ? 'bg-red-50 border-red-300'
+                    : 'bg-gray-50 border-gray-200'
+                  : dragOverIndex === index
+                  ? 'bg-violet-50 border-violet-300 scale-[1.02]'
+                  : 'bg-white border-gray-200 cursor-grab hover:border-violet-200 hover:bg-violet-50/30',
+              ].join(' ')}
+            >
+              <span className="w-6 h-6 flex-shrink-0 rounded-full bg-gray-100 text-gray-500 text-xs font-bold flex items-center justify-center">
+                {index + 1}
+              </span>
+              <span className="flex-1 text-sm text-gray-800">{item.text}</span>
+              {submitted && itemCorrect && (
+                <span className="text-emerald-500 text-base flex-shrink-0">&#10003;</span>
+              )}
+              {submitted && itemWrong && (
+                <span className="text-red-400 text-base flex-shrink-0">&#10007;</span>
+              )}
+              {!submitted && (
+                <span className="text-gray-300 text-lg flex-shrink-0 cursor-grab">&#8801;</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {submitted ? (
+        <div className={`rounded-xl p-4 mb-4 ${isCorrect ? 'bg-emerald-50 border border-emerald-200' : 'bg-amber-50 border border-amber-200'}`}>
+          {isCorrect ? (
+            <p className="text-emerald-700 font-semibold text-sm text-center">
+              你答對了！順序完全正確
+            </p>
+          ) : (
+            <div className="text-center">
+              <p className="text-amber-700 font-semibold text-sm mb-1">順序還不對，再想想看</p>
+              <p className="text-amber-600 text-xs">
+                正確順序：
+                {[...items]
+                  .sort((a, b) => a.correct_order - b.correct_order)
+                  .map((it) => it.text)
+                  .join(' → ')}
+              </p>
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      <div className="flex gap-2">
+        {!submitted && (
+          <button
+            onClick={handleSubmit}
+            className="flex-1 py-2.5 rounded-xl bg-violet-600 hover:bg-violet-500 text-white font-semibold text-sm transition-colors"
+          >
+            送出答案
+          </button>
+        )}
+        {submitted && (
+          <button
+            onClick={handleReset}
+            className="flex-1 py-2.5 rounded-xl bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold text-sm transition-colors"
+          >
+            重新練習
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Trait Inference Exercise ────────────────────────────────────────────────
+
+function TraitInferenceExercise({
+  exercise,
+  onComplete,
+}: {
+  exercise: StrategyExerciseType;
+  onComplete?: () => void;
+}) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const correct = exercise.correct_trait ?? '';
+
+  const handleSelect = (trait: string) => {
+    if (submitted) return;
+    setSelected(trait);
+  };
+
+  const handleSubmit = () => {
+    if (!selected) return;
+    setSubmitted(true);
+    if (selected === correct) onComplete?.();
+  };
+
+  const handleReset = () => {
+    setSelected(null);
+    setSubmitted(false);
+  };
+
+  return (
+    <div>
+      <StrategyHeader name={exercise.strategy_name} instruction={exercise.instruction} />
+
+      <p className="text-sm font-semibold text-gray-700 mb-3">
+        根據下列線索，推論{exercise.character}的人物特質：
+      </p>
+
+      <div className="space-y-2 mb-5">
+        {(exercise.clues ?? []).map((clue, idx) => (
+          <div key={idx} className="flex gap-3 bg-white rounded-xl border border-gray-200 px-4 py-3">
+            <span className="flex-shrink-0 px-2 py-0.5 rounded-md bg-blue-100 text-blue-700 text-xs font-semibold">
+              {clue.source}
+            </span>
+            <span className="text-sm text-gray-800">{clue.text}</span>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-gray-500 mb-2">選出最符合的人物特質：</p>
+      <div className="grid grid-cols-2 gap-2 mb-5">
+        {(exercise.trait_options ?? []).map((trait) => {
+          const isSelected = selected === trait;
+          const isCorrectOption = submitted && trait === correct;
+          const isWrongSelected = submitted && isSelected && trait !== correct;
+          return (
+            <button
+              key={trait}
+              onClick={() => handleSelect(trait)}
+              className={[
+                'py-3 rounded-xl border-2 text-sm font-semibold transition-all',
+                isCorrectOption
+                  ? 'bg-emerald-50 border-emerald-400 text-emerald-700'
+                  : isWrongSelected
+                  ? 'bg-red-50 border-red-300 text-red-600'
+                  : isSelected
+                  ? 'bg-violet-50 border-violet-400 text-violet-700'
+                  : 'bg-white border-gray-200 text-gray-700 hover:border-violet-300 hover:bg-violet-50/30',
+              ].join(' ')}
+            >
+              {trait}
+              {isCorrectOption && <span className="ml-1">&#10003;</span>}
+              {isWrongSelected && <span className="ml-1">&#10007;</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      {submitted && (
+        <div className={`rounded-xl p-4 mb-4 ${selected === correct ? 'bg-emerald-50 border border-emerald-200' : 'bg-amber-50 border border-amber-200'}`}>
+          {selected === correct ? (
+            <p className="text-emerald-700 font-semibold text-sm text-center">
+              你答對了！{exercise.character}的特質是「{correct}」
+            </p>
+          ) : (
+            <p className="text-amber-700 font-semibold text-sm text-center">
+              還不對喔！正確答案是「{correct}」，可以再看看線索
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        {!submitted && (
+          <button
+            onClick={handleSubmit}
+            disabled={!selected}
+            className="flex-1 py-2.5 rounded-xl bg-violet-600 hover:bg-violet-500 disabled:bg-gray-200 disabled:text-gray-400 text-white font-semibold text-sm transition-colors"
+          >
+            送出答案
+          </button>
+        )}
+        {submitted && (
+          <button
+            onClick={handleReset}
+            className="flex-1 py-2.5 rounded-xl bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold text-sm transition-colors"
+          >
+            重新練習
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Guided Steps Exercise ───────────────────────────────────────────────────
+
+function GuidedStepsExercise({
+  exercise,
+  onComplete,
+}: {
+  exercise: StrategyExerciseType;
+  onComplete?: () => void;
+}) {
+  const steps = exercise.steps ?? [];
+  const [answers, setAnswers] = useState<(string | number | null)[]>(
+    () => steps.map(() => null),
+  );
+  const [stepFeedback, setStepFeedback] = useState<(boolean | null)[]>(
+    () => steps.map(() => null),
+  );
+  const [allDone, setAllDone] = useState(false);
+
+  const handleTextChange = (stepIdx: number, value: string) => {
+    if (stepFeedback[stepIdx] !== null) return;
+    setAnswers((prev) => prev.map((a, i) => (i === stepIdx ? value : a)));
+  };
+
+  const handleSelect = (stepIdx: number, optionIdx: number) => {
+    if (stepFeedback[stepIdx] !== null) return;
+    setAnswers((prev) => prev.map((a, i) => (i === stepIdx ? optionIdx : a)));
+  };
+
+  const handleStepSubmit = (stepIdx: number) => {
+    const step = steps[stepIdx];
+    const answer = answers[stepIdx];
+    if (step.type === 'free_text') {
+      if (!answer || String(answer).trim() === '') return;
+      setStepFeedback((prev) => prev.map((f, i) => (i === stepIdx ? true : f)));
+    } else if (step.type === 'select') {
+      if (answer === null) return;
+      const isCorrect = answer === (step.answer ?? 0);
+      setStepFeedback((prev) => prev.map((f, i) => (i === stepIdx ? isCorrect : f)));
+    }
+
+    // Check if all steps done
+    const nextFeedback = stepFeedback.map((f, i) => {
+      if (i === stepIdx) {
+        const step = steps[stepIdx];
+        if (step.type === 'free_text') return true;
+        return answers[stepIdx] === (step.answer ?? 0);
+      }
+      return f;
+    });
+    if (nextFeedback.every((f) => f !== null)) {
+      setAllDone(true);
+      if (nextFeedback.every((f) => f === true)) onComplete?.();
+    }
+  };
+
+  const handleReset = () => {
+    setAnswers(steps.map(() => null));
+    setStepFeedback(steps.map(() => null));
+    setAllDone(false);
+  };
+
+  return (
+    <div>
+      <StrategyHeader name={exercise.strategy_name} instruction={exercise.instruction} />
+
+      <div className="space-y-6">
+        {steps.map((step, stepIdx) => {
+          const feedback = stepFeedback[stepIdx];
+          const isDone = feedback !== null;
+          return (
+            <div key={stepIdx} className="rounded-xl border border-gray-200 bg-white p-4">
+              <div className="flex items-start gap-2 mb-3">
+                <span className="flex-shrink-0 w-6 h-6 rounded-full bg-violet-100 text-violet-700 text-xs font-bold flex items-center justify-center mt-0.5">
+                  {stepIdx + 1}
+                </span>
+                <p className="text-sm font-medium text-gray-700">{step.prompt}</p>
+              </div>
+
+              {step.type === 'free_text' ? (
+                <div>
+                  <textarea
+                    value={String(answers[stepIdx] ?? '')}
+                    onChange={(e) => handleTextChange(stepIdx, e.target.value)}
+                    disabled={isDone}
+                    rows={3}
+                    placeholder="請在此寫下你的答案..."
+                    className={[
+                      'w-full resize-none rounded-lg border px-3 py-2 text-sm outline-none transition-colors',
+                      isDone
+                        ? 'bg-gray-50 border-gray-200 text-gray-500'
+                        : 'bg-white border-gray-300 focus:border-violet-400 focus:ring-2 focus:ring-violet-100',
+                    ].join(' ')}
+                  />
+                  {isDone && (
+                    <p className="mt-2 text-xs text-emerald-600 font-semibold">
+                      &#10003; 已記錄你的答案
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {(step.options ?? []).map((option, optIdx) => {
+                    const isSelected = answers[stepIdx] === optIdx;
+                    const isCorrectOpt = isDone && optIdx === (step.answer ?? 0);
+                    const isWrongSelected = isDone && isSelected && optIdx !== (step.answer ?? 0);
+                    return (
+                      <button
+                        key={optIdx}
+                        onClick={() => handleSelect(stepIdx, optIdx)}
+                        className={[
+                          'w-full text-left px-4 py-2.5 rounded-lg border-2 text-sm transition-all',
+                          isCorrectOpt
+                            ? 'bg-emerald-50 border-emerald-400 text-emerald-700 font-semibold'
+                            : isWrongSelected
+                            ? 'bg-red-50 border-red-300 text-red-600'
+                            : isSelected
+                            ? 'bg-violet-50 border-violet-400 text-violet-700'
+                            : 'bg-white border-gray-200 text-gray-700 hover:border-violet-200',
+                        ].join(' ')}
+                      >
+                        <span className="font-semibold mr-2">
+                          {String.fromCharCode(65 + optIdx)}.
+                        </span>
+                        {option}
+                        {isCorrectOpt && <span className="ml-2 text-emerald-500">&#10003;</span>}
+                        {isWrongSelected && <span className="ml-2 text-red-400">&#10007;</span>}
+                      </button>
+                    );
+                  })}
+                  {isDone && feedback !== null && (
+                    <p className={`mt-1 text-xs font-semibold ${feedback ? 'text-emerald-600' : 'text-amber-600'}`}>
+                      {feedback
+                        ? <>{'\u2713'} 答對了！</>
+                        : `還不對，正確答案是 ${String.fromCharCode(65 + (step.answer ?? 0))}`}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              {!isDone && (
+                <div className="mt-3 flex justify-end">
+                  <button
+                    onClick={() => handleStepSubmit(stepIdx)}
+                    disabled={
+                      step.type === 'free_text'
+                        ? !String(answers[stepIdx] ?? '').trim()
+                        : answers[stepIdx] === null
+                    }
+                    className="px-4 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 disabled:bg-gray-200 disabled:text-gray-400 text-white text-xs font-semibold transition-colors"
+                  >
+                    確認
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {allDone && (
+        <div className="mt-4 rounded-xl p-4 bg-emerald-50 border border-emerald-200">
+          <p className="text-emerald-700 font-semibold text-sm text-center">
+            全部步驟完成！
+          </p>
+        </div>
+      )}
+
+      {allDone && (
+        <div className="mt-3 flex gap-2">
+          <button
+            onClick={handleReset}
+            className="flex-1 py-2.5 rounded-xl bg-gray-100 hover:bg-gray-200 text-gray-600 font-semibold text-sm transition-colors"
+          >
+            重新練習
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Main Component ──────────────────────────────────────────────────────────
+
+const StrategyExercise: React.FC<Props> = ({ exercise, onComplete }) => {
+  const handleComplete = useCallback(() => {
+    onComplete?.();
+  }, [onComplete]);
+
+  if (exercise.type === 'ordering') {
+    return <OrderingExercise exercise={exercise} onComplete={handleComplete} />;
+  }
+  if (exercise.type === 'trait_inference') {
+    return <TraitInferenceExercise exercise={exercise} onComplete={handleComplete} />;
+  }
+  if (exercise.type === 'guided_steps') {
+    return <GuidedStepsExercise exercise={exercise} onComplete={handleComplete} />;
+  }
+
+  return (
+    <div className="p-4 text-gray-400 text-sm text-center">
+      不支援的練習類型：{exercise.type}
+    </div>
+  );
+};
+
+export default StrategyExercise;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -60,6 +60,8 @@ interface ApiStoryDetail extends ApiStoryListItem {
   reading_benchmark: { levels: { threshold: string; feedback: string }[] } | null;
   text_type: string;
   source_file: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  strategy_exercise: Record<string, any> | null;
 }
 
 interface ApiStoryListResponse {
@@ -105,6 +107,7 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     multipleChoice: detail.multiple_choice ?? undefined,
     vocabBank: detail.vocab_bank ?? undefined,
     knowledgeVideoUrl: detail.knowledge_video_url ?? undefined,
+    strategyExercise: detail.strategy_exercise ?? undefined,
   };
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -56,6 +56,39 @@ export interface MultipleChoiceItem {
   explanation: string | null;
 }
 
+// 閱讀策略練習 (#943)
+export interface StrategyExerciseOrderingItem {
+  text: string;
+  correct_order: number;
+}
+
+export interface StrategyExerciseClue {
+  text: string;
+  source: string;
+}
+
+export interface StrategyExerciseStep {
+  prompt: string;
+  type: 'free_text' | 'select';
+  options?: string[];
+  answer?: number; // 0-indexed
+}
+
+export interface StrategyExercise {
+  type: 'ordering' | 'trait_inference' | 'guided_steps';
+  strategy_name: string;
+  instruction: string;
+  // ordering
+  items?: StrategyExerciseOrderingItem[];
+  // trait_inference
+  character?: string;
+  clues?: StrategyExerciseClue[];
+  trait_options?: string[];
+  correct_trait?: string;
+  // guided_steps
+  steps?: StrategyExerciseStep[];
+}
+
 export interface Story {
   id: string;
   title: string;
@@ -80,6 +113,7 @@ export interface Story {
   multipleChoice?: MultipleChoiceItem[];     // ⑦ 閱讀理解選擇題（PDF 現成資料）
   vocabBank?: Record<string, string>;        // { A: "疑難雜症", ... } for fillInBlank
   knowledgeVideoUrl?: string;               // ⑨ 知識補給站 YouTube URL
+  strategyExercise?: StrategyExercise;      // 閱讀策略練習 (#943)
 }
 
 export interface ReadingAttempt {


### PR DESCRIPTION
Fixes #943

## Summary

- Added `strategy_exercise` YAML data to 3 sample lessons:
  - L02 (`ordering` type): 順敘法 — drag-and-drop to sort 4 events in chronological order
  - L08 (`trait_inference` type): 推論人物特質 — view clues then pick the correct trait
  - L16 (`guided_steps` type): 推論文章主旨 — 3-step guided exercise (free_text + select)
- Backend: exposed `strategy_exercise` field through lesson_loader, schema, and stories route
- Frontend types: added `StrategyExercise` and related interfaces to `types.ts`
- Frontend api: mapped `strategy_exercise` in `apiDetailToStory`
- New component: `StrategyExercise.tsx` — renders all 3 exercise types with feedback
- `ComprehensionChat.tsx`: added third tab **閱讀策略** (shown only when data exists), both desktop and mobile

## Exercise types

| Type | Interaction | Feedback |
|------|------------|---------|
| `ordering` | HTML5 native drag-and-drop | green/red per item + correct order shown |
| `trait_inference` | Radio-style buttons | correct/wrong highlight + answer reveal |
| `guided_steps` | textarea + radio per step | per-step confirm, final completion state |

## Test plan

- [ ] Open lesson 2 (十秒的背後) — ComprehensionChat shows 3 tabs including **閱讀策略**
- [ ] Drag-drop ordering items, submit, verify green/red feedback
- [ ] Open lesson 8 (奧運銀牌的自我鍛鍊) — trait_inference tab renders clues + options
- [ ] Select correct trait "自律" → shows correct feedback
- [ ] Open lesson 16 (卡通人氣王) — guided_steps tab renders step 1 textarea + steps 2/3 select
- [ ] Open any other lesson — **閱讀策略** tab should NOT appear (no strategy_exercise data)
- [ ] Verify `npm run build` passes — ✅ confirmed locally
- [ ] Mobile: tab bar includes 閱讀策略 for L02/L08/L16

🤖 Generated with [Claude Code](https://claude.com/claude-code)