### PR TITLE
fix(learning-history): 作業紀錄顯示不出來 + 字太小 + 得分不一致 (Fixes #1245)

### DIFF
--- a/backend/app/routes/learning/learning_sessions.py
+++ b/backend/app/routes/learning/learning_sessions.py
@@ -178,42 +178,96 @@ def list_my_sessions(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List learning sessions for the authenticated student, newest first."""
-    assignment_session_ids_query = (
-        db.query(AssignmentSubmission.session_id)
+    """List learning sessions for the authenticated student, newest first.
+
+    For assignment sessions, "completed" status is determined by the linked
+    AssignmentSubmission.status being 'submitted' or 'graded' — NOT by
+    LearningSession.status — because submit_assignment() does not update the
+    session status to 'completed' (only process_session_completion() does).
+    Issue #1245: this mismatch caused assignment sessions to never appear in
+    the learning history page when filtering by status=completed.
+    """
+    # Fetch all assignment submissions for this student to build two maps:
+    # 1. session_id → submission_status (for assignment "completion" logic)
+    # 2. assignment_session_ids set (for _is_assignment_session checks)
+    submission_rows = (
+        db.query(AssignmentSubmission.session_id, AssignmentSubmission.status)
         .filter(
             AssignmentSubmission.student_id == current_user.id,
             AssignmentSubmission.session_id.is_not(None),
         )
+        .all()
     )
+    assignment_session_ids: set[int] = set()
+    # Maps session_id → submission status ('pending','in_progress','submitted','graded')
+    assignment_submission_status: dict[int, str] = {}
+    for sid, sub_status in submission_rows:
+        if sid is not None:
+            assignment_session_ids.add(sid)
+            assignment_submission_status[sid] = sub_status
+
+    # Whether the caller wants "completed" sessions (includes assignment-submitted ones)
+    statuses: list[str] = []
+    wants_completed = False
+    if status:
+        statuses = [s.strip() for s in status.split(",") if s.strip()]
+        wants_completed = "completed" in statuses
 
     query = db.query(LearningSession).filter(
         LearningSession.student_id == current_user.id,
     )
 
-    if status:
-        statuses = [s.strip() for s in status.split(",") if s.strip()]
-        if statuses:
-            query = query.filter(LearningSession.status.in_(statuses))
     if story_slug:
         query = query.filter(LearningSession.story_slug == normalize_story_slug(story_slug))
+
+    # For self-practice sessions, apply the LearningSession.status filter directly.
+    # For assignment sessions we apply a custom "completed" definition below.
+    # When learning_source=assignment, omit the LearningSession.status filter so
+    # we can include sessions that are 'in_progress' on LearningSession but
+    # 'submitted'/'graded' on AssignmentSubmission.
+    if statuses and learning_source != "assignment":
+        query = query.filter(LearningSession.status.in_(statuses))
 
     all_items = (
         query
         .order_by(LearningSession.started_at.desc())
         .all()
     )
-    assignment_session_ids = {
-        sid for (sid,) in assignment_session_ids_query.all() if sid is not None
-    }
 
     filtered_items: list[LearningSession] = []
     for s in all_items:
         is_assignment = _is_assignment_session(s, assignment_session_ids)
+
+        # --- source filter ---
         if learning_source == "assignment" and not is_assignment:
             continue
         if learning_source == "self" and is_assignment:
             continue
+
+        # --- status filter (assignment-aware) ---
+        if statuses:
+            if is_assignment:
+                # For assignment sessions, "completed" means the submission is
+                # submitted or graded (LearningSession.status may still be
+                # 'in_progress' because submit_assignment() does not update it).
+                sub_status = assignment_submission_status.get(s.id, "")
+                is_submission_done = sub_status in ("submitted", "graded")
+                if wants_completed:
+                    # Keep if session is completed OR submission is done
+                    session_complete = s.status == "completed"
+                    if not session_complete and not is_submission_done:
+                        continue
+                else:
+                    # For non-"completed" status filters, apply session status directly
+                    if s.status not in statuses:
+                        continue
+            else:
+                # Self-practice: already filtered by DB query above (when
+                # learning_source != 'assignment'). When no source filter is set
+                # we need to apply the status filter in Python.
+                if learning_source is None and s.status not in statuses:
+                    continue
+
         filtered_items.append(s)
 
     total = len(filtered_items)

--- a/frontend/src/pages/student/LearningHistoryPage.tsx
+++ b/frontend/src/pages/student/LearningHistoryPage.tsx
@@ -67,6 +67,8 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
   // All completed sessions have all steps done
   const allStepIds = useMemo(() => new Set(ACTIVE_STEPS.map((s) => s.id)), []);
 
+  // Issue #1245: unified score display — prefer overall_score, fallback to accuracy,
+  // show explicit "—" rather than empty when both are null.
   const score =
     session.overall_score != null
       ? Math.round(session.overall_score)
@@ -77,13 +79,28 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
       ? Math.round(session.accuracy * 100)
       : null;
 
+  // Unified display value: overall_score → accuracy → null (show "進行中")
+  const scoreDisplay: string | null =
+    score != null
+      ? `${score}%`
+      : accuracy != null
+        ? `${accuracy}%`
+        : null;
+
+  const scoreLabel: string =
+    score != null
+      ? '得分'
+      : accuracy != null
+        ? '準確率'
+        : '';
+
   return (
     <div className="bg-white rounded-2xl shadow-card p-4">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          {/* Title + status */}
+          {/* Title + status — enlarged to text-base to match /student and /assignments/my */}
           <div className="flex items-center gap-2 flex-wrap">
-            <h3 className="text-sm font-medium text-gray-900 truncate">
+            <h3 className="text-base font-medium text-gray-900 truncate">
               {session.story_title ?? session.story_slug ?? '未知課文'}
             </h3>
             <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
@@ -91,14 +108,13 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
             </span>
           </div>
 
-          {/* Metadata row */}
+          {/* Metadata row — enlarged date to text-sm, score always visible */}
           <div className="flex items-center gap-3 mt-2 flex-wrap">
-            <span className="text-xs text-gray-400">{formatDate(session.started_at)}</span>
-            {score != null && (
-              <span className="text-xs font-medium text-gray-700">得分：{score}%</span>
-            )}
-            {accuracy != null && score == null && (
-              <span className="text-xs text-gray-500">準確率：{accuracy}%</span>
+            <span className="text-sm text-gray-400">{formatDate(session.started_at)}</span>
+            {scoreDisplay != null ? (
+              <span className="text-sm font-medium text-gray-700">{scoreLabel}：{scoreDisplay}</span>
+            ) : (
+              <span className="text-sm text-gray-400">—</span>
             )}
           </div>
 
@@ -106,8 +122,8 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
           {ACTIVE_STEPS.length > 0 && (
             <div className="mt-2.5">
               <div className="flex items-center justify-between mb-1">
-                <p className="text-[11px] text-gray-500">學習關卡進度</p>
-                <p className="text-[11px] text-gray-400">
+                <p className="text-xs text-gray-500">學習關卡進度</p>
+                <p className="text-xs text-gray-400">
                   {ACTIVE_STEPS.length}/{ACTIVE_STEPS.length}
                 </p>
               </div>
@@ -122,7 +138,7 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
         {/* Read-only action */}
         <button
           onClick={() => navigate(`/sessions/${session.id}/report`)}
-          className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-xs font-medium hover:bg-gray-50 transition-colors cursor-pointer shrink-0"
+          className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer shrink-0"
         >
           查看
         </button>
@@ -228,7 +244,7 @@ const TabContent: React.FC<{ source: TabKey }> = ({ source }) => {
     <div className="space-y-6">
       {groups.map((group) => (
         <div key={group.label}>
-          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2">
+          <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-2">
             {group.label}
           </h3>
           <div className="space-y-3">
@@ -266,7 +282,7 @@ const LearningHistoryPage: React.FC = () => {
       <div className="max-w-2xl mx-auto space-y-4">
         <div>
           <h1 className="text-base font-bold text-gray-900">學習紀錄</h1>
-          <p className="text-xs text-gray-500 mt-0.5">回顧過去的學習練習</p>
+          <p className="text-sm text-gray-500 mt-0.5">回顧過去的學習練習</p>
         </div>
 
         {/* Tabs */}
@@ -276,7 +292,7 @@ const LearningHistoryPage: React.FC = () => {
               <button
                 key={tab.key}
                 onClick={() => setActiveTab(tab.key)}
-                className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer ${
+                className={`px-3 py-1.5 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
                   activeTab === tab.key
                     ? 'border-accent text-accent'
                     : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'

--- a/frontend/src/pages/student/SessionHistoryReportPage.tsx
+++ b/frontend/src/pages/student/SessionHistoryReportPage.tsx
@@ -394,8 +394,9 @@ const StepRecordsView: React.FC<{
 
   if (!hasAny) {
     return (
-      <div className="text-center py-12">
-        <p className="text-sm text-gray-500">這筆紀錄沒有儲存作答內容</p>
+      <div className="text-center py-12 space-y-2">
+        <p className="text-sm font-medium text-gray-600">尚無作答紀錄</p>
+        <p className="text-sm text-gray-400">這次學習的作答詳情未儲存，可能是較舊的紀錄或尚未完成所有步驟</p>
       </div>
     );
   }


### PR DESCRIPTION
Fixes #1245

## 根因分析

### 問題 #3（最關鍵）— 作業紀錄全空白

**根因**：`list_my_sessions` 用 `LearningSession.status = 'completed'` 過濾，但 `submit_assignment()` 只把 `AssignmentSubmission.status` 設為 `submitted`，**不更新 `LearningSession.status`**。

結果：所有透過作業流程完成的 session，`LearningSession.status` 還是 `in_progress`，被 `status=completed` 過濾掉，永遠查不到。

班級儀表板查的是 `AssignmentSubmission` 表（`getMyAssignments`），不受影響，所以班級儀表板看得到，但 `/learning-history` 查不到。

**修法**：`learning_source=assignment` 時，跳過 `LearningSession.status` 的 DB filter，改在 Python 層判斷：session 本身是 `completed` OR 對應的 `AssignmentSubmission.status` 是 `submitted/graded`，兩者擇一即可。

## 變更摘要

### Backend (`learning_sessions.py`)
- `list_my_sessions`: `learning_source=assignment` 時改用 assignment-aware status 判斷，不再純靠 `LearningSession.status`
- 同時拿 `AssignmentSubmission.session_id` 和 `status`，建立 `assignment_submission_status` dict

### Frontend (`LearningHistoryPage.tsx`)
- 問題 #1（字太小）：card 標題 `text-sm → text-base`，metadata/tab/月份標題 `text-xs → text-sm`，查看按鈕 `text-xs → text-sm`
- 問題 #2（得分不一致）：統一顯示邏輯 — `overall_score` 優先，fallback `accuracy`，兩者皆 null 顯示「—」，不再空白

### Frontend (`SessionHistoryReportPage.tsx`)
- 問題 #4（學習報告作答紀錄空）：empty state 改為「尚無作答紀錄」+ 說明文字，不再只是灰字一行

## 測試步驟

1. 學生帳號登入 `/learning-history`
2. 確認「作業回顧」tab 顯示已完成的作業 session（之前全空）
3. 確認字級比之前大（card 標題用 `text-base`，metadata 用 `text-sm`）
4. 確認每筆紀錄的得分欄位：有分數顯示分數，null 顯示「—」，不再空白
5. 點「查看」進入 session 報告，作答紀錄 tab 若無資料顯示友善說明文字

## API 行為對比

| | 修復前 | 修復後 |
|---|---|---|
| `GET /api/learning/sessions?learning_source=assignment&status=completed` | 回傳 0 筆（因為 submit_assignment 不更新 session status） | 正確回傳已繳交的 assignment sessions |