### PR TITLE
feat: 句子級重練單位改用 Opus 語意切分 JSONL (#661)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -13,6 +13,7 @@ from ..models.user import User
 from ..auth.dependencies import get_current_user
 from ..auth.rate_limiter import ai_rate_limiter, get_client_key
 from ..services.lesson_loader import search_lessons, get_lesson_by_id, get_available_grades
+from ..services import sentence_loader
 from ..utils.slug import normalize_story_slug
 from ..services.ai_service import generate_story_structure, grade_story_structure
 from ..services.ai_usage_tracker import last_usage, log_ai_usage
@@ -143,6 +144,45 @@ def get_story(story_id: str):
         text_type=story["text_type"],
         source_file=story["source_file"],
         strategy_exercise=story.get("strategy_exercise"),
+    )
+
+
+# ── Sentence units from Opus 4.7 semantic split (#661) ─────────────────────
+
+class SentenceItem(BaseModel):
+    paragraph_idx: int
+    sentence_idx: int
+    text: str
+
+
+class SentenceListResponse(BaseModel):
+    lesson_id: int
+    sentences: list[SentenceItem]
+
+
+@router.get("/stories/{story_id}/sentences", response_model=SentenceListResponse)
+def get_story_sentences(story_id: str):
+    """Return the semantic sentence split for a lesson (#661).
+
+    Source: `backend/data/sentences.v2.jsonl` produced by Opus 4.7 during the
+    TTS v2 rework (#1208). Each sentence is aligned 1:1 with the TTS mp3
+    cache, so LiveTutor's retry UI can show exactly what TTS plays without
+    fighting punctuation-based split (#1142 / #1148).
+
+    Returns an empty list when the lesson has no v2 JSONL entry; the frontend
+    then falls back to regex-based `splitIntoSentences()`.
+    """
+    try:
+        lesson_id = int(normalize_story_slug(story_id))
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=404, detail="Story not found")
+    if not get_lesson_by_id(lesson_id):
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    sentences = sentence_loader.get_sentences(lesson_id)
+    return SentenceListResponse(
+        lesson_id=lesson_id,
+        sentences=[SentenceItem(**s) for s in sentences],
     )
 
 

--- a/backend/app/services/sentence_loader.py
+++ b/backend/app/services/sentence_loader.py
@@ -1,0 +1,81 @@
+"""Sentence loader — reads semantic-split sentences from sentences.v2.jsonl (#661).
+
+Replaces frontend punctuation-based `splitIntoSentences()` with Opus 4.7's
+semantic boundaries. The JSONL is aligned 1:1 with TTS mp3 cache keys so the
+sentence the student sees in the retry UI matches exactly what TTS plays.
+
+The file is loaded once at import time into an in-memory index.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+
+class Sentence(TypedDict):
+    paragraph_idx: int
+    sentence_idx: int
+    text: str
+
+
+# Absolute path resolved from this file's location so it works under Cloud Run
+# (where the working directory differs from dev).
+_DATA_PATH = Path(__file__).resolve().parent.parent.parent / "data" / "sentences.v2.jsonl"
+
+# Indexed by lesson_id. Each lesson's list is sorted by (paragraph_idx, sentence_idx).
+_BY_LESSON: dict[int, list[Sentence]] = {}
+
+
+def _load() -> None:
+    """Read the JSONL file once and build the in-memory index."""
+    if not _DATA_PATH.exists():
+        logger.warning("sentences.v2.jsonl not found at %s", _DATA_PATH)
+        return
+
+    with _DATA_PATH.open("r", encoding="utf-8") as f:
+        for line_num, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                lesson_id = int(obj["lesson_id"])
+                sent: Sentence = {
+                    "paragraph_idx": int(obj["paragraph_idx"]),
+                    "sentence_idx": int(obj["sentence_idx"]),
+                    "text": str(obj["text"]),
+                }
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                logger.warning("sentences.v2.jsonl line %d invalid: %s", line_num, exc)
+                continue
+            _BY_LESSON.setdefault(lesson_id, []).append(sent)
+
+    # Sort each lesson's sentences so callers can rely on order.
+    for sentences in _BY_LESSON.values():
+        sentences.sort(key=lambda s: (s["paragraph_idx"], s["sentence_idx"]))
+
+    total = sum(len(v) for v in _BY_LESSON.values())
+    logger.info(
+        "sentence_loader: loaded %d sentences across %d lessons from %s",
+        total, len(_BY_LESSON), _DATA_PATH.name,
+    )
+
+
+_load()
+
+
+def get_sentences(lesson_id: int) -> list[Sentence]:
+    """Return all semantic sentences for a lesson, ordered by paragraph then sentence.
+
+    Returns an empty list when the lesson has no v2 JSONL entry (frontend then
+    falls back to regex-based `splitIntoSentences()`).
+    """
+    return list(_BY_LESSON.get(lesson_id, []))
+
+
+def has_lesson(lesson_id: int) -> bool:
+    return lesson_id in _BY_LESSON

--- a/backend/app/services/sentence_loader.py
+++ b/backend/app/services/sentence_loader.py
@@ -75,7 +75,3 @@ def get_sentences(lesson_id: int) -> list[Sentence]:
     falls back to regex-based `splitIntoSentences()`).
     """
     return list(_BY_LESSON.get(lesson_id, []))
-
-
-def has_lesson(lesson_id: int) -> bool:
-    return lesson_id in _BY_LESSON

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -7,6 +7,7 @@ import { useIsMobile } from '../../../hooks/useIsMobile';
 import { READING_EXCELLENT } from '../../../utils/personaConfig';
 import ParagraphProgress, { ParagraphStatus } from '../ParagraphProgress';
 import { evaluateReading } from '../../../services/learningApi';
+import { fetchStorySentences } from '../../../services/api';
 import { useAuth } from '../../../contexts/AuthContext';
 import {
   localEvaluateParagraph,
@@ -131,6 +132,43 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   const sentenceStartTimeRef = useRef(0);
   const lastDiffTimeRef = useRef(0);
+
+  // Semantic sentence split from Opus 4.7 JSONL (#661). Null = not loaded yet
+  // or no v2 entry for this lesson → fall back to regex splitIntoSentences().
+  const [v2SentencesByParagraph, setV2SentencesByParagraph] = useState<Map<number, string[]> | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetchStorySentences(String(story.id))
+      .then((list) => {
+        if (cancelled) return;
+        if (list.length === 0) {
+          setV2SentencesByParagraph(null);
+          return;
+        }
+        const grouped = new Map<number, string[]>();
+        // Sentences are already sorted by (paragraph_idx, sentence_idx) server-side.
+        for (const s of list) {
+          if (!grouped.has(s.paragraph_idx)) grouped.set(s.paragraph_idx, []);
+          grouped.get(s.paragraph_idx)!.push(s.text);
+        }
+        setV2SentencesByParagraph(grouped);
+      })
+      .catch(() => {
+        if (!cancelled) setV2SentencesByParagraph(null);
+      });
+    return () => { cancelled = true; };
+  }, [story.id]);
+
+  /** Sentence units for a paragraph. Prefers Opus semantic split (v2 JSONL,
+   *  aligned with TTS cache); falls back to regex when v2 data is missing. */
+  const getSentencesForParagraph = useCallback(
+    (paragraphIdx: number): string[] => {
+      const fromV2 = v2SentencesByParagraph?.get(paragraphIdx);
+      if (fromV2 && fromV2.length > 0) return fromV2;
+      return splitIntoSentences(story.content[paragraphIdx] || '');
+    },
+    [v2SentencesByParagraph, story.content],
+  );
 
   // Sentence-level retry state (#1076)
   const [retrySentenceInfo, setRetrySentenceInfo] = useState<{
@@ -288,7 +326,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   /* ---- init sentence targets when paragraph changes ---- */
   useEffect(() => {
-    const targets = splitIntoSentences(story.content[currentLineIndex] || '');
+    const targets = getSentencesForParagraph(currentLineIndex);
     sentenceTargetsRef.current = targets;
     sentenceResultsRef.current = new Array(targets.length).fill(null);
     nextSentenceIdxRef.current = 0;
@@ -296,7 +334,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setLastDiffTokens(null);
     setSpeakingProgress(0);
     setRealtimeDiffTokens(null);
-  }, [currentLineIndex, story.content]);
+  }, [currentLineIndex, getSentencesForParagraph]);
 
   /* ---- cleanup on unmount ---- */
   useEffect(() => {
@@ -652,7 +690,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setRealtimeDiffTokens(null);
     setLastDiffTokens(null);
     // Reset sentence tracking for fresh attempt (#1076)
-    const targets = splitIntoSentences(story.content[idx] || '');
+    const targets = getSentencesForParagraph(idx);
     sentenceTargetsRef.current = targets;
     sentenceResultsRef.current = new Array(targets.length).fill(null);
     nextSentenceIdxRef.current = 0;
@@ -662,7 +700,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setRetrySentenceInfo(null);
     if (idx === currentLineIndex) { startSession(); }
     else { setTimeout(() => startSession(), 100); }
-  }, [currentLineIndex, story.content, stopSession, startSession]);
+  }, [currentLineIndex, getSentencesForParagraph, stopSession, startSession]);
 
   /* ---- handleRetrySentence: enter single-sentence retry mode (#1076) ---- */
   const handleRetrySentence = useCallback((paragraphIdx: number, sentenceIdx: number) => {
@@ -672,7 +710,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     }
     stopSession();
 
-    const sentences = splitIntoSentences(story.content[paragraphIdx] || '');
+    const sentences = getSentencesForParagraph(paragraphIdx);
     const target = sentences[sentenceIdx];
     // Don't retry single-char sentences (issue 661: 單獨一個字不用重練)
     if (!target || target.replace(CHINESE_PUNCTUATION_REGEX, '').length <= 1) {
@@ -699,7 +737,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setRealtimeDiffTokens(null);
 
     setTimeout(() => startSession(), 100);
-  }, [currentLineIndex, story.content, stopSession, startSession]);
+  }, [currentLineIndex, getSentencesForParagraph, stopSession, startSession]);
 
   /* ---- handleSentenceRetryEval: evaluate single-sentence retry result (#1076) ---- */
   const handleSentenceRetryEval = useCallback(async (transcript: string, durationMs: number) => {

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -153,8 +153,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         }
         setV2SentencesByParagraph(grouped);
       })
-      .catch(() => {
-        if (!cancelled) setV2SentencesByParagraph(null);
+      .catch((err) => {
+        if (cancelled) return;
+        console.warn('[LiveTutor] fetchStorySentences failed, using regex fallback:', err);
+        setV2SentencesByParagraph(null);
       });
     return () => { cancelled = true; };
   }, [story.id]);
@@ -169,6 +171,12 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     },
     [v2SentencesByParagraph, story.content],
   );
+
+  // Ref mirror so the paragraph-init effect can read the latest helper without
+  // re-running (and thus resetting mid-session progress) when v2 JSONL finishes
+  // loading. Next paragraph change picks up the latest data naturally.
+  const getSentencesRef = useRef(getSentencesForParagraph);
+  useEffect(() => { getSentencesRef.current = getSentencesForParagraph; }, [getSentencesForParagraph]);
 
   // Sentence-level retry state (#1076)
   const [retrySentenceInfo, setRetrySentenceInfo] = useState<{
@@ -324,9 +332,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   /* ---- keep streakRef in sync ---- */
   useEffect(() => { streakRef.current = streak; }, [streak]);
 
-  /* ---- init sentence targets when paragraph changes ---- */
+  /* ---- init sentence targets when paragraph changes ----
+   * Depends on `currentLineIndex` only. Helper is read via ref to avoid
+   * resetting progress when v2 JSONL finishes loading mid-session (#661 review). */
   useEffect(() => {
-    const targets = getSentencesForParagraph(currentLineIndex);
+    const targets = getSentencesRef.current(currentLineIndex);
     sentenceTargetsRef.current = targets;
     sentenceResultsRef.current = new Array(targets.length).fill(null);
     nextSentenceIdxRef.current = 0;
@@ -334,7 +344,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setLastDiffTokens(null);
     setSpeakingProgress(0);
     setRealtimeDiffTokens(null);
-  }, [currentLineIndex, getSentencesForParagraph]);
+  }, [currentLineIndex]);
 
   /* ---- cleanup on unmount ---- */
   useEffect(() => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -145,6 +145,51 @@ export async function fetchStory(id: string): Promise<Story> {
   }
 }
 
+// ── Semantic sentence units (#661) ─────────────────────────────────────────
+
+export interface SentenceUnit {
+  paragraph_idx: number;
+  sentence_idx: number;
+  text: string;
+}
+
+interface SentenceListResponse {
+  lesson_id: number;
+  sentences: SentenceUnit[];
+}
+
+const inFlightSentencesById = new Map<string, Promise<SentenceUnit[]>>();
+
+/**
+ * Fetch semantic sentence split for a lesson (#661).
+ *
+ * Returns Opus 4.7's sentence boundaries from sentences.v2.jsonl, aligned 1:1
+ * with TTS mp3 cache. LiveTutor uses this for sentence-level retry so the
+ * displayed sentence matches what TTS plays. Returns empty array when the
+ * lesson has no JSONL entry; callers should fall back to local regex split.
+ */
+export async function fetchStorySentences(id: string): Promise<SentenceUnit[]> {
+  const cached = inFlightSentencesById.get(id);
+  if (cached) return cached;
+
+  const request = (async () => {
+    const res = await fetch(`${API_BASE}/api/stories/${id}/sentences`);
+    if (!res.ok) {
+      // 404 / network error → caller falls back to regex split
+      throw new Error(`fetchStorySentences failed: ${res.status}`);
+    }
+    const data: SentenceListResponse = await res.json();
+    return data.sentences;
+  })();
+
+  inFlightSentencesById.set(id, request);
+  try {
+    return await request;
+  } finally {
+    inFlightSentencesById.delete(id);
+  }
+}
+
 export async function createLearningSession(payload: {
   studentId: string;
   storyId: string;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -158,7 +158,10 @@ interface SentenceListResponse {
   sentences: SentenceUnit[];
 }
 
-const inFlightSentencesById = new Map<string, Promise<SentenceUnit[]>>();
+// Sentence data is static per-lesson, so cache resolved results across the
+// session (not just in-flight dedup). Survives component remounts and route
+// switches; shared Map so multiple callers get the same list.
+const sentencesCacheById = new Map<string, Promise<SentenceUnit[]>>();
 
 /**
  * Fetch semantic sentence split for a lesson (#661).
@@ -169,7 +172,7 @@ const inFlightSentencesById = new Map<string, Promise<SentenceUnit[]>>();
  * lesson has no JSONL entry; callers should fall back to local regex split.
  */
 export async function fetchStorySentences(id: string): Promise<SentenceUnit[]> {
-  const cached = inFlightSentencesById.get(id);
+  const cached = sentencesCacheById.get(id);
   if (cached) return cached;
 
   const request = (async () => {
@@ -182,12 +185,10 @@ export async function fetchStorySentences(id: string): Promise<SentenceUnit[]> {
     return data.sentences;
   })();
 
-  inFlightSentencesById.set(id, request);
-  try {
-    return await request;
-  } finally {
-    inFlightSentencesById.delete(id);
-  }
+  // Cache the promise; on rejection drop the entry so the next caller can retry.
+  sentencesCacheById.set(id, request);
+  request.catch(() => sentencesCacheById.delete(id));
+  return request;
 }
 
 export async function createLearningSession(payload: {


### PR DESCRIPTION
# Issue #661 — 句子級重練單位改用 Opus JSONL

## 背景
之前在 #1142 / #1148 一直跟標點符號切分打架：先加 `：`、做 20 字二次切分、處理 `、─—…」』）` 等等。Young 建議整個方向換掉，改用 #1208 TTS 重做時 Opus 4.7 產的 `backend/data/sentences.v2.jsonl`（2301 句，57 課全覆蓋），因為：

1. **語意不是標點** — Opus 已按句意決定邊界，不用自己猜
2. **跟 TTS 音檔 1:1 對齊** — UI 顯示 = TTS 播放
3. **整類 bug 一次消掉** — 不用再跟標點 regex 打架

## 實作

### Backend
- **`backend/app/services/sentence_loader.py`** — 啟動時讀 JSONL 建 in-memory index
  - `get_sentences(lesson_id)` → `[{paragraph_idx, sentence_idx, text}]`（已排序）
  - `has_lesson(lesson_id)` → bool
- **`GET /api/stories/{story_id}/sentences`** — 新 endpoint，回 `{lesson_id, sentences[]}`
  - 無效 slug / 未知 lesson → 404
  - 已知 lesson 但無 JSONL entry → `sentences: []`

### Frontend
- **`fetchStorySentences(id)`** 在 `api.ts`，含 in-flight dedup
- **`LiveTutor.tsx`**：
  - Story 載入時 fetch，state 存 `Map<paragraph_idx, string[]>`
  - `getSentencesForParagraph(idx)` helper：優先用 v2，否則 fallback 到 `splitIntoSentences`
  - 3 處呼叫改用 helper：
    - init 句子 effect（line 327）
    - `handleRetryParagraph`（重練這段）
    - `handleRetrySentence`（重練這句）

### Fallback
保留 `splitIntoSentences()` 當 fallback，任一失敗情境（API 404、network error、lesson 不在 JSONL）都退回 regex 切句，不 break 現有流程。

## 測試
- Loader 成功載入 57 課 × 2301 句
- `get_sentences(9999)` → `[]`（未知 lesson 的 fallback 路徑）
- TypeScript 無新 error（只有 pre-existing）
- Build 通過

## 效果
**修正前**（L1 p0，regex 切）：
```
「戴資穎戴資穎第一名，
戴資穎戴資穎我愛妳~~~」
這一句洗腦的廣告臺詞，
是否也在你的周遭出現？
（4 段，被逗號、引號搞破碎）
```

**修正後**（v2 JSONL，Opus 語意切）：
```
「戴資穎戴資穎第一名，戴資穎戴資穎我愛妳~~~」這一句洗腦的廣告臺詞，是否也在你的周遭出現？
（整句 1 段，符合口說節奏 + 跟 TTS 一致）
```

## 相關
- #1142 / #1148（regex 切分歷史，已 merged）
- #1208（TTS v2 重做）
- #1209（JSONL 建立的 PR）

## 嚴重性
🟡 Feature — 不修既有 bug，但根治 splitIntoSentences 的整類問題。