### PR TITLE
fix: FullReading 移除學生數字評分，改為星星+鼓勵語 (Fixes #1097)

### DIFF
--- a/backend/app/services/reading_evaluation_service.py
+++ b/backend/app/services/reading_evaluation_service.py
@@ -97,7 +97,7 @@ _SYSTEM_PROMPT = (
     "- diff_tokens 的順序必須與 target_text 字元順序對應\n"
     "- 每個 target_text 字元都要有一個對應的 token（type=missing 若未念到）\n"
     "- 若 spoken 與 char 相同則不需填 spoken 欄位\n"
-    "- feedback 用繁體中文，1-2 句鼓勵語\n"
+    "- feedback 用繁體中文，1-2 句溫柔鼓勵語，禁止提到具體數字（百分比、字數、字/分鐘），多用「不錯！」「再試試看」「繼續加油」等口吻\n"
     "- 嚴格輸出 JSON，不要加任何說明文字\n"
 )
 

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -11,12 +11,22 @@ import { getReadingHistory, type ReadingHistoryPoint } from '../../services/lear
 import { saveReadingHistory } from '../../services/readingHistoryApi';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
 import { useAuth } from '../../contexts/AuthContext';
-import { encourageAccuracy } from '../../utils/encouragement';
-
-/* ------------------------------------------------------------------ */
-
 import { splitZhuyinChars } from '../../utils/zhuyinUtils';
 import { groupIdxForProgress } from '../../utils/ttsHighlight';
+
+/* ── Encouragement helper (same tier logic as ParagraphCard) ─────────────── */
+
+const FULL_READING_TIERS: Array<{ min: number; stars: number; text: string; color: string }> = [
+  { min: 0.90, stars: 5, text: '太厲害了！', color: 'text-emerald-600' },
+  { min: 0.75, stars: 4, text: '唸得很流暢！', color: 'text-green-600' },
+  { min: 0.60, stars: 3, text: '繼續練習！', color: 'text-green-600' },
+  { min: 0,    stars: 2, text: '再多練幾次就會更熟～', color: 'text-amber-600' },
+];
+
+function getFullReadingEncouragement(matchRate: number): { stars: number; text: string; color: string } {
+  const tier = FULL_READING_TIERS.find(t => matchRate >= t.min) ?? FULL_READING_TIERS[FULL_READING_TIERS.length - 1];
+  return { stars: tier.stars, text: tier.text, color: tier.color };
+}
 
 /* ------------------------------------------------------------------ */
 
@@ -259,8 +269,6 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack }) =>
     setStreamingTranscript(cleanChineseText(transcript));
   }, [fullText, stopSession]);
 
-  const percent = result ? Math.round(result.matchRate * 100) : 0;
-
   /* ---- Render paragraph text with optional TTS highlighting ---- */
   const renderParagraph = (line: string, idx: number) => {
     const zhuyinLine = zhuyinLines ? zhuyinLines[idx] : null;
@@ -375,24 +383,30 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack }) =>
           {/* ── Result section ──────────────────────────────────────── */}
           {result && (
             <div className="mt-6 space-y-6">
-              {/* Encouragement panel — Issue #1094: no numeric score/accuracy/CPM for students */}
-              <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 flex flex-col items-center gap-4">
-                <div className={`w-28 h-28 rounded-full flex items-center justify-center ${
-                  percent >= 80 ? 'bg-emerald-100'
-                  : percent >= 60 ? 'bg-amber-100'
-                  : 'bg-tertiary-container/30'
-                }`}>
-                  <span className="material-symbols-outlined text-5xl" aria-hidden="true">
-                    {percent >= 80 ? 'celebration' : percent >= 60 ? 'thumb_up' : 'favorite'}
-                  </span>
-                </div>
-                <p className="text-xl font-headline font-bold text-on-surface text-center">
-                  {encourageAccuracy(percent)}
-                </p>
-                <p className="text-base font-headline text-on-surface-variant text-center">
-                  {result.feedback}
-                </p>
-              </div>
+              {/* Encouragement — no numbers shown to student (Issues #1094, #1097) */}
+              {(() => {
+                const enc = getFullReadingEncouragement(result.matchRate);
+                return (
+                  <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 flex flex-col items-center gap-3">
+                    <div className="flex gap-1">
+                      {Array.from({ length: 5 }).map((_, i) => (
+                        <span
+                          key={i}
+                          className={`material-symbols-outlined text-3xl transition-colors ${
+                            i < enc.stars ? 'text-amber-400' : 'text-on-surface-variant/20'
+                          }`}
+                          style={{ fontVariationSettings: i < enc.stars ? "'FILL' 1" : "'FILL' 0" }}
+                        >
+                          star
+                        </span>
+                      ))}
+                    </div>
+                    <p className={`text-xl font-headline font-bold text-center ${enc.color}`}>
+                      {enc.text}
+                    </p>
+                  </div>
+                );
+              })()}
 
               {/* Transcript */}
               {streamingTranscript && (


### PR DESCRIPTION
Fixes #1097

## Summary

- Replaced the accuracy% circle and CPM/accuracy stats grid with a 5-star rating + single encouragement phrase (no numbers shown to student)
- Star tiers: 90%+ = 5 stars, 75%+ = 4, 60%+ = 3, <60% = 2
- Backend `reading_evaluation_service.py` feedback prompt updated: explicitly forbids mentioning numeric values (百分比/字數/字/分鐘) in the 1-2 sentence encouragement
- All underlying data (matchRate, cpm, feedback) is retained in React state and passed through `onFinish` — teacher backend and report step are unaffected

## What's unchanged (by design)

- 朗讀進步曲線 chart (pre-existing, teacher-oriented data — out of scope for this issue)
- Teacher dashboard routes still receive full numeric data
- Diff display, audio playback, transcript sections untouched

## Test plan

1. Open a lesson → go to Step 3 全文朗讀
2. Complete a reading session
3. Verify: no percentage or CPM number shown in result card
4. Verify: stars (2–5) and encouragement phrase appear
5. Verify: "查看報告" still navigates to report step correctly