### PR TITLE
feat: 全域 UX — 點點箭頭 + 學生端分數移除 + 語音輸入共用元件 #1094

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -118,7 +118,7 @@ const ImmersiveTopBar: React.FC = () => {
   return (
     <header
       aria-label="學習進度列"
-      className="shrink-0 z-30 h-20 md:h-24 flex items-center justify-between px-2 md:px-10 gap-2 glass"
+      className="shrink-0 z-30 h-16 md:h-20 flex items-center justify-between px-2 md:px-10 gap-2 glass"
     >
       {/* Left: back button */}
       <button
@@ -130,53 +130,104 @@ const ImmersiveTopBar: React.FC = () => {
         <span className="material-symbols-outlined text-on-surface text-xl md:text-2xl">arrow_back</span>
       </button>
 
-      {/* Center: story title (context) + step label + hint + progress dots */}
-      <div className="flex-1 min-w-0 flex flex-col items-center gap-0.5 md:gap-1">
-        {selectedStory && (
-          <span
-            className="text-xs md:text-sm text-on-surface-variant truncate max-w-full"
-            title={selectedStory.title}
-          >
-            《{selectedStory.title}》
+      {/* Center: 標題+步驟（row 1）/ 提示（row 2, 小字）/ 點點+箭頭（row 3） */}
+      <div className="flex-1 min-w-0 flex flex-col items-center gap-0.5">
+        {/* Row 1 — 標題 · 步驟 N/total */}
+        <div className="flex items-center gap-2 md:gap-3 max-w-full min-w-0 text-sm md:text-base">
+          {selectedStory && (
+            <span
+              className="text-on-surface-variant truncate"
+              title={selectedStory.title}
+            >
+              《{selectedStory.title}》
+            </span>
+          )}
+          {currentStep && (
+            <>
+              {selectedStory && <span className="text-on-surface-variant/40 shrink-0">·</span>}
+              <span className="font-headline font-bold text-accent tracking-wide shrink-0">
+                {currentStep.label} {currentStepIndex + 1}/{totalSteps}
+              </span>
+            </>
+          )}
+        </div>
+        {/* Row 2 — 提示（小字，桌機才顯示） */}
+        {currentStep?.hint && (
+          <span className="hidden md:inline text-[11px] text-on-surface-variant/70 truncate max-w-full leading-tight">
+            {currentStep.hint}
           </span>
         )}
-        {currentStep && (
-          <>
-            <span className="font-headline font-bold text-sm md:text-base text-accent tracking-wide truncate max-w-full">
-              {currentStep.label} · {currentStepIndex + 1}/{totalSteps}
-            </span>
-            <span className="hidden md:inline text-sm text-on-surface-variant truncate max-w-full">
-              {currentStep.hint}
-            </span>
-          </>
-        )}
 
-        {/* Progress dots — clickable to navigate between steps */}
-        <div className="flex items-center gap-1 md:gap-1.5 max-w-full flex-wrap justify-center" role="navigation" aria-label="學習步驟導航">
-          {ACTIVE_STEPS.map((step, i) => {
-            const isCompleted = completedSet.has(step.id);
-            const isActive = i === currentStepIndex;
-            const isReport = step.id === 'report';
-            const isLocked = isReport && !allNonReportDone;
-
-            let dotClass = 'bg-on-surface-variant/20';
-            if (isCompleted) dotClass = 'bg-emerald-500';
-            if (isActive) dotClass = 'bg-accent scale-125';
-
-            return (
+        {/* Progress dots + left/right arrows (Issue #1094) — tooltip shows step name; arrows fixed-size, dots wrap */}
+        {(() => {
+          const prevStep = (() => {
+            for (let i = currentStepIndex - 1; i >= 0; i--) {
+              const s = ACTIVE_STEPS[i];
+              const locked = s.id === 'report' && !allNonReportDone;
+              if (!locked) return s;
+            }
+            return null;
+          })();
+          const nextStep = (() => {
+            for (let i = currentStepIndex + 1; i < ACTIVE_STEPS.length; i++) {
+              const s = ACTIVE_STEPS[i];
+              const locked = s.id === 'report' && !allNonReportDone;
+              if (!locked) return s;
+            }
+            return null;
+          })();
+          return (
+            <div className="flex items-center gap-1 max-w-full min-w-0 h-4 md:h-5" role="navigation" aria-label="學習步驟導航">
               <button
-                key={step.id}
                 type="button"
-                onClick={() => handleStepClick(step)}
-                disabled={isLocked}
-                className={`w-2 h-2 md:w-2.5 md:h-2.5 rounded-full transition-all hover:scale-150 disabled:cursor-not-allowed disabled:opacity-40 ${dotClass}`}
-                title={`${step.label}${isLocked ? '（完成所有階段後解鎖）' : ''}`}
-                aria-label={step.label}
-                aria-current={isActive ? 'step' : undefined}
-              />
-            );
-          })}
-        </div>
+                onClick={() => prevStep && handleStepClick(prevStep)}
+                disabled={!prevStep || !selectedStory}
+                className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                aria-label={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
+                title={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
+              >
+                <span className="material-symbols-outlined text-sm leading-none" style={{ fontSize: '14px' }}>chevron_left</span>
+              </button>
+
+              <div className="flex items-center gap-1 md:gap-1.5 flex-wrap justify-center min-w-0">
+                {ACTIVE_STEPS.map((step, i) => {
+                  const isCompleted = completedSet.has(step.id);
+                  const isActive = i === currentStepIndex;
+                  const isReport = step.id === 'report';
+                  const isLocked = isReport && !allNonReportDone;
+
+                  let dotClass = 'bg-on-surface-variant/20';
+                  if (isCompleted) dotClass = 'bg-emerald-500';
+                  if (isActive) dotClass = 'bg-accent scale-125';
+
+                  return (
+                    <button
+                      key={step.id}
+                      type="button"
+                      onClick={() => handleStepClick(step)}
+                      disabled={isLocked}
+                      className={`w-2 h-2 md:w-2.5 md:h-2.5 rounded-full transition-all hover:scale-150 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
+                      title={`${i + 1}. ${step.label}${isLocked ? '（完成所有階段後解鎖）' : ''}`}
+                      aria-label={`${i + 1}. ${step.label}`}
+                      aria-current={isActive ? 'step' : undefined}
+                    />
+                  );
+                })}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => nextStep && handleStepClick(nextStep)}
+                disabled={!nextStep || !selectedStory}
+                className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                aria-label={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
+                title={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
+              >
+                <span className="material-symbols-outlined text-sm leading-none" style={{ fontSize: '14px' }}>chevron_right</span>
+              </button>
+            </div>
+          );
+        })()}
       </div>
 
       {/* Right: zhuyin toggle + settings */}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -9,7 +9,7 @@
  * Header removed (2026-04-18): all header functionality (logo, story title,
  * notification bell, zhuyin toggle, logout) is now integrated into Sidebar.
  */
-import React, { useState, useEffect, useCallback, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
@@ -115,6 +115,23 @@ const ImmersiveTopBar: React.FC = () => {
     navigate(`/learn/${selectedStory.id}/${step.id}`);
   };
 
+  // Issue #1094: prev/next step arrows skip the locked report step
+  const prevStep = useMemo(() => {
+    for (let i = currentStepIndex - 1; i >= 0; i--) {
+      const s = ACTIVE_STEPS[i];
+      if (!(s.id === 'report' && !allNonReportDone)) return s;
+    }
+    return null;
+  }, [currentStepIndex, allNonReportDone]);
+
+  const nextStep = useMemo(() => {
+    for (let i = currentStepIndex + 1; i < ACTIVE_STEPS.length; i++) {
+      const s = ACTIVE_STEPS[i];
+      if (!(s.id === 'report' && !allNonReportDone)) return s;
+    }
+    return null;
+  }, [currentStepIndex, allNonReportDone]);
+
   return (
     <header
       aria-label="學習進度列"
@@ -159,75 +176,55 @@ const ImmersiveTopBar: React.FC = () => {
         )}
 
         {/* Progress dots + left/right arrows (Issue #1094) — tooltip shows step name; arrows fixed-size, dots wrap */}
-        {(() => {
-          const prevStep = (() => {
-            for (let i = currentStepIndex - 1; i >= 0; i--) {
-              const s = ACTIVE_STEPS[i];
-              const locked = s.id === 'report' && !allNonReportDone;
-              if (!locked) return s;
-            }
-            return null;
-          })();
-          const nextStep = (() => {
-            for (let i = currentStepIndex + 1; i < ACTIVE_STEPS.length; i++) {
-              const s = ACTIVE_STEPS[i];
-              const locked = s.id === 'report' && !allNonReportDone;
-              if (!locked) return s;
-            }
-            return null;
-          })();
-          return (
-            <div className="flex items-center gap-1 max-w-full min-w-0 h-4 md:h-5" role="navigation" aria-label="學習步驟導航">
-              <button
-                type="button"
-                onClick={() => prevStep && handleStepClick(prevStep)}
-                disabled={!prevStep || !selectedStory}
-                className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                aria-label={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
-                title={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
-              >
-                <span className="material-symbols-outlined text-sm leading-none" style={{ fontSize: '14px' }}>chevron_left</span>
-              </button>
+        <div className="flex items-center gap-1 max-w-full min-w-0 h-4 md:h-5" role="navigation" aria-label="學習步驟導航">
+          <button
+            type="button"
+            onClick={() => prevStep && handleStepClick(prevStep)}
+            disabled={!prevStep || !selectedStory}
+            className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            aria-label={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
+            title={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
+          >
+            <span className="material-symbols-outlined text-sm leading-none" style={{ fontSize: '14px' }}>chevron_left</span>
+          </button>
 
-              <div className="flex items-center gap-1 md:gap-1.5 flex-wrap justify-center min-w-0">
-                {ACTIVE_STEPS.map((step, i) => {
-                  const isCompleted = completedSet.has(step.id);
-                  const isActive = i === currentStepIndex;
-                  const isReport = step.id === 'report';
-                  const isLocked = isReport && !allNonReportDone;
+          <div className="flex items-center gap-1 md:gap-1.5 flex-wrap justify-center min-w-0">
+            {ACTIVE_STEPS.map((step, i) => {
+              const isCompleted = completedSet.has(step.id);
+              const isActive = i === currentStepIndex;
+              const isReport = step.id === 'report';
+              const isLocked = isReport && !allNonReportDone;
 
-                  let dotClass = 'bg-on-surface-variant/20';
-                  if (isCompleted) dotClass = 'bg-emerald-500';
-                  if (isActive) dotClass = 'bg-accent scale-125';
+              let dotClass = 'bg-on-surface-variant/20';
+              if (isCompleted) dotClass = 'bg-emerald-500';
+              if (isActive) dotClass = 'bg-accent scale-125';
 
-                  return (
-                    <button
-                      key={step.id}
-                      type="button"
-                      onClick={() => handleStepClick(step)}
-                      disabled={isLocked}
-                      className={`w-2 h-2 md:w-2.5 md:h-2.5 rounded-full transition-all hover:scale-150 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
-                      title={`${i + 1}. ${step.label}${isLocked ? '（完成所有階段後解鎖）' : ''}`}
-                      aria-label={`${i + 1}. ${step.label}`}
-                      aria-current={isActive ? 'step' : undefined}
-                    />
-                  );
-                })}
-              </div>
+              return (
+                <button
+                  key={step.id}
+                  type="button"
+                  onClick={() => handleStepClick(step)}
+                  disabled={isLocked}
+                  className={`w-2 h-2 md:w-2.5 md:h-2.5 rounded-full transition-all hover:scale-150 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
+                  title={`${i + 1}. ${step.label}${isLocked ? '（完成所有階段後解鎖）' : ''}`}
+                  aria-label={`${i + 1}. ${step.label}`}
+                  aria-current={isActive ? 'step' : undefined}
+                />
+              );
+            })}
+          </div>
 
-              <button
-                type="button"
-                onClick={() => nextStep && handleStepClick(nextStep)}
-                disabled={!nextStep || !selectedStory}
-                className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                aria-label={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
-                title={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
-              >
-                <span className="material-symbols-outlined text-sm leading-none" style={{ fontSize: '14px' }}>chevron_right</span>
-              </button>
-            </div>
-          );
-        })()}
+          <button
+            type="button"
+            onClick={() => nextStep && handleStepClick(nextStep)}
+            disabled={!nextStep || !selectedStory}
+            className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            aria-label={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
+            title={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
+          >
+            <span className="material-symbols-outlined text-sm leading-none" style={{ fontSize: '14px' }}>chevron_right</span>
+          </button>
+        </div>
       </div>
 
       {/* Right: zhuyin toggle + settings */}

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -20,7 +20,7 @@ import GoalAchievementCard from '../ui/GoalAchievementCard';
 import RepeatedErrorAlertModal from '../student/RepeatedErrorAlertModal';
 import { getReadingHistory, type ReadingHistoryPoint } from '../../services/learningApi';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
-import { encourageOverall, encourageAccuracy, encourageReadingSpeed, encourageQuiz } from '../../utils/encouragement';
+import { encourageOverall, encourageAccuracy, encourageReadingDone, encourageQuiz } from '../../utils/encouragement';
 
 /**
  * A wrapper around ResponsiveContainer that only renders the chart
@@ -448,7 +448,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
               <div className="bg-accent/5 rounded-2xl p-6 text-center space-y-2">
                 <p className="text-lg font-bold text-accent">{encourageAccuracy(accuracy)}</p>
                 {readingAttempt && (
-                  <p className="text-sm text-gray-600">{encourageReadingSpeed()}</p>
+                  <p className="text-sm text-gray-600">{encourageReadingDone()}</p>
                 )}
               </div>
             ) : (

--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -20,6 +20,7 @@ import GoalAchievementCard from '../ui/GoalAchievementCard';
 import RepeatedErrorAlertModal from '../student/RepeatedErrorAlertModal';
 import { getReadingHistory, type ReadingHistoryPoint } from '../../services/learningApi';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
+import { encourageOverall, encourageAccuracy, encourageReadingSpeed, encourageQuiz } from '../../utils/encouragement';
 
 /**
  * A wrapper around ResponsiveContainer that only renders the chart
@@ -169,6 +170,10 @@ const Section: React.FC<{
 
 const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onRetry, onGoToVocab, comprehensionScores, comprehensionScoresLoading, readingGoals, dbSessionId, token, readOnly }) => {
   const [expandedLine, setExpandedLine] = useState<number | null>(null);
+
+  // Issue #1094: Student-facing views hide numeric scores/accuracy/CPM and show
+  // encouragement text instead. Teacher view (readOnly) keeps all numbers.
+  const hideScores = !readOnly;
 
   // Track report viewed in localStorage
   useEffect(() => {
@@ -360,8 +365,9 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
 
       {!readOnly && <CelebrationOverlay score={overallScore} />}
 
-      {/* ============ 星星評級 Star Rating (Issue #222) ============ */}
-      {!hasNoData && !readOnly && (
+      {/* ============ 星星評級 Star Rating (Issue #222) —
+          學生端隱藏（Issue #1094：改鼓勵式，不呈現星星/分數） ============ */}
+      {!hasNoData && !hideScores && (
         <StarCelebration
           stars={starCount}
           readingAccuracy={bestReadingAccuracy}
@@ -415,83 +421,98 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
           <p className="text-sm text-gray-400 mt-1">{story.title}</p>
         )}
         {overallScore !== null ? (
-          <div className="mt-4 inline-flex items-center gap-2 bg-accent/10 text-accent px-5 py-2 rounded-full">
-            <span className="text-sm font-bold">綜合成績</span>
-            <span className="text-2xl font-black">{overallScore}%</span>
-          </div>
-        ) : (
+          hideScores ? (
+            <div className="mt-4 inline-flex items-center gap-2 bg-accent/10 text-accent px-5 py-2 rounded-full">
+              <span className="text-sm font-bold">{encourageOverall(overallScore)}</span>
+            </div>
+          ) : (
+            <div className="mt-4 inline-flex items-center gap-2 bg-accent/10 text-accent px-5 py-2 rounded-full">
+              <span className="text-sm font-bold">綜合成績</span>
+              <span className="text-2xl font-black">{overallScore}%</span>
+            </div>
+          )
+        ) : !hideScores ? (
           <div className="mt-4 inline-flex items-center gap-2 bg-gray-100 text-gray-400 px-5 py-2 rounded-full">
             <span className="text-sm font-bold">綜合成績</span>
             <span className="text-2xl font-black">--</span>
           </div>
-        )}
+        ) : null}
       </div>
 
       {/* ============ 環節一：朗讀結果總覽 ============ */}
       <Section number={1} title="朗讀結果總覽" defaultOpen={true} disabled={!readingAttempt && !fullReadingResult}>
         {readingAttempt || fullReadingResult ? (
           <div className="space-y-4">
-            {/* 3 KPI Cards */}
-            <div className="grid grid-cols-3 gap-4">
-              {/* 準確度 */}
-              <div className="text-center p-4 bg-slate-50 rounded-2xl">
-                <div className="w-24 h-24 mx-auto relative">
-                  <SafeResponsiveContainer width="100%" height="100%">
-                    <PieChart>
-                      <Pie data={scoreData} innerRadius={30} outerRadius={42} paddingAngle={5} dataKey="value" startAngle={90} endAngle={-270}>
-                        {scoreData.map((entry, i) => <Cell key={i} fill={entry.color} />)}
-                      </Pie>
-                    </PieChart>
-                  </SafeResponsiveContainer>
-                  <div className="absolute inset-0 flex items-center justify-center">
-                    <span className="text-lg font-black text-accent">{accuracy}%</span>
-                  </div>
-                </div>
-                <p className="text-xs text-gray-500 font-bold mt-1">逐段準確度</p>
-              </div>
-
-              {/* 語速 CPM */}
-              <div className="text-center p-4 bg-slate-50 rounded-2xl flex flex-col items-center justify-center">
-                <span className="text-3xl font-black text-gray-900">{cpm}</span>
-                <span className="text-xs text-gray-500 font-bold">正確字數/分鐘</span>
-                <div className="flex gap-0.5 mt-2 w-full max-w-[120px]">
-                  {speedSegments.map((seg, idx) => (
-                    <div key={idx} className={`flex-1 h-1.5 rounded-sm ${idx === currentSegment ? seg.color : 'bg-gray-200'}`} />
-                  ))}
-                </div>
-                <p className="text-[10px] text-gray-400 mt-1">
-                  {speedSegments[currentSegment]?.label}
-                </p>
-              </div>
-
-              {/* 全文匹配率 */}
-              <div className="text-center p-4 bg-slate-50 rounded-2xl flex flex-col items-center justify-center">
-                {fullMatchPct !== null ? (
-                  <>
-                    <div className={`w-16 h-16 rounded-full flex items-center justify-center border-4 ${
-                      fullMatchPct >= 80 ? 'border-emerald-500 text-emerald-700' : fullMatchPct >= 60 ? 'border-amber-500 text-amber-700' : 'border-red-400 text-red-600'
-                    }`}>
-                      <span className="text-lg font-black">{fullMatchPct}%</span>
-                    </div>
-                    <p className="text-xs text-gray-500 font-bold mt-1">全文匹配</p>
-                    {fullReadingResult?.cpm != null && (
-                      <p className="text-[10px] text-gray-400 mt-0.5">{fullReadingResult.cpm} 正確字數/分鐘</p>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <span className="text-3xl font-black text-gray-300">--</span>
-                    <p className="text-xs text-gray-400 font-bold mt-1">全文匹配</p>
-                  </>
+            {/* KPI Cards — teacher view shows 3 cards with numbers; student view shows encouragement */}
+            {hideScores ? (
+              <div className="bg-accent/5 rounded-2xl p-6 text-center space-y-2">
+                <p className="text-lg font-bold text-accent">{encourageAccuracy(accuracy)}</p>
+                {readingAttempt && (
+                  <p className="text-sm text-gray-600">{encourageReadingSpeed()}</p>
                 )}
               </div>
-            </div>
+            ) : (
+              <div className="grid grid-cols-3 gap-4">
+                {/* 準確度 */}
+                <div className="text-center p-4 bg-slate-50 rounded-2xl">
+                  <div className="w-24 h-24 mx-auto relative">
+                    <SafeResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie data={scoreData} innerRadius={30} outerRadius={42} paddingAngle={5} dataKey="value" startAngle={90} endAngle={-270}>
+                          {scoreData.map((entry, i) => <Cell key={i} fill={entry.color} />)}
+                        </Pie>
+                      </PieChart>
+                    </SafeResponsiveContainer>
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <span className="text-lg font-black text-accent">{accuracy}%</span>
+                    </div>
+                  </div>
+                  <p className="text-xs text-gray-500 font-bold mt-1">逐段準確度</p>
+                </div>
 
-            {/* Speed feedback */}
-            {readingAttempt && (
+                {/* 語速 CPM */}
+                <div className="text-center p-4 bg-slate-50 rounded-2xl flex flex-col items-center justify-center">
+                  <span className="text-3xl font-black text-gray-900">{cpm}</span>
+                  <span className="text-xs text-gray-500 font-bold">正確字數/分鐘</span>
+                  <div className="flex gap-0.5 mt-2 w-full max-w-[120px]">
+                    {speedSegments.map((seg, idx) => (
+                      <div key={idx} className={`flex-1 h-1.5 rounded-sm ${idx === currentSegment ? seg.color : 'bg-gray-200'}`} />
+                    ))}
+                  </div>
+                  <p className="text-[10px] text-gray-400 mt-1">
+                    {speedSegments[currentSegment]?.label}
+                  </p>
+                </div>
+
+                {/* 全文匹配率 */}
+                <div className="text-center p-4 bg-slate-50 rounded-2xl flex flex-col items-center justify-center">
+                  {fullMatchPct !== null ? (
+                    <>
+                      <div className={`w-16 h-16 rounded-full flex items-center justify-center border-4 ${
+                        fullMatchPct >= 80 ? 'border-emerald-500 text-emerald-700' : fullMatchPct >= 60 ? 'border-amber-500 text-amber-700' : 'border-red-400 text-red-600'
+                      }`}>
+                        <span className="text-lg font-black">{fullMatchPct}%</span>
+                      </div>
+                      <p className="text-xs text-gray-500 font-bold mt-1">全文匹配</p>
+                      {fullReadingResult?.cpm != null && (
+                        <p className="text-[10px] text-gray-400 mt-0.5">{fullReadingResult.cpm} 正確字數/分鐘</p>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <span className="text-3xl font-black text-gray-300">--</span>
+                      <p className="text-xs text-gray-400 font-bold mt-1">全文匹配</p>
+                    </>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Speed feedback — text-based encouragement, shown in both views */}
+            {readingAttempt && !hideScores && (
               <p className="text-sm text-gray-600 text-center">{getCpmFeedback(cpm).text}</p>
             )}
-            {story?.readingBenchmark && (() => {
+            {!hideScores && story?.readingBenchmark && (() => {
               const levels = parseReadingBenchmark(story.readingBenchmark.levels);
               const benchCpm = fullReadingResult?.cpm ?? cpm;
               const benchFeedback = getBenchmarkFeedback(benchCpm, levels);
@@ -500,8 +521,8 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
               ) : null;
             })()}
 
-            {/* Goal achievement (Issue #84) — only shown when an assignment has goals */}
-            {readingGoals && (
+            {/* Goal achievement (Issue #84) — hidden for students (numbers-based) */}
+            {readingGoals && !hideScores && (
               <GoalAchievementCard
                 effectiveCpm={readingGoals.effectiveCpm}
                 effectiveAccuracy={readingGoals.effectiveAccuracy}
@@ -529,8 +550,8 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
               </div>
             )}
 
-            {/* 4 category cards */}
-            {lineBreakdown.length > 0 && (
+            {/* 4 category cards — hidden for students (Issue #1094) */}
+            {lineBreakdown.length > 0 && !hideScores && (
               <div>
                 <p className="text-xs text-gray-500 font-bold mb-2">朗讀分析</p>
                 <div className="grid grid-cols-4 gap-3">
@@ -586,10 +607,14 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
                         <p className="text-sm text-gray-700 truncate">{line.transcript || '（未朗讀）'}</p>
                       </div>
                       <div className="flex items-center gap-3 shrink-0">
-                        <span className={`text-sm font-bold ${pct >= 80 ? 'text-emerald-600' : pct >= 60 ? 'text-amber-600' : 'text-red-500'}`}>
-                          {pct}%
-                        </span>
-                        <span className="text-xs text-gray-400">{line.cpm} 字/分</span>
+                        {!hideScores && (
+                          <>
+                            <span className={`text-sm font-bold ${pct >= 80 ? 'text-emerald-600' : pct >= 60 ? 'text-amber-600' : 'text-red-500'}`}>
+                              {pct}%
+                            </span>
+                            <span className="text-xs text-gray-400">{line.cpm} 字/分</span>
+                          </>
+                        )}
                         <svg className={`w-4 h-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
                         </svg>
@@ -598,12 +623,14 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
                     {isExpanded && line.diffTokens && (
                       <div className="px-6 pb-4 pt-1">
                         <DiffDisplay tokens={line.diffTokens} showLegend className="text-lg" />
-                        <div className="flex gap-4 mt-3 text-xs text-gray-400">
-                          <span>正確: {line.diffTokens.filter(t => t.type === 'correct').length} 字</span>
-                          <span>讀錯: {line.diffTokens.filter(t => t.type === 'wrong').length} 字</span>
-                          <span>漏讀: {line.diffTokens.filter(t => t.type === 'missing').length} 字</span>
-                          <span>多讀: {line.diffTokens.filter(t => t.type === 'extra').length} 字</span>
-                        </div>
+                        {!hideScores && (
+                          <div className="flex gap-4 mt-3 text-xs text-gray-400">
+                            <span>正確: {line.diffTokens.filter(t => t.type === 'correct').length} 字</span>
+                            <span>讀錯: {line.diffTokens.filter(t => t.type === 'wrong').length} 字</span>
+                            <span>漏讀: {line.diffTokens.filter(t => t.type === 'missing').length} 字</span>
+                            <span>多讀: {line.diffTokens.filter(t => t.type === 'extra').length} 字</span>
+                          </div>
+                        )}
                       </div>
                     )}
                   </div>
@@ -616,7 +643,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
               <div className="border-t border-slate-200 px-6 py-4">
                 <p className="text-xs text-gray-500 font-bold mb-2">全文朗讀比對</p>
                 <DiffDisplay tokens={fullReadingResult.diffTokens} showLegend className="text-lg" />
-                {fullReadingResult.errorBreakdown && (
+                {fullReadingResult.errorBreakdown && !hideScores && (
                   <div className="flex gap-4 mt-3 text-xs text-gray-400">
                     <span>正確: {fullReadingResult.errorBreakdown.correct} 字</span>
                     <span>讀錯: {fullReadingResult.errorBreakdown.wrong} 字</span>
@@ -737,6 +764,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
             evaluativeScore={comprehensionScores?.evaluative_score ?? 0}
             feedback={comprehensionScores?.feedback ?? null}
             loading={comprehensionScoresLoading}
+            hideScores={hideScores}
           />
         ) : (
           <div className="p-6 bg-gray-50 rounded-2xl text-center">
@@ -764,7 +792,9 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
                     <div className="flex-1 bg-gray-200 rounded-full h-2">
                       <div className="bg-accent h-2 rounded-full transition-all" style={{ width: vocabResult.totalWords > 0 ? `${Math.round((vocabResult.practicedWords.length / vocabResult.totalWords) * 100)}%` : '0%' }} />
                     </div>
-                    <span className="text-xs font-bold text-gray-600">{vocabResult.practicedWords.length}/{vocabResult.totalWords}</span>
+                    {!hideScores && (
+                      <span className="text-xs font-bold text-gray-600">{vocabResult.practicedWords.length}/{vocabResult.totalWords}</span>
+                    )}
                   </div>
                   {vocabResult.practicedWords.length > 0 && (
                     <div className="flex flex-wrap gap-1">
@@ -796,17 +826,25 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
                         style={{ width: dictationResult.totalWords > 0 ? `${Math.round((dictationResult.correctCount / dictationResult.totalWords) * 100)}%` : '0%' }}
                       />
                     </div>
-                    <span className="text-xs font-bold text-gray-600">{dictationResult.correctCount}/{dictationResult.totalWords}</span>
-                  </div>
-                  <div className="flex gap-3 text-xs text-gray-500">
-                    <span className="text-emerald-600 font-medium">正確 {dictationResult.correctCount}</span>
-                    {dictationResult.incorrectCount > 0 && (
-                      <span className="text-red-500 font-medium">錯誤 {dictationResult.incorrectCount}</span>
-                    )}
-                    {dictationResult.skippedCount > 0 && (
-                      <span className="text-gray-400">跳過 {dictationResult.skippedCount}</span>
+                    {!hideScores && (
+                      <span className="text-xs font-bold text-gray-600">{dictationResult.correctCount}/{dictationResult.totalWords}</span>
                     )}
                   </div>
+                  {hideScores ? (
+                    <p className="text-xs text-emerald-600 font-medium">
+                      {encourageQuiz(dictationResult.correctCount, dictationResult.totalWords)}
+                    </p>
+                  ) : (
+                    <div className="flex gap-3 text-xs text-gray-500">
+                      <span className="text-emerald-600 font-medium">正確 {dictationResult.correctCount}</span>
+                      {dictationResult.incorrectCount > 0 && (
+                        <span className="text-red-500 font-medium">錯誤 {dictationResult.incorrectCount}</span>
+                      )}
+                      {dictationResult.skippedCount > 0 && (
+                        <span className="text-gray-400">跳過 {dictationResult.skippedCount}</span>
+                      )}
+                    </div>
+                  )}
                   {dictationResult.results.some(r => !r.isCorrect && !r.skipped) && (
                     <div className="mt-2 space-y-1">
                       <p className="text-[10px] text-gray-400 font-medium uppercase tracking-wide">答錯的詞語</p>
@@ -841,12 +879,16 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
                     <div className="flex-1 bg-gray-200 rounded-full h-2">
                       <div className="bg-emerald-500 h-2 rounded-full transition-all" style={{ width: `${Math.min(100, Math.round((comprehensionResult.understoodCount / Math.max(comprehensionResult.requiredCount, 1)) * 100))}%` }} />
                     </div>
-                    <span className="text-xs font-bold text-gray-600">{comprehensionResult.understoodCount}/{comprehensionResult.requiredCount}</span>
+                    {!hideScores && (
+                      <span className="text-xs font-bold text-gray-600">{comprehensionResult.understoodCount}/{comprehensionResult.requiredCount}</span>
+                    )}
                   </div>
-                  <div className="flex gap-3 text-xs text-gray-500">
-                    <span>對話 {comprehensionResult.conversationLength} 回</span>
-                    <span>理解率 {Math.round((comprehensionResult.understoodCount / Math.max(comprehensionResult.requiredCount, 1)) * 100)}%</span>
-                  </div>
+                  {!hideScores && (
+                    <div className="flex gap-3 text-xs text-gray-500">
+                      <span>對話 {comprehensionResult.conversationLength} 回</span>
+                      <span>理解率 {Math.round((comprehensionResult.understoodCount / Math.max(comprehensionResult.requiredCount, 1)) * 100)}%</span>
+                    </div>
+                  )}
                 </div>
               ) : (
                 <p className="text-xs text-gray-400 text-center py-2">未完成</p>
@@ -867,8 +909,8 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
         />
       )}
 
-      {/* ============ 朗讀進步曲線 (#909) ============ */}
-      {readingHistory.length >= 2 && (
+      {/* ============ 朗讀進步曲線 (#909) — 學生端隱藏（Issue #1094，數據曲線屬教師觀察用） ============ */}
+      {!hideScores && readingHistory.length >= 2 && (
         <Section number={8} title="朗讀進步曲線" defaultOpen={true}>
           <div className="space-y-4">
             <p className="text-sm text-gray-500">

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -295,7 +295,11 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 <div className="flex items-center justify-between mb-2">
                   <span className="text-xs font-headline font-bold text-on-surface-variant">閱讀理解度</span>
                   <span className="text-xs font-headline font-bold text-accent">
-                    {completedCount === totalTabs ? '全部完成！' : '繼續加油'}
+                    {completedCount === totalTabs
+                      ? '全部完成！'
+                      : totalTabs > 0 && completedCount / totalTabs >= 0.5
+                        ? '過半了，快到了！'
+                        : '繼續加油'}
                   </span>
                 </div>
                 <div className="h-2 bg-surface-container-high rounded-full overflow-hidden">

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -229,7 +229,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               <span className="material-symbols-outlined text-3xl text-emerald-600">check_circle</span>
             </div>
             <p className="text-emerald-700 font-headline font-bold">選擇題已完成</p>
-            <p className="text-sm text-on-surface-variant">答對 {mcqScore} / {mcqTotal} 題</p>
+            <p className="text-sm text-on-surface-variant">
+              {mcqTotal > 0 && mcqScore === mcqTotal ? '全部答對，太棒了！' : '你完成了，繼續加油！'}
+            </p>
             <button
               onClick={handleMcqRedo}
               className="px-5 py-2.5 rounded-full text-sm font-bold bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest transition-all"
@@ -292,7 +294,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               <div className="mt-4 pt-4 border-t border-surface-container-high shrink-0">
                 <div className="flex items-center justify-between mb-2">
                   <span className="text-xs font-headline font-bold text-on-surface-variant">閱讀理解度</span>
-                  <span className="text-xs font-headline font-bold text-accent">{progressPercent}%</span>
+                  <span className="text-xs font-headline font-bold text-accent">
+                    {completedCount === totalTabs ? '全部完成！' : '繼續加油'}
+                  </span>
                 </div>
                 <div className="h-2 bg-surface-container-high rounded-full overflow-hidden">
                   <div

--- a/frontend/src/components/reading-steps/ComprehensionScoreCard.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionScoreCard.tsx
@@ -8,6 +8,8 @@ interface ComprehensionScoreCardProps {
   evaluativeScore: number;
   feedback: ComprehensionScoreFeedback | null;
   loading?: boolean;
+  /** Issue #1094: hide numeric scores in student-facing view; show encouragement only */
+  hideScores?: boolean;
 }
 
 const levelConfig = [
@@ -54,6 +56,7 @@ const ComprehensionScoreCard: React.FC<ComprehensionScoreCardProps> = ({
   evaluativeScore,
   feedback,
   loading = false,
+  hideScores = false,
 }) => {
   if (loading) {
     return (
@@ -87,35 +90,39 @@ const ComprehensionScoreCard: React.FC<ComprehensionScoreCardProps> = ({
       {/* Header with overall score */}
       <div className="bg-gradient-to-r from-accent/5 to-violet-50 px-6 py-5 border-b border-slate-100">
         <div className="flex items-center gap-4">
-          {/* Score circle */}
-          <div className="relative w-16 h-16 shrink-0">
-            <svg className="w-16 h-16 -rotate-90" viewBox="0 0 64 64">
-              <circle
-                cx="32" cy="32" r="28"
-                fill="none"
-                stroke="#e2e8f0"
-                strokeWidth="4"
-              />
-              <circle
-                cx="32" cy="32" r="28"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="4"
-                strokeDasharray={`${(comprehensionScore / 100) * 175.93} 175.93`}
-                strokeLinecap="round"
-                className="text-accent transition-all duration-1000"
-              />
-            </svg>
-            <div className="absolute inset-0 flex items-center justify-center">
-              <span className="text-lg font-black text-gray-900">{Math.round(comprehensionScore)}</span>
+          {/* Score circle — teacher view only; student view just shows title + encouragement */}
+          {!hideScores && (
+            <div className="relative w-16 h-16 shrink-0">
+              <svg className="w-16 h-16 -rotate-90" viewBox="0 0 64 64">
+                <circle
+                  cx="32" cy="32" r="28"
+                  fill="none"
+                  stroke="#e2e8f0"
+                  strokeWidth="4"
+                />
+                <circle
+                  cx="32" cy="32" r="28"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                  strokeDasharray={`${(comprehensionScore / 100) * 175.93} 175.93`}
+                  strokeLinecap="round"
+                  className="text-accent transition-all duration-1000"
+                />
+              </svg>
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="text-lg font-black text-gray-900">{Math.round(comprehensionScore)}</span>
+              </div>
             </div>
-          </div>
+          )}
 
           <div>
             <h3 className="text-lg font-bold text-gray-900">課文理解力評估</h3>
-            <p className={`text-sm font-bold ${overallLevel.textColor}`}>
-              {overallLevel.label}
-            </p>
+            {!hideScores && (
+              <p className={`text-sm font-bold ${overallLevel.textColor}`}>
+                {overallLevel.label}
+              </p>
+            )}
             {feedback?.overall && (
               <p className="text-xs text-gray-500 mt-1">{feedback.overall}</p>
             )}
@@ -138,8 +145,16 @@ const ComprehensionScoreCard: React.FC<ComprehensionScoreCardProps> = ({
                   <span className="text-xs text-gray-400 ml-2">{level.description}</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className={`text-xs font-bold ${scoreLevel.textColor}`}>{scoreLevel.label}</span>
-                  <span className="text-lg font-black text-gray-900">{Math.round(score)}</span>
+                  {hideScores ? (
+                    <span className={`text-xs font-bold ${scoreLevel.textColor}`}>
+                      {score >= 60 ? '達成' : '再努力'}
+                    </span>
+                  ) : (
+                    <>
+                      <span className={`text-xs font-bold ${scoreLevel.textColor}`}>{scoreLevel.label}</span>
+                      <span className="text-lg font-black text-gray-900">{Math.round(score)}</span>
+                    </>
+                  )}
                 </div>
               </div>
 

--- a/frontend/src/components/reading-steps/ExitTicket.tsx
+++ b/frontend/src/components/reading-steps/ExitTicket.tsx
@@ -400,7 +400,7 @@ const ExitTicket: React.FC<ExitTicketProps> = ({
                 ? 'bg-emerald-100 text-emerald-700'
                 : 'bg-amber-100 text-amber-700'
             }`}>
-              {correctCount}/{questions.length}
+              {correctCount === questions.length ? '全部答對！' : '已完成'}
             </span>
           )}
         </div>
@@ -490,11 +490,11 @@ const ExitTicket: React.FC<ExitTicketProps> = ({
                 {correctCount === questions.length ? '🎉' : '💪'}
               </p>
               <p className="font-bold text-gray-900 mt-1">
-                {correctCount}/{questions.length} 題正確
+                {correctCount === questions.length ? '太棒了，全部答對！' : '你完成了！'}
               </p>
               <p className="text-sm text-gray-500 mt-0.5">
                 {correctCount === questions.length
-                  ? '太棒了！全部答對！'
+                  ? '繼續保持！'
                   : '沒關係，多練習幾次就會進步！'}
               </p>
             </div>

--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -235,7 +235,7 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
               </span>
             </div>
             <p className="text-2xl font-headline font-black text-on-surface mb-1">
-              {allCorrect ? '全部答對！' : `一次答對 ${firstTryScore}／${firstTryTotal} 題`}
+              {allCorrect ? '全部答對！' : '你完成了！'}
             </p>
             <p className="text-sm text-on-surface-variant">
               {allCorrect ? '每一題都一次答對，表現優異！' : '以下是各題的作答結果'}

--- a/frontend/src/components/reading-steps/FloatingAIHelper.tsx
+++ b/frontend/src/components/reading-steps/FloatingAIHelper.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useRef, useState, useEffect } from 'react';
 import { sendComprehensionChat, SessionExpiredError } from '../../services/learningApi';
 import { useAuth } from '../../contexts/AuthContext';
+import VoiceInputButton from '../ui/VoiceInputButton';
 
 interface FloatingAIHelperProps {
   storyTitle: string;
@@ -179,6 +180,11 @@ const FloatingAIHelper: React.FC<FloatingAIHelperProps> = ({
               rows={1}
               disabled={isLoading}
               className="flex-1 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none disabled:opacity-50"
+            />
+            <VoiceInputButton
+              onTranscript={(text) => setInputText(text)}
+              disabled={isLoading}
+              size="sm"
             />
             <button
               onClick={handleSend}

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -11,7 +11,7 @@ import { getReadingHistory, type ReadingHistoryPoint } from '../../services/lear
 import { saveReadingHistory } from '../../services/readingHistoryApi';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
 import { useAuth } from '../../contexts/AuthContext';
-import { LineChart, Line, XAxis, YAxis, Tooltip, ReferenceLine, ResponsiveContainer } from 'recharts';
+import { encourageAccuracy } from '../../utils/encouragement';
 
 /* ------------------------------------------------------------------ */
 
@@ -375,48 +375,23 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack }) =>
           {/* ── Result section ──────────────────────────────────────── */}
           {result && (
             <div className="mt-6 space-y-6">
-              {/* Score */}
+              {/* Encouragement panel — Issue #1094: no numeric score/accuracy/CPM for students */}
               <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 flex flex-col items-center gap-4">
-                <div className={`w-28 h-28 rounded-full flex items-center justify-center border-4 ${
-                  percent >= 80 ? 'border-emerald-500'
-                  : percent >= 60 ? 'border-amber-500'
-                  : 'border-tertiary'
+                <div className={`w-28 h-28 rounded-full flex items-center justify-center ${
+                  percent >= 80 ? 'bg-emerald-100'
+                  : percent >= 60 ? 'bg-amber-100'
+                  : 'bg-tertiary-container/30'
                 }`}>
-                  <span className={`text-3xl font-headline font-black ${
-                    percent >= 80 ? 'text-emerald-700'
-                    : percent >= 60 ? 'text-amber-700'
-                    : 'text-tertiary'
-                  }`}>{percent}%</span>
+                  <span className="material-symbols-outlined text-5xl" aria-hidden="true">
+                    {percent >= 80 ? 'celebration' : percent >= 60 ? 'thumb_up' : 'favorite'}
+                  </span>
                 </div>
-                <p className={`text-base font-headline font-bold text-center ${
-                  percent >= 80 ? 'text-emerald-700'
-                  : percent >= 60 ? 'text-amber-700'
-                  : 'text-on-surface-variant'
-                }`}>
+                <p className="text-xl font-headline font-bold text-on-surface text-center">
+                  {encourageAccuracy(percent)}
+                </p>
+                <p className="text-base font-headline text-on-surface-variant text-center">
                   {result.feedback}
                 </p>
-              </div>
-
-              {/* Stats grid */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div className="bg-surface-container-low p-5 rounded-3xl flex items-center gap-4">
-                  <div className="w-12 h-12 rounded-full bg-emerald-100 flex items-center justify-center shrink-0">
-                    <span className="material-symbols-outlined text-xl text-emerald-700">speed</span>
-                  </div>
-                  <div>
-                    <div className="font-headline text-on-surface-variant font-bold text-xs uppercase tracking-wider">語速</div>
-                    <div className="text-lg font-headline font-bold text-on-surface mt-0.5">{result.cpm} 字/分</div>
-                  </div>
-                </div>
-                <div className="bg-surface-container-low p-5 rounded-3xl flex items-center gap-4">
-                  <div className="w-12 h-12 rounded-full bg-accent/10 flex items-center justify-center shrink-0">
-                    <span className="material-symbols-outlined text-xl text-accent">verified</span>
-                  </div>
-                  <div>
-                    <div className="font-headline text-on-surface-variant font-bold text-xs uppercase tracking-wider">準確度</div>
-                    <div className="text-lg font-headline font-bold text-on-surface mt-0.5">{percent}%</div>
-                  </div>
-                </div>
               </div>
 
               {/* Transcript */}
@@ -443,44 +418,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack }) =>
                 </div>
               )}
 
-              {/* Reading progress curve (#909) */}
+              {/* Reading progress curve — Issue #1094: 學生端隱藏數據曲線（教師後台可見） */}
               {readingHistory.length >= 1 && (
-                <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
-                  <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">
-                    朗讀進步曲線
-                    {readingHistory.length >= 2 && (() => {
-                      const first = readingHistory[0]?.cpm;
-                      const last = readingHistory[readingHistory.length - 1]?.cpm;
-                      if (first && last && first > 0) {
-                        const pct = Math.round(((last - first) / first) * 100);
-                        return pct > 0
-                          ? <span className="ml-1 text-emerald-600">▲{pct}%</span>
-                          : pct < 0 ? <span className="ml-1 text-tertiary">▼{Math.abs(pct)}%</span> : null;
-                      }
-                      return null;
-                    })()}
-                  </p>
-                  <ResponsiveContainer width="100%" height={160}>
-                    <LineChart data={readingHistory.map((h, i) => ({
-                      attempt: `第${i + 1}次`,
-                      cpm: h.cpm,
-                      accuracy: h.accuracy,
-                    }))}>
-                      <XAxis dataKey="attempt" tick={{ fontSize: 11 }} />
-                      <YAxis yAxisId="cpm" tick={{ fontSize: 11 }} width={32} />
-                      <Tooltip
-                        formatter={(value: number, name: string) => [
-                          name === 'cpm' ? `${value} 字/分` : `${value}%`,
-                          name === 'cpm' ? '語速' : '準確度',
-                        ]}
-                      />
-                      <ReferenceLine yAxisId="cpm" y={90} stroke="#ef4444" strokeDasharray="6 3" label={{ value: '目標 90', position: 'right', fill: '#ef4444', fontSize: 10 }} />
-                      <Line yAxisId="cpm" type="monotone" dataKey="cpm" stroke="#564ABF" strokeWidth={2.5} dot={{ r: 3, fill: '#564ABF' }} name="cpm" />
-                      <Line yAxisId="cpm" type="monotone" dataKey="accuracy" stroke="#006947" strokeWidth={2} dot={{ r: 3, fill: '#006947' }} strokeDasharray="4 2" name="accuracy" />
-                    </LineChart>
-                  </ResponsiveContainer>
-                  <p className="text-xs text-on-surface-variant text-center mt-2">
-                    本篇已練習 {readingHistory.length} 次
+                <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 text-center">
+                  <p className="text-sm font-headline text-on-surface">
+                    本篇已練習 {readingHistory.length} 次，繼續加油！
                   </p>
                 </div>
               )}

--- a/frontend/src/components/reading-steps/ListeningPractice.tsx
+++ b/frontend/src/components/reading-steps/ListeningPractice.tsx
@@ -14,6 +14,7 @@ import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { useAuth } from '../../contexts/AuthContext';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { speakTextWithProgress, cancelTts, TtsProgressInfo } from '../../services/ttsApi';
+import { encourageAccuracy } from '../../utils/encouragement';
 
 export interface ListeningResult {
   score: number;
@@ -49,14 +50,6 @@ function scoreColour(score: number): string {
   if (score >= 80) return 'text-emerald-700';
   if (score >= 60) return 'text-amber-700';
   return 'text-tertiary';
-}
-
-function scoreLabel(score: number): string {
-  if (score >= 90) return '非常優秀！';
-  if (score >= 75) return '表現良好';
-  if (score >= 60) return '尚可，繼續加油';
-  if (score >= 45) return '需要多練習';
-  return '請再聽一次試試看';
 }
 
 const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, onBack }) => {
@@ -342,7 +335,7 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
                     {evalResult.score >= 80 ? 'celebration' : evalResult.score >= 60 ? 'thumb_up' : 'favorite'}
                   </span>
                 </div>
-                <p className={`text-lg font-headline font-bold ${scoreColour(evalResult.score)}`}>{scoreLabel(evalResult.score)}</p>
+                <p className={`text-lg font-headline font-bold ${scoreColour(evalResult.score)}`}>{encourageAccuracy(evalResult.score)}</p>
                 <p className="text-sm text-on-surface-variant text-center leading-relaxed">{evalResult.feedback}</p>
               </div>
 

--- a/frontend/src/components/reading-steps/ListeningPractice.tsx
+++ b/frontend/src/components/reading-steps/ListeningPractice.tsx
@@ -333,12 +333,14 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
           {/* ── Phase 3: Results ──────────────────────────────────── */}
           {phase === 'results' && evalResult && (
             <>
-              {/* Score card */}
+              {/* Feedback card — Issue #1094: 學生端不顯示分數，只保留鼓勵文字 + AI 回饋 */}
               <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 mt-4 flex flex-col items-center gap-4">
-                <div className={`w-28 h-28 rounded-full flex items-center justify-center border-4 ${
-                  evalResult.score >= 80 ? 'border-emerald-500' : evalResult.score >= 60 ? 'border-amber-500' : 'border-tertiary'
+                <div className={`w-20 h-20 rounded-full flex items-center justify-center ${
+                  evalResult.score >= 80 ? 'bg-emerald-100' : evalResult.score >= 60 ? 'bg-amber-100' : 'bg-tertiary-container/30'
                 }`}>
-                  <span className={`text-3xl font-headline font-black ${scoreColour(evalResult.score)}`}>{evalResult.score}</span>
+                  <span className="material-symbols-outlined text-4xl" aria-hidden="true">
+                    {evalResult.score >= 80 ? 'celebration' : evalResult.score >= 60 ? 'thumb_up' : 'favorite'}
+                  </span>
                 </div>
                 <p className={`text-lg font-headline font-bold ${scoreColour(evalResult.score)}`}>{scoreLabel(evalResult.score)}</p>
                 <p className="text-sm text-on-surface-variant text-center leading-relaxed">{evalResult.feedback}</p>

--- a/frontend/src/components/reading-steps/MultipleChoiceExercise.tsx
+++ b/frontend/src/components/reading-steps/MultipleChoiceExercise.tsx
@@ -47,10 +47,10 @@ const MultipleChoiceExercise: React.FC<Props> = ({ questions, onComplete }) => {
   return (
     <div className="flex flex-col gap-4 p-4 max-w-2xl mx-auto"
       style={{ fontFamily: zhuyinActive ? "'BpmfZihiSans', 'Noto Sans TC', sans-serif" : undefined }}>
-      {/* Progress */}
+      {/* Progress — Issue #1094: 學生端不顯示「答對 N 題」數字 */}
       <div className="flex items-center justify-between text-sm text-gray-500">
         <span>第 {current + 1} 題／共 {questions.length} 題</span>
-        <span>答對：{score} 題</span>
+        <span>繼續加油！</span>
       </div>
       <div className="w-full bg-gray-200 rounded-full h-1.5">
         <div

--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -20,6 +20,7 @@ import {
   type ExampleSentence,
   type ExampleSentenceSource,
 } from '../../services/learningApi';
+import VoiceInputButton from '../ui/VoiceInputButton';
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -492,6 +493,10 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
                     : entry.status === 'incorrect' ? 'border-tertiary/40 bg-tertiary-container/10 text-on-surface'
                     : 'border-surface-container-high bg-transparent focus:border-accent text-on-surface'
                   }`}
+                />
+                <VoiceInputButton
+                  onTranscript={(text) => updateSentenceText(idx, text)}
+                  disabled={entry.status === 'loading' || isCurrentDone}
                 />
                 <button
                   onClick={() => handleValidate(idx)}

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -375,7 +375,7 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
                 : 'bg-amber-100 text-amber-700'
             }`}
           >
-            {score >= 80 ? '🎉' : '💪'} {score} 分
+            {score >= 80 ? '🎉 表現超棒！' : '💪 繼續加油'}
           </span>
         )}
       </div>

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -224,9 +224,11 @@ function SummaryScreen({
           </span>
         </div>
         <p className="text-2xl font-headline font-black text-on-surface mb-1">
-          {allCorrect ? '全部答對！' : `答對 ${correctCount} / ${total} 題`}
+          {allCorrect ? '全部答對！' : '你完成了！'}
         </p>
-        <p className="text-sm text-on-surface-variant">正確率 {pct}%</p>
+        <p className="text-sm text-on-surface-variant">
+          {allCorrect ? '太厲害了，繼續保持！' : '有答對一些，再試一次會更好'}
+        </p>
       </div>
 
       {renderResultSection('第一關：選擇題', mcAnswers, 'multiple-choice')}

--- a/frontend/src/components/reading-steps/ZhuyinPhoneticGame.tsx
+++ b/frontend/src/components/reading-steps/ZhuyinPhoneticGame.tsx
@@ -194,8 +194,7 @@ function ScoreBanner({ score, total, onFinish, onRetry }: ScoreBannerProps) {
             {isGreat ? '太厲害了！' : '繼續加油！'}
           </h3>
           <p className="text-gray-500 text-sm mt-1">
-            答對 <span className="font-bold text-indigo-600">{score}</span> / {total} 題
-            （{pct}%）
+            {isGreat ? '幾乎全對，超級棒！' : '有答對一些，再試一次會更好'}
           </p>
         </div>
         <div className="w-full bg-gray-100 rounded-full h-3 overflow-hidden">
@@ -388,8 +387,8 @@ function PickGame({ mode, questions, onFinish, onBack }: PickGameProps) {
           })}
         </div>
 
-        {/* Score */}
-        <p className="text-xs text-gray-400">目前得分：{score} 分</p>
+        {/* Encouragement — Issue #1094: 學生端不顯示得分數字 */}
+        <p className="text-xs text-gray-400">繼續加油！</p>
       </div>
     </div>
   );
@@ -578,7 +577,7 @@ function ComposeGame({ questions, onFinish, onBack }: ComposeGameProps) {
           >
             清除重拼
           </button>
-          <span className="text-xs text-gray-400">得分：{score}</span>
+          <span className="text-xs text-gray-400">加油！</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -866,27 +866,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
             />
           </div>
 
-          {/* Stats grid — CPM + Accuracy placeholders */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-10">
-            <div className="bg-surface-container-low p-6 rounded-3xl flex items-center gap-5">
-              <div className="w-14 h-14 rounded-full bg-emerald-100 flex items-center justify-center shrink-0">
-                <span className="material-symbols-outlined text-2xl text-emerald-700">speed</span>
-              </div>
-              <div>
-                <div className="font-headline text-on-surface-variant font-bold text-xs uppercase tracking-wider">語速 Reading Speed</div>
-                <div className="text-lg font-headline font-bold text-on-surface-variant mt-0.5">開發中</div>
-              </div>
-            </div>
-            <div className="bg-surface-container-low p-6 rounded-3xl flex items-center gap-5">
-              <div className="w-14 h-14 rounded-full bg-accent/10 flex items-center justify-center shrink-0">
-                <span className="material-symbols-outlined text-2xl text-accent">verified</span>
-              </div>
-              <div>
-                <div className="font-headline text-on-surface-variant font-bold text-xs uppercase tracking-wider">準確度 Accuracy</div>
-                <div className="text-lg font-headline font-bold text-on-surface-variant mt-0.5">開發中</div>
-              </div>
-            </div>
-          </div>
+          {/* Issue #1094: 原「語速 / 準確度」佔位卡移除 — 學生端不顯示數據欄位；
+              教師後台（AssessmentReport readOnly）已有完整語速與準確度 */}
         </div>
       </div>
 

--- a/frontend/src/components/student/StudentProgressDashboard.tsx
+++ b/frontend/src/components/student/StudentProgressDashboard.tsx
@@ -76,12 +76,10 @@ interface TooltipProps {
 const ChartTooltip: React.FC<TooltipProps> = ({ active, payload, label }) => {
   if (!active || !payload?.length) return null;
   const sessions = payload.find((p) => p.name === 'sessions')?.value ?? 0;
-  const score = payload.find((p) => p.name === 'score')?.value;
   return (
     <div className="bg-surface-container-lowest border border-[#E5E0D5] rounded-xl shadow-editorial px-3 py-2 text-xs">
       <p className="font-medium text-on-surface mb-1">{label}</p>
       <p className="text-on-surface-variant">完成：{sessions} 篇</p>
-      {score != null && <p className="text-accent font-medium">平均分：{score}%</p>}
     </div>
   );
 };
@@ -182,25 +180,20 @@ const StudentProgressDashboard: React.FC<StudentProgressDashboardProps> = ({
           sub={`共 ${data.total_sessions} 次練習`}
           icon={<span>📚</span>}
         />
-        <StatCard
-          label="平均分數"
-          value={data.avg_score != null ? `${data.avg_score}%` : '—'}
-          sub={data.avg_score != null ? '綜合評量' : '尚無記錄'}
-          icon={<span>⭐</span>}
-        />
+        {/* Issue #1094: 學生端不顯示平均分數；改顯示鼓勵圖示（或省略整張卡） */}
       </div>
 
       {/* New student hint */}
       {isNewStudent && <NewStudentHint />}
 
-      {/* 30-day activity chart */}
+      {/* 30-day activity chart — Issue #1094: 學生端改顯示完成篇數曲線，不顯示平均分數 */}
       {hasActivity && (
         <div className="bg-surface-container-lowest rounded-2xl border border-[#E5E0D5] p-4">
           <h3 className="text-sm font-semibold text-on-surface mb-3">近 30 天學習曲線</h3>
           <ResponsiveContainer width="100%" height={120}>
             <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -24, bottom: 0 }}>
               <defs>
-                <linearGradient id="scoreGradient" x1="0" y1="0" x2="0" y2="1">
+                <linearGradient id="sessionsGradient" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="#5B4FC4" stopOpacity={0.3} />
                   <stop offset="95%" stopColor="#5B4FC4" stopOpacity={0} />
                 </linearGradient>
@@ -214,7 +207,7 @@ const StudentProgressDashboard: React.FC<StudentProgressDashboardProps> = ({
                 axisLine={false}
               />
               <YAxis
-                domain={[0, 100]}
+                allowDecimals={false}
                 tick={{ fontSize: 10, fill: '#9ca3af' }}
                 tickLine={false}
                 axisLine={false}
@@ -222,11 +215,11 @@ const StudentProgressDashboard: React.FC<StudentProgressDashboardProps> = ({
               <Tooltip content={<ChartTooltip />} />
               <Area
                 type="monotone"
-                dataKey="score"
-                name="score"
+                dataKey="sessions"
+                name="sessions"
                 stroke="#5B4FC4"
                 strokeWidth={2}
-                fill="url(#scoreGradient)"
+                fill="url(#sessionsGradient)"
                 dot={false}
                 connectNulls
               />

--- a/frontend/src/components/ui/VoiceInputButton.tsx
+++ b/frontend/src/components/ui/VoiceInputButton.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useRef } from 'react';
+import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
+
+interface VoiceInputButtonProps {
+  /** Called with the full accumulated transcript whenever a new final result arrives */
+  onTranscript: (text: string) => void;
+  /** Speech recognition language (default 'zh-TW') */
+  lang?: string;
+  /** Disable the button externally (e.g. while parent is submitting) */
+  disabled?: boolean;
+  /** Extra Tailwind classes applied to the button */
+  className?: string;
+  /** Size variant: default 'md' (40px), 'sm' (32px) */
+  size?: 'sm' | 'md';
+}
+
+/**
+ * VoiceInputButton — shared mic button for any text input surface.
+ *
+ * Wraps useSpeechRecognition so callers only deal with plain text.
+ * Issue #1094: abstract voice input into a reusable component so every
+ * text-input surface (SentencePractice, ComprehensionChat, ...) can support
+ * speaking instead of typing.
+ */
+const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
+  onTranscript,
+  lang = 'zh-TW',
+  disabled = false,
+  className = '',
+  size = 'md',
+}) => {
+  const onTranscriptRef = useRef(onTranscript);
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  }, [onTranscript]);
+
+  const { status, errorMessage, isSupported, startListening, stopListening } =
+    useSpeechRecognition(lang, (text) => onTranscriptRef.current(text));
+
+  const isListening = status === 'listening';
+  const unsupported = !isSupported || status === 'unsupported';
+
+  const dimension = size === 'sm' ? 'w-8 h-8' : 'w-10 h-10';
+  const iconSize = size === 'sm' ? 'text-lg' : 'text-xl';
+
+  const title = unsupported
+    ? '此瀏覽器不支援語音輸入，請使用 Chrome 或 Safari'
+    : isListening
+    ? '點擊停止錄音'
+    : errorMessage || '點擊開始語音輸入';
+
+  const handleClick = () => {
+    if (unsupported || disabled) return;
+    if (isListening) stopListening();
+    else startListening();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={unsupported || disabled}
+      title={title}
+      aria-label={isListening ? '停止語音輸入' : '語音輸入'}
+      aria-pressed={isListening}
+      className={`${dimension} shrink-0 rounded-full flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
+        unsupported || disabled
+          ? 'bg-gray-100 text-gray-300 cursor-not-allowed'
+          : isListening
+          ? 'bg-red-500 text-white animate-pulse'
+          : 'bg-accent/10 text-accent hover:bg-accent/20'
+      } ${className}`}
+    >
+      <span className={`material-symbols-outlined ${iconSize}`} aria-hidden="true">
+        {isListening ? 'stop' : 'mic'}
+      </span>
+    </button>
+  );
+};
+
+export default VoiceInputButton;

--- a/frontend/src/components/ui/VoiceInputButton.tsx
+++ b/frontend/src/components/ui/VoiceInputButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 
 interface VoiceInputButtonProps {
@@ -29,13 +29,8 @@ const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
   className = '',
   size = 'md',
 }) => {
-  const onTranscriptRef = useRef(onTranscript);
-  useEffect(() => {
-    onTranscriptRef.current = onTranscript;
-  }, [onTranscript]);
-
   const { status, errorMessage, isSupported, startListening, stopListening } =
-    useSpeechRecognition(lang, (text) => onTranscriptRef.current(text));
+    useSpeechRecognition(lang, onTranscript);
 
   const isListening = status === 'listening';
   const unsupported = !isSupported || status === 'unsupported';
@@ -50,7 +45,6 @@ const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
     : errorMessage || '點擊開始語音輸入';
 
   const handleClick = () => {
-    if (unsupported || disabled) return;
     if (isListening) stopListening();
     else startListening();
   };

--- a/frontend/src/pages/student/LearningHistoryPage.tsx
+++ b/frontend/src/pages/student/LearningHistoryPage.tsx
@@ -67,33 +67,6 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
   // All completed sessions have all steps done
   const allStepIds = useMemo(() => new Set(ACTIVE_STEPS.map((s) => s.id)), []);
 
-  // Issue #1245: unified score display — prefer overall_score, fallback to accuracy,
-  // show explicit "—" rather than empty when both are null.
-  const score =
-    session.overall_score != null
-      ? Math.round(session.overall_score)
-      : null;
-
-  const accuracy =
-    session.accuracy != null
-      ? Math.round(session.accuracy * 100)
-      : null;
-
-  // Unified display value: overall_score → accuracy → null (show "進行中")
-  const scoreDisplay: string | null =
-    score != null
-      ? `${score}%`
-      : accuracy != null
-        ? `${accuracy}%`
-        : null;
-
-  const scoreLabel: string =
-    score != null
-      ? '得分'
-      : accuracy != null
-        ? '準確率'
-        : '';
-
   return (
     <div className="bg-white rounded-2xl shadow-card p-4">
       <div className="flex items-start justify-between gap-3">
@@ -108,14 +81,9 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
             </span>
           </div>
 
-          {/* Metadata row — enlarged date to text-sm, score always visible */}
+          {/* Metadata row — Issue #1094: 學生端不顯示得分 / 準確率 */}
           <div className="flex items-center gap-3 mt-2 flex-wrap">
-            <span className="text-sm text-gray-400">{formatDate(session.started_at)}</span>
-            {scoreDisplay != null ? (
-              <span className="text-sm font-medium text-gray-700">{scoreLabel}：{scoreDisplay}</span>
-            ) : (
-              <span className="text-sm text-gray-400">—</span>
-            )}
+            <span className="text-xs text-gray-400">{formatDate(session.started_at)}</span>
           </div>
 
           {/* Step progress strip */}

--- a/frontend/src/pages/student/SessionHistoryReportPage.tsx
+++ b/frontend/src/pages/student/SessionHistoryReportPage.tsx
@@ -151,27 +151,12 @@ const StepSection: React.FC<{ title: string; children: React.ReactNode }> = ({ t
 // ---------------------------------------------------------------------------
 
 const ReadingRecord: React.FC<{ raw: Record<string, unknown> }> = ({ raw }) => {
-  const accuracy = typeof raw.accuracy === 'number' ? Math.round(raw.accuracy * 100) : null;
-  const cpm = typeof raw.cpm === 'number' ? raw.cpm : null;
   const mispronounced = Array.isArray(raw.mispronounced_words) ? (raw.mispronounced_words as string[]) : [];
   const transcription = typeof raw.transcription === 'string' ? raw.transcription : null;
 
   return (
     <StepSection title="逐段朗讀">
-      <div className="flex gap-4 flex-wrap text-sm">
-        {accuracy != null && (
-          <div>
-            <span className="text-xs text-gray-500">準確率</span>
-            <p className="font-semibold text-gray-800">{accuracy}%</p>
-          </div>
-        )}
-        {cpm != null && (
-          <div>
-            <span className="text-xs text-gray-500">語速 (CPM)</span>
-            <p className="font-semibold text-gray-800">{cpm}</p>
-          </div>
-        )}
-      </div>
+      {/* Issue #1094: 學生端不顯示準確率 / CPM 數字，只保留錯字詞與辨識文字 */}
       {mispronounced.length > 0 ? (
         <div>
           <p className="text-xs text-gray-500 mb-1.5">念錯的字詞</p>
@@ -203,38 +188,12 @@ const ReadingRecord: React.FC<{ raw: Record<string, unknown> }> = ({ raw }) => {
 // ---------------------------------------------------------------------------
 
 const FullReadingRecord: React.FC<{ raw: Record<string, unknown> }> = ({ raw }) => {
-  const matchRate = typeof raw.match_rate === 'number' ? Math.round(raw.match_rate * 100) : null;
-  const cpm = typeof raw.cpm === 'number' ? raw.cpm : null;
   const feedback = typeof raw.feedback === 'string' ? raw.feedback : null;
   const diffTokens = Array.isArray(raw.diff_tokens) ? (raw.diff_tokens as DiffToken[]) : [];
-  const errorBreakdown = raw.error_breakdown && typeof raw.error_breakdown === 'object'
-    ? (raw.error_breakdown as { correct: number; wrong: number; missing: number; extra: number })
-    : null;
 
   return (
     <StepSection title="全文朗讀">
-      <div className="flex gap-4 flex-wrap text-sm">
-        {matchRate != null && (
-          <div>
-            <span className="text-xs text-gray-500">符合率</span>
-            <p className="font-semibold text-gray-800">{matchRate}%</p>
-          </div>
-        )}
-        {cpm != null && (
-          <div>
-            <span className="text-xs text-gray-500">語速 (CPM)</span>
-            <p className="font-semibold text-gray-800">{cpm}</p>
-          </div>
-        )}
-      </div>
-      {errorBreakdown && (
-        <div className="flex gap-3 flex-wrap text-xs">
-          <span className="px-2 py-0.5 rounded bg-green-100 text-green-700">正確 {errorBreakdown.correct}</span>
-          <span className="px-2 py-0.5 rounded bg-red-100 text-red-700">錯誤 {errorBreakdown.wrong}</span>
-          <span className="px-2 py-0.5 rounded bg-gray-100 text-gray-600">漏讀 {errorBreakdown.missing}</span>
-          <span className="px-2 py-0.5 rounded bg-orange-100 text-orange-700">多讀 {errorBreakdown.extra}</span>
-        </div>
-      )}
+      {/* Issue #1094: 學生端不顯示符合率 / CPM / 正確漏讀數字 */}
       {diffTokens.length > 0 && (
         <div>
           <p className="text-xs text-gray-500 mb-1.5">朗讀差異對照</p>
@@ -262,44 +221,12 @@ const ComprehensionRecord: React.FC<{
   turns: DialogueTurnItem[];
   scores: ComprehensionScoreResult | null;
 }> = ({ raw, turns, scores }) => {
-  const understood = raw && typeof raw.understood_count === 'number' ? raw.understood_count : null;
-  const required = raw && typeof raw.required_count === 'number' ? raw.required_count : null;
-
   // Only show ai + student turns (skip feedback role for readability)
   const conversationTurns = turns.filter((t) => t.role === 'ai' || t.role === 'student');
 
   return (
     <StepSection title="課文理解">
-      {(understood != null || scores) && (
-        <div className="flex gap-4 flex-wrap text-sm">
-          {understood != null && required != null && (
-            <div>
-              <span className="text-xs text-gray-500">答對題數</span>
-              <p className="font-semibold text-gray-800">{understood} / {required}</p>
-            </div>
-          )}
-          {scores && (
-            <>
-              <div>
-                <span className="text-xs text-gray-500">理解總分</span>
-                <p className="font-semibold text-gray-800">{Math.round(scores.comprehension_score * 100)}%</p>
-              </div>
-              <div>
-                <span className="text-xs text-gray-500">字面</span>
-                <p className="font-semibold text-gray-800">{Math.round(scores.literal_score * 100)}%</p>
-              </div>
-              <div>
-                <span className="text-xs text-gray-500">推論</span>
-                <p className="font-semibold text-gray-800">{Math.round(scores.inferential_score * 100)}%</p>
-              </div>
-              <div>
-                <span className="text-xs text-gray-500">評鑑</span>
-                <p className="font-semibold text-gray-800">{Math.round(scores.evaluative_score * 100)}%</p>
-              </div>
-            </>
-          )}
-        </div>
-      )}
+      {/* Issue #1094: 學生端不顯示答對題數 / 理解率 / 三層次分數，改以對話紀錄為主 */}
 
       {conversationTurns.length > 0 ? (
         <div className="space-y-2 max-h-96 overflow-y-auto pr-1">

--- a/frontend/src/pages/student/StudentProfile.tsx
+++ b/frontend/src/pages/student/StudentProfile.tsx
@@ -156,16 +156,7 @@ const StudentProfile: React.FC = () => {
                 value={gamification?.total_xp ?? 0}
                 sub={gamification ? `Lv.${gamification.level_info.level} ${gamification.level_info.level_name}` : undefined}
               />
-              <StatCard
-                icon="📊"
-                label="平均分數"
-                value={
-                  dashboard?.avg_score != null
-                    ? `${Math.round(dashboard.avg_score)}%`
-                    : '—'
-                }
-                sub="所有課文"
-              />
+              {/* Issue #1094: 學生端不顯示平均分數 */}
             </div>
           </section>
         )}

--- a/frontend/src/utils/encouragement.ts
+++ b/frontend/src/utils/encouragement.ts
@@ -22,3 +22,35 @@ export function getEncouragementMessage(): string {
   const idx = Math.floor(Math.random() * ENCOURAGEMENT_MESSAGES.length);
   return ENCOURAGEMENT_MESSAGES[idx];
 }
+
+/**
+ * Issue #1094 — student-facing views hide numeric scores/accuracy/CPM and
+ * show encouragement-only messages. Teacher dashboard still shows the numbers.
+ */
+
+export function encourageOverall(score: number): string {
+  if (score >= 85) return '表現超棒！繼續保持';
+  if (score >= 70) return '做得很好，再接再厲';
+  if (score >= 50) return '有進步喔，繼續加油';
+  return '一步一步來，你做得到';
+}
+
+export function encourageAccuracy(percent: number): string {
+  if (percent >= 90) return '唸得很清楚！';
+  if (percent >= 75) return '唸得不錯，再熟練一些';
+  if (percent >= 50) return '有唸出來囉，再試一次會更好';
+  return '慢慢來，多練幾次就會更順';
+}
+
+export function encourageReadingSpeed(): string {
+  return '唸完囉！';
+}
+
+export function encourageQuiz(correct: number, total: number): string {
+  if (total === 0) return '繼續加油！';
+  const ratio = correct / total;
+  if (ratio >= 0.9) return '太棒了，幾乎全對！';
+  if (ratio >= 0.7) return '答得不錯，繼續加油';
+  if (ratio >= 0.4) return '有答對一些，再想想看';
+  return '再試一次，你一定可以';
+}

--- a/frontend/src/utils/encouragement.ts
+++ b/frontend/src/utils/encouragement.ts
@@ -42,7 +42,7 @@ export function encourageAccuracy(percent: number): string {
   return '慢慢來，多練幾次就會更順';
 }
 
-export function encourageReadingSpeed(): string {
+export function encourageReadingDone(): string {
   return '唸完囉！';
 }
 


### PR DESCRIPTION
Closes #1094

## 變更內容

### 1. 點點導覽（ImmersiveTopBar）
- 新增左右 chevron 箭頭（`chevron_left` / `chevron_right`），自動跳過 locked 的 report 步驟，頭/尾 disabled
- 每個點 hover 顯示「編號. 步驟名」（`title` 屬性）
- Header 排版：Row 1 標題+步驟、Row 2 hint 小字、Row 3 箭頭+點點；高度 `h-16 md:h-20`

### 2. 學生端分數/正確率/CPM 移除，改鼓勵式文字
利用 `AssessmentReport.readOnly` prop 區分：學生端 `hideScores = !readOnly` 時隱藏數字，教師後台 `/teacher/session-report` 保留完整數據。

**元件**：AssessmentReport、ComprehensionScoreCard、FullReading、MultipleChoiceExercise、ExitTicket、ListeningPractice、ZhuyinPhoneticGame、live-tutor/ParagraphCard、live-tutor/LiveTutor、VocabDefinitionMatch、ComprehensionChat、StoryStructureTable、FillInBlankExercise

**頁面**：SessionHistoryReportPage、LearningHistoryPage、StudentProgressDashboard、StudentProfile

**新 helper**：`utils/encouragement.ts` 新增 `encourageOverall` / `encourageAccuracy` / `encourageQuiz` / `encourageReadingSpeed`（保留既有 #268 API）。

### 3. 語音輸入共用元件
- 新 `components/ui/VoiceInputButton.tsx`（包 `useSpeechRecognition`，支援 `md`/`sm` 兩種尺寸、listening 紅色脈動、不支援瀏覽器 disabled）
- 接入：SentencePractice（造句 input 旁）、FloatingAIHelper（AI 助手 textarea 旁）
- **刻意不加**：DictationPractice（違背聽寫目的）、ExitTicket（無文字輸入）

### 暫不處理（issue 列有但先忽略）
- Onboarding 引導式教學
- 報告前是否強制全部完成

## Test plan
- [ ] 學生登入 → 各步驟 hover 點點顯示步驟名、左右箭頭切換正常
- [ ] 學生端所有步驟 + 報告：無 `%` / `CPM` / `得分` / `答對 N 題` / `正確率` 等數字
- [ ] 學生端 Dashboard / Profile / 學習歷史 / Session 歷史：無平均分、得分、準確率
- [ ] 教師登入 `/teacher/session-report/:id`：所有數字完整（回歸保護）
- [ ] 造句練習 + AI 助手：語音輸入按鈕可錄音並把文字塞進輸入框
- [ ] Firefox：語音按鈕 disabled + tooltip 說明
- [ ] `npm run build` 通過

@claude 幫我 review 這個 PR