### PR TITLE
feat: make karaoke (per-word tracking) optional via toggle (Fixes #1352)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { AuthProvider } from './contexts/AuthContext';
 import { WorkspaceProvider } from './contexts/WorkspaceContext';
 import { LearningNavProvider } from './contexts/LearningNavContext';
 import { ZhuyinProvider } from './context/ZhuyinContext';
+import { KaraokeProvider } from './context/KaraokeContext';
 import TermsGate from './components/auth/TermsGate';
 import AppRoutes from './routes/AppRoutes';
 
@@ -26,9 +27,11 @@ const App: React.FC = () => {
           <WorkspaceProvider>
             <LearningNavProvider>
               <ZhuyinProvider>
-                <TermsGate>
-                  <AppRoutes />
-                </TermsGate>
+                <KaraokeProvider>
+                  <TermsGate>
+                    <AppRoutes />
+                  </TermsGate>
+                </KaraokeProvider>
               </ZhuyinProvider>
             </LearningNavProvider>
           </WorkspaceProvider>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -15,6 +15,7 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { useLearningNav } from '../../contexts/LearningNavContext';
 import { useZhuyin } from '../../context/ZhuyinContext';
+import { useKaraoke } from '../../context/KaraokeContext';
 import { getMyAssignments } from '../../services/assignmentApi';
 import { AppView } from '../../types';
 import { ACTIVE_STEPS } from '../../config/stepConfig';
@@ -180,6 +181,7 @@ const ImmersiveTopBar: React.FC = () => {
   const currentView = useAppView();
   const { selectedStory, session } = useLearningNav();
   const { zhuyinEnabled, zhuyinReady, toggleZhuyin } = useZhuyin();
+  const { karaokeEnabled, toggleKaraoke } = useKaraoke();
 
   // Find current step index and label
   const currentStepIndex = ACTIVE_STEPS.findIndex((s) => s.view === currentView);
@@ -299,8 +301,27 @@ const ImmersiveTopBar: React.FC = () => {
         </div>
       </div>
 
-      {/* Right: zhuyin toggle + settings */}
-      <div className="shrink-0 flex items-center">
+      {/* Right: karaoke toggle + zhuyin toggle */}
+      <div className="shrink-0 flex items-center gap-2">
+        {selectedStory && (
+          <button
+            type="button"
+            onClick={toggleKaraoke}
+            aria-pressed={karaokeEnabled}
+            aria-label={karaokeEnabled ? '關閉跟讀' : '開啟跟讀'}
+            title={karaokeEnabled ? '關閉跟讀' : '開啟跟讀'}
+            className={`relative inline-flex items-center gap-1.5 h-10 pl-3 pr-3 rounded-full font-headline font-bold text-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 active:scale-[0.95] ${
+              karaokeEnabled
+                ? 'bg-accent text-white shadow-[0_4px_16px_rgba(86,74,191,0.3)]'
+                : 'bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest'
+            }`}
+          >
+            <span className="material-symbols-outlined text-base leading-none" style={{ fontVariationSettings: "'FILL' 1" }}>
+              {karaokeEnabled ? 'lyrics' : 'lyrics'}
+            </span>
+            <span className="whitespace-nowrap hidden md:inline">跟讀</span>
+          </button>
+        )}
         {selectedStory && (
           <ZhuyinToggle
             enabled={zhuyinEnabled}

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -4,6 +4,7 @@ import { cleanChineseText } from '../../utils/textDiff';
 import { analyzeFluency } from '../../utils/fluencyAnalyzer';
 import DiffDisplay from '../ui/DiffDisplay';
 import { useZhuyin } from '../../context/ZhuyinContext';
+import { useKaraoke } from '../../context/KaraokeContext';
 import { useAudioRecorder } from '../../hooks/useAudioRecorder';
 import { useTtsPlayback } from '../../hooks/useTtsPlayback';
 import { cancelTts } from '../../services/ttsApi';
@@ -77,6 +78,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
   const [micError, setMicError]                 = useState('');
   const [result, setResult]                     = useState<SavedResult | null>(getInitialResult);
   const { zhuyinActive, processZhuyin } = useZhuyin();
+  const { karaokeEnabled } = useKaraoke();
 
   /* ---- Bug #1320 Bug 1: Auto-scroll to result area when result first appears ---- */
   const resultRef = useRef<HTMLDivElement | null>(null);
@@ -300,10 +302,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     setStreamingTranscript(cleanChineseText(transcript));
   }, [fullText, stopSession]);
 
-  /* ---- Render paragraph text with optional TTS highlighting ---- */
+  /* ---- Render paragraph text with optional KTV TTS highlighting ---- */
   const renderParagraph = (line: string, idx: number) => {
     const zhuyinLine = zhuyinLines ? zhuyinLines[idx] : null;
-    const isTtsHighlighting = isTtsPlaying && idx === currentTtsParagraph;
+    // KTV highlight: only when karaokeEnabled AND TTS is playing this paragraph
+    const isTtsHighlighting = karaokeEnabled && isTtsPlaying && idx === currentTtsParagraph;
 
     if (isTtsHighlighting) {
       const displayText = (zhuyinActive && typeof zhuyinLine === 'string') ? zhuyinLine : line;
@@ -324,8 +327,8 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
       );
     }
 
-    // Finished TTS paragraphs stay fully colored
-    if (isTtsPlaying && currentTtsParagraph > idx) {
+    // When karaoke is ON: finished TTS paragraphs stay fully colored
+    if (karaokeEnabled && isTtsPlaying && currentTtsParagraph > idx) {
       return <span className="text-accent font-bold">{zhuyinLine ?? line}</span>;
     }
 

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -7,6 +7,7 @@ import { CHINESE_PUNCTUATION_REGEX } from '../../../utils/liveTutorHelpers';
 
 import { splitZhuyinChars } from '../../../utils/zhuyinUtils';
 import { groupIdxForProgress } from '../../../utils/ttsHighlight';
+import { useKaraoke } from '../../../context/KaraokeContext';
 
 /* ── Encouragement messages (PR #1076 / #1096) ──────────────────────────── */
 
@@ -113,6 +114,7 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
   storyContent,
 }) => {
   const isCurrentIdx = idx === currentLineIndex;
+  const { karaokeEnabled } = useKaraoke();
   // isTtsLoading comes from useTtsPlayback hook (via LiveTutor) — no local state needed.
   // This removes the old setTimeout-based debounce that was an approximation.
 
@@ -205,8 +207,9 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
       >
         {status === 'locked' ? (
           <span className="blur-sm select-none">{zhuyinLine ?? line}</span>
-        ) : isTtsSpeaking && isCurrentIdx ? (
-          // Highlight chars up to speakingProgress during TTS playback.
+        ) : isTtsSpeaking && isCurrentIdx && karaokeEnabled ? (
+          // KTV highlight: scrolls char-by-char during TTS playback.
+          // Only shown when karaokeEnabled is true (toggle in ImmersiveTopBar).
           // groupIdxForProgress walks char groups so zhuyin PUA selectors
           // (#1112) and symbols stripped by _cleanForTts (#1110) don't push
           // the split past the real char boundary.

--- a/frontend/src/context/KaraokeContext.tsx
+++ b/frontend/src/context/KaraokeContext.tsx
@@ -1,0 +1,77 @@
+/**
+ * KaraokeContext -- global karaoke (KTV-style char highlight) toggle state.
+ *
+ * Controls whether TTS playback shows a scrolling char-by-char highlight
+ * effect (the "KTV" or "karaoke" follow-along animation).
+ *
+ * Manages:
+ *   - karaokeEnabled  -- user preference (persisted in localStorage)
+ *   - toggleKaraoke   -- flip the preference
+ *   - setKaraokeEnabled -- explicit setter
+ *
+ * Pattern mirrors ZhuyinContext so the two toggles behave consistently.
+ * Default: OFF (false) — following 5/1 expert review feedback.
+ *
+ * Components that drive the highlight (ParagraphCard, FullReading) gate
+ * the split-span render on `karaokeEnabled`. When off, plain text is shown
+ * and the TTS audio plays normally without visual animation.
+ */
+
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'karaoke_enabled';
+
+function readStoredPreference(): boolean {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    // Explicit 'true' opt-in; everything else (null / 'false') → off
+    return raw === 'true';
+  } catch {
+    return false; // default off
+  }
+}
+
+interface KaraokeContextValue {
+  karaokeEnabled: boolean;
+  setKaraokeEnabled: (enabled: boolean) => void;
+  toggleKaraoke: () => void;
+}
+
+const KaraokeContext = createContext<KaraokeContextValue>({
+  karaokeEnabled: false,
+  setKaraokeEnabled: () => {},
+  toggleKaraoke: () => {},
+});
+
+export const KaraokeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [karaokeEnabled, setKaraokeEnabledRaw] = useState(readStoredPreference);
+
+  const setKaraokeEnabled = useCallback((enabled: boolean) => {
+    setKaraokeEnabledRaw(enabled);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(enabled));
+    } catch {
+      // Storage full -- ignore
+    }
+  }, []);
+
+  const toggleKaraoke = useCallback(() => {
+    setKaraokeEnabledRaw((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next));
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  return (
+    <KaraokeContext.Provider value={{ karaokeEnabled, setKaraokeEnabled, toggleKaraoke }}>
+      {children}
+    </KaraokeContext.Provider>
+  );
+};
+
+export function useKaraoke(): KaraokeContextValue {
+  return useContext(KaraokeContext);
+}


### PR DESCRIPTION
Fixes #1352

## Summary

- Add `KaraokeContext` (new file: `frontend/src/context/KaraokeContext.tsx`) — mirrors `ZhuyinContext` pattern, persists to `localStorage`, default **OFF**
- Wrap app tree with `KaraokeProvider` in `App.tsx`
- Add **跟讀 toggle button** in `ImmersiveTopBar` (`AppShell.tsx`) — shows when a story is loaded, styled with `aria-pressed` and accessible labels
- Gate KTV char-by-char highlight in `ParagraphCard.tsx` (LiveTutor) on `karaokeEnabled`
- Gate both highlight modes in `FullReading.tsx` on `karaokeEnabled`

Per 5/1 expert review: "跟讀設為選項，不強制" (曾教授: 對閱障學生有幫助 → 老師可派任務時開)

## Behaviour

| State | LiveTutor | FullReading |
|-------|-----------|-------------|
| karaoke OFF (default) | Plain text, TTS audio plays normally | Plain text, TTS audio plays normally |
| karaoke ON | Char-by-char KTV highlight during TTS | Paragraph-level KTV highlight during TTS |

## Test plan

1. Open a lesson, go to 逐段朗讀 (LiveTutor) step
2. Press TTS play — confirm NO char highlight by default
3. Press the 跟讀 button in the top bar — confirm it turns accent-coloured
4. Press TTS play again — confirm KTV char highlight appears
5. Refresh page — confirm toggle state persists (localStorage)
6. Go to 全文朗讀 (FullReading) step — confirm same toggle controls paragraph highlight
7. Toggle OFF mid-playback — highlight should stop immediately

## Files changed

- `frontend/src/context/KaraokeContext.tsx` (**new**) — Context + Provider + hook
- `frontend/src/App.tsx` — add `KaraokeProvider` wrapper
- `frontend/src/components/layout/AppShell.tsx` — add toggle button in `ImmersiveTopBar`
- `frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx` — gate on `karaokeEnabled`
- `frontend/src/components/reading-steps/FullReading.tsx` — gate on `karaokeEnabled`