### PR TITLE
feat: 造句練習語音輸入加上即時辨識顯示 (Fixes #1327)

### DIFF
--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -164,6 +164,9 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
     return restored;
   });
   const [pasteWarning, setPasteWarning] = useState(false);
+  // Live transcript per sentence slot — cleared when user submits / word changes.
+  // Index 0 = first sentence, 1 = second sentence. (#1327)
+  const [liveTranscripts, setLiveTranscripts] = useState<[string, string]>(['', '']);
   const loadedWordsRef = useRef<Set<string>>(new Set());
   // True until the user actually interacts after mount. Prevents the DB sync
   // effect from firing with restored-only state and e.g. rolling `current_step`
@@ -234,6 +237,15 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
 
   const currentWord = practicedWords[currentWordIndex] ?? '';
   const currentState = wordStates[currentWord] ?? makeWordState();
+
+  // Clear live transcript display whenever the active word changes (#1327).
+  const prevWordRef = useRef(currentWord);
+  useEffect(() => {
+    if (prevWordRef.current !== currentWord) {
+      prevWordRef.current = currentWord;
+      setLiveTranscripts(['', '']);
+    }
+  }, [currentWord]);
 
   const loadExamples = useCallback(async () => {
     if (!currentWord || loadedWordsRef.current.has(currentWord)) return;
@@ -495,7 +507,24 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
                   }`}
                 />
                 <VoiceInputButton
-                  onTranscript={(text) => updateSentenceText(idx, text)}
+                  key={currentWord + String(idx)}
+                  onTranscript={(text) => {
+                    updateSentenceText(idx, text);
+                    // Clear live display once final transcript is committed (#1327).
+                    setLiveTranscripts(prev => {
+                      const next: [string, string] = [prev[0], prev[1]];
+                      next[idx] = '';
+                      return next;
+                    });
+                  }}
+                  onLiveTranscript={(text) => {
+                    // Show interim transcript below the input field (#1327).
+                    setLiveTranscripts(prev => {
+                      const next: [string, string] = [prev[0], prev[1]];
+                      next[idx] = text;
+                      return next;
+                    });
+                  }}
                   disabled={entry.status === 'loading' || isCurrentDone}
                 />
                 <button
@@ -515,18 +544,28 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
                 </button>
               </div>
 
-              {/* Feedback */}
+              {/* Live transcript display — shown while mic is active (#1327) */}
+              {liveTranscripts[idx] && (
+                <div className="mt-2 flex items-start gap-1.5 px-2">
+                  <span className="material-symbols-outlined text-sm text-red-400 animate-pulse mt-0.5 shrink-0">mic</span>
+                  <p className="text-sm text-on-surface-variant italic leading-snug">
+                    {liveTranscripts[idx]}
+                  </p>
+                </div>
+              )}
+
+              {/* Feedback — font sizes bumped to text-base / text-sm (#1327) */}
               {(entry.status === 'correct' || entry.status === 'incorrect') && (
-                <div className={`mt-3 rounded-2xl px-4 py-3 ${
+                <div className={`mt-3 rounded-2xl px-4 py-4 ${
                   entry.status === 'correct' ? 'bg-emerald-50' : 'bg-tertiary-container/10'
                 }`}>
                   <div className="flex items-start gap-2">
-                    <span className={`material-symbols-outlined text-lg mt-0.5 ${entry.status === 'correct' ? 'text-emerald-600' : 'text-tertiary'}`}>
+                    <span className={`material-symbols-outlined text-xl mt-0.5 ${entry.status === 'correct' ? 'text-emerald-600' : 'text-tertiary'}`}>
                       {entry.status === 'correct' ? 'check_circle' : 'lightbulb'}
                     </span>
                     <div>
-                      <p className={`text-sm font-medium ${entry.status === 'correct' ? 'text-emerald-800' : 'text-on-surface'}`}>{entry.feedback}</p>
-                      {entry.suggestion && <p className="mt-1 text-xs text-on-surface-variant">{entry.suggestion}</p>}
+                      <p className={`text-base font-medium leading-relaxed ${entry.status === 'correct' ? 'text-emerald-800' : 'text-on-surface'}`}>{entry.feedback}</p>
+                      {entry.suggestion && <p className="mt-1.5 text-sm text-on-surface-variant leading-relaxed">{entry.suggestion}</p>}
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -167,6 +167,11 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   // Live transcript per sentence slot — cleared when user submits / word changes.
   // Index 0 = first sentence, 1 = second sentence. (#1327)
   const [liveTranscripts, setLiveTranscripts] = useState<[string, string]>(['', '']);
+  // Imperative stop refs — one per sentence slot — so 批改 can halt the mic
+  // before submitting, preventing background recording after submit. (#1327)
+  const voiceStopRef0 = useRef<(() => void) | null>(null);
+  const voiceStopRef1 = useRef<(() => void) | null>(null);
+  const voiceStopRefs = [voiceStopRef0, voiceStopRef1] as const;
   const loadedWordsRef = useRef<Set<string>>(new Set());
   // True until the user actually interacts after mount. Prevents the DB sync
   // effect from firing with restored-only state and e.g. rolling `current_step`
@@ -277,6 +282,8 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   }, [currentWord]);
 
   const handleValidate = useCallback(async (sentenceIndex: 0 | 1) => {
+    // Stop mic immediately when 批改 is clicked — prevent background recording. (#1327)
+    voiceStopRefs[sentenceIndex].current?.();
     const sentence = currentState.sentences[sentenceIndex];
     if (!sentence.text.trim()) return;
     setWordStates(prev => {
@@ -526,6 +533,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
                     });
                   }}
                   disabled={entry.status === 'loading' || isCurrentDone}
+                  stopRef={voiceStopRefs[idx]}
                 />
                 <button
                   onClick={() => handleValidate(idx)}

--- a/frontend/src/components/ui/VoiceInputButton.tsx
+++ b/frontend/src/components/ui/VoiceInputButton.tsx
@@ -17,6 +17,12 @@ interface VoiceInputButtonProps {
   className?: string;
   /** Size variant: default 'md' (40px), 'sm' (32px) */
   size?: 'sm' | 'md';
+  /**
+   * Optional ref that the parent can use to imperatively stop recording.
+   * Assign stopListening to this ref so e.g. the submit handler can call
+   * stopRef.current?.() before validating. Issue #1327.
+   */
+  stopRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 /**
@@ -35,9 +41,17 @@ const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
   disabled = false,
   className = '',
   size = 'md',
+  stopRef,
 }) => {
   const { status, transcript, errorMessage, isSupported, startListening, stopListening } =
     useSpeechRecognition(lang, onTranscript);
+
+  // Expose stopListening to parent via stopRef so it can halt recording
+  // imperatively (e.g. when the submit / 批改 button is clicked). (#1327)
+  React.useEffect(() => {
+    if (stopRef) stopRef.current = stopListening;
+    return () => { if (stopRef) stopRef.current = null; };
+  }, [stopRef, stopListening]);
 
   // Propagate live transcript (interim + accumulated finals) to caller (#1327).
   const prevTranscriptRef = React.useRef('');

--- a/frontend/src/components/ui/VoiceInputButton.tsx
+++ b/frontend/src/components/ui/VoiceInputButton.tsx
@@ -4,6 +4,11 @@ import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 interface VoiceInputButtonProps {
   /** Called with the full accumulated transcript whenever a new final result arrives */
   onTranscript: (text: string) => void;
+  /**
+   * Called on every interim + final result change so callers can render live
+   * transcript text while the user is still speaking. Issue #1327.
+   */
+  onLiveTranscript?: (text: string) => void;
   /** Speech recognition language (default 'zh-TW') */
   lang?: string;
   /** Disable the button externally (e.g. while parent is submitting) */
@@ -21,16 +26,28 @@ interface VoiceInputButtonProps {
  * Issue #1094: abstract voice input into a reusable component so every
  * text-input surface (SentencePractice, ComprehensionChat, ...) can support
  * speaking instead of typing.
+ * Issue #1327: exposes onLiveTranscript so callers can render interim results.
  */
 const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
   onTranscript,
+  onLiveTranscript,
   lang = 'zh-TW',
   disabled = false,
   className = '',
   size = 'md',
 }) => {
-  const { status, errorMessage, isSupported, startListening, stopListening } =
+  const { status, transcript, errorMessage, isSupported, startListening, stopListening } =
     useSpeechRecognition(lang, onTranscript);
+
+  // Propagate live transcript (interim + accumulated finals) to caller (#1327).
+  const prevTranscriptRef = React.useRef('');
+  React.useEffect(() => {
+    if (!onLiveTranscript) return;
+    if (transcript !== prevTranscriptRef.current) {
+      prevTranscriptRef.current = transcript;
+      onLiveTranscript(transcript);
+    }
+  }, [transcript, onLiveTranscript]);
 
   const isListening = status === 'listening';
   const unsupported = !isSupported || status === 'unsupported';

--- a/frontend/src/hooks/useSpeechRecognition.ts
+++ b/frontend/src/hooks/useSpeechRecognition.ts
@@ -17,6 +17,8 @@ export interface SpeechRecognitionActions {
 
 /** Maximum recording duration in milliseconds (60 seconds) */
 const MAX_RECORDING_DURATION_MS = 60_000;
+/** Stop recording after this many milliseconds of silence (no new results) */
+const SILENCE_TIMEOUT_MS = 3_000;
 
 function getSpeechRecognitionConstructor(): typeof SpeechRecognition | null {
   if (typeof window === 'undefined') return null;
@@ -39,6 +41,7 @@ export function useSpeechRecognition(
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const onTranscriptRef = useRef(onTranscript);
   const maxDurationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /** Accumulated final results across multiple onresult events (continuous mode) */
   const accumulatedFinalRef = useRef('');
 
@@ -51,6 +54,10 @@ export function useSpeechRecognition(
     if (maxDurationTimerRef.current) {
       clearTimeout(maxDurationTimerRef.current);
       maxDurationTimerRef.current = null;
+    }
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = null;
     }
     if (recognitionRef.current) {
       recognitionRef.current.stop();
@@ -74,6 +81,10 @@ export function useSpeechRecognition(
       clearTimeout(maxDurationTimerRef.current);
       maxDurationTimerRef.current = null;
     }
+    if (silenceTimerRef.current) {
+      clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = null;
+    }
 
     setErrorMessage('');
     setTranscript('');
@@ -92,6 +103,16 @@ export function useSpeechRecognition(
     };
 
     recognition.onresult = (event: SpeechRecognitionEvent) => {
+      // Reset silence timer — user is still speaking (#1327).
+      if (silenceTimerRef.current) {
+        clearTimeout(silenceTimerRef.current);
+      }
+      silenceTimerRef.current = setTimeout(() => {
+        if (recognitionRef.current) {
+          recognitionRef.current.stop();
+        }
+      }, SILENCE_TIMEOUT_MS);
+
       let interim = '';
       let newFinal = '';
       for (let i = event.resultIndex; i < event.results.length; i++) {
@@ -121,6 +142,10 @@ export function useSpeechRecognition(
         clearTimeout(maxDurationTimerRef.current);
         maxDurationTimerRef.current = null;
       }
+      if (silenceTimerRef.current) {
+        clearTimeout(silenceTimerRef.current);
+        silenceTimerRef.current = null;
+      }
       recognitionRef.current = null;
       switch (event.error) {
         case 'not-allowed':
@@ -145,6 +170,10 @@ export function useSpeechRecognition(
       if (maxDurationTimerRef.current) {
         clearTimeout(maxDurationTimerRef.current);
         maxDurationTimerRef.current = null;
+      }
+      if (silenceTimerRef.current) {
+        clearTimeout(silenceTimerRef.current);
+        silenceTimerRef.current = null;
       }
       recognitionRef.current = null;
       setStatus(prev => (prev === 'listening' ? 'idle' : prev));
@@ -180,6 +209,10 @@ export function useSpeechRecognition(
       if (maxDurationTimerRef.current) {
         clearTimeout(maxDurationTimerRef.current);
         maxDurationTimerRef.current = null;
+      }
+      if (silenceTimerRef.current) {
+        clearTimeout(silenceTimerRef.current);
+        silenceTimerRef.current = null;
       }
       if (recognitionRef.current) {
         recognitionRef.current.stop();


### PR DESCRIPTION
Fixes #1327

## Summary

- **VoiceInputButton**: add optional `onLiveTranscript` prop that fires on every transcript state change (interim + accumulated finals), allowing callers to render live text while the user is still speaking. Fully backward compatible — existing callers without the prop are unaffected.
- **SentencePractice**: render live transcript below each sentence input while the mic is active. Pulsing mic icon + italic grey text gives students immediate confirmation the mic is working. Text clears when the final transcript is committed or the user advances to the next word.
- **SentencePractice**: add `key={currentWord + String(idx)}` to each `VoiceInputButton` so React unmounts and remounts it whenever the active vocabulary word changes — this triggers the `useSpeechRecognition` cleanup hook which calls `recognition.stop()`, preventing mic bleed from one word's recording session into the next word's live display area.
- **Feedback block**: bump `text-sm` → `text-base` (main feedback), `text-xs` → `text-sm` (suggestion), icon `text-lg` → `text-xl`, padding `py-3` → `py-4` so students can read AI corrections without squinting.
- **Stop mic on 批改 click**: `handleValidate` now calls `voiceStopRefs[idx].current?.()` immediately before submitting, so any active recording on that slot stops the moment the student clicks 批改.
- **Silence auto-stop (3 s)**: `useSpeechRecognition` resets a `silenceTimerRef` on every `onresult` event; if no new speech arrives within 3 s the timer fires `recognition.stop()` automatically. Timer is cleared in `onerror`, `onend`, `stopListening`, and unmount.

## Test plan

1. Open SentencePractice on a lesson with 2+ vocabulary words
2. Click the mic button on sentence slot 1
3. **Verify**: mic button turns red + pulses; italic grey text appears below the input as you speak (interim)
4. Stop speaking; **verify**: live text clears and the input field is populated with the final transcript
5. While mic is active on slot 1, click a different word in the sidebar
6. **Verify**: mic stops immediately (no audio bleed to new word); live transcript area is empty on the new word
7. **New**: speak into slot 1 then click 批改 — **verify**: mic icon stops pulsing immediately (recording ended before AI call)
8. **New**: start recording, say one phrase, then stay silent for 3+ seconds — **verify**: mic auto-stops without clicking the button
9. Submit a sentence via "批改"; **verify**: AI feedback text is readable at `text-base` size
10. Test on a browser without SpeechRecognition support (Firefox); **verify**: mic button is grayed out, no JS errors