### PR TITLE
fix(learning-history): render session report data (#1245 item 4)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -253,7 +253,9 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
   const { readingAttempt, comprehensionResult, vocabResult, dictationResult, fullReadingResult } = session;
 
   // Determine how many of the 6 key sections the student has completed
-  const hasNoData = !readingAttempt && !comprehensionResult && !vocabResult && !fullReadingResult;
+  // Include comprehensionScores: a session with only Socratic scores (no JSONB result fields)
+  // should NOT be treated as "no data" — the score is the data. (Issue #1245 item 4)
+  const hasNoData = !readingAttempt && !comprehensionResult && !vocabResult && !fullReadingResult && !comprehensionScores;
   const completedSections = [
     !!(readingAttempt || fullReadingResult),  // 環節一 朗讀結果
     !!(readingAttempt || fullReadingResult),  // 環節二 錄音分析

--- a/frontend/src/pages/student/SessionHistoryReportPage.tsx
+++ b/frontend/src/pages/student/SessionHistoryReportPage.tsx
@@ -108,16 +108,29 @@ function buildLearningSession(detail: SessionDetailResponse): LearningSession {
 
 function buildComprehensionScores(detail: SessionDetailResponse): ComprehensionScoreResult | null {
   if (detail.comprehension_score == null) return null;
+
+  // comprehension_feedback is stored in the DB as a JSON string like
+  // '{"literal":"...","inferential":"...","evaluative":"...","overall":"..."}' (Issue #1245 item 4)
+  let feedbackObj: { literal?: string; inferential?: string; evaluative?: string; overall?: string } = {};
+  if (detail.comprehension_feedback) {
+    try {
+      feedbackObj = JSON.parse(detail.comprehension_feedback);
+    } catch {
+      // If parsing fails, treat the raw string as the overall feedback
+      feedbackObj = { overall: detail.comprehension_feedback };
+    }
+  }
+
   return {
     comprehension_score: detail.comprehension_score,
     literal_score: detail.literal_score ?? 0,
     inferential_score: detail.inferential_score ?? 0,
     evaluative_score: detail.evaluative_score ?? 0,
     feedback: {
-      literal: '',
-      inferential: '',
-      evaluative: '',
-      overall: detail.comprehension_feedback ?? '',
+      literal: feedbackObj.literal ?? '',
+      inferential: feedbackObj.inferential ?? '',
+      evaluative: feedbackObj.evaluative ?? '',
+      overall: feedbackObj.overall ?? '',
     },
   };
 }

--- a/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
+++ b/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
@@ -110,16 +110,27 @@ function buildSession(detail: TeacherSessionReport): LearningSession {
 
 function buildScores(detail: TeacherSessionReport): ComprehensionScoreResult | null {
   if (detail.comprehension_score == null) return null;
+
+  // comprehension_feedback is stored in the DB as a JSON string (Issue #1245 item 4)
+  let feedbackObj: { literal?: string; inferential?: string; evaluative?: string; overall?: string } = {};
+  if (detail.comprehension_feedback) {
+    try {
+      feedbackObj = JSON.parse(detail.comprehension_feedback);
+    } catch {
+      feedbackObj = { overall: detail.comprehension_feedback };
+    }
+  }
+
   return {
     comprehension_score: detail.comprehension_score,
     literal_score: detail.literal_score ?? 0,
     inferential_score: detail.inferential_score ?? 0,
     evaluative_score: detail.evaluative_score ?? 0,
     feedback: {
-      literal: '',
-      inferential: '',
-      evaluative: '',
-      overall: detail.comprehension_feedback ?? '',
+      literal: feedbackObj.literal ?? '',
+      inferential: feedbackObj.inferential ?? '',
+      evaluative: feedbackObj.evaluative ?? '',
+      overall: feedbackObj.overall ?? '',
     },
   };
 }


### PR DESCRIPTION
## Scope

Fixes item 4 of #1245: 學習報告頁有資料卻 render 空白。Items 1–3 already shipped (#1250 → #1257).

## Root cause

**Frontend render conditions too strict**, two separate bugs:

1. **`AssessmentReport.tsx`** — `hasNoData` check missed `comprehensionScores`. Sessions with AI-scored comprehension but no reading/vocab data incorrectly showed empty state.
2. **`SessionHistoryReportPage.tsx` + `TeacherSessionReportPage.tsx`** — `comprehension_feedback` stored as JSON string (`{literal, inferential, evaluative, overall}`) was being treated as plain text for only the `overall` field. Per-dimension feedback was always empty, and `overall` showed raw JSON.

## Fix

- Include `comprehensionScores` in `hasNoData` evaluation
- `JSON.parse` `comprehension_feedback` in both report pages, map all four dimensions

## Files

- `frontend/src/components/reading-steps/AssessmentReport.tsx`
- `frontend/src/pages/student/SessionHistoryReportPage.tsx`
- `frontend/src/pages/teacher/TeacherSessionReportPage.tsx`

## Test plan

- [ ] PR preview: login as student, open `/learning-history/session/{id}` for a session with AI comprehension score — report fields render
- [ ] Same URL for a partial-data session (only reading, no Socratic) — renders what exists, doesn't blank everything
- [ ] Teacher view equivalent

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)