### PR TITLE
fix(student): polish /student page design (Fixes #1215)

### DIFF
--- a/frontend/src/components/student/QuickPracticeStrip.tsx
+++ b/frontend/src/components/student/QuickPracticeStrip.tsx
@@ -79,25 +79,28 @@ const QuickPracticeStrip: React.FC = () => {
         </button>
       </div>
 
-      {/* 4-card grid: 2 cols on xs, 4 cols on sm+ */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {/* 4-card grid: 2 cols always (student-friendly touch targets) */}
+      <div className="grid grid-cols-2 gap-3">
         {QUICK_CARDS.map((card) => (
           <button
             key={card.title}
             type="button"
             onClick={() => navigate(card.route)}
             className="
-              text-left bg-surface-container-lowest rounded-2xl border border-gray-100
-              shadow-sm hover:shadow-md hover:scale-[1.02] active:scale-95
-              p-4 flex flex-col gap-2 transition-all duration-150
+              text-left bg-surface-container-lowest rounded-2xl border border-[#E5E0D5]
+              hover:shadow-md hover:scale-[0.995] active:scale-[0.98]
+              p-4 flex items-center gap-3 transition-all duration-150
               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+              min-h-[72px]
             "
             aria-label={`${card.title}${card.needsStory ? '（先選課文）' : ''}`}
           >
-            <span className="text-2xl leading-none" aria-hidden="true">
-              {card.icon}
-            </span>
-            <div className="space-y-0.5">
+            <div className="w-11 h-11 rounded-xl bg-accent-bg flex items-center justify-center shrink-0">
+              <span className="text-2xl leading-none" aria-hidden="true">
+                {card.icon}
+              </span>
+            </div>
+            <div className="flex-1 min-w-0 space-y-0.5">
               <p className="text-sm font-bold text-on-surface leading-tight">
                 {card.title}
               </p>

--- a/frontend/src/components/student/StudentProgressDashboard.tsx
+++ b/frontend/src/components/student/StudentProgressDashboard.tsx
@@ -40,24 +40,26 @@ interface StatCardProps {
 
 const StatCard: React.FC<StatCardProps> = ({ label, value, sub, icon, highlight }) => (
   <div
-    className={`rounded-xl p-4 flex items-start gap-3 ${
-      highlight ? 'bg-accent text-white' : 'bg-white border border-gray-200'
+    className={`rounded-2xl p-4 flex items-start gap-3 ${
+      highlight
+        ? 'bg-gradient-to-br from-accent to-accent-hover text-white shadow-sm'
+        : 'bg-surface-container-lowest border border-[#E5E0D5]'
     }`}
   >
     <div
-      className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center text-lg ${
+      className={`shrink-0 w-9 h-9 rounded-xl flex items-center justify-center text-lg ${
         highlight ? 'bg-white/20' : 'bg-accent-bg'
       }`}
     >
       {icon}
     </div>
     <div className="min-w-0">
-      <div className={`text-2xl font-bold leading-none ${highlight ? 'text-white' : 'text-gray-900'}`}>
+      <div className={`text-2xl font-bold leading-none ${highlight ? 'text-white' : 'text-on-surface'}`}>
         {value}
       </div>
-      <div className={`text-xs mt-0.5 ${highlight ? 'text-white/80' : 'text-gray-500'}`}>{label}</div>
+      <div className={`text-xs mt-0.5 ${highlight ? 'text-white/80' : 'text-on-surface-variant'}`}>{label}</div>
       {sub && (
-        <div className={`text-xs mt-0.5 ${highlight ? 'text-white/60' : 'text-gray-400'}`}>{sub}</div>
+        <div className={`text-xs mt-0.5 ${highlight ? 'text-white/60' : 'text-on-surface-variant/70'}`}>{sub}</div>
       )}
     </div>
   </div>
@@ -76,9 +78,9 @@ const ChartTooltip: React.FC<TooltipProps> = ({ active, payload, label }) => {
   const sessions = payload.find((p) => p.name === 'sessions')?.value ?? 0;
   const score = payload.find((p) => p.name === 'score')?.value;
   return (
-    <div className="bg-white border border-gray-200 rounded-lg shadow-md px-3 py-2 text-xs">
-      <p className="font-medium text-gray-700 mb-1">{label}</p>
-      <p className="text-gray-600">完成：{sessions} 篇</p>
+    <div className="bg-surface-container-lowest border border-[#E5E0D5] rounded-xl shadow-editorial px-3 py-2 text-xs">
+      <p className="font-medium text-on-surface mb-1">{label}</p>
+      <p className="text-on-surface-variant">完成：{sessions} 篇</p>
       {score != null && <p className="text-accent font-medium">平均分：{score}%</p>}
     </div>
   );
@@ -138,7 +140,7 @@ const StudentProgressDashboard: React.FC<StudentProgressDashboardProps> = ({
     return (
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="bg-gray-100 rounded-xl h-20 animate-pulse" />
+          <div key={i} className="bg-surface-container rounded-2xl h-20 animate-pulse" />
         ))}
       </div>
     );
@@ -193,8 +195,8 @@ const StudentProgressDashboard: React.FC<StudentProgressDashboardProps> = ({
 
       {/* 30-day activity chart */}
       {hasActivity && (
-        <div className="bg-white rounded-xl border border-gray-200 p-4">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">近 30 天學習曲線</h3>
+        <div className="bg-surface-container-lowest rounded-2xl border border-[#E5E0D5] p-4">
+          <h3 className="text-sm font-semibold text-on-surface mb-3">近 30 天學習曲線</h3>
           <ResponsiveContainer width="100%" height={120}>
             <AreaChart data={chartData} margin={{ top: 4, right: 4, left: -24, bottom: 0 }}>
               <defs>

--- a/frontend/src/pages/student/StudentHome.tsx
+++ b/frontend/src/pages/student/StudentHome.tsx
@@ -1,15 +1,15 @@
 /**
  * StudentHome — student landing page / dashboard.
  *
- * Issue #1153: merged gamification signals into the home page.
+ * Issue #1215: design polish — visual hierarchy + DESIGN.md palette alignment
  *
  * Layout (top to bottom):
- * 1. Greeting strip — name + avatar
- * 2. GamificationHero — streak + level + XP bar + next badge hint
- * 3. Hero classroom card — "繼續學習" → library
- * 4. Two action cards: Assignments + Library
- * 5. RecentBadgesStrip — last 3 unlocked badges
- * 6. StudentProgressDashboard — learning stats chart
+ * 1. Hero greeting strip — gradient bg + avatar + name + XP bar (GamificationHero inline)
+ * 2. Hero classroom card — "繼續學習" → library
+ * 3. Two action cards: Assignments + Library (2-col)
+ * 4. QuickPracticeStrip
+ * 5. Progress section — StudentProgressDashboard (stats + chart)
+ * 6. RecentBadgesStrip
  * 7. RecommendedStories
  *
  * Issue #457: Students not yet added to any classroom see a friendly waiting
@@ -47,16 +47,18 @@ interface NoClassroomWaitingScreenProps {
 
 const NoClassroomWaitingScreen: React.FC<NoClassroomWaitingScreenProps> = ({ firstName }) => (
   <div className="flex-1 flex items-center justify-center min-h-[60vh]">
-    <div className="max-w-md w-full mx-auto p-6 text-center space-y-6">
+    <div className="max-w-sm w-full mx-auto px-6 py-10 text-center space-y-6">
       <div
-        className="w-20 h-20 rounded-full bg-amber-100 flex items-center justify-center mx-auto"
+        className="w-20 h-20 rounded-full bg-accent/10 flex items-center justify-center mx-auto"
         aria-hidden="true"
       >
         <span className="text-4xl">🏫</span>
       </div>
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">你好，{firstName}！</h1>
-        <p className="text-base text-gray-600 mt-2">你的老師還沒有把你加入班級</p>
+        <h1 className="text-2xl font-bold font-headline text-on-surface">
+          你好，{firstName}！
+        </h1>
+        <p className="text-base text-on-surface-variant mt-2">你的老師還沒有把你加入班級</p>
       </div>
       <div className="bg-amber-50 border border-amber-200 rounded-2xl p-5 text-left space-y-3">
         <p className="text-sm font-semibold text-amber-900">下一步怎麼做？</p>
@@ -66,7 +68,7 @@ const NoClassroomWaitingScreen: React.FC<NoClassroomWaitingScreenProps> = ({ fir
           <li>加入後重新登入，即可開始學習</li>
         </ol>
       </div>
-      <p className="text-xs text-gray-400">加入班級後重新整理頁面即可繼續</p>
+      <p className="text-xs text-on-surface-variant/60">加入班級後重新整理頁面即可繼續</p>
     </div>
   </div>
 );
@@ -89,7 +91,6 @@ const StudentHome: React.FC = () => {
   useEffect(() => {
     if (!token || !user) return;
 
-    // Classrooms
     fetchMyEnrolledClassrooms(token)
       .then((res) => {
         setClassrooms(res.classrooms);
@@ -102,7 +103,6 @@ const StudentHome: React.FC = () => {
       })
       .finally(() => setClassroomsLoaded(true));
 
-    // Gamification — non-blocking, hero appears once loaded
     fetchGamificationSummary(user.id, token)
       .then(setGamification)
       .catch(() => {
@@ -114,9 +114,6 @@ const StudentHome: React.FC = () => {
     navigate(`/library?classroom=${classroomId}`);
   }, [navigate]);
 
-  // Stable no-op passed to StudentProgressDashboard to avoid recreating an
-  // arrow function on every render (inline `() => {}` would cause needless
-  // re-renders even though the child guards with useRef, Issue #1156).
   const noop = useCallback(() => {}, []);
 
   // Issue #457: block full dashboard for students not yet in any classroom
@@ -125,129 +122,138 @@ const StudentHome: React.FC = () => {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-6 space-y-5">
-        {/* Session resume prompt */}
-        {showResumePrompt && (
+    <div className="flex-1 overflow-y-auto bg-surface">
+      {/* ── Session resume prompt ─────────────────────────────────────── */}
+      {showResumePrompt && (
+        <div className="max-w-2xl mx-auto px-4 sm:px-6 pt-4">
           <SessionResumePrompt onDismiss={() => setShowResumePrompt(false)} />
+        </div>
+      )}
+
+      {/* ── Hero greeting strip — warm gradient background ────────────── */}
+      <div className="relative overflow-hidden">
+        {/* Gradient background: accent-tinted top to surface bg */}
+        <div
+          className="absolute inset-0 bg-gradient-to-br from-accent/8 via-surface to-surface-container-low"
+          aria-hidden="true"
+        />
+        <div className="relative max-w-2xl mx-auto px-4 sm:px-6 pt-6 pb-5">
+          {/* Avatar + greeting */}
+          <div className="flex items-center gap-4 mb-4">
+            <div
+              className="w-14 h-14 rounded-2xl bg-accent shadow-editorial flex items-center justify-center shrink-0"
+              aria-hidden="true"
+            >
+              <span className="text-white text-2xl font-bold font-headline">
+                {firstName.charAt(0)}
+              </span>
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold font-headline text-on-surface">
+                你好，{firstName}！
+              </h1>
+              <p className="text-sm text-on-surface-variant mt-0.5">
+                今天想探索什麼故事呢？
+              </p>
+            </div>
+          </div>
+
+          {/* GamificationHero — XP bar + level + streak (compact) */}
+          {gamification && (
+            <GamificationHero summary={gamification} />
+          )}
+        </div>
+      </div>
+
+      {/* ── Main content ─────────────────────────────────────────────────── */}
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 pb-10 space-y-6 mt-2">
+
+        {/* ── Hero card: Continue Learning / Classroom ─────────────────── */}
+        {classroomsLoaded && classrooms.length > 0 && (
+          <button
+            type="button"
+            onClick={() => handleSelectClassroom(classrooms[0].id)}
+            className="w-full text-left bg-surface-container-lowest rounded-3xl shadow-editorial border border-[#E5E0D5] p-5 flex items-center gap-4 transition-all hover:shadow-md hover:scale-[0.995] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
+            aria-label="繼續學習"
+          >
+            <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-accent to-accent-hover flex items-center justify-center shrink-0 shadow-sm">
+              <span className="text-2xl" aria-hidden="true">📖</span>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs font-bold text-accent uppercase tracking-widest mb-0.5">繼續學習</p>
+              <p className="text-lg font-bold text-on-surface truncate">
+                {classrooms[0].name}
+              </p>
+              <p className="text-sm text-on-surface-variant mt-0.5">
+                老師：{classrooms[0].teacher_name}
+              </p>
+            </div>
+            <div
+              className="w-9 h-9 rounded-xl bg-accent/10 flex items-center justify-center shrink-0"
+              aria-hidden="true"
+            >
+              <span className="text-accent text-lg font-bold">→</span>
+            </div>
+          </button>
         )}
 
-        {/* ── Desktop 2-col: left = greeting+actions, right = gamification+progress ── */}
-        <div className="lg:grid lg:grid-cols-[2fr_3fr] lg:gap-6 space-y-5 lg:space-y-0">
-
-          {/* ── Left column: greeting + hero card + action cards ──────────── */}
-          <div className="space-y-4">
-            {/* 1. Greeting strip */}
-            <div className="flex items-center gap-4">
-              <div
-                className="w-14 h-14 rounded-full bg-accent shadow-editorial flex items-center justify-center shrink-0"
-                aria-hidden="true"
-              >
-                <span className="text-white text-2xl font-bold font-headline">
-                  {firstName.charAt(0)}
-                </span>
-              </div>
-              <div>
-                <h1 className="text-2xl font-bold font-headline text-on-surface">
-                  你好，{firstName}！
-                </h1>
-                <p className="text-sm text-on-surface-variant mt-1">
-                  今天想探索什麼故事呢？
-                </p>
-              </div>
+        {/* ── Two action cards: Assignments + Library ──────────────────── */}
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={() => navigate('/assignments')}
+            className="text-left bg-surface-container-lowest rounded-2xl border border-[#E5E0D5] p-4 flex flex-col gap-3 transition-all hover:shadow-md hover:scale-[0.995] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 min-h-[100px]"
+            aria-label="查看班級作業"
+          >
+            <div className="w-11 h-11 rounded-xl bg-amber-100 flex items-center justify-center">
+              <span className="text-2xl" aria-hidden="true">📋</span>
             </div>
-
-            {/* 3. Hero card: Continue Learning / Classroom */}
-            {classroomsLoaded && classrooms.length > 0 && (
-              <button
-                type="button"
-                onClick={() => handleSelectClassroom(classrooms[0].id)}
-                className="w-full text-left bg-surface-container-lowest rounded-3xl shadow-editorial p-5 flex items-center gap-4 transition-all hover:scale-[0.99] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
-                aria-label="繼續學習"
-              >
-                <div className="w-12 h-12 rounded-2xl bg-accent/10 flex items-center justify-center shrink-0">
-                  <span className="text-2xl" aria-hidden="true">📖</span>
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-xs font-semibold text-accent uppercase tracking-wide">繼續學習</p>
-                  <p className="text-lg font-bold text-on-surface mt-0.5 truncate">
-                    {classrooms[0].name}
-                  </p>
-                  <p className="text-sm text-on-surface-variant mt-0.5">
-                    老師：{classrooms[0].teacher_name}
-                  </p>
-                </div>
-                <span className="text-on-surface-variant shrink-0 text-xl" aria-hidden="true">→</span>
-              </button>
-            )}
-
-            {/* 4. Two action cards: Assignments + Library — always 2-col */}
-            <div className="grid grid-cols-2 gap-3">
-              <button
-                type="button"
-                onClick={() => navigate('/assignments')}
-                className="text-left bg-surface-container-lowest rounded-2xl shadow-editorial p-4 flex items-center gap-3 transition-all hover:scale-[0.99] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
-                aria-label="查看班級作業"
-              >
-                <div className="w-10 h-10 rounded-xl bg-amber-100 flex items-center justify-center shrink-0">
-                  <span className="text-xl" aria-hidden="true">📋</span>
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-bold text-on-surface">班級作業</p>
-                  <p className="text-xs text-on-surface-variant mt-0.5">查看待完成的作業</p>
-                </div>
-              </button>
-
-              <button
-                type="button"
-                onClick={() => navigate('/library')}
-                className="text-left bg-surface-container-lowest rounded-2xl shadow-editorial p-4 flex items-center gap-3 transition-all hover:scale-[0.99] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
-                aria-label="前往圖書館"
-              >
-                <div className="w-10 h-10 rounded-xl bg-blue-100 flex items-center justify-center shrink-0">
-                  <span className="text-xl" aria-hidden="true">📚</span>
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-bold text-on-surface">圖書館</p>
-                  <p className="text-xs text-on-surface-variant mt-0.5">探索更多課文</p>
-                </div>
-              </button>
+            <div>
+              <p className="text-sm font-bold text-on-surface leading-tight">班級作業</p>
+              <p className="text-xs text-on-surface-variant mt-0.5">查看待完成的作業</p>
             </div>
+          </button>
 
-            {/* 6. Quick practice strip (left column, below action cards) */}
-            <QuickPracticeStrip />
-          </div>
-
-          {/* ── Right column: gamification + progress stats ───────────────── */}
-          <div className="space-y-4">
-            {/* 2. Gamification Hero */}
-            {gamification && (
-              <GamificationHero summary={gamification} />
-            )}
-
-            {/* 5. Recent badges strip */}
-            {gamification && (
-              <RecentBadgesStrip badges={gamification.badges} />
-            )}
-
-            {/* 8. Progress dashboard */}
-            <section aria-labelledby="progress-title">
-              <h2
-                id="progress-title"
-                className="text-sm font-bold font-headline text-on-surface mb-3"
-              >
-                學習進度
-              </h2>
-              <StudentProgressDashboard onDashboardLoaded={noop} />
-            </section>
-          </div>
+          <button
+            type="button"
+            onClick={() => navigate('/library')}
+            className="text-left bg-surface-container-lowest rounded-2xl border border-[#E5E0D5] p-4 flex flex-col gap-3 transition-all hover:shadow-md hover:scale-[0.995] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 min-h-[100px]"
+            aria-label="前往圖書館"
+          >
+            <div className="w-11 h-11 rounded-xl bg-indigo-100 flex items-center justify-center">
+              <span className="text-2xl" aria-hidden="true">📚</span>
+            </div>
+            <div>
+              <p className="text-sm font-bold text-on-surface leading-tight">圖書館</p>
+              <p className="text-xs text-on-surface-variant mt-0.5">探索更多課文</p>
+            </div>
+          </button>
         </div>
 
-        {/* ── Recommended stories — full width below both columns ─────────── */}
+        {/* ── Quick practice strip ─────────────────────────────────────── */}
+        <QuickPracticeStrip />
+
+        {/* ── Learning progress ────────────────────────────────────────── */}
+        <section aria-labelledby="progress-title">
+          <h2
+            id="progress-title"
+            className="text-base font-bold font-headline text-on-surface mb-3"
+          >
+            學習進度
+          </h2>
+          <StudentProgressDashboard onDashboardLoaded={noop} />
+        </section>
+
+        {/* ── Recent badges ────────────────────────────────────────────── */}
+        {gamification && (
+          <RecentBadgesStrip badges={gamification.badges} />
+        )}
+
+        {/* ── Recommended stories ─────────────────────────────────────── */}
         <section aria-labelledby="recommended-title">
           <h2
             id="recommended-title"
-            className="text-sm font-bold font-headline text-on-surface mb-3"
+            className="text-base font-bold font-headline text-on-surface mb-3"
           >
             推薦課文
           </h2>


### PR DESCRIPTION
Fixes #1215

## Summary

- **StudentHome layout**: Single-column vertical flow replaces cramped 2-col desktop grid. Adds warm gradient hero strip (`accent/8` tint over `surface` bg) that wraps the greeting + GamificationHero XP bar — gives the page a cohesive top section instead of disconnected components
- **Hero classroom card**: Icon container now uses `bg-gradient-to-br from-accent to-accent-hover` for stronger visual weight; border uses DESIGN.md `#E5E0D5` warm border token; arrow indicator wrapped in accent-tinted pill
- **Action cards (班級作業 / 圖書館)**: Changed from `flex items-center` (horizontal) to `flex-col` (vertical) with `min-h-[100px]` — better touch targets, more student-friendly feel
- **QuickPracticeStrip**: Cards now use horizontal layout (icon on left, text on right) with `accent-bg` icon container. Always 2-col (was 4-col on desktop) — 48px+ touch targets per DESIGN.md student spec
- **StudentProgressDashboard StatCard**: Replace hardcoded `bg-white border-gray-200` with design tokens (`surface-container-lowest`, `border-[#E5E0D5]`). Highlight (streak) card uses `bg-gradient-to-br from-accent to-accent-hover`. Loading skeleton uses `bg-surface-container`
- **Text colors**: Replace `text-gray-*` with `text-on-surface` / `text-on-surface-variant` throughout

## Design Alignment

All changes follow `DESIGN.md` Tactile Scholar palette. No new design decisions made.

| Token | Before | After |
|-------|--------|-------|
| Card background | `bg-white` | `bg-surface-container-lowest` |
| Card border | `border-gray-200` | `border-[#E5E0D5]` |
| Highlight card | `bg-accent` | `bg-gradient-to-br from-accent to-accent-hover` |
| Body text | `text-gray-900` | `text-on-surface` |
| Secondary text | `text-gray-500` | `text-on-surface-variant` |

## Test plan

- [ ] Login as student (小明) on PR Preview URL
- [ ] Verify `/student` page loads with warm gradient hero strip
- [ ] Verify classroom card has gradient icon and warm border
- [ ] Verify action cards are vertical layout with comfortable padding
- [ ] Verify QuickPracticeStrip shows 2-col layout with accent-bg icon containers
- [ ] Verify stat cards use warm surface colors (not pure white)
- [ ] Verify 連續學習天數 card has gradient background
- [ ] Check mobile (375px) layout — all cards should stack cleanly