### PR TITLE
fix(ci): refresh DATABASE_URL from GH secret on every preview update (Fixes #1396)

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -178,12 +178,16 @@ jobs:
           echo "frontend_url=${FRONTEND_URL}" >> $GITHUB_OUTPUT
           echo "backend_url=${BACKEND_URL}" >> $GITHUB_OUTPUT
 
-      - name: Update backend CORS with actual frontend URL
+      - name: Update backend CORS + refresh DATABASE_URL from GH secret
         # Skip when backend preview service doesn't exist (frontend-only PR after
         # prior backend cleanup) — otherwise `gcloud run services update` fails.
+        # DATABASE_URL is re-injected on every run so GH secret rotations propagate
+        # to long-lived preview services without needing manual service rebuild
+        # (Fixes #1396).
         if: always() && steps.preview-urls.outputs.frontend_url != 'N/A' && steps.preview-urls.outputs.backend_url != 'N/A'
         env:
           FRONTEND_URL: ${{ steps.preview-urls.outputs.frontend_url }}
+          DATABASE_URL_SECRET: ${{ secrets.PREVIEW_DATABASE_URL }}
         run: |
           STAGING_URL="https://lingoleap-frontend-staging-958347263320.asia-east1.run.app"
           FIREBASE_URL="https://lingoleap-dev.web.app"
@@ -192,7 +196,7 @@ jobs:
           gcloud run services update ${{ env.BACKEND_SERVICE }} \
             --region ${{ env.REGION }} \
             --project ${{ env.PROJECT_ID }} \
-            --update-env-vars "^::^ALLOWED_ORIGINS=${FRONTEND_URL},${ALT_URL},${STAGING_URL},${FIREBASE_URL}"
+            --update-env-vars "^::^ALLOWED_ORIGINS=${FRONTEND_URL},${ALT_URL},${STAGING_URL},${FIREBASE_URL}::DATABASE_URL=${DATABASE_URL_SECRET}"
 
       - name: Warm backend to avoid cold-start CORS errors
         if: always() && steps.preview-urls.outputs.backend_url != 'N/A'


### PR DESCRIPTION
## Why

Per #1396 root cause: Cloud Run service env vars are **sticky**.
- First deploy uses \`--set-env-vars\` → DATABASE_URL plaintext burnt into service config
- Subsequent deploys use \`--update-env-vars ALLOWED_ORIGINS=...\` → DATABASE_URL never re-injected
- When GH secret \`PREVIEW_DATABASE_URL\` (or Cloud SQL postgres password) rotates, long-lived PR preview services keep the old value
- alembic upgrade fails with \`FATAL: password authentication failed for user postgres\` → container exit(1) → STARTUP TCP probe fail → deploy fail

This already bit #1389 today (5/1) — service had to be manually deleted + rebuilt.

## What

\`preview-deploy.yml:181\` step \"Update backend CORS with actual frontend URL\" now also re-injects DATABASE_URL on every run:

\`\`\`yaml
env:
  DATABASE_URL_SECRET: \${{ secrets.PREVIEW_DATABASE_URL }}
run: |
  ...
  --update-env-vars \"^::^ALLOWED_ORIGINS=...::DATABASE_URL=\${DATABASE_URL_SECRET}\"
\`\`\`

Secret passed via \`env:\` (not inline templating) → safe against shell quoting if secret contains special chars.

## Why this works

\`--update-env-vars\` only mutates named keys. Other vars set on first deploy (\`RUN_MIGRATIONS\`, \`AZURE_SPEECH_KEY\`, \`AZURE_SPEECH_REGION\`, \`TTS_PROVIDER\`) are preserved — they're only wiped by \`--set-env-vars\` (which CLAUDE.md explicitly forbids).

GH secret remains the source of truth. Every PR push re-aligns service env to current secret value.

## Verification

- [ ] Merge to staging
- [ ] Watch any subsequent PR preview deploy → confirm \`Update backend CORS + refresh DATABASE_URL\` step succeeds and DATABASE_URL appears in revision env
- [ ] Long-tail: next time someone rotates \`PREVIEW_DATABASE_URL\`, existing PR previews self-heal on next push (no manual service delete needed)

## Refs
- Fixes #1396
- Caused (and fixed via service rebuild): #1389