### PR TITLE
fix: Step 進度 debounce 5 秒，快速刷新頁面可能遺失進度 (FIX: #1072)

### DIFF
--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -19,7 +19,7 @@
  * API failures are fully non-blocking — localStorage still functions.
  */
 import { useCallback, useEffect, useRef } from 'react';
-import { saveStepProgress, loadStepProgress, StepProgressData } from '../services/learningApi';
+import { saveStepProgress, saveStepProgressBeacon, loadStepProgress, StepProgressData } from '../services/learningApi';
 
 const DEBOUNCE_MS = 5_000;
 
@@ -93,6 +93,7 @@ export function useProgressSync({
         if (latestDataRef.current) {
           doSave(latestDataRef.current);
         }
+        debounceTimerRef.current = null;
       }, DEBOUNCE_MS);
     },
     [doSave],
@@ -120,19 +121,7 @@ export function useProgressSync({
       debounceTimerRef.current = null;
 
       if (token && dbSessionId !== null) {
-        const API_BASE = import.meta.env.VITE_API_URL ?? '';
-        const url = `${API_BASE}/api/learning/sessions/${dbSessionId}/progress`;
-        // Use fetch + keepalive to survive page unload while keeping auth headers.
-        // (sendBeacon cannot set Authorization headers.)
-        fetch(url, {
-          method: 'PUT',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(latestDataRef.current),
-          keepalive: true,
-        }).catch(() => { /* non-fatal */ });
+        saveStepProgressBeacon(token, dbSessionId, latestDataRef.current);
       }
     };
 
@@ -153,8 +142,7 @@ export function useProgressSync({
         doSave(latestDataRef.current);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [doSave]);
 
   return { syncProgress, flushProgress };
 }

--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -81,6 +81,10 @@ export function useProgressSync({
     [token, dbSessionId],
   );
 
+  // Keep a ref to the latest doSave so unmount cleanup always uses the current version
+  const doSaveRef = useRef(doSave);
+  useEffect(() => { doSaveRef.current = doSave; }, [doSave]);
+
   // ── Debounced sync ────────────────────────────────────────────────────────
   const syncProgress = useCallback(
     (data: StepProgressData) => {
@@ -137,12 +141,13 @@ export function useProgressSync({
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
         debounceTimerRef.current = null;
-      }
-      if (latestDataRef.current) {
-        doSave(latestDataRef.current);
+        if (latestDataRef.current) {
+          doSaveRef.current(latestDataRef.current);
+        }
       }
     };
-  }, [doSave]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return { syncProgress, flushProgress };
 }

--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -95,7 +95,7 @@ export function useProgressSync({
       }
       debounceTimerRef.current = setTimeout(() => {
         if (latestDataRef.current) {
-          doSave(latestDataRef.current);
+          doSaveRef.current(latestDataRef.current);
         }
         debounceTimerRef.current = null;
       }, DEBOUNCE_MS);

--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -111,13 +111,49 @@ export function useProgressSync({
     [doSave],
   );
 
-  // Cleanup debounce timer on unmount
+  // Flush pending data on page unload (refresh / close / navigate away)
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      if (!latestDataRef.current || !debounceTimerRef.current) return;
+
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+
+      if (token && dbSessionId !== null) {
+        const API_BASE = import.meta.env.VITE_API_URL ?? '';
+        const url = `${API_BASE}/api/learning/sessions/${dbSessionId}/progress`;
+        // Use fetch + keepalive to survive page unload while keeping auth headers.
+        // (sendBeacon cannot set Authorization headers.)
+        fetch(url, {
+          method: 'PUT',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(latestDataRef.current),
+          keepalive: true,
+        }).catch(() => { /* non-fatal */ });
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [token, dbSessionId]);
+
+  // Flush pending data on unmount (SPA navigation away from learning flow)
   useEffect(() => {
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+      if (latestDataRef.current) {
+        doSave(latestDataRef.current);
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return { syncProgress, flushProgress };

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -714,6 +714,27 @@ export async function saveStepProgress(
 }
 
 /**
+ * Fire-and-forget step progress save using fetch + keepalive.
+ * Designed for beforeunload / page teardown where normal fetch may be cancelled.
+ */
+export function saveStepProgressBeacon(
+  token: string,
+  sessionId: number,
+  progress: StepProgressData,
+): void {
+  const url = `${API_BASE}/api/learning/sessions/${sessionId}/progress`;
+  fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(progress),
+    keepalive: true,
+  }).catch(() => { /* non-fatal */ });
+}
+
+/**
  * Load step progress from DB for a given learning session.
  * Returns null step_progress when nothing has been saved yet.
  */


### PR DESCRIPTION
## 修正 1：debounce 期間刷新/關閉頁面導致進度遺失

**修正檔案**
- [frontend/src/hooks/useProgressSync.ts](frontend/src/hooks/useProgressSync.ts) — 新增 `beforeunload` flush + unmount flush

**修正內容**

`useProgressSync` 使用 5 秒 debounce 再將進度寫入 DB。若學生在 debounce 期間（0–5 秒內）刷新或關閉頁面，debounce timer 被清除，DB 未更新，頁面刷新後回到前一步進度。

原本 unmount cleanup（第 114–121 行）只做 `clearTimeout` 清除 timer，但**未 flush 尚未送出的資料**。也沒有 `beforeunload` 事件監聽。

> 注意：所有 step completion（`handleFinish*`）已正確使用 `immediate: true` → `flushProgress()`，不受影響。此問題僅影響 debounce 中的中間狀態更新（如對話歷史、練習進度片段）。

**修正方式**

新增兩層保護：

### 1. `beforeunload` 事件 — 攔截頁面刷新/關閉

```typescript
// Before (不存在)

// After
window.addEventListener('beforeunload', () => {
  if (!latestDataRef.current || !debounceTimerRef.current) return;
  clearTimeout(debounceTimerRef.current);
  // fetch + keepalive: true 可在 unload 時存活，且支援 Authorization header
  fetch(url, { method: 'PUT', headers: { Authorization: ... }, keepalive: true });
});
```

使用 `fetch` + `keepalive: true` 而非 `sendBeacon`，因為後端 API 需要 Bearer token 認證，而 `sendBeacon` 無法設定自訂 headers。

### 2. Unmount cleanup — 攔截 SPA 內部導航離開

```typescript
// Before
useEffect(() => {
  return () => {
    if (debounceTimerRef.current) {
      clearTimeout(debounceTimerRef.current); // ← 只清 timer，資料丟失
    }
  };
}, []);

// After
useEffect(() => {
  return () => {
    if (debounceTimerRef.current) {
      clearTimeout(debounceTimerRef.current);
      debounceTimerRef.current = null;
    }
    if (latestDataRef.current) {
      doSave(latestDataRef.current); // ← flush 尚未送出的資料
    }
  };
}, []);
```

---

**無套件安裝**
