### PR TITLE
feat(admin): add /api/admin/sessions endpoint (ref #1124)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from .routes.semesters import router as semesters_router
 from .routes.co_teaching import router as co_teaching_router
 from .routes.tts import router as tts_router
 from .routes.tts_audit import router as tts_audit_router
+from .routes.admin_sessions import router as admin_sessions_router
 from .utils.logging_config import setup_logging
 from .auth.rate_limiter import general_rate_limiter
 from .services.seed import seed_default_data
@@ -335,6 +336,7 @@ app.include_router(semesters_router, prefix="/api", tags=["semesters"])
 app.include_router(co_teaching_router, prefix="/api", tags=["co-teaching"])
 app.include_router(tts_router)
 app.include_router(tts_audit_router)
+app.include_router(admin_sessions_router, prefix="/api", tags=["admin-sessions"])
 
 
 @app.get("/")

--- a/backend/app/routes/admin_sessions.py
+++ b/backend/app/routes/admin_sessions.py
@@ -1,0 +1,69 @@
+"""
+Admin Session Listing API — list and inspect LearningSession records for debugging.
+
+All endpoints require system_admin role.
+"""
+
+from collections import Counter
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..auth.dependencies import require_role
+from ..database import get_db
+from ..models.session import LearningSession
+
+router = APIRouter(tags=["admin-sessions"])
+
+
+# ── GET /api/admin/sessions ──────────────────────────────────────────────────
+
+@router.get(
+    "/admin/sessions",
+    dependencies=[require_role("system_admin")],
+)
+def list_sessions(
+    student_id: int | None = None,
+    story_slug: str | None = None,
+    status: str | None = None,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+):
+    """List LearningSession records with optional filters.
+
+    Supports filtering by student_id, story_slug, and status.
+    Returns aggregate counts alongside individual session rows.
+    Intended for admin debugging — not for student-facing use.
+    """
+    query = db.query(LearningSession)
+    if student_id is not None:
+        query = query.filter(LearningSession.student_id == student_id)
+    if story_slug is not None:
+        query = query.filter(LearningSession.story_slug == story_slug)
+    if status is not None:
+        query = query.filter(LearningSession.status == status)
+
+    sessions = (
+        query.order_by(LearningSession.started_at.desc()).limit(limit).all()
+    )
+
+    by_status = Counter(s.status for s in sessions)
+    by_slug = Counter(s.story_slug for s in sessions)
+
+    return {
+        "total": len(sessions),
+        "by_status": dict(by_status),
+        "by_slug": dict(by_slug),
+        "sessions": [
+            {
+                "id": s.id,
+                "student_id": s.student_id,
+                "story_slug": s.story_slug,
+                "status": s.status,
+                "current_step": s.current_step,
+                "started_at": s.started_at.isoformat(),
+                "completed_at": s.completed_at.isoformat() if s.completed_at else None,
+            }
+            for s in sessions
+        ],
+    }


### PR DESCRIPTION
ref #1124

## Summary
- New `GET /api/admin/sessions` endpoint in `backend/app/routes/admin_sessions.py`
- Requires `system_admin` role (same guard as all other admin routes)
- Optional query filters: `student_id`, `story_slug`, `status`, `limit` (default 100)
- Returns `total`, `by_status` counter, `by_slug` counter, and `sessions` list
- Registered in `main.py` at `/api/admin/sessions`

## Motivation
Verification for #984 was blocked because no session listing endpoint existed.
This endpoint enables future debugging and orphan-session inspection (ref #1123).

## Test plan
After preview deploy, verify with system_admin token:
```
curl -s -H "Authorization: Bearer <token>" \
  "https://lingoleap-backend-pr-1124-958347263320.asia-east1.run.app/api/admin/sessions?limit=5"
```
Expected: JSON with `total`, `by_status`, `by_slug`, `sessions` array.

## Files changed
- `backend/app/routes/admin_sessions.py` — new file (69 lines)
- `backend/app/main.py` — +2 lines (import + include_router)