### PR TITLE
fix(sso): send client_id='lingoleap' + switch to www.junyiacademy.org (Fixes #1260)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -81,7 +81,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::JUNYI_SSO_BASE_URL=https://ci-live-worktree-sso-multi-rp---rev-proxy-dg4bspkswq-de.a.run.app"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
 
       - name: Verify backend health
         run: |

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -668,9 +668,15 @@ def junyi_login(req: JunyiLoginRequest, request: Request, db: Session = Depends(
     junyi_base = settings.junyi_sso_base_url.rstrip("/")
     exchange_url = f"{junyi_base}/api/v2/auth/code"
     try:
+        # client_id="lingoleap" required after Junyi multi-RP migration (junyi#4083 / #4085).
+        # Without it, Junyi falls back to probe mode and matches the first
+        # client_secret_hash=None entry (jutor) using jutor_auth_ cache prefix,
+        # which can't find lingoleap-issued codes -> AUTH_CODE_NOT_FOUND.
+        # client_secret omitted: LINGOLEAP_CLIENT.client_secret_hash is None
+        # (Phase 1 — see junyi doc/THIRD_PARTY_SSO.md "相容模式").
         resp = httpx.post(
             exchange_url,
-            json={"code": req.code},
+            json={"code": req.code, "client_id": "lingoleap"},
             timeout=10.0,
         )
     except httpx.RequestError as exc:

--- a/frontend/src/pages/JunyiCallbackPage.tsx
+++ b/frontend/src/pages/JunyiCallbackPage.tsx
@@ -49,9 +49,7 @@ export function buildJunyiLoginUrl(returnTo: string = '/'): string {
   sessionStorage.setItem(JUNYI_STATE_KEY, state);
 
   const continueUrl = `${callbackUrl}&state=${state}`;
-  // TODO: switch back to https://www.junyiacademy.org/login once Junyi Part 2 multi-RP lands on prod.
-  // Per 宥辰 2026-04-21: Part 2 currently only on ci-live; prod junyi ignores `continue` param.
-  return `https://ci-live-worktree-sso-multi-rp---rev-proxy-dg4bspkswq-de.a.run.app/login?continue=${encodeURIComponent(continueUrl)}`;
+  return `https://www.junyiacademy.org/login?continue=${encodeURIComponent(continueUrl)}`;
 }
 
 const JunyiCallbackPage: React.FC = () => {


### PR DESCRIPTION
## Root cause
Junyi 主站 multi-RP 已 deploy，但 RP exchange 時須帶 client_id 才能用對的 cache prefix 找 code。
我們不送 → probe mode fallback 到 jutor → 找不到 lingoleap code → AUTH_CODE_NOT_FOUND → 401。

## Fix (3 files)
- `backend/auth.py:672` payload 加 `client_id: 'lingoleap'`
- `frontend/JunyiCallbackPage.tsx:54` ci-live (404) → `https://www.junyiacademy.org/login`
- `staging-deploy.yml` 移除 JUNYI_SSO_BASE_URL override

## Refs
- junyi#4083 / #4085 multi-RP migration
- junyi `sso_clients.py` LINGOLEAP_CLIENT (host whitelist done, secret_hash=None Phase 1)
- junyi `doc/THIRD_PARTY_SSO.md` 「相容模式」table

## Test plan
1. Merge → staging deploy
2. Login as Junyi user on staging → should NOT see 'AUTH_CODE_NOT_FOUND' / 401
3. PR staging→main → prod test
4. Close #1260

Replaces failed PR #1288 (no client_id) + #1306 (revert that)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)