### PR TITLE
fix(api): surface worksheet_intro/section_order in get_story (Refs #1434)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -252,6 +252,9 @@ def get_story(story_id: str):
         layout_mode=story.get("layout_mode") or "standard",
         # Image gallery for graphic-text layout (#1341)
         images=story.get("images") or [],
+        # Worksheet metadata (#1434) — surface to API
+        worksheet_section_order=story.get("worksheet_section_order"),
+        worksheet_intro=story.get("worksheet_intro"),
     )
 
 


### PR DESCRIPTION
Route handler missed passing the 2 new fields to StoryDetail. yml has data, schema has fields, but API returned None. 3-line fix.