### PR TITLE
fix: compute overall_score on session completion (#1063)

### DIFF
--- a/backend/app/services/gamification_service.py
+++ b/backend/app/services/gamification_service.py
@@ -13,6 +13,7 @@ from datetime import date, datetime, timezone
 from sqlalchemy import func as sqlfunc
 from sqlalchemy.orm import Session
 
+from ..models.session import LearningSession
 from ..models.gamification import (
     BADGE_CATALOGUE,
     XP_REWARDS,
@@ -303,6 +304,44 @@ def process_session_completion(
     # --- Compute new totals ---
     new_total_xp = total_xp_before + sum(l.xp_earned for l in xp_earned)
     lv_info = level_progress(new_total_xp)
+
+    # --- Compute and persist overall_score (#1063) ---
+    learning_session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+    if learning_session is not None:
+        scores: list[float] = []
+        weights: list[float] = []
+        # Accuracy from reading (weight: 40%)
+        if learning_session.accuracy is not None:
+            scores.append(learning_session.accuracy * 100)
+            weights.append(0.4)
+        elif reading_accuracy is not None:
+            scores.append(reading_accuracy)
+            weights.append(0.4)
+        # Comprehension score (weight: 40%)
+        if learning_session.comprehension_score is not None:
+            scores.append(learning_session.comprehension_score)
+            weights.append(0.4)
+        elif comprehension_passed:
+            scores.append(80.0)  # default pass score
+            weights.append(0.4)
+        # Vocab result (weight: 20%) — extract from vocab_result JSONB if available
+        if isinstance(learning_session.vocab_result, dict):
+            vocab_accuracy = learning_session.vocab_result.get("accuracy")
+            if isinstance(vocab_accuracy, (int, float)):
+                scores.append(float(vocab_accuracy) * 100 if vocab_accuracy <= 1 else float(vocab_accuracy))
+                weights.append(0.2)
+
+        if scores and weights:
+            total_weight = sum(weights)
+            overall = sum(s * w for s, w in zip(scores, weights)) / total_weight
+            learning_session.overall_score = round(overall, 1)
+            if learning_session.status != "completed":
+                learning_session.status = "completed"
+                learning_session.completed_at = datetime.now(timezone.utc)
+            logger.info(
+                "Set overall_score=%.1f for session %d (sources=%d)",
+                learning_session.overall_score, session_id, len(scores),
+            )
 
     # --- Check badges ---
     newly_unlocked = check_and_award_badges(


### PR DESCRIPTION
## Summary

學生完成學習 session 後，`overall_score` 從未被計算寫入 DB。首頁的「平均分數」對真實用戶永遠顯示「—」，只有 seed 環境才看到假的 69.6%

## Root Cause

`process_session_completion()` 只處理 XP 和 badges，沒有更新 `LearningSession.overall_score`

## Fix

在 `gamification_service.py` 的 `process_session_completion` 裡，`db.commit()` 之前加入 overall_score 計算：

| 來源 | 權重 | 欄位 |
|------|------|------|
| 朗讀正確率 | 40% | `accuracy` 或 `reading_accuracy` 參數 |
| 理解問答 | 40% | `comprehension_score` 或 `comprehension_passed` 參數 |
| 詞彙練習 | 20% | `vocab_result.accuracy` (JSONB) |

- 缺少某個來源時，用現有來源重新分配權重（不補零）
- 同時把 session status 標為 `completed` + 設 `completed_at`

## Test plan

- [ ] 登入學生帳號，完成一篇課文的全部步驟
- [ ] 進入報告頁（觸發 `POST /api/gamification/session-complete`）
- [ ] 確認 DB 的 `learning_sessions.overall_score` 有值（不再是 NULL）
- [ ] 回到首頁，確認「平均分數」顯示實際數字
- [ ] 確認只做朗讀沒做理解的 session，overall_score 只用朗讀分數（不補零）

Closes #1063