### PR TITLE
feat: add PATCH /users/me for updating profile (Fixes #998)

### DIFF
--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..auth.dependencies import get_current_user, require_role
@@ -16,6 +18,18 @@ from ..schemas.user_admin import (
 
 router = APIRouter(tags=["users"])
 logger = logging.getLogger(__name__)
+
+
+class UpdateMeRequest(BaseModel):
+    """Request body for PATCH /users/me.
+
+    All fields are optional — only provided fields are updated.
+    Sensitive fields (email, password, roles) are intentionally excluded.
+    """
+
+    name: Optional[str] = Field(None, max_length=100)
+    avatar_url: Optional[str] = Field(None, max_length=500)
+    phone: Optional[str] = Field(None, max_length=20)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -43,6 +57,72 @@ def get_me(
     db: Session = Depends(get_db),
 ):
     """Get current authenticated user with their roles."""
+    user_roles = (
+        db.query(UserRole, Role)
+        .join(Role, UserRole.role_id == Role.id)
+        .filter(UserRole.user_id == current_user.id, UserRole.is_active == True)
+        .all()
+    )
+
+    roles = [
+        UserRoleResponse(
+            role_name=role.name,
+            role_display_name=role.display_name,
+            scope_type=ur.scope_type,
+            scope_id=ur.scope_id,
+        )
+        for ur, role in user_roles
+    ]
+
+    return UserResponse(
+        id=current_user.id,
+        email=current_user.email,
+        name=current_user.name,
+        phone=current_user.phone,
+        avatar_url=current_user.avatar_url,
+        is_active=current_user.is_active,
+        email_verified=current_user.email_verified,
+        onboarding_completed=current_user.onboarding_completed,
+        last_login_at=current_user.last_login_at,
+        terms_accepted_at=current_user.terms_accepted_at,
+        terms_version=current_user.terms_version,
+        created_at=current_user.created_at,
+        roles=roles,
+    )
+
+
+@router.patch("/users/me", response_model=UserResponse)
+def update_me(
+    payload: UpdateMeRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update the current authenticated user's profile.
+
+    Only name, avatar_url, and phone may be changed here.
+    Sensitive fields (email, password, roles) require dedicated flows.
+    Returns the updated user with their roles.
+    """
+    updated = False
+
+    if payload.name is not None:
+        current_user.name = payload.name
+        updated = True
+
+    if payload.avatar_url is not None:
+        current_user.avatar_url = payload.avatar_url
+        updated = True
+
+    if payload.phone is not None:
+        current_user.phone = payload.phone
+        updated = True
+
+    if updated:
+        db.add(current_user)
+        db.commit()
+        db.refresh(current_user)
+        logger.info("User %d updated profile fields: %s", current_user.id, list(payload.model_fields_set))
+
     user_roles = (
         db.query(UserRole, Role)
         .join(Role, UserRole.role_id == Role.id)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4116,9 +4116,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes #998

## Summary
- Added `PATCH /api/users/me` endpoint to `backend/app/routes/users.py`
- Accepts `name`, `avatar_url`, `phone` (all optional, partial update semantics)
- Returns the same `UserResponse` shape as `GET /users/me`
- Sensitive fields (email, password, roles) are intentionally excluded — those require dedicated flows

## Test Plan
1. `GET /api/users/me` — note current name
2. `PATCH /api/users/me` with `{"name": "New Name"}` — should return 200 with updated name
3. `PATCH /api/users/me` with `{}` — should return 200 with no changes
4. `PATCH /api/users/me` with `{"email": "x@y.com"}` — field is ignored (not in schema)