### PR TITLE
fix: correct Alembic down_revision to fk01idx02add03 (fix multiple heads)

### DIFF
--- a/backend/alembic/versions/b3c4d5e6f7a8_add_dialogue_state_to_learning_sessions.py
+++ b/backend/alembic/versions/b3c4d5e6f7a8_add_dialogue_state_to_learning_sessions.py
@@ -14,7 +14,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 # revision identifiers, used by Alembic.
 revision: str = "b3c4d5e6f7a8"
-down_revision: Union[str, None] = "z6a7b8c9d0e1"
+down_revision: Union[str, None] = "fk01idx02add03"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Problem

The staging backend is failing to start with:
```
FAILED: Multiple head revisions are present for given argument 'head'
```

Root cause: migration `b3c4d5e6f7a8` had `down_revision = "z6a7b8c9d0e1"` but there is already a migration `fk01idx02add03` (add missing FK indexes) that also revises `z6a7b8c9d0e1`. This creates two migration heads.

## Fix

Change `b3c4d5e6f7a8`'s `down_revision` from `"z6a7b8c9d0e1"` to `"fk01idx02add03"`, making the chain:

```
z6a7b8c9d0e1 → fk01idx02add03 → b3c4d5e6f7a8 (dialogue_state column)
```

After this fix, `alembic heads` returns only `['b3c4d5e6f7a8']` (single head).

## Test plan

- `alembic heads` returns only one head after this change
- Staging backend starts successfully