### PR TITLE
fix(tts): null-check empty candidates before indexing (ref #1127)

### DIFF
--- a/backend/app/services/tts_service.py
+++ b/backend/app/services/tts_service.py
@@ -705,9 +705,19 @@ def _synthesize_gemini(text: str) -> bytes:
     except Exception as exc:
         raise TTSError(f"Gemini TTS API error: {exc}") from exc
 
+    # Guard against safety-blocked / empty responses before indexing
+    if not response.candidates:
+        raise TTSError("Gemini TTS returned empty candidates (safety block?)")
+    cand = response.candidates[0]
+    if not cand.content or not cand.content.parts:
+        finish_reason = getattr(cand, "finish_reason", "unknown")
+        raise TTSError(
+            f"Gemini TTS returned empty content (finish_reason={finish_reason})"
+        )
+
     # Extract raw PCM from the response
     try:
-        pcm_data = response.candidates[0].content.parts[0].inline_data.data
+        pcm_data = cand.content.parts[0].inline_data.data
     except (AttributeError, IndexError, TypeError) as exc:
         raise TTSError(f"Gemini TTS unexpected response structure: {exc}") from exc
 

--- a/backend/scripts/batch_gemini_tts.py
+++ b/backend/scripts/batch_gemini_tts.py
@@ -85,7 +85,25 @@ def _synthesize_and_upload(client, bucket, text: str, key: str) -> dict:
                 ),
             ),
         )
-        pcm_data = response.candidates[0].content.parts[0].inline_data.data
+
+        # Guard against safety-blocked / empty responses before indexing
+        if not response.candidates:
+            return {
+                "key": key,
+                "status": "error",
+                "error": "empty candidates (safety block?)",
+                "raw_text": text[:80],
+            }
+        cand = response.candidates[0]
+        if not cand.content or not cand.content.parts:
+            finish_reason = getattr(cand, "finish_reason", "unknown")
+            return {
+                "key": key,
+                "status": "error",
+                "error": f"empty content (finish_reason={finish_reason})",
+                "raw_text": text[:80],
+            }
+        pcm_data = cand.content.parts[0].inline_data.data
         if not pcm_data:
             return {"key": key, "status": "error", "error": "empty PCM"}
 


### PR DESCRIPTION
ref #1127

## Problem

`batch_gemini_tts.py` crashes with `IndexError` when Gemini returns empty candidates (safety block). The batch run logged 66 errors traced to 8 sentences that have been confirmed as hard safety blocks.

The runtime `tts_service.py._synthesize_gemini` had a `try/except IndexError` that caught the crash but produced a misleading error message with no `finish_reason`.

## Changes

**`backend/scripts/batch_gemini_tts.py`** (`_synthesize_and_upload`, line ~88):
- Added guard: `if not response.candidates` → return error dict with `raw_text[:80]` for debug
- Added guard: `if not cand.content or not cand.content.parts` → return error with `finish_reason`
- Replaces bare `candidates[0]` index that crashes on safety-blocked responses

**`backend/app/services/tts_service.py`** (`_synthesize_gemini`, line ~710):
- Added explicit `if not response.candidates` check → raise `TTSError` with "safety block?" hint
- Added `if not cand.content or not cand.content.parts` → raise `TTSError` with `finish_reason`
- Replaces `try/except IndexError` that gave no actionable info

## Verification

```
python -m py_compile backend/scripts/batch_gemini_tts.py  # OK
python -m py_compile backend/app/services/tts_service.py   # OK
```

`grep -A3 "candidates" backend/scripts/batch_gemini_tts.py` shows null-check added before indexing.

## The 8 failing sentences

The 8 sentences that hard-fail (confirmed by agent a344ae99, 57 consecutive attempts) are **not retried** by this fix — they are genuine safety blocks. They will now surface as structured error logs with `raw_text[:80]` for manual inspection:

```
d93a835d... (and 7 others) → finish_reason=SAFETY
```

Young to manually review these 8 sentences and decide: rephrase or skip.

## Test plan
- [ ] Run batch script against staging GCS — safety-blocked sentences now produce `{"status":"error","error":"empty candidates (safety block?)","raw_text":"..."}` instead of traceback
- [ ] Student-facing TTS: safety-blocked text now raises `TTSError` with clear message, not `IndexError` crash