### PR TITLE
feat: zhuyin-off article font → non-gothic for readability (Fixes #1351)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,7 @@
            X-Frame-Options: DENY
          See: https://www.w3.org/TR/CSP3/#frame-ancestors-and-frame-options -->
     <title>AI 朗讀助教 — 國語文閱讀學習平台</title>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&family=cwTeXYen&family=Plus+Jakarta+Sans:wght@400;600;700;800&family=Be+Vietnam+Pro:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;700&family=cwTeXYen&family=cwTeXKai&family=Noto+Serif+TC:wght@400;500;700&family=Plus+Jakarta+Sans:wght@400;600;700;800&family=Be+Vietnam+Pro:wght@400;500;600&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
     <style>
       @font-face {
@@ -26,7 +26,7 @@
         font-display: swap;
       }
       body {
-        font-family: 'Noto Sans TC', sans-serif;
+        font-family: 'cwTeXKai', 'Noto Serif TC', 'PingFang TC', 'Microsoft JhengHei', serif;
         background-color: #FBF6EE;
       }
       .zhuyin-text {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,10 +11,10 @@
   font-family: 'BpmfZihiSans', 'Noto Sans TC', sans-serif !important;
 }
 
-/* Elements with .no-zhuyin and their children keep the default font */
+/* Elements with .no-zhuyin and their children keep the non-gothic font (zhuyin off default) */
 [data-zhuyin-active="true"] .no-zhuyin,
 [data-zhuyin-active="true"] .no-zhuyin * {
-  font-family: 'Noto Sans TC', sans-serif !important;
+  font-family: 'cwTeXKai', 'Noto Serif TC', 'PingFang TC', 'Microsoft JhengHei', serif !important;
 }
 
 /* Zhuyin annotations need slightly more vertical breathing room.

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,7 +7,11 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['"Noto Sans TC"', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        // zhuyin off: 非黑體字型（楷體/明體優先）— 陳淑麗教授：黑體對近視學生不友好
+        // cwTeXKai: 台灣教育楷書（Google Fonts），視覺清晰接近教科書手寫感
+        // Noto Serif TC: 思源宋體，備援明體（Google Fonts），老眼/近視友好
+        // PingFang TC / Microsoft JhengHei: 系統字體備援（macOS/Windows）
+        sans: ['cwTeXKai', '"Noto Serif TC"', '"PingFang TC"', '"Microsoft JhengHei"', 'serif'],
         ui: ['cwTeXYen', '"Noto Sans TC"', 'ui-sans-serif', 'system-ui', 'sans-serif'],
         headline: ['"Plus Jakarta Sans"', '"Noto Sans TC"', 'ui-sans-serif', 'system-ui', 'sans-serif'],
         body: ['"Be Vietnam Pro"', '"Noto Sans TC"', 'ui-sans-serif', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
Fixes #1351

## Summary

Switch the default body/UI font from Noto Sans TC (黑體/gothic) to cwTeXKai + Noto Serif TC per Prof. Chen Shu-li's feedback that gothic fonts cause visual blur for myopic students (2026-05-01 expert review meeting).

**Constraint respected**: BpmfZihiSans is untouched — it is still used exclusively for zhuyin-active mode (required for PUA character rendering).

### Changes

- `frontend/index.html` — add `cwTeXKai` + `Noto Serif TC` to Google Fonts import; change `body` font-family to non-gothic stack
- `frontend/src/index.css` — update `.no-zhuyin` fallback to the same non-gothic stack (comment updated to clarify intent)
- `frontend/tailwind.config.js` — `fontFamily.sans` now uses `cwTeXKai` → `Noto Serif TC` → `PingFang TC` (macOS) → `Microsoft JhengHei` (Windows) → `serif`

### Font rationale

| Font | Type | Source | Why |
|------|------|--------|-----|
| cwTeXKai | 楷書 (KaiShu) | Google Fonts | Taiwan educational style, close to textbook handwriting |
| Noto Serif TC | 明體 (Ming/Serif) | Google Fonts | Low-vision friendly, high stroke contrast |
| PingFang TC | System serif | macOS | System fallback |
| Microsoft JhengHei | System sans | Windows | System fallback (better than generic sans) |

## Test plan

- [ ] Open preview URL → verify article text renders in non-gothic font (楷書感)
- [ ] Toggle zhuyin ON → verify BpmfZihiSans still renders (PUA chars visible)
- [ ] Toggle zhuyin OFF → verify non-gothic font applies to article text and UI labels
- [ ] Check on Windows (should fall back to Microsoft JhengHei)