### PR TITLE
fix: ReadingAnnotation 選字偏移 — 注音 PUA selector 導致位移

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -147,6 +147,46 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   // ── Selection helpers ──────────────────────────────────────────────────
 
   /**
+   * Count raw (non-selector) characters in a string, stopping after `upTo`
+   * UTF-16 code units have been consumed.  When `upTo` is omitted the entire
+   * string is scanned.
+   *
+   * BpmfIansui uses Unicode Variation Selectors Supplement (U+E0100–U+E01EF)
+   * to select polyphonic-character pronunciation variants.  buildZhuyinString()
+   * appends one of U+E01E1–U+E01E5 after each non-default character.  These
+   * code points are above U+FFFF so each occupies 2 UTF-16 code units (a
+   * surrogate pair).  The browser's Selection API reports offsets in UTF-16
+   * code units, so without correction the reported charStart is inflated by
+   * 2 × (number of PUA selectors before the selection point).
+   *
+   * This helper strips those selectors so we always get an index into the
+   * original raw paragraph text.
+   */
+  function countRawChars(text: string, upTo?: number): number {
+    // PUA range used by BpmfIansui variant selectors: U+E0100–U+E01EF.
+    // In UTF-16 these are the surrogate pair: high D83C + low DC00..DCEF.
+    const limit = upTo ?? text.length;
+    let rawCount = 0;
+    let i = 0;
+    while (i < limit) {
+      const code = text.charCodeAt(i);
+      // High surrogate of the PUA Variation Selectors Supplement block
+      // U+E0100–U+E01EF encodes as high surrogate 0xDB40 + low 0xDD00–0xDDEF.
+      if (code === 0xDB40 && i + 1 < text.length) {
+        const low = text.charCodeAt(i + 1);
+        if (low >= 0xDD00 && low <= 0xDDEF) {
+          // This is a PUA selector — skip both code units, don't count
+          i += 2;
+          continue;
+        }
+      }
+      rawCount++;
+      i++;
+    }
+    return rawCount;
+  }
+
+  /**
    * Given a Selection that spans inside a paragraph <p data-para-idx="N">,
    * compute character offsets into the raw paragraph text.
    * Returns null if selection is empty or crosses paragraph boundaries.
@@ -183,21 +223,33 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
 
     // Walk all text nodes inside the paragraph to find where range.startContainer
     // sits and accumulate the character offset up to range.startOffset.
+    //
+    // When zhuyin is active, each text node may contain BpmfIansui PUA variant
+    // selectors (U+E01E1–U+E01E5, stored as surrogate pairs = 2 UTF-16 units
+    // each).  These inflate node.textContent.length and range.startOffset
+    // compared to the raw paragraph text.  countRawChars() strips them so the
+    // stored annotation indices always refer to raw-text positions.
     let charStart = 0;
     let found = false;
     const walker = document.createTreeWalker(paraEl, NodeFilter.SHOW_TEXT);
     let node: Text | null;
     while ((node = walker.nextNode() as Text | null)) {
       if (node === range.startContainer) {
-        charStart += range.startOffset;
+        // range.startOffset is a UTF-16 offset into this text node; convert to
+        // raw-character count by stripping PUA selectors up to that point.
+        charStart += countRawChars(node.textContent ?? '', range.startOffset);
         found = true;
         break;
       }
-      charStart += node.textContent?.length ?? 0;
+      // Accumulate raw (non-selector) character count for completed nodes.
+      charStart += countRawChars(node.textContent ?? '');
     }
     if (!found) return null;
 
-    const charEnd = charStart + selectedText.length;
+    // selectedText from range.toString() also includes PUA selector code points;
+    // strip them to get the raw character count of the selection.
+    const rawSelectedLength = countRawChars(selectedText);
+    const charEnd = charStart + rawSelectedLength;
 
     if (charStart >= charEnd) return null;
 


### PR DESCRIPTION
## 問題
選取「洗腦」兩字按「重要」，高亮卻標記在「的廣」上。偏移 2 個字

## Root Cause
BpmfIansui 字體用 Unicode Variation Selectors (U+E01E1-E01E5) 標記多音字讀音。這些字元在 U+FFFF 以上，每個佔 2 個 UTF-16 code unit（surrogate pair）。瀏覽器 Selection API 回報的 offset 是 UTF-16 單位，導致每個 PUA selector 讓 charStart 多 2

## Fix
新增 `countRawChars()` 函數，遍歷字串時跳過 PUA surrogate pairs (high: 0xDB40, low: 0xDD00-0xDDEF)，確保 annotation 的 charStart/charEnd 對應到原始純文字的位置

## Test plan
- [ ] 開 L01，注音模式開啟
- [ ] 選「洗腦」按重要 → 高亮應在「洗腦」上
- [ ] 選其他有注音的詞試幾個