### PR TITLE
fix: Step 2 停止鈕修復 + 整段漏讀偵測 + 句子切分改善 (#1096)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -386,7 +386,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     if (!cleaned) {
       stopSession();
       const normalizedTarget = normalizeForComparison(targetText);
-      const targetLen = normalizedTarget.length || 1;
+      const targetLen = normalizedTarget.length;
       const emptyDiffTokens: DiffToken[] = Array.from(normalizedTarget).map(ch => ({
         char: ch, type: 'missing' as const,
       }));

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -381,7 +381,29 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const evaluateAndRespond = useCallback(async (rawTranscript: string, rawStt: string, durationMs: number, lineIdx: number) => {
     const targetText = story.content[lineIdx] || '';
     const cleaned = cleanChineseText(rawTranscript);
-    if (!cleaned) return;
+
+    // 整段漏讀：no speech detected → show summary with retry prompt instead of silently returning
+    if (!cleaned) {
+      stopSession();
+      const targetLen = normalizeForComparison(targetText).length || 1;
+      const emptyDiffTokens: DiffToken[] = Array.from(normalizeForComparison(targetText)).map(ch => ({
+        char: ch, type: 'missing' as const,
+      }));
+      setParagraphSummaries(prev => ({
+        ...prev,
+        [lineIdx]: {
+          feedback: '好像沒有偵測到聲音，請再試一次吧！',
+          matchRate: 0,
+          wrongCount: 0,
+          missingCount: targetLen,
+          tier: 3 as const,
+          geminiPending: false,
+        },
+      }));
+      setLastDiffTokens(emptyDiffTokens);
+      setStreamingUserInput('');
+      return;
+    }
 
     // ── Phase 1: local eval (instant, <1ms) ─────────────────────────────────
     const sentResults = sentenceResultsRef.current.filter(Boolean) as LocalEvalResult[];

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -385,8 +385,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     // 整段漏讀：no speech detected → show summary with retry prompt instead of silently returning
     if (!cleaned) {
       stopSession();
-      const targetLen = normalizeForComparison(targetText).length || 1;
-      const emptyDiffTokens: DiffToken[] = Array.from(normalizeForComparison(targetText)).map(ch => ({
+      const normalizedTarget = normalizeForComparison(targetText);
+      const targetLen = normalizedTarget.length || 1;
+      const emptyDiffTokens: DiffToken[] = Array.from(normalizedTarget).map(ch => ({
         char: ch, type: 'missing' as const,
       }));
       setParagraphSummaries(prev => ({

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -211,8 +211,24 @@ export function useTtsPlayback(
     }
     const ua = utteranceRef.current;
     if (ua && ua instanceof HTMLAudioElement) {
+      // Remove event listeners to prevent stale callbacks after stop
+      ua.ontimeupdate = null;
+      ua.onplay = null;
+      ua.onended = null;
+      ua.onerror = null;
       ua.pause();
       ua.currentTime = 0;
+      // Revoke blob URL to prevent memory leak
+      if (ua.src && ua.src.startsWith('blob:')) {
+        URL.revokeObjectURL(ua.src);
+      }
+    } else if (ua) {
+      // Web Speech API path: remove handlers before cancel
+      const utt = ua as SpeechSynthesisUtterance;
+      utt.onstart = null;
+      utt.onend = null;
+      utt.onerror = null;
+      utt.onboundary = null;
     }
     // Stop Web Speech API (fallback path)
     window.speechSynthesis?.cancel();

--- a/frontend/src/utils/liveTutorHelpers.ts
+++ b/frontend/src/utils/liveTutorHelpers.ts
@@ -3,8 +3,9 @@ import { normalizeForComparison } from './textDiff';
 import { isHomophone } from './pinyin';
 
 /** Punctuation characters used to determine retryable sentence length.
+ *  Keep in sync with splitIntoSentences() in localEval.ts.
  *  ⚠️ Has /g flag → stateful lastIndex. Safe with .replace() but do NOT use .test() or .exec() directly. */
-export const CHINESE_PUNCTUATION_REGEX = /[，。！？；]/g;
+export const CHINESE_PUNCTUATION_REGEX = /[，。！？；：、─—…「」『』（）]/g;
 
 /**
  * Look-ahead cursor: for each spoken char, try matching the current target

--- a/frontend/src/utils/localEval.ts
+++ b/frontend/src/utils/localEval.ts
@@ -50,18 +50,36 @@ export function getReadingPassThreshold(targetLength: number): number {
 
 // ── Sentence segmentation ─────────────────────────────────────────────────────
 
+/** Maximum characters per sentence segment before force-splitting. */
+const MAX_SENTENCE_CHARS = 20;
+
 /**
- * Split Chinese text into sentences at ，。！？；
+ * Split Chinese text into sentences at common punctuation marks.
  * Each segment keeps its trailing delimiter so targets stay faithful to the original.
+ *
+ * Punctuation recognized: ，。！？；：、─—…「」『』（）
+ * Primary split: sentence-ending marks (，。！？；：)
+ * If any resulting segment exceeds MAX_SENTENCE_CHARS, further split at secondary marks (、─—…「」)
  *
  * Example: '媽媽說，你好。' → ['媽媽說，', '你好。']
  * Example: '一二三。'       → ['一二三。']
- * Returns the full text as a single element when there are no delimiters.
+ * Returns the full text as a single element when there are no delimiters and text ≤ MAX_SENTENCE_CHARS.
  */
 export function splitIntoSentences(text: string): string[] {
-  // Split after each sentence-final punctuation character
-  const segments = text.split(/(?<=[，。！？；])/u);
-  return segments.filter(s => s.length > 0);
+  // Primary split: sentence-level punctuation
+  const primarySegments = text.split(/(?<=[，。！？；：])/u).filter(s => s.length > 0);
+
+  const result: string[] = [];
+  for (const seg of primarySegments) {
+    if (Array.from(seg).length <= MAX_SENTENCE_CHARS) {
+      result.push(seg);
+    } else {
+      // Secondary split on enumeration / parenthetical marks
+      const subSegments = seg.split(/(?<=[、─—…」』）])/u).filter(s => s.length > 0);
+      result.push(...subSegments);
+    }
+  }
+  return result;
 }
 
 // ── Core local evaluation ─────────────────────────────────────────────────────

--- a/frontend/src/utils/localEval.ts
+++ b/frontend/src/utils/localEval.ts
@@ -57,9 +57,12 @@ const MAX_SENTENCE_CHARS = 20;
  * Split Chinese text into sentences at common punctuation marks.
  * Each segment keeps its trailing delimiter so targets stay faithful to the original.
  *
- * Punctuation recognized: ，。！？；：、─—…「」『』（）
+ * Punctuation recognized: ，。！？；：、─—…」』）
  * Primary split: sentence-ending marks (，。！？；：)
- * If any resulting segment exceeds MAX_SENTENCE_CHARS, further split at secondary marks (、─—…「」)
+ * If any resulting segment exceeds MAX_SENTENCE_CHARS, further split at secondary
+ * marks (、─—…」』）). Only closing quotes/brackets are split points.
+ * If a segment still exceeds MAX_SENTENCE_CHARS after secondary split
+ * (no secondary punctuation present), it is returned as-is.
  *
  * Example: '媽媽說，你好。' → ['媽媽說，', '你好。']
  * Example: '一二三。'       → ['一二三。']


### PR DESCRIPTION
# Issue #1096 修正說明

## 問題摘要
Step 2 逐段朗讀存在三個 bug：(1) TTS 停止按鈕按了不會停，audio 事件未清除導致 stale callbacks；(2) 學生整段沒念（無語音輸入）時系統靜默返回，沒有觸發「重練此段」提示；(3) 句子切分只認 5 種標點（，。！？；），部分段落整段被視為一句，無法做分句練習。

## 修正策略
針對三個 bug 分別以最小侵入性方式修正：
1. **stopTts 清理強化**：在停止前先移除 audio element 所有 event listeners（ontimeupdate/onplay/onended/onerror），防止停止後仍收到 stale callbacks。同時回收 blob URL 防止記憶體洩漏。Web Speech API fallback 也同步清理。
2. **整段漏讀偵測**：在 `evaluateAndRespond` 中，當 `cleanChineseText` 結果為空時，不再靜默 return，改為停止錄音並顯示 paragraphSummary（matchRate=0, tier=3），提示「好像沒有偵測到聲音，請再試一次吧！」，讓學生可以點擊「重練這段」。
3. **切句邏輯擴展**：`splitIntoSentences` 增加 `：`（冒號）為主要切分點；超過 20 字的段落進行二次切分，使用 `、─—…」』）` 等次要標點。`CHINESE_PUNCTUATION_REGEX` 同步擴展以保持一致。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/hooks/useTtsPlayback.ts` | `stopTts()` 增加 event listener 清理 + blob URL 回收 |
| `frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx` | `evaluateAndRespond()` 整段漏讀偵測，顯示重練提示 |
| `frontend/src/utils/localEval.ts` | `splitIntoSentences()` 擴展切句標點 + 20字上限二次切分 |
| `frontend/src/utils/liveTutorHelpers.ts` | `CHINESE_PUNCTUATION_REGEX` 同步擴展標點符號 |

## 修正內容詳述

### 1. `frontend/src/hooks/useTtsPlayback.ts` — stopTts 清理

**Before:**
```typescript
const stopTts = () => {
  // ...cancelAnimationFrame...
  const ua = utteranceRef.current;
  if (ua && ua instanceof HTMLAudioElement) {
    ua.pause();
    ua.currentTime = 0;
  }
  window.speechSynthesis?.cancel();
  utteranceRef.current = null;
  cancelTts();
  // ...setState...
};
```

**After:**
```typescript
const stopTts = () => {
  // ...cancelAnimationFrame...
  const ua = utteranceRef.current;
  if (ua && ua instanceof HTMLAudioElement) {
    ua.ontimeupdate = null;
    ua.onplay = null;
    ua.onended = null;
    ua.onerror = null;
    ua.pause();
    ua.currentTime = 0;
    if (ua.src && ua.src.startsWith('blob:')) {
      URL.revokeObjectURL(ua.src);
    }
  } else if (ua) {
    const utt = ua as SpeechSynthesisUtterance;
    utt.onstart = null;
    utt.onend = null;
    utt.onerror = null;
    utt.onboundary = null;
  }
  window.speechSynthesis?.cancel();
  utteranceRef.current = null;
  cancelTts();
  // ...setState...
};
```

### 2. `frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx` — 整段漏讀

**Before:** `if (!cleaned) return;` — 靜默返回，無任何 UI 回饋

**After:** 偵測到無語音輸入時，停止錄音並顯示 summary：
```typescript
if (!cleaned) {
  stopSession();
  const emptyDiffTokens = Array.from(normalizeForComparison(targetText)).map(ch => ({
    char: ch, type: 'missing' as const,
  }));
  setParagraphSummaries(prev => ({
    ...prev,
    [lineIdx]: {
      feedback: '好像沒有偵測到聲音，請再試一次吧！',
      matchRate: 0, wrongCount: 0, missingCount: targetLen,
      tier: 3, geminiPending: false,
    },
  }));
  setLastDiffTokens(emptyDiffTokens);
  return;
}
```

### 3. `frontend/src/utils/localEval.ts` — 切句改善

**Before:** 只切 `，。！？；` 共 5 種標點
**After:**
- 主要切分：`，。！？；：` 共 6 種
- 超過 20 字的段落進行二次切分：`、─—…」』）`
- 確保每個句段長度合理，支援更細粒度的分句練習

## 測試方式

### 手動測試步驟

1. **停止按鈕測試**
   - 進入 Step 2 逐段朗讀
   - 點擊「AI 朗讀」讓 TTS 開始播放
   - 點擊「停止」按鈕 → 應立即停止播放，按鈕消失

2. **整段漏讀測試**
   - 進入 Step 2，點擊「開始朗讀」
   - 不說話，直接點擊「完成」
   - 應顯示「好像沒有偵測到聲音，請再試一次吧！」提示卡片
   - 可點擊「重練這段」重新開始

3. **切句測試**
   - 選擇含有較長段落的課文（例如整段無逗號的段落）
   - 進入 Step 2，朗讀並觀察分句回饋
   - 應能看到更細的句子切分，而非整段為一句

## 迴歸測試

- Step 2 正常朗讀流程（說話 → 即時辨識 → 評估 → 下一段）
- AI 朗讀的暫停/繼續功能
- 句子重練（第 X 句按鈕）功能
- 段落重練功能
- 朗讀完成後的總結報告

## 嚴重性

- 停止按鈕：中等 — 影響使用體驗，但有其他方式中斷 TTS
- 整段漏讀：中等 — 學生不說話時 UI 無回饋，造成困惑
- 切句：低 — 部分課文切句粒度較粗，但不影響核心功能