### PR TITLE
fix(security): TTS endpoints 加 auth guard (Fixes #1240)

### DIFF
--- a/backend/app/routes/tts.py
+++ b/backend/app/routes/tts.py
@@ -30,10 +30,12 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
+from ..auth.dependencies import get_current_user, require_role
+from ..models.user import User
 from ..services.tts_service import (
     TTSError,
     build_lesson_tts_mapping,
@@ -53,14 +55,21 @@ class TTSRequest(BaseModel):
 
 
 @router.post("/synthesize")
-async def synthesize(req: TTSRequest) -> Response:
+async def synthesize(
+    req: TTSRequest,
+    _current_user: User = Depends(get_current_user),
+) -> Response:
     """Synthesise *text* to MP3 audio using Azure TTS (primary) or Cloud TTS (fallback).
+
+    Requires authentication (any active user).  Anonymous requests are rejected
+    with 401 to prevent bill-washing attacks on the Azure/GCP TTS quota.
 
     Runs in a thread pool via asyncio.to_thread() so the FastAPI event loop is
     not blocked during the 8–15 s remote TTS call (Azure / Google / Gemini).
 
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
+        401  application/json — not authenticated.
         503  application/json — TTS unavailable; client should fall back
              to Web Speech API.
     """
@@ -85,8 +94,14 @@ async def synthesize(req: TTSRequest) -> Response:
 
 
 @router.post("/synthesize-sentence")
-async def synthesize_sentence_endpoint(req: TTSRequest) -> Response:
+async def synthesize_sentence_endpoint(
+    req: TTSRequest,
+    _current_user: User = Depends(get_current_user),
+) -> Response:
     """Synthesise a single sentence to MP3 audio (Issue #667).
+
+    Requires authentication (any active user).  Anonymous requests are rejected
+    with 401 to prevent bill-washing attacks via the pre-generated sentence cache.
 
     Stores audio under azure/sentences/ GCS path for sentence-level caching.
     Functionally identical to /synthesize but semantically scoped to sentences.
@@ -94,6 +109,7 @@ async def synthesize_sentence_endpoint(req: TTSRequest) -> Response:
 
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
+        401  application/json — not authenticated.
         503  application/json — TTS unavailable.
     """
     try:
@@ -149,9 +165,13 @@ def get_tts_mapping(lesson_id: int) -> dict:
     return build_lesson_tts_mapping(lesson)
 
 
-@router.post("/regenerate")
+@router.post("/regenerate", dependencies=[require_role("system_admin")])
 async def regenerate(req: TTSRequest) -> dict:
     """Delete cached audio for *text* and re-synthesise from scratch (Issue #765).
+
+    Requires system_admin role.  This endpoint deletes GCS cache objects and
+    triggers a fresh TTS synthesis — exposing it to non-admins would allow any
+    authenticated user to wipe cached audio and exhaust the TTS quota.
 
     Use this endpoint when a specific sentence has a known mispronunciation
     in its cached audio (e.g. wrong tone for 喝采). The endpoint:
@@ -163,6 +183,8 @@ async def regenerate(req: TTSRequest) -> dict:
 
     Returns:
         200  application/json — { "status": "ok", "key": "...", "gcs_deleted": [...], "bytes": N }
+        401  application/json — not authenticated.
+        403  application/json — insufficient permissions (not system_admin).
         503  application/json — TTS unavailable.
     """
     # Step 1: delete existing caches (GCS I/O — run in thread pool)

--- a/backend/tests/test_tts_auth.py
+++ b/backend/tests/test_tts_auth.py
@@ -1,0 +1,279 @@
+"""
+TDD tests for TTS endpoint authentication (Issue #1240).
+
+Covers:
+- POST /api/tts/synthesize  → 401 without token, 200 with valid token
+- POST /api/tts/synthesize-sentence → 401 without token, 200 with valid token
+- POST /api/tts/regenerate  → 401 without token, 403 for non-admin, 200 for system_admin
+
+Run:
+    cd /path/to/chinese-literacy-platform/backend
+    pytest tests/test_tts_auth.py -v
+"""
+import sys
+import os
+import uuid
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+
+# ---------------------------------------------------------------------------
+# Test DB (SQLite in-memory)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _assign_role(email: str, role_name: str) -> None:
+    # Map role name to the correct scope_type (UserRole.scope_type is NOT NULL)
+    scope_type_map = {
+        "system_admin": "platform",
+        "org_admin": "organization",
+        "principal": "school",
+        "director": "school",
+        "teacher": "school",
+        "homeroom_teacher": "school",
+        "student": "school",
+        "parent": "school",
+    }
+    scope_type = scope_type_map.get(role_name, "platform")
+
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).first()
+        role = db.query(Role).filter(Role.name == role_name).first()
+        existing = db.query(UserRole).filter(
+            UserRole.user_id == user.id,
+            UserRole.role_id == role.id,
+            UserRole.is_active == True,
+        ).first()
+        if not existing:
+            db.add(UserRole(
+                user_id=user.id,
+                role_id=role.id,
+                is_active=True,
+                scope_type=scope_type,
+            ))
+            db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_and_login(client) -> dict:
+    """Register a fresh user and return {'email', 'token'}."""
+    unique = uuid.uuid4().hex[:8]
+    email = f"ttstest_{unique}@example.com"
+    password = "SecurePass123!"
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": f"TTS Test {unique}",
+    })
+    assert resp.status_code == 201, resp.text
+
+    verification_token = resp.json().get("verification_token")
+    if verification_token is not None:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
+
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    token = login_resp.json()["access_token"]
+    return {"email": email, "token": token}
+
+
+@pytest.fixture(scope="module")
+def regular_user(client):
+    return _register_and_login(client)
+
+
+@pytest.fixture(scope="module")
+def admin_user(client):
+    user_info = _register_and_login(client)
+    _assign_role(user_info["email"], "system_admin")
+    return user_info
+
+
+# ---------------------------------------------------------------------------
+# Helper: fake TTS so we don't hit Azure/GCP in tests
+# ---------------------------------------------------------------------------
+
+FAKE_AUDIO = b"FAKE_AUDIO_BYTES"
+
+
+def _patch_tts():
+    """Context manager that patches synthesize_speech and synthesize_sentence."""
+    return patch.multiple(
+        "app.routes.tts",
+        synthesize_speech=MagicMock(return_value=FAKE_AUDIO),
+        synthesize_sentence=MagicMock(return_value=FAKE_AUDIO),
+    )
+
+
+def _patch_regenerate():
+    """Context manager that patches both delete_tts_cache and synthesize_speech for /regenerate."""
+    delete_result = {
+        "key": "abc123",
+        "l1_deleted": True,
+        "gcs_deleted": ["azure/sentences/abc123.mp3"],
+    }
+    return patch.multiple(
+        "app.routes.tts",
+        delete_tts_cache=MagicMock(return_value=delete_result),
+        synthesize_speech=MagicMock(return_value=FAKE_AUDIO),
+    )
+
+
+# ===========================================================================
+# Tests: POST /api/tts/synthesize
+# ===========================================================================
+
+class TestSynthesizeAuth:
+
+    def test_unauthenticated_returns_401(self, client):
+        """Anonymous request must be rejected with 401."""
+        resp = client.post("/api/tts/synthesize", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+
+    def test_authenticated_returns_200(self, client, regular_user):
+        """Authenticated user receives audio bytes."""
+        with _patch_tts():
+            resp = client.post(
+                "/api/tts/synthesize",
+                json={"text": "你好"},
+                headers={"Authorization": f"Bearer {regular_user['token']}"},
+            )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+        assert resp.content == FAKE_AUDIO
+
+
+# ===========================================================================
+# Tests: POST /api/tts/synthesize-sentence
+# ===========================================================================
+
+class TestSynthesizeSentenceAuth:
+
+    def test_unauthenticated_returns_401(self, client):
+        """Anonymous request must be rejected with 401."""
+        resp = client.post("/api/tts/synthesize-sentence", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+
+    def test_authenticated_returns_200(self, client, regular_user):
+        """Authenticated user receives audio bytes."""
+        with _patch_tts():
+            resp = client.post(
+                "/api/tts/synthesize-sentence",
+                json={"text": "你好"},
+                headers={"Authorization": f"Bearer {regular_user['token']}"},
+            )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+        assert resp.content == FAKE_AUDIO
+
+
+# ===========================================================================
+# Tests: POST /api/tts/regenerate
+# ===========================================================================
+
+class TestRegenerateAuth:
+
+    def test_unauthenticated_returns_401(self, client):
+        """Anonymous request must be rejected with 401."""
+        resp = client.post("/api/tts/regenerate", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+
+    def test_non_admin_returns_403(self, client, regular_user):
+        """Regular (non-admin) user must receive 403 Forbidden."""
+        resp = client.post(
+            "/api/tts/regenerate",
+            json={"text": "你好"},
+            headers={"Authorization": f"Bearer {regular_user['token']}"},
+        )
+        assert resp.status_code == 403, f"Expected 403, got {resp.status_code}: {resp.text}"
+
+    def test_system_admin_returns_200(self, client, admin_user):
+        """system_admin user can call /regenerate."""
+        with _patch_regenerate():
+            resp = client.post(
+                "/api/tts/regenerate",
+                json={"text": "你好"},
+                headers={"Authorization": f"Bearer {admin_user['token']}"},
+            )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+        data = resp.json()
+        assert data["status"] == "ok"

--- a/backend/tests/test_tts_service.py
+++ b/backend/tests/test_tts_service.py
@@ -7,6 +7,58 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
+# ---------------------------------------------------------------------------
+# Shared helper: build a minimal FastAPI test app with auth bypassed.
+#
+# After Issue #1240 added get_current_user to the TTS endpoints, tests that
+# use a standalone mini-app (without a real DB) must override the dependency
+# so validation tests can still exercise Pydantic rejection (422) rather than
+# getting blocked at the auth layer (401).
+# ---------------------------------------------------------------------------
+
+def _make_tts_test_app():
+    """Return a FastAPI app with the TTS router and get_current_user stubbed out."""
+    from fastapi import FastAPI
+    from app.routes.tts import router
+    from app.auth.dependencies import get_current_user, require_role
+
+    # Minimal stub user — enough for the dependency to return without hitting the DB.
+    stub_user = MagicMock()
+    stub_user.id = 1
+
+    # Stub role-check dependency for /regenerate (which uses require_role("system_admin")).
+    stub_admin = MagicMock()
+    stub_admin.id = 1
+
+    mini_app = FastAPI()
+    mini_app.include_router(router)
+
+    # Override get_current_user → always succeeds (any-user endpoints).
+    mini_app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    # require_role returns a Depends() object, not a callable — to stub it we
+    # need to override the inner _check_role dependency it wraps.  The simplest
+    # approach is to capture the dependency object at import time and override it.
+    # However, require_role("system_admin") is called at route-decoration time so
+    # the Depends() is already baked in.  We override get_current_user (which
+    # _check_role itself depends on) — this is sufficient because the role check
+    # queries the DB which doesn't exist in mini-app tests; skipping via override
+    # of get_current_user alone won't bypass require_role.
+    #
+    # Strategy: also override the DB dependency so the role query returns admin.
+    # Easiest: completely override require_role's inner dependency (_check_role).
+    # We locate it via the route's dependencies list.
+    from fastapi import routing as fastapi_routing
+    import fastapi
+    for route in mini_app.routes:
+        if hasattr(route, "dependencies"):
+            for dep in route.dependencies:
+                if hasattr(dep, "dependency") and hasattr(dep.dependency, "__name__") and dep.dependency.__name__ == "_check_role":
+                    mini_app.dependency_overrides[dep.dependency] = lambda: stub_admin
+
+    return mini_app
+
 # ---------------------------------------------------------------------------
 # 1. tts_service tests — cache key
 # ---------------------------------------------------------------------------
@@ -172,11 +224,7 @@ class TestTTSPydanticValidation:
     """TTSRequest model must reject empty text and text >5000 chars."""
 
     def _make_app(self):
-        from fastapi import FastAPI
-        from app.routes.tts import router
-        app = FastAPI()
-        app.include_router(router)
-        return app
+        return _make_tts_test_app()
 
     def test_empty_text_rejected(self):
         from fastapi.testclient import TestClient
@@ -427,10 +475,6 @@ class TestTTSRoute:
     @patch("app.services.tts_service._get_tts_client")
     def test_synthesize_returns_audio_response(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from fastapi.testclient import TestClient
-        from app.routes.tts import router
-        from fastapi import FastAPI
-        app = FastAPI()
-        app.include_router(router)
 
         mock_client = MagicMock()
         resp = MagicMock()
@@ -438,30 +482,22 @@ class TestTTSRoute:
         mock_client.synthesize_speech.return_value = resp
         mock_get_client.return_value = mock_client
 
-        client = TestClient(app)
+        client = TestClient(_make_tts_test_app())
         response = client.post("/api/tts/synthesize", json={"text": "你好世界"})
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("audio/")
 
     def test_synthesize_rejects_empty_text(self):
         from fastapi.testclient import TestClient
-        from app.routes.tts import router
-        from fastapi import FastAPI
-        app = FastAPI()
-        app.include_router(router)
 
-        client = TestClient(app)
+        client = TestClient(_make_tts_test_app())
         response = client.post("/api/tts/synthesize", json={"text": ""})
         assert response.status_code == 422  # validation error
 
     def test_synthesize_rejects_too_long_text(self):
         from fastapi.testclient import TestClient
-        from app.routes.tts import router
-        from fastapi import FastAPI
-        app = FastAPI()
-        app.include_router(router)
 
-        client = TestClient(app)
+        client = TestClient(_make_tts_test_app())
         long_text = "你" * 5001
         response = client.post("/api/tts/synthesize", json={"text": long_text})
         assert response.status_code == 422
@@ -851,11 +887,7 @@ class TestRegenerateEndpoint:
     """POST /api/tts/regenerate must delete cache and re-synthesise."""
 
     def _make_app(self):
-        from fastapi import FastAPI
-        from app.routes.tts import router
-        app = FastAPI()
-        app.include_router(router)
-        return app
+        return _make_tts_test_app()
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -1,6 +1,19 @@
 import { useState, useRef, useCallback } from 'react';
 import { cancelTts, cleanForTts, pauseCurrentTts, resumeCurrentTts, speakTextWithProgress, TtsProgressInfo } from '../services/ttsApi';
 
+// Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
+const _TTS_TOKEN_KEY = 'lingoleap_token';
+
+/** Read JWT token from localStorage and return Authorization header if present. */
+function _ttsAuthHeaders(): Record<string, string> {
+  try {
+    const token = localStorage.getItem(_TTS_TOKEN_KEY);
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  } catch {
+    return {};
+  }
+}
+
 /**
  * Manages TTS (Text-to-Speech) audio playback for LiveTutor.
  *
@@ -154,7 +167,7 @@ export function useTtsPlayback(
     // Try Cloud TTS first via <audio> element for better control
     fetch(`${API_BASE}/api/tts/synthesize`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._ttsAuthHeaders() },
       body: JSON.stringify({ text }),
     })
       .then((res) => {

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -16,6 +16,24 @@
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
+// Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
+const TOKEN_KEY = 'lingoleap_token';
+
+/** Read the JWT token from localStorage (same source as AuthContext). */
+function _getAuthToken(): string | null {
+  try {
+    return localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Build Authorization header if a token is available. */
+function _authHeaders(): Record<string, string> {
+  const token = _getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 // In-memory URL cache: sentence text → blob URL.
 // Avoids re-fetching the same sentence audio.
 // Blob URLs are released when the page unloads.
@@ -241,7 +259,7 @@ async function _fetchAudioUrl(sentence: string): Promise<string> {
   if (!audioUrl) {
     const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ text: sentence }),
     });
 


### PR DESCRIPTION
Fixes #1240

## 問題
三個 TTS endpoint 完全無 auth，匿名攻擊者可：
1. 對 /regenerate 送 2413 個句子 → 刪 GCS 快取 + 洗爆 Azure/GCP TTS 帳單
2. 對 /synthesize 送 5000 字 payload 洗帳單

## 變更

### Backend
- `POST /api/tts/synthesize` — 加 `Depends(get_current_user)`（任何登入用戶）
- `POST /api/tts/synthesize-sentence` — 加 `Depends(get_current_user)`（任何登入用戶）
- `POST /api/tts/regenerate` — 加 `require_role("system_admin")`（刪快取需 admin）

### Frontend
- `ttsApi.ts` — `_fetchAudioUrl()` 加 `Authorization: Bearer <token>`（從 localStorage 讀）
- `useTtsPlayback.ts` — single-shot fetch path 加 `Authorization: Bearer <token>`

### Tests
- `test_tts_auth.py`（新增）— 7 個 TDD 測試全過
  - 未登入 → 401（3 endpoints）
  - 非 admin 打 /regenerate → 403
  - system_admin 打 /regenerate → 200
- `test_tts_service.py` — 更新 legacy tests 的 mini-app 繞過 auth dependency

## 前端 token 驗證
前端確認：`ttsApi.ts` 和 `useTtsPlayback.ts` 都從 `localStorage['lingoleap_token']` 讀 token（與 AuthContext 同一個 key），不會 break 朗讀功能。

## Test Results
```
tests/test_tts_auth.py ............. 7 passed
tests/test_tts_service.py .......... 63 passed (70 total)
curl /api/tts/synthesize (no token): 401
curl /api/tts/synthesize-sentence (no token): 401
curl /api/tts/regenerate (no token): 401
```