### PR TITLE
feat: 字典查詢頁 /dictionary (Fixes #1230)

### DIFF
--- a/backend/app/routes/dictionary.py
+++ b/backend/app/routes/dictionary.py
@@ -2,6 +2,9 @@
 
 Provides endpoints to look up Chinese character definitions from the
 MOE (Ministry of Education) dictionary with DB caching.
+
+Auth: all endpoints require a valid JWT (get_current_user).
+Rate limit: 60 req/min per user (DB-backed cache, not AI, so generous ceiling).
 """
 import logging
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -9,11 +12,17 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..database import get_db
+from ..auth.dependencies import get_current_user
+from ..auth.rate_limiter import make_general_rate_limit_dependency
+from ..models.user import User
 from ..services.dictionary_service import lookup_character, lookup_characters_batch
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["dictionary"])
+
+# Rate limit: 60 req/min per authenticated user (generous; results are cached in DB)
+_dict_rl = make_general_rate_limit_dependency(max_requests=60, window_seconds=60)
 
 
 class DefinitionEntry(BaseModel):
@@ -52,6 +61,8 @@ class BatchLookupResponse(BaseModel):
 def get_character(
     character: str,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(_dict_rl),
 ):
     """Look up a single Chinese character from MOE dictionary (cached)."""
     if len(character) != 1:
@@ -71,6 +82,43 @@ def get_character(
     return CharacterLookupResponse(**result)
 
 
+@router.get(
+    "/dictionary/lookup",
+    response_model=BatchLookupResponse,
+    summary="Look up one or more Chinese characters via query string",
+    description=(
+        "Convenience GET endpoint for the dictionary page. "
+        "Pass `chars=攻擊` to look up each character in the string (batch). "
+        "Max 20 characters per request. Each character uses DB cache when available."
+    ),
+)
+def lookup_chars(
+    chars: str = Query(..., description="One or more Chinese characters, e.g. '攻擊'"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(_dict_rl),
+):
+    """GET /dictionary/lookup?chars=XY — splits the string and batch-looks up each character."""
+    char_list = [c for c in chars if c.strip()]
+    if not char_list:
+        raise HTTPException(status_code=422, detail="chars query parameter must not be empty")
+    if len(char_list) > 20:
+        raise HTTPException(status_code=422, detail="at most 20 characters per lookup request")
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique_chars: list[str] = []
+    for ch in char_list:
+        if ch not in seen:
+            seen.add(ch)
+            unique_chars.append(ch)
+
+    results = lookup_characters_batch(unique_chars, db)
+    return BatchLookupResponse(
+        results=[CharacterLookupResponse(**r) for r in results]
+    )
+
+
 @router.post(
     "/dictionary/batch",
     response_model=BatchLookupResponse,
@@ -83,6 +131,8 @@ def get_character(
 def batch_lookup(
     payload: BatchLookupRequest,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(_dict_rl),
 ):
     """Batch look up multiple Chinese characters (max 20)."""
     if not payload.characters:

--- a/backend/tests/test_dictionary_api.py
+++ b/backend/tests/test_dictionary_api.py
@@ -2,8 +2,10 @@
 Tests for the Dictionary API (issue #259: MOE dictionary integration).
 
 Covers:
-- GET  /api/dictionary/character/{character}  — single character lookup
-- POST /api/dictionary/batch                  — batch lookup
+- GET  /api/dictionary/character/{character}  — single character lookup (auth required)
+- GET  /api/dictionary/lookup?chars=XY        — multi-char GET convenience endpoint (auth required, issue #1230)
+- POST /api/dictionary/batch                  — batch lookup (auth required)
+- Auth gate: unauthenticated requests return 401/403
 
 Uses SQLite in-memory DB and mocked HTTP calls to avoid external API dependency.
 
@@ -28,12 +30,17 @@ from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.database import get_db
 from app.models import Base
+from app.models.user import User
+from app.auth.dependencies import get_current_user
 from app.services.dictionary_service import (
     _strip_markup,
     _parse_moe_response,
     lookup_character,
     lookup_characters_batch,
 )
+
+# Fake authenticated user for all route-level tests
+_FAKE_USER = User(id=1, email="dict-test-user", name="Test Student", password_hash="x")
 
 
 # ---------------------------------------------------------------------------
@@ -74,9 +81,27 @@ def client(db):
             pass
 
     app.dependency_overrides[get_db] = override_get_db
+    # Bypass auth: all dict route tests assume a logged-in student
+    app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def unauthenticated_client(db):
+    """Client with NO auth override — verifies 401/403 is returned."""
+    def override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    # Explicitly do NOT override get_current_user
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)
 
 
 # ---------------------------------------------------------------------------
@@ -383,3 +408,106 @@ class TestBatchLookupEndpoint:
     def test_batch_rejects_empty_list(self, client):
         resp = client.post("/api/dictionary/batch", json={"characters": []})
         assert resp.status_code == 422
+
+
+# ===========================================================================
+# GET /api/dictionary/lookup?chars=  (Issue #1230)
+# ===========================================================================
+
+class TestLookupEndpoint:
+    def test_returns_200_for_multi_char_query(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=攻擊")
+
+        assert resp.status_code == 200
+
+    def test_lookup_response_has_results_list(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=攻擊")
+
+        data = resp.json()
+        assert "results" in data
+        # 攻 and 擊 = 2 unique CJK chars
+        assert len(data["results"]) == 2
+
+    def test_lookup_deduplicates_chars(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=山山山")
+
+        data = resp.json()
+        # 山 repeated 3 times → deduplicated to 1
+        assert len(data["results"]) == 1
+
+    def test_lookup_single_char(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=山")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["results"]) == 1
+        assert data["results"][0]["character"] == "山"
+
+    def test_lookup_result_schema(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=水")
+
+        entry = resp.json()["results"][0]
+        assert "character" in entry
+        assert "zhuyin" in entry
+        assert "stroke_count" in entry
+        assert "definitions" in entry
+        assert "cached" in entry
+        assert "not_found" in entry
+
+    def test_lookup_rejects_more_than_20_unique_chars(self, client):
+        # 21 unique CJK characters
+        chars = "一二三四五六七八九十甲乙丙丁戊己庚辛壬癸黃"
+        resp = client.get(f"/api/dictionary/lookup?chars={chars}")
+        assert resp.status_code == 422
+
+    def test_lookup_rejects_missing_chars_param(self, client):
+        resp = client.get("/api/dictionary/lookup")
+        assert resp.status_code == 422
+
+
+# ===========================================================================
+# Auth gate — all endpoints require authentication (Issue #1230)
+# ===========================================================================
+
+class TestAuthGate:
+    """Verify endpoints return 401/403 without a valid token."""
+
+    def test_get_character_requires_auth(self, unauthenticated_client):
+        resp = unauthenticated_client.get("/api/dictionary/character/山")
+        assert resp.status_code in (401, 403)
+
+    def test_lookup_requires_auth(self, unauthenticated_client):
+        resp = unauthenticated_client.get("/api/dictionary/lookup?chars=山")
+        assert resp.status_code in (401, 403)
+
+    def test_batch_requires_auth(self, unauthenticated_client):
+        resp = unauthenticated_client.post(
+            "/api/dictionary/batch",
+            json={"characters": ["山"]},
+        )
+        assert resp.status_code in (401, 403)

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -389,7 +389,10 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
 
   // Targeted practice tools — shown at the BOTTOM of the student sidebar, separated by a divider (#1165)
   const toolsItems: NavItem[] = activeView === 'student'
-    ? [{ icon: '🧰', label: '練習工具箱', path: '/tools' }]
+    ? [
+        { icon: '🧰', label: '練習工具箱', path: '/tools' },
+        { icon: '📖', label: '字典查詢', path: '/dictionary' },
+      ]
     : [];
 
   const teacherItems: NavItem[] = activeView === 'teacher' || activeView === 'admin'

--- a/frontend/src/components/student/QuickPracticeStrip.tsx
+++ b/frontend/src/components/student/QuickPracticeStrip.tsx
@@ -8,11 +8,11 @@
  *   - 筆順字帖  → /write          (no story needed)
  *   - 聽寫挑戰  → /library        (needs story — goes to library first)
  *   - 造句練習  → /library        (needs story)
- *   - 字典查詢  → /vocabulary     (no story needed)
+ *   - 字典查詢  → /dictionary     (no story needed, Issue #1230)
  *
  * "看更多 →" links to /tools (PracticeToolbox page, Issue #1153).
  *
- * Issue #1153
+ * Issue #1153 + #1230
  */
 
 import React from 'react';
@@ -50,9 +50,9 @@ const QUICK_CARDS: PracticeCard[] = [
   },
   {
     icon: '📖',
-    title: '我的生字',
-    description: '看看哪些字需要加強',
-    route: '/vocabulary',
+    title: '字典查詢',
+    description: '查字義、注音、例句',
+    route: '/dictionary',
   },
 ];
 

--- a/frontend/src/pages/student/DictionaryPage.tsx
+++ b/frontend/src/pages/student/DictionaryPage.tsx
@@ -1,0 +1,234 @@
+/**
+ * DictionaryPage — /dictionary
+ *
+ * Stand-alone dictionary lookup page for students.
+ * Supports single-character lookup (via DictionaryPanel) and multi-character
+ * input (splits into individual characters and shows result cards in a grid).
+ *
+ * Backend: GET /api/dictionary/lookup?chars=X or /api/dictionary/character/{c}
+ * Auth: JWT required (learningApi reads from localStorage)
+ *
+ * Issue #1230
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DictionaryPanel from '../../components/dictionary/DictionaryPanel';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface SearchState {
+  query: string;       // raw input (may be multi-char)
+  chars: string[];     // parsed individual CJK characters
+}
+
+const MAX_CHARS = 10;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Extract unique CJK characters from a string, preserve order. */
+function extractCJKChars(input: string): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const ch of input) {
+    // CJK Unified Ideographs (U+4E00–U+9FFF) + Extension A/B common range
+    if (/\p{Script=Han}/u.test(ch) && !seen.has(ch)) {
+      seen.add(ch);
+      result.push(ch);
+    }
+  }
+  return result;
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+const DictionaryPage: React.FC = () => {
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [inputValue, setInputValue] = useState('');
+  const [search, setSearch] = useState<SearchState | null>(null);
+
+  const handleSearch = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+    const chars = extractCJKChars(trimmed);
+    if (chars.length === 0) return;
+    setSearch({ query: trimmed, chars: chars.slice(0, MAX_CHARS) });
+  }, [inputValue]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') handleSearch();
+    },
+    [handleSearch],
+  );
+
+  const handleClear = useCallback(() => {
+    setInputValue('');
+    setSearch(null);
+    inputRef.current?.focus();
+  }, []);
+
+  const isSingle = search != null && search.chars.length === 1;
+  const isMulti   = search != null && search.chars.length > 1;
+
+  return (
+    <div className="flex-1 overflow-y-auto bg-surface">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 pt-6 pb-10 space-y-6">
+
+        {/* ── Header ─────────────────────────────────────────────────────── */}
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="
+              shrink-0 w-9 h-9 flex items-center justify-center rounded-full
+              bg-surface-container-lowest border border-[#E5E0D5]
+              text-on-surface-variant hover:text-on-surface
+              hover:border-accent/40 hover:shadow-sm
+              transition-all duration-150
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+            "
+            aria-label="返回"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 18l-6-6 6-6" />
+            </svg>
+          </button>
+          <div>
+            <h1 className="text-xl sm:text-2xl font-bold font-headline text-on-surface leading-tight">
+              字典查詢
+            </h1>
+            <p className="text-xs sm:text-sm text-on-surface-variant mt-0.5">
+              查字義、注音、例句
+            </p>
+          </div>
+        </div>
+
+        {/* ── Search input ────────────────────────────────────────────────── */}
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <label htmlFor="dict-search-input" className="sr-only">
+              輸入要查詢的字
+            </label>
+            <input
+              id="dict-search-input"
+              ref={inputRef}
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="輸入要查詢的字，例如：攻擊"
+              maxLength={MAX_CHARS + 5}
+              className="
+                w-full rounded-xl border border-[#E5E0D5] bg-surface-container-lowest
+                px-4 py-3 text-base text-on-surface placeholder:text-on-surface-variant/50
+                focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent
+                transition-shadow duration-150
+              "
+              aria-label="輸入要查詢的字"
+              aria-describedby="dict-search-hint"
+            />
+            {inputValue && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="
+                  absolute right-3 top-1/2 -translate-y-1/2
+                  text-on-surface-variant hover:text-on-surface transition-colors
+                "
+                aria-label="清除輸入"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={handleSearch}
+            disabled={!inputValue.trim()}
+            className="
+              shrink-0 px-5 py-3 rounded-xl
+              bg-accent text-white font-semibold text-sm
+              hover:opacity-90 active:scale-[0.98]
+              disabled:opacity-40 disabled:cursor-not-allowed
+              transition-all duration-150
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+            "
+            aria-label="查詢"
+          >
+            查詢
+          </button>
+        </div>
+
+        <p
+          id="dict-search-hint"
+          className="text-xs text-on-surface-variant -mt-4"
+        >
+          最多可一次查 {MAX_CHARS} 個字
+        </p>
+
+        {/* ── Empty state ─────────────────────────────────────────────────── */}
+        {search == null && (
+          <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
+            <span className="text-5xl" aria-hidden="true">📖</span>
+            <p className="text-base font-semibold text-on-surface">輸入字，立刻查字義</p>
+            <p className="text-sm text-on-surface-variant max-w-xs">
+              支援多字查詢：輸入「攻擊」會同時顯示「攻」和「擊」的字典資料
+            </p>
+          </div>
+        )}
+
+        {/* ── No CJK found ────────────────────────────────────────────────── */}
+        {search != null && search.chars.length === 0 && (
+          <div className="rounded-xl border border-[#E5E0D5] bg-surface-container-lowest p-6 text-center">
+            <p className="text-sm text-on-surface-variant">
+              「{search.query}」沒有找到中文字，請重新輸入
+            </p>
+          </div>
+        )}
+
+        {/* ── Single character result ──────────────────────────────────────── */}
+        {isSingle && (
+          <div className="rounded-xl border border-[#E5E0D5] bg-surface-container-lowest p-5">
+            <DictionaryPanel character={search!.chars[0]} />
+          </div>
+        )}
+
+        {/* ── Multi-character results ──────────────────────────────────────── */}
+        {isMulti && (
+          <div className="space-y-4">
+            <p className="text-sm font-semibold text-on-surface">
+              找到 {search!.chars.length} 個字
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {search!.chars.map((ch) => (
+                <div
+                  key={ch}
+                  className="rounded-xl border border-[#E5E0D5] bg-surface-container-lowest p-5"
+                >
+                  <DictionaryPanel character={ch} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* ── Over-limit notice (if input had > MAX_CHARS CJK) ────────────── */}
+        {search != null &&
+          extractCJKChars(search.query).length > MAX_CHARS && (
+            <p className="text-xs text-on-surface-variant text-center">
+              僅顯示前 {MAX_CHARS} 個字的結果
+            </p>
+          )}
+
+      </div>
+    </div>
+  );
+};
+
+export default DictionaryPage;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -64,6 +64,7 @@ const StudentProfile = lazy(() => import('../pages/student/StudentProfile'));
 const SessionHistoryReportPage = lazy(() => import('../pages/student/SessionHistoryReportPage'));
 const LearningHistoryPage = lazy(() => import('../pages/student/LearningHistoryPage'));
 const PracticeToolbox = lazy(() => import('../pages/student/PracticeToolbox'));
+const DictionaryPage = lazy(() => import('../pages/student/DictionaryPage'));
 
 // Parent dashboard — role-specific, split separately
 const ParentDashboard = lazy(() => import('../pages/parent/ParentDashboard'));
@@ -391,6 +392,16 @@ const AppRoutes: React.FC = () => (
           <ProtectedRoute>
             <AppShell>
               <MyVocabulary />
+            </AppShell>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/dictionary"
+        element={
+          <ProtectedRoute>
+            <AppShell>
+              <DictionaryPage />
             </AppShell>
           </ProtectedRoute>
         }

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -615,20 +615,37 @@ export interface DictionaryBatchResponse {
   results: DictionaryEntry[];
 }
 
-/** Look up a single Chinese character from the MOE dictionary (cached). No auth required. */
+// Token key must match AuthContext TOKEN_KEY
+const _DICT_TOKEN_KEY = 'lingoleap_token';
+
+function _getDictAuthHeaders(): Record<string, string> {
+  const token = localStorage.getItem(_DICT_TOKEN_KEY);
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** Look up a single Chinese character from the MOE dictionary (cached). Requires auth. */
 export async function lookupCharacter(character: string): Promise<DictionaryEntry> {
   const res = await fetch(
     `${API_BASE}/api/dictionary/character/${encodeURIComponent(character)}`,
+    { headers: _getDictAuthHeaders() },
   );
   if (!res.ok) throw new Error(`lookupCharacter failed: ${res.status}`);
   return res.json();
 }
 
-/** Batch look up multiple Chinese characters (max 20, deduplication applied). No auth required. */
+/** Batch look up multiple Chinese characters via GET ?chars= (max 20). Requires auth. */
+export async function lookupCharactersQuery(chars: string): Promise<DictionaryBatchResponse> {
+  const url = `${API_BASE}/api/dictionary/lookup?chars=${encodeURIComponent(chars)}`;
+  const res = await fetch(url, { headers: _getDictAuthHeaders() });
+  if (!res.ok) throw new Error(`lookupCharactersQuery failed: ${res.status}`);
+  return res.json();
+}
+
+/** Batch look up multiple Chinese characters (max 20, deduplication applied). Requires auth. */
 export async function lookupCharactersBatch(characters: string[]): Promise<DictionaryBatchResponse> {
   const res = await fetch(`${API_BASE}/api/dictionary/batch`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ..._getDictAuthHeaders() },
     body: JSON.stringify({ characters }),
   });
   if (!res.ok) throw new Error(`lookupCharactersBatch failed: ${res.status}`);


### PR DESCRIPTION
Fixes #1230

## API Contract

### New/Updated Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `GET` | `/api/dictionary/character/{char}` | JWT required | Single char lookup (unchanged URL, now requires auth) |
| `GET` | `/api/dictionary/lookup?chars=攻擊` | JWT required | **New** — multi-char GET convenience endpoint |
| `POST` | `/api/dictionary/batch` | JWT required | Batch lookup (unchanged, now requires auth) |

### Response Schema (`CharacterLookupResponse`)

```json
{
  "character": "山",
  "zhuyin": "ㄕㄢ",
  "stroke_count": 3,
  "definitions": [
    {
      "type": "名",
      "definition": "陸地上高起的部分。",
      "examples": ["登山以望。"]
    }
  ],
  "cached": false,
  "not_found": false,
  "error": null
}
```

**Rate limit**: 60 req/min per user (general limiter, not AI limiter — DB cache makes this fast)

## Frontend Changes

- **New**: `frontend/src/pages/student/DictionaryPage.tsx` — `/dictionary` route
  - Search input (supports multi-char, max 10)
  - Single-char result: full `DictionaryPanel` in card
  - Multi-char result: 2-column grid of result cards
  - Back button, clear input button, empty state, no-CJK warning
  - Design tokens: `bg-surface`, `surface-container-lowest`, `text-on-surface`, `text-on-surface-variant`, `text-accent`, `border-[#E5E0D5]`
- **Updated**: `AppRoutes.tsx` — added `/dictionary` route (lazy-loaded, `ProtectedRoute` + `AppShell`)
- **Updated**: `learningApi.ts` — `lookupCharacter` / `lookupCharactersBatch` now send JWT header; new `lookupCharactersQuery` function
- **Updated**: `QuickPracticeStrip.tsx` — "字典查詢" card now links to `/dictionary` instead of `/vocabulary`

## Test Results

```
42 passed in 3.37s
```

- `TestStripMarkup` (5 tests) — unchanged
- `TestParseMoeResponse` (10 tests) — unchanged
- `TestLookupCharacter` (7 tests) — unchanged
- `TestGetCharacterEndpoint` (5 tests) — updated with auth mock
- `TestBatchLookupEndpoint` (5 tests) — updated with auth mock
- `TestLookupEndpoint` (7 tests) — **new** for GET /lookup
- `TestAuthGate` (3 tests) — **new** for 401/403 without token

## Test Plan

1. 開啟 PR Preview URL
2. 登入學生帳號
3. 前往 `/dictionary` (或從主頁「想練點什麼」點「字典查詢」)
4. 查單字「山」→ 應顯示注音、筆畫數、字義、例句
5. 查多字「攻擊」→ 應顯示 2 張結果卡片
6. 查非中文字「abc」→ 應顯示「沒有找到中文字」提示
7. 不登入直接呼叫 `/api/dictionary/lookup?chars=山` → 應回 401/403