### PR TITLE
fix(stories): bump page_size cap 100→300 to expose 7 designated lessons (Fixes #1394, Resolves #1383)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -170,7 +170,7 @@ def list_stories(
     category: str | None = Query(None),
     search: str | None = Query(None, max_length=100),
     page: int = Query(1, ge=1),
-    page_size: int = Query(60, ge=1, le=100),
+    page_size: int = Query(60, ge=1, le=300),
 ):
     """List published platform stories with optional filters.
 

--- a/backend/tests/test_stories_pagination.py
+++ b/backend/tests/test_stories_pagination.py
@@ -1,0 +1,109 @@
+"""
+Tests for /api/stories pagination — page_size cap (#1383).
+
+Background: backend loads 165 lessons (57 Layer-1 + 108 Layer-2 parsed),
+but the previous page_size cap (le=100) split them across 2+ pages.
+Frontend `fetchStories` defaulted to page=1 and never paginated, so the
+7 教授指定 lessons (G6-L22~25, G7-L28~30, IDs 1076-1110) which sort to
+page 2 were invisible to students.
+
+Fix: bump page_size cap from 100 → 300 so the entire bounded library
+(~270 lessons projected at 8/2026 full curriculum) fits in one request.
+
+Run with:
+    cd backend && python -m pytest tests/test_stories_pagination.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ── Cap boundary ─────────────────────────────────────────────────────────────
+
+
+class TestPageSizeCap:
+    def test_page_size_300_accepted(self, client):
+        """New cap (300) accepts the upper bound."""
+        resp = client.get("/api/stories?page_size=300")
+        assert resp.status_code == 200
+
+    def test_page_size_301_rejected(self, client):
+        """Cap is exclusive at 301 (le=300)."""
+        resp = client.get("/api/stories?page_size=301")
+        assert resp.status_code == 422
+
+    def test_page_size_100_still_works(self, client):
+        """Existing callers using 100 are unaffected."""
+        resp = client.get("/api/stories?page_size=100")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["stories"]) <= 100
+
+    def test_default_page_size_unchanged(self, client):
+        """Default page_size=60 is preserved (backward compat)."""
+        resp = client.get("/api/stories")
+        assert resp.status_code == 200
+        data = resp.json()
+        # total may be > 60; default returns at most 60
+        assert len(data["stories"]) <= 60
+
+
+# ── 7 educator-designated lessons reachable on page 1 with page_size=300 ────
+
+
+class TestSevenDesignatedLessonsReachable:
+    """7 lessons assigned for 7/1 deadline must be in first response when
+    frontend uses page_size=300."""
+
+    DESIGNATED_CODES = [
+        "G6-L22", "G6-L23", "G6-L24", "G6-L25",
+        "G7-L28", "G7-L29", "G7-L30",
+    ]
+
+    def test_all_seven_visible_on_page1_with_300(self, client):
+        resp = client.get("/api/stories?page_size=300")
+        assert resp.status_code == 200
+        codes_in_response = {s["grade_code"] for s in resp.json()["stories"]}
+        missing = [c for c in self.DESIGNATED_CODES if c not in codes_in_response]
+        assert missing == [], f"Missing designated lessons: {missing}"
+
+    def test_total_count_unchanged_by_page_size(self, client):
+        """`total` reflects the full library size regardless of page_size."""
+        small = client.get("/api/stories?page_size=10").json()
+        large = client.get("/api/stories?page_size=300").json()
+        assert small["total"] == large["total"]
+
+
+# ── Pagination math sanity ────────────────────────────────────────────────────
+
+
+class TestPaginationMath:
+    def test_page2_returns_remainder(self, client):
+        """page=2&page_size=100 returns at most (total - 100) stories."""
+        resp_all = client.get("/api/stories?page_size=300").json()
+        total = resp_all["total"]
+
+        resp_p1 = client.get("/api/stories?page=1&page_size=100").json()
+        resp_p2 = client.get("/api/stories?page=2&page_size=100").json()
+
+        assert len(resp_p1["stories"]) == min(100, total)
+        assert len(resp_p2["stories"]) == max(0, min(100, total - 100))
+
+    def test_page_beyond_end_returns_empty(self, client):
+        """Requesting page beyond available data returns empty list (not 404)."""
+        resp = client.get("/api/stories?page=999&page_size=10")
+        assert resp.status_code == 200
+        assert resp.json()["stories"] == []

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -117,7 +117,9 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
 export async function fetchStories(token?: string): Promise<{ stories: Story[]; total: number; grades: number[] }> {
   const headers: Record<string, string> = {};
   if (token) headers['Authorization'] = `Bearer ${token}`;
-  const res = await fetch(`${API_BASE}/api/stories`, { headers });
+  // Bounded content (~270 lessons): fetch all in one request so client-side
+  // grade/search filter responds instantly without re-querying the API.
+  const res = await fetch(`${API_BASE}/api/stories?page_size=300`, { headers });
   if (!res.ok) throw new Error(`fetchStories failed: ${res.status}`);
   const data: ApiStoryListResponse = await res.json();
   return {


### PR DESCRIPTION
## Problem

7 教授指定 lessons (G6-L22~25 摘要策略, G7-L28~30 圖文整合, IDs 1076-1110) 在 students stories list 完全看不到。

**Root cause 糾正**：backend 完整暴露 165 課（`total: 165`）— 是 frontend `fetchStories()` 預設沒帶 `page_size`，只拿 page=1（60 筆），7 課 sort 到 page 2 後就看不到了。

不是 backend gap，是 pagination 沒處理。

## Verification (before fix)

```bash
$ curl ".../api/stories" | jq '{count: .stories|length, total}'
{ count: 60, total: 165 }    # backend 知道有 165 課

$ curl ".../api/stories?page=2&page_size=100" | jq '.stories[].grade_code | select(startswith("G6-L2") or startswith("G7-L"))'
"G6-L22" "G6-L23" "G6-L24" "G6-L25" "G7-L28" "G7-L29" "G7-L30"   # 7 課全在 page 2
```

## Changes

| File | Change |
|---|---|
| `backend/app/routes/stories.py` | `page_size: le=100` → `le=300` |
| `frontend/src/services/api.ts` | `fetchStories` adds `?page_size=300` |
| `backend/tests/test_stories_pagination.py` | 8 new unit tests |

## Why 300 not unlimited

Teaching platform has bounded content: 4-9 年級 × 30 課 + 文言文 ≈ 250-270 lessons by 8/2026 full curriculum. 300 covers full library with headroom while preserving DoS protection.

Client-side filter (grade/search) responds instantly without re-querying API.

## Tests (8 PASS locally)

- `test_page_size_300_accepted` — new cap upper bound works
- `test_page_size_301_rejected` — cap is exclusive
- `test_page_size_100_still_works` — backward compat
- `test_default_page_size_unchanged` — default 60 preserved
- `test_all_seven_visible_on_page1_with_300` — 7 課 reachable
- `test_total_count_unchanged_by_page_size`
- `test_page2_returns_remainder` — pagination math
- `test_page_beyond_end_returns_empty` — graceful overflow

## Reviewed

`feature-dev:code-reviewer` PASS. One brittle test removed per reviewer recommendation (test would flip to false-fail as curriculum grows past 60 lower-grade lessons).

## Related

- PR #1391 — G7 schema fix (already merged)
- PR #1392 — parser coverage fix (in review)
- Together: 7 課 e2e demo unblocked for 7/1 deadline.