### PR TITLE
fix(typography): reduce zhuyin spacing + remove bold for reading-friendly display (Fixes #1338)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -296,7 +296,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                     <span className="text-xs font-headline font-bold text-on-surface-variant/30 pt-1 select-none shrink-0 w-5 text-right">
                       {String(idx + 1).padStart(2, '0')}
                     </span>
-                    <p className={`text-lg md:text-xl text-on-surface leading-[2.6rem] md:leading-[3rem] ${isZhuyinAny ? 'tracking-[0.3em]' : ''}`}>
+                    <p className={`text-lg md:text-xl text-on-surface leading-[2rem] md:leading-[2.2rem] ${isZhuyinAny ? 'tracking-[0.15em]' : ''}`}>
                       {zhuyinLines ? zhuyinLines[idx] : line}
                     </p>
                   </div>

--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -80,8 +80,8 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
                       {String(idx + 1).padStart(2, '0')}
                     </span>
                     <p
-                      className={`text-lg md:text-xl text-on-surface leading-[2.6rem] md:leading-[3rem] ${
-                        zhuyinActive ? 'tracking-[0.3em]' : ''
+                      className={`text-lg md:text-xl text-on-surface leading-[2rem] md:leading-[2.2rem] ${
+                        zhuyinActive ? 'tracking-[0.15em]' : ''
                       }`}
                     >
                       {zhuyinLines ? zhuyinLines[idx] : line}

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -396,7 +396,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
                   <span className="text-xs font-headline font-bold text-on-surface-variant/40 pt-2 select-none shrink-0 w-6 text-right">
                     {String(idx + 1).padStart(2, '0')}
                   </span>
-                  <p className={`text-xl md:text-2xl text-on-surface leading-[3rem] md:leading-[3.5rem] ${isZhuyinAny ? 'tracking-[0.4em]' : ''}`}>
+                  <p className={`text-xl md:text-2xl text-on-surface leading-[2rem] md:leading-[2.2rem] ${isZhuyinAny ? 'tracking-[0.15em]' : ''}`}>
                     {renderParagraph(line, idx)}
                   </p>
                 </div>

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -106,12 +106,12 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 </span>
                 <span className="text-[10px] text-gray-400">難度 {story.level}</span>
               </div>
-              <h1 className={`text-2xl font-bold text-on-surface ${zhuyinActive ? 'leading-[3rem] tracking-[0.4em]' : 'leading-[1.5]'}`}>
+              <h1 className={`text-2xl font-normal text-on-surface ${zhuyinActive ? 'leading-[2.4rem] tracking-[0.15em]' : 'leading-[1.5]'}`}>
                 {processZhuyin(story.title)}
               </h1>
               {story.intro && (
                 <p
-                  className={`text-base ${zhuyinActive ? 'leading-[2.6] tracking-[0.3em]' : 'leading-[1.5]'} text-gray-600`}
+                  className={`text-base ${zhuyinActive ? 'leading-[2] tracking-[0.15em]' : 'leading-[1.5]'} text-gray-600`}
                   aria-label={`作者：${story.intro.author}`}
                 >
                   {processZhuyin(story.intro.author)}
@@ -156,7 +156,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                 </svg>
                 <span className="text-xs font-bold text-accent-light uppercase tracking-widest">課文簡介</span>
               </div>
-              <p className={`text-on-surface text-2xl ${zhuyinActive ? 'leading-[3.5rem] tracking-[0.4em]' : 'leading-[1.6]'}`}>
+              <p className={`text-on-surface text-2xl ${zhuyinActive ? 'leading-[2.4rem] tracking-[0.15em]' : 'leading-[1.6]'}`}>
                 {processZhuyin(story.intro.background)}
               </p>
 

--- a/frontend/src/components/reading-steps/ListeningPractice.tsx
+++ b/frontend/src/components/reading-steps/ListeningPractice.tsx
@@ -224,7 +224,7 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
                       <span className="text-xs font-headline font-bold text-on-surface-variant/40 pt-2 select-none shrink-0 w-6 text-right">
                         {String(idx + 1).padStart(2, '0')}
                       </span>
-                      <p className={`text-xl md:text-2xl text-on-surface leading-[3rem] md:leading-[3.5rem] ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}>
+                      <p className={`text-xl md:text-2xl text-on-surface leading-[2rem] md:leading-[2.2rem] ${zhuyinActive ? 'tracking-[0.15em]' : ''}`}>
                         {zh(line)}
                       </p>
                     </div>

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -575,7 +575,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
 
           {/* Title */}
           <div className="text-center mb-8 px-6">
-            <h1 className="font-headline font-extrabold text-3xl md:text-4xl text-on-surface tracking-tight leading-tight">
+            <h1 className="font-headline font-medium text-3xl md:text-4xl text-on-surface tracking-tight leading-tight">
               {story.title}
             </h1>
           </div>
@@ -599,8 +599,8 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
                     className="text-on-surface/90"
                     style={{
                       fontSize: `${fontSizePx}px`,
-                      lineHeight: isZhuyinAny ? '3.8rem' : '2.0',
-                      letterSpacing: isZhuyinAny ? '0.35em' : '0.02em',
+                      lineHeight: isZhuyinAny ? '2.4rem' : '1.6', /* ruby annotations need 2.4rem minimum to avoid clipping */
+                      letterSpacing: isZhuyinAny ? '0.15em' : '0',
                     }}
                   >
                     {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -199,10 +199,10 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 
       {/* Paragraph text — with TTS character highlight */}
       <p
-        className={`text-on-surface/90 ${zhuyinActive ? 'tracking-[0.4em]' : ''}`}
+        className={`text-on-surface/90 ${zhuyinActive ? 'tracking-[0.15em]' : ''}`}
         style={{
           fontSize: fontSizePx,
-          lineHeight: zhuyinActive ? '3.8rem' : '1.6',
+          lineHeight: zhuyinActive ? '2.4rem' : '1.6', /* ruby annotations need 2.4rem minimum to avoid clipping */
         }}
       >
         {status === 'locked' ? (


### PR DESCRIPTION
Fixes #1338

## Summary

Per 5/1 expert review feedback (陳淑麗教授「字距行距太寬不利閱讀，貼近 Word default」) and Young 2026-05-03 follow-up to make zhuyin mode spacing match non-zhuyin.

### Files changed (7)

| File | Change |
|------|--------|
| `ReadingAnnotation.tsx` | lineHeight 2.0→1.6 / 3.8rem→2.4rem; letterSpacing 0.02em→0 / 0.35em→0.15em; title font-extrabold→font-medium |
| `ParagraphCard.tsx` | tracking-[0.4em]→tracking-[0.15em]; lineHeight 3.8rem→2.4rem |
| `Intro.tsx` | zhuyin title leading-[3rem]→[2.4rem] tracking-[0.4em]→[0.15em]; author leading-[2.6]→[2] tracking-[0.3em]→[0.15em]; bg leading-[3.5rem]→[2.4rem] tracking-[0.4em]→[0.15em]; font-bold→font-normal on h1 |
| `FullReading.tsx` | leading-[3rem] md:leading-[3.5rem] → leading-[2rem] md:leading-[2.2rem]; tracking-[0.4em]→[0.15em] |
| `ComprehensionChat.tsx` | leading-[2.6rem] md:leading-[3rem] → leading-[2rem] md:leading-[2.2rem]; tracking-[0.3em]→[0.15em] |
| `ComprehensionLayout.tsx` | leading-[2.6rem] md:leading-[3rem] → leading-[2rem] md:leading-[2.2rem]; tracking-[0.3em]→[0.15em] |
| `ListeningPractice.tsx` | leading-[3rem] md:leading-[3.5rem] → leading-[2rem] md:leading-[2.2rem]; tracking-[0.4em]→[0.15em] |

Note: 2.4rem zhuyin line-height is the minimum to prevent ruby annotation clipping.

## Test plan

- [ ] Open `/learn/5/reading-annotation`, toggle zhuyin on/off — verify spacing tightens in both modes
- [ ] Verify article title is not bold (font-medium)
- [ ] Verify `/learn/5/tutor` (ParagraphCard) zhuyin spacing matches reading annotation
- [ ] Check `/learn/5/comprehension` sidebar text spacing
- [ ] Check `/learn/5/full-reading` paragraph spacing
- [ ] Confirm zhuyin annotations don't clip into previous line (2.4rem clearance)