### PR TITLE
fix(alembic): merge 3 dangling heads blocking all PR deploys

### DIFF
--- a/backend/alembic/versions/m1e2r3g4h5i6_merge_3_dangling_heads.py
+++ b/backend/alembic/versions/m1e2r3g4h5i6_merge_3_dangling_heads.py
@@ -1,0 +1,28 @@
+"""merge 3 dangling heads: dialogue_state, teacher_review, reading_history
+
+Revision ID: m1e2r3g4h5i6
+Revises: b3c4d5e6f7a8, tc01rv02cm03, z6a7b8c9d0e1
+Create Date: 2026-04-21 11:00:00.000000
+
+Staging accumulated 3 dangling alembic heads (no merge migration was added
+when the forks were introduced), which made `alembic upgrade head` fail at
+Cloud Run container startup with "Multiple head revisions are present".
+This blocked every PR preview deploy that rebuilt the image.
+
+This file only consolidates the chain; it has no schema changes.
+"""
+from typing import Sequence, Union
+
+
+revision: str = 'm1e2r3g4h5i6'
+down_revision: Union[str, tuple] = ('b3c4d5e6f7a8', 'tc01rv02cm03', 'z6a7b8c9d0e1')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

- Staging accumulated 3 alembic heads without a merge migration, causing every PR preview deploy to crash at container startup with `Multiple head revisions are present`
- Adds a no-schema merge migration \`m1e2r3g4h5i6\` consolidating: \`b3c4d5e6f7a8\` + \`tc01rv02cm03\` + \`z6a7b8c9d0e1\`
- **Unblocks**: PR #1193, PR #1194, and any future PR

## Root cause evidence

Cloud Run log (both #1193 and #1194 preview backends):
\`\`\`
Running database migrations...
FAILED: Multiple head revisions are present for given argument 'head'
Container called exit(255).
\`\`\`

Staging's dangling heads (confirmed via \`git show origin/staging:backend/alembic/versions/*.py\`):
| Head rev | File |
|---|---|
| \`b3c4d5e6f7a8\` | add_dialogue_state_to_learning_sessions |
| \`tc01rv02cm03\` | add_teacher_review_to_sessions |
| \`z6a7b8c9d0e1\` | create_reading_history_tables |

## Test plan

- [ ] CI deploys the PR preview successfully (itself proves the fix — the container now starts)
- [ ] After merge to staging, re-run PR #1193 / #1194 CI (靖杭's branches will need a follow-up to repoint their migration's \`down_revision\` from \`z6a7b8c9d0e1\` to \`m1e2r3g4h5i6\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)