### PR TITLE
fix(routes): guard disabled steps from direct URL access (Fixes #1312)

### DIFF
--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -6,7 +6,7 @@
  * only the active route's JS chunk is loaded on demand.
  */
 import React, { lazy, Suspense } from 'react';
-import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { PublicOnlyRoute, ProtectedRoute, StudentClassroomGuard } from '../components/auth/RouteGuards';
 import NoTeacherPage from '../pages/app/NoTeacherPage';
@@ -21,6 +21,7 @@ import {
 } from '../pages/app/InlinePages';
 import PageLoader from '../components/ui/PageLoader';
 import { PARENT_PORTAL_ENABLED } from '../config/featureFlags';
+import { STEP_CONFIG } from '../config/stepConfig';
 
 // Auth pages — eager-loaded (small, needed immediately on first visit)
 import LoginPage from '../pages/LoginPage';
@@ -104,6 +105,28 @@ const StepRoute: React.FC<StepRouteProps> = ({ stepLabel, nextPath, children }) 
       {children}
     </StepErrorBoundary>
   );
+};
+
+// ---------------------------------------------------------------------------
+// StepEnabledGuard — redirects to the first enabled step when a step is disabled
+// in STEP_CONFIG (enabled: false).  Wrap any route whose step may be disabled.
+// ---------------------------------------------------------------------------
+
+interface StepEnabledGuardProps {
+  stepId: string;
+  children: React.ReactNode;
+}
+
+const StepEnabledGuard: React.FC<StepEnabledGuardProps> = ({ stepId, children }) => {
+  const { storyId } = useParams<{ storyId: string }>();
+  const step = STEP_CONFIG.find((s) => s.id === stepId);
+
+  if (step && !step.enabled) {
+    const fallbackId = STEP_CONFIG.find((s) => s.enabled)?.id ?? 'reading-annotation';
+    return <Navigate to={`/learn/${storyId ?? ''}/${fallbackId}`} replace />;
+  }
+
+  return <>{children}</>;
 };
 
 // ---------------------------------------------------------------------------
@@ -492,9 +515,11 @@ const AppRoutes: React.FC = () => (
         <Route
           path="dictation"
           element={
-            <StepRoute stepLabel="聽寫練習" nextPath="vocab-word-search">
-              <DictationPage />
-            </StepRoute>
+            <StepEnabledGuard stepId="dictation">
+              <StepRoute stepLabel="聽寫練習" nextPath="vocab-word-search">
+                <DictationPage />
+              </StepRoute>
+            </StepEnabledGuard>
           }
         />
         <Route


### PR DESCRIPTION
## Summary

Fixes #1312.

When `stepConfig.ts` marks a step `enabled: false` (currently `dictation`, hidden 2026-03-27), only the StepperNav was hiding it — the route `/learn/:storyId/dictation` was still active. Anyone with the URL could open the supposedly-hidden page.

## Change

Add a small `StepEnabledGuard` component in `AppRoutes.tsx` that reads `STEP_CONFIG`, finds the step by id, and redirects to the first enabled step when `enabled === false`. Wrap the dictation route with it.

```tsx
<Route
  path="dictation"
  element={
    <StepEnabledGuard stepId="dictation">
      <StepRoute stepLabel="聽寫練習" nextPath="vocab-word-search">
        <DictationPage />
      </StepRoute>
    </StepEnabledGuard>
  }
/>
```

Future steps marked `enabled: false` are protected by wrapping their route with the same guard — no per-step boilerplate.

## Test plan

- [ ] CI green
- [ ] PR preview deploys
- [ ] Login as `student@test.com` on preview, navigate to `/learn/5/dictation` — should redirect to first enabled step (`/learn/5/reading-annotation`), NOT show the dictation page
- [ ] Confirm StepperNav still shows 12 steps (no regression)
- [ ] Console errors = 0

Discovered during the 2026-04-28 staging `/qa` run. Full report at `.gstack/qa-reports/qa-matrix-2026-04-28.md`.

Reviewed by `pr-review-toolkit:code-reviewer` (LGTM with one minor non-blocking note: `storyId ?? ''` is defensive but harmless given the parent route guarantees `:storyId` is matched).