### PR TITLE
fix(a11y): GamificationHero hero banner text contrast (Fixes #1159)

### DIFF
--- a/frontend/src/components/gamification/GamificationHero.tsx
+++ b/frontend/src/components/gamification/GamificationHero.tsx
@@ -86,11 +86,11 @@ const XPProgressBar: React.FC<XPProgressBarProps> = ({
 }) => (
   <div className="flex-1 min-w-0">
     <div className="flex items-center justify-between text-xs mb-1">
-      <span className="text-white/70 font-medium">{currentXp} XP</span>
+      <span className="text-white font-medium">{currentXp} XP</span>
       {nextLevelXp !== null ? (
-        <span className="text-white/70">還差 {xpToNext} XP</span>
+        <span className="text-white font-medium">還差 {xpToNext} XP</span>
       ) : (
-        <span className="text-white/80 font-bold">已達最高等級</span>
+        <span className="text-white font-bold">已達最高等級</span>
       )}
     </div>
     <div className="h-2 rounded-full bg-white/20 overflow-hidden">
@@ -128,7 +128,7 @@ const GamificationHero: React.FC<GamificationHeroProps> = ({ summary, className 
             <span className="text-white font-black text-lg leading-none tabular-nums">
               {streak.current}
             </span>
-            <span className="text-white/70 text-xs">天</span>
+            <span className="text-white text-xs">天</span>
           </div>
 
           {/* Level pill */}
@@ -150,7 +150,7 @@ const GamificationHero: React.FC<GamificationHeroProps> = ({ summary, className 
 
         {/* ── Row 2: next badge hint + link (hidden on mobile xs, shown sm+) ── */}
         <div className="hidden sm:flex items-center justify-between">
-          <p className="text-white/80 text-xs leading-snug">
+          <p className="text-white text-xs leading-snug">
             {nextBadge ? (
               <>
                 距離
@@ -164,7 +164,7 @@ const GamificationHero: React.FC<GamificationHeroProps> = ({ summary, className 
           <button
             type="button"
             onClick={() => navigate('/achievements')}
-            className="text-white/90 hover:text-white text-xs font-bold shrink-0 ml-3 transition-colors underline-offset-2 hover:underline"
+            className="text-white text-xs font-bold shrink-0 ml-3 transition-colors underline-offset-2 hover:underline"
             aria-label="前往成就頁"
           >
             看全部 →
@@ -173,13 +173,13 @@ const GamificationHero: React.FC<GamificationHeroProps> = ({ summary, className 
 
         {/* Mobile-only: compact "看全部" link */}
         <div className="flex sm:hidden items-center justify-between">
-          <p className="text-white/70 text-xs">
+          <p className="text-white text-xs">
             {li.level_name}
           </p>
           <button
             type="button"
             onClick={() => navigate('/achievements')}
-            className="text-white/90 text-xs font-bold underline-offset-2 hover:underline"
+            className="text-white text-xs font-bold underline-offset-2 hover:underline"
             aria-label="前往成就頁"
           >
             看全部 →


### PR DESCRIPTION
Fixes #1159

## Summary

- Replace all `text-white/70`, `text-white/80`, `text-white/90` opacity-reduced classes with full `text-white` in `GamificationHero.tsx`
- Visual hierarchy between secondary and primary text is now conveyed via font-weight (`font-medium` / `font-bold` / `font-black`) rather than opacity
- All 7 affected text elements on the hero banner now meet WCAG AA contrast ratio (≥ 4.5:1) against the dark indigo-to-purple gradient background

## Changed elements

| Element | Before | After |
|---------|--------|-------|
| Streak "天" label | `text-white/70` | `text-white` |
| Progress bar left XP label | `text-white/70 font-medium` | `text-white font-medium` |
| "還差 N XP" label | `text-white/70` | `text-white font-medium` |
| "已達最高等級" | `text-white/80 font-bold` | `text-white font-bold` |
| Badge hint row | `text-white/80` | `text-white` |
| Desktop "看全部 →" button | `text-white/90 hover:text-white` | `text-white` |
| Mobile "看全部 →" button | `text-white/90` | `text-white` |
| Mobile level_name | `text-white/70` | `text-white` |

## Test plan

- [ ] Open PR Preview URL (auto-posted by CI after deploy)
- [ ] Navigate to `/student` page (log in as a student)
- [ ] Verify the GamificationHero banner shows: streak count + "天", XP progress labels, badge hint row, "看全部 →" — all clearly readable
- [ ] Check both desktop (sm+) and mobile (<sm) widths
- [ ] Verify no regressions on the Lv.N pill (unchanged — already had full white text on its own colored gradient)

🤖 Generated with [Claude Code](https://claude.com/claude-code)