### PR TITLE
fix: VocabWordSearch 孤寂感空白/無法圈選（vocab word 含空格）(Fixes #1469)

### DIFF
--- a/backend/data/lessons/L02.yml
+++ b/backend/data/lessons/L02.yml
@@ -33,7 +33,7 @@ vocabulary:
   definition: 心志被打敗了。
 - word: 事與願違
   definition: 事情的發展和願望相反、相違背。
-- word: 孤 寂 感
+- word: 孤寂感
   definition: 孤單寂寞的感覺。
 - word: 天壤之別
   definition: 比喻差別極大。

--- a/backend/data/lessons/L34.yml
+++ b/backend/data/lessons/L34.yml
@@ -45,7 +45,7 @@ vocabulary:
   definition: 人類生產、運輸和使用產品時，釋出溫室氣體（如二氧化碳）的過程。
 - word: 碳足跡
   definition: 碳排放的總量。
-- word: 提 案
+- word: 提案
   definition: 提出建議或計劃，通常用於解決問題或改善現況。
 - word: 亂竄
   definition: 四處躲藏、亂跑。

--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -260,7 +260,12 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
   const savedRef = useRef(loadSaved());
 
   const vocabWords = useMemo(
-    () => (story.vocabulary ?? []).map((v) => v.word).filter((w) => [...w].length >= 2),
+    // Strip all whitespace from vocab words before grid generation.
+    // Defensive guard: some YAML files historically stored words with spaces
+    // between characters (e.g. '孤 寂 感' → '孤寂感', '提 案' → '提案').
+    // Without stripping, space characters become blank-looking grid cells and
+    // drag-selection never matches because selectedText !== word-with-spaces.
+    () => (story.vocabulary ?? []).map((v) => v.word.replace(/\s+/g, '')).filter((w) => [...w].length >= 2),
     [story.vocabulary]
   );
 


### PR DESCRIPTION
Fixes #1469

## Root Cause

`backend/data/lessons/L02.yml` 的 vocabulary 中，「孤寂感」被儲存為 `'孤 寂 感'`（每個漢字間有 U+0020 空格）。

`VocabWordSearch` 把含空格的字串 `generateGrid` 時，空格字元作為獨立 grid cell 放入，導致：
1. Grid 中出現空白格子（空格字元 render 為空白）
2. 學生拖選「孤寂感」三個漢字時，`selectedText === '孤寂感'` 永遠不等於 stored word `'孤 寂 感'`，無法匹配 → 詞語永遠無法圈選完成

同時發現 `L34.yml` 的「提案」也有相同問題（`'提 案'`）。

## Changes

| 檔案 | 變更 |
|------|------|
| `backend/data/lessons/L02.yml` | `'孤 寂 感'` → `'孤寂感'` |
| `backend/data/lessons/L34.yml` | `'提 案'` → `'提案'` |
| `frontend/src/components/reading-steps/VocabWordSearch.tsx` | 加 `.replace(/\s+/g, '')` 防禦性 strip，避免未來 YAML typo 再次 silent break |

## Test Plan

1. 登入學生小明（quick login）
2. 找到「十秒的背後」課文（G4-L2）
3. 進入「詞語搜尋」步驟
4. 確認 grid 中無空白格子
5. 拖選「孤寂感」3 個漢字 → 應成功匹配，出現紅框 + toast「找到「孤寂感」！」
6. 完成所有詞語 → 完成畫面正常出現