### PR TITLE
fix: G7 strategy_exercise list format causes 500 (Fixes #1390)

### DIFF
--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, Union
 
 
 class VocabItemSchema(BaseModel):
@@ -50,7 +50,7 @@ class StoryDetail(StoryListItem):
     reading_benchmark: Optional[ReadingBenchmarkSchema] = None
     text_type: str = "單"
     source_file: Optional[str] = None
-    strategy_exercise: Optional[dict] = None  # 閱讀策略練習 (#943)
+    strategy_exercise: Optional[Union[dict, list]] = None  # 閱讀策略練習 (#943); list for multi-exercise lessons (G7 圖文整合)
     # Schema-driven step composition (#1374): per-lesson step order from YAML.
     # None means frontend uses DEFAULT_STEP_SEQUENCE fallback.
     step_sequence: Optional[list[str]] = None

--- a/backend/tests/test_strategy_exercise_schema.py
+++ b/backend/tests/test_strategy_exercise_schema.py
@@ -1,0 +1,131 @@
+"""
+Regression test for #1390: strategy_exercise Pydantic schema must accept both
+dict (G6 摘要策略) and list (G7 圖文整合) formats.
+
+Root cause: G7-L28~30 YAML uses `strategy_exercises` (list), which lesson_loader
+maps to the `strategy_exercise` field. The schema previously declared
+`Optional[dict]`, causing Pydantic validation error (500) for all G7 lessons.
+
+Run with:
+    cd backend && python -m pytest tests/test_strategy_exercise_schema.py -v
+"""
+
+import pytest
+from app.schemas.story import StoryDetail
+
+
+# Minimal valid StoryDetail data shared across tests
+def _base_detail(**overrides) -> dict:
+    base = {
+        "id": 1,
+        "title": "Test Story",
+        "grade": 7,
+        "grade_code": "G7",
+        "genre": "說明文",
+        "category": "圖文整合",
+        "char_count": 500,
+        "text_type": "單",
+        "paragraphs": ["第一段文字", "第二段文字"],
+        "strategy_exercise": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestStrategyExerciseSchemaAcceptsNone:
+    """Baseline: None is accepted (G6 摘要策略 without strategy_exercise)."""
+
+    def test_none_accepted(self):
+        detail = StoryDetail(**_base_detail(strategy_exercise=None))
+        assert detail.strategy_exercise is None
+
+
+class TestStrategyExerciseSchemaAcceptsDict:
+    """G6 摘要策略 format: single dict with type/strategy_name/etc."""
+
+    def test_dict_accepted(self):
+        exercise_dict = {
+            "type": "guided_steps",
+            "strategy_name": "摘要策略",
+            "instruction": "找出主角和主要事件",
+            "steps": [
+                {"prompt": "步驟一：找主角", "type": "free_text"},
+                {"prompt": "步驟二：找主要事件", "type": "free_text"},
+            ],
+        }
+        detail = StoryDetail(**_base_detail(strategy_exercise=exercise_dict))
+        assert isinstance(detail.strategy_exercise, dict)
+        assert detail.strategy_exercise["type"] == "guided_steps"
+
+
+class TestStrategyExerciseSchemaAcceptsList:
+    """G7 圖文整合 format: list of exercise items — regression test for #1390."""
+
+    def test_empty_list_accepted(self):
+        """G7-L28 has strategy_exercises: [] (empty list)."""
+        detail = StoryDetail(**_base_detail(strategy_exercise=[]))
+        assert detail.strategy_exercise == []
+
+    def test_list_with_items_accepted(self):
+        """G7-L29 / G7-L30: list with multiple exercise items and steps."""
+        exercises = [
+            {
+                "exercise": "練習一",
+                "description": "第一段 vs 圖一",
+                "steps": [
+                    {"step": "步驟❶", "description": "先讀文字——抓到重點"},
+                    {"step": "步驟❷", "description": "再看圖——先讀懂這張圖"},
+                    {"step": "步驟❸", "description": "回到文字——從圖中找對應的訊息"},
+                    {"step": "步驟❹", "description": "整合文圖——把文和圖合起來想"},
+                ],
+            },
+            {
+                "exercise": "練習二",
+                "description": "第二段 vs 圖二",
+                "steps": [
+                    {"step": "步驟❶", "description": "先讀文字"},
+                    {"step": "步驟❷", "description": "再看圖"},
+                ],
+            },
+        ]
+        detail = StoryDetail(**_base_detail(strategy_exercise=exercises))
+        assert isinstance(detail.strategy_exercise, list)
+        assert len(detail.strategy_exercise) == 2
+        assert detail.strategy_exercise[0]["exercise"] == "練習一"
+
+    def test_list_with_empty_steps_accepted(self):
+        """G7-L30 has some exercises with steps: [] (empty steps list)."""
+        exercises = [
+            {"exercise": "練習一", "description": "第一段 vs 圖一", "steps": []},
+        ]
+        detail = StoryDetail(**_base_detail(strategy_exercise=exercises))
+        assert detail.strategy_exercise[0]["steps"] == []
+
+
+class TestStrategyExerciseG7LessonIdsSimulated:
+    """Simulate the exact data shape that lesson_loader returns for G7-L28/29/30."""
+
+    def test_g7_l28_empty_list(self):
+        """G7-L28: strategy_exercises: [] in YAML → strategy_exercise=[] in schema."""
+        # lesson_loader does: "strategy_exercise": data.get("strategy_exercises")
+        # G7-L28 YAML has: strategy_exercises: []
+        detail = StoryDetail(**_base_detail(id=1108, strategy_exercise=[]))
+        assert detail.strategy_exercise == []
+
+    def test_g7_l29_multi_exercises(self):
+        """G7-L29: strategy_exercises list with 5 exercises."""
+        exercises = [
+            {"exercise": f"練習{i}", "description": f"第{i}段 vs 圖{i}", "steps": []}
+            for i in range(1, 6)
+        ]
+        detail = StoryDetail(**_base_detail(id=1109, strategy_exercise=exercises))
+        assert len(detail.strategy_exercise) == 5
+
+    def test_g7_l30_multi_exercises(self):
+        """G7-L30: strategy_exercises list with 4 exercises."""
+        exercises = [
+            {"exercise": f"練習{i}", "description": f"第{i}段 vs 表{i}", "steps": []}
+            for i in range(1, 5)
+        ]
+        detail = StoryDetail(**_base_detail(id=1110, strategy_exercise=exercises))
+        assert len(detail.strategy_exercise) == 4

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -61,7 +61,7 @@ interface ApiStoryDetail extends ApiStoryListItem {
   text_type: string;
   source_file: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  strategy_exercise: Record<string, any> | null;
+  strategy_exercise: Record<string, any> | any[] | null;  // list for multi-exercise lessons (G7 圖文整合, #1390)
   // Schema-driven step composition (#1374)
   step_sequence: string[] | null;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -93,6 +93,13 @@ export interface StrategyExercise {
   steps?: StrategyExerciseStep[];
 }
 
+/** G7 圖文整合格式：多練習清單，每項含步驟 (#1390) */
+export interface StrategyExerciseItem {
+  exercise: string;
+  description: string;
+  steps: { step: string; description: string }[];
+}
+
 export interface Story {
   id: string;
   title: string;
@@ -117,7 +124,7 @@ export interface Story {
   multipleChoice?: MultipleChoiceItem[];     // ⑦ 閱讀理解選擇題（PDF 現成資料）
   vocabBank?: Record<string, string>;        // { A: "疑難雜症", ... } for fillInBlank
   knowledgeVideoUrl?: string;               // ⑨ 知識補給站 YouTube URL
-  strategyExercise?: StrategyExercise;      // 閱讀策略練習 (#943)
+  strategyExercise?: StrategyExercise | StrategyExerciseItem[];  // 閱讀策略練習 (#943); StrategyExerciseItem[] for G7 圖文整合 (#1390)
   /**
    * Optional per-lesson step sequence loaded from YAML `step_sequence` field (#1374).
    * When present, overrides DEFAULT_STEP_SEQUENCE for StepperNav and next/prev navigation.


### PR DESCRIPTION
Fixes #1390

## Root Cause

G7-L28~30 (圖文整合) YAML uses `strategy_exercises` (plural, list of exercise objects).
`lesson_loader.py` already maps `data.get("strategy_exercises") → strategy_exercise`.
But `StoryDetail` schema declared `strategy_exercise: Optional[dict]` — Pydantic rejected any list, causing HTTP 500.

G6-L22~25 (摘要策略) either have no `strategy_exercise` field (→ None) or a single dict → no problem.

**Error from Cloud Run logs:**
```
1 validation error for StoryDetail
strategy_exercise
Input should be a valid dictionary [type=dict_type, input_value=[...], input_type=list]
```

## Changes (minimal diff)

- `backend/app/schemas/story.py`: `Optional[dict]` → `Optional[Union[dict, list]]`
- `frontend/src/types.ts`: add `StrategyExerciseItem` interface, `Story.strategyExercise` accepts union
- `frontend/src/services/api.ts`: widen `ApiStoryDetail.strategy_exercise` to include `any[]`
- `backend/tests/test_strategy_exercise_schema.py`: 8 regression tests covering None/dict/list/empty-list/G7-L28/29/30 fixture shapes

## Test plan

```bash
# Backend unit tests (8/8 pass)
cd backend && python -m pytest tests/test_strategy_exercise_schema.py -v

# After PR preview deploys:
for id in 1076 1077 1078 1079 1108 1109 1110; do
  curl -s -o /dev/null -w "id=$id %{http_code}\n" "<PREVIEW_URL>/api/stories/$id"
done
# Expected: all 200
```

## What was NOT changed
- YAML data files (data is truth, bug was in code)
- `lesson_loader.py` (correct mapping already existed at line 326)
- No try/except silence, no lesson disable