### PR TITLE
fix: restore Intro page route + add to step sequence

### DIFF
--- a/frontend/src/config/stepConfig.ts
+++ b/frontend/src/config/stepConfig.ts
@@ -251,6 +251,7 @@ export const STEP_REGISTRY: Record<string, StepConfig> = {
  *   - 閱讀理解   (comprehension, dbStep 3)       — was tab 1 inside ComprehensionChat
  */
 export const DEFAULT_STEP_SEQUENCE: string[] = [
+  'intro',
   'reading-annotation',
   'tutor',
   'full-reading',

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -450,7 +450,7 @@ const AppRoutes: React.FC = () => (
           </ProtectedRoute>
         }
       >
-        <Route path="intro" element={<Navigate to="../reading-annotation" replace />} />
+        <Route path="intro" element={<IntroPage />} />
         <Route
           path="reading-annotation"
           element={


### PR DESCRIPTION
After #1336 stepConfig refactor, /intro was hard-redirected to reading-annotation. With #1434 surfacing worksheet_intro to API, Young needs Intro page back to display 學習目標 + 學習單流程.

Fix: AppRoutes IntroPage route + add 'intro' to DEFAULT_STEP_SEQUENCE.

## Test plan
- [ ] /learn/1076/intro shows Intro page (not redirect)
- [ ] StepperNav shows Intro as step 1