### PR TITLE
feat: classroom pill filter on 班級作業 page (Fixes #1158)

### DIFF
--- a/frontend/src/pages/student/MyAssignments.tsx
+++ b/frontend/src/pages/student/MyAssignments.tsx
@@ -380,7 +380,16 @@ const MyAssignments: React.FC = () => {
 
   // Summary bar: unique classroom names from enrolled classrooms
   const classroomNames = useMemo(() => classrooms.map((c) => c.name), [classrooms]);
-  const showClassroomFilter = classrooms.length >= 3;
+  // Show pill filter when student is in 2+ classrooms (#1158)
+  const showClassroomFilter = classrooms.length >= 2;
+
+  // Reset classroom filter if the selected classroom is no longer in the list
+  // (e.g. after classroom API failure returns empty or student left a classroom)
+  useEffect(() => {
+    if (classroomFilter !== 'all' && !classroomNames.includes(classroomFilter)) {
+      setClassroomFilter('all');
+    }
+  }, [classroomNames, classroomFilter]);
 
   return (
     <div className="flex-1 overflow-y-auto p-4 sm:p-6">
@@ -402,8 +411,37 @@ const MyAssignments: React.FC = () => {
           </div>
         )}
 
-        {/* Filter tabs + sort + classroom filter */}
-        <div className="flex items-center justify-between gap-2 border-b border-gray-200 flex-wrap">
+        {/* Classroom pill filter — visible when student is in 2+ classrooms (#1158) */}
+        {showClassroomFilter && !isLoading && (
+          <div className="flex items-center gap-2 flex-wrap" role="group" aria-label="依班級篩選">
+            <button
+              onClick={() => setClassroomFilter('all')}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors cursor-pointer ${
+                classroomFilter === 'all'
+                  ? 'bg-accent text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              全部
+            </button>
+            {classroomNames.map((name) => (
+              <button
+                key={name}
+                onClick={() => setClassroomFilter(name)}
+                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors cursor-pointer ${
+                  classroomFilter === name
+                    ? 'bg-accent text-white'
+                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                {name}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Filter tabs + sort */}
+        <div className="flex items-center justify-between gap-2 border-b border-gray-200">
           <nav className="flex -mb-px" aria-label="Filter tabs">
             {FILTER_TABS.map((tab) => (
               <button
@@ -419,35 +457,18 @@ const MyAssignments: React.FC = () => {
               </button>
             ))}
           </nav>
-          <div className="flex items-center gap-2 mb-px">
-            {showClassroomFilter && (
-              <select
-                value={classroomFilter}
-                onChange={(e) => setClassroomFilter(e.target.value)}
-                className="text-xs text-gray-600 border border-gray-200 rounded-md px-2 py-1 bg-white cursor-pointer focus:outline-none focus:ring-1 focus:ring-accent"
-                aria-label="班級篩選"
-              >
-                <option value="all">全部班級</option>
-                {classroomNames.map((name) => (
-                  <option key={name} value={name}>
-                    {name}
-                  </option>
-                ))}
-              </select>
-            )}
-            <select
-              value={sortKey}
-              onChange={(e) => setSortKey(e.target.value as SortKey)}
-              className="text-xs text-gray-600 border border-gray-200 rounded-md px-2 py-1 bg-white cursor-pointer focus:outline-none focus:ring-1 focus:ring-accent"
-              aria-label="排序方式"
-            >
-              {SORT_OPTIONS.map((opt) => (
-                <option key={opt.key} value={opt.key}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </div>
+          <select
+            value={sortKey}
+            onChange={(e) => setSortKey(e.target.value as SortKey)}
+            className="mb-px text-xs text-gray-600 border border-gray-200 rounded-md px-2 py-1 bg-white cursor-pointer focus:outline-none focus:ring-1 focus:ring-accent"
+            aria-label="排序方式"
+          >
+            {SORT_OPTIONS.map((opt) => (
+              <option key={opt.key} value={opt.key}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
         </div>
 
         {/* Error */}


### PR DESCRIPTION
Fixes #1158

## Summary

- Added horizontal pill tag filter row above the status tabs in `MyAssignments.tsx`
- Pills show: **全部** + one pill per enrolled classroom (e.g., 三年甲班, 七年甲班)
- Filter row is hidden when student is in only 1 classroom (no UI noise)
- Status tabs (待完成/已完成/已批改) and sort dropdown are preserved independently
- Added stale-filter guard: resets to 全部 if selected classroom is no longer in the enrollment list (e.g. API failure or classroom membership change)
- Pure frontend change — `classroom_name` was already present in every `StudentAssignmentResponse`

## Test plan

1. Log in as a student enrolled in 2+ classrooms
2. Navigate to 班級作業 page (`/student/assignments`)
3. Verify pill row appears: 全部 | 三年甲班 | 七年甲班
4. Click 三年甲班 — verify only assignments from that classroom are shown
5. Switch to 已完成 tab — verify both classroom filter and status filter apply together
6. Click 全部 — verify all assignments return
7. Log in as a student in 1 classroom — verify NO pill row appears (clean UI)