### PR TITLE
docs(claude): add 覆寫規則 for prevention skills (Closes #1273)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,18 @@ cd frontend && npm install && npm run dev    # localhost:3000
 cd backend && pip install -r requirements.txt && uvicorn app.main:app --reload  # localhost:8000
 ```
 
+## 覆寫規則（防止反覆 bug）
+
+14 天內同類 bug 反覆出現，以下規則強制執行：
+
+| 情況 | 正確做法 | Skill |
+|------|---------|-------|
+| 新增或修改 `backend/app/models/*.py` | **先跑 `sqlalchemy-model-safety` checklist**（FK index / cascade / timestamps / alembic heads / idempotent DDL）；PostToolUse hook 會自動提醒 | `~/.claude/skills/sqlalchemy-model-safety/` |
+| 新增或修改有 LLM import 的 `backend/app/routes/*.py` | **先跑 `llm-endpoint-hardening` checklist**（rate-limit-after-cache / auth / input cap / fail-closed / reasoning field）；PostToolUse hook 會自動提醒 | `~/.claude/skills/llm-endpoint-hardening/` |
+| 新增 `backend/alembic/versions/*.py` migration | **先確認 `alembic heads` = 1**；PostToolUse hook 會自動執行 `alembic heads` 並在 multi-head 時 WARN | `~/.claude/skills/postgres-best-practices/` |
+
+> 相關 PostToolUse hooks 已在 `~/.claude/settings.json` 全域註冊（#1273）。
+
 ## 學習流程（7 步驟，StepperNav 定義）
 
 1. **簡介** — 課文背景介紹（Intro）


### PR DESCRIPTION
Closes #1273

## Summary

- Adds a `## 覆寫規則（防止反覆 bug）` section to LingoLeap's `CLAUDE.md` that routes Claude to the correct global prevention skill whenever it edits SQLAlchemy models, LLM routes, or Alembic migration files.
- The three global skills (`sqlalchemy-model-safety`, `llm-endpoint-hardening`, `postgres-best-practices`) and their companion PostToolUse hooks live in `~/.claude/` and are **out-of-tree** — this PR only adds the in-repo pointer table that makes the routing explicit for this project.

## Why now

14 days of recurring bugs in the same three categories:
- FK `index=True` missing: #1193 #1194 #1218 #1226 #1227 #1247 #1267 (7 PRs)
- Alembic multi-head conflicts: #1199 #1267 #1269 (3 incidents)
- LLM route hardening gaps: #1240 #1244 #1253 #1254 #1266 (5 fixes)

## Scope boundary

This PR does **not** touch #1267, #1270, or #1269 — those are owned by a parallel session.

## What is NOT in this PR

The two global skill file edits Young made to `~/.claude/skills/llm-endpoint-hardening/SKILL.md` and `~/.claude/skills/sqlalchemy-model-safety/SKILL.md` (token-bucket rate-limit section + query-site rescue paragraph) are personal dotfiles outside this repo and require no PR.

## Test plan

- [ ] `CLAUDE.md` renders correctly in GitHub (table columns aligned, links readable)
- [ ] No production code changed — CI should be green with no test failures
- [ ] Preview deploy health check returns HTTP 200