### PR TITLE
feat: add recommended stories to report page (#1015)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -18,6 +18,7 @@ import StarCelebration from '../gamification/StarCelebration';
 import { calcStarRating } from '../../utils/starRatingCalc';
 import GoalAchievementCard from '../ui/GoalAchievementCard';
 import RepeatedErrorAlertModal from '../student/RepeatedErrorAlertModal';
+import RecommendedStories from '../student/RecommendedStories';
 import { getReadingHistory, type ReadingHistoryPoint } from '../../services/learningApi';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
 
@@ -920,6 +921,18 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
             )}
           </div>
         </Section>
+      )}
+
+      {/* ============ AI 推薦下一篇 (#1015) ============ */}
+      {!readOnly && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="h-px flex-1 bg-gray-200" />
+            <span className="text-sm font-semibold text-gray-500 whitespace-nowrap">接下來讀什麼？</span>
+            <div className="h-px flex-1 bg-gray-200" />
+          </div>
+          <RecommendedStories />
+        </div>
       )}
 
       {/* CTA */}


### PR DESCRIPTION
## Summary
- Added `RecommendedStories` component at bottom of AssessmentReport
- Shows "接下來讀什麼？" section with AI-recommended next stories
- Only visible to students (not teacher readOnly view)
- Closes the learning loop: finish → report → what next?

Fixes #1015

## Test plan
- [ ] Complete a story → report page shows recommended stories at bottom
- [ ] Click recommendation → navigates to that story

🤖 Generated with [Claude Code](https://claude.com/claude-code)