### PR TITLE
fix: 跨裝置登入時 Self-practice 完成紀錄完全失效 （fix: #1071）

### DIFF
--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -15,6 +15,7 @@ import { lazy } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { hasRole } from '../../services/authApi';
 import { clearActiveSession } from '../../services/api';
+import { checkSelfPracticeCompleted } from '../../services/learningApi';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { PARENT_PORTAL_ENABLED } from '../../config/featureFlags';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
@@ -139,11 +140,21 @@ export const LibraryPage: React.FC = () => {
     clearAssignmentContext(story.id);
     cleanupAssignmentScopedProgressKeys(story.id);
 
+    // Check completion: DB first (cross-device), localStorage as fallback.
     let isCompletedBefore = false;
-    try {
-      isCompletedBefore = localStorage.getItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`) === '1';
-    } catch {
-      isCompletedBefore = false;
+    if (token) {
+      isCompletedBefore = await checkSelfPracticeCompleted(story.id, token);
+      // Sync DB truth back to localStorage so subsequent checks are instant.
+      if (isCompletedBefore) {
+        try { localStorage.setItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`, '1'); } catch { /* non-fatal */ }
+      }
+    }
+    if (!isCompletedBefore) {
+      try {
+        isCompletedBefore = localStorage.getItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`) === '1';
+      } catch {
+        isCompletedBefore = false;
+      }
     }
 
     if (isCompletedBefore) {

--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -15,7 +15,7 @@ import { lazy } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { hasRole } from '../../services/authApi';
 import { clearActiveSession } from '../../services/api';
-import { checkSelfPracticeCompleted } from '../../services/learningApi';
+import { checkSelfPracticeCompleted, SessionExpiredError } from '../../services/learningApi';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { PARENT_PORTAL_ENABLED } from '../../config/featureFlags';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
@@ -143,7 +143,14 @@ export const LibraryPage: React.FC = () => {
     // Check completion: DB first (cross-device), localStorage as fallback.
     let isCompletedBefore = false;
     if (token) {
-      isCompletedBefore = await checkSelfPracticeCompleted(story.id, token);
+      try {
+        isCompletedBefore = await checkSelfPracticeCompleted(story.id, token);
+      } catch (err) {
+        if (err instanceof SessionExpiredError) {
+          console.warn('[LibraryPage] checkSelfPracticeCompleted: token expired, falling back to localStorage');
+        }
+        // Fall through to localStorage check below.
+      }
       // Sync DB truth back to localStorage so subsequent checks are instant.
       if (isCompletedBefore) {
         try { localStorage.setItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`, '1'); } catch { /* non-fatal */ }

--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -8,7 +8,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import StoryCard, { Difficulty, DIFFICULTY_CONFIG, getDifficulty } from '../../components/student/StoryCard';
 
 interface StoryLibraryProps {
-  onStartReading: (story: Story) => void;
+  onStartReading: (story: Story) => void | Promise<void>;
   limit?: number;
   /** Slugs of already-completed stories — shows completion badge on card. */
   completedSlugs?: string[];
@@ -114,7 +114,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
     setLoadingStoryId(story.id);
     try {
       const fullStory = await fetchStory(story.id);
-      onStartReading(fullStory);
+      await onStartReading(fullStory);
     } catch (err) {
       setError(err instanceof Error ? err.message : '無法載入課文');
     } finally {

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -142,15 +142,23 @@ export async function checkSelfPracticeCompleted(
       story_slug: storySlug,
       status: 'completed',
       learning_source: 'self',
+      // Note: limit only caps the returned `items` array; `total` still reflects
+      // the full count because learning_source filtering happens in Python after
+      // the SQL query.  We keep limit=1 to minimise payload size.
       limit: '1',
     });
     const res = await fetch(`${API_BASE}/api/learning/sessions?${params}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
+    if (res.status === 401) {
+      throw new SessionExpiredError('checkSelfPracticeCompleted: token expired');
+    }
     if (!res.ok) return false;
     const data = (await res.json()) as { total: number };
     return data.total > 0;
-  } catch {
+  } catch (err) {
+    if (err instanceof SessionExpiredError) throw err;
+    console.error('[checkSelfPracticeCompleted] failed, falling back to localStorage:', err);
     return false;
   }
 }

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -125,6 +125,36 @@ export async function completeSelfPracticeSession(
   }
 }
 
+/**
+ * Check whether the current user has any completed self-practice session for a
+ * given story by querying the DB via GET /api/learning/sessions.
+ *
+ * Returns `true` when at least one completed self-practice session exists,
+ * `false` otherwise (including on network/auth errors — the caller falls back
+ * to localStorage in that case).
+ */
+export async function checkSelfPracticeCompleted(
+  storySlug: string,
+  token: string,
+): Promise<boolean> {
+  try {
+    const params = new URLSearchParams({
+      story_slug: storySlug,
+      status: 'completed',
+      learning_source: 'self',
+      limit: '1',
+    });
+    const res = await fetch(`${API_BASE}/api/learning/sessions?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { total: number };
+    return data.total > 0;
+  } catch {
+    return false;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Comprehension chat
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 修正 1：Self-practice 完成狀態改由 DB 查詢，支援跨裝置同步（Issue #1070）

**修正檔案**
- [frontend/src/services/learningApi.ts](frontend/src/services/learningApi.ts) — 新增 `checkSelfPracticeCompleted()` API 函式
- [frontend/src/pages/app/InlinePages.tsx](frontend/src/pages/app/InlinePages.tsx) — `handleSelectStory` 改為 DB-first 查詢邏輯

**修正內容**

原本學生選擇課文時（`handleSelectStory`），僅從 `localStorage` 讀取 `self-practice-completed-{storyId}` 來判斷是否已完成自學。當學生換裝置登入時，localStorage 不存在該紀錄，系統會重複推薦已完成的課文。

寫入端（`LearningLayout.tsx:926-934`）已在之前的 Issue #1070 修正中加入了 `completeSelfPracticeSession` API 呼叫，會將完成狀態寫入 DB。但**讀取端**（`InlinePages.tsx:144`）仍只檢查 localStorage，未從 DB 查詢。

**修正方式**

### 1. 新增 `checkSelfPracticeCompleted()` — learningApi.ts

利用既有的 `GET /api/learning/sessions` endpoint（已支援 `status`、`story_slug`、`learning_source` 篩選），無需新增後端 endpoint。

```typescript
// Before: 無此函式

// After:
export async function checkSelfPracticeCompleted(
  storySlug: string,
  token: string,
): Promise<boolean> {
  try {
    const params = new URLSearchParams({
      story_slug: storySlug,
      status: 'completed',
      learning_source: 'self',
      limit: '1',
    });
    const res = await fetch(`${API_BASE}/api/learning/sessions?${params}`, {
      headers: { Authorization: `Bearer ${token}` },
    });
    if (!res.ok) return false;
    const data = (await res.json()) as { total: number };
    return data.total > 0;
  } catch {
    return false;
  }
}
```

### 2. 修改 `handleSelectStory` — InlinePages.tsx

DB-first，localStorage 作為 fallback。DB 查詢結果同步寫回 localStorage 以加速後續檢查。

```typescript
// Before:
let isCompletedBefore = false;
try {
  isCompletedBefore = localStorage.getItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`) === '1';
} catch {
  isCompletedBefore = false;
}

// After:
let isCompletedBefore = false;
if (token) {
  isCompletedBefore = await checkSelfPracticeCompleted(story.id, token);
  // Sync DB truth back to localStorage so subsequent checks are instant.
  if (isCompletedBefore) {
    try { localStorage.setItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`, '1'); } catch { /* non-fatal */ }
  }
}
if (!isCompletedBefore) {
  try {
    isCompletedBefore = localStorage.getItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`) === '1';
  } catch {
    isCompletedBefore = false;
  }
}
```

---

**設計決策**

| 面向 | 說明 |
|------|------|
| 不新增 backend endpoint | 既有 `GET /learning/sessions` 已支援所需篩選，複用即可 |
| localStorage 保留為 fallback | 離線/API 失敗時仍可用；DB 結果也會同步回 localStorage 作為 L1 cache |
| 錯誤靜默降級 | `checkSelfPracticeCompleted` 在任何錯誤時回傳 `false`，不阻塞使用者操作 |
