### PR TITLE
perf: add .limit(5000) safety caps to unbounded queries (Fixes #964)

### DIFF
--- a/backend/app/routes/learning/learning_errors.py
+++ b/backend/app/routes/learning/learning_errors.py
@@ -100,6 +100,7 @@ def get_student_story_slugs(
         )
         .distinct()
         .order_by(LearningSession.story_slug)
+        .limit(5000)
         .all()
     )
     slugs = []
@@ -155,6 +156,7 @@ def get_error_patterns(
         .group_by(CharacterError.character)
         .having(sa_func.count(CharacterError.id) >= min_errors)
         .order_by(sa_func.count(CharacterError.id).desc())
+        .limit(5000)
         .all()
     )
 
@@ -165,6 +167,7 @@ def get_error_patterns(
             ErrorCorrection.student_id == student_id,
             ErrorCorrection.correction_type == "mastered",
         )
+        .limit(5000)
         .all()
     )
     for row in mastered_rows:
@@ -207,6 +210,7 @@ def get_recommended_vocab(
             ErrorCorrection.student_id == student_id,
             ErrorCorrection.correction_type == "mastered",
         )
+        .limit(5000)
         .all()
     )
     for row in mastered_rows:
@@ -224,6 +228,7 @@ def get_recommended_vocab(
         )
         .group_by(CharacterError.character)
         .order_by(sa_func.count(CharacterError.id).desc())
+        .limit(5000)
         .all()
     )
 
@@ -302,6 +307,7 @@ def get_repeated_errors_alert(
             ErrorCorrection.student_id == student_id,
             ErrorCorrection.correction_type == "mastered",
         )
+        .limit(5000)
         .all()
     ):
         mastered_chars.add(row.character)
@@ -316,6 +322,7 @@ def get_repeated_errors_alert(
         .group_by(CharacterError.character)
         .having(sa_func.count(CharacterError.id) >= REPEATED_ERROR_THRESHOLD)
         .order_by(sa_func.count(CharacterError.id).desc())
+        .limit(5000)
         .all()
     )
 

--- a/backend/app/routes/teacher/teacher_analytics.py
+++ b/backend/app/routes/teacher/teacher_analytics.py
@@ -57,10 +57,11 @@ def get_classroom_time_stats(
             sessions_last_week=0,
         )
 
-    # All sessions for classroom students
+    # All sessions for classroom students (safety cap to prevent unbounded memory usage)
     sessions = (
         db.query(LearningSession)
         .filter(LearningSession.student_id.in_(student_ids))
+        .limit(5000)
         .all()
     )
 
@@ -127,10 +128,11 @@ def get_classroom_heatmap(
     """
     _check_classroom_access(current_user, classroom_id, db)
 
-    # Get all student IDs in this classroom
+    # Get all student IDs in this classroom (safety cap)
     enrollments = (
         db.query(ClassroomStudent)
         .filter(ClassroomStudent.classroom_id == classroom_id)
+        .limit(5000)
         .all()
     )
 
@@ -140,13 +142,14 @@ def get_classroom_heatmap(
     student_ids = [e.student_id for e in enrollments]
     students_map = {e.student_id: e.student for e in enrollments}
 
-    # Query all sessions for classroom students with a story_slug and score
+    # Query all sessions for classroom students with a story_slug and score (safety cap)
     sessions = (
         db.query(LearningSession)
         .filter(
             LearningSession.student_id.in_(student_ids),
             LearningSession.story_slug.isnot(None),
         )
+        .limit(5000)
         .all()
     )
 
@@ -225,10 +228,11 @@ def get_classroom_error_heatmap(
     """
     _check_classroom_access(current_user, classroom_id, db)
 
-    # Get enrolled students in enrollment order
+    # Get enrolled students in enrollment order (safety cap)
     enrollments = (
         db.query(ClassroomStudent)
         .filter(ClassroomStudent.classroom_id == classroom_id)
+        .limit(5000)
         .all()
     )
     if not enrollments:
@@ -237,7 +241,7 @@ def get_classroom_error_heatmap(
     student_ids = [e.student_id for e in enrollments]
     students_map = {e.student_id: e.student for e in enrollments}
 
-    # Query aggregated error counts: (student_id, character) -> count
+    # Query aggregated error counts: (student_id, character) -> count (safety cap)
     rows = (
         db.query(
             LearningSession.student_id,
@@ -247,6 +251,7 @@ def get_classroom_error_heatmap(
         .join(CharacterError, CharacterError.session_id == LearningSession.id)
         .filter(LearningSession.student_id.in_(student_ids))
         .group_by(LearningSession.student_id, CharacterError.character)
+        .limit(5000)
         .all()
     )
 


### PR DESCRIPTION
Fixes #964

## Summary
- Added `.limit(5000)` safety caps to all unbounded `.all()` queries in `teacher_analytics.py` and `learning_errors.py`
- No API response format changes — purely a server-side guard against unbounded memory usage at extreme scale
- Queries remain classroom-scoped or student-scoped so the cap will never be hit in normal usage

## Files Changed
- `backend/app/routes/teacher/teacher_analytics.py` — 5 queries capped (`get_classroom_time_stats`: sessions; `get_classroom_heatmap`: enrollments + sessions; `get_classroom_error_heatmap`: enrollments + aggregated rows)
- `backend/app/routes/learning/learning_errors.py` — 7 queries capped (`get_student_story_slugs`: slugs; `get_error_patterns`: error groups + mastered rows; `get_recommended_vocab`: mastered rows + error groups; `get_repeated_errors_alert`: mastered chars + alert rows)

## Test Plan
- [x] `python -m pytest tests/test_teacher_analytics.py tests/test_heatmap.py tests/test_error_heatmap.py -x -q` — 33/33 passed