### PR TITLE
fix: teacher report UX — comment above report, hide empty sections, disable celebration (#1005)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -70,6 +70,8 @@ interface AssessmentReportProps {
   dbSessionId?: number | null;
   /** Auth token — passed to ExitTicket for API calls (Issue #463) */
   token?: string | null;
+  /** When true, suppresses celebration overlays and interactive elements (teacher view) */
+  readOnly?: boolean;
 }
 
 // CPM thresholds aligned with backend persona.py (Issue #54)
@@ -165,7 +167,7 @@ const Section: React.FC<{
   );
 };
 
-const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab, comprehensionScores, comprehensionScoresLoading, readingGoals, dbSessionId, token }) => {
+const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab, comprehensionScores, comprehensionScoresLoading, readingGoals, dbSessionId, token, readOnly }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
 
   // Track report viewed in localStorage
@@ -354,10 +356,10 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
         />
       )}
 
-      <CelebrationOverlay score={overallScore} />
+      {!readOnly && <CelebrationOverlay score={overallScore} />}
 
       {/* ============ 星星評級 Star Rating (Issue #222) ============ */}
-      {!hasNoData && (
+      {!hasNoData && !readOnly && (
         <StarCelebration
           stars={starCount}
           readingAccuracy={bestReadingAccuracy}

--- a/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
+++ b/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
@@ -214,17 +214,7 @@ const TeacherSessionReportPage: React.FC = () => {
         </div>
       )}
 
-      {/* Reuse student AssessmentReport (read-only) */}
-      <AssessmentReport
-        session={session}
-        story={story}
-        onRetry={() => navigate(-1)}
-        dbSessionId={sessionId ? Number(sessionId) : null}
-        token={token}
-        comprehensionScores={scores}
-      />
-
-      {/* Teacher comment section */}
+      {/* Teacher comment section — above report so teacher doesn't scroll past empty sections */}
       {report && token && (
         <TeacherCommentSection
           studentId={Number(studentId)}
@@ -234,6 +224,23 @@ const TeacherSessionReportPage: React.FC = () => {
           teacherComment={report.teacher_comment}
           teacherReviewedAt={report.teacher_reviewed_at}
           studentName={report.student_name}
+        />
+      )}
+
+      {/* Reuse student AssessmentReport (read-only) or show empty message */}
+      {report && !report.reading_result && !report.full_reading_result && !report.comprehension_result ? (
+        <div className="bg-gray-50 border border-gray-200 rounded-xl p-6 text-center">
+          <p className="text-sm text-gray-500">學生尚未完成此課文的學習，暫無報告資料</p>
+        </div>
+      ) : (
+        <AssessmentReport
+          session={session}
+          story={story}
+          onRetry={() => navigate(-1)}
+          dbSessionId={sessionId ? Number(sessionId) : null}
+          token={token}
+          comprehensionScores={scores}
+          readOnly
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Move TeacherCommentSection **above** AssessmentReport so teachers see the comment textarea immediately without scrolling past 6 empty sections
- When session has no reading/full_reading/comprehension data, show a simple "尚未完成" message instead of the full AssessmentReport with 6 "尚未完成" sections
- Add `readOnly` prop to AssessmentReport that suppresses CelebrationOverlay and StarCelebration in teacher view

Closes #1005

## Test plan
- [ ] Open a teacher session report for a session with no data (e.g. session 103) — should show comment section at top and simple empty message below
- [ ] Open a teacher session report for a session WITH data — should show comment section at top, then full AssessmentReport without celebration overlay
- [ ] Student view of AssessmentReport unchanged (no `readOnly` prop passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)