### PR TITLE
feat: Step 2 開始錄音後無聲音輸入主動提示 (#1174)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -72,6 +72,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const [isAdvancing, setIsAdvancing] = useState(false);
   const [micError, setMicError] = useState('');
   const [streamingUserInput, setStreamingUserInput] = useState('');
+  // No-audio-detected banner (#1174): shown when user started recording but
+  // no audio detected within 5 seconds.
+  const [noAudioDetected, setNoAudioDetected] = useState(false);
 
   // ── localStorage persistence for reading progress ──────────────────────────
   const loadSavedProgress = () => {
@@ -199,9 +202,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     onSessionReady: () => {
       // session ready callback (kept for compat with hook)
     },
+    onNoAudioDetected: () => setNoAudioDetected(true),
   });
 
-  const startSession = stt.startSession;
+  const startSession = useCallback(() => {
+    setNoAudioDetected(false);
+    stt.startSession();
+  }, [stt]);
   const stopSession = stt.stopSession;
 
   /* ---- scroll helpers ---- */
@@ -881,6 +888,31 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       {micError && (
         <div className="absolute bottom-52 left-1/2 -translate-x-1/2 px-5 py-2 bg-tertiary-container/20 rounded-full z-20">
           <span className="text-sm text-tertiary">{micError}</span>
+        </div>
+      )}
+
+      {/* No-audio-detected banner (#1174) */}
+      {noAudioDetected && stt.isSessionActive && (
+        <div className="absolute bottom-44 left-1/2 -translate-x-1/2 z-20 w-[min(92%,520px)]">
+          <div className="flex items-start gap-3 px-4 py-3 rounded-2xl bg-amber-50 border border-amber-300 shadow-md">
+            <span className="material-symbols-outlined text-amber-600 shrink-0">mic_off</span>
+            <div className="flex-1">
+              <p className="text-sm font-bold text-amber-800">好像沒有偵測到聲音</p>
+              <p className="text-xs text-amber-700 mt-0.5">
+                請確認麥克風權限已開啟、音量足夠，或點擊下方「重新開始」再試一次。
+              </p>
+            </div>
+            <button
+              onClick={() => {
+                stopSession();
+                setNoAudioDetected(false);
+                setTimeout(() => startSession(), 100);
+              }}
+              className="px-3 py-1 rounded-full text-xs font-bold bg-amber-600 text-white hover:bg-amber-700 transition-all shrink-0"
+            >
+              重新開始
+            </button>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -905,7 +905,6 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
             <button
               onClick={() => {
                 stopSession();
-                setNoAudioDetected(false);
                 startSession();
               }}
               className="px-3 py-1 rounded-full text-xs font-bold bg-amber-600 text-white hover:bg-amber-700 transition-all shrink-0"

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -72,7 +72,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const [isAdvancing, setIsAdvancing] = useState(false);
   const [micError, setMicError] = useState('');
   const [streamingUserInput, setStreamingUserInput] = useState('');
-  // No-audio-detected banner (#1174): shown when user started recording but
+  // No-audio-detected banner: shown when user started recording but
   // no audio detected within 5 seconds.
   const [noAudioDetected, setNoAudioDetected] = useState(false);
 
@@ -205,10 +205,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     onNoAudioDetected: () => setNoAudioDetected(true),
   });
 
-  const startSession = useCallback(() => {
+  const startSession = () => {
     setNoAudioDetected(false);
     stt.startSession();
-  }, [stt]);
+  };
   const stopSession = stt.stopSession;
 
   /* ---- scroll helpers ---- */
@@ -891,7 +891,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         </div>
       )}
 
-      {/* No-audio-detected banner (#1174) */}
+      {/* No-audio-detected banner */}
       {noAudioDetected && stt.isSessionActive && (
         <div className="absolute bottom-44 left-1/2 -translate-x-1/2 z-20 w-[min(92%,520px)]">
           <div className="flex items-start gap-3 px-4 py-3 rounded-2xl bg-amber-50 border border-amber-300 shadow-md">
@@ -906,7 +906,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               onClick={() => {
                 stopSession();
                 setNoAudioDetected(false);
-                setTimeout(() => startSession(), 100);
+                startSession();
               }}
               className="px-3 py-1 rounded-full text-xs font-bold bg-amber-600 text-white hover:bg-amber-700 transition-all shrink-0"
             >

--- a/frontend/src/hooks/useLiveTutorSpeech.ts
+++ b/frontend/src/hooks/useLiveTutorSpeech.ts
@@ -53,9 +53,9 @@ export interface UseLiveTutorSpeechOptions {
   onClearTts: () => void;
   /** Called by recognition.onstart (first time only) to add "準備好了" message */
   onSessionReady: () => void;
-  /** Called when no STT audio detected within noAudioTimeoutMs after session starts (#1174) */
+  /** Called when no STT audio detected within noAudioTimeoutMs after session starts. */
   onNoAudioDetected?: () => void;
-  /** Timeout (ms) before onNoAudioDetected fires. Default 5000. (#1174) */
+  /** Timeout (ms) before onNoAudioDetected fires. Default 5000. */
   noAudioTimeoutMs?: number;
 }
 
@@ -96,7 +96,7 @@ export function useLiveTutorSpeech({
   const targetTextRef = useRef(targetText);
   targetTextRef.current = targetText;
 
-  // No-audio-detected timer (#1174): fires onNoAudioDetected if no STT result
+  // No-audio-detected timer: fires onNoAudioDetected if no STT result
   // arrives within noAudioTimeoutMs after session starts.
   const noAudioTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const clearNoAudioTimer = () => {
@@ -159,7 +159,7 @@ export function useLiveTutorSpeech({
       }
       // Successful start doesn't reset error counter — only actual speech results do
 
-      // Start no-audio-detected timer (#1174)
+      // Start no-audio-detected timer
       if (onNoAudioDetected) {
         clearNoAudioTimer();
         noAudioTimerRef.current = setTimeout(() => {
@@ -171,7 +171,7 @@ export function useLiveTutorSpeech({
     };
 
     recognition.onresult = (event: any) => {
-      // Got actual speech — reset error counter and clear no-audio timer (#1174)
+      // Got actual speech — reset error counter and clear no-audio timer
       consecutiveErrorsRef.current = 0;
       clearNoAudioTimer();
       // Build transcript from this recognition session's results

--- a/frontend/src/hooks/useLiveTutorSpeech.ts
+++ b/frontend/src/hooks/useLiveTutorSpeech.ts
@@ -53,6 +53,10 @@ export interface UseLiveTutorSpeechOptions {
   onClearTts: () => void;
   /** Called by recognition.onstart (first time only) to add "準備好了" message */
   onSessionReady: () => void;
+  /** Called when no STT audio detected within noAudioTimeoutMs after session starts (#1174) */
+  onNoAudioDetected?: () => void;
+  /** Timeout (ms) before onNoAudioDetected fires. Default 5000. (#1174) */
+  noAudioTimeoutMs?: number;
 }
 
 export function useLiveTutorSpeech({
@@ -74,6 +78,8 @@ export function useLiveTutorSpeech({
   onMicError,
   onClearTts,
   onSessionReady,
+  onNoAudioDetected,
+  noAudioTimeoutMs = 5000,
 }: UseLiveTutorSpeechOptions) {
   const [isPreparing, setIsPreparing] = useState(false);
   const [isSessionActive, setIsSessionActive] = useState(false);
@@ -89,6 +95,16 @@ export function useLiveTutorSpeech({
   // Mirror of targetText for use inside async recognition callbacks
   const targetTextRef = useRef(targetText);
   targetTextRef.current = targetText;
+
+  // No-audio-detected timer (#1174): fires onNoAudioDetected if no STT result
+  // arrives within noAudioTimeoutMs after session starts.
+  const noAudioTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearNoAudioTimer = () => {
+    if (noAudioTimerRef.current !== null) {
+      clearTimeout(noAudioTimerRef.current);
+      noAudioTimerRef.current = null;
+    }
+  };
 
   const startSession = () => {
     if (isSessionActiveRef.current) return;
@@ -142,11 +158,22 @@ export function useLiveTutorSpeech({
         onSessionReady();
       }
       // Successful start doesn't reset error counter — only actual speech results do
+
+      // Start no-audio-detected timer (#1174)
+      if (onNoAudioDetected) {
+        clearNoAudioTimer();
+        noAudioTimerRef.current = setTimeout(() => {
+          if (isSessionActiveRef.current && !currentTranscriptRef.current) {
+            onNoAudioDetected();
+          }
+        }, noAudioTimeoutMs);
+      }
     };
 
     recognition.onresult = (event: any) => {
-      // Got actual speech — reset error counter
+      // Got actual speech — reset error counter and clear no-audio timer (#1174)
       consecutiveErrorsRef.current = 0;
+      clearNoAudioTimer();
       // Build transcript from this recognition session's results
       let sessionTranscript = '';
       for (let i = 0; i < event.results.length; i++) {
@@ -288,6 +315,7 @@ export function useLiveTutorSpeech({
       onStreamingTranscript('');
       onLastDiffTokens(() => null);
       sentenceStartTimeRef.current = Date.now();
+      clearNoAudioTimer();
       if (isSessionActiveRef.current) {
         try { recognitionRef.current.start(); } catch (_) {}
       }
@@ -301,6 +329,7 @@ export function useLiveTutorSpeech({
     isSessionActiveRef.current = false;
     setIsSessionActive(false);
     setIsPreparing(false);
+    clearNoAudioTimer();
     if (recognitionRef.current) {
       try { recognitionRef.current.abort(); } catch (_) {}
       recognitionRef.current = null;


### PR DESCRIPTION
# Issue #1174 開發說明

## 功能摘要
在 Step 2 逐段朗讀中，當學生按下「開始朗讀」後若 5 秒內未偵測到任何聲音，主動顯示提示卡「好像沒有偵測到聲音」，協助學生發現麥克風權限或硬體問題。補完 PR #1142 漏讀偵測在完成按鈕 disabled 時永遠無法觸發的缺口。

## 開發策略
- **Hook 層**：在 `useLiveTutorSpeech` 加上 `onNoAudioDetected` callback 與 `noAudioTimeoutMs`（默認 5000ms）
- **計時器管理**：`recognition.onstart` 啟動 timer → `onresult` 收到結果時清除 → `stopSession` / `submitSentence` 也會清除，避免跨 session 誤觸發
- **UI 層**：`LiveTutor` 新增 `noAudioDetected` state，只在錄音中顯示 amber 色提示卡，含「重新開始」按鈕
- **啟動重置**：`startSession` wrapper 重置 flag，每次新錄音都能重新觸發

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/hooks/useLiveTutorSpeech.ts` | 新增 `onNoAudioDetected` callback + 計時器管理 |
| `frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx` | `noAudioDetected` state + 提示 UI + 重新開始邏輯 |

## 修正內容詳述

### 1. `useLiveTutorSpeech.ts` — 計時器機制

```typescript
// 新增選項
onNoAudioDetected?: () => void;
noAudioTimeoutMs?: number; // 默認 5000

// onstart 啟動 timer
if (onNoAudioDetected) {
  clearNoAudioTimer();
  noAudioTimerRef.current = setTimeout(() => {
    if (isSessionActiveRef.current && !currentTranscriptRef.current) {
      onNoAudioDetected();
    }
  }, noAudioTimeoutMs);
}

// onresult 清除 timer（第一次收到聲音）
consecutiveErrorsRef.current = 0;
clearNoAudioTimer();

// stopSession / submitSentence 也清除 timer
```

### 2. `LiveTutor.tsx` — 提示 UI

```tsx
// State
const [noAudioDetected, setNoAudioDetected] = useState(false);

// Hook wire-up
onNoAudioDetected: () => setNoAudioDetected(true),

// startSession 重置
const startSession = useCallback(() => {
  setNoAudioDetected(false);
  stt.startSession();
}, [stt]);

// UI（錄音中才顯示）
{noAudioDetected && stt.isSessionActive && (
  <div className="... bg-amber-50 border border-amber-300 ...">
    <span>好像沒有偵測到聲音</span>
    <p>請確認麥克風權限已開啟、音量足夠，或點擊「重新開始」再試一次。</p>
    <button onClick={重新啟動}>重新開始</button>
  </div>
)}
```

## 測試方式

### 手動測試步驟

1. **觸發驗證**
   - 進入 Step 2 逐段朗讀
   - 點擊「開始朗讀」後保持安靜 5 秒
   - 預期：出現 amber 色提示「好像沒有偵測到聲音」+ 重新開始按鈕

2. **正常錄音不觸發**
   - 點擊「開始朗讀」後立即說話
   - 預期：提示不應出現

3. **重新開始按鈕**
   - 觸發提示後點擊「重新開始」
   - 預期：session 停止、提示消失、重新啟動錄音

4. **跨 session 清理**
   - 觸發提示後按「完成」或離開頁面
   - 預期：提示消失，不會殘留到下次錄音

### Build / Type 驗證
- `npm run build` ✅ 通過（4.69s）
- `tsc --noEmit` ✅ 無錯誤

## 迴歸測試

- 正常錄音流程
- 「完成」按鈕原有的整段漏讀偵測（PR #1142）
- 句子重練功能
- 麥克風權限錯誤 / audio-capture 錯誤處理

## 類型

🟢 **Feature** — 提升使用體驗，幫助學生發現麥克風問題