### PR TITLE
feat(strategy): plugin pattern scaffold — loader + 3 yaml + 7 lesson layout_mode (Fixes #1404)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -247,6 +247,9 @@ def get_story(story_id: str):
         source_file=story["source_file"],
         strategy_exercise=story.get("strategy_exercise"),
         step_sequence=story.get("step_sequence"),
+        # Plugin-pattern dispatch fields (#1404):
+        reading_strategy_type=story.get("reading_strategy_type") or "general",
+        layout_mode=story.get("layout_mode") or "standard",
     )
 
 

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -54,6 +54,11 @@ class StoryDetail(StoryListItem):
     # Schema-driven step composition (#1374): per-lesson step order from YAML.
     # None means frontend uses DEFAULT_STEP_SEQUENCE fallback.
     step_sequence: Optional[list[str]] = None
+    # Plugin-pattern dispatch fields (#1404):
+    # canonical strategy type → backend strategy_prompts/{type}/ dispatch
+    reading_strategy_type: str = "general"
+    # frontend ComprehensionChat layout variant: 'standard' | 'graphic-text' | 'graphic-chart'
+    layout_mode: str = "standard"
 
 
 class StoryListResponse(BaseModel):

--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -212,6 +212,9 @@ def _load_layer1_lessons() -> list[dict]:
             "step_sequence": data.get("step_sequence") or None,
             "story_structure_table": data.get("story_structure_table"),
             "story_structure_rows": data.get("story_structure_rows"),
+            # Plugin-pattern dispatch fields (#1404):
+            "reading_strategy_type": data.get("reading_strategy_type") or "general",
+            "layout_mode": data.get("layout_mode") or "standard",
             "intro": _build_intro(data),
             "_layer": 1,
         }
@@ -331,6 +334,9 @@ def _load_layer2_lessons(
             # Schema-driven step composition (#1374): pass through if present in YAML.
             # None (absent) means frontend uses DEFAULT_STEP_SEQUENCE.
             "step_sequence": data.get("step_sequence") or None,
+            # Plugin-pattern dispatch fields (#1404):
+            "reading_strategy_type": data.get("reading_strategy_type") or "general",
+            "layout_mode": data.get("layout_mode") or "standard",
             "intro": _build_intro({**data, "reading_strategy": strategy}),
             "_layer": 2,
         }

--- a/backend/app/services/strategy_prompts.py
+++ b/backend/app/services/strategy_prompts.py
@@ -1,0 +1,112 @@
+"""
+Strategy Prompts loader — plugin pattern for per-strategy AI tutor prompts.
+
+Architecture: docs/architecture/strategy-step-plugin-pattern.md
+
+Each reading_strategy_type maps to a directory under
+backend/data/strategy_prompts/{type}/ containing prompt.yml (and optionally
+step_sequence.yml).
+
+Resolution chain:
+  1. backend/data/strategy_prompts/{strategy_type}/prompt.yml
+  2. backend/data/strategy_prompts/default/prompt.yml (fallback)
+  3. RuntimeError if neither exists (default is required at deploy)
+
+Usage:
+  from app.services.strategy_prompts import load_strategy_prompt
+  prompt = load_strategy_prompt('summary_psr')
+  # → dict with keys: strategy, display_name, opening, steps, ...
+
+This module is intentionally narrow: just yaml loading + fallback. Prompt
+construction (system prompt assembly, history threading) is the caller's job
+in mcq_rescue_agent.py.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# Resolved at import time — directory containing strategy folders.
+_PROMPTS_DIR = Path(__file__).parent.parent.parent / "data" / "strategy_prompts"
+_DEFAULT_TYPE = "default"
+_PROMPT_FILENAME = "prompt.yml"
+
+
+class StrategyPromptError(RuntimeError):
+    """Raised when no prompt yaml can be resolved (default missing)."""
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    """Read a yaml file, return parsed dict. Raises if file is empty/invalid."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise StrategyPromptError(
+            f"Strategy prompt yaml must be a dict, got {type(data).__name__}: {path}"
+        )
+    return data
+
+
+@lru_cache(maxsize=32)
+def _load_prompt_uncached(strategy_type: str | None) -> dict[str, Any]:
+    """Inner cached loader — keyed on normalized strategy_type."""
+    norm = (strategy_type or _DEFAULT_TYPE).strip()
+    if not norm:
+        norm = _DEFAULT_TYPE
+
+    # Try specific strategy first
+    specific = _PROMPTS_DIR / norm / _PROMPT_FILENAME
+    if specific.exists():
+        return _read_yaml(specific)
+
+    # Fallback to default
+    default = _PROMPTS_DIR / _DEFAULT_TYPE / _PROMPT_FILENAME
+    if default.exists():
+        return _read_yaml(default)
+
+    raise StrategyPromptError(
+        f"No prompt.yml found for strategy_type={norm!r} and no default at {default}"
+    )
+
+
+def load_strategy_prompt(strategy_type: str | None) -> dict[str, Any]:
+    """Load the prompt yaml for a given reading_strategy_type.
+
+    Args:
+        strategy_type: canonical strategy type from lesson.yml (e.g. 'summary_psr',
+            'graphic_text_integration', 'inference', 'general'). None or empty
+            string falls back to default.
+
+    Returns:
+        Parsed yaml dict with keys: strategy, display_name, description, opening,
+        steps, terminate_conditions, tone, etc. Caller must validate the keys
+        it needs.
+
+    Raises:
+        StrategyPromptError: if no specific or default yaml is reachable.
+    """
+    return _load_prompt_uncached(strategy_type)
+
+
+def list_available_strategies() -> list[str]:
+    """Return list of strategy_type names with a prompt.yml on disk.
+
+    Used for /admin endpoints / debugging which strategies have custom prompts
+    vs which fall back to default.
+    """
+    if not _PROMPTS_DIR.exists():
+        return []
+    return sorted(
+        d.name for d in _PROMPTS_DIR.iterdir()
+        if d.is_dir() and (d / _PROMPT_FILENAME).exists()
+    )
+
+
+def clear_cache() -> None:
+    """Clear the LRU cache. Used in tests after writing fixture yaml."""
+    _load_prompt_uncached.cache_clear()

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L22.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L22.yml
@@ -3,6 +3,7 @@ grade: 6
 grade_code: G6-L22
 reading_strategy: 摘要策略-問題.解決.結果結構
 reading_strategy_type: summary_psr
+layout_mode: standard
 # Schema-driven step composition (PR #1375 / Issue #1384):
 # story-structure promoted to position 4 (immediately after full-reading)
 # so students fill the PSR table while the story is freshest in memory.

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L23.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L23.yml
@@ -3,6 +3,7 @@ grade: 6
 grade_code: G6-L23
 reading_strategy: 摘要策略-問題.解決結構找重點
 reading_strategy_type: summary_psr
+layout_mode: standard
 source_file: G6-L23老鷹紅豆的故事（摘要策略-問題.解決結構找重點）.docx
 parsed_at: '2026-05-02T00:35:18'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
@@ -3,6 +3,7 @@ grade: 6
 grade_code: G6-L24
 reading_strategy: 摘要策略-問題.解決結構找重點
 reading_strategy_type: summary_psr
+layout_mode: standard
 source_file: G6-L24白鯨救援（摘要策略-問題.解決結構找重點）.docx
 parsed_at: '2026-05-02T00:35:18'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
@@ -3,6 +3,7 @@ grade: 6
 grade_code: G6-L25
 reading_strategy: 摘要策略-問題.解決結構找重點
 reading_strategy_type: summary_psr
+layout_mode: standard
 source_file: G6-L25全世界第一張股票的誕生（摘要策略-問題.解決結構找重點）.docx
 parsed_at: '2026-05-02T00:35:19'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
@@ -3,6 +3,7 @@ grade: 7
 grade_code: G7-L28
 reading_strategy: 圖文整合閱讀策略
 reading_strategy_type: graphic_text_integration
+layout_mode: graphic-text
 source_file: G7-L28看不見的兇手：以實驗破解肉湯腐敗之謎（圖文整合閱讀策略）.docx
 parsed_at: '2026-05-01T21:10:41'
 flags:

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
@@ -3,6 +3,7 @@ grade: 7
 grade_code: G7-L29
 reading_strategy: 圖文整合閱讀策略
 reading_strategy_type: graphic_text_integration
+layout_mode: graphic-text
 source_file: G7-L29四張圖看地球暖化（圖文整合閱讀策略）.docx
 parsed_at: '2026-05-02T00:35:22'
 flags:

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
@@ -3,6 +3,7 @@ grade: 7
 grade_code: G7-L30
 reading_strategy: 圖文表整合閱讀策略
 reading_strategy_type: graphic_text_integration
+layout_mode: graphic-text
 source_file: G7-L30都是八哥為什麼命運不一樣（圖文表整合閱讀策略）.docx
 parsed_at: '2026-05-02T00:35:22'
 flags:

--- a/backend/data/strategy_prompts/default/prompt.yml
+++ b/backend/data/strategy_prompts/default/prompt.yml
@@ -1,0 +1,86 @@
+# Default 5-step rescue dialogue SOP
+# Used when lesson.reading_strategy_type doesn't have a specialized prompt.yml
+# Source: 林國源校長 5-step SOP (5/1 expert meeting), refined for any reading strategy.
+
+strategy: default
+display_name: 通用 5 步驟引導
+description: |
+  學生在閱讀理解 MCQ 答錯時觸發。AI 助教用通用 5 步驟引導學生答對：
+  確認題意 → 回課文找線索 → 自己的話復述 → 拉回題目 → 直接教學（fallback）。
+
+opening: |
+  我看到你選了 {wrong_answer}，沒關係，我們一起想想看。
+  先告訴我，你覺得這題在問什麼？
+
+steps:
+  - step: 1
+    name: confirm_understanding
+    label: 確認題意
+    intent: 確保學生有讀懂題目本身
+    advance_when: 學生能用自己的話複述題目
+    fail_when:
+      - 學生說「不知道」連續 2 次
+      - 學生跳開話題
+      - 學生只重複題目原文沒理解
+    sample_prompt: |
+      引導學生說對題目的理解。如果學生講不出來或誤解，引導他重讀題幹，
+      不要直接給答案。學生用自己話複述題目正確即 advance。
+
+  - step: 2
+    name: locate_in_text
+    label: 找課文線索
+    intent: 引導學生回課文找跟題目相關段落
+    advance_when: 學生能指出對應段落或關鍵句
+    fail_when:
+      - 學生說「都看過了」沒去找
+      - 學生隨機猜段落
+    sample_prompt: |
+      問學生「課文哪裡提到這個？」不要替學生指段落。
+      學生說出段落號碼或引用課文關鍵句即 advance。
+
+  - step: 3
+    name: paraphrase_in_own_words
+    label: 自己的話復述
+    intent: 確認學生真的理解段落內容（不是字面背誦）
+    advance_when: 學生用自己的話講出段落意思
+    fail_when:
+      - 學生只 copy 課文原句
+      - 學生講錯段落意思
+    sample_prompt: |
+      請學生用「自己的話」說明剛剛找到的段落在講什麼。
+      不能直接念課文。學生講出段落核心意思即 advance。
+
+  - step: 4
+    name: relate_to_question
+    label: 拉回題目
+    intent: 把學生對段落的理解連回 MCQ 選項
+    advance_when: 學生指出哪個選項對應段落內容
+    fail_when:
+      - 學生選錯第二次
+      - 學生說「我還是不會」
+    sample_prompt: |
+      問學生「那這樣看，A/B/C/D 哪個選項符合你剛剛說的？」
+      學生選對選項即 advance（terminate=true，學生通過）。
+
+  - step: 5
+    name: direct_teach_fallback
+    label: 直接教學
+    intent: 前 4 步都失敗時的最後手段
+    advance_when: N/A（terminate after this step）
+    sample_prompt: |
+      直接告訴學生「答案是 X，因為課文 Y 段提到 Z」。
+      最後問「現在懂了嗎？」結束（terminate=true）。
+
+terminate_conditions:
+  - student_passes_step_4_correctly: 學生在 step 4 選對選項
+  - give_up_after_3_dont_knows: 連續 3 次「不知道」→ 跳 step 5 直接教
+  - max_steps_5_completed: 5 步驟跑完一定 terminate
+
+tone:
+  - 短句，2-3 句一輪
+  - 口語化（「沒關係」「我們一起」「想想看」「咦」「對」）
+  - 不過度誇獎
+  - 不直接給答案直到 step 5
+  - 不重複學生原話（避免 echo loop）
+
+source: 林國源校長 + 陳淑麗教授 5/1 會議精簡版 SOP

--- a/backend/data/strategy_prompts/graphic_text_integration/prompt.yml
+++ b/backend/data/strategy_prompts/graphic_text_integration/prompt.yml
@@ -1,0 +1,105 @@
+# 圖文整合策略
+# Applies to lessons with reading_strategy_type: graphic_text_integration
+# (G7-L28, G7-L29, G7-L30 — 3 lessons total per 5/1 expert spec)
+# 5/1 會議重點：眼動研究證實低成就學生「完全不看圖」。
+# 教 25 分鐘策略後眼動率與閱讀理解都顯著提升。
+# AI 助教必須主動引導學生「看圖」，而不是被動等學生問。
+
+strategy: graphic_text_integration
+display_name: 圖文整合閱讀策略
+description: |
+  教學重點：學生在閱讀時必須**主動對應圖↔文**，從圖找線索回答課文題目。
+  AI 助教引導時優先問「課文哪段對應這張圖」、「圖告訴你什麼資訊」，
+  而非單純讓學生重讀文字。
+
+opening: |
+  我看到你選了 {wrong_answer}。這題其實答案在{image_hint}（看一下右邊那張圖）。
+  你能看圖告訴我，這張圖在呈現什麼嗎？
+
+steps:
+  - step: 1
+    name: describe_the_image
+    label: 描述圖內容
+    intent: 學生能用自己的話說出圖呈現的訊息
+    advance_when:
+      - 學生講出圖的主題（座標軸 / 比較對象 / 流程）
+      - 學生指出圖上的關鍵元素（線條走向 / 數字 / 標籤）
+    fail_when:
+      - 「沒看圖」「圖看不懂」
+      - 只講顏色不講內容
+    sample_prompt: |
+      引導學生「看圖」，不是「讀文字」。
+      問「這張圖在比較什麼？X 軸是什麼？Y 軸是什麼？」
+      （折線圖類）或「這張圖在描述什麼過程？」（流程圖類）
+      學生說出圖的核心訊息即 advance。
+
+  - step: 2
+    name: locate_text_referring_to_image
+    label: 找課文中提到這張圖的段落
+    intent: 學生在課文中找到「圖文對應錨點」
+    advance_when: 學生指出段落引用圖的關鍵句（如「如圖一所示...」）
+    fail_when:
+      - 隨便指段落
+      - 「課文沒說這張圖」
+    sample_prompt: |
+      問「課文哪裡提到這張圖？哪段在說明這張圖的意思？」
+      學生指出引用圖的段落即 advance。
+
+  - step: 3
+    name: synthesize_image_and_text
+    label: 圖 + 文 整合說明
+    intent: 學生能結合圖+文回答「圖告訴我們什麼」
+    advance_when: 學生用「圖加文」說明結論（不只憑圖、不只憑文字）
+    fail_when:
+      - 只說圖內容
+      - 只說文字內容
+      - 兩者拆開講
+    sample_prompt: |
+      問「綜合圖和課文，你覺得作者想說什麼？」
+      學生能整合（如「圖一顯示氣溫升高，課文也說 1850 年後加快」）即 advance。
+
+  - step: 4
+    name: relate_to_question
+    label: 拉回 MCQ 題目
+    intent: 學生用整合理解選對選項
+    advance_when: 學生選對選項
+    fail_when:
+      - 第二次選錯
+      - 「我還是不會」
+    sample_prompt: |
+      問「那這樣看，A/B/C/D 哪個選項符合你剛剛說的圖加文？」
+      學生選對即 terminate=true（通過）。
+
+  - step: 5
+    name: direct_teach_graphic
+    label: 直接教學（圖文對應示範）
+    intent: 前 4 步未通過時，AI 直接演示圖文對應
+    advance_when: N/A（terminate）
+    sample_prompt: |
+      直接示範：
+      「我們一起看：
+       - 圖告訴我們：{image content}
+       - 課文 X 段說：{matching paragraph}
+       - 結合起來，答案是 Y，因為圖+文都指向...」
+      最後問「現在會看了嗎？下次先看圖再讀文字哦。」結束。
+
+terminate_conditions:
+  - student_passes_step_4_correctly
+  - give_up_after_3_dont_knows
+  - max_steps_5_completed
+
+tone:
+  - 主動鼓勵「看圖」（「你看右邊那張圖」「先別讀字，看圖」）
+  - 引導學生「指」圖（mobile 環境指 = tap）
+  - 強調圖文整合（「圖告訴你 X，文字告訴你 Y，加在一起就是 Z」）
+  - 學生 step 1 說出圖內容時，要主動肯定（「對！你看到圖了」）— 強化看圖行為
+
+variant_notes:
+  # G7-L29「四張圖看地球暖化」— 4 張數據折線圖，學生要對比 4 張看趨勢
+  # G7-L30「都是八哥為什麼命運不一樣」— 對比表 + 物種圖，學生要從表抽特徵
+  # G7-L28「看不見的兇手」— 流程圖（巴斯德實驗），學生要看實驗步驟
+  - G7-L29: step 1 引導「比較這 4 張圖你看到什麼共同趨勢」
+  - G7-L30: step 1 引導「這個表的兩列分別是哪兩種八哥？」
+  - G7-L28: step 1 引導「這張圖是實驗流程，第一步是什麼？」
+
+source: 5/1 expert meeting (陳淑麗 + 簡教授吳大猷獎眼動研究) + 圖文整合教學文獻

--- a/backend/data/strategy_prompts/summary_psr/prompt.yml
+++ b/backend/data/strategy_prompts/summary_psr/prompt.yml
@@ -1,0 +1,98 @@
+# 摘要策略 — 問題 / 解決 / 結果 結構
+# Applies to lessons with reading_strategy_type: summary_psr
+# (G6-L22, G6-L23, G6-L24, G6-L25 — 4 lessons total per 5/1 expert spec)
+# Customizes the default 5-step SOP with PSR-specific scaffolding.
+
+strategy: summary_psr
+display_name: 摘要策略 — 問題.解決.結果
+description: |
+  教學重點：學生讀完故事後，能用「誰遇到什麼問題、怎麼解決、結果如何」三段式
+  結構摘要全文。AI 助教引導時主動要求學生在課文裡標出 P/S/R 三段。
+
+opening: |
+  我看到你選了 {wrong_answer}，沒關係。這題在問{question_focus}。
+  我們用「問題-解決-結果」的順序來想，你覺得這個故事裡，主角遇到什麼問題？
+
+steps:
+  - step: 1
+    name: identify_problem
+    label: 找出「問題」
+    intent: 學生能說出主角面臨的困境
+    advance_when:
+      - 學生說出主角名字 + 遇到的事
+      - 學生指認題目問的是 P / S / R 哪一段
+    fail_when:
+      - 「不知道」連續 2 次
+      - 隨便講不相關事件
+    sample_prompt: |
+      引導學生在課文中找「主角遇到什麼困難」。
+      問：「你能說出主角是誰、他遇到什麼麻煩嗎？」
+      學生答對「主角 + 困難」即 advance。
+
+  - step: 2
+    name: locate_solution_in_text
+    label: 找「解決」段落
+    intent: 學生在課文中指出主角採取行動的段落
+    advance_when: 學生指出段落號或引用解決行動的關鍵句
+    fail_when:
+      - 跳到結果，沒講解決過程
+      - 隨機猜
+    sample_prompt: |
+      問「主角想了什麼辦法？課文哪裡寫的？」
+      學生定位到正確段落（描述行動的段落）即 advance。
+
+  - step: 3
+    name: paraphrase_solution
+    label: 用自己的話講「解決」
+    intent: 學生用自己話復述解決行動，不只 copy 原文
+    advance_when: 學生講出解決行動的核心動作
+    fail_when:
+      - 只重複課文一句
+      - 講錯解決方式
+    sample_prompt: |
+      請學生用「自己的話」說明主角怎麼解決問題。
+      重點抓動作、人、工具，不是修飾語。
+
+  - step: 4
+    name: locate_result
+    label: 找「結果」回答題目
+    intent: 學生連接到問題的答案，扣回 MCQ 選項
+    advance_when: 學生選對選項
+    fail_when:
+      - 第二次選錯
+      - 「我還是不會」
+    sample_prompt: |
+      問「那最後結果怎樣？課文最後一段寫什麼？」
+      引導學生看課文結尾段，再問「這樣看，A/B/C/D 哪個對？」
+      學生選對即 terminate=true（通過）。
+
+  - step: 5
+    name: direct_teach_psr
+    label: 直接教學（PSR 三段式拆解）
+    intent: 前 4 步都未通過時，AI 直接示範 P/S/R 三段
+    advance_when: N/A（terminate）
+    sample_prompt: |
+      直接示範：
+      「我們來拆解一次：
+       - 問題：{summary of problem from story}
+       - 解決：{summary of solution}
+       - 結果：{summary of result}
+       所以答案是 X，對應的是『結果』那段。」
+      最後問「現在懂了嗎？」結束。
+
+terminate_conditions:
+  - student_passes_step_4_correctly
+  - give_up_after_3_dont_knows
+  - max_steps_5_completed
+
+tone:
+  - 強調「順序」：問題 → 解決 → 結果（語氣引導）
+  - 鼓勵學生在課文上動手指（「翻到第幾段？」）
+  - 不過度誇獎，但學生答對某段時可短肯定（「對」「沒錯」）
+
+variant_notes:
+  # G6-L23/24/25 是「摘要-問題.解決」沒有「結果」段，但仍 share 此 prompt。
+  # AI 應感知：若課文真的沒「結果」段，step 4 改成連回主題句即可，不勉強找結果。
+  - lesson G6-L23/24/25: 課文可能只有 P+S 沒明確 R，step 4 改問「主題句」
+
+source: 5/1 expert meeting (曾世杰 + 陳淑麗 + 林國源) + Sci of Reading 摘要策略文獻

--- a/backend/tests/test_strategy_prompts.py
+++ b/backend/tests/test_strategy_prompts.py
@@ -1,0 +1,178 @@
+"""
+Tests for strategy_prompts loader (#1404).
+
+Covers:
+  1. Known strategy type loads its prompt.yml
+  2. Unknown strategy type falls back to default.yml
+  3. None / empty string falls back to default.yml
+  4. Required default exists with required schema keys
+  5. list_available_strategies returns strategies with prompt.yml
+  6. Cache invalidation works
+  7. summary_psr prompt has 5 steps
+  8. graphic_text_integration prompt has 5 steps
+  9. All 7 designated lessons' strategy types resolve cleanly
+
+Run with:
+    cd backend && python -m pytest tests/test_strategy_prompts.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from app.services.strategy_prompts import (
+    StrategyPromptError,
+    clear_cache,
+    list_available_strategies,
+    load_strategy_prompt,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache_each_test():
+    """Each test starts with a clean LRU cache."""
+    clear_cache()
+    yield
+    clear_cache()
+
+
+# ── Specific strategy resolution ─────────────────────────────────────────────
+
+
+class TestKnownStrategyResolves:
+    def test_summary_psr_loads(self):
+        prompt = load_strategy_prompt("summary_psr")
+        assert prompt["strategy"] == "summary_psr"
+        assert "opening" in prompt
+        assert "steps" in prompt
+
+    def test_graphic_text_integration_loads(self):
+        prompt = load_strategy_prompt("graphic_text_integration")
+        assert prompt["strategy"] == "graphic_text_integration"
+
+    def test_default_loads(self):
+        prompt = load_strategy_prompt("default")
+        assert prompt["strategy"] == "default"
+
+
+# ── Fallback to default for unknown / none / empty ───────────────────────────
+
+
+class TestUnknownFallsBackToDefault:
+    def test_unknown_strategy_falls_back(self):
+        prompt = load_strategy_prompt("nonexistent_strategy_xyz")
+        assert prompt["strategy"] == "default"
+
+    def test_none_falls_back(self):
+        prompt = load_strategy_prompt(None)
+        assert prompt["strategy"] == "default"
+
+    def test_empty_string_falls_back(self):
+        prompt = load_strategy_prompt("")
+        assert prompt["strategy"] == "default"
+
+    def test_whitespace_only_falls_back(self):
+        prompt = load_strategy_prompt("   ")
+        assert prompt["strategy"] == "default"
+
+
+# ── Schema sanity for required strategies ────────────────────────────────────
+
+
+class TestPromptSchema:
+    REQUIRED_KEYS = {"strategy", "display_name", "opening", "steps"}
+
+    def test_default_has_required_keys(self):
+        prompt = load_strategy_prompt("default")
+        missing = self.REQUIRED_KEYS - prompt.keys()
+        assert not missing, f"default.yml missing keys: {missing}"
+
+    def test_default_has_5_steps(self):
+        prompt = load_strategy_prompt("default")
+        assert len(prompt["steps"]) == 5
+
+    def test_summary_psr_has_5_steps(self):
+        prompt = load_strategy_prompt("summary_psr")
+        assert len(prompt["steps"]) == 5
+
+    def test_graphic_text_integration_has_5_steps(self):
+        prompt = load_strategy_prompt("graphic_text_integration")
+        assert len(prompt["steps"]) == 5
+
+    def test_each_step_has_required_fields(self):
+        prompt = load_strategy_prompt("summary_psr")
+        for i, step in enumerate(prompt["steps"]):
+            for key in ("step", "name", "label", "intent"):
+                assert key in step, f"summary_psr step {i} missing {key}"
+
+
+# ── Listing ──────────────────────────────────────────────────────────────────
+
+
+class TestListAvailable:
+    def test_list_includes_default(self):
+        strategies = list_available_strategies()
+        assert "default" in strategies
+
+    def test_list_includes_summary_psr(self):
+        strategies = list_available_strategies()
+        assert "summary_psr" in strategies
+
+    def test_list_includes_graphic_text_integration(self):
+        strategies = list_available_strategies()
+        assert "graphic_text_integration" in strategies
+
+    def test_list_is_sorted(self):
+        strategies = list_available_strategies()
+        assert strategies == sorted(strategies)
+
+
+# ── 7 designated lessons all resolve to a non-error prompt ───────────────────
+
+
+class TestSevenDesignatedLessonsResolve:
+    """The 7 lessons assigned for 7/1 deadline must each resolve to a prompt
+    (either specific or default fallback), never raise."""
+
+    DESIGNATED_TYPES = [
+        # G6-L22, G6-L23, G6-L24, G6-L25 → summary_psr
+        ("summary_psr", "G6-L22~25"),
+        # G7-L28, G7-L29, G7-L30 → graphic_text_integration
+        ("graphic_text_integration", "G7-L28~30"),
+    ]
+
+    def test_all_seven_resolve(self):
+        for strategy_type, lessons in self.DESIGNATED_TYPES:
+            prompt = load_strategy_prompt(strategy_type)
+            assert prompt is not None, f"{lessons} ({strategy_type}) didn't resolve"
+            assert "opening" in prompt, f"{lessons} prompt missing opening"
+
+    def test_seven_lessons_use_non_default_specific_prompts(self):
+        """7 designated lessons should use SPECIFIC prompts, not fall back."""
+        for strategy_type, lessons in self.DESIGNATED_TYPES:
+            prompt = load_strategy_prompt(strategy_type)
+            assert prompt["strategy"] == strategy_type, (
+                f"{lessons} ({strategy_type}) fell back to {prompt['strategy']!r} "
+                "— specific prompt.yml missing"
+            )
+
+
+# ── Cache behavior ────────────────────────────────────────────────────────────
+
+
+class TestCacheBehavior:
+    def test_repeated_load_returns_same_object(self):
+        a = load_strategy_prompt("summary_psr")
+        b = load_strategy_prompt("summary_psr")
+        # LRU cache returns same object reference
+        assert a is b
+
+    def test_clear_cache_re_reads(self):
+        a = load_strategy_prompt("summary_psr")
+        clear_cache()
+        b = load_strategy_prompt("summary_psr")
+        # After clear, contents equal but objects differ
+        assert a == b
+        assert a is not b

--- a/docs/architecture/strategy-step-plugin-pattern.md
+++ b/docs/architecture/strategy-step-plugin-pattern.md
@@ -1,0 +1,261 @@
+# Plugin Pattern：策略 + Learning Step 雙軸彈性架構
+
+**Issue**: #1404（scaffold this pattern）
+**Builds on**: #1374（schema-driven step composition）、#1392（reading_strategy_type canonical types）、#1372（AI tutor prompt spec）
+**Date**: 2026-05-02
+**Status**: Active — 此架構是 #1387（AI 助教 implementation）+ #1341（圖文介面）+ 任何未來新策略 / 新 step 的共同基礎
+
+---
+
+## 0. TL;DR
+
+平台用兩個正交的 plugin 軸：
+- **Strategy axis**（教學法軸）：每個閱讀策略 = 一個 backend 資料夾（prompt + step recommendation）
+- **Step axis**（學習活動軸）：每個學習 step = 一個 frontend component（Intro、LiveTutor、ComprehensionChat、...）
+
+新增其中之一**只動單一軸**，另一軸不變。Lesson YAML 只引用 names，動態 dispatch。
+
+```
+新增「比較多元觀點」策略  → 加 1 個 backend 資料夾 + lesson yml 改一個 field（frontend 不動）
+新增「concept-mapping」step → 加 1 個 frontend component + STEP_REGISTRY 註冊（backend 不動）
+```
+
+---
+
+## 1. 兩軸架構
+
+### 1.1 Strategy Axis（backend）
+
+```
+backend/data/strategy_prompts/
+├── default/                            ← fallback when strategy_type unknown
+│   ├── prompt.yml                      ← 5-step SOP (林校長), generic version
+│   └── step_sequence.yml               ← recommended steps (intro, comprehension, vocab, full-reading, report)
+├── summary_psr/                        ← 摘要-問題.解決.結果（reading_strategy_type=summary_psr）
+│   ├── prompt.yml                      ← per-strategy AI tutor prompt
+│   └── step_sequence.yml               ← optional override
+├── summary/                            ← 摘要-其他變體
+├── graphic_text_integration/           ← 圖文整合
+├── inference/                          ← 推論策略 (32 課)
+├── compare_contrast/                   ← 比較多元觀點
+├── problem_solving/                    ← 解決問題-科學探究法
+├── classical_chinese/                  ← 文言文
+├── self_questioning/                   ← 自我提問
+├── writing_technique/                  ← 寫作手法
+└── general/                            ← 65 課的 fallback "general" type
+```
+
+**Loader**: `backend/app/services/strategy_prompts.py`
+```python
+def load_strategy_prompt(strategy_type: str) -> dict:
+    """
+    Resolution chain:
+    1. backend/data/strategy_prompts/{strategy_type}/prompt.yml
+    2. backend/data/strategy_prompts/default/prompt.yml
+    3. raise ValueError if neither exists (shouldn't happen — default is required)
+    """
+```
+
+新增策略只需 `mkdir backend/data/strategy_prompts/{new_type}/` + 寫 `prompt.yml`。
+
+### 1.2 Step Axis（frontend）
+
+已存在（#1374）：
+```
+frontend/src/components/reading-steps/
+├── Intro.tsx
+├── LiveTutor.tsx
+├── ComprehensionChat.tsx
+├── VocabPractice.tsx
+├── ... (25 個 component)
+
+frontend/src/config/stepConfig.ts
+└── STEP_REGISTRY: Map<step-id, {component, label, hint, view, dbStepNumber, enabled}>
+└── DEFAULT_STEP_SEQUENCE: ['intro', 'reading-annotation', 'live-tutor', ...]
+```
+
+**Hook**: `frontend/src/hooks/useStepSequence.ts`
+```ts
+export function useStepSequence(lesson: Story | null): StepConfig[] {
+  // 1. lesson.stepSequence (per-lesson YAML override) if set
+  // 2. DEFAULT_STEP_SEQUENCE fallback
+  // 3. filter by STEP_REGISTRY.enabled
+}
+```
+
+新增 step 只需：
+1. `mkdir frontend/src/components/reading-steps/{new-step}/` + 寫 component
+2. `STEP_REGISTRY` 註冊：`{ id: 'new-step', component: NewStep, label, hint, view, dbStepNumber }`
+3. `AppRoutes.tsx` 加 route
+4. lesson yml 在 `step_sequence` 加 `'new-step'`（或加進 `DEFAULT_STEP_SEQUENCE` 影響全 lesson）
+
+---
+
+## 2. 兩軸交會點：Lesson YAML
+
+每個課文 yml 用 names 引用兩軸（不寫死實作細節）：
+
+```yaml
+# backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
+lesson_code: G7-L28
+title: 看不見的兇手...
+reading_strategy: 圖文整合閱讀策略         # display name (中文，給 UI)
+reading_strategy_type: graphic_text_integration  # canonical type → matches strategy_prompts/{}/
+step_sequence:                              # optional, override DEFAULT_STEP_SEQUENCE
+  - intro
+  - reading-annotation
+  - comprehension-chat
+  - vocab-practice
+  - full-reading
+  - report
+layout_mode: graphic-text                   # ComprehensionChat variant: standard | graphic-text | graphic-chart
+# ... data fields ...
+```
+
+**Dispatch logic**：
+- Backend AI service：`strategy_prompts.load(lesson.reading_strategy_type)` → `prompt.yml`
+- Frontend rendering：`useStepSequence(lesson)` → `step_sequence` or DEFAULT_STEP_SEQUENCE
+- ComprehensionChat layout: detect `lesson.layout_mode` → render `StandardLayout` | `GraphicTextLayout` | `GraphicChartLayout`
+
+---
+
+## 3. 新增策略 — 5 分鐘流程
+
+範例：教授要新增「對比閱讀」策略
+
+```bash
+# 1. 建資料夾
+mkdir backend/data/strategy_prompts/contrast_reading/
+
+# 2. 寫 prompt.yml (template 從 default/prompt.yml copy)
+cp backend/data/strategy_prompts/default/prompt.yml \
+   backend/data/strategy_prompts/contrast_reading/prompt.yml
+# 編輯：客製化 5 步驟 SOP 的 step prompts
+vim backend/data/strategy_prompts/contrast_reading/prompt.yml
+
+# 3.（optional）寫 step_sequence.yml — 推薦這策略用什麼 step 順序
+vim backend/data/strategy_prompts/contrast_reading/step_sequence.yml
+
+# 4. lesson yml 標 strategy_type
+vim backend/data/lessons/_parsed_2026-05-01/G8-L99.yml
+# reading_strategy_type: contrast_reading
+
+# 5. commit + push + PR
+```
+
+**沒動 frontend 任何 code**。
+
+---
+
+## 4. 新增 Learning Step — 30 分鐘流程
+
+範例：要新增「concept mapping」step（學生畫概念圖）
+
+```bash
+# 1. 建 component
+mkdir frontend/src/components/reading-steps/concept-mapping/
+cat > frontend/src/components/reading-steps/concept-mapping/ConceptMapping.tsx <<'EOF'
+import { useLearningSession } from '@/hooks/useLearningSession';
+export function ConceptMapping() {
+  const { lesson } = useLearningSession();
+  return <div>...</div>;
+}
+EOF
+
+# 2. STEP_REGISTRY 註冊
+# frontend/src/config/stepConfig.ts:
+#   import { ConceptMapping } from '@/components/reading-steps/concept-mapping/ConceptMapping';
+#   STEP_REGISTRY['concept-mapping'] = {
+#     id: 'concept-mapping', component: ConceptMapping,
+#     label: '概念圖', hint: '畫出文章主要概念', view: AppView.LEARNING,
+#     dbStepNumber: 13, enabled: true
+#   };
+
+# 3. AppRoutes.tsx 加 route
+# <Route path="/learn/:storyId/concept-mapping" element={<ConceptMapping />} />
+
+# 4. （optional）lesson yml step_sequence 加 'concept-mapping'
+#    若不動 lesson yml，step 永遠不出現（因 DEFAULT_STEP_SEQUENCE 沒列）
+
+# 5. commit + push + PR
+```
+
+**沒動 backend 任何 code**。
+
+---
+
+## 5. 兩軸組合範例
+
+### 範例 A：新增「概念圖」step + 把它對應到「圖文整合」策略
+- 加 step（步驟 4）
+- 改 `backend/data/strategy_prompts/graphic_text_integration/step_sequence.yml`：
+  ```yaml
+  recommended_steps:
+    - intro
+    - reading-annotation
+    - comprehension-chat
+    - concept-mapping       ← NEW
+    - full-reading
+    - report
+  ```
+- G7-L28~30 yml 加 `step_sequence` override 也加 `concept-mapping`
+- 結果：圖文整合課文有概念圖 step，其他策略沒影響
+
+### 範例 B：新增「對比」策略 + 用既有 ComprehensionChat
+- 只做策略部分（步驟 3）
+- 不動 frontend
+- 結果：對比策略課文走既有 step flow，但 AI 助教用客製 prompt
+
+---
+
+## 6. Test Coverage 要求
+
+| 軸 | 必要測試 |
+|---|---|
+| Strategy loader | 1) 已知 type 載入正確 2) unknown type fallback to default 3) prompt.yml 缺欄位時 raise |
+| Step registry | 1) 所有 component import 成功 2) DEFAULT_STEP_SEQUENCE 全在 STEP_REGISTRY 3) hook resolves per-lesson override |
+| Combined | 1) lesson yml `reading_strategy_type` + `step_sequence` 同時設置時都 dispatch 對 |
+
+---
+
+## 7. Anti-pattern（不要做）
+
+❌ 在 `ComprehensionChat.tsx` 寫 `if (lesson.code.startsWith('G7-L28'))` — hardcode lesson ID
+❌ 在 frontend hardcode `if (strategyType === 'summary_psr') ... else if ...` — frontend 不該知道策略名
+❌ 把 prompt 字串寫在 backend Python code — 改 prompt 要動 code
+❌ 新增 step 卻直接改 `DEFAULT_STEP_SEQUENCE` — 影響所有 legacy lesson
+❌ 一個 component 處理多種策略的不同 layout — 用 layout_mode dispatch 變體
+
+---
+
+## 8. 7/1 deadline 內必補的 plumbing
+
+### Done by issue #1404 (this PR)
+- [x] `backend/app/services/strategy_prompts.py` loader（fallback chain）
+- [x] `backend/data/strategy_prompts/default/prompt.yml`
+- [x] `backend/data/strategy_prompts/summary_psr/prompt.yml`（G6-L22 用）
+- [x] `backend/data/strategy_prompts/graphic_text_integration/prompt.yml`（G7-L28~30 用）
+- [x] Unit tests for loader
+- [x] This architecture doc
+
+### Follow-up (不擋 #1404 PR，但 7/1 前要做)
+- [ ] Layer-1 57 課 reading_strategy_type backfill（人工 classify）
+- [ ] 剩 7 個 canonical type 的 prompt.yml（inference/summary/compare_contrast/...）
+- [ ] 7 課 step_sequence override（demo schema-driven）
+- [ ] `general` (65 課) 重新 audit 細分（可選）
+
+### Out of scope（7/2+）
+- 新增 step axis 的 step（concept-mapping、socratic-deep-dive 等）
+- 策略可有多個 prompt variant（A/B test）
+- Strategy → 推薦的 layout_mode 自動 dispatch（目前 layout_mode 在 lesson yml 手動設）
+
+---
+
+## 9. Refs
+
+- #1374 schema-driven step composition（已 ship）
+- #1372 AI tutor prompt spec（已 ship）
+- #1387 AI 助教 implementation（基於本架構）
+- #1341 圖文整合介面（基於 layout_mode dispatch）
+- 5/1 expert meeting record
+- CEO doc: `docs/ceo-review-2026-05-02.md`


### PR DESCRIPTION
## What

Plugin architecture for strategy + step axes — base for #1387 (AI 助教) and #1341 (圖文介面).

## Architecture

Two orthogonal plugin axes:
- **Strategy axis (backend)**: `backend/data/strategy_prompts/{type}/prompt.yml` → loader dispatches by `reading_strategy_type`
- **Step axis (frontend)**: existing `STEP_REGISTRY` in `stepConfig.ts` (#1374)

Lesson YAML uses canonical names. Dispatch is data-driven.

Full doc: `docs/architecture/strategy-step-plugin-pattern.md`

## How future extension works

**新策略（5 min）**: `mkdir backend/data/strategy_prompts/{new_type}/` + `prompt.yml`. Lesson yml 改 `reading_strategy_type`. Frontend 不動。

**新 step（30 min）**: 加 component + STEP_REGISTRY 註冊 + AppRoutes + lesson `step_sequence`. Backend 不動。

## Files

| File | 用途 |
|---|---|
| `docs/architecture/strategy-step-plugin-pattern.md` | Architecture spec |
| `backend/app/services/strategy_prompts.py` | YAML loader + LRU + fallback chain |
| `backend/data/strategy_prompts/default/prompt.yml` | 林校長 5-step generic SOP |
| `backend/data/strategy_prompts/summary_psr/prompt.yml` | G6-L22~25 用 |
| `backend/data/strategy_prompts/graphic_text_integration/prompt.yml` | G7-L28~30 用 |
| `backend/tests/test_strategy_prompts.py` | 20 unit tests |

## Wiring

- `lesson_loader.py`: propagate `reading_strategy_type` + `layout_mode` from yml to dict
- `schemas/story.py`: `StoryDetail` exposes both fields to API consumers
- 7 lesson yml: `layout_mode` added (G6=standard, G7=graphic-text)

## Tests

- 20/20 strategy_prompts tests pass
- 36/36 combined (strategy + yaml-first + schema) tests pass
- Loader probe: G6-L22 strategy_type=summary_psr layout_mode=standard
- Loader probe: G7-L28 strategy_type=graphic_text_integration layout_mode=graphic-text

## Refs

- Fixes #1404
- Depends on #1374 (schema-driven step composition, already shipped)
- Builds on #1372 (AI tutor prompt spec, evolved into per-strategy yaml)
- Unblocks #1387 (AI 助教 implementation)
- Unblocks #1341 (圖文介面 — uses layout_mode dispatch)

## Out of scope (follow-up)

- Layer-1 57 課 reading_strategy_type backfill（needs human classification）
- Other 7 canonical types' prompt.yml (inference/summary/compare_contrast/...)
- 7 課 step_sequence override（demo, P1）
- frontend ComprehensionChat layout_mode dispatch (per #1341 spec)