### PR TITLE
docs: log 2026-04-22~23 backend perf sprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@
 
 （無）
 
+## 2026-04-22 ~ 2026-04-23
+
+### 效能優化（後端熱路徑大掃除）
+
+**N+1 查詢消除（routes 層）** — PR #1218 / #1221
+- `/api/assignments/my`（學生首頁）從 2N+1 → 3 queries（batch pre-load sessions + texts）
+- `/api/classrooms/{id}/assignments`（教師作業清單）從 N+1 → 2 queries
+- 教師熱力圖 + 錯字熱力圖 加 `joinedload(ClassroomStudent.student)`
+- CSV export（`/admin/reports/export`）三層 lazy load → 1 joinedload（student + classroom + school）
+- Gamification leaderboard + `_assert_can_view` 加 `joinedload(UserRole.role)`
+- 21 regression tests（含 query count bound assertions）
+
+**DB Index（熱欄位補齊）** — PR #1226
+- `LearningSession.status` 單欄 index + `(student_id, status)` compound index
+- `AssignmentSubmission.student_id` / `CharacterError.session_id` 補 SQLAlchemy `index=True` 宣告（DB 層 index 2026-04-04 已建）
+- Migration 用 `CREATE INDEX CONCURRENTLY IF NOT EXISTS` 避免 prod lock table
+
+**SQL 聚合下推（service 層）** — PR #1227
+- `learning_dashboard` cumulative stats：Python 雙 loop → 單 SQL aggregate（`func.count/avg/sum(case)`）
+- `teacher_analytics` time-stats：移除 `.limit(5000)` cap，改 SQL `group_by(func.date)`
+- `cross_text_analysis_service._completed_sessions_with_text` 漏網 N+1 修復（改 `joinedload(LearningSession.text)`）
+- 16 regression tests + before/after query count 對比
+
+**I/O 非同步化 + 查詢邊界** — PR #1228
+- TTS 三個路由（`/tts/synthesize`、`/tts/sentence`、`/tts/regenerate`）改 `async def`，內部用 `asyncio.to_thread()` 包同步 SDK 呼叫
+  - 5 concurrent requests 實測：sync 2.5s → async 0.51s（~5x speedup，mock 0.5s 延遲驗證）
+- `learning_path_service` 的 `story_slug IS NOT NULL` 過濾推 SQL WHERE
+- Teacher heatmap 超過 5,000 sessions 改 raise 400（取代靜默截斷），匹配 `_ADMIN_EXPORT_ROW_LIMIT` pattern
+
 ## 2026-03-09 ~ 2026-03-12
 
 ### 新功能

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1105,12 +1105,19 @@
 
 #### 4. 系統效能
 
-| 測試項目 | 驗收標準 | 測試方法 |
-|---------|---------|---------|
-| 並發使用者支援 | 30 人同時使用 | 壓力測試（30 人同時錄音） |
-| 系統穩定度 | > 99% Uptime | 監控工具追蹤 30 天 |
-| 資料庫查詢速度 | < 500ms | 查詢學生練習紀錄的平均時間 |
-| 頁面載入時間 | < 2 秒 | 首次載入教師儀表板的時間 |
+| 測試項目 | 驗收標準 | 測試方法 | 現況（2026-04-23）|
+|---------|---------|---------|------|
+| 並發使用者支援 | 30 人同時使用 | 壓力測試（30 人同時錄音） | TTS 改 async 後 5 concurrent 實測 2.5s → 0.51s（~5x）|
+| 系統穩定度 | > 99% Uptime | 監控工具追蹤 30 天 | — |
+| 資料庫查詢速度 | < 500ms | 查詢學生練習紀錄的平均時間 | 熱路徑 N+1 全消（PR #1218/#1227），hot columns 補 index（#1226）|
+| 頁面載入時間 | < 2 秒 | 首次載入教師儀表板的時間 | dashboard cumulative stats 改 SQL aggregate（#1227），Python 雙 loop 移除 |
+
+**效能優化紀錄（2026-04-22 ~ 2026-04-23）**：詳見 `CHANGELOG.md`
+- 6 個 N+1 query 全消除（routes + services 雙層）
+- 3 個 hot column index 補齊（含 compound `(student_id, status)`）
+- 3 處 Python 端聚合推到 SQL（`func.count/avg/sum/group_by`）
+- TTS 三個路由改 async（`asyncio.to_thread` 包同步 SDK）
+- Unbounded queries 加邊界（heatmap 5k 上限、CSV export 10k 上限）
 
 ---
 


### PR DESCRIPTION
Documentation-only PR following 5 merged perf PRs on 2026-04-22 ~ 2026-04-23.

## CHANGELOG additions

New section `## 2026-04-22 ~ 2026-04-23` covering:
- **N+1 查詢消除** (#1218, #1221) — 6 routes/services, 21 regression tests
- **DB Index** (#1226) — status + compound (student_id, status)
- **SQL 聚合下推** (#1227) — dashboard + time-stats + cross-text
- **I/O 非同步化** (#1228) — TTS routes, learning_path filter, heatmap 5k guard

## PRD update

`docs/PRD.md` § 系統效能 — added 現況 column to the acceptance table showing measured impact:
- Concurrent users: 5 concurrent TTS 2.5s → 0.51s (~5x)
- DB query: N+1 eliminated, hot columns indexed
- Page load: dashboard aggregates moved to SQL

Plus a summary bullet list of all 5 PRs' scope.

## Diff

- CHANGELOG.md: +29 -0
- docs/PRD.md: +13 -6
- No code changes.