### PR TITLE
release: promote #1274 dictionary page to prod

### DIFF
--- a/backend/app/routes/dictionary.py
+++ b/backend/app/routes/dictionary.py
@@ -2,6 +2,9 @@
 
 Provides endpoints to look up Chinese character definitions from the
 MOE (Ministry of Education) dictionary with DB caching.
+
+Auth: all endpoints require a valid JWT (get_current_user).
+Rate limit: 60 req/min per user (DB-backed cache, not AI, so generous ceiling).
 """
 import logging
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -9,11 +12,17 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..database import get_db
+from ..auth.dependencies import get_current_user
+from ..auth.rate_limiter import make_general_rate_limit_dependency
+from ..models.user import User
 from ..services.dictionary_service import lookup_character, lookup_characters_batch
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["dictionary"])
+
+# Rate limit: 60 req/min per authenticated user (generous; results are cached in DB)
+_dict_rl = make_general_rate_limit_dependency(max_requests=60, window_seconds=60)
 
 
 class DefinitionEntry(BaseModel):
@@ -52,6 +61,8 @@ class BatchLookupResponse(BaseModel):
 def get_character(
     character: str,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(_dict_rl),
 ):
     """Look up a single Chinese character from MOE dictionary (cached)."""
     if len(character) != 1:
@@ -71,6 +82,43 @@ def get_character(
     return CharacterLookupResponse(**result)
 
 
+@router.get(
+    "/dictionary/lookup",
+    response_model=BatchLookupResponse,
+    summary="Look up one or more Chinese characters via query string",
+    description=(
+        "Convenience GET endpoint for the dictionary page. "
+        "Pass `chars=攻擊` to look up each character in the string (batch). "
+        "Max 20 characters per request. Each character uses DB cache when available."
+    ),
+)
+def lookup_chars(
+    chars: str = Query(..., description="One or more Chinese characters, e.g. '攻擊'"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(_dict_rl),
+):
+    """GET /dictionary/lookup?chars=XY — splits the string and batch-looks up each character."""
+    char_list = [c for c in chars if c.strip()]
+    if not char_list:
+        raise HTTPException(status_code=422, detail="chars query parameter must not be empty")
+    if len(char_list) > 20:
+        raise HTTPException(status_code=422, detail="at most 20 characters per lookup request")
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique_chars: list[str] = []
+    for ch in char_list:
+        if ch not in seen:
+            seen.add(ch)
+            unique_chars.append(ch)
+
+    results = lookup_characters_batch(unique_chars, db)
+    return BatchLookupResponse(
+        results=[CharacterLookupResponse(**r) for r in results]
+    )
+
+
 @router.post(
     "/dictionary/batch",
     response_model=BatchLookupResponse,
@@ -83,6 +131,8 @@ def get_character(
 def batch_lookup(
     payload: BatchLookupRequest,
     db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+    _rl: None = Depends(_dict_rl),
 ):
     """Batch look up multiple Chinese characters (max 20)."""
     if not payload.characters:

--- a/backend/tests/test_dictionary_api.py
+++ b/backend/tests/test_dictionary_api.py
@@ -2,8 +2,10 @@
 Tests for the Dictionary API (issue #259: MOE dictionary integration).
 
 Covers:
-- GET  /api/dictionary/character/{character}  — single character lookup
-- POST /api/dictionary/batch                  — batch lookup
+- GET  /api/dictionary/character/{character}  — single character lookup (auth required)
+- GET  /api/dictionary/lookup?chars=XY        — multi-char GET convenience endpoint (auth required, issue #1230)
+- POST /api/dictionary/batch                  — batch lookup (auth required)
+- Auth gate: unauthenticated requests return 401/403
 
 Uses SQLite in-memory DB and mocked HTTP calls to avoid external API dependency.
 
@@ -28,12 +30,17 @@ from sqlalchemy.pool import StaticPool
 from app.main import app
 from app.database import get_db
 from app.models import Base
+from app.models.user import User
+from app.auth.dependencies import get_current_user
 from app.services.dictionary_service import (
     _strip_markup,
     _parse_moe_response,
     lookup_character,
     lookup_characters_batch,
 )
+
+# Fake authenticated user for all route-level tests
+_FAKE_USER = User(id=1, email="dict-test-user", name="Test Student", password_hash="x")
 
 
 # ---------------------------------------------------------------------------
@@ -74,9 +81,27 @@ def client(db):
             pass
 
     app.dependency_overrides[get_db] = override_get_db
+    # Bypass auth: all dict route tests assume a logged-in student
+    app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def unauthenticated_client(db):
+    """Client with NO auth override — verifies 401/403 is returned."""
+    def override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    # Explicitly do NOT override get_current_user
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)
 
 
 # ---------------------------------------------------------------------------
@@ -383,3 +408,106 @@ class TestBatchLookupEndpoint:
     def test_batch_rejects_empty_list(self, client):
         resp = client.post("/api/dictionary/batch", json={"characters": []})
         assert resp.status_code == 422
+
+
+# ===========================================================================
+# GET /api/dictionary/lookup?chars=  (Issue #1230)
+# ===========================================================================
+
+class TestLookupEndpoint:
+    def test_returns_200_for_multi_char_query(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=攻擊")
+
+        assert resp.status_code == 200
+
+    def test_lookup_response_has_results_list(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=攻擊")
+
+        data = resp.json()
+        assert "results" in data
+        # 攻 and 擊 = 2 unique CJK chars
+        assert len(data["results"]) == 2
+
+    def test_lookup_deduplicates_chars(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=山山山")
+
+        data = resp.json()
+        # 山 repeated 3 times → deduplicated to 1
+        assert len(data["results"]) == 1
+
+    def test_lookup_single_char(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=山")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["results"]) == 1
+        assert data["results"][0]["character"] == "山"
+
+    def test_lookup_result_schema(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_MOE_RESPONSE
+
+        with patch("app.services.dictionary_service.httpx.get", return_value=mock_response):
+            resp = client.get("/api/dictionary/lookup?chars=水")
+
+        entry = resp.json()["results"][0]
+        assert "character" in entry
+        assert "zhuyin" in entry
+        assert "stroke_count" in entry
+        assert "definitions" in entry
+        assert "cached" in entry
+        assert "not_found" in entry
+
+    def test_lookup_rejects_more_than_20_unique_chars(self, client):
+        # 21 unique CJK characters
+        chars = "一二三四五六七八九十甲乙丙丁戊己庚辛壬癸黃"
+        resp = client.get(f"/api/dictionary/lookup?chars={chars}")
+        assert resp.status_code == 422
+
+    def test_lookup_rejects_missing_chars_param(self, client):
+        resp = client.get("/api/dictionary/lookup")
+        assert resp.status_code == 422
+
+
+# ===========================================================================
+# Auth gate — all endpoints require authentication (Issue #1230)
+# ===========================================================================
+
+class TestAuthGate:
+    """Verify endpoints return 401/403 without a valid token."""
+
+    def test_get_character_requires_auth(self, unauthenticated_client):
+        resp = unauthenticated_client.get("/api/dictionary/character/山")
+        assert resp.status_code in (401, 403)
+
+    def test_lookup_requires_auth(self, unauthenticated_client):
+        resp = unauthenticated_client.get("/api/dictionary/lookup?chars=山")
+        assert resp.status_code in (401, 403)
+
+    def test_batch_requires_auth(self, unauthenticated_client):
+        resp = unauthenticated_client.post(
+            "/api/dictionary/batch",
+            json={"characters": ["山"]},
+        )
+        assert resp.status_code in (401, 403)

--- a/backend/tests/test_learning_sessions_list.py
+++ b/backend/tests/test_learning_sessions_list.py
@@ -1,0 +1,579 @@
+"""
+Regression tests for Issue #1251 — list_my_sessions assignment completion logic.
+
+Context (PR #1250 / Issue #1245):
+  submit_assignment() does NOT update LearningSession.status to 'completed'.
+  The endpoint must treat a session as "completed" when the linked
+  AssignmentSubmission.status is 'submitted' or 'graded', regardless of
+  LearningSession.status.
+
+Tests:
+  1. Assignment session (LearningSession.status='in_progress',
+     AssignmentSubmission.status='submitted') → included in
+     ?learning_source=assignment&status=completed
+  2. Self-practice session (LearningSession.status='in_progress') →
+     excluded from ?learning_source=assignment&status=completed
+  3. Self-practice session (LearningSession.status='completed') →
+     included in ?learning_source=self&status=completed
+  4. Assignment session (AssignmentSubmission.status='graded') →
+     included in ?learning_source=assignment&status=completed
+  5. Assignment session (AssignmentSubmission.status='pending') →
+     excluded from ?learning_source=assignment&status=completed
+  6. No sessions → endpoint returns empty list (not 500)
+  7. Multiple sessions — only completed-assignment ones appear in filtered list
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import uuid
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User
+from app.models.session import LearningSession
+from app.models.assignment import Assignment, AssignmentSubmission
+from app.models.school import School, Classroom, ClassroomStudent
+from app.auth.password import hash_password
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite DB
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    # Disable FK constraints so we can insert test rows without full cascade setup
+    cursor.execute("PRAGMA foreign_keys=OFF")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+_SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin",    "display_name": "Org Admin",    "scope_level": "organization"},
+    {"name": "teacher",      "display_name": "Teacher",      "scope_level": "school"},
+    {"name": "student",      "display_name": "Student",      "scope_level": "school"},
+]
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixture: create tables once
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+
+    for r in _SEED_ROLES:
+        db.add(Role(**r))
+    db.commit()
+
+    db.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _register_and_login(client, suffix: str) -> dict:
+    """Register a new user and return {token, user_id, email}."""
+    email = f"list_sess_{suffix}@example.com"
+    password = "Password1!"
+    resp = client.post("/api/auth/register", json={
+        "email": email, "password": password, "name": f"User {suffix}",
+    })
+    assert resp.status_code == 201, resp.text
+    token = resp.json().get("verification_token")
+    if token:
+        client.get(f"/api/auth/verify-email?token={token}")
+    login = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login.status_code == 200, login.text
+    return {
+        "token": login.json()["access_token"],
+        "email": email,
+    }
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _get_user_id(db, email: str) -> int:
+    return db.query(User).filter(User.email == email).one().id
+
+
+def _create_raw_session(db, student_id: int, status: str = "in_progress") -> int:
+    """Insert a LearningSession row directly and return its id."""
+    s = LearningSession(
+        student_id=student_id,
+        story_slug=None,
+        status=status,
+        current_step=1,
+    )
+    db.add(s)
+    db.commit()
+    db.refresh(s)
+    return s.id
+
+
+def _create_assignment_with_submission(
+    db,
+    teacher_id: int,
+    classroom_id: int,
+    student_id: int,
+    session_id: int,
+    sub_status: str,
+) -> None:
+    """Create an Assignment + AssignmentSubmission linked to the given session."""
+    assignment = Assignment(
+        classroom_id=classroom_id,
+        teacher_id=teacher_id,
+        story_id="1",
+        title="Test Assignment",
+        assignment_type="reading",
+    )
+    db.add(assignment)
+    db.commit()
+    db.refresh(assignment)
+
+    submission = AssignmentSubmission(
+        assignment_id=assignment.id,
+        student_id=student_id,
+        session_id=session_id,
+        status=sub_status,
+    )
+    db.add(submission)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Shared school/teacher/classroom (module-scoped)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def shared_classroom(client) -> dict:
+    """
+    Create a teacher + school + classroom once for the module.
+    Returns {teacher_id, classroom_id}.
+    """
+    db = TestingSessionLocal()
+
+    school = School(name="Regression Test School 1251")
+    db.add(school)
+    db.commit()
+    db.refresh(school)
+
+    teacher = User(
+        email="reg1251_teacher@example.com",
+        username="reg1251_teacher",
+        password_hash=hash_password("Password1!"),
+        name="Reg Teacher",
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(teacher)
+    db.commit()
+    db.refresh(teacher)
+
+    classroom = Classroom(
+        name="Reg Classroom 1251",
+        school_id=school.id,
+        teacher_id=teacher.id,
+        join_code="REG1251",
+    )
+    db.add(classroom)
+    db.commit()
+    db.refresh(classroom)
+
+    teacher_id = teacher.id
+    classroom_id = classroom.id
+    db.close()
+
+    return {"teacher_id": teacher_id, "classroom_id": classroom_id}
+
+
+# ===========================================================================
+# Test 1: assignment session with submission.status='submitted', session.status='in_progress'
+# → MUST appear in ?learning_source=assignment&status=completed
+# ===========================================================================
+
+class TestAssignmentSubmittedCountsAsCompleted:
+    """
+    Core regression: submit_assignment() leaves LearningSession.status='in_progress'.
+    The endpoint must still surface this session when filtering for completed
+    assignment sessions.
+    """
+
+    @pytest.fixture(scope="class")
+    def student(self, client):
+        return _register_and_login(client, "t1_student")
+
+    @pytest.fixture(scope="class")
+    def session_and_submission(self, student, shared_classroom):
+        db = TestingSessionLocal()
+        student_id = _get_user_id(db, student["email"])
+
+        # LearningSession.status is deliberately 'in_progress' (as submit_assignment leaves it)
+        session_id = _create_raw_session(db, student_id, status="in_progress")
+
+        _create_assignment_with_submission(
+            db,
+            teacher_id=shared_classroom["teacher_id"],
+            classroom_id=shared_classroom["classroom_id"],
+            student_id=student_id,
+            session_id=session_id,
+            sub_status="submitted",
+        )
+        db.close()
+        return {"session_id": session_id}
+
+    def test_appears_in_assignment_completed_filter(self, client, student, session_and_submission):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        session_ids = [item["id"] for item in data["items"]]
+        assert session_and_submission["session_id"] in session_ids, (
+            "assignment session with submission.status='submitted' must appear "
+            "in ?learning_source=assignment&status=completed even though "
+            "LearningSession.status='in_progress'"
+        )
+
+    def test_total_is_positive(self, client, student):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.json()["total"] >= 1
+
+    def test_learning_source_field_is_assignment(self, client, student, session_and_submission):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        items = resp.json()["items"]
+        target = next((i for i in items if i["id"] == session_and_submission["session_id"]), None)
+        assert target is not None
+        assert target.get("learning_source") == "assignment"
+
+
+# ===========================================================================
+# Test 2: self-practice in_progress session is excluded from assignment filter
+# ===========================================================================
+
+class TestSelfPracticeExcludedFromAssignmentCompletedFilter:
+    """
+    A self-practice session with status='in_progress' must NOT appear when
+    filtering for completed assignment sessions.
+    """
+
+    @pytest.fixture(scope="class")
+    def student(self, client):
+        return _register_and_login(client, "t2_student")
+
+    @pytest.fixture(scope="class")
+    def self_session(self, student):
+        db = TestingSessionLocal()
+        student_id = _get_user_id(db, student["email"])
+        session_id = _create_raw_session(db, student_id, status="in_progress")
+        # No AssignmentSubmission — pure self practice
+        db.close()
+        return {"session_id": session_id}
+
+    def test_excluded_from_assignment_completed(self, client, student, self_session):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.status_code == 200
+        session_ids = [item["id"] for item in resp.json()["items"]]
+        assert self_session["session_id"] not in session_ids, (
+            "self-practice in_progress session must NOT appear in "
+            "?learning_source=assignment&status=completed"
+        )
+
+    def test_total_is_zero(self, client, student):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.json()["total"] == 0
+
+
+# ===========================================================================
+# Test 3: self-practice completed session appears in self completed filter
+# ===========================================================================
+
+class TestSelfPracticeCompletedSessionAppears:
+    """
+    A self-practice session with LearningSession.status='completed' must appear
+    when filtering ?learning_source=self&status=completed.
+    """
+
+    @pytest.fixture(scope="class")
+    def student(self, client):
+        return _register_and_login(client, "t3_student")
+
+    @pytest.fixture(scope="class")
+    def completed_self_session(self, student):
+        db = TestingSessionLocal()
+        student_id = _get_user_id(db, student["email"])
+        session_id = _create_raw_session(db, student_id, status="completed")
+        db.close()
+        return {"session_id": session_id}
+
+    def test_appears_in_self_completed_filter(self, client, student, completed_self_session):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=self&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.status_code == 200
+        session_ids = [item["id"] for item in resp.json()["items"]]
+        assert completed_self_session["session_id"] in session_ids, (
+            "self-practice session with status='completed' must appear "
+            "in ?learning_source=self&status=completed"
+        )
+
+    def test_learning_source_field_is_self(self, client, student, completed_self_session):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=self&status=completed",
+            headers=_auth(student["token"]),
+        )
+        items = resp.json()["items"]
+        target = next((i for i in items if i["id"] == completed_self_session["session_id"]), None)
+        assert target is not None
+        assert target.get("learning_source") == "self"
+
+
+# ===========================================================================
+# Test 4: assignment session with submission.status='graded' also counts
+# ===========================================================================
+
+class TestAssignmentGradedCountsAsCompleted:
+    """
+    submission.status='graded' is another terminal state that should appear
+    in ?learning_source=assignment&status=completed.
+    """
+
+    @pytest.fixture(scope="class")
+    def student(self, client):
+        return _register_and_login(client, "t4_student")
+
+    @pytest.fixture(scope="class")
+    def graded_session(self, student, shared_classroom):
+        db = TestingSessionLocal()
+        student_id = _get_user_id(db, student["email"])
+        session_id = _create_raw_session(db, student_id, status="in_progress")
+        _create_assignment_with_submission(
+            db,
+            teacher_id=shared_classroom["teacher_id"],
+            classroom_id=shared_classroom["classroom_id"],
+            student_id=student_id,
+            session_id=session_id,
+            sub_status="graded",
+        )
+        db.close()
+        return {"session_id": session_id}
+
+    def test_graded_appears_in_completed_filter(self, client, student, graded_session):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.status_code == 200
+        session_ids = [item["id"] for item in resp.json()["items"]]
+        assert graded_session["session_id"] in session_ids, (
+            "assignment session with submission.status='graded' must appear "
+            "in ?learning_source=assignment&status=completed"
+        )
+
+
+# ===========================================================================
+# Test 5: assignment session with submission.status='pending' is excluded
+# ===========================================================================
+
+class TestAssignmentPendingExcludedFromCompleted:
+    """
+    submission.status='pending' (not done) must NOT appear in the completed filter.
+    """
+
+    @pytest.fixture(scope="class")
+    def student(self, client):
+        return _register_and_login(client, "t5_student")
+
+    @pytest.fixture(scope="class")
+    def pending_session(self, student, shared_classroom):
+        db = TestingSessionLocal()
+        student_id = _get_user_id(db, student["email"])
+        session_id = _create_raw_session(db, student_id, status="in_progress")
+        _create_assignment_with_submission(
+            db,
+            teacher_id=shared_classroom["teacher_id"],
+            classroom_id=shared_classroom["classroom_id"],
+            student_id=student_id,
+            session_id=session_id,
+            sub_status="pending",
+        )
+        db.close()
+        return {"session_id": session_id}
+
+    def test_pending_excluded_from_completed_filter(self, client, student, pending_session):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.status_code == 200
+        session_ids = [item["id"] for item in resp.json()["items"]]
+        assert pending_session["session_id"] not in session_ids, (
+            "assignment session with submission.status='pending' must NOT "
+            "appear in ?learning_source=assignment&status=completed"
+        )
+
+
+# ===========================================================================
+# Test 6: student with no sessions returns empty list (not 500)
+# ===========================================================================
+
+class TestNoSessionsReturnsEmpty:
+    @pytest.fixture(scope="class")
+    def fresh_student(self, client):
+        return _register_and_login(client, "t6_fresh")
+
+    def test_empty_list(self, client, fresh_student):
+        resp = client.get(
+            "/api/learning/sessions",
+            headers=_auth(fresh_student["token"]),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+
+    def test_empty_with_assignment_completed_filter(self, client, fresh_student):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(fresh_student["token"]),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+
+# ===========================================================================
+# Test 7: mixed sessions — filter precision (only correct ones surface)
+# ===========================================================================
+
+class TestMixedSessionsFilterPrecision:
+    """
+    A student has three sessions:
+    - assignment session with submission='submitted'  → completed assignment
+    - assignment session with submission='pending'    → NOT completed
+    - self-practice session with status='completed'   → NOT assignment
+
+    ?learning_source=assignment&status=completed should return exactly 1 item.
+    """
+
+    @pytest.fixture(scope="class")
+    def student(self, client):
+        return _register_and_login(client, "t7_mixed")
+
+    @pytest.fixture(scope="class")
+    def mixed_sessions(self, student, shared_classroom):
+        db = TestingSessionLocal()
+        student_id = _get_user_id(db, student["email"])
+
+        # Session A: assignment, submission submitted → should appear
+        sess_a_id = _create_raw_session(db, student_id, status="in_progress")
+        _create_assignment_with_submission(
+            db,
+            teacher_id=shared_classroom["teacher_id"],
+            classroom_id=shared_classroom["classroom_id"],
+            student_id=student_id,
+            session_id=sess_a_id,
+            sub_status="submitted",
+        )
+
+        # Session B: assignment, submission pending → should NOT appear
+        sess_b_id = _create_raw_session(db, student_id, status="in_progress")
+        _create_assignment_with_submission(
+            db,
+            teacher_id=shared_classroom["teacher_id"],
+            classroom_id=shared_classroom["classroom_id"],
+            student_id=student_id,
+            session_id=sess_b_id,
+            sub_status="pending",
+        )
+
+        # Session C: self-practice completed → should NOT appear for assignment filter
+        sess_c_id = _create_raw_session(db, student_id, status="completed")
+
+        db.close()
+        return {"submitted": sess_a_id, "pending": sess_b_id, "self_completed": sess_c_id}
+
+    def test_only_submitted_assignment_appears(self, client, student, mixed_sessions):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        session_ids = [item["id"] for item in data["items"]]
+
+        assert mixed_sessions["submitted"] in session_ids
+        assert mixed_sessions["pending"] not in session_ids
+        assert mixed_sessions["self_completed"] not in session_ids
+
+    def test_total_is_exactly_one(self, client, student):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=assignment&status=completed",
+            headers=_auth(student["token"]),
+        )
+        assert resp.json()["total"] == 1
+
+    def test_self_completed_appears_in_self_filter(self, client, student, mixed_sessions):
+        resp = client.get(
+            "/api/learning/sessions?learning_source=self&status=completed",
+            headers=_auth(student["token"]),
+        )
+        session_ids = [item["id"] for item in resp.json()["items"]]
+        assert mixed_sessions["self_completed"] in session_ids
+        assert mixed_sessions["submitted"] not in session_ids
+        assert mixed_sessions["pending"] not in session_ids

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -389,7 +389,10 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
 
   // Targeted practice tools — shown at the BOTTOM of the student sidebar, separated by a divider (#1165)
   const toolsItems: NavItem[] = activeView === 'student'
-    ? [{ icon: '🧰', label: '練習工具箱', path: '/tools' }]
+    ? [
+        { icon: '🧰', label: '練習工具箱', path: '/tools' },
+        { icon: '📖', label: '字典查詢', path: '/dictionary' },
+      ]
     : [];
 
   const teacherItems: NavItem[] = activeView === 'teacher' || activeView === 'admin'

--- a/frontend/src/components/student/QuickPracticeStrip.tsx
+++ b/frontend/src/components/student/QuickPracticeStrip.tsx
@@ -8,11 +8,11 @@
  *   - 筆順字帖  → /write          (no story needed)
  *   - 聽寫挑戰  → /library        (needs story — goes to library first)
  *   - 造句練習  → /library        (needs story)
- *   - 字典查詢  → /vocabulary     (no story needed)
+ *   - 字典查詢  → /dictionary     (no story needed, Issue #1230)
  *
  * "看更多 →" links to /tools (PracticeToolbox page, Issue #1153).
  *
- * Issue #1153
+ * Issue #1153 + #1230
  */
 
 import React from 'react';
@@ -50,9 +50,9 @@ const QUICK_CARDS: PracticeCard[] = [
   },
   {
     icon: '📖',
-    title: '我的生字',
-    description: '看看哪些字需要加強',
-    route: '/vocabulary',
+    title: '字典查詢',
+    description: '查字義、注音、例句',
+    route: '/dictionary',
   },
 ];
 

--- a/frontend/src/pages/student/DictionaryPage.tsx
+++ b/frontend/src/pages/student/DictionaryPage.tsx
@@ -1,0 +1,234 @@
+/**
+ * DictionaryPage — /dictionary
+ *
+ * Stand-alone dictionary lookup page for students.
+ * Supports single-character lookup (via DictionaryPanel) and multi-character
+ * input (splits into individual characters and shows result cards in a grid).
+ *
+ * Backend: GET /api/dictionary/lookup?chars=X or /api/dictionary/character/{c}
+ * Auth: JWT required (learningApi reads from localStorage)
+ *
+ * Issue #1230
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DictionaryPanel from '../../components/dictionary/DictionaryPanel';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface SearchState {
+  query: string;       // raw input (may be multi-char)
+  chars: string[];     // parsed individual CJK characters
+}
+
+const MAX_CHARS = 10;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Extract unique CJK characters from a string, preserve order. */
+function extractCJKChars(input: string): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const ch of input) {
+    // CJK Unified Ideographs (U+4E00–U+9FFF) + Extension A/B common range
+    if (/\p{Script=Han}/u.test(ch) && !seen.has(ch)) {
+      seen.add(ch);
+      result.push(ch);
+    }
+  }
+  return result;
+}
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+const DictionaryPage: React.FC = () => {
+  const navigate = useNavigate();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [inputValue, setInputValue] = useState('');
+  const [search, setSearch] = useState<SearchState | null>(null);
+
+  const handleSearch = useCallback(() => {
+    const trimmed = inputValue.trim();
+    if (!trimmed) return;
+    const chars = extractCJKChars(trimmed);
+    if (chars.length === 0) return;
+    setSearch({ query: trimmed, chars: chars.slice(0, MAX_CHARS) });
+  }, [inputValue]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') handleSearch();
+    },
+    [handleSearch],
+  );
+
+  const handleClear = useCallback(() => {
+    setInputValue('');
+    setSearch(null);
+    inputRef.current?.focus();
+  }, []);
+
+  const isSingle = search != null && search.chars.length === 1;
+  const isMulti   = search != null && search.chars.length > 1;
+
+  return (
+    <div className="flex-1 overflow-y-auto bg-surface">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 pt-6 pb-10 space-y-6">
+
+        {/* ── Header ─────────────────────────────────────────────────────── */}
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="
+              shrink-0 w-9 h-9 flex items-center justify-center rounded-full
+              bg-surface-container-lowest border border-[#E5E0D5]
+              text-on-surface-variant hover:text-on-surface
+              hover:border-accent/40 hover:shadow-sm
+              transition-all duration-150
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+            "
+            aria-label="返回"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M15 18l-6-6 6-6" />
+            </svg>
+          </button>
+          <div>
+            <h1 className="text-xl sm:text-2xl font-bold font-headline text-on-surface leading-tight">
+              字典查詢
+            </h1>
+            <p className="text-xs sm:text-sm text-on-surface-variant mt-0.5">
+              查字義、注音、例句
+            </p>
+          </div>
+        </div>
+
+        {/* ── Search input ────────────────────────────────────────────────── */}
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <label htmlFor="dict-search-input" className="sr-only">
+              輸入要查詢的字
+            </label>
+            <input
+              id="dict-search-input"
+              ref={inputRef}
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="輸入要查詢的字，例如：攻擊"
+              maxLength={MAX_CHARS + 5}
+              className="
+                w-full rounded-xl border border-[#E5E0D5] bg-surface-container-lowest
+                px-4 py-3 text-base text-on-surface placeholder:text-on-surface-variant/50
+                focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent
+                transition-shadow duration-150
+              "
+              aria-label="輸入要查詢的字"
+              aria-describedby="dict-search-hint"
+            />
+            {inputValue && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="
+                  absolute right-3 top-1/2 -translate-y-1/2
+                  text-on-surface-variant hover:text-on-surface transition-colors
+                "
+                aria-label="清除輸入"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={handleSearch}
+            disabled={!inputValue.trim()}
+            className="
+              shrink-0 px-5 py-3 rounded-xl
+              bg-accent text-white font-semibold text-sm
+              hover:opacity-90 active:scale-[0.98]
+              disabled:opacity-40 disabled:cursor-not-allowed
+              transition-all duration-150
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+            "
+            aria-label="查詢"
+          >
+            查詢
+          </button>
+        </div>
+
+        <p
+          id="dict-search-hint"
+          className="text-xs text-on-surface-variant -mt-4"
+        >
+          最多可一次查 {MAX_CHARS} 個字
+        </p>
+
+        {/* ── Empty state ─────────────────────────────────────────────────── */}
+        {search == null && (
+          <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
+            <span className="text-5xl" aria-hidden="true">📖</span>
+            <p className="text-base font-semibold text-on-surface">輸入字，立刻查字義</p>
+            <p className="text-sm text-on-surface-variant max-w-xs">
+              支援多字查詢：輸入「攻擊」會同時顯示「攻」和「擊」的字典資料
+            </p>
+          </div>
+        )}
+
+        {/* ── No CJK found ────────────────────────────────────────────────── */}
+        {search != null && search.chars.length === 0 && (
+          <div className="rounded-xl border border-[#E5E0D5] bg-surface-container-lowest p-6 text-center">
+            <p className="text-sm text-on-surface-variant">
+              「{search.query}」沒有找到中文字，請重新輸入
+            </p>
+          </div>
+        )}
+
+        {/* ── Single character result ──────────────────────────────────────── */}
+        {isSingle && (
+          <div className="rounded-xl border border-[#E5E0D5] bg-surface-container-lowest p-5">
+            <DictionaryPanel character={search!.chars[0]} />
+          </div>
+        )}
+
+        {/* ── Multi-character results ──────────────────────────────────────── */}
+        {isMulti && (
+          <div className="space-y-4">
+            <p className="text-sm font-semibold text-on-surface">
+              找到 {search!.chars.length} 個字
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {search!.chars.map((ch) => (
+                <div
+                  key={ch}
+                  className="rounded-xl border border-[#E5E0D5] bg-surface-container-lowest p-5"
+                >
+                  <DictionaryPanel character={ch} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* ── Over-limit notice (if input had > MAX_CHARS CJK) ────────────── */}
+        {search != null &&
+          extractCJKChars(search.query).length > MAX_CHARS && (
+            <p className="text-xs text-on-surface-variant text-center">
+              僅顯示前 {MAX_CHARS} 個字的結果
+            </p>
+          )}
+
+      </div>
+    </div>
+  );
+};
+
+export default DictionaryPage;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -64,6 +64,7 @@ const StudentProfile = lazy(() => import('../pages/student/StudentProfile'));
 const SessionHistoryReportPage = lazy(() => import('../pages/student/SessionHistoryReportPage'));
 const LearningHistoryPage = lazy(() => import('../pages/student/LearningHistoryPage'));
 const PracticeToolbox = lazy(() => import('../pages/student/PracticeToolbox'));
+const DictionaryPage = lazy(() => import('../pages/student/DictionaryPage'));
 
 // Parent dashboard — role-specific, split separately
 const ParentDashboard = lazy(() => import('../pages/parent/ParentDashboard'));
@@ -391,6 +392,16 @@ const AppRoutes: React.FC = () => (
           <ProtectedRoute>
             <AppShell>
               <MyVocabulary />
+            </AppShell>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/dictionary"
+        element={
+          <ProtectedRoute>
+            <AppShell>
+              <DictionaryPage />
             </AppShell>
           </ProtectedRoute>
         }

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -615,20 +615,37 @@ export interface DictionaryBatchResponse {
   results: DictionaryEntry[];
 }
 
-/** Look up a single Chinese character from the MOE dictionary (cached). No auth required. */
+// Token key must match AuthContext TOKEN_KEY
+const _DICT_TOKEN_KEY = 'lingoleap_token';
+
+function _getDictAuthHeaders(): Record<string, string> {
+  const token = localStorage.getItem(_DICT_TOKEN_KEY);
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** Look up a single Chinese character from the MOE dictionary (cached). Requires auth. */
 export async function lookupCharacter(character: string): Promise<DictionaryEntry> {
   const res = await fetch(
     `${API_BASE}/api/dictionary/character/${encodeURIComponent(character)}`,
+    { headers: _getDictAuthHeaders() },
   );
   if (!res.ok) throw new Error(`lookupCharacter failed: ${res.status}`);
   return res.json();
 }
 
-/** Batch look up multiple Chinese characters (max 20, deduplication applied). No auth required. */
+/** Batch look up multiple Chinese characters via GET ?chars= (max 20). Requires auth. */
+export async function lookupCharactersQuery(chars: string): Promise<DictionaryBatchResponse> {
+  const url = `${API_BASE}/api/dictionary/lookup?chars=${encodeURIComponent(chars)}`;
+  const res = await fetch(url, { headers: _getDictAuthHeaders() });
+  if (!res.ok) throw new Error(`lookupCharactersQuery failed: ${res.status}`);
+  return res.json();
+}
+
+/** Batch look up multiple Chinese characters (max 20, deduplication applied). Requires auth. */
 export async function lookupCharactersBatch(characters: string[]): Promise<DictionaryBatchResponse> {
   const res = await fetch(`${API_BASE}/api/dictionary/batch`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ..._getDictAuthHeaders() },
     body: JSON.stringify({ characters }),
   });
   if (!res.ok) throw new Error(`lookupCharactersBatch failed: ${res.status}`);


### PR DESCRIPTION
Staging → main promote. Single logical change: **#1274 /dictionary 字典查詢頁** (新 feature). No migrations, no risk. Post-deploy smoke: curl /api/dictionary/lookup?chars=X → 401 unauth, frontend /dictionary → 200.