### PR TITLE
feat(learn): show story title in immersive top bar

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -130,8 +130,16 @@ const ImmersiveTopBar: React.FC = () => {
         <span className="material-symbols-outlined text-on-surface text-xl md:text-2xl">arrow_back</span>
       </button>
 
-      {/* Center: step label + hint + progress dots */}
-      <div className="flex-1 min-w-0 flex flex-col items-center gap-1 md:gap-1.5">
+      {/* Center: story title (context) + step label + hint + progress dots */}
+      <div className="flex-1 min-w-0 flex flex-col items-center gap-0.5 md:gap-1">
+        {selectedStory && (
+          <span
+            className="text-xs md:text-sm text-on-surface-variant truncate max-w-full"
+            title={selectedStory.title}
+          >
+            《{selectedStory.title}》
+          </span>
+        )}
         {currentStep && (
           <>
             <span className="font-headline font-bold text-sm md:text-base text-accent tracking-wide truncate max-w-full">


### PR DESCRIPTION
## Problem

After #1119 consolidated Header into Sidebar, learn mode lost the story title display.
LearningAppShell hides the sidebar (for focus), so students only saw:
- Step label (e.g. 「讀全文-做記號 · 1/12」)
- Step hint
- Progress dots

**Missing**: which story they're currently reading.

## Fix

Add `《selectedStory.title》` as a small muted line above the step label in the immersive top bar.
Users now see at a glance:

```
《贏得喝采的輸家》
讀全文-做記號 · 1/12
閱讀全文，選取不懂或重要的詞語做記號
● ● ○ ○ ○ ...
```

## Files

- `frontend/src/components/layout/AppShell.tsx` (+10, -2)

## Verification

- Layout: gap-0.5/gap-1 stack fits h-20 mobile without crowding
- Truncation: long story titles wrap via `truncate max-w-full`
- Accessibility: `title` attribute gives full text on hover
- Symbol `《》`: standard Chinese book title brackets

## Related

- Follow-up to #1119 merged earlier today
- Design decision: Option C (banner + step vs Option B: show sidebar in learn mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)