### PR TITLE
docs(meeting): 2026-05-08 agenda + team contributions + intern skill trees

### DIFF
--- a/docs/intern-training/interns/raymond.json
+++ b/docs/intern-training/interns/raymond.json
@@ -3,7 +3,7 @@
   "github": "if-else-master",
   "email": "78069313+if-else-master@users.noreply.github.com",
   "startDate": "2026-03-02",
-  "lastReview": "2026-04-23",
+  "lastReview": "2026-05-08",
   "skills": {
     "1": {
       "level": 3,
@@ -236,13 +236,18 @@
       "maxLevel": 5
     },
     "11": {
-      "level": 2,
+      "level": 3,
       "maxLevel": 5,
       "history": [
         {
           "date": "2026-04-23",
           "level": 2,
           "reason": "PR #1086 step 進度 debounce 5 秒使用 useRef 儲存 timer ID（不觸發 re-render），正確識別不需要 state 的場景，是 useRef 的標準用法。PR #1175 無聲音輸入主動提示使用 useEffect 監聽音訊輸入狀態，逾時後觸發 UI 提示，展現 side effect 管理的基礎能力。目前尚未見到 useMemo 或複雜 cleanup 場景"
+        },
+        {
+          "date": "2026-05-08",
+          "level": 3,
+          "reason": "PR #1465 toolbox Phase 2+3：useEffect mount-only（空 deps []）觸發後端 toolbox session 建立，同時用 useRef recordedRef 防止 #1464 完成畫面的 CTA 重複觸發寫入。兩個 hook 協同解決跨 PR 的設計衝突（#1463 需要 mount 時記錄，#1464 需要 completion 時記錄），展現對 useEffect 生命週期與 useRef 穩定性的組合應用，已超出 debounce 的單一 hook 場景"
         }
       ]
     },
@@ -331,7 +336,7 @@
       ]
     },
     "18": {
-      "level": 3,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
@@ -348,17 +353,22 @@
           "date": "2026-04-23",
           "level": 3,
           "reason": "PR #1193 新增 LearningSession 的 partial unique index（assignment_id + course_id 組合），PR #1194 設定 AssignmentSubmission.session_id ON DELETE SET NULL 刪除政策，PR #1195 在 step_progress 加入版本號機制防進度倒退。三個 PR 都是在 DB schema 層面做設計決策（索引策略、刪除政策、樂觀鎖），而非在應用層繞過問題，顯示對資料庫設計原則的主動應用，不是跟著 bug 修補"
+        },
+        {
+          "date": "2026-05-08",
+          "level": 4,
+          "reason": "PR #1461 用 Alembic 建立 10 張獨立 toolbox session tables，每張對應一個練習工具，schema 設計包含 FK 關聯與索引。PR #1465 獨立設計後端 toolbox.py routes（POST 建立 session、GET 查詢、PATCH 更新完成狀態）+ 前端 toolboxApi.ts 對應呼叫 + 學習紀錄頁 UI 分區整合。這是靖杭首次從零開始設計一個完整 feature 的後端 API，包含 DB schema → route → service → frontend API layer 的完整鏈路，並自主決定 HTTP method 語意（POST/GET/PATCH 各自職責），達到全端架構理解的 level 4"
         }
       ]
     }
   },
   "recommendations": [
-    "架構理解（#18）升到 level 3，DB schema 設計（index/FK 政策/版本鎖）能力已確立。下一步：#1101 詞語定義、#1103 課文理解、#1104 知識補給站 這三個 issue 涵蓋不同步驟的資料流，完成後可嘗試畫出整個學習流程的前後端資料流圖（這是 level 4 的準備）",
-    "元件設計（#13）升到 level 4，下一步挑戰抽取 custom hook。#1102 語詞應用和 #1204 造句持久化都有重複的 beforeunload + session 寫入邏輯，可以試著抽成 useSessionPersistence hook",
-    "獨立開發（#16）升到 level 4。#1105 報告簡化是好的 level 5 候選任務：完整的需求→設計→實作→驗收流程，且涉及 UI 設計決策（不只是 bug 修復）",
-    "React 進階（#11）剛解鎖 level 2（useRef debounce + useEffect 音訊監聽）。下一步在 #1076 逐段朗讀的重練邏輯中嘗試用 useMemo 快取已處理的句子分割結果，避免每次渲染重算"
+    "架構理解（#18）升到 level 4，首次獨立設計完整 feature 後端 API（toolbox POST/GET/PATCH）。下一步：嘗試為 toolbox API 補寫 contract test（pytest）驗證各 endpoint 的 status code + response schema，這是 level 5 的準備——不只能設計 API，也能用測試鎖定合約",
+    "React 進階（#11）升到 level 3（useEffect + useRef 跨 PR 協同）。下一步：在 #1190 或 #1186 中嘗試用 useMemo 快取計算結果，或抽取 custom hook，完成後 #11 有機會升到 level 4",
+    "元件設計（#13）已穩在 level 4。#1464 的 ToolboxCompletionActions 共用元件 + 9 個 reading-step 接入是好的證據。下一步挑戰：把 toolbox session 寫入邏輯抽成 useToolboxSession custom hook，這是 level 5 的證明",
+    "獨立開發（#16）已穩在 level 4。#1457 驗收簽結是好的 level 5 候選機會：完整經歷需求→設計→實作→現場驗收的全循環，且是跨 4 個 PR 的大型功能"
   ],
-  "summary": "4/10~4/23 共 16 個 PR merge，是靖杭迄今最密集的兩週。最大亮點：首次完成 DB schema 設計工作（#1193 partial unique index、#1194 ON DELETE SET NULL、#1195 step_progress 版本機制），顯示從前端工程師成長為全端工程師的關鍵跨越。P1 beta blocker #1073/#1074（跨裝置 session 一致性）在 deadline 前 2 天提前完成。技能升級：#9 Git 工作流（3→4）、#11 React 進階（新解鎖 2）、#13 元件設計（3→4）、#16 獨立開發（3→4）、#18 架構理解（2→3）",
+  "summary": "5/2~5/8 共 4 個 PR merge，全部圍繞練習工具箱完整落地：Phase 1 Alembic 建 10 張 DB tables → per-tool CTA 共用元件 → Phase 2+3 後端 API + 前端 toolboxApi.ts + 學習紀錄頁整合。技術亮點：PR #1465 用 useEffect mount + useRef recordedRef 優雅解決 #1463 和 #1464 的設計衝突，展現跨 PR 架構思維。靖杭首次獨立設計後端 feature API（POST/GET/PATCH）並走完 DB → route → frontend 完整鏈路。技能升級：#11 React 進階（2→3）、#18 架構理解（3→4）",
   "issues": [
     {
       "id": "環境建置",
@@ -603,6 +613,60 @@
       "contribution": "修復中文輸入法選字時 Enter 鍵誤觸提交的問題，同時修正造句和聽寫兩個獨立元件的相同行為",
       "skillsLearned": [10],
       "highlights": ["同一問題在兩個元件同步修復", "IME composition 事件正確處理"]
+    },
+    {
+      "id": "#1351",
+      "title": "zhuyin-off 場景明確 serif fallback（PR #1459）",
+      "date": "2026-05-07",
+      "type": "bugfix",
+      "contribution": "修復非注音模式下缺乏明確字體 fallback 的問題。新增 BpmfZihiSerif（字嗨宋體）作為 zhuyin-off 場景的 serif fallback，建立 fonts.ts helper 集中管理字體 class，更新 11 個相關元件",
+      "skillsLearned": [8, 9],
+      "highlights": [
+        "建立 fonts.ts 集中字體管理，不散落各元件",
+        "理解 IVS variant selector 對 CJK 字體選擇的影響",
+        "11 個元件統一套用，修改範圍廣但邏輯一致"
+      ],
+      "linesChanged": "+多行（11 元件 + fonts.ts helper）"
+    },
+    {
+      "id": "#1460",
+      "title": "toolbox session tables — Phase 1（PR #1461）",
+      "date": "2026-05-07",
+      "type": "feature",
+      "contribution": "用 Alembic migration 建立 10 張獨立 toolbox session tables，每張對應一個練習工具（LiveTutor、FullReading、Listening、VocabPractice 等），包含 FK 關聯與索引。同時為 AppShell 加入 toolbox-aware aria-label 改善 a11y",
+      "skillsLearned": [9, 18],
+      "highlights": [
+        "Alembic 一次建 10 張 table，schema 設計清楚",
+        "FK + index 設計符合 sqlalchemy-model-safety checklist",
+        "a11y aria-label 細節在第 6 輪 @claude review 後補上，展現對細節的追蹤"
+      ]
+    },
+    {
+      "id": "#1462",
+      "title": "toolbox per-tool 完成畫面 CTA（PR #1464）",
+      "date": "2026-05-07",
+      "type": "feature",
+      "contribution": "設計並實作 ToolboxCompletionActions 共用元件，提供「重做」和「回到練習工具箱」兩個 CTA 按鈕。將元件接入 9 個 reading-step 元件，形成統一的完成體驗",
+      "skillsLearned": [6, 13],
+      "highlights": [
+        "共用元件設計，9 個元件接入點統一",
+        "4 輪 @claude review 迭代改善元件 API 設計",
+        "解決與 Phase 2+3 (#1465) 的設計衝突：CTA 的 recordedRef guard 防重複觸發"
+      ]
+    },
+    {
+      "id": "#1463",
+      "title": "toolbox Phase 2+3 — 後端 API + 前端整合 + 學習紀錄頁（PR #1465）",
+      "date": "2026-05-07",
+      "type": "feature",
+      "contribution": "完整實作練習工具箱的資料記錄層：後端 toolbox.py（POST/GET/PATCH routes）、前端 toolboxApi.ts（API 呼叫層）、學習紀錄頁分區顯示工具箱完成紀錄。用 useEffect mount（空 deps）+ useRef recordedRef guard 解決 #1463 和 #1464 的設計衝突",
+      "skillsLearned": [11, 12, 13, 18],
+      "highlights": [
+        "首次獨立設計完整 feature 後端 API（POST/GET/PATCH 語意清楚）",
+        "useEffect + useRef 跨 PR 協同解決設計衝突，展現 React lifecycle 成熟理解",
+        "前後端 + DB 三層完整走完",
+        "4 輪 @claude review 迭代"
+      ]
     }
   ]
 }

--- a/docs/intern-training/interns/xiung.json
+++ b/docs/intern-training/interns/xiung.json
@@ -3,7 +3,7 @@
   "github": "stgst",
   "email": "steven19790906@gmail.com",
   "startDate": "2026-03-06",
-  "lastReview": "2026-04-23",
+  "lastReview": "2026-05-08",
   "skills": {
     "1": {
       "level": 3,
@@ -332,12 +332,12 @@
     }
   },
   "recommendations": [
-    "PR #1087 大幅瘦身元件（-1425 行）是很好的設計整理，但 #1141 全域 UX PR 卡在 review 超過一週。建議主動在 PR 留言說明目前卡點是什麼、是否需要討論，養成主動溝通 blocked 狀態的習慣",
-    "架構理解（#18）升到 level 3，靠的是從 HTML 結構追 JS DOM 行為的完整因果分析。下一步：#1097 全文朗讀和 #1098 聽力持久化都涉及前後端資料流設計，完成後可以嘗試畫出兩個步驟的 sequence diagram（level 4 的準備）",
-    "Tailwind（#8）和元件設計（#13）都升到 level 4，設計系統能力已確立。下一步挑戰：抽取 custom hook，例如把 #1128 部件教學的 moedict fetch + cache + fallback 邏輯抽成 useRadicalDictionary hook",
-    "這兩週 3 個 PR 雖然數量少，但 #1087 規模龐大（+3205/-4777）。下一步建議在 #1100 造句批改中嘗試更小粒度的 PR 拆分，練習把大功能分成 2~3 個獨立 PR（和靖杭的 DB 三連 PR 一樣）"
+    "PR #1480 展現 AI prompt engineering 意識（拆 is_correct=true/false 分別給語氣規則）。下一步：在 #1458 驗收的 AI 助教相關工作中，嘗試設計更結構化的 prompt schema，例如加入 reasoning field（方大哥和 Young 可稽核），這是 AI prompt engineering 升到 level 3 的機會",
+    "架構理解（#18）穩在 level 3。下一步：#1458 剩餘的圖文整合呈現工作涉及前後端 YAML 解析 + layout 分支邏輯，完成後可以嘗試畫出圖文整合的資料流（YAML → loader → API → frontend layout）作為 level 4 的準備",
+    "Tailwind（#8）已升到 level 4，amber palette 整包一致是很好的設計系統實踐。下一步挑戰：把造句練習的 amber 配色邏輯抽成 Tailwind plugin 或 design token，做到不散落在各處 className",
+    "PR #1480 的 1 輪 @claude review 快速 LGTM 是迭代效率提升的好信號。繼續保持，下一個 PR 目標：PR 說明補上「testing steps」清單（這是 level 4 → 5 的一個標誌）"
   ],
-  "summary": "4/10~4/23 共 3 個 PR merge（#1087、#1128、#1130）。數量少但 #1087 是迄今最大規模 PR（+3205/-4777），完整實作沉浸式學習 shell 並建立全站設計系統（surface token、glass utility、全域注音字型）。#1128 step 5 部件教學協調三個資料來源進入同一教學流程。#1130 精準追蹤並修復 #1087 引入的 HTML 結構 regression，展現 root cause analysis 能力。技能升級：#8 Tailwind（2→4）、#12 API 串接（3→4）、#13 元件設計（3→4）、#18 架構理解（2→3）。注意：#1141 全域 UX PR 已卡超過一週，需要 Young 協助或啟翔主動說明卡點",
+  "summary": "5/2~5/8 共 1 個 PR merge（#1480）。PR #1480 修造句練習三個獨立問題：AI 評估語氣歧義（拆 is_correct=true/false 規則，是 AI prompt engineering 意識的展現）、amber palette 配色全包一致、麥克風 wrapper layout 擠壓修正（shrink-0 + flex-col/sm:flex-row）。1 輪 @claude review 快速 LGTM，顯示從上一次多輪迭代進步到快速收斂。本週無技能升級（#8/#13 已在 level 4），但 #1480 的 prompt engineering 拆分思維為新技能維度打下基礎",
   "issues": [
     {
       "id": "環境建置",
@@ -491,6 +491,20 @@
         "Tailwind arbitrary shadow 解決 underline 行為問題"
       ],
       "linesChanged": "+147/-23"
+    },
+    {
+      "id": "造句 polish",
+      "title": "造句練習語氣軟化 + amber 配色 + 麥克風擠壓修正（PR #1480）",
+      "date": "2026-05-07",
+      "type": "feature",
+      "contribution": "修正造句練習三個獨立問題：(1) AI 評估回饋語氣歧義 — 拆分 is_correct=true 和 is_correct=false 兩組語氣規則，避免 prompt 語意模糊；(2) amber 配色不一致 — badge、border、feedback 文字、paste warning 全部對齊 amber palette；(3) 麥克風 wrapper 在窄螢幕被壓縮 — 加 shrink-0 + flex-col/sm:flex-row 自適應佈局",
+      "skillsLearned": [8, 13],
+      "highlights": [
+        "AI prompt engineering：拆 is_correct=true/false 規則解決語氣歧義，顯示對 LLM 輸出結構的設計意識",
+        "amber palette 一致性：4 個使用點全部對齊，展現設計系統紀律",
+        "responsive layout：shrink-0 + flex-col/sm:flex-row 正確處理窄螢幕",
+        "1 輪 @claude review 快速 LGTM，迭代效率提升"
+      ]
     }
   ]
 }

--- a/docs/meetings/2026-05-08-agenda.md
+++ b/docs/meetings/2026-05-08-agenda.md
@@ -1,0 +1,178 @@
+# 會議議程 2026-05-08（五）
+
+## 參與者
+- Young（lead dev）
+- 靖杭 @if-else-master（intern）
+- 啟翔 @stgst（intern）
+- 方大哥 @Shinjou（product owner，視出席狀況）
+
+---
+
+## 本週 Merged PRs 總覽（5/2 ~ 5/7）
+
+| PR | 作者 | 內容 | Issue |
+|----|------|------|-------|
+| #1459 | 靖杭 | fix(font): zhuyin-off 場景明確 serif fallback | Fixes #1351 |
+| #1461 | 靖杭 | feat(toolbox): 建立 10 個 toolbox session tables | Refs #1460 Phase 1 |
+| #1464 | 靖杭 | feat(toolbox): per-tool 完成畫面 CTA polish — 重做 + 回到練習工具箱 | Fixes #1462 |
+| #1465 | 靖杭 | feat(toolbox): Phase 2 + 3 — 寫入新表 + 學習紀錄頁標註 | Fixes #1463 |
+| #1470 | Young | fix: VocabWordSearch 孤寂感空白 / 無法圈選 | Fixes #1469 |
+| #1472 | Young | fix(infra): alembic_version stale 截斷 + re-stamp | Fixes #1471 |
+| #1479 | Young | chore: parser tools from 5/2 WIP | Related to #1478 |
+| #1480 | 啟翔 | fix: 造句練習語氣軟化 + amber 配色 + 麥克風擠壓修正 | — |
+
+---
+
+## 一、靖杭進度報告
+
+> 📊 [技能樹](../intern-training/interns/raymond.json) ｜ [貢獻紀錄](team-contributions.md)
+
+### 本週摘要
+本週 4 個 PR，全部圍繞「練習工具箱」功能完整落地：Phase 1 建 10 張獨立 session tables（#1461）→ Phase 2+3 後端 toolbox.py route + 前端 toolboxApi.ts + 學習紀錄頁分區顯示（#1465）。同時解決字體 fallback（#1459）和完成畫面 CTA 共用元件（#1464）。靖杭在 Phase 2+3 中巧妙用 `useEffect` mount + `useRef` guard 解決 #1463 和 #1464 設計衝突，展現 React state lifecycle 的成熟判斷
+
+### 技能升級
+- **React 進階 #11**: 2 → 3 — `useEffect` mount + `useRef recordedRef` guard pattern，解設計衝突
+- **架構理解 #18**: 3 → 4（候選）— 後端 FastAPI POST/GET/PATCH route 獨立設計 + Alembic 10 張 migration
+
+### 本週完成（5/2 ~ 5/7）
+- ✅ PR #1459 — zhuyin-off 場景 BpmfZihiSerif + 11 元件 + `fonts.ts` helper（fix #1351）
+- ✅ PR #1461 — 10 個 toolbox session tables + AppShell `aria-label` toolbox-aware（feat #1460 Phase 1）
+- ✅ PR #1464 — `ToolboxCompletionActions` 共用元件 + 9 個 reading-step 接入（feat #1462）
+- ✅ PR #1465 — 後端 `toolbox.py` + 前端 `toolboxApi.ts` + 學習紀錄頁分區（feat #1463）
+
+### 待驗收
+- 5/1 會議決議 #1457 — 字體/詞彙/簡介/教材整合整包驗收，PR #1459/#1461/#1464/#1465 全歸此 issue，需現場走過 staging 簽結
+
+### 進行中
+- 🔧 #1190 — 進行中
+- 🔧 #1186 — 進行中
+- 🔧 9 個 `ai-qa-passed + intern-review` label 等實習生 final eye-check
+
+### 待討論
+- #1457 驗收清單現場確認（字體、工具箱 CTA、學習紀錄分區）
+- toolbox 5 個 tech-debt issues (#1473–#1477 Young 開的 follow-up）認領誰做
+
+---
+
+## 二、啟翔進度報告
+
+> 📊 [技能樹](../intern-training/interns/xiung.json) ｜ [貢獻紀錄](team-contributions.md)
+
+### 本週摘要
+PR #1480 修造句練習三個獨立問題：AI 評估語氣歧義（拆 is_correct=true/false 規則）、配色統一（amber palette badge/border/feedback/paste warning 全部對齊）、麥克風 wrapper layout 擠壓（shrink-0 + flex-col/sm:flex-row）。1 輪 @claude review 快速 LGTM，展現 iteration 效率提升
+
+### 本週完成（5/2 ~ 5/7）
+- ✅ PR #1480 — 造句練習語氣軟化 + amber 配色 + 麥克風擠壓修正
+
+### 待驗收
+- 5/1 會議決議 #1458 — 課文理解/圖文整合/AI 助教驗收，PR #1480 部分覆蓋，尚未完整收尾
+
+### 進行中 / 待討論
+- 🔧 PR #1482 — 待 Young admin merge（#1480 follow-up，L285）
+- #1458 驗收哪些項目還差？現場確認剩餘 scope
+
+---
+
+## 三、Young / Claude 本週成果（5/2 ~ 5/7）
+
+### Bug Fix
+- ✅ PR #1470 — VocabWordSearch「孤寂感」空白根因 = YAML L02/L34 含 U+0020 空格，前端加 `.replace` defensive guard
+- ✅ PR #1472 — preview deploy 容器 exit 255（stale `alembic_version`）；`entrypoint.sh` truncate + re-stamp + retry
+
+### 基礎設施 / 工具
+- ✅ PR #1479 — 5/2 WIP triage：`scripts/generate_layer2_thumbnails.py` + spotlight `_REVIEW.md`
+- ✅ 5 個 tech-debt follow-up issues（#1473–#1477）：toolbox POST+PATCH 合併、JSONB DEFAULT '{}'、text_id FK、route order、entrypoint env guard
+- ✅ 流程改善：`intern-review` label（11 個 ai-qa-passed 保留實習生眼驗）+ `needs-rebase`/`needs-fix` labels
+
+---
+
+## 四、待討論議題
+
+### 4.1 PR #1482 Admin Merge（需 Young 現場處理）
+
+**狀態**：PR 待 admin merge，#1480 的 L285 follow-up
+**行動**：Young 現場 merge
+
+---
+
+### 4.2 #1387 閱讀聚光燈 AI 助教（7/1 deadline 大功能）
+
+**現況**：已有 Phase 1 text-only scaffold（PR #1451），但無 assignee
+**規模評估**：這是 7/1 必交 2 模組之一，尚未開工實質功能
+**需討論**：
+- [ ] 誰接這個 issue？（靖杭 / 啟翔 / Young）
+- [ ] 拆 phase 計劃：語音化 AI 助教的 MVP scope 是什麼？
+- [ ] 7/1 deadline = 約 8 週，需要本週就決定
+
+---
+
+### 4.3 #1393 G7-L29/L30 圖文整合 YAML 問題
+
+**現況**：22/25 行純文字無填空，學習單呈現邏輯不完整
+**需確認**：
+- [ ] 方大哥確認圖文整合課的學習單預期呈現方式
+- [ ] 前端是否需要新增「只有圖文閱讀、無填空」的呈現 layout？
+- [ ] 需要 user-facing spec 後才能開發
+
+---
+
+### 4.4 #1453 MCQ rescue route prefix mismatch
+
+**現況**：Bug，後端 route prefix 錯誤（已有修復 PR #1454，但此 issue 本身是 staging 上的 regression）
+**行動**：確認修復是否已 live，issue 是否可關閉
+
+---
+
+### 4.5 #1457 / #1458 5/1 會議驗收簽結
+
+| Issue | 範圍 | 負責 | 狀態 |
+|-------|------|------|------|
+| #1457 | 字體 + 工具箱 + 簡介 + 教材整合（靖杭負責）| 靖杭 | 需現場走 staging 驗收 |
+| #1458 | 課文理解 + 圖文整合 + AI 助教（啟翔負責）| 啟翔 | 部分完成，確認剩餘 |
+
+---
+
+### 4.6 9 個 ai-qa-passed issues 等 intern-review
+
+**現況**：11 個 issue 貼有 `ai-qa-passed + intern-review` label，等實習生 final eye-check 後可關閉
+**行動**：靖杭/啟翔 本週認領自己負責的 issue 確認一遍，確認 OK 後 comment「眼驗通過」
+
+---
+
+## 五、7/1 Deadline 計數
+
+> 7/1 deadline 剩約 **8 週**。兩大模組必須完成：(A) 閱讀聚光燈 AI 助教、(B) 圖文整合 3 課學習單
+
+| 模組 | Issue | 現況 | 風險 |
+|------|-------|------|------|
+| 閱讀聚光燈 AI 助教 | #1387 | Phase 1 scaffold 存在，無 assignee | 🔴 高（尚未實質開工） |
+| 圖文整合 YAML + 呈現 | #1393 | YAML 已有，呈現 spec 待確認 | 🟡 中（spec 確認後可快速啟動） |
+| G4-G5 剩餘 toolbox 整合 | #1463 follow-up | Phase 2+3 已 merge | 🟢 低 |
+
+---
+
+## 六、Tech Debt Follow-up（#1473–#1477）
+
+Young 本週開的 5 個 toolbox tech-debt issues，低優先但本週安排認領避免積壓：
+
+| Issue | 內容 | 難度 |
+|-------|------|------|
+| #1473 | toolbox POST + PATCH 合併 | 中 |
+| #1474 | JSONB DEFAULT '{}' | 低 |
+| #1475 | text_id FK | 低 |
+| #1476 | route order | 低 |
+| #1477 | entrypoint env guard | 低 |
+
+---
+
+## 七、Action Items
+
+| # | Action | 負責 | 完成標準 | Deadline |
+|---|--------|------|---------|----------|
+| A1 | 現場 merge PR #1482 | **Young** | PR merged | 5/8 會議中 |
+| A2 | #1387 閱讀聚光燈 AI 助教 assignee 確認 + Phase 計劃 | **Young + team** | issue 有 assignee + milestone 初稿 | 5/8 會議中 |
+| A3 | #1393 圖文整合學習單呈現 spec 確認 | **方大哥 + Young** | 書面 spec 或 issue comment 確認 | 5/12 前 |
+| A4 | #1457 staging 驗收走過 | **靖杭** | 現場確認 OK 或列出 blocking items | 5/8 會議中 |
+| A5 | #1458 剩餘 scope 確認 | **啟翔** | 確認哪些項目還差，列 PR plan | 5/8 會議中 |
+| A6 | 9 個 intern-review issues 眼驗 | **靖杭 + 啟翔** | 各自 comment 確認，Young close | 5/12 前 |
+| A7 | #1473–#1477 tech-debt 認領 | **靖杭 / 啟翔** | issues 有 assignee | 5/8 會議中 |

--- a/docs/meetings/team-contributions.md
+++ b/docs/meetings/team-contributions.md
@@ -8,6 +8,23 @@
 
 ---
 
+## 5/2 ~ 5/8
+
+| 人 | 狀態 | Issue / 項目 | 做了什麼 |
+|----|------|-------------|---------|
+| 靖杭 | ✅ | PR #1459 字體（#1351）| zhuyin-off 場景 BpmfZihiSerif 字嗨宋體 + 11 元件 + fonts.ts helper |
+| 靖杭 | ✅ | PR #1461 toolbox Phase 1（#1460）| 10 獨立 toolbox session tables + AppShell a11y aria-label toolbox-aware |
+| 靖杭 | ✅ | PR #1464 toolbox CTA polish（#1462）| per-tool 完成畫面「重做 + 回到工具箱」共用元件 + 9 個 reading-step 接入 |
+| 靖杭 | ✅ | PR #1465 toolbox Phase 2+3（#1463）| 後端 toolbox.py + 前端 toolboxApi.ts + 學習紀錄頁分區，useEffect mount + recordedRef guard 解設計衝突 |
+| 啟翔 | ✅ | PR #1480 造句練習 polish | AI 評估語氣軟化（拆 is_correct=true/false 規則）+ amber 配色（badge/border/feedback/paste warning）+ 麥克風 wrapper layout 修正 |
+| Young | ✅ | PR #1470 VocabWordSearch（#1469）| 「孤寂感」grid 空白 root cause = L02.yml YAML 含 U+0020 空格；fix L02 + L34 + 前端 .replace defensive guard |
+| Young | ✅ | PR #1472 alembic infra（#1471）| preview deploy 容器 exit 255 = stale alembic_version；entrypoint.sh truncate + re-stamp + retry |
+| Young | ✅ | PR #1479 parser tools | 5/2 WIP triage：scripts/generate_layer2_thumbnails.py + spotlight _REVIEW.md |
+| Young | ✅ | 5 follow-up issues（#1473–#1477）| toolbox tech-debt（POST+PATCH 合併、JSONB DEFAULT '{}'、text_id FK、route order、entrypoint env guard）|
+| Young | ✅ | 流程改善 | intern-review label（11 個 ai-qa-passed 標保留實習生眼驗）+ needs-rebase/needs-fix labels |
+
+---
+
 ## 4/18 ~ 4/24
 
 > ⚠️ 本週未開會，僅活動紀錄（見 [2026-04-24-record.md](./2026-04-24-record.md)）


### PR DESCRIPTION
## Summary

- Add `docs/meetings/2026-05-08-agenda.md` — 7 agenda sections, 7 action items, 7/1 deadline risk table
- Update `docs/meetings/team-contributions.md` — prepend 5/2~5/8 week (靖杭 4 PR + 啟翔 1 PR + Young 3 PR + toolbox follow-ups)
- Update `docs/intern-training/interns/raymond.json` — lastReview 2026-05-08, skill #11 2→3 (useEffect+useRef toolbox design), skill #18 3→4 (first full backend API design), 5 new issue entries
- Update `docs/intern-training/interns/xiung.json` — lastReview 2026-05-08, 1 new issue entry (PR #1480 造句polish), updated summary + recommendations

## Key agenda items

- 7/1 deadline: #1387 閱讀聚光燈 AI 助教 (🔴 no assignee) + #1393 圖文整合 spec
- 5/1 會議驗收: #1457 (靖杭) + #1458 (啟翔) staging walk-through
- toolbox tech-debt #1473–#1477 assignee decisions
- PR #1482 admin merge

## Test plan

- [ ] `docs/meetings/2026-05-08-agenda.md` renders correctly in GitHub preview
- [ ] `team-contributions.md` 5/2~5/8 section appears at top (after header, before 4/18~4/24)
- [ ] `raymond.json` valid JSON — `jq . raymond.json` passes
- [ ] `xiung.json` valid JSON — `jq . xiung.json` passes