### PR TITLE
fix: allow guided_steps progress after wrong answer

### DIFF
--- a/frontend/src/components/reading-steps/StrategyExercise.tsx
+++ b/frontend/src/components/reading-steps/StrategyExercise.tsx
@@ -369,7 +369,7 @@ function GuidedStepsExercise({
     });
     if (nextFeedback.every((f) => f !== null)) {
       setAllDone(true);
-      if (nextFeedback.every((f) => f === true)) onComplete?.();
+      onComplete?.();
     }
   };
 

--- a/frontend/src/components/reading-steps/__tests__/StrategyExercise.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/StrategyExercise.test.tsx
@@ -33,9 +33,6 @@ function clickConfirm() {
   const confirms = screen.getAllByRole('button', { name: /確認/ });
   fireEvent.click(confirms[0]);
 }
-  const confirms = screen.getAllByRole('button', { name: /確認/ });
-  fireEvent.click(confirms[0]);
-}
 
 describe('StrategyExercise — guided_steps', () => {
   it('does not call onComplete after only Q1 confirmed', () => {

--- a/frontend/src/components/reading-steps/__tests__/StrategyExercise.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/StrategyExercise.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import StrategyExercise from '../StrategyExercise';
+import { StrategyExercise as StrategyExerciseType } from '../../../types';
+
+const guidedTwoSelect: StrategyExerciseType = {
+  type: 'guided_steps',
+  strategy_name: '自我提問',
+  instruction: '練習問重要的問題。',
+  steps: [
+    {
+      prompt: '從「主角是誰」的角度，哪個問題最重要？',
+      type: 'select',
+      options: ['他幾歲？', '他是誰？他有什麼特別之處？', '他住哪裡？'],
+      answer: 1,
+    },
+    {
+      prompt: '從「結果如何」的角度，哪個問題最重要？',
+      type: 'select',
+      options: ['他賺了多少？', '他從中得到什麼？', '他爬了幾座山？'],
+      answer: 1,
+    },
+  ],
+};
+
+function pickOption(label: string) {
+  const btn = screen.getByText(label).closest('button');
+  fireEvent.click(btn!);
+}
+
+function clickConfirm() {
+  const confirms = screen.getAllByRole('button', { name: /確認/ });
+  fireEvent.click(confirms[0]);
+}
+
+describe('StrategyExercise — guided_steps', () => {
+  it('does not call onComplete after only Q1 confirmed', () => {
+    const onComplete = vi.fn();
+    render(<StrategyExercise exercise={guidedTwoSelect} onComplete={onComplete} />);
+
+    pickOption('他是誰？他有什麼特別之處？');
+    clickConfirm();
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it('calls onComplete after all steps answered correctly', () => {
+    const onComplete = vi.fn();
+    render(<StrategyExercise exercise={guidedTwoSelect} onComplete={onComplete} />);
+
+    pickOption('他是誰？他有什麼特別之處？');
+    clickConfirm();
+    pickOption('他從中得到什麼？');
+    clickConfirm();
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onComplete even when some steps are answered wrong (#1491)', () => {
+    const onComplete = vi.fn();
+    render(<StrategyExercise exercise={guidedTwoSelect} onComplete={onComplete} />);
+
+    pickOption('他幾歲？');
+    clickConfirm();
+    pickOption('他從中得到什麼？');
+    clickConfirm();
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/reading-steps/__tests__/StrategyExercise.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/StrategyExercise.test.tsx
@@ -29,6 +29,10 @@ function pickOption(label: string) {
 }
 
 function clickConfirm() {
+  // 已確認的步驟會隱藏確認按鈕（!isDone），所以 confirms[0] 永遠是「第一個未確認步驟」的按鈕
+  const confirms = screen.getAllByRole('button', { name: /確認/ });
+  fireEvent.click(confirms[0]);
+}
   const confirms = screen.getAllByRole('button', { name: /確認/ });
   fireEvent.click(confirms[0]);
 }


### PR DESCRIPTION
## Summary
- guided_steps 答錯任一步驟後底部「下一關」鈕永遠 disabled，學生卡在閱讀聚光燈無法繼續。
- 將 `onComplete` 觸發條件從「全部答對」改為「全部答完」，跟 MCQ / StoryStructureTable 的 UX 一致。
- 錯題輔導另由 #1387 McqRescueDialog 接手。
- 補上 `StrategyExercise.test.tsx`（先前無測試）涵蓋 regression。

## Test plan
- [x] Unit test 3 tests pass（all-correct / only-Q1-confirmed / wrong-but-all-answered）
- [x] 本機 dev server 人測 L22：故意答錯 → 全部答完 → 「下一關」鈕變紫可按
- [ ] PR Preview 上 Young 親測

Closes #1491