### PR TITLE
fix: 文章重點表 NameError — normalized 未定義 (#1039)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -166,17 +166,17 @@ async def get_story_structure(
         story_text=story_text,
         genre=story.get("genre"),
     )
-    _set_cached_structure(normalized, result)
+    _set_cached_structure(story_id, result)
     latency_ms = int((time.monotonic() - start_time) * 1000)
 
     # Track AI usage (Issue #874)
     usage = last_usage.get()
     log_ai_usage(
         db,
-        endpoint=f"/stories/{normalized}/structure",
+        endpoint=f"/stories/{story_id}/structure",
         step="structure",
         student_id=current_user.id,
-        story_id=normalized,
+        story_id=story_id,
         story_title=story["title"],
         input_tokens=usage.input_tokens if usage else 0,
         output_tokens=usage.output_tokens if usage else 0,


### PR DESCRIPTION
## Summary
- `backend/app/routes/stories.py` 第 169/176/179 行引用了 `normalized` 變數，但從未定義（第 145 行定義的是 `numeric_id`）
- Cache miss 時必定 NameError → 500，Cloud Run 重新部署後 cache 清空 → 所有學生都看到「無法載入文章重點表」
- 改為 `story_id`

## Test plan
- [ ] 在 staging 開啟任意課文的課文理解步驟，文章重點表應正常載入
- [ ] 確認 AI usage log 正確記錄

Fixes #1039

🤖 Generated with [Claude Code](https://claude.ai/code)