### PR TITLE
fix: rename duplicate Alembic revision ID blocking staging deploy

### DIFF
--- a/backend/alembic/versions/fk01idx02add03_add_missing_fk_indexes.py
+++ b/backend/alembic/versions/fk01idx02add03_add_missing_fk_indexes.py
@@ -1,6 +1,6 @@
 """add missing fk indexes
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: fk01idx02add03
 Revises: z6a7b8c9d0e1
 Create Date: 2026-04-04 00:00:00.000000
 
@@ -12,7 +12,7 @@ CREATE INDEX (no CONCURRENTLY needed for Alembic — migrations run offline).
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "a1b2c3d4e5f6"
+revision = "fk01idx02add03"
 down_revision = "z6a7b8c9d0e1"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- Two migration files shared the same revision ID `a1b2c3d4e5f6` (unified_user_model + add_missing_fk_indexes), causing `alembic upgrade head` to fail with "Multiple head revisions"
- Renamed FK indexes migration to use unique revision ID `fk01idx02add03`
- Verified `alembic heads` shows exactly 1 head and the chain is linear

## Test plan
- [ ] `cd backend && python3 -m alembic heads` returns exactly 1 head (`fk01idx02add03`)
- [ ] `cd backend && python3 -m alembic history` shows linear chain with no branches
- [ ] Staging backend container starts without crash after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)