### PR TITLE
docs: 7/1 deadline planning + spec (Fixes #1399)

### DIFF
--- a/docs/ceo-review-2026-05-02.md
+++ b/docs/ceo-review-2026-05-02.md
@@ -1,0 +1,280 @@
+# CEO Review — 7/1 Deadline 60 天路線圖
+
+**日期**：2026-05-02（5/1 專家會議 +1 天）
+**分支**：`docs/issue-1378-fluency-research`
+**Mode**：SCOPE REDUCTION（建議）
+**Reviewer**：plan-ceo-review skill (gstack)
+**Source of truth**：[`docs/meetings/2026-05-01-experts-review.md`](meetings/2026-05-01-experts-review.md)
+
+---
+
+## 一、5/1 同日衝刺成果（事實校正）
+
+| 維度 | 5/1 凌晨 | 5/1 22:00 | 變化 |
+|---|---|---|---|
+| Merged PRs（5/1）| 0 | **25** | +25 |
+| Open issues 總數 | ~30 | ~28 | -11 close +9 new |
+| 7/1-deadline label | 16 | **9** | -7（多數已實作） |
+| 158 課 docx → YAML | 0% | **96%**（151/158 parsed） | 全新管線 |
+| YAML fast path | 0% | **6.7%**（14/208） | 邏輯通了，coverage 待擴 |
+| 設計 token 採用 | partial | tightened | #1360 |
+| 流暢度量化 | 無 backend | **CWPM + 三級門檻** | #1378 + #1382 backend；UI 待做 |
+| AI 助教 spec | 無 | **完整 SOP + 5 prompts** | #1372；0 行 code |
+| 圖文整合 | 無 | 無 | **未動** |
+| ComprehensionChat 單肥組件 | 1 個 | **3 個獨立 step** | #1349 |
+
+> **結論**：基礎建設層做掉 80%。剩下都是 user-facing 的 P0 + 兩個 hidden gap。
+
+---
+
+## 二、Premise challenge — 我們在解對的問題嗎？
+
+### 「2 單元 7 課做到極致」是對的框架
+
+✅ **對**。專家拍板，避免 60 天功能蔓延，符合 wartime 紀律。
+
+### 但「極致」沒定義 = 失控風險
+
+⚠️ **必須立刻定義可量化 KPI**（見第六節）。否則 60 天會在「再打磨一下」中被吃掉，尤其 Young 一個人主力。
+
+### 7/1 demo 給誰看？這直接決定砍多少
+
+| Demo 對象 | 隱含 KPI | 砍誰可活 |
+|---|---|---|
+| **教授團隊**（曾世杰、陳淑麗、林校長） | UI/UX 完整、AI 助教引導合教學法、紙本對照清晰 | 砍 OMO、教師後台、遊戲化、Layer-1 57 課 |
+| **真實學生**（8 校 100 人） | 穩定不爆、能自主完成、有進步可見 | 砍 AI 助教語音（先文字）、砍進階儀表板 |
+| **方大哥募資/招生** | Wow factor、現場 5 分鐘看完震撼 | 砍 7 課中的 5 課（只展 G6-L22 + G7-L28）|
+
+> **CEO 建議**：**先答「給誰看」再規劃**。我假設是教授+校長 = 教學法正確性 > UI 炫技 > 規模。
+
+---
+
+## 三、Dream state delta
+
+```
+今天 (5/1)                7/1 milestone              12-MONTH IDEAL
+────────────              ─────────────              ──────────────
+158 課資料齊        →     7 課世界級展示            →  158 課全可教
+AI 助教 0 行 code   →     AI 助教文字版可用          →  AI 助教語音 + 個別化
+圖文整合 = 上下     →     左右並陳 + 滾動同步        →  紙本 OMO 雙向
+YAML 6.7%           →     7 課 100% YAML            →  全 YAML，AI 只診斷
+教授看 demo         →     教授+校長+真實學生用       →  體育班取代教科書
+```
+
+**60 天可達**：左欄 → 中欄
+**60 天不可達**：中欄 → 右欄（不要嘗試）
+
+---
+
+## 四、Implementation alternatives
+
+### Approach A：全廣度（拒絕）
+**Summary**：158 課全填 step_sequence + AI 助教覆蓋 12 策略 + OMO + 教師後台
+**Effort**：XL（人類 6 個月，CC+Young 仍需 12 週）
+**Risk**：High — 60 天根本不可能，每樣都半成品
+**結論**：**砍**
+
+### Approach B：7 課專修（推薦）⭐
+**Summary**：
+- 7 課做到世界級（教授指定 G6-L22~25 + G7-L28~30）
+- AI 助教只訓練 2 套 prompt（摘要 PSR + 圖文整合），覆蓋這 7 課
+- 圖文整合介面只解這 7 課的圖
+- 其他 201 課照舊運作（不引入新功能、不破壞）
+
+**Effort**：CC+Young 約 4-5 週實作 + 2 週 polish + 1 週緩衝 = **57 天**（含 5/1）
+**Risk**：Medium — bottleneck 在 AI 助教 + 圖文介面（兩者都有 design sketch 但 0 行 code）
+**Reuses**：今天 5/1 全部 25 PR、socratic_agent.py pattern、ComprehensionChat 拆分後的容器
+
+### Approach C：Demo only（保底）
+**Summary**：7 課全部 happy path，不上學生 → 教授會議能看，但無真實 traction
+**Effort**：CC+Young 3 週
+**Risk**：Low 但浪費教授團隊已交付的 158 課寶藏
+
+**RECOMMENDATION：Approach B**。理由：時間夠（緊但不爆），保留學生實測機會，且基礎建設今天已就位。
+
+---
+
+## 五、SCOPE REDUCTION — 砍誰可活
+
+### ✂️ 60 天內**不做**（已 confirmed 砍）
+
+| 項目 | 原狀 | 砍的理由 |
+|---|---|---|
+| Layer-1 原始 57 課跑 parser | 從沒跑 → 全打 AI | 7/1 不演這些課 |
+| OMO Cold Start（紙本拍照）| #1343 | 教授肯定但不是 demo 必含 |
+| 教師後台儀表板 | #1364 | 學期實際只 10 節，數據量不足 demo 用 |
+| 努力計分（不只看對錯）| #1363 | 沒 KPI 直接做 = 加料無效 |
+| 年級代號 ABCDE | #1362 | 命名可後改 |
+| 文言文模組 | #1365 已標 P3 暫緩 | 5/1 共識 |
+| 158 課全填 step_sequence | #1384 改 demo 3 課 | scope creep |
+| AI 助教覆蓋 12 策略 | #1372 spec 已有 5 套 | demo 只用 2 套（PSR + 圖文）|
+| AI 助教**語音版** | #1340 spec 含語音 | 7/1 demo 用文字版即可，語音 7/2 後 |
+| 老師批改 UI | 5/1 共識 | 陳教授說系統批即可 |
+
+### ✅ 必做（7/1 不可砍）
+
+| 優先 | 項目 | issue | 預估 effort |
+|---|---|---|---|
+| **P0-1** | 圖文整合左右並陳介面（單元 B 核心）| #1341 | 1 週 |
+| **P0-2** | AI 助教文字版實作（PSR 摘要 + 圖文整合 2 策略）| #1340 → #1387 | 2 週 |
+| **P0-3** | 7 課全部走 YAML fast path（修 parser + 補資料）| 無 issue（agent 修中）| 3-4 天 |
+| **P0-4** | data gap：parsed lessons 暴露於 stories list | #1383 | 1-2 天 |
+| **P1-1** | 流暢度 UI 折線圖（學生看見進步）| #1386 | 3-5 天 |
+| **P1-2** | 7 課 step_sequence demo（schema-driven 證明）| #1384 | 2-3 天 |
+| **P1-3** | 詞彙流程結束重排（理解→應用→造句）| #1336 verify | 1 天（可能已 done） |
+| **P1-4** | 字距行距 / 非黑體 / 注音僅難字 | done | ✅ 都 merged |
+
+### 🟡 機會主義（有空才做）
+
+- 第三階段 L123-L157 教師版（陳教授還沒交，外部 blocker）
+- 閱讀聚光燈引導語音腳本錄製（曾教授會錄，外部 blocker）
+- AI 助教延伸到推論策略 / 比較觀點 / 覺察策略
+- Layer-1 57 課跑 parser 補 YAML
+
+---
+
+## 六、Success KPIs（7/1 demo 通過標準）
+
+**必須在 5/8 之前敲定這份 KPI 表，否則整個 60 天沒有北極星。**
+
+### A. 7 課覆蓋
+
+| KPI | 目標 | 現況 | 量測 |
+|---|---|---|---|
+| 7 課可從 stories list 訪問 | 7/7 | 0/7（僅 backend 載入但 list 沒暴露）| `curl /api/stories \| jq` |
+| 7 課走 YAML fast path（latency < 500ms）| 7/7 | 2/7 | `curl /structure/{id}` 計時 |
+| 7 課圖文整合介面正確顯示 | 3/3 單元 B | 0/3 | 視覺驗證 |
+| 7 課 AI 助教引導正確（per strategy）| 7/7 | 0/7 | 手測 + 錯答觸發引導 |
+
+### B. 教學法品質（教授驗收）
+
+| KPI | 目標 | 量測 |
+|---|---|---|
+| 林校長 5 步驟 SOP 命中率 | ≥ 80% 引導符合 | 教授看 10 個學生答錯實況 |
+| 摘要 PSR 引導引出「問題/解決/結果」三段 | 3/3 | 學生口述含三段 |
+| 圖文整合引導引出「圖↔文對應」 | 3/3 | 學生會在圖上指對應段落 |
+| AI 不直接給答案的比例 | ≥ 90% | rescue session log 抽查 |
+
+### C. 系統穩定（學生實測）
+
+| KPI | 目標 | 量測 |
+|---|---|---|
+| 7 課 e2e 完成率 | ≥ 90% | session 完成 step ≥ 5 |
+| AI 助教平均回應 latency | < 6s p50 | log timing |
+| Crash / 500 / session lost rate | < 1% | Cloud Run logs |
+
+> 沒過上面 KPI = 不能說「7 課做到極致」，等於沒交差。
+
+---
+
+## 七、60 天路線（5/2 → 7/1）
+
+### Week 1（5/2 - 5/8）：Hidden gap 修 + KPI 敲定
+- ⏳ Parser fix（agent 跑中）— 7 課全走 YAML
+- 🆕 #1383 data gap fix — list endpoint 暴露 151 課
+- 🆕 把上面 KPI 表跟方大哥+教授確認（5/8 視訊）
+- 🆕 確定「demo 給誰看」（決定砍/留）
+- ✅ 詞彙流程驗收 #1336
+
+### Week 2-3（5/9 - 5/22）：圖文整合介面
+- 🆕 #1341 左右並陳 + 獨立滾動 + 圖↔文錨點
+- 真實圖片素材（從教授交付的 G7-L28~30 docx 提取）
+- E2E 測 3 課單元 B 視覺正確
+
+### Week 4-6（5/23 - 6/12）：AI 助教文字版
+- 🆕 #1387 backend mcq_rescue_agent.py（沿用 socratic_agent pattern）
+- 🆕 PSR + 圖文整合兩套 strategy_prompts.yml
+- 🆕 frontend RescueChatBox component
+- E2E 測 5 步驟 SOP 在 7 課全跑通
+- 真實學生 alpha 測（5 人，內部）
+
+### Week 7（6/13 - 6/19）：流暢度 UI + schema demo
+- 🆕 #1386 折線圖（4 次練習 + 三級自評）
+- 🆕 #1384 7 課 step_sequence 設定（證明 schema-driven）
+
+### Week 8（6/20 - 6/26）：Polish + 真實學生 beta
+- 全平台 design review pass
+- 邀 5-10 真實學生（透過林校長）跑完 7 課
+- bug fix 衝刺
+
+### Week 9（6/27 - 7/1）：Demo 準備 + 最終驗收
+- 教授團隊 dry run
+- 錄 demo video（萬一現場 demo 出包）
+- 7/1 正式 demo
+
+---
+
+## 八、Risk register（CEO 角度）
+
+| Risk | 機率 | Impact | 緩解 |
+|---|---|---|---|
+| AI 助教 latency 太慢學生放棄 | High | High | 用 gemini-2.5-flash + 預先 cache 常見錯答；< 6s p50 為硬門檻 |
+| 圖文整合介面在小螢幕不可用 | Med | High | 7 課固定用 iPad / desktop 演示；mobile 後做 |
+| 教授團隊增加新需求拖時程 | High | Med | 5/8 凍結 KPI；新增需求一律進 7/2+ backlog |
+| Young 一人主力過勞 | High | High | 把 P1 切給敬行/啟翔；Young 守 P0 |
+| Parser fix 失敗或延宕 | Low | High | agent 跑中；fallback 是 7 課手動補 yaml |
+| 第三階段教師版 docx 卡陳教授 | Med | Low | 7/1 demo 不依賴 L123-157，所以可接受 |
+| Cloud Run 突發費用爆衝 | Low | Med | YAML fast path 已上、AI 配額 5/min/user 限制 |
+
+---
+
+## 九、Team allocation（who does what）
+
+| 人 | 7/1 主責 | 為什麼 |
+|---|---|---|
+| **Young** | #1340/#1387 AI 助教 backend + 整合 | 唯一掌握全棧 + ai_service pattern |
+| **敬行** | #1341 圖文整合介面（state 管理）+ #1386 流暢度 UI | 強項是 data flow + state management |
+| **啟翔** | 7 課 visual polish + design tokens 全平台 audit + #1384 demo 設定 | 強項是 UI/UX 視覺 |
+| **方大哥** | KPI 敲定 + 教授協調（曾教授錄音腳本、陳教授補教師版）| 對外溝通 |
+| **教授團隊** | 5/8 KPI 確認、5/15 中期 review、6/15 alpha 測試陪同 | 教學法把關 |
+
+---
+
+## 十、What I'd push back on
+
+如果你問我「CEO 角度有什麼要挑戰」：
+
+1. **「7 課做到極致」必須 7/1 demo 才有意義**。如果延到 7/8 或 8/1 並沒有外部成本，今天的 wartime 沒必要。確認硬 deadline 是真的（教授會議？募資 milestone？）— 如果是軟的，B 方案還能再緩一週多顯得從容。
+
+2. **AI 助教文字版可能不夠 wow**。林校長許願的是語音對話。如果 7/1 demo 給校長看而拿出文字版 → 失焦。建議在 6/20 alpha beta 時實測一個簡化版「TTS 念出 AI 引導 + 學生語音輸入轉文字」，至少模擬語音感受。
+
+3. **真實學生實測太晚**。Week 8 才上 5-10 學生 → 6/27 之前我們不知道學生會不會卡關。建議週 6 第二週（6/8 起）就邀 2-3 學生跑單一課（不必全 7 課），早期收 feedback。
+
+4. **流暢度 UI #1386 不是 P0**。學生看到自己進步固然好，但不影響教授驗收教學法。可降到 P1 / 機會主義。
+
+5. **沒有人在管 marketing / 招生 / 募資對接**。如果 7/1 demo 後沒有「下一步該怎麼推」的 plan，60 天衝刺的成果就會卡在 demo room 裡。建議 5/15 開始想 7/2-9/1 推廣 plan。
+
+---
+
+## 十一、Decisions waiting
+
+| # | 問題 | 為什麼這時要答 | 我的建議 |
+|---|---|---|---|
+| Q1 | 7/1 demo 給誰看？（教授 / 校長 / 真實學生 / 方大哥募資）| 影響砍誰可活 | 教授+校長為主，學生實測作旁證 |
+| Q2 | AI 助教 7/1 必須語音版嗎？ | 影響 effort 2 倍 | 文字版即可，語音延 7/2+ |
+| Q3 | 7/1 deadline 是硬的嗎？ | 影響整個節奏 | 假設硬，若軟則放鬆 1 週 |
+| Q4 | 真實學生實測哪一週開始？ | 影響 feedback loop | 6/8（早 2 週）|
+| Q5 | 是否同意把 #1386 降為 P1？ | 影響 sequencing | 同意 |
+
+---
+
+## 十二、Completion summary
+
+```
++====================================================================+
+|            CEO PLAN REVIEW — 7/1 DEADLINE 60-DAY ROADMAP            |
++====================================================================+
+| Mode             | SCOPE REDUCTION                                  |
+| Approach         | B — 7 課專修                                      |
+| 5/1 sprint       | 25 PRs merged, 80% 基礎建設完成                   |
+| 真 blocker       | 4（圖文介面、AI 助教、parser、data gap）          |
+| 砍掉             | 10 項（OMO、158 全課、語音、教師後台、12 策略）    |
+| 必做             | 4 P0 + 4 P1                                       |
+| Hidden risk      | parser 6.7% coverage、AI 助教 0 行 code           |
+| Team load        | Young P0、敬行 P1、啟翔 polish                    |
+| Outside blocker  | 教師版 L123-157、AI 助教語音腳本                  |
+| KPI 鎖定截止     | 5/8（demo 對象 + 量化指標）                       |
++====================================================================+
+```
+
+**VERDICT — 60 天可達 Approach B（7 課世界級），條件是：(1) 5/8 前敲定 KPI (2) AI 助教守文字版 (3) 圖文介面 5/22 前 ship。任何延遲必須立刻砍 P1。**

--- a/docs/qa-evidence-2026-05-02-7-lessons-readiness.md
+++ b/docs/qa-evidence-2026-05-02-7-lessons-readiness.md
@@ -1,0 +1,210 @@
+# QA Evidence Pack — 7 課 7/1 Deadline Readiness
+
+**Date**: 2026-05-02 01:30 local
+**Prepared by**: Claude (lingoleap-dev-assistant) + spawned git-issue-pr-flow agents
+**For**: Young + 隔壁工程師 + 任何接手 QA 人員
+
+---
+
+## TL;DR
+
+3 個 Sev-1 / 7/1-blocker 修完，全 staging verified：
+
+| Fix | PR | 修什麼 | 已 staging verified |
+|---|---|---|---|
+| **#1391** | merged 17:13 | G7-L28~30 schema 500 regression（`Optional[Union[dict,list]]`）| ✅ |
+| **#1392** | merged 17:26 | Parser coverage 9.3% → 19.9%；7 課全有 `story_structure_table` | ✅ |
+| **#1395** | merged 17:28 | Stories list page_size cap 100→300；frontend fetch 全 165 課 | ✅ deployed rev 00626 @ 17:38, e2e verified |
+
+7 課 backend e2e ready：HTTP 200 + YAML fast path < 100ms + rows count 對到 expected。
+
+---
+
+## Pre-deploy 狀態（5/1 16:00）
+
+```
+G6-L22 (id 1076) → 200，YAML 85ms，9 rows
+G6-L23~25 (1077-1079) → 200，AI 5s（沒 YAML structure_table）
+G7-L28 (1108) → 200 ❌ 後面 16:19 部署後變 500
+G7-L29~30 (1109-1110) → 500 ❌
+```
+
+7 課可用率：**1/7**（只 G6-L22 demo-ready）
+
+---
+
+## Post-deploy 狀態（5/2 01:30，#1395 部署完成後）
+
+### A. /api/stories/{id} HTTP status（#1391 verified）
+
+```python
+STAGING = "https://lingoleap-backend-staging-958347263320.asia-east1.run.app"
+for id in [1076, 1077, 1078, 1079, 1108, 1109, 1110]:
+    r = requests.get(f"{STAGING}/api/stories/{id}")
+    assert r.status_code == 200
+```
+
+實測結果：
+```
+id=1076 (G6-L22) → 200 ✅
+id=1077 (G6-L23) → 200 ✅
+id=1078 (G6-L24) → 200 ✅
+id=1079 (G6-L25) → 200 ✅
+id=1108 (G7-L28) → 200 ✅ (was 500 pre-#1391)
+id=1109 (G7-L29) → 200 ✅ (was 500 pre-#1391)
+id=1110 (G7-L30) → 200 ✅ (was 500 pre-#1391)
+```
+
+### B. /api/stories/{id}/structure YAML fast path（#1392 verified）
+
+需 teacher token：
+```python
+ts = int(time.time() * 1e6)
+register_payload = {"email": f"qa-{ts}@redutek-test.com", "password": "StgQa2026!Pass",
+                    "name": "QA", "role": "teacher"}
+requests.post(f"{STAGING}/api/auth/register", json=register_payload)
+token = requests.post(f"{STAGING}/api/auth/login", json={"email": email, "password": pwd}).json()["access_token"]
+```
+
+實測結果（all latency < 100ms = YAML path，AI fallback 為 ~5000ms）：
+
+| Code | id | HTTP | latency | path | rows | match expected |
+|------|-----|------|---------|------|------|----------------|
+| G6-L22 | 1076 | 200 | 84ms | YAML | 9 | ✅ |
+| G6-L23 | 1077 | 200 | 85ms | YAML | 5 | ✅ |
+| G6-L24 | 1078 | 200 | 83ms | YAML | 4 | ✅ |
+| G6-L25 | 1079 | 200 | 74ms | YAML | 4 | ✅ |
+| G7-L28 | 1108 | 200 | 85ms | YAML | 6 | ✅ |
+| G7-L29 | 1109 | 200 | 76ms | YAML | 22 | ✅ |
+| G7-L30 | 1110 | 200 | 70ms | YAML | 25 | ✅ |
+
+**60-80x 快過 AI**（70-85ms vs 5000ms），rows count 全部對到 audit 預期。
+
+### C. /api/stories?page_size=300（#1395 verified）
+
+實測結果（5/2 01:39 staging post-deploy）：
+```
+HTTP 200  count=165  total=165  7課 visible=7/7
+page_size=301 → HTTP 422（cap exclusive）✓
+```
+
+Verification code（reproducible）：
+```python
+r = requests.get(f"{STAGING}/api/stories?page_size=300")
+assert r.status_code == 200
+assert r.json()["total"] == 165
+seven = ["G6-L22","G6-L23","G6-L24","G6-L25","G7-L28","G7-L29","G7-L30"]
+visible = sum(1 for s in r.json()["stories"] if s["grade_code"] in seven)
+assert visible == 7  # all 7 designated visible on page 1 with page_size=300
+```
+
+Preview QA 已 pass（`https://lingoleap-backend-issue-1383-oja2sffiya-de.a.run.app`）：
+- count=165 total=165 7/7 visible
+- page_size=301 → 422（cap 邊界正確）
+- default page_size=60 仍 60（backward compat）
+- latency 84ms for full 165 stories
+
+---
+
+## ⚠️ 已知 follow-up（不擋 7/1 demo）
+
+### #1393 — G7-L29/L30 22/25 行純文字、無填空
+- Parser 從 docx 抽 ❶❷❸❹ 步驟段落，原本就是 instructional guidance（不是學生題目）
+- 直接 render 給學生 → 22/25 行 plain text、0 互動
+- **真正解法**：22 步驟改當 #1387 AI 助教 prompt 用、學習單靠 #1341 圖文左右並陳介面承接
+- **不擋 7/1**：教授指定的 demo 重點是 G6 摘要策略（4 課） + G7 圖文整合（3 課），其中圖文整合的真實學習介面（#1341）還沒做，所以 G7-L29/L30 結構表如何呈現此時並不關鍵
+
+### Unrelated open 7/1-deadline issues
+- #1340 — AI 助教語音實作（5/9 起 Young + 隔壁工程師接手）
+- #1341 — 圖文整合左右並陳介面（5/15 開始）
+- #1384 — schema-driven step demo（6/15 前）
+- #1386 — 流暢度 UI（隔壁工程師處理中）
+- #1387 — AI 助教 backend implementation（基於 #1372 spec）
+
+---
+
+## 完整 reproduction script
+
+```python
+#!/usr/bin/env python3
+"""
+QA reproduction for 7-lessons readiness on staging.
+Run: python3 qa_repro.py
+"""
+import json, time, urllib.request as ur
+
+STAGING = "https://lingoleap-backend-staging-958347263320.asia-east1.run.app"
+SEVEN = [
+    ("G6-L22", 1076, 9), ("G6-L23", 1077, 5), ("G6-L24", 1078, 4),
+    ("G6-L25", 1079, 4), ("G7-L28", 1108, 6), ("G7-L29", 1109, 22),
+    ("G7-L30", 1110, 25),
+]
+
+# 1. Register teacher
+ts = int(time.time() * 1e6)
+email = f"qa-{ts}@redutek-test.com"; pwd = "StgQa2026!Pass"
+ur.urlopen(ur.Request(f"{STAGING}/api/auth/register",
+    data=json.dumps({"email":email,"password":pwd,"name":"QA","role":"teacher"}).encode(),
+    headers={"Content-Type":"application/json"}, method="POST")).read()
+token = json.loads(ur.urlopen(ur.Request(f"{STAGING}/api/auth/login",
+    data=json.dumps({"email":email,"password":pwd}).encode(),
+    headers={"Content-Type":"application/json"}, method="POST")).read())["access_token"]
+
+# 2. /api/stories/{id} all 200
+print("## A. HTTP 200 check")
+for code, lid, _ in SEVEN:
+    r = ur.urlopen(f"{STAGING}/api/stories/{lid}")
+    print(f"  {code} id={lid}: HTTP {r.status}")
+    assert r.status == 200, f"{code} not 200"
+
+# 3. /api/stories/{id}/structure YAML fast path
+print("\n## B. YAML fast path")
+for code, lid, expected_rows in SEVEN:
+    t0 = time.monotonic()
+    r = ur.urlopen(ur.Request(f"{STAGING}/api/stories/{lid}/structure",
+        headers={"Authorization": f"Bearer {token}"}))
+    ms = int((time.monotonic()-t0)*1000)
+    d = json.loads(r.read())
+    rows = len(d.get('rows', []))
+    assert ms < 500, f"{code} latency {ms}ms exceeds YAML threshold"
+    assert rows == expected_rows, f"{code} rows {rows} != expected {expected_rows}"
+    print(f"  {code} id={lid}: {ms}ms, {rows} rows ✓")
+
+# 4. page_size=300 (post #1395 deploy)
+print("\n## C. Stories list page_size=300")
+r = ur.urlopen(f"{STAGING}/api/stories?page_size=300")
+d = json.loads(r.read())
+seven_codes = [c for c, _, _ in SEVEN]
+visible = sum(1 for s in d['stories'] if s['grade_code'] in seven_codes)
+assert d['total'] == 165
+assert visible == 7
+print(f"  count={len(d['stories'])} total={d['total']} 7課 visible=7/7 ✓")
+
+print("\n✅ All 7 lessons e2e ready")
+```
+
+---
+
+## What 我已 covered vs what Young 派人需要做
+
+| 維度 | 我已 verify | 還缺人為 QA |
+|---|---|---|
+| Backend HTTP 200 | ✅ 165/165 + 7 課 | — |
+| YAML fast path | ✅ 7 課全 < 100ms | — |
+| Pagination | ✅ Preview，待 staging deploy | 重跑 staging |
+| **Frontend**：學生點 stories list 看到 7 課 | ❌ 沒 verify | **需要做**（瀏覽器） |
+| **Frontend**：學生進 7 課跑 11 步流程 | ❌ 沒 verify | **需要做** |
+| **教學法品質**：rows 內容是否符合學習單 | ❌ 沒 verify | **教授看** |
+| **AI 助教引導**：5 步驟 SOP | n/a | **不在範圍**（#1387 還沒做）|
+| **圖文整合介面** | n/a | **不在範圍**（#1341 還沒做）|
+
+---
+
+## Refs
+
+- PR #1391: https://github.com/Youngger9765/chinese-literacy-platform/pull/1391
+- PR #1392: https://github.com/Youngger9765/chinese-literacy-platform/pull/1392
+- PR #1395: https://github.com/Youngger9765/chinese-literacy-platform/pull/1395
+- Issue #1393 (follow-up): https://github.com/Youngger9765/chinese-literacy-platform/issues/1393
+- CEO doc: `docs/ceo-review-2026-05-02.md`
+- 5/1 meeting record: `docs/meetings/2026-05-01-experts-review.md`

--- a/docs/specs/ai-tutor-implementation-spec-2026-05-02.md
+++ b/docs/specs/ai-tutor-implementation-spec-2026-05-02.md
@@ -1,0 +1,384 @@
+# AI 助教 Implementation Spec（閱讀聚光燈 MCQ Rescue）
+
+**Issues**: #1340（語音版完整）/ #1387（文字版 Phase 1）
+**Priority**: P0 — 7/1 deadline 必含（文字版至少）
+**Date**: 2026-05-02
+**Status**: Draft（pre-implementation, awaiting eng review）
+**Builds on**: `docs/specs/ai-tutor-prompt-template-2026-05-01.md`（prompt + 5 步驟 SOP，PR #1372 已 merge）
+**Refs**: 5/1 會議 §三.4-5、林校長 5 步驟 SOP、CEO doc 60-day plan Week 4-6
+
+---
+
+## 0. TL;DR
+
+**Phase 1（7/1 必達，文字版）**：學生在閱讀聚光燈 MCQ 選錯 → AI 主動 popup 對話框 → 走 5 步驟引導（per-strategy prompt） → 學生重答 → 通過/放棄都記錄。
+
+**Phase 2（7/2+，語音版）**：上面對話改 voice agent（TTS 念 AI 回應 + Web Speech recognize 學生語音轉文字）。本 spec **不**包 Phase 2 細節，只 leave hook。
+
+---
+
+## 1. Why（教學法理據）
+
+### 1.1 林校長：「最想許願的功能」
+> 「閱讀聚光燈如果能變成語音交談，會是我最想許願的功能。」 — 林國源校長
+
+5/1 會議引文。AI 助教 + 語音是專家會議認定的 #1 期望。
+
+### 1.2 5 步驟 SOP（林校長 + 陳教授精簡版）
+1. **確認題意**：學生說對題目的理解
+2. **回課文找線索**：邀請回到課文找對應段落
+3. **自己的話復述**：學生用自己的話講
+4. **拉回題目**：問選項判斷
+5. **直接教學（fallback）**：前 4 步都失敗才直接教
+
+### 1.3 為何不夠用既有 socratic_agent？
+- 既有 socratic_agent = **5 題 3 階段（factual / inferential / evaluative）** 引導學生**全篇**理解
+- AI 助教 = 答**單一 MCQ** 錯時的 **rescue dialogue**，目標讓學生答對這題
+- Scope、target、prompt 形態都不同 → 並行新流程，**不取代** socratic_agent
+
+---
+
+## 2. Architecture
+
+### 2.1 元件樹
+```
+backend/app/services/
+├── socratic_agent.py             (existing, 整篇課文引導)
+├── mcq_rescue_agent.py           (NEW, 單題 rescue)
+│   ├── class RescueState         (dataclass: step 1-5, attempts, give_up_detected)
+│   ├── class RescueSessionStore  (mirror SessionStore, 30min TTL, DB-backed)
+│   ├── class MCQRescueAgent      (mirror SocraticAgent, _build_system_prompt + step()
+│   └── circuit breaker (沿用 ai_service 既有)
+└── strategy_prompts.py           (NEW, prompt loader)
+    ├── load(strategy_type) -> dict
+    └── fallback to default.yml
+
+backend/data/strategy_prompts/    (NEW dir)
+├── default.yml                   (generic 5-step)
+├── summary_psr.yml               (摘要-問題.解決.結果)
+├── summary_problem_solution.yml  (摘要-問題.解決找重點 — G6-L23/24/25)
+├── graphic_text_integration.yml  (圖文整合 — G7-L28/29/30)
+├── inference.yml                 (推論策略 — 共 5 個 type，可細分後續)
+└── ... (per CEO doc, 7/1 demo focus only summary + graphic_text)
+
+backend/app/routes/
+└── learning/mcq_rescue.py        (NEW)
+    ├── POST /api/mcq-rescue/start          (lesson_id, question_id, wrong_answer)
+    ├── POST /api/mcq-rescue/{session_id}/respond  (user_message)
+    └── POST /api/mcq-rescue/{session_id}/give_up
+
+frontend/src/
+├── components/reading-steps/
+│   └── ComprehensionChat.tsx      (existing) ← 偵測學生答錯 → trigger
+└── components/mcq-rescue/         (NEW)
+    ├── RescueChatBox.tsx          (modal popup, fixed bottom-right)
+    ├── RescueMessage.tsx          (single message bubble)
+    ├── RescueGiveUpButton.tsx     ("我放棄這題，看答案")
+    └── (Phase 2) RescueVoiceMic.tsx  (語音輸入按鈕)
+```
+
+### 2.2 Trigger Flow
+
+```
+學生在 ComprehensionChat MCQ 選錯選項
+   ↓
+ComprehensionChat 元件 detect wrong answer
+   ↓
+POST /api/mcq-rescue/start
+   {
+     lesson_id: "G7-L28",
+     question_id: "Q3",
+     wrong_answer: "B",
+     correct_answer: "A",
+     question: "巴斯德的研究問題是什麼？",
+     options: {"A": "...", "B": "...", "C": "...", "D": "..."}
+   }
+   ↓
+Backend mcq_rescue_agent.start()
+   ├─ Look up lesson.reading_strategy → load strategy_prompts/<type>.yml
+   ├─ Build system prompt（per-strategy）
+   ├─ Call Gemini → get Step 1 question (確認題意)
+   └─ Save SessionState to DB + memory cache
+   ↓
+Response: {session_id, current_step: 1, ai_message: "我看到你選了 B...你覺得這題在問什麼？"}
+   ↓
+Frontend RescueChatBox popup with AI message
+   ↓
+學生輸入回應 → POST /api/mcq-rescue/{sid}/respond {user_message: "..."}
+   ↓
+Backend agent.step(user_message)
+   ├─ Append user_message to history
+   ├─ Build system prompt 包含當前 step + 過去對話
+   ├─ Call Gemini → return: { ai_feedback, should_advance, should_terminate, give_up_detected }
+   └─ Save state
+   ↓
+如果 should_advance → step += 1，next AI message 是 Step 2 prompt
+如果 should_terminate → 結束（學生通過 or 放棄），return final score
+如果 give_up_detected → 主動詢問「需要我直接告訴你答案嗎？」（學生可選）
+   ↓
+循環直到 step == 5 finished or give_up
+   ↓
+記錄到 LearningSession.mcq_rescue_attempts (NEW JSONB column)
+   ├─ {question_id, attempts, total_steps, final_step_reached, give_up}
+```
+
+### 2.3 Schema 擴充
+
+**Backend `SessionState`** (in mcq_rescue_agent.py):
+```python
+@dataclass
+class RescueState:
+    session_id: str
+    lesson_id: str
+    question_id: str
+    wrong_answer: str
+    correct_answer: str
+    question_text: str
+    options: dict  # {"A": "...", ...}
+    strategy_type: str  # for prompt selection
+    
+    current_step: int = 1  # 1-5
+    history: list[dict] = field(default_factory=list)  # [{role, content, ts}]
+    attempts: int = 0
+    give_up_detected: bool = False
+    terminated: bool = False
+    final_outcome: str | None = None  # "passed" / "gave_up" / "max_steps"
+    created_at: float = field(default_factory=time.time)
+```
+
+**LLM response schema**（Gemini structured output）:
+```python
+RESCUE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "ai_feedback": {"type": "string", "maxLength": 200},  # 對學生的回應，短
+        "current_step": {"type": "integer", "minimum": 1, "maximum": 5},
+        "should_advance": {"type": "boolean"},  # 進下一步
+        "should_terminate": {"type": "boolean"},  # 結束（學生通過）
+        "give_up_detected": {"type": "boolean"},  # 偵測到放棄訊號（"我不知道"x3）
+        "reasoning": {"type": "string", "maxLength": 100},  # debug + audit (CLAUDE.md memory)
+    },
+    "required": ["ai_feedback", "current_step", "should_advance",
+                 "should_terminate", "give_up_detected", "reasoning"],
+}
+```
+
+**LearningSession DB**（migration needed）:
+```python
+# backend/app/models/learning.py
+class LearningSession(Base):
+    # ... existing fields ...
+    mcq_rescue_attempts = Column(
+        JSONB, nullable=True,
+        server_default=text("'[]'::jsonb")
+    )  # list of {question_id, attempts, final_step, outcome}
+```
+
+---
+
+## 3. Prompt Engineering（Phase 1 必達 2 strategy）
+
+### 3.1 7/1 必含 strategy prompt files
+
+| Lesson 類型 | Strategy type | Prompt file | 哪些課用 |
+|---|---|---|---|
+| 摘要-問題.解決.結果 | `summary_psr` | `summary_psr.yml` | G6-L22 |
+| 摘要-問題.解決找重點 | `summary_problem_solution` | `summary_problem_solution.yml` | G6-L23/24/25 |
+| 圖文整合 | `graphic_text_integration` | `graphic_text_integration.yml` | G7-L28/29/30 |
+
+→ 7 課覆蓋。其他策略 fallback to `default.yml`（後續再補）。
+
+### 3.2 Strategy prompt YAML schema
+
+```yaml
+strategy: summary_psr
+description: 摘要策略 — 問題.解決.結果結構
+opening: |
+  我看到你這題有一點卡住，沒關係，我們一起想想看~先告訴我，
+  你覺得這個題目在問什麼？
+
+steps:
+  - step: 1
+    name: confirm_understanding
+    prompt: |
+      聚焦在「題目本身」。如果學生講不出來或誤解，引導他重讀題幹，
+      不要直接給答案。advance 條件：學生能用自己的話複述題目。
+    advance_signals: [restated_question_correctly, asks_for_clarification_then_understood]
+    fail_signals: [shrug, "不知道", switches_topic]
+
+  - step: 2
+    name: locate_in_text
+    prompt: |
+      引導學生回到課文找「跟題目有關的段落」。問「課文哪裡提到這個？」
+      不要替學生指段落，讓他找。advance 條件：學生說出對應段落或關鍵句。
+    advance_signals: [refers_to_specific_paragraph, quotes_text]
+    fail_signals: [random_guess, "都看過了"]
+
+  - step: 3
+    name: paraphrase_in_own_words
+    # ... 
+
+  - step: 4
+    name: relate_to_question
+    # ...
+
+  - step: 5
+    name: direct_teach_fallback
+    prompt: |
+      前 4 步都未通過。直接教：「答案是 X，因為課文 Y 段提到 Z」。
+      最後問學生「現在懂了嗎？」結束（terminate）。
+
+terminate_conditions:
+  - student_explicitly_passes_test  # answers correctly when re-prompted
+  - give_up_after_3_dont_knows
+  - max_steps_5_completed
+
+tone:
+  - 短句，2-3 句一輪
+  - 口語化（「沒關係」「我們一起」「想想看」）
+  - 不過度誇獎
+  - 不直接給答案直到 step 5
+```
+
+### 3.3 Default fallback `default.yml`
+
+per #1372 spec 的通用 5 步驟版本。
+
+---
+
+## 4. Frontend 整合
+
+### 4.1 Trigger 在 ComprehensionChat
+
+```tsx
+// frontend/src/components/reading-steps/ComprehensionChat.tsx
+function ComprehensionChat({ lesson, session }) {
+  const [activeRescue, setActiveRescue] = useState<RescueSession | null>(null);
+
+  async function handleAnswer(qid: string, answer: string) {
+    const correct = checkAnswer(qid, answer);
+    if (!correct && lesson.images?.length === 0) {  // 文字版優先；圖文題暫不 trigger（待 Phase 2）
+      const rescue = await api.startMcqRescue({
+        lesson_id: lesson.id,
+        question_id: qid,
+        wrong_answer: answer,
+        // ...
+      });
+      setActiveRescue(rescue);
+    }
+  }
+
+  return (
+    <>
+      <McqQuestionList ... />
+      {activeRescue && (
+        <RescueChatBox
+          session={activeRescue}
+          onClose={() => setActiveRescue(null)}
+          onComplete={(outcome) => {
+            // log to analytics + offer retry MCQ
+            setActiveRescue(null);
+          }}
+        />
+      )}
+    </>
+  );
+}
+```
+
+### 4.2 RescueChatBox 元件
+
+- Modal popup，desktop 右下角 fixed，mobile 覆蓋全螢幕底部 50%
+- Message thread（AI + user 交替氣泡）
+- Input 區：text input + send button
+- "我放棄這題" button（give_up，跳 step 5 直接教）
+- 步驟指示：上方小步驟列「1 ─ 2 ─ 3 ─ 4 ─ 5」，當前 step 高亮
+- 載入中：dot dot dot 動畫（AI 思考中）
+
+### 4.3 Phase 2 hook（語音版）
+
+`RescueVoiceMic.tsx`（後續）：
+- Web Speech API recognize 學生語音 → 自動填到 input
+- TTS API 念 AI 回應（Google Chirp3-HD 既有 stack）
+
+→ Phase 1 留 prop hook，Phase 2 直接接上。
+
+---
+
+## 5. Risk + 緩解
+
+| Risk | 機率 | Impact | 緩解 |
+|---|---|---|---|
+| AI hallucination 給錯誤引導（誤導學生）| High | High | per-strategy 收緊 prompt + reasoning field 留 audit + 教授抽查 log + circuit breaker |
+| 5 步驟太死板，學生失去耐心 | High | Med | LLM 可主動 advance / terminate（schema 有 should_advance / should_terminate）+ "我放棄" button |
+| Latency 太久（5s+）學生跑掉 | High | High | 用 gemini-2.5-flash + 不打 Vertex Search + max_output_tokens 控制 200 + 預生成 cache |
+| 答錯就 popup 太煩 | Med | Med | 答錯後 2s 才 popup（給學生看選錯感）+ 學生可關閉（不要 modal 強制）|
+| 5 步驟 SOP 教學上不適用所有策略 | Med | High | strategy_prompts/ 多檔分流，必要時可有 < 5 步驟的 strategy 變體 |
+| Phase 1 文字版若被學生抗拒，Phase 2 語音也救不了 | Low | High | 5 月底先做 5 學生 alpha 測，feedback 進 prompt v2 |
+| 教授覺得引導不像真老師 | High | Med | 教授 review 引導 sample log（per CEO doc Week 6 流程）|
+
+---
+
+## 6. Implementation Plan
+
+### CEO doc Week 4-6 (5/23 ~ 6/12)
+
+**Day 1-2**：Backend service skeleton
+- `backend/app/services/mcq_rescue_agent.py` — class scaffolds, sit on top of existing socratic_agent pattern
+- `backend/app/services/strategy_prompts.py` — yaml loader + fallback chain
+- 1 strategy prompt yaml first（`summary_psr.yml` for G6-L22）
+
+**Day 3-4**：Backend route + DB
+- `backend/app/routes/learning/mcq_rescue.py` — 3 endpoints
+- Alembic migration: `mcq_rescue_attempts JSONB` on LearningSession
+- 沿用既有 rate-limit / auth / circuit breaker
+- Unit test happy path + give_up + 5-step termination
+
+**Day 5-6**：Frontend RescueChatBox
+- `RescueChatBox.tsx` + `RescueMessage.tsx` + `RescueGiveUpButton.tsx`
+- 整合進 ComprehensionChat.tsx wrong-answer handler
+- E2E：G6-L22 跑通完整 5 步驟
+
+**Day 7-8**：剩下 strategy prompts
+- summary_problem_solution, graphic_text_integration（7 課覆蓋）
+- default.yml fallback
+
+**Day 9-10**：Polish + alpha
+- 5 學生內部 alpha 測（透過林校長）
+- bug fix + prompt v2 based on feedback
+
+---
+
+## 7. Acceptance Criteria（7/1 demo gate）
+
+- [ ] 7 課（G6-L22~25, G7-L28~30）MCQ 答錯能 trigger AI 助教
+- [ ] 5 步驟 SOP 在每課都可走完（人工測 ≥3 次每課）
+- [ ] AI 不直接給答案的比例 ≥ 90%（前 4 步驟）
+- [ ] Latency p50 < 3s（gemini-2.5-flash + tight prompt）
+- [ ] 給 up button 可中斷且記錄
+- [ ] 5 步驟通過後可重答 MCQ（學生有第二機會）
+- [ ] mcq_rescue_attempts 寫入 DB，老師後台可看（後續做）
+- [ ] 教授抽查 10 個 rescue session log，引導品質 OK ≥ 80%
+- [ ] Phase 2 voice hook 留好 props（不擋）
+
+---
+
+## 8. Open Questions（pre-impl 釐清）
+
+1. **觸發 timing**：答錯立刻 popup vs 答錯後 2s vs 答完整題組才 popup？
+2. **學生重答 MCQ 機制**：通過 5 步驟後自動回題目重答？還是另開重答 flow？
+3. **#1340 vs #1387 issue 範圍切割**：#1387 標 "Phase 1 implementation" 適合切割成本 spec 的 Day 1-8，剩下 Day 9-10 + Phase 2 進 #1340？
+4. **mcq_rescue_attempts schema 細節**：要不要記 full conversation history? 還是只 outcome？
+5. **Cost 控制**：每次 rescue session ≤ 5 步驟 = 5 次 Gemini call ≈ NT$0.5。150 學生 × 7 課 × 平均 2 題 rescue = 2100 sessions/週 ≈ NT$1000/週 — accept？
+
+---
+
+## 9. Refs
+
+- 既有 spec：`docs/specs/ai-tutor-prompt-template-2026-05-01.md`（PR #1372，prompt + 5 步驟 SOP detail）
+- 5/1 會議記錄 §三.4-5
+- CEO doc Week 4-6 plan
+- Issue #1340（語音版完整 P0）
+- Issue #1387（Phase 1 文字版 P0）
+- 既有 `backend/app/services/socratic_agent.py`（mirror pattern）
+- 既有 `backend/app/services/ai_service.py:generate_*`（reuse Gemini wrapper）

--- a/docs/specs/graphic-text-integration-spec-2026-05-02.md
+++ b/docs/specs/graphic-text-integration-spec-2026-05-02.md
@@ -1,0 +1,321 @@
+# 圖文整合介面 Design Spec — 文圖左右並陳
+
+**Issue**: #1341
+**Priority**: P0 — 7/1 deadline 必含
+**Date**: 2026-05-02
+**Status**: Draft (pre-implementation, awaiting eng review)
+**Refs**: 5/1 專家會議 §三.6、`docs/meetings/2026-05-01-experts-review.md`
+
+---
+
+## 1. Why（教學法理據）
+
+### 1.1 紙本痛點
+- 紙本圖文整合學習單**排版很長**（陳教授：「學習單會被拉得超長」）
+- 學生在紙上**反覆翻頁**對應圖↔文 → 認知負荷高
+
+### 1.2 數位機會
+- 眼動研究（簡教授吳大猷獎）：**低成就學生完全不看圖**
+- 教 25 分鐘圖文整合策略 → 眼動率 + 閱讀理解都顯著提升
+- 結論：**數位介面要主動引導學生看圖**，不是被動讓學生選擇看不看
+
+### 1.3 教授期望
+> 「文圖左右並陳，可獨立滾動」 — 陳淑麗教授
+
+→ **左右雙欄 + 各自獨立滾動 + 圖↔文錨點（可選）**
+
+---
+
+## 2. Scope（7/1 必達 vs 後續）
+
+### 2.1 7/1 必達（單元 B 三課）
+| Lesson | id | 圖數 | 字數 | 範例典型用例 |
+|---|---|---|---|---|
+| G7-L28 看不見的兇手 | 1108 | 8 | 717 | 科學實驗（巴斯德肉湯實驗）|
+| G7-L29 四張圖看地球暖化 | 1109 | 10 | 923 | 折線圖 + 趨勢分析（4 張數據圖典型用例）|
+| G7-L30 都是八哥為什麼命運不一樣 | 1110 | 7 | 840 | 對比表 + 物種比較 |
+
+### 2.2 7/1 不做（後續）
+- 圖↔文 highlight 連動（hover/click 圖時對應段落 highlight）
+- 圖片標註（學生可在圖上畫圈/打點）
+- AI 助教指圖功能（基於 #1340/#1387）
+- 多年級擴展（其他年級的圖文課文也適用）
+
+---
+
+## 3. Architecture
+
+### 3.1 元件樹
+```
+ReadingLayout (existing 11-step container)
+└── ComprehensionChatStep (existing #1349 拆出來)
+    └── GraphicTextLayout (NEW)              ← 新元件，僅在課文 has images > 0 時 render
+        ├── LeftPane (course content)
+        │   ├── StoryText (with paragraph anchors)
+        │   └── (vertical scroll, independent)
+        ├── DividerHandle (NEW)              ← 拖曳調整左右比例（optional, P1 可選）
+        └── RightPane (image gallery)
+            ├── ImageStrip (圖片縮圖列，sticky top)
+            ├── ImageViewer (currently selected image, large)
+            │   ├── ZoomControls
+            │   └── (vertical scroll for tall images, independent)
+            └── ImageCaption (字幕從 yml.images[i].caption)
+```
+
+### 3.2 Layout 規格
+
+**Desktop (≥ 1024px)**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Header (StepperNav)                                             │
+├─────────────────────────────┬───────────────────────────────────┤
+│ Left Pane (50%, scrollable) │ Right Pane (50%, scrollable)      │
+│ ─────────────────────────── │ ────────────────────────────────  │
+│                             │ ┌───┬───┬───┬───┐                 │
+│ 第一段：內容...               │ │圖1│圖2│圖3│圖4│ ← strip       │
+│                             │ └───┴───┴───┴───┘                 │
+│ 第二段：內容...               │ ┌─────────────────────┐           │
+│                             │ │                     │           │
+│ 第三段：內容...               │ │   圖 1 large view   │           │
+│                             │ │   (auto-fit, zoom)  │           │
+│ 第四段：內容...               │ │                     │           │
+│                             │ └─────────────────────┘           │
+│ ↕ scroll                    │ Caption: 圖 1 ：1850 年以來... ↕  │
+└─────────────────────────────┴───────────────────────────────────┘
+```
+
+**Tablet (768px ~ 1023px)**
+- Same layout，但左右各 ~50% width
+- Image strip 橫向 swipe
+
+**Mobile (< 768px)**
+- **垂直堆疊**（fallback per Issue spec），不強制左右
+- 圖片區域 collapsible（toggle button「展開圖片區」）
+- Image viewer fullscreen modal on tap
+
+### 3.3 Independent scroll 實作
+
+```tsx
+// frontend/src/components/reading-steps/GraphicTextLayout.tsx
+<div className="grid grid-cols-1 lg:grid-cols-2 h-full">
+  <div className="overflow-y-auto">  {/* Left independent scroll */}
+    <StoryText paragraphs={lesson.paragraphs} />
+  </div>
+  <div className="overflow-y-auto">  {/* Right independent scroll */}
+    <ImageGallery images={lesson.images} />
+  </div>
+</div>
+```
+
+關鍵 Tailwind class：`overflow-y-auto` + 各自父層 `h-full` → 互不影響。
+
+### 3.4 Data flow
+
+```
+backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
+└── images: [{filename, size_bytes, image_hash, content_type, caption?}, ...]
+    ↓
+backend/app/routes/stories.py:get_story (existing)
+    ↓ serializes images array in response
+    ↓
+frontend/src/services/api.ts:fetchStory
+    ↓
+LearningSession state.lesson.images
+    ↓
+GraphicTextLayout 條件 render：lesson.images.length > 0
+```
+
+**注意**：images 已經 commit 進 git（PR #1369 / #1361），URL pattern：
+```
+/data/lessons/images/G7-L28/G7-L28-01.png
+```
+→ 需在 `frontend/public/` 建 symlink 或 frontend serve 時 proxy 到 backend `/data/lessons/images/`。
+**TODO**: 確認 backend serve image 路徑（grep `/data/lessons/images` in backend routes）。
+
+---
+
+## 4. Components 詳細 spec
+
+### 4.1 `GraphicTextLayout.tsx`（NEW）
+
+**Props**:
+```ts
+interface Props {
+  lesson: Lesson;  // 含 images, paragraphs, story_text
+  onImageSelect?: (idx: number) => void;  // 之後給 AI 助教用
+}
+```
+
+**State**:
+```ts
+const [selectedImageIdx, setSelectedImageIdx] = useState(0);
+const [leftScrollY, setLeftScrollY] = useState(0);  // 持久化 session
+```
+
+**渲染邏輯**:
+- 若 `lesson.images.length === 0` → render fallback（純左欄，現有 ComprehensionChat）
+- 否則 → 左右雙欄
+
+### 4.2 `ImageStrip.tsx`（NEW）
+
+縮圖列，sticky top，水平滾動。
+- 點擊 → setSelectedImageIdx
+- Highlight current selected
+- Lazy load (loading="lazy")
+
+### 4.3 `ImageViewer.tsx`（NEW）
+
+放大顯示當前圖片：
+- 圖片自動 `max-w-full max-h-[60vh] object-contain`
+- 簡單 zoom：`+`/`−` 按鈕（react-zoom-pan-pinch lib，已有？確認）
+- 圖名 + caption 在下方
+
+### 4.4 ResponsiveBreakpoint hook（reuse existing 或新建）
+
+```ts
+const isMobile = useMediaQuery('(max-width: 767px)');
+```
+
+---
+
+## 5. 整合進現有流程
+
+### 5.1 Trigger 條件
+```tsx
+// In ComprehensionChat.tsx (existing)
+{lesson.images && lesson.images.length > 0 ? (
+  <GraphicTextLayout lesson={lesson} />
+) : (
+  <ExistingChatLayout lesson={lesson} />
+)}
+```
+
+→ **不破壞** non-graphic 課文的現有體驗（57 Layer-1 + ~100 Layer-2 沒圖的課照舊）。
+
+### 5.2 Step sequence
+
+per #1374 schema-driven step composition，G7-L28~30 的 yml 應加：
+```yaml
+step_sequence:
+  - introduction
+  - reading-annotation
+  - graphic-text-comprehension  # ← NEW step kind, 替換 comprehension-chat
+  - vocab-practice
+  ...
+```
+
+或：保留 `comprehension-chat` step name，但元件內部 detect images → branch render。**建議後者**（minimal change，#1374 step kind 不增）。
+
+---
+
+## 6. 風險 + 緩解
+
+| Risk | 機率 | Impact | 緩解 |
+|---|---|---|---|
+| 大圖（G7-L29 圖二 188KB）載入慢 | High | Med | 加 lazy load + thumbnail strip 用 small WebP |
+| Mobile 垂直堆疊 + 大圖 → 滾動體驗差 | Med | Med | Image collapse toggle，預設收起，學生 tap 展開 |
+| 圖片 caption 沒抽出來 | High | Low | 7/1 demo G7-L28~30 手動補（3 課 × 8-10 圖 = 30 個 caption）|
+| 圖↔文 highlight 連動不做 → 學生找不到對應 | Med | Med | 7/1 不做，但加段落編號（圖一→第 2 段...）by caption 補強 |
+| 既有 ComprehensionChat 結構表 fill_blank 怎麼放？ | High | High | **見 §7 整合策略** |
+
+---
+
+## 7. 整合策略：圖文 + ComprehensionChat 結構表填空
+
+**問題**：G7-L28 已有 6 行 `story_structure_table` (PSR 結構)，學生要填 fill_blank。但同時要看圖、文。怎麼布局？
+
+**方案 A（推薦）**：左右雙欄 + 結構表浮層
+```
+┌──────────────────┬──────────────────┐
+│ Left: 課文        │ Right: 圖區      │
+└──────────────────┴──────────────────┘
+   ↓ 學生點「題目」按鈕
+┌──────────────────┬──────────────────┐
+│ Left: 課文 (淡)   │ Right: 圖區 (淡) │
+│   ┌──────────┐   │                  │
+│   │ 題目浮層  │   │                  │
+│   │ (Modal)  │   │                  │
+│   └──────────┘   │                  │
+└──────────────────┴──────────────────┘
+```
+
+**方案 B**：三欄
+```
+┌────────┬────────┬────────┐
+│ 課文    │ 圖區    │ 題目    │
+└────────┴────────┴────────┘
+```
+→ Mobile 垮（< 1280px 三欄太擠）。**Reject**.
+
+**方案 C**：題目 inline 在左欄底部
+```
+┌──────────────────┬──────────────────┐
+│ 課文              │ 圖區              │
+│ ───              │                  │
+│ 題目 (collapse)  │                  │
+└──────────────────┴──────────────────┘
+```
+→ 學生答題時要往下滾，看不到課文。**Reject**.
+
+**結論**：採方案 A — Modal 浮層題目，學生可隨時關閉看回課文/圖。
+
+---
+
+## 8. Implementation Plan
+
+### Week 2-3 (5/9 ~ 5/22) per CEO doc
+
+**Day 1-2**：
+- 建 `GraphicTextLayout` 元件殼 + Tailwind grid
+- 接 `lesson.images` data flow
+
+**Day 3-4**：
+- `ImageStrip` + `ImageViewer` + zoom
+- Lazy load + responsive breakpoint
+
+**Day 5**：
+- 整合進 ComprehensionChat（圖數 > 0 條件 render）
+- Mobile fallback 垂直堆疊
+
+**Day 6**：
+- 結構表填空 Modal（方案 A）
+- E2E 測 G7-L28~30 三課
+
+**Day 7**：
+- 截圖驗證（desktop / tablet / mobile）
+- 教授 review
+
+---
+
+## 9. Acceptance Criteria
+
+- [ ] G7-L28~30 三課使用左右雙欄渲染
+- [ ] 左右欄各自獨立滾動（測：滾左欄、右欄不動）
+- [ ] 桌面 1024px+ 顯示左右並陳
+- [ ] Tablet 768~1023px 顯示左右並陳（等比縮放）
+- [ ] Mobile < 768px 垂直堆疊 + image collapse toggle
+- [ ] 點 Image strip 縮圖切換 viewer 大圖
+- [ ] 圖片可 zoom in/out（按鈕或 pinch）
+- [ ] 結構表填空 Modal 浮層，可關閉
+- [ ] 既有 non-graphic 課文（任何 lesson.images.length === 0）不受影響
+- [ ] Lighthouse Performance ≥ 80（圖片 lazy load）
+
+---
+
+## 10. Open Questions（pre-impl 要釐清）
+
+1. **圖片 caption 從哪來？** docx 抽出來的 yml `images[].caption` 大多空。需教授提供 3 課 × ~10 caption。
+2. **圖片 served 路徑？** backend 是否有 `/data/lessons/images/{code}/...` route 或 frontend `public/lessons-images/` symlink？
+3. **react-zoom-pan-pinch lib 已安裝？** 若無，要不要加？
+4. **G7-L29 22 行 structure_table（per #1393）怎麼呈現？** 不適合放 Modal，建議 hide for G7-L29/30 + 用 AI 助教 prompt 替代。
+
+---
+
+## 11. Refs
+
+- Issue #1341 — 本 spec 實作
+- Issue #1387 — AI 助教 implementation（之後接圖文 context）
+- Issue #1393 — G7-L29/L30 結構表呈現問題（影響 §7 設計）
+- 5/1 會議記錄 §三.6
+- CEO doc Week 2-3 plan
+- PR #1369 / #1361 — 圖片 yml metadata 已抽


### PR DESCRIPTION
## What

3 docs，doc-only PR：

| File | 用途 |
|---|---|
| `docs/ceo-review-2026-05-02.md` | 60-day roadmap to 7/1。SCOPE REDUCTION mode、Approach B（7 課專修）、KPIs、team allocation、risk register |
| `docs/qa-evidence-2026-05-02-7-lessons-readiness.md` | 今天 5/1 backend QA evidence pack（PR #1391/#1392/#1395 e2e 證據）+ reproducible script |
| `docs/specs/graphic-text-integration-spec-2026-05-02.md` | #1341 圖文整合介面 pre-impl spec（11 sections）|

## Why

5/1 教授會議結論「2 單元 7 課做到極致」+ 衝刺完成 25 PRs 後，把策略文件留下來給接手者。

## Refs

- Fixes #1399
- 5/1 meeting `docs/meetings/2026-05-01-experts-review.md`
- 今天已 ship: #1391 + #1392 + #1395
- 觸及 #1341 / #1387 後續 implementation