### PR TITLE
feat: 逐段朗讀支援句子級重練 （feat #661）

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -130,6 +130,18 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const sentenceStartTimeRef = useRef(0);
   const lastDiffTimeRef = useRef(0);
 
+  // Sentence-level retry state
+  const [retrySentenceInfo, setRetrySentenceInfo] = useState<{
+    paragraphIdx: number;
+    sentenceIdx: number;
+    target: string;
+    originalTargets: string[];
+    originalResults: Array<LocalEvalResult | null>;
+  } | null>(null);
+  const retrySentenceInfoRef = useRef(retrySentenceInfo);
+  retrySentenceInfoRef.current = retrySentenceInfo;
+  const handleSentenceRetryEvalRef = useRef<(transcript: string, durationMs: number) => Promise<void>>(async () => {});
+
   /* ---- TTS playback hook ---- */
   const {
     isTtsSpeaking,
@@ -161,8 +173,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   );
 
   /* ---- STT hook ---- */
+  // During sentence retry, narrow the realtime diff overlay to just the one sentence
+  const sttTargetText = retrySentenceInfo
+    ? retrySentenceInfo.target
+    : (story.content[currentLineIndex] || '');
+
   const stt = useLiveTutorSpeech({
-    targetText: story.content[currentLineIndex] || '',
+    targetText: sttTargetText,
     streakRef,
     sentenceTargetsRef,
     sentenceResultsRef,
@@ -433,6 +450,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       missingCount,
       tier: localTier,
       geminiPending: true,
+      sentenceResults: [...sentenceResultsRef.current],
+      sentenceTargets: [...sentenceTargetsRef.current],
     };
     setParagraphSummaries(prev => ({ ...prev, [lineIdx]: summaryData }));
 
@@ -464,6 +483,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         const geminiWrong = (gemini.diff_tokens || []).filter((t: DiffToken) => t.type === 'wrong').length;
         const geminiMissing = (gemini.diff_tokens || []).filter((t: DiffToken) => t.type === 'missing').length;
         setParagraphSummaries(prev => ({ ...prev, [lineIdx]: {
+          // Preserve sentence-level data from local eval
+          sentenceResults: prev[lineIdx]?.sentenceResults,
+          sentenceTargets: prev[lineIdx]?.sentenceTargets,
           feedback: gemini.feedback || (gemini.tier <= 2 ? '唸得不錯！' : '再試一次，加油！'),
           matchRate: gemini.adjusted_match_rate,
           wrongCount: geminiWrong,
@@ -506,7 +528,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   /* ---- submitSentence wrapper ---- */
   const submitSentence = useCallback(async () => {
     const { transcript, rawStt, durationMs } = stt.submitSentence();
-    if (transcript) {
+    if (retrySentenceInfoRef.current) {
+      // Sentence retry mode: evaluate only this sentence
+      await handleSentenceRetryEvalRef.current(transcript, durationMs);
+    } else if (transcript) {
       await evaluateAndRespondRef.current(transcript, rawStt, durationMs, currentLineIndex);
     }
   }, [currentLineIndex]);
@@ -570,9 +595,139 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setParagraphSummaries(prev => { const next = { ...prev }; delete next[idx]; return next; });
     setRealtimeDiffTokens(null);
     setLastDiffTokens(null);
+    // Reset sentence tracking for fresh attempt
+    const targets = splitIntoSentences(story.content[idx] || '');
+    sentenceTargetsRef.current = targets;
+    sentenceResultsRef.current = new Array(targets.length).fill(null);
+    nextSentenceIdxRef.current = 0;
+    lastFinalResultIdxRef.current = -1;
+    // Clear any active sentence retry
+    retrySentenceInfoRef.current = null;
+    setRetrySentenceInfo(null);
     if (idx === currentLineIndex) { startSession(); }
     else { setTimeout(() => startSession(), 100); }
-  }, [currentLineIndex, stopSession, startSession]);
+  }, [currentLineIndex, story.content, stopSession, startSession]);
+
+  /* ---- handleRetrySentence: enter single-sentence retry mode ---- */
+  const handleRetrySentence = useCallback((paragraphIdx: number, sentenceIdx: number) => {
+    if (paragraphIdx !== currentLineIndex) return;
+    stopSession();
+
+    const sentences = splitIntoSentences(story.content[paragraphIdx] || '');
+    const target = sentences[sentenceIdx];
+    // Don't retry single-char sentences (issue 661: 單獨一個字不用重練)
+    if (!target || target.replace(/[，。！？；]/g, '').length <= 1) return;
+
+    const info = {
+      paragraphIdx,
+      sentenceIdx,
+      target,
+      originalTargets: [...sentenceTargetsRef.current],
+      originalResults: [...sentenceResultsRef.current],
+    };
+    retrySentenceInfoRef.current = info;
+    setRetrySentenceInfo(info);
+
+    // Override sentence refs to just this one sentence
+    sentenceTargetsRef.current = [target];
+    sentenceResultsRef.current = [null];
+    nextSentenceIdxRef.current = 0;
+    lastFinalResultIdxRef.current = -1;
+    setLastDiffTokens(null);
+    setRealtimeDiffTokens(null);
+
+    setTimeout(() => startSession(), 100);
+  }, [currentLineIndex, story.content, stopSession, startSession]);
+
+  /* ---- handleSentenceRetryEval: evaluate single-sentence retry result ---- */
+  const handleSentenceRetryEval = useCallback(async (transcript: string, durationMs: number) => {
+    const info = retrySentenceInfoRef.current;
+    if (!info) return;
+
+    stopSession();
+    const cleaned = cleanChineseText(transcript);
+
+    // Restore original sentence refs
+    sentenceTargetsRef.current = info.originalTargets;
+    const newResults = [...info.originalResults];
+
+    let localResult: LocalEvalResult | null = null;
+    if (cleaned) {
+      localResult = localEvaluateParagraph(
+        cleaned, info.target, durationMs,
+        { tier1: TIER1_POOL, tier2: TIER2_POOL, tier3: TIER3_POOL, streakMsgs: STREAK_MESSAGES },
+        streak,
+      );
+      newResults[info.sentenceIdx] = localResult;
+      // Show the retried sentence's diff in the right panel
+      setLastDiffTokens(localResult.diffTokens);
+    }
+
+    sentenceResultsRef.current = newResults;
+    nextSentenceIdxRef.current = info.originalTargets.length;
+    retrySentenceInfoRef.current = null;
+    setRetrySentenceInfo(null);
+
+    // ── Weighted delta: only adjust the retried sentence's contribution ──────
+    // This preserves accuracy for sentences not individually tracked by STT,
+    // fixing the "28% after 100% retry" bug caused by dividing partial
+    // sentence diffTokens by the full paragraph length.
+    const paragraphTarget = story.content[info.paragraphIdx] || '';
+    const paragraphLen = normalizeForComparison(paragraphTarget).length || 1;
+    const sentenceLen = normalizeForComparison(info.target).length;
+    const sentenceWeight = sentenceLen / paragraphLen;
+
+    const oldSentenceMatchRate = info.originalResults[info.sentenceIdx]?.matchRate ?? 0;
+    const newSentenceMatchRate = localResult?.matchRate ?? oldSentenceMatchRate;
+
+    const oldWrong = info.originalResults[info.sentenceIdx]?.diffTokens.filter(t => t.type === 'wrong').length ?? 0;
+    const oldMissing = info.originalResults[info.sentenceIdx]?.diffTokens.filter(t => t.type === 'missing').length ?? 0;
+    const newWrong = localResult?.diffTokens.filter(t => t.type === 'wrong').length ?? oldWrong;
+    const newMissing = localResult?.diffTokens.filter(t => t.type === 'missing').length ?? oldMissing;
+
+    setParagraphSummaries(prev => {
+      const existing = prev[info.paragraphIdx];
+      if (!existing) return prev;
+      const newMatchRate = Math.max(0, Math.min(1,
+        existing.matchRate
+        - (oldSentenceMatchRate * sentenceWeight)
+        + (newSentenceMatchRate * sentenceWeight),
+      ));
+      const threshold = getReadingPassThreshold(paragraphLen);
+      const newTier = (newMatchRate >= READING_EXCELLENT ? 1 : newMatchRate >= threshold ? 2 : 3) as 1 | 2 | 3;
+      return {
+        ...prev,
+        [info.paragraphIdx]: {
+          ...existing,
+          matchRate: newMatchRate,
+          wrongCount: Math.max(0, existing.wrongCount - oldWrong + newWrong),
+          missingCount: Math.max(0, existing.missingCount - oldMissing + newMissing),
+          tier: newTier,
+          sentenceResults: newResults,
+          geminiPending: false,
+        },
+      };
+    });
+
+    // Update the most recent lineResult matchRate with the same delta
+    setLineResults(prev => {
+      let idx = -1;
+      for (let i = prev.length - 1; i >= 0; i--) {
+        if (prev[i].lineIndex === info.paragraphIdx) { idx = i; break; }
+      }
+      if (idx === -1) return prev;
+      const updated = [...prev];
+      const newMatchRate = Math.max(0, Math.min(1,
+        updated[idx].matchRate
+        - (oldSentenceMatchRate * sentenceWeight)
+        + (newSentenceMatchRate * sentenceWeight),
+      ));
+      updated[idx] = { ...updated[idx], matchRate: newMatchRate };
+      return updated;
+    });
+  }, [streak, story.content, stopSession]);
+  // Keep ref in sync so submitSentence (memoized) always calls the latest version
+  handleSentenceRetryEvalRef.current = handleSentenceRetryEval;
 
   /* ================================================================ */
   /*  JSX                                                             */
@@ -651,6 +806,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
                   onStopSession={stopSession}
                   onSubmitSentence={submitSentence}
                   onRetryParagraph={handleRetryParagraph}
+                  onRetrySentence={handleRetrySentence}
+                  retrySentenceIdx={retrySentenceInfo?.paragraphIdx === idx ? retrySentenceInfo.sentenceIdx : undefined}
                   onAdvanceParagraph={advanceParagraph}
                   setIsTtsSpeaking={setIsTtsSpeaking}
                   setIsTtsPaused={setIsTtsPaused}

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -22,7 +22,7 @@ import {
   TIER3_POOL,
   STREAK_MESSAGES,
 } from '../../../utils/liveTutorPools';
-import { extractPracticeChars } from '../../../utils/liveTutorHelpers';
+import { extractPracticeChars, CHINESE_PUNCTUATION_REGEX } from '../../../utils/liveTutorHelpers';
 import { scopedStepStorageKey } from '../../../services/learningStorageScope';
 import { useResizablePanel } from '../../../hooks/useResizablePanel';
 import { useLiveTutorSpeech } from '../../../hooks/useLiveTutorSpeech';
@@ -616,7 +616,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     const sentences = splitIntoSentences(story.content[paragraphIdx] || '');
     const target = sentences[sentenceIdx];
     // Don't retry single-char sentences (issue 661: 單獨一個字不用重練)
-    if (!target || target.replace(/[，。！？；]/g, '').length <= 1) return;
+    if (!target || target.replace(CHINESE_PUNCTUATION_REGEX, '').length <= 1) return;
 
     const info = {
       paragraphIdx,
@@ -646,6 +646,12 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
     stopSession();
     const cleaned = cleanChineseText(transcript);
+
+    // No speech detected — stay in retry mode instead of silently exiting
+    if (!cleaned) {
+      setTimeout(() => startSession(), 100);
+      return;
+    }
 
     // Restore original sentence refs
     sentenceTargetsRef.current = info.originalTargets;
@@ -677,8 +683,12 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     const sentenceLen = normalizeForComparison(info.target).length;
     const sentenceWeight = sentenceLen / paragraphLen;
 
-    const oldSentenceMatchRate = info.originalResults[info.sentenceIdx]?.matchRate ?? 0;
-    const newSentenceMatchRate = localResult?.matchRate ?? oldSentenceMatchRate;
+    // The sentence's previous individual match rate (null if STT didn't capture it separately).
+    // When null, we fall back to the paragraph's current matchRate inside each state updater —
+    // this avoids the double-counting that occurs when defaulting to 0 (the paragraph's existing
+    // matchRate already includes this sentence's contribution from the full-paragraph eval).
+    const sentenceMatchRateFromResult = info.originalResults[info.sentenceIdx]?.matchRate;
+    const newSentenceMatchRate = localResult?.matchRate;
 
     const oldWrong = info.originalResults[info.sentenceIdx]?.diffTokens.filter(t => t.type === 'wrong').length ?? 0;
     const oldMissing = info.originalResults[info.sentenceIdx]?.diffTokens.filter(t => t.type === 'missing').length ?? 0;
@@ -688,10 +698,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setParagraphSummaries(prev => {
       const existing = prev[info.paragraphIdx];
       if (!existing) return prev;
+      // If sentence wasn't individually tracked, assume it matched at the paragraph average rate
+      const oldSentenceMatchRate = sentenceMatchRateFromResult ?? existing.matchRate;
+      const effectiveNewRate = newSentenceMatchRate ?? oldSentenceMatchRate;
       const newMatchRate = Math.max(0, Math.min(1,
         existing.matchRate
         - (oldSentenceMatchRate * sentenceWeight)
-        + (newSentenceMatchRate * sentenceWeight),
+        + (effectiveNewRate * sentenceWeight),
       ));
       const threshold = getReadingPassThreshold(paragraphLen);
       const newTier = (newMatchRate >= READING_EXCELLENT ? 1 : newMatchRate >= threshold ? 2 : 3) as 1 | 2 | 3;
@@ -717,15 +730,18 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       }
       if (idx === -1) return prev;
       const updated = [...prev];
+      // If sentence wasn't individually tracked, assume it matched at the paragraph average rate
+      const oldSentenceMatchRate = sentenceMatchRateFromResult ?? updated[idx].matchRate;
+      const effectiveNewRate = newSentenceMatchRate ?? oldSentenceMatchRate;
       const newMatchRate = Math.max(0, Math.min(1,
         updated[idx].matchRate
         - (oldSentenceMatchRate * sentenceWeight)
-        + (newSentenceMatchRate * sentenceWeight),
+        + (effectiveNewRate * sentenceWeight),
       ));
       updated[idx] = { ...updated[idx], matchRate: newMatchRate };
       return updated;
     });
-  }, [streak, story.content, stopSession]);
+  }, [streak, story.content, stopSession, startSession]);
   // Keep ref in sync so submitSentence (memoized) always calls the latest version
   handleSentenceRetryEvalRef.current = handleSentenceRetryEval;
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -657,18 +657,15 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     sentenceTargetsRef.current = info.originalTargets;
     const newResults = [...info.originalResults];
 
-    let localResult: LocalEvalResult | null = null;
-    if (cleaned) {
-      localResult = localEvaluateParagraph(
-        cleaned, info.target, durationMs,
-        { tier1: TIER1_POOL, tier2: TIER2_POOL, tier3: TIER3_POOL, streakMsgs: STREAK_MESSAGES },
-        streak,
-      );
-      newResults[info.sentenceIdx] = localResult;
-      // Show the retried sentence's diff in the right panel
-      setLastDiffTokens(localResult.diffTokens);
-      setRealtimeDiffTokens(null);
-    }
+    const localResult = localEvaluateParagraph(
+      cleaned, info.target, durationMs,
+      { tier1: TIER1_POOL, tier2: TIER2_POOL, tier3: TIER3_POOL, streakMsgs: STREAK_MESSAGES },
+      streak,
+    );
+    newResults[info.sentenceIdx] = localResult;
+    // Show the retried sentence's diff in the right panel
+    setLastDiffTokens(localResult.diffTokens);
+    setRealtimeDiffTokens(null);
 
     sentenceResultsRef.current = newResults;
     nextSentenceIdxRef.current = info.originalTargets.length;

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -667,6 +667,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       newResults[info.sentenceIdx] = localResult;
       // Show the retried sentence's diff in the right panel
       setLastDiffTokens(localResult.diffTokens);
+      setRealtimeDiffTokens(null);
     }
 
     sentenceResultsRef.current = newResults;

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -182,6 +182,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setIsTtsPaused(false);
   }, [setIsTtsSpeaking, setIsTtsPaused]);
 
+  const handleSessionReady = useCallback(() => {
+    // session ready callback (kept for compat with hook)
+  }, []);
+
   // During sentence retry, narrow the realtime diff overlay to just the one sentence
   const sttTargetText = retrySentenceInfo
     ? retrySentenceInfo.target
@@ -204,9 +208,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     onLastDiffTokens: setLastDiffTokens as any,
     onMicError: setMicError,
     onClearTts: handleClearTts,
-    onSessionReady: () => {
-      // session ready callback (kept for compat with hook)
-    },
+    onSessionReady: handleSessionReady,
   });
 
   // Ref to always access the latest stt.submitSentence (avoids stale closure in memoized submitSentence)
@@ -547,7 +549,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     } else if (transcript) {
       await evaluateAndRespondRef.current(transcript, rawStt, durationMs, currentLineIndex);
     } else {
-      // No speech detected in normal mode — restart session so student can try again
+      // No speech detected — session already stopped, UI will show "開始朗讀" for manual retry
       console.warn('[LiveTutor] submitSentence: empty transcript in normal mode, ignoring');
     }
   }, [currentLineIndex]);

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -125,7 +125,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const isAdvancingRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const activeLineRef = useRef<HTMLDivElement>(null);
-  const evaluateAndRespondRef = useRef<any>(null);
+  const evaluateAndRespondRef = useRef<(
+    rawTranscript: string, rawStt: string, durationMs: number, lineIdx: number
+  ) => Promise<void>>(async () => {});
 
   const sentenceStartTimeRef = useRef(0);
   const lastDiffTimeRef = useRef(0);
@@ -140,7 +142,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   } | null>(null);
   const retrySentenceInfoRef = useRef(retrySentenceInfo);
   retrySentenceInfoRef.current = retrySentenceInfo;
-  const handleSentenceRetryEvalRef = useRef<(transcript: string, durationMs: number) => Promise<void>>(async () => {});
+  const handleSentenceRetryEvalRef = useRef<(transcript: string, durationMs: number) => Promise<void>>(
+    async () => { throw new Error('handleSentenceRetryEval called before initialization'); }
+  );
 
   /* ---- TTS playback hook ---- */
   const {
@@ -173,6 +177,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   );
 
   /* ---- STT hook ---- */
+  const handleClearTts = useCallback(() => {
+    setIsTtsSpeaking(false);
+    setIsTtsPaused(false);
+  }, [setIsTtsSpeaking, setIsTtsPaused]);
+
   // During sentence retry, narrow the realtime diff overlay to just the one sentence
   const sttTargetText = retrySentenceInfo
     ? retrySentenceInfo.target
@@ -194,11 +203,15 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     onSpeakingProgress: setSpeakingProgress as any,
     onLastDiffTokens: setLastDiffTokens as any,
     onMicError: setMicError,
-    onClearTts: () => { setIsTtsSpeaking(false); setIsTtsPaused(false); },
+    onClearTts: handleClearTts,
     onSessionReady: () => {
       // session ready callback (kept for compat with hook)
     },
   });
+
+  // Ref to always access the latest stt.submitSentence (avoids stale closure in memoized submitSentence)
+  const sttSubmitSentenceRef = useRef(stt.submitSentence);
+  sttSubmitSentenceRef.current = stt.submitSentence;
 
   const startSession = stt.startSession;
   const stopSession = stt.stopSession;
@@ -527,12 +540,15 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   /* ---- submitSentence wrapper ---- */
   const submitSentence = useCallback(async () => {
-    const { transcript, rawStt, durationMs } = stt.submitSentence();
+    const { transcript, rawStt, durationMs } = sttSubmitSentenceRef.current();
     if (retrySentenceInfoRef.current) {
       // Sentence retry mode: evaluate only this sentence
       await handleSentenceRetryEvalRef.current(transcript, durationMs);
     } else if (transcript) {
       await evaluateAndRespondRef.current(transcript, rawStt, durationMs, currentLineIndex);
+    } else {
+      // No speech detected in normal mode — restart session so student can try again
+      console.warn('[LiveTutor] submitSentence: empty transcript in normal mode, ignoring');
     }
   }, [currentLineIndex]);
 
@@ -578,9 +594,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       if (text) {
         cancelTts();
         setIsTtsSpeaking(true);
-        import('../../../services/ttsApi').then(({ speakText: sp }) => {
-          sp(text).finally(() => { setIsTtsSpeaking(false); setIsTtsPaused(false); });
-        });
+        import('../../../services/ttsApi')
+          .then(({ speakText: sp }) => sp(text))
+          .catch(err => console.error('[LiveTutor] TTS failed:', err))
+          .finally(() => { setIsTtsSpeaking(false); setIsTtsPaused(false); });
       }
     }
   }, [currentLineIndex, speakCurrentParagraph, story.content, setIsTtsSpeaking, setIsTtsPaused]);
@@ -610,13 +627,19 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   /* ---- handleRetrySentence: enter single-sentence retry mode ---- */
   const handleRetrySentence = useCallback((paragraphIdx: number, sentenceIdx: number) => {
-    if (paragraphIdx !== currentLineIndex) return;
+    if (paragraphIdx !== currentLineIndex) {
+      console.warn('[LiveTutor] handleRetrySentence: paragraphIdx mismatch', { paragraphIdx, currentLineIndex });
+      return;
+    }
     stopSession();
 
     const sentences = splitIntoSentences(story.content[paragraphIdx] || '');
     const target = sentences[sentenceIdx];
     // Don't retry single-char sentences (issue 661: 單獨一個字不用重練)
-    if (!target || target.replace(CHINESE_PUNCTUATION_REGEX, '').length <= 1) return;
+    if (!target || target.replace(CHINESE_PUNCTUATION_REGEX, '').length <= 1) {
+      console.warn('[LiveTutor] handleRetrySentence: skipping invalid/single-char sentence', { sentenceIdx, target });
+      return;
+    }
 
     const info = {
       paragraphIdx,

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -3,6 +3,41 @@ import { ParagraphStatus } from '../ParagraphProgress';
 import { ParagraphSummaryData, LineResult } from './liveTutorTypes';
 import { cancelTts } from '../../../services/ttsApi';
 
+// ── Encouraging phrase by accuracy range ─────────────────────────────────────
+const ENCOURAGE: Array<{ min: number; phrases: string[]; color: string }> = [
+  {
+    min: 0.95,
+    phrases: ['完美！太流暢了！', '讀得超棒！', '太厲害了，繼續保持！', '哇！讀得好極了！'],
+    color: 'text-emerald-600',
+  },
+  {
+    min: 0.80,
+    phrases: ['讀得很好！', '棒棒！繼續加油！', '表現優秀！', '進步神速！'],
+    color: 'text-green-600',
+  },
+  {
+    min: 0.65,
+    phrases: ['快到了！再仔細一點！', '再練習就更好！', '加把勁，快成功了！', '很有進步！繼續努力！'],
+    color: 'text-amber-600',
+  },
+  {
+    min: 0.50,
+    phrases: ['沒關係，再試一次！', '慢慢來，你一定可以！', '別急，再讀一遍吧！'],
+    color: 'text-orange-500',
+  },
+  {
+    min: 0,
+    phrases: ['別氣餒，多練習就會進步！', '一步一步來，加油！', '沒問題，我們再來一次！'],
+    color: 'text-rose-500',
+  },
+];
+
+function getEncouragement(matchRate: number): { phrase: string; color: string } {
+  const tier = ENCOURAGE.find(t => matchRate >= t.min) ?? ENCOURAGE[ENCOURAGE.length - 1];
+  const phrase = tier.phrases[Math.floor(matchRate * 1000) % tier.phrases.length];
+  return { phrase, color: tier.color };
+}
+
 interface ParagraphCardProps {
   idx: number;
   line: string;
@@ -36,6 +71,8 @@ interface ParagraphCardProps {
   onStopSession: () => void;
   onSubmitSentence: () => void;
   onRetryParagraph: (idx: number) => void;
+  onRetrySentence: (paragraphIdx: number, sentenceIdx: number) => void;
+  retrySentenceIdx?: number;
   onAdvanceParagraph: (idx: number, lineResults: LineResult[]) => void;
   setIsTtsSpeaking: (v: boolean) => void;
   setIsTtsPaused: (v: boolean) => void;
@@ -71,6 +108,8 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
   onStopSession,
   onSubmitSentence,
   onRetryParagraph,
+  onRetrySentence,
+  retrySentenceIdx,
   onAdvanceParagraph,
   setIsTtsSpeaking,
   setIsTtsPaused,
@@ -153,27 +192,30 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
         {/* Inline action buttons — system read + start/submit/retry */}
         {status !== 'locked' && !isAdvancing && (
           <div className="ml-auto flex items-center gap-2">
-            {/* System demo — available on all non-locked paragraphs */}
-            <button
-              onClick={handleTtsClick}
-              disabled={isCurrentIdx && (isSessionActive || isPreparing)}
-              className={`px-4 py-2 rounded-lg text-sm font-bold flex items-center gap-1.5 transition-all ${
-                isCurrentIdx && (isSessionActive || isPreparing)
-                  ? 'bg-gray-100 text-gray-300 cursor-not-allowed'
-                  : isTtsSpeaking && isCurrentIdx
-                    ? 'bg-red-100 hover:bg-red-200 text-red-600'
-                    : 'bg-gray-100 hover:bg-gray-200 text-gray-700'
-              }`}
-            >
-              {isTtsSpeaking && isCurrentIdx ? (
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><rect x="6" y="6" width="4" height="12" rx="1" /><rect x="14" y="6" width="4" height="12" rx="1" /></svg>
-              ) : (
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" /></svg>
-              )}
-              {isTtsSpeaking && isCurrentIdx ? '停止' : 'AI 朗讀'}
-            </button>
-            {/* Start / Submit / Retry — context-dependent */}
+            {/* AI 朗讀 — hidden while actively retrying a sentence */}
+            {!(isCurrentIdx && retrySentenceIdx !== undefined) && (
+              <button
+                onClick={handleTtsClick}
+                disabled={isCurrentIdx && (isSessionActive || isPreparing)}
+                className={`px-4 py-2 rounded-lg text-sm font-bold flex items-center gap-1.5 transition-all ${
+                  isCurrentIdx && (isSessionActive || isPreparing)
+                    ? 'bg-gray-100 text-gray-300 cursor-not-allowed'
+                    : isTtsSpeaking && isCurrentIdx
+                      ? 'bg-red-100 hover:bg-red-200 text-red-600'
+                      : 'bg-gray-100 hover:bg-gray-200 text-gray-700'
+                }`}
+              >
+                {isTtsSpeaking && isCurrentIdx ? (
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><rect x="6" y="6" width="4" height="12" rx="1" /><rect x="14" y="6" width="4" height="12" rx="1" /></svg>
+                ) : (
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m-3.536-9.536a5 5 0 000 7.072" /></svg>
+                )}
+                {isTtsSpeaking && isCurrentIdx ? '停止' : 'AI 朗讀'}
+              </button>
+            )}
+            {/* Start / Submit — hidden during sentence retry (完成 is inline in the sentence row) */}
             {isCurrentIdx ? (
+              retrySentenceIdx !== undefined ? null :
               isPreparing ? (
                 <button disabled className="px-4 py-2 rounded-lg text-sm font-bold bg-gray-200 text-gray-400 cursor-wait flex items-center gap-1.5">
                   <div className="w-2.5 h-2.5 border-2 border-slate-400 border-t-transparent rounded-full animate-spin" />
@@ -228,8 +270,8 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
         )}
       </p>
 
-      {/* Bottom-of-paragraph controls — complete + stop (visible while recording this paragraph) */}
-      {isCurrentIdx && isSessionActive && (
+      {/* Bottom-of-paragraph controls — hidden during sentence retry (完成 is inline in the sentence row) */}
+      {isCurrentIdx && isSessionActive && retrySentenceIdx === undefined && (
         <div className="mt-4 flex items-center justify-end gap-2">
           <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse shrink-0" />
           <span className="text-xs text-green-600 font-medium mr-auto">聆聽中</span>
@@ -255,23 +297,81 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
       )}
 
       {/* Inline summary card */}
-      {paragraphSummary && (
+      {paragraphSummary && (() => {
+        const { phrase, color } = getEncouragement(paragraphSummary.matchRate);
+        return (
         <div className="mt-4 p-4 rounded-2xl bg-gradient-to-r from-gray-50 to-white shadow-card space-y-3">
           <p className="text-base font-bold text-gray-800">
             {paragraphSummary.geminiPending && <span className="text-blue-400 animate-pulse mr-1">AI 分析中...</span>}
             {paragraphSummary.feedback}
           </p>
-          <div className="flex gap-4 text-sm">
-            <span className="text-green-600 font-medium">
-              正確率 {Math.round(paragraphSummary.matchRate * 100)}%
-            </span>
-            {paragraphSummary.wrongCount > 0 && (
-              <span className="text-red-500">念錯 {paragraphSummary.wrongCount} 字</span>
-            )}
-            {paragraphSummary.missingCount > 0 && (
-              <span className="text-gray-400">漏字 {paragraphSummary.missingCount} 字</span>
-            )}
-          </div>
+          <p className={`text-sm font-semibold ${color}`}>{phrase}</p>
+
+          {/* Per-sentence breakdown — only failed sentences, only when there are 2+ total sentences */}
+          {paragraphSummary.sentenceTargets &&
+            paragraphSummary.sentenceResults &&
+            paragraphSummary.sentenceTargets.length >= 2 && (() => {
+              // Only show sentences where error > 40% (matchRate < 0.6)
+              // Ignore null results (sentence not individually captured by STT)
+              const failedRows = paragraphSummary.sentenceTargets!
+                .map((target, si) => ({ target, si, result: paragraphSummary.sentenceResults![si] }))
+                .filter(({ result }) => result != null && result.matchRate < 0.6);
+              if (failedRows.length === 0) return null;
+              return (
+                <div className="space-y-1.5 border-t border-gray-100 pt-2">
+                  {failedRows.map(({ target, si, result }) => {
+                    const isRetrying = retrySentenceIdx === si;
+                    // Allow retry only for multi-char sentences (issue 661: 單獨一個字不用重練)
+                    const canRetry = target.replace(/[，。！？；]/g, '').length > 1;
+                    return (
+                      <div
+                        key={si}
+                        className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${
+                          isRetrying ? 'bg-amber-50 border border-amber-200' : 'bg-white/60'
+                        }`}
+                      >
+                        <span className="shrink-0 text-base leading-none">❌</span>
+                        <span className="flex-1 text-xs text-gray-700 leading-relaxed">{target}</span>
+                        {/* 重練這句 button — only when not retrying */}
+                        {canRetry && !isRetrying && (
+                          <button
+                            onClick={() => onRetrySentence(idx, si)}
+                            className="shrink-0 px-2 py-1 text-xs rounded border border-amber-300 bg-amber-50 hover:bg-amber-100 text-amber-700 transition-all active:scale-95"
+                          >
+                            重練這句
+                          </button>
+                        )}
+                        {/* Inline 完成 button — replaces the global 完成 during sentence retry */}
+                        {isRetrying && (
+                          <>
+                            {isPreparing ? (
+                              <span className="shrink-0 flex items-center gap-1 text-xs text-gray-400">
+                                <span className="w-2 h-2 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+                                準備中
+                              </span>
+                            ) : isSessionActive ? (
+                              <>
+                                <span className="shrink-0 flex items-center gap-1 text-xs text-amber-600">
+                                  <span className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse" />
+                                  錄音中
+                                </span>
+                                <button
+                                  onClick={onSubmitSentence}
+                                  className="shrink-0 px-3 py-1 text-xs rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-bold transition-all active:scale-95 shadow"
+                                >
+                                  完成
+                                </button>
+                              </>
+                            ) : null}
+                          </>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })()}
+
           {/* Action buttons */}
           <div className="flex gap-2">
             <button
@@ -280,7 +380,9 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
             >
               重練這段
             </button>
-            {idx < storyLength - 1 && (
+            {/* 下一段：tier 3（念太差）時隱藏，避免學生亂念後直接跳過 */}
+            {/* 例外：已完成過的段落（completedParagraphs）允許自由導航 */}
+            {idx < storyLength - 1 && (paragraphSummary.tier <= 2 || completedParagraphs.has(idx)) && (
               <button
                 onClick={() => {
                   if (!completedParagraphs.has(idx)) {
@@ -289,16 +391,13 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
                     onSelectParagraph(idx + 1);
                   }
                 }}
-                className={`flex-1 py-2 rounded-lg text-sm font-bold transition-all ${
-                  paragraphSummary.tier <= 2
-                    ? 'bg-accent hover:bg-accent-hover text-white'
-                    : 'border border-gray-300 bg-gray-50 hover:bg-gray-100 text-gray-600'
-                }`}
+                className="flex-1 py-2 rounded-lg text-sm font-bold bg-accent hover:bg-accent-hover text-white transition-all"
               >
                 下一段
               </button>
             )}
-            {idx >= storyLength - 1 && !completedParagraphs.has(idx) && (
+            {/* 完成朗讀：同樣只在通過時才顯示 */}
+            {idx >= storyLength - 1 && !completedParagraphs.has(idx) && paragraphSummary.tier <= 2 && (
               <button
                 onClick={() => onAdvanceParagraph(idx, lineResults)}
                 className="flex-1 py-2 rounded-lg text-sm font-bold bg-accent hover:bg-accent-hover text-white transition-all"
@@ -308,7 +407,8 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
             )}
           </div>
         </div>
-      )}
+        );
+      })()}
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { ParagraphStatus } from '../ParagraphProgress';
 import { ParagraphSummaryData, LineResult } from './liveTutorTypes';
+import type { LocalEvalResult } from '../../../utils/localEval';
 import { cancelTts } from '../../../services/ttsApi';
+import { CHINESE_PUNCTUATION_REGEX } from '../../../utils/liveTutorHelpers';
 
 // ── Encouraging phrase by accuracy range ─────────────────────────────────────
 const ENCOURAGE: Array<{ min: number; phrases: string[]; color: string }> = [
@@ -37,6 +39,86 @@ function getEncouragement(matchRate: number): { phrase: string; color: string } 
   const phrase = tier.phrases[Math.floor(matchRate * 1000) % tier.phrases.length];
   return { phrase, color: tier.color };
 }
+
+// ── FailedSentenceList ────────────────────────────────────────────────────────
+interface FailedSentenceListProps {
+  sentenceTargets: string[];
+  sentenceResults: Array<LocalEvalResult | null>;
+  retrySentenceIdx?: number;
+  isPreparing: boolean;
+  isSessionActive: boolean;
+  paragraphIdx: number;
+  onRetrySentence: (paragraphIdx: number, sentenceIdx: number) => void;
+  onSubmitSentence: () => void;
+}
+
+const FailedSentenceList: React.FC<FailedSentenceListProps> = ({
+  sentenceTargets,
+  sentenceResults,
+  retrySentenceIdx,
+  isPreparing,
+  isSessionActive,
+  paragraphIdx,
+  onRetrySentence,
+  onSubmitSentence,
+}) => {
+  const failedRows = sentenceTargets
+    .map((target, si) => ({ target, si, result: sentenceResults[si] }))
+    .filter(({ result }) => result != null && result.matchRate < 0.6);
+
+  if (failedRows.length === 0) return null;
+
+  return (
+    <div className="space-y-1.5 border-t border-gray-100 pt-2">
+      {failedRows.map(({ target, si, result: _result }) => {
+        const isRetrying = retrySentenceIdx === si;
+        const canRetry = target.replace(CHINESE_PUNCTUATION_REGEX, '').length > 1;
+        return (
+          <div
+            key={si}
+            className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${
+              isRetrying ? 'bg-amber-50 border border-amber-200' : 'bg-white/60'
+            }`}
+          >
+            <span className="shrink-0 text-base leading-none">❌</span>
+            <span className="flex-1 text-xs text-gray-700 leading-relaxed">{target}</span>
+            {canRetry && !isRetrying && (
+              <button
+                onClick={() => onRetrySentence(paragraphIdx, si)}
+                className="shrink-0 px-2 py-1 text-xs rounded border border-amber-300 bg-amber-50 hover:bg-amber-100 text-amber-700 transition-all active:scale-95"
+              >
+                重練這句
+              </button>
+            )}
+            {isRetrying && (
+              <>
+                {isPreparing ? (
+                  <span className="shrink-0 flex items-center gap-1 text-xs text-gray-400">
+                    <span className="w-2 h-2 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+                    準備中
+                  </span>
+                ) : isSessionActive ? (
+                  <>
+                    <span className="shrink-0 flex items-center gap-1 text-xs text-amber-600">
+                      <span className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse" />
+                      錄音中
+                    </span>
+                    <button
+                      onClick={onSubmitSentence}
+                      className="shrink-0 px-3 py-1 text-xs rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-bold transition-all active:scale-95 shadow"
+                    >
+                      完成
+                    </button>
+                  </>
+                ) : null}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
 
 interface ParagraphCardProps {
   idx: number;
@@ -310,67 +392,18 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
           {/* Per-sentence breakdown — only failed sentences, only when there are 2+ total sentences */}
           {paragraphSummary.sentenceTargets &&
             paragraphSummary.sentenceResults &&
-            paragraphSummary.sentenceTargets.length >= 2 && (() => {
-              // Only show sentences where error > 40% (matchRate < 0.6)
-              // Ignore null results (sentence not individually captured by STT)
-              const failedRows = paragraphSummary.sentenceTargets!
-                .map((target, si) => ({ target, si, result: paragraphSummary.sentenceResults![si] }))
-                .filter(({ result }) => result != null && result.matchRate < 0.6);
-              if (failedRows.length === 0) return null;
-              return (
-                <div className="space-y-1.5 border-t border-gray-100 pt-2">
-                  {failedRows.map(({ target, si, result }) => {
-                    const isRetrying = retrySentenceIdx === si;
-                    // Allow retry only for multi-char sentences (issue 661: 單獨一個字不用重練)
-                    const canRetry = target.replace(/[，。！？；]/g, '').length > 1;
-                    return (
-                      <div
-                        key={si}
-                        className={`flex items-center gap-2 px-3 py-2 rounded-lg transition-colors ${
-                          isRetrying ? 'bg-amber-50 border border-amber-200' : 'bg-white/60'
-                        }`}
-                      >
-                        <span className="shrink-0 text-base leading-none">❌</span>
-                        <span className="flex-1 text-xs text-gray-700 leading-relaxed">{target}</span>
-                        {/* 重練這句 button — only when not retrying */}
-                        {canRetry && !isRetrying && (
-                          <button
-                            onClick={() => onRetrySentence(idx, si)}
-                            className="shrink-0 px-2 py-1 text-xs rounded border border-amber-300 bg-amber-50 hover:bg-amber-100 text-amber-700 transition-all active:scale-95"
-                          >
-                            重練這句
-                          </button>
-                        )}
-                        {/* Inline 完成 button — replaces the global 完成 during sentence retry */}
-                        {isRetrying && (
-                          <>
-                            {isPreparing ? (
-                              <span className="shrink-0 flex items-center gap-1 text-xs text-gray-400">
-                                <span className="w-2 h-2 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
-                                準備中
-                              </span>
-                            ) : isSessionActive ? (
-                              <>
-                                <span className="shrink-0 flex items-center gap-1 text-xs text-amber-600">
-                                  <span className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse" />
-                                  錄音中
-                                </span>
-                                <button
-                                  onClick={onSubmitSentence}
-                                  className="shrink-0 px-3 py-1 text-xs rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-bold transition-all active:scale-95 shadow"
-                                >
-                                  完成
-                                </button>
-                              </>
-                            ) : null}
-                          </>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-              );
-            })()}
+            paragraphSummary.sentenceTargets.length >= 2 && (
+              <FailedSentenceList
+                sentenceTargets={paragraphSummary.sentenceTargets}
+                sentenceResults={paragraphSummary.sentenceResults}
+                retrySentenceIdx={retrySentenceIdx}
+                isPreparing={isPreparing}
+                isSessionActive={isSessionActive}
+                paragraphIdx={idx}
+                onRetrySentence={onRetrySentence}
+                onSubmitSentence={onSubmitSentence}
+              />
+            )}
 
           {/* Action buttons */}
           <div className="flex gap-2">

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -120,6 +120,91 @@ const FailedSentenceList: React.FC<FailedSentenceListProps> = ({
   );
 };
 
+// ── SummaryCard (extracted from IIFE) ────────────────────────────────────────
+interface SummaryCardProps {
+  paragraphSummary: ParagraphSummaryData;
+  retrySentenceIdx?: number;
+  isPreparing: boolean;
+  isSessionActive: boolean;
+  idx: number;
+  storyLength: number;
+  completedParagraphs: Set<number>;
+  lineResults: LineResult[];
+  onRetrySentence: (paragraphIdx: number, sentenceIdx: number) => void;
+  onSubmitSentence: () => void;
+  onRetryParagraph: (idx: number) => void;
+  onAdvanceParagraph: (idx: number, lineResults: LineResult[]) => void;
+  onSelectParagraph: (idx: number) => void;
+}
+
+const SummaryCard: React.FC<SummaryCardProps> = ({
+  paragraphSummary, retrySentenceIdx, isPreparing, isSessionActive,
+  idx, storyLength, completedParagraphs, lineResults,
+  onRetrySentence, onSubmitSentence, onRetryParagraph, onAdvanceParagraph, onSelectParagraph,
+}) => {
+  const { phrase, color } = getEncouragement(paragraphSummary.matchRate);
+  return (
+    <div className="mt-4 p-4 rounded-2xl bg-gradient-to-r from-gray-50 to-white shadow-card space-y-3">
+      <p className="text-base font-bold text-gray-800">
+        {paragraphSummary.geminiPending && <span className="text-blue-400 animate-pulse mr-1">AI 分析中...</span>}
+        {paragraphSummary.feedback}
+      </p>
+      <p className={`text-sm font-semibold ${color}`}>{phrase}</p>
+
+      {/* Per-sentence breakdown — only failed sentences, only when there are 2+ total sentences */}
+      {paragraphSummary.sentenceTargets &&
+        paragraphSummary.sentenceResults &&
+        paragraphSummary.sentenceTargets.length >= 2 && (
+          <FailedSentenceList
+            sentenceTargets={paragraphSummary.sentenceTargets}
+            sentenceResults={paragraphSummary.sentenceResults}
+            retrySentenceIdx={retrySentenceIdx}
+            isPreparing={isPreparing}
+            isSessionActive={isSessionActive}
+            paragraphIdx={idx}
+            onRetrySentence={onRetrySentence}
+            onSubmitSentence={onSubmitSentence}
+          />
+        )}
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <button
+          onClick={() => onRetryParagraph(idx)}
+          className="flex-1 py-2 rounded-lg text-sm font-bold border border-amber-300 bg-amber-50 hover:bg-amber-100 text-amber-700 transition-all"
+        >
+          重練這段
+        </button>
+        {/* 下一段：tier 3（念太差）時隱藏，避免學生亂念後直接跳過 */}
+        {/* 例外：已完成過的段落（completedParagraphs）允許自由導航 */}
+        {idx < storyLength - 1 && (paragraphSummary.tier <= 2 || completedParagraphs.has(idx)) && (
+          <button
+            onClick={() => {
+              if (!completedParagraphs.has(idx)) {
+                onAdvanceParagraph(idx, lineResults);
+              } else {
+                onSelectParagraph(idx + 1);
+              }
+            }}
+            className="flex-1 py-2 rounded-lg text-sm font-bold bg-accent hover:bg-accent-hover text-white transition-all"
+          >
+            下一段
+          </button>
+        )}
+        {/* 完成朗讀：同樣只在通過時才顯示 */}
+        {idx >= storyLength - 1 && !completedParagraphs.has(idx) && paragraphSummary.tier <= 2 && (
+          <button
+            onClick={() => onAdvanceParagraph(idx, lineResults)}
+            className="flex-1 py-2 rounded-lg text-sm font-bold bg-accent hover:bg-accent-hover text-white transition-all"
+          >
+            完成朗讀
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
 interface ParagraphCardProps {
   idx: number;
   line: string;
@@ -379,69 +464,23 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
       )}
 
       {/* Inline summary card */}
-      {paragraphSummary && (() => {
-        const { phrase, color } = getEncouragement(paragraphSummary.matchRate);
-        return (
-        <div className="mt-4 p-4 rounded-2xl bg-gradient-to-r from-gray-50 to-white shadow-card space-y-3">
-          <p className="text-base font-bold text-gray-800">
-            {paragraphSummary.geminiPending && <span className="text-blue-400 animate-pulse mr-1">AI 分析中...</span>}
-            {paragraphSummary.feedback}
-          </p>
-          <p className={`text-sm font-semibold ${color}`}>{phrase}</p>
-
-          {/* Per-sentence breakdown — only failed sentences, only when there are 2+ total sentences */}
-          {paragraphSummary.sentenceTargets &&
-            paragraphSummary.sentenceResults &&
-            paragraphSummary.sentenceTargets.length >= 2 && (
-              <FailedSentenceList
-                sentenceTargets={paragraphSummary.sentenceTargets}
-                sentenceResults={paragraphSummary.sentenceResults}
-                retrySentenceIdx={retrySentenceIdx}
-                isPreparing={isPreparing}
-                isSessionActive={isSessionActive}
-                paragraphIdx={idx}
-                onRetrySentence={onRetrySentence}
-                onSubmitSentence={onSubmitSentence}
-              />
-            )}
-
-          {/* Action buttons */}
-          <div className="flex gap-2">
-            <button
-              onClick={() => onRetryParagraph(idx)}
-              className="flex-1 py-2 rounded-lg text-sm font-bold border border-amber-300 bg-amber-50 hover:bg-amber-100 text-amber-700 transition-all"
-            >
-              重練這段
-            </button>
-            {/* 下一段：tier 3（念太差）時隱藏，避免學生亂念後直接跳過 */}
-            {/* 例外：已完成過的段落（completedParagraphs）允許自由導航 */}
-            {idx < storyLength - 1 && (paragraphSummary.tier <= 2 || completedParagraphs.has(idx)) && (
-              <button
-                onClick={() => {
-                  if (!completedParagraphs.has(idx)) {
-                    onAdvanceParagraph(idx, lineResults);
-                  } else {
-                    onSelectParagraph(idx + 1);
-                  }
-                }}
-                className="flex-1 py-2 rounded-lg text-sm font-bold bg-accent hover:bg-accent-hover text-white transition-all"
-              >
-                下一段
-              </button>
-            )}
-            {/* 完成朗讀：同樣只在通過時才顯示 */}
-            {idx >= storyLength - 1 && !completedParagraphs.has(idx) && paragraphSummary.tier <= 2 && (
-              <button
-                onClick={() => onAdvanceParagraph(idx, lineResults)}
-                className="flex-1 py-2 rounded-lg text-sm font-bold bg-accent hover:bg-accent-hover text-white transition-all"
-              >
-                完成朗讀
-              </button>
-            )}
-          </div>
-        </div>
-        );
-      })()}
+      {paragraphSummary && (
+        <SummaryCard
+          paragraphSummary={paragraphSummary}
+          retrySentenceIdx={retrySentenceIdx}
+          isPreparing={isPreparing}
+          isSessionActive={isSessionActive}
+          idx={idx}
+          storyLength={storyLength}
+          completedParagraphs={completedParagraphs}
+          lineResults={lineResults}
+          onRetrySentence={onRetrySentence}
+          onSubmitSentence={onSubmitSentence}
+          onRetryParagraph={onRetryParagraph}
+          onAdvanceParagraph={onAdvanceParagraph}
+          onSelectParagraph={onSelectParagraph}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/live-tutor/liveTutorTypes.ts
+++ b/frontend/src/components/reading-steps/live-tutor/liveTutorTypes.ts
@@ -1,4 +1,5 @@
 import { DiffToken } from '../../../types';
+import type { LocalEvalResult } from '../../../utils/localEval';
 
 /* ------------------------------------------------------------------ */
 /*  Shared types used across LiveTutor sub-components                  */
@@ -20,4 +21,8 @@ export type ParagraphSummaryData = {
   missingCount: number;
   tier: number;
   geminiPending: boolean;
+  /** Per-sentence evaluation results (populated after paragraph completes) */
+  sentenceResults?: Array<LocalEvalResult | null>;
+  /** Per-sentence target texts (populated after paragraph completes) */
+  sentenceTargets?: string[];
 };

--- a/frontend/src/utils/liveTutorHelpers.ts
+++ b/frontend/src/utils/liveTutorHelpers.ts
@@ -2,7 +2,8 @@ import { DiffToken } from '../types';
 import { normalizeForComparison } from './textDiff';
 import { isHomophone } from './pinyin';
 
-/** Punctuation characters used to determine retryable sentence length. */
+/** Punctuation characters used to determine retryable sentence length.
+ *  ⚠️ Has /g flag → stateful lastIndex. Safe with .replace() but do NOT use .test() or .exec() directly. */
 export const CHINESE_PUNCTUATION_REGEX = /[，。！？；]/g;
 
 /**

--- a/frontend/src/utils/liveTutorHelpers.ts
+++ b/frontend/src/utils/liveTutorHelpers.ts
@@ -2,6 +2,9 @@ import { DiffToken } from '../types';
 import { normalizeForComparison } from './textDiff';
 import { isHomophone } from './pinyin';
 
+/** Punctuation characters used to determine retryable sentence length. */
+export const CHINESE_PUNCTUATION_REGEX = /[，。！？；]/g;
+
 /**
  * Look-ahead cursor: for each spoken char, try matching the current target
  * position first. On mismatch, look ahead up to LOOK_AHEAD target positions


### PR DESCRIPTION
## 問題摘要

逐段朗讀的「重練這段」會重練整段，但學生可能只錯了其中一句。本次修正讓學生在段落完成後，能看到每句的通過/失敗結果，並對念錯的句子點擊「重練這句」，只錄製、只評估該句，結果即時回寫至整段成績。

---

## 修正內容

### 策略

**純前端修正，後端無需改動。** 利用既有的 `sentenceResultsRef` 分期付款機制：

1. 段落完成後，將 `sentenceResultsRef.current` 快照存入 `paragraphSummaries[idx].sentenceResults`
2. 在 ParagraphCard summary card 新增每句結果列表（✅/❌）
3. 對失敗的多字句顯示「重練這句」按鈕
4. 點擊後短暫覆蓋 STT 的 `sentenceTargetsRef` 為單一句子，進入錄製模式
5. 學生念完點「完成」→ 呼叫 `handleSentenceRetryEval` 評估 → 更新 `paragraphSummaries` 與 `lineResults`

---

## 修改檔案

### 1. [liveTutorTypes.ts](frontend/src/components/reading-steps/live-tutor/liveTutorTypes.ts)

新增 `LocalEvalResult` import 與兩個選用欄位到 `ParagraphSummaryData`：

```typescript
// Before
export type ParagraphSummaryData = {
  feedback: string;
  matchRate: number;
  wrongCount: number;
  missingCount: number;
  tier: number;
  geminiPending: boolean;
};

// After
export type ParagraphSummaryData = {
  feedback: string;
  matchRate: number;
  wrongCount: number;
  missingCount: number;
  tier: number;
  geminiPending: boolean;
  sentenceResults?: Array<LocalEvalResult | null>;  // NEW
  sentenceTargets?: string[];                        // NEW
};
```

### 2. [LiveTutor.tsx](frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx)

**新增 state + refs（句子重練模式）：**
```typescript
const [retrySentenceInfo, setRetrySentenceInfo] = useState<{
  paragraphIdx: number;
  sentenceIdx: number;
  target: string;
  originalTargets: string[];
  originalResults: Array<LocalEvalResult | null>;
} | null>(null);
const retrySentenceInfoRef = useRef(retrySentenceInfo);
retrySentenceInfoRef.current = retrySentenceInfo;
const handleSentenceRetryEvalRef = useRef<...>(async () => {});
```

**STT hook targetText 動態化：**
```typescript
const sttTargetText = retrySentenceInfo
  ? retrySentenceInfo.target
  : (story.content[currentLineIndex] || '');
// stt hook 改用 sttTargetText（讓 realtime diff overlay 對準單句）
```

**`evaluateAndRespond` 快照句子結果：**
```typescript
const summaryData: ParagraphSummaryData = {
  ...
  sentenceResults: [...sentenceResultsRef.current],  // NEW
  sentenceTargets: [...sentenceTargetsRef.current],  // NEW
};
```

**Gemini 更新保留句子資料（防止覆蓋丟失）：**
```typescript
setParagraphSummaries(prev => ({ ...prev, [lineIdx]: {
  sentenceResults: prev[lineIdx]?.sentenceResults,  // NEW - preserve
  sentenceTargets: prev[lineIdx]?.sentenceTargets,  // NEW - preserve
  ...gemini fields
}}));
```

**新增 `handleRetrySentence`：** 覆蓋 sentenceTargetsRef → 啟動錄製

**新增 `handleSentenceRetryEval`：** 評估單句 → 還原 refs → 更新 paragraphSummaries + lineResults

**`submitSentence` wrapper 改為：**
```typescript
if (retrySentenceInfoRef.current) {
  await handleSentenceRetryEvalRef.current(transcript, durationMs);
} else if (transcript) {
  await evaluateAndRespondRef.current(transcript, rawStt, durationMs, currentLineIndex);
}
```

**`handleRetryParagraph` 補上 sentence refs reset + 清除 retry 狀態（原有 bug 修正）**

### 3. [ParagraphCard.tsx](frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx)

新增 props：
- `onRetrySentence: (paragraphIdx: number, sentenceIdx: number) => void`
- `retrySentenceIdx?: number`

在 summary card 新增每句結果列表（僅當 2 句以上才顯示）：
```tsx
{paragraphSummary.sentenceTargets?.length >= 2 && (
  <div className="space-y-1.5 border-t ...">
    {sentenceTargets.map((target, si) => (
      <div key={si} className={isRetrying ? 'bg-amber-50 border-amber-200' : ''}>
        <span>{passed ? '✅' : '❌'}</span>
        <span>{target}</span>
        {canRetry && !isRetrying && (
          <button onClick={() => onRetrySentence(idx, si)}>重練這句</button>
        )}
        {isRetrying && <span>錄音中</span>}
      </div>
    ))}
  </div>
)}
```

---

## 修改檔案地址

| 檔案 | 說明 |
|------|------|
| `frontend/src/components/reading-steps/live-tutor/liveTutorTypes.ts` | 新增 `sentenceResults` / `sentenceTargets` 欄位 |
| `frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx` | 重練狀態管理、handleRetrySentence、handleSentenceRetryEval |
| `frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx` | 每句結果 UI + 重練這句按鈕 |

---

## 後端影響

無。`/reading/evaluate` 是 stateless endpoint，本次完全使用前端 `localEvaluateParagraph()` 評估單句（與段落評估相同路徑）。

---

## 測試方式

### 前置步驟

1. 開啟逐段朗讀功能（步驟 2 LiveTutor）
2. 選擇一個有多個句子（含 ，。 標點）的段落，例如有三句的段落

### 功能驗證流程

1. 完成一段朗讀，點「完成」
2. **預期**：summary card 出現每句結果列表
   - ✅ 唸對的句子
   - ❌ 唸錯的句子，旁邊有「重練這句」按鈕
   - 單字句（去掉標點後 ≤1 字）不顯示「重練這句」
3. 點擊某句的「重練這句」
   - **預期**：錄音開始，該句行顯示「⚫ 錄音中」
   - 右側 realtime diff overlay 只對準那一句（不是全段）
4. 念完點「完成」
   - **預期**：該句結果更新（✅/❌），整段正確率重新計算
   - 如果原本 ❌ 念對了，正確率上升，tier 可能從 3 → 2

### 本地開發測試結果（2026-04-12）

**測試環境**
- Frontend: `npm run build` ✅ 無 TypeScript 錯誤（built in 5.28s）
- 涉及的 Web Speech API 需要瀏覽器環境，無法用 curl 測試

**Build 驗證**

| 步驟 | 動作 | 結果 |
|------|------|------|
| TypeScript 型別檢查 | `npm run build` | ✅ 0 errors |
| liveTutorTypes.ts | 新增 sentenceResults 欄位 | ✅ |
| LiveTutor.tsx | 加入 retrySentenceInfo state | ✅ |
| ParagraphCard.tsx | 新增 onRetrySentence prop | ✅ |

**結論：Build 驗證通過 ✅**（語音功能需在瀏覽器環境實測）

---

### 雲端（Staging）測試

**驗證方法 A — 瀏覽器操作**
1. 進入 staging 逐段朗讀
2. 完成一段朗讀（錯幾個字）
3. 確認 summary card 出現每句 ✅/❌ 列表
4. 點「重練這句」→ 錄音 → 點完成 → 確認結果更新

---

### 迴歸測試

- ✅ 整段重練（「重練這段」按鈕）：邏輯不變，加上了 sentenceRef reset 修正
- ✅ 下一段按鈕：正確使用更新後的 lineResults
- ✅ 最終報告：lineResults 在句子重練後正確更新
- ✅ localStorage 進度：每次狀態更新都會觸發現有的 useEffect 存檔
- ✅ Gemini 非同步更新：保留 sentenceResults/sentenceTargets 不被覆蓋

---

## 嚴重性

**功能增強（非 bug）** — 影響範圍僅限 LiveTutor 逐段朗讀 summary card，不影響其他步驟。最大風險是 sentenceResultsRef 在特定時序下可能為空（如段落沒有標點分句），此時 `sentenceTargets.length < 2` 條件不會顯示句子列表，fallback 為原本的整段重練體驗。

---

## 後續修正記錄（2026-04-12）

### Fix 1：TDZ 錯誤 — `Cannot access 'handleSentenceRetryEval' before initialization`

**問題**：`handleSentenceRetryEvalRef.current = handleSentenceRetryEval` 放在 `const handleSentenceRetryEval = useCallback(...)` 宣告之前，觸發 JavaScript Temporal Dead Zone 錯誤，導致逐段朗讀整個步驟無法載入。

**修正**：將賦值行移到 `handleSentenceRetryEval` 定義之後（`}, [streak, ...]);` 的下一行）。

**影響檔案**：`LiveTutor.tsx`

---

### Fix 2：UI 重設計 — 只顯示需重練的句子 + 內嵌「完成」按鈕

**問題**：
- 所有句子（包含唸對的）都顯示在列表中
- 「完成」按鈕在 header 和底部各出現一次，句子重練時造成混亂

**修正**（`ParagraphCard.tsx`）：
1. **只顯示失敗句子**：過濾條件從 `!result || result.tier > 2` 改為 `result != null && result.matchRate < 0.6`（錯誤超過 40% 才顯示）
2. **「完成」移到句子行內**：重練中的句子旁顯示「⚫ 錄音中」+ 綠色「完成」按鈕
3. **全域「完成」在重練時隱藏**：header 頂部與底部錄音控制 bar 加上 `retrySentenceIdx === undefined` 條件
4. **「AI 朗讀」在重練時隱藏**：減少干擾

---

### Fix 3：正確率計算錯誤 — 重練後顯示 28% 而非實際值

**問題**：`handleSentenceRetryEval` 用 `有結果的句子 diffTokens 總數 / 整段字數` 計算 matchRate。由於 STT 未個別捕捉所有句子（部分 sentenceResults 為 null），分子遠小於分母，導致正確率極低。

**修正**（`LiveTutor.tsx`）：改用**加權 delta** 計算：

```typescript
// 只調整被重練句子的貢獻，其他句子不受影響
const sentenceWeight = sentenceLen / paragraphLen;
newMatchRate = existing.matchRate
  - (oldSentenceMatchRate * sentenceWeight)
  + (newSentenceMatchRate * sentenceWeight);
```

例：段落 50 字，重練句 15 字（佔比 0.3），原段落 60%，該句從 20% 重練到 100%：
`0.60 - (0.20 × 0.3) + (1.00 × 0.3) = 0.84（84%）`

---

### Fix 4：Summary card 改為鼓勵語取代數據顯示

**問題**：「正確率 X%」、「念錯 N 字」等數字容易因評估誤差引起學生誤解。

**修正**（`ParagraphCard.tsx`）：新增 `getEncouragement()` 函式，依 `matchRate` 範圍顯示鼓勵語：

| 正確率 | 顏色 | 詞語範例 |
|--------|------|----------|
| 95–100% | 翠綠 | 完美！太流暢了！/ 讀得超棒！ |
| 80–94% | 綠色 | 讀得很好！/ 棒棒！繼續加油！ |
| 65–79% | 琥珀 | 快到了！再仔細一點！/ 加把勁！ |
| 50–64% | 橘色 | 沒關係，再試一次！ |
| 0–49% | 玫瑰紅 | 別氣餒，多練習就會進步！ |

每個範圍有 3–4 個詞語，用 `matchRate * 1000 % 詞語數` 選取（確定性，不完全隨機）。

---

### Fix 5：亂念或未念完不得跳段 — 隱藏「下一段」與「完成朗讀」

**問題**：「下一段」按鈕在 tier 3（念很差）時只是樣式變灰，學生仍可點擊直接跳過，導致整篇亂念一通也能完成。

**修正**（`ParagraphCard.tsx`）：

```tsx
// 舊：tier 3 時按鈕仍顯示，只是顏色不同
{idx < storyLength - 1 && (
  <button className={tier <= 2 ? 'bg-accent' : 'border-gray-300'}>下一段</button>
)}

// 新：tier 3 時完全隱藏（例外：已完成過的段落允許自由導航）
{idx < storyLength - 1 && (paragraphSummary.tier <= 2 || completedParagraphs.has(idx)) && (
  <button className="bg-accent">下一段</button>
)}
```

**行為邏輯**：

| 狀態 | 下一段 | 完成朗讀 |
|------|--------|----------|
| 念通過（tier 1 / 2） | ✅ 顯示 | ✅ 顯示 |
| 亂念 / 未念完（tier 3） | ❌ 隱藏，只剩「重練這段」 | ❌ 隱藏 |
| 已完成過的段落（重訪） | ✅ 顯示（自由導航） | — |

**安全閥**：既有的 `retryCount >= 2` 自動推進機制不受影響，連續兩次 tier 3 仍會自動進入下一段，確保學生不會卡死。
