### PR TITLE
feat: step UX — 課文理解下一關按鈕 + 知識站缺漏提示 (Fixes #1103, #1104)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -314,7 +314,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         </div>
       </div>
 
-      {/* ── Fixed bottom CTA ──────────────────────────────────────── */}
+      {/* ── Fixed bottom CTA — shows after MCQ (or structure) is complete ── */}
       {isWorksheetComplete && (
         <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
              style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
@@ -324,7 +324,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
               style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
             >
-              <span>繼續下一步</span>
+              <span>下一關</span>
               <span className="material-symbols-outlined text-xl">arrow_forward</span>
             </button>
           </div>

--- a/frontend/src/components/reading-steps/KnowledgeStation.tsx
+++ b/frontend/src/components/reading-steps/KnowledgeStation.tsx
@@ -1,18 +1,35 @@
 /**
  * 知識補給站 — 三民學習單第九步
  * 顯示課文相關的 YouTube 影片和延伸資料
+ * #1104: 加缺漏步驟提示卡片，讓學生看到哪些關卡還沒完成（但不強制）
  */
 import React, { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import type { Story } from '../../types';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
+
+export interface MissingStep {
+  id: string;
+  label: string;
+}
 
 interface KnowledgeStationProps {
   story: Story;
   onFinish: () => void;
+  /** Steps not yet completed — shown as a soft reminder above the CTA. #1104 */
+  missingSteps?: MissingStep[];
 }
 
-const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish }) => {
+const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish, missingSteps }) => {
   const storageKey = scopedStepStorageKey('knowledge_viewed_', story.id);
+  const navigate = useNavigate();
+  const { storyId } = useParams<{ storyId: string }>();
+
+  const hasMissingSteps = missingSteps && missingSteps.length > 0;
+
+  const handleGoToStep = (stepId: string) => {
+    navigate(`/learn/${storyId ?? story.id}/${stepId}`);
+  };
 
   useEffect(() => {
     try { localStorage.setItem(storageKey, JSON.stringify({ viewed: true })); } catch {}
@@ -72,10 +89,34 @@ const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish }) 
         </div>
       </div>
 
-      {/* Fixed bottom CTA */}
+      {/* Fixed bottom CTA — with optional missing-step reminder (#1104) */}
       <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
            style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
-        <div className="max-w-md mx-auto pointer-events-auto">
+        <div className="max-w-md mx-auto pointer-events-auto space-y-3">
+          {/* Soft reminder: steps not yet completed */}
+          {hasMissingSteps && (
+            <div className="bg-surface-container-lowest border border-surface-container-high rounded-2xl p-4 shadow-sm">
+              <div className="flex items-start gap-2 mb-3">
+                <span className="material-symbols-outlined text-base text-amber-500 mt-0.5 shrink-0">info</span>
+                <p className="text-sm font-headline font-bold text-on-surface">
+                  你還有 {missingSteps!.length} 個關卡沒有完成
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {missingSteps!.map((step) => (
+                  <button
+                    key={step.id}
+                    onClick={() => handleGoToStep(step.id)}
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-accent/10 text-accent text-xs font-headline font-bold hover:bg-accent/20 active:scale-[0.97] transition-all"
+                  >
+                    <span className="material-symbols-outlined text-sm">play_circle</span>
+                    {step.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           <button
             onClick={onFinish}
             className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"

--- a/frontend/src/pages/learning/KnowledgeStationPage.tsx
+++ b/frontend/src/pages/learning/KnowledgeStationPage.tsx
@@ -3,14 +3,21 @@ import KnowledgeStation from '../../components/reading-steps/KnowledgeStation';
 import { useLearningContext } from '../../layouts/LearningLayout';
 
 const KnowledgeStationPage: React.FC = () => {
-  const { selectedStory, handleFinishKnowledgeStation } = useLearningContext();
+  const { selectedStory, handleFinishKnowledgeStation, missingAssignmentSteps } = useLearningContext();
 
   if (!selectedStory) return null;
+
+  // Exclude 'knowledge-station' and 'report' from the missing list shown in the reminder
+  // (student is already on knowledge-station; report is the destination)
+  const missingStepsForReminder = missingAssignmentSteps.filter(
+    (s) => s.id !== 'knowledge-station' && s.id !== 'report',
+  );
 
   return (
     <KnowledgeStation
       story={selectedStory}
       onFinish={handleFinishKnowledgeStation}
+      missingSteps={missingStepsForReminder}
     />
   );
 };


### PR DESCRIPTION
Fixes #1103
Fixes #1104

## 變更摘要

### #1103 — Step 9 課文理解（ComprehensionChat）
- AI提問（MCQ）5 題完成後，底部 CTA 按鈕由「繼續下一步」改為「下一關 →」
- 觸發條件不變（`mcqDone === true` 時才顯示），純文字更新

### #1104 — Step 11 知識補給站（KnowledgeStation）
- 在「繼續前往報告」按鈕上方加可選的提示卡片
- 若有未完成的關卡，列出每個缺漏步驟的可點擊 chip，點擊可跳回該 step
- 「繼續前往報告」按鈕永遠可點，不強制完成
- `KnowledgeStationPage` 從 `LearningLayout` 取 `missingAssignmentSteps`，過濾掉 `knowledge-station` 和 `report` 自身再傳入

## 不在此 PR 範圍
- 不強制完成才能看報告
- 不動 API / data fetch / state logic
- 不改 Step 8 / Step 10 / Step 12

## 測試步驟
1. 登入學生帳號，開啟任一課文
2. 到 Step 9（課文理解）
   - 完成 AI 提問全部題目後，確認底部出現「下一關 →」按鈕
3. 到 Step 11（知識補給站）
   - 若有未完成步驟，確認「繼續前往報告」按鈕上方出現提示卡片，列出缺漏關卡
   - 點擊各 chip 確認可以跳到對應 step
   - 確認「繼續前往報告」按鈕任何情況下都可點

## TypeScript
我的 3 個改動檔案零 TS 錯誤（`tsc --noEmit` 確認）