### PR TITLE
feat: 學生練習紀錄查詢頁面（Feat #416）

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -339,6 +339,7 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
         { icon: '🏠', label: '主頁', path: '/student' },
         { icon: '📚', label: '圖書館', path: '/library' },
         { icon: '📋', label: '我的作業', path: '/assignments', badge: pendingAssignmentCount },
+        { icon: '📖', label: '學習紀錄', path: '/learning-history' },
         { icon: '⭐', label: '成就', path: '/achievements' },
         // Hidden: 學習進度, 生字本, 對話記錄 — 整合到「我的作業」(#643)
         { icon: '🏫', label: '我的班級', path: '/classroom-dashboard' },

--- a/frontend/src/components/ui/StepProgressStrip.tsx
+++ b/frontend/src/components/ui/StepProgressStrip.tsx
@@ -1,11 +1,11 @@
 /**
- * StepProgressStrip — horizontal scrollable strip showing learning step status.
+ * StepProgressStrip — flex-wrap grid showing learning step status (max 5 per row).
  *
  * Shared by MyAssignments and LearningHistoryPage.
- * Each step bubble shows: completed (amber), current (blue), or pending (gray).
+ * Each step bubble shows: completed (green), current (yellow), or pending (gray).
  */
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React from 'react';
 
 export interface ProgressStep {
   id: string;
@@ -23,92 +23,29 @@ const StepProgressStrip: React.FC<StepProgressStripProps> = ({
   completedSteps,
   currentStepPath = null,
 }) => {
-  const scrollerRef = useRef<HTMLDivElement | null>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollControls = useCallback(() => {
-    const el = scrollerRef.current;
-    if (!el) return;
-    const maxLeft = el.scrollWidth - el.clientWidth;
-    setCanScrollLeft(el.scrollLeft > 4);
-    setCanScrollRight(maxLeft - el.scrollLeft > 4);
-  }, []);
-
-  useEffect(() => {
-    updateScrollControls();
-    const el = scrollerRef.current;
-    if (!el) return;
-    el.addEventListener('scroll', updateScrollControls, { passive: true });
-    window.addEventListener('resize', updateScrollControls);
-    return () => {
-      el.removeEventListener('scroll', updateScrollControls);
-      window.removeEventListener('resize', updateScrollControls);
-    };
-  }, [steps.length, updateScrollControls]);
-
-  const scrollByDirection = (dir: 'left' | 'right') => {
-    const el = scrollerRef.current;
-    if (!el) return;
-    const amount = Math.max(180, Math.floor(el.clientWidth * 0.65));
-    el.scrollBy({ left: dir === 'left' ? -amount : amount, behavior: 'smooth' });
-    window.setTimeout(updateScrollControls, 180);
-  };
-
   return (
-    <div className="relative">
-      <div className="pointer-events-none absolute left-0 top-0 bottom-0 w-10 bg-gradient-to-r from-white to-transparent z-[1]" />
-      <div className="pointer-events-none absolute right-0 top-0 bottom-0 w-10 bg-gradient-to-l from-white to-transparent z-[1]" />
-
-      <button
-        type="button"
-        onClick={() => scrollByDirection('left')}
-        aria-label="向左查看關卡"
-        disabled={!canScrollLeft}
-        className="absolute left-0 top-1/2 -translate-y-1/2 z-20 w-8 h-8 rounded-full border border-gray-300 bg-white/95 shadow-sm hover:bg-white hover:shadow transition-all flex items-center justify-center disabled:opacity-30 disabled:cursor-not-allowed"
-      >
-        <svg className="w-4 h-4 text-gray-700" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fillRule="evenodd" d="M11.78 15.53a.75.75 0 0 1-1.06 0l-5-5a.75.75 0 0 1 0-1.06l5-5a.75.75 0 1 1 1.06 1.06L7.31 10l4.47 4.47a.75.75 0 0 1 0 1.06Z" clipRule="evenodd" />
-        </svg>
-      </button>
-
-      <div ref={scrollerRef} className="overflow-x-auto pb-1 px-8">
-        <div className="flex gap-1.5 min-w-max">
-          {steps.map((step) => {
-            const isDone = completedSteps.has(step.id);
-            const isCurrent = !isDone && currentStepPath === step.id;
-            return (
-              <div
-                key={step.id}
-                title={step.label}
-                className={`min-w-[84px] min-h-[40px] rounded-md border px-2 py-1 flex items-center justify-center transition-colors ${
-                  isDone
-                    ? 'bg-amber-100 border-amber-200 text-amber-800'
-                    : isCurrent
-                      ? 'bg-blue-50 border-blue-200 text-blue-700'
-                      : 'bg-gray-50 border-gray-200 text-gray-500'
-                }`}
-              >
-                <span className="text-[11px] leading-tight font-medium text-center whitespace-normal break-words">
-                  {step.label}
-                </span>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      <button
-        type="button"
-        onClick={() => scrollByDirection('right')}
-        aria-label="向右查看關卡"
-        disabled={!canScrollRight}
-        className="absolute right-0 top-1/2 -translate-y-1/2 z-20 w-8 h-8 rounded-full border border-gray-300 bg-white/95 shadow-sm hover:bg-white hover:shadow transition-all flex items-center justify-center disabled:opacity-30 disabled:cursor-not-allowed"
-      >
-        <svg className="w-4 h-4 text-gray-700" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fillRule="evenodd" d="M8.22 4.47a.75.75 0 0 1 1.06 0l5 5a.75.75 0 0 1 0 1.06l-5 5a.75.75 0 1 1-1.06-1.06L12.69 10 8.22 5.53a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
-        </svg>
-      </button>
+    <div className="flex flex-wrap gap-1.5">
+      {steps.map((step) => {
+        const isDone = completedSteps.has(step.id);
+        const isCurrent = !isDone && currentStepPath === step.id;
+        return (
+          <div
+            key={step.id}
+            title={step.label}
+            className={`w-[calc(20%-6px)] min-h-[40px] rounded-md border px-2 py-1 flex items-center justify-center transition-colors ${
+              isDone
+                ? 'bg-green-100 border-green-200 text-green-800'
+                : isCurrent
+                  ? 'bg-yellow-50 border-yellow-200 text-yellow-700'
+                  : 'bg-gray-50 border-gray-200 text-gray-500'
+            }`}
+          >
+            <span className="text-[11px] leading-tight font-medium text-center whitespace-normal break-words">
+              {step.label}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/components/ui/StepProgressStrip.tsx
+++ b/frontend/src/components/ui/StepProgressStrip.tsx
@@ -1,0 +1,116 @@
+/**
+ * StepProgressStrip — horizontal scrollable strip showing learning step status.
+ *
+ * Shared by MyAssignments and LearningHistoryPage.
+ * Each step bubble shows: completed (amber), current (blue), or pending (gray).
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+export interface ProgressStep {
+  id: string;
+  label: string;
+}
+
+interface StepProgressStripProps {
+  steps: ProgressStep[];
+  completedSteps: Set<string>;
+  currentStepPath?: string | null;
+}
+
+const StepProgressStrip: React.FC<StepProgressStripProps> = ({
+  steps,
+  completedSteps,
+  currentStepPath = null,
+}) => {
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollControls = useCallback(() => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const maxLeft = el.scrollWidth - el.clientWidth;
+    setCanScrollLeft(el.scrollLeft > 4);
+    setCanScrollRight(maxLeft - el.scrollLeft > 4);
+  }, []);
+
+  useEffect(() => {
+    updateScrollControls();
+    const el = scrollerRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', updateScrollControls, { passive: true });
+    window.addEventListener('resize', updateScrollControls);
+    return () => {
+      el.removeEventListener('scroll', updateScrollControls);
+      window.removeEventListener('resize', updateScrollControls);
+    };
+  }, [steps.length, updateScrollControls]);
+
+  const scrollByDirection = (dir: 'left' | 'right') => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const amount = Math.max(180, Math.floor(el.clientWidth * 0.65));
+    el.scrollBy({ left: dir === 'left' ? -amount : amount, behavior: 'smooth' });
+    window.setTimeout(updateScrollControls, 180);
+  };
+
+  return (
+    <div className="relative">
+      <div className="pointer-events-none absolute left-0 top-0 bottom-0 w-10 bg-gradient-to-r from-white to-transparent z-[1]" />
+      <div className="pointer-events-none absolute right-0 top-0 bottom-0 w-10 bg-gradient-to-l from-white to-transparent z-[1]" />
+
+      <button
+        type="button"
+        onClick={() => scrollByDirection('left')}
+        aria-label="向左查看關卡"
+        disabled={!canScrollLeft}
+        className="absolute left-0 top-1/2 -translate-y-1/2 z-20 w-8 h-8 rounded-full border border-gray-300 bg-white/95 shadow-sm hover:bg-white hover:shadow transition-all flex items-center justify-center disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <svg className="w-4 h-4 text-gray-700" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M11.78 15.53a.75.75 0 0 1-1.06 0l-5-5a.75.75 0 0 1 0-1.06l5-5a.75.75 0 1 1 1.06 1.06L7.31 10l4.47 4.47a.75.75 0 0 1 0 1.06Z" clipRule="evenodd" />
+        </svg>
+      </button>
+
+      <div ref={scrollerRef} className="overflow-x-auto pb-1 px-8">
+        <div className="flex gap-1.5 min-w-max">
+          {steps.map((step) => {
+            const isDone = completedSteps.has(step.id);
+            const isCurrent = !isDone && currentStepPath === step.id;
+            return (
+              <div
+                key={step.id}
+                title={step.label}
+                className={`min-w-[84px] min-h-[40px] rounded-md border px-2 py-1 flex items-center justify-center transition-colors ${
+                  isDone
+                    ? 'bg-amber-100 border-amber-200 text-amber-800'
+                    : isCurrent
+                      ? 'bg-blue-50 border-blue-200 text-blue-700'
+                      : 'bg-gray-50 border-gray-200 text-gray-500'
+                }`}
+              >
+                <span className="text-[11px] leading-tight font-medium text-center whitespace-normal break-words">
+                  {step.label}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => scrollByDirection('right')}
+        aria-label="向右查看關卡"
+        disabled={!canScrollRight}
+        className="absolute right-0 top-1/2 -translate-y-1/2 z-20 w-8 h-8 rounded-full border border-gray-300 bg-white/95 shadow-sm hover:bg-white hover:shadow transition-all flex items-center justify-center disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <svg className="w-4 h-4 text-gray-700" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M8.22 4.47a.75.75 0 0 1 1.06 0l5 5a.75.75 0 0 1 0 1.06l-5 5a.75.75 0 1 1-1.06-1.06L12.69 10 8.22 5.53a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default StepProgressStrip;

--- a/frontend/src/components/ui/StepProgressStrip.tsx
+++ b/frontend/src/components/ui/StepProgressStrip.tsx
@@ -32,11 +32,11 @@ const StepProgressStrip: React.FC<StepProgressStripProps> = ({
           <div
             key={step.id}
             title={step.label}
-            className={`w-[calc(20%-6px)] min-h-[40px] rounded-md border px-2 py-1 flex items-center justify-center transition-colors ${
+            className={`w-[calc((100%-1.5rem)/5)] min-h-[40px] rounded-md border px-2 py-1 flex items-center justify-center transition-colors ${
               isDone
                 ? 'bg-green-100 border-green-200 text-green-800'
                 : isCurrent
-                  ? 'bg-yellow-50 border-yellow-200 text-yellow-700'
+                  ? 'bg-yellow-100 border-yellow-200 text-yellow-800'
                   : 'bg-gray-50 border-gray-200 text-gray-500'
             }`}
           >

--- a/frontend/src/pages/student/LearningHistoryPage.tsx
+++ b/frontend/src/pages/student/LearningHistoryPage.tsx
@@ -1,0 +1,297 @@
+/**
+ * LearningHistoryPage — student's learning history overview.
+ *
+ * Two tabs:
+ *  - 作業回顧: sessions with learning_source = 'assignment'
+ *  - 自學紀錄: sessions with learning_source = 'self'
+ *
+ * Card layout mirrors MyAssignments (step progress strip + metadata),
+ * but all actions are read-only (查看 report only).
+ * Route: /learning-history
+ */
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import { fetchLearningSessions, type LearningSummary } from '../../services/learningApi';
+import { ACTIVE_STEPS } from '../../config/stepConfig';
+import StepProgressStrip from '../../components/ui/StepProgressStrip';
+
+type TabKey = 'assignment' | 'self';
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'assignment', label: '作業回顧' },
+  { key: 'self', label: '自學紀錄' },
+];
+
+const PAGE_SIZE = 20;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function groupByMonth(sessions: LearningSummary[]): { label: string; items: LearningSummary[] }[] {
+  const map = new Map<string, LearningSummary[]>();
+  for (const s of sessions) {
+    const d = new Date(s.started_at);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(s);
+  }
+  return Array.from(map.entries())
+    .sort((a, b) => b[0].localeCompare(a[0]))
+    .map(([, items]) => ({
+      label: new Date(items[0].started_at).toLocaleDateString('zh-TW', {
+        year: 'numeric',
+        month: 'long',
+      }),
+      items,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Session card — mirrors MyAssignments layout, read-only
+// ---------------------------------------------------------------------------
+
+const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
+  const navigate = useNavigate();
+
+  // All completed sessions have all steps done
+  const allStepIds = useMemo(() => new Set(ACTIVE_STEPS.map((s) => s.id)), []);
+
+  const score =
+    session.overall_score != null
+      ? Math.round(session.overall_score)
+      : null;
+
+  const accuracy =
+    session.accuracy != null
+      ? Math.round(session.accuracy * 100)
+      : null;
+
+  return (
+    <div className="bg-white rounded-2xl shadow-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          {/* Title + status */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-sm font-medium text-gray-900 truncate">
+              {session.story_title ?? session.story_slug ?? '未知課文'}
+            </h3>
+            <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+              已完成
+            </span>
+          </div>
+
+          {/* Metadata row */}
+          <div className="flex items-center gap-3 mt-2 flex-wrap">
+            <span className="text-xs text-gray-400">{formatDate(session.started_at)}</span>
+            {score != null && (
+              <span className="text-xs font-medium text-gray-700">得分：{score}%</span>
+            )}
+            {accuracy != null && score == null && (
+              <span className="text-xs text-gray-500">準確率：{accuracy}%</span>
+            )}
+          </div>
+
+          {/* Step progress strip */}
+          {ACTIVE_STEPS.length > 0 && (
+            <div className="mt-2.5">
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-[11px] text-gray-500">學習關卡進度</p>
+                <p className="text-[11px] text-gray-400">
+                  {ACTIVE_STEPS.length}/{ACTIVE_STEPS.length}
+                </p>
+              </div>
+              <StepProgressStrip
+                steps={ACTIVE_STEPS}
+                completedSteps={allStepIds}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Read-only action */}
+        <button
+          onClick={() => navigate(`/sessions/${session.id}/report`)}
+          className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-xs font-medium hover:bg-gray-50 transition-colors cursor-pointer shrink-0"
+        >
+          查看
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Tab content
+// ---------------------------------------------------------------------------
+
+const TabContent: React.FC<{ source: TabKey }> = ({ source }) => {
+  const { token } = useAuth();
+  const [sessions, setSessions] = useState<LearningSummary[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState('');
+
+  const load = useCallback(
+    async (offset: number, append: boolean) => {
+      if (!token) return;
+      if (offset === 0) setIsLoading(true);
+      else setIsLoadingMore(true);
+      setError('');
+      try {
+        const result = await fetchLearningSessions(token, {
+          learning_source: source,
+          limit: PAGE_SIZE,
+          offset,
+          status: 'completed',
+        });
+        setSessions((prev) => (append ? [...prev, ...result.items] : result.items));
+        setTotal(result.total);
+      } catch {
+        setError('無法載入學習紀錄，請稍後再試');
+      } finally {
+        setIsLoading(false);
+        setIsLoadingMore(false);
+      }
+    },
+    [token, source],
+  );
+
+  useEffect(() => {
+    setSessions([]);
+    setTotal(0);
+    load(0, false);
+  }, [load]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="bg-white rounded-2xl shadow-card p-4">
+            <div className="h-4 bg-gray-200 animate-pulse rounded w-2/3 mb-3" />
+            <div className="h-3 bg-gray-200 animate-pulse rounded w-1/3 mb-2" />
+            <div className="h-4 bg-gray-200 animate-pulse rounded w-full" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+        {error}
+      </div>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <div className="inline-flex items-center justify-center w-14 h-14 bg-accent-bg rounded-xl mb-4">
+          <svg className="w-7 h-7 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+            />
+          </svg>
+        </div>
+        <p className="text-sm font-medium text-gray-700 mb-1">
+          {source === 'assignment' ? '還沒有作業學習紀錄' : '還沒有自學紀錄'}
+        </p>
+        <p className="text-xs text-gray-500">
+          {source === 'assignment'
+            ? '完成老師指派的作業後會出現在這裡'
+            : '在圖書館自主練習後會出現在這裡'}
+        </p>
+      </div>
+    );
+  }
+
+  const groups = groupByMonth(sessions);
+  const hasMore = sessions.length < total;
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <div key={group.label}>
+          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2">
+            {group.label}
+          </h3>
+          <div className="space-y-3">
+            {group.items.map((s) => (
+              <SessionCard key={s.id} session={s} />
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {hasMore && (
+        <div className="text-center pt-2">
+          <button
+            onClick={() => load(sessions.length, true)}
+            disabled={isLoadingMore}
+            className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-xs font-medium hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoadingMore ? '載入中...' : `載入更多（還有 ${total - sessions.length} 筆）`}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+const LearningHistoryPage: React.FC = () => {
+  const [activeTab, setActiveTab] = useState<TabKey>('assignment');
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+      <div className="max-w-2xl mx-auto space-y-4">
+        <div>
+          <h1 className="text-base font-bold text-gray-900">學習紀錄</h1>
+          <p className="text-xs text-gray-500 mt-0.5">回顧過去的學習練習</p>
+        </div>
+
+        {/* Tabs */}
+        <div className="border-b border-gray-200">
+          <nav className="flex -mb-px" aria-label="學習紀錄分頁">
+            {TABS.map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer ${
+                  activeTab === tab.key
+                    ? 'border-accent text-accent'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </nav>
+        </div>
+
+        <TabContent key={activeTab} source={activeTab} />
+      </div>
+    </div>
+  );
+};
+
+export default LearningHistoryPage;

--- a/frontend/src/pages/student/MyAssignments.tsx
+++ b/frontend/src/pages/student/MyAssignments.tsx
@@ -8,6 +8,7 @@ import {
   AssignmentApiError,
 } from '../../services/assignmentApi';
 import { ACTIVE_STEPS } from '../../config/stepConfig';
+import StepProgressStrip from '../../components/ui/StepProgressStrip';
 
 type FilterTab = 'pending' | 'completed' | 'graded';
 
@@ -19,41 +20,6 @@ const FILTER_TABS: { key: FilterTab; label: string }[] = [
 
 const ACTIVE_ASSIGNMENT_CONTEXT_KEY = 'activeAssignmentContext';
 const ASSIGNMENT_DB_SESSION_KEY_PREFIX = 'assignment-db-session-';
-
-interface ProgressStep {
-  id: string;
-  label: string;
-}
-
-const AssignmentProgressStrip: React.FC<{
-  steps: ProgressStep[];
-  completedSteps: Set<string>;
-  currentStepPath: string | null;
-}> = ({ steps, completedSteps, currentStepPath }) => (
-  <div className="flex flex-wrap gap-1.5">
-    {steps.map((step) => {
-      const isDone = completedSteps.has(step.id);
-      const isCurrent = !isDone && currentStepPath === step.id;
-      return (
-        <div
-          key={step.id}
-          title={step.label}
-          className={`w-[calc((100%-1.5rem)/5)] min-h-[40px] rounded-md border px-2 py-1 flex items-center justify-center transition-colors ${
-            isDone
-              ? 'bg-green-100 border-green-200 text-green-800'
-              : isCurrent
-                ? 'bg-yellow-100 border-yellow-200 text-yellow-800'
-                : 'bg-gray-50 border-gray-200 text-gray-500'
-          }`}
-        >
-          <span className="text-[11px] leading-tight font-medium text-center whitespace-normal break-words">
-            {step.label}
-          </span>
-        </div>
-      );
-    })}
-  </div>
-);
 
 const MyAssignments: React.FC = () => {
   const navigate = useNavigate();
@@ -497,7 +463,7 @@ const MyAssignments: React.FC = () => {
                               {completedSteps.size}/{assignmentSteps.length}
                             </p>
                           </div>
-                          <AssignmentProgressStrip
+                          <StepProgressStrip
                             steps={assignmentSteps}
                             completedSteps={completedSteps}
                             currentStepPath={currentStepPath}

--- a/frontend/src/pages/student/SessionHistoryReportPage.tsx
+++ b/frontend/src/pages/student/SessionHistoryReportPage.tsx
@@ -1,13 +1,10 @@
 /**
- * SessionHistoryReportPage — shows AssessmentReport for a historical session.
- *
- * Unlike ReportPage (which reads live session data from LearningContext),
- * this page fetches the persisted session data from
- * GET /api/learning/sessions/:sessionId/report and reconstructs a
- * LearningSession-shaped object so that AssessmentReport can render it.
+ * SessionHistoryReportPage — shows a historical session in two tabs:
+ *   1. 學習報告 — overall AssessmentReport (existing)
+ *   2. 作答紀錄 — per-step answer records (reading errors, dialogue Q&A, vocab, full-reading diff)
  *
  * Route: /sessions/:sessionId/report
- * Issue #580
+ * Issue #580 + feattodo new requirement
  */
 
 import React, { useEffect, useState } from 'react';
@@ -16,8 +13,10 @@ import { useAuth } from '../../contexts/AuthContext';
 import { fetchStory } from '../../services/api';
 import {
   fetchSessionReport,
+  fetchDialogueHistory,
   type SessionDetailResponse,
   type ComprehensionScoreResult,
+  type DialogueTurnItem,
 } from '../../services/learningApi';
 import type {
   LearningSession,
@@ -29,6 +28,7 @@ import type {
   Story,
 } from '../../types';
 import AssessmentReport from '../../components/reading-steps/AssessmentReport';
+import DiffDisplay from '../../components/ui/DiffDisplay';
 import PageLoader from '../../components/ui/PageLoader';
 
 // ---------------------------------------------------------------------------
@@ -47,7 +47,6 @@ function toReadingAttempt(raw: Record<string, unknown> | null, storyId: string):
       : [],
     transcription: typeof raw.transcription === 'string' ? raw.transcription : '',
     timestamp: typeof raw.timestamp === 'number' ? raw.timestamp : Date.now(),
-    // diff_tokens stored as-is — AssessmentReport uses DiffDisplay internally
     lineBreakdown: undefined,
   };
 }
@@ -55,19 +54,15 @@ function toReadingAttempt(raw: Record<string, unknown> | null, storyId: string):
 function toComprehensionResult(raw: Record<string, unknown> | null): ComprehensionResult | null {
   if (!raw) return null;
   return {
-    understoodCount:
-      typeof raw.understood_count === 'number' ? raw.understood_count : 0,
-    requiredCount:
-      typeof raw.required_count === 'number' ? raw.required_count : 0,
+    understoodCount: typeof raw.understood_count === 'number' ? raw.understood_count : 0,
+    requiredCount: typeof raw.required_count === 'number' ? raw.required_count : 0,
     isComplete: raw.is_complete === true,
-    conversationLength:
-      typeof raw.conversation_length === 'number' ? raw.conversation_length : 0,
+    conversationLength: typeof raw.conversation_length === 'number' ? raw.conversation_length : 0,
   };
 }
 
 function toVocabResult(raw: Record<string, unknown> | null): VocabResult | null {
   if (!raw) return null;
-  // Support both new (practiced_words) and legacy (practiced_chars) formats
   const words = Array.isArray(raw.practiced_words)
     ? (raw.practiced_words as string[])
     : Array.isArray(raw.practiced_chars)
@@ -92,9 +87,7 @@ function toFullReadingResult(raw: Record<string, unknown> | null): FullReadingRe
       raw.error_breakdown && typeof raw.error_breakdown === 'object'
         ? (raw.error_breakdown as { correct: number; wrong: number; missing: number; extra: number })
         : undefined,
-    diffTokens: Array.isArray(raw.diff_tokens)
-      ? (raw.diff_tokens as DiffToken[])
-      : undefined,
+    diffTokens: Array.isArray(raw.diff_tokens) ? (raw.diff_tokens as DiffToken[]) : undefined,
     transcript: typeof raw.transcript === 'string' ? raw.transcript : undefined,
   };
 }
@@ -130,21 +123,330 @@ function buildComprehensionScores(detail: SessionDetailResponse): ComprehensionS
 }
 
 // ---------------------------------------------------------------------------
+// Section wrapper
+// ---------------------------------------------------------------------------
+
+const StepSection: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div className="bg-white rounded-2xl shadow-card p-4 space-y-3">
+    <h3 className="text-sm font-semibold text-gray-800 border-b border-gray-100 pb-2">{title}</h3>
+    {children}
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// 逐段朗讀 record
+// ---------------------------------------------------------------------------
+
+const ReadingRecord: React.FC<{ raw: Record<string, unknown> }> = ({ raw }) => {
+  const accuracy = typeof raw.accuracy === 'number' ? Math.round(raw.accuracy * 100) : null;
+  const cpm = typeof raw.cpm === 'number' ? raw.cpm : null;
+  const mispronounced = Array.isArray(raw.mispronounced_words) ? (raw.mispronounced_words as string[]) : [];
+  const transcription = typeof raw.transcription === 'string' ? raw.transcription : null;
+
+  return (
+    <StepSection title="逐段朗讀">
+      <div className="flex gap-4 flex-wrap text-sm">
+        {accuracy != null && (
+          <div>
+            <span className="text-xs text-gray-500">準確率</span>
+            <p className="font-semibold text-gray-800">{accuracy}%</p>
+          </div>
+        )}
+        {cpm != null && (
+          <div>
+            <span className="text-xs text-gray-500">語速 (CPM)</span>
+            <p className="font-semibold text-gray-800">{cpm}</p>
+          </div>
+        )}
+      </div>
+      {mispronounced.length > 0 ? (
+        <div>
+          <p className="text-xs text-gray-500 mb-1.5">念錯的字詞</p>
+          <div className="flex flex-wrap gap-1.5">
+            {mispronounced.map((w, i) => (
+              <span key={i} className="px-2 py-0.5 rounded bg-red-100 text-red-700 text-sm font-medium">
+                {w}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <p className="text-xs text-green-600">沒有念錯的字詞</p>
+      )}
+      {transcription && (
+        <div>
+          <p className="text-xs text-gray-500 mb-1">辨識文字</p>
+          <p className="text-xs text-gray-600 leading-relaxed bg-gray-50 rounded-lg p-2.5 whitespace-pre-wrap">
+            {transcription}
+          </p>
+        </div>
+      )}
+    </StepSection>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// 全文朗讀 record
+// ---------------------------------------------------------------------------
+
+const FullReadingRecord: React.FC<{ raw: Record<string, unknown> }> = ({ raw }) => {
+  const matchRate = typeof raw.match_rate === 'number' ? Math.round(raw.match_rate * 100) : null;
+  const cpm = typeof raw.cpm === 'number' ? raw.cpm : null;
+  const feedback = typeof raw.feedback === 'string' ? raw.feedback : null;
+  const diffTokens = Array.isArray(raw.diff_tokens) ? (raw.diff_tokens as DiffToken[]) : [];
+  const errorBreakdown = raw.error_breakdown && typeof raw.error_breakdown === 'object'
+    ? (raw.error_breakdown as { correct: number; wrong: number; missing: number; extra: number })
+    : null;
+
+  return (
+    <StepSection title="全文朗讀">
+      <div className="flex gap-4 flex-wrap text-sm">
+        {matchRate != null && (
+          <div>
+            <span className="text-xs text-gray-500">符合率</span>
+            <p className="font-semibold text-gray-800">{matchRate}%</p>
+          </div>
+        )}
+        {cpm != null && (
+          <div>
+            <span className="text-xs text-gray-500">語速 (CPM)</span>
+            <p className="font-semibold text-gray-800">{cpm}</p>
+          </div>
+        )}
+      </div>
+      {errorBreakdown && (
+        <div className="flex gap-3 flex-wrap text-xs">
+          <span className="px-2 py-0.5 rounded bg-green-100 text-green-700">正確 {errorBreakdown.correct}</span>
+          <span className="px-2 py-0.5 rounded bg-red-100 text-red-700">錯誤 {errorBreakdown.wrong}</span>
+          <span className="px-2 py-0.5 rounded bg-gray-100 text-gray-600">漏讀 {errorBreakdown.missing}</span>
+          <span className="px-2 py-0.5 rounded bg-orange-100 text-orange-700">多讀 {errorBreakdown.extra}</span>
+        </div>
+      )}
+      {diffTokens.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 mb-1.5">朗讀差異對照</p>
+          <div className="text-base leading-loose bg-gray-50 rounded-lg p-3">
+            <DiffDisplay tokens={diffTokens} showLegend />
+          </div>
+        </div>
+      )}
+      {feedback && (
+        <div className="bg-blue-50 border border-blue-100 rounded-lg p-3">
+          <p className="text-xs font-medium text-blue-700 mb-0.5">AI 回饋</p>
+          <p className="text-sm text-gray-700 leading-relaxed">{feedback}</p>
+        </div>
+      )}
+    </StepSection>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// 課文理解 dialogue record
+// ---------------------------------------------------------------------------
+
+const ComprehensionRecord: React.FC<{
+  raw: Record<string, unknown> | null;
+  turns: DialogueTurnItem[];
+  scores: ComprehensionScoreResult | null;
+}> = ({ raw, turns, scores }) => {
+  const understood = raw && typeof raw.understood_count === 'number' ? raw.understood_count : null;
+  const required = raw && typeof raw.required_count === 'number' ? raw.required_count : null;
+
+  // Only show ai + student turns (skip feedback role for readability)
+  const conversationTurns = turns.filter((t) => t.role === 'ai' || t.role === 'student');
+
+  return (
+    <StepSection title="課文理解">
+      {(understood != null || scores) && (
+        <div className="flex gap-4 flex-wrap text-sm">
+          {understood != null && required != null && (
+            <div>
+              <span className="text-xs text-gray-500">答對題數</span>
+              <p className="font-semibold text-gray-800">{understood} / {required}</p>
+            </div>
+          )}
+          {scores && (
+            <>
+              <div>
+                <span className="text-xs text-gray-500">理解總分</span>
+                <p className="font-semibold text-gray-800">{Math.round(scores.comprehension_score * 100)}%</p>
+              </div>
+              <div>
+                <span className="text-xs text-gray-500">字面</span>
+                <p className="font-semibold text-gray-800">{Math.round(scores.literal_score * 100)}%</p>
+              </div>
+              <div>
+                <span className="text-xs text-gray-500">推論</span>
+                <p className="font-semibold text-gray-800">{Math.round(scores.inferential_score * 100)}%</p>
+              </div>
+              <div>
+                <span className="text-xs text-gray-500">評鑑</span>
+                <p className="font-semibold text-gray-800">{Math.round(scores.evaluative_score * 100)}%</p>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {conversationTurns.length > 0 ? (
+        <div className="space-y-2 max-h-96 overflow-y-auto pr-1">
+          {conversationTurns.map((turn) => (
+            <div
+              key={turn.id}
+              className={`flex ${turn.role === 'student' ? 'justify-end' : 'justify-start'}`}
+            >
+              <div
+                className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm leading-relaxed ${
+                  turn.role === 'ai'
+                    ? 'bg-gray-100 text-gray-800 rounded-tl-sm'
+                    : turn.is_correct === false
+                      ? 'bg-red-100 text-red-800 rounded-tr-sm'
+                      : 'bg-accent-bg text-accent rounded-tr-sm'
+                }`}
+              >
+                {turn.text}
+                {turn.role === 'student' && turn.is_correct === false && (
+                  <span className="block text-xs text-red-500 mt-0.5">✗ 答錯</span>
+                )}
+                {turn.role === 'student' && turn.is_correct === true && (
+                  <span className="block text-xs text-green-600 mt-0.5">✓ 答對</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-gray-400">沒有對話紀錄</p>
+      )}
+
+      {scores?.feedback.overall && (
+        <div className="bg-emerald-50 border border-emerald-100 rounded-lg p-3">
+          <p className="text-xs font-medium text-emerald-700 mb-0.5">AI 整體回饋</p>
+          <p className="text-sm text-gray-700 leading-relaxed">{scores.feedback.overall}</p>
+        </div>
+      )}
+    </StepSection>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// 生字練習 record
+// ---------------------------------------------------------------------------
+
+const VocabRecord: React.FC<{ raw: Record<string, unknown> }> = ({ raw }) => {
+  const words = Array.isArray(raw.practiced_words)
+    ? (raw.practiced_words as string[])
+    : Array.isArray(raw.practiced_chars)
+      ? (raw.practiced_chars as string[])
+      : [];
+  const total = typeof raw.total_words === 'number' ? raw.total_words
+    : typeof raw.total_chars === 'number' ? raw.total_chars : 0;
+
+  return (
+    <StepSection title="生字練習">
+      <div className="text-sm">
+        <span className="text-xs text-gray-500">練習進度</span>
+        <p className="font-semibold text-gray-800">{words.length} / {total} 個生字</p>
+      </div>
+      {words.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 mb-1.5">已練習的生字</p>
+          <div className="flex flex-wrap gap-2">
+            {words.map((w, i) => (
+              <span key={i} className="px-2.5 py-1 rounded-lg bg-amber-100 text-amber-800 text-base font-medium">
+                {w}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </StepSection>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// 作答紀錄 tab — all step records
+// ---------------------------------------------------------------------------
+
+const StepRecordsView: React.FC<{
+  detail: SessionDetailResponse;
+  comprehensionScores: ComprehensionScoreResult | null;
+  token: string;
+  sessionId: number;
+}> = ({ detail, comprehensionScores, token, sessionId }) => {
+  const [turns, setTurns] = useState<DialogueTurnItem[]>([]);
+  const [loadingTurns, setLoadingTurns] = useState(false);
+
+  useEffect(() => {
+    if (!detail.comprehension_result) return;
+    setLoadingTurns(true);
+    fetchDialogueHistory(token, sessionId)
+      .then((r) => setTurns(r.turns))
+      .catch(() => {/* non-critical */})
+      .finally(() => setLoadingTurns(false));
+  }, [token, sessionId, detail.comprehension_result]);
+
+  const hasReading = !!detail.reading_result;
+  const hasFullReading = !!detail.full_reading_result;
+  const hasComprehension = !!detail.comprehension_result;
+  const hasVocab = !!detail.vocab_result;
+  const hasAny = hasReading || hasFullReading || hasComprehension || hasVocab;
+
+  if (!hasAny) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-sm text-gray-500">這筆紀錄沒有儲存作答內容</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {hasReading && (
+        <ReadingRecord raw={detail.reading_result!} />
+      )}
+      {hasFullReading && (
+        <FullReadingRecord raw={detail.full_reading_result!} />
+      )}
+      {hasComprehension && (
+        loadingTurns
+          ? <div className="bg-white rounded-2xl shadow-card p-4">
+              <div className="h-4 bg-gray-200 animate-pulse rounded w-1/3 mb-3" />
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => <div key={i} className="h-8 bg-gray-100 animate-pulse rounded-xl" />)}
+              </div>
+            </div>
+          : <ComprehensionRecord
+              raw={detail.comprehension_result}
+              turns={turns}
+              scores={comprehensionScores}
+            />
+      )}
+      {hasVocab && (
+        <VocabRecord raw={detail.vocab_result!} />
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Page component
 // ---------------------------------------------------------------------------
+
+type PageTab = 'report' | 'steps';
 
 const SessionHistoryReportPage: React.FC = () => {
   const { sessionId } = useParams<{ sessionId: string }>();
   const { token } = useAuth();
   const navigate = useNavigate();
 
+  const [detail, setDetail] = useState<SessionDetailResponse | null>(null);
   const [session, setSession] = useState<LearningSession | null>(null);
   const [story, setStory] = useState<Story | null>(null);
   const [comprehensionScores, setComprehensionScores] = useState<ComprehensionScoreResult | null>(null);
-  const [teacherReviewedAt, setTeacherReviewedAt] = useState<string | null>(null);
-  const [teacherComment, setTeacherComment] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
+  const [activeTab, setActiveTab] = useState<PageTab>('report');
 
   useEffect(() => {
     if (!token || !sessionId) return;
@@ -159,19 +461,16 @@ const SessionHistoryReportPage: React.FC = () => {
     setError('');
 
     fetchSessionReport(token, id)
-      .then(async (detail) => {
-        setSession(buildLearningSession(detail));
-        setComprehensionScores(buildComprehensionScores(detail));
-        setTeacherReviewedAt(detail.teacher_reviewed_at ?? null);
-        setTeacherComment(detail.teacher_comment ?? null);
+      .then(async (d) => {
+        setDetail(d);
+        setSession(buildLearningSession(d));
+        setComprehensionScores(buildComprehensionScores(d));
 
-        // Try to load the Story for AssessmentReport (best-effort — non-blocking)
-        if (detail.story_slug) {
+        if (d.story_slug) {
           try {
-            const s = await fetchStory(detail.story_slug);
-            setStory(s);
+            setStory(await fetchStory(d.story_slug));
           } catch {
-            // Non-critical — AssessmentReport gracefully handles story=null
+            // non-critical
           }
         }
       })
@@ -189,7 +488,7 @@ const SessionHistoryReportPage: React.FC = () => {
         <div className="text-center space-y-4">
           <p className="text-red-600 text-sm">{error}</p>
           <button
-            onClick={() => navigate('/history')}
+            onClick={() => navigate('/learning-history')}
             className="px-4 py-2 rounded-lg bg-accent hover:bg-accent-hover text-white text-sm font-medium transition-colors cursor-pointer"
           >
             返回學習記錄
@@ -199,32 +498,74 @@ const SessionHistoryReportPage: React.FC = () => {
     );
   }
 
+  const teacherReviewedAt = detail?.teacher_reviewed_at ?? null;
+  const teacherComment = detail?.teacher_comment ?? null;
+
   return (
-    <div className="p-8 max-w-4xl mx-auto w-full">
-      {teacherReviewedAt && (
-        <div className="mb-4 space-y-3">
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-50 border border-emerald-200 text-emerald-700 text-xs font-medium">
-            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-            </svg>
-            老師已查看（{new Date(teacherReviewedAt).toLocaleDateString('zh-TW')}）
-          </div>
-          {teacherComment && (
-            <div className="bg-purple-50 border border-purple-200 rounded-xl p-4">
-              <p className="text-xs font-semibold text-purple-700 mb-1">老師評語</p>
-              <p className="text-sm text-gray-800 leading-relaxed whitespace-pre-wrap">{teacherComment}</p>
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-4xl mx-auto px-4 sm:px-8 py-6 space-y-4">
+
+        {/* Teacher review banner */}
+        {teacherReviewedAt && (
+          <div className="space-y-3">
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-50 border border-emerald-200 text-emerald-700 text-xs font-medium">
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              老師已查看（{new Date(teacherReviewedAt).toLocaleDateString('zh-TW')}）
             </div>
-          )}
+            {teacherComment && (
+              <div className="bg-purple-50 border border-purple-200 rounded-xl p-4">
+                <p className="text-xs font-semibold text-purple-700 mb-1">老師評語</p>
+                <p className="text-sm text-gray-800 leading-relaxed whitespace-pre-wrap">{teacherComment}</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Tab nav */}
+        <div className="border-b border-gray-200">
+          <nav className="flex -mb-px" aria-label="檢視模式">
+            {([
+              { key: 'report', label: '學習報告' },
+              { key: 'steps', label: '作答紀錄' },
+            ] as { key: PageTab; label: string }[]).map((tab) => (
+              <button
+                key={tab.key}
+                onClick={() => setActiveTab(tab.key)}
+                className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
+                  activeTab === tab.key
+                    ? 'border-accent text-accent'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </nav>
         </div>
-      )}
-      <AssessmentReport
-        session={session}
-        story={story}
-        onRetry={() => navigate('/history')}
-        dbSessionId={sessionId ? Number(sessionId) : null}
-        token={token}
-        comprehensionScores={comprehensionScores}
-      />
+
+        {/* Tab content */}
+        {activeTab === 'report' ? (
+          <AssessmentReport
+            session={session}
+            story={story}
+            onRetry={() => navigate('/learning-history')}
+            dbSessionId={sessionId ? Number(sessionId) : null}
+            token={token}
+            comprehensionScores={comprehensionScores}
+          />
+        ) : (
+          detail && (
+            <StepRecordsView
+              detail={detail}
+              comprehensionScores={comprehensionScores}
+              token={token!}
+              sessionId={Number(sessionId)}
+            />
+          )
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/student/SessionHistoryReportPage.tsx
+++ b/frontend/src/pages/student/SessionHistoryReportPage.tsx
@@ -4,7 +4,7 @@
  *   2. 作答紀錄 — per-step answer records (reading errors, dialogue Q&A, vocab, full-reading diff)
  *
  * Route: /sessions/:sessionId/report
- * Issue #580 + feattodo new requirement
+ * Issue #580 + #416
  */
 
 import React, { useEffect, useState } from 'react';

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -61,6 +61,7 @@ const AchievementsPage = lazy(() => import('../pages/student/AchievementsPage'))
 const StudentClassroomDashboard = lazy(() => import('../pages/student/StudentClassroomDashboard'));
 const StudentProfile = lazy(() => import('../pages/student/StudentProfile'));
 const SessionHistoryReportPage = lazy(() => import('../pages/student/SessionHistoryReportPage'));
+const LearningHistoryPage = lazy(() => import('../pages/student/LearningHistoryPage'));
 
 // Parent dashboard — role-specific, split separately
 const ParentDashboard = lazy(() => import('../pages/parent/ParentDashboard'));
@@ -298,10 +299,20 @@ const AppRoutes: React.FC = () => (
         }
       />
       <Route
+        path="/learning-history"
+        element={
+          <ProtectedRoute>
+            <AppShell>
+              <LearningHistoryPage />
+            </AppShell>
+          </ProtectedRoute>
+        }
+      />
+      <Route
         path="/history"
         element={
           <ProtectedRoute>
-            <Navigate to="/assignments" replace />
+            <Navigate to="/learning-history" replace />
           </ProtectedRoute>
         }
       />


### PR DESCRIPTION
## 功能說明

建立學生的「學習紀錄」頁面（`/learning-history`），讓學生能回顧過去所有練習紀錄。

頁面分為兩個 Tab：

| Tab | 說明 | 資料來源 |
|-----|------|---------|
| 作業回顧 | 老師指派作業的完成紀錄 | `learning_source = assignment` |
| 自學紀錄 | 學生在圖書館自主練習的紀錄 | `learning_source = self` |

每筆紀錄使用與「我的作業」相同的卡片版面，顯示：
- 課文名稱、完成日期、得分
- **學習關卡進度條**（全部步驟標示為已完成，唯讀不可操作）
- 右上角「查看」按鈕，進入 `/sessions/:id/report` 查看詳情

查看頁面分兩個 Tab：
- **學習報告**：原有 AssessmentReport 整體評估
- **作答紀錄**：每個關卡的實際作答內容（唯讀）
  - 逐段朗讀：準確率、語速、念錯字詞列表、辨識文字
  - 全文朗讀：符合率、語速、錯誤統計（正確/錯誤/漏讀/多讀）、DiffDisplay 對照原文
  - 課文理解：完整問答對話紀錄（學生/AI 泡泡）、答對答錯標記、三層分數（字面/推論/評鑑）、AI 整體回饋
  - 生字練習：已練習生字列表、完成進度

紀錄按月份分組呈現，資料量大時提供「載入更多」按鈕（每次 20 筆）。

## 開發方式

- **後端 API**：沿用現有
  - `GET /api/learning/sessions?learning_source=assignment|self&status=completed` — 列表
  - `GET /api/learning/sessions/:id/report` — session 詳情（含各關卡 result JSON）
  - `GET /api/learning/sessions/:id/dialogue` — 課文理解問答對話紀錄（已有，學生可存取）
- **步驟進度條**：將 `MyAssignments.tsx` 的 `AssignmentProgressStrip` 抽取為共用元件 `StepProgressStrip`，同時供兩頁使用。
- **作答紀錄渲染**：讀取 session detail 的 `reading_result`、`full_reading_result`、`comprehension_result`、`vocab_result` JSON 欄位，各自用獨立 section 顯示；課文理解另外呼叫 dialogue API 取得完整對話。
- **分頁**：Load More 模式；每次 20 筆，顯示剩餘筆數。

## 開發檔案地址

| 動作 | 檔案 |
|------|------|
| 新增 | `frontend/src/pages/student/LearningHistoryPage.tsx` |
| 新增（共用步驟進度條元件） | `frontend/src/components/ui/StepProgressStrip.tsx` |
| 修改（新增 route + lazy import） | `frontend/src/routes/AppRoutes.tsx` |
| 修改（移除內嵌 AssignmentProgressStrip，改用共用元件） | `frontend/src/pages/student/MyAssignments.tsx` |
| 修改（加入作答紀錄 tab，顯示各關卡作答內容） | `frontend/src/pages/student/SessionHistoryReportPage.tsx` |
| 修改（側邊欄加入「學習紀錄」入口） | `frontend/src/components/layout/Sidebar.tsx` |

## 驗收對照

- [x] 學生能看到所有歷次練習紀錄（作業 / 自學分開顯示）
- [x] 紀錄按月份分組、由新到舊排列
- [x] 可點「查看」進入單筆紀錄詳情（既有 SessionHistoryReportPage）
- [x] 卡片版面與「我的作業」一致，含學習關卡進度條（唯讀）
- [x] 查看頁面有「作答紀錄」分頁，顯示各關卡實際作答內容（錯字、對話、生字、朗讀 diff）
