### PR TITLE
fix(sso): point Junyi login entry at ci-live server

### DIFF
--- a/frontend/src/pages/JunyiCallbackPage.tsx
+++ b/frontend/src/pages/JunyiCallbackPage.tsx
@@ -31,7 +31,9 @@ export function buildJunyiLoginUrl(returnTo: string = '/'): string {
   sessionStorage.setItem(JUNYI_STATE_KEY, state);
 
   const continueUrl = `${callbackUrl}&state=${state}`;
-  return `https://www.junyiacademy.org/login?continue=${encodeURIComponent(continueUrl)}`;
+  // TODO: switch back to https://www.junyiacademy.org/login once Junyi Part 2 multi-RP lands on prod.
+  // Per 宥辰 2026-04-21: Part 2 currently only on ci-live; prod junyi ignores `continue` param.
+  return `https://ci-live-worktree-sso-multi-rp---rev-proxy-dg4bspkswq-de.a.run.app/login?continue=${encodeURIComponent(continueUrl)}`;
 }
 
 const JunyiCallbackPage: React.FC = () => {


### PR DESCRIPTION
## Summary

SSO round-trip in staging was failing because the login entry hardcoded to `https://www.junyiacademy.org/login` — that host does not yet have Junyi Part 2 multi-RP refactor deployed, so it ignores the \`continue\` param and leaves users stranded on the Junyi home page after login.

Per 宥辰 (2026-04-21): Part 2 currently only on \`ci-live-worktree-sso-multi-rp\`. Use that until Part 2 ships to prod, then revert this one-liner.

## Changes

- \`frontend/src/pages/JunyiCallbackPage.tsx\` L34: swap login entry host from \`www.junyiacademy.org\` → \`ci-live-worktree-sso-multi-rp---rev-proxy-dg4bspkswq-de.a.run.app\`
- Cloud Run staging backend \`JUNYI_SSO_BASE_URL\` env already updated to match (no code change).

## Test plan

- [ ] Merge → staging deploy green
- [ ] https://lingoleap-staging.web.app/login → 使用均一帳號登入 → bounces to ci-live login
- [ ] Login on ci-live → redirects back to /junyi-callback?code=...&state=...
- [ ] Session created, student lands on home

🤖 Generated with [Claude Code](https://claude.com/claude-code)