### PR TITLE
Release: gamification Phase 1 + bug fixes

### DIFF
--- a/backend/app/models/gamification.py
+++ b/backend/app/models/gamification.py
@@ -26,6 +26,10 @@ XP_REWARDS = {
     "streak_bonus": 5,            # daily login streak bonus (per day)
     "first_story": 30,            # bonus for completing very first story
     "vocab_practice": 5,          # completed vocabulary practice step
+    "step_complete": 3,            # completed any learning step
+    "strategy_exercise_complete": 10,  # completed strategy exercise
+    "all_steps_complete": 25,      # completed all 10 steps for one lesson
+    "daily_first_login": 3,        # first activity of the day
 }
 
 # Cumulative XP thresholds per level (index = level-1, value = XP needed to reach it)
@@ -180,6 +184,20 @@ BADGE_CATALOGUE = {
         "description": "累計獲得 1000 XP",
         "icon": "zap",
         "color": "orange",
+    },
+    "perfect_week": {
+        "name": "完美一週",
+        "description": "一週內每天都學習",
+        "icon": "calendar-check",
+        "color": "emerald",
+        "hidden": True,
+    },
+    "explorer": {
+        "name": "步步探索",
+        "description": "嘗試過所有 10 種步驟類型",
+        "icon": "compass",
+        "color": "teal",
+        "hidden": True,
     },
 }
 

--- a/backend/app/services/gamification_service.py
+++ b/backend/app/services/gamification_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime, timezone
 
+from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session
 
 from ..models.gamification import (
@@ -31,19 +32,27 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _get_or_create_xp_log_entry(db: Session, student_id: int) -> tuple[int, list[StudentXPLog]]:
-    """Return the student's cumulative XP and all XP log rows.
-
-    We compute cumulative XP from the log to avoid a separate summary table,
-    keeping the schema simple while still allowing full auditability.
-    """
-    logs = (
-        db.query(StudentXPLog)
+def _get_total_xp(db: Session, student_id: int) -> int:
+    """Return the student's cumulative XP using a DB-side aggregate."""
+    result = (
+        db.query(sqlfunc.coalesce(sqlfunc.sum(StudentXPLog.xp_earned), 0))
         .filter(StudentXPLog.student_id == student_id)
-        .all()
+        .scalar()
     )
-    total = sum(log.xp_earned for log in logs)
-    return total, logs
+    return int(result)
+
+
+def _get_stories_completed(db: Session, student_id: int) -> int:
+    """Return count of 'session_complete' XP log entries for a student."""
+    result = (
+        db.query(sqlfunc.count(StudentXPLog.id))
+        .filter(
+            StudentXPLog.student_id == student_id,
+            StudentXPLog.event_type == "session_complete",
+        )
+        .scalar()
+    )
+    return int(result)
 
 
 def _get_or_create_streak(db: Session, student_id: int) -> StudentStreak:
@@ -152,8 +161,8 @@ def check_and_award_badges(
 
     Returns list of newly unlocked badge keys.
     """
-    total_xp, logs = _get_or_create_xp_log_entry(db, student_id)
-    stories_completed = sum(1 for log in logs if log.event_type == "session_complete")
+    total_xp = _get_total_xp(db, student_id)
+    stories_completed = _get_stories_completed(db, student_id)
     level = xp_to_level(total_xp)
     streak = _get_or_create_streak(db, student_id)
     unlocked = _get_unlocked_badge_keys(db, student_id)
@@ -165,6 +174,9 @@ def check_and_award_badges(
             if row:
                 newly_unlocked.append(badge_key)
 
+    # First session badge (B1 fix: triggers on first story completion)
+    _try("first_session", stories_completed >= 1)
+
     # Story completion badges
     _try("first_story", stories_completed >= 1)
     _try("story_5", stories_completed >= 5)
@@ -175,6 +187,9 @@ def check_and_award_badges(
     _try("streak_3", streak.current_streak >= 3)
     _try("streak_7", streak.current_streak >= 7)
     _try("streak_30", streak.current_streak >= 30)
+
+    # Hidden: perfect_week — longest streak >= 7 days
+    _try("perfect_week", streak.longest_streak >= 7)
 
     # Accuracy badges
     if reading_accuracy is not None:
@@ -188,6 +203,14 @@ def check_and_award_badges(
     # XP milestone badges
     _try("xp_500", total_xp >= 500)
     _try("xp_1000", total_xp >= 1000)
+
+    # Hidden: explorer — 10+ distinct event types in XP log
+    distinct_event_count = (
+        db.query(sqlfunc.count(sqlfunc.distinct(StudentXPLog.event_type)))
+        .filter(StudentXPLog.student_id == student_id)
+        .scalar()
+    )
+    _try("explorer", (distinct_event_count or 0) >= 10)
 
     return newly_unlocked
 
@@ -205,11 +228,48 @@ def process_session_completion(
     Awards XP, updates streak, checks badges, commits all changes.
     Returns a summary dict with XP earned, badges unlocked, and level info.
     """
+    # --- Idempotency check (B2): skip if this session already awarded XP ---
+    existing_logs = (
+        db.query(StudentXPLog)
+        .filter(StudentXPLog.session_id == session_id)
+        .first()
+    )
+    if existing_logs is not None:
+        # Already processed — return existing summary without awarding again
+        total_xp = _get_total_xp(db, student_id)
+        lv_info = level_progress(total_xp)
+        streak = _get_or_create_streak(db, student_id)
+        all_session_logs = (
+            db.query(StudentXPLog)
+            .filter(StudentXPLog.session_id == session_id)
+            .all()
+        )
+        logger.info(
+            "Session %d already processed for student %d — returning cached summary",
+            session_id,
+            student_id,
+        )
+        return {
+            "xp_earned": sum(l.xp_earned for l in all_session_logs),
+            "xp_breakdown": [
+                {"event_type": l.event_type, "xp": l.xp_earned, "note": l.note}
+                for l in all_session_logs
+            ],
+            "new_total_xp": total_xp,
+            "level_info": lv_info,
+            "streak": {
+                "current": streak.current_streak,
+                "longest": streak.longest_streak,
+            },
+            "badges_unlocked": [],
+            "notes": ["（已處理，不重複計算）"],
+        }
+
     xp_earned: list[StudentXPLog] = []
     notes: list[str] = []
 
     # --- Base session XP ---
-    total_xp_before, _ = _get_or_create_xp_log_entry(db, student_id)
+    total_xp_before = _get_total_xp(db, student_id)
     is_first_story = total_xp_before == 0
 
     log = award_xp(db, student_id, "session_complete", session_id=session_id, note="完成課文學習")
@@ -288,8 +348,8 @@ def process_session_completion(
 
 def get_student_summary(db: Session, student_id: int) -> dict:
     """Return full gamification summary for a student."""
-    total_xp, logs = _get_or_create_xp_log_entry(db, student_id)
-    stories_completed = sum(1 for l in logs if l.event_type == "session_complete")
+    total_xp = _get_total_xp(db, student_id)
+    stories_completed = _get_stories_completed(db, student_id)
     lv_info = level_progress(total_xp)
 
     streak = _get_or_create_streak(db, student_id)
@@ -340,13 +400,13 @@ def get_student_summary(db: Session, student_id: int) -> dict:
                 "unlocked": key in {b["key"] for b in badge_list},
             }
             for key, info in BADGE_CATALOGUE.items()
+            if not info.get("hidden") or key in {b["key"] for b in badge_list}
         ],
     }
 
 
 def get_classroom_leaderboard(db: Session, classroom_id: int, limit: int = 10) -> list[dict]:
     """Return top N students in a classroom ranked by total XP."""
-    from sqlalchemy import func as sqlfunc
     from ..models.user import User
 
     # Get all student IDs in classroom

--- a/backend/tests/test_gamification.py
+++ b/backend/tests/test_gamification.py
@@ -11,6 +11,7 @@ from app.models.gamification import (
     BADGE_CATALOGUE,
     LEVEL_THRESHOLDS,
     LEVEL_NAMES,
+    XP_REWARDS,
     StudentBadge,
     StudentStreak,
     StudentXPLog,
@@ -333,3 +334,110 @@ class TestUpdateStreak:
         streak = update_streak(db_session, student_id=1, activity_date=date(2026, 3, 9))
         assert streak.current_streak == 1
         assert streak.longest_streak == 3
+
+
+# ── B1: first_session badge triggers on first story completion ───────────────
+
+
+class TestFirstSessionBadge:
+    def test_first_session_badge_triggers_on_first_completion(self, db_session):
+        """B1 fix: first_session badge should unlock when stories_completed >= 1."""
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+
+        result = process_session_completion(db_session, student_id=1, session_id=1)
+        assert "first_session" in result["badges_unlocked"]
+
+    def test_first_session_badge_not_awarded_twice(self, db_session):
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+        _make_session(db_session, 2, 1)
+
+        r1 = process_session_completion(db_session, student_id=1, session_id=1)
+        assert "first_session" in r1["badges_unlocked"]
+
+        r2 = process_session_completion(db_session, student_id=1, session_id=2)
+        assert "first_session" not in r2["badges_unlocked"]
+
+
+# ── B2: Idempotency — duplicate session_id returns cached, no double XP ──────
+
+
+class TestIdempotency:
+    def test_duplicate_session_id_does_not_double_xp(self, db_session):
+        """B2 fix: calling process_session_completion twice with same session_id
+        should only award XP once."""
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+
+        r1 = process_session_completion(db_session, student_id=1, session_id=1)
+        r2 = process_session_completion(db_session, student_id=1, session_id=1)
+
+        # Same total XP — no double award
+        assert r2["new_total_xp"] == r1["new_total_xp"]
+        # Second call returns same XP breakdown amount
+        assert r2["xp_earned"] == r1["xp_earned"]
+        # Second call should NOT unlock any new badges
+        assert r2["badges_unlocked"] == []
+
+    def test_different_session_ids_award_separately(self, db_session):
+        """Different session_ids should each award XP normally."""
+        from app.services.gamification_service import process_session_completion
+        _make_user(db_session, 1)
+        _make_session(db_session, 1, 1)
+        _make_session(db_session, 2, 1)
+
+        r1 = process_session_completion(db_session, student_id=1, session_id=1)
+        r2 = process_session_completion(db_session, student_id=1, session_id=2)
+
+        assert r2["new_total_xp"] > r1["new_total_xp"]
+
+
+# ── New XP events and badges exist ───────────────────────────────────────────
+
+
+class TestNewXpEvents:
+    @pytest.mark.parametrize("event_type", [
+        "step_complete",
+        "strategy_exercise_complete",
+        "all_steps_complete",
+        "daily_first_login",
+    ])
+    def test_new_xp_event_exists(self, event_type):
+        assert event_type in XP_REWARDS
+        assert XP_REWARDS[event_type] > 0
+
+    def test_step_complete_value(self):
+        assert XP_REWARDS["step_complete"] == 3
+
+    def test_strategy_exercise_complete_value(self):
+        assert XP_REWARDS["strategy_exercise_complete"] == 10
+
+    def test_all_steps_complete_value(self):
+        assert XP_REWARDS["all_steps_complete"] == 25
+
+    def test_daily_first_login_value(self):
+        assert XP_REWARDS["daily_first_login"] == 3
+
+
+class TestNewBadges:
+    def test_perfect_week_badge_exists(self):
+        assert "perfect_week" in BADGE_CATALOGUE
+        badge = BADGE_CATALOGUE["perfect_week"]
+        assert badge["name"] == "完美一週"
+        assert badge.get("hidden") is True
+
+    def test_explorer_badge_exists(self):
+        assert "explorer" in BADGE_CATALOGUE
+        badge = BADGE_CATALOGUE["explorer"]
+        assert badge["name"] == "步步探索"
+        assert badge.get("hidden") is True
+
+    def test_new_badges_have_required_fields(self):
+        for key in ("perfect_week", "explorer"):
+            badge = BADGE_CATALOGUE[key]
+            for field in ("name", "description", "icon", "color"):
+                assert field in badge, f"Badge {key!r} missing field {field!r}"

--- a/frontend/src/components/gamification/AchievementCard.tsx
+++ b/frontend/src/components/gamification/AchievementCard.tsx
@@ -35,6 +35,8 @@ const ICON_EMOJI: Record<string, string> = {
   brain: '🧠',
   crown: '👑',
   zap: '⚡',
+  'calendar-check': '📅',
+  compass: '🧭',
 };
 
 // Map color keys to Tailwind classes
@@ -48,6 +50,8 @@ const COLOR_MAP: Record<string, { bg: string; ring: string; text: string }> = {
   green: { bg: 'bg-green-50', ring: 'ring-green-300', text: 'text-green-700' },
   indigo: { bg: 'bg-indigo-50', ring: 'ring-indigo-300', text: 'text-indigo-700' },
   gray: { bg: 'bg-gray-50', ring: 'ring-gray-300', text: 'text-gray-600' },
+  emerald: { bg: 'bg-emerald-50', ring: 'ring-emerald-300', text: 'text-emerald-700' },
+  teal: { bg: 'bg-teal-50', ring: 'ring-teal-300', text: 'text-teal-700' },
 };
 
 function getColors(color: string, unlocked: boolean) {
@@ -77,22 +81,36 @@ const AchievementCard: React.FC<AchievementCardProps> = ({ badge, size = 'md' })
       `}
       title={badge.description}
     >
-      <div
-        className={`
-          ${sizeClasses.icon} leading-none
-          ${unlocked ? '' : 'grayscale'}
-        `}
-      >
-        {unlocked ? emoji : '🔒'}
+      <div className="relative">
+        <div
+          className={`
+            ${sizeClasses.icon} leading-none
+            ${unlocked ? '' : 'grayscale'}
+          `}
+          style={unlocked ? undefined : { filter: 'blur(4px)', opacity: 0.5 }}
+        >
+          {emoji}
+        </div>
+        {!unlocked && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="text-lg">🔒</span>
+          </div>
+        )}
       </div>
 
       <div>
         <div className={`font-black ${sizeClasses.name} ${unlocked ? colors.text : 'text-gray-400'}`}>
           {badge.name}
         </div>
-        <div className={`${sizeClasses.desc} text-gray-500 mt-0.5 leading-snug`}>
-          {badge.description}
-        </div>
+        {unlocked ? (
+          <div className={`${sizeClasses.desc} text-gray-500 mt-0.5 leading-snug`}>
+            {badge.description}
+          </div>
+        ) : (
+          <div className={`${sizeClasses.desc} text-gray-400 mt-0.5 leading-snug italic`}>
+            {badge.description}
+          </div>
+        )}
       </div>
 
       {unlocked && badge.unlocked_at && (

--- a/frontend/src/components/gamification/XPAwardToast.tsx
+++ b/frontend/src/components/gamification/XPAwardToast.tsx
@@ -3,7 +3,7 @@
  * Shows XP earned, level up (if any), and new badges.
  * Auto-dismisses after 4 seconds or on button click.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 /** Minimal shape needed for the toast — compatible with both gamificationApi and api.ts results. */
 export interface XPAwardResult {
@@ -46,6 +46,9 @@ const BADGE_ICONS: Record<string, string> = {
   level_10:    '👑',
   xp_500:      '⚡',
   xp_1000:     '⚡',
+  first_session:'⭐',
+  perfect_week: '📅',
+  explorer:     '🧭',
 };
 
 const BADGE_NAMES: Record<string, string> = {
@@ -62,33 +65,77 @@ const BADGE_NAMES: Record<string, string> = {
   level_10:    '國文之星',
   xp_500:      '積分達人',
   xp_1000:     '千分英雄',
+  first_session:'初次學習',
+  perfect_week: '完美一週',
+  explorer:     '步步探索',
 };
+
+/** XP thresholds for each level. Index = level number (level 0 starts at 0 XP). */
+const LEVEL_THRESHOLDS = [0, 100, 250, 500, 800, 1200, 1700, 2300, 3000, 4000] as const;
+
+/** Given a total XP value, return the corresponding 1-based level (matches backend xp_to_level). */
+function getLevelForXP(totalXP: number): number {
+  for (let i = LEVEL_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (totalXP >= LEVEL_THRESHOLDS[i]) return i + 1;
+  }
+  return 1;
+}
+
+const AUTO_DISMISS_MS = 4000;
 
 const XPAwardToast: React.FC<XPAwardToastProps> = ({ result, onDismiss }) => {
   const [visible, setVisible] = useState(false);
 
+  // --- Pause-on-hover timer (WCAG 2.2.1) ---
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef(AUTO_DISMISS_MS);
+  const startedAtRef = useRef(Date.now());
+
+  const startDismissTimer = useCallback(() => {
+    startedAtRef.current = Date.now();
+    dismissTimerRef.current = setTimeout(() => {
+      setVisible(false);
+      setTimeout(onDismiss, 300);
+    }, remainingRef.current);
+  }, [onDismiss]);
+
+  const pauseDismissTimer = useCallback(() => {
+    if (dismissTimerRef.current != null) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+      const elapsed = Date.now() - startedAtRef.current;
+      remainingRef.current = Math.max(remainingRef.current - elapsed, 500);
+    }
+  }, []);
+
   useEffect(() => {
     // Trigger animation in
     const showTimer = setTimeout(() => setVisible(true), 50);
-    // Auto-dismiss after 4 seconds
-    const hideTimer = setTimeout(() => {
-      setVisible(false);
-      setTimeout(onDismiss, 300);
-    }, 4000);
+    // Start auto-dismiss countdown
+    startDismissTimer();
     return () => {
       clearTimeout(showTimer);
-      clearTimeout(hideTimer);
+      if (dismissTimerRef.current != null) clearTimeout(dismissTimerRef.current);
     };
-  }, [onDismiss]);
+  }, [startDismissTimer]);
+
+  const handleMouseEnter = () => pauseDismissTimer();
+  const handleMouseLeave = () => startDismissTimer();
 
   const { xp_earned, new_total_xp, level_info, badges_unlocked } = result;
-  const levelUp = result.level_info.level > (new_total_xp - xp_earned >= 100 ? 2 : 1);
+
+  // Level-up detection: compare level before this XP award vs current level
+  const previousTotalXP = level_info.total_xp - xp_earned;
+  const previousLevel = getLevelForXP(previousTotalXP);
+  const levelUp = previousLevel < level_info.level;
 
   return (
     <div
       className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 transition-all duration-300 ${
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
       }`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
     >
       <div className="bg-white rounded-3xl shadow-2xl border-2 border-blue-100 px-6 py-5 min-w-[280px] max-w-sm">
         {/* XP gained */}

--- a/frontend/src/components/student/StoryCard.tsx
+++ b/frontend/src/components/student/StoryCard.tsx
@@ -30,9 +30,13 @@ interface StoryCardProps {
   isLoading: boolean;
   isCompleted: boolean;
   onClick: () => void;
+  /** Estimated XP for completing this story (e.g. 60). Shown as a small badge. */
+  estimatedXP?: number;
+  /** When true, shows a "level up soon" hint instead of the XP estimate. */
+  closeToLevelUp?: boolean;
 }
 
-const StoryCard: React.FC<StoryCardProps> = ({ story, isLoading, isCompleted, onClick }) => {
+const StoryCard: React.FC<StoryCardProps> = ({ story, isLoading, isCompleted, onClick, estimatedXP, closeToLevelUp }) => {
   const diff = getDifficulty(story);
   const diffConfig = DIFFICULTY_CONFIG[diff];
 
@@ -97,6 +101,20 @@ const StoryCard: React.FC<StoryCardProps> = ({ story, isLoading, isCompleted, on
                 {tag}
               </span>
             ))}
+          </div>
+        )}
+        {/* XP callout */}
+        {!isCompleted && (closeToLevelUp || (estimatedXP != null && estimatedXP > 0)) && (
+          <div className="mt-2">
+            {closeToLevelUp ? (
+              <span className="text-xs font-semibold text-[#5B4FC4] bg-[#5B4FC4]/10 px-2 py-0.5 rounded-full">
+                ⚡ 再 1 篇就升級！
+              </span>
+            ) : (
+              <span className="text-xs text-gray-500">
+                ⚡ 完成可得 ~{estimatedXP} XP
+              </span>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Story } from '../../types';
 import { fetchStories, fetchStory } from '../../services/api';
 import { getClassroomTexts } from '../../services/teacherApi';
+import { getGamificationPoints } from '../../services/gamificationApi';
 import { useAuth } from '../../contexts/AuthContext';
 import StoryCard, { Difficulty, DIFFICULTY_CONFIG, getDifficulty } from '../../components/student/StoryCard';
 
@@ -35,7 +36,8 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
   completedSlugs = [],
   classroomId = null,
 }) => {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
+  const [xpToNext, setXpToNext] = useState<number | null>(null);
   const [selectedGrade, setSelectedGrade] = useState<number | null>(null);
   const [selectedDifficulty, setSelectedDifficulty] = useState<Difficulty | null>(null);
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -48,6 +50,14 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
   const [classroomFilterLabel, setClassroomFilterLabel] = useState<string | null>(null);
 
   const completedSet = new Set(completedSlugs);
+
+  // Fetch XP info for callout badges (lightweight, non-blocking)
+  useEffect(() => {
+    if (!token || !user) return;
+    getGamificationPoints(user.id, token)
+      .then((data) => setXpToNext(data.level_info.xp_to_next))
+      .catch(() => {/* silently ignore — XP callout is cosmetic */});
+  }, [token, user]);
 
   useEffect(() => {
     if (!token) return;
@@ -268,15 +278,21 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
       {/* Story grid */}
       {!isLoading && (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {stories.map((story) => (
-            <StoryCard
-              key={story.id}
-              story={story}
-              isLoading={loadingStoryId === story.id}
-              isCompleted={completedSet.has(story.id)}
-              onClick={() => handleStoryClick(story)}
-            />
-          ))}
+          {stories.map((story) => {
+            const ESTIMATED_XP = 60;
+            const isCloseToLevelUp = xpToNext != null && xpToNext > 0 && xpToNext <= ESTIMATED_XP;
+            return (
+              <StoryCard
+                key={story.id}
+                story={story}
+                isLoading={loadingStoryId === story.id}
+                isCompleted={completedSet.has(story.id)}
+                onClick={() => handleStoryClick(story)}
+                estimatedXP={ESTIMATED_XP}
+                closeToLevelUp={isCloseToLevelUp}
+              />
+            );
+          })}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Sync staging → main. Includes PR #957:

- Gamification bug fixes (first_session badge, idempotency, XP scan perf, level-up detection)
- New XP events (step_complete, strategy_exercise, all_steps, daily_login)
- Hidden badges (完美一週, 步步探索)
- Onboarding UX (XP callout, blurred badge preview, Toast hover pause)
- Code review fixes (icon mappings, hidden filter, off-by-one)

## Test plan
- [x] 49 backend tests pass
- [x] CI pass
- [x] Staging QA — 0 bugs, all features verified
- [x] Gamification API returns correct data (XP, badges, hidden filter)

🤖 Generated with [Claude Code](https://claude.ai/code)