### PR TITLE
feat: 注音 3-state 切換控制（無/難字/全）(Fixes #1337)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -180,7 +180,7 @@ const ImmersiveTopBar: React.FC = () => {
   const navigate = useNavigate();
   const currentView = useAppView();
   const { selectedStory, session } = useLearningNav();
-  const { zhuyinEnabled, zhuyinReady, toggleZhuyin } = useZhuyin();
+  const { zhuyinMode, zhuyinReady, setZhuyinMode } = useZhuyin();
   const { karaokeEnabled, toggleKaraoke } = useKaraoke();
 
   // Find current step index and label
@@ -324,9 +324,9 @@ const ImmersiveTopBar: React.FC = () => {
         )}
         {selectedStory && (
           <ZhuyinToggle
-            enabled={zhuyinEnabled}
+            mode={zhuyinMode}
             ready={zhuyinReady}
-            onToggle={toggleZhuyin}
+            onModeChange={setZhuyinMode}
           />
         )}
       </div>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -303,7 +303,7 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { selectedStory: navStory } = useLearningNav();
-  const { zhuyinEnabled, zhuyinReady, toggleZhuyin } = useZhuyin();
+  const { zhuyinMode, zhuyinReady, setZhuyinMode } = useZhuyin();
 
   // Determine initial collapsed state from localStorage
   const [collapsed, setCollapsed] = useState<boolean>(() => {
@@ -578,9 +578,9 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
           {navStory && (
             <div className={collapsed ? '' : 'w-full px-1'}>
               <ZhuyinToggle
-                enabled={zhuyinEnabled}
+                mode={zhuyinMode}
                 ready={zhuyinReady}
-                onToggle={toggleZhuyin}
+                onModeChange={setZhuyinMode}
               />
             </div>
           )}

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -82,12 +82,16 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     persistedActiveTab ?? (hasMcq ? 'mcq' : 'structure'),
   );
 
-  const { zhuyinActive, processLines: zhuyinProcessLines } = useZhuyin();
+  const { isZhuyinAny, processLinesSelective } = useZhuyin();
+  const vocabWords = useMemo(
+    () => (story.vocabulary ?? []).map((v) => v.word).filter(Boolean),
+    [story.vocabulary]
+  );
 
-  const zhuyinLines = useMemo(() => {
-    if (!zhuyinActive) return null;
-    return zhuyinProcessLines(story.content);
-  }, [story.content, zhuyinActive, zhuyinProcessLines]);
+  const zhuyinLines = useMemo(
+    () => processLinesSelective(story.content, vocabWords),
+    [story.content, vocabWords, processLinesSelective]
+  );
 
   const handleTabChange = useCallback((tab: 'mcq' | 'structure' | 'strategy') => {
     setActiveTab(tab);
@@ -284,7 +288,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                     <span className="text-xs font-headline font-bold text-on-surface-variant/30 pt-1 select-none shrink-0 w-5 text-right">
                       {String(idx + 1).padStart(2, '0')}
                     </span>
-                    <p className={`text-lg md:text-xl text-on-surface ${zhuyinActive ? 'leading-[2.6rem] md:leading-[3rem] tracking-[0.3em]' : 'leading-[1.6]'}`}>
+                    <p className={`text-lg md:text-xl text-on-surface leading-[2.6rem] md:leading-[3rem] ${isZhuyinAny ? 'tracking-[0.3em]' : ''}`}>
                       {zhuyinLines ? zhuyinLines[idx] : line}
                     </p>
                   </div>

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -77,8 +77,12 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
   const [streamingTranscript, setStreamingTranscript] = useState(() => savedProgress.current?.transcript ?? '');
   const [micError, setMicError]                 = useState('');
   const [result, setResult]                     = useState<SavedResult | null>(getInitialResult);
-  const { zhuyinActive, processZhuyin } = useZhuyin();
+  const { zhuyinActive, isZhuyinAny, processLinesSelective } = useZhuyin();
   const { karaokeEnabled } = useKaraoke();
+  const vocabWords = useMemo(
+    () => (story.vocabulary ?? []).map((v) => v.word).filter(Boolean),
+    [story.vocabulary]
+  );
 
   /* ---- Bug #1320 Bug 1: Auto-scroll to result area when result first appears ---- */
   const resultRef = useRef<HTMLDivElement | null>(null);
@@ -187,10 +191,10 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     } catch {}
   }, [result, streamingTranscript, storageKey]);
 
-  const zhuyinLines = useMemo(() => {
-    if (!zhuyinActive) return null;
-    return story.content.map((line) => processZhuyin(line));
-  }, [story.content, zhuyinActive, processZhuyin]);
+  const zhuyinLines = useMemo(
+    () => processLinesSelective(story.content, vocabWords),
+    [story.content, vocabWords, processLinesSelective]
+  );
 
   /* ---- Cleanup ---- */
   useEffect(() => {
@@ -309,7 +313,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     const isTtsHighlighting = karaokeEnabled && isTtsPlaying && idx === currentTtsParagraph;
 
     if (isTtsHighlighting) {
-      const displayText = (zhuyinActive && typeof zhuyinLine === 'string') ? zhuyinLine : line;
+      const displayText = (isZhuyinAny && typeof zhuyinLine === 'string') ? zhuyinLine : line;
       const chars = splitZhuyinChars(displayText);
       // groupIdxForProgress walks char groups so zhuyin PUA selectors (#1112)
       // and symbols stripped by _cleanForTts (#1110) don't push the split

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -347,7 +347,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     <div
       className="flex flex-col flex-1 h-full bg-surface overflow-hidden relative"
       style={{
-        fontFamily: zhuyinActive
+        fontFamily: isZhuyinAny
           ? "'BpmfZihiSans', 'Noto Sans TC', sans-serif"
           : undefined,
       }}
@@ -396,7 +396,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
                   <span className="text-xs font-headline font-bold text-on-surface-variant/40 pt-2 select-none shrink-0 w-6 text-right">
                     {String(idx + 1).padStart(2, '0')}
                   </span>
-                  <p className={`text-xl md:text-2xl text-on-surface ${zhuyinActive ? 'leading-[3rem] md:leading-[3.5rem] tracking-[0.4em]' : 'leading-[1.6]'}`}>
+                  <p className={`text-xl md:text-2xl text-on-surface leading-[3rem] md:leading-[3.5rem] ${isZhuyinAny ? 'tracking-[0.4em]' : ''}`}>
                     {renderParagraph(line, idx)}
                   </p>
                 </div>

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -448,8 +448,9 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     // Fix: strip PUA selectors from the rendering string before slicing.  After stripping,
     // .length == raw char count, so raw indices and UTF-16 slice indices agree perfectly.
     //
-    // NOTE: when zhuyin is active, displayText contains BpmfIansui PUA selectors AND ruby
-    // annotations that cannot be split character-by-character, so we fall back to rawText.
+    // NOTE: when zhuyin is active (any mode with ruby), displayText contains BpmfZihiSans PUA
+    // selectors AND ruby annotations that cannot be split character-by-character, so we fall
+    // back to rawText for annotation offset calculations.
     const baseText = zhuyinActive ? rawText : displayText;
     // Strip PUA Variation Selectors so that .length == raw char count and slice indices match.
     const textToRender = stripPUASelectors(baseText);

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -75,7 +75,11 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   fontSizePx = 22,
 }) => {
   // Zhuyin state from global context
-  const { zhuyinActive, processZhuyin } = useZhuyin();
+  const { isZhuyinAny, processLinesSelective } = useZhuyin();
+  const vocabWords = useMemo(
+    () => (story.vocabulary ?? []).map((v) => v.word).filter(Boolean),
+    [story.vocabulary]
+  );
 
   // Annotations persisted to localStorage
   const [annotations, setAnnotations] = useState<Annotation[]>(() => {
@@ -107,10 +111,10 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
 
   // ── Zhuyin ─────────────────────────────────────────────────────────────
 
-  const zhuyinParagraphs = useMemo(() => {
-    if (!zhuyinActive) return null;
-    return story.content.map((p) => processZhuyin(p));
-  }, [story.content, zhuyinActive, processZhuyin]);
+  const zhuyinParagraphs = useMemo(
+    () => processLinesSelective(story.content, vocabWords),
+    [story.content, vocabWords, processLinesSelective]
+  );
 
   // ── Persist annotations ────────────────────────────────────────────────
 
@@ -451,7 +455,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     // NOTE: when zhuyin is active (any mode with ruby), displayText contains BpmfZihiSans PUA
     // selectors AND ruby annotations that cannot be split character-by-character, so we fall
     // back to rawText for annotation offset calculations.
-    const baseText = zhuyinActive ? rawText : displayText;
+    const baseText = isZhuyinAny ? rawText : displayText;
     // Strip PUA Variation Selectors so that .length == raw char count and slice indices match.
     const textToRender = stripPUASelectors(baseText);
 
@@ -508,7 +512,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     <div
       className="flex-1 flex flex-col bg-surface overflow-hidden select-none"
       style={{
-        fontFamily: zhuyinActive
+        fontFamily: isZhuyinAny
           ? "'BpmfZihiSans', 'Noto Sans TC', sans-serif"
           : undefined,
       }}
@@ -595,8 +599,8 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
                     className="text-on-surface/90"
                     style={{
                       fontSize: `${fontSizePx}px`,
-                      lineHeight: zhuyinActive ? '3.8rem' : '1.6',
-                      letterSpacing: zhuyinActive ? '0.35em' : '0',
+                      lineHeight: isZhuyinAny ? '3.8rem' : '2.0',
+                      letterSpacing: isZhuyinAny ? '0.35em' : '0.02em',
                     }}
                   >
                     {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -95,7 +95,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     savedProgress.current?.lineResults ?? []
   );
   const [streak, setStreak] = useState(0);
-  const { zhuyinActive, processZhuyin } = useZhuyin();
+  const { zhuyinActive, processLines } = useZhuyin();
   const [isAwaitingGemini, setIsAwaitingGemini] = useState(false);
   const [lastDiffTokens, setLastDiffTokens] = useState<DiffToken[] | null>(null);
   const [showRecorder, setShowRecorder] = useState(false);
@@ -243,10 +243,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   }, []);
 
   /** Pre-process each story line through the polyphonic processor for zhuyin rendering */
-  const zhuyinLines = useMemo(() => {
-    if (!zhuyinActive) return null;
-    return story.content.map((line) => processZhuyin(line));
-  }, [story.content, zhuyinActive, processZhuyin]);
+  const zhuyinLines = useMemo(
+    () => processLines(story.content),
+    [story.content, processLines]
+  );
 
   /** Compute completed/current/locked status for each paragraph. */
   const lineStatuses = useMemo<ParagraphStatus[]>(() => {

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -95,7 +95,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     savedProgress.current?.lineResults ?? []
   );
   const [streak, setStreak] = useState(0);
-  const { zhuyinActive, processLines } = useZhuyin();
+  const { zhuyinActive, isZhuyinAny, processLinesSelective } = useZhuyin();
+  const vocabWords = useMemo(
+    () => (story.vocabulary ?? []).map((v) => v.word).filter(Boolean),
+    [story.vocabulary]
+  );
   const [isAwaitingGemini, setIsAwaitingGemini] = useState(false);
   const [lastDiffTokens, setLastDiffTokens] = useState<DiffToken[] | null>(null);
   const [showRecorder, setShowRecorder] = useState(false);
@@ -242,10 +246,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       .catch(() => {});
   }, []);
 
-  /** Pre-process each story line through the polyphonic processor for zhuyin rendering */
+  /** Pre-process each story line; respects 3-state mode (none/difficult/all) */
   const zhuyinLines = useMemo(
-    () => processLines(story.content),
-    [story.content, processLines]
+    () => processLinesSelective(story.content, vocabWords),
+    [story.content, vocabWords, processLinesSelective]
   );
 
   /** Compute completed/current/locked status for each paragraph. */
@@ -815,7 +819,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     <div
       className="flex flex-col flex-1 h-full bg-surface overflow-hidden relative"
       style={{
-        fontFamily: zhuyinActive
+        fontFamily: isZhuyinAny
           ? "'BpmfZihiSans', 'Noto Sans TC', sans-serif"
           : undefined,
       }}
@@ -834,7 +838,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               isAdvancing={isAdvancing}
               fontSizePx={fontSizePx}
               zhuyinLine={zhuyinLines ? zhuyinLines[currentLineIndex] : null}
-              zhuyinActive={zhuyinActive}
+              zhuyinActive={isZhuyinAny}
               isSessionActive={stt.isSessionActive}
               isPreparing={stt.isPreparing}
               isTtsSpeaking={isTtsSpeaking}

--- a/frontend/src/components/ui/ZhuyinToggle.tsx
+++ b/frontend/src/components/ui/ZhuyinToggle.tsx
@@ -1,35 +1,52 @@
+import { ZhuyinMode } from '../../context/ZhuyinContext';
+
 interface ZhuyinToggleProps {
-  enabled: boolean;
+  mode: ZhuyinMode;
   ready: boolean;
-  onToggle: () => void;
+  onModeChange: (mode: ZhuyinMode) => void;
+  /** @deprecated use mode + onModeChange */
+  enabled?: boolean;
+  /** @deprecated use onModeChange */
+  onToggle?: () => void;
 }
 
-export default function ZhuyinToggle({ enabled, ready, onToggle }: ZhuyinToggleProps) {
-  const isOn = enabled && ready;
-  const label = isOn ? '隱藏注音符號' : '顯示注音符號';
+const SEGMENTS: Array<{ mode: ZhuyinMode; label: string; title: string }> = [
+  { mode: 'none', label: '無', title: '關閉注音' },
+  { mode: 'all',  label: '全', title: '顯示全文注音' },
+  // Future: { mode: 'difficult', label: '難字', title: '僅標示難字注音' }
+];
+
+export default function ZhuyinToggle({ mode, ready, onModeChange }: ZhuyinToggleProps) {
+  const isLoading = !ready;
 
   return (
-    <button
-      type="button"
-      onClick={onToggle}
-      aria-pressed={isOn}
-      aria-label={label}
-      title={label}
-      className={`relative inline-flex items-center gap-2 h-10 pl-3 pr-4 rounded-full font-headline font-bold text-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 active:scale-[0.95] ${
-        isOn
-          ? 'bg-accent text-white shadow-[0_4px_16px_rgba(86,74,191,0.3)]'
-          : 'bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest'
+    <div
+      role="group"
+      aria-label="注音顯示模式"
+      className={`inline-flex items-center rounded-full bg-surface-container-high p-0.5 gap-0.5 transition-opacity ${
+        isLoading ? 'opacity-50 pointer-events-none' : ''
       }`}
     >
-      {/* Toggle track */}
-      <span className={`relative w-8 h-5 rounded-full transition-colors duration-300 ${
-        isOn ? 'bg-white/30' : 'bg-on-surface-variant/20'
-      }`}>
-        <span className={`absolute top-0.5 w-4 h-4 rounded-full transition-all duration-300 shadow-sm ${
-          isOn ? 'left-3.5 bg-white' : 'left-0.5 bg-on-surface-variant/60'
-        }`} />
-      </span>
-      <span className="whitespace-nowrap">注音</span>
-    </button>
+      {SEGMENTS.map((seg) => {
+        const isActive = mode === seg.mode;
+        return (
+          <button
+            key={seg.mode}
+            type="button"
+            onClick={() => onModeChange(seg.mode)}
+            aria-pressed={isActive}
+            aria-label={seg.title}
+            title={seg.title}
+            className={`h-9 px-3 rounded-full font-headline font-bold text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 active:scale-95 whitespace-nowrap ${
+              isActive
+                ? 'bg-accent text-white shadow-[0_2px_10px_rgba(86,74,191,0.35)]'
+                : 'text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface'
+            }`}
+          >
+            {seg.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/frontend/src/components/ui/ZhuyinToggle.tsx
+++ b/frontend/src/components/ui/ZhuyinToggle.tsx
@@ -11,9 +11,9 @@ interface ZhuyinToggleProps {
 }
 
 const SEGMENTS: Array<{ mode: ZhuyinMode; label: string; title: string }> = [
-  { mode: 'none', label: '無', title: '關閉注音' },
-  { mode: 'all',  label: '全', title: '顯示全文注音' },
-  // Future: { mode: 'difficult', label: '難字', title: '僅標示難字注音' }
+  { mode: 'none',      label: '無',   title: '關閉注音' },
+  { mode: 'difficult', label: '難字', title: '僅標示難字注音（詞彙表）' },
+  { mode: 'all',       label: '全',   title: '顯示全文注音' },
 ];
 
 export default function ZhuyinToggle({ mode, ready, onModeChange }: ZhuyinToggleProps) {

--- a/frontend/src/context/ZhuyinContext.tsx
+++ b/frontend/src/context/ZhuyinContext.tsx
@@ -1,62 +1,72 @@
 /**
- * ZhuyinContext -- global zhuyin (bopomofo) segmented-control state.
+ * ZhuyinContext -- global zhuyin (bopomofo) 3-state segmented-control.
  *
- * zhuyinMode:
- *   'none' -- no ruby annotation (was zhuyinEnabled=false)
- *   'all'  -- ruby on all characters (was zhuyinEnabled=true)
+ * THREE display states:
+ *   'none'      -- no ruby annotation
+ *   'difficult' -- ruby only on vocabulary words (v1: lesson YAML vocabulary field)
+ *   'all'       -- ruby on all characters
  *
- * Visual is a 2-segment control (no zhuyin / full zhuyin).
- * A third segment for difficult-word-only mode is reserved for a future issue.
+ * Internally, zhuyinMode is 'none' | 'all' for the processor gate, and
+ * vocabOnly (boolean) selects between 'difficult' and 'all' when mode='all'.
+ * The combined triState is the canonical 3-way value exposed to the UI.
  *
  * Backward-compat helpers:
- *   zhuyinActive  -- true when mode is 'all' AND processor is ready
- *   isZhuyinAny   -- alias of zhuyinActive (components may use this)
+ *   zhuyinActive  -- true when triState is 'all' AND processor is ready
+ *   isZhuyinAny   -- true when triState is 'difficult' OR 'all' AND ready
  *   isZhuyinAll   -- alias of zhuyinActive
- *   isZhuyinNone  -- true when mode is 'none'
- *   zhuyinEnabled -- true when mode !== 'none' (legacy boolean compat)
+ *   isZhuyinNone  -- true when triState is 'none'
+ *   zhuyinEnabled -- true when triState !== 'none' (legacy boolean compat)
+ *
+ * processLinesSelective(lines, vocabWords):
+ *   - triState='none'      -> null
+ *   - triState='all'       -> fully-processed ruby lines
+ *   - triState='difficult' -> ruby only on vocab-word substrings
  */
 
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { PolyphonicProcessor, buildZhuyinString } from '../components/zhuyin/polyphonicProcessor';
 
-export type ZhuyinMode = 'none' | 'all';
+export type ZhuyinMode = 'none' | 'difficult' | 'all';
 
-const STORAGE_KEY = 'zhuyin_mode';
+const STORAGE_KEY = 'zhuyin_mode_v2';
 const LEGACY_KEY  = 'zhuyin_enabled';
 
-const MODE_CYCLE: ZhuyinMode[] = ['none', 'all'];
+const MODE_CYCLE: ZhuyinMode[] = ['none', 'difficult', 'all'];
 
 function readStoredMode(): ZhuyinMode {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw === 'none' || raw === 'all') return raw;
-    // Migrate from legacy boolean key
+    if (raw === 'none' || raw === 'difficult' || raw === 'all') return raw;
+    // Migrate from old boolean key
     const legacy = localStorage.getItem(LEGACY_KEY);
     if (legacy === 'false') return 'none';
-    return 'all'; // default: full zhuyin on
+    return 'all';
   } catch {
     return 'all';
   }
 }
 
 interface ZhuyinContextValue {
+  /** 3-state mode: 'none' | 'difficult' | 'all' */
   zhuyinMode: ZhuyinMode;
   zhuyinReady: boolean;
   /** true when mode='all' AND processor ready */
   zhuyinActive: boolean;
-  /** alias of zhuyinActive */
+  /** true when mode='difficult' OR 'all' AND processor ready */
   isZhuyinAny: boolean;
   isZhuyinAll: boolean;
   isZhuyinNone: boolean;
-  /** @deprecated -- use zhuyinMode; kept for backward compat */
+  /** @deprecated -- true when mode !== 'none' */
   zhuyinEnabled: boolean;
   setZhuyinMode: (mode: ZhuyinMode) => void;
   /** @deprecated -- use setZhuyinMode */
   setZhuyinEnabled: (enabled: boolean) => void;
-  /** Cycle: none -> all -> none */
+  /** Cycle: none -> difficult -> all -> none */
   toggleZhuyin: () => void;
   processZhuyin: (text: string) => string;
   processLines: (lines: string[]) => string[] | null;
+  /** 3-state selective processing: respects 'none'/'difficult'/'all' modes */
+  processLinesSelective: (lines: string[], vocabWords: string[]) => string[] | null;
 }
 
 const ZhuyinContext = createContext<ZhuyinContextValue>({
@@ -72,6 +82,7 @@ const ZhuyinContext = createContext<ZhuyinContextValue>({
   toggleZhuyin: () => {},
   processZhuyin: (t) => t,
   processLines: () => null,
+  processLinesSelective: () => null,
 });
 
 export const ZhuyinProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -79,7 +90,7 @@ export const ZhuyinProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [zhuyinReady, setZhuyinReady] = useState(() => PolyphonicProcessor.instance.isLoaded);
 
   const zhuyinActive = zhuyinReady && zhuyinMode === 'all';
-  const isZhuyinAny  = zhuyinActive;
+  const isZhuyinAny  = zhuyinReady && zhuyinMode !== 'none';
   const isZhuyinAll  = zhuyinActive;
   const isZhuyinNone = zhuyinMode === 'none';
   const zhuyinEnabled = zhuyinMode !== 'none';
@@ -104,7 +115,6 @@ export const ZhuyinProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   }, []);
 
-  // Legacy compat
   const setZhuyinEnabled = useCallback((enabled: boolean) => {
     setZhuyinMode(enabled ? 'all' : 'none');
   }, [setZhuyinMode]);
@@ -121,22 +131,79 @@ export const ZhuyinProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   const processZhuyin = useCallback((text: string): string => {
-    if (!zhuyinActive) return text;
+    if (!isZhuyinAny) return text;
     try {
       return buildZhuyinString(PolyphonicProcessor.instance.process(text));
     } catch {
       return text;
     }
-  }, [zhuyinActive]);
+  }, [isZhuyinAny]);
 
   const processLines = useCallback((lines: string[]): string[] | null => {
-    if (!zhuyinActive) return null;
+    if (!isZhuyinAny) return null;
     try {
       return lines.map((line) => buildZhuyinString(PolyphonicProcessor.instance.process(line)));
     } catch {
       return null;
     }
-  }, [zhuyinActive]);
+  }, [isZhuyinAny]);
+
+  const processLinesSelective = useCallback(
+    (lines: string[], vocabWords: string[]): string[] | null => {
+      if (!zhuyinReady || zhuyinMode === 'none') return null;
+      if (zhuyinMode === 'all') {
+        try {
+          return lines.map((line) =>
+            buildZhuyinString(PolyphonicProcessor.instance.process(line))
+          );
+        } catch {
+          return null;
+        }
+      }
+      // 'difficult': ruby only on vocab word substrings
+      const validWords = vocabWords.filter(Boolean);
+      if (validWords.length === 0) return null;
+      try {
+        return lines.map((line) => {
+          const matches: Array<{ start: number; end: number }> = [];
+          for (const word of validWords) {
+            let pos = 0;
+            while (pos < line.length) {
+              const idx = line.indexOf(word, pos);
+              if (idx === -1) break;
+              matches.push({ start: idx, end: idx + word.length });
+              pos = idx + 1;
+            }
+          }
+          if (matches.length === 0) return line;
+          matches.sort((a, b) => a.start - b.start);
+          const deduped: typeof matches = [];
+          let cursor = 0;
+          for (const m of matches) {
+            if (m.start >= cursor) { deduped.push(m); cursor = m.end; }
+          }
+          let result = '';
+          let charPos = 0;
+          for (const { start, end } of deduped) {
+            if (charPos < start) result += line.slice(charPos, start);
+            try {
+              result += buildZhuyinString(
+                PolyphonicProcessor.instance.process(line.slice(start, end))
+              );
+            } catch {
+              result += line.slice(start, end);
+            }
+            charPos = end;
+          }
+          if (charPos < line.length) result += line.slice(charPos);
+          return result;
+        });
+      } catch {
+        return null;
+      }
+    },
+    [zhuyinReady, zhuyinMode]
+  );
 
   return (
     <ZhuyinContext.Provider value={{
@@ -152,6 +219,7 @@ export const ZhuyinProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       toggleZhuyin,
       processZhuyin,
       processLines,
+      processLinesSelective,
     }}>
       {children}
     </ZhuyinContext.Provider>

--- a/frontend/src/context/ZhuyinContext.tsx
+++ b/frontend/src/context/ZhuyinContext.tsx
@@ -1,44 +1,73 @@
 /**
- * ZhuyinContext -- global zhuyin (bopomofo) toggle state.
+ * ZhuyinContext -- global zhuyin (bopomofo) segmented-control state.
  *
- * Manages:
- *   - zhuyinEnabled  -- user preference (persisted in localStorage)
- *   - zhuyinReady    -- true once PolyphonicProcessor data is loaded
- *   - zhuyinActive   -- enabled AND ready (convenience derived value)
- *   - processZhuyin  -- helper: text -> zhuyin string (passthrough when inactive)
+ * zhuyinMode:
+ *   'none' -- no ruby annotation (was zhuyinEnabled=false)
+ *   'all'  -- ruby on all characters (was zhuyinEnabled=true)
  *
- * Provided at the App level so every step component shares a single toggle.
+ * Visual is a 2-segment control (no zhuyin / full zhuyin).
+ * A third segment for difficult-word-only mode is reserved for a future issue.
+ *
+ * Backward-compat helpers:
+ *   zhuyinActive  -- true when mode is 'all' AND processor is ready
+ *   isZhuyinAny   -- alias of zhuyinActive (components may use this)
+ *   isZhuyinAll   -- alias of zhuyinActive
+ *   isZhuyinNone  -- true when mode is 'none'
+ *   zhuyinEnabled -- true when mode !== 'none' (legacy boolean compat)
  */
 
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { PolyphonicProcessor, buildZhuyinString } from '../components/zhuyin/polyphonicProcessor';
 
-const STORAGE_KEY = 'zhuyin_enabled';
+export type ZhuyinMode = 'none' | 'all';
 
-function readStoredPreference(): boolean {
+const STORAGE_KEY = 'zhuyin_mode';
+const LEGACY_KEY  = 'zhuyin_enabled';
+
+const MODE_CYCLE: ZhuyinMode[] = ['none', 'all'];
+
+function readStoredMode(): ZhuyinMode {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw === 'false') return false;
-    return true; // default on
+    if (raw === 'none' || raw === 'all') return raw;
+    // Migrate from legacy boolean key
+    const legacy = localStorage.getItem(LEGACY_KEY);
+    if (legacy === 'false') return 'none';
+    return 'all'; // default: full zhuyin on
   } catch {
-    return true;
+    return 'all';
   }
 }
 
 interface ZhuyinContextValue {
-  zhuyinEnabled: boolean;
+  zhuyinMode: ZhuyinMode;
   zhuyinReady: boolean;
+  /** true when mode='all' AND processor ready */
   zhuyinActive: boolean;
+  /** alias of zhuyinActive */
+  isZhuyinAny: boolean;
+  isZhuyinAll: boolean;
+  isZhuyinNone: boolean;
+  /** @deprecated -- use zhuyinMode; kept for backward compat */
+  zhuyinEnabled: boolean;
+  setZhuyinMode: (mode: ZhuyinMode) => void;
+  /** @deprecated -- use setZhuyinMode */
   setZhuyinEnabled: (enabled: boolean) => void;
+  /** Cycle: none -> all -> none */
   toggleZhuyin: () => void;
   processZhuyin: (text: string) => string;
   processLines: (lines: string[]) => string[] | null;
 }
 
 const ZhuyinContext = createContext<ZhuyinContextValue>({
-  zhuyinEnabled: true,
+  zhuyinMode: 'all',
   zhuyinReady: false,
   zhuyinActive: false,
+  isZhuyinAny: false,
+  isZhuyinAll: false,
+  isZhuyinNone: false,
+  zhuyinEnabled: true,
+  setZhuyinMode: () => {},
   setZhuyinEnabled: () => {},
   toggleZhuyin: () => {},
   processZhuyin: (t) => t,
@@ -46,10 +75,14 @@ const ZhuyinContext = createContext<ZhuyinContextValue>({
 });
 
 export const ZhuyinProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [zhuyinEnabled, setZhuyinEnabledRaw] = useState(readStoredPreference);
+  const [zhuyinMode, setZhuyinModeRaw] = useState<ZhuyinMode>(readStoredMode);
   const [zhuyinReady, setZhuyinReady] = useState(() => PolyphonicProcessor.instance.isLoaded);
 
-  const zhuyinActive = zhuyinReady && zhuyinEnabled;
+  const zhuyinActive = zhuyinReady && zhuyinMode === 'all';
+  const isZhuyinAny  = zhuyinActive;
+  const isZhuyinAll  = zhuyinActive;
+  const isZhuyinNone = zhuyinMode === 'none';
+  const zhuyinEnabled = zhuyinMode !== 'none';
 
   // Load polyphonic data once
   useEffect(() => {
@@ -62,48 +95,59 @@ export const ZhuyinProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       .catch((err) => console.error('Failed to load zhuyin data:', err));
   }, []);
 
-  const setZhuyinEnabled = useCallback((enabled: boolean) => {
-    setZhuyinEnabledRaw(enabled);
+  const setZhuyinMode = useCallback((mode: ZhuyinMode) => {
+    setZhuyinModeRaw(mode);
     try {
-      localStorage.setItem(STORAGE_KEY, String(enabled));
+      localStorage.setItem(STORAGE_KEY, mode);
     } catch {
       // Storage full -- ignore
     }
   }, []);
 
+  // Legacy compat
+  const setZhuyinEnabled = useCallback((enabled: boolean) => {
+    setZhuyinMode(enabled ? 'all' : 'none');
+  }, [setZhuyinMode]);
+
   const toggleZhuyin = useCallback(() => {
-    setZhuyinEnabledRaw((prev) => {
-      const next = !prev;
+    setZhuyinModeRaw((prev) => {
+      const idx = MODE_CYCLE.indexOf(prev);
+      const next = MODE_CYCLE[(idx + 1) % MODE_CYCLE.length];
       try {
-        localStorage.setItem(STORAGE_KEY, String(next));
+        localStorage.setItem(STORAGE_KEY, next);
       } catch {}
       return next;
     });
   }, []);
 
   const processZhuyin = useCallback((text: string): string => {
-    if (!(zhuyinReady && zhuyinEnabled)) return text;
+    if (!zhuyinActive) return text;
     try {
       return buildZhuyinString(PolyphonicProcessor.instance.process(text));
     } catch {
       return text;
     }
-  }, [zhuyinReady, zhuyinEnabled]);
+  }, [zhuyinActive]);
 
   const processLines = useCallback((lines: string[]): string[] | null => {
-    if (!(zhuyinReady && zhuyinEnabled)) return null;
+    if (!zhuyinActive) return null;
     try {
       return lines.map((line) => buildZhuyinString(PolyphonicProcessor.instance.process(line)));
     } catch {
       return null;
     }
-  }, [zhuyinReady, zhuyinEnabled]);
+  }, [zhuyinActive]);
 
   return (
     <ZhuyinContext.Provider value={{
-      zhuyinEnabled,
+      zhuyinMode,
       zhuyinReady,
       zhuyinActive,
+      isZhuyinAny,
+      isZhuyinAll,
+      isZhuyinNone,
+      zhuyinEnabled,
+      setZhuyinMode,
       setZhuyinEnabled,
       toggleZhuyin,
       processZhuyin,


### PR DESCRIPTION
Fixes #1337

## Summary

實現注音 3-state 切換，依陳淑麗教授建議「注音僅標示難字即可」。

- **ZhuyinContext** — `ZhuyinMode` 從 `'none'|'all'` 擴展為 `'none'|'difficult'|'all'`；新增 `processLinesSelective(lines, vocabWords)` 支援難字選擇性 ruby 標注
- **ZhuyinToggle** — 改為 3-segment control（無 / 難字 / 全）
- **AppShell + Sidebar** — 傳入新 props（mode/onModeChange）
- **ReadingAnnotation, FullReading, LiveTutor, ComprehensionChat** — 改用 `processLinesSelective`；font/layout 改用 `isZhuyinAny`

### 難字資料來源 v1

Lesson YAML `vocabulary` 欄位 — 靜態詞彙清單。v2 可接 Gemini 動態判斷。

### localStorage

新 key `zhuyin_mode_v2`（存 `none|difficult|all`），自動從舊 boolean key 遷移。

## Test plan

- [ ] 3 個模式截圖（無注音 / 難字注音 / 全注音）
- [ ] 切換不刷新頁面
- [ ] 重開瀏覽器後選擇持久
- [ ] 難字模式：只有 vocabulary 詞彙有 ruby
- [ ] `npm run build` 通過

🤖 Generated with Claude Code (Sonnet 4.6)