### PR TITLE
ci: cap AR cleanup step at 10 min

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -251,6 +251,7 @@ jobs:
     needs: [deploy-backend, deploy-frontend]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
## Summary
Staging deploys spent 1h+ showing \`in_progress\` because the \`Cleanup old AR images\` job runs ~1.7 hours. Add \`timeout-minutes: 10\`.

## Diagnosis (via bug-fixer agent on run 24544950542)

- Registry: 1,100 backend images + 1,077 frontend images
- Cleanup loops serially (\`while read\`) calling \`gcloud artifacts docker images delete\` per image (~4s each)
- Full pass ≈ 1,588 sequential API calls × 4s ≈ 1.7 hours
- No job \`timeout-minutes\` → GitHub Actions 6h default → step stays \`in_progress\`

The step isn't broken, just slow. GCP Artifact Registry has \`keep-recent-tagged=3\` async cleanup policy that catches whatever this step doesn't finish in 10 min. Partial cleanup per deploy is acceptable.

## Follow-up (deliberately not in this PR)
Parallelise with \`xargs -P 10\` (~10x faster) or move cleanup to a scheduled workflow so it never blocks deploy visibility.

## Test plan
- [ ] Next staging deploy: \`cleanup-images\` job completes or times out within 10 min, not 1h+
- [ ] \`Deploy to Staging\` run no longer shows \`in_progress\` for an hour