### PR TITLE
fix: Claude PR review trigger to @claude mention only

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,17 +1,21 @@
 name: Claude PR Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   review:
-    # Only review PRs from team members (not random forks)
+    # Only trigger when someone comments @claude on a PR
     if: >-
-      github.event.pull_request.user.login == 'Youngger9765' ||
-      github.event.pull_request.user.login == 'if-else-master' ||
-      github.event.pull_request.user.login == 'stgst' ||
-      github.event.pull_request.user.login == 'Shinjou'
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude') &&
+      (
+        github.event.comment.user.login == 'Youngger9765' ||
+        github.event.comment.user.login == 'if-else-master' ||
+        github.event.comment.user.login == 'stgst' ||
+        github.event.comment.user.login == 'Shinjou'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Changed from auto-trigger on every push to manual trigger via `@claude` comment
- Prevents burning Max subscription quota on repeated pushes
- Only team members (4 people whitelist) can trigger

## Before vs After
| | Before | After |
|--|--------|-------|
| Trigger | Every push | `@claude` comment |
| Cost control | ❌ Burns on every commit | ✅ On-demand only |

## Test plan
- [ ] Comment `@claude` on a PR to verify trigger