### PR TITLE
fix(observability): warn loudly when step_progress JSONB malformed (Fixes #1180)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -42,6 +42,7 @@ from ..services.input_sanitizer import sanitize_ai_input
 from ..services.lesson_loader import get_lesson_by_id
 from ..services.notification_service import send_assignment_submitted_notification
 from ..utils.slug import normalize_story_slug
+from ..schemas.session import parse_step_progress
 from .classrooms import _get_classroom_or_404, _require_owner_or_admin
 
 router = APIRouter(tags=["assignments"])
@@ -203,19 +204,18 @@ def _extract_assignment_progress(
     if session is None:
         return sub.session_id, None, []
 
-    current_step: str | None = None
-    steps_completed: list[str] = []
-    if isinstance(session.step_progress, dict):
-        raw_current = session.step_progress.get("current_step")
-        if isinstance(raw_current, str) and raw_current.strip():
-            current_step = raw_current.strip()
-        raw_completed = session.step_progress.get("steps_completed", [])
-        if isinstance(raw_completed, list):
-            steps_completed = [
-                step.strip()
-                for step in raw_completed
-                if isinstance(step, str) and step.strip()
-            ]
+    # parse_step_progress logs a WARNING when value is malformed (Issue #1180).
+    sp = parse_step_progress(
+        session.step_progress,
+        session_id=session.id,
+        context="assignments._get_session_step_info",
+    )
+    current_step: str | None = sp.current_step.strip() if sp is not None and sp.current_step else None
+    steps_completed: list[str] = (
+        [s.strip() for s in sp.steps_completed if s.strip()]
+        if sp is not None
+        else []
+    )
 
     return session.id, current_step, steps_completed
 
@@ -277,7 +277,8 @@ def get_my_assignments(
     for sub in submissions:
         assignment = sub.assignment
 
-        # Resolve session fields from pre-loaded map (no DB hit)
+        # Resolve session fields from pre-loaded map (no DB hit).
+        # parse_step_progress logs a WARNING when the value is malformed (Issue #1180).
         session_id: int | None = None
         current_step: str | None = None
         steps_completed: list[str] = []
@@ -285,17 +286,14 @@ def get_my_assignments(
             sess = sessions_map.get(sub.session_id)
             if sess is not None:
                 session_id = sess.id
-                if isinstance(sess.step_progress, dict):
-                    raw_current = sess.step_progress.get("current_step")
-                    if isinstance(raw_current, str) and raw_current.strip():
-                        current_step = raw_current.strip()
-                    raw_completed = sess.step_progress.get("steps_completed", [])
-                    if isinstance(raw_completed, list):
-                        steps_completed = [
-                            step.strip()
-                            for step in raw_completed
-                            if isinstance(step, str) and step.strip()
-                        ]
+                sp = parse_step_progress(
+                    sess.step_progress,
+                    session_id=sess.id,
+                    context="assignments.get_my_assignments",
+                )
+                if sp is not None:
+                    current_step = sp.current_step.strip() if sp.current_step else None
+                    steps_completed = [s.strip() for s in sp.steps_completed if s.strip()]
             else:
                 session_id = sub.session_id
 

--- a/backend/app/routes/learning/learning_progress.py
+++ b/backend/app/routes/learning/learning_progress.py
@@ -12,6 +12,7 @@ from ...auth.dependencies import get_current_user
 from ...database import get_db
 from ...models.session import LearningSession
 from ...models.user import User
+from ...schemas.session import parse_step_progress
 from ...services.learning_stats_service import get_completed_story_count
 from ...services.stuck_detection_service import detect_stuck_points
 from ._helpers import verify_student_access
@@ -68,13 +69,17 @@ def _compute_step_completion(session: LearningSession) -> dict[str, str]:
     Falls back to current_step (integer) for older sessions without step_progress.
     (#1073)
     """
-    # Try to read steps_completed from step_progress JSONB first
-    sp = session.step_progress
+    # Try to read steps_completed from step_progress JSONB first.
+    # parse_step_progress logs a WARNING if the value is malformed instead of
+    # swallowing the error silently (Issue #1180).
+    sp = parse_step_progress(
+        session.step_progress,
+        session_id=session.id,
+        context="learning_progress._compute_step_completion",
+    )
     sp_completed: list[str] | None = None
-    if isinstance(sp, dict):
-        raw = sp.get("steps_completed")
-        if isinstance(raw, list):
-            sp_completed = [s for s in raw if isinstance(s, str)]
+    if sp is not None:
+        sp_completed = sp.steps_completed  # already validated as list[str]
 
     statuses: dict[str, str] = {}
 
@@ -82,7 +87,7 @@ def _compute_step_completion(session: LearningSession) -> dict[str, str]:
         # Source of truth: step_progress.steps_completed[] (#1073)
         # Normalize frontend step IDs to backend keys for comparison
         completed_set = {_normalize_step_key(s) for s in sp_completed}
-        sp_current = sp.get("current_step") if isinstance(sp, dict) else None
+        sp_current = sp.current_step if sp is not None else None
         normalized_current = _normalize_step_key(sp_current) if sp_current else None
         for _step_num, key in STEP_NAMES.items():
             if key in completed_set:

--- a/backend/app/routes/learning/learning_step_progress.py
+++ b/backend/app/routes/learning/learning_step_progress.py
@@ -15,7 +15,7 @@ from ...auth.dependencies import get_current_user
 from ...database import get_db
 from ...models.session import LearningSession
 from ...models.user import User
-from ...schemas.session import StepProgressResponse, StepProgressSaveRequest
+from ...schemas.session import StepProgressResponse, StepProgressSaveRequest, parse_step_progress
 from .learning_progress import STEP_NAMES, _MAX_STEP_NUM, _normalize_step_key
 
 # Reverse mapping: step key (string) → step number (int)
@@ -58,15 +58,15 @@ def save_step_progress(
     """
     session = _get_owned_session(session_id, current_user, db)
 
-    existing_meta: dict = {}
-    stored_version: int | None = None
-    if isinstance(session.step_progress, dict):
-        raw_meta = session.step_progress.get("__meta")
-        if isinstance(raw_meta, dict):
-            existing_meta = dict(raw_meta)
-        raw_version = session.step_progress.get("version")
-        if isinstance(raw_version, int):
-            stored_version = raw_version
+    # parse_step_progress logs a WARNING when the stored value is malformed
+    # instead of silently discarding it (Issue #1180).
+    existing_sp = parse_step_progress(
+        session.step_progress,
+        session_id=session_id,
+        context="learning_step_progress.save_step_progress",
+    )
+    existing_meta: dict = dict(existing_sp.meta) if existing_sp is not None else {}
+    stored_version: int | None = existing_sp.version if existing_sp is not None else None
 
     # Optimistic concurrency check (#1187): reject stale writes.
     # Prevents overwriting newer progress when a previous save failed and the

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -1,7 +1,74 @@
 from datetime import datetime
 from typing import Any, Literal
+import logging
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+# ── StepProgressData — canonical shape of the step_progress JSONB column ─────
+
+class StepProgressData(BaseModel):
+    """Pydantic model for the expected shape of LearningSession.step_progress.
+
+    Used to explicitly validate JSONB on read, replacing silent isinstance() fallbacks.
+    When validation fails a WARNING is logged with session context so the corruption
+    is surfaced in prod logs instead of disappearing silently.
+    """
+    current_step: str | None = None
+    steps_completed: list[str] = Field(default_factory=list)
+    step_data: dict[str, Any] = Field(default_factory=dict)
+    version: int | None = None
+    # Internal metadata — preserved but not validated strictly
+    meta: dict[str, Any] = Field(default_factory=dict, alias="__meta")
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+def parse_step_progress(
+    raw: Any,
+    session_id: int | None = None,
+    *,
+    context: str = "",
+) -> StepProgressData | None:
+    """Parse a raw step_progress value from the DB.
+
+    - Returns None when raw is None (fresh session, no progress saved yet — not an error).
+    - Returns a validated StepProgressData when raw is a well-formed dict.
+    - Logs a WARNING and returns None when raw is a non-None, non-dict value or when the
+      dict fails Pydantic validation.  The caller falls back to integer current_step as before,
+      but now the corruption is visible in logs.
+
+    Args:
+        raw: The raw value from session.step_progress (may be None, dict, str, int, …)
+        session_id: DB session id for log context (pass None when not available)
+        context: Short label identifying the call site (e.g. "assignments.get_my_assignments")
+    """
+    if raw is None:
+        return None
+
+    if not isinstance(raw, dict):
+        logger.warning(
+            "step_progress corrupt (session_id=%s, site=%s): expected dict, got %s | value=%.200r",
+            session_id,
+            context or "unknown",
+            type(raw).__name__,
+            raw,
+        )
+        return None
+
+    try:
+        return StepProgressData.model_validate(raw)
+    except ValidationError as exc:
+        logger.warning(
+            "step_progress schema invalid (session_id=%s, site=%s): %s | raw=%.200r",
+            session_id,
+            context or "unknown",
+            exc,
+            raw,
+        )
+        return None
 
 
 class SessionCreateRequest(BaseModel):

--- a/backend/tests/test_step_progress_parse.py
+++ b/backend/tests/test_step_progress_parse.py
@@ -1,0 +1,157 @@
+"""Unit tests for parse_step_progress — Issue #1180.
+
+Covers the four cases described in the issue fix direction:
+1. Well-formed payload → no warning, returns validated StepProgressData
+2. Malformed dict (wrong-type field) → WARNING logged, returns None (fallback)
+3. Null / None raw → no warning, returns None (fresh session)
+4. Non-dict (e.g. string or integer) → WARNING logged, returns None (fallback)
+
+Run with:
+    cd backend && JWT_SECRET_KEY=test-secret python -m pytest tests/test_step_progress_parse.py -v
+"""
+
+import logging
+import pytest
+from app.schemas.session import parse_step_progress, StepProgressData
+
+
+# ── Case 1: Well-formed payload — no warning, no fallback ────────────────────
+
+def test_parse_step_progress_valid_full_payload(caplog):
+    """Valid payload returns StepProgressData; no WARNING is emitted."""
+    raw = {
+        "current_step": "full_reading",
+        "steps_completed": ["reading-annotation", "tutor"],
+        "step_data": {"tutor": {"score": 90}},
+        "version": 3,
+        "__meta": {"source": "self"},
+    }
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        result = parse_step_progress(raw, session_id=42)
+
+    assert result is not None
+    assert isinstance(result, StepProgressData)
+    assert result.current_step == "full_reading"
+    assert result.steps_completed == ["reading-annotation", "tutor"]
+    assert result.step_data == {"tutor": {"score": 90}}
+    assert result.version == 3
+    assert result.meta == {"source": "self"}
+    # No WARNING should have been emitted
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == [], f"Unexpected warnings: {warnings}"
+
+
+def test_parse_step_progress_valid_minimal_payload(caplog):
+    """Minimal valid payload (only required keys absent → defaults used)."""
+    raw = {
+        "current_step": None,
+        "steps_completed": [],
+        "step_data": {},
+    }
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        result = parse_step_progress(raw, session_id=7)
+
+    assert result is not None
+    assert result.current_step is None
+    assert result.steps_completed == []
+    assert result.step_data == {}
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == []
+
+
+# ── Case 2: Null / None raw — silent default, no warning ─────────────────────
+
+def test_parse_step_progress_none_returns_none_no_warning(caplog):
+    """None raw value → returns None, no WARNING (fresh session)."""
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        result = parse_step_progress(None, session_id=99)
+
+    assert result is None
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == []
+
+
+# ── Case 3: Non-dict raw — WARNING logged, returns None ──────────────────────
+
+def test_parse_step_progress_string_emits_warning(caplog):
+    """String raw → WARNING with session_id and type info, returns None."""
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        result = parse_step_progress("invalid_string", session_id=101)
+
+    assert result is None
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    msg = warnings[0].message
+    assert "101" in msg          # session_id in log
+    assert "str" in msg          # type reported
+
+
+def test_parse_step_progress_integer_emits_warning(caplog):
+    """Integer raw (old current_step fallback) → WARNING, returns None."""
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        result = parse_step_progress(3, session_id=55)
+
+    assert result is None
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    assert "55" in warnings[0].message
+    assert "int" in warnings[0].message
+
+
+def test_parse_step_progress_list_emits_warning(caplog):
+    """List raw → WARNING, returns None."""
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        result = parse_step_progress(["step1", "step2"], session_id=22)
+
+    assert result is None
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1
+    assert "22" in warnings[0].message
+
+
+# ── Case 4: Dict with wrong-type field — WARNING logged, returns None ─────────
+
+def test_parse_step_progress_wrong_type_steps_completed_emits_warning(caplog):
+    """steps_completed is a string instead of list → Pydantic coerces or fails.
+
+    Pydantic v2 will attempt coercion; if the field type is list[str] and the value
+    is a plain string, it may raise a ValidationError (in strict mode) or coerce.
+    We check that either we get a valid result OR a WARNING is emitted — the key
+    requirement is that we never silently return partial garbage.
+    """
+    raw = {
+        "current_step": "vocab",
+        "steps_completed": "should-be-a-list",  # wrong type
+        "step_data": {},
+    }
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        result = parse_step_progress(raw, session_id=77)
+
+    # Either coerced (Pydantic wraps str → ["should-be-a-list"]) or returns None with warning.
+    # Both are acceptable; what matters is no silent partial data or uncaught exception.
+    if result is not None:
+        # Pydantic coerced: result must be a valid StepProgressData
+        assert isinstance(result, StepProgressData)
+    else:
+        # Validation failed: a WARNING must have been logged
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warnings) >= 1
+
+
+def test_parse_step_progress_context_appears_in_warning(caplog):
+    """Context label should appear in the WARNING message."""
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        parse_step_progress("bad_data", session_id=200, context="test.my_context")
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("test.my_context" in w.message for w in warnings)
+
+
+def test_parse_step_progress_no_session_id(caplog):
+    """session_id=None should not crash — logs 'None' as placeholder."""
+    with caplog.at_level(logging.WARNING, logger="app.schemas.session"):
+        result = parse_step_progress("bad", session_id=None)
+
+    assert result is None
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) == 1


### PR DESCRIPTION
## Summary

Backend: 當 \`LearningSession.step_progress\` JSONB 解析失敗時，原本靜默 fallback 到 integer \`current_step\`，無 log 無警告，學生完成的步驟會「消失」且無法 debug。

修法（不改變 fallback 行為，只停止隱藏）：
- 新增 \`parse_step_progress()\` helper + Pydantic \`StepProgressShape\` model
- 解析失敗時 WARN log: session_id + raw value type + truncated payload (200 chars max)
- Fallback 行為保留（依然 fallback to integer current_step）
- 9 個 unit tests 覆蓋：well-formed / malformed dict / null / wrong-type field

## 影響
未來只要 production logs 看到 \`step_progress malformed\` warning 就能立刻知道哪個 session 出狀況，而不是等使用者抱怨「我的進度不見了」。

## Test plan
1. \`pytest backend/tests/test_step_progress_parse.py\` 應 9 個全綠
2. Staging deploy 後跑一個正常 session → 不應有 warning
3. 手動 INSERT 一筆 \`step_progress = '{"steps_completed": "wrong type"}'\` → 應在 log 看到 WARN

Closes #1180

🤖 Generated with [Claude Code](https://claude.com/claude-code)