### PR TITLE
fix: unify completed story count across all endpoints (#981)

### DIFF
--- a/backend/app/routes/learning/learning_dashboard.py
+++ b/backend/app/routes/learning/learning_dashboard.py
@@ -14,6 +14,7 @@ from ...auth.dependencies import get_current_user
 from ...database import get_db
 from ...models.session import LearningSession
 from ...models.user import User
+from ...services.learning_stats_service import get_completed_story_slugs
 from ._helpers import verify_student_access
 
 router = APIRouter()
@@ -149,10 +150,8 @@ def get_student_dashboard(
                 streak_check = 1
         longest_streak = max(longest_streak, streak_check)
 
-    # Completed story slugs
-    completed_story_slugs = list({
-        s.story_slug for s in completed if s.story_slug
-    })
+    # Completed story slugs — use canonical query (Issue #981)
+    completed_story_slugs = get_completed_story_slugs(db, student_id)
 
     return DashboardResponse(
         total_sessions=total_sessions,

--- a/backend/app/routes/learning/learning_progress.py
+++ b/backend/app/routes/learning/learning_progress.py
@@ -12,6 +12,7 @@ from ...auth.dependencies import get_current_user
 from ...database import get_db
 from ...models.session import LearningSession
 from ...models.user import User
+from ...services.learning_stats_service import get_completed_story_count
 from ...services.stuck_detection_service import detect_stuck_points
 from ._helpers import verify_student_access
 
@@ -277,7 +278,8 @@ def get_student_progress(
             next_step=next_step,
         ))
 
-    texts_completed = sum(1 for t in texts if t.status == "completed")
+    # Use canonical query for the aggregate count (Issue #981)
+    texts_completed = get_completed_story_count(db, student_id)
     average_score = round(sum(scores) / len(scores), 1) if scores else None
 
     logger.info(

--- a/backend/app/services/gamification_service.py
+++ b/backend/app/services/gamification_service.py
@@ -23,6 +23,7 @@ from ..models.gamification import (
     xp_to_level,
 )
 from ..models.school import Classroom, ClassroomStudent
+from .learning_stats_service import get_completed_story_count
 
 logger = logging.getLogger(__name__)
 
@@ -43,16 +44,12 @@ def _get_total_xp(db: Session, student_id: int) -> int:
 
 
 def _get_stories_completed(db: Session, student_id: int) -> int:
-    """Return count of 'session_complete' XP log entries for a student."""
-    result = (
-        db.query(sqlfunc.count(StudentXPLog.id))
-        .filter(
-            StudentXPLog.student_id == student_id,
-            StudentXPLog.event_type == "session_complete",
-        )
-        .scalar()
-    )
-    return int(result)
+    """Return the number of distinct completed stories for a student.
+
+    Delegates to the canonical shared helper so that gamification, dashboard,
+    and progress endpoints all report the same value (Issue #981).
+    """
+    return get_completed_story_count(db, student_id)
 
 
 def _get_or_create_streak(db: Session, student_id: int) -> StudentStreak:

--- a/backend/app/services/learning_stats_service.py
+++ b/backend/app/services/learning_stats_service.py
@@ -1,0 +1,50 @@
+"""Shared helpers for computing learning statistics.
+
+Centralises canonical queries so that dashboard, progress, and gamification
+endpoints always return consistent numbers.
+"""
+from __future__ import annotations
+
+from sqlalchemy import func as sqlfunc
+from sqlalchemy.orm import Session
+
+from ..models.session import LearningSession
+
+
+def get_completed_story_count(db: Session, student_id: int) -> int:
+    """Return the number of distinct stories a student has completed.
+
+    Canonical definition: COUNT(DISTINCT story_slug) FROM learning_sessions
+    WHERE student_id = ? AND status = 'completed' AND story_slug IS NOT NULL.
+
+    This is the single source of truth used by the dashboard, progress, and
+    gamification endpoints to ensure they all report the same value.
+    """
+    result = (
+        db.query(sqlfunc.count(sqlfunc.distinct(LearningSession.story_slug)))
+        .filter(
+            LearningSession.student_id == student_id,
+            LearningSession.status == "completed",
+            LearningSession.story_slug.isnot(None),
+        )
+        .scalar()
+    )
+    return int(result or 0)
+
+
+def get_completed_story_slugs(db: Session, student_id: int) -> list[str]:
+    """Return the distinct story slugs the student has completed.
+
+    Same canonical filter as :func:`get_completed_story_count`; the dashboard
+    uses the slug list while other endpoints use just the count.
+    """
+    rows = (
+        db.query(sqlfunc.distinct(LearningSession.story_slug))
+        .filter(
+            LearningSession.student_id == student_id,
+            LearningSession.status == "completed",
+            LearningSession.story_slug.isnot(None),
+        )
+        .all()
+    )
+    return [r[0] for r in rows]


### PR DESCRIPTION
## Summary
- New `learning_stats_service.py` with canonical `get_completed_story_count()` and `get_completed_story_slugs()`
- Uses `COUNT(DISTINCT story_slug) WHERE status='completed'`
- Replaced 3 divergent queries in dashboard, progress, and gamification endpoints
- Root cause: dashboard counted all sessions, progress only latest per slug, gamification counted XP events

Fixes #981

## Test plan
- [ ] Check dashboard, progress, gamification summary — all show same count
- [ ] Complete a story twice → count stays the same (distinct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)