### PR TITLE
feat: 文章重點表互動化 — 填空+勾選+AI批改 (#1082)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -246,9 +246,11 @@ async def grade_story_structure_endpoint(
             detail="Structure not yet generated. Call GET /api/stories/{story_id}/structure first.",
         )
 
+    story_text = story.get("full_text") or "\n".join(story.get("paragraphs", []))
     answers_payload = [a.model_dump() for a in body.answers]
     result = await grade_story_structure(
         structure=cached,
         answers=answers_payload,
+        story_text=story_text,
     )
     return result

--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -5,6 +5,7 @@ No database dependency for platform content.
 
 import time
 from fastapi import APIRouter, Query, HTTPException, Depends, Request
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..database import get_db
@@ -13,27 +14,48 @@ from ..auth.dependencies import get_current_user
 from ..auth.rate_limiter import ai_rate_limiter, get_client_key
 from ..services.lesson_loader import search_lessons, get_lesson_by_id, get_available_grades
 from ..utils.slug import normalize_story_slug
-from ..services.ai_service import generate_story_structure
+from ..services.ai_service import generate_story_structure, grade_story_structure
 from ..services.ai_usage_tracker import last_usage, log_ai_usage
 from ..schemas.story import StoryListItem, StoryDetail, StoryListResponse, StoryIntroSchema
 
 # ---------------------------------------------------------------------------
 # Simple TTL cache for story structure results (avoids redundant Gemini calls)
+# v2 cache key prefix — invalidates old non-interactive cache entries (#1082)
 # ---------------------------------------------------------------------------
 
 _structure_cache: dict[str, tuple[float, object]] = {}
 _CACHE_TTL = 86400  # 24 hours
+_CACHE_VERSION = "v2"  # bump when schema changes to auto-invalidate
+
+
+def _cache_key(story_id: str) -> str:
+    return f"{_CACHE_VERSION}:{story_id}"
 
 
 def _get_cached_structure(story_id: str):
-    entry = _structure_cache.get(story_id)
+    entry = _structure_cache.get(_cache_key(story_id))
     if entry and time.time() - entry[0] < _CACHE_TTL:
         return entry[1]
     return None
 
 
 def _set_cached_structure(story_id: str, result):
-    _structure_cache[story_id] = (time.time(), result)
+    _structure_cache[_cache_key(story_id)] = (time.time(), result)
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas for grading
+# ---------------------------------------------------------------------------
+
+class StructureAnswerItem(BaseModel):
+    row_index: int
+    sub_row_index: int | None = None
+    value: str | None = None          # for fill_blank
+    selected_options: list[int] | None = None  # for checkbox
+
+
+class GradeStructureRequest(BaseModel):
+    answers: list[StructureAnswerItem]
 
 router = APIRouter(tags=["stories"])
 
@@ -189,5 +211,44 @@ async def get_story_structure(
         content_filtered=usage.content_filtered if usage else False,
         cache_hit=False,
         prompt_template_id="story_structure",
+    )
+    return result
+
+
+# ── ⑤ 文章重點表 批改 endpoint (#1082) ────────────────────────────────────────
+
+@router.post("/stories/{story_id}/structure/grade")
+async def grade_story_structure_endpoint(
+    story_id: str,
+    body: GradeStructureRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Grade student answers for the interactive story structure table (#1082).
+
+    Requires authentication. Uses the cached structure (must have called GET first).
+    For fill_blank rows: fuzzy Chinese text match.
+    For checkbox rows: exact index match against correct_options.
+
+    Returns {results: [...], score: 0-100}.
+    """
+    try:
+        numeric_id = int(normalize_story_slug(story_id))
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=404, detail="Story not found")
+    story = get_lesson_by_id(numeric_id)
+    if not story:
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    cached = _get_cached_structure(story_id)
+    if cached is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Structure not yet generated. Call GET /api/stories/{story_id}/structure first.",
+        )
+
+    answers_payload = [a.model_dump() for a in body.answers]
+    result = await grade_story_structure(
+        structure=cached,
+        answers=answers_payload,
     )
     return result

--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -496,11 +496,14 @@ async def generate_story_structure(
         return {"rows": [{"label": "錯誤", "value": "無法載入文章重點表，請稍後再試", "interactive_type": "display"}]}
 
 
-def _fuzzy_match_chinese(student: str, reference: str) -> bool:
-    """Check if student answer contains key terms from the reference answer.
+def _fuzzy_match_chinese(student: str, reference: str, story_text: str = "") -> bool:
+    """Check if student answer is semantically close to the reference answer.
 
-    A student answer is considered correct if it contains at least half of the
-    key characters from the reference (excluding common particles/punctuation).
+    Matching strategies (any one passing = correct):
+    1. Exact match or containment (either direction)
+    2. Nickname/abbreviation: student answer appears in story_text AND shares
+       at least one key character with reference (handles 小戴 vs 戴資穎)
+    3. Character overlap >= 50% of reference key characters
     """
     if not student or not reference:
         return False
@@ -509,16 +512,25 @@ def _fuzzy_match_chinese(student: str, reference: str) -> bool:
     student = student.strip()
     reference = reference.strip()
 
-    # Exact match or containment
+    # Strategy 1: Exact match or containment
     if student == reference or reference in student or student in reference:
         return True
 
-    # Character-level overlap — exclude common single-character particles
     _PARTICLES = set("的了在是有和與也都就把被讓給從到著過嗎呢吧啊、，。！？")
     ref_chars = [c for c in reference if c not in _PARTICLES and '\u4e00' <= c <= '\u9fff']
+    stu_chars = [c for c in student if c not in _PARTICLES and '\u4e00' <= c <= '\u9fff']
+
     if not ref_chars:
         return len(student) > 0
 
+    # Strategy 2: Nickname/abbreviation — student answer appears in story text
+    # and shares at least one key character with reference
+    if story_text and student in story_text:
+        shared = sum(1 for c in stu_chars if c in reference)
+        if shared >= 1:
+            return True
+
+    # Strategy 3: Character-level overlap >= 50%
     matched = sum(1 for c in ref_chars if c in student)
     return matched / len(ref_chars) >= 0.5
 
@@ -526,12 +538,14 @@ def _fuzzy_match_chinese(student: str, reference: str) -> bool:
 async def grade_story_structure(
     structure: dict,
     answers: list[dict],
+    story_text: str = "",
 ) -> dict:
     """Grade student answers against the AI-generated structure reference.
 
     Args:
         structure: The cached structure dict (with 'rows' containing reference answers)
         answers: List of answer objects:
+        story_text: Original story text for nickname/abbreviation matching
             - For top-level rows: {"row_index": int, "value": str}
             - For sub-rows: {"row_index": int, "sub_row_index": int, "selected_options": [int, ...]}
             - For checkbox rows: {"row_index": int, "selected_options": [int, ...]}
@@ -593,7 +607,7 @@ async def grade_story_structure(
         else:
             # fill_blank: fuzzy text match
             student_value = str(answer.get("value") or "").strip()
-            is_correct = _fuzzy_match_chinese(student_value, correct_answer)
+            is_correct = _fuzzy_match_chinese(student_value, correct_answer, story_text)
             result_entry["correct"] = is_correct
             result_entry["correct_answer"] = correct_answer
             if is_correct:

--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -22,6 +22,7 @@ __all__ = [
     "generate_example_sentences",
     "validate_student_sentence",
     "generate_story_structure",
+    "grade_story_structure",
     "generate_teacher_comment",
     "EXIT_TICKET_SCHEMA",
     "EXAMPLE_SENTENCES_SCHEMA",
@@ -295,7 +296,12 @@ async def validate_student_sentence(
     return result
 
 
-# ── ⑤ 文章重點表 — AI-generated story structure (#615) ────────────────────────
+# ── ⑤ 文章重點表 — AI-generated story structure (#615, #1082) ─────────────────
+
+# interactive_type values:
+#   "fill_blank" — student types in the answer (open-ended)
+#   "checkbox"   — student picks from options (single or multi-select)
+#   "display"    — shown as context, not interactive
 
 STORY_STRUCTURE_SCHEMA = {
     "type": "object",
@@ -307,6 +313,18 @@ STORY_STRUCTURE_SCHEMA = {
                 "properties": {
                     "label": {"type": "string"},
                     "value": {"type": "string"},
+                    "interactive_type": {"type": "string"},
+                    "hint": {"type": "string"},
+                    "options": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "nullable": True,
+                    },
+                    "correct_options": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "nullable": True,
+                    },
                     "sub_rows": {
                         "type": "array",
                         "items": {
@@ -314,13 +332,25 @@ STORY_STRUCTURE_SCHEMA = {
                             "properties": {
                                 "label": {"type": "string"},
                                 "value": {"type": "string"},
+                                "interactive_type": {"type": "string"},
+                                "hint": {"type": "string"},
+                                "options": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "nullable": True,
+                                },
+                                "correct_options": {
+                                    "type": "array",
+                                    "items": {"type": "integer"},
+                                    "nullable": True,
+                                },
                             },
-                            "required": ["label", "value"],
+                            "required": ["label", "value", "interactive_type"],
                         },
                         "nullable": True,
                     },
                 },
-                "required": ["label", "value"],
+                "required": ["label", "value", "interactive_type"],
             },
         }
     },
@@ -328,38 +358,84 @@ STORY_STRUCTURE_SCHEMA = {
 }
 
 _STRUCTURE_PROMPTS = {
-    "記敘文": """請根據課文，用繁體中文填寫文章重點表（記敘文格式）：
-rows 應包含：
-- 主角（課文的主要人物）
-- 主題（一句話說明課文的核心訊息）
-- 特色（主角的特質或行為模式）
-- 事例，sub_rows 包含：
-  - 背景（故事發生的情境/時間/地點）
-  - 經過（主角遇到的挑戰及如何因應）
-  - 結果（最終的結果或影響）
-每格 value 控制在 20 字以內，使用臺灣繁體中文。""",
+    "記敘文": """請根據課文，用繁體中文填寫互動式文章重點表（記敘文格式）。
 
-    "說明文": """請根據課文，用繁體中文填寫文章重點表（說明文格式）：
-rows 應包含：
-- 主題（被說明的對象是什麼）
-- 重要事實 1（最重要的說明內容）
-- 重要事實 2（第二重要的說明內容）
-- 重要事實 3（第三重要的說明內容）
-- 結論（課文想讓讀者知道或做的事）
-每格 value 控制在 25 字以內，使用臺灣繁體中文。""",
+每個欄位必須包含：
+- label：欄位名稱
+- value：正確答案（AI 參考答案，15字以內）
+- interactive_type：欄位互動類型
+- hint：學生填答的提示（10字以內，不透露答案）
+- options（當 interactive_type 為 "checkbox" 時必填）：2~4個選項，其中至少1個是干擾選項
+- correct_options（當 interactive_type 為 "checkbox" 時必填）：正確答案在 options 中的索引（從0開始）
 
-    "議論文": """請根據課文，用繁體中文填寫文章重點表（議論文格式）：
-rows 應包含：
-- 論點（作者的主要主張是什麼）
-- 論據 1（支持論點的第一個理由或例子）
-- 論據 2（支持論點的第二個理由或例子）
-- 結論（作者希望讀者怎麼做或怎麼想）
-每格 value 控制在 25 字以內，使用臺灣繁體中文。""",
+rows 應包含以下欄位：
+1. 主角（interactive_type: "fill_blank"，讓學生自己填入課文主角名稱）
+2. 主題（interactive_type: "fill_blank"，讓學生填入核心訊息，hint: "一句話說明課文想告訴我們什麼"）
+3. 特色（interactive_type: "fill_blank"，讓學生填入主角特質，hint: "主角有什麼特別的地方？"）
+4. 事例（interactive_type: "display"，value: ""，sub_rows 包含：
+   - 背景（interactive_type: "checkbox"，提供 3 個選項，其中 1~2 個正確）
+   - 經過（interactive_type: "checkbox"，提供 3 個選項，其中 1~2 個正確）
+   - 結果（interactive_type: "checkbox"，提供 3 個選項，其中 1 個正確）
+）
+
+checkbox 的選項設計原則：
+- 選項都要和課文內容相關，不要出現明顯錯誤的干擾項
+- 干擾項要讓學生需要仔細閱讀才能判斷
+- 使用臺灣繁體中文""",
+
+    "說明文": """請根據課文，用繁體中文填寫互動式文章重點表（說明文格式）。
+
+每個欄位必須包含：
+- label：欄位名稱
+- value：正確答案（AI 參考答案，20字以內）
+- interactive_type：欄位互動類型
+- hint：學生填答的提示（10字以內，不透露答案）
+- options（當 interactive_type 為 "checkbox" 時必填）：2~4個選項
+- correct_options（當 interactive_type 為 "checkbox" 時必填）：正確答案在 options 中的索引（從0開始）
+
+rows 應包含以下欄位：
+1. 主題（interactive_type: "fill_blank"，讓學生填入被說明的對象）
+2. 重要事實 1（interactive_type: "checkbox"，3個選項，1個正確）
+3. 重要事實 2（interactive_type: "checkbox"，3個選項，1個正確）
+4. 重要事實 3（interactive_type: "checkbox"，3個選項，1個正確）
+5. 結論（interactive_type: "fill_blank"，讓學生填入課文結論，hint: "課文最後想告訴我們什麼？"）
+
+checkbox 選項都要和課文內容相關，使用臺灣繁體中文。""",
+
+    "議論文": """請根據課文，用繁體中文填寫互動式文章重點表（議論文格式）。
+
+每個欄位必須包含：
+- label：欄位名稱
+- value：正確答案（AI 參考答案，20字以內）
+- interactive_type：欄位互動類型
+- hint：學生填答的提示（10字以內，不透露答案）
+- options（當 interactive_type 為 "checkbox" 時必填）：2~4個選項
+- correct_options（當 interactive_type 為 "checkbox" 時必填）：正確答案在 options 中的索引（從0開始）
+
+rows 應包含以下欄位：
+1. 論點（interactive_type: "fill_blank"，讓學生填入主要主張，hint: "作者最想說的是什麼？"）
+2. 論據 1（interactive_type: "checkbox"，3個選項，1個正確）
+3. 論據 2（interactive_type: "checkbox"，3個選項，1個正確）
+4. 結論（interactive_type: "fill_blank"，hint: "作者希望讀者怎麼做或怎麼想？"）
+
+checkbox 選項都要和課文內容相關，使用臺灣繁體中文。""",
 }
 
-_DEFAULT_STRUCTURE_PROMPT = """請根據課文，用繁體中文填寫文章重點表：
-rows 應包含：主題、重要內容 1、重要內容 2、結論。
-每格 value 控制在 25 字以內，使用臺灣繁體中文。"""
+_DEFAULT_STRUCTURE_PROMPT = """請根據課文，用繁體中文填寫互動式文章重點表。
+
+每個欄位必須包含：
+- label：欄位名稱
+- value：正確答案（15字以內）
+- interactive_type："fill_blank" 或 "checkbox"
+- hint：學生填答的提示
+
+rows 應包含：
+1. 主題（interactive_type: "fill_blank"）
+2. 重要內容 1（interactive_type: "checkbox"，3個選項，1個正確，含 options 和 correct_options）
+3. 重要內容 2（interactive_type: "checkbox"，3個選項，1個正確，含 options 和 correct_options）
+4. 結論（interactive_type: "fill_blank"）
+
+使用臺灣繁體中文。"""
 
 
 async def generate_story_structure(
@@ -367,17 +443,24 @@ async def generate_story_structure(
     story_text: str,
     genre: str | None = None,
 ) -> dict:
-    """Generate a structured story summary table for ⑤ 文章重點表 (#615).
+    """Generate an interactive story structure table for ⑤ 文章重點表 (#615, #1082).
 
-    Returns a dict with 'rows', each row having 'label', 'value',
-    and optionally 'sub_rows' for nested entries (e.g. 事例).
+    Returns a dict with 'rows', each row having 'label', 'value', 'interactive_type',
+    optional 'hint', 'options', 'correct_options', and optional 'sub_rows'.
+
+    interactive_type:
+      - "fill_blank": student types the answer (graded by fuzzy text match)
+      - "checkbox": student picks from options (graded by correct_options index match)
+      - "display": shown as context, not interactive
     """
     prompt_instruction = _STRUCTURE_PROMPTS.get(genre or "", _DEFAULT_STRUCTURE_PROMPT)
 
     system_prompt = (
         "你是國語文教學助手，專門幫學生整理課文重點。"
         "請務必使用臺灣繁體中文，禁止大陸用語。"
-        "每個 value 盡量簡潔，讓國小高年級學生容易理解。"
+        "每個 value（正確答案）盡量簡潔，讓國小高年級學生容易理解。"
+        "interactive_type 必須是以下三種之一：fill_blank、checkbox、display。"
+        "若 interactive_type 為 checkbox，則 options 和 correct_options 為必填。"
     )
     user_msg = (
         f"課文標題：{story_title}\n\n"
@@ -397,13 +480,133 @@ async def generate_story_structure(
             system_prompt=system_prompt,
             contents=contents,
             response_schema=STORY_STRUCTURE_SCHEMA,
-            max_tokens=1024,
+            max_tokens=2048,
             temperature=0.3,
         )
+        # Ensure every row has interactive_type (backward compat guard)
+        for row in result.get("rows", []):
+            if "interactive_type" not in row:
+                row["interactive_type"] = "fill_blank"
+            for sub in row.get("sub_rows") or []:
+                if "interactive_type" not in sub:
+                    sub["interactive_type"] = "fill_blank"
         return result
     except Exception as e:
         logger.warning("generate_story_structure failed: %s", e)
-        return {"rows": [{"label": "錯誤", "value": "無法載入文章重點表，請稍後再試"}]}
+        return {"rows": [{"label": "錯誤", "value": "無法載入文章重點表，請稍後再試", "interactive_type": "display"}]}
+
+
+def _fuzzy_match_chinese(student: str, reference: str) -> bool:
+    """Check if student answer contains key terms from the reference answer.
+
+    A student answer is considered correct if it contains at least half of the
+    key characters from the reference (excluding common particles/punctuation).
+    """
+    if not student or not reference:
+        return False
+
+    # Normalize
+    student = student.strip()
+    reference = reference.strip()
+
+    # Exact match or containment
+    if student == reference or reference in student or student in reference:
+        return True
+
+    # Character-level overlap — exclude common single-character particles
+    _PARTICLES = set("的了在是有和與也都就把被讓給從到著過嗎呢吧啊、，。！？")
+    ref_chars = [c for c in reference if c not in _PARTICLES and '\u4e00' <= c <= '\u9fff']
+    if not ref_chars:
+        return len(student) > 0
+
+    matched = sum(1 for c in ref_chars if c in student)
+    return matched / len(ref_chars) >= 0.5
+
+
+async def grade_story_structure(
+    structure: dict,
+    answers: list[dict],
+) -> dict:
+    """Grade student answers against the AI-generated structure reference.
+
+    Args:
+        structure: The cached structure dict (with 'rows' containing reference answers)
+        answers: List of answer objects:
+            - For top-level rows: {"row_index": int, "value": str}
+            - For sub-rows: {"row_index": int, "sub_row_index": int, "selected_options": [int, ...]}
+            - For checkbox rows: {"row_index": int, "selected_options": [int, ...]}
+
+    Returns:
+        {
+            "results": [{"row_index": int, "sub_row_index"?: int, "correct": bool, "feedback": str, "correct_answer": str}],
+            "score": int  # 0-100
+        }
+    """
+    rows = structure.get("rows", [])
+    results = []
+    total = 0
+    correct_count = 0
+
+    for answer in answers:
+        row_idx = answer.get("row_index")
+        sub_idx = answer.get("sub_row_index")
+
+        if row_idx is None or row_idx >= len(rows):
+            continue
+
+        row = rows[row_idx]
+
+        # Resolve the target row (top-level or sub-row)
+        if sub_idx is not None:
+            sub_rows = row.get("sub_rows") or []
+            if sub_idx >= len(sub_rows):
+                continue
+            target = sub_rows[sub_idx]
+        else:
+            target = row
+
+        interactive_type = target.get("interactive_type", "fill_blank")
+
+        # Skip display rows — they're not graded
+        if interactive_type == "display":
+            continue
+
+        total += 1
+        correct_answer = target.get("value", "")
+        result_entry: dict = {"row_index": row_idx}
+        if sub_idx is not None:
+            result_entry["sub_row_index"] = sub_idx
+
+        if interactive_type == "checkbox":
+            selected = set(answer.get("selected_options") or [])
+            expected = set(target.get("correct_options") or [])
+            is_correct = selected == expected
+            result_entry["correct"] = is_correct
+            result_entry["correct_answer"] = correct_answer
+            if is_correct:
+                result_entry["feedback"] = "答對了！"
+            else:
+                # Build correct answer display from options
+                options = target.get("options") or []
+                correct_texts = [options[i] for i in sorted(expected) if i < len(options)]
+                result_entry["feedback"] = f"正確答案是：{'、'.join(correct_texts)}"
+        else:
+            # fill_blank: fuzzy text match
+            student_value = str(answer.get("value") or "").strip()
+            is_correct = _fuzzy_match_chinese(student_value, correct_answer)
+            result_entry["correct"] = is_correct
+            result_entry["correct_answer"] = correct_answer
+            if is_correct:
+                result_entry["feedback"] = "答對了！"
+            else:
+                result_entry["feedback"] = f"參考答案：{correct_answer}"
+
+        if result_entry["correct"]:
+            correct_count += 1
+        results.append(result_entry)
+
+    score = round((correct_count / total) * 100) if total > 0 else 0
+    return {"results": results, "score": score}
 
 
 # ── Teacher Comment Generation (Issue #993) ──────────────────────────────────

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -1,33 +1,235 @@
 /**
- * StoryStructureTable — 文章重點表 (#615, #845)
+ * StoryStructureTable — 互動式文章重點表 (#615, #845, #1082)
  *
  * Fetches AI-generated story structure from /api/stories/{id}/structure.
- * Displays a labelled table matching 三民教材's 文章重點表 format.
+ * Supports interactive fill-in-the-blank and checkbox questions with AI grading.
  * Genre-aware: 記敘文 shows 主角/主題/事例, 說明文 shows concept structure, etc.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type InteractiveType = 'fill_blank' | 'checkbox' | 'display';
+
+interface StructureSubRow {
+  label: string;
+  value: string;
+  interactive_type: InteractiveType;
+  hint?: string;
+  options?: string[];
+  correct_options?: number[];
+}
 
 interface StructureRow {
   label: string;
   value: string;
-  sub_rows?: Array<{ label: string; value: string }>;
+  interactive_type: InteractiveType;
+  hint?: string;
+  options?: string[];
+  correct_options?: number[];
+  sub_rows?: StructureSubRow[];
 }
+
+interface StructureData {
+  rows: StructureRow[];
+}
+
+interface GradeResultItem {
+  row_index: number;
+  sub_row_index?: number;
+  correct: boolean;
+  feedback: string;
+  correct_answer: string;
+}
+
+interface GradeResult {
+  results: GradeResultItem[];
+  score: number;
+}
+
+// Answer state key: "rowIdx" for top-level, "rowIdx-subIdx" for sub-rows
+type AnswerMap = Record<string, string | number[]>;
 
 interface Props {
   storyId: string;
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function answerKey(rowIdx: number, subIdx?: number): string {
+  return subIdx !== undefined ? `${rowIdx}-${subIdx}` : `${rowIdx}`;
+}
+
+function findGradeItem(
+  results: GradeResultItem[],
+  rowIdx: number,
+  subIdx?: number,
+): GradeResultItem | undefined {
+  return results.find(
+    (r) => r.row_index === rowIdx && r.sub_row_index === subIdx,
+  );
+}
+
+// ── FillBlankCell ─────────────────────────────────────────────────────────────
+
+interface FillBlankCellProps {
+  hint?: string;
+  value: string;
+  onChange: (v: string) => void;
+  submitted: boolean;
+  gradeItem?: GradeResultItem;
+}
+
+const FillBlankCell: React.FC<FillBlankCellProps> = ({
+  hint,
+  value,
+  onChange,
+  submitted,
+  gradeItem,
+}) => {
+  if (submitted && gradeItem) {
+    const isCorrect = gradeItem.correct;
+    return (
+      <div className="flex flex-col gap-1">
+        <div
+          className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium border ${
+            isCorrect
+              ? 'bg-emerald-50 text-emerald-800 border-emerald-300'
+              : 'bg-red-50 text-red-800 border-red-300'
+          }`}
+        >
+          <span>{isCorrect ? '✓' : '✗'}</span>
+          <span>{value || '（未填）'}</span>
+        </div>
+        {!isCorrect && (
+          <p className="text-xs text-gray-500 pl-1">{gradeItem.feedback}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center gap-0.5 text-gray-700 text-sm">
+      <span className="text-gray-400 font-medium">【</span>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={hint ?? '請填入答案'}
+        className="w-36 bg-amber-50 border-b-2 border-amber-400 text-gray-900 text-sm placeholder-gray-400 focus:outline-none focus:border-amber-600 px-1 py-0.5 text-center"
+        disabled={submitted}
+      />
+      <span className="text-gray-400 font-medium">】</span>
+    </div>
+  );
+};
+
+// ── CheckboxCell ──────────────────────────────────────────────────────────────
+
+interface CheckboxCellProps {
+  options: string[];
+  selected: number[];
+  onChange: (indices: number[]) => void;
+  submitted: boolean;
+  gradeItem?: GradeResultItem;
+  correctOptions?: number[];
+}
+
+const CheckboxCell: React.FC<CheckboxCellProps> = ({
+  options,
+  selected,
+  onChange,
+  submitted,
+  gradeItem,
+  correctOptions,
+}) => {
+  const toggle = (idx: number) => {
+    if (submitted) return;
+    if (selected.includes(idx)) {
+      onChange(selected.filter((i) => i !== idx));
+    } else {
+      onChange([...selected, idx]);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {options.map((opt, idx) => {
+        const isSelected = selected.includes(idx);
+        const isCorrectOption = (correctOptions ?? []).includes(idx);
+
+        let rowStyle =
+          'border-gray-300 bg-white text-gray-800 hover:border-amber-400 hover:bg-amber-50';
+        let boxStyle = 'border-gray-400';
+
+        if (submitted && gradeItem) {
+          if (isCorrectOption) {
+            rowStyle = 'border-emerald-400 bg-emerald-50 text-emerald-800';
+            boxStyle = 'border-emerald-500 bg-emerald-500 text-white';
+          } else if (isSelected) {
+            rowStyle = 'border-red-400 bg-red-50 text-red-700';
+            boxStyle = 'border-red-400 bg-red-100';
+          } else {
+            rowStyle = 'border-gray-200 bg-gray-50 text-gray-400';
+          }
+        } else if (isSelected) {
+          rowStyle = 'border-amber-500 bg-amber-100 text-amber-900';
+          boxStyle = 'border-amber-500 bg-amber-500 text-white';
+        }
+
+        return (
+          <label
+            key={idx}
+            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors select-none ${rowStyle} ${
+              submitted ? 'cursor-default' : 'cursor-pointer'
+            }`}
+          >
+            <span
+              className={`w-4 h-4 shrink-0 rounded border-2 flex items-center justify-center text-xs ${boxStyle}`}
+            >
+              {(submitted && isCorrectOption) || (!submitted && isSelected) ? '✓' : ''}
+            </span>
+            <input
+              type="checkbox"
+              className="sr-only"
+              checked={isSelected}
+              onChange={() => toggle(idx)}
+              disabled={submitted}
+            />
+            {opt}
+            {submitted && gradeItem && isCorrectOption && (
+              <span className="ml-auto text-xs text-emerald-600 font-medium">正確</span>
+            )}
+          </label>
+        );
+      })}
+      {submitted && gradeItem && !gradeItem.correct && (
+        <p className="text-xs text-gray-500 pl-1">{gradeItem.feedback}</p>
+      )}
+    </div>
+  );
+};
+
+// ── Main Component ────────────────────────────────────────────────────────────
+
 const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
   const { token } = useAuth();
-  const [rows, setRows] = useState<StructureRow[] | null>(null);
+  const [structure, setStructure] = useState<StructureData | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [fetchError, setFetchError] = useState(false);
+
+  const [answers, setAnswers] = useState<AnswerMap>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [gradeResult, setGradeResult] = useState<GradeResult | null>(null);
+
+  const API_BASE = import.meta.env.VITE_API_URL || '';
 
   useEffect(() => {
     setLoading(true);
-    setError(false);
-    const API_BASE = import.meta.env.VITE_API_URL || '';
+    setFetchError(false);
+    setAnswers({});
+    setGradeResult(null);
     const headers: Record<string, string> = {};
     if (token) headers['Authorization'] = `Bearer ${token}`;
     fetch(`${API_BASE}/api/stories/${storyId}/structure`, { headers })
@@ -35,10 +237,112 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
         return r.json();
       })
-      .then((data) => setRows(data.rows ?? []))
-      .catch(() => setError(true))
+      .then((data: StructureData) => setStructure(data))
+      .catch(() => setFetchError(true))
       .finally(() => setLoading(false));
-  }, [storyId, token]);
+  }, [storyId, token, API_BASE]);
+
+  const setAnswer = useCallback((key: string, value: string | number[]) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  // Build the answer payload for POST /structure/grade
+  const buildAnswerPayload = useCallback((): object[] => {
+    if (!structure) return [];
+    const payload: object[] = [];
+
+    structure.rows.forEach((row, rowIdx) => {
+      if (row.sub_rows && row.sub_rows.length > 0) {
+        row.sub_rows.forEach((sub, subIdx) => {
+          if (sub.interactive_type === 'display') return;
+          const key = answerKey(rowIdx, subIdx);
+          const val = answers[key];
+          if (sub.interactive_type === 'checkbox') {
+            payload.push({
+              row_index: rowIdx,
+              sub_row_index: subIdx,
+              selected_options: Array.isArray(val) ? val : [],
+            });
+          } else {
+            payload.push({
+              row_index: rowIdx,
+              sub_row_index: subIdx,
+              value: typeof val === 'string' ? val : '',
+            });
+          }
+        });
+      } else {
+        if (row.interactive_type === 'display') return;
+        const key = answerKey(rowIdx);
+        const val = answers[key];
+        if (row.interactive_type === 'checkbox') {
+          payload.push({
+            row_index: rowIdx,
+            selected_options: Array.isArray(val) ? val : [],
+          });
+        } else {
+          payload.push({
+            row_index: rowIdx,
+            value: typeof val === 'string' ? val : '',
+          });
+        }
+      }
+    });
+
+    return payload;
+  }, [structure, answers]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!structure || submitting || gradeResult !== null) return;
+    setSubmitting(true);
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      const res = await fetch(`${API_BASE}/api/stories/${storyId}/structure/grade`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ answers: buildAnswerPayload() }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data: GradeResult = await res.json();
+      setGradeResult(data);
+    } catch {
+      setGradeResult({ results: [], score: -1 });
+    } finally {
+      setSubmitting(false);
+    }
+  }, [structure, submitting, gradeResult, token, storyId, API_BASE, buildAnswerPayload]);
+
+  // Count total interactive fields and how many are answered
+  const { totalInteractive, totalAnswered } = (() => {
+    if (!structure) return { totalInteractive: 0, totalAnswered: 0 };
+    let total = 0;
+    let answered = 0;
+    structure.rows.forEach((row, rowIdx) => {
+      const targets = row.sub_rows?.length
+        ? row.sub_rows.map((s, si) => ({ ...s, _key: answerKey(rowIdx, si) }))
+        : [{ ...row, _key: answerKey(rowIdx) }];
+
+      targets.forEach(({ interactive_type, _key }) => {
+        if (interactive_type === 'display') return;
+        total++;
+        const val = answers[_key];
+        if (interactive_type === 'checkbox') {
+          if (Array.isArray(val) && val.length > 0) answered++;
+        } else {
+          if (typeof val === 'string' && val.trim().length > 0) answered++;
+        }
+      });
+    });
+    return { totalInteractive: total, totalAnswered: answered };
+  })();
+
+  const allAnswered = totalAnswered >= totalInteractive && totalInteractive > 0;
+  const submitted = gradeResult !== null;
+  const gradeResults = gradeResult?.results ?? [];
+  const score = gradeResult?.score ?? 0;
+
+  // ── Render ─────────────────────────────────────────────────────────────────
 
   if (loading) {
     return (
@@ -48,7 +352,7 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
     );
   }
 
-  if (error || !rows) {
+  if (fetchError || !structure) {
     return (
       <div className="p-4 text-sm text-red-500 text-center">
         無法載入文章重點表，請重新整理頁面
@@ -56,53 +360,188 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
     );
   }
 
+  const { rows } = structure;
+
   return (
     <div className="overflow-hidden rounded-xl border-2 border-gray-300 shadow-sm max-w-2xl mx-auto">
       {/* Header */}
-      <div className="bg-amber-50 border-b-2 border-amber-400 px-5 py-3">
+      <div className="bg-amber-50 border-b-2 border-amber-400 px-5 py-3 flex items-center justify-between">
         <span className="text-amber-800 font-bold text-base">📋 文章重點表</span>
+        {submitted && score >= 0 && (
+          <span
+            className={`text-sm font-bold px-3 py-1 rounded-full ${
+              score >= 80
+                ? 'bg-emerald-100 text-emerald-700'
+                : 'bg-amber-100 text-amber-700'
+            }`}
+          >
+            {score >= 80 ? '🎉' : '💪'} {score} 分
+          </span>
+        )}
       </div>
+
       {/* Table */}
       <table className="w-full text-base" style={{ borderCollapse: 'collapse' }}>
         <tbody>
-          {rows.map((row, idx) => (
+          {rows.map((row, rowIdx) =>
             row.sub_rows && row.sub_rows.length > 0 ? (
-              row.sub_rows.map((sub, sIdx) => (
-                <tr key={`${idx}-${sIdx}`} style={{ borderBottom: '1.5px solid #d1d5db' }}>
-                  {sIdx === 0 && (
+              row.sub_rows.map((sub, subIdx) => {
+                const key = answerKey(rowIdx, subIdx);
+                const gradeItem = submitted
+                  ? findGradeItem(gradeResults, rowIdx, subIdx)
+                  : undefined;
+
+                return (
+                  <tr
+                    key={`${rowIdx}-${subIdx}`}
+                    style={{ borderBottom: '1.5px solid #d1d5db' }}
+                  >
+                    {subIdx === 0 && (
+                      <td
+                        rowSpan={row.sub_rows!.length}
+                        className="bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center align-middle w-20"
+                        style={{ borderRight: '1.5px solid #d1d5db' }}
+                      >
+                        {row.label}
+                      </td>
+                    )}
                     <td
-                      rowSpan={row.sub_rows!.length}
-                      className="bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center align-middle w-20"
+                      className="bg-gray-50 px-3 py-3 font-semibold text-gray-600 text-center w-16"
                       style={{ borderRight: '1.5px solid #d1d5db' }}
                     >
-                      {row.label}
+                      {sub.label}
                     </td>
-                  )}
-                  <td
-                    className="bg-gray-50 px-3 py-3 font-semibold text-gray-600 text-center w-16"
-                    style={{ borderRight: '1.5px solid #d1d5db' }}
-                  >
-                    {sub.label}
-                  </td>
-                  <td className="px-5 py-3 text-gray-800 leading-relaxed">{sub.value}</td>
-                </tr>
-              ))
+                    <td className="px-4 py-3 text-gray-800 leading-relaxed">
+                      {sub.interactive_type === 'display' ? (
+                        <span>{sub.value}</span>
+                      ) : sub.interactive_type === 'checkbox' ? (
+                        <CheckboxCell
+                          options={sub.options ?? []}
+                          selected={
+                            Array.isArray(answers[key])
+                              ? (answers[key] as number[])
+                              : []
+                          }
+                          onChange={(v) => setAnswer(key, v)}
+                          submitted={submitted}
+                          gradeItem={gradeItem}
+                          correctOptions={sub.correct_options}
+                        />
+                      ) : (
+                        <FillBlankCell
+                          hint={sub.hint}
+                          value={
+                            typeof answers[key] === 'string'
+                              ? (answers[key] as string)
+                              : ''
+                          }
+                          onChange={(v) => setAnswer(key, v)}
+                          submitted={submitted}
+                          gradeItem={gradeItem}
+                        />
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
             ) : (
-              <tr key={idx} style={{ borderBottom: '1.5px solid #d1d5db' }}>
+              <tr key={rowIdx} style={{ borderBottom: '1.5px solid #d1d5db' }}>
                 <td
                   className="bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center w-20"
                   style={{ borderRight: '1.5px solid #d1d5db' }}
                 >
                   {row.label}
                 </td>
-                <td colSpan={2} className="px-5 py-3 text-gray-800 leading-relaxed">
-                  {row.value}
-                </td>
+                {row.interactive_type === 'display' ? (
+                  <td colSpan={2} className="px-5 py-3 text-gray-800 leading-relaxed">
+                    {row.value}
+                  </td>
+                ) : (
+                  <td colSpan={2} className="px-4 py-3">
+                    {row.interactive_type === 'checkbox' ? (
+                      <CheckboxCell
+                        options={row.options ?? []}
+                        selected={
+                          Array.isArray(answers[answerKey(rowIdx)])
+                            ? (answers[answerKey(rowIdx)] as number[])
+                            : []
+                        }
+                        onChange={(v) => setAnswer(answerKey(rowIdx), v)}
+                        submitted={submitted}
+                        gradeItem={
+                          submitted
+                            ? findGradeItem(gradeResults, rowIdx)
+                            : undefined
+                        }
+                        correctOptions={row.correct_options}
+                      />
+                    ) : (
+                      <FillBlankCell
+                        hint={row.hint}
+                        value={
+                          typeof answers[answerKey(rowIdx)] === 'string'
+                            ? (answers[answerKey(rowIdx)] as string)
+                            : ''
+                        }
+                        onChange={(v) => setAnswer(answerKey(rowIdx), v)}
+                        submitted={submitted}
+                        gradeItem={
+                          submitted
+                            ? findGradeItem(gradeResults, rowIdx)
+                            : undefined
+                        }
+                      />
+                    )}
+                  </td>
+                )}
               </tr>
-            )
-          ))}
+            ),
+          )}
         </tbody>
       </table>
+
+      {/* Submit / Result bar */}
+      <div className="px-5 py-4 border-t-2 border-gray-200 bg-gray-50">
+        {!submitted ? (
+          <div className="flex items-center justify-between gap-4">
+            <p className="text-xs text-gray-400">
+              已填 {totalAnswered} / {totalInteractive} 題
+            </p>
+            <button
+              onClick={handleSubmit}
+              disabled={!allAnswered || submitting}
+              className={`px-6 py-2 rounded-xl font-bold text-sm transition-all ${
+                allAnswered && !submitting
+                  ? 'bg-amber-500 text-white hover:bg-amber-600 active:scale-95'
+                  : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+              }`}
+            >
+              {submitting ? '批改中…' : '提交答案'}
+            </button>
+          </div>
+        ) : score < 0 ? (
+          <p className="text-sm text-red-500 text-center">
+            批改失敗，請重新整理後再試
+          </p>
+        ) : (
+          <div
+            className={`rounded-xl p-4 text-center ${
+              score >= 80
+                ? 'bg-emerald-50 border border-emerald-200'
+                : 'bg-amber-50 border border-amber-200'
+            }`}
+          >
+            <p className="font-bold text-gray-900">
+              {score >= 80 ? '太棒了！' : '繼續加油！'}
+            </p>
+            <p className="text-sm text-gray-500 mt-0.5">
+              {score >= 80
+                ? '你已掌握這篇課文的重點'
+                : '可以再讀一遍課文，試著找出關鍵句子'}
+            </p>
+          </div>
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- 文章重點表從「顯示模式」改成「互動模式」，對齊三民學習單設計
- 學生填空+勾選，AI 批改，顯示對錯和回饋
- 支援記敘文/說明文/議論文三種文體格式

## 改動
### Backend
- `ai_generation.py`：AI prompt 生成互動欄位（fill_blank/checkbox/display）+ 新增 `grade_story_structure()` 批改函數
- `stories.py`：新增 `POST /stories/{id}/structure/grade` 批改 API + cache 版本升級 v2

### Frontend  
- `StoryStructureTable.tsx`：完整重寫
  - fill_blank → 【　input　】括號填空
  - checkbox → □ 勾選選項（對齊學習單格式）
  - 提交後顯示分數 + 逐題對錯回饋

## Test plan
- [ ] 開一篇記敘文（如 L01），確認重點表有填空+勾選
- [ ] 開一篇說明文（如 L03），確認格式不同
- [ ] 填完提交，確認 AI 批改正確顯示
- [ ] 確認舊的顯示模式仍可用（教師端）

🤖 Generated with [Claude Code](https://claude.com/claude-code)