### PR TITLE
fix(stories): move rate-limit check below cache validation

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -233,10 +233,6 @@ async def grade_story_structure_endpoint(
     Rate limited: 5 requests per minute per user/IP (Issue #1253).
     Returns {results: [...], score: 0-100}.
     """
-    # Rate limit before the Gemini grading call (Issue #1253)
-    rl_key = f"ai:{get_client_key(request)}"
-    if not ai_rate_limiter.check(rl_key, max_requests=5, window_seconds=60):
-        raise HTTPException(status_code=429, detail="AI endpoint rate limit exceeded. Please wait before retrying.")
     try:
         numeric_id = int(normalize_story_slug(story_id))
     except (ValueError, TypeError):
@@ -251,6 +247,11 @@ async def grade_story_structure_endpoint(
             status_code=400,
             detail="Structure not yet generated. Call GET /api/stories/{story_id}/structure first.",
         )
+
+    # Rate limit only after all early-return checks pass, so failed pre-flight requests don't burn quota
+    rl_key = f"ai:{get_client_key(request)}"
+    if not ai_rate_limiter.check(rl_key, max_requests=5, window_seconds=60):
+        raise HTTPException(status_code=429, detail="AI endpoint rate limit exceeded. Please wait before retrying.")
 
     story_text = story.get("full_text") or "\n".join(story.get("paragraphs", []))
     answers_payload = [a.model_dump() for a in body.answers]

--- a/backend/tests/test_llm_rate_limits.py
+++ b/backend/tests/test_llm_rate_limits.py
@@ -177,12 +177,20 @@ class TestStoryStructureGradeRateLimit:
         assert res.status_code == 401, f"Expected 401, got {res.status_code}: {res.text}"
 
     def test_rate_limit_exceeded_returns_429(self, client):
-        """When rate limiter blocks, endpoint must return 429."""
+        """When rate limiter blocks, endpoint must return 429.
+
+        The rate-limit check runs AFTER story lookup + cache validation (so
+        failed pre-flight requests don't burn quota). We mock both to reach
+        the rate-limit path.
+        """
         headers = _register_and_login(client, role="teacher")
 
-        # Patch the rate limiter to simulate limit exceeded
-        with patch("app.routes.stories.ai_rate_limiter") as mock_rl:
+        with patch("app.routes.stories.ai_rate_limiter") as mock_rl, \
+             patch("app.routes.stories.get_lesson_by_id") as mock_lesson, \
+             patch("app.routes.stories._get_cached_structure") as mock_cache:
             mock_rl.check.return_value = False
+            mock_lesson.return_value = {"id": 1, "full_text": "test", "paragraphs": ["test"]}
+            mock_cache.return_value = {"rows": []}
             res = client.post(
                 "/api/stories/1/structure/grade",
                 json={"answers": []},


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1266. Fixes issue flagged by Claude code review.

Rate limiter was consuming quota before `_get_cached_structure`, so cache-miss requests (which raise 400 without calling Gemini) still burned a slot. Moved check to fire only after all early-return validation passes.

## Changes
- `backend/app/routes/stories.py` — rate-limit check moved below story lookup + cache validation
- `backend/tests/test_llm_rate_limits.py` — test updated to mock `get_lesson_by_id` + `_get_cached_structure` so it still reaches the rate-limit path

## Test plan
- [x] `pytest tests/test_llm_rate_limits.py -v` — 4/4 pass
- [ ] Verify 429 still fires when limit genuinely exceeded in staging

Related: #1253, PR #1266

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)