### PR TITLE
chore(sso): switch Junyi SSO from ci-live to production URL (#1260)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -81,7 +81,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::JUNYI_SSO_BASE_URL=https://ci-live-worktree-sso-multi-rp---rev-proxy-dg4bspkswq-de.a.run.app"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
 
       - name: Verify backend health
         run: |

--- a/frontend/src/pages/JunyiCallbackPage.tsx
+++ b/frontend/src/pages/JunyiCallbackPage.tsx
@@ -49,9 +49,7 @@ export function buildJunyiLoginUrl(returnTo: string = '/'): string {
   sessionStorage.setItem(JUNYI_STATE_KEY, state);
 
   const continueUrl = `${callbackUrl}&state=${state}`;
-  // TODO: switch back to https://www.junyiacademy.org/login once Junyi Part 2 multi-RP lands on prod.
-  // Per 宥辰 2026-04-21: Part 2 currently only on ci-live; prod junyi ignores `continue` param.
-  return `https://ci-live-worktree-sso-multi-rp---rev-proxy-dg4bspkswq-de.a.run.app/login?continue=${encodeURIComponent(continueUrl)}`;
+  return `https://www.junyiacademy.org/login?continue=${encodeURIComponent(continueUrl)}`;
 }
 
 const JunyiCallbackPage: React.FC = () => {


### PR DESCRIPTION
## Summary

均一主站 Part 2（多 RP 支援）預計 **2026-04-28 中午後** 由 @isacl-junyi deploy 到 `https://www.junyiacademy.org`。本 PR 把 LingoLeap 全環境的 Junyi SSO URL 從 ci-live 暫用 URL 切回主站。

- `frontend/src/pages/JunyiCallbackPage.tsx`：移除 hardcoded `ci-live-worktree-sso-multi-rp---rev-proxy-...run.app` URL，改回 `https://www.junyiacademy.org/login`，並移除過渡期 TODO 註解
- `.github/workflows/staging-deploy.yml`：移除 `JUNYI_SSO_BASE_URL` env var override，讓 backend 用 `app/config.py` default（也是主站）

Backend default 已是主站、production `deploy.yml` 從未設 override → 不需修改。

## ⚠️ DO NOT MERGE before 2026-04-28 12:00

均一主站 Part 2 deploy 前 merge → SSO 會壞（主站還沒支援 multi-RP，會 ignore `continue` param）。

Slack 紀錄：

> **宥辰** 4/24 14:23：對，週一中午後，就需要改成主站 URL。其他不需要修改。

## Test plan (4/28 12:00 後執行)

- [ ] 確認 @isacl-junyi 已 deploy 主站 SSO Part 2（看 junyiacademy/junyiacademy#4083）
- [ ] Merge this PR → staging（auto-deploy）
- [ ] 在 https://lingoleap-staging.web.app 用 Junyi 帳號登入成功
- [ ] 開 PR `staging → main`，merge
- [ ] 在 https://lingoleap-prod.web.app 用 Junyi 帳號登入成功

## Refs

- Closes #1260
- junyiacademy/junyiacademy#4083 (Part 2 main site deploy)
- 既有實作：#1200（Part 3）#1201（callback origin）#1202（env var）#1205（login entry）

🤖 Generated with [Claude Code](https://claude.com/claude-code)