### PR TITLE
fix: 詞語應用沒有答案的問題修正（fix: #1029）

### DIFF
--- a/backend/app/routes/learning/learning_vocab.py
+++ b/backend/app/routes/learning/learning_vocab.py
@@ -193,7 +193,7 @@ async def validate_sentence(
             return ValidateSentenceResponse(
                 is_correct=False,
                 feedback="這個句子好像是從課文或例句中複製的喔！請試著用自己的話造一個新句子。",
-                suggestion=f"試著用「{payload.character}」描述你自己的生活經驗或想像一個新的情境。",
+                suggestion=f"試著用「{payload.word}」描述你自己的生活經驗或想像一個新的情境。",
             )
 
         # Check: sentence matches a paragraph substring
@@ -202,14 +202,14 @@ async def validate_sentence(
                 return ValidateSentenceResponse(
                     is_correct=False,
                     feedback="這個句子和課文或例句內容太相似了，請用自己的話重新造句。",
-                    suggestion=f"嘗試用「{payload.character}」造一個和課文、例句不同情境的句子。",
+                    suggestion=f"嘗試用「{payload.word}」造一個和課文、例句不同情境的句子。",
                 )
 
-        # Extract passage sentences containing the target char for AI cross-reference
+        # Extract passage sentences containing the target word for AI cross-reference
         raw_sentences = re.split(r"[。！？]", full_text)
         passage_sentences = [
             s.strip() for s in raw_sentences
-            if payload.character in s and s.strip()
+            if payload.word in s and s.strip()
         ][:5]
 
     start_time = time.monotonic()

--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -266,7 +266,7 @@ async def validate_student_sentence(
         passage_ref = "\n".join(f"- {s}" for s in passage_sentences[:5])
         system_prompt += f"""
 
-以下是課文或例句中包含「{safe_char}」的句子片段（供參考比對）：
+以下是課文或例句中包含「{safe_word}」的句子片段（供參考比對）：
 {passage_ref}
 
 如果學生的句子與上述片段高度相似（只改了幾個字但意思和結構幾乎一樣），判定 is_correct=false，

--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -13,6 +13,18 @@ import yaml
 
 _LESSONS_DIR = Path(__file__).parent.parent.parent / "data" / "lessons"
 
+def _halfwidth(code: str) -> str:
+    """Convert fullwidth ASCII letters (Ａ-Ｚ, ａ-ｚ) to halfwidth (A-Z, a-z).
+
+    YAML fill_in_blank answers are sometimes typed as fullwidth (Ａ, Ｂ…)
+    while vocab_bank keys are always halfwidth (A, B…), causing mismatches.
+    """
+    return "".join(
+        chr(ord(c) - 0xFEE0) if 0xFF01 <= ord(c) <= 0xFF5E else c
+        for c in (code or "")
+    )
+
+
 _GENRE_TO_CATEGORY = {
     "記敘文": "Fable",
     "說明文": "Science",
@@ -75,7 +87,10 @@ def _load_lessons() -> list[dict]:
             "char_count": data.get("char_count", 0),
             "thumbnail_url": f"https://storage.googleapis.com/lingoleap-assets/stories/thumbnails/lesson-{data['lesson_number']}.webp",
             "vocabulary": data.get("vocabulary"),
-            "fill_in_blank": data.get("fill_in_blank"),
+            "fill_in_blank": [
+                {**item, "answer": _halfwidth(item.get("answer", ""))}
+                for item in (data.get("fill_in_blank") or [])
+            ] or None,
             "multiple_choice": data.get("multiple_choice"),
             "vocab_bank": data.get("vocab_bank"),
             "knowledge_video_url": data.get("knowledge_video_url"),


### PR DESCRIPTION
# 修正說明

## 修正 1：validate_sentence 路由 — `payload.character` 未定義屬性

**修正檔案**
- [backend/app/routes/learning/learning_vocab.py](backend/app/routes/learning/learning_vocab.py)

**問題怎麼出現的**

copy-paste 檢測區塊（Issue #928）實作時，誤用 `payload.character`，但 `ValidateSentenceRequest` 只有 `word` 欄位。

有對應 YAML 課文檔的故事 → `get_lesson_by_title` 回傳課文 → 進入 copy-paste 區塊 → `AttributeError` → HTTP 500。
沒有課文檔的故事 → 跳過區塊 → AI 正常呼叫。

**修正方式**

三處 `payload.character` → `payload.word`（L197、L205、L213）

---

## 修正 2：validate_student_sentence AI 服務 — `safe_char` 未定義變數

**修正檔案**
- [backend/app/services/ai_generation.py](backend/app/services/ai_generation.py)

**問題怎麼出現的**

修正 1 後，`passage_sentences`（課文中含目標詞語的句子）正確傳入 AI 服務。但 `ai_generation.py` L269 prompt 拼接時用了 `safe_char`（未定義），應為 `safe_word`。

課文含目標詞語（如「崎嶇」出現在黑猩猩守護者課文）→ `passage_sentences` 非空 → `NameError` → HTTP 500。

**修正方式**

`safe_char` → `safe_word`（L269）

---

## 修正 3：填空題答案永遠無法選對 — 全形 vs 半形字母不符

**修正檔案**
- [backend/app/services/lesson_loader.py](backend/app/services/lesson_loader.py)

**真正根本原因**

8 個 YAML 課文檔（L03、L05、L07、L08、L14、L18、L27、L51）的 `fill_in_blank.answer` 使用**全形字母**（Ａ、Ｂ、Ｃ… Unicode U+FF21-FF3A），但 `vocab_bank` 的 key 是**半形字母**（A、B、C… Unicode U+0041-005A）。

前端比對 `selected === currentSentence.answer` 時，`"A" === "Ａ"` 永遠為 false，導致選項中根本沒有正確答案，學生無論怎麼選都是錯的。

同一個課文的 YAML 甚至混用兩種格式（如 L07 第 4 題用半形 `A`，其餘題用全形 `Ａ`），更難察覺。

**修正方式**

在 `lesson_loader.py` 載入 YAML 時，統一將 `fill_in_blank.answer` 的全形字母轉為半形，一次修正所有 8 個受影響課文，不需修改 YAML 原始檔，也不需修改前端比對邏輯。

```python
# 新增正規化函式
def _halfwidth(code: str) -> str:
    return "".join(
        chr(ord(c) - 0xFEE0) if 0xFF01 <= ord(c) <= 0xFF5E else c
        for c in (code or "")
    )

# 載入時套用
"fill_in_blank": [
    {**item, "answer": _halfwidth(item.get("answer", ""))}
    for item in (data.get("fill_in_blank") or [])
] or None,
```

**受影響課文（共 8 篇，34 筆全形答案）**

| 課文 | 全形答案數 |
|------|-----------|
| L03 | 3 |
| L05 | 4 |
| L07 | 6 |
| L08 | 3 |
| L14 | 5 |
| L18 | 4 |
| L27 | 7 |
| L51 | 2 |

---

**總結**

| # | 檔案 | 錯誤 | 修正 |
|---|------|------|------|
| 1 | `learning_vocab.py` | `payload.character` 不存在 | → `payload.word` |
| 2 | `ai_generation.py` | `safe_char` 未定義 | → `safe_word` |
| 3 | `lesson_loader.py` | 全形/半形字母不符 | 載入時正規化 `fill_in_blank.answer` |
