### PR TITLE
fix(live-tutor): 4-state TTS button UX — loading/playing/idle/error (Fixes #1210)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -150,6 +150,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const {
     isTtsSpeaking,
     isTtsPaused,
+    isTtsLoading,
+    ttsError,
     setIsTtsSpeaking,
     setIsTtsPaused,
     utteranceRef,
@@ -836,6 +838,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               isSessionActive={stt.isSessionActive}
               isPreparing={stt.isPreparing}
               isTtsSpeaking={isTtsSpeaking}
+              isTtsLoading={isTtsLoading}
               speakingProgress={speakingProgress}
               utteranceRef={utteranceRef}
               ttsRafRef={ttsRafRef}
@@ -953,6 +956,26 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               <div className="w-4 h-4 border-2 border-on-surface-variant border-t-transparent rounded-full animate-spin" />
               準備中...
             </button>
+          ) : isTtsLoading ? (
+            /* TTS loading — fetching audio, show spinner + disabled AI朗讀 */
+            <div className="w-full flex gap-3">
+              <button
+                disabled
+                title="載入中..."
+                className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-high text-on-surface-variant cursor-wait flex items-center justify-center gap-2"
+              >
+                <div className="w-4 h-4 border-2 border-on-surface-variant border-t-transparent rounded-full animate-spin" />
+                載入中...
+              </button>
+              <button
+                onClick={startSession}
+                className="flex-1 h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-3 animate-pulse"
+                style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+              >
+                <span className="material-symbols-outlined text-2xl" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
+                {retryCount > 0 ? '再試一次' : '開始朗讀'}
+              </button>
+            </div>
           ) : isTtsSpeaking ? (
             /* TTS playing — pause/stop */
             <div className="w-full flex gap-3">
@@ -985,15 +1008,28 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               </button>
             </>
           ) : !isAdvancing ? (
-            /* Idle — AI朗讀 + 開始朗讀 side by side */
+            /* Idle (or error) — AI朗讀 + 開始朗讀 side by side */
             <div className="w-full flex gap-3">
-              <button
-                onClick={() => speakCurrentParagraph()}
-                className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-              >
-                <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>volume_up</span>
-                AI 朗讀
-              </button>
+              {ttsError ? (
+                /* Error state — retry button */
+                <button
+                  onClick={() => speakCurrentParagraph()}
+                  title={ttsError}
+                  className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-tertiary-container/30 text-tertiary border border-tertiary/30 hover:bg-tertiary-container/50 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+                >
+                  <span className="material-symbols-outlined text-xl">refresh</span>
+                  重試朗讀
+                </button>
+              ) : (
+                /* Idle state — normal AI朗讀 button */
+                <button
+                  onClick={() => speakCurrentParagraph()}
+                  className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+                >
+                  <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>volume_up</span>
+                  AI 朗讀
+                </button>
+              )}
               <button
                 onClick={startSession}
                 className="flex-1 h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-3 animate-pulse"

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -41,6 +41,8 @@ interface ParagraphCardProps {
   isPreparing: boolean;
   // TTS state
   isTtsSpeaking: boolean;
+  /** True while audio is being fetched (before first byte plays). */
+  isTtsLoading: boolean;
   /** Current character position during TTS playback (0-based) */
   speakingProgress: number;
   utteranceRef: React.MutableRefObject<HTMLAudioElement | SpeechSynthesisUtterance | null>;
@@ -84,6 +86,7 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
   isSessionActive,
   isPreparing,
   isTtsSpeaking,
+  isTtsLoading,
   speakingProgress,
   utteranceRef,
   ttsRafRef,
@@ -110,10 +113,11 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
   storyContent,
 }) => {
   const isCurrentIdx = idx === currentLineIndex;
-  const [ttsLoading, setTtsLoading] = React.useState(false);
+  // isTtsLoading comes from useTtsPlayback hook (via LiveTutor) — no local state needed.
+  // This removes the old setTimeout-based debounce that was an approximation.
 
   const handleTtsClick = () => {
-    if (ttsLoading) return; // debounce
+    if (isTtsLoading) return; // debounce: ignore if still fetching
     if (idx !== currentLineIndex) {
       onSelectParagraph(idx);
     }
@@ -139,17 +143,9 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
       setIsTtsSpeaking(false);
       setIsTtsPaused(false);
     } else {
-      setTtsLoading(true);
       onTtsToggle(idx);
-      // Clear loading after TTS starts or after timeout
-      setTimeout(() => setTtsLoading(false), 5000);
     }
   };
-
-  // Clear loading when TTS actually starts playing
-  React.useEffect(() => {
-    if (isTtsSpeaking) setTtsLoading(false);
-  }, [isTtsSpeaking]);
 
   // Encouragement for summary display
   const encouragement = useMemo(() => {

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -27,6 +27,18 @@ export function useTtsPlayback(
 ) {
   const [isTtsSpeaking, setIsTtsSpeaking] = useState(false);
   const [isTtsPaused, setIsTtsPaused] = useState(false);
+  /**
+   * isTtsLoading — true from the moment speakText() is called until the first
+   * audio byte starts playing (or until an error occurs).  UI should show a
+   * spinner and disable the button during this window.
+   */
+  const [isTtsLoading, setIsTtsLoading] = useState(false);
+  /**
+   * ttsError — non-null when the last TTS request failed and no fallback was
+   * available.  UI should show a retry affordance.  Cleared automatically the
+   * next time speakText() is called.
+   */
+  const [ttsError, setTtsError] = useState<string | null>(null);
 
   // Strong ref to TTS utterance — prevents Chrome GC bug where a local utterance
   // gets collected mid-playback, silencing onend/onboundary callbacks.
@@ -61,9 +73,10 @@ export function useTtsPlayback(
     if (!text) return;
     cancelTts();
     setIsTtsPaused(false);
-    setIsTtsSpeaking(true);
-    onRealtimeDiffTokensClear();
-    onSpeakingProgress(0);
+    setIsTtsLoading(true);
+    setTtsError(null);
+    // isTtsSpeaking stays false until audio actually starts playing —
+    // during the loading window only isTtsLoading is true.
 
     // When lesson context is available, use sentence-level sequential playback
     // so SHA-256 keys match pre-generated GCS blobs (Issue #1208 fix).
@@ -73,16 +86,29 @@ export function useTtsPlayback(
       const charCount = Array.from(cleanForTts(text)).length;
       v2PathActiveRef.current = true;
       utteranceRef.current = null;
+      // v2 path: the first sentence starts playing very quickly; treat first
+      // progress callback as the "playing" signal to flip loading → speaking.
+      let v2PlaybackStarted = false;
       speakTextWithProgress(
         text,
         (info: TtsProgressInfo) => {
+          if (!v2PlaybackStarted) {
+            v2PlaybackStarted = true;
+            setIsTtsLoading(false);
+            setIsTtsSpeaking(true);
+            onRealtimeDiffTokensClear();
+            onSpeakingProgress(0);
+          }
           const pos = Math.min(Math.floor(info.progress * charCount), charCount);
           onSpeakingProgress(pos);
         },
         lessonId,
         paragraphIdx,
-      ).finally(() => {
+      ).catch(() => {
+        setTtsError('音檔載入失敗，請重試');
+      }).finally(() => {
         v2PathActiveRef.current = false;
+        setIsTtsLoading(false);
         setIsTtsSpeaking(false);
         setIsTtsPaused(false);
       });
@@ -114,6 +140,15 @@ export function useTtsPlayback(
       stopTtsAnimation();
       setIsTtsSpeaking(false);
       setIsTtsPaused(false);
+      setIsTtsLoading(false);
+    };
+
+    const onSpeechError = () => {
+      stopTtsAnimation();
+      setIsTtsSpeaking(false);
+      setIsTtsPaused(false);
+      setIsTtsLoading(false);
+      setTtsError('音檔載入失敗，請重試');
     };
 
     // Try Cloud TTS first via <audio> element for better control
@@ -145,21 +180,22 @@ export function useTtsPlayback(
           onSpeakingProgress(pos);
         };
 
-        // onplay: only sets speaking state + resets progress to 0. No rAF started here.
+        // onplay: flip loading → speaking as soon as first bytes play.
         audio.onplay = () => {
+          setIsTtsLoading(false);
           setIsTtsSpeaking(true);
           onRealtimeDiffTokensClear();
           onSpeakingProgress(0);
         };
 
         audio.onended = () => { URL.revokeObjectURL(url); onSpeechEnd(); };
-        audio.onerror = () => { URL.revokeObjectURL(url); onSpeechEnd(); };
+        audio.onerror = () => { URL.revokeObjectURL(url); onSpeechError(); };
         return audio.play();
       })
       .catch(() => {
         // Fallback: Web Speech API — rAF + wall-clock timing path (unchanged)
         msPerCharRef.current = 240; // reset to default estimate for Web Speech
-        if (!window.speechSynthesis) { onSpeechEnd(); return; }
+        if (!window.speechSynthesis) { onSpeechError(); return; }
         window.speechSynthesis.cancel();
         const utterance = new SpeechSynthesisUtterance(text);
         utteranceRef.current = utterance;
@@ -173,6 +209,8 @@ export function useTtsPlayback(
         if (preferred) utterance.voice = preferred;
 
         const startCursorAnimation = () => {
+          // Web Speech API started: flip loading → speaking
+          setIsTtsLoading(false);
           setIsTtsSpeaking(true);
           onSpeakingProgress(0);
           onRealtimeDiffTokensClear();
@@ -192,7 +230,7 @@ export function useTtsPlayback(
         utterance.onstart = startCursorAnimation;
         utterance.onboundary = (e) => { onSpeakingProgress(e.charIndex); };
         utterance.onend = onSpeechEnd;
-        utterance.onerror = onSpeechEnd;
+        utterance.onerror = onSpeechError;
 
         const doSpeak = () => window.speechSynthesis.speak(utterance);
         if (window.speechSynthesis.getVoices().length === 0) {
@@ -289,11 +327,15 @@ export function useTtsPlayback(
     cancelTts();
     setIsTtsSpeaking(false);
     setIsTtsPaused(false);
+    setIsTtsLoading(false);
+    setTtsError(null);
   };
 
   return {
     isTtsSpeaking,
     isTtsPaused,
+    isTtsLoading,
+    ttsError,
     setIsTtsSpeaking,
     setIsTtsPaused,
     utteranceRef,


### PR DESCRIPTION
Fixes #1210

## Summary

- **useTtsPlayback hook**: adds `isTtsLoading` + `ttsError` states
  - `isTtsLoading=true` fires **immediately** on `speakText()` call (synchronous), clearing when `audio.onplay` fires
  - `ttsError` set on fetch/playback failure, cleared on next `speakText()`
  - v2 sentence path: first progress callback flips loading → speaking
  - `stopTts()` now also clears loading + error

- **LiveTutor bottom CTA**: 4-state button machine
  - **Loading**: spinner + disabled button + `載入中...` text
  - **Playing**: pause/stop controls (unchanged)
  - **Error**: `refresh` icon + `重試朗讀` in tertiary-container color
  - **Idle**: `volume_up` icon + `AI 朗讀` (unchanged)

- **ParagraphCard**: replaces local `ttsLoading` state + 5s `setTimeout` hack with `isTtsLoading` prop from the hook — now uses real playback state instead of approximation

## Test plan

1. Open any lesson → LiveTutor step
2. **Idle state**: 「AI 朗讀」button with 🔊 icon visible
3. **Loading state**: click 「AI 朗讀」 → spinner appears **immediately** (< 100ms, no delay)
4. **Playing state**: audio starts → button changes to pause/stop controls; paragraph text highlights
5. **Pause**: click pause → icon changes to play_arrow + 「繼續」
6. **Error state**: (simulate by blocking network) → button shows 「重試朗讀」with refresh icon
7. Double-click: second click during loading is ignored (no duplicate request)