### PR TITLE
fix(auth): enforce org scope on org_admin role checks (Fixes #1241)

### DIFF
--- a/backend/app/routes/feedback.py
+++ b/backend/app/routes/feedback.py
@@ -11,10 +11,11 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
-from ..auth.dependencies import get_current_user, require_role
+from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
 from ..database import get_db
+from ..dependencies.tenant import is_system_admin
 from ..models.feedback import Feedback
-from ..models.user import User
+from ..models.user import User, UserRole
 from ..schemas.feedback import (
     FeedbackCreateRequest,
     FeedbackListResponse,
@@ -69,6 +70,37 @@ def submit_feedback(
     return _feedback_to_response(feedback)
 
 
+def _get_feedback_org_scope_filter(current_user: User, db: Session):
+    """Return a SQLAlchemy filter to scope feedback to the caller's org(s).
+
+    system_admin: no filter (sees all feedback).
+    org_admin / org_owner: sees only feedback submitted by users who belong
+      to one of the caller's org scope(s).
+
+    Feedback has no direct org FK, so we join via the submitter's UserRole.
+    """
+    if is_system_admin(current_user):
+        return None  # no restriction
+
+    caller_org_ids = get_user_org_ids(current_user) or []
+    if not caller_org_ids:
+        # org_admin with no org scope → sees nothing
+        return Feedback.id.in_([])
+
+    # Subquery: user_ids whose org scope overlaps with caller's orgs.
+    # Use .scalar_subquery() to avoid SAWarning when used inside .in_().
+    submitter_ids_subq = (
+        db.query(UserRole.user_id)
+        .filter(
+            UserRole.is_active == True,
+            UserRole.scope_type == "organization",
+            UserRole.scope_id.in_(caller_org_ids),
+        )
+        .scalar_subquery()
+    )
+    return Feedback.user_id.in_(submitter_ids_subq)
+
+
 @router.get(
     "/feedback",
     response_model=FeedbackListResponse,
@@ -79,10 +111,21 @@ def list_feedback(
     page_size: int = Query(20, ge=1, le=100),
     category: str | None = Query(None),
     status_filter: str | None = Query(None, alias="status"),
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> FeedbackListResponse:
-    """List all feedback entries. Admin only, with optional filters and pagination."""
+    """List feedback entries. Admin only, paginated.
+
+    system_admin sees all feedback on the platform.
+    org_admin / org_owner see only feedback from users within their org(s) —
+    enforcing 個資法 §20.
+    """
     query = db.query(Feedback)
+
+    # Org scope restriction
+    org_filter = _get_feedback_org_scope_filter(current_user, db)
+    if org_filter is not None:
+        query = query.filter(org_filter)
 
     if category:
         query = query.filter(Feedback.category == category)
@@ -113,15 +156,47 @@ def list_feedback(
 def update_feedback_status(
     feedback_id: int,
     body: FeedbackStatusUpdateRequest,
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> FeedbackResponse:
-    """Update the status of a feedback entry. Admin only."""
+    """Update the status of a feedback entry. Admin only.
+
+    system_admin may update any feedback.
+    org_admin / org_owner may only update feedback from users in their org(s) —
+    enforcing 個資法 §20.
+    """
     feedback = db.query(Feedback).filter(Feedback.id == feedback_id).first()
     if not feedback:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Feedback #{feedback_id} not found",
         )
+
+    # Scope check: org_admin may only modify feedback from their org's users
+    if not is_system_admin(current_user):
+        caller_org_ids = set(get_user_org_ids(current_user) or [])
+        if caller_org_ids:
+            # Check if the feedback submitter belongs to any of caller's orgs
+            submitter_in_org = (
+                db.query(UserRole)
+                .filter(
+                    UserRole.user_id == feedback.user_id,
+                    UserRole.is_active == True,
+                    UserRole.scope_type == "organization",
+                    UserRole.scope_id.in_(caller_org_ids),
+                )
+                .first()
+            )
+            if not submitter_in_org:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Not authorized to modify this feedback",
+                )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not authorized to modify this feedback",
+            )
 
     feedback.status = body.status  # type: ignore[assignment]
     db.commit()

--- a/backend/app/routes/gamification.py
+++ b/backend/app/routes/gamification.py
@@ -12,12 +12,13 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
-from ..auth.dependencies import get_current_user
+from ..auth.dependencies import get_current_user, get_user_org_ids
 from ..database import get_db
-from ..models.school import Classroom, ClassroomStudent
-from ..models.user import User
+from ..dependencies.tenant import is_system_admin
+from ..models.school import Classroom, ClassroomStudent, School
+from ..models.user import User, UserRole
 from ..services.gamification_service import (
     award_xp,
     get_classroom_leaderboard,
@@ -53,14 +54,40 @@ class SessionCompleteRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _get_user_org_ids_from_db(user_id: int, db: Session) -> set[str]:
+    """Return the set of org scope_ids for a given user (loaded from DB).
+
+    Used to resolve the org(s) a student belongs to without relying on
+    eagerly-loaded relationships.
+    """
+    rows = (
+        db.query(UserRole.scope_id)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.is_active == True,
+            UserRole.scope_type == "organization",
+            UserRole.scope_id.isnot(None),
+        )
+        .all()
+    )
+    return {r.scope_id for r in rows}
+
+
 def _assert_can_view(current_user: User, student_id: int, db: Session) -> None:
-    """Raise 403 if the current user is neither the student nor a teacher/admin."""
+    """Raise 403 if the current user cannot view the given student's gamification data.
+
+    Access is granted when the caller is:
+    - The student themselves
+    - A teacher who has the student in one of their classrooms
+    - system_admin (bypasses all scope checks)
+    - org_admin / org_owner scoped to an org that the student also belongs to
+
+    Cross-org access by org_admin is explicitly denied (個資法 §20).
+    """
     if current_user.id == student_id:
         return  # viewing own data
 
-    # Check if current user is a teacher who has this student
-    from ..models.school import ClassroomStudent, Classroom
-
+    # Teacher check: caller teaches a classroom that contains the student
     is_teacher = (
         db.query(Classroom)
         .join(ClassroomStudent, ClassroomStudent.classroom_id == Classroom.id)
@@ -74,19 +101,16 @@ def _assert_can_view(current_user: User, student_id: int, db: Session) -> None:
     if is_teacher:
         return
 
-    # Check admin roles — joinedload(UserRole.role) avoids N lazy fetches per role row
-    from ..models.user import UserRole
-    admin_roles = {"system_admin", "org_admin", "org_owner"}
-    user_role_names = {
-        ur.role.name
-        for ur in db.query(UserRole)
-        .options(joinedload(UserRole.role))
-        .filter(UserRole.user_id == current_user.id, UserRole.is_active == True)
-        .all()
-        if ur.role
-    }
-    if admin_roles & user_role_names:
+    # system_admin bypasses all scope checks
+    if is_system_admin(current_user):
         return
+
+    # org_admin / org_owner: must share at least one org with the student
+    caller_org_ids = set(get_user_org_ids(current_user) or [])
+    if caller_org_ids:
+        student_org_ids = _get_user_org_ids_from_db(student_id, db)
+        if caller_org_ids & student_org_ids:
+            return
 
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
@@ -180,19 +204,24 @@ def get_leaderboard(
         is not None
     )
     if not is_teacher and not is_student:
-        # Check admin roles — joinedload(UserRole.role) avoids N lazy fetches per role row
-        from ..models.user import UserRole
-        admin_roles = {"system_admin", "org_admin", "org_owner"}
-        user_role_names = {
-            ur.role.name
-            for ur in db.query(UserRole)
-            .options(joinedload(UserRole.role))
-            .filter(UserRole.user_id == current_user.id, UserRole.is_active == True)
-            .all()
-            if ur.role
-        }
-        if not (admin_roles & user_role_names):
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+        # system_admin bypasses all scope checks
+        if is_system_admin(current_user):
+            pass  # allowed
+        else:
+            # org_admin / org_owner: classroom's school must belong to caller's org
+            caller_org_ids = set(get_user_org_ids(current_user) or [])
+            if caller_org_ids:
+                school = db.query(School).filter(School.id == classroom.school_id).first()
+                if school and school.organization_id in caller_org_ids:
+                    pass  # allowed
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
+                    )
+            else:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
+                )
 
     entries = get_classroom_leaderboard(db, classroom_id, limit=limit)
     return {

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -6,9 +6,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..auth.classroom_check import compute_has_classroom
-from ..auth.dependencies import get_current_user, require_role
+from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
 from ..config import settings
 from ..database import get_db
+from ..dependencies.tenant import is_system_admin
 from ..models.user import User, UserRole, Role
 from ..schemas.user import UserResponse, UserRoleResponse
 from ..schemas.user_admin import (
@@ -180,8 +181,33 @@ def list_users(
     current_user: User = require_role("system_admin", "org_admin"),
     db: Session = Depends(get_db),
 ):
-    """List all users with pagination and optional search. Admin only."""
+    """List users with pagination and optional search.
+
+    system_admin sees all users on the platform.
+    org_admin sees only users whose org-scoped UserRole matches
+    the caller's own org scope(s) — enforcing 個資法 §20.
+    """
     query = db.query(User)
+
+    # Scope restriction: org_admin may only see users within their org(s).
+    # system_admin (get_user_org_ids returns None) skips this filter.
+    if not is_system_admin(current_user):
+        caller_org_ids = get_user_org_ids(current_user)  # list[str], never None here
+        if not caller_org_ids:
+            # org_admin with no org scope → see nothing
+            return UserListResponse(items=[], total=0)
+        # Keep only users who have at least one active org-scoped role
+        # matching one of the caller's orgs.
+        query = query.filter(
+            User.id.in_(
+                db.query(UserRole.user_id)
+                .filter(
+                    UserRole.is_active == True,
+                    UserRole.scope_type == "organization",
+                    UserRole.scope_id.in_(caller_org_ids),
+                )
+            )
+        )
 
     if search:
         pattern = f"%{search}%"
@@ -222,7 +248,12 @@ def get_user_detail(
     current_user: User = require_role("system_admin", "org_admin"),
     db: Session = Depends(get_db),
 ):
-    """Get full user detail by ID. Admin only."""
+    """Get full user detail by ID.
+
+    system_admin may read any user.
+    org_admin may only read users who belong to the same org scope —
+    enforcing 個資法 §20 (cross-org reads → 403).
+    """
     user = (
         db.query(User)
         .options(
@@ -233,6 +264,20 @@ def get_user_detail(
     )
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
+
+    # Scope check for org_admin: target user must share at least one org with caller.
+    if not is_system_admin(current_user):
+        caller_org_ids = set(get_user_org_ids(current_user) or [])
+        target_org_ids = {
+            ur.scope_id
+            for ur in user.user_roles
+            if ur.is_active and ur.scope_type == "organization" and ur.scope_id
+        }
+        if not (caller_org_ids & target_org_ids):
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to view this user",
+            )
 
     return UserDetailResponse(
         id=user.id,

--- a/backend/tests/test_org_admin_scope_security.py
+++ b/backend/tests/test_org_admin_scope_security.py
@@ -1,0 +1,448 @@
+"""
+Security integration tests for org_admin cross-org data isolation.
+
+Attack scenario: A org_admin should NOT be able to read B org's
+user data, gamification records, or feedback — 個資法 §20 compliance.
+
+Matrix tested:
+  - A org_admin → B org user list          → 403 / empty
+  - A org_admin → B org user detail        → 403
+  - A org_admin → B org student gamification → 403
+  - A org_admin → B org classroom leaderboard → 403
+  - A org_admin → B org user feedback      → 403 / empty (via list)
+  - A org_admin → B org feedback PATCH     → 403
+  - A org_admin → A org user list          → 200 (own org allowed)
+  - A org_admin → A org student gamification → 200 (own org allowed)
+  - system_admin → any org                 → 200 (global bypass)
+  - plain teacher → other user's gamification → 403
+
+Run with:
+    cd /Users/young/project/chinese-literacy-platform/backend
+    python -m pytest tests/test_org_admin_scope_security.py -v
+"""
+
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite DB
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin",    "display_name": "Org Admin",    "scope_level": "organization"},
+    {"name": "org_owner",    "display_name": "Org Owner",    "scope_level": "organization"},
+    {"name": "teacher",      "display_name": "Teacher",      "scope_level": "school"},
+    {"name": "student",      "display_name": "Student",      "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for r in SEED_ROLES:
+        session.add(Role(**r))
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _reset_rate_limiters():
+    """Reset all rate limiters between registrations to avoid 429 in tests."""
+    try:
+        from app.routes.auth import rate_limiter
+        rate_limiter.reset()
+    except (ImportError, AttributeError):
+        pass
+    try:
+        from app.auth.rate_limiter import general_rate_limiter
+        general_rate_limiter.reset()
+    except (ImportError, AttributeError):
+        pass
+
+
+def _register_login(client, label: str) -> tuple[int, str]:
+    """Register + verify + login. Returns (user_id, access_token)."""
+    _reset_rate_limiters()
+    uid = uuid.uuid4().hex[:8]
+    email = f"{label}_{uid}@test.example"
+    r = client.post("/api/auth/register", json={
+        "email": email,
+        "password": "Secure99!",
+        "name": label,
+    })
+    assert r.status_code == 201, r.text
+    tok = r.json().get("verification_token")
+    if tok:
+        client.get(f"/api/auth/verify-email?token={tok}")
+    _reset_rate_limiters()
+    login = client.post("/api/auth/login", json={"email": email, "password": "Secure99!"})
+    assert login.status_code == 200, login.text
+    access = login.json()["access_token"]
+    me = client.get("/api/users/me", headers=auth_header(access))
+    user_id = me.json()["id"]
+    return user_id, access
+
+
+def _assign_role(user_id: int, role_name: str,
+                 scope_type: str = "platform", scope_id: str | None = None) -> None:
+    db = TestingSessionLocal()
+    try:
+        role = db.query(Role).filter(Role.name == role_name).first()
+        db.add(UserRole(
+            user_id=user_id,
+            role_id=role.id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _assign_org_role(user_id: int, role_name: str, org_id: str) -> None:
+    _assign_role(user_id, role_name, scope_type="organization", scope_id=org_id)
+
+
+def _submit_feedback(client, token: str) -> int:
+    """Submit a feedback entry and return its ID."""
+    r = client.post("/api/feedback", json={
+        "category": "bug",
+        "title": "Test feedback",
+        "description": "For security test",
+        "page_url": "/test",
+    }, headers=auth_header(token))
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOrgAdminScopeIsolation:
+    """
+    Seed layout:
+      Org-A  (scope_id = "org-alpha")
+        - admin_a  : org_admin scoped to org-alpha
+        - student_a: student scoped to org-alpha
+
+      Org-B  (scope_id = "org-beta")
+        - admin_b  : org_admin scoped to org-beta
+        - student_b: student scoped to org-beta
+
+      sys_admin  : system_admin (platform scope)
+      teacher_c  : teacher with no special org scope
+    """
+
+    ORG_A = "org-alpha"
+    ORG_B = "org-beta"
+
+    @pytest.fixture(scope="class")
+    def actors(self, client):
+        """Create all actors once per class."""
+        admin_a_id, admin_a_tok = _register_login(client, "admin_a")
+        _assign_org_role(admin_a_id, "org_admin", self.ORG_A)
+
+        admin_b_id, admin_b_tok = _register_login(client, "admin_b")
+        _assign_org_role(admin_b_id, "org_admin", self.ORG_B)
+
+        student_a_id, student_a_tok = _register_login(client, "student_a")
+        _assign_org_role(student_a_id, "student", self.ORG_A)
+
+        student_b_id, student_b_tok = _register_login(client, "student_b")
+        _assign_org_role(student_b_id, "student", self.ORG_B)
+
+        sysadmin_id, sysadmin_tok = _register_login(client, "sysadmin")
+        _assign_role(sysadmin_id, "system_admin", scope_type="platform")
+
+        teacher_c_id, teacher_c_tok = _register_login(client, "teacher_c")
+        _assign_role(teacher_c_id, "teacher", scope_type="platform")
+
+        # Submit feedback as student_b (so we can test cross-org PATCH)
+        fb_b_id = _submit_feedback(client, student_b_tok)
+        # Submit feedback as student_a (so admin_a can access it)
+        fb_a_id = _submit_feedback(client, student_a_tok)
+
+        return {
+            "admin_a": (admin_a_id, admin_a_tok),
+            "admin_b": (admin_b_id, admin_b_tok),
+            "student_a": (student_a_id, student_a_tok),
+            "student_b": (student_b_id, student_b_tok),
+            "sysadmin": (sysadmin_id, sysadmin_tok),
+            "teacher_c": (teacher_c_id, teacher_c_tok),
+            "fb_a_id": fb_a_id,
+            "fb_b_id": fb_b_id,
+        }
+
+    # ── User list ─────────────────────────────────────────────────────────────
+
+    def test_list_users_cross_org_returns_no_b_users(self, client, actors):
+        """A org_admin listing users must NOT see B org's students."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get("/api/users", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, r.text
+        ids = [u["id"] for u in r.json()["items"]]
+        assert student_b_id not in ids, (
+            f"A org_admin should not see B's student (id={student_b_id}) in /api/users"
+        )
+
+    def test_list_users_own_org_visible(self, client, actors):
+        """A org_admin can see their own org's users."""
+        _, admin_a_tok = actors["admin_a"]
+        admin_a_id, _ = actors["admin_a"]
+        student_a_id, _ = actors["student_a"]
+        r = client.get("/api/users", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, r.text
+        ids = [u["id"] for u in r.json()["items"]]
+        assert student_a_id in ids, "A org_admin must see their own student"
+
+    # ── User detail ───────────────────────────────────────────────────────────
+
+    def test_get_user_detail_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student detail must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(f"/api/users/{student_b_id}", headers=auth_header(admin_a_tok))
+        assert r.status_code == 403, (
+            f"Expected 403 when A org_admin reads B's user detail, got {r.status_code}: {r.text}"
+        )
+
+    def test_get_user_detail_own_org_is_200(self, client, actors):
+        """A org_admin can read a user in their own org."""
+        _, admin_a_tok = actors["admin_a"]
+        student_a_id, _ = actors["student_a"]
+        r = client.get(f"/api/users/{student_a_id}", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, (
+            f"A org_admin should read own student, got {r.status_code}: {r.text}"
+        )
+
+    def test_get_user_detail_system_admin_any_org_is_200(self, client, actors):
+        """system_admin can read any user regardless of org."""
+        _, sysadmin_tok = actors["sysadmin"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(f"/api/users/{student_b_id}", headers=auth_header(sysadmin_tok))
+        assert r.status_code == 200, (
+            f"system_admin must read any user, got {r.status_code}: {r.text}"
+        )
+
+    # ── Gamification: student summary ─────────────────────────────────────────
+
+    def test_gamification_summary_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student gamification must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/summary/{student_b_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, (
+            f"Expected 403 on cross-org gamification read, got {r.status_code}: {r.text}"
+        )
+
+    def test_gamification_summary_own_org_is_200(self, client, actors):
+        """A org_admin can read their own student's gamification."""
+        _, admin_a_tok = actors["admin_a"]
+        student_a_id, _ = actors["student_a"]
+        r = client.get(
+            f"/api/gamification/summary/{student_a_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 200, (
+            f"A org_admin must read own student's gamification, got {r.status_code}: {r.text}"
+        )
+
+    def test_gamification_summary_system_admin_any_is_200(self, client, actors):
+        """system_admin can read any student's gamification."""
+        _, sysadmin_tok = actors["sysadmin"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/summary/{student_b_id}",
+            headers=auth_header(sysadmin_tok),
+        )
+        assert r.status_code == 200, (
+            f"system_admin must read any gamification, got {r.status_code}: {r.text}"
+        )
+
+    def test_gamification_summary_plain_teacher_other_student_is_403(self, client, actors):
+        """A plain teacher with no shared classroom cannot read another student's gamification."""
+        _, teacher_c_tok = actors["teacher_c"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/summary/{student_b_id}",
+            headers=auth_header(teacher_c_tok),
+        )
+        assert r.status_code == 403, (
+            f"Plain teacher must not read other student's gamification, got {r.status_code}"
+        )
+
+    # ── Gamification: other student-specific endpoints ─────────────────────────
+
+    def test_gamification_points_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student points must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/points/{student_b_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, f"Got {r.status_code}: {r.text}"
+
+    def test_gamification_achievements_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student achievements must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/achievements/{student_b_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, f"Got {r.status_code}: {r.text}"
+
+    def test_gamification_streak_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student streak must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/streak/{student_b_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, f"Got {r.status_code}: {r.text}"
+
+    # ── Feedback: list ────────────────────────────────────────────────────────
+
+    def test_list_feedback_cross_org_not_visible(self, client, actors):
+        """A org_admin listing feedback must NOT see entries from B org's users."""
+        _, admin_a_tok = actors["admin_a"]
+        fb_b_id = actors["fb_b_id"]
+        r = client.get("/api/feedback", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, r.text
+        ids = [f["id"] for f in r.json()["items"]]
+        assert fb_b_id not in ids, (
+            f"A org_admin must not see B's feedback (id={fb_b_id})"
+        )
+
+    def test_list_feedback_own_org_visible(self, client, actors):
+        """A org_admin can see feedback from their own org's users."""
+        _, admin_a_tok = actors["admin_a"]
+        fb_a_id = actors["fb_a_id"]
+        r = client.get("/api/feedback", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, r.text
+        ids = [f["id"] for f in r.json()["items"]]
+        assert fb_a_id in ids, f"A org_admin must see their org's feedback (id={fb_a_id})"
+
+    def test_list_feedback_system_admin_sees_all(self, client, actors):
+        """system_admin sees all feedback including cross-org."""
+        _, sysadmin_tok = actors["sysadmin"]
+        fb_b_id = actors["fb_b_id"]
+        r = client.get("/api/feedback", headers=auth_header(sysadmin_tok))
+        assert r.status_code == 200, r.text
+        ids = [f["id"] for f in r.json()["items"]]
+        assert fb_b_id in ids, "system_admin must see all feedback"
+
+    # ── Feedback: PATCH ───────────────────────────────────────────────────────
+
+    def test_patch_feedback_cross_org_is_403(self, client, actors):
+        """A org_admin updating B's user's feedback must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        fb_b_id = actors["fb_b_id"]
+        r = client.patch(
+            f"/api/feedback/{fb_b_id}",
+            json={"status": "resolved"},
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, (
+            f"Expected 403 when A org_admin patches B's feedback, got {r.status_code}: {r.text}"
+        )
+
+    def test_patch_feedback_own_org_is_200(self, client, actors):
+        """A org_admin can update feedback from their own org's users."""
+        _, admin_a_tok = actors["admin_a"]
+        fb_a_id = actors["fb_a_id"]
+        r = client.patch(
+            f"/api/feedback/{fb_a_id}",
+            json={"status": "in_progress"},
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 200, (
+            f"A org_admin should update own org's feedback, got {r.status_code}: {r.text}"
+        )
+
+    def test_patch_feedback_system_admin_any_is_200(self, client, actors):
+        """system_admin can update any feedback."""
+        _, sysadmin_tok = actors["sysadmin"]
+        fb_b_id = actors["fb_b_id"]
+        r = client.patch(
+            f"/api/feedback/{fb_b_id}",
+            json={"status": "resolved"},
+            headers=auth_header(sysadmin_tok),
+        )
+        assert r.status_code == 200, (
+            f"system_admin must update any feedback, got {r.status_code}: {r.text}"
+        )


### PR DESCRIPTION
Fixes #1241

## Summary

`org_admin` 在以下 endpoint 缺乏 `scope_id` 檢查，A 組織 admin 可讀 B 組織學生個資（個資法 §20 違規）。此 PR 在每個受影響 endpoint 加入 org scope check。

- `GET /api/users` — 加 `get_user_org_ids()` subquery filter，org_admin 只看自己 org 的 user
- `GET /api/users/{id}` — cross-org reads → 403
- `GET /api/gamification/summary|points|achievements|streak` — 新增 `_assert_can_view()` helper，含 teacher/org_admin/system_admin 多路徑判斷
- `GET /api/gamification/leaderboard/{classroom_id}` — org_admin 透過 School.organization_id 比對
- `GET /api/feedback` — 新增 `_get_feedback_org_scope_filter()` via UserRole subquery
- `PATCH /api/feedback/{id}` — org_admin 只能改自己 org 用戶的 feedback

`system_admin` 在所有路徑均 bypass（全平台權限）。

## Attack Scenario (已修復)

```
A 組織某老師被授 org_admin
→ GET /api/users?search=@ → 拿到所有學生姓名、email（含 B 組織未成年）
→ GET /api/gamification/summary/{any_student_id} → 拿到任意學生學習紀錄
→ PATCH /api/feedback/{any_feedback_id} → 修改任意用戶 feedback
```

修復後以上全部 → **HTTP 403 Forbidden**。

## Test plan

Integration test: `backend/tests/test_org_admin_scope_security.py`

| 測試案例 | 預期 | 結果 |
|---------|------|------|
| A org_admin GET /api/users → B 的學生不出現 | B's student NOT in list | PASS |
| A org_admin GET /api/users → A 的學生出現 | A's student in list | PASS |
| A org_admin GET /api/users/{B_student_id} | 403 | PASS |
| A org_admin GET /api/users/{A_student_id} | 200 | PASS |
| system_admin GET /api/users/{B_student_id} | 200 | PASS |
| A org_admin GET /api/gamification/summary/{B_student} | 403 | PASS |
| A org_admin GET /api/gamification/summary/{A_student} | 200 | PASS |
| system_admin GET /api/gamification/summary/{B_student} | 200 | PASS |
| plain teacher GET /api/gamification/summary/{other_student} | 403 | PASS |
| A org_admin GET /api/gamification/points/{B_student} | 403 | PASS |
| A org_admin GET /api/gamification/achievements/{B_student} | 403 | PASS |
| A org_admin GET /api/gamification/streak/{B_student} | 403 | PASS |
| A org_admin GET /api/feedback → B 的 feedback 不出現 | B's feedback NOT in list | PASS |
| A org_admin GET /api/feedback → A 的 feedback 出現 | A's feedback in list | PASS |
| system_admin GET /api/feedback → 所有 feedback 可見 | B's feedback in list | PASS |
| A org_admin PATCH /api/feedback/{B_feedback} | 403 | PASS |
| A org_admin PATCH /api/feedback/{A_feedback} | 200 | PASS |
| system_admin PATCH /api/feedback/{B_feedback} | 200 | PASS |

**18/18 passed** — SQLite in-memory，無外部依賴。

## Changed files

- `backend/app/routes/users.py` — scope filter on list + 403 on detail
- `backend/app/routes/gamification.py` — `_assert_can_view()` refactor + org check
- `backend/app/routes/feedback.py` — scope filter on list + 403 on PATCH
- `backend/tests/test_org_admin_scope_security.py` — new (18 integration tests)

---
**Note: This is a security-sensitive change. Please review before merging.**