### PR TITLE
experiment: 學習路徑方案 A — Duolingo 蜿蜒地圖

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -2,22 +2,25 @@
  * AppShell — the authenticated app chrome (header + sidebar + main area).
  *
  * LearningAppShell — thin wrapper that puts LearningLayout inside AppShell,
- * used for all /learn/:storyId/* routes. It renders the StepperNav as a
- * horizontal top navigation bar above the learning content.
+ * used for all /learn/:storyId/* routes. Supports two nav styles:
+ *   classic — horizontal StepperNav top bar (default)
+ *   map     — Duolingo-style winding path sidebar (#1047)
  */
-import React, { useState, useEffect, useCallback, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { useLearningNav } from '../../contexts/LearningNavContext';
 import { getMyAssignments } from '../../services/assignmentApi';
 import { AppView } from '../../types';
-import { VIEW_TO_PATH } from '../../config/stepConfig';
+import { VIEW_TO_PATH, ACTIVE_STEPS } from '../../config/stepConfig';
 import { useAppView } from '../../hooks/useAppView';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import LearningLayout from '../../layouts/LearningLayout';
 import StepperNav from '../StepperNav';
+import LearningPathMap from '../ui/LearningPathMap';
+import type { PathStep } from '../ui/LearningPathMap';
 import { OnboardingWrapper } from '../../pages/app/InlinePages';
 
 /** The authenticated app shell with header + sidebar. */
@@ -109,16 +112,62 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
   );
 };
 
+/** localStorage key for the nav style preference. */
+const NAV_STYLE_KEY = 'learning-nav-style';
+
+type NavStyle = 'classic' | 'map';
+
 /**
  * Inner content for the learning flow: StepperNav top bar + LearningLayout.
  * Rendered inside AppShell's <main> element.
  *
- * Layout: flex-col — [StepperNav horizontal bar] stacked above [LearningLayout full-width]
+ * Nav style options (persisted to localStorage):
+ *   classic — horizontal StepperNav top bar (default)
+ *   map     — Duolingo-style winding path sidebar (#1047)
  */
 const LearningContent: React.FC = () => {
   const navigate = useNavigate();
   const currentView = useAppView();
   const { session: navSession, selectedStory: navStory } = useLearningNav();
+
+  // ── Nav style toggle ───────────────────────────────────────────────────────
+
+  const [navStyle, setNavStyle] = useState<NavStyle>(() => {
+    try {
+      const saved = localStorage.getItem(NAV_STYLE_KEY);
+      if (saved === 'map') return 'map';
+    } catch { /* non-fatal */ }
+    return 'classic';
+  });
+
+  const toggleNavStyle = useCallback(() => {
+    setNavStyle((prev) => {
+      const next: NavStyle = prev === 'classic' ? 'map' : 'classic';
+      try { localStorage.setItem(NAV_STYLE_KEY, next); } catch { /* non-fatal */ }
+      return next;
+    });
+  }, []);
+
+  // ── Path map data (from config — never hardcoded) ──────────────────────────
+
+  /** Current step ID derived from URL path segment. */
+  const currentStepId = useMemo(() => {
+    const segment = window.location.pathname.split('/').pop() ?? '';
+    const found = ACTIVE_STEPS.find((s) => s.id === segment);
+    return found ? found.id : (ACTIVE_STEPS[0]?.id ?? '');
+  }, [currentView]); // re-derive whenever the view changes
+
+  const pathMapSteps: PathStep[] = useMemo(
+    () => ACTIVE_STEPS.map((s) => ({ id: s.id, label: s.label, category: s.category })),
+    [],
+  );
+
+  const completedSteps = useMemo(
+    () => new Set<string>(navSession?.completedSteps ?? []),
+    [navSession?.completedSteps],
+  );
+
+  // ── Navigation handlers ────────────────────────────────────────────────────
 
   const handleStepperNavigate = (view: AppView) => {
     switch (view) {
@@ -142,29 +191,98 @@ const LearningContent: React.FC = () => {
     }
   };
 
+  const handlePathMapClick = useCallback((stepId: string) => {
+    const match = window.location.pathname.match(/\/learn\/([^/]+)/);
+    const storyId = match?.[1];
+    if (storyId) {
+      navigate(`/learn/${storyId}/${stepId}`);
+    }
+  }, [navigate]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      {/* Horizontal step nav bar at the top */}
-      <StepperNav
-        currentView={currentView}
-        session={navSession}
-        selectedStory={navStory}
-        onNavigate={handleStepperNavigate}
-      />
-
-      {/* Learning step content — full width below the top nav.
-          overflow-y-auto keeps the height capped to the viewport so steps with
-          internal scroll containers scroll correctly (#815, #824). */}
-      <div className="flex-1 flex flex-col overflow-y-auto pb-14 md:pb-0">
-        <LearningLayout />
+      {/* Nav style toggle — top-right corner, minimal footprint */}
+      <div className="flex items-center justify-end px-3 py-1 bg-white/60 border-b border-gray-100 shrink-0">
+        <button
+          type="button"
+          onClick={toggleNavStyle}
+          className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium text-gray-500 hover:text-accent hover:bg-accent/10 transition-colors"
+          aria-label={navStyle === 'classic' ? '切換到地圖模式' : '切換到經典模式'}
+          title={navStyle === 'classic' ? '切換到地圖模式' : '切換到經典模式'}
+        >
+          {navStyle === 'classic' ? (
+            <>
+              {/* Map icon */}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M3 6l6-3 6 3 6-3v15l-6 3-6-3-6 3z"/>
+                <path d="M9 3v15"/>
+                <path d="M15 6v15"/>
+              </svg>
+              地圖
+            </>
+          ) : (
+            <>
+              {/* List icon */}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M4 6h16M4 12h16M4 18h16"/>
+              </svg>
+              經典
+            </>
+          )}
+        </button>
       </div>
+
+      {navStyle === 'classic' ? (
+        <>
+          {/* Classic mode: horizontal StepperNav at top */}
+          <StepperNav
+            currentView={currentView}
+            session={navSession}
+            selectedStory={navStory}
+            onNavigate={handleStepperNavigate}
+          />
+
+          {/* Learning step content — full width below the top nav.
+              overflow-y-auto keeps height capped to viewport so steps with
+              internal scroll containers scroll correctly (#815, #824). */}
+          <div className="flex-1 flex flex-col overflow-y-auto pb-14 md:pb-0">
+            <LearningLayout />
+          </div>
+        </>
+      ) : (
+        /* Map mode: winding path sidebar + content side by side (desktop);
+           stacked vertically on mobile. */
+        <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
+          {/* Path map sidebar */}
+          <aside
+            className="w-full md:w-[280px] lg:w-[320px] shrink-0 border-b md:border-b-0 md:border-r border-gray-200 bg-white/80 overflow-y-auto"
+            aria-label="學習路徑地圖"
+          >
+            <div className="py-4 px-2">
+              <LearningPathMap
+                steps={pathMapSteps}
+                completedSteps={completedSteps}
+                currentStepId={currentStepId}
+                onStepClick={handlePathMapClick}
+              />
+            </div>
+          </aside>
+
+          {/* Learning step content */}
+          <div className="flex-1 flex flex-col overflow-y-auto pb-14 md:pb-0">
+            <LearningLayout />
+          </div>
+        </div>
+      )}
     </div>
   );
 };
 
 /**
  * AppShell wrapper specifically for the learning flow.
- * Renders StepperNav as a sidebar alongside LearningLayout.
+ * Renders StepperNav or LearningPathMap sidebar alongside LearningLayout.
  */
 export const LearningAppShell: React.FC = () => {
   return (

--- a/frontend/src/components/ui/LearningPathMap.tsx
+++ b/frontend/src/components/ui/LearningPathMap.tsx
@@ -1,0 +1,283 @@
+/**
+ * LearningPathMap — Duolingo-style winding path showing learning step progress.
+ *
+ * Renders a vertical snake-like path where nodes zigzag left-right.
+ * Completed nodes are green with a checkmark, current node pulses with
+ * primary accent color, future nodes are gray and semi-transparent.
+ *
+ * Props receive step data from ACTIVE_STEPS (stepConfig.ts) — never hardcoded.
+ * If steps grow from 10 to 12 (or shrink), the layout adapts automatically.
+ */
+
+import React, { useMemo } from 'react';
+import type { StepCategory } from '../../config/stepConfig';
+import { STEP_CATEGORY_COLORS } from '../../config/stepConfig';
+
+export interface PathStep {
+  id: string;
+  label: string;
+  category?: StepCategory;
+}
+
+interface LearningPathMapProps {
+  steps: PathStep[];
+  completedSteps: Set<string>;
+  currentStepId: string;
+  onStepClick: (id: string) => void;
+}
+
+// ── Layout constants ─────────────────────────────────────────────────────────
+
+/** Regular node radius (px). Diameter = 48px. */
+const NODE_R = 24;
+/** Current-step node radius (px). Diameter = 56px. */
+const NODE_R_CURRENT = 28;
+/** Horizontal padding on each side. */
+const PADDING_X = 52;
+/** Vertical padding at top and bottom. */
+const PADDING_Y = 40;
+/** Vertical distance between node centers. */
+const ROW_HEIGHT = 100;
+/** How far each node shifts left or right from the center axis. */
+const ZIGZAG_OFFSET = 68;
+
+type NodeStatus = 'completed' | 'current' | 'future';
+
+function getNodeStatus(
+  stepId: string,
+  completedSteps: Set<string>,
+  currentStepId: string,
+): NodeStatus {
+  if (completedSteps.has(stepId)) return 'completed';
+  if (stepId === currentStepId) return 'current';
+  return 'future';
+}
+
+/** Resolve the fill hex for a category badge dot. */
+function categoryDotFill(badge: string): string {
+  if (badge.includes('orange')) return '#f97316';
+  if (badge.includes('emerald')) return '#10b981';
+  if (badge.includes('blue')) return '#3b82f6';
+  return '#5b4fc4'; // default: primary
+}
+
+/** SVG cubic bezier between two zigzag nodes. */
+function curvedPath(x1: number, y1: number, x2: number, y2: number): string {
+  const midY = (y1 + y2) / 2;
+  return `M ${x1} ${y1} C ${x1} ${midY}, ${x2} ${midY}, ${x2} ${y2}`;
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+const LearningPathMap: React.FC<LearningPathMapProps> = ({
+  steps,
+  completedSteps,
+  currentStepId,
+  onStepClick,
+}) => {
+  const centerX = PADDING_X + ZIGZAG_OFFSET + NODE_R_CURRENT;
+
+  const nodes = useMemo(() => {
+    return steps.map((step, i) => {
+      // Even index → left of center; odd index → right of center.
+      const side = i % 2 === 0 ? -1 : 1;
+      const x = centerX + side * ZIGZAG_OFFSET;
+      const y = PADDING_Y + NODE_R_CURRENT + i * ROW_HEIGHT;
+      return { ...step, x, y, index: i };
+    });
+  }, [steps, centerX]);
+
+  const svgWidth = PADDING_X * 2 + ZIGZAG_OFFSET * 2 + NODE_R_CURRENT * 2;
+  const svgHeight =
+    nodes.length > 0
+      ? nodes[nodes.length - 1].y + NODE_R_CURRENT + PADDING_Y + 24 // label space
+      : 200;
+
+  const currentIndex = nodes.findIndex((n) => n.id === currentStepId);
+
+  return (
+    <div className="w-full flex justify-center select-none">
+      <div className="w-full max-w-[400px]">
+        <svg
+          viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+          width="100%"
+          height={svgHeight}
+          className="block overflow-visible"
+          aria-label="學習路徑地圖"
+          role="img"
+        >
+          <defs>
+            <style>{`
+              @keyframes lpm-pulse {
+                0%, 100% { r: ${NODE_R_CURRENT}px; opacity: 0.35; }
+                50%       { r: ${NODE_R_CURRENT + 10}px; opacity: 0; }
+              }
+              .lpm-pulse-ring {
+                animation: lpm-pulse 2s ease-in-out infinite;
+                transform-box: fill-box;
+                transform-origin: center;
+              }
+            `}</style>
+          </defs>
+
+          {/* ── Connector lines ───────────────────────────────────────────── */}
+          {nodes.map((node, i) => {
+            if (i === 0) return null;
+            const prev = nodes[i - 1];
+            const pathD = curvedPath(prev.x, prev.y, node.x, node.y);
+
+            // Segment is green when it connects two completed/current nodes.
+            const segmentDone =
+              i <= currentIndex ||
+              (completedSteps.has(prev.id) && completedSteps.has(node.id));
+
+            return (
+              <path
+                key={`line-${node.id}`}
+                d={pathD}
+                fill="none"
+                stroke={segmentDone ? '#10b981' : '#d1d5db'}
+                strokeWidth={segmentDone ? 4 : 3}
+                strokeLinecap="round"
+                className="transition-colors duration-500"
+              />
+            );
+          })}
+
+          {/* ── Step nodes ────────────────────────────────────────────────── */}
+          {nodes.map((node) => {
+            const status = getNodeStatus(node.id, completedSteps, currentStepId);
+            const r = status === 'current' ? NODE_R_CURRENT : NODE_R;
+            const categoryColor = node.category
+              ? STEP_CATEGORY_COLORS[node.category]
+              : null;
+
+            const circleFill =
+              status === 'completed'
+                ? '#10b981'
+                : status === 'current'
+                  ? '#5b4fc4'
+                  : '#e5e7eb';
+
+            const circleStroke =
+              status === 'completed'
+                ? '#059669'
+                : status === 'current'
+                  ? '#4a3fa3'
+                  : '#d1d5db';
+
+            return (
+              <g
+                key={node.id}
+                className="cursor-pointer"
+                onClick={() => onStepClick(node.id)}
+                role="button"
+                tabIndex={0}
+                aria-label={`${node.label} — ${
+                  status === 'completed'
+                    ? '已完成'
+                    : status === 'current'
+                      ? '進行中'
+                      : '尚未開始'
+                }`}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onStepClick(node.id);
+                  }
+                }}
+              >
+                {/* Pulse ring — current node only */}
+                {status === 'current' && (
+                  <circle
+                    cx={node.x}
+                    cy={node.y}
+                    r={NODE_R_CURRENT}
+                    fill="none"
+                    stroke="#5b4fc4"
+                    strokeWidth={3}
+                    className="lpm-pulse-ring"
+                  />
+                )}
+
+                {/* Main circle */}
+                <circle
+                  cx={node.x}
+                  cy={node.y}
+                  r={r}
+                  fill={circleFill}
+                  stroke={circleStroke}
+                  strokeWidth={3}
+                  opacity={status === 'future' ? 0.55 : 1}
+                  className="transition-all duration-300"
+                />
+
+                {/* Checkmark for completed; step number otherwise */}
+                {status === 'completed' ? (
+                  <path
+                    d={`M ${node.x - 8} ${node.y} l 5 5 l 10 -10`}
+                    fill="none"
+                    stroke="white"
+                    strokeWidth={3}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="pointer-events-none"
+                  />
+                ) : (
+                  <text
+                    x={node.x}
+                    y={node.y}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fill={status === 'current' ? 'white' : '#9ca3af'}
+                    fontSize={status === 'current' ? 14 : 13}
+                    fontWeight={600}
+                    className="pointer-events-none"
+                  >
+                    {node.index + 1}
+                  </text>
+                )}
+
+                {/* Category dot — top-right corner of the node */}
+                {categoryColor && status !== 'completed' && (
+                  <circle
+                    cx={node.x + r - 4}
+                    cy={node.y - r + 4}
+                    r={5}
+                    fill={categoryDotFill(categoryColor.badge)}
+                    stroke="white"
+                    strokeWidth={1.5}
+                    opacity={status === 'future' ? 0.45 : 1}
+                    className="pointer-events-none"
+                  />
+                )}
+
+                {/* Step label below the node */}
+                <text
+                  x={node.x}
+                  y={node.y + r + 18}
+                  textAnchor="middle"
+                  fill={
+                    status === 'completed'
+                      ? '#059669'
+                      : status === 'current'
+                        ? '#374151'
+                        : '#9ca3af'
+                  }
+                  fontSize={12}
+                  fontWeight={status === 'current' ? 600 : 400}
+                  opacity={status === 'future' ? 0.65 : 1}
+                  className="pointer-events-none"
+                >
+                  {node.label}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+};
+
+export default LearningPathMap;


### PR DESCRIPTION
## Summary

- 新增 `LearningPathMap.tsx` — SVG 蜿蜒路徑地圖元件（Duolingo 風格）
- 修改 `AppShell.tsx` — 在學習流程加入「地圖/經典」切換按鈕
- 切換偏好存 `localStorage`，預設保持現有 classic 模式不受影響

## 設計決策

**佈局**：10 個節點垂直排列，左右交錯 zigzag，SVG cubic bezier 曲線連接

**節點狀態**：
- 已完成：`#10b981` 綠色 + checkmark
- 進行中：`#5b4fc4` primary 紫色 + pulse 動畫（CSS keyframes in `<style>`，零外部依賴）
- 未開始：`#e5e7eb` 灰色，55% 不透明

**類別小圓點**：右上角小圓點對應 reading/comprehension/practice/report，使用現有 `STEP_CATEGORY_COLORS`

**步驟資料**：100% 讀取 `ACTIVE_STEPS`，步驟數從 10 變 8 或 12 會自動適應

**Responsive**：desktop `md:` 側邊欄 280-320px；mobile 頂部折疊 sidebar

**Accessibility**：WCAG keyboard nav（`tabIndex=0`，Enter/Space 觸發切換）

## Layout ASCII

```
    [1] 讀全文
         \
         [2] 逐段朗讀
        /
  [3] 全文朗讀
         \
         [4] 生字練習
        /
     ...
```

## Test plan

- [ ] 開啟任何學習步驟頁面，右上角出現「地圖」按鈕
- [ ] 點擊切換到地圖模式，左側出現蜿蜒路徑 sidebar
- [ ] 路徑顯示正確步驟數量（與 ACTIVE_STEPS 一致，目前 10 個）
- [ ] 當前步驟節點有 pulse 動畫
- [ ] 點擊已完成或進行中節點可導航到對應步驟
- [ ] 重新整理頁面，切換偏好被保存（localStorage）
- [ ] mobile 版本（375px）：sidebar 顯示在頂部，不遮擋內容
- [ ] keyboard nav：Tab 到節點，Enter/Space 觸發導航

Closes #1047

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)