### PR TITLE
fix: student-teacher gating with feature flag (dormant) (#457)

### DIFF
--- a/backend/app/auth/classroom_check.py
+++ b/backend/app/auth/classroom_check.py
@@ -1,0 +1,45 @@
+"""Classroom membership helpers — issue #457.
+
+Extracted here (away from routes/auth.py) so both routes/auth.py and
+routes/users.py can import without circular dependencies.
+"""
+
+from sqlalchemy.orm import Session
+
+from ..models.school import ClassroomStudent
+from ..models.user import UserRole, Role
+
+
+def has_active_role(db: Session, user_id: int, role_name: str) -> bool:
+    """Return True if the user has an active role with the given name."""
+    return (
+        db.query(UserRole)
+        .join(Role, UserRole.role_id == Role.id)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.is_active == True,
+            Role.name == role_name,
+        )
+        .first()
+        is not None
+    )
+
+
+def compute_has_classroom(db: Session, user_id: int) -> bool:
+    """Return True if user is not a student OR if they belong to at least one classroom.
+
+    Issue #457: students who are not yet enrolled in any classroom should see a
+    friendly waiting screen on the frontend instead of the full dashboard.
+    Teachers, admins, and all other roles always return True (not gated).
+    """
+    is_student = has_active_role(db, user_id, "student")
+    if not is_student:
+        # Non-students (teachers, admins, parents, etc.) are never gated
+        return True
+
+    enrolled = (
+        db.query(ClassroomStudent)
+        .filter(ClassroomStudent.student_id == user_id)
+        .first()
+    )
+    return enrolled is not None

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,6 +22,11 @@ class Settings(BaseSettings):
     # False (default): auto-verify on registration — existing flow unchanged.
     # True: new registrations get email_verified=False and must click a link before login.
     require_email_verification: bool = False
+    # Teacher-gating (issue #457).
+    # False (default): students without a classroom can still access the platform.
+    # True: students without a classroom are redirected to the "no teacher" waiting screen.
+    # Flip via Cloud Run env var ENFORCE_TEACHER_GATING=true when ready to enforce.
+    enforce_teacher_gating: bool = False
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
+from ..auth.classroom_check import compute_has_classroom
 from ..auth.dependencies import get_current_user
 from ..auth.jwt import create_access_token
 from ..auth.password import hash_password, verify_password
@@ -11,7 +12,7 @@ from ..auth.rate_limiter import InMemoryRateLimiter
 from ..config import settings
 from ..database import get_db
 from ..models.user import User, UserRole, Role
-from ..models.school import School, ClassroomStudent
+from ..models.school import School
 from ..schemas.auth import (
     ChangePasswordRequest,
     ForgotPasswordRequest,
@@ -41,41 +42,6 @@ PASSWORD_RESET_TOKEN_BYTES = 32
 PASSWORD_RESET_EXPIRY_HOURS = 1
 EMAIL_VERIFICATION_TOKEN_BYTES = 32
 
-
-def _has_active_role(db: Session, user_id: int, role_name: str) -> bool:
-    """Return whether the user has an active role with the given name."""
-    return (
-        db.query(UserRole)
-        .join(Role, UserRole.role_id == Role.id)
-        .filter(
-            UserRole.user_id == user_id,
-            UserRole.is_active == True,
-            Role.name == role_name,
-        )
-        .first()
-        is not None
-    )
-
-
-def _compute_has_classroom(db: Session, user_id: int) -> bool:
-    """Return True if user is not a student OR if they belong to at least one classroom.
-
-    Issue #457: students who are not yet enrolled in any classroom should see a
-    friendly waiting screen on the frontend instead of the full dashboard.
-    Teachers, admins, and all other roles always return True (not gated).
-    """
-    is_student = _has_active_role(db, user_id, "student")
-    if not is_student:
-        # Non-students (teachers, admins, parents, etc.) are never gated
-        return True
-
-    # Student — check if enrolled in at least one classroom
-    enrolled = (
-        db.query(ClassroomStudent)
-        .filter(ClassroomStudent.student_id == user_id)
-        .first()
-    )
-    return enrolled is not None
 
 
 def _ensure_parent_login_allowed(user: User, db: Session) -> None:
@@ -307,7 +273,7 @@ def login(req: LoginRequest, request: Request, db: Session = Depends(get_db)):
 
     # Issue #457: determine whether this user has at least one classroom.
     # Only applies to students — teachers and admins always get True.
-    has_classroom = _compute_has_classroom(db, user.id)
+    has_classroom = compute_has_classroom(db, user.id)
 
     token = create_access_token(user.id)
     return TokenResponse(

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -5,7 +5,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, joinedload, selectinload
 
+from ..auth.classroom_check import compute_has_classroom
 from ..auth.dependencies import get_current_user, require_role
+from ..config import settings
 from ..database import get_db
 from ..models.user import User, UserRole, Role
 from ..schemas.user import UserResponse, UserRoleResponse
@@ -56,7 +58,13 @@ def get_me(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Get current authenticated user with their roles."""
+    """Get current authenticated user with their roles.
+
+    Also includes issue #457 fields:
+    - has_classroom: True unless user is a student with no classroom enrollment.
+    - teacher_gating_enforced: mirrors the ENFORCE_TEACHER_GATING env var so the
+      frontend knows whether to enforce the classroom gate.
+    """
     user_roles = (
         db.query(UserRole, Role)
         .join(Role, UserRole.role_id == Role.id)
@@ -74,6 +82,8 @@ def get_me(
         for ur, role in user_roles
     ]
 
+    has_classroom = compute_has_classroom(db, current_user.id)
+
     return UserResponse(
         id=current_user.id,
         email=current_user.email,
@@ -88,6 +98,8 @@ def get_me(
         terms_version=current_user.terms_version,
         created_at=current_user.created_at,
         roles=roles,
+        has_classroom=has_classroom,
+        teacher_gating_enforced=settings.enforce_teacher_gating,
     )
 
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -27,6 +27,13 @@ class UserResponse(BaseModel):
     terms_accepted: bool = False
     created_at: datetime
     roles: list[UserRoleResponse] = []
+    # Issue #457: classroom membership flag.
+    # True for non-students and for students enrolled in at least one classroom.
+    # False only for students with no classroom enrollment.
+    has_classroom: bool = True
+    # Issue #457: whether the teacher-gating feature is active (reads ENFORCE_TEACHER_GATING).
+    # Frontend uses this to decide whether to redirect to the waiting screen.
+    teacher_gating_enforced: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/frontend/src/components/auth/RouteGuards.tsx
+++ b/frontend/src/components/auth/RouteGuards.tsx
@@ -31,3 +31,33 @@ export const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ childr
 
   return <>{children}</>;
 };
+
+/**
+ * Issue #457: redirect student users without a classroom to /no-teacher.
+ *
+ * Only active when teacherGatingEnforced is true (ENFORCE_TEACHER_GATING env var).
+ * Teachers, admins, and other non-student roles are never gated.
+ * The /no-teacher, /join, /profile, and /change-password pages are exempt
+ * so the user can still join a classroom or manage their account.
+ */
+export const StudentClassroomGuard: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { isAuthenticated, isLoading, hasClassroom, teacherGatingEnforced } = useAuth();
+  const location = useLocation();
+
+  // Exempt paths — always accessible even without a classroom
+  const exemptPaths = ['/no-teacher', '/join', '/profile', '/change-password', '/privacy', '/help'];
+  const isExempt = exemptPaths.some((p) => location.pathname.startsWith(p));
+
+  if (isLoading) return <AuthLoadingSpinner />;
+
+  if (
+    isAuthenticated &&
+    teacherGatingEnforced &&
+    !hasClassroom &&
+    !isExempt
+  ) {
+    return <Navigate to="/no-teacher" replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -13,6 +13,16 @@ interface AuthContextValue {
   mustChangePassword: boolean;
   loginPassword: string | null;
   needsTermsAcceptance: boolean;
+  /**
+   * Issue #457: false only for students with no classroom enrollment.
+   * Derived from user.has_classroom; defaults to true while loading.
+   */
+  hasClassroom: boolean;
+  /**
+   * Issue #457: mirrors ENFORCE_TEACHER_GATING env var.
+   * When false the classroom gate is dormant even if hasClassroom is false.
+   */
+  teacherGatingEnforced: boolean;
   login: (email: string, password: string) => Promise<{ mustChangePassword: boolean }>;
   register: (email: string, password: string, name: string) => Promise<RegisterResponse>;
   logout: () => void;
@@ -172,6 +182,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   // Derived: user is authenticated but hasn't accepted terms
   const needsTermsAcceptance = !!user && !user.terms_accepted;
 
+  // Issue #457: classroom gate state — default to true (safe) while loading
+  const hasClassroom = user ? (user.has_classroom ?? true) : true;
+  const teacherGatingEnforced = user ? (user.teacher_gating_enforced ?? false) : false;
+
   const value: AuthContextValue = {
     user,
     token,
@@ -180,6 +194,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     mustChangePassword,
     loginPassword,
     needsTermsAcceptance,
+    hasClassroom,
+    teacherGatingEnforced,
     login,
     register,
     logout,

--- a/frontend/src/pages/app/NoTeacherPage.tsx
+++ b/frontend/src/pages/app/NoTeacherPage.tsx
@@ -1,0 +1,160 @@
+/**
+ * NoTeacherPage — shown to students who have not yet joined any classroom.
+ *
+ * Issue #457: students without a classroom cannot access learning features.
+ * This page explains the situation in a friendly way and lets them:
+ *  1. Enter a classroom join code (if they have one from their teacher).
+ *  2. Log out and wait for their teacher to add them.
+ */
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { joinClassroomByCode, ClassroomApiError } from '../../services/classroomApi';
+
+const NoTeacherPage: React.FC = () => {
+  const { token, logout, refreshUser } = useAuth();
+  const navigate = useNavigate();
+
+  const [joinCode, setJoinCode] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 6);
+    setJoinCode(val);
+    setError('');
+  };
+
+  const handleJoin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (joinCode.length !== 6) {
+      setError('請輸入完整的 6 碼加入代碼');
+      return;
+    }
+
+    if (!token) {
+      setError('請先登入');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const result = await joinClassroomByCode(token, joinCode);
+      setSuccess(`成功加入「${result.classroom_name}」！`);
+      // Refresh user profile so hasClassroom updates, then navigate home
+      await refreshUser();
+      setTimeout(() => navigate('/'), 1500);
+    } catch (err) {
+      if (err instanceof ClassroomApiError) {
+        if (err.status === 404) {
+          setError('找不到此加入代碼，請確認代碼是否正確');
+        } else if (err.status === 409) {
+          setError('你已經加入這個班級了');
+        } else if (err.status === 400) {
+          setError(err.message || '加入代碼無效');
+        } else {
+          setError(err.message || '加入失敗，請稍後再試');
+        }
+      } else {
+        setError('加入失敗，請稍後再試');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-amber-50 px-4">
+      <div className="w-full max-w-md">
+        {/* Illustration area */}
+        <div className="text-center mb-8">
+          <div
+            className="w-24 h-24 mx-auto mb-6 rounded-full bg-purple-100 flex items-center justify-center"
+            aria-hidden="true"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="w-12 h-12 text-purple-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m4-4a4 4 0 100-8 4 4 0 000 8z"
+              />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">還沒加入班級</h1>
+          <p className="text-gray-600 leading-relaxed">
+            你的帳號還沒有被加入任何班級
+            <br />
+            請聯繫你的老師，請老師把你加入班級
+          </p>
+        </div>
+
+        {/* Join by code card */}
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 mb-4">
+          <h2 className="text-base font-semibold text-gray-800 mb-1">有加入代碼？</h2>
+          <p className="text-sm text-gray-500 mb-4">如果老師給了你 6 碼代碼，可以在這裡輸入</p>
+
+          <form onSubmit={handleJoin} noValidate>
+            <div className="mb-3">
+              <label htmlFor="join-code" className="block text-sm font-medium text-gray-700 mb-1">
+                班級代碼
+              </label>
+              <input
+                id="join-code"
+                type="text"
+                value={joinCode}
+                onChange={handleCodeChange}
+                placeholder="例如：AB1234"
+                maxLength={6}
+                autoComplete="off"
+                className="w-full px-4 py-2.5 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-center text-lg font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent transition"
+              />
+            </div>
+
+            {error && (
+              <p role="alert" className="text-sm text-red-600 mb-3">
+                {error}
+              </p>
+            )}
+            {success && (
+              <p role="status" className="text-sm text-green-600 mb-3">
+                {success}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSubmitting || joinCode.length !== 6}
+              className="w-full py-2.5 rounded-lg bg-purple-600 text-white font-medium text-sm hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition"
+            >
+              {isSubmitting ? '加入中...' : '加入班級'}
+            </button>
+          </form>
+        </div>
+
+        {/* Logout */}
+        <p className="text-center text-sm text-gray-500">
+          帳號不對？{' '}
+          <button
+            type="button"
+            onClick={logout}
+            className="text-purple-600 hover:text-purple-700 underline underline-offset-2 focus:outline-none"
+          >
+            登出
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default NoTeacherPage;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -8,7 +8,8 @@
 import React, { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 
-import { PublicOnlyRoute, ProtectedRoute } from '../components/auth/RouteGuards';
+import { PublicOnlyRoute, ProtectedRoute, StudentClassroomGuard } from '../components/auth/RouteGuards';
+import NoTeacherPage from '../pages/app/NoTeacherPage';
 import { AppShell, LearningAppShell } from '../components/layout/AppShell';
 import StepErrorBoundary from '../components/StepErrorBoundary';
 import {
@@ -102,7 +103,18 @@ const StepRoute: React.FC<StepRouteProps> = ({ stepLabel, nextPath, children }) 
 
 const AppRoutes: React.FC = () => (
   <Suspense fallback={<PageLoader />}>
+    <StudentClassroomGuard>
     <Routes>
+      {/* Issue #457: students without classroom see this page when gating is enabled */}
+      <Route
+        path="/no-teacher"
+        element={
+          <ProtectedRoute>
+            <NoTeacherPage />
+          </ProtectedRoute>
+        }
+      />
+
       {/* Public-only routes (redirect to / if already logged in) */}
       <Route
         path="/login"
@@ -476,6 +488,7 @@ const AppRoutes: React.FC = () => (
       {/* Catch-all: redirect to home */}
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
+    </StudentClassroomGuard>
   </Suspense>
 );
 

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -22,6 +22,10 @@ export interface AuthUser {
   terms_accepted: boolean;
   terms_accepted_at: string | null;
   terms_version: string | null;
+  /** Issue #457: false only for students with no classroom enrollment. */
+  has_classroom: boolean;
+  /** Issue #457: mirrors ENFORCE_TEACHER_GATING env var on the backend. */
+  teacher_gating_enforced: boolean;
 }
 
 /** Check if user has a specific role (ignores scope). */


### PR DESCRIPTION
## Summary
- **Built but NOT enabled** — `ENFORCE_TEACHER_GATING=false` by default
- Backend: `has_classroom` + `teacher_gating_enforced` in user profile response
- Frontend: `StudentClassroomGuard` redirects to `/no-teacher` only when flag is on
- NoTeacherPage: friendly message + classroom join code input
- Flip `ENFORCE_TEACHER_GATING=true` in Cloud Run env when ready to enforce

Fixes #457

## Test plan
- [ ] Default: students without classroom can still access everything ✅
- [ ] Set env `ENFORCE_TEACHER_GATING=true` → students without classroom redirected
- [ ] Student enters join code on NoTeacherPage → joins classroom → redirected to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)