### PR TITLE
fix(layout): graphic-text dispatch in ComprehensionLayout (Fixes #1413)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -43,6 +43,13 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
 
   const storyText = useMemo(() => story.content.join('\n'), [story.content]);
 
+  // ── #1341 plugin-pattern dispatch: graphic-text adds middle image pane ────
+  // For G7-L28~30 (圖文整合策略): 3-pane (story 4 / images 4 / exercise 4)
+  // For other lessons: 2-pane (story 7 / exercise 5) — unchanged
+  const isGraphicText = story.layout_mode === 'graphic-text';
+  const storyImages = story.images ?? [];
+  const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden bg-surface relative">
       {/* ── Main content area ─────────────────────────────────────────────────── */}
@@ -55,7 +62,8 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
         <div className="w-full h-full grid grid-cols-1 md:grid-cols-12 grid-rows-[1fr] gap-6">
 
           {/* ── Left: Story text card ─────────────────────────────────────────── */}
-          <div className="md:col-span-7 min-h-0 flex">
+          <div className={`${isGraphicText ? 'md:col-span-4' : 'md:col-span-7'} min-h-0 flex`}>
+
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full min-h-0">
               <div className="flex items-center gap-2 mb-4 shrink-0">
                 <span className="material-symbols-outlined text-accent text-xl">menu_book</span>
@@ -104,7 +112,52 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
           </div>
 
           {/* ── Right: Exercise panel ─────────────────────────────────────────── */}
-          <div className="md:col-span-5 min-h-0 flex flex-col">
+          {/* ── Middle: Image gallery (graphic-text mode only) ─────── #1341 */}
+          {isGraphicText && (
+            <div data-testid="graphic-text-image-pane" className="md:col-span-4 min-h-0 flex">
+              <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full min-h-0">
+                <div className="flex items-center gap-2 mb-4 shrink-0">
+                  <span className="material-symbols-outlined text-accent text-xl">photo_library</span>
+                  <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">
+                    圖文對照
+                  </span>
+                  <span className="text-xs text-on-surface-variant ml-2">{storyImages.length} 張</span>
+                </div>
+                <div className="flex-1 min-h-0 overflow-y-auto pr-2 custom-scrollbar">
+                  {storyImages.length === 0 ? (
+                    <div className="flex items-center justify-center h-48 text-on-surface-variant text-sm">
+                      暫無圖片
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-1 gap-4">
+                      {storyImages.map((img, idx) => (
+                        <figure key={idx} className="space-y-2">
+                          <img
+                            src={`${GCS_IMAGE_BASE}/${story.lesson_code}/${img.filename}`}
+                            alt={img.caption ?? `圖 ${idx + 1}`}
+                            loading="lazy"
+                            className="w-full rounded-lg border border-outline-variant bg-surface"
+                            onError={(e) => {
+                              const el = e.currentTarget;
+                              el.style.display = 'none';
+                            }}
+                          />
+                          {img.caption && (
+                            <figcaption className="text-xs text-on-surface-variant">
+                              {img.caption}
+                            </figcaption>
+                          )}
+                        </figure>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* ── Right: Exercise panel ─────────────────────────────────────────── */}
+          <div className={`${isGraphicText ? 'md:col-span-4' : 'md:col-span-5'} min-h-0 flex flex-col`}>
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex-1 min-h-0 overflow-y-auto custom-scrollbar">
               {children}
             </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -64,6 +64,10 @@ interface ApiStoryDetail extends ApiStoryListItem {
   strategy_exercise: Record<string, any> | any[] | null;  // list for multi-exercise lessons (G7 圖文整合, #1390)
   // Schema-driven step composition (#1374)
   step_sequence: string[] | null;
+  // Plugin-pattern dispatch fields (#1404 / #1341)
+  layout_mode?: 'standard' | 'graphic-text' | 'graphic-chart';
+  reading_strategy_type?: string;
+  images?: Array<{ filename: string; size_bytes: number; image_hash: string; content_type: string; caption?: string }>;
 }
 
 interface ApiStoryListResponse {
@@ -111,6 +115,12 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     knowledgeVideoUrl: detail.knowledge_video_url ?? undefined,
     strategyExercise: detail.strategy_exercise ?? undefined,
     stepSequence: detail.step_sequence ?? undefined,
+    // Plugin-pattern dispatch fields (#1404 / #1341):
+    layout_mode: (detail.layout_mode as Story['layout_mode']) ?? 'standard',
+    reading_strategy_type: detail.reading_strategy_type ?? 'general',
+    images: detail.images ?? [],
+    lesson_code: detail.grade_code ?? '',
+    paragraphs: detail.paragraphs,
   };
 }
 


### PR DESCRIPTION
Fix wrong-component edit from PR #1406. Move 3-pane dispatch from ComprehensionChat (dead code) to ComprehensionLayout (real shared wrapper).

Refs #1341 / #1413 / #1406