### PR TITLE
Release: 閱讀策略練習全量資料 + cleanup workflow

### DIFF
--- a/backend/data/lessons/L03.yml
+++ b/backend/data/lessons/L03.yml
@@ -117,6 +117,29 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G4-3-L3長高的祕密.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 遞進複句
+  instruction: 遞進複句是後面的意思比前面更進一步，常用「不但……而且……」「不只……更……」「不僅……還……」等連接詞。請找出課文中的遞進關係
+  steps:
+    - prompt: 課文第四段提到運動太過激烈的後果，使用了哪一組遞進連接詞？
+      type: select
+      options:
+        - 因為……所以……
+        - 不只……更……
+        - 雖然……但是……
+      answer: 1
+    - prompt: 「運動若是太過激烈，不只容易造成運動傷害，更無法達到促進生長的效果」這句話中，哪個部分是「更進一步」的意思？
+      type: select
+      options:
+        - 容易造成運動傷害
+        - 無法達到促進生長的效果
+        - 運動若是太過激烈
+      answer: 1
+    - prompt: 課文第五段提到亂吃的後果：「不但會讓體重過重，反而不會長高」，請用「不只……更……」改寫這句話
+      type: free_text
+    - prompt: 請用「不但……而且……」造一個和長高有關的遞進複句
+      type: free_text
 story_structure:
 - label: 主題
   value: 長高的祕密

--- a/backend/data/lessons/L04.yml
+++ b/backend/data/lessons/L04.yml
@@ -126,6 +126,29 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G4-4-L4運動科學.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 條件複句
+  instruction: 條件複句是用「如果……就……」「只要……就……」「除非……否則……」等連接詞，表示在某個條件下會有某個結果。請從課文中找出條件關係
+  steps:
+    - prompt: 課文第二段提到有氧運動和肌肉訓練的關係，哪一句話包含條件關係？
+      type: select
+      options:
+        - 這四種運動方式是相互衝突的
+        - 把肌肉鍛鍊跟有氧運動的時間分開，才會達到較好的訓練效果
+        - 仰臥起坐對腰部容易造成很大的壓力
+      answer: 1
+    - prompt: 「把肌肉鍛鍊跟有氧運動的時間分開，才會達到較好的訓練效果」，這句話的「條件」是什麼？
+      type: select
+      options:
+        - 達到較好的訓練效果
+        - 把肌肉鍛鍊跟有氧運動的時間分開
+        - 這四種運動方式相互衝突
+      answer: 1
+    - prompt: 課文最後一段說運動科學的目標是讓每個人都有機會參與，請用「只要……就……」寫一個和運動科學有關的條件複句
+      type: free_text
+    - prompt: 請用「如果……就……」寫一個和運動訓練有關的條件複句
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L05.yml
+++ b/backend/data/lessons/L05.yml
@@ -117,6 +117,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G4-5-L5穿越極限的跑者.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 推論指稱詞
+  instruction: 指稱詞（代名詞）是用來代替前面提過的人或事物的詞，例如「他」「她」「它」「這」「那」。讀文章時要找出指稱詞代替的是誰或什麼事
+  steps:
+    - prompt: 第一段「他跑過沙漠、高山和冰原」，這裡的「他」指的是誰？
+      type: select
+      options:
+        - 林義傑
+        - 陳彥博
+        - 劉柏園
+      answer: 1
+    - prompt: 第二段「這場比賽帶給他的感動無可言喻，也是他跨入極地賽的夢想起點」，「這場比賽」指的是哪場比賽？
+      type: select
+      options:
+        - 四大極地超級馬拉松巡迴賽
+        - 磁北極六百五十公里極限馬拉松
+        - 世界七大洲超級馬拉松
+      answer: 1
+    - prompt: 第五段「如果上天給了他再活一次的機會，怎麼能夠不痛快淋漓的享受它？」這裡的「它」指的是什麼？
+      type: select
+      options:
+        - 上天給的機會
+        - 跑步這件事
+        - 極地馬拉松比賽
+      answer: 1
+    - prompt: 第三段提到「遇到一段意外的插曲」，這個「插曲」指的是什麼事？請用自己的話說明
+      type: free_text
 story_structure:
 - label: 主角
   value: 陳彥博

--- a/backend/data/lessons/L06.yml
+++ b/backend/data/lessons/L06.yml
@@ -124,6 +124,29 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G4-6-L6第一百碗麵.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 換位思考
+  instruction: 換位思考是站在別人的角度看事情，了解對方的感受。我們可以用三個步驟來學習：1. 觀察對方的處境 2. 想想對方的感受 3. 思考怎麼做對對方最好
+  steps:
+    - prompt: 老闆說老人是「第一百個客人」，他真正的用意是什麼？
+      type: select
+      options:
+        - 店裡真的有這個促銷活動
+        - 想免費請老人吃麵，又不傷害老人的自尊心
+        - 想吸引更多客人來吃麵
+      answer: 1
+    - prompt: 寒流那天，老闆打電話請朋友來吃麵，他站在誰的角度在思考？
+      type: select
+      options:
+        - 站在自己賺錢的角度
+        - 站在小男孩想請阿公吃麵的角度
+        - 站在朋友想吃免費麵的角度
+      answer: 1
+    - prompt: 小男孩最後說「我很飽，飽的像蜘蛛一樣」，他是學誰的做法？這代表他學會了什麼？
+      type: free_text
+    - prompt: 如果你是故事中的老闆娘，你會怎麼幫助這對祖孫？請站在他們的角度想一想
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L07.yml
+++ b/backend/data/lessons/L07.yml
@@ -142,6 +142,21 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G5-1-L7黑猩猩的守護者.docx
 flags: []
+strategy_exercise:
+  type: ordering
+  strategy_name: 記敘文結構－故事體
+  instruction: 故事體的記敘文會按照時間順序描述事件的發展。請把珍古德的故事依照發生的先後順序排列
+  items:
+    - text: 珍古德小時候閱讀《杜立德醫生非洲歷險記》，夢想去非洲探險
+      correct_order: 1
+    - text: 二十三歲時從英國前往非洲，在博物館找到工作
+      correct_order: 2
+    - text: 前往岡貝研究黑猩猩，初期被黑猩猩拒於千里之外
+      correct_order: 3
+    - text: 經過長時間的耐心等待，黑猩猩終於卸下心防接受她
+      correct_order: 4
+    - text: 成立國際珍古德協會，推動環境教育和野生動物保育
+      correct_order: 5
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L09.yml
+++ b/backend/data/lessons/L09.yml
@@ -121,6 +121,26 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G5-3-L9周天成的一天-頂尖選手的養成.docx
 flags: []
+strategy_exercise:
+  type: trait_inference
+  strategy_name: 推論人物特質
+  instruction: 推論人物特質，我們可以從一個人說的話、做的事、態度來推論他是什麼樣的人
+  character: 周天成
+  clues:
+    - text: 日復一日進行基本訓練，完成羽球訓練後直奔健身房繼續重量訓練
+      source: 做的事
+    - text: 連吃飯都是有設計、有紀律的，每口慢慢咀嚼
+      source: 做的事
+    - text: 每當我驕傲起來，就無法在場上打出好表現
+      source: 說的話
+    - text: 哪怕只有百分之一的進步機會，他都會去嘗試
+      source: 態度
+  trait_options:
+    - 自律
+    - 聰明
+    - 隨性
+    - 驕傲
+  correct_trait: 自律
 story_structure:
 - label: 主角
   value: 周天成

--- a/backend/data/lessons/L10.yml
+++ b/backend/data/lessons/L10.yml
@@ -143,6 +143,26 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G5-4-L10從童工到大學教授之路.docx
 flags: []
+strategy_exercise:
+  type: trait_inference
+  strategy_name: 推論人物特質
+  instruction: 推論人物特質，我們可以從一個人說的話、做的事、態度來推論他是什麼樣的人
+  character: 小花
+  clues:
+    - text: 大學聯考落榜後，跟媽媽爭取再給自己一次機會，靠著教育翻身
+      source: 做的事
+    - text: 為了要活下去，我必須要有策略
+      source: 說的話
+    - text: 在很短的時間就成了業績第一名的工讀生
+      source: 做的事
+    - text: 格外珍惜得來不易的大學教育機會，畢業後繼續念碩士和博士
+      source: 態度
+  trait_options:
+    - 堅毅不屈
+    - 膽小害怕
+    - 隨遇而安
+    - 好高騖遠
+  correct_trait: 堅毅不屈
 story_structure:
 - label: 主角
   value: 世界充滿愛

--- a/backend/data/lessons/L11.yml
+++ b/backend/data/lessons/L11.yml
@@ -134,6 +134,26 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G5-5-L11拳力出擊-陳念琴.docx
 flags: []
+strategy_exercise:
+  type: trait_inference
+  strategy_name: 推論人物特質
+  instruction: 推論人物特質，我們可以從一個人說的話、做的事、態度來推論他是什麼樣的人
+  character: 陳念琴
+  clues:
+    - text: 每天和男生對練，想辦法讓自己輸得不那麼難看，一點一滴掌握對打技巧
+      source: 做的事
+    - text: 在苦難或強大的壓力下，要讓自己的心平靜下來，才有能力尋求方法解決問題
+      source: 說的話
+    - text: 罹患淋巴癌後，一邊備戰奧運一邊接受化學治療
+      source: 做的事
+    - text: 為了夢想我願意忍耐，在追求成功的過程中，再苦再累我都要咬牙撐過
+      source: 說的話
+  trait_options:
+    - 堅韌不拔
+    - 好勝心強
+    - 膽小退縮
+    - 隨波逐流
+  correct_trait: 堅韌不拔
 story_structure:
 - label: 主角
   value: 陳念琴

--- a/backend/data/lessons/L12.yml
+++ b/backend/data/lessons/L12.yml
@@ -122,6 +122,38 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G5-6-L12我有一個棒球夢.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 時間管理
+  instruction: 時間管理有四個步驟：1.計畫 2.設定優先順序 3.合理安排 4.保持彈性。請根據課文內容練習這四個步驟
+  steps:
+    - prompt: 根據課文，學生棒球員面臨的最大困難是什麼？
+      type: select
+      options:
+        - 訓練太辛苦，身體受不了
+        - 學業與棒球訓練難以兼顧
+        - 教練太嚴格，壓力很大
+      answer: 1
+    - prompt: 花蓮三民國中用了哪些方法幫助球員擠出讀書時間？（可複選）
+      type: checkbox
+      options:
+        - 增加宿舍淋浴間及洗衣機
+        - 取消棒球訓練
+        - 要求學業成績達標才能出賽
+        - 減少上課時間
+      answer:
+        - 0
+        - 2
+    - prompt: 如果你是一位學生棒球員，每天放學後有4小時的自由時間，你會怎麼安排「練球」和「讀書」的優先順序？請說明理由
+      type: free_text
+    - prompt: 課文提到「愛接棒計畫」提供夜間課輔，這屬於時間管理四步驟中的哪一步？
+      type: select
+      options:
+        - 計畫
+        - 設定優先順序
+        - 合理安排
+        - 保持彈性
+      answer: 2
 story_structure:
 - label: 結論
   value: 力

--- a/backend/data/lessons/L13.yml
+++ b/backend/data/lessons/L13.yml
@@ -129,6 +129,33 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G5-7-L13六塊肌六塊雞.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 說明文文章結構
+  instruction: 說明文常用「主題＋描述」的結構，先提出主題，再用事實、例子、數據來說明。請找出本課的主題和描述
+  steps:
+    - prompt: 本課的主題是什麼？
+      type: select
+      options:
+        - 雷神索爾的健身方法
+        - 減脂增肌的基本原則
+        - 各種肌肉的名稱
+      answer: 1
+    - prompt: 課文用了哪三個重點來描述（說明）減脂增肌的方法？
+      type: checkbox
+      options:
+        - 均衡的飲食控制
+        - 保持良好的睡眠
+        - 專業且規律的訓練
+        - 吃營養補充品
+      answer:
+        - 0
+        - 1
+        - 2
+    - prompt: 第三段用了哪些「例子」來說明不同訓練方式會增強不同肌肉？請舉出兩組
+      type: free_text
+    - prompt: 第四段提到新手容易犯的錯誤是什麼？作者用這個例子想說明什麼道理？
+      type: free_text
 story_structure:
 - label: 主題
   value: 小主題

--- a/backend/data/lessons/L14.yml
+++ b/backend/data/lessons/L14.yml
@@ -138,6 +138,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-1-L14運動傷害，怎麼辦.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 倒反法
+  instruction: 倒反法是說反話的修辭技巧，表面上說的和心裡想的相反，常用來表達幽默或諷刺。使用倒反法時，要注意對象和場合
+  steps:
+    - prompt: 詹老師說皓祥的腳「雙喜臨門」，這句話是什麼意思？
+      type: select
+      options:
+        - 皓祥有兩件好事發生
+        - 皓祥同時腳踝扭傷又小腿抽筋，用反話來幽默化解緊張
+        - 皓祥贏了比賽又進了球
+      answer: 1
+    - prompt: 詹老師說皓祥「這樣的好運，很少見啊」，這裡的「好運」真正的意思是什麼？
+      type: select
+      options:
+        - 皓祥真的很幸運
+        - 皓祥很倒楣，同時扭傷又抽筋
+        - 皓祥的運氣一直都很好
+      answer: 1
+    - prompt: 為什麼詹老師可以對皓祥使用倒反法，卻不會讓皓祥不開心？
+      type: select
+      options:
+        - 因為皓祥聽不懂反話
+        - 因為他們關係親近，像亦師亦友
+        - 因為倒反法對任何人都可以使用
+      answer: 1
+    - prompt: 請你也用倒反法寫一句話，描述一個同學在體育課跌倒的情境（要有趣但不傷人）
+      type: free_text
 story_structure:
 - label: 主題
   value: 運動傷害的處理與預防

--- a/backend/data/lessons/L15.yml
+++ b/backend/data/lessons/L15.yml
@@ -127,6 +127,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-2-L15兩千五百歲的酷老師.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 推論文章主旨
+  instruction: 推論文章主旨的方法：先摘取文章大意，再從標題和首末段找出關鍵語句，最後歸納主旨
+  steps:
+    - prompt: 從標題「兩千五百歲的酷老師」，你覺得文章要介紹的主角是誰？
+      type: select
+      options:
+        - 一位很老的老師
+        - 孔子
+        - 阿里山神木
+      answer: 1
+    - prompt: 文章最後一段提到哪一本書記錄了孔子的言行？
+      type: select
+      options:
+        - 杜立德醫生非洲歷險記
+        - 論語
+        - 經書
+      answer: 1
+    - prompt: 以下哪一句話最能代表本課的主旨？
+      type: select
+      options:
+        - 孔子很會唱歌、射箭和駕車
+        - 孔子是博學有智慧、有教無類、因材施教，為理想奉獻一生的老師
+        - 宰予上課睡覺被孔子罵了
+      answer: 1
+    - prompt: 課文用了哪些事例來說明孔子是「酷老師」？請舉出兩個例子
+      type: free_text
 story_structure:
 - label: 主角
   value: 孔子

--- a/backend/data/lessons/L17.yml
+++ b/backend/data/lessons/L17.yml
@@ -202,6 +202,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-4-L17心理出狀況，是壞事導致的嗎?.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 推論段落主旨
+  instruction: 推論段落主旨的方法：先找出每個段落的大意，再找出關鍵語句，歸納出段落想表達的重點
+  steps:
+    - prompt: 故事一中，阿堅和小芸來自同一個家庭，但結果不同。這個段落的主旨是什麼？
+      type: select
+      options:
+        - 失能的家庭一定會害了孩子
+        - 同樣的環境，不同的想法會帶來不同的結果
+        - 姊姊比較聰明所以比較成功
+      answer: 1
+    - prompt: 故事二中，鄧小姐聽了名醫的話之後就不憂鬱了。她的「事實」改變了嗎？
+      type: select
+      options:
+        - 改變了，她不用再吃藥
+        - 沒有改變，但她改變了對這件事的看法
+        - 改變了，她的血壓恢復正常
+      answer: 1
+    - prompt: 故事三中，黃美廉在黑板上寫了很多她擁有的東西。她想表達的是什麼？
+      type: select
+      options:
+        - 她的生活比別人好
+        - 她擁有很多，不應該只看她沒有的
+        - 她最喜歡的是她的貓
+      answer: 1
+    - prompt: 最後一段的關鍵語句是「改變自己對壞事的看法」，請用自己的話解釋這三個故事的共同主旨
+      type: free_text
 story_structure:
 - label: 主角
   value: 心理

--- a/backend/data/lessons/L18.yml
+++ b/backend/data/lessons/L18.yml
@@ -148,6 +148,37 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-5-L18動物談情說愛的方式.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 說明文結構－找出舉例與細節
+  instruction: 說明文常常會用「主題＋舉例」的方式來說明，每個小主題底下會有動物的例子和細節來支持。讓我們一起來找出課文中的舉例和細節吧！
+  steps:
+    - prompt: 課文介紹了哪些動物求偶的方式？請選出正確的分類
+      type: select
+      options:
+        - 用歌聲、用舞姿、用氣味、用武力展示
+        - 用歌聲、用顏色、用氣味、用速度
+        - 用歌聲、用舞姿、用築巢、用武力展示
+      answer: 0
+    - prompt: 在「用歌聲求偶」這個小主題下，課文舉了哪些動物的例子？
+      type: checkbox
+      options:
+        - 雄蛙
+        - 五色鳥
+        - 海馬
+        - 鴕鳥
+      answer:
+        - 0
+        - 1
+    - prompt: 海馬的求偶細節是什麼？
+      type: select
+      options:
+        - 用歌聲吸引仰慕者
+        - 以忽明忽暗的體色和曼妙的舞姿吸引仰慕者
+        - 快速揮動大螯，展示武力
+      answer: 1
+    - prompt: 課文最後一段總結了什麼？用自己的話寫下來
+      type: free_text
 story_structure:
 - label: 主題
   value: 本段的小標題也是：用歌聲求偶。

--- a/backend/data/lessons/L19.yml
+++ b/backend/data/lessons/L19.yml
@@ -136,6 +136,46 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-6-L19祝你好眠.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 說明文結構－找小主題
+  instruction: 說明文的每一段通常都有一個「小主題」，也就是那段最重要的重點。我們可以直接從段落中找到核心概念，當作小主題的名稱。一起來練習找出每段的小主題吧！
+  steps:
+    - prompt: 第三段提到「睡眠與健康的關係密切」，這段的小主題最適合叫什麼？
+      type: select
+      options:
+        - 阿勝的煩惱
+        - 睡眠時間的建議
+        - 睡眠不足的原因
+      answer: 1
+    - prompt: 第四段提到大腦在睡眠時會修補肌肉、清除代謝物，這段的小主題最適合叫什麼？
+      type: select
+      options:
+        - 睡眠對健康的好處
+        - 大腦的構造
+        - 疾病的種類
+      answer: 0
+    - prompt: 第五段提到大腦在睡眠中會進行記憶的重整，這段的小主題最適合叫什麼？
+      type: select
+      options:
+        - 古人讀書的方法
+        - 睡眠幫助學習與記憶
+        - 懸樑刺股的故事
+      answer: 1
+    - prompt: 第六段提到「平日熬夜沒關係，假日補眠」和「睡前喝酒能幫助入眠」，這段的小主題最適合叫什麼？
+      type: select
+      options:
+        - 關於睡眠的錯誤觀念
+        - 生理時鐘的發明
+        - 喝酒的壞處
+      answer: 0
+    - prompt: 第七段提到3C產品讓人捨不得睡覺，這段的小主題最適合叫什麼？
+      type: select
+      options:
+        - 社群媒體的種類
+        - 睡前拖延症與3C產品
+        - 工作壓力太大
+      answer: 1
 story_structure:
 - label: 主題
   value: (1)小主題可以直接從段落中找到：找出該段的核心概念，當小主題名

--- a/backend/data/lessons/L20.yml
+++ b/backend/data/lessons/L20.yml
@@ -147,6 +147,42 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-7-L20-末日種子庫.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 說明文結構－找小主題和細節
+  instruction: 說明文除了有小主題，每個小主題底下還有重要的「細節」來補充說明。我們可以一邊讀一邊把重要細節勾選出來，幫助理解文章。一起來練習吧！
+  steps:
+    - prompt: 第三段說明了興建種子庫的目的，請選出正確的小主題
+      type: select
+      options:
+        - 種子庫的地理位置
+        - 為什麼要建末日種子庫
+        - 臺灣的小米種子
+      answer: 1
+    - prompt: 關於種子庫的保存環境，下列哪些是課文提到的重要細節？
+      type: checkbox
+      options:
+        - 溫度維持在攝氏零下18度
+        - 種子經過真空包裝，用三層鋁箔密封
+        - 種子庫建在永久凍土區的山脈內部
+        - 種子庫有窗戶可以照到陽光
+      answer:
+        - 0
+        - 1
+        - 2
+    - prompt: 關於種子庫的安全設計，下列哪些是課文提到的重要細節？
+      type: checkbox
+      options:
+        - 需要通過5扇有密碼裝置的門
+        - 外牆混凝土厚達1公尺
+        - 位在海拔130公尺高的地方
+        - 有機器人巡邏守衛
+      answer:
+        - 0
+        - 1
+        - 2
+    - prompt: 課文提到2015年敘利亞內戰時，研究人員提取了130箱種子。這個例子說明了什麼？用自己的話寫下來
+      type: free_text
 story_structure:
 - label: 主題
   value: 重要細節

--- a/backend/data/lessons/L21.yml
+++ b/backend/data/lessons/L21.yml
@@ -143,6 +143,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-8-L21森林大軍的守護者.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 自我提問－問好奇的問題
+  instruction: 閱讀時，如果你能持續問自己問題，例如「他為什麼會這樣？」「這是真的嗎？」就能更深入理解文章。讓我們一起來對課文提出好奇的問題吧！
+  steps:
+    - prompt: 讀到「賴桑花了三千萬買下第一座山，卻發現整座山佈滿垃圾」，你會想問什麼問題？
+      type: select
+      options:
+        - 賴桑為什麼明知是垃圾山還要買？
+        - 垃圾山有多少公斤？
+        - 賴桑的爸爸是做什麼的？
+      answer: 0
+    - prompt: 賴桑說「我的信仰就是種樹，人類過去砍了太多樹，我要把它們種回來！」讀到這裡，你心中會浮現什麼好奇的問題？
+      type: free_text
+    - prompt: 讀到「親友們都認為賴桑若不是瘋了，就是很笨」，你覺得最好的提問是哪一個？
+      type: select
+      options:
+        - 賴桑的親友有幾個人？
+        - 為什麼親友會覺得賴桑瘋了？他做了什麼讓人不理解的事？
+        - 賴桑的妻子叫什麼名字？
+      answer: 1
+    - prompt: 讀到「兒子們也開始種咖啡樹，將販售所得投入父親的種樹志業」，你會想問什麼疑惑的問題？
+      type: select
+      options:
+        - 咖啡樹可以長多高？
+        - 兒子從不理解到支持，中間發生了什麼轉變？
+        - 咖啡一杯賣多少錢？
+      answer: 1
 story_structure:
 - label: 主角
   value: 賴桑為什麼要買一座垃圾山？

--- a/backend/data/lessons/L22.yml
+++ b/backend/data/lessons/L22.yml
@@ -171,6 +171,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-9-L22-植物獵人.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 自我提問－問重要的問題
+  instruction: 閱讀「記人」類文章時，我們可以從文章重點表（主角是誰、做了什麼事、為什麼這樣做、結果如何）來轉化成重要的問題，幫助我們更深入理解人物。一起來練習吧！
+  steps:
+    - prompt: 從「主角是誰」的角度，以下哪個是最重要的問題？
+      type: select
+      options:
+        - 阿介喜歡吃什麼？
+        - 阿介是誰？他有什麼特別的地方？
+        - 阿介住在哪裡？
+      answer: 1
+    - prompt: 從「為什麼需要植物獵人」的角度提問，以下哪個是最重要的問題？
+      type: select
+      options:
+        - 植物獵人的薪水有多少？
+        - 地球上有多少種植物？
+        - 為什麼科學家自己不去採集，需要像阿介這樣的人幫忙？
+      answer: 2
+    - prompt: 阿介被保種中心拒絕後，他做了什麼來克服困難？請用自己的話回答
+      type: free_text
+    - prompt: 從「結果如何」的角度，以下哪個問題最能幫助我們理解文章的核心意義？
+      type: select
+      options:
+        - 阿介最後賺了多少錢？
+        - 阿介從植物獵人的工作中得到了什麼？
+        - 阿介爬過幾座山？
+      answer: 1
 story_structure:
 - label: 主角
   value: 學 習

--- a/backend/data/lessons/L23.yml
+++ b/backend/data/lessons/L23.yml
@@ -124,6 +124,29 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-10-L23小藍鯨之死.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 自我提問－事實、感受、反思、行動
+  instruction: 讀完一篇文章後，我們可以用「事實→感受→反思→行動」四個步驟來整理自己的想法。事實是文章告訴我們的事情，感受是讀完後的心情，反思是我們從中學到什麼，行動是我們可以做什麼。一起來練習吧！
+  steps:
+    - prompt: 【事實】小藍鯨死亡的原因是什麼？
+      type: select
+      options:
+        - 被捕鯨者用鯨砲獵殺
+        - 被海廢漁具繩索纏繞頭部，無法進食而餓死
+        - 因為海水溫度太高而生病死亡
+      answer: 1
+    - prompt: 【感受】讀到「小藍鯨近乎空腹，食道和胃裡只有一隻半消化的魚眼睛」，你的感受是什麼？
+      type: free_text
+    - prompt: 【反思】小藍鯨之死讓我們反思什麼問題？
+      type: select
+      options:
+        - 海洋博物館應該收集更多標本
+        - 人類隨意丟棄漁具會傷害海洋生物
+        - 藍鯨游泳的速度不夠快
+      answer: 1
+    - prompt: 【行動】讀完這篇文章後，你覺得我們可以採取什麼行動來保護海洋？請寫出你的想法
+      type: free_text
 story_structure:
 - label: 主題
   value: 小藍鯨擱淺死亡事件

--- a/backend/data/lessons/L24.yml
+++ b/backend/data/lessons/L24.yml
@@ -149,6 +149,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-11-L24昆蟲會思考嗎？.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 解決問題－用觀察證據回答科學問題
+  instruction: 科學家回答問題時，必須有足夠的觀察證據才能下結論。讓我們跟著李淳陽的觀察，用證據來回答「昆蟲會不會思考」這個科學問題！
+  steps:
+    - prompt: 捲葉象鼻蟲母蟲捲葉子做育嬰室，這個行為屬於什麼？
+      type: select
+      options:
+        - 本能行為（每隻母蟲都會做的固定程序）
+        - 思考行為（遇到問題後才想出來的）
+        - 學習行為（跟其他蟲學的）
+      answer: 0
+    - prompt: 有一隻捲葉象鼻蟲折彎葉片角度不對，轉不動了。牠怎麼解決這個問題？
+      type: select
+      options:
+        - 放棄這片葉子，去找另一片
+        - 轉頭跑到葉片基部，把葉緣拉過來包住葉苞
+        - 請其他象鼻蟲來幫忙
+      answer: 1
+    - prompt: 黃面蜂抓捲葉蛾幼蟲時，最關鍵的行為是什麼？
+      type: select
+      options:
+        - 用觸鬚碰碰葉苞嚇幼蟲
+        - 以迅雷不及掩耳的速度追趕
+        - 觀察到幼蟲來回奔跑的規律後，打破追逐模式，在開口處守株待兔
+      answer: 2
+    - prompt: 根據以上觀察證據，你覺得李淳陽會得到什麼結論？請用自己的話寫下來
+      type: free_text
 story_structure:
 - label: 結論
   value: 2. 黃面蜂打破規律，抓住獵物。

--- a/backend/data/lessons/L25.yml
+++ b/backend/data/lessons/L25.yml
@@ -186,6 +186,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-12-L25給神明發會診單.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 品格力－跨文化接納理解
+  instruction: 這篇課文讓我們看到，面對不同的文化和信仰，我們可以選擇理解和包容，而不是排斥和批判。讓我們一起來練習「跨文化接納理解」的思考方式！
+  steps:
+    - prompt: 一般醫師面對家屬想請乩童來醫院，通常會怎麼反應？
+      type: select
+      options:
+        - 覺得迷信、無知，拒絕讓乩童進來
+        - 主動邀請乩童來合作
+        - 完全不在意，隨便家屬怎麼做
+      answer: 0
+    - prompt: 陳醫師為什麼願意讓乩童來？他是怎麼想的？
+      type: select
+      options:
+        - 他相信乩童有神力可以治病
+        - 他認為這是家屬的祝福和心意，不是對醫療的不信任
+        - 他覺得反正病人快不行了，隨便吧
+      answer: 1
+    - prompt: 陳醫師說乩童「也是我們的伙伴，就像前來協助會診的醫師一樣」，這句話展現了什麼態度？
+      type: select
+      options:
+        - 放棄自己的專業判斷
+        - 用尊重和平等的態度看待不同文化的做法
+        - 認為乩童比醫生厲害
+      answer: 1
+    - prompt: 在你的生活中，有沒有遇過不同文化或信仰的人做了你不理解的事？你覺得可以怎麼做？請寫下你的想法
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L26.yml
+++ b/backend/data/lessons/L26.yml
@@ -149,6 +149,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-13-L26奇蹟行動.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 野外求生技能
+  instruction: 萊絲莉帶著弟弟妹妹在亞馬遜雨林求生了40天，靠的是從族人那裡學到的野外求生技巧。讓我們一起來整理她用了哪些求生方法吧！
+  steps:
+    - prompt: 萊絲莉怎麼解決「吃」的問題？
+      type: select
+      options:
+        - 獵捕野生動物來吃
+        - 先吃飛機上帶下來的木薯粉，之後採集種子、野果和根莖類植物充飢
+        - 等搜救隊空投食物箱
+      answer: 1
+    - prompt: 萊絲莉怎麼解決「喝水」的問題？
+      type: select
+      options:
+        - 直接喝叢林裡的溪水
+        - 只喝雨水，先承接雨水等沉澱淨化後再喝
+        - 從樹幹裡擠出水分來喝
+      answer: 1
+    - prompt: 萊絲莉怎麼解決「住」的問題，保護大家的安全？
+      type: select
+      options:
+        - 住在飛機殘骸裡
+        - 挖地洞躲起來
+        - 和弟弟在樹上搭建小屋，避免地面野獸攻擊
+      answer: 2
+    - prompt: 萊絲莉能在雨林中求生，最主要是因為什麼？這對你有什麼啟發？請寫下你的想法
+      type: free_text
 story_structure:
 - label: 主角
   value: 萊絲莉和她的三個弟妹

--- a/backend/data/lessons/L27.yml
+++ b/backend/data/lessons/L27.yml
@@ -147,6 +147,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-14-L27把手上的餅吃香一點.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 品格力－正向思考轉換
+  instruction: 我們常常覺得「別人的比較好」，但其實問題不在東西本身，而在我們怎麼看待它。讓我們一起練習辨識「負向思考」和「正向思考」，並學習把負向思考轉換成正向思考吧！
+  steps:
+    - prompt: 以下哪一個是課文中作者小時候的「負向思考」？
+      type: select
+      options:
+        - 姊姊把餅分得很公平，我很滿意
+        - 不管怎麼選，我總覺得姊姊的餅比我的大
+        - 和姊姊分享餅是一件開心的事
+      answer: 1
+    - prompt: 湯姆被姨媽叫去刷籬笆油漆，他怎麼把這件苦差事變成正向的？
+      type: select
+      options:
+        - 他偷偷跑去玩，不刷了
+        - 他把自己當成正在創作偉大壁畫的藝術家，全神投入享受
+        - 他請姨媽幫他一起刷
+      answer: 1
+    - prompt: 作者長大後，回程飛機延誤，他怎麼用正向思考看待這件事？
+      type: select
+      options:
+        - 太倒楣了，浪費時間
+        - 太棒了，還可以在國外多玩一天
+        - 都是航空公司的錯
+      answer: 1
+    - prompt: 請你想一個生活中不順心的事情（例如下雨不能出去玩），試著用正向思考的方式重新看待它，寫下來
+      type: free_text
 story_structure:
 - label: 主角
   value: 作者（小時候的自己）

--- a/backend/data/lessons/L28.yml
+++ b/backend/data/lessons/L28.yml
@@ -145,6 +145,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G6-15-L28紅領帶.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 品格力－用「至少、還好、很好啊」轉念
+  instruction: 媽媽面對生病的痛苦，總是能用「轉念」的方式找到值得感恩的地方。我們可以學習用「至少……」「還好……」「很好啊……」這些句型，把困難的事情換個角度來看。一起來練習吧！
+  steps:
+    - prompt: 媽媽全胃切除後，無法躺著睡覺。她怎麼轉念？
+      type: select
+      options:
+        - 「沒有胃真好，這樣就不會胃痛了」
+        - 「沒有胃真慘，以後什麼都不能吃」
+        - 「至少還可以站著睡」
+      answer: 0
+    - prompt: 媽媽化療後很虛弱，只能坐在沙發看電視。她怎麼轉念？
+      type: select
+      options:
+        - 「生病最大的好處就是可以整天躺在沙發看林書豪打球，一點罪惡感都沒有」
+        - 「生病真的太痛苦了」
+        - 「至少不用去上班」
+      answer: 0
+    - prompt: 作者說「很多事不是我們能掌控的，但我們還是可以決定如何面對它」。請選出最符合這句話的例子
+      type: select
+      options:
+        - 考試考不好，一直哭，覺得自己很笨
+        - 考試考不好，告訴自己「至少我知道哪裡不會了，下次可以加強」
+        - 考試考不好，假裝什麼事都沒發生
+      answer: 1
+    - prompt: 請你想一件最近遇到的不開心的事，試著用「至少……」「還好……」或「很好啊……」的句型來轉念，寫下來
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L29.yml
+++ b/backend/data/lessons/L29.yml
@@ -145,6 +145,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-1-L29澳洲奧運金牌的X機密.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 用表格整理訊息－比較兩組對象
+  instruction: 這篇文章比較了澳洲和臺灣的體育發展。我們可以用表格來整理兩組對象的細節，進行比較。先想好「比較的對象」（澳洲 vs 臺灣），再列出「比較的項目」，最後填入細節。一起來練習吧！
+  steps:
+    - prompt: 在「政府支持」這個項目上，澳洲的做法是什麼？
+      type: select
+      options:
+        - 政府斥資設置體育設施、體育學校，成立國家運動中心
+        - 政府只負責舉辦奧運比賽
+        - 政府讓民間自己發展體育
+      answer: 0
+    - prompt: 在「家長態度」這個項目上，澳洲和臺灣最大的差別是什麼？
+      type: select
+      options:
+        - 澳洲家長不讓孩子運動，臺灣家長鼓勵運動
+        - 澳洲家長認為體育能培養品格，熱衷讓孩子參加運動俱樂部；臺灣家長重視課業，放學後多送孩子去補習
+        - 兩邊家長態度差不多
+      answer: 1
+    - prompt: 在「運動員退役後的發展」這個項目上，澳洲和臺灣有什麼不同？
+      type: select
+      options:
+        - 澳洲運動員退役後有其他職業，沒有後顧之憂；臺灣運動員因犧牲課業，退役後就業困難
+        - 澳洲和臺灣的運動員退役後都能順利找到工作
+        - 澳洲運動員退役後都當教練，臺灣運動員退役後都當老師
+      answer: 0
+    - prompt: 根據表格的比較，你覺得臺灣可以學習澳洲的哪一點來改善體育環境？請寫下你的想法
+      type: free_text
 story_structure:
 - label: 主題
   value: 澳洲奧運金牌的祕密

--- a/backend/data/lessons/L30.yml
+++ b/backend/data/lessons/L30.yml
@@ -160,6 +160,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-2-L30女性太空人登月.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 用表格整理訊息－比較後推論上位概念
+  instruction: 這篇文章比較了「阿波羅計畫」和「阿提米絲計畫」。我們不只要整理兩者的細節，還要進一步推論出每個比較項目的「上位概念」（也就是幫這個項目取一個總稱）。一起來練習吧！
+  steps:
+    - prompt: 阿波羅計畫在1969年啟動，阿提米絲計畫在2022年重啟。這兩個細節可以歸納成什麼比較項目？
+      type: select
+      options:
+        - 計畫花費
+        - 啟動時間
+        - 太空人人數
+      answer: 1
+    - prompt: 阿波羅計畫的12位太空人都是男性，阿提米絲計畫要送女性和有色族裔登月。這兩個細節可以歸納成什麼比較項目？
+      type: select
+      options:
+        - 太空人的背景與多元性
+        - 太空人的體重
+        - 太空人的訓練方式
+      answer: 0
+    - prompt: 阿波羅計畫的目標是登月，阿提米絲計畫的目標除了登月，還要建立月球基地、為登陸火星做準備。這兩個細節可以歸納成什麼比較項目？
+      type: select
+      options:
+        - 火箭大小
+        - 計畫的長期目標
+        - 太空人的薪水
+      answer: 1
+    - prompt: 比較完這兩個計畫後，你覺得從阿波羅到阿提米絲，人類的太空探索有什麼重要的改變？請寫下你的想法
+      type: free_text
 story_structure:
 - label: 主題
   value: 女性太空人登月

--- a/backend/data/lessons/L31.yml
+++ b/backend/data/lessons/L31.yml
@@ -156,6 +156,36 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-3-L31奧運性別平等這條路.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 用表格整理訊息
+  instruction: 用表格整理文章中的數據資料，可以幫助我們看出趨勢和變化。請根據課文內容，回答以下問題
+  steps:
+    - prompt: 根據課文，1900年巴黎奧運的女性選手人數和比例分別是多少？
+      type: select
+      options:
+        - 22名，占2.2%
+        - 100名，占10%
+        - 50名，占5%
+      answer: 0
+    - prompt: 根據課文，到了2004年雅典奧運，女性選手參與率達到多少？
+      type: select
+      options:
+        - 25.3%
+        - 40.7%
+        - 50%
+      answer: 1
+    - prompt: 2024年巴黎奧運達成了什麼重要的里程碑？
+      type: select
+      options:
+        - 女性選手人數首次超過男性
+        - 男女參賽選手達到1:1
+        - 所有比賽項目都設有女子組
+      answer: 1
+    - prompt: 從1900年到2024年，女性參與奧運的比例呈現什麼趨勢？請用一句話說明
+      type: free_text
+    - prompt: 除了「人數平等」，文章提到奧運在性別平等上還有哪些仍需努力的地方？請舉一個例子
+      type: free_text
 story_structure:
 - label: 主題
   value: 奧運性別平等的發展與現況

--- a/backend/data/lessons/L32.yml
+++ b/backend/data/lessons/L32.yml
@@ -163,6 +163,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-4-L32科學怪人.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: PERT表達看法
+  instruction: PERT是一種表達看法的方法，包含四個步驟：P（主張）說出你的看法、E（原因）說明為什麼、R（舉例）舉出例子、T（結論）做總結。請根據課文練習
+  steps:
+    - prompt: "「科學怪人」這個書名，你認為指的是誰？"
+      type: select
+      options:
+        - 指怪物，因為他是科學實驗造出來的怪物
+        - 指弗蘭肯斯坦，因為他是用瘋狂科學創造生命的人
+        - 兩者都可以，因為書中沒有明確說明
+      answer: 2
+    - prompt: 弗蘭肯斯坦被比喻為「現代普羅米修斯」，原因是什麼？
+      type: select
+      options:
+        - 他們都被鐵鍊鎖在山上
+        - 他們都觸犯了神的禁忌，帶來了後果
+        - 他們都是希臘神話中的人物
+      answer: 1
+    - prompt: 根據課文，怪物被弗蘭肯斯坦拋棄後，經歷了什麼遭遇？
+      type: select
+      options:
+        - 被人類接納，過著幸福的生活
+        - 因醜陋的外表，不斷遭受誤解與傷害
+        - 回到實驗室，找到了自己的名字
+      answer: 1
+    - prompt: 請用PERT方法表達你的看法：科學的發展應不應該有倫理道德的界線？寫出你的主張和原因
+      type: free_text
 story_structure:
 - label: 主角
   value: "希臘神話-眾\n      負責！《科學怪人》                         神篇 第八期"

--- a/backend/data/lessons/L33.yml
+++ b/backend/data/lessons/L33.yml
@@ -143,6 +143,36 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-5-L33吐瓦魯：逐漸被淹沒的島國.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 4F反思法
+  instruction: 4F反思法幫助我們深入思考一個議題，包含四個步驟：事實（Fact）發生了什麼事、感受（Feeling）你有什麼感覺、反思（Finding）你發現了什麼道理、行動（Future）你可以怎麼做。請根據課文練習
+  steps:
+    - prompt: "【事實】根據課文，吐瓦魯面臨什麼危機？"
+      type: select
+      options:
+        - 因為戰爭，人民被迫離開家園
+        - 因為全球暖化、海平面上升，國土即將被淹沒
+        - 因為經濟衰退，人民生活困難
+      answer: 1
+    - prompt: "【事實】吐瓦魯部長柯飛提出了什麼計畫來因應危機？"
+      type: select
+      options:
+        - 搬遷到其他國家
+        - 建造巨大海堤保護島嶼
+        - 建立「元宇宙國家」，把國家轉移到雲端
+      answer: 2
+    - prompt: "【感受】讀到吐瓦魯的溫室氣體排放僅占全球0.03%，卻要承受國土被淹沒的後果，你有什麼感受？"
+      type: free_text
+    - prompt: "【反思】文章提到臺灣海平面也在上升，你覺得這跟吐瓦魯的處境有什麼關聯？"
+      type: select
+      options:
+        - 臺灣也可能面臨類似的問題，全球暖化影響每個人
+        - 臺灣面積比較大，所以完全不用擔心
+        - 臺灣應該幫吐瓦魯搬家
+      answer: 0
+    - prompt: "【行動】為了減緩全球暖化，你在日常生活中可以做什麼？請舉出一個具體行動"
+      type: free_text
 story_structure:
 - label: 結論
   value: 類的避難󠇡所嗎？

--- a/backend/data/lessons/L34.yml
+++ b/backend/data/lessons/L34.yml
@@ -158,6 +158,36 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-6-L34綠色賽事.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 環保3R
+  instruction: 環保3R是指 Reduce（減少使用）、Reuse（物盡其用）、Recycle（循環回收）。請根據課文內容，判斷以下做法分別屬於哪一個R
+  steps:
+    - prompt: 課文中提到「許多賽事採用網路報名，不再印製秩序冊，完賽證書也能線上下載」，這屬於環保3R的哪一個？
+      type: select
+      options:
+        - Reduce（減少使用）
+        - Reuse（物盡其用）
+        - Recycle（循環回收）
+      answer: 0
+    - prompt: 課文中提到「比賽過程提供可重複使用的環保杯，一杯用到底」，這屬於環保3R的哪一個？
+      type: select
+      options:
+        - Reduce（減少使用）
+        - Reuse（物盡其用）
+        - Recycle（循環回收）
+      answer: 1
+    - prompt: 課文中提到「臺灣利用寶特瓶回收製成的環保球衣，在世界盃足球賽中大放異彩」，這屬於環保3R的哪一個？
+      type: select
+      options:
+        - Reduce（減少使用）
+        - Reuse（物盡其用）
+        - Recycle（循環回收）
+      answer: 2
+    - prompt: 阿國在路跑賽後看到了哪些汙染環境的現象？請舉出兩個例子
+      type: free_text
+    - prompt: 如果你們學校要舉辦運動會，請想一個落實環保3R的做法，並說明它屬於哪一個R
+      type: free_text
 story_structure:
 - label: 結論
   value: 中。不要把【 快樂

--- a/backend/data/lessons/L35.yml
+++ b/backend/data/lessons/L35.yml
@@ -144,6 +144,36 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-7-L35看到了嗎，然後呢.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 推理三要素
+  instruction: 推理三要素是：細心觀察、具備背景知識、慣於推論。請根據課文中的兩個故事來練習推理
+  steps:
+    - prompt: 福爾摩斯從帽子上觀察到哪些細節？請選出正確的組合
+      type: select
+      options:
+        - 高級用料、灰白髮絲、補丁以墨水染黑
+        - 帽子的顏色、帽子的價錢、帽主的姓名
+        - 帽子的品牌、帽子的產地、帽主的職業
+      answer: 0
+    - prompt: 福爾摩斯推論帽主「家道中落」的依據是什麼？
+      type: select
+      options:
+        - 帽子是便宜貨
+        - 鬆緊帶壞了沒換，補丁用墨水染黑
+        - 帽子裡有灰白髮絲
+      answer: 1
+    - prompt: 王戎的故事中，他觀察到什麼現象？
+      type: select
+      options:
+        - 李子樹長在路邊，結了很多果實卻沒人採
+        - 李子樹的葉子枯黃，看起來快枯死了
+        - 李子樹上有蟲，果實都爛掉了
+      answer: 0
+    - prompt: 王戎用了什麼「背景知識」來推論李子是苦的？
+      type: free_text
+    - prompt: 請你試著用推理三要素來分析一個生活中的現象。例如：你看到教室地上有水漬，你能推論出什麼？
+      type: free_text
 story_structure:
 - label: 主角
   value: 家境殷實

--- a/backend/data/lessons/L36.yml
+++ b/backend/data/lessons/L36.yml
@@ -148,6 +148,37 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-8-L36果醬男孩.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 問題解決流程
+  instruction: 問題解決流程有四個步驟：認清問題、拆解問題、思考解決方案、選擇方案並執行。請根據課文中林韡勳的故事來練習
+  steps:
+    - prompt: 林韡勳一開始面臨的主要問題是什麼？
+      type: select
+      options:
+        - 因為過敏無法繼續做動物相關工作，在鄉間又找不到工作機會
+        - 他不喜歡讀書，大學畢業後不想工作
+        - 他的家人反對他做果醬
+      answer: 0
+    - prompt: 林韡勳開始做果醬後，遇到了很多小問題，以下哪些是他遇到的困難？
+      type: checkbox
+      options:
+        - 果醬又糊又黑、太甜或燒焦
+        - 做失敗的果醬不知道怎麼處理
+        - 成本太高、單價無法壓低
+        - 沒有人願意品嚐他的果醬
+      answer: [0, 1, 2]
+    - prompt: 面對果醬賣不出去的問題，林韡勳用了什麼解決方案？
+      type: select
+      options:
+        - 降低品質來壓低價格
+        - 分送親友試吃、到市集擺攤，慢慢建立口碑
+        - 放棄做果醬，改做其他食品
+      answer: 1
+    - prompt: 林韡勳的「茶金」果醬本來茶味不足，他想出了什麼創新的解決方法？
+      type: free_text
+    - prompt: 如果你遇到一個困難，請用「問題解決流程」的四個步驟來分析：認清問題是什麼、拆解成小問題、想出解決方案、選擇最好的方案
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L37.yml
+++ b/backend/data/lessons/L37.yml
@@ -165,6 +165,36 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-9-L37用科學方法伸張正義的神探.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 科學方法思考歷程
+  instruction: 科學方法的步驟是：發現問題、提出假設、驗證假設、得到解答。請根據李昌鈺博士的辦案過程來練習
+  steps:
+    - prompt: "【發現問題】李昌鈺到現場後，發現了什麼不尋常的地方？"
+      type: select
+      options:
+        - 老太太身上沒有傷口
+        - 老太太被刺了18刀，但地上卻看不到血
+        - 凶器不見了
+      answer: 1
+    - prompt: "【提出假設】李昌鈺對「地上沒有血」提出了哪兩個假設？"
+      type: select
+      options:
+        - 老太太可能不是被刺死的；或是法醫搞錯了
+        - 血跡已經被清理過了；或者這裡不是第一現場
+        - 血液可能滲透到地板下面了；或是被水沖走了
+      answer: 1
+    - prompt: "【驗證假設】李昌鈺用什麼方法來驗證假設？"
+      type: select
+      options:
+        - 在地板上噴化學藥品，藥品和血液中的鐵離子反應後會發出藍色螢光
+        - 用放大鏡仔細觀察地板上的每一個角落
+        - 請法醫重新檢查老太太的傷口
+      answer: 0
+    - prompt: "【推論】李昌鈺為什麼判斷凶手是老太太的熟人？"
+      type: free_text
+    - prompt: 李昌鈺為什麼堅持當晚就要派200名刑警去搜垃圾箱？他說了什麼理由？
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L38.yml
+++ b/backend/data/lessons/L38.yml
@@ -138,6 +138,36 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-10-L38你看見時代的灰犀牛了嗎談人口負成長.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 認識折線圖
+  instruction: 折線圖可以幫助我們看出數據的變化趨勢。請根據課文中提到的數據，回答以下問題
+  steps:
+    - prompt: 根據課文，民國40年（1951年）臺灣每位婦女一生平均生育幾個子女？
+      type: select
+      options:
+        - 2.1個
+        - 5個
+        - 7個
+      answer: 2
+    - prompt: 根據課文，臺灣的出生人數和死亡人數大約在哪一年出現「死亡交叉」（死亡人數開始超過出生人數）？
+      type: select
+      options:
+        - 2015年
+        - 2019年
+        - 2024年
+      answer: 1
+    - prompt: 根據課文，2025年臺灣大約幾名生產者扶養1名被扶養者？到2065年預估會變成多少？
+      type: select
+      options:
+        - 2025年3人扶養1人，2065年2人扶養1人
+        - 2025年2人扶養1人，2065年1人扶養1人
+        - 2025年5人扶養1人，2065年3人扶養1人
+      answer: 1
+    - prompt: 如果要畫一張「臺灣婦女總生育率」的折線圖，橫軸（X軸）和縱軸（Y軸）分別應該放什麼？
+      type: free_text
+    - prompt: 文章提到人口負成長也可能有「樂觀」的一面，請舉出一個課文中提到的例子
+      type: free_text
 story_structure:
 - label: 主題
   value: 人口負成長這個「灰犀牛」現象

--- a/backend/data/lessons/L39.yml
+++ b/backend/data/lessons/L39.yml
@@ -122,6 +122,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-11-L39網紅的電子煙實驗：偽科學的陷阱.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 辨別網路訊息真偽
+  instruction: 網路上有很多看起來像真的假訊息。我們可以從「來源」「傳播途徑」「查證方式」三個方向來辨別真偽。請根據課文練習
+  steps:
+    - prompt: 課文開頭的「芬蘭廢除中小學課程教育」新聞，你覺得它可能是假新聞的線索是什麼？
+      type: select
+      options:
+        - 新聞來源是「每日頭條」，不是官方媒體
+        - 文章中有許多簡體字混用，不像正式報導
+        - 以上兩個都是可疑的線索
+      answer: 2
+    - prompt: 課文提到電子煙廠商會把年輕人當成「長期提款機」，這是什麼意思？
+      type: select
+      options:
+        - 年輕人很有錢，可以一直買電子煙
+        - 讓年輕人上癮後，就會長期消費，為廠商帶來穩定收入
+        - 年輕人會幫廠商推銷電子煙給朋友
+      answer: 1
+    - prompt: 網紅的電子煙實驗看起來像科學實驗，但其實是「偽科學」。判斷偽科學最重要的方法是什麼？
+      type: select
+      options:
+        - 看影片的觀看次數多不多
+        - 看實驗是否經過專業機構或科學家的驗證
+        - 看網紅是不是很有名
+      answer: 1
+    - prompt: 如果你在網路上看到一則很吸引人的健康資訊，你可以用什麼方法來查證它的真假？請寫出至少兩種方法
+      type: free_text
 story_structure:
 - label: 結論
   value: 電子煙對人體【     無害

--- a/backend/data/lessons/L40.yml
+++ b/backend/data/lessons/L40.yml
@@ -159,6 +159,36 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-12-L40別上「誘餌式標題」的鉤.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 辨識誘餌式標題
+  instruction: 誘餌式標題有四種常見手法：引發好奇、誇張句子、誇大的情緒字眼、利用熱門話題或公眾人物。請根據課文練習辨識
+  steps:
+    - prompt: 課文中「下週雷雨炸全臺！氣象署急發快訊」這個標題，實際內容是什麼？
+      type: select
+      options:
+        - 全臺灣真的會被雷雨轟炸
+        - 只是局部地區有雷擊和瞬間大雨的機率，氣象署只是例行發布預報
+        - 氣象署發出了緊急警報要大家躲在家裡
+      answer: 1
+    - prompt: 媒體為什麼要使用誘餌式標題？
+      type: select
+      options:
+        - 因為記者寫作能力不好
+        - 為了增加點擊率和廣告收益，或帶風向影響大眾認知
+        - 因為法律規定標題要寫得吸引人
+      answer: 1
+    - prompt: 以下哪一個標題最可能是誘餌式標題？
+      type: select
+      options:
+        - 教育部公布112年國中教育會考成績統計
+        - 震驚！國中生吃了這個東西，竟然變成天才！
+        - 颱風預計明天登陸，各縣市停班停課資訊整理
+      answer: 1
+    - prompt: 課文提到面對誘餌式標題的三個方法，請用自己的話寫出其中兩個
+      type: free_text
+    - prompt: 請你自己舉一個在生活中看過的誘餌式標題例子，並說明它用了哪種手法（引發好奇、誇張句子、誇大情緒字眼、或利用熱門話題）
+      type: free_text
 story_structure:
 - label: 主題
   value: 誘餌式標題

--- a/backend/data/lessons/L41.yml
+++ b/backend/data/lessons/L41.yml
@@ -151,6 +151,36 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G7-13-L41信眾與教主.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 建立思辨超能力
+  instruction: 思辨能力就是不盲目相信，學會用證據來判斷。請根據課文中的心理學研究來練習思辨
+  steps:
+    - prompt: 課文中的末日預言教主說1954年12月21日是世界末日，結果那天發生了什麼事？
+      type: select
+      options:
+        - 真的發生了大洪水
+        - 什麼都沒有發生，外星人沒有來，也沒有洪水
+        - 只有小規模的水災
+      answer: 1
+    - prompt: 預言失敗後，教主告訴信眾什麼？
+      type: select
+      options:
+        - 承認自己的預言是錯的
+        - 說信眾的虔誠感動了外星人，所以外星人決定不毀滅地球了
+        - 說下一次世界末日改在明年
+      answer: 1
+    - prompt: 根據課文，哪一種信眾在預言失敗後，反而更加崇拜教主？
+      type: select
+      options:
+        - 平常就會「聽其言、觀其行」的信眾
+        - 曾經為教主犧牲奉獻、付出很大代價的信眾
+        - 剛加入不久的新信眾
+      answer: 1
+    - prompt: 哈佛大學校長福斯特說「教育的目標在確保學生能夠辨別有人在胡說八道」，你覺得這句話的意思是什麼？
+      type: free_text
+    - prompt: 在日常生活中，你有沒有遇過類似的情況——有人說了不合理的話，但很多人卻相信？請舉一個例子，並說明你會怎麼判斷真假
+      type: free_text
 story_structure:
 - label: 結論
   value: □可能會不看證據，做出匪夷所思的判斷

--- a/backend/data/lessons/L42.yml
+++ b/backend/data/lessons/L42.yml
@@ -101,6 +101,41 @@ reading_benchmark:
     feedback: 速度再快一點！
 source_file: G8-1-L42愛讀書的顧寧人.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 一字多義：少
+  instruction: "「少」這個字在文言文中有不同的讀音和意思。請根據課文練習分辨「少」的不同用法"
+  steps:
+    - prompt: "「旅店少休」的「少」是什麼意思？"
+      type: select
+      options:
+        - 稍微、短暫地（ㄕㄠˇ）
+        - 缺少、很少（ㄕㄠˇ）
+        - 年幼、年輕的（ㄕㄠˋ）
+      answer: 0
+    - prompt: "「少負絕異之資」的「少」是什麼意思？"
+      type: select
+      options:
+        - 稍微、短暫地（ㄕㄠˇ）
+        - 缺少、很少（ㄕㄠˇ）
+        - 年幼、年輕的（ㄕㄠˋ）
+      answer: 2
+    - prompt: "「自少至老，未嘗一日廢書」的「少」是什麼意思？"
+      type: select
+      options:
+        - 稍微、短暫地（ㄕㄠˇ）
+        - 缺少、很少（ㄕㄠˇ）
+        - 年幼、年輕的（ㄕㄠˋ）
+      answer: 2
+    - prompt: "「但少閑人如吾兩人耳」的「少」是什麼意思？"
+      type: select
+      options:
+        - 稍微、短暫地（ㄕㄠˇ）
+        - 缺少、很少（ㄕㄠˇ）
+        - 年幼、年輕的（ㄕㄠˋ）
+      answer: 1
+    - prompt: 請用「少」的三種不同意思，各造一個句子
+      type: free_text
 story_structure:
 - label: 主角
   value: 顧寧人

--- a/backend/data/lessons/L43.yml
+++ b/backend/data/lessons/L43.yml
@@ -108,6 +108,41 @@ reading_benchmark:
     feedback: 速度再快一點！
 source_file: G8-2-L43從天才跌為凡人的神童.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 一字多義：聞
+  instruction: "「聞」這個字在文言文中有不同的意思。請根據課文練習分辨「聞」的不同用法"
+  steps:
+    - prompt: "「予聞之也久」的「聞」是什麼意思？"
+      type: select
+      options:
+        - 聽到、聽說
+        - 有名、著稱
+        - 聽見的事情、消息
+      answer: 0
+    - prompt: "「不能稱前時之聞」的「聞」是什麼意思？"
+      type: select
+      options:
+        - 聽到、聽說
+        - 有名、著稱
+        - 聽見的事情、消息（傳聞）
+      answer: 2
+    - prompt: "「風流天下聞」的「聞」是什麼意思？"
+      type: select
+      options:
+        - 聽到、聽說
+        - 有名、著稱
+        - 聽見的事情、消息
+      answer: 1
+    - prompt: 方仲永從天才變成普通人，最主要的原因是什麼？
+      type: select
+      options:
+        - 他天生的才能本來就不夠好
+        - 他的父親為了賺錢，天天帶他四處拜訪，沒有讓他學習
+        - 他自己不願意讀書學習
+      answer: 1
+    - prompt: 這個故事告訴我們什麼道理？請用自己的話寫出來
+      type: free_text
 story_structure:
 - label: 主角
   value: ''

--- a/backend/data/lessons/L44.yml
+++ b/backend/data/lessons/L44.yml
@@ -173,6 +173,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G8-3-L44假新聞？鞭虎救弟記.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 數位閱讀與論證
+  instruction: 閱讀文章時，我們可以用「提問→合理質疑→找證據→下結論」的方法來判斷內容是不是真的。請跟著步驟練習
+  steps:
+    - prompt: 讀完「鞭虎救弟記」的故事後，你覺得哪一個部分最讓人懷疑？
+      type: select
+      options:
+        - 含光在山上遇到老虎
+        - 含光追上老虎並打退牠
+        - 含光吸血數升救活弟弟
+      answer: 2
+    - prompt: 作者用什麼方式來檢驗「人類追得上老虎嗎」這個質疑？
+      type: select
+      options:
+        - 訪問動物園管理員
+        - 用老虎的體重和咬著獵物的速度來推算
+        - 找古書的其他記載
+      answer: 1
+    - prompt: 作者根據康熙年間的度量衡計算，發現「吸血數升」有什麼問題？
+      type: select
+      options:
+        - 數量太少，不足以排毒
+        - 失血量超過人體血液的一半，人會死亡
+        - 古代的「升」比現在的大很多
+      answer: 1
+    - prompt: 綜合所有證據，作者得出什麼結論？請用自己的話寫出來
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L45.yml
+++ b/backend/data/lessons/L45.yml
@@ -121,6 +121,39 @@ reading_benchmark: null
 source_file: G8-4-L45文言文怎麼讀？以鞭虎救弟記為例.docx
 flags:
 - NO_VOCABULARY
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 文言文閱讀方法
+  instruction: 文言文比白話文精簡很多，我們可以用「找代名詞→猜詞意→全句翻譯→讀出作者意圖」的步驟來讀懂。請跟著練習
+  steps:
+    - prompt: 文言文主要用哪三種方式來節省用字？
+      type: checkbox
+      options:
+        - 用詞精簡
+        - 加入插圖
+        - 省略主詞或受詞
+        - 省略連接詞
+        - 使用注音符號
+      answer:
+        - 0
+        - 2
+        - 3
+    - prompt: 「虎牙有毒，深入，惡血不盡出，不可救」這句話中，「深入」省略了什麼？
+      type: select
+      options:
+        - 省略了主詞「虎牙的毒」和受詞「傷者的身體」
+        - 省略了時間「很久以後」
+        - 省略了地點「山裡面」
+      answer: 0
+    - prompt: 「惡血不盡出，不可救」省略了哪些連接詞？
+      type: select
+      options:
+        - 「因為」和「所以」
+        - 「如果」和「就」
+        - 「雖然」和「但是」
+      answer: 1
+    - prompt: 讀文言文時遇到不認識的字詞，課文建議我們怎麼做？請用自己的話回答
+      type: free_text
 story_structure:
 - label: 主題
   value: 文言文的閱讀方法與特色

--- a/backend/data/lessons/L46.yml
+++ b/backend/data/lessons/L46.yml
@@ -105,6 +105,34 @@ reading_benchmark:
     feedback: 速度有點快，要讀清楚哦!
 source_file: G8-5-L46不量田.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 文言文判讀主語
+  instruction: 文言文經常省略主語，讀的時候要自己「腦補」出誰在做這件事。請跟著步驟練習判讀主語
+  steps:
+    - prompt: 「賈人某，至直隸界，忽大雨雹，伏禾中」，這裡「伏禾中」的主語是誰？
+      type: select
+      options:
+        - 張不量
+        - 商人（賈人）
+        - 上天
+      answer: 1
+    - prompt: 「聞空中云：此張不量田，勿傷其稼」，說這句話的主語是誰？
+      type: select
+      options:
+        - 商人自言自語
+        - 空中的聲音（上天）
+        - 村裡的人
+      answer: 1
+    - prompt: 「雹止，入村，訪問其人」，這裡連續三個動作「雹止、入村、訪問」的主語分別是誰？
+      type: select
+      options:
+        - 全部都是商人
+        - 「雹止」主語是冰雹，「入村、訪問」主語是商人
+        - 全部都是冰雹
+      answer: 1
+    - prompt: 張氏被稱為「不量」而非「不良」，真正的原因是什麼？請用自己的話回答
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L47.yml
+++ b/backend/data/lessons/L47.yml
@@ -158,6 +158,34 @@ reading_benchmark:
 source_file: G8-6-L47陸公買硯.docx
 flags:
 - NO_VOCABULARY
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 文言文斷句與判讀主語
+  instruction: 文言文沒有標點符號，要先「斷句」切成小段再讀。斷句後再判讀每段的主語是誰。請跟著步驟練習
+  steps:
+    - prompt: 「門人持硯歸，公訝其不類」，這裡「公」指的是誰？
+      type: select
+      options:
+        - 僕人（門人）
+        - 陸盧峰（陸公）
+        - 石工
+      answer: 1
+    - prompt: 「吾嫌其微凸，路值石工，幸有餘銀，令磨而平之」，這段話的主語「吾」是誰？
+      type: select
+      options:
+        - 陸盧峰
+        - 僕人（門人）
+        - 賣硯的商人
+      answer: 1
+    - prompt: 僕人把硯臺的「鴝鵒眼」磨平了，陸公為什麼感到「大惋惜」？
+      type: select
+      options:
+        - 因為磨平後硯臺裂開了
+        - 因為鴝鵒眼正是硯臺最珍貴的特徵，被僕人破壞了
+        - 因為花了太多銀子請石工
+      answer: 1
+    - prompt: 這個故事告訴我們什麼道理？請用自己的話回答
+      type: free_text
 story_structure:
 - label: 事例
   sub_rows:

--- a/backend/data/lessons/L48.yml
+++ b/backend/data/lessons/L48.yml
@@ -145,6 +145,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G9-1-L48盡信書不如無書：從一件殺人案@談起.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 假新聞思辨
+  instruction: 面對新聞報導，我們要學會辨別真假。這篇文章用凱蒂謀殺案告訴我們，連教科書都可能傳播錯誤資訊。請跟著步驟練習思辨
+  steps:
+    - prompt: 《紐約時報》的報導說有38位目擊者看著凱蒂被殺卻未報警，後來研究者發現真相是什麼？
+      type: select
+      options:
+        - 確實有38位目擊者，但他們都害怕
+        - 根本沒有38位目擊者，而且有人打電話報警但被吃案
+        - 目擊者有報警，但警察太慢趕到
+      answer: 1
+    - prompt: 心理學家根據這則報導提出了「旁觀者效應」理論，這個理論長達43年沒人質疑，最可能的原因是什麼？
+      type: select
+      options:
+        - 沒有人看過原始的警方紀錄
+        - 大家迷信權威，不加質疑
+        - 研究者都覺得這件事不重要
+      answer: 1
+    - prompt: 作者說「盡信書不如無書」，這句話的意思是什麼？
+      type: select
+      options:
+        - 讀書沒有用，不如不讀
+        - 如果完全相信書上寫的，還不如不讀，要保有質疑精神
+        - 書本太貴了，不要買
+      answer: 1
+    - prompt: 在生活中遇到一則聳動的新聞時，你可以用哪些方法來判斷真假？請寫出至少兩個方法
+      type: free_text
 story_structure:
 - label: 結論
   value: 不怕權威的去檢驗、質疑舊的理論，才能使我們一步步逼近

--- a/backend/data/lessons/L49.yml
+++ b/backend/data/lessons/L49.yml
@@ -125,6 +125,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G9-2-L49預防近視？多點戶外活動就對了！.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 科學方法說服他人
+  instruction: 要說服別人，需要用「事實→論點→找證據支持→結論」的步驟。這篇文章用科學研究來說服我們「戶外活動可以預防近視」。請跟著步驟分析
+  steps:
+    - prompt: 過去大家認為造成近視的原因是什麼？
+      type: select
+      options:
+        - 遺傳和近距離工作（看書、看手機）
+        - 眼球缺乏陽光
+        - 睡眠不足
+      answer: 0
+    - prompt: 文章提出的新論點是什麼？
+      type: select
+      options:
+        - 看電視是造成近視的主因
+        - 眼球缺乏陽光才是近視的重要原因
+        - 遺傳決定一切，無法預防
+      answer: 1
+    - prompt: 澳洲和新加坡華裔兒童的比較研究發現了什麼？
+      type: select
+      options:
+        - 新加坡兒童讀書時間多，所以近視率高
+        - 澳洲兒童戶外活動時間多（每週13小時），近視率只有3%；新加坡只有3小時，近視率29%
+        - 兩國兒童的近視率差不多
+      answer: 1
+    - prompt: 室內開燈能不能取代戶外陽光來預防近視？為什麼？請用課文中的數據回答
+      type: free_text
 story_structure:
 - label: 結論
   value: 孩子應該【多出去玩，別關在家／多去戶外晒太陽

--- a/backend/data/lessons/L50.yml
+++ b/backend/data/lessons/L50.yml
@@ -166,6 +166,38 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G9-3-L50#MeToo運動與我們的權利.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 性別平等與身體自主權
+  instruction: 這篇文章介紹了#MeToo運動，教我們認識身體自主權和身體界線。請跟著步驟思考
+  steps:
+    - prompt: 受害者常常不敢站出來舉報，根據課文，以下哪些是原因？
+      type: checkbox
+      options:
+        - 怕自己變成大家茶餘飯後的八卦話題
+        - 加害者和受害者之間有「權力不對等」的關係
+        - 受害者覺得自己有錯
+        - 性犯罪發生在隱密空間，難以舉證
+      answer:
+        - 0
+        - 1
+        - 3
+    - prompt: 「身體界線」會因為什麼而有所不同？
+      type: select
+      options:
+        - 只看對方的年紀
+        - 對象、情境、時間
+        - 只看自己的心情
+      answer: 1
+    - prompt: 下面哪個情境可能已經越過身體界線？
+      type: select
+      options:
+        - 比賽結束後教練擁抱你慶祝
+        - 朋友在你同意下拍拍你的肩膀
+        - 有人一直盯著你的身體看，讓你覺得不舒服
+      answer: 2
+    - prompt: 如果有人對你做了讓你不舒服的事，你可以怎麼做？請寫出至少兩個方法
+      type: free_text
 story_structure:
 - label: 主題
   value: '#MeToo運動的意義與影響'

--- a/backend/data/lessons/L51.yml
+++ b/backend/data/lessons/L51.yml
@@ -135,6 +135,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G9-4-L51靈異與科學.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 科學方法解決問題
+  instruction: 遇到無法解釋的現象時，可以用「提問→假設→檢驗」的科學方法來找答案。請跟著步驟，用科學方法分析課文中的靈異現象
+  steps:
+    - prompt: 對於「鬼火」現象，科學家提出的解釋是什麼？
+      type: select
+      options:
+        - 鬼魂在夜晚出來活動發出的光
+        - 屍體腐化產生的磷化氫和沼氣混合，在低溫就能燃燒的「冷焰」
+        - 地底下的火山氣體噴出來
+      answer: 1
+    - prompt: 為什麼鬼火最常出現在夏天的墳場？
+      type: select
+      options:
+        - 夏天氣溫高，容易達到冷焰的燃點（攝氏30度），墳場有腐化的遺骸產生磷化氫
+        - 夏天鬼魂比較活躍
+        - 夏天的月亮比較亮
+      answer: 0
+    - prompt: 「鬼壓床」在醫學上叫什麼？它發生在睡眠週期的哪個階段？
+      type: select
+      options:
+        - 睡眠障礙症，發生在深睡期
+        - 睡眠癱瘓症，發生在快速眼動期
+        - 夢遊症，發生在淺睡期
+      answer: 1
+    - prompt: 課文說睡覺時動彈不得其實是身體的「保護機制」，為什麼？請用自己的話回答
+      type: free_text
 story_structure:
 - label: 結論
   value: 理性的科學方法，讓我們不再害怕，對現象有更客觀的認識。

--- a/backend/data/lessons/L52.yml
+++ b/backend/data/lessons/L52.yml
@@ -127,6 +127,34 @@ reading_benchmark:
     feedback: 哇嗚，超級厲害！
 source_file: G9-5-L52從基因來的特別禮物.docx
 flags: []
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 認識統計圖表
+  instruction: 統計圖表可以幫助我們快速看出數據的重點。這篇文章用數據和圖表來說明阿美族人的特殊血型。請跟著步驟練習讀懂數據
+  steps:
+    - prompt: 課文提到阿美族約占全臺灣人口的1%，但在2021年東京奧運國手中占了10.3%，這叫做什麼現象？
+      type: select
+      options:
+        - 正常分布
+        - 過度表徵
+        - 隨機巧合
+      answer: 1
+    - prompt: 根據課文，哪個族群帶有米田堡血型的比率最高？
+      type: select
+      options:
+        - 白種人（0.002%）
+        - 臺灣人整體（5%）
+        - 阿美族（88%）
+      answer: 2
+    - prompt: 馬偕醫院的踏階運動實驗發現，有米田堡血型的人和沒有的人有什麼差異？
+      type: select
+      options:
+        - 有米田堡血型的人跑得比較快
+        - 有米田堡血型的人運動後排出二氧化碳只需1到2分鐘，比一般人的2到3分鐘更快
+        - 兩組人沒有差異
+      answer: 1
+    - prompt: 課文結尾說除了努力練習之外，基因決定的身體素質也會影響運動表現。你覺得「因材施教」這個概念可以怎麼應用？請用自己的話回答
+      type: free_text
 story_structure:
 - label: 結論
   value: (1)除了努力練習，

--- a/backend/data/lessons/L53.yml
+++ b/backend/data/lessons/L53.yml
@@ -111,6 +111,38 @@ reading_benchmark: null
 source_file: G9-6-L53臺灣學生的閱讀力：美麗與哀愁.docx
 flags:
 - NO_VOCABULARY
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 判讀統計圖
+  instruction: 判讀統計圖時，要先看圖表類型、標題、橫軸和縱軸的名稱，再理解圖例，最後讀出圖表要表達什麼。請跟著步驟練習
+  steps:
+    - prompt: 根據課文，臺灣學生的PISA閱讀力世界排名，從2015年到2022年的變化是什麼？
+      type: select
+      options:
+        - 從第23名退步到第30名
+        - 從第23名進步到第5名
+        - 一直維持在第17名
+      answer: 1
+    - prompt: 2022年全球閱讀力表現下滑，但臺灣卻逆勢推升，課文提到的可能原因有哪些？
+      type: checkbox
+      options:
+        - 臺灣學校停課時間比其他國家短
+        - 臺灣老師能有效實施遠距教學
+        - 108課綱重視核心素養及自主學習
+        - 臺灣學生考試能力比較強
+      answer:
+        - 0
+        - 1
+        - 2
+    - prompt: 臺灣閱讀力雖然進步，但有一個明顯的弱項是什麼？
+      type: select
+      options:
+        - 男生的閱讀力比女生差很多
+        - 城鄉差距明顯，偏鄉學生閱讀力落後都會區超過兩個年級
+        - 科學領域的表現下滑
+      answer: 1
+    - prompt: 如果你是偏鄉國中的校長，你會怎麼提升學生的閱讀力？請提出一個具體的做法
+      type: free_text
 story_structure:
 - label: 主題
   value: 臺灣學生的閱讀力現況

--- a/backend/data/lessons/L54.yml
+++ b/backend/data/lessons/L54.yml
@@ -106,6 +106,34 @@ source_file: G9-7-L54力與美表現的競技體操.docx
 flags:
 - NO_VOCABULARY
 - NO_MC_QUESTIONS
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 摘要與組織圖表
+  instruction: 這篇文章介紹了競技體操的計分方式，資訊很多。我們可以用摘要的方法，把重要資訊整理成簡單的架構。請跟著步驟練習
+  steps:
+    - prompt: 競技體操的總分由哪兩種分數組成？
+      type: select
+      options:
+        - A分（藝術分）和B分（表現分）
+        - D分（難度分）和E分（實施分）
+        - 技術分和風格分
+      answer: 1
+    - prompt: D分的計算包含哪兩個部分？
+      type: select
+      options:
+        - 動作難度和動作組群
+        - 起跳分和落地分
+        - 速度分和力量分
+      answer: 0
+    - prompt: E分的評審方式是什麼？
+      type: select
+      options:
+        - 從0分開始，做得好就加分
+        - 從10分開始，有錯誤就扣分
+        - 7位裁判的平均分數
+      answer: 1
+    - prompt: 李智凱在東京奧運鞍馬拿下15.40分，請根據課文的計分規則，說明這個分數大概是怎麼來的（D分加E分）
+      type: free_text
 story_structure:
 - label: 主題
   value: 競技體操的計分方式

--- a/backend/data/lessons/L56.yml
+++ b/backend/data/lessons/L56.yml
@@ -143,6 +143,34 @@ reading_benchmark: null
 source_file: G9-9.10-L56~57多文本-未解之謎-巨石陣+摩艾石像.docx
 flags:
 - MULTI_TEXT
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 比較異同與科學方法
+  instruction: 這兩篇文章分別介紹了巨石陣和摩艾石像。我們可以比較它們的相同和不同之處，並學習用「假設→考驗→結論」的方法來思考。請跟著步驟練習
+  steps:
+    - prompt: 巨石陣和摩艾石像有一個共同的未解之謎，是什麼？
+      type: select
+      options:
+        - 它們是誰建造的
+        - 古代人在沒有大型機械的情況下，如何搬運巨大的石頭
+        - 石頭是從哪裡來的
+      answer: 1
+    - prompt: 關於巨石陣設立的目的，哪個假設目前最可能成立？
+      type: select
+      options:
+        - 外星人的基地
+        - 古代的醫院
+        - 古代人為了觀測天文而建造
+      answer: 2
+    - prompt: 關於摩艾石像的移動方式，課文提到的三個假設中，哪一個有實驗支持？
+      type: select
+      options:
+        - 超自然力量移動石像
+        - 用滾輪把石像移到海邊
+        - 把石像立起來，用繩索拉扯移動
+      answer: 2
+    - prompt: 比較巨石陣和摩艾石像，寫出一個相同點和一個不同點
+      type: free_text
 story_structure:
 - label: 主題
   value: 巨石陣與摩艾石像的未解之謎

--- a/backend/data/lessons/L58.yml
+++ b/backend/data/lessons/L58.yml
@@ -199,6 +199,38 @@ reading_benchmark: null
 source_file: G9-11.12.13-L58~60多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素.docx
 flags:
 - MULTI_TEXT
+strategy_exercise:
+  type: guided_steps
+  strategy_name: 比較不同作者觀點
+  instruction: 這三篇文章從不同角度討論運動表現。閱讀時要找出每位作者的主要觀點，比較異同，再形成自己的看法。請跟著步驟練習
+  steps:
+    - prompt: 第一篇文章認為基普喬吉成功的原因有哪些？
+      type: checkbox
+      options:
+        - 天生的身體優勢（高海拔、小腿細長）
+        - 團隊合作（陪跑員、教練團）
+        - 自律、內省與閱讀
+        - 只靠高科技跑鞋
+      answer:
+        - 0
+        - 1
+        - 2
+    - prompt: 第二篇文章提出了什麼質疑？
+      type: select
+      options:
+        - 基普喬吉的訓練方式不科學
+        - 高科技跑鞋可能造成比賽不公平
+        - 馬拉松的距離應該縮短
+      answer: 1
+    - prompt: 第三篇文章認為，運動成績進步的兩大因素是什麼？
+      type: select
+      options:
+        - 營養和休息
+        - 科技進步和專項選才
+        - 獎金和國家支持
+      answer: 1
+    - prompt: 綜合三篇文章，你認為基普喬吉破紀錄主要靠自己的實力，還是靠外在因素（跑鞋、團隊、科技）？請說明你的理由
+      type: free_text
 story_structure:
 - label: 主角
   value: 基普喬吉、歐文斯、博爾特


### PR DESCRIPTION
## Summary
- feat: 閱讀策略練習 Phase 2 — 52 篇課文策略資料 (#943, PR #951)
- 總覆蓋率 55/57 篇（L01/L55 無策略）
- Type: ordering (2) + trait_inference (4) + guided_steps (49)

## Staging verification
- L07 ordering 5 items ✅
- L09 trait_inference 周天成 ✅  
- L35 guided_steps 5 steps ✅
- L50 guided_steps 4 steps ✅
- L01 null (correct) ✅

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)