### PR TITLE
fix: 縮小 StepHeader + 拖拉配對雙欄獨立捲動 (Fixes #1034 #1035)

### DIFF
--- a/frontend/src/components/reading-steps/VocabApplication.tsx
+++ b/frontend/src/components/reading-steps/VocabApplication.tsx
@@ -60,14 +60,12 @@ export interface VocabApplicationProps {
 /* ------------------------------------------------------------------ */
 
 /** Header banner matching other step components' amber-50 style */
-function StepHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+function StepHeader({ subtitle }: { title?: string; subtitle?: string }) {
+  if (!subtitle) return null;
   return (
-    <div className="bg-amber-50 border-b border-amber-200 px-6 py-4">
+    <div className="bg-amber-50 border-b border-amber-200 px-4 py-2">
       <div className="max-w-2xl mx-auto">
-        <h2 className="text-xl font-bold text-amber-900">{title}</h2>
-        {subtitle && (
-          <p className="mt-0.5 text-sm text-amber-700">{subtitle}</p>
-        )}
+        <p className="text-xs text-amber-700">{subtitle}</p>
       </div>
     </div>
   );

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -110,14 +110,12 @@ function shuffle<T>(arr: T[]): T[] {
 /*  Shared sub-components                                               */
 /* ------------------------------------------------------------------ */
 
-function StepHeader({ title, subtitle }: { title: string; subtitle?: string }) {
+function StepHeader({ subtitle }: { title?: string; subtitle?: string }) {
+  if (!subtitle) return null;
   return (
-    <div className="bg-amber-50 border-b border-amber-200 px-6 py-4">
+    <div className="bg-amber-50 border-b border-amber-200 px-4 py-2">
       <div className="max-w-2xl mx-auto">
-        <h2 className="text-xl font-bold text-amber-900">{title}</h2>
-        {subtitle && (
-          <p className="mt-1 text-base text-amber-700">{subtitle}</p>
-        )}
+        <p className="text-xs text-amber-700">{subtitle}</p>
       </div>
     </div>
   );
@@ -747,9 +745,9 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
       </div>
 
       {/* Desktop: two-column layout — definitions left (scrollable), word bank right (sticky) */}
-      <div className="md:flex md:gap-6 md:items-start">
-        {/* Left column — definition slots */}
-        <div className="flex-1 min-w-0">
+      <div className="md:flex md:gap-6 md:items-start md:max-h-[calc(100vh-16rem)]">
+        {/* Left column — definition slots, independently scrollable on desktop */}
+        <div className="flex-1 min-w-0 md:overflow-y-auto md:max-h-[calc(100vh-16rem)]">
           <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2 text-center md:text-left">
             定義欄位
           </p>
@@ -758,8 +756,8 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
           </div>
         </div>
 
-        {/* Right column — word bank panel, sticky (desktop only) */}
-        <div className="hidden md:block w-52 flex-shrink-0 sticky top-4 self-start">
+        {/* Right column — word bank panel, independently scrollable on desktop */}
+        <div className="hidden md:flex md:flex-col w-52 flex-shrink-0 overflow-y-auto max-h-[calc(100vh-16rem)]">
           {wordBankContent}
         </div>
       </div>


### PR DESCRIPTION
Fixes #1034
Fixes #1035

## Summary

- **#1034 StepHeader 太佔空間**: 移除 `VocabDefinitionMatch` 和 `VocabApplication` 中 `StepHeader` 的 title（與上方 stepper 重複），保留 subtitle 作為小提示；padding 從 `px-6 py-4` 縮小至 `px-4 py-2`，文字從 `text-xl`/`text-base` 改為 `text-xs`
- **#1035 左右區域獨立捲動**: 在 `DragDropMode` 桌面版雙欄佈局，對左欄（定義欄位）和右欄（語詞庫）各加 `overflow-y-auto` + `max-h-[calc(100vh-16rem)]`，兩側可獨立捲動

## Changed Files

- `frontend/src/components/reading-steps/VocabDefinitionMatch.tsx`
- `frontend/src/components/reading-steps/VocabApplication.tsx`

## Test Plan

- [ ] 進入語詞定義配對步驟，確認頂部不再出現大標題，只有小字提示
- [ ] 進入語詞應用步驟，確認頂部同樣只顯示小字提示
- [ ] 桌面寬度 (≥768px)，語詞定義配對拖拉配對模式，詞彙量多時，左欄和右欄可獨立上下捲動
- [ ] 手機版不受影響，仍使用 sticky 頂部語詞庫