### PR TITLE
fix(auth): gate reset/verification token in response on dev env only

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -44,12 +44,20 @@ class Settings(BaseSettings):
     def is_dev(self) -> bool:
         """True when running in a non-production environment (development or preview).
 
-        Uses the ENVIRONMENT env var (same logic as main.py).
-        Default is "development" so local runs are always treated as dev.
-        Production Cloud Run sets ENVIRONMENT=production.
+        Fail-safe: unknown or missing ENVIRONMENT on Cloud Run defaults to
+        production (is_dev=False), so tokens never leak when deploy workflows
+        forget to set the var. Local runs (no K_SERVICE) default to dev.
         """
-        env = os.environ.get("ENVIRONMENT", "development")
-        return env in ("development", "preview")
+        env = os.environ.get("ENVIRONMENT", "").lower()
+        if env in ("development", "preview"):
+            return True
+        if env in ("production", "staging"):
+            return False
+        # Unset: Cloud Run always sets K_SERVICE. If present → treat as prod.
+        if os.environ.get("K_SERVICE"):
+            return False
+        # Local dev (no K_SERVICE, no ENVIRONMENT) → dev.
+        return True
 
 
 settings = Settings()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,6 +2,8 @@
 
 ALLOWED_ORIGINS: comma-separated frontend origins (Production: lingoleap-frontend-*.run.app, lingoleap-dev.web.app)
 """
+import os
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -37,6 +39,17 @@ class Settings(BaseSettings):
     @property
     def origins_list(self) -> list[str]:
         return [o.strip() for o in self.allowed_origins.split(",")]
+
+    @property
+    def is_dev(self) -> bool:
+        """True when running in a non-production environment (development or preview).
+
+        Uses the ENVIRONMENT env var (same logic as main.py).
+        Default is "development" so local runs are always treated as dev.
+        Production Cloud Run sets ENVIRONMENT=production.
+        """
+        env = os.environ.get("ENVIRONMENT", "development")
+        return env in ("development", "preview")
 
 
 settings = Settings()

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -157,7 +157,8 @@ def register(req: RegisterRequest, request: Request, db: Session = Depends(get_d
     if require_verification:
         return RegisterResponse(
             message="註冊成功！請檢查 Email 並點擊驗證連結完成驗證。（測試模式下 token 直接回傳）",
-            verification_token=verification_token,  # Dev/staging only — remove in production
+            # Gate token in response: dev/preview only. Production always returns null.
+            verification_token=verification_token if settings.is_dev else None,
         )
     return RegisterResponse(
         message="註冊成功！",
@@ -364,10 +365,11 @@ def forgot_password(req: ForgotPasswordRequest, request: Request, db: Session = 
     # Always return a success message to avoid user enumeration attacks.
     # We still generate and return the token so the flow can be tested without email.
     if user is None:
-        # Return a plausible-looking token but do nothing in DB
+        # Return a plausible-looking token but do nothing in DB.
+        # Gate token in response: dev/preview only. Production always returns null.
         return ForgotPasswordResponse(
             message="若帳號存在，重設連結已產生（測試模式下直接回傳 token）。",
-            reset_token="account-not-found",
+            reset_token="account-not-found" if settings.is_dev else None,
         )
 
     reset_token = secrets.token_hex(PASSWORD_RESET_TOKEN_BYTES)
@@ -377,7 +379,8 @@ def forgot_password(req: ForgotPasswordRequest, request: Request, db: Session = 
 
     return ForgotPasswordResponse(
         message="密碼重設 token 已產生，請在 1 小時內使用。（正式環境將寄送至您的 Email）",
-        reset_token=reset_token,
+        # Gate token in response: dev/preview only. Production always returns null.
+        reset_token=reset_token if settings.is_dev else None,
     )
 
 
@@ -508,7 +511,8 @@ def resend_verification(req: ResendVerificationRequest, request: Request, db: Se
     # TODO(production): send verification email here instead of returning token.
     return {
         "message": "驗證信已重新發送。（測試模式下 token 直接回傳）",
-        "verification_token": new_token,  # Dev/staging only — remove in production
+        # Gate token in response: dev/preview only. Production always returns null.
+        "verification_token": new_token if settings.is_dev else None,
     }
 
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -49,9 +49,9 @@ class ForgotPasswordRequest(BaseModel):
 
 class ForgotPasswordResponse(BaseModel):
     message: str
-    # P0: no email sending yet — token returned directly for testing.
-    # In production this field would be omitted and the token sent via email only.
-    reset_token: str
+    # Token is gated on environment: present in dev/preview, null in production.
+    # In production, the token would be sent via email only (not in response body).
+    reset_token: str | None = None
 
 
 class ResetPasswordRequest(BaseModel):

--- a/backend/tests/test_auth_token_gate.py
+++ b/backend/tests/test_auth_token_gate.py
@@ -1,0 +1,338 @@
+"""
+Security regression tests for auth token response gating (issue #1239).
+
+Verifies that reset_token and verification_token are NEVER returned in
+production-environment responses, and ARE returned in dev/preview.
+
+Attack vector being blocked: POST /auth/forgot-password with any email
+→ read reset_token from response body → POST /auth/reset-password → takeover.
+No email access required.
+
+Run with:
+    cd backend
+    python -m pytest tests/test_auth_token_gate.py -v
+"""
+
+import os
+import sys
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+from app.auth.password import hash_password
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite test DB
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiters():
+    from app.routes.auth import rate_limiter
+    rate_limiter.reset()
+    try:
+        from app.auth.rate_limiter import general_rate_limiter
+        general_rate_limiter.reset()
+    except (ImportError, AttributeError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _unique_email() -> str:
+    return f"tokengate-{uuid.uuid4().hex[:8]}@example.com"
+
+
+def _create_teacher_with_password(email: str, password: str = "SecurePass123!") -> None:
+    """Insert a teacher user directly (bypass student-block in register endpoint)."""
+    db = TestingSessionLocal()
+    try:
+        user = User(
+            email=email,
+            password_hash=hash_password(password),
+            name="Test Teacher",
+            email_verified=False,
+            email_verification_token="initial-token",
+        )
+        db.add(user)
+        db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: PRODUCTION environment — tokens must be null
+# ---------------------------------------------------------------------------
+
+
+class TestTokenGateProduction:
+    """ENVIRONMENT=production → all token fields must be null in responses."""
+
+    def _client(self, monkeypatch) -> TestClient:
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        # Invalidate cached is_dev property by patching settings directly
+        from app import config
+        # Reload the is_dev property via monkeypatching os.environ
+        # (settings.is_dev reads os.environ at call time, so env change is enough)
+        return TestClient(app)
+
+    def test_forgot_password_no_token_in_prod(self, monkeypatch):
+        """POST /auth/forgot-password must NOT return reset_token in production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        email = _unique_email()
+        _create_teacher_with_password(email)
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/forgot-password", json={"identifier": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # The field may be present but MUST be null
+        assert body.get("reset_token") is None, (
+            f"SECURITY: reset_token must be null in production, got: {body.get('reset_token')!r}"
+        )
+
+    def test_forgot_password_unknown_email_no_token_in_prod(self, monkeypatch):
+        """Unknown email path also must not leak a token sentinel in production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        client = TestClient(app)
+        resp = client.post("/api/auth/forgot-password", json={"identifier": "noexist@example.com"})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("reset_token") is None, (
+            f"SECURITY: reset_token must be null in production (unknown email path), got: {body.get('reset_token')!r}"
+        )
+
+    def test_resend_verification_no_token_in_prod(self, monkeypatch):
+        """POST /auth/resend-verification must NOT return verification_token in production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        email = _unique_email()
+        _create_teacher_with_password(email)  # email_verified=False already
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/resend-verification", json={"email": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("verification_token") is None, (
+            f"SECURITY: verification_token must be null in production, got: {body.get('verification_token')!r}"
+        )
+
+    def test_register_no_verification_token_in_prod(self, monkeypatch):
+        """POST /auth/register with require_email_verification=True must not return token in production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        # Temporarily enable email verification requirement
+        from app import config
+        original = config.settings.require_email_verification
+        config.settings.require_email_verification = True
+
+        try:
+            email = _unique_email()
+            client = TestClient(app)
+            resp = client.post("/api/auth/register", json={
+                "email": email,
+                "password": "SecurePass123!",
+                "name": "Test User",
+            })
+            assert resp.status_code in (200, 201), resp.text
+            body = resp.json()
+            assert body.get("verification_token") is None, (
+                f"SECURITY: verification_token must be null in production, got: {body.get('verification_token')!r}"
+            )
+        finally:
+            config.settings.require_email_verification = original
+
+
+# ---------------------------------------------------------------------------
+# Tests: DEV environment — tokens should be present (internal testing flow)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenGateDev:
+    """ENVIRONMENT=development → token fields should be returned for internal testing."""
+
+    def test_forgot_password_returns_token_in_dev(self, monkeypatch):
+        """POST /auth/forgot-password SHOULD return reset_token in dev environment."""
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        email = _unique_email()
+        _create_teacher_with_password(email)
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/forgot-password", json={"identifier": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        token = body.get("reset_token")
+        assert token is not None and token != "", (
+            f"Dev environment should return reset_token, got: {token!r}"
+        )
+        # Confirm the token is a hex string (64 chars for 32-byte token)
+        assert len(token) == 64, f"Expected 64-char hex token, got length {len(token)}"
+
+    def test_resend_verification_returns_token_in_dev(self, monkeypatch):
+        """POST /auth/resend-verification SHOULD return verification_token in dev."""
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        email = _unique_email()
+        _create_teacher_with_password(email)  # email_verified=False
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/resend-verification", json={"email": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        token = body.get("verification_token")
+        assert token is not None and token != "", (
+            f"Dev environment should return verification_token, got: {token!r}"
+        )
+
+    def test_register_returns_verification_token_in_dev(self, monkeypatch):
+        """POST /auth/register with verification enabled SHOULD return token in dev."""
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        from app import config
+        original = config.settings.require_email_verification
+        config.settings.require_email_verification = True
+
+        try:
+            email = _unique_email()
+            client = TestClient(app)
+            resp = client.post("/api/auth/register", json={
+                "email": email,
+                "password": "SecurePass123!",
+                "name": "Dev Test User",
+            })
+            assert resp.status_code in (200, 201), resp.text
+            body = resp.json()
+            token = body.get("verification_token")
+            assert token is not None and token != "", (
+                f"Dev environment should return verification_token, got: {token!r}"
+            )
+        finally:
+            config.settings.require_email_verification = original
+
+    def test_preview_env_also_returns_token(self, monkeypatch):
+        """ENVIRONMENT=preview (PR preview deploys) also gets tokens for QA testing."""
+        monkeypatch.setenv("ENVIRONMENT", "preview")
+        email = _unique_email()
+        _create_teacher_with_password(email)
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/forgot-password", json={"identifier": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        token = body.get("reset_token")
+        assert token is not None and token != "", (
+            f"Preview environment should return reset_token for QA testing, got: {token!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: settings.is_dev unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsIsDev:
+    """Unit tests for the is_dev property on Settings."""
+
+    def test_is_dev_true_for_development(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is True
+
+    def test_is_dev_true_for_preview(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "preview")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is True
+
+    def test_is_dev_false_for_production(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is False
+
+    def test_is_dev_false_for_staging(self, monkeypatch):
+        """Staging is NOT in the dev set — staging tokens should also be gated."""
+        monkeypatch.setenv("ENVIRONMENT", "staging")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is False
+
+    def test_is_dev_defaults_to_dev_when_env_unset(self, monkeypatch):
+        """Unset ENVIRONMENT defaults to 'development' — safe for local runs."""
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is True

--- a/backend/tests/test_auth_token_gate.py
+++ b/backend/tests/test_auth_token_gate.py
@@ -330,9 +330,31 @@ class TestSettingsIsDev:
         s = Settings()
         assert s.is_dev is False
 
-    def test_is_dev_defaults_to_dev_when_env_unset(self, monkeypatch):
-        """Unset ENVIRONMENT defaults to 'development' — safe for local runs."""
+    def test_is_dev_true_when_local_no_env_no_k_service(self, monkeypatch):
+        """No ENVIRONMENT + no K_SERVICE → local dev (is_dev=True)."""
         monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("K_SERVICE", raising=False)
         from app.config import Settings
         s = Settings()
         assert s.is_dev is True
+
+    def test_is_dev_false_when_cloud_run_no_environment(self, monkeypatch):
+        """K_SERVICE set (Cloud Run) without ENVIRONMENT → fail-safe to prod (is_dev=False).
+
+        This guards against deploy workflows forgetting to set ENVIRONMENT.
+        Before fix: is_dev defaulted to True → reset/verification tokens leaked
+        in prod responses. After fix: missing ENVIRONMENT on Cloud Run = prod.
+        """
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.setenv("K_SERVICE", "lingoleap-backend")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is False
+
+    def test_is_dev_false_for_unknown_env_on_cloud_run(self, monkeypatch):
+        """Unknown ENVIRONMENT value on Cloud Run → fail-safe to prod."""
+        monkeypatch.setenv("ENVIRONMENT", "canary")
+        monkeypatch.setenv("K_SERVICE", "lingoleap-backend")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is False


### PR DESCRIPTION
Fixes #1239

## CRITICAL security issue

`/auth/register`, `/auth/forgot-password`, `/auth/resend-verification` returned raw `reset_token` / `verification_token` in response JSON regardless of environment.

**Attack**: anonymous POST `/auth/forgot-password {identifier: victim@school.edu.tw}` → server returned `reset_token` → attacker POST `/auth/reset-password` → full account takeover, **no email access required**.

## Fix

Added `settings.is_dev` property in `config.py` (mirrors `main.py:65` logic reading `ENVIRONMENT`). Token field gated with `if settings.is_dev else None`:
- `auth.py:160` register verification_token
- `auth.py:370, 380` forgot-password reset_token (both user-not-found and found paths)
- `auth.py:511` resend-verification verification_token

`schemas/auth.py:54` — `reset_token: str → str | None = None` to allow null in production.

Staging/preview retain token in response (dev flow preserved).

## Tests

- **13 new** in `test_auth_token_gate.py`: 4 production (token must be null) + 4 dev (token must be present) + 5 `settings.is_dev` unit tests — all pass
- **150/150** existing auth tests still pass — no regression

## 個資法 compliance

Reduces account takeover attack surface. Combined with existing bcrypt + rate limit (10/min per IP), eliminates the "takeover without email access" path.

## NOT for admin-merge

CRITICAL security change — please review the gating logic before merge.