### PR TITLE
fix(db): add ReadingAttemptHistory for versioned reading_result snapshots (Fixes #1183)

### DIFF
--- a/backend/alembic/versions/ra01hist02ver03_add_reading_attempt_history.py
+++ b/backend/alembic/versions/ra01hist02ver03_add_reading_attempt_history.py
@@ -1,0 +1,58 @@
+"""add reading_attempt_history table for versioned reading_result snapshots
+
+Revision ID: ra01hist02ver03
+Revises: dt01fk02cascade03
+Create Date: 2026-04-26 00:00:00.000000
+
+Issue #1183: reading_result JSONB 無版本紀錄（重練覆蓋歷史）
+
+Creates reading_attempt_history to snapshot previous reading_result values
+before each overwrite on learning_sessions.reading_result.
+
+DDL is idempotent (IF NOT EXISTS / EXCEPTION WHEN duplicate_object / DROP IF EXISTS)
+so it is safe to re-run on shared preview-db / staging-db environments.
+"""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "ra01hist02ver03"
+down_revision: Union[str, None] = "dt01fk02cascade03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create table (idempotent: CREATE TABLE IF NOT EXISTS via raw DDL)
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS reading_attempt_history (
+            id          SERIAL PRIMARY KEY,
+            session_id  INTEGER NOT NULL
+                            REFERENCES learning_sessions(id) ON DELETE CASCADE,
+            attempt_no  INTEGER NOT NULL,
+            reading_result JSONB NOT NULL,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    """)
+
+    # FK index on session_id (Rule 1: every FK must have index=True)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_reading_attempt_history_session_id "
+        "ON reading_attempt_history (session_id)"
+    )
+
+    # Composite index for fast "max attempt_no per session" lookups
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_reading_attempt_history_session_attempt "
+        "ON reading_attempt_history (session_id, attempt_no)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_reading_attempt_history_session_attempt")
+    op.execute("DROP INDEX IF EXISTS ix_reading_attempt_history_session_id")
+    op.execute("DROP TABLE IF EXISTS reading_attempt_history")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,7 +3,7 @@ from .user import User, Role, UserRole, StudentProfile  # noqa: F401
 from .organization import Organization  # noqa: F401
 from .school import School, Classroom, ClassroomStudent, ClassroomText, ClassroomTeacher  # noqa: F401
 from .text import Text, VisibilityLevel, TextStatus  # noqa: F401
-from .session import LearningSession, CharacterError, ErrorCorrection, DialogueTurn  # noqa: F401
+from .session import LearningSession, CharacterError, ErrorCorrection, DialogueTurn, ReadingAttemptHistory  # noqa: F401
 from .assignment import Assignment, AssignmentSubmission  # noqa: F401
 from .points_log import OrganizationPointsLog  # noqa: F401
 from .feedback import Feedback  # noqa: F401

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -5,6 +5,41 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .base import Base
 
 
+class ReadingAttemptHistory(Base):
+    """Versioned history of reading_result JSONB snapshots for a LearningSession.
+
+    Each time reading_result is overwritten on LearningSession, the previous
+    value is snapshotted here before the overwrite so no attempt is lost.
+    attempt_no is 1-based; attempt_no=1 is the first recorded attempt.
+
+    Issue #1183: reading_result JSONB 無版本紀錄（重練覆蓋歷史）
+    """
+    __tablename__ = "reading_attempt_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # FK with index=True (Rule 1) + CASCADE so rows are removed when session is deleted
+    session_id: Mapped[int] = mapped_column(
+        ForeignKey("learning_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # 1-based attempt counter; composite index enables fast "latest attempt" lookup
+    attempt_no: Mapped[int] = mapped_column(Integer, nullable=False)
+    reading_result: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index("ix_reading_attempt_history_session_attempt", "session_id", "attempt_no"),
+    )
+
+    session: Mapped["LearningSession"] = relationship(  # type: ignore[name-defined]
+        "LearningSession",
+        back_populates="reading_attempts",
+    )
+
+
 class ErrorCorrection(Base):
     """Tracks when a student marks a character as practiced or mastered."""
     __tablename__ = "error_corrections"
@@ -74,6 +109,13 @@ class LearningSession(Base):
     classroom: Mapped["Classroom | None"] = relationship("Classroom")  # type: ignore[name-defined]
     character_errors: Mapped[list["CharacterError"]] = relationship(
         "CharacterError", back_populates="session"
+    )
+    reading_attempts: Mapped[list["ReadingAttemptHistory"]] = relationship(
+        "ReadingAttemptHistory",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="ReadingAttemptHistory.attempt_no",
     )
     dialogue_turns: Mapped[list["DialogueTurn"]] = relationship(
         "DialogueTurn",

--- a/backend/app/routes/learning/learning_sessions.py
+++ b/backend/app/routes/learning/learning_sessions.py
@@ -13,6 +13,7 @@ from ...auth.dependencies import get_current_user
 from ...database import get_db
 from ...models.assignment import AssignmentSubmission
 from ...models.session import CharacterError, LearningSession
+from ...services.reading_attempt_service import snapshot_reading_result
 from ...models.text import Text
 from ...models.user import User
 from ...services.lesson_loader import get_lesson_by_id
@@ -470,6 +471,10 @@ def update_session(
     # Auto-set completed_at when status changes to completed (Issue #1070)
     if update_data.get("status") == "completed" and session.completed_at is None:
         session.completed_at = datetime.now(timezone.utc)
+
+    # Snapshot previous reading_result before overwrite (Issue #1183)
+    if "reading_result" in update_data and update_data["reading_result"] is not None:
+        snapshot_reading_result(db, session)
 
     # Auto-persist CharacterError records from reading_result.error_chars (Issue #248)
     if "reading_result" in update_data:

--- a/backend/app/services/reading_attempt_service.py
+++ b/backend/app/services/reading_attempt_service.py
@@ -1,0 +1,97 @@
+"""Service helpers for versioned reading_result snapshots.
+
+Issue #1183: reading_result JSONB 無版本紀錄（重練覆蓋歷史）
+
+When a student retries a reading exercise, the previous reading_result must be
+snapshotted to ReadingAttemptHistory BEFORE the LearningSession column is
+overwritten.  This ensures no attempt is ever silently lost.
+
+Public API
+----------
+snapshot_reading_result(db, session)
+    Call this BEFORE assigning session.reading_result = new_value.
+    Snapshots the *current* value (if not None) into ReadingAttemptHistory.
+
+get_reading_history(db, session_id) -> list[dict]
+    Return all historical attempts for a session, ordered by attempt_no.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.session import LearningSession, ReadingAttemptHistory
+
+if TYPE_CHECKING:
+    pass  # avoid circular imports
+
+logger = logging.getLogger(__name__)
+
+
+def snapshot_reading_result(db: DBSession, session: LearningSession) -> int | None:
+    """Snapshot session.reading_result into ReadingAttemptHistory.
+
+    Must be called BEFORE the caller overwrites session.reading_result.
+
+    Returns
+    -------
+    int | None
+        The attempt_no assigned to the new snapshot, or None if there was
+        nothing to snapshot (session.reading_result was already None).
+    """
+    if session.reading_result is None:
+        return None
+
+    # Determine the next attempt_no (current max + 1, 1-based)
+    existing_max = (
+        db.query(ReadingAttemptHistory.attempt_no)
+        .filter(ReadingAttemptHistory.session_id == session.id)
+        .order_by(ReadingAttemptHistory.attempt_no.desc())
+        .limit(1)
+        .scalar()
+    )
+    next_attempt_no = (existing_max or 0) + 1
+
+    snapshot = ReadingAttemptHistory(
+        session_id=session.id,
+        attempt_no=next_attempt_no,
+        reading_result=session.reading_result,
+    )
+    db.add(snapshot)
+    logger.info(
+        "Snapshotted reading_result for session %d → attempt_no=%d",
+        session.id,
+        next_attempt_no,
+    )
+    return next_attempt_no
+
+
+def get_reading_history(db: DBSession, session_id: int) -> list[dict]:
+    """Return all snapshotted reading_result attempts for session_id.
+
+    The list is ordered by attempt_no ascending (oldest first).
+    The *current* value on LearningSession.reading_result is NOT included —
+    callers should append it separately if they want a complete picture.
+
+    Returns
+    -------
+    list[dict]
+        Each entry: {"attempt_no": int, "reading_result": dict, "created_at": str}
+    """
+    rows = (
+        db.query(ReadingAttemptHistory)
+        .filter(ReadingAttemptHistory.session_id == session_id)
+        .order_by(ReadingAttemptHistory.attempt_no)
+        .all()
+    )
+    return [
+        {
+            "attempt_no": row.attempt_no,
+            "reading_result": row.reading_result,
+            "created_at": row.created_at.isoformat(),
+        }
+        for row in rows
+    ]

--- a/backend/tests/test_reading_attempt_history.py
+++ b/backend/tests/test_reading_attempt_history.py
@@ -1,0 +1,164 @@
+"""Regression tests for reading_result versioning (Issue #1183).
+
+Tests the reading_attempt_service helper functions directly against an
+in-memory SQLite DB.  FK enforcement is intentionally disabled so we can
+insert LearningSession rows without creating User/School/StudentProfile
+scaffolding — the behaviour under test is the snapshot logic, not referential
+integrity.
+
+Verifies:
+1. snapshot_reading_result() returns None when reading_result is None (nothing to save).
+2. Writing reading_result twice: snapshot_reading_result() before the second write
+   creates exactly 1 ReadingAttemptHistory row holding the FIRST value.
+3. LearningSession.reading_result holds the LATEST written value.
+4. get_reading_history() returns snapshots ordered by attempt_no ascending.
+5. History row count == total writes - 1 (first write has nothing to snapshot).
+
+Uses SQLite in-memory DB; conftest.py patches JSONB → JSON for compatibility.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.session import LearningSession, ReadingAttemptHistory
+from app.services.reading_attempt_service import get_reading_history, snapshot_reading_result
+
+# ---------------------------------------------------------------------------
+# SQLite in-memory engine — NO PRAGMA foreign_keys so we can create
+# LearningSession rows without scaffolding the full User hierarchy.
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def db():
+    """Provide a SQLite in-memory DB session for unit tests."""
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def learning_session(db):
+    """Create a bare LearningSession (no FK enforcement → no User needed)."""
+    sess = LearningSession(
+        student_id=999,   # phantom student_id; FK not enforced in SQLite here
+        story_slug="test-story-1183",
+        status="in_progress",
+        current_step=1,
+        reading_result=None,
+    )
+    db.add(sess)
+    db.commit()
+    db.refresh(sess)
+    return sess
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadingAttemptHistory:
+    """Unit tests for snapshot_reading_result and get_reading_history."""
+
+    def test_no_snapshot_when_reading_result_is_none(self, db, learning_session):
+        """snapshot_reading_result on a None field returns None; no row created."""
+        assert learning_session.reading_result is None
+
+        result = snapshot_reading_result(db, learning_session)
+        assert result is None
+
+        count = (
+            db.query(ReadingAttemptHistory)
+            .filter(ReadingAttemptHistory.session_id == learning_session.id)
+            .count()
+        )
+        assert count == 0, "No snapshot row should be created when reading_result is None"
+
+    def test_snapshot_created_before_second_write(self, db, learning_session):
+        """First write sets reading_result; second write snapshots the first value."""
+        # Write #1 — set a value (no prior value to snapshot)
+        first_result = {"accuracy": 0.75, "cpm": 100, "transcript": "first attempt"}
+        learning_session.reading_result = first_result
+        db.commit()
+        db.refresh(learning_session)
+
+        # Still no history row (we set from None → value, nothing was snapshotted)
+        count_before = (
+            db.query(ReadingAttemptHistory)
+            .filter(ReadingAttemptHistory.session_id == learning_session.id)
+            .count()
+        )
+        assert count_before == 0
+
+        # Write #2 — snapshot the first value, then overwrite
+        attempt_no = snapshot_reading_result(db, learning_session)
+        assert attempt_no == 1
+
+        second_result = {"accuracy": 0.85, "cpm": 120, "transcript": "second attempt"}
+        learning_session.reading_result = second_result
+        db.commit()
+        db.refresh(learning_session)
+
+        # Exactly 1 history row, holding the FIRST value
+        rows = (
+            db.query(ReadingAttemptHistory)
+            .filter(ReadingAttemptHistory.session_id == learning_session.id)
+            .all()
+        )
+        assert len(rows) == 1
+        assert rows[0].attempt_no == 1
+        assert rows[0].reading_result["accuracy"] == 0.75
+
+        # Current session holds the SECOND value
+        assert learning_session.reading_result["accuracy"] == 0.85
+
+    def test_get_reading_history_returns_snapshots_ordered(self, db, learning_session):
+        """get_reading_history() returns all snapshots sorted by attempt_no ascending."""
+        # Write #3 — snapshot second value, then overwrite
+        snapshot_reading_result(db, learning_session)
+        third_result = {"accuracy": 0.90, "cpm": 135, "transcript": "third attempt"}
+        learning_session.reading_result = third_result
+        db.commit()
+
+        history = get_reading_history(db, learning_session.id)
+        # 2 snapshots: attempt_no 1 (accuracy=0.75) and attempt_no 2 (accuracy=0.85)
+        assert len(history) == 2
+        assert history[0]["attempt_no"] == 1
+        assert history[1]["attempt_no"] == 2
+        assert history[0]["reading_result"]["accuracy"] == 0.75
+        assert history[1]["reading_result"]["accuracy"] == 0.85
+        # Each entry has an ISO-format created_at string
+        assert "T" in history[0]["created_at"]
+
+    def test_current_session_holds_latest_value(self, db, learning_session):
+        """After three writes, session.reading_result is the last-written value."""
+        assert learning_session.reading_result["accuracy"] == 0.90
+
+    def test_history_count_invariant(self, db, learning_session):
+        """History rows = (number of writes) - 1: first write never has a prior to snapshot."""
+        # 3 total writes → 2 history rows
+        history = get_reading_history(db, learning_session.id)
+        assert len(history) == 2


### PR DESCRIPTION
Fixes #1183

## Summary

- Add `ReadingAttemptHistory` model: stores snapshots of `LearningSession.reading_result` before each overwrite, so no attempt is ever silently lost
- Add `reading_attempt_service` with two helpers: `snapshot_reading_result()` (call before overwrite) and `get_reading_history()` (read all past attempts)
- Wire snapshot into `PATCH /learning/sessions/{id}` — fires before `reading_result` is overwritten, adds one `ReadingAttemptHistory` row per overwrite
- Alembic migration `ra01hist02ver03` with idempotent DDL (safe for shared preview-db/staging-db)
- `LearningSession.reading_result` column shape unchanged — no breaking changes to existing callers

## Schema

```
reading_attempt_history
  id          SERIAL PK
  session_id  FK → learning_sessions(id) ON DELETE CASCADE, index=True
  attempt_no  INTEGER (1-based)
  reading_result JSONB NOT NULL
  created_at  TIMESTAMPTZ server_default=NOW()

Indexes:
  ix_reading_attempt_history_session_id      (session_id)
  ix_reading_attempt_history_session_attempt (session_id, attempt_no)
```

## Constraints respected

- Did NOT touch `routes/assignments.py`
- Did NOT touch `current_step` logic
- Did NOT touch `story_slug` logic

## Migration head

- Before: `dt01fk02cascade03`
- After:  `ra01hist02ver03` (single head, no conflict)

## Test plan

- 5 unit tests in `backend/tests/test_reading_attempt_history.py` — all pass
- Tests cover: no-op on None, snapshot on second write, ordering, latest-value invariant, count invariant