### PR TITLE
fix(sso): force callback origin to Junyi whitelist (Refs #1198)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -179,7 +179,9 @@ jobs:
           echo "backend_url=${BACKEND_URL}" >> $GITHUB_OUTPUT
 
       - name: Update backend CORS with actual frontend URL
-        if: always() && steps.preview-urls.outputs.frontend_url != 'N/A'
+        # Skip when backend preview service doesn't exist (frontend-only PR after
+        # prior backend cleanup) — otherwise `gcloud run services update` fails.
+        if: always() && steps.preview-urls.outputs.frontend_url != 'N/A' && steps.preview-urls.outputs.backend_url != 'N/A'
         env:
           FRONTEND_URL: ${{ steps.preview-urls.outputs.frontend_url }}
         run: |

--- a/frontend/src/pages/JunyiCallbackPage.tsx
+++ b/frontend/src/pages/JunyiCallbackPage.tsx
@@ -19,12 +19,30 @@ import { trackEvent } from '../utils/analytics';
 
 const JUNYI_STATE_KEY = 'junyi_sso_state';
 
-/** Build the Junyi login URL pointing at the current environment's callback. */
-export function buildJunyiLoginUrl(returnTo: string = '/'): string {
-  // Encode the return path inside the callback URL so we can restore it after the round-trip.
-  const callbackUrl = `${window.location.origin}/junyi-callback?returnTo=${encodeURIComponent(returnTo)}`;
+// Hosts registered in Junyi SSO whitelist. Callback origin MUST be one of these
+// or Junyi silently refuses to redirect the ?code= back.
+const WHITELISTED_CALLBACK_ORIGINS = [
+  'https://lingoleap-prod.web.app',
+  'https://lingoleap-staging.web.app',
+  'https://lingoleap-dev.web.app',
+];
 
-  // Generate and persist a CSRF state token.
+/** True when the current origin is a Junyi-whitelisted host (SSO can round-trip). */
+export function isSsoSupported(): boolean {
+  return WHITELISTED_CALLBACK_ORIGINS.includes(window.location.origin);
+}
+
+/** Build the Junyi login URL pointing at a whitelisted callback origin. */
+export function buildJunyiLoginUrl(returnTo: string = '/'): string {
+  // Use current origin only if it is whitelisted; otherwise fall back to staging
+  // (covers PR previews / Cloud Run direct URLs / localhost — SSO won't actually
+  // complete there due to cross-origin sessionStorage, but at least the redirect
+  // reaches a real host Junyi accepts instead of hanging).
+  const callbackOrigin = isSsoSupported()
+    ? window.location.origin
+    : WHITELISTED_CALLBACK_ORIGINS[1]; // staging
+  const callbackUrl = `${callbackOrigin}/junyi-callback?returnTo=${encodeURIComponent(returnTo)}`;
+
   const state = Array.from(crypto.getRandomValues(new Uint8Array(16)))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { AuthError } from '../services/authApi';
 import { trackEvent } from '../utils/analytics';
 import GoogleSignInButton from '../components/GoogleSignInButton';
-import { buildJunyiLoginUrl } from './JunyiCallbackPage';
+import { buildJunyiLoginUrl, isSsoSupported } from './JunyiCallbackPage';
 
 interface LoginPageProps {
   onSwitchToRegister?: () => void;
@@ -170,15 +170,17 @@ const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
             <GoogleSignInButton onCredential={handleGoogleCredential} width={352} />
           </div>
 
-          {/* Junyi SSO (issue #1198) */}
-          <button
-            type="button"
-            onClick={handleJunyiLogin}
-            className="w-full h-11 flex items-center justify-center gap-2 bg-white border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
-          >
-            <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[#FF6B35] text-white text-[10px] font-black leading-none">均</span>
-            使用均一帳號登入
-          </button>
+          {/* Junyi SSO (issue #1198) — only shown on whitelisted hosts where callback works */}
+          {isSsoSupported() && (
+            <button
+              type="button"
+              onClick={handleJunyiLogin}
+              className="w-full h-11 flex items-center justify-center gap-2 bg-white border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+            >
+              <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[#FF6B35] text-white text-[10px] font-black leading-none">均</span>
+              使用均一帳號登入
+            </button>
+          )}
         </div>
 
         {/* Switch to Register */}


### PR DESCRIPTION
## Summary

- `buildJunyiLoginUrl` now resolves the callback origin against a hard-coded whitelist (`lingoleap-{prod,staging,dev}.web.app`). If the current origin isn't whitelisted, we fall back to staging so the redirect at least reaches a host Junyi accepts.
- New `isSsoSupported()` helper — `LoginPage` hides the 均一 login button on PR previews / Cloud Run direct URLs / localhost where the round-trip can't complete anyway (cross-origin sessionStorage would break CSRF state).

## Why

Junyi SSO hard-codes a host whitelist. If a user entered the site via a non-whitelisted host (e.g. a PR preview URL or the raw Cloud Run URL) and clicked 均一 login, Junyi would silently refuse to redirect `?code=` back after login, leaving the user stuck on Junyi's page. We can't fix the whitelist side (that's Junyi infra), but we can guarantee we only ever hand Junyi a whitelisted callback.

## Whitelist (from junyi issue #4083)

- `https://lingoleap-prod.web.app`
- `https://lingoleap-staging.web.app`
- `https://lingoleap-dev.web.app`

## Test plan

- [ ] Open `https://lingoleap-staging.web.app/login` → 均一 button visible, click → land on junyi login → after login, URL bar returns to `lingoleap-staging.web.app/junyi-callback?code=...` (this is the one that needs a real 均一 account to verify end-to-end)
- [ ] Open PR preview URL → 均一 button hidden, email/password + Google still work
- [ ] Open `localhost:3000/login` → 均一 button hidden
- [ ] Open `lingoleap-prod.web.app/login` → 均一 button visible, callback goes back to prod

Refs #1198