### PR TITLE
fix(mcq-rescue): route prefix /learning/mcq-rescue/* (Fixes #1453)

### DIFF
--- a/backend/app/routes/learning/mcq_rescue.py
+++ b/backend/app/routes/learning/mcq_rescue.py
@@ -68,7 +68,7 @@ class McqRescueRespondResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 @router.post(
-    "/mcq-rescue/start",
+    "/learning/mcq-rescue/start",
     response_model=McqRescueStartResponse,
     dependencies=[Depends(ai_limit_10_per_min)],
 )
@@ -111,7 +111,7 @@ async def mcq_rescue_start(
 
 
 @router.post(
-    "/mcq-rescue/respond",
+    "/learning/mcq-rescue/respond",
     response_model=McqRescueRespondResponse,
     dependencies=[Depends(ai_limit_10_per_min)],
 )


### PR DESCRIPTION
## Summary

Frontend \`learningApi.ts\` calls \`/api/learning/mcq-rescue/*\` but backend served \`/api/mcq-rescue/*\`. Fixes the prefix on the two route decorators in \`mcq_rescue.py\` to match sibling files in the learning router.

## Verification (live on staging)

\`\`\`
pre-fix:  ['/api/mcq-rescue/start', '/api/mcq-rescue/respond']
post-fix: ['/api/learning/mcq-rescue/start', '/api/learning/mcq-rescue/respond']
\`\`\`

(Source: \`curl /openapi.json | jq '.paths | keys[] | select(test("mcq"))'\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)