### PR TITLE
feat: extract worksheet intro + render step list (Fixes #1434)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(touch .git/security-audit-passed)",
+      "Bash(git commit -m ' *)",
+      "Bash(/Users/young/project/chinese-literacy-platform/backend/.venv/bin/python -m pytest backend/tests/test_stories_pagination.py -v)",
+      "Bash(git add *)",
+      "Bash(touch .git/claude-code-review-passed)",
+      "Bash(touch /Users/young/project/chinese-literacy-platform/.git/worktrees/clp-issue-1417/security-audit-passed)"
+    ]
+  }
+}

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -62,6 +62,11 @@ class StoryDetail(StoryListItem):
     # Image gallery for graphic-text layout (#1341)
     # Each image: {filename, size_bytes, image_hash, content_type, caption?}
     images: list[dict] = []
+    # 學習單 section ordering + intro metadata (#1434)
+    # worksheet_section_order: [{number: '二', name: '念順順', type: 'reading_timer'}, ...]
+    worksheet_section_order: Optional[list[dict]] = None
+    # worksheet_intro: {step_label, target_strategy, instructions, level_label, lesson_label, authors}
+    worksheet_intro: Optional[dict] = None
 
 
 class StoryListResponse(BaseModel):

--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -218,6 +218,9 @@ def _load_layer1_lessons() -> list[dict]:
             # Image gallery for graphic-text layout (#1341)
             "images": data.get("images") or [],
             "intro": _build_intro(data),
+            # 學習單 section order + intro metadata (#1434) — None for Layer-1
+            "worksheet_section_order": data.get("worksheet_section_order"),
+            "worksheet_intro": data.get("worksheet_intro"),
             "_layer": 1,
         }
         lessons.append(lesson)
@@ -347,6 +350,9 @@ def _load_layer2_lessons(
             # Image gallery for graphic-text layout (#1341)
             "images": data.get("images") or [],
             "intro": _build_intro({**data, "reading_strategy": strategy}),
+            # 學習單 section order + intro metadata (#1434)
+            "worksheet_section_order": data.get("worksheet_section_order"),
+            "worksheet_intro": data.get("worksheet_intro"),
             "_layer": 2,
         }
         lessons.append(lesson)

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L1.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L1.yml
@@ -204,3 +204,10 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第1課  贏得喝󠇡采的輸家

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L10.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L10.yml
@@ -340,3 +340,12 @@ worksheet_section_order:
 - number: 八
   name: 詞語複習
   type: word_search
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第10課　美好的一天
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L11.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L11.yml
@@ -367,3 +367,12 @@ worksheet_section_order:
 - number: 八
   name: 詞語複習
   type: word_search
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第11課　誤會
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L12.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L12.yml
@@ -276,3 +276,12 @@ worksheet_section_order:
 - number: 八
   name: 詞語複習
   type: word_search
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第12課　黃絲帶
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L13.yml
@@ -200,3 +200,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第13課  第一百碗麵

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L14.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L14.yml
@@ -202,3 +202,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第14課  白牙的最後一戰
+  authors: 課文：曾世杰  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L15.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L15.yml
@@ -239,3 +239,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・抒情文
+  lesson_label: 第15課 感情小日記1──是友情還是愛情？

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L16.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L16.yml
@@ -229,3 +229,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・抒情文
+  lesson_label: 第16課  感情小日記2──喜歡是什麼？

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L17.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L17.yml
@@ -256,3 +256,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 生涯探索──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・應用文
+  lesson_label: 第17課 把球打好，就夠了嗎？
+  authors: 課文：許元耕  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L18.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L18.yml
@@ -189,3 +189,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 生涯探索──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・應用文
+  lesson_label: 第18課 想讀書，該從哪裡著手？
+  authors: 課文：許元耕  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L19.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L19.yml
@@ -287,3 +287,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 用表格整理訊息
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・說明文
+  lesson_label: 第19課  救援大隊的好幫手
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L2.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L2.yml
@@ -257,3 +257,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 寫作手法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第2課 十秒的背後
+  authors: 課文：吳漢庭  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L20-22.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L20-22.yml
@@ -330,3 +330,12 @@ worksheet_section_order:
 - number: 十
   name: 念順順
   type: reading_timer
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 多文本閱讀──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。-
+  lesson_label: 第20課 物以稀為貴：
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L23.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L23.yml
@@ -241,3 +241,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格聚光燈──自我覺察
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・議論文
+  lesson_label: 第23課  心，也要一起練

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L24.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L24.yml
@@ -221,3 +221,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格聚光燈
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第24課  成為身體的最佳夥伴

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L25.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L25.yml
@@ -238,3 +238,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格聚光燈
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・議論文
+  lesson_label: 第25課  身體，謝謝你

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L26.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L26.yml
@@ -243,3 +243,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格聚光燈
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・議論文
+  lesson_label: 第26課  專注當下：關掉內心的批評噪音

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L27.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L27.yml
@@ -209,3 +209,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格聚光燈
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・議論文
+  lesson_label: 第27課  從白熊到藍海豚：學習與念頭和平相處

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L3.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L3.yml
@@ -259,3 +259,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 認識句型──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・說明文
+  lesson_label: 第3課 長高的祕密
+  authors: 課文：吳漢庭  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L4.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L4.yml
@@ -390,3 +390,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 認識句型
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・說明文
+  lesson_label: 第4課  運動科學
+  authors: 課文：吳漢庭  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L5.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L5.yml
@@ -226,3 +226,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──推論代名詞0
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第5課  穿越極限的跑者
+  authors: 課文：吳漢庭  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L6.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L6.yml
@@ -259,3 +259,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──推論代名詞
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・說明文
+  lesson_label: 第6課  這是什麼「意思」？

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L7.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L7.yml
@@ -331,3 +331,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第7課　正太與小豬：武僧的養成之路
+  authors: 課文：曾世杰  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L8.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L8.yml
@@ -293,3 +293,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・記敘文
+  lesson_label: 第8課  最美的畫面
+  authors: 課文：林玫伶  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G4-L9.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G4-L9.yml
@@ -304,3 +304,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略── 列舉結構：找重要細節
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 4・說明文
+  lesson_label: 第9課  大自然的氣象小幫手
+  authors: 課文：曾世杰  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L1.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L1.yml
@@ -230,3 +230,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 拆詞釋義──藉由拆解字詞來推測詞義
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  lesson_label: 第1課  兵來將擋，水來土掩
+  authors: 課文：曾世杰  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L10.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L10.yml
@@ -235,3 +235,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──從言行推論人物特質
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第10課 從童工到大學教授之路
+  authors: 課文：陳淑麗  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L11.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L11.yml
@@ -209,3 +209,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──從言行推論人物特質
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第11課 「拳」力出擊──陳念琴
+  authors: 課文：余茹帆  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L12.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L12.yml
@@ -355,3 +355,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  lesson_label: 第12課  六塊肌、六塊雞
+  authors: 課文：吳漢庭  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L13.yml
@@ -310,3 +310,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  lesson_label: 第13課  小丑醫生
+  authors: 課文：林玫伶  學習單：高芳瑄

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L14.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L14.yml
@@ -272,3 +272,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  lesson_label: 第14課  垃圾食物的誘惑與代價
+  authors: 課文：林玫伶  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L15.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L15.yml
@@ -283,3 +283,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 提取上位概念
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  lesson_label: 第15課  信件的力量──寫信馬拉松

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L16.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L16.yml
@@ -264,3 +264,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 提取上位概念─從具體描述提取上位概念
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第16課  臺灣棒球先驅──來自花蓮的能高團

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L17.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L17.yml
@@ -484,3 +484,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 用表格整理訊息 ──表格閱讀策略
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  lesson_label: 第17課 掃雷英雄馬嘎瓦
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L18.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L18.yml
@@ -277,3 +277,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  lesson_label: 第18課  魚來了，叮咚叮咚請開門
+  authors: 課文：林玫伶  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L19.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L19.yml
@@ -236,3 +236,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・抒情文
+  lesson_label: 第19課  感情小日記3──吃醋的滋味

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L2.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L2.yml
@@ -290,3 +290,9 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 拆詞釋義──藉由拆解字詞來推測詞義
+  level_label: Level 5・說明文
+  lesson_label: 第2課  以植物為師的科學
+  authors: 課文：林玫伶  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L20.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L20.yml
@@ -239,3 +239,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・抒情文
+  lesson_label: 第20課  感情小日記4──我被告白了

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L21.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L21.yml
@@ -213,3 +213,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──建立好習慣
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第21課  抗拒指尖上的誘惑
+  authors: 課文：陳韻如  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L22.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L22.yml
@@ -194,3 +194,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 自我管理
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  lesson_label: 第22課  我有一個棒球夢

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L23.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L23.yml
@@ -227,3 +227,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 時間管理──制定作息時間表
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第23課 我的電競夢：從熬夜打遊戲到拿下全國冠軍
+  authors: 課文：陳韻如  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L24-25.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L24-25.yml
@@ -290,3 +290,12 @@ worksheet_section_order:
 - number: 十
   name: 文章重點表
   type: structure_table
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 多文本閱讀──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。-
+  lesson_label: 第24課　牧羊少年的逆轉勝
+  authors: 課文：曾世杰  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L26.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L26.yml
@@ -230,3 +230,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 用表格整理訊息──比較異同
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  authors: 課文：曾世杰  學習單：陳虹君

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L27.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L27.yml
@@ -248,3 +248,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 寫作手法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・說明文
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L3.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L3.yml
@@ -233,3 +233,9 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 從上下文推測詞義
+  level_label: Level 5・記敘文
+  lesson_label: 第3課  工地大嫂
+  authors: 課文：林立青  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L4.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L4.yml
@@ -259,3 +259,9 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 拆詞釋義、
+  level_label: Level 5・記敘文
+  lesson_label: 第4課  災難預言準不準？
+  authors: 課文：林玫伶  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L5.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L5.yml
@@ -298,3 +298,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・應用文
+  lesson_label: 第5課  比運氣更重要的事：《長腿叔叔》的啟發
+  authors: 課文：林玫伶  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L6.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L6.yml
@@ -330,3 +330,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第6課  堅持到底的棒球人生──周思齊(前篇)

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L7.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L7.yml
@@ -263,3 +263,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第7課  堅持到底的棒球人生──周思齊(後篇)

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L8.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L8.yml
@@ -279,3 +279,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──認識推論人物特質策略
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第8課  奧運銀牌的自我鍛鍊
+  authors: 課文：吳漢庭  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G5-L9.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G5-L9.yml
@@ -271,3 +271,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──從言行推論人物特質
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 5・記敘文
+  lesson_label: 第9課  周天成的一天──頂尖選手的養成
+  authors: 課文：余茹帆  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L1.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L1.yml
@@ -237,3 +237,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 寫作手法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第1課  運動傷害，怎麼辦？
+  authors: 課文：吳漢庭  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L10.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L10.yml
@@ -276,3 +276,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第10課  末日種子庫
+  authors: 課文：林玫伶  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L11.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L11.yml
@@ -272,3 +272,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第11課  古代畫家心中的仙境
+  authors: 課文：陳韻如  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L12.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L12.yml
@@ -294,3 +294,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──從段落找主題句
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第12課  愛冒險逞強的雄性動物
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L13.yml
@@ -365,3 +365,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 自我提問──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第13課  森林大軍的守護者

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L14.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L14.yml
@@ -318,3 +318,11 @@ worksheet_section_order:
 - number: 八
   name: 詞語複習
   type: word_search
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 自我提問──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第14課  植物獵人

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L15.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L15.yml
@@ -356,3 +356,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 自我提問──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第15課  小藍鯨之死
+  authors: 課文：林玫伶  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L16.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L16.yml
@@ -305,3 +305,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第16課  奇蹟行動
+  authors: 課文：林玫伶  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L17.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L17.yml
@@ -228,3 +228,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第17課  給神明發會診單
+  authors: 課文：陳志金  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L18.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L18.yml
@@ -147,3 +147,13 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。-
+  level_label: Level 6・記敘文
+  lesson_label: 第18課  把手上的餅吃香一點！
+  authors: 課文：曾世杰  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L19.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L19.yml
@@ -196,3 +196,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第19課  紅領帶
+  authors: 課文：曾子安  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L2.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L2.yml
@@ -277,3 +277,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 寫作手法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・抒情文
+  lesson_label: 第2課 與小學說再見

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L20.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L20.yml
@@ -235,3 +235,10 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・抒情文
+  lesson_label: 第20課  感情小日記5──我該告白嗎？

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L21.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L21.yml
@@ -234,3 +234,11 @@ worksheet_section_order:
 - number: 八
   name: 詞語複習
   type: word_search
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・抒情文
+  lesson_label: 第21課  感情小日記6──我失戀了

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L22.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L22.yml
@@ -345,3 +345,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──問題.解決.結果結構
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第22課  小兵立大功：雞鳴狗盜的故事
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L23.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L23.yml
@@ -268,3 +268,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第23課  老鷹紅豆的故事
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
@@ -217,3 +217,12 @@ worksheet_section_order:
 - number: 八
   name: 詞語複習
   type: word_search
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第24課  白鯨救援：一場人與自然的協奏曲
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
@@ -240,3 +240,12 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第25課 荷蘭東印度公司：全世界第一張股票的誕生
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L3.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L3.yml
@@ -226,3 +226,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 解決問題──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第3課  昆蟲會思考嗎?
+  authors: 課文  ：黃金萍學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L4.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L4.yml
@@ -236,3 +236,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第4課  兩千五百歲的酷老師
+  authors: 課文  ：黃金萍學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L5.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L5.yml
@@ -289,3 +289,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第5課  卡通人氣王票選政見發表會
+  authors: 課文  ：黃金萍學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L6.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L6.yml
@@ -210,3 +210,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・議論文
+  lesson_label: 第6課  心理出狀況，是壞事導致的嗎？
+  authors: 課文：曾世杰  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L7.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L7.yml
@@ -250,3 +250,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・記敘文
+  lesson_label: 第7課 黑猩猩的守護者
+  authors: 課文：葉馨蓮  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L8.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L8.yml
@@ -265,3 +265,12 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第8課  動物談情說愛的方式
+  authors: 課文：葉馨蓮  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L9.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L9.yml
@@ -218,3 +218,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 6・說明文
+  lesson_label: 第9課  祝你好眠
+  authors: 課文：林玫伶  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L1.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L1.yml
@@ -281,3 +281,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 寫作手法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・抒情文
+  lesson_label: 第1課  長大後，我才讀懂〈夏夜〉

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L10.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L10.yml
@@ -238,3 +238,12 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・議論文
+  lesson_label: 第10課  塑膠，好用不好甩
+  authors: 課文：林玫伶  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L11.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L11.yml
@@ -241,3 +241,12 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・議論文
+  lesson_label: 第11課  AI什麼都會，我們還要學什麼？
+  authors: 課文：林玫伶  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L12.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L12.yml
@@ -385,3 +385,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第12課  你以為的浪漫可能是跟騷
+  authors: 課文：林玫伶  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L13.yml
@@ -228,3 +228,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格力──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第13課  綠色賽事
+  authors: 課文：林玫伶  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L14.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L14.yml
@@ -241,3 +241,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 品格聚光燈
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第14課  隱藏在日常對話中的微歧視
+  authors: 課文：林玫伶  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L15.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L15.yml
@@ -304,3 +304,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 解決問題──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・記敘文
+  lesson_label: 第15課  看到了嗎？然後呢？

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L16.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L16.yml
@@ -405,3 +405,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 解決問題──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・記敘文
+  lesson_label: 第16課  果醬男孩

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L17.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L17.yml
@@ -293,3 +293,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 解決問題──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・記敘文
+  lesson_label: 第17課　用科學方法伸張正義的神探
+  authors: 課文：曾世杰  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L18.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L18.yml
@@ -284,3 +284,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 從事實歸納概念－從具體事實歸納要表達的抽象概念
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・應用文
+  lesson_label: 第18課  一封向醫師求助的信
+  authors: 課文：曾世杰  學習單：張筱晴

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L19.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L19.yml
@@ -281,3 +281,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 自我提問
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・記敘文
+  lesson_label: 第19課  「背影」讀書會
+  authors: 課文：林玫伶  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L2.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L2.yml
@@ -271,3 +271,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 用表格整理訊息
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第2課  澳洲奧運金牌的X機密
+  authors: 課文：陳淑麗  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L20.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L20.yml
@@ -357,3 +357,12 @@ worksheet_section_order:
 - number: 九
   name: 閱讀聚光燈
   type: spotlight
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 媒體素養與識讀──辨別網路訊息真偽
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第20課  網紅的電子煙實驗：偽科學的陷阱
+  authors: 課文：林玫伶  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L21.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L21.yml
@@ -375,3 +375,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 媒體素養與識讀──認識誘餌式新聞標題
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第21課  別上「誘餌式標題」的鉤
+  authors: 課文：林玫伶  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L22.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L22.yml
@@ -261,3 +261,12 @@ worksheet_section_order:
 - number: 九
   name: 閱讀聚光燈
   type: spotlight
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 媒體素養與識讀──辨識不合理的詐騙訊息
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第22課 信眾與教主
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L23.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L23.yml
@@ -158,3 +158,9 @@ worksheet_section_order:
 - number: 六
   name: 閱讀理解
   type: mcq
+worksheet_intro:
+  step_label: 讀全文
+  target_strategy: 閱讀策略─
+  level_label: Level 7・說明文
+  lesson_label: 第23課  第一篇 雨林裡的奇蹟藥物
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L24.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L24.yml
@@ -234,3 +234,9 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 閱讀策略─
+  level_label: Level 7・說明文
+  lesson_label: 第24課  未來的農夫
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L25.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L25.yml
@@ -282,3 +282,12 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明/議論
+  lesson_label: 第25課  當全世界都在笑你，你可以怎麼做？
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L26.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L26.yml
@@ -327,3 +327,11 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・說明文
+  lesson_label: 第26課  小米酒的祝福

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L27.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L27.yml
@@ -158,3 +158,9 @@ worksheet_section_order:
 - number: 一
   name: 閱讀聚光燈
   type: spotlight
+worksheet_intro:
+  step_label: 閱讀聚光燈
+  target_strategy: 解題策略──
+  level_label: Level 7・說明文
+  lesson_label: 第27課  帶著「血拼清單」閱讀
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
@@ -345,3 +345,9 @@ image_captions:
 - figure_number: 一
   figure_index: 1
   caption: 巴斯德的鵝頸瓶實驗的設計與程序
+worksheet_intro:
+  step_label: 讀全文
+  target_strategy: 圖文整合閱讀策略
+  level_label: Level 7・說明文
+  lesson_label: 第28課 看不見的兇手:以實驗破解肉湯腐敗之謎
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
@@ -251,3 +251,8 @@ image_captions:
 - figure_number: 一
   figure_index: 1
   caption: 看生活感受例子，圖二看人類歷史發展
+worksheet_intro:
+  step_label: 讀全文
+  target_strategy: 圖文整合閱讀策略
+  level_label: Level 7・說明文
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L3.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L3.yml
@@ -304,3 +304,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 用表格整理訊息
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第3課  女性太空人登月
+  authors: 課文：林玫伶  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
@@ -188,3 +188,9 @@ image_captions:
 - figure_number: 一
   figure_index: 1
   caption: ，看看表格怎麼幫助你把文字讀得更清楚
+worksheet_intro:
+  step_label: 讀全文
+  target_strategy: 文圖表整合閱讀策略
+  level_label: Level 7・說明文
+  lesson_label: 第30課   都是八哥，為什麼命運不一樣？
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L4.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L4.yml
@@ -279,3 +279,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 用表格整理訊息──比較異同
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・議論文
+  lesson_label: 第4課  從〈螞蟻與蟋蟀〉看生命的多樣性
+  authors: 課文：林玫伶  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L5.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L5.yml
@@ -248,3 +248,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 用表格整理訊息──從細節歸納標題列名稱
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・記敘文
+  lesson_label: 第5課　爺爺奶奶來了以後
+  authors: 課文：陳韻如  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L6.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L6.yml
@@ -301,3 +301,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 用表格整理訊息
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第6課  奧運性別平等這條路
+  authors: 課文：林玫伶  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L7.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L7.yml
@@ -377,3 +377,12 @@ image_captions:
 - figure_number: 一
   figure_index: 1
   caption: '是某天上午九時到下午五時的溫度折線圖:'
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 圖表繪製與判
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第7課 你看見時代的灰犀牛了嗎？談人口負成長
+  authors: 課文：曾世杰陳淑麗  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L8.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L8.yml
@@ -273,3 +273,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 表達看法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・應用文(讀書報告)
+  lesson_label: 第8課　科學怪人
+  authors: 課文：林玫伶  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L9.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L9.yml
@@ -292,3 +292,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 表達看法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 7・說明文
+  lesson_label: 第9課  吐瓦魯：逐漸被淹沒的島國
+  authors: 課文：林玫伶  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L1.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L1.yml
@@ -275,3 +275,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 寫作手法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・抒情文
+  lesson_label: 第1課  致台東：一封過客的情書

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L10.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L10.yml
@@ -386,3 +386,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 找作者主要論點
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・議論文
+  lesson_label: 第10課  「按讚」背後的真相！
+  authors: 課文：林玫伶  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L12.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L12.yml
@@ -297,3 +297,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・說明文
+  lesson_label: 第12課 語言的足跡：從臺北 萬華到南太平洋的航海之路
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L13.yml
@@ -349,3 +349,12 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 解決問題──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・說明文
+  lesson_label: 第13課 《構樹：南島祖先「出台灣說」的植物證據》
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L14.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L14.yml
@@ -280,3 +280,12 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 解決問題──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・說明文
+  lesson_label: 第14課  科學辦案：破解蝴蝶蘭的花期密碼
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L15.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L15.yml
@@ -316,3 +316,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・議論文
+  lesson_label: 第15課  球場上的另類指揮家
+  authors: 課文：林玫伶  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L16.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L16.yml
@@ -347,3 +347,12 @@ worksheet_section_order:
 - number: 九
   name: 詞語複習
   type: word_search
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・記敘抒情文
+  lesson_label: 第16課  我的阿嬤
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L17.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L17.yml
@@ -298,3 +298,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 比較多元觀點
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・論說文
+  lesson_label: 第17課  我能不能選擇告別方式?
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L18.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L18.yml
@@ -308,3 +308,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 比較多元觀點
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・論說文
+  lesson_label: 第18課  石虎保育：遷移與否的兩難
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L19.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L19.yml
@@ -404,3 +404,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 比較多元觀點
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・議論文
+  lesson_label: 第19課  核能的兩難抉擇
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L2.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L2.yml
@@ -267,3 +267,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 寫作手法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・記敘抒情文
+  lesson_label: 第2課  爸爸的恩人們
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L3.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L3.yml
@@ -361,3 +361,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 寫作手法──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・議論文
+  lesson_label: 第3課 當壞事已不可逆轉：集中營裡的一門課
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L4.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L4.yml
@@ -263,3 +263,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──由課文觀點找出支持理由
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・說明文
+  lesson_label: 第4課  新奇！「植物肉」你聽過嗎?
+  authors: 課文：陳韻如  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L5.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L5.yml
@@ -260,3 +260,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──推論人物行為的背後動機
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・記敘文
+  lesson_label: 第5課  好心沒好報的玻璃娃娃爭議事件
+  authors: 課文：曾世杰  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L6.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L6.yml
@@ -250,3 +250,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・記敘文
+  lesson_label: 第6課 戲院、賭場、檳榔攤：在時代夾縫中成長的我
+  authors: 課文：林玫伶  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L7.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L7.yml
@@ -385,3 +385,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・說明文
+  lesson_label: 第7課  讓你口中的甜蜜成為遠方農民的希望
+  authors: 課文：林玫伶  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L8.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L8.yml
@@ -263,3 +263,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・說明文
+  lesson_label: 第8課  隱形的征服者
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L9.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L9.yml
@@ -341,3 +341,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 推論策略──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 8・說明文
+  lesson_label: 第9課  讓黑猩猩被看見的人
+  authors: 課文：林玫伶  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L1.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L1.yml
@@ -261,3 +261,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 媒體素養與識讀──辨識假新聞
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第1課  盡信書不如無書：從一件殺人案談起
+  authors: 課文：曾志朗  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L10.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L10.yml
@@ -186,3 +186,12 @@ worksheet_section_order:
 - number: 八
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 無
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第10課  高地訓練有助於運動表現嗎?
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L11.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L11.yml
@@ -302,3 +302,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 摘要策略──科學探究文本結構
+  instructions:
+  - 請在不太了解的字、詞或句做記號
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第11課  見前人所未見—達爾文與長喙天蛾的故事
+  authors: 課文：曾世杰  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L12.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L12.yml
@@ -288,3 +288,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第12課  臺灣的太空之眼
+  authors: 課文：林玫伶  學習單：陳淑麗

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L13.yml
@@ -198,3 +198,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 正向思考──學習樂觀思考
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第13課 樂觀者勝：向NBA球員學習「詮釋失敗」的智慧
+  authors: 課文：曾世杰  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L14.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L14.yml
@@ -214,3 +214,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 正向思考──培養心理韌性
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第14課  焚而不毀的倫敦
+  authors: 課文  ：曾世杰 學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L2.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L2.yml
@@ -364,3 +364,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 分辨事實與判斷
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・記敘文
+  lesson_label: 第2課  帝國家書：一個普通家庭的生與死
+  authors: 課文：二大爺  學習單：唐儀庭

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L3.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L3.yml
@@ -344,3 +344,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 議論文結構──
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・議論文
+  lesson_label: 第3課  國高中數學課當然可以使用計算機！
+  authors: 課文：曾世杰  學習單：高芳瑄

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L4.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L4.yml
@@ -236,3 +236,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 表達看法——以科學證據說服人
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第4課  預防近視？多點戶外活動就對了！
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L5.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L5.yml
@@ -223,3 +223,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: '第5課  #MeToo運動與我們的權利'
+  authors: 課文：林玫伶  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L6.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L6.yml
@@ -271,3 +271,12 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 解決問題——
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第6課  靈異與科學
+  authors: 課文：吳漢庭  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L7.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L7.yml
@@ -305,3 +305,12 @@ worksheet_section_order:
 - number: 九
   name: 閱讀聚光燈
   type: spotlight
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 圖表繪製與判讀
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第7課  從基因來的特別禮物
+  authors: 課文：許淳欣  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L8.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L8.yml
@@ -360,3 +360,12 @@ image_captions:
 - figure_number: 二
   figure_index: 2
   caption: 完成下面的表格
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 圖表繪製與判讀
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文
+  lesson_label: 第8課  臺灣學生的閱讀力：美麗與哀愁
+  authors: 課文：陳淑麗  學習單：陳允捷

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L9.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L9.yml
@@ -116,3 +116,11 @@ image_captions:
 - figure_number: 一
   figure_index: 1
   caption: 階層圖
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 圖表繪製與判讀——圖文表綜合判讀
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  level_label: Level 9・說明文(圖表)
+  lesson_label: 第9課  力與美表現的競技體操

--- a/backend/data/lessons/_parsed_2026-05-01/文-L1.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L1.yml
@@ -247,3 +247,11 @@ worksheet_section_order:
 - number: 九
   name: 知識補給站
   type: knowledge_station
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 媒體素養與識讀
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  lesson_label: 第1課  這是假新聞嗎？--以「鞭虎救弟記」為例
+  authors: 課文：曾世杰  學習單：巫怡蓉

--- a/backend/data/lessons/_parsed_2026-05-01/文-L2.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L2.yml
@@ -136,3 +136,11 @@ worksheet_section_order:
 - number: 四
   name: 閱讀理解
   type: mcq
+worksheet_intro:
+  step_label: 讀全文-做記號
+  target_strategy: 文言文閱讀策略──如何讀懂文言文
+  instructions:
+  - 請在不太了解的字、詞或句做記號。
+  - 重要的地方、喜歡的語詞、句子或段落做上記號。
+  lesson_label: 第2課  文言文怎麼讀？-以「鞭虎救弟記」為例
+  authors: 課文：曾世杰  學習單：張明珠

--- a/backend/data/lessons/_parsed_2026-05-01/文-L3.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L3.yml
@@ -159,3 +159,5 @@ worksheet_section_order:
 - number: 五
   name: 閱讀理解
   type: mcq
+worksheet_intro:
+  lesson_label: 第3課　不量田

--- a/backend/data/lessons/_parsed_2026-05-01/文-L4.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L4.yml
@@ -158,3 +158,5 @@ worksheet_section_order:
 - number: 五
   name: 閱讀理解
   type: mcq
+worksheet_intro:
+  lesson_label: 第4課  陸公買硯

--- a/backend/data/lessons/_parsed_2026-05-01/文-L5.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L5.yml
@@ -197,3 +197,5 @@ strategy_exercise:
     answer: 2
     reasoning: 胡兵相互議論說「我輩無義之人」，故「我輩」指胡兵。
 strategy_exercise_source: gemini-2.5-flash-2026-05-02
+worksheet_intro:
+  lesson_label: 第5課  重義的荀巨伯

--- a/backend/data/lessons/_parsed_2026-05-01/文-L6.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L6.yml
@@ -159,3 +159,5 @@ strategy_exercise:
     type: free_text
     reasoning: 這是原文中提出的開放性問題，答案未在提供的文本中直接給出，需要學生思考並在閱讀完整課文後才能得知最終結果。原文提示「答案就隱藏在本課的某一頁中」。
 strategy_exercise_source: gemini-2.5-flash-2026-05-02
+worksheet_intro:
+  lesson_label: 第6課  江乙媽媽告御狀

--- a/backend/data/lessons/_parsed_2026-05-01/文-L7.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L7.yml
@@ -132,3 +132,5 @@ strategy_exercise:
     answer: 2
     reasoning: 此題旨在確認學生是否能正確理解故事的最終發展和結局，強調信守承諾的結果。
 strategy_exercise_source: gemini-2.5-flash-2026-05-02
+worksheet_intro:
+  lesson_label: 第7課  相隔千里的約定

--- a/backend/data/lessons/_parsed_2026-05-01/文-L8.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L8.yml
@@ -129,3 +129,5 @@ strategy_exercise:
     answer: 0
     reasoning: 原文「自少至老」在古文今譯中為「從小到老」，故「少」在此處意指「年輕時」。
 strategy_exercise_source: gemini-2.5-flash-2026-05-02
+worksheet_intro:
+  lesson_label: 第8課  愛讀書的顧寧人

--- a/backend/data/lessons/_parsed_2026-05-01/文-L9.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/文-L9.yml
@@ -136,3 +136,5 @@ strategy_exercise:
     type: free_text
     reasoning: 此開放題旨在鼓勵學生歸納總結「聞」字在課文不同語境下的多重意義，加深對「一字多義」策略的理解與應用。
 strategy_exercise_source: gemini-2.5-flash-2026-05-02
+worksheet_intro:
+  lesson_label: 第9課  從天才跌為凡人的神童

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -147,7 +147,34 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
             );
           })()}
 
-          {/* Background section */}
+          {/* 學習目標 banner — worksheet_intro.target_strategy (#1434) */}
+          {story.worksheetIntro?.target_strategy && (
+            <div className="bg-blue-50 border border-blue-200 rounded-2xl p-6 space-y-3">
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
+                </svg>
+                <span className="text-xs font-bold text-blue-600 uppercase tracking-widest">學習目標</span>
+              </div>
+              <p className={`text-blue-800 text-xl font-semibold ${zhuyinActive ? 'leading-[3rem] tracking-[0.3em]' : 'leading-[1.5]'}`}>
+                {processZhuyin(story.worksheetIntro.target_strategy)}
+              </p>
+
+              {/* 學習提示 checklist */}
+              {story.worksheetIntro.instructions && story.worksheetIntro.instructions.length > 0 && (
+                <ul className="space-y-1.5 pt-1" aria-label="學習提示">
+                  {story.worksheetIntro.instructions.map((item, idx) => (
+                    <li key={idx} className={`flex items-start gap-2 text-blue-700 ${zhuyinActive ? 'text-lg leading-[2.8rem] tracking-[0.2em]' : 'text-base leading-[1.6]'}`}>
+                      <span className="mt-1 flex-shrink-0 text-blue-400" aria-hidden="true">&#9655;</span>
+                      <span>{processZhuyin(item)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {/* Background section — story.intro.background (Layer-1 backward compat) */}
           {story.intro ? (
             <div className="bg-surface-container-low border border-gray-200 rounded-2xl p-6 space-y-4">
               <div className="flex items-center gap-2">
@@ -193,8 +220,36 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
               </div>
             </div>
           ) : (
-            <div className="bg-surface-container-low border border-gray-200 rounded-2xl p-6 text-gray-500 text-sm">
-              這篇課文目前沒有簡介資料。
+            !story.worksheetIntro && (
+              <div className="bg-surface-container-low border border-gray-200 rounded-2xl p-6 text-gray-500 text-sm">
+                這篇課文目前沒有簡介資料。
+              </div>
+            )
+          )}
+
+          {/* 學習單流程 — worksheet_section_order (#1434) */}
+          {story.worksheetSectionOrder && story.worksheetSectionOrder.length > 0 && (
+            <div className="bg-surface-container-low border border-gray-200 rounded-2xl p-6 space-y-3">
+              <div className="flex items-center gap-2">
+                <svg className="w-4 h-4 text-accent-light" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                </svg>
+                <span className="text-xs font-bold text-accent-light uppercase tracking-widest">
+                  本課 {story.worksheetSectionOrder.length} 個學習步驟
+                </span>
+              </div>
+              <ol className="space-y-2" aria-label="學習單流程">
+                {story.worksheetSectionOrder.map((section, idx) => (
+                  <li key={idx} className="flex items-center gap-3">
+                    <span className="flex-shrink-0 w-7 h-7 rounded-full bg-accent-bg-subtle text-accent-hover text-sm font-bold flex items-center justify-center">
+                      {section.number}
+                    </span>
+                    <span className={`text-on-surface ${zhuyinActive ? 'text-lg leading-[2.8rem] tracking-[0.2em]' : 'text-base'}`}>
+                      {processZhuyin(section.name)}
+                    </span>
+                  </li>
+                ))}
+              </ol>
             </div>
           )}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -68,6 +68,16 @@ interface ApiStoryDetail extends ApiStoryListItem {
   layout_mode?: 'standard' | 'graphic-text' | 'graphic-chart';
   reading_strategy_type?: string;
   images?: Array<{ filename: string; size_bytes: number; image_hash: string; content_type: string; caption?: string }>;
+  // 學習單 section order + intro metadata (#1434)
+  worksheet_section_order?: Array<{ number: string; name: string; type: string }> | null;
+  worksheet_intro?: {
+    step_label?: string;
+    target_strategy?: string;
+    instructions?: string[];
+    level_label?: string;
+    lesson_label?: string;
+    authors?: string;
+  } | null;
 }
 
 interface ApiStoryListResponse {
@@ -115,6 +125,8 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     knowledgeVideoUrl: detail.knowledge_video_url ?? undefined,
     strategyExercise: detail.strategy_exercise ?? undefined,
     stepSequence: detail.step_sequence ?? undefined,
+    worksheetSectionOrder: detail.worksheet_section_order ?? undefined,
+    worksheetIntro: detail.worksheet_intro ?? undefined,
     // Plugin-pattern dispatch fields (#1404 / #1341):
     layout_mode: (detail.layout_mode as Story['layout_mode']) ?? 'standard',
     reading_strategy_type: detail.reading_strategy_type ?? 'general',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -147,6 +147,17 @@ export interface Story {
   }[];
   /** Paragraphs array (Layer-2 lessons use this instead of content). */
   paragraphs?: string[];
+  /** 學習單 section ordering (#1434). e.g. [{number: '二', name: '念順順', type: 'reading_timer'}, ...] */
+  worksheetSectionOrder?: Array<{ number: string; name: string; type: string }>;
+  /** 學習單 intro metadata (#1434). Present only for Layer-2 lessons parsed from docx. */
+  worksheetIntro?: {
+    step_label?: string;
+    target_strategy?: string;
+    instructions?: string[];
+    level_label?: string;
+    lesson_label?: string;
+    authors?: string;
+  };
 }
 
 export interface ReadingAttempt {

--- a/scripts/merge_reparsed_to_prod.py
+++ b/scripts/merge_reparsed_to_prod.py
@@ -147,6 +147,12 @@ def merge_lesson(code: str) -> dict:
         new["worksheet_section_order"] = reparsed["worksheet_section_order"]
         changes.append(f"worksheet_section_order: {len(reparsed['worksheet_section_order'])} sections")
 
+    # ── 8b. worksheet_intro — always overwrite (metadata, #1434) ────────────
+    if reparsed.get("worksheet_intro"):
+        new["worksheet_intro"] = reparsed["worksheet_intro"]
+        strategy = reparsed["worksheet_intro"].get("target_strategy", "")[:30]
+        changes.append(f"worksheet_intro: strategy={strategy}")
+
     # ── 9. image_captions (graphic-text only) ───────────────────────────────
     if is_empty(prod.get("image_captions")) and reparsed.get("image_captions"):
         new["image_captions"] = reparsed["image_captions"]

--- a/scripts/reparse_with_textboxes.py
+++ b/scripts/reparse_with_textboxes.py
@@ -178,6 +178,111 @@ def extract_worksheet_section_order(text: str) -> list[dict]:
     return seen
 
 
+def extract_worksheet_intro(text: str) -> dict:
+    """Extract the 學習單 intro section from the top of the docx.
+
+    The intro lives BEFORE the lesson body — it contains:
+    - step_label:       e.g. "讀全文-做記號" (from "一\\n讀全文-做記號" header)
+    - target_strategy:  e.g. "摘要策略──問題.解決.結果結構"
+    - instructions:     lines starting with □ (full-width checkbox)
+    - level_label:      e.g. "Level 6・記敘文"
+    - lesson_label:     e.g. "第22課 小兵立大功：雞鳴狗盜的故事"
+    - authors:          e.g. "課文：曾世杰  學習單：張明珠"
+
+    Typical raw text (G6-L22):
+      "一\\n讀全文-做記號00\\n目標策略：摘要策略──...\\n□ 請在...\\nLevel 6・記敘文..."
+
+    The Word object ID digits (e.g. "00") appear between real content lines.
+    We strip those before matching.
+    """
+    # Limit search to the first ~3000 chars (intro is near top of doc)
+    intro_region = text[:3000]
+
+    # Strip Word object IDs — digit-only tokens between Chinese content.
+    # Pattern: 2+ digits at a line boundary, alone or adjacent to newlines.
+    cleaned = re.sub(r"\n\s*\d{2,}\s*(?=\n)", "\n", intro_region)
+
+    result: dict = {}
+
+    # step_label: "一\n讀全文-做記號" or "一 讀全文-做記號"
+    # The leading Chinese numeral "一" marks the first section of the worksheet.
+    step_m = re.search(r"[一]\s*\n\s*([^\n0-9]{2,30})", cleaned)
+    if not step_m:
+        step_m = re.search(r"[一]\s+([^\n0-9]{2,30})", cleaned)
+    if step_m:
+        result["step_label"] = step_m.group(1).strip()
+
+    # target_strategy: line with "目標策略：" prefix (may have trailing digits stripped)
+    strategy_m = re.search(r"目標策略[：:]\s*([^\n]+)", cleaned)
+    if strategy_m:
+        val = strategy_m.group(1).strip()
+        # Strip trailing Word object ID digits
+        val = re.sub(r"\s*\d{2,}\s*$", "", val).strip()
+        if val:
+            result["target_strategy"] = val
+
+    # instructions: lines starting with □ (U+25A1 or half-width □)
+    # Only capture lines that begin with Chinese text (not numeric benchmarks like "＜210字").
+    # Docx may have "□ text00\n□ text" — strip trailing digits.
+    instructions = []
+    seen_instr: set[str] = set()
+    for m in re.finditer(r"[□]\s+([^\n□]{2,100})", cleaned):
+        line = m.group(1).strip()
+        # Strip trailing Word object IDs
+        line = re.sub(r"\s*\d{2,}\s*$", "", line).strip()
+        # Skip numeric/symbol benchmarks (e.g. "＜210字", "211~240字")
+        # Valid instructions start with a CJK character or punctuation like 「
+        if not line or line in seen_instr:
+            continue
+        first_char = line[0]
+        if re.match(r"[一-鿿「」《》【】]", first_char):
+            instructions.append(line)
+            seen_instr.add(line)
+    if instructions:
+        result["instructions"] = instructions
+
+    # level_label: "Level N・文類" pattern
+    level_m = re.search(r"(Level\s+\d+\s*[・·]\s*[^\n0-9]{1,20})", cleaned)
+    if level_m:
+        val = level_m.group(1).strip()
+        val = re.sub(r"\s*\d{2,}\s*$", "", val).strip()
+        if val:
+            result["level_label"] = val
+
+    # lesson_label: "第N課 title" — lesson title line
+    lesson_m = re.search(r"(第\d+課\s+[^\n]{1,60})", cleaned)
+    if lesson_m:
+        val = lesson_m.group(1).strip()
+        # Strip trailing Word object ID digits and position markers
+        val = re.sub(r"\s+\d{1,5}\s*$", "", val).strip()
+        if val:
+            result["lesson_label"] = val
+
+    # authors: "課文 ：A\n學習單：B" — may span two lines in docx
+    # Approach: find "課文" occurrence, grab next 2 lines
+    authors_m = re.search(
+        r"課文\s*[：:]\s*([^\n]{1,40})\n\s*學習單[：:]\s*([^\n]{1,40})",
+        cleaned,
+    )
+    if authors_m:
+        c = re.sub(r"\s*\d{2,}\s*$", "", authors_m.group(1)).strip()
+        w = re.sub(r"\s*\d{2,}\s*$", "", authors_m.group(2)).strip()
+        if c or w:
+            result["authors"] = f"課文：{c}  學習單：{w}"
+    else:
+        # Single-line: "課文：A 學習單：B"
+        authors_single = re.search(
+            r"(課文\s*[：:][^\n]{1,40}學習單[：:][^\n]{1,30})",
+            cleaned,
+        )
+        if authors_single:
+            raw = authors_single.group(1).strip()
+            raw = re.sub(r"\s{2,}", "  ", raw)
+            result["authors"] = raw
+
+    return result if result else {}
+
+
 EXCLUDE_MARKERS = (
     "計時", "影片", "閱讀聚光燈", "文章重點表", "知識補給站", "詞語複習",
     "步驟❶", "目標策略", "Level ", "字數", "完讀時間", "□", "請根據文章",
@@ -483,7 +588,7 @@ def parse_video_links(section: str) -> list[dict]:
     if not section:
         return []
     # Strip Word object IDs (long digit runs) that prefix video index numbers.
-    # Pattern: "196469057150001. 成語任務" → "1. 成語任務"
+    # e.g. docx export adds "XXXXXX1. 成語任務" → strip leading digits to get "1. 成語任務"
     cleaned = re.sub(r"\d{6,}(?=[1-9][.．])", "", section)
     videos: list[dict] = []
     pat = re.compile(
@@ -562,6 +667,7 @@ def parse_lesson(docx: Path) -> dict:
     text = extract_full_text(docx)
     sections = split_sections(text)
     worksheet_order = extract_worksheet_section_order(text)
+    worksheet_intro = extract_worksheet_intro(text)
 
     paragraphs = extract_paragraphs_from_table(docx)
     full_story = "\n".join(paragraphs)
@@ -621,6 +727,8 @@ def parse_lesson(docx: Path) -> dict:
         # frontend can render the worksheet in its native order, OR reorder
         # for customization (e.g. demo skipping word_search).
         "worksheet_section_order": worksheet_order,
+        # ── 學習單 intro metadata (#1434) ──────────────────────────────────
+        "worksheet_intro": worksheet_intro if worksheet_intro else None,
         # ── Story body ────────────────────────────────────────────────────
         "paragraphs": paragraphs,
         "story_text": full_story,


### PR DESCRIPTION
## Changes
- Parser extract \`worksheet_intro\` (target_strategy, instructions, level_label, lesson_label, authors)
- Backend surface \`worksheet_intro\` + \`worksheet_section_order\` in API
- Frontend Intro.tsx renders 學習目標 banner + 學習提示 list + 學習單流程 list

## Stats
- 151 lesson yml files re-merged
- Layer-1 backward compat

## Test
- [ ] Staging G6-L22 Intro: 目標策略 banner + 學習單流程 8 段 list