### PR TITLE
fix(comprehension): prevent layout shift after MCQ submit (Fixes #1330)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -271,7 +271,7 @@ export const LearningAppShell: React.FC = () => {
         id="main-content"
         role="main"
         aria-label="學習內容"
-        className="flex-1 flex flex-col overflow-y-auto"
+        className="flex-1 min-h-0 flex flex-col overflow-y-auto"
         tabIndex={-1}
       >
         <LearningLayout />

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -3,8 +3,11 @@
  *
  * Layout: left=scrollable lesson text card, right=MCQ/structure/strategy tabs
  * AI 功能為獨立浮動小助手（FloatingAIHelper）
+ *
+ * Fix #1330: Scroll right panel to top on tab change to prevent position jump.
+ * FloatingAIHelper repositions above the "下一關" CTA when it is visible.
  */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Story, ReadingAttempt, ComprehensionResult } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import StoryStructureTable from './StoryStructureTable';
@@ -84,6 +87,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
   const { zhuyinActive, processLines: zhuyinProcessLines } = useZhuyin();
 
+  // Fix #1330: ref to the right-panel scroll container so we can reset scroll on tab change
+  const rightPanelRef = useRef<HTMLDivElement>(null);
+
   const zhuyinLines = useMemo(() => {
     if (!zhuyinActive) return null;
     return zhuyinProcessLines(story.content);
@@ -91,6 +97,9 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
   const handleTabChange = useCallback((tab: 'mcq' | 'structure' | 'strategy') => {
     setActiveTab(tab);
+    // Fix #1330: scroll right panel back to top when switching tabs so new content
+    // is immediately visible without the user having to manually scroll up
+    rightPanelRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
     if (tab === 'structure' && !tabCompletion.structureVisited) {
       setTabCompletion(prev => ({ ...prev, structureVisited: true }));
     }
@@ -100,6 +109,11 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     setTabCompletion(prev => ({ ...prev, mcqDone: true }));
     setMcqScore(score);
     setMcqTotal(total);
+    // Fix #1330: MCQ done → panel content swaps to completion card.
+    // Scroll right panel to top so the completion card is visible from the start.
+    requestAnimationFrame(() => {
+      rightPanelRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+    });
   }, []);
 
   const handleStructureRedo = useCallback(() => {
@@ -315,7 +329,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
           {/* ── Right: Exercise panel ─────────────────────────────── */}
           <div className="md:col-span-5 lg:col-span-5 min-h-0 flex flex-col">
             <div className="shrink-0">{renderTabs()}</div>
-            <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex-1 min-h-0 overflow-y-auto custom-scrollbar">
+            {/* Fix #1330: attach ref so tab-change and MCQ-complete can scroll to top */}
+            <div ref={rightPanelRef} className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex-1 min-h-0 overflow-y-auto custom-scrollbar">
               {renderRightContent()}
             </div>
           </div>
@@ -339,11 +354,12 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
         </div>
       )}
 
-      {/* Floating AI helper */}
+      {/* Floating AI helper — repositions above fixed CTA when it is visible (#1330) */}
       <FloatingAIHelper
         storyTitle={story.title}
         storyText={storyText}
         dbSessionId={dbSessionId}
+        bottomOffset={isWorksheetComplete ? 'bottom-28' : 'bottom-6'}
       />
 
       {/* Skip button when worksheet not yet complete */}

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -282,13 +282,8 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       className="flex flex-col flex-1 min-h-0 bg-surface overflow-hidden relative"
     >
       {/* ── Main content area — fills viewport, no page scroll ──── */}
-      {/* overflow-hidden is required here: without it, grid content height changes
-          (e.g. checkbox re-render in StoryStructureTable) propagate upward and
-          cause the flex parent to recalculate, collapsing both panels. (#1330) */}
-      <div className="flex-1 min-h-0 overflow-hidden px-4 md:px-6 py-6 md:py-8">
-        {/* grid-rows-[1fr] pins the single row to exactly fill h-full,
-            preventing auto-row height from re-expanding on content changes. */}
-        <div className="w-full h-full grid grid-rows-[1fr] grid-cols-1 md:grid-cols-12 gap-6">
+      <div className="flex-1 min-h-0 px-4 md:px-6 py-6 md:py-8">
+        <div className="w-full h-full grid grid-cols-1 md:grid-cols-12 gap-6">
 
           {/* ── Left: Story text card ────────────────────────────── */}
           <div className="md:col-span-7 lg:col-span-7 min-h-0 flex">

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -238,7 +238,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     if (hasMcq) {
       if (tabCompletion.mcqDone) {
         return (
-          <div className="flex flex-col items-center justify-center py-12 gap-4">
+          <div className="flex flex-col items-center justify-center min-h-full py-12 gap-4">
             <div className="w-16 h-16 rounded-full bg-emerald-100 flex items-center justify-center">
               <span className="material-symbols-outlined text-3xl text-emerald-600">check_circle</span>
             </div>
@@ -279,7 +279,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
   return (
     <div
-      className="flex flex-col flex-1 h-full bg-surface overflow-hidden relative"
+      className="flex flex-col flex-1 min-h-0 bg-surface overflow-hidden relative"
     >
       {/* ── Main content area — fills viewport, no page scroll ──── */}
       <div className="flex-1 min-h-0 px-4 md:px-6 py-6 md:py-8">

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -282,8 +282,13 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
       className="flex flex-col flex-1 min-h-0 bg-surface overflow-hidden relative"
     >
       {/* ── Main content area — fills viewport, no page scroll ──── */}
-      <div className="flex-1 min-h-0 px-4 md:px-6 py-6 md:py-8">
-        <div className="w-full h-full grid grid-cols-1 md:grid-cols-12 gap-6">
+      {/* overflow-hidden is required here: without it, grid content height changes
+          (e.g. checkbox re-render in StoryStructureTable) propagate upward and
+          cause the flex parent to recalculate, collapsing both panels. (#1330) */}
+      <div className="flex-1 min-h-0 overflow-hidden px-4 md:px-6 py-6 md:py-8">
+        {/* grid-rows-[1fr] pins the single row to exactly fill h-full,
+            preventing auto-row height from re-expanding on content changes. */}
+        <div className="w-full h-full grid grid-rows-[1fr] grid-cols-1 md:grid-cols-12 gap-6">
 
           {/* ── Left: Story text card ────────────────────────────── */}
           <div className="md:col-span-7 lg:col-span-7 min-h-0 flex">

--- a/frontend/src/components/reading-steps/FloatingAIHelper.tsx
+++ b/frontend/src/components/reading-steps/FloatingAIHelper.tsx
@@ -14,6 +14,10 @@ interface FloatingAIHelperProps {
   storyTitle: string;
   storyText: string;
   dbSessionId?: number;
+  /** Fix #1330: Tailwind class for button bottom position. Defaults to 'bottom-6'.
+   *  Pass 'bottom-28' when a fixed CTA occupies the viewport bottom so the button
+   *  doesn't overlap it. */
+  bottomOffset?: string;
 }
 
 type HelperMessage =
@@ -24,6 +28,7 @@ const FloatingAIHelper: React.FC<FloatingAIHelperProps> = ({
   storyTitle,
   storyText,
   dbSessionId,
+  bottomOffset = 'bottom-6',
 }) => {
   const { token } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
@@ -92,11 +97,11 @@ const FloatingAIHelper: React.FC<FloatingAIHelperProps> = ({
 
   return (
     <>
-      {/* Floating button */}
+      {/* Floating button — bottomOffset adjusts position to avoid fixed CTA overlap (#1330) */}
       <button
         type="button"
         onClick={() => setIsOpen(prev => !prev)}
-        className={`fixed bottom-6 right-6 z-50 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-all hover:scale-105 active:scale-95 ${
+        className={`fixed ${bottomOffset} right-6 z-50 w-14 h-14 rounded-full shadow-lg flex items-center justify-center transition-all hover:scale-105 active:scale-95 ${
           isOpen ? 'bg-gray-500 hover:bg-gray-600' : 'bg-accent hover:bg-accent-hover'
         }`}
         title={isOpen ? '關閉 AI 小助手' : '打開 AI 小助手'}
@@ -113,9 +118,10 @@ const FloatingAIHelper: React.FC<FloatingAIHelperProps> = ({
         )}
       </button>
 
-      {/* Chat popup */}
+      {/* Chat popup — sits above the floating button; bottom adjusts with button position (#1330) */}
       {isOpen && (
-        <div className="fixed bottom-24 right-6 z-50 w-80 sm:w-96 max-h-[28rem] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden">
+        <div className={`fixed right-6 z-50 w-80 sm:w-96 max-h-[28rem] bg-white rounded-2xl shadow-2xl border border-gray-200 flex flex-col overflow-hidden`}
+             style={{ bottom: bottomOffset === 'bottom-28' ? '8rem' : '5rem' }}>
           {/* Header */}
           <div className="shrink-0 bg-accent px-4 py-3 flex items-center gap-2">
             <div className="w-7 h-7 rounded-full bg-white/20 flex items-center justify-center">

--- a/frontend/src/components/reading-steps/MultipleChoiceExercise.tsx
+++ b/frontend/src/components/reading-steps/MultipleChoiceExercise.tsx
@@ -7,7 +7,7 @@
  * Fix #1330: Show inline completion summary before calling onComplete to prevent
  * layout shift caused by the parent swapping the entire panel DOM.
  */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { MultipleChoiceItem } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 
@@ -28,17 +28,8 @@ const MultipleChoiceExercise: React.FC<Props> = ({ questions, onComplete }) => {
   // Fix #1330: show inline done summary so the parent panel doesn't DOM-swap abruptly
   const [showDone, setShowDone] = useState(false);
   const [finalScore, setFinalScore] = useState(0);
-  const doneRef = useRef<HTMLDivElement>(null);
-
   const q = questions[current];
   const isLast = current === questions.length - 1;
-
-  // Scroll done card into view smoothly without resetting parent scroll (#1330)
-  useEffect(() => {
-    if (showDone) {
-      doneRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-    }
-  }, [showDone]);
 
   function handleSelect(label: string) {
     if (revealed) return;
@@ -49,9 +40,10 @@ const MultipleChoiceExercise: React.FC<Props> = ({ questions, onComplete }) => {
 
   function handleNext() {
     if (isLast) {
-      // Fix #1330: show inline summary first; parent onComplete called via "確認完成" button
-      const nextScore = selected === q.answer ? score + 1 : score;
-      setFinalScore(nextScore);
+      // Fix #1330: show inline summary first; parent onComplete called via "確認完成" button.
+      // Use `score` directly — handleSelect already called setScore(s => s+1) for a correct
+      // answer on this question before handleNext fires (separate click event, state committed).
+      setFinalScore(score);
       setShowDone(true);
       return;
     }
@@ -69,8 +61,7 @@ const MultipleChoiceExercise: React.FC<Props> = ({ questions, onComplete }) => {
     const allCorrect = finalScore === questions.length;
     return (
       <div
-        ref={doneRef}
-        className="flex flex-col items-center justify-center py-10 gap-5 px-4"
+        className="flex flex-col items-center justify-center min-h-full py-10 gap-5 px-4"
         style={{ fontFamily: zhuyinActive ? "'BpmfZihiSans', 'Noto Sans TC', sans-serif" : undefined }}
       >
         <div className="w-16 h-16 rounded-full bg-emerald-100 flex items-center justify-center">

--- a/frontend/src/components/reading-steps/MultipleChoiceExercise.tsx
+++ b/frontend/src/components/reading-steps/MultipleChoiceExercise.tsx
@@ -3,8 +3,11 @@
  *
  * Displays MCQ questions from the PDF-extracted YAML data.
  * Shows one question at a time; reveals correct answer + explanation after selection.
+ *
+ * Fix #1330: Show inline completion summary before calling onComplete to prevent
+ * layout shift caused by the parent swapping the entire panel DOM.
  */
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { MultipleChoiceItem } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 
@@ -22,10 +25,20 @@ const MultipleChoiceExercise: React.FC<Props> = ({ questions, onComplete }) => {
   const [selected, setSelected] = useState<string | null>(null);
   const [revealed, setRevealed] = useState(false);
   const [score, setScore] = useState(0);
+  // Fix #1330: show inline done summary so the parent panel doesn't DOM-swap abruptly
+  const [showDone, setShowDone] = useState(false);
+  const [finalScore, setFinalScore] = useState(0);
+  const doneRef = useRef<HTMLDivElement>(null);
 
   const q = questions[current];
-  const isCorrect = selected === q.answer;
   const isLast = current === questions.length - 1;
+
+  // Scroll done card into view smoothly without resetting parent scroll (#1330)
+  useEffect(() => {
+    if (showDone) {
+      doneRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [showDone]);
 
   function handleSelect(label: string) {
     if (revealed) return;
@@ -36,12 +49,60 @@ const MultipleChoiceExercise: React.FC<Props> = ({ questions, onComplete }) => {
 
   function handleNext() {
     if (isLast) {
-      onComplete(score, questions.length);
+      // Fix #1330: show inline summary first; parent onComplete called via "確認完成" button
+      const nextScore = selected === q.answer ? score + 1 : score;
+      setFinalScore(nextScore);
+      setShowDone(true);
       return;
     }
     setCurrent((c) => c + 1);
     setSelected(null);
     setRevealed(false);
+  }
+
+  function handleConfirmDone() {
+    onComplete(finalScore, questions.length);
+  }
+
+  // Inline completion summary — keeps layout stable (#1330)
+  if (showDone) {
+    const allCorrect = finalScore === questions.length;
+    return (
+      <div
+        ref={doneRef}
+        className="flex flex-col items-center justify-center py-10 gap-5 px-4"
+        style={{ fontFamily: zhuyinActive ? "'BpmfZihiSans', 'Noto Sans TC', sans-serif" : undefined }}
+      >
+        <div className="w-16 h-16 rounded-full bg-emerald-100 flex items-center justify-center">
+          <svg className="w-8 h-8 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <div className="text-center">
+          <p className="text-emerald-700 font-bold text-lg">
+            {allCorrect ? '全部答對，太棒了！' : '測驗完成，繼續加油！'}
+          </p>
+          <p className="text-sm text-gray-500 mt-1">
+            共 {questions.length} 題，答對 {finalScore} 題
+          </p>
+        </div>
+        {/* Progress bar showing final score */}
+        <div className="w-full max-w-xs">
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-emerald-500 h-2 rounded-full transition-all duration-700"
+              style={{ width: `${(finalScore / questions.length) * 100}%` }}
+            />
+          </div>
+        </div>
+        <button
+          onClick={handleConfirmDone}
+          className="rounded-lg bg-blue-500 px-8 py-2.5 text-white text-sm font-medium hover:bg-blue-600 transition-colors"
+        >
+          確認完成
+        </button>
+      </div>
+    );
   }
 
   return (

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -154,7 +154,7 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-2 w-full">
+    <div className="flex flex-col gap-2">
       {options.map((opt, idx) => {
         const isSelected = selected.includes(idx);
         const isCorrectOption = (correctOptions ?? []).includes(idx);
@@ -181,7 +181,7 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
         return (
           <label
             key={idx}
-            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors select-none w-full min-w-0 ${rowStyle} ${
+            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors select-none ${rowStyle} ${
               submitted ? 'cursor-default' : 'cursor-pointer'
             }`}
           >

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -1,9 +1,12 @@
 /**
- * StoryStructureTable — 互動式文章重點表 (#615, #845, #1082)
+ * StoryStructureTable — 互動式文章重點表 (#615, #845, #1082, #1330)
  *
  * Fetches AI-generated story structure from /api/stories/{id}/structure.
  * Supports interactive fill-in-the-blank and checkbox questions with AI grading.
  * Genre-aware: 記敘文 shows 主角/主題/事例, 說明文 shows concept structure, etc.
+ *
+ * Layout: pure CSS Grid (div-based). Replaced <table> to avoid the table
+ * layout algorithm fighting flex/grid height containment (#1330).
  */
 import React, { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
@@ -154,7 +157,7 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 w-full">
       {options.map((opt, idx) => {
         const isSelected = selected.includes(idx);
         const isCorrectOption = (correctOptions ?? []).includes(idx);
@@ -181,7 +184,7 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
         return (
           <label
             key={idx}
-            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors select-none ${rowStyle} ${
+            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors select-none w-full min-w-0 ${rowStyle} ${
               submitted ? 'cursor-default' : 'cursor-pointer'
             }`}
           >
@@ -208,6 +211,54 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
         <p className="text-xs text-gray-500 pl-1">{gradeItem.feedback}</p>
       )}
     </div>
+  );
+};
+
+// ── CellContent ───────────────────────────────────────────────────────────────
+// Renders the interactive content for a single cell (display / fill_blank / checkbox)
+
+interface CellContentProps {
+  row: StructureRow | StructureSubRow;
+  answerVal: string | number[] | undefined;
+  submitted: boolean;
+  gradeItem: GradeResultItem | undefined;
+  onChangeString: (v: string) => void;
+  onChangeArray: (v: number[]) => void;
+}
+
+const CellContent: React.FC<CellContentProps> = ({
+  row,
+  answerVal,
+  submitted,
+  gradeItem,
+  onChangeString,
+  onChangeArray,
+}) => {
+  // Treat missing/undefined interactive_type as 'display' (backward-compatible)
+  if (!row.interactive_type || row.interactive_type === 'display') {
+    return <span className="text-gray-800 leading-relaxed">{row.value}</span>;
+  }
+  if (row.interactive_type === 'checkbox') {
+    return (
+      <CheckboxCell
+        options={row.options ?? []}
+        selected={Array.isArray(answerVal) ? (answerVal as number[]) : []}
+        onChange={onChangeArray}
+        submitted={submitted}
+        gradeItem={gradeItem}
+        correctOptions={row.correct_options}
+      />
+    );
+  }
+  // fill_blank
+  return (
+    <FillBlankCell
+      hint={row.hint}
+      value={typeof answerVal === 'string' ? answerVal : ''}
+      onChange={onChangeString}
+      submitted={submitted}
+      gradeItem={gradeItem}
+    />
   );
 };
 
@@ -362,143 +413,164 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
 
   const { rows } = structure;
 
-  return (
-    <div className="overflow-hidden rounded-xl border-2 border-gray-300 shadow-sm max-w-2xl mx-auto">
-      {/* Header */}
-      <div className="bg-amber-50 border-b-2 border-amber-400 px-5 py-3 flex items-center justify-between">
-        <span className="text-amber-800 font-bold text-base">📋 文章重點表</span>
-        {submitted && score >= 0 && (
-          <span
-            className={`text-sm font-bold px-3 py-1 rounded-full ${
-              score >= 80
-                ? 'bg-emerald-100 text-emerald-700'
-                : 'bg-amber-100 text-amber-700'
-            }`}
+  // ── CSS Grid row rendering ─────────────────────────────────────────────────
+  //
+  // Grid: 3 columns — [category label | sub-label | content]
+  // gridTemplateColumns: auto auto 1fr
+  //   col 1 (auto): category label — shrinks to content width
+  //   col 2 (auto): sub-label — shrinks to content width; empty for flat rows
+  //   col 3 (1fr): cell content — takes remaining space
+  //
+  // Row with sub_rows (e.g. 事例 → 背景/経過/結果):
+  //   Col 1 spans all sub-rows via gridRow: "N / span M"
+  //   Col 2 & 3: one pair per sub-row
+  //
+  // Flat row (no sub_rows):
+  //   Col 1: category label
+  //   Col 2+3 merged (gridColumn: "2 / span 2"): cell content
+  //
+  // Border strategy:
+  //   - right border on col 1 and col 2 (borderRight)
+  //   - bottom border on all cells except last visible row
+
+  const totalRows = rows.length;
+  const gridItems: React.ReactNode[] = [];
+  let gridRowStart = 2; // row 1 is the header (col-span-3)
+
+  rows.forEach((row, rowIdx) => {
+    const isLastRow = rowIdx === totalRows - 1;
+
+    if (row.sub_rows && row.sub_rows.length > 0) {
+      const subCount = row.sub_rows.length;
+
+      // Col 1: category label spanning all sub-rows
+      gridItems.push(
+        <div
+          key={`cat-${rowIdx}`}
+          className={`bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center flex items-center justify-center border-r-[1.5px] border-gray-300 ${
+            isLastRow ? '' : 'border-b-[1.5px] border-gray-300'
+          }`}
+          style={{
+            gridColumn: 1,
+            gridRow: `${gridRowStart} / span ${subCount}`,
+          }}
+        >
+          {row.label}
+        </div>,
+      );
+
+      row.sub_rows.forEach((sub, subIdx) => {
+        const key = answerKey(rowIdx, subIdx);
+        const gradeItem = submitted
+          ? findGradeItem(gradeResults, rowIdx, subIdx)
+          : undefined;
+        const isLastSubRow = subIdx === subCount - 1;
+        const bottomBorder =
+          isLastRow && isLastSubRow ? '' : 'border-b-[1.5px] border-gray-300';
+        const currentGridRow = gridRowStart + subIdx;
+
+        // Col 2: sub-label
+        gridItems.push(
+          <div
+            key={`sub-label-${rowIdx}-${subIdx}`}
+            className={`bg-gray-50 px-3 py-3 font-semibold text-gray-600 text-center flex items-center justify-center border-r-[1.5px] border-gray-300 ${bottomBorder}`}
+            style={{ gridColumn: 2, gridRow: currentGridRow }}
           >
-            {score >= 80 ? '🎉 表現超棒！' : '💪 繼續加油'}
-          </span>
-        )}
-      </div>
+            {sub.label}
+          </div>,
+        );
 
-      {/* Table */}
-      <table className="w-full text-base" style={{ borderCollapse: 'collapse' }}>
-        <tbody>
-          {rows.map((row, rowIdx) =>
-            row.sub_rows && row.sub_rows.length > 0 ? (
-              row.sub_rows.map((sub, subIdx) => {
-                const key = answerKey(rowIdx, subIdx);
-                const gradeItem = submitted
-                  ? findGradeItem(gradeResults, rowIdx, subIdx)
-                  : undefined;
+        // Col 3: cell content
+        gridItems.push(
+          <div
+            key={`cell-${rowIdx}-${subIdx}`}
+            className={`px-4 py-3 ${bottomBorder}`}
+            style={{ gridColumn: 3, gridRow: currentGridRow }}
+          >
+            <CellContent
+              row={sub}
+              answerVal={answers[key]}
+              submitted={submitted}
+              gradeItem={gradeItem}
+              onChangeString={(v) => setAnswer(key, v)}
+              onChangeArray={(v) => setAnswer(key, v)}
+            />
+          </div>,
+        );
+      });
 
-                return (
-                  <tr
-                    key={`${rowIdx}-${subIdx}`}
-                    style={{ borderBottom: '1.5px solid #d1d5db' }}
-                  >
-                    {subIdx === 0 && (
-                      <td
-                        rowSpan={row.sub_rows!.length}
-                        className="bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center align-middle w-20"
-                        style={{ borderRight: '1.5px solid #d1d5db' }}
-                      >
-                        {row.label}
-                      </td>
-                    )}
-                    <td
-                      className="bg-gray-50 px-3 py-3 font-semibold text-gray-600 text-center w-16"
-                      style={{ borderRight: '1.5px solid #d1d5db' }}
-                    >
-                      {sub.label}
-                    </td>
-                    <td className="px-4 py-3 text-gray-800 leading-relaxed">
-                      {sub.interactive_type === 'display' ? (
-                        <span>{sub.value}</span>
-                      ) : sub.interactive_type === 'checkbox' ? (
-                        <CheckboxCell
-                          options={sub.options ?? []}
-                          selected={
-                            Array.isArray(answers[key])
-                              ? (answers[key] as number[])
-                              : []
-                          }
-                          onChange={(v) => setAnswer(key, v)}
-                          submitted={submitted}
-                          gradeItem={gradeItem}
-                          correctOptions={sub.correct_options}
-                        />
-                      ) : (
-                        <FillBlankCell
-                          hint={sub.hint}
-                          value={
-                            typeof answers[key] === 'string'
-                              ? (answers[key] as string)
-                              : ''
-                          }
-                          onChange={(v) => setAnswer(key, v)}
-                          submitted={submitted}
-                          gradeItem={gradeItem}
-                        />
-                      )}
-                    </td>
-                  </tr>
-                );
-              })
-            ) : (
-              <tr key={rowIdx} style={{ borderBottom: '1.5px solid #d1d5db' }}>
-                <td
-                  className="bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center w-20"
-                  style={{ borderRight: '1.5px solid #d1d5db' }}
-                >
-                  {row.label}
-                </td>
-                {row.interactive_type === 'display' ? (
-                  <td colSpan={2} className="px-5 py-3 text-gray-800 leading-relaxed">
-                    {row.value}
-                  </td>
-                ) : (
-                  <td colSpan={2} className="px-4 py-3">
-                    {row.interactive_type === 'checkbox' ? (
-                      <CheckboxCell
-                        options={row.options ?? []}
-                        selected={
-                          Array.isArray(answers[answerKey(rowIdx)])
-                            ? (answers[answerKey(rowIdx)] as number[])
-                            : []
-                        }
-                        onChange={(v) => setAnswer(answerKey(rowIdx), v)}
-                        submitted={submitted}
-                        gradeItem={
-                          submitted
-                            ? findGradeItem(gradeResults, rowIdx)
-                            : undefined
-                        }
-                        correctOptions={row.correct_options}
-                      />
-                    ) : (
-                      <FillBlankCell
-                        hint={row.hint}
-                        value={
-                          typeof answers[answerKey(rowIdx)] === 'string'
-                            ? (answers[answerKey(rowIdx)] as string)
-                            : ''
-                        }
-                        onChange={(v) => setAnswer(answerKey(rowIdx), v)}
-                        submitted={submitted}
-                        gradeItem={
-                          submitted
-                            ? findGradeItem(gradeResults, rowIdx)
-                            : undefined
-                        }
-                      />
-                    )}
-                  </td>
-                )}
-              </tr>
-            ),
+      gridRowStart += subCount;
+    } else {
+      // Flat row
+      const bottomBorder = isLastRow ? '' : 'border-b-[1.5px] border-gray-300';
+      const key = answerKey(rowIdx);
+      const gradeItem = submitted
+        ? findGradeItem(gradeResults, rowIdx)
+        : undefined;
+
+      // Col 1: category label
+      gridItems.push(
+        <div
+          key={`cat-${rowIdx}`}
+          className={`bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center flex items-center justify-center border-r-[1.5px] border-gray-300 ${bottomBorder}`}
+          style={{ gridColumn: 1, gridRow: gridRowStart }}
+        >
+          {row.label}
+        </div>,
+      );
+
+      // Col 2+3: content (col-span-2)
+      gridItems.push(
+        <div
+          key={`cell-${rowIdx}`}
+          className={`px-4 py-3 leading-relaxed ${bottomBorder}`}
+          style={{ gridColumn: '2 / span 2', gridRow: gridRowStart }}
+        >
+          <CellContent
+            row={row}
+            answerVal={answers[key]}
+            submitted={submitted}
+            gradeItem={gradeItem}
+            onChangeString={(v) => setAnswer(key, v)}
+            onChangeArray={(v) => setAnswer(key, v)}
+          />
+        </div>,
+      );
+
+      gridRowStart += 1;
+    }
+  });
+
+  return (
+    <div className="rounded-xl border-2 border-gray-300 shadow-sm max-w-2xl mx-auto overflow-hidden">
+      {/* CSS Grid container — replaces <table> to avoid table layout algorithm
+          fighting flex/grid height containment (#1330) */}
+      <div
+        className="grid w-full text-base bg-white"
+        style={{ gridTemplateColumns: 'auto auto 1fr' }}
+      >
+        {/* Header row — spans all 3 columns */}
+        <div
+          className="bg-amber-50 border-b-2 border-amber-400 px-5 py-3 flex items-center justify-between"
+          style={{ gridColumn: '1 / span 3', gridRow: 1 }}
+        >
+          <span className="text-amber-800 font-bold text-base">📋 文章重點表</span>
+          {submitted && score >= 0 && (
+            <span
+              className={`text-sm font-bold px-3 py-1 rounded-full ${
+                score >= 80
+                  ? 'bg-emerald-100 text-emerald-700'
+                  : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {score >= 80 ? '🎉 表現超棒！' : '💪 繼續加油'}
+            </span>
           )}
-        </tbody>
-      </table>
+        </div>
+
+        {/* Data rows (built above) */}
+        {gridItems}
+      </div>
 
       {/* Submit / Result bar */}
       <div className="px-5 py-4 border-t-2 border-gray-200 bg-gray-50">

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -154,7 +154,7 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 w-full">
       {options.map((opt, idx) => {
         const isSelected = selected.includes(idx);
         const isCorrectOption = (correctOptions ?? []).includes(idx);
@@ -181,7 +181,7 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
         return (
           <label
             key={idx}
-            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors select-none ${rowStyle} ${
+            className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors select-none w-full min-w-0 ${rowStyle} ${
               submitted ? 'cursor-default' : 'cursor-pointer'
             }`}
           >

--- a/frontend/src/components/reading-steps/__tests__/StoryStructureTable.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/StoryStructureTable.test.tsx
@@ -2,6 +2,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import StoryStructureTable from '../StoryStructureTable';
 
+// Mock useAuth so the component can render without AuthProvider in tests
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: null }),
+}));
+
 const simpleRows = [
   { label: '主角', value: '小明' },
   { label: '主題', value: '友情的重要性' },


### PR DESCRIPTION
## Summary

Fixes the panel collapse on checkbox click in 課文理解 > 文章重點表 tab.

**Previous 3 commits (89c18b1, f8a130d, 0314c70) did NOT fix the bug.**
They addressed symptoms (scrollIntoView, min-h-full on completion card, w-full on CheckboxCell labels) but missed the structural root cause.

## Root Cause (4th commit — actual root cause)

**File**: `frontend/src/components/reading-steps/ComprehensionChat.tsx`

The `flex-1 min-h-0` wrapper div around the 2-column grid was **missing `overflow-hidden`**.

When a checkbox in `StoryStructureTable` is clicked:
1. `setAnswers()` fires → `CheckboxCell` re-renders with new visual state
2. The `<table>` (with `border-collapse: collapse`, auto row heights) recomputes its height
3. This propagates up through the un-contained `flex-1 min-h-0` div to the grid
4. The grid row uses `auto` height (no explicit `grid-template-rows`) → recalculates
5. `h-full` on the grid now resolves against a recalculating parent → both panels collapse
6. Large empty whitespace appears below; 提交答案 button disappears off-screen

## Fix (2 CSS class changes, no logic changes)

1. **Added `overflow-hidden`** to the `flex-1 min-h-0` wrapper (line 285): establishes an overflow containment boundary so grid height changes from StoryStructureTable cannot escape upward into the flex parent chain.

2. **Added `grid-rows-[1fr]`** to the grid div (line 286): pins the single grid row to exactly fill `h-full`, preventing auto-row height re-expansion on content changes.

## Test

Lesson 8 「十秒的背後」, step 9/12 課文理解, 文章重點表 tab:
- Click any checkbox option → both panels should stay full height
- 提交答案 button should remain visible at bottom
- All 6 rows should remain visible