### PR TITLE
fix: ReadingAnnotation 選字偏移 regression — PUA selectors in YAML raw text (Fixes #1325)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -150,6 +150,20 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   // ── Selection helpers ──────────────────────────────────────────────────
 
   /**
+   * Strip BpmfIansui PUA Variation Selector surrogate pairs from a string.
+   *
+   * Both buildZhuyinString() and some YAML lesson files embed PUA Variation
+   * Selectors Supplement (U+E0100–U+E01EF) directly in the paragraph text.
+   * Each occupies 2 UTF-16 code units (surrogate pair: 0xDB40 + 0xDD00–0xDDEF).
+   * These have no semantic content — they are font rendering hints only.
+   * Stripping them gives a string where .length equals the raw character count,
+   * so standard Array/String slice operations work correctly with raw char indices.
+   */
+  function stripPUASelectors(text: string): string {
+    return text.replace(/\uDB40[\uDC00-\uDFFF]/g, '');
+  }
+
+  /**
    * Count raw (non-selector) characters in a string, stopping after `upTo`
    * UTF-16 code units have been consumed.  When `upTo` is omitted the entire
    * string is scanned.
@@ -236,33 +250,17 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     let found = false;
     const walker = document.createTreeWalker(paraEl, NodeFilter.SHOW_TEXT);
     let node: Text | null;
-    // DEBUG #1325: log all text nodes encountered by TreeWalker
-    const debugNodes: Array<{ text: string; rawLen: number; isTarget: boolean; startOffset?: number }> = [];
     while ((node = walker.nextNode() as Text | null)) {
       if (node === range.startContainer) {
         // range.startOffset is a UTF-16 offset into this text node; convert to
         // raw-character count by stripping PUA selectors up to that point.
-        const addedRaw = countRawChars(node.textContent ?? '', range.startOffset);
-        debugNodes.push({ text: (node.textContent ?? '').slice(0, 20), rawLen: countRawChars(node.textContent ?? ''), isTarget: true, startOffset: range.startOffset });
-        charStart += addedRaw;
+        charStart += countRawChars(node.textContent ?? '', range.startOffset);
         found = true;
         break;
       }
       // Accumulate raw (non-selector) character count for completed nodes.
-      const rawLen = countRawChars(node.textContent ?? '');
-      debugNodes.push({ text: (node.textContent ?? '').slice(0, 20), rawLen, isTarget: false });
-      charStart += rawLen;
+      charStart += countRawChars(node.textContent ?? '');
     }
-    // eslint-disable-next-line no-console
-    console.log('[DEBUG #1325] getSelectionInfo:', {
-      paraIdx: paragraphIndex,
-      selectedText: selectedText.slice(0, 30),
-      charStart,
-      rawSelectedLength: countRawChars(selectedText),
-      charEnd: charStart + countRawChars(selectedText),
-      startContainerParent: (range.startContainer.parentElement?.tagName ?? 'none') + ' > ' + (range.startContainer.parentElement?.className ?? '').slice(0, 40),
-      nodes: debugNodes,
-    });
     if (!found) return null;
 
     // selectedText from range.toString() also includes PUA selector code points;
@@ -435,12 +433,26 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       return displayText;
     }
 
-    // Build segments from raw text char offsets, render display text char-by-char
-    // NOTE: when zhuyin is active, displayText has different length than rawText.
-    // We annotate by raw char positions and render rawText characters
-    // (zhuyin adds ruby annotations which we can't easily split here).
-    // So when zhuyin is active, we fall back to rendering rawText for annotated paragraphs.
-    const textToRender = zhuyinActive ? rawText : displayText;
+    // Build segments from raw text char offsets, render display text char-by-char.
+    //
+    // ann.charStart / ann.charEnd are RAW character indices — PUA Variation Selectors
+    // (U+E0100–U+E01EF, stored as surrogate pairs) are NOT counted.  See countRawChars().
+    //
+    // However, lesson YAML files may embed these PUA selectors directly in the paragraph
+    // text (e.g. L01 paragraph 1: 「著󠇣頭緒」has a selector after 著).  This means rawText
+    // and even displayText (when zhuyin is off) may contain PUA surrogates, making their
+    // .length exceed the raw char count.  Using raw char indices directly as slice() indices
+    // would then slice the string at the wrong UTF-16 positions, putting the annotation
+    // highlight on the wrong characters — this was the regression introduced by PR #1155.
+    //
+    // Fix: strip PUA selectors from the rendering string before slicing.  After stripping,
+    // .length == raw char count, so raw indices and UTF-16 slice indices agree perfectly.
+    //
+    // NOTE: when zhuyin is active, displayText contains BpmfIansui PUA selectors AND ruby
+    // annotations that cannot be split character-by-character, so we fall back to rawText.
+    const baseText = zhuyinActive ? rawText : displayText;
+    // Strip PUA Variation Selectors so that .length == raw char count and slice indices match.
+    const textToRender = stripPUASelectors(baseText);
 
     const segments: Array<{ start: number; end: number; annotation?: Annotation }> = [];
     let cursor = 0;

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -236,17 +236,33 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     let found = false;
     const walker = document.createTreeWalker(paraEl, NodeFilter.SHOW_TEXT);
     let node: Text | null;
+    // DEBUG #1325: log all text nodes encountered by TreeWalker
+    const debugNodes: Array<{ text: string; rawLen: number; isTarget: boolean; startOffset?: number }> = [];
     while ((node = walker.nextNode() as Text | null)) {
       if (node === range.startContainer) {
         // range.startOffset is a UTF-16 offset into this text node; convert to
         // raw-character count by stripping PUA selectors up to that point.
-        charStart += countRawChars(node.textContent ?? '', range.startOffset);
+        const addedRaw = countRawChars(node.textContent ?? '', range.startOffset);
+        debugNodes.push({ text: (node.textContent ?? '').slice(0, 20), rawLen: countRawChars(node.textContent ?? ''), isTarget: true, startOffset: range.startOffset });
+        charStart += addedRaw;
         found = true;
         break;
       }
       // Accumulate raw (non-selector) character count for completed nodes.
-      charStart += countRawChars(node.textContent ?? '');
+      const rawLen = countRawChars(node.textContent ?? '');
+      debugNodes.push({ text: (node.textContent ?? '').slice(0, 20), rawLen, isTarget: false });
+      charStart += rawLen;
     }
+    // eslint-disable-next-line no-console
+    console.log('[DEBUG #1325] getSelectionInfo:', {
+      paraIdx: paragraphIndex,
+      selectedText: selectedText.slice(0, 30),
+      charStart,
+      rawSelectedLength: countRawChars(selectedText),
+      charEnd: charStart + countRawChars(selectedText),
+      startContainerParent: (range.startContainer.parentElement?.tagName ?? 'none') + ' > ' + (range.startContainer.parentElement?.className ?? '').slice(0, 40),
+      nodes: debugNodes,
+    });
     if (!found) return null;
 
     // selectedText from range.toString() also includes PUA selector code points;


### PR DESCRIPTION
Fixes #1325

## Root Cause (confirmed by static analysis)

lesson YAML 檔案（例如 L01）的 paragraph raw text 本身就內嵌了 BpmfIansui PUA Variation Selectors（U+E0100–U+E01EF，surrogate pairs）。以 L01 第二段為例：

```
...讓對手摸不著󠇣頭緒...
```

「著」後面有一個 PUA selector（U+E01E3），佔 2 個 UTF-16 code units。

**getSelectionInfo()** 正確計算 raw char index（用 countRawChars 去掉 PUA）：
- 「頭」的 raw char index = 79
- charStart = 79, charEnd = 81 ✅

**renderAnnotatedParagraph()** 將 raw char index 直接當 UTF-16 slice index 使用：
- rawText 的 UTF-16 pos 79-80 = PUA surrogate pair（不是「頭緒」）!
- 所以 annotation span 渲染了不可見的 PUA char，「頭緒」反而顯示在 span 外面

## Fix

新增 `stripPUASelectors()`，在 `renderAnnotatedParagraph` 用 raw text 做 slice 之前先去掉 PUA surrogate pairs。去掉後 `.length == raw char count`，raw indices 直接等於 UTF-16 slice indices。

```ts
function stripPUASelectors(text: string): string {
  return text.replace(/\uDB40[\uDC00-\uDFFF]/g, '');
}
```

## Regression History

| PR | Fix |
|----|-----|
| #1084 | 修 getSelectionInfo PUA offset（countRawChars）|
| #1130 | 修段落序號 badge 被 TreeWalker 計入 offset |
| #1155 | 加右側 panel — getSelectionInfo 沒 regression，但 renderAnnotatedParagraph 從未針對 YAML raw PUA 做防護 |

## Change Summary

- `ReadingAnnotation.tsx` — 新增 `stripPUASelectors()`，在 renderAnnotatedParagraph 裡 apply 到 baseText 再建 segments

## Test Plan

- [ ] PR Preview 部署成功
- [ ] 進入 /learn/1/reading-annotation（L01 = 戴資穎課文）
- [ ] 選取第二段「頭緒」等位於 PUA selector 之後的文字
- [ ] 確認 annotation 標記在正確的字上
- [ ] 選取第一段前幾個字（PUA selector 之前）
- [ ] 確認標記位置也正確
- [ ] 注音開啟/關閉兩種狀態都測試