### PR TITLE
fix: rename Alembic migration ID to avoid collision (hotfix for #961)

### DIFF
--- a/backend/alembic/versions/b3c4d5e6f7a8_add_dialogue_state_to_learning_sessions.py
+++ b/backend/alembic/versions/b3c4d5e6f7a8_add_dialogue_state_to_learning_sessions.py
@@ -1,6 +1,6 @@
 """add dialogue_state to learning_sessions
 
-Revision ID: a1b2c3d4e5f6
+Revision ID: b3c4d5e6f7a8
 Revises: z6a7b8c9d0e1
 Create Date: 2026-04-05 00:00:00.000000
 
@@ -13,7 +13,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
+revision: str = "b3c4d5e6f7a8"
 down_revision: Union[str, None] = "z6a7b8c9d0e1"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Problem

PR #970 merged with Alembic revision ID `a1b2c3d4e5f6` which collides with the existing `a1b2c3d4e5f6_unified_user_model.py` migration. This causes staging backend to fail startup with:

```
FAILED: Multiple head revisions are present for given argument 'head'
UserWarning: Revision a1b2c3d4e5f6 is present more than once
```

## Fix

Rename `a1b2c3d4e5f6_add_dialogue_state_to_learning_sessions.py` to `b3c4d5e6f7a8_add_dialogue_state_to_learning_sessions.py` (same revision chain, unique ID).

## Test plan

- Alembic `upgrade head` should succeed without "multiple head" error
- `LearningSession.dialogue_state` column added as before