### PR TITLE
fix(db): AssignmentSubmission.session_id 加 ON DELETE SET NULL (#1178)

### DIFF
--- a/backend/alembic/versions/b8c9d0e1f2g3_submission_session_set_null.py
+++ b/backend/alembic/versions/b8c9d0e1f2g3_submission_session_set_null.py
@@ -1,7 +1,7 @@
 """add ondelete SET NULL to assignment_submissions.session_id
 
 Revision ID: b8c9d0e1f2g3
-Revises: m1e2r3g4h5i6
+Revises: a7b8c9d0e1f2
 Create Date: 2026-04-21 00:10:00.000000
 
 Fixes #1178: when a LearningSession is deleted (by cleanup/maintenance),
@@ -21,7 +21,7 @@ from alembic import op
 
 
 revision: str = "b8c9d0e1f2g3"
-down_revision: Union[str, None] = "m1e2r3g4h5i6"
+down_revision: Union[str, None] = "a7b8c9d0e1f2"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/b8c9d0e1f2g3_submission_session_set_null.py
+++ b/backend/alembic/versions/b8c9d0e1f2g3_submission_session_set_null.py
@@ -1,0 +1,89 @@
+"""add ondelete SET NULL to assignment_submissions.session_id
+
+Revision ID: b8c9d0e1f2g3
+Revises: z6a7b8c9d0e1
+Create Date: 2026-04-21 00:10:00.000000
+
+Fixes #1178: when a LearningSession is deleted (by cleanup/maintenance),
+AssignmentSubmission.session_id currently becomes a dangling pointer because
+the FK has no ondelete policy.  This migration drops the existing FK and
+recreates it with `ON DELETE SET NULL` so that submissions with a deleted
+session simply have session_id set to NULL instead of breaking referential
+integrity.
+
+FK name is looked up dynamically because different migration eras used
+different naming conventions (postgres default "<table>_<col>_fkey" vs
+SQLAlchemy "fk_<table>_<col>_<ref>").
+"""
+from typing import Union
+
+from alembic import op
+
+
+revision: str = "b8c9d0e1f2g3"
+down_revision: Union[str, None] = "z6a7b8c9d0e1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Look up the actual FK constraint name from pg_catalog and drop it,
+    # then recreate with ON DELETE SET NULL.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            fk_name text;
+        BEGIN
+            SELECT conname INTO fk_name
+            FROM pg_constraint c
+            JOIN pg_class t ON c.conrelid = t.oid
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
+            WHERE t.relname = 'assignment_submissions'
+              AND c.contype = 'f'
+              AND a.attname = 'session_id'
+            LIMIT 1;
+
+            IF fk_name IS NOT NULL THEN
+                EXECUTE format('ALTER TABLE assignment_submissions DROP CONSTRAINT %I', fk_name);
+            END IF;
+
+            ALTER TABLE assignment_submissions
+                ADD CONSTRAINT assignment_submissions_session_id_fkey
+                FOREIGN KEY (session_id)
+                REFERENCES learning_sessions (id)
+                ON DELETE SET NULL;
+        END
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            fk_name text;
+        BEGIN
+            SELECT conname INTO fk_name
+            FROM pg_constraint c
+            JOIN pg_class t ON c.conrelid = t.oid
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
+            WHERE t.relname = 'assignment_submissions'
+              AND c.contype = 'f'
+              AND a.attname = 'session_id'
+            LIMIT 1;
+
+            IF fk_name IS NOT NULL THEN
+                EXECUTE format('ALTER TABLE assignment_submissions DROP CONSTRAINT %I', fk_name);
+            END IF;
+
+            ALTER TABLE assignment_submissions
+                ADD CONSTRAINT assignment_submissions_session_id_fkey
+                FOREIGN KEY (session_id)
+                REFERENCES learning_sessions (id);
+        END
+        $$;
+        """
+    )

--- a/backend/alembic/versions/b8c9d0e1f2g3_submission_session_set_null.py
+++ b/backend/alembic/versions/b8c9d0e1f2g3_submission_session_set_null.py
@@ -1,7 +1,7 @@
 """add ondelete SET NULL to assignment_submissions.session_id
 
 Revision ID: b8c9d0e1f2g3
-Revises: z6a7b8c9d0e1
+Revises: m1e2r3g4h5i6
 Create Date: 2026-04-21 00:10:00.000000
 
 Fixes #1178: when a LearningSession is deleted (by cleanup/maintenance),
@@ -21,7 +21,7 @@ from alembic import op
 
 
 revision: str = "b8c9d0e1f2g3"
-down_revision: Union[str, None] = "z6a7b8c9d0e1"
+down_revision: Union[str, None] = "m1e2r3g4h5i6"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -90,4 +90,8 @@ class AssignmentSubmission(Base):
     # Relationships
     assignment: Mapped["Assignment"] = relationship("Assignment", back_populates="submissions")
     student: Mapped["User"] = relationship("User", foreign_keys=[student_id])  # type: ignore[name-defined]
-    session: Mapped["LearningSession"] = relationship("LearningSession", foreign_keys=[session_id])  # type: ignore[name-defined]
+    # passive_deletes=True defers to DB-level ON DELETE SET NULL so SQLAlchemy
+    # skips the redundant UPDATE when the parent session is removed.
+    session: Mapped["LearningSession"] = relationship(  # type: ignore[name-defined]
+        "LearningSession", foreign_keys=[session_id], passive_deletes=True,
+    )

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -77,7 +77,9 @@ class AssignmentSubmission(Base):
     )
     student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     status: Mapped[str] = mapped_column(String(20), default="pending")  # "pending" | "in_progress" | "submitted" | "graded"
-    session_id: Mapped[int | None] = mapped_column(ForeignKey("learning_sessions.id"), nullable=True)
+    session_id: Mapped[int | None] = mapped_column(
+        ForeignKey("learning_sessions.id", ondelete="SET NULL"), nullable=True
+    )
     submitted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     score: Mapped[float | None] = mapped_column(Float, nullable=True)  # from LearningSession accuracy
     teacher_feedback: Mapped[str | None] = mapped_column(Text, nullable=True)  # per-student teacher comment (Issue #424)


### PR DESCRIPTION
# Issue #1178 修正說明

## 問題摘要
`AssignmentSubmission.session_id` FK 無 `ondelete` 策略，當 LearningSession 被刪除或清理時，submission.session_id 變成指向不存在紀錄的 dangling pointer，學生作業資料「消失」。

## 修正策略
加 `ondelete="SET NULL"` — session 被刪除時 submission.session_id 自動變 NULL，比 dangling pointer 更清楚且可由 code 層處理。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `backend/app/models/assignment.py` | session_id FK 加 ondelete="SET NULL" |
| `backend/alembic/versions/b8c9d0e1f2g3_submission_session_set_null.py` | Migration：動態查找並 DROP/ADD constraint |

## 修正內容詳述

### 1. `assignment.py` — Model

```python
class AssignmentSubmission(Base):
    session_id: Mapped[int | None] = mapped_column(
        ForeignKey("learning_sessions.id", ondelete="SET NULL"),
        nullable=True,
    )
```

### 2. Migration — 動態 FK 查找

不同時期建立的 FK constraint 命名格式不同（`<table>_<col>_fkey` vs `fk_<table>_<col>_<ref>`），migration 用 PL/pgSQL 從 `pg_constraint` 動態查找名稱再 DROP，避免寫死名稱導致不同環境失敗。

```sql
DO $$
DECLARE
    fk_name text;
BEGIN
    SELECT conname INTO fk_name
    FROM pg_constraint c
    JOIN pg_class t ON c.conrelid = t.oid
    JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
    WHERE t.relname = 'assignment_submissions'
      AND c.contype = 'f'
      AND a.attname = 'session_id'
    LIMIT 1;

    IF fk_name IS NOT NULL THEN
        EXECUTE format('ALTER TABLE assignment_submissions DROP CONSTRAINT %I', fk_name);
    END IF;

    ALTER TABLE assignment_submissions
        ADD CONSTRAINT assignment_submissions_session_id_fkey
        FOREIGN KEY (session_id) REFERENCES learning_sessions (id)
        ON DELETE SET NULL;
END
$$;
```

## 測試驗證

- Python syntax 通過
- Alembic offline SQL 生成正確
- 動態 FK 查找不寫死 constraint 名稱，相容不同 DB 環境

## 行為變化

**修正前**：
- LearningSession 被刪除 → submission.session_id 指向不存在紀錄
- 查 submission 時發現 FK 違反，可能導致 exception 或錯誤資料

**修正後**：
- LearningSession 被刪除 → submission.session_id 自動設為 NULL
- Code 層可清楚判斷 session 已不存在（session_id IS NULL）
- 作業狀態可正確降級顯示

## 迴歸測試

- 正常 assignment start / submit 流程
- Session 刪除後 submission 查詢
- 並發 session 清理

## 嚴重性

🔴 **Critical** — 學生作業資料會消失且 FK 不一致