### PR TITLE
release: promote #1282 + #1283 + #1284 to prod

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -253,7 +253,9 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
   const { readingAttempt, comprehensionResult, vocabResult, dictationResult, fullReadingResult } = session;
 
   // Determine how many of the 6 key sections the student has completed
-  const hasNoData = !readingAttempt && !comprehensionResult && !vocabResult && !fullReadingResult;
+  // Include comprehensionScores: a session with only Socratic scores (no JSONB result fields)
+  // should NOT be treated as "no data" — the score is the data. (Issue #1245 item 4)
+  const hasNoData = !readingAttempt && !comprehensionResult && !vocabResult && !fullReadingResult && !comprehensionScores;
   const completedSections = [
     !!(readingAttempt || fullReadingResult),  // 環節一 朗讀結果
     !!(readingAttempt || fullReadingResult),  // 環節二 錄音分析

--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -103,7 +103,9 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
     if (done && phase === 'exercise') setPhase('summary');
   }, [done, phase]);
 
-  const availableEntries = bankEntries.filter(([code]) => !usedCodes.has(code));
+  // Show all bank entries; used ones stay visible as decoys (greyed-out, non-selectable).
+  // This gives subsequent questions strategic distractor options (issue #1102 fix 3).
+  const availableEntries = bankEntries;
   const currentSentence = !done ? activeSentences[currentIdx] : null;
   const currentOriginalIdx = retryMode ? retryIndices[currentIdx] : currentIdx;
 
@@ -359,24 +361,39 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
           <div className="grid grid-cols-2 gap-3">
             {availableEntries.map(([code, word]) => {
               const isSelected = selected === code;
+              // Words already used for previous questions stay as decoys:
+              // greyed-out, non-interactive, but visible to add strategic difficulty.
+              const isUsedDecoy = usedCodes.has(code);
               return (
                 <button
                   key={code}
-                  onClick={() => handleSelect(code)}
-                  className={`rounded-2xl border-2 p-4 text-left flex items-center gap-3 transition-all active:scale-[0.97] min-h-[56px] ${
-                    isSelected
-                      ? 'border-accent bg-accent/5 shadow-sm'
-                      : 'border-surface-container-high bg-surface-container-lowest hover:border-on-surface-variant/30'
+                  onClick={() => !isUsedDecoy && handleSelect(code)}
+                  disabled={isUsedDecoy}
+                  aria-disabled={isUsedDecoy}
+                  className={`rounded-2xl border-2 p-4 text-left flex items-center gap-3 transition-all min-h-[56px] ${
+                    isUsedDecoy
+                      ? 'border-surface-container-high bg-surface-container-high/40 opacity-40 cursor-not-allowed'
+                      : isSelected
+                      ? 'border-accent bg-accent/5 shadow-sm active:scale-[0.97]'
+                      : 'border-surface-container-high bg-surface-container-lowest hover:border-on-surface-variant/30 active:scale-[0.97]'
                   }`}
                 >
                   <span className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-sm font-headline font-black ${
-                    isSelected
+                    isUsedDecoy
+                      ? 'bg-surface-container-high text-on-surface-variant/40'
+                      : isSelected
                       ? 'bg-accent text-white'
                       : 'bg-surface-container-high text-on-surface-variant'
                   }`}>
                     {code}
                   </span>
-                  <span className={`font-bold text-base ${isSelected ? 'text-accent' : 'text-on-surface'}`}>
+                  <span className={`font-bold text-base ${
+                    isUsedDecoy
+                      ? 'text-on-surface-variant/40 line-through'
+                      : isSelected
+                      ? 'text-accent'
+                      : 'text-on-surface'
+                  }`}>
                     {zh(word)}
                   </span>
                 </button>

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -361,10 +361,15 @@ function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: MultipleChoi
 
   const currentDefIdx = activeDefIndices[queueIdx];
 
-  // Shuffle 4 options for current question (1 correct + 3 distractors from all vocab)
+  // Shuffle 4 options for current question (1 correct + 3 distractors from all vocab).
+  // Fix #1101: always include all vocab words as distractor candidates so that even on
+  // the last question — when few "unused" words remain — there are still at least 2
+  // visible choices (never a forced-correct single-option question).
   const options = useMemo(() => {
     const allIndices = vocab.map((_, i) => i);
-    const distractors = shuffle(allIndices.filter((i) => i !== currentDefIdx)).slice(0, 3);
+    const otherIndices = allIndices.filter((i) => i !== currentDefIdx);
+    // Aim for 3 distractors; if vocab is small, take as many as available.
+    const distractors = shuffle(otherIndices).slice(0, Math.min(3, otherIndices.length));
     return shuffle([currentDefIdx, ...distractors]);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queueIdx, currentDefIdx, vocab]);
@@ -414,11 +419,13 @@ function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: MultipleChoi
       </div>
 
       {/* Options — 2-column grid */}
+      {/* Fix #1101 (字置中): flex items-center justify-center ensures the Chinese
+          character is vertically and horizontally centered within the min-h button */}
       <div className="grid grid-cols-2 gap-3">
         {options.map((vocabIdx) => (
           <button
             key={vocabIdx}
-            className="rounded-2xl border-2 p-4 text-center font-bold text-xl transition-all duration-200 select-none active:scale-[0.97] min-h-[56px] border-surface-container-high bg-surface-container-lowest text-on-surface hover:border-accent hover:bg-accent/5 disabled:opacity-50"
+            className="rounded-2xl border-2 p-4 flex items-center justify-center font-bold text-xl transition-all duration-200 select-none active:scale-[0.97] min-h-[56px] border-surface-container-high bg-surface-container-lowest text-on-surface hover:border-accent hover:bg-accent/5 disabled:opacity-50"
             onClick={() => handleChoice(vocabIdx)}
             disabled={pendingAdvance}
           >
@@ -584,10 +591,29 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
       <div className="flex flex-wrap gap-2 min-h-[56px]">
         {activeShuffledWords.map((vocabIdx) => {
           const isPlaced = placedVocabIdxSet.has(vocabIdx);
-          if (isPlaced) return null;
+          // Fix #1101 (炮灰選項): Keep correctly-confirmed words visible as locked
+          // "cannon fodder" chips so the last drag-drop question always has multiple
+          // options in the bank — no more forced-correct final question.
+          const isConfirmedWord = confirmed.has(vocabIdx);
 
           const isDragging = draggingVocabIdx === vocabIdx;
           const isTouchSelected = touchSelected === vocabIdx;
+
+          // Confirmed words: show as locked/dimmed, not draggable
+          if (isConfirmedWord) {
+            return (
+              <div
+                key={vocabIdx}
+                className="rounded-2xl border-2 px-4 py-2.5 text-center font-bold text-base select-none border-emerald-200 bg-emerald-50 text-emerald-400 cursor-not-allowed opacity-60 line-through"
+                aria-label={`${vocab[vocabIdx]?.word} 已配對`}
+              >
+                {vocab[vocabIdx]?.word}
+              </div>
+            );
+          }
+
+          // Placed but not yet confirmed (pending validation — bounce-back in progress)
+          if (isPlaced) return null;
 
           let cls =
             'rounded-2xl border-2 px-4 py-2.5 text-center font-bold text-base select-none transition-all duration-200 ';

--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -455,6 +455,8 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
   const [wrongFlash, setWrongFlash] = useState<Set<number>>(new Set());
   const [hoverTarget, setHoverTarget] = useState<number | null>(null);
   const [touchSelected, setTouchSelected] = useState<number | null>(null);
+  // vocabIdx values currently playing the fly-away exit animation
+  const [flyingAway, setFlyingAway] = useState<Set<number>>(new Set());
 
   // Track last answer per slot for summary (correct ones only, since wrong bounce back)
   const answersRef = useRef<AnswerRecord[]>(
@@ -471,6 +473,7 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
     setWrongFlash(new Set());
     setHoverTarget(null);
     setTouchSelected(null);
+    setFlyingAway(new Set());
     answersRef.current = activeDefIndices.map((defIdx) => ({
       defIndex: defIdx,
       answeredWordIdx: null,
@@ -495,7 +498,7 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
       });
 
       if (vocabIdx === defIdx) {
-        // Correct
+        // Correct — trigger fly-away animation on the word chip, then mark confirmed
         const wrongAttempts = wrongAttemptCountRef.current.get(defIdx) ?? 0;
         answersRef.current = answersRef.current.map((a) =>
           a.defIndex === defIdx ? {
@@ -507,14 +510,24 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
         );
         confirmedRef.current = new Set([...confirmedRef.current, defIdx]);
 
-        setConfirmed((prev) => {
-          const next = new Set(prev);
-          next.add(defIdx);
-          if (next.size === activeDefIndices.length) {
-            setTimeout(() => onAllDone(answersRef.current), 600);
-          }
-          return next;
-        });
+        // Start fly-away animation on the chip
+        setFlyingAway((prev) => new Set([...prev, vocabIdx]));
+        // After animation completes, mark the slot as confirmed (chip is now hidden)
+        setTimeout(() => {
+          setFlyingAway((prev) => {
+            const next = new Set(prev);
+            next.delete(vocabIdx);
+            return next;
+          });
+          setConfirmed((prev) => {
+            const next = new Set(prev);
+            next.add(defIdx);
+            if (next.size === activeDefIndices.length) {
+              setTimeout(() => onAllDone(answersRef.current), 600);
+            }
+            return next;
+          });
+        }, 550);
       } else {
         // Wrong — record attempt, flash, bounce back
         const wrongAttempts = (wrongAttemptCountRef.current.get(defIdx) ?? 0) + 1;
@@ -591,6 +604,7 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
       <div className="flex flex-wrap gap-2 min-h-[56px]">
         {activeShuffledWords.map((vocabIdx) => {
           const isPlaced = placedVocabIdxSet.has(vocabIdx);
+          const isFlying = flyingAway.has(vocabIdx);
           // Fix #1101 (炮灰選項): Keep correctly-confirmed words visible as locked
           // "cannon fodder" chips so the last drag-drop question always has multiple
           // options in the bank — no more forced-correct final question.
@@ -599,8 +613,8 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
           const isDragging = draggingVocabIdx === vocabIdx;
           const isTouchSelected = touchSelected === vocabIdx;
 
-          // Confirmed words: show as locked/dimmed, not draggable
-          if (isConfirmedWord) {
+          // Confirmed words (fly-away animation already finished): show as locked/dimmed
+          if (isConfirmedWord && !isFlying) {
             return (
               <div
                 key={vocabIdx}
@@ -612,12 +626,15 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
             );
           }
 
-          // Placed but not yet confirmed (pending validation — bounce-back in progress)
-          if (isPlaced) return null;
+          // Placed but not yet confirmed (pending validation — bounce-back in progress).
+          // Fly-away in progress (#1102) still needs to render its animation chip.
+          if (isPlaced && !isFlying) return null;
 
           let cls =
             'rounded-2xl border-2 px-4 py-2.5 text-center font-bold text-base select-none transition-all duration-200 ';
-          if (isDragging) {
+          if (isFlying) {
+            cls += 'border-emerald-400 bg-emerald-100 text-emerald-700 animate-fly-away pointer-events-none';
+          } else if (isDragging) {
             cls += 'border-accent bg-accent/10 text-accent shadow-xl scale-105 opacity-80 cursor-grabbing';
           } else if (isTouchSelected) {
             cls += 'border-accent bg-accent/10 text-accent shadow-md scale-105 cursor-pointer';
@@ -628,11 +645,11 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
           return (
             <div
               key={vocabIdx}
-              draggable
-              onDragStart={() => handleDragStart(vocabIdx)}
+              draggable={!isFlying}
+              onDragStart={() => !isFlying && handleDragStart(vocabIdx)}
               onDragEnd={handleDragEnd}
-              onTouchStart={() => handleTouchStart(vocabIdx)}
-              onClick={() => handleTouchStart(vocabIdx)}
+              onTouchStart={() => !isFlying && handleTouchStart(vocabIdx)}
+              onClick={() => !isFlying && handleTouchStart(vocabIdx)}
               className={cls}
             >
               {vocab[vocabIdx]?.word}
@@ -649,7 +666,18 @@ function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone }: Dra
   );
 
   /* ---- Definition slots ---- */
-  const definitionSlots = activeDefIndices.map((defIdx) => {
+  // Sort: unmatched slots first so remaining options stay near the top as pairs are confirmed
+  const sortedDefIndices = useMemo(
+    () => [...activeDefIndices].sort((a, b) => {
+      const aConfirmed = confirmed.has(a) ? 1 : 0;
+      const bConfirmed = confirmed.has(b) ? 1 : 0;
+      return aConfirmed - bConfirmed;
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeDefIndices, confirmed.size],
+  );
+
+  const definitionSlots = sortedDefIndices.map((defIdx) => {
     const item = vocab[defIdx];
     const placedVocabIdx = placements.get(defIdx) ?? null;
     const isCorrect = confirmed.has(defIdx);

--- a/frontend/src/pages/student/SessionHistoryReportPage.tsx
+++ b/frontend/src/pages/student/SessionHistoryReportPage.tsx
@@ -108,16 +108,29 @@ function buildLearningSession(detail: SessionDetailResponse): LearningSession {
 
 function buildComprehensionScores(detail: SessionDetailResponse): ComprehensionScoreResult | null {
   if (detail.comprehension_score == null) return null;
+
+  // comprehension_feedback is stored in the DB as a JSON string like
+  // '{"literal":"...","inferential":"...","evaluative":"...","overall":"..."}' (Issue #1245 item 4)
+  let feedbackObj: { literal?: string; inferential?: string; evaluative?: string; overall?: string } = {};
+  if (detail.comprehension_feedback) {
+    try {
+      feedbackObj = JSON.parse(detail.comprehension_feedback);
+    } catch {
+      // If parsing fails, treat the raw string as the overall feedback
+      feedbackObj = { overall: detail.comprehension_feedback };
+    }
+  }
+
   return {
     comprehension_score: detail.comprehension_score,
     literal_score: detail.literal_score ?? 0,
     inferential_score: detail.inferential_score ?? 0,
     evaluative_score: detail.evaluative_score ?? 0,
     feedback: {
-      literal: '',
-      inferential: '',
-      evaluative: '',
-      overall: detail.comprehension_feedback ?? '',
+      literal: feedbackObj.literal ?? '',
+      inferential: feedbackObj.inferential ?? '',
+      evaluative: feedbackObj.evaluative ?? '',
+      overall: feedbackObj.overall ?? '',
     },
   };
 }

--- a/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
+++ b/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
@@ -110,16 +110,27 @@ function buildSession(detail: TeacherSessionReport): LearningSession {
 
 function buildScores(detail: TeacherSessionReport): ComprehensionScoreResult | null {
   if (detail.comprehension_score == null) return null;
+
+  // comprehension_feedback is stored in the DB as a JSON string (Issue #1245 item 4)
+  let feedbackObj: { literal?: string; inferential?: string; evaluative?: string; overall?: string } = {};
+  if (detail.comprehension_feedback) {
+    try {
+      feedbackObj = JSON.parse(detail.comprehension_feedback);
+    } catch {
+      feedbackObj = { overall: detail.comprehension_feedback };
+    }
+  }
+
   return {
     comprehension_score: detail.comprehension_score,
     literal_score: detail.literal_score ?? 0,
     inferential_score: detail.inferential_score ?? 0,
     evaluative_score: detail.evaluative_score ?? 0,
     feedback: {
-      literal: '',
-      inferential: '',
-      evaluative: '',
-      overall: detail.comprehension_feedback ?? '',
+      literal: feedbackObj.literal ?? '',
+      inferential: feedbackObj.inferential ?? '',
+      evaluative: feedbackObj.evaluative ?? '',
+      overall: feedbackObj.overall ?? '',
     },
   };
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -117,6 +117,11 @@ export default {
           '50%':  { transform: 'scale(1.4) rotate(180deg)', opacity: '1' },
           '100%': { transform: 'scale(1) rotate(360deg)', opacity: '1' },
         },
+        'fly-away': {
+          '0%':   { transform: 'scale(1) translateY(0)',   opacity: '1' },
+          '40%':  { transform: 'scale(1.15) translateY(-8px)', opacity: '1' },
+          '100%': { transform: 'scale(0.4) translateY(-40px)', opacity: '0' },
+        },
       },
       animation: {
         shake: 'shake 0.45s ease-in-out',
@@ -130,6 +135,7 @@ export default {
         'confetti-drop-2': 'confetti-drop-2 1.1s ease-in 0.2s forwards',
         'confetti-drop-3': 'confetti-drop-3 0.9s ease-in 0s forwards',
         'star-burst': 'star-burst 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)',
+        'fly-away': 'fly-away 0.55s cubic-bezier(0.4, 0, 0.6, 1) forwards',
       },
     },
   },


### PR DESCRIPTION
Staging → main promote.

## Promotes to prod
- **#1282** — fix(learning-history): render session report data correctly (Fixes #1245 item 4 — render conditions too strict + JSON string parse)
- **#1283** — fix: retain cannon-fodder options in drag-drop and center MC buttons (Fixes #1101 Step 7 詞語定義)
- **#1284** — fix: drag-match fly-away animation, scroll fix, fill-in decoy options (Fixes #1102 Step 8 語詞應用)

## Risk: LOW
- All frontend-only UX fixes
- No API / schema changes
- Staging currently healthy

## Post-merge plan
1. Watch deploy.yml green
2. Prod smoke: frontend + backend HTTP 200
3. Close #1101 + #1102 issues (addressed by #1283 / #1284)
