### PR TITLE
fix: session dedup — get_or_create + client guard (#984)

### DIFF
--- a/backend/app/routes/learning/learning_sessions.py
+++ b/backend/app/routes/learning/learning_sessions.py
@@ -49,7 +49,36 @@ def create_learning_session(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Create a new learning session for the authenticated student."""
+    """Create a new learning session for the authenticated student.
+
+    Uses a get-or-create pattern: if an in_progress session already exists for
+    the same student + story_slug, return that session instead of creating a
+    duplicate.  This prevents the race condition described in Issue #984 where
+    the frontend fires two concurrent POST requests before the first response
+    arrives.
+    """
+    # Normalize slug using the centralized normalizer (#985 + #984)
+    normalized_slug = normalize_story_slug(payload.story_slug) if payload.story_slug else None
+
+    # --- get-or-create: return existing in_progress session if one exists (#984) ---
+    if normalized_slug:
+        existing = (
+            db.query(LearningSession)
+            .filter(
+                LearningSession.student_id == current_user.id,
+                LearningSession.story_slug == normalized_slug,
+                LearningSession.status == "in_progress",
+            )
+            .order_by(LearningSession.started_at.desc())
+            .first()
+        )
+        if existing:
+            logger.info(
+                "Returning existing in_progress session %d for user %d, story=%s (dedup #984)",
+                existing.id, current_user.id, normalized_slug,
+            )
+            return existing
+
     # Auto-fill classroom_id from the student's first active enrollment (if any)
     enrollment = (
         db.query(ClassroomStudent)
@@ -58,8 +87,7 @@ def create_learning_session(
     )
     classroom_id = enrollment.classroom_id if enrollment else None
 
-    # Normalize and resolve text_id from story_slug (supports "13", "L06", "06", etc.)
-    normalized_slug = normalize_story_slug(payload.story_slug) if payload.story_slug else None
+    # Resolve text_id from normalized story_slug
     text_id = None
     if normalized_slug:
         try:
@@ -83,7 +111,7 @@ def create_learning_session(
     db.refresh(session)
     logger.info(
         "Created learning session %d for user %d, story=%s",
-        session.id, current_user.id, payload.story_slug,
+        session.id, current_user.id, normalized_slug,
     )
     return session
 

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -243,6 +243,8 @@ const LearningLayout: React.FC = () => {
   const [showTimeoutWarning, setShowTimeoutWarning] = useState(false);
   /** Ref to the idle-timer reset function so handleContinueLearning can call it. */
   const idleResetRef = useRef<(() => void) | null>(null);
+  /** Guard ref that prevents concurrent POST /api/learning/sessions calls (Issue #984). */
+  const isCreatingSession = useRef(false);
   const [stepProgressState, setStepProgressState] = useState<StepProgressData>({
     current_step: null,
     steps_completed: [],
@@ -583,9 +585,12 @@ const LearningLayout: React.FC = () => {
 
   // Ensure a DB session exists for step_progress persistence even when the flow
   // starts from assignment entry points that skip the legacy intro action.
+  // Guard with isCreatingSession ref to prevent concurrent POSTs (Issue #984).
   useEffect(() => {
     if (!token || !storyId || dbSessionId !== null || isLoading) return;
+    if (isCreatingSession.current) return;
 
+    isCreatingSession.current = true;
     fetch(`${API_BASE}/api/learning/sessions`, {
       method: 'POST',
       headers: {
@@ -608,6 +613,9 @@ const LearningLayout: React.FC = () => {
       })
       .catch(() => {
         // Non-fatal: local progress still works without DB.
+      })
+      .finally(() => {
+        isCreatingSession.current = false;
       });
   }, [token, storyId, dbSessionId, isLoading, activeDbSessionStorageKey, legacyDbSessionStorageKey]);
 
@@ -630,8 +638,10 @@ const LearningLayout: React.FC = () => {
     });
     persistStep(STEP_PATH_TO_NUMBER['reading-annotation']);
 
-    // Create a DB learning session so dialogue can be persisted (Issue #242)
-    if (token && storyId && dbSessionId === null) {
+    // Create a DB learning session so dialogue can be persisted (Issue #242).
+    // Skip if a session already exists or another creation is in flight (Issue #984).
+    if (token && storyId && dbSessionId === null && !isCreatingSession.current) {
+      isCreatingSession.current = true;
       fetch(`${API_BASE}/api/learning/sessions`, {
         method: 'POST',
         headers: {
@@ -654,6 +664,9 @@ const LearningLayout: React.FC = () => {
         })
         .catch(() => {
           // Non-fatal — dialogue won't be persisted but learning still works
+        })
+        .finally(() => {
+          isCreatingSession.current = false;
         });
     }
 


### PR DESCRIPTION
## Summary
- Backend: check for existing `in_progress` session before creating new one (get_or_create pattern)
- Frontend: `isCreatingSession` ref guard prevents concurrent POST calls in LearningLayout
- Two-layer defense: client prevents race, server handles edge cases (tabs, reload)

Fixes #984

## Test plan
- [ ] Open same story in 2 tabs — verify only 1 session created
- [ ] Complete a story, reopen — verify reuses existing session
- [ ] `/qa` full 10-step flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)