### PR TITLE
fix: 造句練習加入完整持久化 (#1203)

### DIFF
--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -134,12 +134,9 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   const { zhuyinActive, processZhuyin } = useZhuyin();
   const zh = (text: string) => zhuyinActive ? processZhuyin(text) : text;
 
-  // Restore from localStorage (#1203) — run once on mount.
-  const savedRef = useRef<SavedProgress | null>(null);
-  if (savedRef.current === null) {
-    savedRef.current = loadSaved(storyId);
-  }
-  const saved = savedRef.current;
+  // Restore from localStorage (#1203) — lazy init so the disk read happens
+  // exactly once even when loadSaved returns null (no re-reads on re-render).
+  const [saved] = useState<SavedProgress | null>(() => loadSaved(storyId));
 
   const [currentWordIndex, setCurrentWordIndex] = useState<number>(() => {
     if (saved && saved.currentWordIndex < practicedWords.length) {
@@ -167,6 +164,10 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   });
   const [pasteWarning, setPasteWarning] = useState(false);
   const loadedWordsRef = useRef<Set<string>>(new Set());
+  // True until the user actually interacts after mount. Prevents the DB sync
+  // effect from firing with restored-only state and e.g. rolling `current_step`
+  // back to 'sentence-practice' when the student has already moved on.
+  const isRestoringRef = useRef(true);
 
   // Persist progress to localStorage whenever it changes (#1203).
   const storageKey = useMemo(() => storageKeyFor(storyId), [storyId]);
@@ -183,7 +184,13 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   }, [storageKey, wordStates, completedWords, currentWordIndex]);
 
   // DB sync (#1203): mid-exercise patch on progress change; markCompleted when every word done.
+  // Skip first fire so restored localStorage state doesn't clobber LearningLayout's
+  // current_step (e.g. student already moved to vocab-definition and just revisits).
   useEffect(() => {
+    if (isRestoringRef.current) {
+      isRestoringRef.current = false;
+      return;
+    }
     if (!saveStepProgressPatch) return;
     const allDone =
       practicedWords.length > 0 && practicedWords.every((w) => completedWords.has(w));
@@ -217,6 +224,11 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
 
   const loadExamples = useCallback(async () => {
     if (!currentWord || loadedWordsRef.current.has(currentWord)) return;
+    // Skip API call if examples were restored from localStorage (#1203).
+    if (currentState.exampleSentences !== null) {
+      loadedWordsRef.current.add(currentWord);
+      return;
+    }
     loadedWordsRef.current.add(currentWord);
     setWordStates(prev => ({ ...prev, [currentWord]: { ...prev[currentWord], examplesLoading: true, examplesError: '' } }));
     try {
@@ -226,7 +238,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
       loadedWordsRef.current.delete(currentWord);
       setWordStates(prev => ({ ...prev, [currentWord]: { ...prev[currentWord], examplesLoading: false, examplesError: '例句載入失敗，請稍後再試。' } }));
     }
-  }, [currentWord, storyTitle, token]);
+  }, [currentWord, currentState.exampleSentences, storyTitle, token]);
 
   React.useEffect(() => { loadExamples(); }, [loadExamples]);
 

--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -168,6 +168,12 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   // effect from firing with restored-only state and e.g. rolling `current_step`
   // back to 'sentence-practice' when the student has already moved on.
   const isRestoringRef = useRef(true);
+  // Ref mirror of saveStepProgressPatch so the DB sync effect does NOT depend
+  // on its identity. The prop is recreated on every LearningLayout render
+  // (onProgressLoaded is inline), so including it in deps would make the
+  // effect fire every render and PUT until the rate limiter kicks in (429).
+  const savePatchRef = useRef(saveStepProgressPatch);
+  useEffect(() => { savePatchRef.current = saveStepProgressPatch; }, [saveStepProgressPatch]);
 
   // Persist progress to localStorage whenever it changes (#1203).
   const storageKey = useMemo(() => storageKeyFor(storyId), [storyId]);
@@ -186,16 +192,19 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   // DB sync (#1203): mid-exercise patch on progress change; markCompleted when every word done.
   // Skip first fire so restored localStorage state doesn't clobber LearningLayout's
   // current_step (e.g. student already moved to vocab-definition and just revisits).
+  // Uses savePatchRef (not the prop directly) to avoid re-running on every parent
+  // render caused by unstable `saveStepProgressPatch` identity.
   useEffect(() => {
     if (isRestoringRef.current) {
       isRestoringRef.current = false;
       return;
     }
-    if (!saveStepProgressPatch) return;
+    const patch = savePatchRef.current;
+    if (!patch) return;
     const allDone =
       practicedWords.length > 0 && practicedWords.every((w) => completedWords.has(w));
     if (allDone) {
-      saveStepProgressPatch({
+      patch({
         stepId: 'sentence-practice',
         currentStep: 'sentence-practice',
         markCompleted: true,
@@ -207,7 +216,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
         },
       });
     } else if (completedWords.size > 0) {
-      saveStepProgressPatch({
+      patch({
         stepId: 'sentence-practice',
         currentStep: 'sentence-practice',
         stepData: {
@@ -217,7 +226,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
         },
       });
     }
-  }, [completedWords, currentWordIndex, practicedWords, saveStepProgressPatch]);
+  }, [completedWords, currentWordIndex, practicedWords]);
 
   const currentWord = practicedWords[currentWordIndex] ?? '';
   const currentState = wordStates[currentWord] ?? makeWordState();

--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -1,12 +1,19 @@
 /**
- * SentencePractice — Issue #109, #927
+ * SentencePractice — Issue #109, #927, #1203
  *
  * After stroke order practice, students compose 2 sentences using each
  * practiced vocabulary word. AI validates grammar and word usage.
+ *
+ * Persistence (#1203):
+ * - localStorage key `sentencePractice_progress_${scope}` stores wordStates,
+ *   completedWords, currentWordIndex so refreshing preserves progress.
+ * - When caller passes `saveStepProgressPatch`, DB is synced with step_data
+ *   (mid-exercise) and markCompleted (when every word is finished).
  */
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useZhuyin } from '../../context/ZhuyinContext';
+import { scopedStepStorageKey } from '../../services/learningStorageScope';
 import {
   fetchExampleSentences,
   validateSentence,
@@ -67,25 +74,143 @@ interface SentencePracticeProps {
   onFinish: () => void;
   onBack: () => void;
   inline?: boolean;
+  /** Story id — used to scope localStorage key (#1203). */
+  storyId?: string | number;
+  /** Merge-based DB sync from LearningLayout (#1203). Optional — when absent,
+   *  only localStorage persistence is active (good for /tools standalone). */
+  saveStepProgressPatch?: (opts: {
+    stepId: string;
+    stepData: Record<string, unknown>;
+    currentStep?: string | null;
+    markCompleted?: boolean;
+    immediate?: boolean;
+  }) => void;
+}
+
+/* ------------------------------------------------------------------ */
+/*  localStorage helpers (#1203)                                        */
+/* ------------------------------------------------------------------ */
+
+const STATE_STORAGE_PREFIX = 'sentencePractice_progress_';
+
+interface SavedProgress {
+  wordStates: Record<string, WordPracticeState>;
+  completedWords: string[];
+  currentWordIndex: number;
+}
+
+function storageKeyFor(storyId: string | number | undefined): string | null {
+  if (storyId === undefined || storyId === null || storyId === '') return null;
+  return scopedStepStorageKey(STATE_STORAGE_PREFIX, storyId);
+}
+
+function loadSaved(storyId: string | number | undefined): SavedProgress | null {
+  const key = storageKeyFor(storyId);
+  if (!key) return null;
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<SavedProgress>;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      parsed.wordStates &&
+      Array.isArray(parsed.completedWords) &&
+      typeof parsed.currentWordIndex === 'number'
+    ) {
+      return parsed as SavedProgress;
+    }
+  } catch { /* non-fatal */ }
+  return null;
 }
 
 // ── Component ─────────────────────────────────────────────────────────────
 
 const SentencePractice: React.FC<SentencePracticeProps> = ({
   practicedWords, storyTitle, onFinish, onBack, inline = false,
+  storyId, saveStepProgressPatch,
 }) => {
   const { token } = useAuth();
   const { zhuyinActive, processZhuyin } = useZhuyin();
   const zh = (text: string) => zhuyinActive ? processZhuyin(text) : text;
-  const [currentWordIndex, setCurrentWordIndex] = useState(0);
+
+  // Restore from localStorage (#1203) — run once on mount.
+  const savedRef = useRef<SavedProgress | null>(null);
+  if (savedRef.current === null) {
+    savedRef.current = loadSaved(storyId);
+  }
+  const saved = savedRef.current;
+
+  const [currentWordIndex, setCurrentWordIndex] = useState<number>(() => {
+    if (saved && saved.currentWordIndex < practicedWords.length) {
+      return saved.currentWordIndex;
+    }
+    return 0;
+  });
+
   const [wordStates, setWordStates] = useState<Record<string, WordPracticeState>>(() => {
     const init: Record<string, WordPracticeState> = {};
-    for (const w of practicedWords) init[w] = makeWordState();
+    for (const w of practicedWords) {
+      const restored = saved?.wordStates?.[w];
+      init[w] = restored ?? makeWordState();
+    }
     return init;
   });
-  const [completedWords, setCompletedWords] = useState<Set<string>>(new Set());
+
+  const [completedWords, setCompletedWords] = useState<Set<string>>(() => {
+    if (!saved) return new Set();
+    const restored = new Set<string>();
+    for (const w of saved.completedWords) {
+      if (practicedWords.includes(w)) restored.add(w);
+    }
+    return restored;
+  });
   const [pasteWarning, setPasteWarning] = useState(false);
   const loadedWordsRef = useRef<Set<string>>(new Set());
+
+  // Persist progress to localStorage whenever it changes (#1203).
+  const storageKey = useMemo(() => storageKeyFor(storyId), [storyId]);
+  useEffect(() => {
+    if (!storageKey) return;
+    try {
+      const payload: SavedProgress = {
+        wordStates,
+        completedWords: Array.from(completedWords),
+        currentWordIndex,
+      };
+      localStorage.setItem(storageKey, JSON.stringify(payload));
+    } catch { /* non-fatal */ }
+  }, [storageKey, wordStates, completedWords, currentWordIndex]);
+
+  // DB sync (#1203): mid-exercise patch on progress change; markCompleted when every word done.
+  useEffect(() => {
+    if (!saveStepProgressPatch) return;
+    const allDone =
+      practicedWords.length > 0 && practicedWords.every((w) => completedWords.has(w));
+    if (allDone) {
+      saveStepProgressPatch({
+        stepId: 'sentence-practice',
+        currentStep: 'sentence-practice',
+        markCompleted: true,
+        immediate: true,
+        stepData: {
+          completed: true,
+          completedAt: new Date().toISOString(),
+          wordCount: practicedWords.length,
+        },
+      });
+    } else if (completedWords.size > 0) {
+      saveStepProgressPatch({
+        stepId: 'sentence-practice',
+        currentStep: 'sentence-practice',
+        stepData: {
+          completedWords: Array.from(completedWords),
+          currentWordIndex,
+          partialAt: new Date().toISOString(),
+        },
+      });
+    }
+  }, [completedWords, currentWordIndex, practicedWords, saveStepProgressPatch]);
 
   const currentWord = practicedWords[currentWordIndex] ?? '';
   const currentState = wordStates[currentWord] ?? makeWordState();

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -64,6 +64,7 @@ export interface LearningContext {
   handleFinishReadingAnnotation: (summary: AnnotationSummary) => void;
   handleFinishVocabDefinitionMatch: (result: VocabDefinitionMatchResult) => void;
   handleFinishVocabApplication: (result: VocabApplicationResult) => void;
+  handleFinishSentencePractice: () => void;
   handleFinishVocabWordSearch: (elapsedSeconds: number) => void;
   handleFinishKnowledgeStation: () => void;
   handleRetry: () => void;
@@ -865,6 +866,24 @@ const LearningLayout: React.FC = () => {
     [storyId, navigate, persistStep, persistStepProgressState],
   );
 
+  const handleFinishSentencePractice = useCallback(
+    () => {
+      persistStepProgressState(
+        {
+          completeStep: 'sentence-practice',
+          currentStep: 'vocab-definition',
+          stepDataPatch: {
+            'sentence-practice': { completed: true },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['sentence-practice']);
+      navigate(`/learn/${storyId}/vocab-definition`);
+    },
+    [storyId, navigate, persistStep, persistStepProgressState],
+  );
+
   const handleFinishVocabWordSearch = useCallback(
     (_elapsedSeconds: number) => {
       setSession((prev) => (prev ? { ...prev, vocabWordSearchCompleted: true } : null));
@@ -1066,6 +1085,7 @@ const LearningLayout: React.FC = () => {
     handleFinishReadingAnnotation,
     handleFinishVocabDefinitionMatch,
     handleFinishVocabApplication,
+    handleFinishSentencePractice,
     handleFinishVocabWordSearch,
     handleFinishKnowledgeStation,
     handleRetry,

--- a/frontend/src/pages/learning/SentencePracticePage.tsx
+++ b/frontend/src/pages/learning/SentencePracticePage.tsx
@@ -5,7 +5,11 @@ import { useLearningContext } from '../../layouts/LearningLayout';
 
 const SentencePracticePage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
-  const { selectedStory } = useLearningContext();
+  const {
+    selectedStory,
+    handleFinishSentencePractice,
+    saveStepProgressPatch,
+  } = useLearningContext();
   const navigate = useNavigate();
 
   const practicedWords = useMemo(() => {
@@ -25,7 +29,9 @@ const SentencePracticePage: React.FC = () => {
     <SentencePractice
       practicedWords={practicedWords}
       storyTitle={selectedStory.title}
-      onFinish={() => navigate(`/learn/${storyId}/vocab-definition`)}
+      storyId={selectedStory.id}
+      saveStepProgressPatch={saveStepProgressPatch}
+      onFinish={handleFinishSentencePractice}
       onBack={() => navigate(`/learn/${storyId}/vocab`)}
     />
   );


### PR DESCRIPTION
# Issue #1203 修正說明

## 問題摘要
造句練習（`SentencePractice`）完全沒有任何持久化：完成後 `step_progress.steps_completed` 不含 `sentence-practice`、刷新頁面進度全失、下次進入從零開始。

## 修正策略
**雙層持久化** + **補上缺漏的 handler**：
1. **localStorage**：即時存 `wordStates` / `completedWords` / `currentWordIndex` → 刷新能還原
2. **DB 層**：透過 `saveStepProgressPatch`（merge 語意，不覆蓋其他步驟）
   - 部分完成 → 只寫 `step_data`
   - 全部完成 → `markCompleted: true` 加入 `steps_completed`
3. **LearningLayout**：新增 `handleFinishSentencePractice` callback，其他步驟都有只有這個缺

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/components/reading-steps/SentencePractice.tsx` | 加 localStorage 持久化 + DB sync effects + 2 個新 props |
| `frontend/src/pages/learning/SentencePracticePage.tsx` | 從 context 取 handler + saveStepProgressPatch，傳 storyId |
| `frontend/src/layouts/LearningLayout.tsx` | 新增 `handleFinishSentencePractice` + context interface/value |

## 修正細節

### 1. `SentencePractice.tsx`

```typescript
interface SentencePracticeProps {
  // ...既有
  storyId?: string | number;
  saveStepProgressPatch?: (opts: { stepId, stepData, ... }) => void;
}

// localStorage 還原
const [wordStates, setWordStates] = useState(() => {
  const saved = loadSaved(storyId);
  // ...優先還原，fallback 到 fresh init
});

// 即時存 localStorage
useEffect(() => {
  localStorage.setItem(storageKey, JSON.stringify({ wordStates, completedWords, currentWordIndex }));
}, [wordStates, completedWords, currentWordIndex]);

// DB sync
useEffect(() => {
  if (!saveStepProgressPatch) return;
  const allDone = practicedWords.every(w => completedWords.has(w));
  if (allDone) {
    saveStepProgressPatch({ stepId: 'sentence-practice', markCompleted: true, immediate: true, stepData: {...} });
  } else if (completedWords.size > 0) {
    saveStepProgressPatch({ stepId: 'sentence-practice', stepData: {...} });
  }
}, [completedWords, currentWordIndex]);
```

### 2. `LearningLayout.tsx`

```typescript
const handleFinishSentencePractice = useCallback(() => {
  persistStepProgressState(
    {
      completeStep: 'sentence-practice',
      currentStep: 'vocab-definition',
      stepDataPatch: { 'sentence-practice': { completed: true } },
    },
    true,
  );
  persistStep(STEP_PATH_TO_NUMBER['sentence-practice']);
  navigate(`/learn/${storyId}/vocab-definition`);
}, [storyId, navigate, persistStep, persistStepProgressState]);
```

### 3. `SentencePracticePage.tsx`

```typescript
const { selectedStory, handleFinishSentencePractice, saveStepProgressPatch } = useLearningContext();
// ...
<SentencePractice
  storyId={selectedStory.id}
  saveStepProgressPatch={saveStepProgressPatch}
  onFinish={handleFinishSentencePractice}
  // ...
/>
```

## 測試驗證
- ✅ TypeScript 檢查通過（無 SentencePractice/LearningLayout 錯誤）
- ✅ `npm run build` 通過

## 行為變化

**修正前**：
- 完成所有題目 → navigate 到下一步，但 `step_progress.steps_completed` 不含 `sentence-practice` → 作業列表看起來沒做過
- 刷新 → wordStates/completedWords/currentWordIndex 全 reset

**修正後**：
- 完成所有題目 → `markCompleted: true` 加入 `steps_completed`（merge 不覆蓋其他步驟）+ navigate
- 刷新 → 從 localStorage 還原造句文字、批改結果、完成進度
- 中途完成部分詞語 → 先寫 `step_data`（不標 completed），下次進入從該位置繼續

## 迴歸測試
- ✅ 已有 localStorage 的情境能正確讀回
- ✅ 無 `saveStepProgressPatch` 情境（如 /tools 獨立使用）只走 localStorage，不 crash
- ✅ `practicedWords` 變動時，舊 localStorage 不在清單的字會被過濾
- ✅ `completedWords` 用 Set 去重，`Array.from` serialize 後還原

## 嚴重性
🔴 **Critical** — 此步驟原本完全不可用於追蹤學習進度，使用者體驗差。