### PR TITLE
fix(gamification): remove broken inline style that wiped hero gradient (Fixes #1170)

### DIFF
--- a/frontend/src/components/gamification/GamificationHero.tsx
+++ b/frontend/src/components/gamification/GamificationHero.tsx
@@ -115,7 +115,6 @@ const GamificationHero: React.FC<GamificationHeroProps> = ({ summary, className 
   return (
     <div
       className={`rounded-3xl bg-gradient-to-br from-accent to-accent/80 shadow-editorial overflow-hidden ${className}`}
-      style={{ background: 'linear-gradient(135deg, var(--color-accent, #5b7fff) 0%, #7c5cbf 100%)' }}
     >
       <div className="px-5 py-4 space-y-3">
         {/* ── Row 1: streak + level pill + XP bar ── */}


### PR DESCRIPTION
Fixes #1170

## Root Cause

`GamificationHero.tsx` had both a Tailwind class AND an inline style on the same div:

```tsx
// Before (broken)
<div
  className={`rounded-3xl bg-gradient-to-br from-accent to-accent/80 ...`}
  style={{ background: 'linear-gradient(135deg, var(--color-accent, #5b7fff) 0%, #7c5cbf 100%)' }}
>
```

`--color-accent` is defined as `86 74 191` (space-separated RGB triplet for Tailwind's `rgb(var(--color-accent) / alpha)` syntax). When used directly in a `linear-gradient()`, it produces invalid CSS. A browser drops an invalid `background` shorthand entirely — resetting `backgroundImage` to `none` and `backgroundColor` to transparent. Since inline styles have higher specificity than Tailwind classes, the entire gradient disappears.

## Computed style evidence on staging (before fix)

| CSS property | Actual value | Expected |
|---|---|---|
| `backgroundImage` | `none` | `linear-gradient(...)` |
| `backgroundColor` | `rgba(0,0,0,0)` | transparent (OK — gradient container) |
| `--tw-gradient-from` | `rgb(86 74 191 / 1)` | Tailwind was correct |
| `--tw-gradient-stops` | `rgb(86 74 191 / 1), rgb(86 74 191 / .8)` | Tailwind was correct |

Tailwind had the right values all along — the inline style was overwriting them with invalid CSS.

## Fix

Remove the inline style. One line deleted.

```tsx
// After (fixed)
<div
  className={`rounded-3xl bg-gradient-to-br from-accent to-accent/80 ...`}
>
```

Tailwind's `bg-gradient-to-br from-accent to-accent/80` produces `linear-gradient(to bottom right, rgb(86 74 191), rgb(86 74 191 / 0.8))` — a correct dark purple gradient.

## Summary

- `frontend/src/components/gamification/GamificationHero.tsx` — remove 1 line (broken inline style)

## Test plan

1. Open PR Preview URL on /login
2. Quick-login as 學生小明
3. Verify hero banner shows dark purple gradient background
4. Verify white text (streak, XP, level) is readable against dark background
5. Check `getComputedStyle(heroEl).backgroundImage` is no longer `none`