### PR TITLE
ci: warm preview backend after CORS update to avoid cold-start errors

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -192,6 +192,21 @@ jobs:
             --project ${{ env.PROJECT_ID }} \
             --update-env-vars "^::^ALLOWED_ORIGINS=${FRONTEND_URL},${ALT_URL},${STAGING_URL},${FIREBASE_URL}"
 
+      - name: Warm backend to avoid cold-start CORS errors
+        if: always() && steps.preview-urls.outputs.backend_url != 'N/A'
+        env:
+          BACKEND_URL: ${{ steps.preview-urls.outputs.backend_url }}
+        run: |
+          # CORS env update creates a new Cloud Run revision which is cold.
+          # Browsers hitting a cold revision see 5xx without CORS headers,
+          # surfacing as spurious "blocked by CORS policy" console errors.
+          # Pre-warm so the first real user request lands on a warm instance.
+          for i in 1 2 3; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$BACKEND_URL/" || echo timeout)
+            echo "Warmup attempt $i: HTTP $code"
+            case "$code" in timeout|000) sleep 2 ;; *) break ;; esac
+          done
+
       - name: Comment PR with preview URLs
         uses: actions/github-script@v8
         with:


### PR DESCRIPTION
## Summary
- Adds a backend warmup curl step after "Update backend CORS with actual frontend URL"
- Prevents spurious "blocked by CORS policy" console errors on PR preview first load
- Discovered while QA'ing PR #1087 preview

## Root cause
`gcloud run services update --update-env-vars` creates a **new** Cloud Run revision, which is cold. The first browser request to this cold revision hits a Cloud Run 5xx error page that does **not** carry CORS headers — even though `ALLOWED_ORIGINS` is correctly configured. The browser sees the missing header and reports "No 'Access-Control-Allow-Origin' header is present".

Verified via curl: direct `OPTIONS` / `GET` to the backend returns the correct `access-control-allow-origin` header. Only browsers hitting the cold-start error page see the issue.

## Fix
After the CORS env update, hit `${BACKEND_URL}/` with curl (up to 3 retries) to force a warm instance before the PR is announced in the comment.

## Test plan
- [ ] Open a test PR, confirm preview comment appears after warmup step
- [ ] Visit preview URL and check DevTools console — no CORS errors on first request
- [ ] Verify `fetch('/api/assignments/my')` succeeds without retry