### PR TITLE
release: 4 security/bug fixes (#1242 #1244 #1246 #1250)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,6 +2,8 @@
 
 ALLOWED_ORIGINS: comma-separated frontend origins (Production: lingoleap-frontend-*.run.app, lingoleap-dev.web.app)
 """
+import os
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -37,6 +39,25 @@ class Settings(BaseSettings):
     @property
     def origins_list(self) -> list[str]:
         return [o.strip() for o in self.allowed_origins.split(",")]
+
+    @property
+    def is_dev(self) -> bool:
+        """True when running in a non-production environment (development or preview).
+
+        Fail-safe: unknown or missing ENVIRONMENT on Cloud Run defaults to
+        production (is_dev=False), so tokens never leak when deploy workflows
+        forget to set the var. Local runs (no K_SERVICE) default to dev.
+        """
+        env = os.environ.get("ENVIRONMENT", "").lower()
+        if env in ("development", "preview"):
+            return True
+        if env in ("production", "staging"):
+            return False
+        # Unset: Cloud Run always sets K_SERVICE. If present → treat as prod.
+        if os.environ.get("K_SERVICE"):
+            return False
+        # Local dev (no K_SERVICE, no ENVIRONMENT) → dev.
+        return True
 
 
 settings = Settings()

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -157,7 +157,8 @@ def register(req: RegisterRequest, request: Request, db: Session = Depends(get_d
     if require_verification:
         return RegisterResponse(
             message="註冊成功！請檢查 Email 並點擊驗證連結完成驗證。（測試模式下 token 直接回傳）",
-            verification_token=verification_token,  # Dev/staging only — remove in production
+            # Gate token in response: dev/preview only. Production always returns null.
+            verification_token=verification_token if settings.is_dev else None,
         )
     return RegisterResponse(
         message="註冊成功！",
@@ -364,10 +365,11 @@ def forgot_password(req: ForgotPasswordRequest, request: Request, db: Session = 
     # Always return a success message to avoid user enumeration attacks.
     # We still generate and return the token so the flow can be tested without email.
     if user is None:
-        # Return a plausible-looking token but do nothing in DB
+        # Return a plausible-looking token but do nothing in DB.
+        # Gate token in response: dev/preview only. Production always returns null.
         return ForgotPasswordResponse(
             message="若帳號存在，重設連結已產生（測試模式下直接回傳 token）。",
-            reset_token="account-not-found",
+            reset_token="account-not-found" if settings.is_dev else None,
         )
 
     reset_token = secrets.token_hex(PASSWORD_RESET_TOKEN_BYTES)
@@ -377,7 +379,8 @@ def forgot_password(req: ForgotPasswordRequest, request: Request, db: Session = 
 
     return ForgotPasswordResponse(
         message="密碼重設 token 已產生，請在 1 小時內使用。（正式環境將寄送至您的 Email）",
-        reset_token=reset_token,
+        # Gate token in response: dev/preview only. Production always returns null.
+        reset_token=reset_token if settings.is_dev else None,
     )
 
 
@@ -508,7 +511,8 @@ def resend_verification(req: ResendVerificationRequest, request: Request, db: Se
     # TODO(production): send verification email here instead of returning token.
     return {
         "message": "驗證信已重新發送。（測試模式下 token 直接回傳）",
-        "verification_token": new_token,  # Dev/staging only — remove in production
+        # Gate token in response: dev/preview only. Production always returns null.
+        "verification_token": new_token if settings.is_dev else None,
     }
 
 

--- a/backend/app/routes/feedback.py
+++ b/backend/app/routes/feedback.py
@@ -11,10 +11,11 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
-from ..auth.dependencies import get_current_user, require_role
+from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
 from ..database import get_db
+from ..dependencies.tenant import is_system_admin
 from ..models.feedback import Feedback
-from ..models.user import User
+from ..models.user import User, UserRole
 from ..schemas.feedback import (
     FeedbackCreateRequest,
     FeedbackListResponse,
@@ -69,6 +70,37 @@ def submit_feedback(
     return _feedback_to_response(feedback)
 
 
+def _get_feedback_org_scope_filter(current_user: User, db: Session):
+    """Return a SQLAlchemy filter to scope feedback to the caller's org(s).
+
+    system_admin: no filter (sees all feedback).
+    org_admin / org_owner: sees only feedback submitted by users who belong
+      to one of the caller's org scope(s).
+
+    Feedback has no direct org FK, so we join via the submitter's UserRole.
+    """
+    if is_system_admin(current_user):
+        return None  # no restriction
+
+    caller_org_ids = get_user_org_ids(current_user) or []
+    if not caller_org_ids:
+        # org_admin with no org scope → sees nothing
+        return Feedback.id.in_([])
+
+    # Subquery: user_ids whose org scope overlaps with caller's orgs.
+    # Use .scalar_subquery() to avoid SAWarning when used inside .in_().
+    submitter_ids_subq = (
+        db.query(UserRole.user_id)
+        .filter(
+            UserRole.is_active == True,
+            UserRole.scope_type == "organization",
+            UserRole.scope_id.in_(caller_org_ids),
+        )
+        .scalar_subquery()
+    )
+    return Feedback.user_id.in_(submitter_ids_subq)
+
+
 @router.get(
     "/feedback",
     response_model=FeedbackListResponse,
@@ -79,10 +111,21 @@ def list_feedback(
     page_size: int = Query(20, ge=1, le=100),
     category: str | None = Query(None),
     status_filter: str | None = Query(None, alias="status"),
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> FeedbackListResponse:
-    """List all feedback entries. Admin only, with optional filters and pagination."""
+    """List feedback entries. Admin only, paginated.
+
+    system_admin sees all feedback on the platform.
+    org_admin / org_owner see only feedback from users within their org(s) —
+    enforcing 個資法 §20.
+    """
     query = db.query(Feedback)
+
+    # Org scope restriction
+    org_filter = _get_feedback_org_scope_filter(current_user, db)
+    if org_filter is not None:
+        query = query.filter(org_filter)
 
     if category:
         query = query.filter(Feedback.category == category)
@@ -113,15 +156,47 @@ def list_feedback(
 def update_feedback_status(
     feedback_id: int,
     body: FeedbackStatusUpdateRequest,
+    current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> FeedbackResponse:
-    """Update the status of a feedback entry. Admin only."""
+    """Update the status of a feedback entry. Admin only.
+
+    system_admin may update any feedback.
+    org_admin / org_owner may only update feedback from users in their org(s) —
+    enforcing 個資法 §20.
+    """
     feedback = db.query(Feedback).filter(Feedback.id == feedback_id).first()
     if not feedback:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Feedback #{feedback_id} not found",
         )
+
+    # Scope check: org_admin may only modify feedback from their org's users
+    if not is_system_admin(current_user):
+        caller_org_ids = set(get_user_org_ids(current_user) or [])
+        if caller_org_ids:
+            # Check if the feedback submitter belongs to any of caller's orgs
+            submitter_in_org = (
+                db.query(UserRole)
+                .filter(
+                    UserRole.user_id == feedback.user_id,
+                    UserRole.is_active == True,
+                    UserRole.scope_type == "organization",
+                    UserRole.scope_id.in_(caller_org_ids),
+                )
+                .first()
+            )
+            if not submitter_in_org:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Not authorized to modify this feedback",
+                )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not authorized to modify this feedback",
+            )
 
     feedback.status = body.status  # type: ignore[assignment]
     db.commit()

--- a/backend/app/routes/gamification.py
+++ b/backend/app/routes/gamification.py
@@ -12,12 +12,13 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
-from ..auth.dependencies import get_current_user
+from ..auth.dependencies import get_current_user, get_user_org_ids
 from ..database import get_db
-from ..models.school import Classroom, ClassroomStudent
-from ..models.user import User
+from ..dependencies.tenant import is_system_admin
+from ..models.school import Classroom, ClassroomStudent, School
+from ..models.user import User, UserRole
 from ..services.gamification_service import (
     award_xp,
     get_classroom_leaderboard,
@@ -53,14 +54,40 @@ class SessionCompleteRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _get_user_org_ids_from_db(user_id: int, db: Session) -> set[str]:
+    """Return the set of org scope_ids for a given user (loaded from DB).
+
+    Used to resolve the org(s) a student belongs to without relying on
+    eagerly-loaded relationships.
+    """
+    rows = (
+        db.query(UserRole.scope_id)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.is_active == True,
+            UserRole.scope_type == "organization",
+            UserRole.scope_id.isnot(None),
+        )
+        .all()
+    )
+    return {r.scope_id for r in rows}
+
+
 def _assert_can_view(current_user: User, student_id: int, db: Session) -> None:
-    """Raise 403 if the current user is neither the student nor a teacher/admin."""
+    """Raise 403 if the current user cannot view the given student's gamification data.
+
+    Access is granted when the caller is:
+    - The student themselves
+    - A teacher who has the student in one of their classrooms
+    - system_admin (bypasses all scope checks)
+    - org_admin / org_owner scoped to an org that the student also belongs to
+
+    Cross-org access by org_admin is explicitly denied (個資法 §20).
+    """
     if current_user.id == student_id:
         return  # viewing own data
 
-    # Check if current user is a teacher who has this student
-    from ..models.school import ClassroomStudent, Classroom
-
+    # Teacher check: caller teaches a classroom that contains the student
     is_teacher = (
         db.query(Classroom)
         .join(ClassroomStudent, ClassroomStudent.classroom_id == Classroom.id)
@@ -74,19 +101,16 @@ def _assert_can_view(current_user: User, student_id: int, db: Session) -> None:
     if is_teacher:
         return
 
-    # Check admin roles — joinedload(UserRole.role) avoids N lazy fetches per role row
-    from ..models.user import UserRole
-    admin_roles = {"system_admin", "org_admin", "org_owner"}
-    user_role_names = {
-        ur.role.name
-        for ur in db.query(UserRole)
-        .options(joinedload(UserRole.role))
-        .filter(UserRole.user_id == current_user.id, UserRole.is_active == True)
-        .all()
-        if ur.role
-    }
-    if admin_roles & user_role_names:
+    # system_admin bypasses all scope checks
+    if is_system_admin(current_user):
         return
+
+    # org_admin / org_owner: must share at least one org with the student
+    caller_org_ids = set(get_user_org_ids(current_user) or [])
+    if caller_org_ids:
+        student_org_ids = _get_user_org_ids_from_db(student_id, db)
+        if caller_org_ids & student_org_ids:
+            return
 
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
@@ -180,19 +204,24 @@ def get_leaderboard(
         is not None
     )
     if not is_teacher and not is_student:
-        # Check admin roles — joinedload(UserRole.role) avoids N lazy fetches per role row
-        from ..models.user import UserRole
-        admin_roles = {"system_admin", "org_admin", "org_owner"}
-        user_role_names = {
-            ur.role.name
-            for ur in db.query(UserRole)
-            .options(joinedload(UserRole.role))
-            .filter(UserRole.user_id == current_user.id, UserRole.is_active == True)
-            .all()
-            if ur.role
-        }
-        if not (admin_roles & user_role_names):
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+        # system_admin bypasses all scope checks
+        if is_system_admin(current_user):
+            pass  # allowed
+        else:
+            # org_admin / org_owner: classroom's school must belong to caller's org
+            caller_org_ids = set(get_user_org_ids(current_user) or [])
+            if caller_org_ids:
+                school = db.query(School).filter(School.id == classroom.school_id).first()
+                if school and school.organization_id in caller_org_ids:
+                    pass  # allowed
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
+                    )
+            else:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
+                )
 
     entries = get_classroom_leaderboard(db, classroom_id, limit=limit)
     return {

--- a/backend/app/routes/learning/learning_sessions.py
+++ b/backend/app/routes/learning/learning_sessions.py
@@ -178,42 +178,96 @@ def list_my_sessions(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """List learning sessions for the authenticated student, newest first."""
-    assignment_session_ids_query = (
-        db.query(AssignmentSubmission.session_id)
+    """List learning sessions for the authenticated student, newest first.
+
+    For assignment sessions, "completed" status is determined by the linked
+    AssignmentSubmission.status being 'submitted' or 'graded' — NOT by
+    LearningSession.status — because submit_assignment() does not update the
+    session status to 'completed' (only process_session_completion() does).
+    Issue #1245: this mismatch caused assignment sessions to never appear in
+    the learning history page when filtering by status=completed.
+    """
+    # Fetch all assignment submissions for this student to build two maps:
+    # 1. session_id → submission_status (for assignment "completion" logic)
+    # 2. assignment_session_ids set (for _is_assignment_session checks)
+    submission_rows = (
+        db.query(AssignmentSubmission.session_id, AssignmentSubmission.status)
         .filter(
             AssignmentSubmission.student_id == current_user.id,
             AssignmentSubmission.session_id.is_not(None),
         )
+        .all()
     )
+    assignment_session_ids: set[int] = set()
+    # Maps session_id → submission status ('pending','in_progress','submitted','graded')
+    assignment_submission_status: dict[int, str] = {}
+    for sid, sub_status in submission_rows:
+        if sid is not None:
+            assignment_session_ids.add(sid)
+            assignment_submission_status[sid] = sub_status
+
+    # Whether the caller wants "completed" sessions (includes assignment-submitted ones)
+    statuses: list[str] = []
+    wants_completed = False
+    if status:
+        statuses = [s.strip() for s in status.split(",") if s.strip()]
+        wants_completed = "completed" in statuses
 
     query = db.query(LearningSession).filter(
         LearningSession.student_id == current_user.id,
     )
 
-    if status:
-        statuses = [s.strip() for s in status.split(",") if s.strip()]
-        if statuses:
-            query = query.filter(LearningSession.status.in_(statuses))
     if story_slug:
         query = query.filter(LearningSession.story_slug == normalize_story_slug(story_slug))
+
+    # For self-practice sessions, apply the LearningSession.status filter directly.
+    # For assignment sessions we apply a custom "completed" definition below.
+    # When learning_source=assignment, omit the LearningSession.status filter so
+    # we can include sessions that are 'in_progress' on LearningSession but
+    # 'submitted'/'graded' on AssignmentSubmission.
+    if statuses and learning_source != "assignment":
+        query = query.filter(LearningSession.status.in_(statuses))
 
     all_items = (
         query
         .order_by(LearningSession.started_at.desc())
         .all()
     )
-    assignment_session_ids = {
-        sid for (sid,) in assignment_session_ids_query.all() if sid is not None
-    }
 
     filtered_items: list[LearningSession] = []
     for s in all_items:
         is_assignment = _is_assignment_session(s, assignment_session_ids)
+
+        # --- source filter ---
         if learning_source == "assignment" and not is_assignment:
             continue
         if learning_source == "self" and is_assignment:
             continue
+
+        # --- status filter (assignment-aware) ---
+        if statuses:
+            if is_assignment:
+                # For assignment sessions, "completed" means the submission is
+                # submitted or graded (LearningSession.status may still be
+                # 'in_progress' because submit_assignment() does not update it).
+                sub_status = assignment_submission_status.get(s.id, "")
+                is_submission_done = sub_status in ("submitted", "graded")
+                if wants_completed:
+                    # Keep if session is completed OR submission is done
+                    session_complete = s.status == "completed"
+                    if not session_complete and not is_submission_done:
+                        continue
+                else:
+                    # For non-"completed" status filters, apply session status directly
+                    if s.status not in statuses:
+                        continue
+            else:
+                # Self-practice: already filtered by DB query above (when
+                # learning_source != 'assignment'). When no source filter is set
+                # we need to apply the status filter in Python.
+                if learning_source is None and s.status not in statuses:
+                    continue
+
         filtered_items.append(s)
 
     total = len(filtered_items)

--- a/backend/app/routes/tts.py
+++ b/backend/app/routes/tts.py
@@ -30,10 +30,12 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
+from ..auth.dependencies import get_current_user, require_role
+from ..models.user import User
 from ..services.tts_service import (
     TTSError,
     build_lesson_tts_mapping,
@@ -53,14 +55,21 @@ class TTSRequest(BaseModel):
 
 
 @router.post("/synthesize")
-async def synthesize(req: TTSRequest) -> Response:
+async def synthesize(
+    req: TTSRequest,
+    _current_user: User = Depends(get_current_user),
+) -> Response:
     """Synthesise *text* to MP3 audio using Azure TTS (primary) or Cloud TTS (fallback).
+
+    Requires authentication (any active user).  Anonymous requests are rejected
+    with 401 to prevent bill-washing attacks on the Azure/GCP TTS quota.
 
     Runs in a thread pool via asyncio.to_thread() so the FastAPI event loop is
     not blocked during the 8–15 s remote TTS call (Azure / Google / Gemini).
 
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
+        401  application/json — not authenticated.
         503  application/json — TTS unavailable; client should fall back
              to Web Speech API.
     """
@@ -85,8 +94,14 @@ async def synthesize(req: TTSRequest) -> Response:
 
 
 @router.post("/synthesize-sentence")
-async def synthesize_sentence_endpoint(req: TTSRequest) -> Response:
+async def synthesize_sentence_endpoint(
+    req: TTSRequest,
+    _current_user: User = Depends(get_current_user),
+) -> Response:
     """Synthesise a single sentence to MP3 audio (Issue #667).
+
+    Requires authentication (any active user).  Anonymous requests are rejected
+    with 401 to prevent bill-washing attacks via the pre-generated sentence cache.
 
     Stores audio under azure/sentences/ GCS path for sentence-level caching.
     Functionally identical to /synthesize but semantically scoped to sentences.
@@ -94,6 +109,7 @@ async def synthesize_sentence_endpoint(req: TTSRequest) -> Response:
 
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
+        401  application/json — not authenticated.
         503  application/json — TTS unavailable.
     """
     try:
@@ -149,9 +165,13 @@ def get_tts_mapping(lesson_id: int) -> dict:
     return build_lesson_tts_mapping(lesson)
 
 
-@router.post("/regenerate")
+@router.post("/regenerate", dependencies=[require_role("system_admin")])
 async def regenerate(req: TTSRequest) -> dict:
     """Delete cached audio for *text* and re-synthesise from scratch (Issue #765).
+
+    Requires system_admin role.  This endpoint deletes GCS cache objects and
+    triggers a fresh TTS synthesis — exposing it to non-admins would allow any
+    authenticated user to wipe cached audio and exhaust the TTS quota.
 
     Use this endpoint when a specific sentence has a known mispronunciation
     in its cached audio (e.g. wrong tone for 喝采). The endpoint:
@@ -163,6 +183,8 @@ async def regenerate(req: TTSRequest) -> dict:
 
     Returns:
         200  application/json — { "status": "ok", "key": "...", "gcs_deleted": [...], "bytes": N }
+        401  application/json — not authenticated.
+        403  application/json — insufficient permissions (not system_admin).
         503  application/json — TTS unavailable.
     """
     # Step 1: delete existing caches (GCS I/O — run in thread pool)

--- a/backend/app/routes/users.py
+++ b/backend/app/routes/users.py
@@ -6,9 +6,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session, joinedload, selectinload
 
 from ..auth.classroom_check import compute_has_classroom
-from ..auth.dependencies import get_current_user, require_role
+from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
 from ..config import settings
 from ..database import get_db
+from ..dependencies.tenant import is_system_admin
 from ..models.user import User, UserRole, Role
 from ..schemas.user import UserResponse, UserRoleResponse
 from ..schemas.user_admin import (
@@ -180,8 +181,33 @@ def list_users(
     current_user: User = require_role("system_admin", "org_admin"),
     db: Session = Depends(get_db),
 ):
-    """List all users with pagination and optional search. Admin only."""
+    """List users with pagination and optional search.
+
+    system_admin sees all users on the platform.
+    org_admin sees only users whose org-scoped UserRole matches
+    the caller's own org scope(s) — enforcing 個資法 §20.
+    """
     query = db.query(User)
+
+    # Scope restriction: org_admin may only see users within their org(s).
+    # system_admin (get_user_org_ids returns None) skips this filter.
+    if not is_system_admin(current_user):
+        caller_org_ids = get_user_org_ids(current_user)  # list[str], never None here
+        if not caller_org_ids:
+            # org_admin with no org scope → see nothing
+            return UserListResponse(items=[], total=0)
+        # Keep only users who have at least one active org-scoped role
+        # matching one of the caller's orgs.
+        query = query.filter(
+            User.id.in_(
+                db.query(UserRole.user_id)
+                .filter(
+                    UserRole.is_active == True,
+                    UserRole.scope_type == "organization",
+                    UserRole.scope_id.in_(caller_org_ids),
+                )
+            )
+        )
 
     if search:
         pattern = f"%{search}%"
@@ -222,7 +248,12 @@ def get_user_detail(
     current_user: User = require_role("system_admin", "org_admin"),
     db: Session = Depends(get_db),
 ):
-    """Get full user detail by ID. Admin only."""
+    """Get full user detail by ID.
+
+    system_admin may read any user.
+    org_admin may only read users who belong to the same org scope —
+    enforcing 個資法 §20 (cross-org reads → 403).
+    """
     user = (
         db.query(User)
         .options(
@@ -233,6 +264,20 @@ def get_user_detail(
     )
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
+
+    # Scope check for org_admin: target user must share at least one org with caller.
+    if not is_system_admin(current_user):
+        caller_org_ids = set(get_user_org_ids(current_user) or [])
+        target_org_ids = {
+            ur.scope_id
+            for ur in user.user_roles
+            if ur.is_active and ur.scope_type == "organization" and ur.scope_id
+        }
+        if not (caller_org_ids & target_org_ids):
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to view this user",
+            )
 
     return UserDetailResponse(
         id=user.id,

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -49,9 +49,9 @@ class ForgotPasswordRequest(BaseModel):
 
 class ForgotPasswordResponse(BaseModel):
     message: str
-    # P0: no email sending yet — token returned directly for testing.
-    # In production this field would be omitted and the token sent via email only.
-    reset_token: str
+    # Token is gated on environment: present in dev/preview, null in production.
+    # In production, the token would be sent via email only (not in response body).
+    reset_token: str | None = None
 
 
 class ResetPasswordRequest(BaseModel):

--- a/backend/tests/test_auth_token_gate.py
+++ b/backend/tests/test_auth_token_gate.py
@@ -1,0 +1,360 @@
+"""
+Security regression tests for auth token response gating (issue #1239).
+
+Verifies that reset_token and verification_token are NEVER returned in
+production-environment responses, and ARE returned in dev/preview.
+
+Attack vector being blocked: POST /auth/forgot-password with any email
+→ read reset_token from response body → POST /auth/reset-password → takeover.
+No email access required.
+
+Run with:
+    cd backend
+    python -m pytest tests/test_auth_token_gate.py -v
+"""
+
+import os
+import sys
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+from app.auth.password import hash_password
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite test DB
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiters():
+    from app.routes.auth import rate_limiter
+    rate_limiter.reset()
+    try:
+        from app.auth.rate_limiter import general_rate_limiter
+        general_rate_limiter.reset()
+    except (ImportError, AttributeError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _unique_email() -> str:
+    return f"tokengate-{uuid.uuid4().hex[:8]}@example.com"
+
+
+def _create_teacher_with_password(email: str, password: str = "SecurePass123!") -> None:
+    """Insert a teacher user directly (bypass student-block in register endpoint)."""
+    db = TestingSessionLocal()
+    try:
+        user = User(
+            email=email,
+            password_hash=hash_password(password),
+            name="Test Teacher",
+            email_verified=False,
+            email_verification_token="initial-token",
+        )
+        db.add(user)
+        db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: PRODUCTION environment — tokens must be null
+# ---------------------------------------------------------------------------
+
+
+class TestTokenGateProduction:
+    """ENVIRONMENT=production → all token fields must be null in responses."""
+
+    def _client(self, monkeypatch) -> TestClient:
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        # Invalidate cached is_dev property by patching settings directly
+        from app import config
+        # Reload the is_dev property via monkeypatching os.environ
+        # (settings.is_dev reads os.environ at call time, so env change is enough)
+        return TestClient(app)
+
+    def test_forgot_password_no_token_in_prod(self, monkeypatch):
+        """POST /auth/forgot-password must NOT return reset_token in production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        email = _unique_email()
+        _create_teacher_with_password(email)
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/forgot-password", json={"identifier": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # The field may be present but MUST be null
+        assert body.get("reset_token") is None, (
+            f"SECURITY: reset_token must be null in production, got: {body.get('reset_token')!r}"
+        )
+
+    def test_forgot_password_unknown_email_no_token_in_prod(self, monkeypatch):
+        """Unknown email path also must not leak a token sentinel in production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        client = TestClient(app)
+        resp = client.post("/api/auth/forgot-password", json={"identifier": "noexist@example.com"})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("reset_token") is None, (
+            f"SECURITY: reset_token must be null in production (unknown email path), got: {body.get('reset_token')!r}"
+        )
+
+    def test_resend_verification_no_token_in_prod(self, monkeypatch):
+        """POST /auth/resend-verification must NOT return verification_token in production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        email = _unique_email()
+        _create_teacher_with_password(email)  # email_verified=False already
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/resend-verification", json={"email": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body.get("verification_token") is None, (
+            f"SECURITY: verification_token must be null in production, got: {body.get('verification_token')!r}"
+        )
+
+    def test_register_no_verification_token_in_prod(self, monkeypatch):
+        """POST /auth/register with require_email_verification=True must not return token in production."""
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        # Temporarily enable email verification requirement
+        from app import config
+        original = config.settings.require_email_verification
+        config.settings.require_email_verification = True
+
+        try:
+            email = _unique_email()
+            client = TestClient(app)
+            resp = client.post("/api/auth/register", json={
+                "email": email,
+                "password": "SecurePass123!",
+                "name": "Test User",
+            })
+            assert resp.status_code in (200, 201), resp.text
+            body = resp.json()
+            assert body.get("verification_token") is None, (
+                f"SECURITY: verification_token must be null in production, got: {body.get('verification_token')!r}"
+            )
+        finally:
+            config.settings.require_email_verification = original
+
+
+# ---------------------------------------------------------------------------
+# Tests: DEV environment — tokens should be present (internal testing flow)
+# ---------------------------------------------------------------------------
+
+
+class TestTokenGateDev:
+    """ENVIRONMENT=development → token fields should be returned for internal testing."""
+
+    def test_forgot_password_returns_token_in_dev(self, monkeypatch):
+        """POST /auth/forgot-password SHOULD return reset_token in dev environment."""
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        email = _unique_email()
+        _create_teacher_with_password(email)
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/forgot-password", json={"identifier": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        token = body.get("reset_token")
+        assert token is not None and token != "", (
+            f"Dev environment should return reset_token, got: {token!r}"
+        )
+        # Confirm the token is a hex string (64 chars for 32-byte token)
+        assert len(token) == 64, f"Expected 64-char hex token, got length {len(token)}"
+
+    def test_resend_verification_returns_token_in_dev(self, monkeypatch):
+        """POST /auth/resend-verification SHOULD return verification_token in dev."""
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        email = _unique_email()
+        _create_teacher_with_password(email)  # email_verified=False
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/resend-verification", json={"email": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        token = body.get("verification_token")
+        assert token is not None and token != "", (
+            f"Dev environment should return verification_token, got: {token!r}"
+        )
+
+    def test_register_returns_verification_token_in_dev(self, monkeypatch):
+        """POST /auth/register with verification enabled SHOULD return token in dev."""
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        from app import config
+        original = config.settings.require_email_verification
+        config.settings.require_email_verification = True
+
+        try:
+            email = _unique_email()
+            client = TestClient(app)
+            resp = client.post("/api/auth/register", json={
+                "email": email,
+                "password": "SecurePass123!",
+                "name": "Dev Test User",
+            })
+            assert resp.status_code in (200, 201), resp.text
+            body = resp.json()
+            token = body.get("verification_token")
+            assert token is not None and token != "", (
+                f"Dev environment should return verification_token, got: {token!r}"
+            )
+        finally:
+            config.settings.require_email_verification = original
+
+    def test_preview_env_also_returns_token(self, monkeypatch):
+        """ENVIRONMENT=preview (PR preview deploys) also gets tokens for QA testing."""
+        monkeypatch.setenv("ENVIRONMENT", "preview")
+        email = _unique_email()
+        _create_teacher_with_password(email)
+
+        client = TestClient(app)
+        resp = client.post("/api/auth/forgot-password", json={"identifier": email})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        token = body.get("reset_token")
+        assert token is not None and token != "", (
+            f"Preview environment should return reset_token for QA testing, got: {token!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: settings.is_dev unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSettingsIsDev:
+    """Unit tests for the is_dev property on Settings."""
+
+    def test_is_dev_true_for_development(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is True
+
+    def test_is_dev_true_for_preview(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "preview")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is True
+
+    def test_is_dev_false_for_production(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is False
+
+    def test_is_dev_false_for_staging(self, monkeypatch):
+        """Staging is NOT in the dev set — staging tokens should also be gated."""
+        monkeypatch.setenv("ENVIRONMENT", "staging")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is False
+
+    def test_is_dev_true_when_local_no_env_no_k_service(self, monkeypatch):
+        """No ENVIRONMENT + no K_SERVICE → local dev (is_dev=True)."""
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("K_SERVICE", raising=False)
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is True
+
+    def test_is_dev_false_when_cloud_run_no_environment(self, monkeypatch):
+        """K_SERVICE set (Cloud Run) without ENVIRONMENT → fail-safe to prod (is_dev=False).
+
+        This guards against deploy workflows forgetting to set ENVIRONMENT.
+        Before fix: is_dev defaulted to True → reset/verification tokens leaked
+        in prod responses. After fix: missing ENVIRONMENT on Cloud Run = prod.
+        """
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.setenv("K_SERVICE", "lingoleap-backend")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is False
+
+    def test_is_dev_false_for_unknown_env_on_cloud_run(self, monkeypatch):
+        """Unknown ENVIRONMENT value on Cloud Run → fail-safe to prod."""
+        monkeypatch.setenv("ENVIRONMENT", "canary")
+        monkeypatch.setenv("K_SERVICE", "lingoleap-backend")
+        from app.config import Settings
+        s = Settings()
+        assert s.is_dev is False

--- a/backend/tests/test_org_admin_scope_security.py
+++ b/backend/tests/test_org_admin_scope_security.py
@@ -1,0 +1,448 @@
+"""
+Security integration tests for org_admin cross-org data isolation.
+
+Attack scenario: A org_admin should NOT be able to read B org's
+user data, gamification records, or feedback — 個資法 §20 compliance.
+
+Matrix tested:
+  - A org_admin → B org user list          → 403 / empty
+  - A org_admin → B org user detail        → 403
+  - A org_admin → B org student gamification → 403
+  - A org_admin → B org classroom leaderboard → 403
+  - A org_admin → B org user feedback      → 403 / empty (via list)
+  - A org_admin → B org feedback PATCH     → 403
+  - A org_admin → A org user list          → 200 (own org allowed)
+  - A org_admin → A org student gamification → 200 (own org allowed)
+  - system_admin → any org                 → 200 (global bypass)
+  - plain teacher → other user's gamification → 403
+
+Run with:
+    cd /Users/young/project/chinese-literacy-platform/backend
+    python -m pytest tests/test_org_admin_scope_security.py -v
+"""
+
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite DB
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin",    "display_name": "Org Admin",    "scope_level": "organization"},
+    {"name": "org_owner",    "display_name": "Org Owner",    "scope_level": "organization"},
+    {"name": "teacher",      "display_name": "Teacher",      "scope_level": "school"},
+    {"name": "student",      "display_name": "Student",      "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for r in SEED_ROLES:
+        session.add(Role(**r))
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _reset_rate_limiters():
+    """Reset all rate limiters between registrations to avoid 429 in tests."""
+    try:
+        from app.routes.auth import rate_limiter
+        rate_limiter.reset()
+    except (ImportError, AttributeError):
+        pass
+    try:
+        from app.auth.rate_limiter import general_rate_limiter
+        general_rate_limiter.reset()
+    except (ImportError, AttributeError):
+        pass
+
+
+def _register_login(client, label: str) -> tuple[int, str]:
+    """Register + verify + login. Returns (user_id, access_token)."""
+    _reset_rate_limiters()
+    uid = uuid.uuid4().hex[:8]
+    email = f"{label}_{uid}@test.example"
+    r = client.post("/api/auth/register", json={
+        "email": email,
+        "password": "Secure99!",
+        "name": label,
+    })
+    assert r.status_code == 201, r.text
+    tok = r.json().get("verification_token")
+    if tok:
+        client.get(f"/api/auth/verify-email?token={tok}")
+    _reset_rate_limiters()
+    login = client.post("/api/auth/login", json={"email": email, "password": "Secure99!"})
+    assert login.status_code == 200, login.text
+    access = login.json()["access_token"]
+    me = client.get("/api/users/me", headers=auth_header(access))
+    user_id = me.json()["id"]
+    return user_id, access
+
+
+def _assign_role(user_id: int, role_name: str,
+                 scope_type: str = "platform", scope_id: str | None = None) -> None:
+    db = TestingSessionLocal()
+    try:
+        role = db.query(Role).filter(Role.name == role_name).first()
+        db.add(UserRole(
+            user_id=user_id,
+            role_id=role.id,
+            scope_type=scope_type,
+            scope_id=scope_id,
+        ))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _assign_org_role(user_id: int, role_name: str, org_id: str) -> None:
+    _assign_role(user_id, role_name, scope_type="organization", scope_id=org_id)
+
+
+def _submit_feedback(client, token: str) -> int:
+    """Submit a feedback entry and return its ID."""
+    r = client.post("/api/feedback", json={
+        "category": "bug",
+        "title": "Test feedback",
+        "description": "For security test",
+        "page_url": "/test",
+    }, headers=auth_header(token))
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOrgAdminScopeIsolation:
+    """
+    Seed layout:
+      Org-A  (scope_id = "org-alpha")
+        - admin_a  : org_admin scoped to org-alpha
+        - student_a: student scoped to org-alpha
+
+      Org-B  (scope_id = "org-beta")
+        - admin_b  : org_admin scoped to org-beta
+        - student_b: student scoped to org-beta
+
+      sys_admin  : system_admin (platform scope)
+      teacher_c  : teacher with no special org scope
+    """
+
+    ORG_A = "org-alpha"
+    ORG_B = "org-beta"
+
+    @pytest.fixture(scope="class")
+    def actors(self, client):
+        """Create all actors once per class."""
+        admin_a_id, admin_a_tok = _register_login(client, "admin_a")
+        _assign_org_role(admin_a_id, "org_admin", self.ORG_A)
+
+        admin_b_id, admin_b_tok = _register_login(client, "admin_b")
+        _assign_org_role(admin_b_id, "org_admin", self.ORG_B)
+
+        student_a_id, student_a_tok = _register_login(client, "student_a")
+        _assign_org_role(student_a_id, "student", self.ORG_A)
+
+        student_b_id, student_b_tok = _register_login(client, "student_b")
+        _assign_org_role(student_b_id, "student", self.ORG_B)
+
+        sysadmin_id, sysadmin_tok = _register_login(client, "sysadmin")
+        _assign_role(sysadmin_id, "system_admin", scope_type="platform")
+
+        teacher_c_id, teacher_c_tok = _register_login(client, "teacher_c")
+        _assign_role(teacher_c_id, "teacher", scope_type="platform")
+
+        # Submit feedback as student_b (so we can test cross-org PATCH)
+        fb_b_id = _submit_feedback(client, student_b_tok)
+        # Submit feedback as student_a (so admin_a can access it)
+        fb_a_id = _submit_feedback(client, student_a_tok)
+
+        return {
+            "admin_a": (admin_a_id, admin_a_tok),
+            "admin_b": (admin_b_id, admin_b_tok),
+            "student_a": (student_a_id, student_a_tok),
+            "student_b": (student_b_id, student_b_tok),
+            "sysadmin": (sysadmin_id, sysadmin_tok),
+            "teacher_c": (teacher_c_id, teacher_c_tok),
+            "fb_a_id": fb_a_id,
+            "fb_b_id": fb_b_id,
+        }
+
+    # ── User list ─────────────────────────────────────────────────────────────
+
+    def test_list_users_cross_org_returns_no_b_users(self, client, actors):
+        """A org_admin listing users must NOT see B org's students."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get("/api/users", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, r.text
+        ids = [u["id"] for u in r.json()["items"]]
+        assert student_b_id not in ids, (
+            f"A org_admin should not see B's student (id={student_b_id}) in /api/users"
+        )
+
+    def test_list_users_own_org_visible(self, client, actors):
+        """A org_admin can see their own org's users."""
+        _, admin_a_tok = actors["admin_a"]
+        admin_a_id, _ = actors["admin_a"]
+        student_a_id, _ = actors["student_a"]
+        r = client.get("/api/users", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, r.text
+        ids = [u["id"] for u in r.json()["items"]]
+        assert student_a_id in ids, "A org_admin must see their own student"
+
+    # ── User detail ───────────────────────────────────────────────────────────
+
+    def test_get_user_detail_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student detail must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(f"/api/users/{student_b_id}", headers=auth_header(admin_a_tok))
+        assert r.status_code == 403, (
+            f"Expected 403 when A org_admin reads B's user detail, got {r.status_code}: {r.text}"
+        )
+
+    def test_get_user_detail_own_org_is_200(self, client, actors):
+        """A org_admin can read a user in their own org."""
+        _, admin_a_tok = actors["admin_a"]
+        student_a_id, _ = actors["student_a"]
+        r = client.get(f"/api/users/{student_a_id}", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, (
+            f"A org_admin should read own student, got {r.status_code}: {r.text}"
+        )
+
+    def test_get_user_detail_system_admin_any_org_is_200(self, client, actors):
+        """system_admin can read any user regardless of org."""
+        _, sysadmin_tok = actors["sysadmin"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(f"/api/users/{student_b_id}", headers=auth_header(sysadmin_tok))
+        assert r.status_code == 200, (
+            f"system_admin must read any user, got {r.status_code}: {r.text}"
+        )
+
+    # ── Gamification: student summary ─────────────────────────────────────────
+
+    def test_gamification_summary_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student gamification must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/summary/{student_b_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, (
+            f"Expected 403 on cross-org gamification read, got {r.status_code}: {r.text}"
+        )
+
+    def test_gamification_summary_own_org_is_200(self, client, actors):
+        """A org_admin can read their own student's gamification."""
+        _, admin_a_tok = actors["admin_a"]
+        student_a_id, _ = actors["student_a"]
+        r = client.get(
+            f"/api/gamification/summary/{student_a_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 200, (
+            f"A org_admin must read own student's gamification, got {r.status_code}: {r.text}"
+        )
+
+    def test_gamification_summary_system_admin_any_is_200(self, client, actors):
+        """system_admin can read any student's gamification."""
+        _, sysadmin_tok = actors["sysadmin"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/summary/{student_b_id}",
+            headers=auth_header(sysadmin_tok),
+        )
+        assert r.status_code == 200, (
+            f"system_admin must read any gamification, got {r.status_code}: {r.text}"
+        )
+
+    def test_gamification_summary_plain_teacher_other_student_is_403(self, client, actors):
+        """A plain teacher with no shared classroom cannot read another student's gamification."""
+        _, teacher_c_tok = actors["teacher_c"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/summary/{student_b_id}",
+            headers=auth_header(teacher_c_tok),
+        )
+        assert r.status_code == 403, (
+            f"Plain teacher must not read other student's gamification, got {r.status_code}"
+        )
+
+    # ── Gamification: other student-specific endpoints ─────────────────────────
+
+    def test_gamification_points_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student points must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/points/{student_b_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, f"Got {r.status_code}: {r.text}"
+
+    def test_gamification_achievements_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student achievements must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/achievements/{student_b_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, f"Got {r.status_code}: {r.text}"
+
+    def test_gamification_streak_cross_org_is_403(self, client, actors):
+        """A org_admin reading B's student streak must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        student_b_id, _ = actors["student_b"]
+        r = client.get(
+            f"/api/gamification/streak/{student_b_id}",
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, f"Got {r.status_code}: {r.text}"
+
+    # ── Feedback: list ────────────────────────────────────────────────────────
+
+    def test_list_feedback_cross_org_not_visible(self, client, actors):
+        """A org_admin listing feedback must NOT see entries from B org's users."""
+        _, admin_a_tok = actors["admin_a"]
+        fb_b_id = actors["fb_b_id"]
+        r = client.get("/api/feedback", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, r.text
+        ids = [f["id"] for f in r.json()["items"]]
+        assert fb_b_id not in ids, (
+            f"A org_admin must not see B's feedback (id={fb_b_id})"
+        )
+
+    def test_list_feedback_own_org_visible(self, client, actors):
+        """A org_admin can see feedback from their own org's users."""
+        _, admin_a_tok = actors["admin_a"]
+        fb_a_id = actors["fb_a_id"]
+        r = client.get("/api/feedback", headers=auth_header(admin_a_tok))
+        assert r.status_code == 200, r.text
+        ids = [f["id"] for f in r.json()["items"]]
+        assert fb_a_id in ids, f"A org_admin must see their org's feedback (id={fb_a_id})"
+
+    def test_list_feedback_system_admin_sees_all(self, client, actors):
+        """system_admin sees all feedback including cross-org."""
+        _, sysadmin_tok = actors["sysadmin"]
+        fb_b_id = actors["fb_b_id"]
+        r = client.get("/api/feedback", headers=auth_header(sysadmin_tok))
+        assert r.status_code == 200, r.text
+        ids = [f["id"] for f in r.json()["items"]]
+        assert fb_b_id in ids, "system_admin must see all feedback"
+
+    # ── Feedback: PATCH ───────────────────────────────────────────────────────
+
+    def test_patch_feedback_cross_org_is_403(self, client, actors):
+        """A org_admin updating B's user's feedback must get 403."""
+        _, admin_a_tok = actors["admin_a"]
+        fb_b_id = actors["fb_b_id"]
+        r = client.patch(
+            f"/api/feedback/{fb_b_id}",
+            json={"status": "resolved"},
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 403, (
+            f"Expected 403 when A org_admin patches B's feedback, got {r.status_code}: {r.text}"
+        )
+
+    def test_patch_feedback_own_org_is_200(self, client, actors):
+        """A org_admin can update feedback from their own org's users."""
+        _, admin_a_tok = actors["admin_a"]
+        fb_a_id = actors["fb_a_id"]
+        r = client.patch(
+            f"/api/feedback/{fb_a_id}",
+            json={"status": "in_progress"},
+            headers=auth_header(admin_a_tok),
+        )
+        assert r.status_code == 200, (
+            f"A org_admin should update own org's feedback, got {r.status_code}: {r.text}"
+        )
+
+    def test_patch_feedback_system_admin_any_is_200(self, client, actors):
+        """system_admin can update any feedback."""
+        _, sysadmin_tok = actors["sysadmin"]
+        fb_b_id = actors["fb_b_id"]
+        r = client.patch(
+            f"/api/feedback/{fb_b_id}",
+            json={"status": "resolved"},
+            headers=auth_header(sysadmin_tok),
+        )
+        assert r.status_code == 200, (
+            f"system_admin must update any feedback, got {r.status_code}: {r.text}"
+        )

--- a/backend/tests/test_tts_auth.py
+++ b/backend/tests/test_tts_auth.py
@@ -1,0 +1,279 @@
+"""
+TDD tests for TTS endpoint authentication (Issue #1240).
+
+Covers:
+- POST /api/tts/synthesize  → 401 without token, 200 with valid token
+- POST /api/tts/synthesize-sentence → 401 without token, 200 with valid token
+- POST /api/tts/regenerate  → 401 without token, 403 for non-admin, 200 for system_admin
+
+Run:
+    cd /path/to/chinese-literacy-platform/backend
+    pytest tests/test_tts_auth.py -v
+"""
+import sys
+import os
+import uuid
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+
+# ---------------------------------------------------------------------------
+# Test DB (SQLite in-memory)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _assign_role(email: str, role_name: str) -> None:
+    # Map role name to the correct scope_type (UserRole.scope_type is NOT NULL)
+    scope_type_map = {
+        "system_admin": "platform",
+        "org_admin": "organization",
+        "principal": "school",
+        "director": "school",
+        "teacher": "school",
+        "homeroom_teacher": "school",
+        "student": "school",
+        "parent": "school",
+    }
+    scope_type = scope_type_map.get(role_name, "platform")
+
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).first()
+        role = db.query(Role).filter(Role.name == role_name).first()
+        existing = db.query(UserRole).filter(
+            UserRole.user_id == user.id,
+            UserRole.role_id == role.id,
+            UserRole.is_active == True,
+        ).first()
+        if not existing:
+            db.add(UserRole(
+                user_id=user.id,
+                role_id=role.id,
+                is_active=True,
+                scope_type=scope_type,
+            ))
+            db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_and_login(client) -> dict:
+    """Register a fresh user and return {'email', 'token'}."""
+    unique = uuid.uuid4().hex[:8]
+    email = f"ttstest_{unique}@example.com"
+    password = "SecurePass123!"
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": f"TTS Test {unique}",
+    })
+    assert resp.status_code == 201, resp.text
+
+    verification_token = resp.json().get("verification_token")
+    if verification_token is not None:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
+
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    token = login_resp.json()["access_token"]
+    return {"email": email, "token": token}
+
+
+@pytest.fixture(scope="module")
+def regular_user(client):
+    return _register_and_login(client)
+
+
+@pytest.fixture(scope="module")
+def admin_user(client):
+    user_info = _register_and_login(client)
+    _assign_role(user_info["email"], "system_admin")
+    return user_info
+
+
+# ---------------------------------------------------------------------------
+# Helper: fake TTS so we don't hit Azure/GCP in tests
+# ---------------------------------------------------------------------------
+
+FAKE_AUDIO = b"FAKE_AUDIO_BYTES"
+
+
+def _patch_tts():
+    """Context manager that patches synthesize_speech and synthesize_sentence."""
+    return patch.multiple(
+        "app.routes.tts",
+        synthesize_speech=MagicMock(return_value=FAKE_AUDIO),
+        synthesize_sentence=MagicMock(return_value=FAKE_AUDIO),
+    )
+
+
+def _patch_regenerate():
+    """Context manager that patches both delete_tts_cache and synthesize_speech for /regenerate."""
+    delete_result = {
+        "key": "abc123",
+        "l1_deleted": True,
+        "gcs_deleted": ["azure/sentences/abc123.mp3"],
+    }
+    return patch.multiple(
+        "app.routes.tts",
+        delete_tts_cache=MagicMock(return_value=delete_result),
+        synthesize_speech=MagicMock(return_value=FAKE_AUDIO),
+    )
+
+
+# ===========================================================================
+# Tests: POST /api/tts/synthesize
+# ===========================================================================
+
+class TestSynthesizeAuth:
+
+    def test_unauthenticated_returns_401(self, client):
+        """Anonymous request must be rejected with 401."""
+        resp = client.post("/api/tts/synthesize", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+
+    def test_authenticated_returns_200(self, client, regular_user):
+        """Authenticated user receives audio bytes."""
+        with _patch_tts():
+            resp = client.post(
+                "/api/tts/synthesize",
+                json={"text": "你好"},
+                headers={"Authorization": f"Bearer {regular_user['token']}"},
+            )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+        assert resp.content == FAKE_AUDIO
+
+
+# ===========================================================================
+# Tests: POST /api/tts/synthesize-sentence
+# ===========================================================================
+
+class TestSynthesizeSentenceAuth:
+
+    def test_unauthenticated_returns_401(self, client):
+        """Anonymous request must be rejected with 401."""
+        resp = client.post("/api/tts/synthesize-sentence", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+
+    def test_authenticated_returns_200(self, client, regular_user):
+        """Authenticated user receives audio bytes."""
+        with _patch_tts():
+            resp = client.post(
+                "/api/tts/synthesize-sentence",
+                json={"text": "你好"},
+                headers={"Authorization": f"Bearer {regular_user['token']}"},
+            )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+        assert resp.content == FAKE_AUDIO
+
+
+# ===========================================================================
+# Tests: POST /api/tts/regenerate
+# ===========================================================================
+
+class TestRegenerateAuth:
+
+    def test_unauthenticated_returns_401(self, client):
+        """Anonymous request must be rejected with 401."""
+        resp = client.post("/api/tts/regenerate", json={"text": "你好"})
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+
+    def test_non_admin_returns_403(self, client, regular_user):
+        """Regular (non-admin) user must receive 403 Forbidden."""
+        resp = client.post(
+            "/api/tts/regenerate",
+            json={"text": "你好"},
+            headers={"Authorization": f"Bearer {regular_user['token']}"},
+        )
+        assert resp.status_code == 403, f"Expected 403, got {resp.status_code}: {resp.text}"
+
+    def test_system_admin_returns_200(self, client, admin_user):
+        """system_admin user can call /regenerate."""
+        with _patch_regenerate():
+            resp = client.post(
+                "/api/tts/regenerate",
+                json={"text": "你好"},
+                headers={"Authorization": f"Bearer {admin_user['token']}"},
+            )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+        data = resp.json()
+        assert data["status"] == "ok"

--- a/backend/tests/test_tts_service.py
+++ b/backend/tests/test_tts_service.py
@@ -7,6 +7,58 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
+# ---------------------------------------------------------------------------
+# Shared helper: build a minimal FastAPI test app with auth bypassed.
+#
+# After Issue #1240 added get_current_user to the TTS endpoints, tests that
+# use a standalone mini-app (without a real DB) must override the dependency
+# so validation tests can still exercise Pydantic rejection (422) rather than
+# getting blocked at the auth layer (401).
+# ---------------------------------------------------------------------------
+
+def _make_tts_test_app():
+    """Return a FastAPI app with the TTS router and get_current_user stubbed out."""
+    from fastapi import FastAPI
+    from app.routes.tts import router
+    from app.auth.dependencies import get_current_user, require_role
+
+    # Minimal stub user — enough for the dependency to return without hitting the DB.
+    stub_user = MagicMock()
+    stub_user.id = 1
+
+    # Stub role-check dependency for /regenerate (which uses require_role("system_admin")).
+    stub_admin = MagicMock()
+    stub_admin.id = 1
+
+    mini_app = FastAPI()
+    mini_app.include_router(router)
+
+    # Override get_current_user → always succeeds (any-user endpoints).
+    mini_app.dependency_overrides[get_current_user] = lambda: stub_user
+
+    # require_role returns a Depends() object, not a callable — to stub it we
+    # need to override the inner _check_role dependency it wraps.  The simplest
+    # approach is to capture the dependency object at import time and override it.
+    # However, require_role("system_admin") is called at route-decoration time so
+    # the Depends() is already baked in.  We override get_current_user (which
+    # _check_role itself depends on) — this is sufficient because the role check
+    # queries the DB which doesn't exist in mini-app tests; skipping via override
+    # of get_current_user alone won't bypass require_role.
+    #
+    # Strategy: also override the DB dependency so the role query returns admin.
+    # Easiest: completely override require_role's inner dependency (_check_role).
+    # We locate it via the route's dependencies list.
+    from fastapi import routing as fastapi_routing
+    import fastapi
+    for route in mini_app.routes:
+        if hasattr(route, "dependencies"):
+            for dep in route.dependencies:
+                if hasattr(dep, "dependency") and hasattr(dep.dependency, "__name__") and dep.dependency.__name__ == "_check_role":
+                    mini_app.dependency_overrides[dep.dependency] = lambda: stub_admin
+
+    return mini_app
+
 # ---------------------------------------------------------------------------
 # 1. tts_service tests — cache key
 # ---------------------------------------------------------------------------
@@ -172,11 +224,7 @@ class TestTTSPydanticValidation:
     """TTSRequest model must reject empty text and text >5000 chars."""
 
     def _make_app(self):
-        from fastapi import FastAPI
-        from app.routes.tts import router
-        app = FastAPI()
-        app.include_router(router)
-        return app
+        return _make_tts_test_app()
 
     def test_empty_text_rejected(self):
         from fastapi.testclient import TestClient
@@ -427,10 +475,6 @@ class TestTTSRoute:
     @patch("app.services.tts_service._get_tts_client")
     def test_synthesize_returns_audio_response(self, mock_get_client, mock_gcs_put, mock_gcs_get):
         from fastapi.testclient import TestClient
-        from app.routes.tts import router
-        from fastapi import FastAPI
-        app = FastAPI()
-        app.include_router(router)
 
         mock_client = MagicMock()
         resp = MagicMock()
@@ -438,30 +482,22 @@ class TestTTSRoute:
         mock_client.synthesize_speech.return_value = resp
         mock_get_client.return_value = mock_client
 
-        client = TestClient(app)
+        client = TestClient(_make_tts_test_app())
         response = client.post("/api/tts/synthesize", json={"text": "你好世界"})
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("audio/")
 
     def test_synthesize_rejects_empty_text(self):
         from fastapi.testclient import TestClient
-        from app.routes.tts import router
-        from fastapi import FastAPI
-        app = FastAPI()
-        app.include_router(router)
 
-        client = TestClient(app)
+        client = TestClient(_make_tts_test_app())
         response = client.post("/api/tts/synthesize", json={"text": ""})
         assert response.status_code == 422  # validation error
 
     def test_synthesize_rejects_too_long_text(self):
         from fastapi.testclient import TestClient
-        from app.routes.tts import router
-        from fastapi import FastAPI
-        app = FastAPI()
-        app.include_router(router)
 
-        client = TestClient(app)
+        client = TestClient(_make_tts_test_app())
         long_text = "你" * 5001
         response = client.post("/api/tts/synthesize", json={"text": long_text})
         assert response.status_code == 422
@@ -851,11 +887,7 @@ class TestRegenerateEndpoint:
     """POST /api/tts/regenerate must delete cache and re-synthesise."""
 
     def _make_app(self):
-        from fastapi import FastAPI
-        from app.routes.tts import router
-        app = FastAPI()
-        app.include_router(router)
-        return app
+        return _make_tts_test_app()
 
     @patch("app.services.tts_service._gcs_get", return_value=None)
     @patch("app.services.tts_service._gcs_put")

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -1,6 +1,19 @@
 import { useState, useRef, useCallback } from 'react';
 import { cancelTts, cleanForTts, pauseCurrentTts, resumeCurrentTts, speakTextWithProgress, TtsProgressInfo } from '../services/ttsApi';
 
+// Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
+const _TTS_TOKEN_KEY = 'lingoleap_token';
+
+/** Read JWT token from localStorage and return Authorization header if present. */
+function _ttsAuthHeaders(): Record<string, string> {
+  try {
+    const token = localStorage.getItem(_TTS_TOKEN_KEY);
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  } catch {
+    return {};
+  }
+}
+
 /**
  * Manages TTS (Text-to-Speech) audio playback for LiveTutor.
  *
@@ -154,7 +167,7 @@ export function useTtsPlayback(
     // Try Cloud TTS first via <audio> element for better control
     fetch(`${API_BASE}/api/tts/synthesize`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._ttsAuthHeaders() },
       body: JSON.stringify({ text }),
     })
       .then((res) => {

--- a/frontend/src/pages/student/LearningHistoryPage.tsx
+++ b/frontend/src/pages/student/LearningHistoryPage.tsx
@@ -67,6 +67,8 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
   // All completed sessions have all steps done
   const allStepIds = useMemo(() => new Set(ACTIVE_STEPS.map((s) => s.id)), []);
 
+  // Issue #1245: unified score display — prefer overall_score, fallback to accuracy,
+  // show explicit "—" rather than empty when both are null.
   const score =
     session.overall_score != null
       ? Math.round(session.overall_score)
@@ -77,13 +79,28 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
       ? Math.round(session.accuracy * 100)
       : null;
 
+  // Unified display value: overall_score → accuracy → null (show "進行中")
+  const scoreDisplay: string | null =
+    score != null
+      ? `${score}%`
+      : accuracy != null
+        ? `${accuracy}%`
+        : null;
+
+  const scoreLabel: string =
+    score != null
+      ? '得分'
+      : accuracy != null
+        ? '準確率'
+        : '';
+
   return (
     <div className="bg-white rounded-2xl shadow-card p-4">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          {/* Title + status */}
+          {/* Title + status — enlarged to text-base to match /student and /assignments/my */}
           <div className="flex items-center gap-2 flex-wrap">
-            <h3 className="text-sm font-medium text-gray-900 truncate">
+            <h3 className="text-base font-medium text-gray-900 truncate">
               {session.story_title ?? session.story_slug ?? '未知課文'}
             </h3>
             <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
@@ -91,14 +108,13 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
             </span>
           </div>
 
-          {/* Metadata row */}
+          {/* Metadata row — enlarged date to text-sm, score always visible */}
           <div className="flex items-center gap-3 mt-2 flex-wrap">
-            <span className="text-xs text-gray-400">{formatDate(session.started_at)}</span>
-            {score != null && (
-              <span className="text-xs font-medium text-gray-700">得分：{score}%</span>
-            )}
-            {accuracy != null && score == null && (
-              <span className="text-xs text-gray-500">準確率：{accuracy}%</span>
+            <span className="text-sm text-gray-400">{formatDate(session.started_at)}</span>
+            {scoreDisplay != null ? (
+              <span className="text-sm font-medium text-gray-700">{scoreLabel}：{scoreDisplay}</span>
+            ) : (
+              <span className="text-sm text-gray-400">—</span>
             )}
           </div>
 
@@ -106,8 +122,8 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
           {ACTIVE_STEPS.length > 0 && (
             <div className="mt-2.5">
               <div className="flex items-center justify-between mb-1">
-                <p className="text-[11px] text-gray-500">學習關卡進度</p>
-                <p className="text-[11px] text-gray-400">
+                <p className="text-xs text-gray-500">學習關卡進度</p>
+                <p className="text-xs text-gray-400">
                   {ACTIVE_STEPS.length}/{ACTIVE_STEPS.length}
                 </p>
               </div>
@@ -122,7 +138,7 @@ const SessionCard: React.FC<{ session: LearningSummary }> = ({ session }) => {
         {/* Read-only action */}
         <button
           onClick={() => navigate(`/sessions/${session.id}/report`)}
-          className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-xs font-medium hover:bg-gray-50 transition-colors cursor-pointer shrink-0"
+          className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer shrink-0"
         >
           查看
         </button>
@@ -228,7 +244,7 @@ const TabContent: React.FC<{ source: TabKey }> = ({ source }) => {
     <div className="space-y-6">
       {groups.map((group) => (
         <div key={group.label}>
-          <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wide mb-2">
+          <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-2">
             {group.label}
           </h3>
           <div className="space-y-3">
@@ -266,7 +282,7 @@ const LearningHistoryPage: React.FC = () => {
       <div className="max-w-2xl mx-auto space-y-4">
         <div>
           <h1 className="text-base font-bold text-gray-900">學習紀錄</h1>
-          <p className="text-xs text-gray-500 mt-0.5">回顧過去的學習練習</p>
+          <p className="text-sm text-gray-500 mt-0.5">回顧過去的學習練習</p>
         </div>
 
         {/* Tabs */}
@@ -276,7 +292,7 @@ const LearningHistoryPage: React.FC = () => {
               <button
                 key={tab.key}
                 onClick={() => setActiveTab(tab.key)}
-                className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors cursor-pointer ${
+                className={`px-3 py-1.5 text-sm font-medium border-b-2 transition-colors cursor-pointer ${
                   activeTab === tab.key
                     ? 'border-accent text-accent'
                     : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'

--- a/frontend/src/pages/student/SessionHistoryReportPage.tsx
+++ b/frontend/src/pages/student/SessionHistoryReportPage.tsx
@@ -394,8 +394,9 @@ const StepRecordsView: React.FC<{
 
   if (!hasAny) {
     return (
-      <div className="text-center py-12">
-        <p className="text-sm text-gray-500">這筆紀錄沒有儲存作答內容</p>
+      <div className="text-center py-12 space-y-2">
+        <p className="text-sm font-medium text-gray-600">尚無作答紀錄</p>
+        <p className="text-sm text-gray-400">這次學習的作答詳情未儲存，可能是較舊的紀錄或尚未完成所有步驟</p>
       </div>
     );
   }

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -16,6 +16,24 @@
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
+// Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
+const TOKEN_KEY = 'lingoleap_token';
+
+/** Read the JWT token from localStorage (same source as AuthContext). */
+function _getAuthToken(): string | null {
+  try {
+    return localStorage.getItem(TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Build Authorization header if a token is available. */
+function _authHeaders(): Record<string, string> {
+  const token = _getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 // In-memory URL cache: sentence text → blob URL.
 // Avoids re-fetching the same sentence audio.
 // Blob URLs are released when the page unloads.
@@ -241,7 +259,7 @@ async function _fetchAudioUrl(sentence: string): Promise<string> {
   if (!audioUrl) {
     const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ text: sentence }),
     });
 


### PR DESCRIPTION
## Summary

Promote 4 merged staging PRs to production:

| PR | Category | Fix |
|----|----------|-----|
| #1242 | 🔒 個資法 §20 | org-admin cross-org data leak — enforce org scope on role checks |
| #1244 | 🔒 Billing abuse | TTS endpoints now require auth (synthesize) / admin (regenerate) |
| #1246 | 🔒 Token leak | auth reset/verification tokens only returned in dev (K_SERVICE fail-safe) |
| #1250 | 🐛 UX bug | student assignment sessions invisible + font size + score display |

## Staging verification (API smoke)

- `/api/users`, `/api/feedback`, `/api/gamification/*` → 401 unauth ✓
- `/api/tts/synthesize*`, `/api/tts/regenerate` → 401 unauth ✓
- `/api/auth/register|forgot-password|resend-verification` → `token: null` ✓
- `/api/learning/sessions` → 401 unauth ✓

## Follow-ups

- #1251 backend regression test for list_my_sessions (low priority)
- Frontend `/browse` QA on #1250 not done on staging (curl smoke only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)