### PR TITLE
fix: remove duplicate 成就 sidebar entry (Fixes #1163)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -381,7 +381,7 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
         { icon: '🏫', label: '班級作業', path: '/assignments', badge: pendingAssignmentCount },
         { icon: '🧰', label: '練習工具箱', path: '/tools' },
         { icon: '📖', label: '學習紀錄', path: '/learning-history' },
-        { icon: '⭐', label: '成就', path: '/achievements' },
+        // Hidden: 成就 — merged into student home page (recent achievements strip + Lv banner) (#1163)
         // Hidden: 學習進度, 生字本, 對話記錄 — 整合到「班級作業」(#643)
         // Hidden: 我的班級 — merged into /assignments (#1146)
         // Hidden: 加入班級 — students join via invite code, not sidebar (#838)


### PR DESCRIPTION
Fixes #1163

## Summary
- Removed `{ icon: '⭐', label: '成就', path: '/achievements' }` from `studentItems` in Sidebar.tsx
- Added a comment explaining the item was merged into the student home page (recent achievements strip + Lv banner)
- The `/achievements` route itself is **not touched** — deep-linking from the home page "看全部 →" button still works correctly

## Change
Single line in `frontend/src/components/layout/Sidebar.tsx` — nav item removed, replaced with comment.

## Test plan
- [ ] Open preview URL → `/student` — sidebar should NOT show 成就 item
- [ ] On home page, click "看全部 →" on 近期成就 strip → should navigate to `/achievements` correctly
- [ ] No other sidebar items affected