### PR TITLE
fix: VocabApplication beforeunload 覆蓋 steps_completed=[] 造成進度消失 (#1196)

### DIFF
--- a/frontend/src/components/reading-steps/VocabApplication.tsx
+++ b/frontend/src/components/reading-steps/VocabApplication.tsx
@@ -8,15 +8,17 @@
  * Standalone step component. Receives `story` prop and calls `onFinish`
  * with a score result when the student completes all fill-in-blank exercises.
  *
- * Props: { story, onFinish, zhuyinActive?, fontSizePx?, token?, dbSessionId?,
- *          syncProgress?, flushProgress? }
+ * Props: { story, onFinish, fontSizePx?, saveStepProgressPatch? }
  *
  * Persistence strategy:
  * - FillInBlankExercise saves in-progress answers to localStorage on every
  *   selection (key: `vocab_app_progress_${story.id}`, Issue #709).
  * - VocabApplication saves phase/result to `vocabApp_progress_${story.id}`.
- * - On completion, DB is updated via flushProgress (if token + dbSessionId available).
- * - On page unload (beforeunload), DB is flushed with whatever progress exists.
+ * - On completion, DB is updated via `saveStepProgressPatch` which merges into
+ *   LearningLayout's authoritative step_progress — does NOT overwrite other
+ *   steps' completion state (#1196).
+ * - On page unload (beforeunload), mid-exercise state is patched without
+ *   touching `steps_completed`; the done-phase flushes with `markCompleted`.
  * - On manual redo, both localStorage keys are cleared.
  * - Fix #758: handleFinish no longer removes phase storage — completion persists.
  */

--- a/frontend/src/components/reading-steps/VocabApplication.tsx
+++ b/frontend/src/components/reading-steps/VocabApplication.tsx
@@ -24,7 +24,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Story } from '../../types';
 import FillInBlankExercise from './FillInBlankExercise';
 import type { QuestionResult } from './FillInBlankExercise';
-import type { StepProgressData } from '../../services/learningApi';
 import { getLearningStorageScope, scopedStepStorageKey } from '../../services/learningStorageScope';
 
 /* ------------------------------------------------------------------ */
@@ -42,10 +41,19 @@ export interface VocabApplicationProps {
   onFinish: (result: VocabApplicationResult) => void;
   /** Base font size in px for accessibility scaling */
   fontSizePx?: number;
-  /** Debounced DB sync from useProgressSync (Issue #660). */
-  syncProgress?: (data: StepProgressData) => void;
-  /** Immediate DB flush — use on completion or page unload (Issue #660). */
-  flushProgress?: (data: StepProgressData) => void;
+  /**
+   * Merge-based progress patch from LearningLayout (preserves other steps' data
+   * and completed list). Only touches step_data[stepId] and optionally appends
+   * stepId to steps_completed. Replaces the old syncProgress/flushProgress pair
+   * that overwrote the entire snapshot.
+   */
+  saveStepProgressPatch?: (opts: {
+    stepId: string;
+    stepData: Record<string, unknown>;
+    currentStep?: string | null;
+    markCompleted?: boolean;
+    immediate?: boolean;
+  }) => void;
 }
 
 /* ------------------------------------------------------------------ */
@@ -107,8 +115,7 @@ const VocabApplication: React.FC<VocabApplicationProps> = ({
   story,
   onFinish,
   fontSizePx,
-  flushProgress,
-  syncProgress,
+  saveStepProgressPatch,
 }) => {
   const storageKey = phaseStorageKey(story.id);
   const loadSaved = () => {
@@ -138,63 +145,61 @@ const VocabApplication: React.FC<VocabApplicationProps> = ({
   }, [phase, result, savedFirstTryResults, storageKey]);
 
   // ── DB persistence on completion ─────────────────────────────────────────
-  // When phase transitions to 'done', flush progress to DB immediately
+  // When phase transitions to 'done', flush progress to DB immediately via patch
+  // (merges with other steps' data instead of overwriting the snapshot).
   useEffect(() => {
-    if (phase === 'done' && result && flushProgress) {
-      flushProgress({
-        current_step: 'vocab-application',
-        steps_completed: ['vocab-application'],
-        step_data: {
-          vocab_application: {
-            score: result.score,
-            total: result.total,
-            completionRate: result.total > 0 ? result.score / result.total : 1,
-            completedAt: new Date().toISOString(),
-          },
+    if (phase === 'done' && result && saveStepProgressPatch) {
+      saveStepProgressPatch({
+        stepId: 'vocab-application',
+        currentStep: 'vocab-application',
+        markCompleted: true,
+        immediate: true,
+        stepData: {
+          score: result.score,
+          total: result.total,
+          completionRate: result.total > 0 ? result.score / result.total : 1,
+          completedAt: new Date().toISOString(),
         },
       });
     }
-  }, [phase, result, flushProgress]);
+  }, [phase, result, saveStepProgressPatch]);
 
   // ── DB persistence on page unload (beforeunload) ─────────────────────────
-  // Sync whatever progress exists when user navigates away mid-exercise
-  const flushRef = useRef(flushProgress);
-  const syncRef = useRef(syncProgress);
+  // Uses patch semantics so we never overwrite other steps' progress.
+  const patchRef = useRef(saveStepProgressPatch);
   const phaseRef = useRef(phase);
   const resultRef = useRef(result);
-  useEffect(() => { flushRef.current = flushProgress; }, [flushProgress]);
-  useEffect(() => { syncRef.current = syncProgress; }, [syncProgress]);
+  useEffect(() => { patchRef.current = saveStepProgressPatch; }, [saveStepProgressPatch]);
   useEffect(() => { phaseRef.current = phase; }, [phase]);
   useEffect(() => { resultRef.current = result; }, [result]);
 
   useEffect(() => {
     function handleBeforeUnload() {
-      const flush = flushRef.current;
-      if (!flush) return;
+      const patch = patchRef.current;
+      if (!patch) return;
       const currentPhase = phaseRef.current;
       const currentResult = resultRef.current;
 
       if (currentPhase === 'exercise') {
-        // Mid-exercise: sync partial progress
-        const sync = syncRef.current;
-        if (sync) {
-          sync({
-            current_step: 'vocab-application',
-            steps_completed: [],
-            step_data: { vocab_application: { phase: 'exercise', partialAt: new Date().toISOString() } },
-          });
-        }
+        // Mid-exercise: record that the student is working on vocab-application
+        // WITHOUT touching steps_completed (#1196).  markCompleted stays false.
+        patch({
+          stepId: 'vocab-application',
+          currentStep: 'vocab-application',
+          immediate: true,
+          stepData: { phase: 'exercise', partialAt: new Date().toISOString() },
+        });
       } else if (currentPhase === 'done' && currentResult) {
         // Completed but user is leaving — make sure it's flushed
-        flush({
-          current_step: 'vocab-application',
-          steps_completed: ['vocab-application'],
-          step_data: {
-            vocab_application: {
-              score: currentResult.score,
-              total: currentResult.total,
-              completionRate: currentResult.total > 0 ? currentResult.score / currentResult.total : 1,
-            },
+        patch({
+          stepId: 'vocab-application',
+          currentStep: 'vocab-application',
+          markCompleted: true,
+          immediate: true,
+          stepData: {
+            score: currentResult.score,
+            total: currentResult.total,
+            completionRate: currentResult.total > 0 ? currentResult.score / currentResult.total : 1,
           },
         });
       }

--- a/frontend/src/pages/learning/VocabApplicationPage.tsx
+++ b/frontend/src/pages/learning/VocabApplicationPage.tsx
@@ -3,7 +3,7 @@ import VocabApplication from '../../components/reading-steps/VocabApplication';
 import { useLearningContext } from '../../layouts/LearningLayout';
 
 const VocabApplicationPage: React.FC = () => {
-  const { selectedStory, handleFinishVocabApplication, syncProgress, flushProgress } = useLearningContext();
+  const { selectedStory, handleFinishVocabApplication, saveStepProgressPatch } = useLearningContext();
 
   if (!selectedStory) return null;
 
@@ -11,8 +11,7 @@ const VocabApplicationPage: React.FC = () => {
     <VocabApplication
       story={selectedStory}
       onFinish={handleFinishVocabApplication}
-      syncProgress={syncProgress}
-      flushProgress={flushProgress}
+      saveStepProgressPatch={saveStepProgressPatch}
     />
   );
 };


### PR DESCRIPTION
# Issue #1196 修正說明

## 問題摘要
`VocabApplication.tsx` 三處直接呼叫 `syncProgress` / `flushProgress` 並傳整個 `steps_completed` 陣列（`[]` 或 `['vocab-application']`），覆蓋了 LearningLayout 維護的完整進度。特別是 `beforeunload` mid-exercise 路徑送出 `steps_completed: []`，把之前所有步驟的完成紀錄清空。結果：學生離開頁面後進度條、StepperNav 綠點全消失，但 `reading_result` 等獨立欄位還在。

## 根因
檔案：`frontend/src/components/reading-steps/VocabApplication.tsx`

三處 overwrite：
1. **Line 142-157（completion useEffect）** — 只在 `steps_completed` 放 `['vocab-application']`，覆蓋其他已完成步驟
2. **Line 181-186（beforeunload mid-exercise）** — 送出 `steps_completed: []` 🔴 最致命
3. **Line 187-200（beforeunload done）** — 同 1 的問題

## 修正策略
改用 `LearningLayout` 暴露的 **`saveStepProgressPatch(opts)`**，內部經 `persistStepProgressState` 做合併：

```typescript
// persistStepProgressState 的合併邏輯（已存在）
const completed = new Set<string>(prev.steps_completed);
if (opts.completeStep) completed.add(opts.completeStep);  // 只加不 overwrite
const next = {
  steps_completed: Array.from(completed),
  step_data: { ...prev.step_data, ...(opts.stepDataPatch ?? {}) },  // spread 合併
};
```

VocabApplication 改為：
- **完成時**：`saveStepProgressPatch({ stepId: 'vocab-application', markCompleted: true, immediate: true, stepData: {...} })`
- **mid-exercise beforeunload**：`markCompleted` 不設 → 不動 `steps_completed`
- **done beforeunload**：`markCompleted: true`，與正常完成相同

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/components/reading-steps/VocabApplication.tsx` | 改 props：`syncProgress/flushProgress` → `saveStepProgressPatch` |
| `frontend/src/pages/learning/VocabApplicationPage.tsx` | Context 取得 `saveStepProgressPatch` 傳給子元件 |

## 修正內容詳述

### Before

```typescript
// Mid-exercise
sync({
  current_step: 'vocab-application',
  steps_completed: [],  // ← 清空所有進度
  step_data: { vocab_application: {...} },
});
```

### After

```typescript
// Mid-exercise — 只記錄 step_data，不動 steps_completed
patch({
  stepId: 'vocab-application',
  currentStep: 'vocab-application',
  immediate: true,
  stepData: { phase: 'exercise', partialAt: new Date().toISOString() },
  // 沒有 markCompleted → steps_completed 保持原樣
});
```

## 測試驗證

- TypeScript 檢查通過（無 VocabApplication/Page 錯誤）
- Tests：4 個預先存在的 UI string 測試失敗（跟本修正無關，staging 就有）

## 行為變化

**修正前**：
- 學生完成 step 1-4 → 進入 vocab-application mid-exercise → 刷新 →
- Beacon 送出 `steps_completed: []` → DB 清空 → 進度條歸零、綠點消失
- 作答資料（reading_result 等）保留因為是獨立欄位

**修正後**：
- 學生完成 step 1-4 → 進入 vocab-application mid-exercise → 刷新 →
- Beacon 送出 patch（只含 step_data） → DB 保留之前的 steps_completed
- 進度條、綠點維持正確

## 迴歸測試

- ✅ VocabApplication 正常完成：觸發 markCompleted → vocab-application 加入 steps_completed
- ✅ VocabApplication mid-exercise 離開：steps_completed 保留
- ✅ VocabApplication 完成後離開：markCompleted 保持 true
- ⚠️ 其他 reading-steps 元件建議審視有無相同 pattern（issue 中 checklist 已列）

## 嚴重性

🔴 **Critical** — 使用者體驗嚴重，學生看到進度消失會以為之前白做。

## 相關

- #1072（加 beforeunload flush）— 間接讓此 bug 從無聲變成會寫入 DB
- #1187（版本機制）— 部分緩解但無法根治（VocabApplication 送出時版本仍是最新的）
- #709（VocabApplication 持久化）— 原始建立此邏輯