### PR TITLE
chore: remove _user_has_admin_role dead code + hard-cap reading-history (Fixes #1261 #1262)

### DIFF
--- a/backend/app/routes/gamification.py
+++ b/backend/app/routes/gamification.py
@@ -12,14 +12,13 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user, get_user_org_ids
 from ..database import get_db
 from ..dependencies.tenant import is_system_admin
 from ..models.school import Classroom, ClassroomStudent, School
-from ..models.user import Role, User, UserRole
+from ..models.user import User, UserRole
 from ..services.gamification_service import (
     award_xp,
     get_classroom_leaderboard,
@@ -53,29 +52,6 @@ class SessionCompleteRequest(BaseModel):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-_ADMIN_ROLES = frozenset({"system_admin", "org_admin", "org_owner"})
-
-
-def _user_has_admin_role(db: Session, user_id: int) -> bool:
-    """Return True if the user has any active admin-level role.
-
-    Issues a single SQL COUNT query (joined to the roles table) instead of
-    loading all UserRole rows into Python and doing a set intersection.
-    Before this fix each call emitted N lazy SQL fetches — one per UserRole row.
-    """
-    count = (
-        db.query(func.count(UserRole.id))
-        .join(Role, Role.id == UserRole.role_id)
-        .filter(
-            UserRole.user_id == user_id,
-            UserRole.is_active == True,
-            Role.name.in_(_ADMIN_ROLES),
-        )
-        .scalar()
-    )
-    return (count or 0) > 0
-
 
 def _get_user_org_ids_from_db(user_id: int, db: Session) -> set[str]:
     """Return the set of org scope_ids for a given user (loaded from DB).

--- a/backend/app/routes/learning/learning_sessions.py
+++ b/backend/app/routes/learning/learning_sessions.py
@@ -30,6 +30,12 @@ from ...schemas.session import (
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+# Hard cap on reading-history SQL fetch to bound memory even for abnormally
+# re-read stories. A student reading the same text 500+ times is abusive; we
+# surface up to MAX_READING_HISTORY_FETCH rows, then let the caller-supplied
+# limit cap the final result set.  See #1262 for the heuristic rationale.
+MAX_READING_HISTORY_FETCH = 500
+
 
 def _is_assignment_session(
     session: LearningSession,
@@ -324,11 +330,13 @@ def get_reading_history(
         )
     )
 
-    # Push a SQL-level cap to avoid loading the full history for popular stories.
-    # We fetch (limit + 50) rows as a buffer because the Python-side learning_source
-    # filter (which also checks step_progress.__meta.source) may drop some rows.
-    # The final sessions[:limit] slice still caps the result to the requested limit.
-    sql_fetch_limit = limit + 50
+    # Cap SQL fetch: prevent memory blowup when a single student has hundreds of
+    # sessions on the same story, but leave headroom for the Python-side
+    # learning_source filter (which checks step_progress.__meta.source — a JSON
+    # path not portably expressible in SQLite tests). Cap at MAX_READING_HISTORY_FETCH
+    # regardless of requested limit; if the caller asks for more than that we still
+    # honour their slice but prevent unbounded DB reads.
+    sql_fetch_limit = min(limit + 50, MAX_READING_HISTORY_FETCH)
     all_sessions = (
         sessions_query
         .order_by(LearningSession.started_at.asc())

--- a/backend/tests/test_perf_1243_remaining_optimizations.py
+++ b/backend/tests/test_perf_1243_remaining_optimizations.py
@@ -369,14 +369,19 @@ class TestReadingHistorySQLLimit:
 
 
 # ---------------------------------------------------------------------------
-# 3. Gamification _user_has_admin_role SQL COUNT helper
+# 3. Gamification access control (admin / teacher / student paths)
 # ---------------------------------------------------------------------------
 
-class TestUserHasAdminRoleSQLCount:
-    """Verify _user_has_admin_role issues a single SQL COUNT, not N lazy loads."""
+class TestGamificationAccessControl:
+    """Integration tests for /gamification/summary + /leaderboard access control.
+
+    Note: the original SQL COUNT helper `_user_has_admin_role` was removed in
+    #1261 because the conflict merge of #1247 into main resolved the admin
+    check to `is_system_admin(current_user)` (in-memory roles path), leaving
+    the helper as dead code. These tests remain as access-control contracts.
+    """
 
     def test_admin_can_view_summary(self, client):
-        """Admin user should get 200 on /gamification/summary/{student_id}."""
         token = _login(client, _state["admin_email"])
         resp = client.get(
             f"/api/gamification/summary/{_state['student_id']}",
@@ -385,8 +390,6 @@ class TestUserHasAdminRoleSQLCount:
         assert resp.status_code == 200
 
     def test_non_admin_non_teacher_cannot_view_others_summary(self, client):
-        """A plain student cannot view another user's gamification summary."""
-        # Create a second plain student
         db = TestingSessionLocal()
         other = User(
             email="p1243_other@test.com",
@@ -410,7 +413,6 @@ class TestUserHasAdminRoleSQLCount:
         assert resp.status_code == 403
 
     def test_student_can_view_own_summary(self, client):
-        """Student can always view their own gamification data."""
         token = _login(client, _state["student_email"])
         resp = client.get(
             f"/api/gamification/summary/{_state['student_id']}",
@@ -418,35 +420,7 @@ class TestUserHasAdminRoleSQLCount:
         )
         assert resp.status_code == 200
 
-    def test_admin_role_check_issues_single_count_query(self, client):
-        """_user_has_admin_role must not issue N lazy queries per UserRole row.
-
-        Before the fix: db.query(UserRole).all() loaded all rows, then accessed
-        ur.role.name which could trigger N lazy fetches for the joined Role.
-        After the fix: a single SELECT COUNT(*) JOIN roles WHERE ... is issued.
-        """
-        token = _login(client, _state["admin_email"])
-
-        # Count queries for admin viewing a student summary.
-        # The admin check path: is_teacher=False → _user_has_admin_role()
-        # Before fix: would emit O(num_user_roles) queries
-        # After fix: exactly 1 COUNT query for the role check
-        n_queries = count_queries_during(
-            lambda: client.get(
-                f"/api/gamification/summary/{_state['student_id']}",
-                headers={"Authorization": f"Bearer {token}"},
-            )
-        )
-
-        # Absolute upper bound: auth(1) + is_teacher(1) + count_check(1) + summary(~3)
-        # should be well under 20. N lazy loads would produce >5 for a user with 3+ roles.
-        assert n_queries < 15, (
-            f"gamification/summary admin path issued {n_queries} queries. "
-            f"Expected < 15 (SQL COUNT should replace N lazy role fetches)."
-        )
-
     def test_admin_leaderboard_access(self, client):
-        """Admin can view the classroom leaderboard even without being teacher/student."""
         token = _login(client, _state["admin_email"])
         resp = client.get(
             f"/api/gamification/leaderboard/{_state['classroom_id']}",
@@ -455,22 +429,9 @@ class TestUserHasAdminRoleSQLCount:
         assert resp.status_code == 200
 
     def test_teacher_leaderboard_access(self, client):
-        """Classroom teacher can view their own classroom's leaderboard."""
         token = _login(client, _state["teacher_email"])
         resp = client.get(
             f"/api/gamification/leaderboard/{_state['classroom_id']}",
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 200
-
-    def test_helper_function_returns_bool(self):
-        """_user_has_admin_role returns True for admin, False for student."""
-        from app.routes.gamification import _user_has_admin_role
-        db = TestingSessionLocal()
-        try:
-            admin = db.query(User).filter(User.email == _state["admin_email"]).first()
-            student = db.query(User).filter(User.email == _state["student_email"]).first()
-            assert _user_has_admin_role(db, admin.id) is True
-            assert _user_has_admin_role(db, student.id) is False
-        finally:
-            db.close()


### PR DESCRIPTION
Follow-up to PR #1257 eng review. Two small hygiene items merged into one PR.

## #1261 — Remove `_user_has_admin_role` dead code

Helper was defined in PR #1247 to replace Python-side role set comprehension with SQL COUNT, but the main-merge conflict resolution in #1257 picked `is_system_admin(current_user)` (in-memory roles) instead. Helper remained as dead code.

**Changes:**
- Delete `_user_has_admin_role()` in `gamification.py`
- Remove now-unused `func`, `Role` imports
- Drop 2 helper-specific tests (query count + direct call)
- Rename test class to `TestGamificationAccessControl`; keep 5 access-control integration tests

## #1262 — Hard-cap reading-history SQL fetch

Current code: `sql_fetch_limit = limit + 50` — the +50 buffer handles Python-side `learning_source` filter. If a caller passes limit=10000, we'd fetch 10050 rows with no upper bound.

**Changes:**
- Add module constant `MAX_READING_HISTORY_FETCH = 500`
- `sql_fetch_limit = min(limit + 50, 500)`
- Rewrite comment to explain why Python filter is needed (JSONB path not portable to SQLite tests)

Normal usage unchanged. Bounds memory even for adversarial/abnormal inputs.

## Tests

84 passing in gamification + n1 + org-admin test suites. 4 pre-existing failures (`first_story_badge` / `first_session_badge`) caused by UNIQUE constraint seeding — not this PR.

## Diff

- gamification.py: -26 +0
- learning_sessions.py: -8 +10  (+ module constant)
- test_perf_1243: -44 +13 (class rename + 2 test drops)

Pure cleanup. Safe for admin-merge after CI green.