### PR TITLE
ci(staging): serialize concurrent deploys (fix race)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -5,6 +5,13 @@ on:
     branches: [staging]
   workflow_dispatch:
 
+# Serialize concurrent deploys. Back-to-back merges to staging would
+# race each other on Cloud Run revision/traffic. With this group,
+# new runs queue behind the in-flight one.
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: false
+
 env:
   PROJECT_ID: lingoleap-dev
   REGION: asia-east1


### PR DESCRIPTION
Fixes race condition where multiple merges trigger parallel deploys that race Cloud Run. Evidence: run 24607043163 failed at deploy-frontend today. Adds workflow-level concurrency group. cancel-in-progress: false so every commit still deploys.