### PR TITLE
fix(yaml): restore G7 layout_mode lost in #1408 (Fixes #1411)

### DIFF
--- a/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
@@ -3,6 +3,7 @@ grade: 7
 grade_code: G7-L28
 reading_strategy: 圖文整合閱讀策略
 reading_strategy_type: graphic_text_integration
+layout_mode: graphic-text
 source_file: G7-L28看不見的兇手：以實驗破解肉湯腐敗之謎（圖文整合閱讀策略）.docx
 parsed_at: '2026-05-02T16:24:34'
 flags:

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
@@ -3,6 +3,7 @@ grade: 7
 grade_code: G7-L29
 reading_strategy: 圖文整合閱讀策略
 reading_strategy_type: graphic_text_integration
+layout_mode: graphic-text
 source_file: G7-L29四張圖看地球暖化（圖文整合閱讀策略）.docx
 parsed_at: '2026-05-02T16:24:34'
 flags:

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
@@ -3,6 +3,7 @@ grade: 7
 grade_code: G7-L30
 reading_strategy: 圖文表整合閱讀策略
 reading_strategy_type: graphic_text_integration
+layout_mode: graphic-text
 source_file: G7-L30都是八哥為什麼命運不一樣（圖文表整合閱讀策略）.docx
 parsed_at: '2026-05-02T16:24:35'
 flags:


### PR DESCRIPTION
Restore `layout_mode: graphic-text` for G7-L28/29/30. 3-line fix.

Refs: #1411, regression from #1408