### PR TITLE
fix(tts): char-weighted progress + prefetch — cure highlight sync drift (#1211)

### DIFF
--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -311,21 +311,62 @@ async function _speakViaBackendWithProgress(
 
   const total = sentences.length;
 
+  // Bug 1 (#1211): progress must be char-weighted, not sentence-weighted.
+  // Consumer computes `pos = Math.floor(progress * charCount)` against the
+  // whole paragraph's cleaned char count. Sentence-weighted progress drifts
+  // 2-12 chars when sentence lengths are highly variable (Opus v2 segmenter).
+  //
+  // _cleanForTts is idempotent for all transforms we use on already-clean
+  // canonical sentences; the only edge is adjacent 「，」 which collapses only
+  // at paragraph-level cleaning (1-3 char delta across a whole paragraph),
+  // well under the 2-12 char drift this PR targets.
+  const sentChars = sentences.map((s) => Array.from(_cleanForTts(s || '')).length);
+  const cumChars: number[] = [0];
+  for (const n of sentChars) cumChars.push(cumChars[cumChars.length - 1] + n);
+  const totalChars = Math.max(cumChars[cumChars.length - 1], 1);
+
+  // Bug 2 (#1211): prefetch next sentence's audio URL while current plays
+  // so 100-500ms inter-sentence fetch doesn't freeze the highlight.
+  const firstIdx = sentences.findIndex((s) => s?.trim());
+  let pending: { idx: number; promise: Promise<string> } | null =
+    firstIdx >= 0
+      ? { idx: firstIdx, promise: _fetchAudioUrl(sentences[firstIdx]) }
+      : null;
+
   for (let i = 0; i < total; i++) {
     if (_cancelRequested) break;
     const sentence = sentences[i];
-    if (!sentence.trim()) continue;
+    if (!sentence?.trim()) continue;
 
-    // Emit start of this sentence
-    onProgress({ sentenceIndex: i, totalSentences: total, progress: i / total });
+    onProgress({
+      sentenceIndex: i,
+      totalSentences: total,
+      progress: cumChars[i] / totalChars,
+    });
 
-    const audioUrl = await _fetchAudioUrl(sentence);
+    const audioUrl = pending && pending.idx === i
+      ? await pending.promise
+      : await _fetchAudioUrl(sentence);
     if (_cancelRequested) break;
 
+    // Start prefetch for next non-empty sentence BEFORE awaiting playback.
+    let j = i + 1;
+    while (j < total && !sentences[j]?.trim()) j++;
+    pending = j < total
+      ? { idx: j, promise: _fetchAudioUrl(sentences[j]) }
+      : null;
+
+    const startChar = cumChars[i];
+    const nChars = sentChars[i];
+
     await _playSingleAudio(audioUrl, (currentTime, duration) => {
-      const withinSentence = duration > 0 ? currentTime / duration : 0;
-      const progress = (i + withinSentence) / total;
-      onProgress({ sentenceIndex: i, totalSentences: total, progress });
+      const within = duration > 0 ? Math.min(currentTime / duration, 1) : 0;
+      const charPos = startChar + within * nChars;
+      onProgress({
+        sentenceIndex: i,
+        totalSentences: total,
+        progress: charPos / totalChars,
+      });
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #1211. TTS voice and reverse-highlight drift 2-12 chars once #1208's Opus v2 semantic segmentation started producing variable-length sentences (5-80 chars).

## Root cause (two bugs)

**Bug 1 — Progress was sentence-weighted, not char-weighted**

`_speakViaBackendWithProgress` emitted `progress = (i + within) / totalSentences`. Consumer `useTtsPlayback.ts:102` then did `pos = Math.floor(progress * charCount)`. For sentences `[5, 80, 5]` at i=1 within=0.25:
- old pos = `((1 + 0.25) / 3) * 90` = **37**
- real pos = `5 + 80*0.25` = **25**
- **12-char lag** — highlight permanently trails the voice inside long sentences.

Why it started now: old regex `_splitSentences` forced ≤40-char uniform chunks; Opus v2 semantic boundaries are highly variable. Uniform case happened to work because `(i + within) / N ≈ (chars_so_far) / totalChars` only when every sentence has equal char count.

**Bug 2 — Inter-sentence fetch froze the highlight**

Each sentence ran `await _fetchAudioUrl(sentence)` BEFORE playback, freezing the progress callback for 100-500ms at every sentence boundary.

## Fix

```ts
const sentChars = sentences.map(s => Array.from(_cleanForTts(s)).length);
const cumChars = [0]; for (const n of sentChars) cumChars.push(cumChars.at(-1)! + n);
const totalChars = Math.max(cumChars.at(-1)!, 1);

// Prefetch next sentence while current plays
let pending = firstIdx >= 0 ? { idx: firstIdx, promise: _fetchAudioUrl(sentences[firstIdx]) } : null;

for (let i = 0; i < total; i++) {
  // ... start prefetch for i+1 BEFORE awaiting i's playback ...
  await _playSingleAudio(audioUrl, (t, dur) => {
    const within = dur > 0 ? Math.min(t / dur, 1) : 0;
    const charPos = cumChars[i] + within * sentChars[i];
    onProgress({ ..., progress: charPos / totalChars });
  });
}
```

## Test plan (L1-L4)

- [x] **L1 Math**: cum-char formula gives correct pos for `[5,80,5]` at i=1 within=0.25 → 25 (old gave 37)
- [x] **L1 TS**: no new type errors (tsc shows only pre-existing unrelated errors)
- [x] **Critic review**: passed with 1 noted limitation (prefetch in-flight is not abortable on cancel — result still caches, not a regression in correctness)
- [ ] **L2 Browse**: play L01 on preview URL, verify progress callbacks against audio.currentTime
- [ ] **L3 Visual**: compare highlight position during playback (before/after screenshots)
- [ ] **L4 Human ear**: Young to play L01 p0 and L05 p2 (variable sentence lengths) and confirm sync

## Known limitation

In-flight prefetch cannot be aborted if `cancelTts` is called mid-playback (same behavior as pre-existing code — no `AbortController` in `_fetchAudioUrl`). Fetch result still lands in `_urlCache`, so next playback cache-hits. Follow-up: wire up AbortController if cancellation latency becomes a problem on slow networks.

Fixes #1211