### PR TITLE
fix: 移除報告頁 AI 推薦課文區塊 (Fixes #1044)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -18,7 +18,6 @@ import StarCelebration from '../gamification/StarCelebration';
 import { calcStarRating } from '../../utils/starRatingCalc';
 import GoalAchievementCard from '../ui/GoalAchievementCard';
 import RepeatedErrorAlertModal from '../student/RepeatedErrorAlertModal';
-import RecommendedStories from '../student/RecommendedStories';
 import { getReadingHistory, type ReadingHistoryPoint } from '../../services/learningApi';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
 
@@ -921,18 +920,6 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
             )}
           </div>
         </Section>
-      )}
-
-      {/* ============ AI 推薦下一篇 (#1015) ============ */}
-      {!readOnly && (
-        <div className="space-y-3">
-          <div className="flex items-center gap-3">
-            <div className="h-px flex-1 bg-gray-200" />
-            <span className="text-sm font-semibold text-gray-500 whitespace-nowrap">接下來讀什麼？</span>
-            <div className="h-px flex-1 bg-gray-200" />
-          </div>
-          <RecommendedStories />
-        </div>
       )}
 
       {/* CTA */}


### PR DESCRIPTION
Fixes #1044

## Summary
- 從 `AssessmentReport.tsx` 移除「AI 為你推薦的課文」(接下來讀什麼？) 整個 JSX 區塊
- 移除對應的 `RecommendedStories` import（不再使用）

## Changes
- `frontend/src/components/reading-steps/AssessmentReport.tsx` — 刪除 13 行（import + section block）

## Test plan
- 開啟報告頁（AssessmentReport），確認底部不再顯示「接下來讀什麼？」區塊
- 確認 CTA「回圖書館」按鈕仍正常顯示