### PR TITLE
fix(ci): force-promote staging Cloud Run traffic to latest revision (Fixes #1449)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -83,6 +83,13 @@ jobs:
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
             --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
 
+      - name: Promote backend traffic to latest revision (Fixes #1449)
+        run: |
+          gcloud run services update-traffic ${{ env.BACKEND_SERVICE }} \
+            --to-latest \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT_ID }}
+
       - name: Verify backend health
         run: |
           URL=$(gcloud run services describe ${{ env.BACKEND_SERVICE }} \
@@ -164,6 +171,13 @@ jobs:
             --min-instances=0 \
             --max-instances=1 \
             --timeout=300s
+
+      - name: Promote frontend traffic to latest revision (Fixes #1449)
+        run: |
+          gcloud run services update-traffic ${{ env.FRONTEND_SERVICE }} \
+            --to-latest \
+            --region ${{ env.REGION }} \
+            --project ${{ env.PROJECT_ID }}
 
       - name: Verify frontend health
         run: |


### PR DESCRIPTION
## Summary

Adds \`gcloud run services update-traffic --to-latest\` after each Cloud Run deploy step in \`staging-deploy.yml\`. Defends against the staging-stuck-on-old-revision bug (#1449) that hit us on 2026-05-02.

## What happened

- 19:55 UTC: PR #1445 (lesson_intro) merged. Deploy run 25260431941 created revision \`lingoleap-backend-staging-00647-g75\` from image \`staging-e492225c\`. Cloud Run reported it Ready.
- Traffic did not promote. \`lingoleap-backend-staging-00646-4vp\` (image \`9f263b50\`, pre-#1445) kept serving 100% of requests.
- Smoke test passed because \`/api/health\` returns 200 from either revision.
- Backend served stale code for ~12 hours. \`/api/stories/1108\` returned \`lesson_intro: None\` despite yml having data.

## Manual fix already applied to staging

\`\`\`
gcloud run services update-traffic lingoleap-backend-staging \\
  --to-revisions=lingoleap-backend-staging-00647-g75=100 \\
  --region=asia-east1
\`\`\`

Verified: \`/api/stories/1108\` now returns full \`lesson_intro\` payload.

## This PR

Adds defense-in-depth: every backend + frontend Cloud Run deploy now ends with \`update-traffic --to-latest\`. Idempotent when traffic was already correct, force-corrects when not.

## Test plan

- [ ] CI green
- [ ] After merge, observe next staging deploy: \`Promote backend/frontend traffic to latest revision\` step shows \`100% LATEST\`
- [ ] \`gcloud run services describe lingoleap-backend-staging --region=asia-east1 --format='value(status.traffic[0].revisionName,status.latestReadyRevisionName)'\` returns the same revision name on both fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)