### PR TITLE
feat(comprehension): graphic-text 3-pane dispatch + apply to 7 課 (Fixes #1341)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -250,6 +250,8 @@ def get_story(story_id: str):
         # Plugin-pattern dispatch fields (#1404):
         reading_strategy_type=story.get("reading_strategy_type") or "general",
         layout_mode=story.get("layout_mode") or "standard",
+        # Image gallery for graphic-text layout (#1341)
+        images=story.get("images") or [],
     )
 
 

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -59,6 +59,9 @@ class StoryDetail(StoryListItem):
     reading_strategy_type: str = "general"
     # frontend ComprehensionChat layout variant: 'standard' | 'graphic-text' | 'graphic-chart'
     layout_mode: str = "standard"
+    # Image gallery for graphic-text layout (#1341)
+    # Each image: {filename, size_bytes, image_hash, content_type, caption?}
+    images: list[dict] = []
 
 
 class StoryListResponse(BaseModel):

--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -215,6 +215,8 @@ def _load_layer1_lessons() -> list[dict]:
             # Plugin-pattern dispatch fields (#1404):
             "reading_strategy_type": data.get("reading_strategy_type") or "general",
             "layout_mode": data.get("layout_mode") or "standard",
+            # Image gallery for graphic-text layout (#1341)
+            "images": data.get("images") or [],
             "intro": _build_intro(data),
             "_layer": 1,
         }
@@ -337,6 +339,8 @@ def _load_layer2_lessons(
             # Plugin-pattern dispatch fields (#1404):
             "reading_strategy_type": data.get("reading_strategy_type") or "general",
             "layout_mode": data.get("layout_mode") or "standard",
+            # Image gallery for graphic-text layout (#1341)
+            "images": data.get("images") or [],
             "intro": _build_intro({**data, "reading_strategy": strategy}),
             "_layer": 2,
         }

--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -267,16 +267,24 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   const totalTabs = [hasMcq, true, hasStrategy].filter(Boolean).length;
   const progressPercent = totalTabs > 0 ? Math.round((completedCount / totalTabs) * 100) : 0;
 
+  // ── #1341 Plugin pattern dispatch: graphic-text mode adds a middle image pane ──
+  // For G7-L28~30 (圖文整合策略): 3-pane layout (text 4 / images 4 / tabs 4)
+  // For other lessons (layout_mode=standard or undefined): 2-pane (text 7 / tabs 5)
+  const isGraphicText = story.layout_mode === 'graphic-text';
+  const storyImages = story.images ?? [];
+  const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+
   return (
     <div
       className="flex flex-col flex-1 h-full bg-surface overflow-hidden relative"
     >
       {/* ── Main content area — fills viewport, no page scroll ──── */}
       <div className="flex-1 min-h-0 px-4 md:px-6 py-6 md:py-8">
-        <div className="w-full h-full grid grid-cols-1 md:grid-cols-12 gap-6">
+        <div className={`w-full h-full grid grid-cols-1 ${isGraphicText ? 'lg:grid-cols-12' : 'md:grid-cols-12'} gap-6`}>
 
           {/* ── Left: Story text card ────────────────────────────── */}
-          <div className="md:col-span-7 lg:col-span-7 min-h-0 flex">
+          <div className={`${isGraphicText ? 'lg:col-span-4' : 'md:col-span-7 lg:col-span-7'} min-h-0 flex`}>
+
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full">
               <div className="flex items-center gap-2 mb-4 shrink-0">
                 <span className="material-symbols-outlined text-accent text-xl">menu_book</span>
@@ -316,8 +324,52 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
             </div>
           </div>
 
+          {/* ── Middle: Image gallery (graphic-text mode only) ─────── #1341 */}
+          {isGraphicText && (
+            <div data-testid="graphic-text-image-pane" className="lg:col-span-4 min-h-0 flex">
+              <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full">
+                <div className="flex items-center gap-2 mb-4 shrink-0">
+                  <span className="material-symbols-outlined text-accent text-xl">photo_library</span>
+                  <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">圖文對照</span>
+                  <span className="text-xs text-on-surface-variant ml-2">{storyImages.length} 張</span>
+                </div>
+                <div className="flex-1 min-h-0 overflow-y-auto pr-2 custom-scrollbar">
+                  {storyImages.length === 0 ? (
+                    <div className="flex items-center justify-center h-48 text-on-surface-variant text-sm">
+                      暫無圖片
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-1 gap-4">
+                      {storyImages.map((img, idx) => (
+                        <figure key={idx} className="space-y-2">
+                          <img
+                            src={`${GCS_IMAGE_BASE}/${story.lesson_code}/${img.filename}`}
+                            alt={img.caption ?? `圖 ${idx + 1}`}
+                            loading="lazy"
+                            className="w-full rounded-lg border border-outline-variant bg-surface"
+                            onError={(e) => {
+                              // Graceful fallback: hide broken image
+                              const el = e.currentTarget;
+                              el.style.display = 'none';
+                            }}
+                          />
+                          {img.caption && (
+                            <figcaption className="text-xs text-on-surface-variant">
+                              {img.caption}
+                            </figcaption>
+                          )}
+                        </figure>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* ── Right: Exercise panel ─────────────────────────────── */}
-          <div className="md:col-span-5 lg:col-span-5 min-h-0 flex flex-col">
+          <div className={`${isGraphicText ? 'lg:col-span-4' : 'md:col-span-5 lg:col-span-5'} min-h-0 flex flex-col`}>
+
             <div className="shrink-0">{renderTabs()}</div>
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex-1 min-h-0 overflow-y-auto custom-scrollbar">
               {renderRightContent()}

--- a/frontend/src/components/reading-steps/comprehension-layouts/GraphicTextLayout.tsx
+++ b/frontend/src/components/reading-steps/comprehension-layouts/GraphicTextLayout.tsx
@@ -1,0 +1,101 @@
+/**
+ * GraphicTextLayout — 圖文整合左右雙欄 layout (Day 1 shell).
+ *
+ * Day 1 scope:
+ * - Left pane: lesson paragraphs (independent scroll)
+ * - Right pane: grid of image placeholders (independent scroll)
+ *   Images are rendered as <img> tags using the GCS URL pattern.
+ *   No ImageStrip / ImageViewer / zoom yet (Day 3-4).
+ *
+ * Related to #1341
+ */
+import React from 'react';
+import { Story } from '../../../types';
+
+/** GCS image base URL pattern (Day 2 will verify actual serving) */
+const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+
+interface GraphicTextLayoutProps {
+  story: Story;
+}
+
+const GraphicTextLayout: React.FC<GraphicTextLayoutProps> = ({ story }) => {
+  const images = story.images ?? [];
+
+  return (
+    <div
+      data-testid="graphic-text-layout"
+      className="grid grid-cols-1 lg:grid-cols-2 h-full gap-0"
+    >
+      {/* Left pane: lesson text */}
+      <div className="overflow-y-auto border-r border-outline-variant p-4 lg:p-6">
+        <div className="space-y-4">
+          {(story.paragraphs ?? story.content ?? []).map((para, idx) => (
+            <p
+              key={idx}
+              data-paragraph-index={idx}
+              className="text-on-surface leading-relaxed text-base"
+            >
+              {para}
+            </p>
+          ))}
+        </div>
+      </div>
+
+      {/* Right pane: image gallery placeholder */}
+      <div className="overflow-y-auto p-4 lg:p-6 bg-surface-container">
+        {images.length === 0 ? (
+          <div className="flex items-center justify-center h-48 text-on-surface-variant text-sm">
+            暫無圖片
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3">
+            {images.map((img, idx) => {
+              // Build URL: GCS base / lesson_code / filename (strip "images/G7-LXX/" prefix if present)
+              const rawFilename = img.filename ?? '';
+              // filename in YAML is like "images/G7-L28/G7-L28-01.png"
+              // We need to convert to GCS key: lingoleap-assets/lessons-images/G7-L28/G7-L28-01.png
+              const parts = rawFilename.split('/');
+              const lessonCode = story.lesson_code ?? (parts.length >= 2 ? parts[1] : '');
+              const basename = parts[parts.length - 1];
+              const imgUrl = `${GCS_IMAGE_BASE}/${lessonCode}/${basename}`;
+
+              return (
+                <div
+                  key={idx}
+                  className="rounded-lg overflow-hidden bg-surface-container-high border border-outline-variant"
+                >
+                  <img
+                    src={imgUrl}
+                    alt={img.caption || `圖 ${idx + 1}`}
+                    loading="lazy"
+                    className="w-full object-contain"
+                    onError={(e) => {
+                      // Fallback: grey placeholder on load error
+                      const target = e.currentTarget;
+                      target.style.display = 'none';
+                      const fallback = target.nextElementSibling as HTMLElement | null;
+                      if (fallback) fallback.style.display = 'flex';
+                    }}
+                  />
+                  {/* Fallback placeholder (hidden until img error) */}
+                  <div
+                    className="hidden items-center justify-center h-24 text-xs text-on-surface-variant"
+                    aria-hidden="true"
+                  >
+                    圖 {idx + 1}
+                  </div>
+                  {img.caption && (
+                    <p className="text-xs text-on-surface-variant px-2 py-1">{img.caption}</p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GraphicTextLayout;

--- a/frontend/src/components/reading-steps/comprehension-layouts/LayoutShell.tsx
+++ b/frontend/src/components/reading-steps/comprehension-layouts/LayoutShell.tsx
@@ -1,0 +1,32 @@
+/**
+ * LayoutShell — dispatches ComprehensionChat to the correct layout variant
+ * based on lesson.layout_mode.
+ *
+ * layout_mode === 'graphic-text'  → GraphicTextLayout (left/right dual-pane)
+ * layout_mode === 'standard' | undefined → StandardLayout (existing 1-col)
+ *
+ * Related to #1341
+ */
+import React from 'react';
+import { Story, ReadingAttempt, ComprehensionResult } from '../../../types';
+import GraphicTextLayout from './GraphicTextLayout';
+import StandardLayout from './StandardLayout';
+
+interface LayoutShellProps {
+  story: Story;
+  attempt: ReadingAttempt;
+  onFinish: (result: ComprehensionResult) => void;
+  onBack: () => void;
+  dbSessionId?: number;
+  initialProgress?: Record<string, unknown>;
+  onProgressChange?: (stepData: Record<string, unknown>, immediate?: boolean) => void;
+}
+
+const LayoutShell: React.FC<LayoutShellProps> = ({ story, ...rest }) => {
+  if (story.layout_mode === 'graphic-text') {
+    return <GraphicTextLayout story={story} />;
+  }
+  return <StandardLayout story={story} {...rest} />;
+};
+
+export default LayoutShell;

--- a/frontend/src/components/reading-steps/comprehension-layouts/StandardLayout.tsx
+++ b/frontend/src/components/reading-steps/comprehension-layouts/StandardLayout.tsx
@@ -1,0 +1,27 @@
+/**
+ * StandardLayout — default 1-column comprehension layout.
+ *
+ * Extracts the existing ComprehensionChat visual output into its own component
+ * so LayoutShell can swap variants cleanly. Zero behaviour change.
+ *
+ * Related to #1341
+ */
+import React from 'react';
+import { Story, ReadingAttempt, ComprehensionResult } from '../../../types';
+import ComprehensionChat from '../ComprehensionChat';
+
+interface StandardLayoutProps {
+  story: Story;
+  attempt: ReadingAttempt;
+  onFinish: (result: ComprehensionResult) => void;
+  onBack: () => void;
+  dbSessionId?: number;
+  initialProgress?: Record<string, unknown>;
+  onProgressChange?: (stepData: Record<string, unknown>, immediate?: boolean) => void;
+}
+
+const StandardLayout: React.FC<StandardLayoutProps> = (props) => {
+  return <ComprehensionChat {...props} />;
+};
+
+export default StandardLayout;

--- a/frontend/src/components/reading-steps/comprehension-layouts/__tests__/LayoutShell.test.tsx
+++ b/frontend/src/components/reading-steps/comprehension-layouts/__tests__/LayoutShell.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * LayoutShell unit tests
+ * Tests that layout_mode correctly dispatches to the right layout variant.
+ *
+ * Related to #1341
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import LayoutShell from '../LayoutShell';
+import { Story, ReadingAttempt, ComprehensionResult } from '../../../../types';
+
+// Stub child components to keep tests focused on dispatch logic
+vi.mock('../GraphicTextLayout', () => ({
+  default: () => <div data-testid="graphic-text-layout">GraphicTextLayout</div>,
+}));
+
+vi.mock('../StandardLayout', () => ({
+  default: () => <div data-testid="standard-layout">StandardLayout</div>,
+}));
+
+const baseStory: Story = {
+  id: 'test-1',
+  title: '測試課文',
+  level: 5,
+  content: ['第一段', '第二段'],
+  thumbnail: '',
+  category: 'Daily',
+  filename: 'test.yml',
+};
+
+const baseAttempt: ReadingAttempt = {
+  storyId: 'test-1',
+  accuracy: 0.9,
+  fluency: 0.8,
+  cpm: 200,
+  mispronouncedWords: [],
+  transcription: '',
+  timestamp: Date.now(),
+};
+
+const noopFinish = (_: ComprehensionResult) => {};
+const noopBack = () => {};
+
+describe('LayoutShell', () => {
+  it('renders GraphicTextLayout when layout_mode is graphic-text', () => {
+    render(
+      <LayoutShell
+        story={{ ...baseStory, layout_mode: 'graphic-text' }}
+        attempt={baseAttempt}
+        onFinish={noopFinish}
+        onBack={noopBack}
+      />
+    );
+    expect(screen.getByTestId('graphic-text-layout')).toBeTruthy();
+    expect(screen.queryByTestId('standard-layout')).toBeNull();
+  });
+
+  it('renders StandardLayout when layout_mode is standard', () => {
+    render(
+      <LayoutShell
+        story={{ ...baseStory, layout_mode: 'standard' }}
+        attempt={baseAttempt}
+        onFinish={noopFinish}
+        onBack={noopBack}
+      />
+    );
+    expect(screen.getByTestId('standard-layout')).toBeTruthy();
+    expect(screen.queryByTestId('graphic-text-layout')).toBeNull();
+  });
+
+  it('falls back to StandardLayout when layout_mode is undefined', () => {
+    render(
+      <LayoutShell
+        story={{ ...baseStory }}
+        attempt={baseAttempt}
+        onFinish={noopFinish}
+        onBack={noopBack}
+      />
+    );
+    expect(screen.getByTestId('standard-layout')).toBeTruthy();
+    expect(screen.queryByTestId('graphic-text-layout')).toBeNull();
+  });
+});

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -131,6 +131,22 @@ export interface Story {
    * Absent for all legacy (Layer-1) lessons — they use DEFAULT_STEP_SEQUENCE as fallback.
    */
   stepSequence?: string[];
+  /** Layout variant for ComprehensionChat (#1341). Default: 'standard'. */
+  layout_mode?: 'standard' | 'graphic-text' | 'graphic-chart';
+  /** Canonical strategy type for backend dispatch (#1404). */
+  reading_strategy_type?: string;
+  /** Lesson code (e.g. 'G7-L28'), used for image URL construction (#1341). */
+  lesson_code?: string;
+  /** Images for graphic-text layout (#1341). */
+  images?: {
+    filename: string;
+    size_bytes: number;
+    image_hash: string;
+    content_type: string;
+    caption?: string;
+  }[];
+  /** Paragraphs array (Layer-2 lessons use this instead of content). */
+  paragraphs?: string[];
 }
 
 export interface ReadingAttempt {


### PR DESCRIPTION
## What

Plugin-pattern dispatch implementation — lesson.layout_mode 真的切換 frontend layout，套用到 7 課 2 策略。

## Lesson dispatch matrix

| 課 | strategy_type | layout_mode | UI 變化 |
|---|---|---|---|
| G6-L22~25 (摘要策略) | summary_psr | standard | 既有 2-pane (story 7col + exercises 5col)，**無 regression** |
| G7-L28~30 (圖文整合) | graphic_text_integration | graphic-text | **新 3-pane** (story 4col + images 4col + exercises 4col) |

## Files

- frontend/src/components/reading-steps/comprehension-layouts/{LayoutShell,StandardLayout,GraphicTextLayout}.tsx — Day 1 layout shells (preserved)
- frontend/src/components/reading-steps/comprehension-layouts/__tests__/LayoutShell.test.tsx
- frontend/src/types.ts — Story type extended with layout_mode / reading_strategy_type / images / paragraphs / lesson_code
- **frontend/src/components/reading-steps/ComprehensionChat.tsx — 整合**：偵測 layout_mode 在 grid markup 直接 dispatch（minimal-diff），不破壞 standard 2-pane behavior

## Image source

GCS pattern: `lingoleap-assets/lessons-images/{lesson_code}/{filename}` (matches existing thumbnail GCS bucket).
Image onError 隱藏 broken image，graceful fallback。Day 2 verify GCS serving。

## Verify after merge

```bash
# G6-L22 → 既有 2-pane
open https://lingoleap-frontend-staging-958347263320.asia-east1.run.app/learn/1076/comprehension

# G7-L28 → NEW 3-pane (text | images | exercises)
open https://lingoleap-frontend-staging-958347263320.asia-east1.run.app/learn/1108/comprehension
```

## Refs
- Fixes #1341
- Builds on #1404 plugin pattern (loader + 3 strategy_prompts yaml)
- Uses #1411 layout_mode restore (G7 yml)
- Per 5/1 expert meeting §三.6 (圖文整合左右並陳)