### PR TITLE
fix: sync session.status/completed_at on assignment submit (Fixes #1181)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -1042,7 +1042,7 @@ def submit_assignment(
             effective_accuracy=assignment.target_accuracy if assignment.target_accuracy is not None else DEFAULT_TARGET_ACCURACY,
         )
 
-    # Pull score from linked LearningSession if available
+    # Pull score from linked LearningSession if available; also sync session status.
     score: float | None = None
     if submission.session_id is not None:
         learning_session = (
@@ -1050,8 +1050,15 @@ def submit_assignment(
             .filter(LearningSession.id == submission.session_id)
             .first()
         )
-        if learning_session and learning_session.overall_score is not None:
-            score = float(learning_session.overall_score)
+        if learning_session:
+            if learning_session.overall_score is not None:
+                score = float(learning_session.overall_score)
+            # Issue #1181: sync session status/completed_at at write time so all
+            # read paths (dashboard, list_sessions) agree without extra joins.
+            if learning_session.status == "in_progress":
+                learning_session.status = "completed"
+                if learning_session.completed_at is None:
+                    learning_session.completed_at = datetime.now(tz=timezone.utc)
 
     submission.status = "submitted"
     submission.submitted_at = datetime.now(tz=timezone.utc)

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -1299,6 +1299,92 @@ class TestSubmitAssignment:
         )
         assert resp.status_code == 204
 
+    def test_submit_syncs_session_status_and_completed_at(
+        self, client, teacher, school_id
+    ):
+        """Regression #1181: submit must flip session.status → completed and set completed_at.
+
+        Before the fix, only submission.status was updated. The linked LearningSession
+        kept status='in_progress' and completed_at=NULL, causing dashboard queries to miss
+        the session when filtering for completed work.
+
+        Uses a fresh student to avoid unique-index collisions from earlier tests.
+        """
+        from app.models.session import LearningSession
+
+        # Use a dedicated fresh student so no existing in_progress session conflicts
+        fresh_student = _register_user(client, "stu_1181")
+        _make_student_role(fresh_student["user_id"], school_id)
+
+        # Create a private classroom for this test so we can enroll only our student
+        cls_resp = client.post(
+            "/api/classrooms",
+            json={"name": "Regression 1181 Classroom", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        assert cls_resp.status_code == 201
+        classroom_id = cls_resp.json()["id"]
+
+        client.post(
+            f"/api/classrooms/{classroom_id}/students",
+            json={"student_id": fresh_student["user_id"]},
+            headers=auth_header(teacher["token"]),
+        )
+
+        # Create assignment and start it
+        # Use story "2" (a different lesson) so this test's completed session
+        # does not collide with other tests that use story "1" via student1.
+        create_resp = client.post(
+            f"/api/classrooms/{classroom_id}/assignments",
+            json={
+                "classroom_id": classroom_id,
+                "story_id": "2",
+                "title": "Session Sync Regression #1181",
+            },
+            headers=auth_header(teacher["token"]),
+        )
+        assert create_resp.status_code == 201
+        assignment_id = create_resp.json()["id"]
+
+        start_resp = client.post(
+            f"/api/assignments/{assignment_id}/start",
+            headers=auth_header(fresh_student["token"]),
+        )
+        assert start_resp.status_code == 200
+        session_id = start_resp.json()["session_id"]
+
+        # Confirm session is in_progress before submit
+        db = TestingSessionLocal()
+        try:
+            sess = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+            assert sess is not None
+            assert sess.status == "in_progress"
+            assert sess.completed_at is None
+        finally:
+            db.close()
+
+        # Student submits the assignment
+        submit_resp = client.post(
+            f"/api/assignments/{assignment_id}/submit",
+            headers=auth_header(fresh_student["token"]),
+        )
+        assert submit_resp.status_code == 200
+        assert submit_resp.json()["status"] == "submitted"
+
+        # Verify the linked session was synced atomically in the same transaction
+        db = TestingSessionLocal()
+        try:
+            sess = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+            assert sess is not None, "LearningSession must still exist after submit"
+            assert sess.status == "completed", (
+                f"Expected session.status='completed' after submit, got '{sess.status}'"
+            )
+            assert sess.completed_at is not None, (
+                "session.completed_at must be set after submit (was NULL before fix)"
+            )
+        finally:
+            db.close()
+
 
 # ====================================================================# Notification service — unit tests (no HTTP needed)
 # ====================================================================
@@ -1368,12 +1454,17 @@ class TestSubmissionReadingMetrics:
     pulled from the linked LearningSession when available."""
 
     def _create_assignment_and_start(self, client, teacher, student, classroom_id):
-        """Create assignment, start it as student. Returns (assignment_id, session_id)."""
+        """Create assignment, start it as student. Returns (assignment_id, session_id).
+
+        Uses story_id="2" (not VALID_STORY_ID="1") so that earlier submit tests
+        which mark story-1 sessions as 'completed' don't cause a unique-index
+        collision in SQLite (which lacks partial-index support).
+        """
         create_resp = client.post(
             f"/api/classrooms/{classroom_id}/assignments",
             json={
                 "classroom_id": classroom_id,
-                "story_id": VALID_STORY_ID,
+                "story_id": "2",
                 "title": "Reading Metrics Test",
             },
             headers=auth_header(teacher["token"]),


### PR DESCRIPTION
Fixes #1181

## Summary

- In `submit_assignment`, atomically update the linked `LearningSession` in the same `db.commit()` as the submission status change
- If `session.status == 'in_progress'` → set to `'completed'`
- If `session.completed_at is None` → set to `datetime.now(tz=timezone.utc)`
- Only updates when status is actually `in_progress` (safe for idempotent calls)

## Root Cause

The `submit_assignment` endpoint only updated `submission.status = "submitted"` but never touched the linked `LearningSession`. Dashboard queries filtering by `session.status = 'completed'` or `session.completed_at IS NOT NULL` would miss these sessions.

## Test Plan

- New regression test `test_submit_syncs_session_status_and_completed_at` confirms:
  1. Before submit: `session.status == 'in_progress'`, `session.completed_at is None`
  2. After `POST /assignments/{id}/submit`: `session.status == 'completed'`, `session.completed_at is not None`
- All 65 tests in `test_assignments.py` pass (64 existing + 1 new)

## Files Changed

- `backend/app/routes/assignments.py` — sync session status in `submit_assignment` (+7 / -2)
- `backend/tests/test_assignments.py` — regression test for #1181 + fix SQLite test ordering issue (+96 / -3)