### PR TITLE
fix: deprecate LearningSession.current_step integer; step_progress as single source of truth (Fixes #1182)

### DIFF
--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -4,6 +4,32 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .base import Base
 
+# ---------------------------------------------------------------------------
+# Step name constants — single source of truth for step number ↔ key mapping.
+# Kept at module level so they can be imported by routes without importing the
+# full ORM model (avoids circular-import risk in lightweight scripts).
+# ---------------------------------------------------------------------------
+
+_STEP_NAMES: dict[int, str] = {
+    1: "intro",
+    2: "live_tutor",
+    3: "comprehension",
+    4: "vocab",
+    5: "full_reading",
+    6: "report",
+}
+_MAX_STEP_NUM: int = max(_STEP_NAMES)
+_STEP_KEY_TO_NUM: dict[str, int] = {v: k for k, v in _STEP_NAMES.items()}
+_STEP_NUM_TO_KEY: dict[int, str] = dict(_STEP_NAMES)  # same as _STEP_NAMES, explicit alias
+
+# Frontend step path keys differ from canonical backend STEP_NAMES values.
+# Map frontend alias → canonical key.
+_FRONTEND_STEP_ALIAS: dict[str, str] = {
+    "tutor": "live_tutor",
+    "full-reading": "full_reading",
+    "reading-annotation": "intro",
+}
+
 
 class ErrorCorrection(Base):
     """Tracks when a student marks a character as practiced or mastered."""
@@ -35,12 +61,21 @@ class LearningSession(Base):
         Index("ix_learning_sessions_student_id_status", "student_id", "status"),
     )
 
+    # ── Class-level step constants (mirrors module-level dicts; exposed here so
+    # tests and callers can access them via the model class directly) ──────────
+    _STEP_KEY_TO_NUM: dict[int, str] = _STEP_KEY_TO_NUM  # type: ignore[assignment]
+    _STEP_NUM_TO_KEY: dict[int, str] = _STEP_NUM_TO_KEY  # type: ignore[assignment]
+    _FRONTEND_STEP_ALIAS: dict[str, str] = _FRONTEND_STEP_ALIAS  # type: ignore[assignment]
+
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     text_id: Mapped[int | None] = mapped_column(ForeignKey("texts.id"), nullable=True)
     classroom_id: Mapped[int | None] = mapped_column(ForeignKey("classrooms.id"), nullable=True)
     story_slug: Mapped[str | None] = mapped_column(String(100), nullable=True, index=True)
     status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="in_progress", index=True)
+    # DEPRECATED: use current_step_derived computed from step_progress.steps_completed (#1182).
+    # Do NOT write to this column from application code. Column kept for zero-downtime
+    # deprecation; will be dropped post-demo once step_progress is the sole source of truth.
     current_step: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     accuracy: Mapped[float | None] = mapped_column(Float, nullable=True)
     overall_score: Mapped[float | None] = mapped_column(Float, nullable=True)
@@ -68,6 +103,42 @@ class LearningSession(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # ── Derived property — single source of truth for "current step" ─────────
+
+    @property
+    def current_step_derived(self) -> int:
+        """Compute the current step number from step_progress.steps_completed.
+
+        Returns the step number the student should be on next (= max completed + 1),
+        capped at _MAX_STEP_NUM so it never exceeds the last step.
+
+        Returns 1 (first step) when:
+        - step_progress is None (fresh session)
+        - step_progress is not a dict (corrupt value)
+        - steps_completed is empty or absent
+        - all keys in steps_completed are unknown
+
+        This is the authoritative value; do NOT read the deprecated integer
+        current_step column from application code.  (#1182)
+        """
+        sp = self.step_progress
+        if not isinstance(sp, dict):
+            return 1
+        steps_completed = sp.get("steps_completed")
+        if not isinstance(steps_completed, list) or len(steps_completed) == 0:
+            return 1
+        alias = self._FRONTEND_STEP_ALIAS
+        key_to_num = self._STEP_KEY_TO_NUM
+        max_num: int = 0
+        for s in steps_completed:
+            canonical = alias.get(s, s) if isinstance(s, str) else s
+            num = key_to_num.get(canonical, 0)
+            if num > max_num:
+                max_num = num
+        if max_num == 0:
+            return 1
+        return min(max_num + 1, _MAX_STEP_NUM)
 
     student: Mapped["User"] = relationship("User", back_populates="sessions")  # type: ignore[name-defined]
     text: Mapped["Text"] = relationship("Text", back_populates="sessions")  # type: ignore[name-defined]

--- a/backend/app/routes/admin_sessions.py
+++ b/backend/app/routes/admin_sessions.py
@@ -60,7 +60,7 @@ def list_sessions(
                 "student_id": s.student_id,
                 "story_slug": s.story_slug,
                 "status": s.status,
-                "current_step": s.current_step,
+                "current_step": s.current_step_derived,  # derived from step_progress (#1182)
                 "started_at": s.started_at.isoformat(),
                 "completed_at": s.completed_at.isoformat() if s.completed_at else None,
             }

--- a/backend/app/routes/learning/learning_progress.py
+++ b/backend/app/routes/learning/learning_progress.py
@@ -101,12 +101,14 @@ def _compute_step_completion(session: LearningSession) -> dict[str, str]:
             else:
                 statuses[key] = "not_started"
     else:
-        # Fallback: derive from integer current_step (legacy sessions)
-        completed_step = session.current_step if session.status == "completed" else session.current_step - 1
+        # Fallback: step_progress absent (legacy sessions or fresh session).
+        # Use current_step_derived (which itself falls back to 1 when no data). (#1182)
+        derived = session.current_step_derived
+        completed_step = derived if session.status == "completed" else derived - 1
         for step_num, key in STEP_NAMES.items():
             if step_num <= completed_step:
                 statuses[key] = "completed"
-            elif step_num == session.current_step and session.status == "in_progress":
+            elif step_num == derived and session.status == "in_progress":
                 statuses[key] = "in_progress"
             else:
                 statuses[key] = "not_started"
@@ -134,7 +136,11 @@ def _recommend_next_step(session: LearningSession) -> dict:
 
     accuracy = session.accuracy or 0.0
 
-    if session.current_step >= 5 and session.full_reading_result:
+    # Use derived step (single source of truth via step_progress) for all
+    # rule comparisons.  (#1182)
+    current_step = session.current_step_derived
+
+    if current_step >= 5 and session.full_reading_result:
         full_score = 0.0
         if isinstance(session.full_reading_result, dict):
             full_score = session.full_reading_result.get("match_rate", 0) or 0.0
@@ -146,7 +152,7 @@ def _recommend_next_step(session: LearningSession) -> dict:
                 "reason": f"全文朗讀正確率 {full_score:.0f}%，建議再練習一次。",
             }
 
-    if error_count >= 3 and session.current_step < 4:
+    if error_count >= 3 and current_step < 4:
         return {
             "action": "retry_step",
             "step": "vocab",
@@ -154,7 +160,7 @@ def _recommend_next_step(session: LearningSession) -> dict:
             "reason": f"發現 {error_count} 個錯字，建議先做生字練習。",
         }
 
-    if accuracy > 0 and accuracy < 70 and session.current_step <= 2:
+    if accuracy > 0 and accuracy < 70 and current_step <= 2:
         return {
             "action": "retry_step",
             "step": "live_tutor",
@@ -162,11 +168,11 @@ def _recommend_next_step(session: LearningSession) -> dict:
             "reason": f"朗讀正確率 {accuracy:.0f}%，建議重練逐段朗讀。",
         }
 
-    current_key = STEP_NAMES.get(session.current_step, "intro")
+    current_key = STEP_NAMES.get(current_step, "intro")
     return {
         "action": "continue",
         "step": current_key,
-        "step_label": STEP_LABELS.get(session.current_step, ""),
+        "step_label": STEP_LABELS.get(current_step, ""),
         "reason": "繼續未完成的學習步驟。",
     }
 

--- a/backend/app/routes/learning/learning_sessions.py
+++ b/backend/app/routes/learning/learning_sessions.py
@@ -127,7 +127,9 @@ def create_learning_session(
         story_slug=normalized_slug,
         text_id=text_id,
         status="in_progress",
-        current_step=1,
+        # DEPRECATED (#1182): current_step integer column is deprecated; step tracking
+        # is done via step_progress.steps_completed + current_step_derived property.
+        # Omitting current_step here lets the DB default (1) apply.
         classroom_id=classroom_id,
     )
     db.add(session)
@@ -435,7 +437,9 @@ def get_session_status(
     return SessionStatusResponse(
         id=session.id,
         story_slug=session.story_slug,
-        current_step=session.current_step,
+        # Use derived step so resume picks up where step_progress says, not the
+        # deprecated integer column (#1182).
+        current_step=session.current_step_derived,
         status=session.status,
         is_resumable=is_resumable,
         is_completed=is_completed,
@@ -465,6 +469,10 @@ def update_session(
 
     update_data = payload.model_dump(exclude_unset=True)
     for field, value in update_data.items():
+        # DEPRECATED (#1182): silently discard writes to current_step integer column.
+        # Step tracking is now done exclusively via step_progress.steps_completed.
+        if field == "current_step":
+            continue
         setattr(session, field, value)
 
     # Auto-set completed_at when status changes to completed (Issue #1070)

--- a/backend/app/routes/learning/learning_step_progress.py
+++ b/backend/app/routes/learning/learning_step_progress.py
@@ -16,10 +16,8 @@ from ...database import get_db
 from ...models.session import LearningSession
 from ...models.user import User
 from ...schemas.session import StepProgressResponse, StepProgressSaveRequest, parse_step_progress
-from .learning_progress import STEP_NAMES, _MAX_STEP_NUM, _normalize_step_key
-
-# Reverse mapping: step key (string) → step number (int)
-_STEP_KEY_TO_NUM = {v: k for k, v in STEP_NAMES.items()}
+# DEPRECATED (#1182): _STEP_KEY_TO_NUM / _MAX_STEP_NUM / _normalize_step_key were used
+# to sync the integer current_step column. Sync removed; imports no longer needed here.
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -100,17 +98,10 @@ def save_step_progress(
         "__meta": existing_meta,
     }
 
-    # Sync integer current_step from steps_completed to prevent desync (#1073).
-    # Normalize frontend step IDs → backend keys before lookup.
-    if payload.steps_completed:
-        max_completed_num = max(
-            (_STEP_KEY_TO_NUM.get(_normalize_step_key(s), 0) for s in payload.steps_completed),
-            default=0,
-        )
-        if max_completed_num > 0:
-            new_current = min(max_completed_num + 1, _MAX_STEP_NUM)
-            if new_current != session.current_step:
-                session.current_step = new_current
+    # DEPRECATED (#1182): integer current_step sync removed.
+    # step_progress.steps_completed is now the single source of truth;
+    # session.current_step_derived computes the step number on the fly.
+    # Do NOT add writes to session.current_step here.
 
     db.commit()
     db.refresh(session)

--- a/backend/tests/test_current_step_deprecation.py
+++ b/backend/tests/test_current_step_deprecation.py
@@ -1,0 +1,326 @@
+"""
+Regression tests for Issue #1182 — deprecate current_step integer column.
+
+Verifies:
+- LearningSession.current_step_derived returns correct step from step_progress
+- current_step_derived returns 1 for sessions with no step_progress
+- Saving step progress via PUT does NOT write to current_step integer column
+- Session creation does NOT set current_step to a non-default value
+- GET /learning/sessions/{id}/status returns derived step (not stale integer)
+- PATCH /learning/sessions/{id} with current_step payload does NOT write the column
+
+Run with:
+    cd backend && JWT_SECRET_KEY=test-secret python -m pytest tests/test_current_step_deprecation.py -v
+"""
+
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.session import LearningSession
+from app.models.text import Text
+from app.models.user import Role
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite test database
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+# Use lesson_number=98 (unlikely to collide with other test modules)
+VALID_LESSON_NUM = 98
+VALID_SLUG = str(VALID_LESSON_NUM)
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    with TestingSessionLocal() as db:
+        for role_data in SEED_ROLES:
+            if not db.query(Role).filter_by(name=role_data["name"]).first():
+                db.add(Role(**role_data))
+        # Seed a Text row for story_slug validation (#1135)
+        if not db.query(Text).filter_by(lesson_number=VALID_LESSON_NUM).first():
+            db.add(Text(
+                title="Test Lesson 1182",
+                paragraphs=["Test paragraph."],
+                char_count=14,
+                grade=4,
+                grade_code="G4-1",
+                genre="記敘文",
+                text_type="單",
+                category="Fable",
+                lesson_number=VALID_LESSON_NUM,
+            ))
+        db.commit()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_and_login(client, suffix: str | None = None) -> dict:
+    unique = suffix or uuid.uuid4().hex[:8]
+    email = f"cs1182_{unique}@example.com"
+    password = "DeprecatePass1!"
+    resp = client.post(
+        "/api/auth/register",
+        json={"email": email, "password": password, "name": f"CS1182 {unique}"},
+    )
+    assert resp.status_code == 201, resp.text
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    return {"email": email, "token": login_resp.json()["access_token"]}
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="module")
+def student(client):
+    return _register_and_login(client, "student")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: current_step_derived property (without ORM overhead)
+#
+# We test the property logic directly by creating minimal stand-in objects
+# that mimic the shape the property reads from (just step_progress).
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Minimal stand-in for LearningSession that carries the property logic.
+
+    The property is defined on LearningSession and reads self.step_progress,
+    self._FRONTEND_STEP_ALIAS, self._STEP_KEY_TO_NUM, and self._STEP_NUM_TO_KEY.
+    Rather than fighting SQLAlchemy's ORM machinery in a unit test, we borrow
+    the exact same property method and bind it to a plain Python object.
+    """
+    _STEP_KEY_TO_NUM = LearningSession._STEP_KEY_TO_NUM
+    _FRONTEND_STEP_ALIAS = LearningSession._FRONTEND_STEP_ALIAS
+    _STEP_NUM_TO_KEY = LearningSession._STEP_NUM_TO_KEY
+    # Bind the same property method
+    current_step_derived = LearningSession.current_step_derived
+
+    def __init__(self, step_progress):
+        self.step_progress = step_progress
+
+
+class TestCurrentStepDerivedProperty:
+    """Test the derived property logic independently."""
+
+    def test_no_step_progress_returns_1(self):
+        s = _FakeSession(None)
+        assert s.current_step_derived == 1
+
+    def test_empty_steps_completed_returns_1(self):
+        s = _FakeSession({"current_step": "intro", "steps_completed": []})
+        assert s.current_step_derived == 1
+
+    def test_one_step_completed_returns_next(self):
+        # completed intro (step 1) → derived = 2
+        s = _FakeSession({"steps_completed": ["intro"]})
+        assert s.current_step_derived == 2
+
+    def test_two_steps_completed(self):
+        # completed intro + live_tutor (steps 1, 2) → derived = 3
+        s = _FakeSession({"steps_completed": ["intro", "live_tutor"]})
+        assert s.current_step_derived == 3
+
+    def test_frontend_alias_tutor(self):
+        # frontend sends "tutor" (alias for live_tutor = step 2)
+        # reading-annotation→intro(1), tutor→live_tutor(2) → max=2 → derived=3
+        s = _FakeSession({"steps_completed": ["reading-annotation", "tutor"]})
+        assert s.current_step_derived == 3
+
+    def test_frontend_alias_full_reading(self):
+        # full-reading → full_reading = step 5 → max=5 → derived=6
+        s = _FakeSession({"steps_completed": ["intro", "live_tutor", "comprehension", "vocab", "full-reading"]})
+        assert s.current_step_derived == 6
+
+    def test_caps_at_max_step(self):
+        # all 6 steps completed → max=6 → min(7, 6) = 6
+        s = _FakeSession({
+            "steps_completed": ["intro", "live_tutor", "comprehension", "vocab", "full_reading", "report"]
+        })
+        assert s.current_step_derived == 6
+
+    def test_non_dict_step_progress_returns_1(self):
+        s = _FakeSession("invalid_string")
+        assert s.current_step_derived == 1
+
+    def test_unknown_step_keys_ignored(self):
+        # unknown keys should not crash and should return 1 (max_num stays 0)
+        s = _FakeSession({"steps_completed": ["unknown_step"]})
+        assert s.current_step_derived == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: write sites must NOT update current_step column
+# ---------------------------------------------------------------------------
+
+
+def test_session_creation_does_not_write_current_step(client, student):
+    """POST /learning/sessions — new session current_step stays at default (1)."""
+    resp = client.post(
+        "/api/learning/sessions",
+        json={"story_slug": VALID_SLUG},
+        headers=auth_header(student["token"]),
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = resp.json()["id"]
+    # The integer column retains the DB default (1) — we intentionally don't set it
+    with TestingSessionLocal() as db:
+        session = db.query(LearningSession).get(session_id)
+        assert session is not None
+        assert session.current_step == 1
+
+
+def test_saving_step_progress_does_not_update_current_step_column(client, student):
+    """PUT /progress must NOT write to the integer current_step column."""
+    # Use existing session from previous test (same student + slug returns same session)
+    # or create a fresh one with a distinct slug is not possible here; re-use existing.
+    # Get the existing session_id from the previous test via the API.
+    list_resp = client.get(
+        "/api/learning/sessions",
+        headers=auth_header(student["token"]),
+    )
+    assert list_resp.status_code == 200, list_resp.text
+    sessions = list_resp.json()["items"]
+    assert len(sessions) >= 1
+    session_id = sessions[0]["id"]
+
+    # Simulate student completing 3 steps
+    put_resp = client.put(
+        f"/api/learning/sessions/{session_id}/progress",
+        json={
+            "current_step": "vocab",
+            "steps_completed": ["reading-annotation", "tutor", "comprehension"],
+            "step_data": {},
+        },
+        headers=auth_header(student["token"]),
+    )
+    assert put_resp.status_code == 200, put_resp.text
+
+    # Verify the integer column was NOT updated
+    with TestingSessionLocal() as db:
+        session = db.query(LearningSession).get(session_id)
+        assert session is not None
+        assert session.current_step == 1, (
+            f"current_step integer column was written (got {session.current_step}), "
+            "but it should be deprecated and untouched (#1182)"
+        )
+
+    # But current_step_derived should return the correct derived value
+    with TestingSessionLocal() as db:
+        session = db.query(LearningSession).get(session_id)
+        # reading-annotation→intro(1), tutor→live_tutor(2), comprehension(3) → max=3 → derived=4
+        assert session.current_step_derived == 4, (
+            f"current_step_derived should be 4, got {session.current_step_derived}"
+        )
+
+
+def test_get_session_status_returns_derived_step(client, student):
+    """GET /sessions/{id}/status current_step must reflect step_progress, not the column."""
+    list_resp = client.get(
+        "/api/learning/sessions",
+        headers=auth_header(student["token"]),
+    )
+    session_id = list_resp.json()["items"][0]["id"]
+
+    # Check status endpoint returns derived value (4 from previous test), not stale column (1)
+    status_resp = client.get(
+        f"/api/learning/sessions/{session_id}/status",
+        headers=auth_header(student["token"]),
+    )
+    assert status_resp.status_code == 200, status_resp.text
+    body = status_resp.json()
+    # After saving progress with 3 steps (intro, live_tutor, comprehension) → derived=4
+    assert body["current_step"] == 4, (
+        f"status endpoint returned current_step={body['current_step']}, expected 4 (derived). "
+        "The deprecated integer column (1) must not be returned."
+    )
+
+
+def test_patch_session_with_current_step_does_not_write_column(client, student):
+    """PATCH /sessions/{id} with current_step in payload must silently discard it."""
+    list_resp = client.get(
+        "/api/learning/sessions",
+        headers=auth_header(student["token"]),
+    )
+    session_id = list_resp.json()["items"][0]["id"]
+
+    # Try patching current_step directly (should be silently ignored)
+    patch_resp = client.patch(
+        f"/api/learning/sessions/{session_id}",
+        json={"current_step": 5, "accuracy": 85.0},
+        headers=auth_header(student["token"]),
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+
+    # Verify the column was NOT updated to 5
+    with TestingSessionLocal() as db:
+        session = db.query(LearningSession).get(session_id)
+        assert session is not None
+        assert session.current_step != 5, (
+            "current_step integer column was written to 5 via PATCH, "
+            "but writes should be disabled (#1182)"
+        )
+        # Accuracy should still have been updated
+        assert session.accuracy == 85.0


### PR DESCRIPTION
## Summary
LearningSession 同時有 `current_step` (integer column) 和 `step_progress.steps_completed` (JSONB array)。Two parallel mechanisms 有 race condition。本 PR 廢除 integer column 寫入，改用 step_progress 作為 single source of truth。

## Changes
- Add `@property current_step_derived` 從 `step_progress.steps_completed` 推導
- **Disable 3 write sites** to integer `current_step`（保留 column zero-downtime）
- **Update 6 read sites** 改用 derived property
- Deprecation comment on integer column
- 13/13 regression tests pass
- **No alembic migration** — defer column drop to post-demo

## Files
- `backend/app/models/session.py` (+71 lines: constants, derived property, deprecation comment)
- `backend/app/routes/learning/learning_step_progress.py` (remove #1073 sync block)
- `backend/app/routes/learning/learning_sessions.py` (creation kwargs, status endpoint, PATCH skip)
- `backend/app/routes/learning/learning_progress.py` (_recommend_next_step + _compute_step_completion)
- `backend/app/routes/admin_sessions.py` (use derived)
- `backend/tests/test_current_step_deprecation.py` (NEW, 326 lines)

## Test plan
1. `pytest tests/test_current_step_deprecation.py -v` 應 13/13 pass
2. Staging deploy 後跑 session resume → 應正確返回 current step
3. 跑舊 session 含 step_progress 異常 → 應 fallback gracefully

Closes #1182