### PR TITLE
fix(student): rename 字典查詢 card to 我的生字 to match /vocabulary (Fixes #1222)

### DIFF
--- a/frontend/src/components/student/QuickPracticeStrip.tsx
+++ b/frontend/src/components/student/QuickPracticeStrip.tsx
@@ -50,8 +50,8 @@ const QUICK_CARDS: PracticeCard[] = [
   },
   {
     icon: '📖',
-    title: '字典查詢',
-    description: '查字義、注音、例句',
+    title: '我的生字',
+    description: '看看哪些字需要加強',
     route: '/vocabulary',
   },
 ];


### PR DESCRIPTION
Fixes #1222

## Summary
- Rename the `QuickPracticeStrip` card from `字典查詢 / 查字義、注音、例句` to `我的生字 / 看看哪些字需要加強`
- `/vocabulary` renders `MyVocabulary` (weak-word tracker), not a dictionary — card copy now matches the destination

## QA Finding (from PR #1219)
PR #1219 QA flagged that the "字典查詢" card misleads students into expecting a dictionary lookup page, but the route delivers a personalised weak-word list instead.

## Change
Single field edit in `frontend/src/components/student/QuickPracticeStrip.tsx`:
- `title`: `字典查詢` → `我的生字`
- `description`: `查字義、注音、例句` → `看看哪些字需要加強`
- Icon (`📖`) and route (`/vocabulary`) unchanged

## Test plan
- [ ] Open `/student` page
- [ ] Verify the shelf card now shows `我的生字` with description `看看哪些字需要加強`
- [ ] Click the card — confirm it navigates to `/vocabulary` and renders `MyVocabulary`