### PR TITLE
perf(db): add indexes on hot query columns (Fixes #1223)

### DIFF
--- a/backend/alembic/versions/mg01merge02heads03_merge_all_current_heads.py
+++ b/backend/alembic/versions/mg01merge02heads03_merge_all_current_heads.py
@@ -1,0 +1,31 @@
+"""merge all current migration heads
+
+Revision ID: mg01merge02heads03
+Revises: f6g7h8i9j0k1, k2l3m4n5o6p7, fk01idx02add03, tc01rv02cm03, c9d0e1f2g3h4, g7h8i9j0k1l2, b3c4d5e6f7a8
+Create Date: 2026-04-22 00:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "mg01merge02heads03"
+down_revision = (
+    "f6g7h8i9j0k1",
+    "k2l3m4n5o6p7",
+    "fk01idx02add03",
+    "tc01rv02cm03",
+    "c9d0e1f2g3h4",
+    "g7h8i9j0k1l2",
+    "b3c4d5e6f7a8",
+)
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/px01perf02idx03_add_performance_indexes_on_sessions.py
+++ b/backend/alembic/versions/px01perf02idx03_add_performance_indexes_on_sessions.py
@@ -1,0 +1,76 @@
+"""add performance indexes on hot query columns (issue #1223)
+
+Revision ID: px01perf02idx03
+Revises: mg01merge02heads03
+Create Date: 2026-04-22 01:00:00.000000
+
+Adds indexes for P0 performance optimization wave:
+  - learning_sessions.status         (ix_learning_sessions_status)
+  - learning_sessions(student_id, status)  (ix_learning_sessions_student_id_status)
+
+Note: assignment_submissions.student_id and character_errors.session_id were
+already indexed by fk01idx02add03 (2026-04-04).  The SQLAlchemy model now
+declares index=True for those columns as well so ORM introspection is accurate;
+no additional DB migration is needed for them.
+
+All new indexes use CREATE INDEX CONCURRENTLY to avoid table locks on production.
+Alembic requires autocommit mode for CONCURRENTLY.
+"""
+
+from alembic import op
+from sqlalchemy import inspect as sa_inspect
+
+# revision identifiers, used by Alembic.
+revision = "px01perf02idx03"
+down_revision = "mg01merge02heads03"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    return table_name in sa_inspect(bind).get_table_names()
+
+
+def _index_exists(bind, table_name: str, index_name: str) -> bool:
+    if not _table_exists(bind, table_name):
+        return False
+    return any(
+        idx["name"] == index_name
+        for idx in sa_inspect(bind).get_indexes(table_name)
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # ── learning_sessions.status (single-column) ──────────────────────────────
+    if not _index_exists(bind, "learning_sessions", "ix_learning_sessions_status"):
+        with op.get_context().autocommit_block():
+            op.execute(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_learning_sessions_status "
+                "ON learning_sessions (status)"
+            )
+
+    # ── learning_sessions(student_id, status) (compound) ─────────────────────
+    if not _index_exists(bind, "learning_sessions", "ix_learning_sessions_student_id_status"):
+        with op.get_context().autocommit_block():
+            op.execute(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_learning_sessions_student_id_status "
+                "ON learning_sessions (student_id, status)"
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    if _index_exists(bind, "learning_sessions", "ix_learning_sessions_student_id_status"):
+        op.drop_index(
+            "ix_learning_sessions_student_id_status",
+            table_name="learning_sessions",
+        )
+
+    if _index_exists(bind, "learning_sessions", "ix_learning_sessions_status"):
+        op.drop_index(
+            "ix_learning_sessions_status",
+            table_name="learning_sessions",
+        )

--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -75,7 +75,7 @@ class AssignmentSubmission(Base):
     assignment_id: Mapped[int] = mapped_column(
         ForeignKey("assignments.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     status: Mapped[str] = mapped_column(String(20), default="pending")  # "pending" | "in_progress" | "submitted" | "graded"
     session_id: Mapped[int | None] = mapped_column(
         ForeignKey("learning_sessions.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -31,6 +31,8 @@ class LearningSession(Base):
             unique=True,
             postgresql_where=text("status = 'in_progress' AND story_slug IS NOT NULL"),
         ),
+        # Compound index for student dashboard session filter (#1223)
+        Index("ix_learning_sessions_student_id_status", "student_id", "status"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -38,7 +40,7 @@ class LearningSession(Base):
     text_id: Mapped[int | None] = mapped_column(ForeignKey("texts.id"), nullable=True)
     classroom_id: Mapped[int | None] = mapped_column(ForeignKey("classrooms.id"), nullable=True)
     story_slug: Mapped[str | None] = mapped_column(String(100), nullable=True, index=True)
-    status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="in_progress")
+    status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="in_progress", index=True)
     current_step: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     accuracy: Mapped[float | None] = mapped_column(Float, nullable=True)
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
@@ -82,7 +84,7 @@ class CharacterError(Base):
     __tablename__ = "character_errors"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    session_id: Mapped[int] = mapped_column(ForeignKey("learning_sessions.id"), nullable=False)
+    session_id: Mapped[int] = mapped_column(ForeignKey("learning_sessions.id"), nullable=False, index=True)
     character: Mapped[str] = mapped_column(String(4), nullable=False)
     error_type: Mapped[str] = mapped_column(String(50), nullable=False)
 


### PR DESCRIPTION
Fixes #1223

## Summary

P0 performance wave — adds missing indexes on hot-path DB columns.

| Table | Column(s) | Index Name | Type | Status |
|-------|-----------|------------|------|--------|
| `assignment_submissions` | `student_id` | `ix_assignment_submissions_student_id` | B-tree | Already in DB via `fk01idx02add03`; model annotation synced |
| `character_errors` | `session_id` | `ix_character_errors_session_id` | B-tree | Already in DB via `fk01idx02add03`; model annotation synced |
| `learning_sessions` | `status` | `ix_learning_sessions_status` | B-tree | **NEW** |
| `learning_sessions` | `(student_id, status)` | `ix_learning_sessions_student_id_status` | Compound B-tree | **NEW** |

### Discovery

Checked existing migrations before writing — `fk01idx02add03` (2026-04-04) already created indexes for `assignment_submissions.student_id` and `character_errors.session_id`. This PR:
1. Syncs the SQLAlchemy model declarations (`index=True`) to match the DB reality
2. Adds the genuinely missing `status` and compound indexes on `learning_sessions`

## Migration Details

- `mg01merge02heads03` — merge migration collapsing 7 existing heads into a single linear chain
- `px01perf02idx03` — adds the 2 new `learning_sessions` indexes using `CREATE INDEX CONCURRENTLY` (no table lock in production)
- Both migrations are idempotent (`IF NOT EXISTS` guards)

## Test Plan

- [x] `tests/test_assignments.py` — 64 passed
- [x] `tests/test_learning_sessions_api.py` — passed
- [x] `tests/test_n1_queries_fix_1217.py` — 131 total passed
- [x] Migration chain verified: single head `px01perf02idx03` (alembic ScriptDirectory check)
- [ ] Review migration file contains only the 2 new index additions (no unexpected schema drift)