### PR TITLE
fix(ai): force suggestion="" when is_correct=true (Fixes #1481)

### DIFF
--- a/backend/app/services/ai_generation.py
+++ b/backend/app/services/ai_generation.py
@@ -289,8 +289,8 @@ async def validate_student_sentence(
         temperature=0.3,
     )
 
-    # Ensure suggestion is empty string if correct
-    if result.get("is_correct") and not result.get("suggestion"):
+    # Ensure suggestion is empty string if correct (defensive, in case model violates prompt)
+    if result.get("is_correct"):
         result["suggestion"] = ""
 
     return result


### PR DESCRIPTION
Fixes #1481

## Summary

- `backend/app/services/ai_generation.py` L292-294: remove the `and not result.get("suggestion")` guard so `suggestion` is **unconditionally cleared** whenever `is_correct=true`

## Why

The old condition only cleared `suggestion` when it was already falsy. If Gemini returned `is_correct=true` AND a non-empty `suggestion` (prompt non-compliance), the suggestion would leak through to the frontend. `SentencePractice.tsx` renders the suggestion field unconditionally, so users would see a confusing "correct + suggestion text" state.

## Reference

- Found by claude bot's automatic review on PR #1480 at 2026-05-06T12:25Z (L285 review finding)
- PR #1480 merged (`be5b603b`) fixed L254 (語氣規則歧義) but missed this fix

## Test plan

- [ ] Submit a correct sentence in 造句練習
- [ ] Verify response has `suggestion: ""` regardless of what the model returns
- [ ] No "answer correct but shows suggestion" UX regression