### PR TITLE
feat(auth): Junyi Academy SSO login Part 3 (#1198)

### DIFF
--- a/backend/alembic/versions/c9d0e1f2g3h4_add_junyi_identity_id_to_users.py
+++ b/backend/alembic/versions/c9d0e1f2g3h4_add_junyi_identity_id_to_users.py
@@ -1,0 +1,43 @@
+"""add junyi_identity_id to users table
+
+Revision ID: c9d0e1f2g3h4
+Revises: b8c9d0e1f2g3
+Create Date: 2026-04-21 12:00:00.000000
+
+Adds junyi_identity_id column to users table for Junyi SSO integration (issue #1198).
+Mirrors the existing google_id pattern: nullable, unique, indexed (single unique index,
+no redundant constraint).
+"""
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d0e1f2g3h4"
+down_revision: Union[str, None] = "b8c9d0e1f2g3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "junyi_identity_id",
+            sa.String(length=128),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_users_junyi_identity_id",
+        "users",
+        ["junyi_identity_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_junyi_identity_id", table_name="users")
+    op.drop_column("users", "junyi_identity_id")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -17,6 +17,10 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 480  # 8 hours
     google_client_id: str = ""  # set GOOGLE_CLIENT_ID env var in Cloud Run
+    # Junyi SSO base URL (issue #1198).
+    # Production: https://www.junyiacademy.org
+    # Testing ci-live server: override with JUNYI_SSO_BASE_URL env var
+    junyi_sso_base_url: str = "https://www.junyiacademy.org"
     parent_portal_enabled: bool = False
     # Email verification gate (issue #460).
     # False (default): auto-verify on registration — existing flow unchanged.

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -35,6 +35,8 @@ class User(Base):
     email_verification_token: Mapped[str | None] = mapped_column(String(64), nullable=True)
     # Google OAuth — nullable so existing email/password users are unaffected
     google_id: Mapped[str | None] = mapped_column(String(128), unique=True, nullable=True, index=True)
+    # Junyi SSO — mirrors google_id pattern (issue #1198)
+    junyi_identity_id: Mapped[str | None] = mapped_column(String(128), unique=True, nullable=True, index=True)
     terms_accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     terms_version: Mapped[str | None] = mapped_column(String(20), nullable=True)
     privacy_accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,8 +1,12 @@
+import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
 
 from ..auth.classroom_check import compute_has_classroom
 from ..auth.dependencies import get_current_user
@@ -19,6 +23,8 @@ from ..schemas.auth import (
     ForgotPasswordResponse,
     GoogleLoginRequest,
     GoogleLoginResponse,
+    JunyiLoginRequest,
+    JunyiLoginResponse,
     LoginRequest,
     RegisterRequest,
     RegisterResponse,
@@ -635,3 +641,119 @@ def accept_terms(
         created_at=current_user.created_at,
         roles=roles,
     )
+
+
+@router.post("/junyi", response_model=JunyiLoginResponse)
+def junyi_login(req: JunyiLoginRequest, request: Request, db: Session = Depends(get_db)):
+    """Authenticate (or register) a user via Junyi SSO auth code (issue #1198).
+
+    Flow (mirrors jutor.ai reference implementation):
+    1. Exchange the one-time code with Junyi's /api/v2/auth/code endpoint.
+    2. If a user with matching junyi_identity_id exists -> login.
+    3. Else if a user with matching email exists -> link junyi_identity_id + login.
+    4. Else -> create a new user account (student role, email_verified=True).
+
+    The code is single-use with a 600s TTL (enforced by Junyi's backend).
+    Junyi returns: {"data": {"userId": "...", "userEmail": "...", "userDisplayName": "..."}}
+    """
+    client_ip = request.client.host if request.client else "unknown"
+    if not rate_limiter.check(f"junyi-login:{client_ip}", max_requests=20, window_seconds=60):
+        raise HTTPException(status_code=429, detail="Too many requests. Please try again later.")
+
+    # Exchange auth code with Junyi backend
+    junyi_base = settings.junyi_sso_base_url.rstrip("/")
+    exchange_url = f"{junyi_base}/api/v2/auth/code"
+    try:
+        resp = httpx.post(
+            exchange_url,
+            json={"code": req.code},
+            timeout=10.0,
+        )
+    except httpx.RequestError as exc:
+        logger.error("junyi_login: network error contacting Junyi SSO: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="無法連線到均一登入服務，請稍後再試。",
+        )
+
+    if resp.status_code == 404:
+        # Code expired, already used, or forged — guide user to retry
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="均一登入連結已過期或已使用，請重新點擊「使用均一帳號登入」。",
+        )
+    if resp.status_code != 200:
+        logger.error(
+            "junyi_login: unexpected status %s from Junyi SSO (url=%s)",
+            resp.status_code,
+            exchange_url,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="均一登入服務回應異常，請稍後再試。",
+        )
+
+    try:
+        payload = resp.json()
+        data = payload["data"]
+        junyi_user_id: str = data["userId"]
+        junyi_email: str = data.get("userEmail", "")
+        junyi_display_name: str = data.get("userDisplayName", "") or junyi_email.split("@")[0]
+    except (KeyError, ValueError) as exc:
+        logger.error("junyi_login: malformed Junyi payload: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="均一登入回傳資料格式異常。",
+        )
+
+    is_new_user = False
+
+    # 1. Look up by junyi_identity_id (returning user)
+    user = db.query(User).filter(
+        User.junyi_identity_id == junyi_user_id,
+        User.is_active == True,
+    ).first()
+
+    if user is None and junyi_email:
+        # 2. Look up by email (link existing account)
+        user = db.query(User).filter(
+            User.email == junyi_email,
+            User.is_active == True,
+        ).first()
+        if user is not None:
+            _ensure_parent_login_allowed(user, db)
+            user.junyi_identity_id = junyi_user_id
+
+    if user is None:
+        # 3. Create new account — unusable password hash (SSO-only account)
+        if not junyi_email:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="均一帳號未提供 Email，無法建立 LingoLeap 帳號。",
+            )
+        unusable_hash = hash_password(secrets.token_hex(32))
+        user = User(
+            email=junyi_email,
+            password_hash=unusable_hash,
+            name=junyi_display_name,
+            junyi_identity_id=junyi_user_id,
+            email_verified=True,  # Junyi already verified
+        )
+        db.add(user)
+        is_new_user = True
+    elif user.junyi_identity_id is None:
+        # Covers the email-match path above (already set) and any edge case
+        user.junyi_identity_id = junyi_user_id
+
+    user.last_login_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(user)
+
+    token = create_access_token(user.id)
+    logger.info(
+        "junyi_login: user_id=%s junyi_identity_id=%s is_new=%s",
+        user.id,
+        junyi_user_id,
+        is_new_user,
+    )
+    return JunyiLoginResponse(access_token=token, is_new_user=is_new_user)

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -79,3 +79,19 @@ class GoogleLoginResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     is_new_user: bool = False
+
+
+class JunyiLoginRequest(BaseModel):
+    """One-time auth code from Junyi SSO callback (issue #1198).
+
+    The frontend receives this code at /junyi-callback?code=<...> and immediately
+    forwards it here. The backend exchanges it with Junyi's /api/v2/auth/code
+    endpoint (code is single-use, TTL 600s).
+    """
+    code: str = Field(..., min_length=1, max_length=256)
+
+
+class JunyiLoginResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+    is_new_user: bool = False

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { login as apiLogin, register as apiRegister, getMe, acceptTerms as apiAcceptTerms, googleLogin as apiGoogleLogin, AuthUser, AuthError, RegisterResponse } from '../services/authApi';
+import { login as apiLogin, register as apiRegister, getMe, acceptTerms as apiAcceptTerms, googleLogin as apiGoogleLogin, junyiLogin as apiJunyiLogin, AuthUser, AuthError, RegisterResponse } from '../services/authApi';
 import { SESSION_UNAUTHORIZED_EVENT } from '../services/sessionGuard';
 
 const TOKEN_KEY = 'lingoleap_token';
@@ -31,6 +31,8 @@ interface AuthContextValue {
   refreshUser: () => Promise<void>;
   acceptTerms: () => Promise<void>;
   loginWithGoogle: (credential: string) => Promise<{ isNewUser: boolean }>;
+  /** Exchange a Junyi SSO one-time code for a LingoLeap session (issue #1198). */
+  loginWithJunyi: (code: string) => Promise<{ isNewUser: boolean }>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -139,6 +141,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return { isNewUser: response.is_new_user };
   }, []);
 
+  const loginWithJunyi = useCallback(async (code: string): Promise<{ isNewUser: boolean }> => {
+    const response = await apiJunyiLogin(code);
+    const newToken = response.access_token;
+    // Same ordering as loginWithGoogle: pre-fetch user so token-change useEffect
+    // sees user !== null and skips the redundant /me call (Issue #1156).
+    const userData = await getMe(newToken);
+    localStorage.setItem(TOKEN_KEY, newToken);
+    setUser(userData);
+    setToken(newToken);
+    return { isNewUser: response.is_new_user };
+  }, []);
+
   const logout = useCallback(() => {
     localStorage.removeItem(TOKEN_KEY);
     try {
@@ -224,6 +238,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     refreshUser,
     acceptTerms,
     loginWithGoogle,
+    loginWithJunyi,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/pages/JunyiCallbackPage.tsx
+++ b/frontend/src/pages/JunyiCallbackPage.tsx
@@ -1,0 +1,127 @@
+/**
+ * JunyiCallbackPage — handles the OAuth-like callback from Junyi SSO (issue #1198).
+ *
+ * Flow:
+ * 1. Junyi redirects back to /junyi-callback?code=<one-time-code>(&state=<csrf-token>)
+ * 2. This page immediately reads the code from the URL and exchanges it via loginWithJunyi().
+ * 3. On success → navigate to the originally requested page (or home).
+ * 4. On failure → show a clear error with a "retry" button that re-initiates SSO.
+ *
+ * Security:
+ * - CSRF state is validated against sessionStorage before exchanging the code.
+ * - The code is consumed and removed from the URL immediately to prevent re-use via back/reload.
+ * - We call replaceState() before the exchange so the code never lingers in browser history.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { trackEvent } from '../utils/analytics';
+
+const JUNYI_STATE_KEY = 'junyi_sso_state';
+
+/** Build the Junyi login URL pointing at the current environment's callback. */
+export function buildJunyiLoginUrl(returnTo: string = '/'): string {
+  // Encode the return path inside the callback URL so we can restore it after the round-trip.
+  const callbackUrl = `${window.location.origin}/junyi-callback?returnTo=${encodeURIComponent(returnTo)}`;
+
+  // Generate and persist a CSRF state token.
+  const state = Array.from(crypto.getRandomValues(new Uint8Array(16)))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  sessionStorage.setItem(JUNYI_STATE_KEY, state);
+
+  const continueUrl = `${callbackUrl}&state=${state}`;
+  return `https://www.junyiacademy.org/login?continue=${encodeURIComponent(continueUrl)}`;
+}
+
+const JunyiCallbackPage: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { loginWithJunyi } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+  const exchanged = useRef(false); // prevent double-fire in React StrictMode
+
+  useEffect(() => {
+    if (exchanged.current) return;
+    exchanged.current = true;
+
+    const code = searchParams.get('code');
+    const stateParam = searchParams.get('state');
+    const returnTo = searchParams.get('returnTo') || '/';
+
+    // --- CSRF state validation ---
+    const storedState = sessionStorage.getItem(JUNYI_STATE_KEY);
+    sessionStorage.removeItem(JUNYI_STATE_KEY);
+
+    if (stateParam && storedState && stateParam !== storedState) {
+      setError('登入驗證失敗（CSRF state 不符），請重新嘗試。');
+      trackEvent('auth', 'junyi_login_csrf_mismatch');
+      return;
+    }
+
+    if (!code) {
+      setError('未收到均一登入憑證，請重新嘗試。');
+      trackEvent('auth', 'junyi_login_no_code');
+      return;
+    }
+
+    // Remove the code from the URL immediately so it never stays in browser history.
+    window.history.replaceState({}, '', '/junyi-callback');
+
+    loginWithJunyi(code)
+      .then(({ isNewUser }) => {
+        trackEvent('auth', isNewUser ? 'junyi_login_new_user' : 'junyi_login_success');
+        navigate(returnTo, { replace: true });
+      })
+      .catch((err: unknown) => {
+        const message =
+          err instanceof Error ? err.message : '均一登入失敗，請稍後再試。';
+        setError(message);
+        trackEvent('auth', 'junyi_login_error');
+      });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // run once on mount — searchParams is stable at mount time
+
+  const handleRetry = () => {
+    window.location.href = buildJunyiLoginUrl('/');
+  };
+
+  if (error) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-amber-50 px-4">
+        <div className="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-200 p-6 space-y-4 text-center">
+          <div className="text-4xl">均一登入失敗</div>
+          <p className="text-red-600 text-sm">{error}</p>
+          <button
+            type="button"
+            onClick={handleRetry}
+            className="w-full h-11 bg-[#FF6B35] hover:bg-[#e55a25] text-white rounded-lg font-bold text-sm transition-colors"
+          >
+            重新使用均一帳號登入
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('/login', { replace: true })}
+            className="w-full h-11 border border-gray-300 text-gray-700 rounded-lg text-sm hover:bg-gray-50 transition-colors"
+          >
+            返回登入頁
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading state — code is being exchanged with the backend
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-amber-50 px-4">
+      <div className="w-full max-w-sm bg-white rounded-2xl shadow-sm border border-gray-200 p-6 text-center space-y-4">
+        <div className="flex justify-center">
+          <div className="w-10 h-10 border-4 border-[#FF6B35] border-t-transparent rounded-full animate-spin" />
+        </div>
+        <p className="text-gray-600 text-sm">正在驗證均一帳號...</p>
+      </div>
+    </div>
+  );
+};
+
+export default JunyiCallbackPage;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { AuthError } from '../services/authApi';
 import { trackEvent } from '../utils/analytics';
 import GoogleSignInButton from '../components/GoogleSignInButton';
+import { buildJunyiLoginUrl } from './JunyiCallbackPage';
 
 interface LoginPageProps {
   onSwitchToRegister?: () => void;
@@ -14,6 +15,11 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
   const location = useLocation();
   const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/';
   const { login, loginWithGoogle } = useAuth();
+
+  const handleJunyiLogin = () => {
+    trackEvent('auth', 'junyi_login_initiated');
+    window.location.href = buildJunyiLoginUrl(from);
+  };
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -148,8 +154,8 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
           </div>
         </form>
 
-        {/* Google Sign-In */}
-        <div className="mt-4">
+        {/* Third-party sign-in options */}
+        <div className="mt-4 space-y-3">
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
               <div className="w-full border-t border-gray-200" />
@@ -158,9 +164,21 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
               <span className="px-2 bg-amber-50 text-gray-400">或</span>
             </div>
           </div>
-          <div className="mt-4">
+
+          {/* Google Sign-In */}
+          <div>
             <GoogleSignInButton onCredential={handleGoogleCredential} width={352} />
           </div>
+
+          {/* Junyi SSO (issue #1198) */}
+          <button
+            type="button"
+            onClick={handleJunyiLogin}
+            className="w-full h-11 flex items-center justify-center gap-2 bg-white border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[#FF6B35] text-white text-[10px] font-black leading-none">均</span>
+            使用均一帳號登入
+          </button>
         </div>
 
         {/* Switch to Register */}

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -27,6 +27,7 @@ import LoginPage from '../pages/LoginPage';
 import RegisterPage from '../pages/RegisterPage';
 import ChangePasswordPage from '../pages/ChangePasswordPage';
 import ForgotPassword from '../pages/ForgotPassword';
+import JunyiCallbackPage from '../pages/JunyiCallbackPage';
 
 // ---------------------------------------------------------------------------
 // Route-level code splitting (lazy loading)
@@ -145,6 +146,9 @@ const AppRoutes: React.FC = () => (
           </PublicOnlyRoute>
         }
       />
+
+      {/* Junyi SSO callback — public route, handles the one-time code exchange (issue #1198) */}
+      <Route path="/junyi-callback" element={<JunyiCallbackPage />} />
 
       {/* Change password (after first login) */}
       <Route

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -216,3 +216,23 @@ export async function googleLogin(credential: string): Promise<GoogleLoginRespon
   });
   return handleAuthResponse<GoogleLoginResponse>(res);
 }
+
+export interface JunyiLoginResponse {
+  access_token: string;
+  token_type: string;
+  is_new_user: boolean;
+}
+
+/**
+ * Exchange a Junyi SSO one-time auth code for a LingoLeap JWT (issue #1198).
+ * The code is obtained from the /junyi-callback?code=<...> URL parameter.
+ * It is single-use and expires in 600 seconds — must be sent immediately.
+ */
+export async function junyiLogin(code: string): Promise<JunyiLoginResponse> {
+  const res = await fetch(`${API_BASE}/api/auth/junyi`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  });
+  return handleAuthResponse<JunyiLoginResponse>(res);
+}


### PR DESCRIPTION
Closes #1198

## Summary

Part 3 of Junyi Academy SSO — wires up the full round-trip so LingoLeap users can log in with their Junyi account.

Flow:
1. `/login` → click **使用均一帳號登入** → redirect to `www.junyiacademy.org/login?continue=<our_callback>`
2. Junyi bounces back to `/junyi-callback?code=<one-time>&state=<csrf>`
3. Frontend validates CSRF state, POSTs `code` to `/api/auth/junyi`
4. Backend calls Junyi `/api/v2/auth/code` → gets `{userId, userEmail, userDisplayName}`
5. User mapping: `junyi_identity_id` match → login; else email match → link; else create new account
6. Returns JWT, frontend stores + navigates

## Changes

**Backend** (5 files)
- `config.py`: new `JUNYI_SSO_BASE_URL` env (default prod, override for ci-live)
- `models/user.py`: new `junyi_identity_id` column (mirrors `google_id`)
- `schemas/auth.py`: `JunyiLoginRequest` / `JunyiLoginResponse`
- `routes/auth.py`: `POST /api/auth/junyi` (rate-limit 20/min, reuses `_ensure_parent_login_allowed`)
- `alembic c9d0e1f2g3h4`: `ALTER TABLE users ADD COLUMN junyi_identity_id` (down_revision = current staging head `b8c9d0e1f2g3`)

**Frontend** (5 files)
- `JunyiCallbackPage.tsx` (new): CSRF validation, StrictMode double-fire guard, `replaceState` strips code from URL
- `AppRoutes.tsx`: public `/junyi-callback` route
- `LoginPage.tsx`: new 使用均一帳號登入 button
- `authApi.ts` + `AuthContext.tsx`: `junyiLogin` / `loginWithJunyi` wiring

## Security

- CSRF state token in sessionStorage, cleared after validation
- Auth code stripped from URL before network call (no history leak)
- SSO-only accounts: `unusable_hash = hash_password(secrets.token_hex(32))` (can't login via password)
- Rate limit 20 req/min per IP
- 404 from Junyi → 401 with retry-friendly message

## Test plan

- [ ] PR preview builds clean (alembic single head ✅ verified locally)
- [ ] 請宥辰 whitelist preview + staging callback URLs
- [ ] 請宥辰 給 ci-live `JUNYI_SSO_BASE_URL` (optional — 否則打 prod)
- [ ] Set `JUNYI_SSO_BASE_URL` env var on Cloud Run staging
- [ ] Round-trip test: click 使用均一帳號登入 → 均一登入 → 回彈 → 拿到 JWT → 進得去
- [ ] New user flow: 第一次均一登入 → 自動建帳號 + `is_new_user=true`
- [ ] Returning user flow: 同一個 junyi_identity_id 再登入 → 直接登入
- [ ] Email-link flow: 已有 email 密碼帳號 → 均一登入後 `junyi_identity_id` 寫入 users 表

## 依賴

需要均一端配合（阻擋項）：
1. Whitelist `https://lingoleap-frontend-pr-{N}-*.run.app/junyi-callback` (for preview)
2. Whitelist staging + prod callback
3. 提供 ci-live base URL（如有）

🤖 Generated with [Claude Code](https://claude.com/claude-code)