### PR TITLE
fix(ci): grant issues:write to notify-staging job (Fixes #1446)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -381,11 +381,15 @@ jobs:
     needs: smoke-test
     if: success()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
       - name: Comment on referenced issues
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_MSG: ${{ github.event.head_commit.message }}


### PR DESCRIPTION
## Summary

- Add \`permissions: { contents: read, issues: write }\` to staging \`notify-staging\` job (matches production \`deploy.yml\`)
- Add \`continue-on-error: true\` to the comment step — defense-in-depth so notify failure never fails the deploy

## Why

Every staging deploy currently reports \`failure\` even when backend, frontend, Firebase, and smoke tests all pass. Cause: \`notify-staging\` job hits \`Resource not accessible by integration\` posting to \`gh issue comment\` because the job has no \`permissions:\` block. Production already does this correctly.

Run example: [25260431941](https://github.com/Youngger9765/chinese-literacy-platform/actions/runs/25260431941)

## Test plan

- [ ] Merge to staging
- [ ] Watch next staging deploy run — \`notify-staging\` shows ✅
- [ ] Issue referenced in commit (this PR's \`#1446\`) receives "Deployed to Staging" comment
- [ ] Workflow conclusion is \`success\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)