### PR TITLE
fix: centralize story_slug normalization (#985)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -40,6 +40,7 @@ from ..services.assignment_copy_strategy import resolve_text_for_assignment
 from ..services.input_sanitizer import sanitize_ai_input
 from ..services.lesson_loader import get_lesson_by_id
 from ..services.notification_service import send_assignment_submitted_notification
+from ..utils.slug import normalize_story_slug
 from .classrooms import _get_classroom_or_404, _require_owner_or_admin
 
 router = APIRouter(tags=["assignments"])
@@ -55,7 +56,7 @@ def _resolve_story_title_from_yaml(story_id: str) -> str | None:
     Accepts both numeric strings ("6") and L-prefixed format ("L06").
     """
     try:
-        story = get_lesson_by_id(int(story_id.lstrip("Ll")))
+        story = get_lesson_by_id(int(normalize_story_slug(story_id)))
         if story:
             return story["title"]
     except (ValueError, TypeError):
@@ -385,14 +386,14 @@ def create_assignment(
 
     if payload.story_id is not None:
         # --- Platform YAML text path ---
-        # Normalize L-prefix format ("L06" → "6") before int() conversion
+        # Normalize slug ("L06" / "06" → "6") before lookup and storage
         try:
-            story = get_lesson_by_id(int(payload.story_id.lstrip("Ll")))
+            story = get_lesson_by_id(int(normalize_story_slug(payload.story_id)))
         except (ValueError, TypeError):
             story = None
         if not story:
             raise HTTPException(status_code=422, detail="Invalid story_id: story not found")
-        resolved_story_id = payload.story_id
+        resolved_story_id = normalize_story_slug(payload.story_id)
 
     else:
         # --- DB text path (with copy strategy) ---
@@ -823,8 +824,9 @@ def start_assignment(
             effective_accuracy=assignment.target_accuracy if assignment.target_accuracy is not None else DEFAULT_TARGET_ACCURACY,
         )
 
-    # story_slug for LearningSession: use story_id (YAML) or text_id as string
-    story_slug = assignment.story_id or str(assignment.text_id)
+    # story_slug for LearningSession: use normalized story_id (YAML) or text_id as string
+    raw_slug = assignment.story_id or str(assignment.text_id)
+    story_slug = normalize_story_slug(raw_slug)
 
     # Create a new LearningSession
     learning_session = LearningSession(

--- a/backend/app/routes/learning/learning_sessions.py
+++ b/backend/app/routes/learning/learning_sessions.py
@@ -15,6 +15,7 @@ from ...models.session import CharacterError, LearningSession
 from ...models.text import Text
 from ...models.user import User
 from ...services.lesson_loader import get_lesson_by_id
+from ...utils.slug import normalize_story_slug
 from ...schemas.session import (
     SessionCreateRequest,
     SessionDetailResponse,
@@ -57,11 +58,12 @@ def create_learning_session(
     )
     classroom_id = enrollment.classroom_id if enrollment else None
 
-    # Resolve text_id from story_slug (supports numeric "13" or L-prefixed "L06")
+    # Normalize and resolve text_id from story_slug (supports "13", "L06", "06", etc.)
+    normalized_slug = normalize_story_slug(payload.story_slug) if payload.story_slug else None
     text_id = None
-    if payload.story_slug:
+    if normalized_slug:
         try:
-            ln = int(payload.story_slug.lstrip("Ll"))
+            ln = int(normalized_slug)
             text_record = db.query(Text).filter(Text.lesson_number == ln).first()
             if text_record:
                 text_id = text_record.id
@@ -70,7 +72,7 @@ def create_learning_session(
 
     session = LearningSession(
         student_id=current_user.id,
-        story_slug=payload.story_slug,
+        story_slug=normalized_slug,
         text_id=text_id,
         status="in_progress",
         current_step=1,
@@ -123,7 +125,7 @@ def list_my_sessions(
         if statuses:
             query = query.filter(LearningSession.status.in_(statuses))
     if story_slug:
-        query = query.filter(LearningSession.story_slug == story_slug)
+        query = query.filter(LearningSession.story_slug == normalize_story_slug(story_slug))
 
     all_items = (
         query
@@ -154,9 +156,8 @@ def list_my_sessions(
         if s.text is not None:
             summary.story_title = s.text.title
         elif s.story_slug:
-            normalized = s.story_slug.lstrip("Ll")
             try:
-                lesson = get_lesson_by_id(int(normalized))
+                lesson = get_lesson_by_id(int(normalize_story_slug(s.story_slug)))
                 if lesson:
                     summary.story_title = lesson["title"]
             except (ValueError, TypeError):
@@ -193,7 +194,7 @@ def get_reading_history(
         db.query(LearningSession)
         .filter(
             LearningSession.student_id == current_user.id,
-            LearningSession.story_slug == story_slug,
+            LearningSession.story_slug == normalize_story_slug(story_slug),
             LearningSession.status == "completed",
         )
     )

--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -12,6 +12,7 @@ from ..models.user import User
 from ..auth.dependencies import get_current_user
 from ..auth.rate_limiter import ai_rate_limiter, get_client_key
 from ..services.lesson_loader import search_lessons, get_lesson_by_id, get_available_grades
+from ..utils.slug import normalize_story_slug
 from ..services.ai_service import generate_story_structure
 from ..services.ai_usage_tracker import last_usage, log_ai_usage
 from ..schemas.story import StoryListItem, StoryDetail, StoryListResponse, StoryIntroSchema
@@ -89,10 +90,9 @@ def get_story(story_id: str):
     Non-numeric or unknown IDs return 404.
     This prevents 422 errors when legacy sessions store slug-format story_slugs.
     """
-    # Normalize "L06" → "6" format (assignments store story_id with L-prefix)
-    normalized = story_id.lstrip("Ll")
+    # Normalize slug: "L06" / "06" / "6" → "6"
     try:
-        numeric_id = int(normalized)
+        numeric_id = int(normalize_story_slug(story_id))
     except (ValueError, TypeError):
         raise HTTPException(status_code=404, detail="Story not found")
     story = get_lesson_by_id(numeric_id)
@@ -141,9 +141,8 @@ async def get_story_structure(
     Requires authentication. Rate-limited to 5 req/min per user (cache miss only).
     Responses are cached in-memory for 24 h to avoid redundant Gemini calls.
     """
-    normalized = story_id.lstrip("Ll")
     try:
-        numeric_id = int(normalized)
+        numeric_id = int(normalize_story_slug(story_id))
     except (ValueError, TypeError):
         raise HTTPException(status_code=404, detail="Story not found")
     story = get_lesson_by_id(numeric_id)

--- a/backend/app/services/ai_usage_tracker.py
+++ b/backend/app/services/ai_usage_tracker.py
@@ -188,8 +188,8 @@ def _resolve_context(
             # Try to get genre from story loader
             from ..routes.stories import get_lesson_by_id
 
-            normalized = story_id.lstrip("Ll")
-            numeric_id = int(normalized)
+            from ..utils.slug import normalize_story_slug
+            numeric_id = int(normalize_story_slug(story_id))
             story = get_lesson_by_id(numeric_id)
             if story:
                 result["genre"] = story.get("genre")

--- a/backend/app/utils/slug.py
+++ b/backend/app/utils/slug.py
@@ -1,0 +1,20 @@
+"""Slug normalization utilities for story identifiers."""
+
+
+def normalize_story_slug(slug: str) -> str:
+    """Normalize story slug to canonical format (plain number string, e.g. '6').
+
+    Accepts multiple input formats:
+    - "6"   → "6"
+    - "06"  → "6"
+    - "L6"  → "6"
+    - "L06" → "6"
+    - "l06" → "6"
+
+    Falls back to the input (stripped of L/l prefix) for non-numeric slugs.
+    """
+    stripped = slug.lstrip("Ll")
+    try:
+        return str(int(stripped))
+    except ValueError:
+        return stripped


### PR DESCRIPTION
## Summary
- New `backend/app/utils/slug.py` with `normalize_story_slug()` — converts any format to canonical integer string
- Replaced all scattered `.lstrip("Ll")` calls across 4 files
- Sessions now store normalized slug — no more progress splitting

Fixes #985

## Test plan
- [ ] Create session via "L06" URL → verify DB stores "6"
- [ ] Check existing endpoints return consistent slugs
- [ ] `/qa` full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)