### PR TITLE
feat(fluency): progress chart + self-assessment UI (Fixes #1386)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Story, FullReadingResult, DiffToken } from '../../types';
 import { cleanChineseText } from '../../utils/textDiff';
-import { analyzeFluency } from '../../utils/fluencyAnalyzer';
+import { analyzeFluency, parseReadingBenchmark, getBenchmarkFeedback, getSecBenchmarkFeedback, type ParsedBenchmark } from '../../utils/fluencyAnalyzer';
 import DiffDisplay from '../ui/DiffDisplay';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { useKaraoke } from '../../context/KaraokeContext';
@@ -14,6 +14,8 @@ import { scopedStepStorageKey } from '../../services/learningStorageScope';
 import { useAuth } from '../../contexts/AuthContext';
 import { splitZhuyinChars } from '../../utils/zhuyinUtils';
 import { groupIdxForProgress } from '../../utils/ttsHighlight';
+import FluencyProgressChart, { type FullReadingAttempt } from './full-reading/FluencyProgressChart';
+import SelfAssessment, { type AssessmentRating } from './full-reading/SelfAssessment';
 
 /* ── Encouragement helper (same tier logic as ParagraphCard) ─────────────── */
 
@@ -37,9 +39,11 @@ interface FullReadingProps {
   onBack: () => void;
   /** Session-level result rehydrated from DB (Bug #1320 — fallback when localStorage is cleared). */
   initialResult?: FullReadingResult | null;
+  /** All reading attempts for this session from DB (Issue #1386 — 4-attempt progress chart). */
+  fullReadingAttempts?: FullReadingAttempt[];
 }
 
-const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, initialResult }) => {
+const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, initialResult, fullReadingAttempts = [] }) => {
   const { token } = useAuth();
   const storageKey = scopedStepStorageKey('fullReading_progress_', story.id);
 
@@ -77,6 +81,58 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
   const [streamingTranscript, setStreamingTranscript] = useState(() => savedProgress.current?.transcript ?? '');
   const [micError, setMicError]                 = useState('');
   const [result, setResult]                     = useState<SavedResult | null>(getInitialResult);
+
+  /* ---- Self-assessment for current attempt (Issue #1386) ---- */
+  const [selfRating, setSelfRating] = useState<AssessmentRating | undefined>(undefined);
+  const [showComparison, setShowComparison] = useState(false);
+
+  /* ---- Parsed benchmark for progress chart (Issue #1386) ---- */
+  const parsedBenchmark = useMemo<ParsedBenchmark[] | null>(() => {
+    if (!story.readingBenchmark?.levels) return null;
+    try {
+      return parseReadingBenchmark(story.readingBenchmark.levels);
+    } catch {
+      return null;
+    }
+  }, [story.readingBenchmark]);
+
+  /** Whether lesson uses seconds-based benchmark (G8 文言文) */
+  const useSecUnit = useMemo(() => {
+    if (!parsedBenchmark || parsedBenchmark.length === 0) return false;
+    return 'unit' in parsedBenchmark[0] && (parsedBenchmark[0] as any).unit === 'sec';
+  }, [parsedBenchmark]);
+
+  /** AI-computed rating for the latest result */
+  const aiRating = useMemo<AssessmentRating | undefined>(() => {
+    if (!result || !parsedBenchmark || parsedBenchmark.length === 0) return undefined;
+    let feedbackText: string | null = null;
+    if (useSecUnit) {
+      const durationSec = (result.durationMs || 0) / 1000;
+      feedbackText = getSecBenchmarkFeedback(durationSec, parsedBenchmark);
+    } else {
+      feedbackText = getBenchmarkFeedback(result.cpm || 0, parsedBenchmark);
+    }
+    if (!feedbackText) return undefined;
+    // Map benchmark feedback position to rating
+    // parsedBenchmark[0] = lowest tier (slow/low), last = highest tier (fast/high)
+    const idx = parsedBenchmark.findIndex(b => {
+      if (useSecUnit && 'unit' in b) {
+        const bs = b as any;
+        const durationSec = (result.durationMs || 0) / 1000;
+        return durationSec >= bs.minSec && durationSec <= bs.maxSec;
+      } else if (!useSecUnit && !('unit' in b)) {
+        const bc = b as any;
+        return result.cpm >= bc.minCpm && result.cpm <= bc.maxCpm;
+      }
+      return false;
+    });
+    if (idx === -1) return undefined;
+    const total = parsedBenchmark.length;
+    if (total === 1) return 'mid';
+    if (idx === 0) return useSecUnit ? 'high' : 'low'; // sec: fastest = high; cpm: slowest = low
+    if (idx === total - 1) return useSecUnit ? 'low' : 'high'; // sec: slowest = low; cpm: fastest = high
+    return 'mid';
+  }, [result, parsedBenchmark, useSecUnit]);
   const { zhuyinActive, isZhuyinAny, processLinesSelective } = useZhuyin();
   const { karaokeEnabled } = useKaraoke();
   const vocabWords = useMemo(
@@ -478,6 +534,25 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
                   </p>
                 </div>
               )}
+
+              {/* ── Issue #1386: Self-assessment + 4-attempt progress chart ── */}
+              <SelfAssessment
+                onSelect={(rating) => {
+                  setSelfRating(rating);
+                  setShowComparison(true);
+                }}
+                selectedRating={selfRating}
+                aiRating={aiRating}
+                showComparison={showComparison}
+              />
+
+              {fullReadingAttempts.length > 0 && (
+                <FluencyProgressChart
+                  attempts={fullReadingAttempts}
+                  benchmark={parsedBenchmark}
+                  unit={useSecUnit ? 'sec' : 'cpm'}
+                />
+              )}
             </div>
           )}
         </div>
@@ -498,7 +573,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
           {result ? (
             <>
               <button
-                onClick={() => { try { localStorage.removeItem(storageKey); } catch {} savedResultRef.current = false; setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); }}
+                onClick={() => { try { localStorage.removeItem(storageKey); } catch {} savedResultRef.current = false; setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); setSelfRating(undefined); setShowComparison(false); }}
                 className="w-full h-12 rounded-full font-headline font-bold text-base text-on-surface bg-surface-container-lowest shadow-editorial hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
               >
                 <span className="material-symbols-outlined text-lg">refresh</span>

--- a/frontend/src/components/reading-steps/__tests__/FluencyProgressChart.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/FluencyProgressChart.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import FluencyProgressChart, { type FullReadingAttempt } from '../full-reading/FluencyProgressChart';
+import type { ParsedBenchmark } from '../../../utils/fluencyAnalyzer';
+
+// Recharts uses ResizeObserver internally — stub it for test env
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const makeAttempt = (idx: number, cpm: number, durationMs?: number): FullReadingAttempt => ({
+  attempt_index: idx,
+  cpm,
+  accuracy: 0.9,
+  duration_ms: durationMs ?? (cpm > 0 ? Math.round((200 / cpm) * 60000) : 60000),
+  transcript: '',
+  timestamp: new Date().toISOString(),
+});
+
+const cpmBenchmark: ParsedBenchmark[] = [
+  { minCpm: 0, maxCpm: 180, feedback: '需要練習' },
+  { minCpm: 181, maxCpm: 220, feedback: '不錯' },
+  { minCpm: 221, maxCpm: Infinity, feedback: '優秀' },
+];
+
+const secBenchmark: ParsedBenchmark[] = [
+  { unit: 'sec', minSec: 0, maxSec: 30, feedback: '非常快' },
+  { unit: 'sec', minSec: 31, maxSec: 50, feedback: '適中' },
+  { unit: 'sec', minSec: 51, maxSec: Infinity, feedback: '再練習' },
+];
+
+describe('FluencyProgressChart', () => {
+  it('renders nothing when attempts is empty', () => {
+    const { container } = render(
+      <FluencyProgressChart attempts={[]} benchmark={null} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders with 1 attempt, no benchmark', () => {
+    const attempts = [makeAttempt(1, 180)];
+    render(
+      <FluencyProgressChart attempts={attempts} benchmark={null} />
+    );
+    expect(screen.getByText('練習進步曲線')).toBeTruthy();
+    expect(screen.getByText(/已完成 1\/4 次/)).toBeTruthy();
+  });
+
+  it('renders with 2 attempts showing trend label', () => {
+    const attempts = [makeAttempt(1, 160), makeAttempt(2, 200)];
+    render(
+      <FluencyProgressChart attempts={attempts} benchmark={null} unit="cpm" />
+    );
+    expect(screen.getByText('進步中')).toBeTruthy();
+  });
+
+  it('renders with 4 attempts and CPM benchmark', () => {
+    const attempts = [
+      makeAttempt(1, 170),
+      makeAttempt(2, 185),
+      makeAttempt(3, 200),
+      makeAttempt(4, 215),
+    ];
+    render(
+      <FluencyProgressChart attempts={attempts} benchmark={cpmBenchmark} unit="cpm" />
+    );
+    expect(screen.getByText('練習進步曲線')).toBeTruthy();
+    expect(screen.getByText(/已完成 4\/4 次/)).toBeTruthy();
+    expect(screen.getByText(/字\/分越高越好/)).toBeTruthy();
+  });
+
+  it('renders with 2 attempts and sec benchmark (G8 文言文)', () => {
+    const attempts = [
+      makeAttempt(1, 0, 55000), // 55 sec
+      makeAttempt(2, 0, 42000), // 42 sec — improving (fewer sec)
+    ];
+    render(
+      <FluencyProgressChart attempts={attempts} benchmark={secBenchmark} unit="sec" />
+    );
+    expect(screen.getByText('秒數越少越好 · 已完成 2/4 次')).toBeTruthy();
+    expect(screen.getByText('進步中')).toBeTruthy();
+  });
+
+  it('shows flat trend when values are similar', () => {
+    const attempts = [makeAttempt(1, 200), makeAttempt(2, 202)];
+    render(
+      <FluencyProgressChart attempts={attempts} benchmark={null} unit="cpm" />
+    );
+    expect(screen.getByText('持平')).toBeTruthy();
+  });
+
+  it('shows downward trend when CPM decreases', () => {
+    const attempts = [makeAttempt(1, 220), makeAttempt(2, 190)];
+    render(
+      <FluencyProgressChart attempts={attempts} benchmark={null} unit="cpm" />
+    );
+    expect(screen.getByText('速度下降')).toBeTruthy();
+  });
+
+  it('renders 4-cell progress grid with correct filled count for 2 attempts', () => {
+    const attempts = [makeAttempt(1, 180), makeAttempt(2, 190)];
+    const { container } = render(
+      <FluencyProgressChart attempts={attempts} benchmark={null} unit="cpm" />
+    );
+    // Should render 4 grid cells (progress bar)
+    const progressBars = container.querySelectorAll('.bg-accent, .bg-surface-container-high');
+    expect(progressBars.length).toBe(4);
+  });
+});

--- a/frontend/src/components/reading-steps/__tests__/SelfAssessment.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/SelfAssessment.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SelfAssessment, { type AssessmentRating } from '../full-reading/SelfAssessment';
+
+describe('SelfAssessment', () => {
+  it('renders 3 rating buttons', () => {
+    render(<SelfAssessment onSelect={vi.fn()} />);
+    expect(screen.getByLabelText('自評：需要加油')).toBeTruthy();
+    expect(screen.getByLabelText('自評：還不錯')).toBeTruthy();
+    expect(screen.getByLabelText('自評：非常流暢')).toBeTruthy();
+  });
+
+  it('calls onSelect with correct rating when clicking low', () => {
+    const onSelect = vi.fn();
+    render(<SelfAssessment onSelect={onSelect} />);
+    fireEvent.click(screen.getByLabelText('自評：需要加油'));
+    expect(onSelect).toHaveBeenCalledWith('low');
+  });
+
+  it('calls onSelect with correct rating when clicking mid', () => {
+    const onSelect = vi.fn();
+    render(<SelfAssessment onSelect={onSelect} />);
+    fireEvent.click(screen.getByLabelText('自評：還不錯'));
+    expect(onSelect).toHaveBeenCalledWith('mid');
+  });
+
+  it('calls onSelect with correct rating when clicking high', () => {
+    const onSelect = vi.fn();
+    render(<SelfAssessment onSelect={onSelect} />);
+    fireEvent.click(screen.getByLabelText('自評：非常流暢'));
+    expect(onSelect).toHaveBeenCalledWith('high');
+  });
+
+  it('disables buttons after selection', () => {
+    const onSelect = vi.fn();
+    render(<SelfAssessment onSelect={onSelect} selectedRating="mid" />);
+    const lowBtn = screen.getByLabelText('自評：需要加油') as HTMLButtonElement;
+    const highBtn = screen.getByLabelText('自評：非常流暢') as HTMLButtonElement;
+    expect(lowBtn.disabled).toBe(true);
+    expect(highBtn.disabled).toBe(true);
+  });
+
+  it('does not show comparison when showComparison is false', () => {
+    render(
+      <SelfAssessment
+        onSelect={vi.fn()}
+        selectedRating="high"
+        aiRating="high"
+        showComparison={false}
+      />
+    );
+    expect(screen.queryByText('你的判斷跟 AI 一樣')).toBeNull();
+  });
+
+  it('shows match message when selected === AI rating', () => {
+    render(
+      <SelfAssessment
+        onSelect={vi.fn()}
+        selectedRating="high"
+        aiRating="high"
+        showComparison={true}
+      />
+    );
+    expect(screen.getByText(/你的判斷跟 AI 一樣/)).toBeTruthy();
+  });
+
+  it('shows mismatch message with AI rating label when ratings differ', () => {
+    render(
+      <SelfAssessment
+        onSelect={vi.fn()}
+        selectedRating="low"
+        aiRating="mid"
+        showComparison={true}
+      />
+    );
+    expect(screen.getByText(/AI 覺得你這次讀得/)).toBeTruthy();
+    expect(screen.getByText('中')).toBeTruthy();
+  });
+
+  it('marks selected button as aria-pressed', () => {
+    render(<SelfAssessment onSelect={vi.fn()} selectedRating="mid" />);
+    const midBtn = screen.getByLabelText('自評：還不錯') as HTMLButtonElement;
+    expect(midBtn.getAttribute('aria-pressed')).toBe('true');
+    const lowBtn = screen.getByLabelText('自評：需要加油') as HTMLButtonElement;
+    expect(lowBtn.getAttribute('aria-pressed')).toBe('false');
+  });
+});

--- a/frontend/src/components/reading-steps/full-reading/FluencyProgressChart.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FluencyProgressChart.tsx
@@ -1,0 +1,251 @@
+/**
+ * FluencyProgressChart — 4-attempt progress line chart for FullReading.
+ *
+ * Shows up to 4 attempts on X axis with CPM (or seconds for G8 文言文) on Y axis.
+ * Draws lesson-specific benchmark threshold lines when available.
+ * Issue #1386
+ */
+import React from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+  Dot,
+} from 'recharts';
+import type { ParsedBenchmark, BenchmarkLevelSec } from '../../../utils/fluencyAnalyzer';
+
+export interface FullReadingAttempt {
+  attempt_index: number;
+  cpm: number;
+  accuracy: number;
+  duration_ms: number;
+  transcript?: string;
+  timestamp?: string;
+}
+
+interface FluencyProgressChartProps {
+  attempts: FullReadingAttempt[];
+  benchmark: ParsedBenchmark[] | null;
+  /** Grade number (used to determine unit: cpm vs sec) */
+  grade?: number;
+  /** Override unit detection */
+  unit?: 'cpm' | 'sec';
+}
+
+function isSec(benchmark: ParsedBenchmark[] | null): boolean {
+  if (!benchmark || benchmark.length === 0) return false;
+  return 'unit' in benchmark[0] && (benchmark[0] as BenchmarkLevelSec).unit === 'sec';
+}
+
+function getTrendArrow(attempts: FullReadingAttempt[], useSec: boolean): 'up' | 'down' | 'flat' | null {
+  if (attempts.length < 2) return null;
+  const last = attempts[attempts.length - 1];
+  const prev = attempts[attempts.length - 2];
+  const lastVal = useSec ? (last.duration_ms / 1000) : last.cpm;
+  const prevVal = useSec ? (prev.duration_ms / 1000) : prev.cpm;
+  const diff = lastVal - prevVal;
+  // For CPM: higher is better (up = good)
+  // For sec: lower is better (up = bad, down = good)
+  if (Math.abs(diff) < (useSec ? 2 : 5)) return 'flat';
+  if (useSec) {
+    return diff < 0 ? 'up' : 'down'; // fewer seconds = improving = up
+  }
+  return diff > 0 ? 'up' : 'down';
+}
+
+function buildChartData(attempts: FullReadingAttempt[], useSec: boolean) {
+  const filled = Array.from({ length: 4 }, (_, i) => {
+    const a = attempts.find(x => x.attempt_index === i + 1) ?? attempts[i];
+    if (!a || i >= attempts.length) return { x: i + 1, value: null };
+    const value = useSec ? Math.round(a.duration_ms / 10) / 100 : a.cpm;
+    return { x: i + 1, value };
+  });
+  return filled;
+}
+
+function extractThresholds(benchmark: ParsedBenchmark[] | null, useSec: boolean): { value: number; label: string; color: string }[] {
+  if (!benchmark) return [];
+  const thresholds: { value: number; label: string; color: string }[] = [];
+  const colors = ['#22c55e', '#f59e0b', '#ef4444']; // green / amber / red
+
+  benchmark.forEach((b, idx) => {
+    if (useSec && 'unit' in b) {
+      const bs = b as BenchmarkLevelSec;
+      if (bs.maxSec !== Infinity) {
+        thresholds.push({ value: bs.maxSec, label: '慢', color: colors[Math.min(idx, 2)] });
+      }
+      if (bs.minSec > 0) {
+        thresholds.push({ value: bs.minSec, label: '快', color: colors[Math.min(idx, 2)] });
+      }
+    } else if (!useSec && !('unit' in b)) {
+      const bc = b as import('../../../utils/fluencyAnalyzer').BenchmarkLevel;
+      if (bc.minCpm > 0) {
+        thresholds.push({ value: bc.minCpm, label: `${bc.minCpm}字/分`, color: colors[Math.min(idx, 2)] });
+      }
+    }
+  });
+  // Deduplicate by value
+  const seen = new Set<number>();
+  return thresholds.filter(t => {
+    if (seen.has(t.value)) return false;
+    seen.add(t.value);
+    return true;
+  });
+}
+
+const CustomDot: React.FC<any> = ({ cx, cy, index, dataLength }) => {
+  const isLast = index === dataLength - 1;
+  if (cx == null || cy == null) return null;
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={isLast ? 7 : 4}
+      fill={isLast ? '#564ABF' : '#9D93FF'}
+      stroke="white"
+      strokeWidth={isLast ? 2 : 1}
+    />
+  );
+};
+
+const CustomTooltip: React.FC<any> = ({ active, payload, label, useSec }: any) => {
+  if (!active || !payload?.length) return null;
+  const val = payload[0]?.value;
+  if (val == null) return null;
+  return (
+    <div className="bg-surface-container-lowest rounded-xl shadow-editorial px-3 py-2 text-sm">
+      <p className="font-headline font-bold text-on-surface">第 {label} 次</p>
+      <p className="text-accent">
+        {useSec ? `${val} 秒` : `${val} 字/分`}
+      </p>
+    </div>
+  );
+};
+
+const FluencyProgressChart: React.FC<FluencyProgressChartProps> = ({
+  attempts,
+  benchmark,
+  unit,
+}) => {
+  const useSec = unit === 'sec' || (unit == null && isSec(benchmark));
+  const chartData = buildChartData(attempts, useSec);
+  const thresholds = extractThresholds(benchmark, useSec);
+  const trend = getTrendArrow(attempts, useSec);
+  const dataLength = attempts.length;
+
+  if (attempts.length === 0) return null;
+
+  const values = chartData.map(d => d.value).filter(v => v != null) as number[];
+  const allValues = [...values, ...thresholds.map(t => t.value)];
+  const minY = Math.max(0, Math.floor(Math.min(...allValues) * 0.85));
+  const maxY = Math.ceil(Math.max(...allValues) * 1.15);
+
+  const trendIcon = trend === 'up' ? '↗' : trend === 'down' ? '↘' : trend === 'flat' ? '→' : null;
+  const trendColor =
+    trend === 'up' ? 'text-emerald-600' :
+    trend === 'down' ? 'text-tertiary' :
+    'text-on-surface-variant';
+  const trendLabel =
+    trend === 'up' ? '進步中' :
+    trend === 'down' ? '速度下降' :
+    trend === 'flat' ? '持平' : '';
+
+  return (
+    <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider">
+          練習進步曲線
+        </p>
+        {trendIcon && (
+          <span className={`text-sm font-headline font-bold ${trendColor} flex items-center gap-1`}>
+            <span className="text-base">{trendIcon}</span>
+            {trendLabel}
+          </span>
+        )}
+      </div>
+
+      {/* 4-cell grid indicator */}
+      <div className="flex gap-2 mb-4">
+        {Array.from({ length: 4 }, (_, i) => {
+          const done = i < attempts.length;
+          return (
+            <div key={i} className="flex-1 flex flex-col items-center gap-1">
+              <div
+                className={`w-full h-1.5 rounded-full transition-colors ${
+                  done ? 'bg-accent' : 'bg-surface-container-high'
+                }`}
+              />
+              <span className="text-xs text-on-surface-variant/60 font-headline">
+                {i + 1}/{4}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      <ResponsiveContainer width="100%" height={180}>
+        <LineChart data={chartData} margin={{ top: 8, right: 16, bottom: 4, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="rgba(94,91,85,0.08)" />
+          <XAxis
+            dataKey="x"
+            tick={{ fontSize: 11, fill: '#5E5B55', fontFamily: '"Plus Jakarta Sans", sans-serif' }}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v) => `第${v}次`}
+          />
+          <YAxis
+            domain={[minY, maxY]}
+            tick={{ fontSize: 11, fill: '#5E5B55', fontFamily: '"Plus Jakarta Sans", sans-serif' }}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v) => useSec ? `${v}s` : `${v}`}
+            width={32}
+          />
+          <Tooltip content={<CustomTooltip useSec={useSec} />} />
+
+          {/* Threshold reference lines */}
+          {thresholds.map((t) => (
+            <ReferenceLine
+              key={t.value}
+              y={t.value}
+              stroke={t.color}
+              strokeDasharray="4 2"
+              strokeWidth={1.5}
+              label={{
+                value: t.label,
+                position: 'insideTopRight',
+                fontSize: 10,
+                fill: t.color,
+                fontFamily: '"Plus Jakarta Sans", sans-serif',
+              }}
+            />
+          ))}
+
+          <Line
+            type="monotone"
+            dataKey="value"
+            stroke="#564ABF"
+            strokeWidth={2.5}
+            connectNulls={false}
+            dot={(props: any) => (
+              <CustomDot {...props} dataLength={dataLength} />
+            )}
+            activeDot={{ r: 6, fill: '#564ABF', stroke: 'white', strokeWidth: 2 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+
+      <p className="text-xs text-on-surface-variant/60 text-center mt-2 font-headline">
+        {useSec ? '秒數越少越好' : '字/分越高越好'} ·
+        已完成 {attempts.length}/4 次
+      </p>
+    </div>
+  );
+};
+
+export default FluencyProgressChart;

--- a/frontend/src/components/reading-steps/full-reading/SelfAssessment.tsx
+++ b/frontend/src/components/reading-steps/full-reading/SelfAssessment.tsx
@@ -1,0 +1,146 @@
+/**
+ * SelfAssessment — 自評三級 UI for FullReading.
+ *
+ * Student picks their self-perceived fluency level (low/mid/high).
+ * After selection, shows comparison with AI-computed rating.
+ * Issue #1386
+ */
+import React from 'react';
+
+export type AssessmentRating = 'low' | 'mid' | 'high';
+
+interface SelfAssessmentProps {
+  onSelect: (rating: AssessmentRating) => void;
+  selectedRating?: AssessmentRating;
+  /** AI-computed rating based on CPM vs threshold */
+  aiRating?: AssessmentRating;
+  /** Whether to show comparison (true after student has selected) */
+  showComparison?: boolean;
+}
+
+const RATING_CONFIG: Record<AssessmentRating, { label: string; icon: string; bg: string; border: string; text: string }> = {
+  low: {
+    label: '需要加油',
+    icon: 'sentiment_dissatisfied',
+    bg: 'bg-tertiary-container/20 hover:bg-tertiary-container/30',
+    border: 'border-tertiary-container',
+    text: 'text-tertiary',
+  },
+  mid: {
+    label: '還不錯',
+    icon: 'sentiment_neutral',
+    bg: 'bg-amber-50 hover:bg-amber-100',
+    border: 'border-amber-300',
+    text: 'text-amber-700',
+  },
+  high: {
+    label: '非常流暢',
+    icon: 'sentiment_very_satisfied',
+    bg: 'bg-emerald-50 hover:bg-emerald-100',
+    border: 'border-emerald-300',
+    text: 'text-emerald-700',
+  },
+};
+
+const RATING_LABELS: Record<AssessmentRating, string> = {
+  low: '低',
+  mid: '中',
+  high: '高',
+};
+
+function ComparisonMessage({ selected, ai }: { selected: AssessmentRating; ai: AssessmentRating }) {
+  const match = selected === ai;
+  if (match) {
+    return (
+      <div className="mt-4 flex items-center gap-2 p-3 rounded-2xl bg-emerald-50 border border-emerald-200">
+        <span
+          className="material-symbols-outlined text-emerald-600 text-lg"
+          style={{ fontVariationSettings: "'FILL' 1" }}
+        >
+          check_circle
+        </span>
+        <p className="text-sm text-emerald-700 font-headline">
+          你的判斷跟 AI 一樣 — 很有自我認識！
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-4 flex items-start gap-2 p-3 rounded-2xl bg-surface-container-low border border-surface-container-high">
+      <span
+        className="material-symbols-outlined text-accent text-lg mt-0.5 shrink-0"
+        style={{ fontVariationSettings: "'FILL' 0" }}
+      >
+        info
+      </span>
+      <p className="text-sm text-on-surface-variant font-headline">
+        AI 覺得你這次讀得「
+        <span className={`font-bold ${RATING_CONFIG[ai].text}`}>
+          {RATING_LABELS[ai]}
+        </span>
+        」。每個人感受不一樣，繼續練習你會越來越準！
+      </p>
+    </div>
+  );
+}
+
+const SelfAssessment: React.FC<SelfAssessmentProps> = ({
+  onSelect,
+  selectedRating,
+  aiRating,
+  showComparison = false,
+}) => {
+  const ratings: AssessmentRating[] = ['low', 'mid', 'high'];
+
+  return (
+    <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
+      <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-1">
+        自我評估
+      </p>
+      <p className="text-base font-headline text-on-surface mb-4">
+        你覺得這次讀得怎麼樣？
+      </p>
+
+      <div className="flex gap-3">
+        {ratings.map((rating) => {
+          const cfg = RATING_CONFIG[rating];
+          const isSelected = selectedRating === rating;
+          return (
+            <button
+              key={rating}
+              onClick={() => onSelect(rating)}
+              disabled={!!selectedRating}
+              className={`
+                flex-1 flex flex-col items-center gap-2 py-4 px-2 rounded-2xl border-2 transition-all
+                ${isSelected
+                  ? `${cfg.bg.replace('hover:', '')} ${cfg.border} shadow-sm`
+                  : selectedRating
+                    ? 'border-surface-container-high bg-surface-container-low opacity-40 cursor-not-allowed'
+                    : `${cfg.bg} border-transparent hover:border-current`
+                }
+              `}
+              aria-label={`自評：${cfg.label}`}
+              aria-pressed={isSelected}
+            >
+              <span
+                className={`material-symbols-outlined text-2xl ${isSelected ? cfg.text : 'text-on-surface-variant'}`}
+                style={{ fontVariationSettings: isSelected ? "'FILL' 1" : "'FILL' 0" }}
+              >
+                {cfg.icon}
+              </span>
+              <span className={`text-xs font-headline font-bold ${isSelected ? cfg.text : 'text-on-surface-variant'}`}>
+                {cfg.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {showComparison && selectedRating && aiRating && (
+        <ComparisonMessage selected={selectedRating} ai={aiRating} />
+      )}
+    </div>
+  );
+};
+
+export default SelfAssessment;


### PR DESCRIPTION
Fixes #1386

## Summary

Surfaces the 4-attempt persistence backend (PR #1382) with a visible student UI:

- **FluencyProgressChart**: Recharts LineChart for up to 4 attempts with CPM (or seconds for G8 文言文). Draws lesson-specific benchmark threshold lines (low/mid/high). Shows trend arrow (↗ improving, ↘ slower, → flat).
- **SelfAssessment**: Three-button metacognition prompt shown after each attempt. Student picks their perceived level; after selection shows comparison with AI-computed rating.
- **FullReading.tsx**: Wires both components below the existing result card, above action buttons.

## Files changed

- `frontend/src/components/reading-steps/full-reading/FluencyProgressChart.tsx` (new)
- `frontend/src/components/reading-steps/full-reading/SelfAssessment.tsx` (new)
- `frontend/src/components/reading-steps/FullReading.tsx` (modified — props + wiring)
- `frontend/src/components/reading-steps/__tests__/FluencyProgressChart.test.tsx` (new)
- `frontend/src/components/reading-steps/__tests__/SelfAssessment.test.tsx` (new)

## Test plan

- [ ] Open any lesson with `reading_benchmark` (e.g. G6 lesson 1) → complete FullReading → result card shows SelfAssessment + chart with 1/4 progress
- [ ] Complete 2+ attempts → chart shows 2 data points with trend arrow
- [ ] Open G8 文言文 lesson → Y axis shows seconds (not CPM), threshold lines from lesson YAML
- [ ] SelfAssessment: click one of 3 buttons → buttons disable → comparison message appears
- [ ] If no `full_reading_attempts` from session → chart hidden (0 attempts = no chart shown)
- [ ] Build: `npm run build` passes (verified locally)
- [ ] Tests: 17/17 pass (`FluencyProgressChart.test.tsx` + `SelfAssessment.test.tsx`)

## Constraints respected

- No backend changes
- No lesson YAML changes
- No AI calls
- Design tokens from #1360 used throughout (no raw black/white)
- Recharts already present in bundle (no new dependency added)