### PR TITLE
feat: enlarge ImmersiveTopBar stepper dots and chevrons 2x (Fixes #1319)

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -87,10 +87,10 @@ const StepBadge: React.FC<{
 
   return (
     <span
-      className={`w-12 h-12 text-sm rounded-full flex items-center justify-center font-bold shrink-0 ${styleMap[status]}`}
+      className={`w-6 h-6 text-xs rounded-full flex items-center justify-center font-bold shrink-0 ${styleMap[status]}`}
     >
       {status === 'completed' ? (
-        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
+        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
           <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
         </svg>
       ) : (
@@ -134,7 +134,7 @@ const StepperNav: React.FC<StepperNavProps> = ({
       aria-label="學習步驟導覽"
       className="font-ui bg-white border-b border-gray-200 shrink-0 overflow-x-auto scrollbar-hide"
     >
-      <div className="flex items-center gap-2 px-3 py-3 min-w-max">
+      <div className="flex items-center gap-1 px-3 py-2 min-w-max">
         {/* Story title pill — desktop only */}
         {selectedStory && (
           <div className="hidden md:flex items-center mr-2 pr-3 border-r border-gray-200">
@@ -158,7 +158,7 @@ const StepperNav: React.FC<StepperNavProps> = ({
               disabled={isDisabled}
               aria-current={isActive ? 'step' : undefined}
               aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${isActive ? '目前' : isDisabled ? '未解鎖' : status === 'completed' ? '已完成' : '未完成'}）`}
-              className={`flex items-center gap-3 px-3 py-2 rounded-xl transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
+              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                 isActive
                   ? `${categoryColors.activeBg} ${categoryColors.text}`
                   : isDisabled

--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -87,10 +87,10 @@ const StepBadge: React.FC<{
 
   return (
     <span
-      className={`w-6 h-6 text-xs rounded-full flex items-center justify-center font-bold shrink-0 ${styleMap[status]}`}
+      className={`w-12 h-12 text-sm rounded-full flex items-center justify-center font-bold shrink-0 ${styleMap[status]}`}
     >
       {status === 'completed' ? (
-        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
           <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
         </svg>
       ) : (
@@ -134,7 +134,7 @@ const StepperNav: React.FC<StepperNavProps> = ({
       aria-label="學習步驟導覽"
       className="font-ui bg-white border-b border-gray-200 shrink-0 overflow-x-auto scrollbar-hide"
     >
-      <div className="flex items-center gap-1 px-3 py-2 min-w-max">
+      <div className="flex items-center gap-2 px-3 py-3 min-w-max">
         {/* Story title pill — desktop only */}
         {selectedStory && (
           <div className="hidden md:flex items-center mr-2 pr-3 border-r border-gray-200">
@@ -158,7 +158,7 @@ const StepperNav: React.FC<StepperNavProps> = ({
               disabled={isDisabled}
               aria-current={isActive ? 'step' : undefined}
               aria-label={`步驟 ${stepDef.step}：${stepDef.label}（${isActive ? '目前' : isDisabled ? '未解鎖' : status === 'completed' ? '已完成' : '未完成'}）`}
-              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
+              className={`flex items-center gap-3 px-3 py-2 rounded-xl transition-colors whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${
                 isActive
                   ? `${categoryColors.activeBg} ${categoryColors.text}`
                   : isDisabled

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -176,19 +176,19 @@ const ImmersiveTopBar: React.FC = () => {
         )}
 
         {/* Progress dots + left/right arrows (Issue #1094) — tooltip shows step name; arrows fixed-size, dots wrap */}
-        <div className="flex items-center gap-1 max-w-full min-w-0 h-4 md:h-5" role="navigation" aria-label="學習步驟導航">
+        <div className="flex items-center gap-1 max-w-full min-w-0 h-8 md:h-10" role="navigation" aria-label="學習步驟導航">
           <button
             type="button"
             onClick={() => prevStep && handleStepClick(prevStep)}
             disabled={!prevStep || !selectedStory}
-            className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             aria-label={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
             title={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
           >
-            <span className="material-symbols-outlined text-sm leading-none" style={{ fontSize: '14px' }}>chevron_left</span>
+            <span className="material-symbols-outlined leading-none" style={{ fontSize: '28px' }}>chevron_left</span>
           </button>
 
-          <div className="flex items-center gap-1 md:gap-1.5 flex-wrap justify-center min-w-0">
+          <div className="flex items-center gap-2 md:gap-3 flex-wrap justify-center min-w-0">
             {ACTIVE_STEPS.map((step, i) => {
               const isCompleted = completedSet.has(step.id);
               const isActive = i === currentStepIndex;
@@ -205,7 +205,7 @@ const ImmersiveTopBar: React.FC = () => {
                   type="button"
                   onClick={() => handleStepClick(step)}
                   disabled={isLocked}
-                  className={`w-2 h-2 md:w-2.5 md:h-2.5 rounded-full transition-all hover:scale-150 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
+                  className={`w-4 h-4 md:w-5 md:h-5 rounded-full transition-all hover:scale-150 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
                   title={`${i + 1}. ${step.label}${isLocked ? '（完成所有階段後解鎖）' : ''}`}
                   aria-label={`${i + 1}. ${step.label}`}
                   aria-current={isActive ? 'step' : undefined}
@@ -218,11 +218,11 @@ const ImmersiveTopBar: React.FC = () => {
             type="button"
             onClick={() => nextStep && handleStepClick(nextStep)}
             disabled={!nextStep || !selectedStory}
-            className="shrink-0 w-4 h-4 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
             aria-label={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
             title={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
           >
-            <span className="material-symbols-outlined text-sm leading-none" style={{ fontSize: '14px' }}>chevron_right</span>
+            <span className="material-symbols-outlined leading-none" style={{ fontSize: '28px' }}>chevron_right</span>
           </button>
         </div>
       </div>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -9,7 +9,7 @@
  * Header removed (2026-04-18): all header functionality (logo, story title,
  * notification bell, zhuyin toggle, logout) is now integrated into Sidebar.
  */
-import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
@@ -76,6 +76,96 @@ export const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) 
       <Suspense fallback={null}>
         <OnboardingWrapper />
       </Suspense>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// StepDots — progress dot row with per-dot hover/tap tooltip
+// ---------------------------------------------------------------------------
+
+interface StepDotsProps {
+  steps: typeof ACTIVE_STEPS;
+  currentStepIndex: number;
+  completedSet: Set<string>;
+  allNonReportDone: boolean;
+  onStepClick: (step: typeof ACTIVE_STEPS[number]) => void;
+}
+
+const StepDots: React.FC<StepDotsProps> = ({
+  steps,
+  currentStepIndex,
+  completedSet,
+  allNonReportDone,
+  onStepClick,
+}) => {
+  const [activeTooltip, setActiveTooltip] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close tooltip when clicking outside (mobile tap-away)
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setActiveTooltip(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="flex items-center gap-2 md:gap-3 flex-wrap justify-center min-w-0">
+      {steps.map((step, i) => {
+        const isCompleted = completedSet.has(step.id);
+        const isActive = i === currentStepIndex;
+        const isReport = step.id === 'report';
+        const isLocked = isReport && !allNonReportDone;
+        const tooltipVisible = activeTooltip === step.id;
+
+        let dotClass = 'bg-on-surface-variant/20';
+        if (isCompleted) dotClass = 'bg-emerald-500';
+        if (isActive) dotClass = 'bg-accent scale-125';
+
+        return (
+          <span key={step.id} className="relative flex items-center justify-center">
+            <button
+              type="button"
+              onClick={() => {
+                if (isLocked) return;
+                // Mobile: toggle tooltip on tap; navigation on second tap if tooltip already showing
+                if (activeTooltip === step.id) {
+                  setActiveTooltip(null);
+                  onStepClick(step);
+                } else {
+                  setActiveTooltip(step.id);
+                }
+              }}
+              onMouseEnter={() => !isLocked && setActiveTooltip(step.id)}
+              onMouseLeave={() => setActiveTooltip(null)}
+              disabled={isLocked}
+              className={`w-4 h-4 md:w-5 md:h-5 rounded-full transition-all hover:scale-150 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
+              aria-label={`${i + 1}. ${step.label}${isLocked ? '（完成所有階段後解鎖）' : ''}`}
+              aria-current={isActive ? 'step' : undefined}
+            />
+            {/* Tooltip — shown on hover (desktop) or tap (mobile) */}
+            {tooltipVisible && (
+              <span
+                role="tooltip"
+                className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 pointer-events-none"
+              >
+                <span className="block bg-gray-900 text-white text-sm font-medium px-2.5 py-1 rounded-lg shadow-lg whitespace-nowrap leading-tight">
+                  {step.label}
+                </span>
+                {/* Arrow pointing down toward dot */}
+                <span
+                  className="block w-0 h-0 mx-auto border-x-4 border-x-transparent border-t-4 border-t-gray-900"
+                  aria-hidden="true"
+                />
+              </span>
+            )}
+          </span>
+        );
+      })}
     </div>
   );
 };
@@ -188,31 +278,13 @@ const ImmersiveTopBar: React.FC = () => {
             <span className="material-symbols-outlined leading-none" style={{ fontSize: '28px' }}>chevron_left</span>
           </button>
 
-          <div className="flex items-center gap-2 md:gap-3 flex-wrap justify-center min-w-0">
-            {ACTIVE_STEPS.map((step, i) => {
-              const isCompleted = completedSet.has(step.id);
-              const isActive = i === currentStepIndex;
-              const isReport = step.id === 'report';
-              const isLocked = isReport && !allNonReportDone;
-
-              let dotClass = 'bg-on-surface-variant/20';
-              if (isCompleted) dotClass = 'bg-emerald-500';
-              if (isActive) dotClass = 'bg-accent scale-125';
-
-              return (
-                <button
-                  key={step.id}
-                  type="button"
-                  onClick={() => handleStepClick(step)}
-                  disabled={isLocked}
-                  className={`w-4 h-4 md:w-5 md:h-5 rounded-full transition-all hover:scale-150 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
-                  title={`${i + 1}. ${step.label}${isLocked ? '（完成所有階段後解鎖）' : ''}`}
-                  aria-label={`${i + 1}. ${step.label}`}
-                  aria-current={isActive ? 'step' : undefined}
-                />
-              );
-            })}
-          </div>
+          <StepDots
+            steps={ACTIVE_STEPS}
+            currentStepIndex={currentStepIndex}
+            completedSet={completedSet}
+            allNonReportDone={allNonReportDone}
+            onStepClick={handleStepClick}
+          />
 
           <button
             type="button"


### PR DESCRIPTION
Fixes #1319

## Change 1: Enlarge stepper dots and chevrons 2x

Component: `ImmersiveTopBar` in `frontend/src/components/layout/AppShell.tsx`

| Item | Before | After |
|------|--------|-------|
| Dots (mobile) | `w-2 h-2` (8px) | `w-4 h-4` (16px, 2x) |
| Dots (desktop) | `md:w-2.5 md:h-2.5` (10px) | `md:w-5 md:h-5` (20px, 2x) |
| Dot gap | `gap-1 md:gap-1.5` | `gap-2 md:gap-3` |
| Chevron buttons | `w-4 h-4` (16px) | `w-8 h-8` (32px, 2x) |
| Chevron icon | `14px` | `28px` (2x) |
| Row height | `h-4 md:h-5` | `h-8 md:h-10` |

`StepperNav.tsx` net change: zero (reverted — it is the non-immersive tab nav).

## Change 2: Hover/tap tooltip with step name

- Extracted dots into `StepDots` sub-component in the same file
- **Desktop**: `onMouseEnter` → tooltip appears above dot, `onMouseLeave` → hides
- **Mobile**: first tap → tooltip shows step label; second tap → navigates to step
- Tap-outside closes any open tooltip (mousedown handler on container ref)
- Tooltip style: `bg-gray-900 text-white text-sm font-medium px-2.5 py-1 rounded-lg shadow-lg`
- Downward arrow triangle pointing at the dot, positioned `bottom-full` (above dot)
- Step label from `ACTIVE_STEPS[i].label` (e.g. 逐段朗讀, 課文理解, 生字練習)
- `stepConfig.ts` read-only — zero changes

DOM verified: `document.querySelector('[role="tooltip"]')?.textContent` → `"逐段朗讀"` after hover.

## Files changed

- `frontend/src/components/layout/AppShell.tsx` only