### PR TITLE
release: promote #1270 + #1272 + #1267 to prod

### DIFF
--- a/backend/app/models/assignment.py
+++ b/backend/app/models/assignment.py
@@ -78,7 +78,7 @@ class AssignmentSubmission(Base):
     student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     status: Mapped[str] = mapped_column(String(20), default="pending")  # "pending" | "in_progress" | "submitted" | "graded"
     session_id: Mapped[int | None] = mapped_column(
-        ForeignKey("learning_sessions.id", ondelete="SET NULL"), nullable=True
+        ForeignKey("learning_sessions.id", ondelete="SET NULL"), nullable=True, index=True
     )
     submitted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     score: Mapped[float | None] = mapped_column(Float, nullable=True)  # from LearningSession accuracy

--- a/backend/app/models/school.py
+++ b/backend/app/models/school.py
@@ -60,7 +60,7 @@ class Classroom(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     school_id: Mapped[int] = mapped_column(ForeignKey("schools.id"), nullable=False)
-    teacher_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    teacher_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     grade: Mapped[int | None] = mapped_column(Integer, nullable=True)
     join_code: Mapped[str | None] = mapped_column(String(8), unique=True, nullable=True)
@@ -85,8 +85,8 @@ class ClassroomStudent(Base):
     __table_args__ = (UniqueConstraint("classroom_id", "student_id"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    classroom_id: Mapped[int] = mapped_column(ForeignKey("classrooms.id"), nullable=False)
-    student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    classroom_id: Mapped[int] = mapped_column(ForeignKey("classrooms.id"), nullable=False, index=True)
+    student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     enrolled_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -77,7 +77,7 @@ class UserRole(Base):
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     role_id: Mapped[int] = mapped_column(ForeignKey("roles.id"), nullable=False)
     scope_type: Mapped[str] = mapped_column(String(20), nullable=False)  # platform | organization | school
     scope_id: Mapped[str | None] = mapped_column(String(100), nullable=True)  # org UUID or school ID; platform = NULL

--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -233,10 +233,6 @@ async def grade_story_structure_endpoint(
     Rate limited: 5 requests per minute per user/IP (Issue #1253).
     Returns {results: [...], score: 0-100}.
     """
-    # Rate limit before the Gemini grading call (Issue #1253)
-    rl_key = f"ai:{get_client_key(request)}"
-    if not ai_rate_limiter.check(rl_key, max_requests=5, window_seconds=60):
-        raise HTTPException(status_code=429, detail="AI endpoint rate limit exceeded. Please wait before retrying.")
     try:
         numeric_id = int(normalize_story_slug(story_id))
     except (ValueError, TypeError):
@@ -251,6 +247,11 @@ async def grade_story_structure_endpoint(
             status_code=400,
             detail="Structure not yet generated. Call GET /api/stories/{story_id}/structure first.",
         )
+
+    # Rate limit only after all early-return checks pass, so failed pre-flight requests don't burn quota
+    rl_key = f"ai:{get_client_key(request)}"
+    if not ai_rate_limiter.check(rl_key, max_requests=5, window_seconds=60):
+        raise HTTPException(status_code=429, detail="AI endpoint rate limit exceeded. Please wait before retrying.")
 
     story_text = story.get("full_text") or "\n".join(story.get("paragraphs", []))
     answers_payload = [a.model_dump() for a in body.answers]

--- a/backend/tests/test_llm_rate_limits.py
+++ b/backend/tests/test_llm_rate_limits.py
@@ -177,12 +177,20 @@ class TestStoryStructureGradeRateLimit:
         assert res.status_code == 401, f"Expected 401, got {res.status_code}: {res.text}"
 
     def test_rate_limit_exceeded_returns_429(self, client):
-        """When rate limiter blocks, endpoint must return 429."""
+        """When rate limiter blocks, endpoint must return 429.
+
+        The rate-limit check runs AFTER story lookup + cache validation (so
+        failed pre-flight requests don't burn quota). We mock both to reach
+        the rate-limit path.
+        """
         headers = _register_and_login(client, role="teacher")
 
-        # Patch the rate limiter to simulate limit exceeded
-        with patch("app.routes.stories.ai_rate_limiter") as mock_rl:
+        with patch("app.routes.stories.ai_rate_limiter") as mock_rl, \
+             patch("app.routes.stories.get_lesson_by_id") as mock_lesson, \
+             patch("app.routes.stories._get_cached_structure") as mock_cache:
             mock_rl.check.return_value = False
+            mock_lesson.return_value = {"id": 1, "full_text": "test", "paragraphs": ["test"]}
+            mock_cache.return_value = {"rows": []}
             res = client.post(
                 "/api/stories/1/structure/grade",
                 json={"answers": []},

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -314,7 +314,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         </div>
       </div>
 
-      {/* ── Fixed bottom CTA ──────────────────────────────────────── */}
+      {/* ── Fixed bottom CTA — shows after MCQ (or structure) is complete ── */}
       {isWorksheetComplete && (
         <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
              style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
@@ -324,7 +324,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
               className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
               style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
             >
-              <span>繼續下一步</span>
+              <span>下一關</span>
               <span className="material-symbols-outlined text-xl">arrow_forward</span>
             </button>
           </div>

--- a/frontend/src/components/reading-steps/KnowledgeStation.tsx
+++ b/frontend/src/components/reading-steps/KnowledgeStation.tsx
@@ -1,18 +1,35 @@
 /**
  * 知識補給站 — 三民學習單第九步
  * 顯示課文相關的 YouTube 影片和延伸資料
+ * #1104: 加缺漏步驟提示卡片，讓學生看到哪些關卡還沒完成（但不強制）
  */
 import React, { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import type { Story } from '../../types';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
+
+export interface MissingStep {
+  id: string;
+  label: string;
+}
 
 interface KnowledgeStationProps {
   story: Story;
   onFinish: () => void;
+  /** Steps not yet completed — shown as a soft reminder above the CTA. #1104 */
+  missingSteps?: MissingStep[];
 }
 
-const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish }) => {
+const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish, missingSteps }) => {
   const storageKey = scopedStepStorageKey('knowledge_viewed_', story.id);
+  const navigate = useNavigate();
+  const { storyId } = useParams<{ storyId: string }>();
+
+  const hasMissingSteps = missingSteps && missingSteps.length > 0;
+
+  const handleGoToStep = (stepId: string) => {
+    navigate(`/learn/${storyId ?? story.id}/${stepId}`);
+  };
 
   useEffect(() => {
     try { localStorage.setItem(storageKey, JSON.stringify({ viewed: true })); } catch {}
@@ -72,10 +89,34 @@ const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish }) 
         </div>
       </div>
 
-      {/* Fixed bottom CTA */}
+      {/* Fixed bottom CTA — with optional missing-step reminder (#1104) */}
       <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
            style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
-        <div className="max-w-md mx-auto pointer-events-auto">
+        <div className="max-w-md mx-auto pointer-events-auto space-y-3">
+          {/* Soft reminder: steps not yet completed */}
+          {hasMissingSteps && (
+            <div className="bg-surface-container-lowest border border-surface-container-high rounded-2xl p-4 shadow-sm">
+              <div className="flex items-start gap-2 mb-3">
+                <span className="material-symbols-outlined text-base text-amber-500 mt-0.5 shrink-0">info</span>
+                <p className="text-sm font-headline font-bold text-on-surface">
+                  你還有 {missingSteps!.length} 個關卡沒有完成
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {missingSteps!.map((step) => (
+                  <button
+                    key={step.id}
+                    onClick={() => handleGoToStep(step.id)}
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-accent/10 text-accent text-xs font-headline font-bold hover:bg-accent/20 active:scale-[0.97] transition-all"
+                  >
+                    <span className="material-symbols-outlined text-sm">play_circle</span>
+                    {step.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           <button
             onClick={onFinish}
             className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"

--- a/frontend/src/pages/learning/KnowledgeStationPage.tsx
+++ b/frontend/src/pages/learning/KnowledgeStationPage.tsx
@@ -3,14 +3,21 @@ import KnowledgeStation from '../../components/reading-steps/KnowledgeStation';
 import { useLearningContext } from '../../layouts/LearningLayout';
 
 const KnowledgeStationPage: React.FC = () => {
-  const { selectedStory, handleFinishKnowledgeStation } = useLearningContext();
+  const { selectedStory, handleFinishKnowledgeStation, missingAssignmentSteps } = useLearningContext();
 
   if (!selectedStory) return null;
+
+  // Exclude 'knowledge-station' and 'report' from the missing list shown in the reminder
+  // (student is already on knowledge-station; report is the destination)
+  const missingStepsForReminder = missingAssignmentSteps.filter(
+    (s) => s.id !== 'knowledge-station' && s.id !== 'report',
+  );
 
   return (
     <KnowledgeStation
       story={selectedStory}
       onFinish={handleFinishKnowledgeStation}
+      missingSteps={missingStepsForReminder}
     />
   );
 };


### PR DESCRIPTION
Staging → main promote.

## Promotes to prod
- **#1270** — fix(stories): move rate-limit check below cache validation (avoid burning quota on cache-miss 400s)
- **#1272** — feat(step UX): Step 9 ComprehensionChat 加「下一關」按鈕 + Step 11 KnowledgeStation 缺漏提示 (Fixes #1103, #1104)
- **#1267** — perf: sync 5 FK index model annotations (DB indexes already exist from 2026-04-04 migration; this only adds `index=True` to models for ORM introspection consistency)

## Risk: LOW
- #1270: 1 line behavior fix, tests pass
- #1272: frontend-only (2 components), no API change
- #1267: pure ORM annotation sync, NO migration, NO DB schema change
- Staging backend healthy (HTTP 200)

## Post-merge plan
1. Watch deploy.yml green
2. Prod smoke test:
   - Frontend `/` HTTP 200
   - Backend `/` HTTP 200
   - `/api/stories/.../grade` unauthed → 401
   - Existing sanity endpoints stay 401
