### PR TITLE
feat: 練習工具箱 2-column 單課單工具 MVP (Fixes #1165)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -379,14 +379,17 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
         { icon: '🏠', label: '主頁', path: '/student' },
         { icon: '📚', label: '圖書館', path: '/library' },
         { icon: '🏫', label: '班級作業', path: '/assignments', badge: pendingAssignmentCount },
-        { icon: '🧰', label: '練習工具箱', path: '/tools' },
         { icon: '📖', label: '學習紀錄', path: '/learning-history' },
         // Hidden: 成就 — merged into student home page (recent achievements strip + Lv banner) (#1163)
         // Hidden: 學習進度, 生字本, 對話記錄 — 整合到「班級作業」(#643)
         // Hidden: 我的班級 — merged into /assignments (#1146)
         // Hidden: 加入班級 — students join via invite code, not sidebar (#838)
-
       ]
+    : [];
+
+  // Targeted practice tools — shown at the BOTTOM of the student sidebar, separated by a divider (#1165)
+  const toolsItems: NavItem[] = activeView === 'student'
+    ? [{ icon: '🧰', label: '練習工具箱', path: '/tools' }]
     : [];
 
   const teacherItems: NavItem[] = activeView === 'teacher' || activeView === 'admin'
@@ -539,6 +542,21 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
               onClick={() => handleNavigate(item.path)}
             />
           ))}
+
+          {/* Divider before targeted practice tools (#1165) */}
+          {toolsItems.length > 0 && (
+            <div className="my-1 border-t border-gray-100" aria-hidden="true" />
+          )}
+
+          {toolsItems.map((item) => (
+            <NavButton
+              key={item.path}
+              item={item}
+              collapsed={collapsed}
+              active={isActive(pathname, item.path)}
+              onClick={() => handleNavigate(item.path)}
+            />
+          ))}
         </nav>
 
         {/* Bottom section — notification bell, zhuyin toggle, logout, footer */}
@@ -613,7 +631,7 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
       <MobileTabBar
         studentItems={studentItems}
         teacherItems={teacherItems}
-        extraItems={extraItems}
+        extraItems={[...extraItems, ...toolsItems]}
         pathname={pathname}
         onNavigate={handleNavigate}
         hasMultipleViews={hasMultipleViews}

--- a/frontend/src/components/tools/LessonPicker.tsx
+++ b/frontend/src/components/tools/LessonPicker.tsx
@@ -1,0 +1,197 @@
+/**
+ * LessonPicker — left column of the /tools 練習工具箱 page.
+ *
+ * Renders a radio-select list of lessons with grade tabs + search box.
+ * Reuses fetchStories from api.ts (same data source as StoryLibrary).
+ */
+import React, { useState, useEffect, useMemo } from 'react';
+import { Story } from '../../types';
+import { fetchStories } from '../../services/api';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface LessonPickerProps {
+  selectedId: string | null;
+  onChange: (story: Story | null) => void;
+}
+
+const GRADE_LABELS: Record<number, string> = {
+  3: '三年級',
+  4: '四年級',
+  5: '五年級',
+  6: '六年級',
+  7: '七年級',
+};
+
+const LessonPicker: React.FC<LessonPickerProps> = ({ selectedId, onChange }) => {
+  const { token } = useAuth();
+  const [allStories, setAllStories] = useState<Story[]>([]);
+  const [grades, setGrades] = useState<number[]>([]);
+  const [selectedGrade, setSelectedGrade] = useState<number | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+    setIsLoading(true);
+    fetchStories(token)
+      .then(({ stories, grades: g }) => {
+        setAllStories(stories);
+        setGrades(g);
+      })
+      .catch((err) => setError(err.message ?? '無法載入課文'))
+      .finally(() => setIsLoading(false));
+  }, [token]);
+
+  const filtered = useMemo(() => {
+    let list = allStories;
+    if (selectedGrade != null) list = list.filter((s) => s.grade === selectedGrade);
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      list = list.filter((s) => s.title.toLowerCase().includes(q));
+    }
+    return list;
+  }, [allStories, selectedGrade, searchQuery]);
+
+  const handleSelect = (story: Story) => {
+    onChange(selectedId === story.id ? null : story);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="mb-3">
+        <h2 className="text-lg font-bold text-gray-900">選擇課文</h2>
+        <p className="text-sm text-gray-500 mt-0.5">選一篇課文開始練習</p>
+      </div>
+
+      {/* Grade tabs */}
+      <div className="flex flex-wrap gap-1.5 mb-3">
+        <button
+          type="button"
+          onClick={() => setSelectedGrade(null)}
+          className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+            selectedGrade === null
+              ? 'bg-accent text-white'
+              : 'bg-white text-gray-600 border border-gray-200 hover:border-accent'
+          }`}
+        >
+          全部
+        </button>
+        {grades.map((g) => (
+          <button
+            key={g}
+            type="button"
+            onClick={() => setSelectedGrade(selectedGrade === g ? null : g)}
+            className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${
+              selectedGrade === g
+                ? 'bg-accent text-white'
+                : 'bg-white text-gray-600 border border-gray-200 hover:border-accent'
+            }`}
+          >
+            {GRADE_LABELS[g] ?? `${g}年級`}
+          </button>
+        ))}
+      </div>
+
+      {/* Search box */}
+      <div className="relative mb-3">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="搜尋課文標題..."
+          className="w-full px-3 py-2 pr-8 border border-gray-200 rounded-lg text-sm bg-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+        />
+        {searchQuery ? (
+          <button
+            type="button"
+            onClick={() => setSearchQuery('')}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+            aria-label="清除搜尋"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        ) : (
+          <svg className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        )}
+      </div>
+
+      {/* Result count */}
+      {(selectedGrade != null || searchQuery) && !isLoading && (
+        <p className="text-xs text-gray-400 mb-2">找到 {filtered.length} 篇</p>
+      )}
+
+      {/* List */}
+      <div className="flex-1 overflow-y-auto space-y-1 pr-1">
+        {isLoading && (
+          <div className="space-y-2">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="h-12 bg-gray-100 animate-pulse rounded-lg" />
+            ))}
+          </div>
+        )}
+
+        {error && (
+          <div className="text-center py-6 text-red-500 text-sm">
+            <p>載入失敗：{error}</p>
+          </div>
+        )}
+
+        {!isLoading && !error && filtered.length === 0 && (
+          <div className="text-center py-10 text-gray-400 text-sm">
+            <p>沒有符合的課文</p>
+          </div>
+        )}
+
+        {!isLoading &&
+          filtered.map((story) => {
+            const isSelected = selectedId === story.id;
+            return (
+              <button
+                key={story.id}
+                type="button"
+                onClick={() => handleSelect(story)}
+                aria-pressed={isSelected}
+                className={`
+                  w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left transition-all
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+                  ${isSelected
+                    ? 'bg-accent-bg border border-accent text-accent'
+                    : 'bg-white border border-gray-100 text-gray-700 hover:bg-gray-50 hover:border-gray-200'
+                  }
+                `}
+              >
+                {/* Radio indicator */}
+                <span
+                  className={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                    isSelected ? 'border-accent' : 'border-gray-300'
+                  }`}
+                  aria-hidden="true"
+                >
+                  {isSelected && (
+                    <span className="w-2 h-2 rounded-full bg-accent" />
+                  )}
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="block text-sm font-medium truncate">{story.title}</span>
+                  {story.grade && (
+                    <span className="text-xs text-gray-400">
+                      {GRADE_LABELS[story.grade] ?? `${story.grade}年級`}
+                      {story.genre ? ` · ${story.genre}` : ''}
+                    </span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+      </div>
+    </div>
+  );
+};
+
+export default LessonPicker;

--- a/frontend/src/components/tools/ToolPicker.tsx
+++ b/frontend/src/components/tools/ToolPicker.tsx
@@ -1,0 +1,157 @@
+/**
+ * ToolPicker — right column of the /tools 練習工具箱 page.
+ *
+ * Renders a radio-select list of 10 practice tools.
+ */
+import React from 'react';
+
+export interface ToolOption {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+  /** Route segment under /learn/:storyId/ */
+  stepPath: string;
+}
+
+export const TOOL_OPTIONS: ToolOption[] = [
+  {
+    id: 'tutor',
+    label: '朗讀練習',
+    description: '逐段朗讀，AI 即時糾正',
+    icon: '🎤',
+    stepPath: 'tutor',
+  },
+  {
+    id: 'listening',
+    label: '聽力理解',
+    description: '聽 AI 朗讀，回答問題',
+    icon: '👂',
+    stepPath: 'listening',
+  },
+  {
+    id: 'sentence-practice',
+    label: '造句練習',
+    description: 'AI 引導造句，加深語感',
+    icon: '✏️',
+    stepPath: 'sentence-practice',
+  },
+  {
+    id: 'vocab',
+    label: '生字書寫',
+    description: '筆順練習 + 注音引導',
+    icon: '🖊️',
+    stepPath: 'vocab',
+  },
+  {
+    id: 'vocab-definition',
+    label: '詞語配對',
+    description: '詞語與定義連連看',
+    icon: '🔗',
+    stepPath: 'vocab-definition',
+  },
+  {
+    id: 'vocab-application',
+    label: '詞語應用',
+    description: '填空練習，活用詞語',
+    icon: '📝',
+    stepPath: 'vocab-application',
+  },
+  {
+    id: 'vocab-word-search',
+    label: '詞搜尋',
+    description: '在文章中找出目標詞語',
+    icon: '🔍',
+    stepPath: 'vocab-word-search',
+  },
+  {
+    id: 'knowledge-station',
+    label: '知識補給站',
+    description: '延伸知識影片與補充',
+    icon: '💡',
+    stepPath: 'knowledge-station',
+  },
+  {
+    id: 'full-reading',
+    label: '全文朗讀',
+    description: '完整朗讀評估',
+    icon: '📖',
+    stepPath: 'full-reading',
+  },
+  {
+    id: 'comprehension',
+    label: '課文理解',
+    description: '蘇格拉底式 AI 對話',
+    icon: '💬',
+    stepPath: 'comprehension',
+  },
+];
+
+interface ToolPickerProps {
+  selectedId: string | null;
+  onChange: (tool: ToolOption | null) => void;
+}
+
+const ToolPicker: React.FC<ToolPickerProps> = ({ selectedId, onChange }) => {
+  const handleSelect = (tool: ToolOption) => {
+    onChange(selectedId === tool.id ? null : tool);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="mb-3">
+        <h2 className="text-lg font-bold text-gray-900">選擇工具</h2>
+        <p className="text-sm text-gray-500 mt-0.5">選一個練習方式</p>
+      </div>
+
+      {/* Tool list */}
+      <div className="flex-1 overflow-y-auto space-y-1.5 pr-1">
+        {TOOL_OPTIONS.map((tool) => {
+          const isSelected = selectedId === tool.id;
+          return (
+            <button
+              key={tool.id}
+              type="button"
+              onClick={() => handleSelect(tool)}
+              aria-pressed={isSelected}
+              className={`
+                w-full flex items-center gap-3 px-3 py-3 rounded-lg text-left transition-all
+                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+                ${isSelected
+                  ? 'bg-accent-bg border border-accent'
+                  : 'bg-white border border-gray-100 hover:bg-gray-50 hover:border-gray-200'
+                }
+              `}
+            >
+              {/* Radio indicator */}
+              <span
+                className={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 ${
+                  isSelected ? 'border-accent' : 'border-gray-300'
+                }`}
+                aria-hidden="true"
+              >
+                {isSelected && (
+                  <span className="w-2 h-2 rounded-full bg-accent" />
+                )}
+              </span>
+
+              {/* Icon */}
+              <span className="text-xl shrink-0" aria-hidden="true">{tool.icon}</span>
+
+              {/* Label + desc */}
+              <span className="flex-1 min-w-0">
+                <span className={`block text-sm font-medium ${isSelected ? 'text-accent' : 'text-gray-800'}`}>
+                  {tool.label}
+                </span>
+                <span className="block text-xs text-gray-400 mt-0.5">{tool.description}</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default ToolPicker;

--- a/frontend/src/pages/student/PracticeToolbox.tsx
+++ b/frontend/src/pages/student/PracticeToolbox.tsx
@@ -1,227 +1,112 @@
 /**
- * PracticeToolbox — student self-directed practice landing page.
+ * PracticeToolbox — /tools 練習工具箱
  *
- * Route: /tools
- * Issue #1153
+ * 2-column layout: left = lesson picker (radio), right = tool picker (radio).
+ * Bottom sticky action bar shows selection + 開始練習 button.
  *
- * Shows 6-8 practice tools grouped by category. Tools that require a
- * story (LiveTutor, ComprehensionChat) route to the library first so
- * students can pick a text before starting.
+ * Flow: 開始練習 → /learn/:storyId/:toolPath
+ * The step page's onFinish / onCancel should navigate back to /tools.
  *
- * "不用等作業，自己選想練的"
+ * Issue #1165 (replaces #1153 card-grid design)
  */
-
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface Tool {
-  icon: string;
-  title: string;
-  description: string;
-  /** Route to navigate to. '#needs-story' = go to library first. */
-  route: string;
-  /** If true, button label changes to "選課文開始". */
-  needsStory?: boolean;
-}
-
-interface ToolGroup {
-  icon: string;
-  label: string;
-  tools: Tool[];
-}
-
-// ---------------------------------------------------------------------------
-// Tool catalogue (curated, no smart recommendation)
-// ---------------------------------------------------------------------------
-
-const TOOL_GROUPS: ToolGroup[] = [
-  {
-    icon: '🗣️',
-    label: '朗讀',
-    tools: [
-      {
-        icon: '🎙️',
-        title: '逐段朗讀',
-        description: 'AI 即時指導，一段一段練好再往下',
-        route: '/library',
-        needsStory: true,
-      },
-      {
-        icon: '📢',
-        title: '全文朗讀',
-        description: '完整朗讀一篇課文，聽自己的聲音',
-        route: '/library',
-        needsStory: true,
-      },
-    ],
-  },
-  {
-    icon: '✍️',
-    label: '寫字',
-    tools: [
-      {
-        icon: '🖊️',
-        title: '筆順字帖',
-        description: '跟著動畫練正確筆順，不怕寫錯',
-        route: '/write',
-      },
-      {
-        icon: '🔤',
-        title: '生字練習',
-        description: '學習本課生字，注音+筆順一起來',
-        route: '/library',
-        needsStory: true,
-      },
-    ],
-  },
-  {
-    icon: '👂',
-    label: '聽寫',
-    tools: [
-      {
-        icon: '🎧',
-        title: '聽寫挑戰',
-        description: 'AI 唸字，你來打字，邊聽邊學',
-        route: '/library',
-        needsStory: true,
-      },
-    ],
-  },
-  {
-    icon: '📝',
-    label: '字詞',
-    tools: [
-      {
-        icon: '✏️',
-        title: '造句練習',
-        description: 'AI 出題，練習用學過的詞造好句子',
-        route: '/library',
-        needsStory: true,
-      },
-      {
-        icon: '🔍',
-        title: '詞語定義配對',
-        description: '把詞語和它的意思配對，加深記憶',
-        route: '/library',
-        needsStory: true,
-      },
-      {
-        icon: '📖',
-        title: '字典查詢',
-        description: '查字義、注音、例句，隨時查隨時懂',
-        route: '/vocabulary',
-      },
-    ],
-  },
-  {
-    icon: '🧠',
-    label: '理解',
-    tools: [
-      {
-        icon: '💬',
-        title: '課文理解對話',
-        description: '蘇格拉底式 AI 對話，深入理解課文',
-        route: '/library',
-        needsStory: true,
-      },
-    ],
-  },
-];
-
-// ---------------------------------------------------------------------------
-// ToolCard — single practice tool card
-// ---------------------------------------------------------------------------
-
-interface ToolCardProps {
-  tool: Tool;
-}
-
-const ToolCard: React.FC<ToolCardProps> = ({ tool }) => {
-  const navigate = useNavigate();
-
-  return (
-    <div className="bg-surface-container-lowest rounded-2xl border border-gray-100 shadow-sm p-4 flex flex-col gap-3 hover:shadow-md transition-all duration-200">
-      <div className="flex items-start gap-3">
-        <div
-          className="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center shrink-0"
-          aria-hidden="true"
-        >
-          <span className="text-xl">{tool.icon}</span>
-        </div>
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-bold text-on-surface leading-tight">{tool.title}</p>
-          <p className="text-xs text-on-surface-variant mt-0.5 leading-snug">{tool.description}</p>
-        </div>
-      </div>
-      <button
-        type="button"
-        onClick={() => navigate(tool.route)}
-        className="w-full py-2 rounded-xl bg-accent text-white text-xs font-bold hover:bg-accent/90 active:scale-95 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
-      >
-        {tool.needsStory ? '選課文開始' : '開始練習'}
-      </button>
-    </div>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// ToolGroup section
-// ---------------------------------------------------------------------------
-
-interface ToolGroupSectionProps {
-  group: ToolGroup;
-}
-
-const ToolGroupSection: React.FC<ToolGroupSectionProps> = ({ group }) => (
-  <section aria-labelledby={`group-${group.label}`}>
-    <h2
-      id={`group-${group.label}`}
-      className="flex items-center gap-2 text-sm font-bold text-on-surface-variant uppercase tracking-wide mb-3"
-    >
-      <span aria-hidden="true">{group.icon}</span>
-      {group.label}
-    </h2>
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-      {group.tools.map((tool) => (
-        <ToolCard key={tool.title} tool={tool} />
-      ))}
-    </div>
-  </section>
-);
-
-// ---------------------------------------------------------------------------
-// Page
-// ---------------------------------------------------------------------------
+import { Story } from '../../types';
+import LessonPicker from '../../components/tools/LessonPicker';
+import ToolPicker, { ToolOption } from '../../components/tools/ToolPicker';
 
 const PracticeToolbox: React.FC = () => {
+  const navigate = useNavigate();
+  const [selectedStory, setSelectedStory] = useState<Story | null>(null);
+  const [selectedTool, setSelectedTool] = useState<ToolOption | null>(null);
+
+  const canStart = selectedStory != null && selectedTool != null;
+
+  const handleStart = () => {
+    if (!canStart) return;
+    navigate(`/learn/${selectedStory.id}/${selectedTool.stepPath}`, {
+      state: { returnTo: '/tools' },
+    });
+  };
+
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-2xl mx-auto px-5 py-8 space-y-8">
-        {/* Header */}
-        <div>
-          <h1 className="text-2xl font-bold font-headline text-on-surface">
-            練習工具箱
-          </h1>
-          <p className="text-sm text-on-surface-variant mt-1">
-            不用等作業，自己選想練的
-          </p>
+    <div className="flex flex-col h-full bg-bg">
+      {/* Page header */}
+      <div className="px-6 py-5 border-b border-gray-100 bg-white shrink-0">
+        <h1 className="text-2xl font-bold text-gray-900">練習工具箱</h1>
+        <p className="text-sm text-gray-500 mt-1">選一篇課文，搭配一種練習方式，專注深練</p>
+      </div>
+
+      {/* 2-column body */}
+      <div className="flex-1 overflow-hidden flex min-h-0">
+        {/* Left column — lesson picker */}
+        <div className="flex-1 min-w-0 overflow-hidden border-r border-gray-100 bg-white">
+          <div className="h-full p-5 overflow-y-auto">
+            <LessonPicker
+              selectedId={selectedStory?.id ?? null}
+              onChange={setSelectedStory}
+            />
+          </div>
         </div>
 
-        {/* Tool groups */}
-        {TOOL_GROUPS.map((group) => (
-          <ToolGroupSection key={group.label} group={group} />
-        ))}
+        {/* Right column — tool picker */}
+        <div className="w-72 shrink-0 bg-white overflow-hidden">
+          <div className="h-full p-5 overflow-y-auto">
+            <ToolPicker
+              selectedId={selectedTool?.id ?? null}
+              onChange={setSelectedTool}
+            />
+          </div>
+        </div>
+      </div>
 
-        {/* Footer note for story-required tools */}
-        <div className="rounded-2xl bg-amber-50 border border-amber-100 p-4">
-          <p className="text-xs text-amber-700 leading-snug">
-            <span className="font-bold">「選課文開始」</span> 的工具需要先選一篇課文才能練習。
-            點選後會帶你到圖書館選課文，選完就直接進入練習。
-          </p>
+      {/* Sticky action bar */}
+      <div className="shrink-0 border-t border-gray-200 bg-white px-6 py-4">
+        <div className="flex items-center justify-between gap-4 max-w-4xl mx-auto">
+          {/* Selection summary */}
+          <div className="flex-1 min-w-0">
+            {!selectedStory && !selectedTool && (
+              <p className="text-sm text-gray-400">請先選擇課文和練習工具</p>
+            )}
+            {selectedStory && !selectedTool && (
+              <p className="text-sm text-gray-600">
+                已選課文：
+                <span className="font-semibold text-gray-900">{selectedStory.title}</span>
+                <span className="text-gray-400"> · 請選擇工具</span>
+              </p>
+            )}
+            {!selectedStory && selectedTool && (
+              <p className="text-sm text-gray-600">
+                已選工具：
+                <span className="font-semibold text-gray-900">{selectedTool.label}</span>
+                <span className="text-gray-400"> · 請選擇課文</span>
+              </p>
+            )}
+            {selectedStory && selectedTool && (
+              <p className="text-sm text-gray-600">
+                <span className="font-semibold text-gray-900">{selectedStory.title}</span>
+                <span className="text-gray-400 mx-2">×</span>
+                <span className="font-semibold text-accent">{selectedTool.label}</span>
+              </p>
+            )}
+          </div>
+
+          {/* Start button */}
+          <button
+            type="button"
+            onClick={handleStart}
+            disabled={!canStart}
+            className={`
+              px-6 py-2.5 rounded-xl text-sm font-semibold transition-all shrink-0
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
+              ${canStart
+                ? 'bg-accent text-white hover:bg-primary-light shadow-sm active:scale-95'
+                : 'bg-gray-100 text-gray-400 cursor-not-allowed'
+              }
+            `}
+          >
+            開始練習
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #1165

## Summary

Replaces the #1153 card-grid PracticeToolbox with a proper 2-column lesson-picker × tool-picker layout.

- **Left column**: radio-select lesson list — grade tabs (三~七年級), search box, skeleton loading, reuses `fetchStories` from `api.ts`
- **Right column**: radio-select 10 tools — icon + name + description for each
- **Sticky action bar**: shows `[課文名] × [工具名]` summary; 開始練習 button disabled until both are selected
- **Sidebar**: moved 練習工具箱 🧰 to bottom of student nav, separated from main items by a divider
- **Navigation**: 開始練習 → `/learn/:storyId/:stepPath` (with `state.returnTo = '/tools'` for future return-to-tools from step completions)

## Files changed

| File | Change |
|------|--------|
| `frontend/src/pages/student/PracticeToolbox.tsx` | Replaced card-grid with 2-column layout |
| `frontend/src/components/tools/LessonPicker.tsx` | New component — lesson radio-select |
| `frontend/src/components/tools/ToolPicker.tsx` | New component — tool radio-select (10 tools) |
| `frontend/src/components/layout/Sidebar.tsx` | Move 練習工具箱 to bottom with divider |

## Backend gaps

No DB migration needed. The `state.returnTo` for post-tool return to `/tools` is frontend-only. Individual tool steps (TutorPage, ListeningPage, etc.) use their own `onFinish` handlers — those currently navigate to `/library`. Returning to `/tools` after a tool finishes would require reading `location.state.returnTo` in each step page — **this is NOT implemented in this PR** (out of scope for MVP). Students can manually go back to `/tools` via sidebar after finishing a tool.

## Test plan

1. Go to `/tools`
2. Verify 2-column layout: left = lessons with grade tabs + search; right = 10 tools
3. Verify 練習工具箱 is at the bottom of the sidebar with a divider
4. Select a lesson → action bar shows the title
5. Select a tool → action bar shows `[title] × [tool]`
6. Verify 開始練習 button is disabled when either is unselected
7. Click 開始練習 → navigates to `/learn/:storyId/:stepPath`
8. Grade tab filter → lessons filter correctly
9. Search box → lessons filter by title