### PR TITLE
fix: sync story_id to classroom_texts when creating assignment (Fixes #997)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Session
 from ..auth.dependencies import get_current_user
 from ..database import get_db
 from ..models.assignment import Assignment, AssignmentSubmission
-from ..models.school import Classroom, ClassroomStudent
+from ..models.school import Classroom, ClassroomStudent, ClassroomText
 from ..models.session import LearningSession, CharacterError, DialogueTurn
 from ..models.text import Text
 from ..models.user import User, UserRole, Role
@@ -421,6 +421,25 @@ def create_assignment(
     )
     db.add(assignment)
     db.flush()  # get assignment.id
+
+    # Sync story_id to classroom_texts so the library page shows it (#997)
+    if resolved_story_id is not None:
+        existing_ct = (
+            db.query(ClassroomText)
+            .filter(
+                ClassroomText.classroom_id == classroom_id,
+                ClassroomText.text_id == resolved_story_id,
+                ClassroomText.deleted_at.is_(None),
+            )
+            .first()
+        )
+        if existing_ct is None:
+            db.add(ClassroomText(
+                classroom_id=classroom_id,
+                text_id=resolved_story_id,
+                assigned_by=current_user.id,
+                expires_at=payload.due_date,
+            ))
 
     # Bulk-create submissions for all enrolled students
     enrollments = (


### PR DESCRIPTION
Fixes #997

## Summary
- When `create_assignment` is called with a `story_id`, also upsert a `ClassroomText` row so the library page (`/library?classroom=N`) shows the assigned story
- Skips creation if a `classroom_text` row already exists for that story (idempotent)
- `expires_at` mirrors `assignment.due_date` for optional auto-cleanup

## Root Cause
The library page queries `classroom_texts` exclusively. Assignments created via the YAML-story path (`story_id`) never wrote to `classroom_texts`, causing a disconnect.

## Test Plan
1. Create a classroom + add at least one student
2. Create an assignment with a YAML story_id
3. Log in as the student → "My Assignments" shows the assignment
4. Navigate to "Library" for that classroom → the story should now appear