### PR TITLE
fix: replace deprecated Pydantic class Config

### DIFF
--- a/backend/app/routes/learning/learning_reading_history.py
+++ b/backend/app/routes/learning/learning_reading_history.py
@@ -59,8 +59,7 @@ class ReadingHistoryItem(BaseModel):
     duration_seconds: float
     created_at: str
 
-    class Config:
-        from_attributes = True
+    model_config = {"from_attributes": True}
 
 
 class ReadingHistoryResponse(BaseModel):


### PR DESCRIPTION
## Summary
Replace deprecated `class Config` with `model_config` dict in `ReadingHistoryItem`.
Eliminates `PydanticDeprecatedSince20` warning from test runs.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)