### PR TITLE
fix(tts): require auth on synthesize endpoints, admin on regenerate (Fixes #1234)

### DIFF
--- a/backend/app/routes/tts.py
+++ b/backend/app/routes/tts.py
@@ -29,10 +29,12 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
+from ..auth.dependencies import get_current_user, require_role
+from ..models.user import User
 from ..services.tts_service import (
     TTSError,
     build_lesson_tts_mapping,
@@ -52,11 +54,17 @@ class TTSRequest(BaseModel):
 
 
 @router.post("/synthesize")
-def synthesize(req: TTSRequest) -> Response:
+def synthesize(
+    req: TTSRequest,
+    _current_user: User = Depends(get_current_user),
+) -> Response:
     """Synthesise *text* to MP3 audio using Azure TTS (primary) or Cloud TTS (fallback).
+
+    Requires authentication (Issue #1234: prevent anonymous billing abuse).
 
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
+        401  application/json — Not authenticated.
         503  application/json — TTS unavailable; client should fall back
              to Web Speech API.
     """
@@ -81,14 +89,20 @@ def synthesize(req: TTSRequest) -> Response:
 
 
 @router.post("/synthesize-sentence")
-def synthesize_sentence_endpoint(req: TTSRequest) -> Response:
+def synthesize_sentence_endpoint(
+    req: TTSRequest,
+    _current_user: User = Depends(get_current_user),
+) -> Response:
     """Synthesise a single sentence to MP3 audio (Issue #667).
 
     Stores audio under azure/sentences/ GCS path for sentence-level caching.
     Functionally identical to /synthesize but semantically scoped to sentences.
 
+    Requires authentication (Issue #1234: prevent anonymous billing abuse).
+
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
+        401  application/json — Not authenticated.
         503  application/json — TTS unavailable.
     """
     try:
@@ -144,7 +158,7 @@ def get_tts_mapping(lesson_id: int) -> dict:
     return build_lesson_tts_mapping(lesson)
 
 
-@router.post("/regenerate")
+@router.post("/regenerate", dependencies=[require_role("system_admin")])
 def regenerate(req: TTSRequest) -> dict:
     """Delete cached audio for *text* and re-synthesise from scratch (Issue #765).
 
@@ -155,8 +169,12 @@ def regenerate(req: TTSRequest) -> dict:
       3. Calls Azure TTS (with phoneme corrections applied) to produce fresh audio.
       4. Stores the new audio in L1 + GCS.
 
+    Requires system_admin role (Issue #1234: prevent anonymous cache deletion + billing abuse).
+
     Returns:
         200  application/json — { "status": "ok", "key": "...", "gcs_deleted": [...], "bytes": N }
+        401  application/json — Not authenticated.
+        403  application/json — Insufficient permissions.
         503  application/json — TTS unavailable.
     """
     # Step 1: delete existing caches

--- a/backend/tests/test_tts_auth.py
+++ b/backend/tests/test_tts_auth.py
@@ -1,0 +1,241 @@
+"""
+TDD tests for TTS endpoint auth (Issue #1234).
+
+Covers:
+- POST /api/tts/synthesize     → 401 when unauthenticated, 200 when authenticated
+- POST /api/tts/synthesize-sentence → 401 when unauthenticated
+- POST /api/tts/regenerate     → 401 when unauthenticated, 403 when non-admin, 200 when system_admin
+
+Run with:
+    cd /path/to/project/backend
+    python -m pytest tests/test_tts_auth.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Set JWT secret before importing the app so auth works in tests
+if not os.environ.get("JWT_SECRET_KEY"):
+    os.environ["JWT_SECRET_KEY"] = "test-secret-key-for-tts-auth-tests"
+
+from unittest.mock import patch, MagicMock
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+from app.auth.password import hash_password
+from app.auth.jwt import create_access_token
+
+
+# ---------------------------------------------------------------------------
+# Test DB setup (SQLite in-memory)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+]
+
+
+def _seed_roles(db):
+    for role_data in SEED_ROLES:
+        if not db.query(Role).filter_by(name=role_data["name"]).first():
+            db.add(Role(
+                name=role_data["name"],
+                display_name=role_data["display_name"],
+                scope_level=role_data["scope_level"],
+            ))
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _create_user_with_role(db, role_name: str) -> tuple[User, str]:
+    """Create a user, assign role, return (user, jwt_token)."""
+    unique = uuid.uuid4().hex[:8]
+    email = f"ttstest_{role_name}_{unique}@example.com"
+    user = User(
+        email=email,
+        name=f"TTS Test {role_name}",
+        password_hash=hash_password("TestPass123!"),
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(user)
+    db.flush()
+
+    role = db.query(Role).filter_by(name=role_name).first()
+    if role:
+        scope_type = role.scope_level  # "platform", "organization", or "school"
+        ur = UserRole(user_id=user.id, role_id=role.id, scope_type=scope_type, is_active=True)
+        db.add(ur)
+
+    db.commit()
+    db.refresh(user)
+    token = create_access_token(user_id=user.id)
+    return user, token
+
+
+@pytest.fixture(scope="module")
+def student_token():
+    db = TestingSessionLocal()
+    try:
+        _, token = _create_user_with_role(db, "student")
+        return token
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module")
+def admin_token():
+    db = TestingSessionLocal()
+    try:
+        _, token = _create_user_with_role(db, "system_admin")
+        return token
+    finally:
+        db.close()
+
+
+FAKE_AUDIO = b"FAKE_MP3_AUDIO"
+
+
+# ---------------------------------------------------------------------------
+# Tests: /api/tts/synthesize
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeAuth:
+    """POST /api/tts/synthesize must require authentication."""
+
+    def test_unauthenticated_returns_401(self, client):
+        resp = client.post("/api/tts/synthesize", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+
+    def test_no_bearer_prefix_returns_401(self, client):
+        resp = client.post(
+            "/api/tts/synthesize",
+            json={"text": "你好"},
+            headers={"Authorization": "notabearer"},
+        )
+        assert resp.status_code == 401
+
+    @patch("app.routes.tts.synthesize_speech", return_value=FAKE_AUDIO)
+    def test_authenticated_student_returns_200(self, mock_synth, client, student_token):
+        resp = client.post(
+            "/api/tts/synthesize",
+            json={"text": "你好"},
+            headers={"Authorization": f"Bearer {student_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/mpeg"
+
+
+# ---------------------------------------------------------------------------
+# Tests: /api/tts/synthesize-sentence
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeSentenceAuth:
+    """POST /api/tts/synthesize-sentence must require authentication."""
+
+    def test_unauthenticated_returns_401(self, client):
+        resp = client.post("/api/tts/synthesize-sentence", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+
+    @patch("app.routes.tts.synthesize_sentence", return_value=FAKE_AUDIO)
+    def test_authenticated_student_returns_200(self, mock_synth, client, student_token):
+        resp = client.post(
+            "/api/tts/synthesize-sentence",
+            json={"text": "你好"},
+            headers={"Authorization": f"Bearer {student_token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "audio/mpeg"
+
+
+# ---------------------------------------------------------------------------
+# Tests: /api/tts/regenerate (system_admin only)
+# ---------------------------------------------------------------------------
+
+
+class TestRegenerateAuth:
+    """POST /api/tts/regenerate must require system_admin role."""
+
+    def test_unauthenticated_returns_401(self, client):
+        resp = client.post("/api/tts/regenerate", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+
+    def test_non_admin_returns_403(self, client, student_token):
+        resp = client.post(
+            "/api/tts/regenerate",
+            json={"text": "你好"},
+            headers={"Authorization": f"Bearer {student_token}"},
+        )
+        assert resp.status_code == 403, f"Expected 403 for non-admin, got {resp.status_code}"
+
+    @patch("app.routes.tts.delete_tts_cache", return_value={
+        "key": "abc123hash",
+        "l1_deleted": True,
+        "gcs_deleted": [],
+    })
+    @patch("app.routes.tts.synthesize_speech", return_value=FAKE_AUDIO)
+    def test_system_admin_returns_200(self, mock_synth, mock_delete, client, admin_token):
+        resp = client.post(
+            "/api/tts/regenerate",
+            json={"text": "你好"},
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert resp.status_code == 200, f"Expected 200 for admin, got {resp.status_code}: {resp.text}"
+        data = resp.json()
+        assert data["status"] == "ok"

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { login as apiLogin, register as apiRegister, getMe, acceptTerms as apiAcceptTerms, googleLogin as apiGoogleLogin, AuthUser, AuthError, RegisterResponse } from '../services/authApi';
 import { SESSION_UNAUTHORIZED_EVENT } from '../services/sessionGuard';
+import { setAuthToken as setTtsAuthToken } from '../services/ttsApi';
 
 const TOKEN_KEY = 'lingoleap_token';
 const ACTIVE_ASSIGNMENT_CONTEXT_KEY = 'activeAssignmentContext';
@@ -53,9 +54,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   // Load user from stored token on mount
   useEffect(() => {
     if (!token) {
+      setTtsAuthToken(null);
       setIsLoading(false);
       return;
     }
+
+    // Prime TTS token store immediately so TTS works as soon as auth is ready
+    setTtsAuthToken(token);
 
     let cancelled = false;
 
@@ -71,6 +76,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           localStorage.removeItem(TOKEN_KEY);
           setToken(null);
           setUser(null);
+          setTtsAuthToken(null);
         }
       })
       .finally(() => {
@@ -89,6 +95,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const newToken = response.access_token;
     localStorage.setItem(TOKEN_KEY, newToken);
     setToken(newToken);
+    setTtsAuthToken(newToken);
 
     const needsPasswordChange = !!response.must_change_password;
     if (needsPasswordChange) {
@@ -113,6 +120,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const newToken = response.access_token;
     localStorage.setItem(TOKEN_KEY, newToken);
     setToken(newToken);
+    setTtsAuthToken(newToken);
     const userData = await getMe(newToken);
     setUser(userData);
     return { isNewUser: response.is_new_user };
@@ -120,6 +128,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const logout = useCallback(() => {
     localStorage.removeItem(TOKEN_KEY);
+    setTtsAuthToken(null);
     try {
       sessionStorage.removeItem('activeAssignmentId');
       sessionStorage.removeItem('activeAssignmentGoals');

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -1,5 +1,8 @@
 import { useState, useRef, useCallback } from 'react';
-import { cancelTts, cleanForTts } from '../services/ttsApi';
+import { cancelTts, cleanForTts, setAuthToken as _setAuthToken } from '../services/ttsApi';
+
+// Re-export for convenience (components that need to prime the token store)
+export { _setAuthToken };
 
 /**
  * Manages TTS (Text-to-Speech) audio playback for LiveTutor.
@@ -84,9 +87,15 @@ export function useTtsPlayback(
     };
 
     // Try Cloud TTS first via <audio> element for better control
+    // Include auth token if available (Issue #1234: TTS endpoint now requires auth)
+    const _ttsToken = (() => {
+      try { return localStorage.getItem('lingoleap_token'); } catch { return null; }
+    })();
+    const _ttsHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (_ttsToken) _ttsHeaders['Authorization'] = `Bearer ${_ttsToken}`;
     fetch(`${API_BASE}/api/tts/synthesize`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: _ttsHeaders,
       body: JSON.stringify({ text }),
     })
       .then((res) => {

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -27,6 +27,31 @@ let _currentAudio: HTMLAudioElement | null = null;
 // Flag to signal cancellation mid-sequence
 let _cancelRequested = false;
 
+// Auth token for TTS requests (Issue #1234: secure TTS endpoints)
+// Set via setAuthToken() from AuthContext on login/logout.
+let _authToken: string | null = null;
+
+/**
+ * Set the auth token used for TTS backend requests.
+ * Call this from AuthContext whenever the token changes (login / logout).
+ */
+export function setAuthToken(token: string | null): void {
+  _authToken = token;
+}
+
+/**
+ * Get the current auth token, falling back to localStorage.
+ * The localStorage fallback covers the window between page load and AuthContext mount.
+ */
+function _getToken(): string | null {
+  if (_authToken) return _authToken;
+  try {
+    return localStorage.getItem('lingoleap_token');
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Stop any TTS currently in progress.
  */
@@ -96,6 +121,7 @@ export const _testInternals = {
   reset() {
     _cancelRequested = false;
     _urlCache.clear();
+    _authToken = null;
   },
   splitSentences: _splitSentences,
   cleanForTts: _cleanForTts,
@@ -164,9 +190,12 @@ function _splitSentences(text: string): string[] {
 async function _fetchAudioUrl(sentence: string): Promise<string> {
   let audioUrl = _urlCache.get(sentence);
   if (!audioUrl) {
+    const token = _getToken();
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
     const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers,
       body: JSON.stringify({ text: sentence }),
     });
 


### PR DESCRIPTION
Fixes #1234

## Summary

**SECURITY FIX**: Three TTS POST endpoints were completely unauthenticated, allowing anonymous actors to:
1. Call `/api/tts/regenerate` for all 2413 pre-generated sentences → delete entire GCS cache + exhaust Azure/GCP TTS billing quota + wipe audit trail
2. Send 5000-char payloads to `/api/tts/synthesize` → billing abuse

## Changes

### Backend (`backend/app/routes/tts.py`)
- `POST /api/tts/synthesize` — added `Depends(get_current_user)` → 401 for anonymous
- `POST /api/tts/synthesize-sentence` — added `Depends(get_current_user)` → 401 for anonymous
- `POST /api/tts/regenerate` — added `Depends(require_role("system_admin"))` → 401/403 for non-admins

### Frontend
- `frontend/src/services/ttsApi.ts` — added `setAuthToken()` module-level token store; `_fetchAudioUrl()` now includes `Authorization: Bearer <token>` header
- `frontend/src/contexts/AuthContext.tsx` — calls `setAuthToken(token)` on login, loginWithGoogle, and mount; calls `setAuthToken(null)` on logout
- `frontend/src/hooks/useTtsPlayback.ts` — reads `lingoleap_token` from localStorage for Bearer header in direct fetch call

### Tests (`backend/tests/test_tts_auth.py`)
- 8 new tests: unauthenticated → 401; non-admin → 403; authenticated → 200; admin → 200

## Test Results

```
8 passed in 3.09s
```

| Test | Result |
|------|--------|
| `/synthesize` unauthenticated → 401 | PASS |
| `/synthesize` bad Bearer → 401 | PASS |
| `/synthesize` authenticated student → 200 | PASS |
| `/synthesize-sentence` unauthenticated → 401 | PASS |
| `/synthesize-sentence` authenticated student → 200 | PASS |
| `/regenerate` unauthenticated → 401 | PASS |
| `/regenerate` non-admin student → 403 | PASS |
| `/regenerate` system_admin → 200 | PASS |

## Frontend token verification

Confirmed that `useTtsPlayback.ts` (LiveTutor) and `ttsApi.ts` (main TTS client) were NOT sending auth tokens. Fixed both. `AuthContext.tsx` now primes the token store immediately on mount/login so TTS works as soon as auth is ready.

## Breaking changes

None — all frontend TTS callers are now authenticated via the shared token store populated by `AuthContext`. Anonymous access is intentionally blocked.