### PR TITLE
ci: add OPTIONS preflight warmup for API routes on PR preview

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -196,15 +196,30 @@ jobs:
         if: always() && steps.preview-urls.outputs.backend_url != 'N/A'
         env:
           BACKEND_URL: ${{ steps.preview-urls.outputs.backend_url }}
+          FRONTEND_URL: ${{ steps.preview-urls.outputs.frontend_url }}
         run: |
           # CORS env update creates a new Cloud Run revision which is cold.
           # Browsers hitting a cold revision see 5xx without CORS headers,
           # surfacing as spurious "blocked by CORS policy" console errors.
-          # Pre-warm so the first real user request lands on a warm instance.
+          #
+          # Two warmups:
+          # 1. Root GET — warms one instance through Cloud Run routing.
+          # 2. OPTIONS preflight with Origin — mimics what the browser will do
+          #    for the first fetch(), ensuring the API route + CORS middleware
+          #    are both JIT-loaded before the real user request arrives.
           for i in 1 2 3; do
             code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$BACKEND_URL/" || echo timeout)
-            echo "Warmup attempt $i: HTTP $code"
+            echo "Warmup root attempt $i: HTTP $code"
             case "$code" in timeout|000) sleep 2 ;; *) break ;; esac
+          done
+          for path in /api/assignments/my /api/gamification/streak /api/stories; do
+            code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 20 \
+              -X OPTIONS \
+              -H "Origin: $FRONTEND_URL" \
+              -H "Access-Control-Request-Method: GET" \
+              -H "Access-Control-Request-Headers: authorization,content-type" \
+              "${BACKEND_URL}${path}" || echo timeout)
+            echo "Preflight $path: HTTP $code"
           done
 
       - name: Comment PR with preview URLs


### PR DESCRIPTION
## Summary
Follow-up to #1088. Root GET warmup alone didn't eliminate the cold-start CORS errors because FastAPI route handlers + CORS middleware JIT-load only when an actual API path is hit.

Add a second warmup pass that mimics the browser preflight (OPTIONS + Origin header) against the three endpoints the student UI calls first: `/api/assignments/my`, `/api/gamification/streak`, `/api/stories`.

## Why
Observed on PR #1089 preview (`5d54a7d5` commit):

```
[error] Access to fetch at '…/api/assignments/my' has been blocked by
CORS policy: No 'Access-Control-Allow-Origin' header is present on
the requested resource.
```

Direct `curl -X OPTIONS` with Origin header confirms CORS is correctly
configured on the backend — only the cold-start 5xx page is missing
headers. Warming the preflight path fixes it.

## Test plan
- [ ] Open fresh PR preview → confirm CORS errors are gone in DevTools console
- [ ] Regression: preview deploy time increases by ~5 seconds (3 extra curls)