### PR TITLE
release: 2026-04-28 — QA findings: Report popup conflict + Dictation route guard

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -363,7 +363,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({ session, story, onR
         />
       )}
 
-      {!readOnly && <CelebrationOverlay score={overallScore} />}
+      {!readOnly && !hasNoData && <CelebrationOverlay score={overallScore} />}
 
       {/* ============ 星星評級 Star Rating (Issue #222) —
           學生端隱藏（Issue #1094：改鼓勵式，不呈現星星/分數） ============ */}

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -6,7 +6,7 @@
  * only the active route's JS chunk is loaded on demand.
  */
 import React, { lazy, Suspense } from 'react';
-import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useNavigate, useParams } from 'react-router-dom';
 
 import { PublicOnlyRoute, ProtectedRoute, StudentClassroomGuard } from '../components/auth/RouteGuards';
 import NoTeacherPage from '../pages/app/NoTeacherPage';
@@ -21,6 +21,7 @@ import {
 } from '../pages/app/InlinePages';
 import PageLoader from '../components/ui/PageLoader';
 import { PARENT_PORTAL_ENABLED } from '../config/featureFlags';
+import { STEP_CONFIG } from '../config/stepConfig';
 
 // Auth pages — eager-loaded (small, needed immediately on first visit)
 import LoginPage from '../pages/LoginPage';
@@ -104,6 +105,28 @@ const StepRoute: React.FC<StepRouteProps> = ({ stepLabel, nextPath, children }) 
       {children}
     </StepErrorBoundary>
   );
+};
+
+// ---------------------------------------------------------------------------
+// StepEnabledGuard — redirects to the first enabled step when a step is disabled
+// in STEP_CONFIG (enabled: false).  Wrap any route whose step may be disabled.
+// ---------------------------------------------------------------------------
+
+interface StepEnabledGuardProps {
+  stepId: string;
+  children: React.ReactNode;
+}
+
+const StepEnabledGuard: React.FC<StepEnabledGuardProps> = ({ stepId, children }) => {
+  const { storyId } = useParams<{ storyId: string }>();
+  const step = STEP_CONFIG.find((s) => s.id === stepId);
+
+  if (step && !step.enabled) {
+    const fallbackId = STEP_CONFIG.find((s) => s.enabled)?.id ?? 'reading-annotation';
+    return <Navigate to={`/learn/${storyId ?? ''}/${fallbackId}`} replace />;
+  }
+
+  return <>{children}</>;
 };
 
 // ---------------------------------------------------------------------------
@@ -492,9 +515,11 @@ const AppRoutes: React.FC = () => (
         <Route
           path="dictation"
           element={
-            <StepRoute stepLabel="聽寫練習" nextPath="vocab-word-search">
-              <DictationPage />
-            </StepRoute>
+            <StepEnabledGuard stepId="dictation">
+              <StepRoute stepLabel="聽寫練習" nextPath="vocab-word-search">
+                <DictationPage />
+              </StepRoute>
+            </StepEnabledGuard>
           }
         />
         <Route


### PR DESCRIPTION
## Release Notes — 2 PRs

Promotes 2 fixes from `staging` to production. Both were discovered during the 2026-04-28 staging `/qa` run (full 13-step QA matrix at `.gstack/qa-reports/qa-matrix-2026-04-28.md`).

### Included PRs

| PR | Issue | What |
|----|-------|------|
| #1313 | #1311 | `fix(report): suppress 恭喜完成 popup when no reading data` — adds `!hasNoData` guard so the celebration overlay only renders when actual reading data exists |
| #1314 | #1312 | `fix(routes): guard disabled steps from direct URL access` — adds `<StepEnabledGuard>` reading `STEP_CONFIG`; routes for steps with `enabled: false` now redirect (currently affects `dictation`) |

### Files changed

- `frontend/src/components/reading-steps/AssessmentReport.tsx` (+1/-1)
- `frontend/src/routes/AppRoutes.tsx` (+29/-4)

### Already verified on staging

- Frontend bundle hash flipped: `index-C0Tv58iV.js` → `index-Ddy0utSv.js`
- `/learn/5/dictation` redirects to `/learn/5/reading-annotation` ✅
- `/learn/5/report` (no reading data) shows only the yellow warning, no popup ✅
- Console errors: 0
- Staging health: frontend 200, backend 200

### Test plan for production

- [ ] CI green
- [ ] Production deploy succeeds
- [ ] Smoke: `https://lingoleap-frontend-958347263320.asia-east1.run.app/learn/5/dictation` redirects (note: prod story_id 5 may differ — confirm a valid lesson)
- [ ] Smoke: any logged-in student visiting an unstarted `/learn/N/report` does NOT see the celebration popup

### Risk

Low. Both changes are frontend-only, narrow scope (single guard + single component conditional). Behind the existing route structure; rollback = revert merge commit.