### PR TITLE
fix: create assignment submissions for late-joining students (#996)

### DIFF
--- a/backend/app/routes/classrooms/classroom_batch.py
+++ b/backend/app/routes/classrooms/classroom_batch.py
@@ -21,6 +21,7 @@ from ...schemas.classroom import (
 from ...services.input_sanitizer import sanitize_ai_input
 from .helpers import (
     check_email_domain,
+    create_submissions_for_new_student,
     get_classroom_or_404,
     require_owner_or_admin,
 )
@@ -125,21 +126,8 @@ def batch_create_students(
             db.add(cs)
             db.flush()
 
-            # Backfill submissions for all active assignments in this classroom (#996)
-            active_assignments = (
-                db.query(Assignment)
-                .filter(
-                    Assignment.classroom_id == classroom_id,
-                    Assignment.is_active == True,
-                )
-                .all()
-            )
-            for assignment in active_assignments:
-                db.add(AssignmentSubmission(
-                    assignment_id=assignment.id,
-                    student_id=user.id,
-                    status="pending",
-                ))
+            # Back-fill submissions for active assignments (#996)
+            create_submissions_for_new_student(classroom_id, user.id, db)
 
             created.append(CreatedStudentInfo(
                 name=item.name,

--- a/backend/app/routes/classrooms/classroom_csv.py
+++ b/backend/app/routes/classrooms/classroom_csv.py
@@ -16,6 +16,7 @@ from ...schemas.classroom import BatchStudentError, CreatedStudentInfo, CsvUploa
 from ...auth.password import hash_password
 from .helpers import (
     check_email_domain,
+    create_submissions_for_new_student,
     get_classroom_or_404,
     require_owner_or_admin,
 )
@@ -222,6 +223,9 @@ async def upload_csv_students(
             )
             db.add(cs)
             db.flush()
+
+            # Back-fill submissions for active assignments (#996)
+            create_submissions_for_new_student(classroom_id, user.id, db)
 
             created.append(CreatedStudentInfo(
                 name=name,

--- a/backend/app/routes/classrooms/classroom_join.py
+++ b/backend/app/routes/classrooms/classroom_join.py
@@ -11,6 +11,7 @@ from ...models.user import User
 from ...schemas.classroom import ClassroomJoinRequest, ClassroomResponse
 from .helpers import (
     classroom_to_response,
+    create_submissions_for_new_student,
     generate_join_code,
     get_classroom_or_404,
     require_owner_or_admin,
@@ -61,6 +62,11 @@ def join_classroom_by_code(
         student_id=current_user.id,
     )
     db.add(cs)
+    db.flush()
+
+    # Back-fill submissions for active assignments the student missed (#996)
+    create_submissions_for_new_student(classroom.id, current_user.id, db)
+
     db.commit()
     db.refresh(classroom)
     logger.info(

--- a/backend/app/routes/classrooms/classroom_students.py
+++ b/backend/app/routes/classrooms/classroom_students.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
 from ...database import get_db
-from ...models.assignment import Assignment, AssignmentSubmission
 from ...models.school import ClassroomStudent
 from ...models.user import User
 from ...schemas.classroom import (
@@ -17,6 +16,7 @@ from ...schemas.classroom import (
 )
 from ...services.audit_logger import AuditAction, audit_log_endpoint
 from .helpers import (
+    create_submissions_for_new_student,
     get_classroom_or_404,
     require_member_or_admin,
     require_owner_or_admin,
@@ -61,39 +61,16 @@ def add_student_to_classroom(
         student_id=payload.student_id,
     )
     db.add(cs)
-    db.flush()  # get cs.id without committing yet
+    db.flush()
 
-    # Backfill submissions for all active assignments in this classroom (#996)
-    active_assignments = (
-        db.query(Assignment)
-        .filter(
-            Assignment.classroom_id == classroom_id,
-            Assignment.is_active == True,
-        )
-        .all()
-    )
-    for assignment in active_assignments:
-        # Skip if submission already exists (defensive guard against double-add)
-        existing_sub = (
-            db.query(AssignmentSubmission)
-            .filter(
-                AssignmentSubmission.assignment_id == assignment.id,
-                AssignmentSubmission.student_id == payload.student_id,
-            )
-            .first()
-        )
-        if existing_sub is None:
-            db.add(AssignmentSubmission(
-                assignment_id=assignment.id,
-                student_id=payload.student_id,
-                status="pending",
-            ))
+    # Back-fill submissions for active assignments the student missed (#996)
+    create_submissions_for_new_student(classroom_id, payload.student_id, db)
 
     db.commit()
     db.refresh(cs)
     logger.info(
-        "Added student %d to classroom %d; backfilled %d submission(s)",
-        payload.student_id, classroom_id, len(active_assignments),
+        "Added student %d to classroom %d (submissions backfilled)",
+        payload.student_id, classroom_id,
     )
     return StudentInClassroomResponse(
         id=student.id,

--- a/backend/app/routes/classrooms/helpers.py
+++ b/backend/app/routes/classrooms/helpers.py
@@ -1,4 +1,5 @@
 """Shared helpers, constants, and permission checks for the classrooms module."""
+import logging
 import secrets
 import string
 
@@ -7,9 +8,12 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ...auth.dependencies import get_current_user  # noqa: F401 — re-exported for convenience
+from ...models.assignment import Assignment, AssignmentSubmission
 from ...models.school import Classroom, ClassroomStudent, ClassroomTeacher
 from ...models.user import Role, User, UserRole
 from ...schemas.classroom import ClassroomDetailResponse, ClassroomResponse, StudentInClassroomResponse
+
+logger = logging.getLogger(__name__)
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -151,6 +155,66 @@ def check_email_domain(email: str, school_domain: str | None) -> str | None:
     if email_domain != school_domain.lower().lstrip("@"):
         return f"學生 {email} 的 email 不屬於學校 domain ({school_domain})"
     return None
+
+
+# ── Late-join Assignment Submissions ─────────────────────────────────────────
+
+
+def create_submissions_for_new_student(
+    classroom_id: int, student_id: int, db: Session
+) -> int:
+    """Create AssignmentSubmission records for active assignments the student missed.
+
+    When a student joins a classroom after assignments have already been created,
+    they won't have submission records. This helper back-fills them so the student
+    can see and complete those assignments.
+
+    Returns the number of submissions created.
+    """
+    active_assignments = (
+        db.query(Assignment)
+        .filter(
+            Assignment.classroom_id == classroom_id,
+            Assignment.is_active == True,
+        )
+        .all()
+    )
+    if not active_assignments:
+        return 0
+
+    # Fetch any existing submissions for this student in this classroom
+    # (defensive: should be empty for a brand-new enrollment, but guard anyway)
+    existing_assignment_ids = set(
+        row[0]
+        for row in db.query(AssignmentSubmission.assignment_id)
+        .filter(
+            AssignmentSubmission.student_id == student_id,
+            AssignmentSubmission.assignment_id.in_(
+                [a.id for a in active_assignments]
+            ),
+        )
+        .all()
+    )
+
+    created = 0
+    for assignment in active_assignments:
+        if assignment.id in existing_assignment_ids:
+            continue
+        db.add(
+            AssignmentSubmission(
+                assignment_id=assignment.id,
+                student_id=student_id,
+                status="pending",
+            )
+        )
+        created += 1
+
+    if created:
+        logger.info(
+            "Created %d assignment submissions for late-joining student %d in classroom %d",
+            created, student_id, classroom_id,
+        )
+    return created
 
 
 # ── Response Converters ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- When a student joins a classroom after assignments have been created, they now automatically get `AssignmentSubmission` records for all active assignments
- Added `create_submissions_for_new_student()` helper in `helpers.py` that queries active assignments and back-fills missing submissions
- Integrated into all 4 enrollment paths: manual add, join code, batch create, CSV upload

## Test plan
- [ ] Create a classroom with a teacher account
- [ ] Create an assignment for the classroom
- [ ] Add a new student to the classroom (via manual add / join code / batch / CSV)
- [ ] Verify the new student can see the assignment (has a pending submission)
- [ ] Verify existing students' submissions are unaffected

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)