### PR TITLE
feat: persist Socratic SessionStore to DB (Fixes #961)

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_dialogue_state_to_learning_sessions.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_dialogue_state_to_learning_sessions.py
@@ -1,0 +1,30 @@
+"""add dialogue_state to learning_sessions
+
+Revision ID: a1b2c3d4e5f6
+Revises: z6a7b8c9d0e1
+Create Date: 2026-04-05 00:00:00.000000
+
+"""
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "z6a7b8c9d0e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "learning_sessions",
+        sa.Column("dialogue_state", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("learning_sessions", "dialogue_state")

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -39,6 +39,8 @@ class LearningSession(Base):
     # General step progress store for all learning steps (Issue #660)
     # Stores current_step, steps_completed[], and per-step step_data
     step_progress: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # Serialized Socratic SessionState snapshot for fast Cloud Run restart recovery (Issue #961)
+    dialogue_state: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     ai_analysis: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
     # 3-level comprehension scoring (Issue #243)
     comprehension_score: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/backend/app/routes/learning/learning_comprehension.py
+++ b/backend/app/routes/learning/learning_comprehension.py
@@ -261,6 +261,8 @@ async def comprehension_chat(
             result = await socratic_agent.process_answer(
                 session_id=payload.session_id,
                 student_answer=safe_student_answer,
+                db=db,
+                db_session_id=payload.db_session_id,
             )
     except ValueError as e:
         ai_success = False

--- a/backend/app/services/socratic_agent.py
+++ b/backend/app/services/socratic_agent.py
@@ -41,7 +41,16 @@ class SessionState:
 
 
 class SessionStore:
-    """In-memory session store with 30-minute TTL cleanup."""
+    """DB-backed session store with in-memory hot cache and 30-minute TTL cleanup.
+
+    Persistence strategy (Issue #961):
+    - save(state, db, db_session_id): writes serialized SessionState to
+      LearningSession.dialogue_state JSONB column AND the in-memory cache.
+    - get(session_id, db, db_session_id): reads from in-memory cache first
+      (fast path); falls back to DB on cache miss (survives Cloud Run restarts).
+    - save(state) without db: writes to in-memory cache only (backwards compatible).
+    - get(session_id) without db: returns None on cache miss (backwards compatible).
+    """
 
     TTL_SECONDS = 30 * 60
     RATE_LIMIT = 30  # max requests per minute per session
@@ -51,12 +60,124 @@ class SessionStore:
         self._sessions: dict[str, SessionState] = {}
         self._rate_counts: dict[str, list[float]] = {}  # session_id -> [timestamps]
 
-    def get(self, session_id: str) -> SessionState | None:
+    def get(
+        self,
+        session_id: str,
+        db: "Session | None" = None,
+        db_session_id: int | None = None,
+    ) -> SessionState | None:
+        """Return SessionState from in-memory cache, or restore from DB on miss."""
         self._cleanup()
-        return self._sessions.get(session_id)
+        if session_id in self._sessions:
+            return self._sessions[session_id]
 
-    def save(self, state: SessionState) -> None:
+        # Cache miss — attempt DB restore if context provided
+        if db is not None and db_session_id is not None:
+            return self._restore_from_db(session_id, db, db_session_id)
+
+        return None
+
+    def save(
+        self,
+        state: SessionState,
+        db: "Session | None" = None,
+        db_session_id: int | None = None,
+    ) -> None:
+        """Persist SessionState to in-memory cache, and optionally to DB."""
         self._sessions[state.session_id] = state
+
+        if db is not None and db_session_id is not None:
+            self._persist_to_db(state, db, db_session_id)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _serialize(self, state: SessionState) -> dict:
+        """Convert SessionState dataclass to a JSON-serializable dict."""
+        import dataclasses
+        return dataclasses.asdict(state)
+
+    def _deserialize(self, data: dict) -> SessionState:
+        """Reconstruct SessionState from a dict (e.g., loaded from JSONB)."""
+        return SessionState(
+            session_id=data["session_id"],
+            story_title=data.get("story_title", ""),
+            story_text=data.get("story_text", ""),
+            conversation=data.get("conversation", []),
+            understood_count=data.get("understood_count", 0),
+            total_attempts=data.get("total_attempts", 0),
+            current_phase=data.get("current_phase", "factual"),
+            created_at=data.get("created_at", time.time()),
+            consecutive_errors=data.get("consecutive_errors", 0),
+            mispronounced_words=data.get("mispronounced_words"),
+            accuracy=data.get("accuracy"),
+            cpm=data.get("cpm"),
+            teacher_instructions=data.get("teacher_instructions"),
+            genre=data.get("genre"),
+            reading_strategy=data.get("reading_strategy"),
+        )
+
+    def _persist_to_db(
+        self,
+        state: SessionState,
+        db: "Session",
+        db_session_id: int,
+    ) -> None:
+        """Write serialized state to LearningSession.dialogue_state column."""
+        try:
+            from ..models.session import LearningSession  # noqa: PLC0415
+
+            ls = db.query(LearningSession).filter_by(id=db_session_id).first()
+            if ls is not None:
+                ls.dialogue_state = self._serialize(state)
+                db.commit()
+        except Exception:
+            logger.warning(
+                "Failed to persist dialogue_state to DB for db_session_id=%s",
+                db_session_id,
+                exc_info=True,
+            )
+            try:
+                db.rollback()
+            except Exception:
+                pass
+
+    def _restore_from_db(
+        self,
+        session_id: str,
+        db: "Session",
+        db_session_id: int,
+    ) -> SessionState | None:
+        """Load SessionState from LearningSession.dialogue_state column."""
+        try:
+            from ..models.session import LearningSession  # noqa: PLC0415
+
+            ls = db.query(LearningSession).filter_by(id=db_session_id).first()
+            if ls is None or ls.dialogue_state is None:
+                return None
+
+            data = ls.dialogue_state
+            # Validate that the stored snapshot belongs to this session
+            if data.get("session_id") != session_id:
+                logger.warning(
+                    "dialogue_state session_id mismatch: stored=%s requested=%s",
+                    data.get("session_id"),
+                    session_id,
+                )
+                return None
+
+            state = self._deserialize(data)
+            # Warm the in-memory cache so subsequent calls don't hit DB
+            self._sessions[session_id] = state
+            return state
+        except Exception:
+            logger.warning(
+                "Failed to restore dialogue_state from DB for db_session_id=%s",
+                db_session_id,
+                exc_info=True,
+            )
+            return None
 
     def _cleanup(self) -> None:
         now = time.time()
@@ -272,8 +393,8 @@ class SocraticAgent:
         is_resumed=True means the session was restored from memory or DB (no Gemini call).
         is_resumed=False means a fresh Gemini call was made.
         """
-        # 1. Check in-memory first (fastest path — no DB or Gemini needed)
-        existing_state = _store.get(session_id)
+        # 1. Check in-memory cache first; fall back to dialogue_state DB snapshot (Issue #961)
+        existing_state = _store.get(session_id, db=db, db_session_id=db_session_id)
         if existing_state is not None:
             last_ai_turn = next(
                 (t for t in reversed(existing_state.conversation) if t["role"] == "ai"),
@@ -316,7 +437,7 @@ class SocraticAgent:
                         genre=genre,
                         reading_strategy=reading_strategy,
                     )
-                    _store.save(state)
+                    _store.save(state, db=db, db_session_id=db_session_id)
                     last_ai_turn = next(
                         (t for t in reversed(state.conversation) if t["role"] == "ai"),
                         None,
@@ -332,7 +453,7 @@ class SocraticAgent:
                         is_complete=state.understood_count >= self.REQUIRED_UNDERSTOOD,
                     ), True
             except Exception as e:
-                logger.warning("Failed to restore session from DB (will start fresh): %s", e)
+                logger.warning("Failed to restore session from DB turns (will start fresh): %s", e)
 
         # 3. Fresh start — only Gemini call that's actually needed
         state = SessionState(
@@ -370,7 +491,7 @@ class SocraticAgent:
 
         state.current_phase = phase
         state.conversation.append({"role": "ai", "text": question})
-        _store.save(state)
+        _store.save(state, db=db, db_session_id=db_session_id)
 
         return AgentResponse(
             question=question,
@@ -448,20 +569,29 @@ class SocraticAgent:
         if session_id in _store._sessions:
             del _store._sessions[session_id]
 
-        # Delete DB turns for this learning session so next mount starts fresh
+        # Delete DB turns and dialogue_state snapshot so next mount starts fresh
         if db is not None and db_session_id is not None:
             try:
-                from ..models.session import DialogueTurn  # noqa: PLC0415
+                from ..models.session import DialogueTurn, LearningSession  # noqa: PLC0415
 
                 db.query(DialogueTurn).filter(
                     DialogueTurn.learning_session_id == db_session_id
                 ).delete(synchronize_session=False)
+
+                ls = db.query(LearningSession).filter_by(id=db_session_id).first()
+                if ls is not None:
+                    ls.dialogue_state = None
+
                 db.commit()
             except Exception as e:
                 logger.warning("Failed to delete DB dialogue turns on restart: %s", e)
 
     async def process_answer(
-        self, session_id: str, student_answer: str
+        self,
+        session_id: str,
+        student_answer: str,
+        db: Session | None = None,
+        db_session_id: int | None = None,
     ) -> AgentResponse:
         """Process a student's answer, evaluate understanding, return next question."""
         # Rate limiting check
@@ -480,7 +610,7 @@ class SocraticAgent:
             student_answer, user_id=session_id
         )
 
-        state = _store.get(session_id)
+        state = _store.get(session_id, db=db, db_session_id=db_session_id)
         if state is None:
             raise ValueError(f"Session {session_id} not found or expired")
 
@@ -575,7 +705,7 @@ class SocraticAgent:
                         "session_id": session_id,
                     },
                 )
-                _store.save(state)
+                _store.save(state, db=db, db_session_id=db_session_id)
                 raise RuntimeError("AI 服務暫時無法使用，請稍後再試。") from e
 
             understood = False  # Don't auto-pass on error; re-ask instead
@@ -603,7 +733,7 @@ class SocraticAgent:
         if not is_complete:
             state.conversation.append({"role": "ai", "text": question})
 
-        _store.save(state)
+        _store.save(state, db=db, db_session_id=db_session_id)
 
         return AgentResponse(
             question=question,

--- a/backend/tests/test_socratic_session_persistence.py
+++ b/backend/tests/test_socratic_session_persistence.py
@@ -1,0 +1,377 @@
+"""
+Tests for Socratic SessionStore DB persistence (Issue #961).
+
+Verifies that:
+- SessionStore.save() writes serialized SessionState to LearningSession.dialogue_state
+- SessionStore.get() falls back to DB when in-memory cache is cold
+- DB snapshot survives an in-memory cache eviction (simulates Cloud Run restart)
+- SessionStore.save() with no db context writes only to in-memory cache (no crash)
+- LearningSession.dialogue_state JSONB column exists on the model
+
+Run with:
+    cd backend
+    python -m pytest tests/test_socratic_session_persistence.py -v
+"""
+
+import sys
+import os
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.session import LearningSession
+
+
+# ---------------------------------------------------------------------------
+# SQLite in-memory test database
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_learning_session(db) -> int:
+    """Create a minimal LearningSession row and return its id."""
+    from app.models.user import User as UserModel, Role
+    from app.auth.password import hash_password
+    import uuid
+
+    # Ensure a student role exists
+    role = db.query(Role).filter_by(name="student").first()
+    if not role:
+        role = Role(name="student", display_name="Student", scope_level="school")
+        db.add(role)
+        db.commit()
+        db.refresh(role)
+
+    unique = uuid.uuid4().hex[:8]
+    user = UserModel(
+        email=f"persist_test_{unique}@example.com",
+        password_hash=hash_password("Password123!"),
+        name=f"PersistTest {unique}",
+        email_verified=True,
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    ls = LearningSession(student_id=user.id, story_slug="test-story")
+    db.add(ls)
+    db.commit()
+    db.refresh(ls)
+    return ls.id
+
+
+# ---------------------------------------------------------------------------
+# Tests: LearningSession.dialogue_state column exists
+# ---------------------------------------------------------------------------
+
+
+class TestDialogueStateColumn:
+    def test_column_exists_on_model(self):
+        """LearningSession must have a dialogue_state attribute."""
+        assert hasattr(LearningSession, "dialogue_state"), (
+            "LearningSession missing dialogue_state column. "
+            "Run the Alembic migration for Issue #961."
+        )
+
+    def test_column_is_nullable_and_defaults_to_none(self):
+        """A newly created LearningSession row should have dialogue_state=None."""
+        db = TestingSessionLocal()
+        try:
+            ls_id = _make_learning_session(db)
+            ls = db.query(LearningSession).filter_by(id=ls_id).one()
+            assert ls.dialogue_state is None
+        finally:
+            db.close()
+
+    def test_column_accepts_dict_payload(self):
+        """dialogue_state should store and retrieve an arbitrary dict."""
+        db = TestingSessionLocal()
+        try:
+            ls_id = _make_learning_session(db)
+            payload = {
+                "session_id": "uuid-abc",
+                "story_title": "玉山",
+                "understood_count": 3,
+                "current_phase": "inferential",
+                "conversation": [{"role": "ai", "text": "主角是誰？"}],
+            }
+            ls = db.query(LearningSession).filter_by(id=ls_id).one()
+            ls.dialogue_state = payload
+            db.commit()
+
+            db.expire(ls)
+            ls = db.query(LearningSession).filter_by(id=ls_id).one()
+            assert ls.dialogue_state == payload
+            assert ls.dialogue_state["understood_count"] == 3
+        finally:
+            db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: SessionStore DB-backed persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStoreDBPersistence:
+    def _make_state(self, session_id: str = "test-session-id"):
+        from app.services.socratic_agent import SessionState
+
+        return SessionState(
+            session_id=session_id,
+            story_title="玉山的故事",
+            story_text="玉山是台灣最高峰。\n標高3952公尺。",
+            conversation=[
+                {"role": "ai", "text": "課文的主角是誰？"},
+                {"role": "student", "text": "玉山"},
+            ],
+            understood_count=2,
+            total_attempts=3,
+            current_phase="inferential",
+            consecutive_errors=0,
+            mispronounced_words=["標高"],
+            accuracy=85.0,
+            cpm=120.0,
+            teacher_instructions=["多鼓勵"],
+            genre="說明文",
+            reading_strategy="摘要",
+        )
+
+    def test_save_writes_dialogue_state_to_db(self):
+        """SessionStore.save() with db + db_session_id must update dialogue_state column."""
+        from app.services.socratic_agent import SessionStore
+
+        store = SessionStore()
+        db = TestingSessionLocal()
+        try:
+            ls_id = _make_learning_session(db)
+            state = self._make_state("save-test-session")
+
+            store.save(state, db=db, db_session_id=ls_id)
+
+            db.expire_all()
+            ls = db.query(LearningSession).filter_by(id=ls_id).one()
+            assert ls.dialogue_state is not None, "dialogue_state should be set after save()"
+            assert ls.dialogue_state["session_id"] == "save-test-session"
+            assert ls.dialogue_state["understood_count"] == 2
+            assert ls.dialogue_state["current_phase"] == "inferential"
+            assert ls.dialogue_state["genre"] == "說明文"
+            assert ls.dialogue_state["reading_strategy"] == "摘要"
+        finally:
+            db.close()
+
+    def test_get_falls_back_to_db_when_memory_cold(self):
+        """SessionStore.get() with a cold cache must restore state from DB."""
+        from app.services.socratic_agent import SessionStore
+
+        store = SessionStore()
+        db = TestingSessionLocal()
+        try:
+            ls_id = _make_learning_session(db)
+            state = self._make_state("cold-cache-session")
+
+            # Write to DB only (bypass in-memory cache by writing directly to the column)
+            ls = db.query(LearningSession).filter_by(id=ls_id).one()
+            ls.dialogue_state = {
+                "session_id": "cold-cache-session",
+                "story_title": "玉山的故事",
+                "story_text": "玉山是台灣最高峰。\n標高3952公尺。",
+                "conversation": [{"role": "ai", "text": "課文的主角是誰？"}],
+                "understood_count": 1,
+                "total_attempts": 2,
+                "current_phase": "factual",
+                "consecutive_errors": 0,
+                "mispronounced_words": None,
+                "accuracy": None,
+                "cpm": None,
+                "teacher_instructions": None,
+                "genre": None,
+                "reading_strategy": None,
+                "created_at": time.time(),
+            }
+            db.commit()
+
+            # Cold cache — session not in memory
+            assert store._sessions.get("cold-cache-session") is None
+
+            # get() with db context should restore from DB
+            restored = store.get("cold-cache-session", db=db, db_session_id=ls_id)
+            assert restored is not None, "get() should restore state from DB on cache miss"
+            assert restored.session_id == "cold-cache-session"
+            assert restored.understood_count == 1
+            assert restored.current_phase == "factual"
+            assert restored.conversation == [{"role": "ai", "text": "課文的主角是誰？"}]
+        finally:
+            db.close()
+
+    def test_restored_state_is_cached_in_memory(self):
+        """After DB restore, the state must also be in the in-memory cache."""
+        from app.services.socratic_agent import SessionStore
+
+        store = SessionStore()
+        db = TestingSessionLocal()
+        try:
+            ls_id = _make_learning_session(db)
+
+            ls = db.query(LearningSession).filter_by(id=ls_id).one()
+            ls.dialogue_state = {
+                "session_id": "warm-after-restore",
+                "story_title": "Test",
+                "story_text": "Line1\nLine2",
+                "conversation": [],
+                "understood_count": 0,
+                "total_attempts": 0,
+                "current_phase": "factual",
+                "consecutive_errors": 0,
+                "mispronounced_words": None,
+                "accuracy": None,
+                "cpm": None,
+                "teacher_instructions": None,
+                "genre": None,
+                "reading_strategy": None,
+                "created_at": time.time(),
+            }
+            db.commit()
+
+            store.get("warm-after-restore", db=db, db_session_id=ls_id)
+
+            # Second call should hit memory, not DB
+            cached = store._sessions.get("warm-after-restore")
+            assert cached is not None, "State should be in memory after first DB restore"
+            assert cached.session_id == "warm-after-restore"
+        finally:
+            db.close()
+
+    def test_save_without_db_context_does_not_crash(self):
+        """save() without db context must still store state in-memory (no crash)."""
+        from app.services.socratic_agent import SessionStore
+
+        store = SessionStore()
+        state = self._make_state("no-db-session")
+
+        # Must not raise
+        store.save(state)
+
+        assert store._sessions.get("no-db-session") is not None
+
+    def test_get_without_db_context_returns_none_on_cache_miss(self):
+        """get() without db context returns None when session not in memory."""
+        from app.services.socratic_agent import SessionStore
+
+        store = SessionStore()
+        result = store.get("nonexistent-session")
+        assert result is None
+
+    def test_db_snapshot_survives_memory_eviction(self):
+        """Simulates Cloud Run restart: after clearing in-memory cache, DB restore works."""
+        from app.services.socratic_agent import SessionStore
+
+        store = SessionStore()
+        db = TestingSessionLocal()
+        try:
+            ls_id = _make_learning_session(db)
+            state = self._make_state("eviction-test-session")
+
+            # Save with DB
+            store.save(state, db=db, db_session_id=ls_id)
+
+            # Simulate restart: clear in-memory cache
+            store._sessions.clear()
+            assert "eviction-test-session" not in store._sessions
+
+            # Restore from DB
+            restored = store.get("eviction-test-session", db=db, db_session_id=ls_id)
+            assert restored is not None
+            assert restored.session_id == "eviction-test-session"
+            assert restored.understood_count == 2
+            assert restored.story_title == "玉山的故事"
+        finally:
+            db.close()
+
+    def test_serialized_fields_roundtrip_correctly(self):
+        """All SessionState fields must survive JSON serialization round-trip."""
+        from app.services.socratic_agent import SessionStore, SessionState
+
+        store = SessionStore()
+        db = TestingSessionLocal()
+        try:
+            ls_id = _make_learning_session(db)
+            state = SessionState(
+                session_id="roundtrip-session",
+                story_title="Title With Unicode 台灣",
+                story_text="Paragraph 1\nParagraph 2",
+                conversation=[
+                    {"role": "ai", "text": "Q1?"},
+                    {"role": "student", "text": "A1"},
+                    {"role": "ai", "text": "Q2?"},
+                ],
+                understood_count=1,
+                total_attempts=2,
+                current_phase="inferential",
+                consecutive_errors=1,
+                mispronounced_words=["台灣", "玉山"],
+                accuracy=72.5,
+                cpm=95.3,
+                teacher_instructions=["鼓勵學生", "不要催促"],
+                genre="記敘文",
+                reading_strategy="預測",
+            )
+
+            store.save(state, db=db, db_session_id=ls_id)
+
+            # Evict from memory
+            store._sessions.clear()
+
+            restored = store.get("roundtrip-session", db=db, db_session_id=ls_id)
+            assert restored is not None
+            assert restored.story_title == "Title With Unicode 台灣"
+            assert restored.conversation == [
+                {"role": "ai", "text": "Q1?"},
+                {"role": "student", "text": "A1"},
+                {"role": "ai", "text": "Q2?"},
+            ]
+            assert restored.understood_count == 1
+            assert restored.total_attempts == 2
+            assert restored.current_phase == "inferential"
+            assert restored.consecutive_errors == 1
+            assert restored.mispronounced_words == ["台灣", "玉山"]
+            assert abs(restored.accuracy - 72.5) < 0.001
+            assert abs(restored.cpm - 95.3) < 0.001
+            assert restored.teacher_instructions == ["鼓勵學生", "不要催促"]
+            assert restored.genre == "記敘文"
+            assert restored.reading_strategy == "預測"
+        finally:
+            db.close()


### PR DESCRIPTION
Fixes #961

## Summary

- Add nullable JSONB `dialogue_state` column to `learning_sessions` table
- New Alembic migration `a1b2c3d4e5f6` adds the column with `downgrade()` support
- `SessionStore.save(state, db, db_session_id)` now writes a full serialized snapshot of `SessionState` to the column (in addition to in-memory cache)
- `SessionStore.get(session_id, db, db_session_id)` falls back to DB restore on cache miss, then warms the in-memory cache — survives Cloud Run redeploy/scale
- `SocraticAgent.process_answer()` accepts optional `db` / `db_session_id` parameters; route passes them through
- `clear_session()` nulls `dialogue_state` column so a "restart" is clean
- Backwards-compatible: all calls without db context still work as before

## Persistence layers (priority order)

1. In-memory cache (fast path, same process)
2. `dialogue_state` JSONB snapshot (new — fast single-row read on restart)
3. `DialogueTurn` rows replay (existing — still used by `start_session` as a third fallback)

## Test plan

- 10 new unit tests in `tests/test_socratic_session_persistence.py`
  - `TestDialogueStateColumn` — column exists, nullable default, accepts dict
  - `TestSessionStoreDBPersistence` — save writes to DB, get restores from DB, memory warm after restore, no-db fallback, eviction simulation, full field roundtrip
- All 10 pass; pre-existing failures (test_exit_ticket, test_rate_limiting, test_gemini_content_filter, etc.) are unaffected by this PR