### PR TITLE
fix: 跨裝置 session 復用 — GET-first + 後端 dedup (#1074)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import func
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
 
 from ..auth.dependencies import get_current_user
 from ..database import get_db
@@ -842,13 +843,15 @@ def start_assignment(
         .first()
     )
     if learning_session:
-        # Ensure assignment metadata is present on the reused session
+        # Ensure assignment metadata and classroom_id are present on the reused session
         progress = learning_session.step_progress or {}
         if not isinstance(progress.get("__meta"), dict) or progress["__meta"].get("assignment_id") != assignment.id:
             progress["__meta"] = {"source": "assignment", "assignment_id": assignment.id}
             learning_session.step_progress = progress
-            from sqlalchemy.orm.attributes import flag_modified
             flag_modified(learning_session, "step_progress")
+        # Sync classroom_id if the reused session was from self-practice (#1074 review)
+        if learning_session.classroom_id is None and assignment.classroom_id is not None:
+            learning_session.classroom_id = assignment.classroom_id
         logger.info(
             "Reusing existing session %d for assignment %d (student %d, story=%s) #1074",
             learning_session.id, assignment.id, current_user.id, story_slug,

--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -828,22 +828,47 @@ def start_assignment(
     raw_slug = assignment.story_id or str(assignment.text_id)
     story_slug = normalize_story_slug(raw_slug)
 
-    # Create a new LearningSession
-    learning_session = LearningSession(
-        student_id=current_user.id,
-        story_slug=story_slug,
-        classroom_id=assignment.classroom_id,
-        status="in_progress",
-        current_step=1,
-        step_progress={
-            "__meta": {
-                "source": "assignment",
-                "assignment_id": assignment.id,
-            }
-        },
+    # Reuse existing in_progress session for same student + story to avoid
+    # duplicates when switching devices (#1074).  Attach assignment metadata
+    # so the session is associated with this assignment.
+    learning_session = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.student_id == current_user.id,
+            LearningSession.story_slug == story_slug,
+            LearningSession.status == "in_progress",
+        )
+        .order_by(LearningSession.started_at.desc())
+        .first()
     )
-    db.add(learning_session)
-    db.flush()  # get learning_session.id
+    if learning_session:
+        # Ensure assignment metadata is present on the reused session
+        progress = learning_session.step_progress or {}
+        if not isinstance(progress.get("__meta"), dict) or progress["__meta"].get("assignment_id") != assignment.id:
+            progress["__meta"] = {"source": "assignment", "assignment_id": assignment.id}
+            learning_session.step_progress = progress
+            from sqlalchemy.orm.attributes import flag_modified
+            flag_modified(learning_session, "step_progress")
+        logger.info(
+            "Reusing existing session %d for assignment %d (student %d, story=%s) #1074",
+            learning_session.id, assignment.id, current_user.id, story_slug,
+        )
+    else:
+        learning_session = LearningSession(
+            student_id=current_user.id,
+            story_slug=story_slug,
+            classroom_id=assignment.classroom_id,
+            status="in_progress",
+            current_step=1,
+            step_progress={
+                "__meta": {
+                    "source": "assignment",
+                    "assignment_id": assignment.id,
+                }
+            },
+        )
+        db.add(learning_session)
+        db.flush()  # get learning_session.id
 
     # Update submission
     submission.status = "in_progress"

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -597,30 +597,58 @@ const LearningLayout: React.FC = () => {
 
   // Ensure a DB session exists for step_progress persistence even when the flow
   // starts from assignment entry points that skip the legacy intro action.
-  // Guard with isCreatingSession ref to prevent concurrent POSTs (Issue #984).
+  // Guard with isCreatingSession ref to prevent concurrent requests (Issue #984).
+  //
+  // Cross-device fix (#1074): when sessionStorage is empty (new device/browser),
+  // first try GET to find an existing in_progress session before creating a new
+  // one.  The backend POST already has get-or-create semantics, but an explicit
+  // GET avoids creating sessions when one already exists with a different source
+  // (assignment vs self-practice).
   useEffect(() => {
     if (!token || !storyId || dbSessionId !== null || isLoading) return;
     if (isCreatingSession.current) return;
 
     isCreatingSession.current = true;
-    fetch(`${API_BASE}/api/learning/sessions`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ story_slug: storyId }),
+
+    const storeSessionId = (id: number) => {
+      setDbSessionId(id);
+      if (activeDbSessionStorageKey) {
+        try { sessionStorage.setItem(activeDbSessionStorageKey, String(id)); } catch { /* non-fatal */ }
+      }
+      if (legacyDbSessionStorageKey) {
+        try { sessionStorage.removeItem(legacyDbSessionStorageKey); } catch { /* non-fatal */ }
+      }
+    };
+
+    // Step 1: Try to find an existing in_progress session for this story (#1074)
+    fetch(`${API_BASE}/api/learning/sessions?story_slug=${encodeURIComponent(storyId)}&status=in_progress&limit=1`, {
+      headers: { Authorization: `Bearer ${token}` },
     })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
+        const existing = data?.items?.[0];
+        if (existing?.id) {
+          // Recovered existing session from server — no need to create
+          storeSessionId(existing.id);
+          return null; // signal: skip POST
+        }
+        // Step 2: No existing session found — create via POST (get-or-create)
+        return fetch(`${API_BASE}/api/learning/sessions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ story_slug: storyId }),
+        });
+      })
+      .then((res) => {
+        if (!res) return null; // skipped POST (existing session found)
+        return res.ok ? res.json() : null;
+      })
+      .then((data) => {
         if (data?.id) {
-          setDbSessionId(data.id);
-          if (activeDbSessionStorageKey) {
-            try { sessionStorage.setItem(activeDbSessionStorageKey, String(data.id)); } catch { /* non-fatal */ }
-          }
-          if (legacyDbSessionStorageKey) {
-            try { sessionStorage.removeItem(legacyDbSessionStorageKey); } catch { /* non-fatal */ }
-          }
+          storeSessionId(data.id);
         }
       })
       .catch(() => {


### PR DESCRIPTION
# Issue #1074 修正說明

## 問題摘要
學生在不同裝置或新瀏覽器開啟學習頁面時，`sessionStorage` 為空，導致前端找不到既有的 `dbSessionId`，直接建立全新的 `LearningSession`。同一學生同一作業可能因此存在多個 session，進度分散、`AssignmentSubmission` 關聯不確定。

## 修正策略
採用「前端 GET-first + 後端 dedup 強化」的雙重防護策略：

1. **前端 GET-first**：`sessionStorage` 為空時，先呼叫 `GET /api/learning/sessions?story_slug={id}&status=in_progress` 查詢伺服器上是否已有進行中的 session。找到就直接復用（存入 sessionStorage），找不到才 POST 建立。
2. **後端 assignment dedup**：`POST /api/assignments/{id}/start` 原本每次都建立新 `LearningSession`（即使同一學生同一故事已有進行中的 session）。修正後先查詢 `(student_id, story_slug, status="in_progress")`，若存在則重用並附加 assignment metadata。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/layouts/LearningLayout.tsx` | session 建立邏輯改為 GET-first → POST-fallback |
| `backend/app/routes/assignments.py` | `start_assignment` 新增 session dedup，重用既有 in_progress session |

## 修正內容詳述

### 1. `frontend/src/layouts/LearningLayout.tsx` — GET-first 查詢

**Before:**
```typescript
// sessionStorage 為空 → 直接 POST 建立新 session
fetch(`${API_BASE}/api/learning/sessions`, {
  method: 'POST',
  body: JSON.stringify({ story_slug: storyId }),
})
```

**After:**
```typescript
// Step 1: 先 GET 查詢是否已有 in_progress session
fetch(`${API_BASE}/api/learning/sessions?story_slug=${storyId}&status=in_progress&limit=1`)
  .then(res => res.json())
  .then(data => {
    if (data?.items?.[0]?.id) {
      // 找到既有 session → 直接復用
      storeSessionId(data.items[0].id);
      return null; // 跳過 POST
    }
    // Step 2: 找不到 → POST 建立（backend get-or-create）
    return fetch(`${API_BASE}/api/learning/sessions`, { method: 'POST', ... });
  })
```

### 2. `backend/app/routes/assignments.py` — start_assignment dedup

**Before:**
```python
# 每次都建立新 LearningSession
learning_session = LearningSession(
    student_id=current_user.id,
    story_slug=story_slug,
    ...
)
db.add(learning_session)
```

**After:**
```python
# 先查詢是否已有 in_progress session
learning_session = db.query(LearningSession).filter(
    LearningSession.student_id == current_user.id,
    LearningSession.story_slug == story_slug,
    LearningSession.status == "in_progress",
).order_by(LearningSession.started_at.desc()).first()

if learning_session:
    # 重用既有 session，附加 assignment metadata
    progress["__meta"] = {"source": "assignment", "assignment_id": assignment.id}
else:
    # 建立新 session
    learning_session = LearningSession(...)
```

## 測試方式

### 手動測試步驟

1. **基本復用測試**
   - 裝置 A：開始一篇課文的學習（建立 session）
   - 裝置 B（或無痕模式）：開啟相同課文
   - 預期：前端 GET 到既有 session，不建立新的

2. **Assignment 復用測試**
   - 裝置 A：從作業頁面開始學習
   - 裝置 B：直接以 URL 開啟同一課文（`/learn/{storyId}`）
   - 預期：前端恢復到裝置 A 的 session

3. **全新 session 測試**
   - 確認完全沒有進行中 session 時，仍能正常建立新 session

### 驗證方法 — 查 DB

```sql
-- 確認同一學生同一故事只有一個 in_progress session
SELECT id, student_id, story_slug, status, started_at
FROM learning_sessions
WHERE student_id = <test_student_id>
  AND story_slug = '<test_slug>'
ORDER BY started_at DESC;
```

## 迴歸測試

- 正常學習流程（從作業進入 → 完成各步驟）
- 自主練習流程（從課文庫進入）
- Session 進度同步（step_progress 在新裝置上正確載入）
- Assignment 提交（submission.session_id 指向正確 session）

## 嚴重性

🟡 **中** — 影響使用多裝置的學生，進度資料可能分散在多個 session。後端已有部分 dedup 邏輯可緩解，本修正補完前後端的完整防護。