### PR TITLE
fix(tts): sync highlight with speech by using cleaned char count (ref #1110)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -16,6 +16,7 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine, ResponsiveContai
 /* ------------------------------------------------------------------ */
 
 import { splitZhuyinChars } from '../../utils/zhuyinUtils';
+import { displayIdxForProgress } from '../../utils/ttsHighlight';
 
 /* ------------------------------------------------------------------ */
 
@@ -268,13 +269,16 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack }) =>
     if (isTtsHighlighting) {
       const displayText = (zhuyinActive && typeof zhuyinLine === 'string') ? zhuyinLine : line;
       const chars = splitZhuyinChars(displayText);
+      // Use displayIdxForProgress so symbols stripped by _cleanForTts (~~~, ──, …)
+      // don't consume TTS progress budget — fixes highlight lag (Issue #1110).
+      const splitIdx = displayIdxForProgress(displayText, speakingProgress);
       return (
         <>
           {speakingProgress > 0 && (
-            <span className="text-accent font-bold">{chars.slice(0, speakingProgress).join('')}</span>
+            <span className="text-accent font-bold">{chars.slice(0, splitIdx).join('')}</span>
           )}
           <span className={speakingProgress > 0 ? 'opacity-30' : 'opacity-90'}>
-            {chars.slice(speakingProgress).join('')}
+            {chars.slice(splitIdx).join('')}
           </span>
         </>
       );

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -6,6 +6,7 @@ import { splitIntoSentences } from '../../../utils/localEval';
 import { CHINESE_PUNCTUATION_REGEX } from '../../../utils/liveTutorHelpers';
 
 import { splitZhuyinChars } from '../../../utils/zhuyinUtils';
+import { displayIdxForProgress } from '../../../utils/ttsHighlight';
 
 interface ParagraphCardProps {
   idx: number;
@@ -185,17 +186,20 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
         {status === 'locked' ? (
           <span className="blur-sm select-none">{zhuyinLine ?? line}</span>
         ) : isTtsSpeaking && isCurrentIdx ? (
-          // Highlight chars up to speakingProgress during TTS playback
+          // Highlight chars up to speakingProgress during TTS playback.
+          // Use displayIdxForProgress so symbols stripped by _cleanForTts
+          // (~~~, ──, …) don't consume TTS progress budget (Issue #1110).
           (() => {
             const displayText = (zhuyinActive && typeof zhuyinLine === 'string') ? zhuyinLine : line;
             const chars = splitZhuyinChars(displayText);
+            const splitIdx = displayIdxForProgress(displayText, speakingProgress);
             return (
               <>
                 {speakingProgress > 0 && (
-                  <span className="text-accent font-bold">{chars.slice(0, speakingProgress).join('')}</span>
+                  <span className="text-accent font-bold">{chars.slice(0, splitIdx).join('')}</span>
                 )}
                 <span className={speakingProgress > 0 ? 'text-on-surface/30' : 'text-on-surface/90'}>
-                  {chars.slice(speakingProgress).join('')}
+                  {chars.slice(splitIdx).join('')}
                 </span>
               </>
             );

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -1,5 +1,5 @@
 import { useState, useRef, useCallback } from 'react';
-import { cancelTts } from '../services/ttsApi';
+import { cancelTts, cleanForTts } from '../services/ttsApi';
 
 /**
  * Manages TTS (Text-to-Speech) audio playback for LiveTutor.
@@ -63,7 +63,9 @@ export function useTtsPlayback(
       onSpeakingProgress(0);
       onRealtimeDiffTokensClear();
       ttsStartTimeRef.current = performance.now();
-      ttsTotalCharsRef.current = Array.from(text).length;
+      // Use cleaned char count so the animation ceiling matches the audio's
+      // actual char count (cleaned chars only, same as msPerChar basis).
+      ttsTotalCharsRef.current = Array.from(cleanForTts(text)).length;
       const animate = () => {
         const elapsed = performance.now() - ttsStartTimeRef.current;
         const pos = Math.min(Math.floor(elapsed / msPerCharRef.current), ttsTotalCharsRef.current);
@@ -97,8 +99,11 @@ export function useTtsPlayback(
         const audio = new Audio(url);
         utteranceRef.current = audio as unknown as SpeechSynthesisUtterance;
         audio.onloadedmetadata = () => {
-          // Calculate per-char timing from actual audio duration
-          const charCount = Array.from(text).length;
+          // TTS audio duration corresponds to _cleanForTts(text), not raw text.
+          // Using raw length makes msPerChar too small → cursor outruns speech.
+          // Fix: compute charCount from the cleaned string (Issue #1110).
+          const cleanedText = cleanForTts(text);
+          const charCount = Array.from(cleanedText).length;
           if (audio.duration > 0 && charCount > 0) {
             msPerCharRef.current = (audio.duration * 1000) / charCount;
           }

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -84,6 +84,13 @@ export async function speakTextWithProgress(
   await _speakViaBackendWithProgress(text, onProgress);
 }
 
+/**
+ * Public alias for _cleanForTts — allows other modules to compute the cleaned
+ * character count without duplicating the regex logic.
+ * Used by useTtsPlayback to calculate msPerChar from the TTS-actual char count.
+ */
+export const cleanForTts = _cleanForTts;
+
 // Exported for testing only
 export const _testInternals = {
   reset() {

--- a/frontend/src/utils/ttsHighlight.ts
+++ b/frontend/src/utils/ttsHighlight.ts
@@ -1,0 +1,89 @@
+/**
+ * ttsHighlight.ts
+ *
+ * Helper for syncing TTS highlight progress with display text that contains
+ * symbols stripped by _cleanForTts().
+ *
+ * Problem: displayText may contain ~~~, ──, …, etc. that are removed before
+ * TTS audio is generated. The audio's character-count progress doesn't match
+ * the display character index, causing highlights to lag behind.
+ *
+ * Solution: Walk display chars; skip chars that _cleanForTts would strip so
+ * they don't consume TTS progress budget.
+ */
+
+/**
+ * _cleanForTts has two distinct transformation types — we must treat them
+ * differently when walking display chars:
+ *
+ * 1. TRULY STRIPPED (→ ''): these chars vanish from TTS audio entirely.
+ *    They must NOT advance `effective` (no audio time consumed).
+ *    Examples: [~～], #, [/\|], [*\[\]{}], [·‧・°○]
+ *
+ * 2. REPLACED WITH ONE CHAR (→ '，'): these chars become a single pause char.
+ *    They MUST advance `effective` by 1 (one char worth of audio time).
+ *    Examples: [──—–−] and […⋯] and -{2,}  (all → '，')
+ *
+ * 3. REPLACED WITH THREE CHARS (→ '百分之'): % becomes 3 TTS chars.
+ *    Advances `effective` by 3.
+ *
+ * Treating category 2/3 as "stripped" (category 1) makes the highlight split
+ * arrive ahead of the speech whenever those chars appear in displayText.
+ * E.g. L01.yml contains '球后──戴資穎' — the '──' must count as 1 TTS char.
+ *
+ * Keep in sync with _cleanForTts in frontend/src/services/ttsApi.ts.
+ */
+
+/** Truly removed by _cleanForTts — contribute 0 TTS chars. */
+const STRIP_RE = /[~～#/\\|*[\]{}·‧・°○]/;
+
+/** Replaced by '，' (1 TTS char) — contribute 1 TTS char. */
+const PAUSE_ONE_RE = /[──—–−…⋯]/;
+
+/**
+ * Given a display string (which may contain TTS-stripped/replaced symbols) and
+ * a TTS progress count (number of cleaned chars already spoken), return the
+ * index in displayText where highlighting should split.
+ *
+ * Walk display chars, mapping each to its TTS char contribution:
+ *   - truly stripped chars → 0
+ *   - pause chars (──, …)  → 1
+ *   - % → 3 (百分之)
+ *   - double-hyphen run    → 1
+ *   - all other chars      → 1
+ */
+export function displayIdxForProgress(displayText: string, progress: number): number {
+  let effective = 0;
+  for (let i = 0; i < displayText.length; i++) {
+    if (effective >= progress) return i;
+    const ch = displayText[i];
+
+    // Double-hyphen run "-{2,}" → '，' (1 TTS char)
+    if (ch === '-' && displayText[i + 1] === '-') {
+      while (i + 1 < displayText.length && displayText[i + 1] === '-') i++;
+      effective++;
+      continue;
+    }
+
+    // % → '百分之' (3 TTS chars)
+    if (ch === '%') {
+      effective += 3;
+      continue;
+    }
+
+    // Pause chars (em-dash, ellipsis) → '，' (1 TTS char)
+    if (PAUSE_ONE_RE.test(ch)) {
+      effective++;
+      continue;
+    }
+
+    // Truly stripped chars → 0 TTS chars
+    if (STRIP_RE.test(ch)) {
+      continue;
+    }
+
+    // All other chars (CJK, punctuation, letters) → 1 TTS char
+    effective++;
+  }
+  return displayText.length;
+}


### PR DESCRIPTION
ref #1110

## 問題描述

逐段朗讀和全文朗讀的字色高亮追不上朗讀速度，含有 `~~~`、`──`、`…` 等符號的段落尤其明顯。

## Root Cause（兩個 bug 同時存在）

**Bug A — `useTtsPlayback.ts` 的 msPerChar 計算用了 raw text 長度**

TTS 音檔時長對應的是 `_cleanForTts()` 處理後的字元數，不是原始文字長度。
raw length > cleaned length（差異等於被刪除的符號數），所以 `msPerChar` 偏小 → rAF cursor 跑在語音前面。

**Bug B — FullReading/ParagraphCard 用 raw `speakingProgress` 當 `chars.slice()` 的切割點**

`speakingProgress` 是 cleaned char 計數，但 `chars.slice(speakingProgress)` 把每個 display char（含 `~~~`、`──` 等）都當成一個 TTS char，這些符號消耗了不應消耗的 progress budget → 高亮切點落後。

## 修法（A-D 四個改動）

**A. `ttsApi.ts`** — 將 `_cleanForTts` export 為 `cleanForTts` public alias

**B. `useTtsPlayback.ts`** — `msPerChar` 分母和 `ttsTotalCharsRef` 上限都改用 `Array.from(cleanForTts(text)).length`

**C. `frontend/src/utils/ttsHighlight.ts`（新增）** — `displayIdxForProgress()` 將 cleaned-char progress 映射回 display string index。關鍵：區分三類 `_cleanForTts` 轉換：
- 真正刪除（`~~~`, `#`, `/`, `*`）→ 貢獻 0 TTS chars
- 替換成 `，`（`──`, `…`）→ 貢獻 1 TTS char
- 替換成 `百分之`（`%`）→ 貢獻 3 TTS chars

L01.yml 包含 `球后──戴資穎`，em-dash 必須計 1 個 TTS char，若全部當 skip 高亮就會提前。

**D. `FullReading.tsx` + `ParagraphCard.tsx`** — 將 `chars.slice(0, speakingProgress)` 改為 `chars.slice(0, displayIdxForProgress(displayText, speakingProgress))`

## 驗證步驟

請在 preview URL 測試：

1. 開啟 L01（戴資穎），進入「全文朗讀」步驟
2. 點「AI 朗讀」，聆聽第一段「戴資穎戴資穎第一名，戴資穎戴資穎我愛妳~~~」
3. 觀察 `~~~` 出現時，高亮是否正確停在 `妳` 而非直接跳過 `~~~` 繼續往後亮
4. 觀察 `球后──戴資穎` 這句，`──` 出現時高亮應在 em-dash 停留一拍（對應 TTS 的 `，`），不應直接跳過
5. 進入「逐段朗讀」步驟，重複上述觀察