### PR TITLE
ci: fix Firebase deploy job skipping on infra-only changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      firebase: ${{ steps.filter.outputs.firebase }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -27,6 +28,10 @@ jobs:
             backend:
               - 'backend/**'
             frontend:
+              - 'frontend/**'
+            firebase:
+              - 'firebase.json'
+              - '.firebaserc'
               - 'frontend/**'
 
   deploy-backend:
@@ -152,11 +157,10 @@ jobs:
 
   deploy-frontend-firebase:
     name: Deploy frontend to Firebase Hosting (prod)
-    needs: [detect-changes, deploy-frontend]
+    needs: [detect-changes]
     if: |
-      always() && !cancelled() &&
-      (needs.detect-changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch') &&
-      needs.deploy-frontend.result == 'success'
+      needs.detect-changes.outputs.firebase == 'true' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       COMMIT_SHA: ${{ github.sha }}
@@ -173,10 +177,11 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Build frontend for Firebase (relative API paths)
+      - name: Build frontend for Firebase (relative API paths, no demo login)
         working-directory: frontend
         env:
           VITE_API_URL: ""
+          VITE_SHOW_DEMO_LOGIN: "false"
         run: npm run build
 
       - id: auth

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
+      firebase: ${{ steps.filter.outputs.firebase }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -34,6 +35,10 @@ jobs:
             backend:
               - 'backend/**'
             frontend:
+              - 'frontend/**'
+            firebase:
+              - 'firebase.json'
+              - '.firebaserc'
               - 'frontend/**'
 
   deploy-backend:
@@ -196,11 +201,10 @@ jobs:
 
   deploy-frontend-firebase:
     name: Deploy frontend to Firebase Hosting (staging + dev)
-    needs: [detect-changes, deploy-frontend]
+    needs: [detect-changes]
     if: |
-      always() && !cancelled() &&
-      (needs.detect-changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch') &&
-      needs.deploy-frontend.result == 'success'
+      needs.detect-changes.outputs.firebase == 'true' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       COMMIT_SHA: ${{ github.sha }}


### PR DESCRIPTION
## Summary
- `deploy-frontend-firebase` job required `deploy-frontend.result == 'success'`, so infra-only changes (or `workflow_dispatch`) would skip Firebase deploy entirely
- Observed after #1143 merged to main: Cloud Run deploy skipped (no frontend diff) → Firebase job skipped → had to deploy prod manually
- Fix: add `firebase` path filter + decouple from `deploy-frontend` so Firebase has its own independent trigger
- Bonus: prod Firebase build now forces `VITE_SHOW_DEMO_LOGIN=false` so the public prod site won't show demo login buttons

## Test plan
- [ ] Merge to staging → staging-deploy runs → deploy-frontend-firebase runs (not skipped)
- [ ] Verify https://lingoleap-staging.web.app + https://lingoleap-dev.web.app redeploy
- [ ] Merge staging → main → deploy runs → deploy-frontend-firebase runs (not skipped)
- [ ] Verify https://lingoleap-prod.web.app redeploys with demo buttons hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)