### PR TITLE
fix(colors): adopt design tokens in 4 violating components (Refs #1358)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionScoreCard.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionScoreCard.tsx
@@ -60,7 +60,7 @@ const ComprehensionScoreCard: React.FC<ComprehensionScoreCardProps> = ({
 }) => {
   if (loading) {
     return (
-      <div className="rounded-2xl border border-slate-200 bg-white p-6 animate-pulse">
+      <div className="rounded-2xl border border-slate-200 bg-surface p-6 animate-pulse">
         <div className="flex items-center gap-3 mb-6">
           <div className="w-16 h-16 rounded-full bg-gray-200" />
           <div className="space-y-2">
@@ -86,7 +86,7 @@ const ComprehensionScoreCard: React.FC<ComprehensionScoreCardProps> = ({
   const overallLevel = getScoreLevel(comprehensionScore);
 
   return (
-    <div className="rounded-2xl border border-slate-200 bg-white overflow-hidden">
+    <div className="rounded-2xl border border-slate-200 bg-surface overflow-hidden">
       {/* Header with overall score */}
       <div className="bg-gradient-to-r from-accent/5 to-violet-50 px-6 py-5 border-b border-slate-100">
         <div className="flex items-center gap-4">
@@ -111,13 +111,13 @@ const ComprehensionScoreCard: React.FC<ComprehensionScoreCardProps> = ({
                 />
               </svg>
               <div className="absolute inset-0 flex items-center justify-center">
-                <span className="text-lg font-black text-gray-900">{Math.round(comprehensionScore)}</span>
+                <span className="text-lg font-black text-on-surface">{Math.round(comprehensionScore)}</span>
               </div>
             </div>
           )}
 
           <div>
-            <h3 className="text-lg font-bold text-gray-900">課文理解力評估</h3>
+            <h3 className="text-lg font-bold text-on-surface">課文理解力評估</h3>
             {!hideScores && (
               <p className={`text-sm font-bold ${overallLevel.textColor}`}>
                 {overallLevel.label}
@@ -152,7 +152,7 @@ const ComprehensionScoreCard: React.FC<ComprehensionScoreCardProps> = ({
                   ) : (
                     <>
                       <span className={`text-xs font-bold ${scoreLevel.textColor}`}>{scoreLevel.label}</span>
-                      <span className="text-lg font-black text-gray-900">{Math.round(score)}</span>
+                      <span className="text-lg font-black text-on-surface">{Math.round(score)}</span>
                     </>
                   )}
                 </div>

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -69,7 +69,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
       }}
     >
       {/* Top bar */}
-      <nav aria-label="麵包屑導覽" className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-3">
+      <nav aria-label="麵包屑導覽" className="h-9 bg-surface-container-lowest border-b border-gray-200 flex items-center px-4 gap-3">
         <button
           type="button"
           onClick={onBack}
@@ -106,7 +106,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 </span>
                 <span className="text-[10px] text-gray-400">難度 {story.level}</span>
               </div>
-              <h1 className={`text-2xl font-bold text-gray-900 ${zhuyinActive ? 'leading-[3rem] tracking-[0.4em]' : 'leading-[1.5]'}`}>
+              <h1 className={`text-2xl font-bold text-on-surface ${zhuyinActive ? 'leading-[3rem] tracking-[0.4em]' : 'leading-[1.5]'}`}>
                 {processZhuyin(story.title)}
               </h1>
               {story.intro && (
@@ -127,7 +127,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
             const videoId = match?.[1];
             if (!videoId) return null;
             return (
-              <div className="bg-white border border-gray-200 rounded-2xl p-6 space-y-3">
+              <div className="bg-surface-container-low border border-gray-200 rounded-2xl p-6 space-y-3">
                 <div className="flex items-center gap-2">
                   <svg className="w-4 h-4 text-red-500" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
@@ -149,14 +149,14 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
 
           {/* Background section */}
           {story.intro ? (
-            <div className="bg-white border border-gray-200 rounded-2xl p-6 space-y-4">
+            <div className="bg-surface-container-low border border-gray-200 rounded-2xl p-6 space-y-4">
               <div className="flex items-center gap-2">
                 <svg className="w-4 h-4 text-accent-light" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <span className="text-xs font-bold text-accent-light uppercase tracking-widest">課文簡介</span>
               </div>
-              <p className={`text-gray-900 text-2xl ${zhuyinActive ? 'leading-[3.5rem] tracking-[0.4em]' : 'leading-[1.6]'}`}>
+              <p className={`text-on-surface text-2xl ${zhuyinActive ? 'leading-[3.5rem] tracking-[0.4em]' : 'leading-[1.6]'}`}>
                 {processZhuyin(story.intro.background)}
               </p>
 
@@ -193,7 +193,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
               </div>
             </div>
           ) : (
-            <div className="bg-white border border-gray-200 rounded-2xl p-6 text-gray-500 text-sm">
+            <div className="bg-surface-container-low border border-gray-200 rounded-2xl p-6 text-gray-500 text-sm">
               這篇課文目前沒有簡介資料。
             </div>
           )}
@@ -202,7 +202,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
       </div>
 
       {/* Bottom action */}
-      <div className="flex-shrink-0 bg-white border-t border-gray-200 px-6 py-4 flex items-center justify-between">
+      <div className="flex-shrink-0 bg-surface-container-lowest border-t border-gray-200 px-6 py-4 flex items-center justify-between">
         <button
           type="button"
           onClick={onBack}

--- a/frontend/src/components/reading-steps/RadicalDecomposition.tsx
+++ b/frontend/src/components/reading-steps/RadicalDecomposition.tsx
@@ -87,11 +87,11 @@ const RelatedCharCard: React.FC<RelatedCharCardProps> = ({ item, isSelected, onC
       'flex flex-col items-center gap-1 px-3 py-2 rounded-xl border transition-all active:scale-95 text-left',
       isSelected
         ? 'bg-indigo-50 border-indigo-300 ring-1 ring-indigo-200'
-        : 'bg-white border-gray-200 hover:bg-gray-50 hover:border-gray-300',
+        : 'bg-surface-container-low border-gray-200 hover:bg-surface-container hover:border-gray-300',
     ].join(' ')}
     aria-pressed={isSelected}
   >
-    <span className="text-2xl font-bold text-gray-800 leading-none">{item.char}</span>
+    <span className="text-2xl font-bold text-on-surface leading-none">{item.char}</span>
   </button>
 );
 
@@ -115,12 +115,12 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
     // Character is an independent form (獨體字) or not in the database.
     // Show a friendly educational message instead of silently hiding the panel.
     return (
-      <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden shadow-sm">
+      <div className="bg-surface rounded-2xl border border-gray-200 overflow-hidden shadow-sm">
         <div className="px-4 py-3 bg-gradient-to-r from-indigo-50 to-purple-50 border-b border-gray-100 flex items-center gap-2">
-          <span className="text-base font-bold text-gray-700 whitespace-nowrap">部件拆解</span>
+          <span className="text-base font-bold text-on-surface-variant whitespace-nowrap">部件拆解</span>
         </div>
         <div className="p-4 flex flex-col items-center gap-3 text-center">
-          <span className="text-4xl font-black text-gray-900 leading-none">{char}</span>
+          <span className="text-4xl font-black text-on-surface leading-none">{char}</span>
           <p className="text-sm text-gray-600">
             此字為<span className="font-semibold text-indigo-700">獨體字</span>，無法再拆解
           </p>
@@ -198,10 +198,10 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
   };
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden shadow-sm">
+    <div className="bg-surface rounded-2xl border border-gray-200 overflow-hidden shadow-sm">
       {/* Header */}
       <div className="px-4 py-3 bg-gradient-to-r from-indigo-50 to-purple-50 border-b border-gray-100 flex items-center gap-2">
-        <span className="text-base font-bold text-gray-700 whitespace-nowrap">部件拆解</span>
+        <span className="text-base font-bold text-on-surface-variant whitespace-nowrap">部件拆解</span>
         <span className="text-xs text-gray-400 whitespace-nowrap">點擊部件查看相關字</span>
       </div>
 
@@ -210,7 +210,7 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
         <div className="flex items-center justify-center gap-3">
           {/* The character itself */}
           <div className="flex flex-col items-center shrink-0">
-            <span className="text-3xl font-black text-gray-900 leading-none">{char}</span>
+            <span className="text-3xl font-black text-on-surface leading-none">{char}</span>
             <span className="text-[10px] text-gray-400 mt-1 whitespace-nowrap">目標字</span>
           </div>
 
@@ -234,7 +234,7 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
                     ].join(' ')}
                     title={info?.meaning ?? comp.label}
                   >
-                    <span className="text-2xl font-bold text-gray-800 leading-none">{comp.radical}</span>
+                    <span className="text-2xl font-bold text-on-surface leading-none">{comp.radical}</span>
                     <span
                       className={`text-[8px] px-1 py-0.5 rounded-full border font-medium whitespace-nowrap ${ROLE_STYLES[comp.role]}`}
                     >
@@ -263,10 +263,10 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
           </div>
         ) : displayRadical && relatedChars.length === 0 ? (
           /* 部件資料庫尚未收錄此部件 — 顯示 fallback 以免點擊無回饋（#1099） */
-          <div className="rounded-xl bg-gray-50 border border-dashed border-gray-300 px-4 py-3 space-y-1">
+          <div className="rounded-xl bg-surface-container border border-dashed border-gray-300 px-4 py-3 space-y-1">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-lg font-bold text-gray-700">{displayRadical}</span>
-              <span className="text-[9px] px-1.5 py-0.5 rounded-full border border-gray-200 bg-white text-gray-500 font-medium">
+              <span className="text-lg font-bold text-on-surface-variant">{displayRadical}</span>
+              <span className="text-[9px] px-1.5 py-0.5 rounded-full border border-gray-200 bg-surface-container-low text-on-surface-variant font-medium">
                 部件
               </span>
             </div>
@@ -295,8 +295,8 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
 
             {/* Selected character meaning popup */}
             {selectedRelated && (
-              <div className="mt-2 px-3 py-2 bg-gray-50 rounded-xl border border-gray-200 text-sm text-gray-700">
-                <span className="font-bold text-gray-900">{selectedRelated.char}</span>
+              <div className="mt-2 px-3 py-2 bg-surface-container-low rounded-xl border border-gray-200 text-sm text-on-surface-variant">
+                <span className="font-bold text-on-surface">{selectedRelated.char}</span>
                 {' — '}
                 {getRelatedDisplayMeaning(selectedRelated)}
               </div>

--- a/frontend/src/components/reading-steps/StrategyExercise.tsx
+++ b/frontend/src/components/reading-steps/StrategyExercise.tsx
@@ -138,13 +138,13 @@ function OrderingExercise({
                     : 'bg-gray-50 border-gray-200'
                   : dragOverIndex === index
                   ? 'bg-violet-50 border-violet-300 scale-[1.02]'
-                  : 'bg-white border-gray-200 cursor-grab hover:border-violet-200 hover:bg-violet-50/30',
+                  : 'bg-surface-container-low border-gray-200 cursor-grab hover:border-violet-200 hover:bg-violet-50/30',
               ].join(' ')}
             >
               <span className="w-6 h-6 flex-shrink-0 rounded-full bg-gray-100 text-gray-500 text-xs font-bold flex items-center justify-center">
                 {index + 1}
               </span>
-              <span className="flex-1 text-sm text-gray-800">{item.text}</span>
+              <span className="flex-1 text-sm text-on-surface">{item.text}</span>
               {submitted && itemCorrect && (
                 <span className="text-emerald-500 text-base flex-shrink-0">&#10003;</span>
               )}
@@ -242,11 +242,11 @@ function TraitInferenceExercise({
 
       <div className="space-y-2 mb-5">
         {(exercise.clues ?? []).map((clue, idx) => (
-          <div key={idx} className="flex gap-3 bg-white rounded-xl border border-gray-200 px-4 py-3">
+          <div key={idx} className="flex gap-3 bg-surface-container-low rounded-xl border border-gray-200 px-4 py-3">
             <span className="flex-shrink-0 px-2 py-0.5 rounded-md bg-blue-100 text-blue-700 text-xs font-semibold">
               {clue.source}
             </span>
-            <span className="text-sm text-gray-800">{clue.text}</span>
+            <span className="text-sm text-on-surface">{clue.text}</span>
           </div>
         ))}
       </div>
@@ -269,7 +269,7 @@ function TraitInferenceExercise({
                   ? 'bg-red-50 border-red-300 text-red-600'
                   : isSelected
                   ? 'bg-violet-50 border-violet-400 text-violet-700'
-                  : 'bg-white border-gray-200 text-gray-700 hover:border-violet-300 hover:bg-violet-50/30',
+                  : 'bg-surface-container-low border-gray-200 text-on-surface-variant hover:border-violet-300 hover:bg-violet-50/30',
               ].join(' ')}
             >
               {trait}
@@ -387,12 +387,12 @@ function GuidedStepsExercise({
           const feedback = stepFeedback[stepIdx];
           const isDone = feedback !== null;
           return (
-            <div key={stepIdx} className="rounded-xl border border-gray-200 bg-white p-4">
+            <div key={stepIdx} className="rounded-xl border border-gray-200 bg-surface-container-low p-4">
               <div className="flex items-start gap-2 mb-3">
                 <span className="flex-shrink-0 w-6 h-6 rounded-full bg-violet-100 text-violet-700 text-xs font-bold flex items-center justify-center mt-0.5">
                   {stepIdx + 1}
                 </span>
-                <p className="text-sm font-medium text-gray-700">{step.prompt}</p>
+                <p className="text-sm font-medium text-on-surface-variant">{step.prompt}</p>
               </div>
 
               {step.type === 'free_text' ? (
@@ -434,7 +434,7 @@ function GuidedStepsExercise({
                             ? 'bg-red-50 border-red-300 text-red-600'
                             : isSelected
                             ? 'bg-violet-50 border-violet-400 text-violet-700'
-                            : 'bg-white border-gray-200 text-gray-700 hover:border-violet-200',
+                            : 'bg-surface-container-low border-gray-200 text-on-surface-variant hover:border-violet-200',
                         ].join(' ')}
                       >
                         <span className="font-semibold mr-2">


### PR DESCRIPTION
Refs #1358

## Summary

- Replaces `text-gray-900` / `bg-white` (contrast 17.74:1, violates BDA dark-not-black principle) with existing design tokens in 4 components identified by color contrast research (PR #1359)
- No new tokens added, no tailwind.config.js changes — pure className refactor
- Per Young's directive: 課文符合規定就好，不要全黑字

## Files changed

| File | Changes |
|------|---------|
| `Intro.tsx` | `text-gray-900` → `text-on-surface` (title + article body); `bg-white` → `bg-surface-container-low` (cards), `bg-surface-container-lowest` (nav + bottom bar) |
| `RadicalDecomposition.tsx` | `bg-white` → `bg-surface`; `text-gray-900/800/700` → `text-on-surface` / `text-on-surface-variant` throughout |
| `StrategyExercise.tsx` | `bg-white` → `bg-surface-container-low` (drag cards, clue cards, step containers, option buttons); `text-gray-800/700` → `text-on-surface` / `text-on-surface-variant` |
| `ComprehensionScoreCard.tsx` | `bg-white` → `bg-surface`; `text-gray-900` → `text-on-surface` (score numbers + heading) |

## Visual impact

Subtle. Article text shifts from `#111827` (gray-900, 17.74:1 on white) to `#302F2A` (on-surface, 12.47:1 on cream). Still AAA. Less harsh for nearsighted readers per BDA guidance.

## What was NOT changed (intentional)

- Hover states on nav/bottom bar buttons (`hover:text-gray-900`) — UI interaction chrome
- Form textarea input when active (`bg-white border-gray-300`) — form input per guidelines
- Progress bar track `bg-white/60` — translucent overlay on colored card backgrounds
- Zhuyin ruby colors — separate concern per research notes

## Test plan

- [ ] Open Intro step: title and article body should appear in warm charcoal (#302F2A) on cream, not harsh black
- [ ] Open RadicalDecomposition panel: character + radical chips should use same warm charcoal
- [ ] Open StrategyExercise (ordering / trait_inference / guided_steps): drag cards + clue cards + option buttons on cream-toned background
- [ ] Open ComprehensionScoreCard: score numbers and "課文理解力評估" heading in warm charcoal
- [ ] No visual regression on existing colored states (emerald/red/violet feedback states unchanged)