### PR TITLE
fix(live-tutor): 段落通過後永遠顯示「下一段」按鈕 (Fixes #1318)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -324,20 +324,50 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 
             const totalRetryable = targets.filter(t => t.replace(CHINESE_PUNCTUATION_REGEX, '').length > 1).length;
 
-            // Rule 2: if > half the sentences failed → suggest redo entire paragraph
+            // Rule 2: if > half the sentences failed → suggest redo, but still show next-segment
+            // if paragraph-level evaluation passed (matchRate >= 0.5 or already completed).
+            // Sentence retry is advisory — never block paragraph-level progress. (#1318)
             if (failedSentences.length > totalRetryable / 2) {
+              const canAdvanceRule2 = paragraphSummary.matchRate >= 0.5
+                || completedParagraphs.has(idx);
               return (
                 <div className="pt-3 border-t border-on-surface/10">
                   <p className="text-sm text-on-surface-variant text-center">
                     這段有比較多地方需要加強，我們重新唸一次吧！
                   </p>
-                  <div className="flex justify-center pt-3">
+                  <div className="flex gap-3 justify-center pt-3">
                     <button
                       onClick={() => onRetryParagraph(idx)}
                       className="btn-encourage !text-sm !py-2.5 !px-6 !min-h-0"
                     >
                       重練這段
                     </button>
+                    {idx < storyLength - 1 && canAdvanceRule2 && (
+                      <button
+                        onClick={() => {
+                          if (!completedParagraphs.has(idx)) {
+                            onAdvanceParagraph(idx, lineResults);
+                          } else {
+                            onSelectParagraph(idx + 1);
+                          }
+                        }}
+                        className="px-6 py-2.5 rounded-full text-sm font-bold text-white transition-all active:scale-95 flex items-center gap-2"
+                        style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+                      >
+                        下一段
+                        <span className="material-symbols-outlined text-lg">arrow_forward</span>
+                      </button>
+                    )}
+                    {idx >= storyLength - 1 && !completedParagraphs.has(idx) && canAdvanceRule2 && (
+                      <button
+                        onClick={() => onAdvanceParagraph(idx, lineResults)}
+                        className="px-6 py-2.5 rounded-full text-sm font-bold text-white transition-all active:scale-95 flex items-center gap-2"
+                        style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+                      >
+                        完成朗讀
+                        <span className="material-symbols-outlined text-lg">arrow_forward</span>
+                      </button>
+                    )}
                   </div>
                 </div>
               );
@@ -393,14 +423,10 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 
           {/* Action buttons — hidden during sentence retry */}
           {retrySentenceIdx === undefined && (() => {
-            // Check if there are still failed sentences (same threshold as retry list)
-            const results = paragraphSummary.sentenceResults ?? [];
-            const SENTENCE_FAIL = 0.5;
-            const remainingFailed = results.filter(r => r !== null && r.matchRate < SENTENCE_FAIL).length;
-            const canAdvance = (paragraphSummary.matchRate >= 0.5 && remainingFailed === 0)
+            // canAdvance is based on paragraph-level matchRate only.
+            // Sentence retry suggestions are advisory and must not block paragraph progress. (#1318)
+            const canAdvance = paragraphSummary.matchRate >= 0.5
               || completedParagraphs.has(idx);
-            // Block if still have any failed sentences (except already-completed paragraphs)
-            const blockedByRetry = remainingFailed > 0 && !completedParagraphs.has(idx);
 
             return (
             <div className="flex gap-3 justify-center pt-2">
@@ -410,8 +436,8 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
               >
                 重練這段
               </button>
-              {/* Rule 3: 重讀後大多數對了（matchRate >= 0.5）就放行 */}
-              {idx < storyLength - 1 && canAdvance && !blockedByRetry && (
+              {/* Always show 下一段 when paragraph-level passed (matchRate >= 0.5) */}
+              {idx < storyLength - 1 && canAdvance && (
                 <button
                   onClick={() => {
                     if (!completedParagraphs.has(idx)) {
@@ -427,7 +453,7 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
                   <span className="material-symbols-outlined text-lg">arrow_forward</span>
                 </button>
               )}
-              {idx >= storyLength - 1 && !completedParagraphs.has(idx) && canAdvance && !blockedByRetry && (
+              {idx >= storyLength - 1 && !completedParagraphs.has(idx) && canAdvance && (
                 <button
                   onClick={() => onAdvanceParagraph(idx, lineResults)}
                   className="px-6 py-2.5 rounded-full text-sm font-bold text-white transition-all active:scale-95 flex items-center gap-2"


### PR DESCRIPTION
Fixes #1318

## 根因

`ParagraphCard.tsx` 的句子級重練邏輯有兩個地方會隱藏「下一段」按鈕：

1. **Rule 2 early-return**（行 328-343）：超過一半句子失敗時 early return，只顯示「重練這段」，「下一段」完全消失
2. **Action buttons 區塊**（行 394-442）：`blockedByRetry` 邏輯在有失敗句子時隱藏「下一段」

核心設計問題：句子級評估和段落級評估的判定標準不一致。段落整體 tier ≤ 2（通過）+ 個別句子 matchRate < 0.5 → 學生收到「讀得很好！」訊息，卻完全無法前進。

## 修法

**最小修法：句子重練建議改為純粹 advisory，不封鎖段落級前進。**

- Rule 2 block 補上「下一段」/「完成朗讀」，以段落 matchRate >= 0.5 為放行條件
- Action buttons 移除 `blockedByRetry` 判斷，`canAdvance` 改為純段落 matchRate 判斷
- 行為不變：段落失敗（matchRate < 0.5）時不顯示「下一段」（需要重練）

## 測試計劃

- [ ] 唸第一段通過（tier 1/2）→ 確認「下一段」出現
- [ ] 唸最後一段通過 → 確認「完成朗讀」出現
- [ ] 唸失敗（matchRate < 0.5）→ 確認「下一段」不出現（只有「重練這段」）
- [ ] 句子重練後再提交 → 確認行為正常
- [ ] 已完成段落（completedParagraphs）→ 確認仍顯示「下一段」

## 受影響範圍

僅 `frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx`，不碰 backend、ReadingAnnotation、zhuyin 相關檔案。