### PR TITLE
fix: current_step 與 steps_completed 同步機制 (#1073)

### DIFF
--- a/backend/app/routes/learning/learning_progress.py
+++ b/backend/app/routes/learning/learning_progress.py
@@ -47,16 +47,44 @@ def _compute_step_completion(session: LearningSession) -> dict[str, str]:
     """Derive per-step status from a LearningSession record.
 
     Returns a dict mapping step key -> 'completed' | 'in_progress' | 'not_started'.
+
+    Priority: use step_progress.steps_completed[] (string array) as the source
+    of truth when available, since the frontend writes this field directly.
+    Falls back to current_step (integer) for older sessions without step_progress.
+    (#1073)
     """
-    completed_step = session.current_step if session.status == "completed" else session.current_step - 1
+    # Try to read steps_completed from step_progress JSONB first
+    sp = session.step_progress
+    sp_completed: list[str] | None = None
+    if isinstance(sp, dict):
+        raw = sp.get("steps_completed")
+        if isinstance(raw, list):
+            sp_completed = [s for s in raw if isinstance(s, str)]
+
     statuses: dict[str, str] = {}
-    for step_num, key in STEP_NAMES.items():
-        if step_num <= completed_step:
-            statuses[key] = "completed"
-        elif step_num == session.current_step and session.status == "in_progress":
-            statuses[key] = "in_progress"
-        else:
-            statuses[key] = "not_started"
+
+    if sp_completed is not None:
+        # Source of truth: step_progress.steps_completed[] (#1073)
+        completed_set = set(sp_completed)
+        sp_current = sp.get("current_step") if isinstance(sp, dict) else None
+        for _step_num, key in STEP_NAMES.items():
+            if key in completed_set:
+                statuses[key] = "completed"
+            elif key == sp_current and session.status == "in_progress":
+                statuses[key] = "in_progress"
+            else:
+                statuses[key] = "not_started"
+    else:
+        # Fallback: derive from integer current_step (legacy sessions)
+        completed_step = session.current_step if session.status == "completed" else session.current_step - 1
+        for step_num, key in STEP_NAMES.items():
+            if step_num <= completed_step:
+                statuses[key] = "completed"
+            elif step_num == session.current_step and session.status == "in_progress":
+                statuses[key] = "in_progress"
+            else:
+                statuses[key] = "not_started"
+
     return statuses
 
 

--- a/backend/app/routes/learning/learning_progress.py
+++ b/backend/app/routes/learning/learning_progress.py
@@ -31,6 +31,8 @@ STEP_NAMES = {
     6: "report",
 }
 
+_MAX_STEP_NUM = max(STEP_NAMES.keys())
+
 STEP_LABELS = {
     1: "簡介",
     2: "逐段朗讀",
@@ -39,6 +41,19 @@ STEP_LABELS = {
     5: "全文朗讀",
     6: "學習報告",
 }
+
+# Frontend step IDs may differ from backend STEP_NAMES values.
+# This mapping normalizes frontend keys → backend keys (#1073).
+_FRONTEND_STEP_ALIAS: dict[str, str] = {
+    "tutor": "live_tutor",
+    "full-reading": "full_reading",
+    "reading-annotation": "intro",
+}
+
+
+def _normalize_step_key(key: str) -> str:
+    """Map a frontend step ID to the canonical backend STEP_NAMES key."""
+    return _FRONTEND_STEP_ALIAS.get(key, key)
 
 
 # ── Helper functions ──────────────────────────────────────────────────────────
@@ -65,13 +80,19 @@ def _compute_step_completion(session: LearningSession) -> dict[str, str]:
 
     if sp_completed is not None:
         # Source of truth: step_progress.steps_completed[] (#1073)
-        completed_set = set(sp_completed)
+        # Normalize frontend step IDs to backend keys for comparison
+        completed_set = {_normalize_step_key(s) for s in sp_completed}
         sp_current = sp.get("current_step") if isinstance(sp, dict) else None
+        normalized_current = _normalize_step_key(sp_current) if sp_current else None
         for _step_num, key in STEP_NAMES.items():
             if key in completed_set:
                 statuses[key] = "completed"
-            elif key == sp_current and session.status == "in_progress":
+            elif key == normalized_current and session.status == "in_progress":
                 statuses[key] = "in_progress"
+            elif session.status == "completed":
+                # Completed session: treat all steps as completed even if
+                # steps_completed[] is incomplete (#1073 review)
+                statuses[key] = "completed"
             else:
                 statuses[key] = "not_started"
     else:

--- a/backend/app/routes/learning/learning_step_progress.py
+++ b/backend/app/routes/learning/learning_step_progress.py
@@ -15,6 +15,10 @@ from ...database import get_db
 from ...models.session import LearningSession
 from ...models.user import User
 from ...schemas.session import StepProgressResponse, StepProgressSaveRequest
+from .learning_progress import STEP_NAMES
+
+# Reverse mapping: step key (string) → step number (int)
+_STEP_KEY_TO_NUM = {v: k for k, v in STEP_NAMES.items()}
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -66,6 +70,19 @@ def save_step_progress(
     }
     if existing_meta:
         session.step_progress["__meta"] = existing_meta
+
+    # Sync integer current_step from steps_completed to prevent desync (#1073).
+    # Derive the highest completed step number, then set current_step = next step.
+    if payload.steps_completed:
+        max_completed_num = max(
+            (_STEP_KEY_TO_NUM.get(s, 0) for s in payload.steps_completed),
+            default=0,
+        )
+        if max_completed_num > 0:
+            new_current = min(max_completed_num + 1, max(STEP_NAMES.keys()))
+            if new_current != session.current_step:
+                session.current_step = new_current
+
     db.commit()
     db.refresh(session)
     logger.info(

--- a/backend/app/routes/learning/learning_step_progress.py
+++ b/backend/app/routes/learning/learning_step_progress.py
@@ -15,7 +15,7 @@ from ...database import get_db
 from ...models.session import LearningSession
 from ...models.user import User
 from ...schemas.session import StepProgressResponse, StepProgressSaveRequest
-from .learning_progress import STEP_NAMES
+from .learning_progress import STEP_NAMES, _MAX_STEP_NUM, _normalize_step_key
 
 # Reverse mapping: step key (string) → step number (int)
 _STEP_KEY_TO_NUM = {v: k for k, v in STEP_NAMES.items()}
@@ -72,14 +72,14 @@ def save_step_progress(
         session.step_progress["__meta"] = existing_meta
 
     # Sync integer current_step from steps_completed to prevent desync (#1073).
-    # Derive the highest completed step number, then set current_step = next step.
+    # Normalize frontend step IDs → backend keys before lookup.
     if payload.steps_completed:
         max_completed_num = max(
-            (_STEP_KEY_TO_NUM.get(s, 0) for s in payload.steps_completed),
+            (_STEP_KEY_TO_NUM.get(_normalize_step_key(s), 0) for s in payload.steps_completed),
             default=0,
         )
         if max_completed_num > 0:
-            new_current = min(max_completed_num + 1, max(STEP_NAMES.keys()))
+            new_current = min(max_completed_num + 1, _MAX_STEP_NUM)
             if new_current != session.current_step:
                 session.current_step = new_current
 


### PR DESCRIPTION
# Issue #1073 修正說明

## 問題摘要
後端 `LearningSession` 有兩套獨立的進度資料：`current_step`（整數，1-6）和 `step_progress.steps_completed[]`（字串陣列）。後端 `_compute_step_completion()` 只讀取 `current_step` 整數，前端卻以 `steps_completed[]` 為準，兩者可能不一致，導致教師看到的學生進度不正確。

## 修正策略
雙向同步：
1. **讀取方向**：`_compute_step_completion()` 改為優先讀取 `step_progress.steps_completed[]`（前端寫入的最新資料），舊 session 不含此欄位時 fallback 到 `current_step` 整數。
2. **寫入方向**：`save_step_progress()` 在更新 `step_progress` JSONB 時，同步推算並更新 `session.current_step` 整數（取 steps_completed 中最高的 step number + 1），確保兩套資料永遠一致。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `backend/app/routes/learning/learning_progress.py` | `_compute_step_completion()` 優先使用 `steps_completed[]` |
| `backend/app/routes/learning/learning_step_progress.py` | `save_step_progress()` 同步更新 `current_step` 整數 |

## 修正內容詳述

### 1. `learning_progress.py` — `_compute_step_completion()`

**Before:**
```python
def _compute_step_completion(session):
    completed_step = session.current_step if session.status == "completed" else session.current_step - 1
    for step_num, key in STEP_NAMES.items():
        if step_num <= completed_step:
            statuses[key] = "completed"
```
只讀 `current_step` 整數，忽略 `steps_completed[]`。

**After:**
```python
def _compute_step_completion(session):
    sp = session.step_progress
    sp_completed = sp.get("steps_completed") if isinstance(sp, dict) else None

    if sp_completed is not None:
        # 優先使用 steps_completed[]（前端寫入的最新資料）
        completed_set = set(sp_completed)
        for step_num, key in STEP_NAMES.items():
            if key in completed_set:
                statuses[key] = "completed"
            elif key == sp_current:
                statuses[key] = "in_progress"
            else:
                statuses[key] = "not_started"
    else:
        # Fallback: 舊 session 用 current_step 整數
        ...原有邏輯...
```

### 2. `learning_step_progress.py` — `save_step_progress()`

**新增同步邏輯：**
```python
# 寫入 step_progress 時同步 current_step 整數
if payload.steps_completed:
    max_completed_num = max(
        (_STEP_KEY_TO_NUM.get(s, 0) for s in payload.steps_completed),
        default=0,
    )
    if max_completed_num > 0:
        new_current = min(max_completed_num + 1, max(STEP_NAMES.keys()))
        if new_current != session.current_step:
            session.current_step = new_current
```

## 測試方式

### 手動測試

1. **進度一致性驗證**
   - 學生完成 Step 1（intro）和 Step 2（live_tutor）
   - 查 DB：`session.current_step` 應為 3，`step_progress.steps_completed` 應包含 `["intro", "live_tutor"]`
   - 教師後台進度頁應顯示 Step 1, 2 為「已完成」，Step 3 為「進行中」

2. **跳步驗證**
   - 學生直接跳到 Step 4（vocab），完成後
   - `steps_completed` 包含 `["vocab"]`，`current_step` 應為 5
   - 教師後台應只顯示 vocab 為已完成

### 驗證方法 — 查 DB

```sql
SELECT id, current_step, step_progress->'steps_completed' as steps_completed
FROM learning_sessions
WHERE student_id = <test_id>
ORDER BY started_at DESC LIMIT 5;
```

## 迴歸測試

- 正常學習流程（依序完成各步驟）
- 教師後台學生進度頁面
- 作業完成狀態判定
- 舊 session（無 step_progress）的進度顯示

## 嚴重性

🟡 **中** — 影響教師對學生學習狀態的判讀，但不影響學生的主要學習流程。