### PR TITLE
revert: SSO switch — junyi main 還沒上 multi-RP，登入 401 (Related to #1260)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -81,7 +81,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::JUNYI_SSO_BASE_URL=https://ci-live-worktree-sso-multi-rp---rev-proxy-dg4bspkswq-de.a.run.app"
 
       - name: Verify backend health
         run: |

--- a/frontend/src/pages/JunyiCallbackPage.tsx
+++ b/frontend/src/pages/JunyiCallbackPage.tsx
@@ -49,7 +49,9 @@ export function buildJunyiLoginUrl(returnTo: string = '/'): string {
   sessionStorage.setItem(JUNYI_STATE_KEY, state);
 
   const continueUrl = `${callbackUrl}&state=${state}`;
-  return `https://www.junyiacademy.org/login?continue=${encodeURIComponent(continueUrl)}`;
+  // TODO: switch back to https://www.junyiacademy.org/login once Junyi Part 2 multi-RP lands on prod.
+  // Per 宥辰 2026-04-21: Part 2 currently only on ci-live; prod junyi ignores `continue` param.
+  return `https://ci-live-worktree-sso-multi-rp---rev-proxy-dg4bspkswq-de.a.run.app/login?continue=${encodeURIComponent(continueUrl)}`;
 }
 
 const JunyiCallbackPage: React.FC = () => {


### PR DESCRIPTION
## Why

剛 merged PR #1288 後 staging 測試 Junyi SSO 登入失敗：
- Frontend: 「均一登入失敗 / 連結已過期或已使用」
- Backend log: `POST /api/auth/junyi -> 401 Unauthorized` 多次連續

## Root cause

Junyi 主站（www.junyiacademy.org）還沒 deploy SSO Part 2 (multi-RP)：
- junyi#4085 ('refactor(auth): generalize jutor SSO to support multiple RPs') merged 2026-04-24 進 junyi **staging**
- 沒 PR 進 junyi main today (`gh pr list --search 'merged:>=2026-04-27' --filter SSO` = 0)
- 我們 backend 拿 code 去主站 `/api/v2/auth/code` exchange 仍被 reject

## Action

Revert #1288。等真正 prod multi-RP 上了再切。

Closes nothing — issue #1260 仍 open，等宥辰真正 prod deploy。

🤖 Generated with [Claude Code](https://claude.com/claude-code)