### PR TITLE
fix(ui): remove broken GamificationHero inline style (Related to #1159)

### DIFF
--- a/frontend/src/components/gamification/GamificationHero.tsx
+++ b/frontend/src/components/gamification/GamificationHero.tsx
@@ -115,7 +115,6 @@ const GamificationHero: React.FC<GamificationHeroProps> = ({ summary, className 
   return (
     <div
       className={`rounded-3xl bg-gradient-to-br from-accent to-accent/80 shadow-editorial overflow-hidden ${className}`}
-      style={{ background: 'linear-gradient(135deg, var(--color-accent, #5b7fff) 0%, #7c5cbf 100%)' }}
     >
       <div className="px-5 py-4 space-y-3">
         {/* ── Row 1: streak + level pill + XP bar ── */}


### PR DESCRIPTION
## Root Cause

`GamificationHero.tsx` had a conflicting inline style:

```tsx
// BEFORE — broken
className="bg-gradient-to-br from-accent to-accent/80 ..."
style={{ background: 'linear-gradient(135deg, var(--color-accent, #5b7fff) 0%, #7c5cbf 100%)' }}
```

`--color-accent` stores an RGB triplet (`86 74 191`) per Tailwind alpha-value convention — NOT a valid CSS color string. When injected into `linear-gradient(135deg, 86 74 191 0%, ...)` the browser sees invalid syntax and silently drops the entire inline `style` declaration.

With the inline style dropped, the fallback `#5b7fff` (blue) from the CSS var default takes over rather than the intended `#564ABF` (deep purple), producing the wrong hero banner color.

## Fix

Remove the `style` prop entirely. The Tailwind class `bg-gradient-to-br from-accent to-accent/80` on the same element already generates the correct deep-purple gradient using the token correctly.

```tsx
// AFTER — correct
className="bg-gradient-to-br from-accent to-accent/80 ..."
// style prop removed
```

## Verification

- Build passes: `vite build` in 6.31s, no errors
- Single file changed: 1 line deleted
- Related to #1159 (contrast fix PR that addressed text opacity but not this root cause)