### PR TITLE
fix: dedupe login API calls (Closes #1156)

### DIFF
--- a/frontend/src/components/student/RecommendedStories.tsx
+++ b/frontend/src/components/student/RecommendedStories.tsx
@@ -118,12 +118,17 @@ const RecommendedStories: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Use user.id (primitive) rather than the full user object reference so that
+  // AuthContext re-renders (e.g. isLoading → false) that produce a new user
+  // object but the same identity do NOT retrigger the fetch (Issue #1156).
+  const userId = user?.id;
+
   const fetchRecs = useCallback(async () => {
-    if (!token || !user) return;
+    if (!token || !userId) return;
     try {
       setLoading(true);
       setError(null);
-      const data = await getStoryRecommendations(token, user.id, 5);
+      const data = await getStoryRecommendations(token, userId, 5);
       setRecs(data.recommendations);
     } catch (err) {
       setError('載入推薦課文失敗');
@@ -131,7 +136,7 @@ const RecommendedStories: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  }, [token, user]);
+  }, [token, userId]);
 
   useEffect(() => {
     fetchRecs();

--- a/frontend/src/components/student/StudentProgressDashboard.tsx
+++ b/frontend/src/components/student/StudentProgressDashboard.tsx
@@ -8,7 +8,7 @@
  * Issue #25
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   ResponsiveContainer,
   AreaChart,
@@ -111,16 +111,28 @@ const StudentProgressDashboard: React.FC<StudentProgressDashboardProps> = ({
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
 
+  // Keep a stable ref so the callback never causes the effect to re-run.
+  // The effect only needs to fire when user/token become available, not when the
+  // callback reference changes (Issue #1156 — dashboard was fetched 3x on login).
+  const onDashboardLoadedRef = useRef(onDashboardLoaded);
+  useEffect(() => { onDashboardLoadedRef.current = onDashboardLoaded; });
+
+  // Use user.id (primitive) rather than the full user object so that a new
+  // object reference (e.g. after isLoading toggles) does NOT re-trigger the
+  // fetch.  The dashboard only needs to reload when the logged-in user changes
+  // or the token is rotated (Issue #1156 — was fetching 3x on login).
+  const userId = user?.id;
+
   useEffect(() => {
-    if (!user || !token) return;
-    fetchStudentDashboard(token, user.id)
+    if (!userId || !token) return;
+    fetchStudentDashboard(token, userId)
       .then((d) => {
         setData(d);
-        onDashboardLoaded?.(d.completed_story_slugs);
+        onDashboardLoadedRef.current?.(d.completed_story_slugs);
       })
       .catch((err) => setError(err.message))
       .finally(() => setIsLoading(false));
-  }, [user, token, onDashboardLoaded]);
+  }, [userId, token]); // onDashboardLoaded intentionally excluded — use ref above
 
   if (isLoading) {
     return (

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -50,9 +50,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [mustChangePassword, setMustChangePassword] = useState(false);
   const [loginPassword, setLoginPassword] = useState<string | null>(null);
 
-  // Load user from stored token on mount
+  // Load user from stored token on mount (page reload / direct token hydration).
+  // This effect watches [token] so it fires when the token first becomes available
+  // from localStorage on mount.  During a fresh login, login() already fetches user
+  // data and calls setUser() BEFORE calling setToken(), so by the time this effect
+  // runs `user` is already set — we skip the redundant /me call in that case.
+  // This eliminates the duplicate /api/users/me that was previously fired on every
+  // login (Issue #1156).
   useEffect(() => {
     if (!token) {
+      setIsLoading(false);
+      return;
+    }
+
+    // User already set by login() / loginWithGoogle() — no need to re-fetch /me.
+    if (user) {
       setIsLoading(false);
       return;
     }
@@ -82,22 +94,29 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]); // intentionally omit `user` — re-run only when token changes
 
   const login = useCallback(async (email: string, password: string): Promise<{ mustChangePassword: boolean }> => {
     const response = await apiLogin(email, password);
     const newToken = response.access_token;
-    localStorage.setItem(TOKEN_KEY, newToken);
-    setToken(newToken);
 
     const needsPasswordChange = !!response.must_change_password;
+
+    // Fetch user data ONCE here, then set user BEFORE setting token so that the
+    // token-change useEffect above sees user !== null and skips its own /me call.
+    // Previously getMe() was called here AND triggered again by the useEffect,
+    // causing a duplicate /api/users/me on every login (Issue #1156).
+    const userData = await getMe(newToken);
+
+    localStorage.setItem(TOKEN_KEY, newToken);
+    setUser(userData);
+    setToken(newToken);
+
     if (needsPasswordChange) {
       setMustChangePassword(true);
       setLoginPassword(password);
     }
-
-    const userData = await getMe(newToken);
-    setUser(userData);
 
     return { mustChangePassword: needsPasswordChange };
   }, []);
@@ -111,10 +130,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const loginWithGoogle = useCallback(async (credential: string): Promise<{ isNewUser: boolean }> => {
     const response = await apiGoogleLogin(credential);
     const newToken = response.access_token;
-    localStorage.setItem(TOKEN_KEY, newToken);
-    setToken(newToken);
+    // Same ordering as login(): fetch user first, then set user before token so
+    // the token-change useEffect skips its redundant /me call (Issue #1156).
     const userData = await getMe(newToken);
+    localStorage.setItem(TOKEN_KEY, newToken);
     setUser(userData);
+    setToken(newToken);
     return { isNewUser: response.is_new_user };
   }, []);
 

--- a/frontend/src/pages/student/StudentHome.tsx
+++ b/frontend/src/pages/student/StudentHome.tsx
@@ -16,7 +16,7 @@
  * Route: /student
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import StudentProgressDashboard from '../../components/student/StudentProgressDashboard';
@@ -107,9 +107,14 @@ const StudentHome: React.FC = () => {
       .finally(() => setClassroomsLoaded(true));
   }, [token, navigate]);
 
-  const handleSelectClassroom = (classroomId: number) => {
+  const handleSelectClassroom = useCallback((classroomId: number) => {
     navigate(`/library?classroom=${classroomId}`);
-  };
+  }, [navigate]);
+
+  // Stable no-op passed to StudentProgressDashboard to avoid recreating an
+  // arrow function on every render (inline `() => {}` would cause needless
+  // re-renders even though the child guards with useRef, Issue #1156).
+  const noop = useCallback(() => {}, []);
 
   // Issue #457: block the full dashboard for students not yet added to any classroom.
   if (classroomsLoaded && classrooms.length === 0) {
@@ -209,7 +214,7 @@ const StudentHome: React.FC = () => {
           >
             學習進度
           </h2>
-          <StudentProgressDashboard onDashboardLoaded={() => {}} />
+          <StudentProgressDashboard onDashboardLoaded={noop} />
         </section>
 
         {/* ── Recommended stories ─────────────────────────────────────── */}


### PR DESCRIPTION
Closes #1156

## Root cause

After a student logs in, 3 components each trigger independent `useEffect` fetches, causing duplicate API calls:

1. **`/api/users/me` x2** — `AuthContext.login()` called `getMe()` explicitly, then set `token`, which triggered the `useEffect([token])` to call `getMe()` a second time before `user` was set.

2. **`/api/learning/students/{id}/dashboard` x3** — `StudentProgressDashboard` had `useEffect([user, token])` where `user` is the full object reference. Each AuthContext state transition (`user=null→data`, `isLoading=true→false`) produces a new object reference even if the data is identical, retriggering the effect. The `onDashboardLoaded={() => {}}` inline arrow in `StudentHome` also contributed an extra trigger.

3. **`/api/learning/recommendations/{id}` x2** — `RecommendedStories` wrapped the fetch in `useCallback([token, user])` where `user` is the full object. Same reference-churn problem: when AuthContext re-renders (e.g. `isLoading` flip), a new `user` object reference causes `fetchRecs` to be recreated, which triggers the `useEffect([fetchRecs])`.

## Fix

| File | Change |
|------|--------|
| `AuthContext.tsx` | `login()` and `loginWithGoogle()` now call `setUser(userData)` **before** `setToken()`. The `useEffect([token])` checks `if (user) { setIsLoading(false); return; }` — so on fresh login the `/me` re-fetch is skipped entirely. |
| `StudentProgressDashboard.tsx` | Changed `useEffect` dep from `[user, token]` to `[user?.id, token]` (primitive). Added `useRef` guard for `onDashboardLoaded` callback so prop changes don't trigger refetches. |
| `RecommendedStories.tsx` | Changed `useCallback` dep from `[token, user]` to `[token, user?.id]` (primitive). |
| `StudentHome.tsx` | Replaced inline `onDashboardLoaded={() => {}}` with a stable `useCallback(() => {}, [])` ref. |

## Before / After prediction

| Endpoint | Before | After |
|----------|--------|-------|
| `/api/users/me` | 2 calls | 1 call |
| `/api/learning/students/{id}/dashboard` | 3 calls | 1 call |
| `/api/learning/recommendations/{id}` | 2 calls | 1 call |
| **Total savings** | **~1.5s wasted** | **4 fewer round-trips** |

## Test plan

- [ ] Log in with email/password → Network tab shows exactly 1 call each to `/me`, `/dashboard`, `/recommendations`
- [ ] Page reload (token in localStorage) → `/me` still fires once on mount, dashboard and recommendations fire once
- [ ] Log in with Google → same dedup behavior
- [ ] Navigate away and back to `/student` → dashboard and recommendations refetch (expected, not a regression)
- [ ] `npx vite build` passes cleanly (verified locally)