### PR TITLE
fix(loader): accept singular strategy_exercise key (Gemini guided_steps)

### DIFF
--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -329,7 +329,12 @@ def _load_layer2_lessons(
             ),
             "reading_benchmark": data.get("reading_benchmark"),
             "source_file": data.get("source_file"),
-            "strategy_exercise": data.get("strategy_exercises"),  # note: parsed key differs
+            # Accept both keys: 'strategy_exercise' (singular, guided_steps shape — Gemini
+            # structured output from #1418) OR 'strategy_exercises' (plural, legacy skeleton
+            # list shape for G7 圖文整合). Singular takes priority.
+            "strategy_exercise": (
+                data.get("strategy_exercise") or data.get("strategy_exercises")
+            ),
             "story_structure_table": data.get("story_structure_table"),
             "story_structure_rows": data.get("story_structure_rows"),
             "display_order": display_order,


### PR DESCRIPTION
## Bug

After #1418 merged Gemini-structured guided_steps into G6-L22~25 yml under key
\`strategy_exercise\` (singular), the API returns \`strategy_exercise: null\`
for those lessons. Frontend shows "此課文尚未有閱讀聚光燈練習" despite the
data being in yml.

Root cause: \`lesson_loader._load_layer2_lessons\` only reads
\`data.get('strategy_exercises')\` (plural — legacy parser key).

## Fix

One-line: try singular first, fall back to plural.

\`\`\`python
"strategy_exercise": (
    data.get("strategy_exercise") or data.get("strategy_exercises")
),
\`\`\`

## Test plan

- [ ] Staging API GET /api/stories/1076 returns \`strategy_exercise.type='guided_steps'\` with 8 steps
- [ ] G6-L22 reading-strategy frontend page renders the 8-step exercise (not "尚未有")
- [ ] G7-L29/L30 still render legacy skeleton (plural key, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)