### PR TITLE
fix: add rate limiting to generate-ai-comment LLM endpoint (Fixes #1254)

### DIFF
--- a/backend/app/routes/teacher/teacher_students.py
+++ b/backend/app/routes/teacher/teacher_students.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
+from ...auth.rate_limiter import ai_limit_5_per_min
 from ...database import get_db
 from ...dependencies.tenant import _check_classroom_access
 from ...models.school import Classroom, ClassroomStudent
@@ -558,6 +559,7 @@ def save_teacher_comment(
 @router.post(
     "/teacher/students/{student_id}/sessions/{session_id}/generate-ai-comment",
     response_model=AICommentResponse,
+    dependencies=[Depends(ai_limit_5_per_min)],
 )
 async def generate_session_ai_comment(
     student_id: int,
@@ -565,7 +567,10 @@ async def generate_session_ai_comment(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Generate AI comment for a session. Returns cached version if already generated."""
+    """Generate AI comment for a session. Returns cached version if already generated.
+
+    Rate limited: 5 requests per minute per user/IP (Issue #1254).
+    """
     from ...services.ai_generation import generate_teacher_comment
 
     session = _get_session_for_teacher(current_user.id, student_id, session_id, db)


### PR DESCRIPTION
Fixes #1254

## Summary

- `POST /teacher/students/{student_id}/sessions/{session_id}/generate-ai-comment` was the only Gemini-calling endpoint without a rate limit guard
- Added `ai_limit_5_per_min` dependency (5 req/min per user/IP), consistent with other heavy Gemini endpoints
- This was identified in the post-#1244 security audit of all LLM endpoints

## Changes

- `backend/app/routes/teacher/teacher_students.py` — import `ai_limit_5_per_min` + add `dependencies=[Depends(ai_limit_5_per_min)]` to the endpoint decorator + docstring update

## Audit Results

All 12 LLM-calling endpoints were audited. 11 were already protected; this PR fixes the remaining 1:

| Endpoint | Auth | Rate Limit |
|---|---|---|
| POST /comprehension/question | YES | 10/min |
| POST /comprehension/chat | YES | 10/min |
| POST /comprehension/restart | YES | 10/min |
| POST /learning/sessions/{id}/comprehension-score | YES | 5/min |
| POST /learning/sessions/{id}/ai-analysis | YES | 5/min |
| POST /learning/ai-analysis | YES | 5/min |
| POST /reading/evaluate | YES | 10/min |
| POST /learning/sentence-practice/example-sentences | YES | 10/min |
| POST /learning/sentence-practice/validate | YES | 10/min |
| POST /learning/listening/evaluate | YES | 5/min |
| GET /stories/{id}/structure | YES | 5/min |
| POST /teacher/students/{sid}/sessions/{id}/generate-ai-comment | YES | **5/min (this PR)** |

## Test plan

- [ ] Deploy to preview, call `POST /teacher/students/{sid}/sessions/{id}/generate-ai-comment` 6 times in under 60 seconds as a teacher — 6th call should return HTTP 429
- [ ] First 5 calls within the window succeed as before
- [ ] Non-LLM teacher endpoints unaffected