### PR TITLE
fix: 造句練習語氣軟化、amber 配色、麥克風擠壓修正

### DIFF
--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -251,9 +251,9 @@ async def validate_student_sentence(
 - 否則 → is_correct=false
 
 回覆規則（非常重要）：
-- feedback **只能一句話**，先肯定再溫柔提醒，不要用「錯」「不對」「不行」「不正確」等否定字眼
-- is_correct=true：feedback 是一句鼓勵；suggestion 留空字串
-- is_correct=false：feedback 是一句溫柔提醒（例如「再想想看…」「換個說法可能更順喔」）；suggestion 是一句改寫提示
+- feedback **只能一句話**，不要用「錯」「不對」「不行」「不正確」等否定字眼
+- is_correct=true：feedback 是一句純鼓勵（不要加提醒）；suggestion 留空字串
+- is_correct=false：feedback 是一句溫柔提醒（先肯定再提示，例如「再想想看…」「換個說法可能更順喔」）；suggestion 是一句改寫提示
 - 一律使用臺灣繁體中文（zh-TW）"""
 
     if passage_sentences:

--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -244,35 +244,27 @@ async def validate_student_sentence(
 
     system_prompt = f"""{TUTOR_PERSONA}
 
-你是一位親切的國語文老師，正在批改學生的造句練習。
+正在陪學生練習用「{safe_word}」造句（課文：《{safe_title}》）。
 
-目標詞語：「{safe_word}」
-課文：《{safe_title}》
+判斷規則：
+- 句子有用到「{safe_word}」、語法基本通順、是學生自己寫的（沒抄課文或例句）→ is_correct=true
+- 否則 → is_correct=false
 
-評估標準：
-1. 句子是否包含目標詞語「{safe_word}」
-2. 句子是否語法正確、語意通順
-3. 目標詞語的用法是否恰當
-4. 適合國小高年級～國中程度
-5. 句子必須是學生自己創作的，不能是從課文或例句中抄寫或稍微改寫的
-
-請給予鼓勵性的評語，用繁體中文（zh-TW）回覆。
-- 若造句正確：is_correct=true，給予鼓勵
-- 若有問題：is_correct=false，指出問題並提供改進建議
-
-注意：只要學生的句子基本語法正確、有使用目標詞語，就算通過。
-不要過度嚴格，給予適度的鼓勵。"""
+回覆規則（非常重要）：
+- feedback **只能一句話**，先肯定再溫柔提醒，不要用「錯」「不對」「不行」「不正確」等否定字眼
+- is_correct=true：feedback 是一句鼓勵；suggestion 留空字串
+- is_correct=false：feedback 是一句溫柔提醒（例如「再想想看…」「換個說法可能更順喔」）；suggestion 是一句改寫提示
+- 一律使用臺灣繁體中文（zh-TW）"""
 
     if passage_sentences:
         passage_ref = "\n".join(f"- {s}" for s in passage_sentences[:5])
         system_prompt += f"""
 
-以下是課文或例句中包含「{safe_word}」的句子片段（供參考比對）：
+以下是課文或例句中含「{safe_word}」的片段（供比對是否抄寫）：
 {passage_ref}
 
-如果學生的句子與上述片段高度相似（只改了幾個字但意思和結構幾乎一樣），判定 is_correct=false，
-並在 feedback 中提示學生「不要照抄課文或例句」，請用自己的話造句。
-注意：feedback 中不要具體指出是「跟課文裡的某某詞像」，因為來源也可能是例句，請統一說「和課文或例句太相似」。"""
+若學生的句子與上述片段意思和結構幾乎一樣，判 is_correct=false，
+feedback 統一說「和課文或例句有點像，試試看用自己的話說說看」，不要點名是哪一句。"""
 
     contents = [
         genai_types.Content(

--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -485,7 +485,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
               <div className="flex items-center gap-2 mb-3">
                 <span className={`w-7 h-7 rounded-full flex items-center justify-center text-sm font-headline font-black ${
                   entry.status === 'correct' ? 'bg-emerald-500 text-white'
-                  : entry.status === 'incorrect' ? 'bg-tertiary text-white'
+                  : entry.status === 'incorrect' ? 'bg-amber-400 text-amber-900'
                   : 'bg-surface-container-high text-on-surface-variant'
                 }`}>
                   {entry.status === 'correct' ? <span className="material-symbols-outlined text-sm">check</span>
@@ -495,7 +495,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
                 <span className="text-sm font-headline font-bold text-on-surface-variant">第 {idx + 1} 句</span>
               </div>
 
-              <div className="flex gap-2">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
                 <input
                   type="text"
                   value={entry.text}
@@ -508,49 +508,49 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
                   onDragOver={e => e.preventDefault()}
                   disabled={entry.status === 'loading' || isCurrentDone}
                   placeholder={`用「${zh(currentWord)}」造一個句子…`}
-                  className={`flex-1 rounded-2xl border-2 px-4 py-3 text-base outline-none transition-all ${
+                  className={`flex-1 min-w-0 rounded-2xl border-2 px-4 py-3 text-base outline-none transition-all ${
                     entry.status === 'correct' ? 'border-emerald-400 bg-emerald-50 text-emerald-900'
-                    : entry.status === 'incorrect' ? 'border-tertiary/40 bg-tertiary-container/10 text-on-surface'
+                    : entry.status === 'incorrect' ? 'border-amber-300 bg-amber-50 text-on-surface'
                     : 'border-surface-container-high bg-transparent focus:border-accent text-on-surface'
                   }`}
                 />
-                <VoiceInputButton
-                  key={currentWord + String(idx)}
-                  onTranscript={(text) => {
-                    updateSentenceText(idx, text);
-                    // Clear live display once final transcript is committed (#1327).
-                    setLiveTranscripts(prev => {
-                      const next: [string, string] = [prev[0], prev[1]];
-                      next[idx] = '';
-                      return next;
-                    });
-                  }}
-                  onLiveTranscript={(text) => {
-                    // Show interim transcript below the input field (#1327).
-                    setLiveTranscripts(prev => {
-                      const next: [string, string] = [prev[0], prev[1]];
-                      next[idx] = text;
-                      return next;
-                    });
-                  }}
-                  disabled={entry.status === 'loading' || isCurrentDone}
-                  stopRef={voiceStopRefs[idx]}
-                />
-                <button
-                  onClick={() => handleValidate(idx)}
-                  disabled={!entry.text.trim() || entry.status === 'loading' || isCurrentDone}
-                  className={`px-5 py-3 rounded-2xl text-sm font-headline font-bold transition-all active:scale-[0.97] shrink-0 ${
-                    entry.status === 'loading' ? 'bg-surface-container-high text-on-surface-variant cursor-wait'
-                    : entry.status === 'correct' ? 'bg-emerald-500 text-white'
-                    : 'bg-accent hover:brightness-110 text-white disabled:opacity-40 disabled:cursor-not-allowed'
-                  }`}
-                >
-                  {entry.status === 'loading' ? (
-                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                  ) : entry.status === 'correct' ? (
-                    <span className="material-symbols-outlined text-lg">check</span>
-                  ) : '批改'}
-                </button>
+                <div className="flex gap-2 justify-end sm:shrink-0">
+                  <VoiceInputButton
+                    key={currentWord + String(idx)}
+                    onTranscript={(text) => {
+                      updateSentenceText(idx, text);
+                      setLiveTranscripts(prev => {
+                        const next: [string, string] = [prev[0], prev[1]];
+                        next[idx] = '';
+                        return next;
+                      });
+                    }}
+                    onLiveTranscript={(text) => {
+                      setLiveTranscripts(prev => {
+                        const next: [string, string] = [prev[0], prev[1]];
+                        next[idx] = text;
+                        return next;
+                      });
+                    }}
+                    disabled={entry.status === 'loading' || isCurrentDone}
+                    stopRef={voiceStopRefs[idx]}
+                  />
+                  <button
+                    onClick={() => handleValidate(idx)}
+                    disabled={!entry.text.trim() || entry.status === 'loading' || isCurrentDone}
+                    className={`px-5 py-3 rounded-2xl text-sm font-headline font-bold transition-all active:scale-[0.97] shrink-0 ${
+                      entry.status === 'loading' ? 'bg-surface-container-high text-on-surface-variant cursor-wait'
+                      : entry.status === 'correct' ? 'bg-emerald-500 text-white'
+                      : 'bg-accent hover:brightness-110 text-white disabled:opacity-40 disabled:cursor-not-allowed'
+                    }`}
+                  >
+                    {entry.status === 'loading' ? (
+                      <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                    ) : entry.status === 'correct' ? (
+                      <span className="material-symbols-outlined text-lg">check</span>
+                    ) : '送出'}
+                  </button>
+                </div>
               </div>
 
               {/* Live transcript display — shown while mic is active (#1327) */}
@@ -563,17 +563,16 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
                 </div>
               )}
 
-              {/* Feedback — font sizes bumped to text-base / text-sm (#1327) */}
               {(entry.status === 'correct' || entry.status === 'incorrect') && (
                 <div className={`mt-3 rounded-2xl px-4 py-4 ${
-                  entry.status === 'correct' ? 'bg-emerald-50' : 'bg-tertiary-container/10'
+                  entry.status === 'correct' ? 'bg-emerald-50' : 'bg-amber-50'
                 }`}>
                   <div className="flex items-start gap-2">
-                    <span className={`material-symbols-outlined text-xl mt-0.5 ${entry.status === 'correct' ? 'text-emerald-600' : 'text-tertiary'}`}>
+                    <span className={`material-symbols-outlined text-xl mt-0.5 ${entry.status === 'correct' ? 'text-emerald-600' : 'text-amber-600'}`}>
                       {entry.status === 'correct' ? 'check_circle' : 'lightbulb'}
                     </span>
                     <div>
-                      <p className={`text-base font-medium leading-relaxed ${entry.status === 'correct' ? 'text-emerald-800' : 'text-on-surface'}`}>{entry.feedback}</p>
+                      <p className={`text-base font-medium leading-relaxed ${entry.status === 'correct' ? 'text-emerald-800' : 'text-amber-900'}`}>{entry.feedback}</p>
                       {entry.suggestion && <p className="mt-1.5 text-sm text-on-surface-variant leading-relaxed">{entry.suggestion}</p>}
                     </div>
                   </div>
@@ -585,8 +584,8 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
 
         {/* Paste warning */}
         {pasteWarning && (
-          <div className="rounded-2xl bg-tertiary-container/15 border border-tertiary/20 px-5 py-3 text-center animate-fade-in">
-            <span className="text-sm text-tertiary font-medium">請用自己的話造句，不要複製貼上喔！</span>
+          <div className="rounded-2xl bg-amber-50 border border-amber-200 px-5 py-3 text-center animate-fade-in">
+            <span className="text-sm text-amber-700 font-medium">請用自己的話造句，不要複製貼上喔！</span>
           </div>
         )}
 
@@ -626,17 +625,19 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
   // ── Standalone mode — two-column: content left + word tabs right ──
   return (
     <div className="flex flex-col flex-1 h-full bg-surface overflow-hidden relative">
-      <div className="flex-1 min-h-0 px-4 md:px-6 py-6 md:py-8">
-        <div className="w-full h-full flex gap-6">
+      <div className="flex-1 min-h-0 px-4 md:px-8 py-6 md:py-8">
+        <div className="w-full h-full flex gap-4">
 
-          {/* Left: main content (scrollable) */}
+          {/* Left: main content (scrollable, max-w-2xl centered) */}
           <div className="flex-1 min-w-0 overflow-y-auto pb-32 custom-scrollbar">
-            {renderContent()}
+            <div className="max-w-2xl mx-auto w-full">
+              {renderContent()}
+            </div>
           </div>
 
           {/* Right: vertical word tab sidebar */}
           {practicedWords.length > 1 && (
-            <div className="hidden md:block w-48 lg:w-56 shrink-0 overflow-y-auto custom-scrollbar">
+            <div className="hidden md:block w-40 lg:w-48 shrink-0 overflow-y-auto custom-scrollbar">
               {wordSidebar}
             </div>
           )}


### PR DESCRIPTION
Closes #1100

## 變更

- **AI prompt**：feedback 限一句、開頭先肯定再溫柔提醒，移除「錯／不對／不行」等否定字眼（`backend/app/services/ai_generation.py`）
- **配色**：incorrect 狀態從 tertiary（橘紅）→ amber（暖黃），含序號徽章、input 邊框、feedback 卡片、paste warning
- **按鈕字**：「批改」→「送出」
- **麥克風擠壓**：窄寬 input 一列、mic+送出 下方靠右；桌面 mic+送出 群組 `shrink-0`，不被 input 壓縮
- **排版收斂**：內容區 `max-w-2xl mx-auto`、`gap-6→gap-4`、側欄 `w-48/w-56→w-40/w-48`

語音輸入功能本身於 #1141 已完成，本 PR 不重做。

## Test plan（PR Preview 部署後）

進入 `/tools` → 選一篇 vocabulary ≥ 2 詞的課文 → 「✏️ 造句練習」（或直接 `/learn/<storyId>/sentence-practice`）：

1. **AI 一句話 + 溫柔語氣**
   - 故意造錯（沒帶目標詞、語法不通、抄課文）→ feedback 必為一句、無「錯/不對/不行」字眼，suggestion 一句
   - 正確造句 → feedback 一句鼓勵，suggestion 為空
2. **amber 配色**
   - 失敗時序號徽章、input 邊框、feedback 卡片、paste warning 全為暖黃，**不應看到任何橘紅**
3. **麥克風佈局**
   - DevTools 切 375px：input 整列獨佔，mic + 送出 下方靠右
   - 桌面：三件同列，mic + 送出 不被 input 壓縮
4. **排版收斂**
   - 桌面多詞模式：內容置中 max-w-2xl，左右大量留白可看到背景裝飾色塊；側欄 w-40 / lg:w-48