### PR TITLE
docs(meeting): 5/8 reintegrate week — add #1482/#1485/#1487 (Fixes #1488)

### DIFF
--- a/docs/intern-training/interns/raymond.json
+++ b/docs/intern-training/interns/raymond.json
@@ -368,7 +368,7 @@
     "元件設計（#13）已穩在 level 4。#1464 的 ToolboxCompletionActions 共用元件 + 9 個 reading-step 接入是好的證據。下一步挑戰：把 toolbox session 寫入邏輯抽成 useToolboxSession custom hook，這是 level 5 的證明",
     "獨立開發（#16）已穩在 level 4。#1457 驗收簽結是好的 level 5 候選機會：完整經歷需求→設計→實作→現場驗收的全循環，且是跨 4 個 PR 的大型功能"
   ],
-  "summary": "5/2~5/8 共 4 個 PR merge，全部圍繞練習工具箱完整落地：Phase 1 Alembic 建 10 張 DB tables → per-tool CTA 共用元件 → Phase 2+3 後端 API + 前端 toolboxApi.ts + 學習紀錄頁整合。技術亮點：PR #1465 用 useEffect mount + useRef recordedRef 優雅解決 #1463 和 #1464 的設計衝突，展現跨 PR 架構思維。靖杭首次獨立設計後端 feature API（POST/GET/PATCH）並走完 DB → route → frontend 完整鏈路。技能升級：#11 React 進階（2→3）、#18 架構理解（3→4）",
+  "summary": "5/4~5/8 共 4 個 PR merge，全部圍繞練習工具箱完整落地：Phase 1 Alembic 建 10 張 DB tables → per-tool CTA 共用元件 → Phase 2+3 後端 API + 前端 toolboxApi.ts + 學習紀錄頁整合。技術亮點：PR #1465 用 useEffect mount + useRef recordedRef 優雅解決 #1463 和 #1464 的設計衝突，展現跨 PR 架構思維。靖杭首次獨立設計後端 feature API（POST/GET/PATCH）並走完 DB → route → frontend 完整鏈路。技能升級：#11 React 進階（2→3）、#18 架構理解（3→4）。[5/7 補充] Young 補了 #1482（PR #1480 follow-up，is_correct=True 強制 suggestion=\"\"）+ #1485/#1487 meeting-prep skill 建立，靖杭本週無新 intern PR",
   "issues": [
     {
       "id": "環境建置",

--- a/docs/intern-training/interns/xiung.json
+++ b/docs/intern-training/interns/xiung.json
@@ -337,7 +337,7 @@
     "Tailwind（#8）已升到 level 4，amber palette 整包一致是很好的設計系統實踐。下一步挑戰：把造句練習的 amber 配色邏輯抽成 Tailwind plugin 或 design token，做到不散落在各處 className",
     "PR #1480 的 1 輪 @claude review 快速 LGTM 是迭代效率提升的好信號。繼續保持，下一個 PR 目標：PR 說明補上「testing steps」清單（這是 level 4 → 5 的一個標誌）"
   ],
-  "summary": "5/2~5/8 共 1 個 PR merge（#1480）。PR #1480 修造句練習三個獨立問題：AI 評估語氣歧義（拆 is_correct=true/false 規則，是 AI prompt engineering 意識的展現）、amber palette 配色全包一致、麥克風 wrapper layout 擠壓修正（shrink-0 + flex-col/sm:flex-row）。1 輪 @claude review 快速 LGTM，顯示從上一次多輪迭代進步到快速收斂。本週無技能升級（#8/#13 已在 level 4），但 #1480 的 prompt engineering 拆分思維為新技能維度打下基礎",
+  "summary": "5/4~5/8 共 1 個 PR merge（#1480）。PR #1480 修造句練習三個獨立問題：AI 評估語氣歧義（拆 is_correct=true/false 規則，是 AI prompt engineering 意識的展現）、amber palette 配色全包一致、麥克風 wrapper layout 擠壓修正（shrink-0 + flex-col/sm:flex-row）。1 輪 @claude review 快速 LGTM，顯示從上一次多輪迭代進步到快速收斂。本週無技能升級（#8/#13 已在 level 4），但 #1480 的 prompt engineering 拆分思維為新技能維度打下基礎。[5/7 補充] Young 補了 #1482（是 #1480 claude-bot 找到的 L285 follow-up fix）+ #1485/#1487 meeting-prep skill 建立，啟翔本週無新 intern PR",
   "issues": [
     {
       "id": "環境建置",

--- a/docs/meetings/2026-05-08-agenda.md
+++ b/docs/meetings/2026-05-08-agenda.md
@@ -8,7 +8,7 @@
 
 ---
 
-## 本週 Merged PRs 總覽（5/2 ~ 5/7）
+## 本週 Merged PRs 總覽（5/4 ~ 5/8）
 
 | PR | 作者 | 內容 | Issue |
 |----|------|------|-------|
@@ -20,6 +20,9 @@
 | #1472 | Young | fix(infra): alembic_version stale 截斷 + re-stamp | Fixes #1471 |
 | #1479 | Young | chore: parser tools from 5/2 WIP | Related to #1478 |
 | #1480 | 啟翔 | fix: 造句練習語氣軟化 + amber 配色 + 麥克風擠壓修正 | — |
+| #1482 | Young | fix(ai): is_correct=true 時強制 suggestion="" | Fixes #1481 |
+| #1485 | Young | feat(skill): friday-meeting-prep skill 建立 | — |
+| #1487 | Young | feat(skill): 泛化 meeting-prep，不假設週五 | Fixes #1486 |
 
 ---
 
@@ -73,25 +76,29 @@ PR #1480 修造句練習三個獨立問題：AI 評估語氣歧義（拆 is_corr
 
 ---
 
-## 三、Young / Claude 本週成果（5/2 ~ 5/7）
+## 三、Young / Claude 本週成果（5/4 ~ 5/8）
 
 ### Bug Fix
 - ✅ PR #1470 — VocabWordSearch「孤寂感」空白根因 = YAML L02/L34 含 U+0020 空格，前端加 `.replace` defensive guard
 - ✅ PR #1472 — preview deploy 容器 exit 255（stale `alembic_version`）；`entrypoint.sh` truncate + re-stamp + retry
+- ✅ PR #1482 — `ai_generation.py` L292 一行防禦修正：`is_correct=True` 時強制 `suggestion=""`，避免造句通過後仍顯示建議文字（#1480 claude-bot 找到的 L285 問題）
 
 ### 基礎設施 / 工具
 - ✅ PR #1479 — 5/2 WIP triage：`scripts/generate_layer2_thumbnails.py` + spotlight `_REVIEW.md`
 - ✅ 5 個 tech-debt follow-up issues（#1473–#1477）：toolbox POST+PATCH 合併、JSONB DEFAULT '{}'、text_id FK、route order、entrypoint env guard
 - ✅ 流程改善：`intern-review` label（11 個 ai-qa-passed 保留實習生眼驗）+ `needs-rebase`/`needs-fix` labels
 
+### 開發流程 Skill
+- ✅ PR #1485 — meeting-prep skill 首建：4 份文件自動產出（議程 + 貢獻 + 2 個 intern JSON），開 PR 到 staging
+- ✅ PR #1487 — 泛化為 `meeting-prep`（不假設週五）+ 加 AskUserQuestion 邏輯，回應 Young 「不一定週五」feedback
+
 ---
 
 ## 四、待討論議題
 
-### 4.1 PR #1482 Admin Merge（需 Young 現場處理）
+### 4.1 ~~PR #1482 Admin Merge~~ — ✅ 已 Merge（5/7）
 
-**狀態**：PR 待 admin merge，#1480 的 L285 follow-up
-**行動**：Young 現場 merge
+PR #1482 已於 5/7 merge，`is_correct=True` 時 `suggestion=""` 防禦修正上線
 
 ---
 
@@ -169,7 +176,7 @@ Young 本週開的 5 個 toolbox tech-debt issues，低優先但本週安排認�
 
 | # | Action | 負責 | 完成標準 | Deadline |
 |---|--------|------|---------|----------|
-| A1 | 現場 merge PR #1482 | **Young** | PR merged | 5/8 會議中 |
+| ~~A1~~ | ~~現場 merge PR #1482~~ | ~~Young~~ | ✅ 已完成（5/7 merge） | — |
 | A2 | #1387 閱讀聚光燈 AI 助教 assignee 確認 + Phase 計劃 | **Young + team** | issue 有 assignee + milestone 初稿 | 5/8 會議中 |
 | A3 | #1393 圖文整合學習單呈現 spec 確認 | **方大哥 + Young** | 書面 spec 或 issue comment 確認 | 5/12 前 |
 | A4 | #1457 staging 驗收走過 | **靖杭** | 現場確認 OK 或列出 blocking items | 5/8 會議中 |

--- a/docs/meetings/team-contributions.md
+++ b/docs/meetings/team-contributions.md
@@ -8,7 +8,7 @@
 
 ---
 
-## 5/2 ~ 5/8
+## 5/4 ~ 5/8
 
 | 人 | 狀態 | Issue / 項目 | 做了什麼 |
 |----|------|-------------|---------|
@@ -22,6 +22,9 @@
 | Young | ✅ | PR #1479 parser tools | 5/2 WIP triage：scripts/generate_layer2_thumbnails.py + spotlight _REVIEW.md |
 | Young | ✅ | 5 follow-up issues（#1473–#1477）| toolbox tech-debt（POST+PATCH 合併、JSONB DEFAULT '{}'、text_id FK、route order、entrypoint env guard）|
 | Young | ✅ | 流程改善 | intern-review label（11 個 ai-qa-passed 標保留實習生眼驗）+ needs-rebase/needs-fix labels |
+| Young | ✅ | PR #1482 fix(ai)（#1481）| is_correct=True 時強制 suggestion=""（ai_generation.py L292 一行 defensive fix，#1480 claude-bot L285 finding）|
+| Young | ✅ | PR #1485 feat(skill) | meeting-prep skill 首建：4 份文件自動產出 + worktree + PR 到 staging 全流程 |
+| Young | ✅ | PR #1487 feat(skill)（#1486）| 泛化 meeting-prep：不假設週五、AskUserQuestion 問日期、DOW_ZH case 支援週一到週日 |
 
 ---
 


### PR DESCRIPTION
Fixes #1488

## Summary

- `docs/meetings/2026-05-08-agenda.md` — 補 PR #1482/#1485/#1487 到總覽表和 Young 成果區；標記 4.1 PR #1482 已 merge；Action A1 標為完成；週區間 label 統一為 5/4~5/8
- `docs/meetings/team-contributions.md` — header `## 5/2 ~ 5/8` → `## 5/4 ~ 5/8`；補 3 行 Young 新 PR
- `docs/intern-training/interns/raymond.json` — summary 加 5/7 context note（無新 intern PR，不動 skill level）
- `docs/intern-training/interns/xiung.json` — summary 加 5/7 context note（無新 intern PR，不動 skill level）

## New PRs covered

| PR | 作者 | 內容 |
|----|------|------|
| #1482 | Young | fix(ai): force suggestion="" when is_correct=true (Fixes #1481) |
| #1485 | Young | feat(skill): friday-meeting-prep skill 首建 |
| #1487 | Young | feat(skill): generalize meeting-prep — 不假設週五 (Fixes #1486) |

## Week label decision

統一使用 `5/4~5/8`（Mon-Fri 工作週）— 本週 PR 全部在工作日 merge，不 cover 週末

## Test plan

- [ ] `docs/meetings/2026-05-08-agenda.md` GitHub preview 正常，PR 表格含 11 筆（原 8 + 新 3）
- [ ] `team-contributions.md` 週標頭為 `## 5/4 ~ 5/8`，Young 欄位有 13 行
- [ ] `raymond.json` valid JSON — `jq . raymond.json` passes
- [ ] `xiung.json` valid JSON — `jq . xiung.json` passes