### PR TITLE
feat(vocab): radical color decomposition + recall round 2 (Fixes #1342)

### DIFF
--- a/frontend/src/components/reading-steps/RadicalDecomposition.tsx
+++ b/frontend/src/components/reading-steps/RadicalDecomposition.tsx
@@ -6,6 +6,9 @@
  * the same radical.
  *
  * Based on 部件教學法 by Prof. Tseng Shih-chieh (曾世杰教授).
+ *
+ * #1342: added colorMode + mergeMode props for round-1 radical coloring
+ * and round-1→round-2 "合體" fade-back animation.
  */
 
 import React, { useState, useEffect } from 'react';
@@ -56,9 +59,41 @@ const pickFirstRealDef = (defs: Array<{ definition: string }> | undefined): stri
   return defs[0]?.definition || '';
 };
 
+/**
+ * Color palette for radical components — WCAG AAA contrast + color-blind friendly.
+ * Exported so VocabPractice can build a legend if needed.
+ */
+export const RADICAL_COLOR_CLASSES: readonly string[] = [
+  'text-emerald-700',   // position 0 — green
+  'text-blue-700',      // position 1 — blue
+  'text-amber-700',     // position 2 — amber/gold
+  'text-rose-700',      // position 3 — rose (avoids pure red for color-blind safety)
+  'text-violet-700',    // position 4 — violet
+];
+
+/** Border + bg tints matching each color, for the interactive component button */
+const RADICAL_COLOR_BORDER: readonly string[] = [
+  'border-emerald-300 bg-emerald-50 hover:bg-emerald-100',
+  'border-blue-300 bg-blue-50 hover:bg-blue-100',
+  'border-amber-300 bg-amber-50 hover:bg-amber-100',
+  'border-rose-300 bg-rose-50 hover:bg-rose-100',
+  'border-violet-300 bg-violet-50 hover:bg-violet-100',
+];
+
 interface RadicalDecompositionProps {
   /** The character to decompose */
   char: string;
+  /**
+   * When true, component buttons are colored by position index to visually
+   * highlight radical structure. Default: false.
+   */
+  colorMode?: boolean;
+  /**
+   * "合體" mode — only takes effect when colorMode is true.
+   * Shows all radical characters faded back to default text color with a
+   * transition, reinforcing the concept "字 = 部件合體". Default: false.
+   */
+  mergeMode?: boolean;
 }
 
 // Role badge colours
@@ -95,7 +130,11 @@ const RelatedCharCard: React.FC<RelatedCharCardProps> = ({ item, isSelected, onC
   </button>
 );
 
-const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => {
+const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({
+  char,
+  colorMode = false,
+  mergeMode = false,
+}) => {
   const [selectedRelated, setSelectedRelated] = useState<RelatedChar | null>(null);
   const [activeRadical, setActiveRadical] = useState<string | null>(null);
   const [, forceUpdate] = useState(0);
@@ -197,12 +236,25 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
     setSelectedRelated(null);
   };
 
+  // ── color-mode header label ──────────────────────────────────────
+  const headerLabel = colorMode
+    ? mergeMode
+      ? '合體！'
+      : '部件上色'
+    : '部件拆解';
+
+  const headerSub = colorMode
+    ? mergeMode
+      ? '部件合在一起，就是這個字'
+      : '每個部件用不同顏色標示'
+    : '點擊部件查看相關字';
+
   return (
     <div className="bg-surface rounded-2xl border border-gray-200 overflow-hidden shadow-sm">
       {/* Header */}
       <div className="px-4 py-3 bg-gradient-to-r from-indigo-50 to-purple-50 border-b border-gray-100 flex items-center gap-2">
-        <span className="text-base font-bold text-on-surface-variant whitespace-nowrap">部件拆解</span>
-        <span className="text-xs text-gray-400 whitespace-nowrap">點擊部件查看相關字</span>
+        <span className="text-base font-bold text-on-surface-variant whitespace-nowrap">{headerLabel}</span>
+        <span className="text-xs text-gray-400 whitespace-nowrap">{headerSub}</span>
       </div>
 
       <div className="p-4 space-y-4">
@@ -210,8 +262,18 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
         <div className="flex items-center justify-center gap-3">
           {/* The character itself */}
           <div className="flex flex-col items-center shrink-0">
-            <span className="text-3xl font-black text-on-surface leading-none">{char}</span>
-            <span className="text-[10px] text-gray-400 mt-1 whitespace-nowrap">目標字</span>
+            {/* In mergeMode show the complete character in default color with a gentle grow */}
+            <span
+              className={[
+                'text-3xl font-black leading-none transition-all duration-700',
+                colorMode && mergeMode ? 'text-on-surface scale-110' : 'text-on-surface',
+              ].join(' ')}
+            >
+              {char}
+            </span>
+            <span className="text-[10px] text-gray-400 mt-1 whitespace-nowrap">
+              {colorMode && mergeMode ? '合體字' : '目標字'}
+            </span>
           </div>
 
           <span className="text-gray-400 text-lg font-light shrink-0">=</span>
@@ -221,20 +283,40 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
             {decomp.components.map((comp, idx) => {
               const info = getRadicalInfo(comp.radical);
               const isActive = activeRadical === comp.radical || (!activeRadical && comp.radical === primaryFormRadical);
+
+              // Color-mode overrides the button appearance
+              const colorIdx = idx % RADICAL_COLOR_CLASSES.length;
+              const radicalTextColor = colorMode && !mergeMode
+                ? RADICAL_COLOR_CLASSES[colorIdx]
+                : 'text-on-surface';
+              const buttonBorderBg = colorMode && !mergeMode
+                ? RADICAL_COLOR_BORDER[colorIdx]
+                : isActive
+                  ? 'bg-indigo-50 border-indigo-300 ring-1 ring-indigo-200'
+                  : 'bg-gray-50 border-gray-200 hover:bg-indigo-50 hover:border-indigo-200';
+
               return (
                 <React.Fragment key={`${comp.radical}-${idx}`}>
                   {idx > 0 && <span className="text-gray-400 text-sm shrink-0">+</span>}
                   <button
-                    onClick={() => handleRadicalClick(comp.radical)}
+                    onClick={() => !colorMode && handleRadicalClick(comp.radical)}
                     className={[
-                      'flex flex-col items-center gap-0.5 px-2.5 py-1.5 rounded-xl border transition-all active:scale-95',
-                      isActive
-                        ? 'bg-indigo-50 border-indigo-300 ring-1 ring-indigo-200'
-                        : 'bg-gray-50 border-gray-200 hover:bg-indigo-50 hover:border-indigo-200',
+                      'flex flex-col items-center gap-0.5 px-2.5 py-1.5 rounded-xl border transition-all duration-500',
+                      colorMode ? 'active:scale-95 cursor-default' : 'active:scale-95',
+                      buttonBorderBg,
                     ].join(' ')}
                     title={info?.meaning ?? comp.label}
+                    // In colorMode we disable normal radical-detail interactions
+                    aria-disabled={colorMode}
                   >
-                    <span className="text-2xl font-bold text-on-surface leading-none">{comp.radical}</span>
+                    <span
+                      className={[
+                        'text-2xl font-bold leading-none transition-colors duration-700',
+                        radicalTextColor,
+                      ].join(' ')}
+                    >
+                      {comp.radical}
+                    </span>
                     <span
                       className={`text-[8px] px-1 py-0.5 rounded-full border font-medium whitespace-nowrap ${ROLE_STYLES[comp.role]}`}
                     >
@@ -248,60 +330,90 @@ const RadicalDecomposition: React.FC<RadicalDecompositionProps> = ({ char }) => 
           </div>
         </div>
 
-        {/* Active radical detail */}
-        {displayRadicalInfo ? (
-          <div className="rounded-xl bg-indigo-50 border border-indigo-100 px-4 py-3 space-y-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-lg font-bold text-indigo-800">{displayRadical}</span>
-              <span
-                className={`text-[9px] px-1.5 py-0.5 rounded-full border font-medium ${ROLE_STYLES[displayRadicalInfo.role]}`}
-              >
-                {displayRadicalInfo.role} — {ROLE_DESCRIPTIONS[displayRadicalInfo.role]}
-              </span>
-            </div>
-            <p className="text-sm text-indigo-700">{displayRadicalInfo.meaning}</p>
+        {/* Color legend — show when in colorMode and not mergeMode */}
+        {colorMode && !mergeMode && decomp.components.length > 1 && (
+          <div className="flex flex-wrap gap-2 justify-center">
+            {decomp.components.map((comp, idx) => {
+              const colorIdx = idx % RADICAL_COLOR_CLASSES.length;
+              return (
+                <span
+                  key={`legend-${idx}`}
+                  className={`text-xs font-semibold px-2 py-0.5 rounded-full bg-surface-container-low ${RADICAL_COLOR_CLASSES[colorIdx]}`}
+                >
+                  {comp.radical} = {comp.label}
+                </span>
+              );
+            })}
           </div>
-        ) : displayRadical && relatedChars.length === 0 ? (
-          /* 部件資料庫尚未收錄此部件 — 顯示 fallback 以免點擊無回饋（#1099） */
-          <div className="rounded-xl bg-surface-container border border-dashed border-gray-300 px-4 py-3 space-y-1">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-lg font-bold text-on-surface-variant">{displayRadical}</span>
-              <span className="text-[9px] px-1.5 py-0.5 rounded-full border border-gray-200 bg-surface-container-low text-on-surface-variant font-medium">
-                部件
-              </span>
-            </div>
-            <p className="text-sm text-gray-600">此部件目前暫無詳細資料</p>
-            <p className="text-xs text-gray-400">教學團隊持續補充中</p>
+        )}
+
+        {/* mergeMode celebration banner */}
+        {colorMode && mergeMode && (
+          <div className="rounded-xl bg-emerald-50 border border-emerald-200 px-4 py-3 text-center animate-fade-in">
+            <p className="text-sm font-semibold text-emerald-700">
+              部件合在一起，就成了「{char}」這個字！
+            </p>
           </div>
-        ) : null}
+        )}
 
-        {/* Related characters */}
-        {relatedChars.length > 0 && (
-          <div className="space-y-2">
-            <div className="flex items-center gap-1.5">
-              <span className="text-xs font-semibold text-gray-600">含「{displayRadical}」的相關字</span>
-              <span className="text-[10px] text-gray-400">（點擊查看意思）</span>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {relatedChars.slice(0, MAX_CHIPS).map(item => (
-                <RelatedCharCard
-                  key={item.char}
-                  item={item}
-                  isSelected={selectedRelated?.char === item.char}
-                  onClick={() => handleRelatedClick(item)}
-                />
-              ))}
-            </div>
+        {/* Normal mode: active radical detail — hidden when colorMode is on */}
+        {!colorMode && (
+          <>
+            {displayRadicalInfo ? (
+              <div className="rounded-xl bg-indigo-50 border border-indigo-100 px-4 py-3 space-y-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-lg font-bold text-indigo-800">{displayRadical}</span>
+                  <span
+                    className={`text-[9px] px-1.5 py-0.5 rounded-full border font-medium ${ROLE_STYLES[displayRadicalInfo.role]}`}
+                  >
+                    {displayRadicalInfo.role} — {ROLE_DESCRIPTIONS[displayRadicalInfo.role]}
+                  </span>
+                </div>
+                <p className="text-sm text-indigo-700">{displayRadicalInfo.meaning}</p>
+              </div>
+            ) : displayRadical && relatedChars.length === 0 ? (
+              /* 部件資料庫尚未收錄此部件 — 顯示 fallback 以免點擊無回饋（#1099） */
+              <div className="rounded-xl bg-surface-container border border-dashed border-gray-300 px-4 py-3 space-y-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-lg font-bold text-on-surface-variant">{displayRadical}</span>
+                  <span className="text-[9px] px-1.5 py-0.5 rounded-full border border-gray-200 bg-surface-container-low text-on-surface-variant font-medium">
+                    部件
+                  </span>
+                </div>
+                <p className="text-sm text-gray-600">此部件目前暫無詳細資料</p>
+                <p className="text-xs text-gray-400">教學團隊持續補充中</p>
+              </div>
+            ) : null}
 
-            {/* Selected character meaning popup */}
-            {selectedRelated && (
-              <div className="mt-2 px-3 py-2 bg-surface-container-low rounded-xl border border-gray-200 text-sm text-on-surface-variant">
-                <span className="font-bold text-on-surface">{selectedRelated.char}</span>
-                {' — '}
-                {getRelatedDisplayMeaning(selectedRelated)}
+            {/* Related characters */}
+            {relatedChars.length > 0 && (
+              <div className="space-y-2">
+                <div className="flex items-center gap-1.5">
+                  <span className="text-xs font-semibold text-gray-600">含「{displayRadical}」的相關字</span>
+                  <span className="text-[10px] text-gray-400">（點擊查看意思）</span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {relatedChars.slice(0, MAX_CHIPS).map(item => (
+                    <RelatedCharCard
+                      key={item.char}
+                      item={item}
+                      isSelected={selectedRelated?.char === item.char}
+                      onClick={() => handleRelatedClick(item)}
+                    />
+                  ))}
+                </div>
+
+                {/* Selected character meaning popup */}
+                {selectedRelated && (
+                  <div className="mt-2 px-3 py-2 bg-surface-container-low rounded-xl border border-gray-200 text-sm text-on-surface-variant">
+                    <span className="font-bold text-on-surface">{selectedRelated.char}</span>
+                    {' — '}
+                    {getRelatedDisplayMeaning(selectedRelated)}
+                  </div>
+                )}
               </div>
             )}
-          </div>
+          </>
         )}
       </div>
 

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -1,3 +1,15 @@
+/**
+ * VocabPractice
+ *
+ * #1342 additions:
+ *  - practiceRound: 1 | 2 | 'done' state per character
+ *    - Round 1 (仿寫): left panel (character + radical) visible
+ *    - Round 2 (再生回憶): left panel hidden; student writes from memory
+ *  - RadicalDecomposition now rendered with colorMode=true in round 1,
+ *    and a brief mergeMode flash before transitioning to round 2
+ *  - Skip button for round 2 (tracked but not blocking)
+ */
+
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Story, ReadingAttempt, VocabResult } from '../../types';
 import { hasStrokeData } from '../stroke-order/strokeData';
@@ -13,6 +25,9 @@ interface VocabPracticeProps {
   onFinish: (result: VocabResult) => void;
   onBack: () => void;
 }
+
+/** Per-character practice round state */
+type CharRound = 1 | 2 | 'done';
 
 /* ================================================================ */
 /*  Main component                                                   */
@@ -40,6 +55,17 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   );
   const [currentIndex, setCurrentIndex] = useState(savedProgress.current?.currentIndex ?? 0);
 
+  // ── #1342: per-character round tracking ──────────────────────────
+  // charRounds maps char → current round. Characters start at round 1.
+  // "done" = both rounds completed (or round 2 skipped).
+  const [charRounds, setCharRounds] = useState<Map<string, CharRound>>(new Map());
+
+  // Whether the "合體" merge animation is playing between round 1 → 2
+  const [showMergeAnimation, setShowMergeAnimation] = useState(false);
+
+  // Tracks which chars had round 2 skipped (for analytics / reporting)
+  const skippedRecallRef = useRef<Set<string>>(new Set());
+
   const { zhuyinActive, processZhuyin } = useZhuyin();
 
   // Persist progress
@@ -60,7 +86,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
     const optional: string[] = [];
     for (const line of story.content) {
       for (const ch of line) {
-        if (/[\u4e00-\u9fa5]/.test(ch) && hasStrokeData(ch) && !seen.has(ch)) {
+        if (/[一-龥]/.test(ch) && hasStrokeData(ch) && !seen.has(ch)) {
           optional.push(ch);
           seen.add(ch);
         }
@@ -85,11 +111,34 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   const zhuyinStr = zhuyinActive ? processZhuyin(currentChar) : null;
   const allDone = displayChars.length > 0 && displayChars.every(ch => practicedChars.has(ch));
 
+  // Current round for this character (default 1 if not set)
+  const currentRound: CharRound = charRounds.get(currentChar) ?? 1;
+
+  // ── Round helpers ─────────────────────────────────────────────────
+
+  /**
+   * Called when WriteCharacter fires onComplete (user finished all strokes).
+   * Round 1 → show 合體 animation → advance to round 2.
+   * Round 2 / done → mark as practiced and move to next char.
+   */
   const handleCharComplete = () => {
+    if (currentRound === 1) {
+      // Show merge animation for ~1.2 s then switch to round 2
+      setShowMergeAnimation(true);
+      setCharRounds(prev => new Map(prev).set(currentChar, 2));
+      setTimeout(() => setShowMergeAnimation(false), 1200);
+    } else {
+      // Round 2 complete — mark done and advance
+      markCharDone(currentChar);
+    }
+  };
+
+  const markCharDone = (ch: string) => {
+    setCharRounds(prev => new Map(prev).set(ch, 'done'));
     setPracticedChars(prev => {
-      const next = new Set(prev).add(currentChar);
+      const next = new Set(prev).add(ch);
       // Auto-advance to next unpracticed character (use updated set)
-      const nextUnpracticed = displayChars.findIndex((ch, i) => i > currentIndex && !next.has(ch));
+      const nextUnpracticed = displayChars.findIndex((c, i) => i > currentIndex && !next.has(c));
       if (nextUnpracticed >= 0) {
         setCurrentIndex(nextUnpracticed);
       } else if (currentIndex < displayChars.length - 1) {
@@ -97,6 +146,14 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
       }
       return next;
     });
+  };
+
+  /**
+   * Skip round 2 — mark as done immediately, log skip.
+   */
+  const handleSkipRecall = () => {
+    skippedRecallRef.current.add(currentChar);
+    markCharDone(currentChar);
   };
 
   // The "unlocked" character: first unpracticed overall (next to complete)
@@ -147,6 +204,13 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
       </div>
     );
   }
+
+  // Whether to show left stimulus panel (hide in round 2 = recall mode)
+  const showLeftPanel = currentRound !== 2;
+  // Whether RadicalDecomposition should use colorMode
+  const radicalColorMode = currentRound === 1;
+  // Whether to show mergeMode (brief flash when transitioning 1→2)
+  const radicalMergeMode = showMergeAnimation;
 
   return (
     <div className="flex-1 flex flex-col bg-surface overflow-y-auto pb-32">
@@ -235,58 +299,109 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
           </div>
         )}
 
-        <div className="w-full max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-12 gap-6 items-start">
+        {/* ── Round indicator banner ─────────────────────────────────── */}
+        {!practicedChars.has(currentChar) && (
+          <div className="max-w-6xl mx-auto mb-4">
+            {currentRound === 1 ? (
+              <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-blue-50 border border-blue-200 w-fit">
+                <span className="w-5 h-5 rounded-full bg-blue-600 text-white text-xs font-bold flex items-center justify-center shrink-0">1</span>
+                <span className="text-sm font-medium text-blue-700">第 1 次：仿寫練習（參考左側提示）</span>
+              </div>
+            ) : currentRound === 2 ? (
+              <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-amber-50 border border-amber-300 w-fit">
+                <span className="w-5 h-5 rounded-full bg-amber-600 text-white text-xs font-bold flex items-center justify-center shrink-0">2</span>
+                <span className="text-sm font-medium text-amber-700">第 2 次：再生回憶（靠記憶寫，不看提示！）</span>
+              </div>
+            ) : null}
+          </div>
+        )}
+
+        <div className={[
+          'w-full max-w-6xl mx-auto grid gap-6 items-start',
+          showLeftPanel ? 'grid-cols-1 md:grid-cols-12' : 'grid-cols-1',
+        ].join(' ')}>
 
           {/* ── Left panel: character info + radical decomposition ──── */}
-          <div className="md:col-span-5 lg:col-span-4 flex flex-col gap-4">
-            {/* Character + zhuyin + pronunciation */}
-            <div
-              className="p-6 rounded-3xl bg-surface-container-lowest shadow-editorial flex items-center justify-center gap-5"
-              style={{
-                fontFamily: zhuyinActive
-                  ? "'BpmfZihiSans', 'Noto Sans TC', sans-serif"
-                  : undefined,
-              }}
-            >
-              <p className="text-7xl font-bold text-on-surface leading-none">{zhuyinActive ? zhuyinStr : currentChar}</p>
-              <button
-                onClick={() => {
-                  if (window.speechSynthesis) {
-                    const u = new SpeechSynthesisUtterance(currentChar);
-                    u.lang = 'zh-TW';
-                    u.rate = 0.8;
-                    window.speechSynthesis.speak(u);
-                  }
+          {/* Hidden in round 2 (再生回憶) */}
+          {showLeftPanel && (
+            <div className="md:col-span-5 lg:col-span-4 flex flex-col gap-4">
+              {/* Character + zhuyin + pronunciation */}
+              <div
+                className="p-6 rounded-3xl bg-surface-container-lowest shadow-editorial flex items-center justify-center gap-5"
+                style={{
+                  fontFamily: zhuyinActive
+                    ? "'BpmfZihiSans', 'Noto Sans TC', sans-serif"
+                    : undefined,
                 }}
-                className="w-12 h-12 rounded-full bg-accent/10 flex items-center justify-center hover:bg-accent/15 active:scale-[0.95] transition-all shrink-0"
-                aria-label="聽發音"
               >
-                <span className="material-symbols-outlined text-accent text-2xl" style={{ fontVariationSettings: "'FILL' 1" }}>volume_up</span>
-              </button>
-            </div>
-
-            {/* Radical decomposition — inline */}
-            {decomp && (
-              <div className="rounded-3xl bg-surface-container-low">
-                <RadicalDecomposition char={currentChar} />
+                <p className="text-7xl font-bold text-on-surface leading-none">{zhuyinActive ? zhuyinStr : currentChar}</p>
+                <button
+                  onClick={() => {
+                    if (window.speechSynthesis) {
+                      const u = new SpeechSynthesisUtterance(currentChar);
+                      u.lang = 'zh-TW';
+                      u.rate = 0.8;
+                      window.speechSynthesis.speak(u);
+                    }
+                  }}
+                  className="w-12 h-12 rounded-full bg-accent/10 flex items-center justify-center hover:bg-accent/15 active:scale-[0.95] transition-all shrink-0"
+                  aria-label="聽發音"
+                >
+                  <span className="material-symbols-outlined text-accent text-2xl" style={{ fontVariationSettings: "'FILL' 1" }}>volume_up</span>
+                </button>
               </div>
-            )}
-          </div>
+
+              {/* Radical decomposition — inline, with colorMode in round 1 */}
+              {decomp && (
+                <div className="rounded-3xl bg-surface-container-low">
+                  <RadicalDecomposition
+                    char={currentChar}
+                    colorMode={radicalColorMode}
+                    mergeMode={radicalMergeMode}
+                  />
+                </div>
+              )}
+            </div>
+          )}
 
           {/* ── Right panel: writing canvas ─────────────────────────── */}
-          <div className="md:col-span-7 lg:col-span-8 flex flex-col gap-4">
+          <div className={showLeftPanel ? 'md:col-span-7 lg:col-span-8 flex flex-col gap-4' : 'flex flex-col gap-4'}>
+
+            {/* Round 2 recall reminder — shown above the canvas when left panel is hidden */}
+            {currentRound === 2 && (
+              <div className="rounded-2xl bg-amber-50 border border-amber-200 px-5 py-4 flex items-start gap-3">
+                <span className="text-2xl leading-none mt-0.5">🧠</span>
+                <div>
+                  <p className="text-sm font-semibold text-amber-800">再生回憶模式</p>
+                  <p className="text-xs text-amber-700 mt-0.5">
+                    左側提示已收起。憑剛才的印象，試著把「{currentChar}」完整寫出來！
+                  </p>
+                </div>
+              </div>
+            )}
+
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-6">
               <WriteCharacter
-                key={currentChar}
+                key={`${currentChar}-round${currentRound}`}
                 character={currentChar}
                 onComplete={handleCharComplete}
                 embedded
               />
             </div>
+
+            {/* Skip round 2 button */}
+            {currentRound === 2 && (
+              <div className="flex justify-end">
+                <button
+                  onClick={handleSkipRecall}
+                  className="text-xs text-on-surface-variant hover:text-on-surface px-3 py-1.5 rounded-full hover:bg-surface-container-high transition-all"
+                >
+                  跳過第 2 次練習
+                </button>
+              </div>
+            )}
           </div>
         </div>
-
-        {/* Character chip strip handles navigation — no separate selector needed */}
       </div>
 
       {/* ── Fixed bottom CTA — only show "完成練習" when all done ──── */}

--- a/frontend/src/components/reading-steps/__tests__/RadicalDecomposition.colorMode.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/RadicalDecomposition.colorMode.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Tests for #1342: RadicalDecomposition colorMode + mergeMode props.
+ *
+ * These tests only verify the structural/textual changes driven by the new
+ * props. Canvas-heavy or API-dependent behavior is covered by e2e/QA tests.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import RadicalDecomposition, { RADICAL_COLOR_CLASSES } from '../RadicalDecomposition';
+
+// Stub the data/radicals module so we don't need the large JSON chunks
+vi.mock('../../../data/radicals', () => ({
+  getDecomposition: vi.fn((char: string) => {
+    if (char === '攻') {
+      return {
+        components: [
+          { radical: '工', role: '聲符', label: '音符' },
+          { radical: '攵', role: '形符', label: '動作' },
+        ],
+      };
+    }
+    return null; // treated as 獨體字
+  }),
+  getDecompositionSource: vi.fn(() => 'hand-curated'),
+  getRadicalInfo: vi.fn(() => null),
+  getRelatedChars: vi.fn(() => []),
+  initGeneratedDecompositions: vi.fn(() => Promise.resolve()),
+  initRadicalMeanings: vi.fn(() => Promise.resolve()),
+}));
+
+// Stub lookupCharactersBatch
+vi.mock('../../../services/learningApi', () => ({
+  lookupCharactersBatch: vi.fn(() => Promise.resolve({ results: [] })),
+}));
+
+describe('RadicalDecomposition colorMode + mergeMode (#1342)', () => {
+  it('exports RADICAL_COLOR_CLASSES array with at least 3 entries', () => {
+    expect(Array.isArray(RADICAL_COLOR_CLASSES)).toBe(true);
+    expect(RADICAL_COLOR_CLASSES.length).toBeGreaterThanOrEqual(3);
+    // All entries must be Tailwind text-* classes
+    for (const cls of RADICAL_COLOR_CLASSES) {
+      expect(cls).toMatch(/^text-/);
+    }
+  });
+
+  it('renders 部件拆解 header in default mode', () => {
+    render(<RadicalDecomposition char="攻" />);
+    expect(screen.getByText('部件拆解')).toBeTruthy();
+  });
+
+  it('renders 部件上色 header when colorMode=true', () => {
+    render(<RadicalDecomposition char="攻" colorMode />);
+    expect(screen.getByText('部件上色')).toBeTruthy();
+  });
+
+  it('renders 合體！ header when colorMode=true and mergeMode=true', () => {
+    render(<RadicalDecomposition char="攻" colorMode mergeMode />);
+    expect(screen.getByText('合體！')).toBeTruthy();
+  });
+
+  it('shows merge celebration banner in mergeMode', () => {
+    render(<RadicalDecomposition char="攻" colorMode mergeMode />);
+    expect(screen.getByText(/部件合在一起，就成了「攻」這個字！/)).toBeTruthy();
+  });
+
+  it('hides related-chars section in colorMode', () => {
+    render(<RadicalDecomposition char="攻" colorMode />);
+    // Related chars section label should not be present
+    expect(screen.queryByText(/含「/)).toBeNull();
+  });
+
+  it('shows color legend when colorMode=true and not mergeMode', () => {
+    render(<RadicalDecomposition char="攻" colorMode />);
+    // Color legend shows "radical = label" format
+    expect(screen.getByText(/工 = 音符/)).toBeTruthy();
+    expect(screen.getByText(/攵 = 動作/)).toBeTruthy();
+  });
+
+  it('renders 獨體字 fallback when char has no decomposition', () => {
+    render(<RadicalDecomposition char="一" colorMode />);
+    expect(screen.getByText('獨體字')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #1342

## Summary

Per 5/1 曾教授 / 陳教授 framework on automating Chinese character learning:

- **部件拆解上色**: Each radical component gets a distinct color (emerald / blue / amber / rose / violet — WCAG AAA + color-blind friendly). After round-1 writing, a brief 「合體」 animation fades all colors back to default, reinforcing「字 = 部件合體」
- **第 2 次再生回憶**: After completing round-1 strokes, the left stimulus panel (character + decomposition) is hidden and student writes from memory only. A skip button is available (tracked but non-blocking)

## Files changed

| File | Change |
|------|--------|
| `RadicalDecomposition.tsx` | Added `colorMode` + `mergeMode` props; exported `RADICAL_COLOR_CLASSES` |
| `VocabPractice.tsx` | Added `charRounds` state (1→2→done), conditional left panel, skip button, round indicator banner |
| `RadicalDecomposition.colorMode.test.tsx` | 8 new tests for colorMode/mergeMode props |

## Test plan

1. Open any lesson (e.g. lesson with 攻 or 練)
2. Navigate to 生字練習 step (VocabPractice)
3. **Round 1**: left panel shows character + colored radical decomposition, color legend visible
4. Complete all strokes → brief 「合體！」 banner appears on the decomposition panel
5. **Round 2**: left panel hidden, amber recall-mode banner shown above canvas, student writes from memory
6. Complete round 2 → character marked done, chip gets green checkmark
7. **Skip**: in round 2, tap 跳過 → character still marked done
8. `npm run build` — clean

## Smoke test

- Lesson: any lesson from `backend/data/lessons/`
- Character: 攻 (2 components: 工 聲符 + 攵 形符) — tests both color positions