### PR TITLE
experiment: 學習路徑方案 B — 三階段分組

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -2,22 +2,24 @@
  * AppShell — the authenticated app chrome (header + sidebar + main area).
  *
  * LearningAppShell — thin wrapper that puts LearningLayout inside AppShell,
- * used for all /learn/:storyId/* routes. It renders the StepperNav as a
- * horizontal top navigation bar above the learning content.
+ * used for all /learn/:storyId/* routes. Supports two nav styles:
+ *   classic — horizontal StepperNav top bar (default)
+ *   phases  — vertical 3-phase accordion sidebar (#1048)
  */
-import React, { useState, useEffect, useCallback, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { useLearningNav } from '../../contexts/LearningNavContext';
 import { getMyAssignments } from '../../services/assignmentApi';
 import { AppView } from '../../types';
-import { VIEW_TO_PATH } from '../../config/stepConfig';
+import { VIEW_TO_PATH, ACTIVE_STEPS } from '../../config/stepConfig';
 import { useAppView } from '../../hooks/useAppView';
 import Header from './Header';
 import Sidebar from './Sidebar';
 import LearningLayout from '../../layouts/LearningLayout';
 import StepperNav from '../StepperNav';
+import LearningPhases from '../ui/LearningPhases';
 import { OnboardingWrapper } from '../../pages/app/InlinePages';
 
 /** The authenticated app shell with header + sidebar. */
@@ -26,7 +28,6 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
   const { activeView } = useWorkspace();
   const navigate = useNavigate();
 
-  // Pending assignment count for the student nav badge
   const [pendingAssignmentCount, setPendingAssignmentCount] = useState(0);
 
   const refreshPendingCount = useCallback(async () => {
@@ -47,7 +48,6 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
   }, [refreshPendingCount]);
 
   const handleStepperNavigate = (view: AppView) => {
-    // Map AppView back to route paths for StepperNav clicks
     switch (view) {
       case AppView.HOME:
         navigate('/');
@@ -56,9 +56,6 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
         navigate('/library');
         break;
       default: {
-        // Learning step navigation: look up path from config-driven VIEW_TO_PATH map.
-        // ACTIVE_STEPS drives which views are valid learning steps, so any view
-        // that resolves in VIEW_TO_PATH is a learning step.
         const pathId = VIEW_TO_PATH[view];
         if (pathId) {
           const match = window.location.pathname.match(/\/learn\/([^/]+)/);
@@ -74,7 +71,6 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
 
   return (
     <div className="h-screen flex flex-col bg-amber-50 text-gray-900 font-sans overflow-hidden">
-      {/* Skip-to-content link — visually hidden until focused (WCAG 2.4.1) */}
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-accent focus:text-white focus:rounded focus:font-medium focus:text-sm focus:shadow-lg"
@@ -82,10 +78,8 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
         跳至主要內容
       </a>
 
-      {/* Header — global chrome only (logo, user info, logout). No stepper here. */}
       <Header onStepperNavigate={handleStepperNavigate} />
 
-      {/* Body: sidebar + main content */}
       <div className="flex-1 flex overflow-hidden">
         <Sidebar pendingAssignmentCount={pendingAssignmentCount} />
 
@@ -100,27 +94,65 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
         </main>
       </div>
 
-      {/* Onboarding overlay for first-time students */}
       <Suspense fallback={null}>
         <OnboardingWrapper />
       </Suspense>
-
     </div>
   );
 };
 
+/** localStorage key for the nav style preference */
+const NAV_STYLE_KEY = 'learning-nav-style';
+
+type NavStyle = 'classic' | 'phases';
+
 /**
- * Inner content for the learning flow: StepperNav top bar + LearningLayout.
- * Rendered inside AppShell's <main> element.
- *
- * Layout: flex-col — [StepperNav horizontal bar] stacked above [LearningLayout full-width]
+ * Inner content for the learning flow.
+ * Supports two nav styles:
+ *   classic — horizontal StepperNav top bar (default)
+ *   phases  — vertical 3-phase accordion sidebar (#1048)
  */
 const LearningContent: React.FC = () => {
   const navigate = useNavigate();
   const currentView = useAppView();
   const { session: navSession, selectedStory: navStory } = useLearningNav();
 
-  const handleStepperNavigate = (view: AppView) => {
+  const [navStyle, setNavStyle] = useState<NavStyle>(() => {
+    try {
+      const saved = localStorage.getItem(NAV_STYLE_KEY);
+      if (saved === 'phases') return 'phases';
+    } catch { /* non-fatal */ }
+    return 'classic';
+  });
+
+  const toggleNavStyle = useCallback(() => {
+    setNavStyle((prev) => {
+      const next: NavStyle = prev === 'classic' ? 'phases' : 'classic';
+      try { localStorage.setItem(NAV_STYLE_KEY, next); } catch { /* non-fatal */ }
+      return next;
+    });
+  }, []);
+
+  /** Derive current step ID from URL for the phases sidebar */
+  const currentStepId = useMemo(() => {
+    const stepId = window.location.pathname.split('/').pop() ?? '';
+    const found = ACTIVE_STEPS.find((s) => s.id === stepId);
+    return found ? found.id : ACTIVE_STEPS[0]?.id ?? '';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentView]);
+
+  /** Steps data for LearningPhases */
+  const phaseSteps = useMemo(
+    () => ACTIVE_STEPS.map((s) => ({ id: s.id, label: s.label })),
+    [],
+  );
+
+  /** Completed steps derived from session data */
+  const completedSteps = useMemo(() => {
+    return new Set<string>(navSession?.completedSteps ?? []);
+  }, [navSession?.completedSteps]);
+
+  const handleStepperNavigate = useCallback((view: AppView) => {
     switch (view) {
       case AppView.HOME:
         navigate('/');
@@ -140,31 +172,87 @@ const LearningContent: React.FC = () => {
         break;
       }
     }
-  };
+  }, [navigate]);
+
+  const handlePhaseStepClick = useCallback((stepId: string) => {
+    const match = window.location.pathname.match(/\/learn\/([^/]+)/);
+    const storyId = match?.[1];
+    if (storyId) {
+      navigate(`/learn/${storyId}/${stepId}`);
+    }
+  }, [navigate]);
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden">
-      {/* Horizontal step nav bar at the top */}
-      <StepperNav
-        currentView={currentView}
-        session={navSession}
-        selectedStory={navStory}
-        onNavigate={handleStepperNavigate}
-      />
-
-      {/* Learning step content — full width below the top nav.
-          overflow-y-auto keeps the height capped to the viewport so steps with
-          internal scroll containers scroll correctly (#815, #824). */}
-      <div className="flex-1 flex flex-col overflow-y-auto pb-14 md:pb-0">
-        <LearningLayout />
+      {/* Nav style toggle button */}
+      <div className="flex items-center justify-end px-3 py-1 bg-white/60 border-b border-gray-100">
+        <button
+          type="button"
+          onClick={toggleNavStyle}
+          className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium text-gray-500 hover:text-accent hover:bg-accent-bg transition-colors"
+          aria-label={navStyle === 'classic' ? '切換到階段模式' : '切換到經典模式'}
+        >
+          {navStyle === 'classic' ? (
+            <>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="3" width="18" height="18" rx="2"/>
+                <path d="M3 9h18M3 15h18"/>
+              </svg>
+              階段
+            </>
+          ) : (
+            <>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M4 6h16M4 12h16M4 18h16"/>
+              </svg>
+              經典
+            </>
+          )}
+        </button>
       </div>
+
+      {navStyle === 'classic' ? (
+        <>
+          {/* Horizontal step nav bar at the top */}
+          <StepperNav
+            currentView={currentView}
+            session={navSession}
+            selectedStory={navStory}
+            onNavigate={handleStepperNavigate}
+          />
+
+          <div className="flex-1 flex flex-col overflow-y-auto pb-14 md:pb-0">
+            <LearningLayout />
+          </div>
+        </>
+      ) : (
+        /* Phases mode: 3-phase accordion sidebar on desktop, stacked on mobile */
+        <div className="flex-1 flex flex-col md:flex-row overflow-hidden">
+          <aside
+            className="w-full md:w-[280px] lg:w-[320px] shrink-0 border-b md:border-b-0 md:border-r border-gray-200 bg-white/80 overflow-y-auto"
+            aria-label="學習階段導航"
+          >
+            <div className="py-4 px-3">
+              <LearningPhases
+                steps={phaseSteps}
+                completedSteps={completedSteps}
+                currentStepId={currentStepId}
+                onStepClick={handlePhaseStepClick}
+              />
+            </div>
+          </aside>
+
+          <div className="flex-1 flex flex-col overflow-y-auto pb-14 md:pb-0">
+            <LearningLayout />
+          </div>
+        </div>
+      )}
     </div>
   );
 };
 
 /**
  * AppShell wrapper specifically for the learning flow.
- * Renders StepperNav as a sidebar alongside LearningLayout.
  */
 export const LearningAppShell: React.FC = () => {
   return (

--- a/frontend/src/components/ui/LearningPhases.tsx
+++ b/frontend/src/components/ui/LearningPhases.tsx
@@ -1,0 +1,362 @@
+/**
+ * LearningPhases — vertical accordion that groups learning steps into 3 phases.
+ *
+ * Each phase is a collapsible card showing:
+ *   - Icon + label + description + progress count
+ *   - Completed phases: green checkmark, collapsed
+ *   - Current phase: expanded with step list
+ *   - Future phases: lock icon, collapsed, dimmed
+ *   - Phase completion triggers a CSS celebration animation
+ */
+
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { LEARNING_PHASES, STEP_TO_PHASE } from '../../config/phaseConfig';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface LearningStep {
+  id: string;
+  label: string;
+}
+
+interface LearningPhasesProps {
+  steps: LearningStep[];
+  completedSteps: Set<string>;
+  currentStepId: string;
+  onStepClick: (id: string) => void;
+}
+
+type PhaseStatus = 'completed' | 'current' | 'future';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function getPhaseStatus(
+  phaseId: string,
+  phaseStepIds: string[],
+  completedSteps: Set<string>,
+  currentStepId: string,
+): PhaseStatus {
+  const allDone = phaseStepIds.length > 0 && phaseStepIds.every((id) => completedSteps.has(id));
+  if (allDone) return 'completed';
+
+  const currentPhaseId = STEP_TO_PHASE[currentStepId];
+  if (phaseId === currentPhaseId) return 'current';
+  if (phaseStepIds.includes(currentStepId)) return 'current';
+
+  return 'future';
+}
+
+function getCompletedCount(phaseStepIds: string[], completedSteps: Set<string>): number {
+  return phaseStepIds.filter((id) => completedSteps.has(id)).length;
+}
+
+// ── Phase status styling ───────────────────────────────────────────────────
+
+const PHASE_STYLES: Record<PhaseStatus, {
+  card: string;
+  header: string;
+  icon: string;
+  label: string;
+  description: string;
+  progress: string;
+  indicator: string;
+}> = {
+  completed: {
+    card: 'border-green-200 bg-green-50/60',
+    header: 'cursor-pointer',
+    icon: 'text-green-600',
+    label: 'text-green-800',
+    description: 'text-green-600/70',
+    progress: 'text-green-600 font-semibold',
+    indicator: 'bg-green-500',
+  },
+  current: {
+    card: 'border-accent/30 bg-white shadow-card ring-1 ring-accent/10',
+    header: 'cursor-pointer',
+    icon: 'text-accent',
+    label: 'text-gray-900',
+    description: 'text-gray-500',
+    progress: 'text-accent font-semibold',
+    indicator: 'bg-accent',
+  },
+  future: {
+    card: 'border-gray-200 bg-gray-50/60 opacity-60',
+    header: 'cursor-default',
+    icon: 'text-gray-400',
+    label: 'text-gray-500',
+    description: 'text-gray-400',
+    progress: 'text-gray-400',
+    indicator: 'bg-gray-300',
+  },
+};
+
+// ── Step item inside expanded phase ────────────────────────────────────────
+
+interface StepItemProps {
+  step: LearningStep;
+  isCompleted: boolean;
+  isCurrent: boolean;
+  isFuture: boolean;
+  onClick: () => void;
+}
+
+const StepItem: React.FC<StepItemProps> = React.memo(
+  ({ step, isCompleted, isCurrent, isFuture, onClick }) => {
+    const canClick = isCompleted || isCurrent;
+    return (
+      <button
+        type="button"
+        onClick={canClick ? onClick : undefined}
+        disabled={isFuture}
+        className={[
+          'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left',
+          'transition-colors duration-150',
+          isCompleted
+            ? 'bg-green-50 hover:bg-green-100/80'
+            : isCurrent
+              ? 'bg-accent-bg ring-1 ring-accent/20'
+              : 'bg-gray-50',
+          canClick ? 'cursor-pointer' : 'cursor-default',
+        ].join(' ')}
+        aria-current={isCurrent ? 'step' : undefined}
+      >
+        {/* Status indicator */}
+        <span className="flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full text-xs font-bold">
+          {isCompleted ? (
+            <span className="w-6 h-6 rounded-full bg-green-500 text-white flex items-center justify-center">
+              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </span>
+          ) : isCurrent ? (
+            <span className="w-6 h-6 rounded-full bg-accent text-white flex items-center justify-center">
+              <span className="w-2 h-2 rounded-full bg-white animate-pulse" />
+            </span>
+          ) : (
+            <span className="w-6 h-6 rounded-full bg-gray-200 text-gray-400 flex items-center justify-center">
+              <span className="w-1.5 h-1.5 rounded-full bg-gray-400" />
+            </span>
+          )}
+        </span>
+
+        {/* Step label */}
+        <span
+          className={[
+            'text-sm leading-snug',
+            isCompleted
+              ? 'text-green-700'
+              : isCurrent
+                ? 'text-gray-900 font-medium'
+                : 'text-gray-400',
+          ].join(' ')}
+        >
+          {step.label}
+        </span>
+      </button>
+    );
+  },
+);
+
+StepItem.displayName = 'StepItem';
+
+// ── Celebration animation (pure CSS confetti) ──────────────────────────────
+
+const CelebrationBurst: React.FC<{ show: boolean }> = ({ show }) => {
+  if (!show) return null;
+  return (
+    <span className="absolute -top-1 right-3 pointer-events-none" aria-hidden="true">
+      <span className="absolute w-2 h-2 rounded-full bg-yellow-400 animate-confetti-drop-1" />
+      <span className="absolute w-2 h-2 rounded-full bg-accent animate-confetti-drop-2" />
+      <span className="absolute w-2 h-2 rounded-full bg-green-400 animate-confetti-drop-3" />
+      <span className="absolute w-5 h-5 text-yellow-500 animate-star-burst">
+        <svg viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 2l2.09 6.26L20.18 9l-5.09 3.74L16.18 19 12 15.27 7.82 19l1.09-6.26L3.82 9l6.09-.74z" />
+        </svg>
+      </span>
+    </span>
+  );
+};
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+const LearningPhases: React.FC<LearningPhasesProps> = ({
+  steps,
+  completedSteps,
+  currentStepId,
+  onStepClick,
+}) => {
+  const stepMap = useMemo(
+    () => new Map(steps.map((s) => [s.id, s])),
+    [steps],
+  );
+
+  const [celebratingPhase, setCelebratingPhase] = useState<string | null>(null);
+  const prevCompletedPhasesRef = useRef<Set<string>>(new Set());
+
+  const currentPhaseId = STEP_TO_PHASE[currentStepId] ?? LEARNING_PHASES[0]?.id;
+  const [expandedPhaseId, setExpandedPhaseId] = useState<string>(currentPhaseId);
+
+  // Keep expanded phase in sync with current step
+  useEffect(() => {
+    const newPhaseId = STEP_TO_PHASE[currentStepId];
+    if (newPhaseId) {
+      setExpandedPhaseId(newPhaseId);
+    }
+  }, [currentStepId]);
+
+  // Detect newly completed phases for celebration
+  useEffect(() => {
+    const nowCompleted = new Set<string>();
+    for (const phase of LEARNING_PHASES) {
+      if (phase.stepIds.length > 0 && phase.stepIds.every((id) => completedSteps.has(id))) {
+        nowCompleted.add(phase.id);
+      }
+    }
+
+    for (const phaseId of nowCompleted) {
+      if (!prevCompletedPhasesRef.current.has(phaseId)) {
+        setCelebratingPhase(phaseId);
+        const timer = setTimeout(() => setCelebratingPhase(null), 1200);
+        prevCompletedPhasesRef.current = nowCompleted;
+        return () => clearTimeout(timer);
+      }
+    }
+
+    prevCompletedPhasesRef.current = nowCompleted;
+  }, [completedSteps]);
+
+  const handleToggle = useCallback(
+    (phaseId: string, status: PhaseStatus) => {
+      if (status === 'future') return;
+      setExpandedPhaseId((prev) => (prev === phaseId ? '' : phaseId));
+    },
+    [],
+  );
+
+  return (
+    <div className="flex flex-col gap-3 w-full" role="navigation" aria-label="學習階段">
+      {LEARNING_PHASES.map((phase) => {
+        const status = getPhaseStatus(phase.id, phase.stepIds, completedSteps, currentStepId);
+        const style = PHASE_STYLES[status];
+        const completedCount = getCompletedCount(phase.stepIds, completedSteps);
+        const totalCount = phase.stepIds.length;
+        const isExpanded = expandedPhaseId === phase.id;
+        const isCelebrating = celebratingPhase === phase.id;
+        const progressPct = totalCount > 0 ? (completedCount / totalCount) * 100 : 0;
+
+        return (
+          <div
+            key={phase.id}
+            className={`relative rounded-xl border transition-all duration-300 overflow-hidden ${style.card}`}
+          >
+            <CelebrationBurst show={isCelebrating} />
+
+            {/* Phase header */}
+            <div
+              role="button"
+              tabIndex={status !== 'future' ? 0 : -1}
+              aria-expanded={isExpanded}
+              aria-controls={`phase-content-${phase.id}`}
+              className={`flex items-center gap-3 px-4 py-3.5 select-none ${style.header}`}
+              onClick={() => handleToggle(phase.id, status)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleToggle(phase.id, status);
+                }
+              }}
+            >
+              {/* Status icon */}
+              <span className={`flex-shrink-0 text-xl ${style.icon}`}>
+                {status === 'completed' ? (
+                  <svg className="w-6 h-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                ) : status === 'future' ? (
+                  <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                  </svg>
+                ) : (
+                  <span className="text-lg leading-none">{phase.label.slice(0, 2)}</span>
+                )}
+              </span>
+
+              {/* Label + description */}
+              <div className="flex-1 min-w-0">
+                <div className={`text-sm font-semibold leading-tight ${style.label}`}>
+                  {phase.label}
+                </div>
+                <div className={`text-xs mt-0.5 ${style.description}`}>
+                  {phase.description}
+                </div>
+              </div>
+
+              {/* Progress count + chevron */}
+              <div className="flex-shrink-0 flex items-center gap-2">
+                <span className={`text-xs tabular-nums ${style.progress}`}>
+                  {completedCount}/{totalCount}
+                </span>
+                {status !== 'future' && (
+                  <svg
+                    className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${
+                      isExpanded ? 'rotate-180' : ''
+                    }`}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                  </svg>
+                )}
+              </div>
+            </div>
+
+            {/* Progress bar */}
+            <div className="px-4 pb-1">
+              <div className="h-1 rounded-full bg-gray-200/60 overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all duration-500 ease-out ${style.indicator}`}
+                  style={{ width: `${progressPct}%` }}
+                />
+              </div>
+            </div>
+
+            {/* Expandable step list */}
+            <div
+              id={`phase-content-${phase.id}`}
+              className={[
+                'transition-all duration-300 ease-in-out overflow-hidden',
+                isExpanded ? 'max-h-[500px] opacity-100' : 'max-h-0 opacity-0',
+              ].join(' ')}
+            >
+              <div className="px-4 pb-4 pt-2 flex flex-col gap-1.5">
+                {phase.stepIds.map((stepId) => {
+                  const step = stepMap.get(stepId);
+                  if (!step) return null;
+
+                  const isStepCompleted = completedSteps.has(stepId);
+                  const isStepCurrent = stepId === currentStepId;
+                  const isStepFuture = !isStepCompleted && !isStepCurrent;
+
+                  return (
+                    <StepItem
+                      key={stepId}
+                      step={step}
+                      isCompleted={isStepCompleted}
+                      isCurrent={isStepCurrent}
+                      isFuture={isStepFuture}
+                      onClick={() => onStepClick(stepId)}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default React.memo(LearningPhases);

--- a/frontend/src/config/phaseConfig.ts
+++ b/frontend/src/config/phaseConfig.ts
@@ -1,0 +1,68 @@
+/**
+ * phaseConfig.ts — maps ACTIVE_STEPS into 3 learning phases.
+ *
+ * Phases auto-distribute steps from ACTIVE_STEPS so the grouping adapts
+ * when steps are added, removed, or reordered in stepConfig.ts.
+ *
+ * To override which steps belong to which phase, edit PHASE_TEMPLATES
+ * and supply explicit stepIds arrays. When stepIds is empty the phase
+ * receives its share of ACTIVE_STEPS via round-robin distribution.
+ */
+
+import { ACTIVE_STEPS, type StepConfig } from './stepConfig';
+
+export interface PhaseDefinition {
+  /** Unique phase key */
+  id: string;
+  /** Display label (includes emoji) */
+  label: string;
+  /** Short description shown under the label */
+  description: string;
+  /** Explicit step IDs — leave empty for auto-distribution */
+  stepIds: string[];
+}
+
+/**
+ * Phase definitions. stepIds are populated at runtime by distributeSteps()
+ * when left empty. To pin specific steps to a phase, fill stepIds manually.
+ */
+const PHASE_TEMPLATES: readonly PhaseDefinition[] = [
+  { id: 'explore', label: '📖 認識課文', description: '讀懂這篇文章', stepIds: [] },
+  { id: 'practice', label: '✏️ 字詞練功', description: '掌握生字詞彙', stepIds: [] },
+  { id: 'challenge', label: '🎯 挑戰闖關', description: '證明你會了', stepIds: [] },
+] as const;
+
+/** Distribute ACTIVE_STEPS roughly equally into 3 phase buckets. */
+function distributeSteps(
+  templates: readonly PhaseDefinition[],
+  steps: readonly StepConfig[],
+): PhaseDefinition[] {
+  const claimed = new Set(templates.flatMap((t) => t.stepIds));
+  const unclaimed = steps.filter((s) => !claimed.has(s.id));
+
+  const phaseCount = templates.length;
+  const baseSize = Math.floor(unclaimed.length / phaseCount);
+  const remainder = unclaimed.length % phaseCount;
+
+  let cursor = 0;
+  return templates.map((template, phaseIdx) => {
+    if (template.stepIds.length > 0) {
+      return { ...template };
+    }
+    // Earlier phases get the extra steps when remainder > 0
+    const size = baseSize + (phaseIdx < remainder ? 1 : 0);
+    const assigned = unclaimed.slice(cursor, cursor + size).map((s) => s.id);
+    cursor += size;
+    return { ...template, stepIds: assigned };
+  });
+}
+
+/** Resolved phases with step IDs populated from ACTIVE_STEPS. */
+export const LEARNING_PHASES: PhaseDefinition[] = distributeSteps(PHASE_TEMPLATES, ACTIVE_STEPS);
+
+/** Quick lookup: stepId -> phaseId */
+export const STEP_TO_PHASE: Record<string, string> = Object.fromEntries(
+  LEARNING_PHASES.flatMap((phase) =>
+    phase.stepIds.map((stepId) => [stepId, phase.id]),
+  ),
+);


### PR DESCRIPTION
## Summary
- Add `LearningPhases` component: vertical accordion grouping 10 learning steps into 3 collapsible phases (認識課文 / 字詞練功 / 挑戰闖關)
- Add `phaseConfig.ts`: auto-distributes `ACTIVE_STEPS` into 3 roughly equal groups — adapts automatically when steps change
- Integrate as toggle-able alternative view alongside existing StepperNav in `AppShell.tsx`

## Design
- Current phase: expanded with step list, accent border + shadow
- Completed phases: green checkmark, collapsed, green tint
- Future phases: lock icon, collapsed, dimmed (60% opacity)
- Phase completion triggers CSS confetti + star burst animation (uses existing Tailwind keyframes)
- Mobile: phases stack vertically, only current expanded
- Desktop: 280-320px sidebar alongside learning content

## Technical
- Props: `steps`, `completedSteps: Set<string>`, `currentStepId`, `onStepClick`
- Phase distribution is config-driven via `LEARNING_PHASES` / `STEP_TO_PHASE` exports
- Toggle persists to `localStorage` key `learning-nav-style`
- No hardcoded step names or counts — reads from `ACTIVE_STEPS`

## Test plan
- [ ] Toggle between classic/phases mode in learning flow
- [ ] Verify current phase auto-expands when navigating steps
- [ ] Verify completed steps show green checkmarks
- [ ] Verify future phases show lock icon and cannot be expanded
- [ ] Test on mobile viewport (stacked layout)
- [ ] Add/remove a step in stepConfig.ts and verify phases redistribute

Closes #1048

🤖 Generated with [Claude Code](https://claude.ai/code)