### PR TITLE
feat(hosting): Firebase multi-site for prod/staging/dev

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,14 @@
 {
   "projects": {
     "default": "lingoleap-dev"
+  },
+  "targets": {
+    "lingoleap-dev": {
+      "hosting": {
+        "prod": ["lingoleap-prod"],
+        "staging": ["lingoleap-staging"],
+        "dev": ["lingoleap-dev"]
+      }
+    }
   }
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
             --max-instances=3 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
 
       - name: Verify backend health
         run: |
@@ -145,9 +145,67 @@ jobs:
         run: |
           echo "## Production Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Frontend:** https://lingoleap-frontend-958347263320.asia-east1.run.app" >> $GITHUB_STEP_SUMMARY
+          echo "**Frontend (Cloud Run):** https://lingoleap-frontend-958347263320.asia-east1.run.app" >> $GITHUB_STEP_SUMMARY
+          echo "**Frontend (Firebase):** https://lingoleap-prod.web.app" >> $GITHUB_STEP_SUMMARY
           echo "**Backend:** https://lingoleap-backend-958347263320.asia-east1.run.app" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+
+  deploy-frontend-firebase:
+    name: Deploy frontend to Firebase Hosting (prod)
+    needs: [detect-changes, deploy-frontend]
+    if: |
+      always() && !cancelled() &&
+      (needs.detect-changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch') &&
+      needs.deploy-frontend.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend for Firebase (relative API paths)
+        working-directory: frontend
+        env:
+          VITE_API_URL: ""
+        run: npm run build
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools@13
+
+      - name: Deploy to Firebase Hosting (prod)
+        run: |
+          firebase deploy \
+            --only hosting:prod \
+            --project lingoleap-dev \
+            --non-interactive \
+            --message "Deploy ${COMMIT_SHA}"
+
+      - name: Verify Firebase site
+        run: |
+          for i in 1 2 3 4 5; do
+            FE=$(curl -s -o /dev/null -w '%{http_code}' https://lingoleap-prod.web.app/)
+            API=$(curl -s -o /dev/null -w '%{http_code}' https://lingoleap-prod.web.app/api/health)
+            echo "Attempt $i: FE=$FE /api/health=$API"
+            if [ "$FE" = "200" ] && [ "$API" = "200" ]; then exit 0; fi
+            sleep 10
+          done
+          echo "::error::Firebase prod site verification failed"
+          exit 1
 
   post-deploy-healthcheck:
     name: Post-deploy health check

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -76,7 +76,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
 
       - name: Verify backend health
         run: |
@@ -188,9 +188,75 @@ jobs:
             --format='value(status.url)' 2>/dev/null || echo "N/A")
           echo "## Staging Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Frontend:** ${FRONTEND_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "**Frontend (Cloud Run):** ${FRONTEND_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "**Frontend (Firebase staging):** https://lingoleap-staging.web.app" >> $GITHUB_STEP_SUMMARY
+          echo "**Frontend (Firebase dev):** https://lingoleap-dev.web.app" >> $GITHUB_STEP_SUMMARY
           echo "**Backend:** ${BACKEND_URL}" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+
+  deploy-frontend-firebase:
+    name: Deploy frontend to Firebase Hosting (staging + dev)
+    needs: [detect-changes, deploy-frontend]
+    if: |
+      always() && !cancelled() &&
+      (needs.detect-changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch') &&
+      needs.deploy-frontend.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend for Firebase (relative API paths + demo creds)
+        working-directory: frontend
+        env:
+          VITE_API_URL: ""
+          VITE_SHOW_DEMO_LOGIN: "true"
+          VITE_DEMO_ADMIN_EMAIL: ${{ secrets.DEMO_ADMIN_EMAIL }}
+          VITE_DEMO_ADMIN_PW: ${{ secrets.DEMO_ADMIN_PW }}
+          VITE_DEMO_TEACHER_EMAIL: ${{ secrets.DEMO_TEACHER_EMAIL }}
+          VITE_DEMO_TEACHER_PW: ${{ secrets.DEMO_TEACHER_PW }}
+          VITE_DEMO_STUDENT_EMAIL: ${{ secrets.DEMO_STUDENT_EMAIL }}
+          VITE_DEMO_STUDENT_PW: ${{ secrets.DEMO_STUDENT_PW }}
+        run: npm run build
+
+      - id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools@13
+
+      - name: Deploy to Firebase Hosting (staging + dev)
+        run: |
+          firebase deploy \
+            --only hosting:staging,hosting:dev \
+            --project lingoleap-dev \
+            --non-interactive \
+            --message "Deploy ${COMMIT_SHA}"
+
+      - name: Verify Firebase sites
+        run: |
+          for site in lingoleap-staging lingoleap-dev; do
+            FE=$(curl -s -o /dev/null -w '%{http_code}' "https://${site}.web.app/")
+            API=$(curl -s -o /dev/null -w '%{http_code}' "https://${site}.web.app/api/health")
+            echo "${site}.web.app: FE=${FE} /api/health=${API}"
+            if [ "$FE" != "200" ] || [ "$API" != "200" ]; then
+              echo "::error::${site}.web.app verification failed"
+              exit 1
+            fi
+          done
 
   smoke-test:
     name: Smoke test staging API

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ tests/load-testing/.venv/
 .DS_Store
 .gstack/
 .worktrees/
+
+# Firebase deploy cache
+.firebase/

--- a/firebase.json
+++ b/firebase.json
@@ -1,19 +1,58 @@
 {
-  "hosting": {
-    "public": "frontend/dist",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
-    "rewrites": [
-      {
-        "source": "/api/**",
-        "run": {
-          "serviceId": "lingoleap-backend",
-          "region": "asia-east1"
+  "hosting": [
+    {
+      "target": "prod",
+      "public": "frontend/dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "/api/**",
+          "run": {
+            "serviceId": "lingoleap-backend",
+            "region": "asia-east1"
+          }
+        },
+        {
+          "source": "**",
+          "destination": "/index.html"
         }
-      },
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
-  }
+      ]
+    },
+    {
+      "target": "staging",
+      "public": "frontend/dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "/api/**",
+          "run": {
+            "serviceId": "lingoleap-backend-staging",
+            "region": "asia-east1"
+          }
+        },
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    {
+      "target": "dev",
+      "public": "frontend/dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        {
+          "source": "/api/**",
+          "run": {
+            "serviceId": "lingoleap-backend-staging",
+            "region": "asia-east1"
+          }
+        },
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

給 LingoLeap 三個環境各自一個乾淨的 Firebase Hosting URL，為 Junyi SSO 白名單串接鋪路（[junyiacademy#4083 Part 3](https://github.com/junyiacademy/junyiacademy/issues/4083)）。

| URL | 環境 | Backend (via rewrites) |
|---|---|---|
| `https://lingoleap-prod.web.app` | production | `lingoleap-backend` |
| `https://lingoleap-staging.web.app` | staging | `lingoleap-backend-staging` |
| `https://lingoleap-dev.web.app` | dev / preview | `lingoleap-backend-staging` |

## Changes

**Firebase hosting config**
- 建立 2 個新 Firebase site：`lingoleap-prod`、`lingoleap-staging`（`lingoleap-dev` 既有、改用途）
- `.firebaserc`：加 `targets.lingoleap-dev.hosting` 三個 target
- `firebase.json`：從單一 `hosting` object 改成 array，每個 target 各自 rewrites 到對應 Cloud Run backend

**CI auto-deploy**
- `deploy.yml`：新增 `deploy-frontend-firebase` job → merge main 時自動 deploy `hosting:prod`
- `staging-deploy.yml`：新增 `deploy-frontend-firebase` job → merge staging 時自動 deploy `hosting:staging` + `hosting:dev`
- Frontend build 用 `VITE_API_URL=""`（相對路徑），透過 Firebase rewrites proxy 到 Cloud Run backend，避免 CORS preflight
- Staging/dev build 保留 `VITE_DEMO_*` env → 顯示 demo login buttons；prod build 不注入 demo env

**Backend CORS**
- `deploy.yml` ALLOWED_ORIGINS：`lingoleap-prod.web.app` 加入白名單
- `staging-deploy.yml` ALLOWED_ORIGINS：`lingoleap-staging.web.app` 加入白名單
- Running services 已手動套用對應 env vars

**Service account**
- 現有 `github-actions@lingoleap-dev.iam.gserviceaccount.com` 加上 `roles/firebasehosting.admin`（不新建 secret，沿用 `GCP_SA_KEY`）

## Test plan

已驗證（手動 deploy + curl）：
- [x] `curl https://lingoleap-prod.web.app/` → HTTP 200
- [x] `curl https://lingoleap-prod.web.app/api/health` → HTTP 200
- [x] `curl https://lingoleap-staging.web.app/` → HTTP 200
- [x] `curl https://lingoleap-staging.web.app/api/health` → HTTP 200
- [x] `curl https://lingoleap-dev.web.app/` → HTTP 200
- [x] `curl https://lingoleap-dev.web.app/api/health` → HTTP 200
- [x] gstack `/browse` 3 站登入頁可訪問，無 console error
- [x] Backend CORS 更新（`gcloud run services describe` 確認）

Merge 後：
- [ ] 推 staging → CI 自動 deploy staging + dev
- [ ] 推 main → CI 自動 deploy prod（prod 站 demo buttons 會被清掉）

## Junyi SSO 白名單（給宥辰）

```
https://lingoleap-prod.web.app
https://lingoleap-staging.web.app
https://lingoleap-dev.web.app
```

Callback path 細節等我們實作 SSO route 時再確認（未入此 PR）。

## Out of scope (follow-up)

- `preview-deploy.yml` Firebase 整合（PR preview 還是用 Cloud Run ephemeral）
- 更新實習生訓練教材引用的 URL
- 棄用 `lingoleap-frontend*` Cloud Run service（觀察 2 週後決定）