### PR TITLE
fix: Step 8 語詞應用 — 配對飛掉動畫 + 填充炮灰選項 (Fixes #1102)

### DIFF
--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -103,7 +103,9 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
     if (done && phase === 'exercise') setPhase('summary');
   }, [done, phase]);
 
-  const availableEntries = bankEntries.filter(([code]) => !usedCodes.has(code));
+  // Show all bank entries; used ones stay visible as decoys (greyed-out, non-selectable).
+  // This gives subsequent questions strategic distractor options (issue #1102 fix 3).
+  const availableEntries = bankEntries;
   const currentSentence = !done ? activeSentences[currentIdx] : null;
   const currentOriginalIdx = retryMode ? retryIndices[currentIdx] : currentIdx;
 
@@ -359,24 +361,39 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
           <div className="grid grid-cols-2 gap-3">
             {availableEntries.map(([code, word]) => {
               const isSelected = selected === code;
+              // Words already used for previous questions stay as decoys:
+              // greyed-out, non-interactive, but visible to add strategic difficulty.
+              const isUsedDecoy = usedCodes.has(code);
               return (
                 <button
                   key={code}
-                  onClick={() => handleSelect(code)}
-                  className={`rounded-2xl border-2 p-4 text-left flex items-center gap-3 transition-all active:scale-[0.97] min-h-[56px] ${
-                    isSelected
-                      ? 'border-accent bg-accent/5 shadow-sm'
-                      : 'border-surface-container-high bg-surface-container-lowest hover:border-on-surface-variant/30'
+                  onClick={() => !isUsedDecoy && handleSelect(code)}
+                  disabled={isUsedDecoy}
+                  aria-disabled={isUsedDecoy}
+                  className={`rounded-2xl border-2 p-4 text-left flex items-center gap-3 transition-all min-h-[56px] ${
+                    isUsedDecoy
+                      ? 'border-surface-container-high bg-surface-container-high/40 opacity-40 cursor-not-allowed'
+                      : isSelected
+                      ? 'border-accent bg-accent/5 shadow-sm active:scale-[0.97]'
+                      : 'border-surface-container-high bg-surface-container-lowest hover:border-on-surface-variant/30 active:scale-[0.97]'
                   }`}
                 >
                   <span className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-sm font-headline font-black ${
-                    isSelected
+                    isUsedDecoy
+                      ? 'bg-surface-container-high text-on-surface-variant/40'
+                      : isSelected
                       ? 'bg-accent text-white'
                       : 'bg-surface-container-high text-on-surface-variant'
                   }`}>
                     {code}
                   </span>
-                  <span className={`font-bold text-base ${isSelected ? 'text-accent' : 'text-on-surface'}`}>
+                  <span className={`font-bold text-base ${
+                    isUsedDecoy
+                      ? 'text-on-surface-variant/40 line-through'
+                      : isSelected
+                      ? 'text-accent'
+                      : 'text-on-surface'
+                  }`}>
                     {zh(word)}
                   </span>
                 </button>

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -455,6 +455,8 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
   const [wrongFlash, setWrongFlash] = useState<Set<number>>(new Set());
   const [hoverTarget, setHoverTarget] = useState<number | null>(null);
   const [touchSelected, setTouchSelected] = useState<number | null>(null);
+  // vocabIdx values currently playing the fly-away exit animation
+  const [flyingAway, setFlyingAway] = useState<Set<number>>(new Set());
 
   // Track last answer per slot for summary (correct ones only, since wrong bounce back)
   const answersRef = useRef<AnswerRecord[]>(
@@ -471,6 +473,7 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
     setWrongFlash(new Set());
     setHoverTarget(null);
     setTouchSelected(null);
+    setFlyingAway(new Set());
     answersRef.current = activeDefIndices.map((defIdx) => ({
       defIndex: defIdx,
       answeredWordIdx: null,
@@ -495,7 +498,7 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
       });
 
       if (vocabIdx === defIdx) {
-        // Correct
+        // Correct — trigger fly-away animation on the word chip, then mark confirmed
         const wrongAttempts = wrongAttemptCountRef.current.get(defIdx) ?? 0;
         answersRef.current = answersRef.current.map((a) =>
           a.defIndex === defIdx ? {
@@ -507,14 +510,24 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
         );
         confirmedRef.current = new Set([...confirmedRef.current, defIdx]);
 
-        setConfirmed((prev) => {
-          const next = new Set(prev);
-          next.add(defIdx);
-          if (next.size === activeDefIndices.length) {
-            setTimeout(() => onAllDone(answersRef.current), 600);
-          }
-          return next;
-        });
+        // Start fly-away animation on the chip
+        setFlyingAway((prev) => new Set([...prev, vocabIdx]));
+        // After animation completes, mark the slot as confirmed (chip is now hidden)
+        setTimeout(() => {
+          setFlyingAway((prev) => {
+            const next = new Set(prev);
+            next.delete(vocabIdx);
+            return next;
+          });
+          setConfirmed((prev) => {
+            const next = new Set(prev);
+            next.add(defIdx);
+            if (next.size === activeDefIndices.length) {
+              setTimeout(() => onAllDone(answersRef.current), 600);
+            }
+            return next;
+          });
+        }, 550);
       } else {
         // Wrong — record attempt, flash, bounce back
         const wrongAttempts = (wrongAttemptCountRef.current.get(defIdx) ?? 0) + 1;
@@ -591,6 +604,7 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
       <div className="flex flex-wrap gap-2 min-h-[56px]">
         {activeShuffledWords.map((vocabIdx) => {
           const isPlaced = placedVocabIdxSet.has(vocabIdx);
+          const isFlying = flyingAway.has(vocabIdx);
           // Fix #1101 (炮灰選項): Keep correctly-confirmed words visible as locked
           // "cannon fodder" chips so the last drag-drop question always has multiple
           // options in the bank — no more forced-correct final question.
@@ -599,8 +613,8 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
           const isDragging = draggingVocabIdx === vocabIdx;
           const isTouchSelected = touchSelected === vocabIdx;
 
-          // Confirmed words: show as locked/dimmed, not draggable
-          if (isConfirmedWord) {
+          // Confirmed words (fly-away animation already finished): show as locked/dimmed
+          if (isConfirmedWord && !isFlying) {
             return (
               <div
                 key={vocabIdx}
@@ -612,12 +626,15 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
             );
           }
 
-          // Placed but not yet confirmed (pending validation — bounce-back in progress)
-          if (isPlaced) return null;
+          // Placed but not yet confirmed (pending validation — bounce-back in progress).
+          // Fly-away in progress (#1102) still needs to render its animation chip.
+          if (isPlaced && !isFlying) return null;
 
           let cls =
             'rounded-2xl border-2 px-4 py-2.5 text-center font-bold text-base select-none transition-all duration-200 ';
-          if (isDragging) {
+          if (isFlying) {
+            cls += 'border-emerald-400 bg-emerald-100 text-emerald-700 animate-fly-away pointer-events-none';
+          } else if (isDragging) {
             cls += 'border-accent bg-accent/10 text-accent shadow-xl scale-105 opacity-80 cursor-grabbing';
           } else if (isTouchSelected) {
             cls += 'border-accent bg-accent/10 text-accent shadow-md scale-105 cursor-pointer';
@@ -628,11 +645,11 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
           return (
             <div
               key={vocabIdx}
-              draggable
-              onDragStart={() => handleDragStart(vocabIdx)}
+              draggable={!isFlying}
+              onDragStart={() => !isFlying && handleDragStart(vocabIdx)}
               onDragEnd={handleDragEnd}
-              onTouchStart={() => handleTouchStart(vocabIdx)}
-              onClick={() => handleTouchStart(vocabIdx)}
+              onTouchStart={() => !isFlying && handleTouchStart(vocabIdx)}
+              onClick={() => !isFlying && handleTouchStart(vocabIdx)}
               className={cls}
             >
               {vocab[vocabIdx]?.word}
@@ -649,7 +666,18 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
   );
 
   /* ---- Definition slots ---- */
-  const definitionSlots = activeDefIndices.map((defIdx) => {
+  // Sort: unmatched slots first so remaining options stay near the top as pairs are confirmed
+  const sortedDefIndices = useMemo(
+    () => [...activeDefIndices].sort((a, b) => {
+      const aConfirmed = confirmed.has(a) ? 1 : 0;
+      const bConfirmed = confirmed.has(b) ? 1 : 0;
+      return aConfirmed - bConfirmed;
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeDefIndices, confirmed.size],
+  );
+
+  const definitionSlots = sortedDefIndices.map((defIdx) => {
     const item = vocab[defIdx];
     const placedVocabIdx = placements.get(defIdx) ?? null;
     const isCorrect = confirmed.has(defIdx);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -117,6 +117,11 @@ export default {
           '50%':  { transform: 'scale(1.4) rotate(180deg)', opacity: '1' },
           '100%': { transform: 'scale(1) rotate(360deg)', opacity: '1' },
         },
+        'fly-away': {
+          '0%':   { transform: 'scale(1) translateY(0)',   opacity: '1' },
+          '40%':  { transform: 'scale(1.15) translateY(-8px)', opacity: '1' },
+          '100%': { transform: 'scale(0.4) translateY(-40px)', opacity: '0' },
+        },
       },
       animation: {
         shake: 'shake 0.45s ease-in-out',
@@ -130,6 +135,7 @@ export default {
         'confetti-drop-2': 'confetti-drop-2 1.1s ease-in 0.2s forwards',
         'confetti-drop-3': 'confetti-drop-3 0.9s ease-in 0s forwards',
         'star-burst': 'star-burst 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)',
+        'fly-away': 'fly-away 0.55s cubic-bezier(0.4, 0, 0.6, 1) forwards',
       },
     },
   },


### PR DESCRIPTION
Fixes #1102

## Summary

Three UX fixes for Step 8 語詞應用:

### 拖拉配對 (VocabDefinitionMatch)
- **飛掉動畫**: Correctly matched word chips now play a fly-away exit animation (`scale → translateY → fade out`, 550ms) before disappearing from the word bank. Previously they just vanished instantly.
- **滾動問題**: Unmatched definition slots are now sorted to the top as pairs are confirmed. The remaining 2 slots stay near the top of the page instead of being buried below all the confirmed (green) slots.

### 填充題 (FillInBlankExercise)
- **炮灰選項**: Previously-used words are now kept visible in the answer grid as greyed-out, strikethrough, non-clickable decoys. This adds strategic difficulty and prevents the option pool from shrinking to near-zero on later questions.

### Technical
- Added `fly-away` keyframe to `tailwind.config.js`
- Added `flyingAway: Set<number>` state to `DragDropMode` — chip plays animation first, then slot confirms 550ms later
- Added `sortedDefIndices` (memoized) that bubbles unmatched slots to top
- `availableEntries` in `FillInBlankExercise` now shows all bank entries; `isUsedDecoy` flag drives visual state

## Test plan
1. Open a story and go to Step 8 語詞應用
2. **拖拉配對**: drag a word to the correct definition — chip should animate upward and fade out before the slot turns green
3. **拖拉配對**: complete half the pairs — remaining unmatched slots should float to the top, not require scrolling
4. **填充題**: answer the first fill-in-blank correctly — the used word should remain visible as a greyed/strikethrough option in subsequent questions