### PR TITLE
fix: FullReading UX + report nav + session rehydration (Fixes #1320)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -502,7 +502,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
                 className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
                 style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
               >
-                <span>查看報告</span>
+                <span>下一關</span>
                 <span className="material-symbols-outlined text-xl">arrow_forward</span>
               </button>
             </>

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -34,9 +34,11 @@ interface FullReadingProps {
   story: Story;
   onFinish: (result: FullReadingResult) => void;
   onBack: () => void;
+  /** Session-level result rehydrated from DB (Bug #1320 — fallback when localStorage is cleared). */
+  initialResult?: FullReadingResult | null;
 }
 
-const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack }) => {
+const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, initialResult }) => {
   const { token } = useAuth();
   const storageKey = scopedStepStorageKey('fullReading_progress_', story.id);
 
@@ -50,12 +52,41 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack }) =>
   };
   const savedProgress = useRef(loadSaved());
 
+  /* ---- Bug #1320 Bug 3: Derive initial result priority:
+   *   1. localStorage (same-browser persistence, most complete — has diffTokens)
+   *   2. session.fullReadingResult rehydrated from DB (cross-browser / cleared localStorage)
+   *   localStorage wins because it contains diffTokens which the DB result may lack. ---- */
+  const getInitialResult = (): SavedResult | null => {
+    if (savedProgress.current?.result) return savedProgress.current.result;
+    if (initialResult) {
+      return {
+        matchRate: initialResult.matchRate,
+        feedback: initialResult.feedback,
+        diffTokens: initialResult.diffTokens ?? [],
+        cpm: initialResult.cpm ?? 0,
+        durationMs: initialResult.durationMs ?? 0,
+        errorBreakdown: initialResult.errorBreakdown ?? { correct: 0, wrong: 0, missing: 0, extra: 0 },
+      };
+    }
+    return null;
+  };
+
   const [isPreparing, setIsPreparing]           = useState(false);
   const [isSessionActive, setIsSessionActive]   = useState(false);
   const [streamingTranscript, setStreamingTranscript] = useState(() => savedProgress.current?.transcript ?? '');
   const [micError, setMicError]                 = useState('');
-  const [result, setResult]                     = useState<SavedResult | null>(() => savedProgress.current?.result ?? null);
+  const [result, setResult]                     = useState<SavedResult | null>(getInitialResult);
   const { zhuyinActive, processZhuyin } = useZhuyin();
+
+  /* ---- Bug #1320 Bug 1: Auto-scroll to result area when result first appears ---- */
+  const resultRef = useRef<HTMLDivElement | null>(null);
+  const prevResultRef = useRef<SavedResult | null>(null);
+  useEffect(() => {
+    if (result && !prevResultRef.current && resultRef.current) {
+      resultRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+    prevResultRef.current = result;
+  }, [result]);
 
   const isSessionActiveRef        = useRef(false);
   const recognitionRef            = useRef<any>(null);
@@ -382,7 +413,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack }) =>
 
           {/* ── Result section ──────────────────────────────────────── */}
           {result && (
-            <div className="mt-6 space-y-6">
+            <div ref={resultRef} className="mt-6 space-y-6">
               {/* Encouragement — no numbers shown to student (Issues #1094, #1097) */}
               {(() => {
                 const enc = getFullReadingEncouragement(result.matchRate);

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -798,15 +798,15 @@ const LearningLayout: React.FC = () => {
       persistStepProgressState(
         {
           completeStep: 'full-reading',
-          // currentStep stays null — navigate goes to report, not the next step
+          // currentStep advances to listening — the next enabled step after full-reading
           stepDataPatch: {
             'full-reading': { result },
           },
         },
         true,
       );
-      persistStep(STEP_PATH_TO_NUMBER['report']);
-      navigate(`/learn/${storyId}/report`);
+      persistStep(STEP_PATH_TO_NUMBER['listening']);
+      navigate(`/learn/${storyId}/listening`);
     },
     [storyId, navigate, persistStep, persistStepProgressState],
   );

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -798,15 +798,15 @@ const LearningLayout: React.FC = () => {
       persistStepProgressState(
         {
           completeStep: 'full-reading',
-          currentStep: 'vocab',
+          // currentStep stays null — navigate goes to report, not the next step
           stepDataPatch: {
             'full-reading': { result },
           },
         },
         true,
       );
-      persistStep(STEP_PATH_TO_NUMBER['vocab']);
-      navigate(`/learn/${storyId}/vocab`);
+      persistStep(STEP_PATH_TO_NUMBER['report']);
+      navigate(`/learn/${storyId}/report`);
     },
     [storyId, navigate, persistStep, persistStepProgressState],
   );

--- a/frontend/src/pages/learning/FullReadingPage.tsx
+++ b/frontend/src/pages/learning/FullReadingPage.tsx
@@ -8,6 +8,7 @@ const FullReadingPage: React.FC = () => {
   const {
     selectedStory,
     handleFinishFullReading,
+    session,
   } = useLearningContext();
   const navigate = useNavigate();
 
@@ -17,7 +18,8 @@ const FullReadingPage: React.FC = () => {
     <FullReading
       story={selectedStory}
       onFinish={handleFinishFullReading}
-      onBack={() => navigate(`/learn/${storyId}/vocab`)}
+      onBack={() => navigate(`/learn/${storyId}/tutor`)}
+      initialResult={session?.fullReadingResult ?? null}
     />
   );
 };


### PR DESCRIPTION
Fixes #1320

## Summary

Three bugs fixed in the FullReading (全文朗讀) step, all in one component ecosystem:

- **Bug 1 (UX guidance)**: After recording completes, result section was off-screen with no auto-scroll. Added \`resultRef\` and a \`useEffect\` that triggers \`scrollIntoView({behavior:'smooth', block:'start'})\` when \`result\` first appears.
- **Bug 2 (nav destination — corrected in c1ad61ce)**: The 「下一關」 button in \`handleFinishFullReading\` now navigates to \`/listening\` (聽力理解 — the actual next step in the stepper) instead of \`/report\`. \`persistStep\` also updated to \`STEP_PATH_TO_NUMBER['listening']\`.
- **Bug 3 (persistence)**: Result only lived in \`localStorage\`. On reload it recovered fine, but on cross-browser or cleared localStorage, results were lost despite being stored in DB via \`persistStepProgressState\`. Added \`initialResult\` prop to \`FullReading\`; \`FullReadingPage\` now passes \`session?.fullReadingResult\` (already rehydrated from DB by \`LearningLayout\`). localStorage still takes priority since it contains \`diffTokens\` that the DB result may lack.
- **UX tweak**: Renamed the completion CTA from「查看報告」→「下一關」to frame it as learning progression rather than viewing results.

## Step order context

\`\`\`
reading-annotation → tutor → full-reading → listening → vocab → sentence-practice → ...
\`\`\`

「下一關」from 全文朗讀 correctly advances to 聽力理解 (the immediate next enabled step).

## Files changed

- \`frontend/src/components/reading-steps/FullReading.tsx\` — Bug 1 (scroll ref) + Bug 3 (initialResult prop + getInitialResult logic) + UX tweak (button label)
- \`frontend/src/pages/learning/FullReadingPage.tsx\` — Bug 3 (pass initialResult from session) + corrected onBack to \`/tutor\`
- \`frontend/src/layouts/LearningLayout.tsx\` — Bug 2 (navigate to /listening, persistStep listening)

## Test plan

1. Go to a lesson full-reading step, complete a recording
2. Bug 1: After tapping 「完成朗讀」, page should smoothly scroll to the star encouragement card
3. Bug 2: Tap「下一關」— should navigate to **聽力理解** (not 報告, not 生字練習)
4. Bug 3: Complete recording, hard-reload the page, return to full-reading step — result should still show (restored from session/DB)

## No-touch zones respected

- Did NOT touch \`ReadingAnnotation*\`, \`LiveTutor*\`, \`App.tsx\`, \`api.ts\`
- \`stepConfig.ts\` read-only (confirmed step id 'listening' is the next step after 'full-reading')
- No DB schema changes, no migration needed