### PR TITLE
fix: add index=True to ai_usage.teacher_id for ORM accuracy (Closes #1279)

### DIFF
--- a/backend/app/models/ai_usage.py
+++ b/backend/app/models/ai_usage.py
@@ -37,7 +37,7 @@ class AIUsageLog(Base):
     # ── Denormalized dimensions (snapshot at call time) ──
     student_name = Column(String(100))
     grade_level = Column(String(20))
-    teacher_id = Column(Integer)
+    teacher_id = Column(Integer, index=True)
     teacher_name = Column(String(100))
     org_id = Column(Integer)
     school_name = Column(String(100))


### PR DESCRIPTION
Closes #1279

## Summary

- `ai_usage.teacher_id` was missing `index=True` in the SQLAlchemy model, causing ORM introspection mismatch
- The DB index `idx_ai_usage_teacher` already exists (created by migration `y5z6a7b8c9d0_create_ai_usage_log.py` line 84)
- This is a **model-only fix** — no new migration needed, same pattern as `px01perf02idx03` which notes "no additional DB migration is needed" for already-indexed columns
- Found by the `post-edit-sqlalchemy-fk-check` hook that landed via #1273 / PR #1276

## What changed

`backend/app/models/ai_usage.py` — added `index=True` to `teacher_id` column:
```python
# Before:
teacher_id = Column(Integer)

# After:
teacher_id = Column(Integer, index=True)
```

## Why no migration

The existing migration `y5z6a7b8c9d0_create_ai_usage_log` already creates `idx_ai_usage_teacher` on `teacher_id` at line 84. Running a new migration with `CREATE INDEX IF NOT EXISTS` would be a no-op on existing DBs. The model declaration is updated solely for ORM introspection accuracy.

## Test plan

- [x] `git diff` confirms 1-line change, no migration file added
- [ ] CI backend build passes
- [ ] Preview backend health check `/api/health` returns 200