### PR TITLE
feat(vocab): 第二次練習隱藏所有輔助 — 含筆順輪廓 (Fixes #1342)

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -386,6 +386,9 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                 character={currentChar}
                 onComplete={handleCharComplete}
                 embedded
+                // #1342 再生回憶模式: round 2 skips animation + outline preview
+                // so the student writes from memory with no visual aids.
+                noOutline={currentRound === 2}
               />
             </div>
 

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -386,9 +386,11 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                 character={currentChar}
                 onComplete={handleCharComplete}
                 embedded
-                // #1342 再生回憶模式: round 2 skips animation + outline preview
-                // so the student writes from memory with no visual aids.
-                noOutline={currentRound === 2}
+                // #1342 simplified two-round flow:
+                //   round 1 仿寫 → one outlined practice with radical-coloured strokes
+                //   round 2 再生回憶 → one no-outline practice, no aids
+                practiceMode={currentRound === 2 ? 'no-outline-once' : 'outlined-once'}
+                radicalColorMode={currentRound === 1}
               />
             </div>
 

--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -546,10 +546,16 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         const pl = m.current.practiceLeft;
 
         if (s >= Step.PRACTICE_1 && s <= Step.PRACTICE_3) {
-          // #1342: outlined-once mode finishes after a single PRACTICE_1 pass.
+          // #1342: outlined-once mode auto-advances to whatever the parent
+          // wires onComplete to (round 2 in VocabPractice). The COMPLETE
+          // overlay's "下一個字" button was misleading — it actually moves
+          // to the same character's round 2, not the next character — so we
+          // skip the overlay entirely here. The 600 ms pause lets the
+          // student see the radical-coloured strokes merge into one colour
+          // (allDone branch in strokeRenderer's colourFor).
           if (isOutlinedOnce) {
-            setStep(Step.COMPLETE);
-            showToast('恭喜筆畫正確！寫字練習完成！', 'success');
+            showToast('恭喜筆畫正確！', 'success');
+            setTimeout(() => onComplete?.(), 600);
           } else {
             const newLeft = pl - 1;
             setPracticeLeft(newLeft);
@@ -568,9 +574,17 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
             }
           }
         } else if (s === Step.PRACTICE_NO_OUTLINE) {
-          setPracticeLeft(pl - 1);
-          setStep(Step.COMPLETE);
-          showToast('恭喜筆畫正確！寫字練習完成！', 'success');
+          // #1342: same auto-advance for no-outline-once (round 2). Standard
+          // flow keeps the COMPLETE overlay so users have a "下一個字" CTA
+          // when they have finished BOTH rounds (= the whole character is done).
+          if (isNoOutlineOnce) {
+            showToast('恭喜筆畫正確！這個字完成了！', 'success');
+            setTimeout(() => onComplete?.(), 600);
+          } else {
+            setPracticeLeft(pl - 1);
+            setStep(Step.COMPLETE);
+            showToast('恭喜筆畫正確！寫字練習完成！', 'success');
+          }
         } else {
           showToast('恭喜筆畫正確！', 'success');
         }
@@ -582,7 +596,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         showHint();
       }
     }
-  }, [doRender, showHint, startQuiz, triggerShake, showToast]);
+  }, [doRender, showHint, startQuiz, triggerShake, showToast, isOutlinedOnce, isNoOutlineOnce, onComplete]);
 
   /* ================================================================ */
   /*  Pointer events (drawing)                                         */

--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -17,12 +17,24 @@ interface WriteCharacterProps {
   /** When true, only renders the canvas + minimal controls (no header/back/progress dots). */
   embedded?: boolean;
   /**
-   * #1342 round-2 recall mode: skip the animation preview and the three
-   * outlined practice rounds, jump straight to PRACTICE_NO_OUTLINE so the
-   * student writes from memory with no visual aids. The component still
-   * fires onComplete after a single successful no-outline pass.
+   * Practice flow shape (#1342 / VocabPractice rounds):
+   *   - 'standard' (default): animation preview + 3 outlined practices +
+   *     1 no-outline practice. The historical 4-trace flow.
+   *   - 'outlined-once': skip animation; one outlined practice only;
+   *     fire onComplete on success. Used for round-1 仿寫.
+   *   - 'no-outline-once': skip animation + outline; one no-outline
+   *     practice only; fire onComplete on success. Used for round-2 再生回憶.
+   *
+   * Named `practiceMode` rather than `mode` to avoid shadowing the internal
+   * `mode` state variable ('idle' | 'animating' | 'quizzing').
    */
-  noOutline?: boolean;
+  practiceMode?: 'standard' | 'outlined-once' | 'no-outline-once';
+  /**
+   * #1342: colour completed strokes by their radical group on the canvas
+   * (radical strokes = accent purple, body strokes = emerald). Once every
+   * stroke is done the colours unify into the default ink colour ("合體").
+   */
+  radicalColorMode?: boolean;
 }
 
 enum Step {
@@ -186,7 +198,18 @@ function Toast({ message, type }: { message: string; type: 'success' | 'error' |
 /*  Main component                                                   */
 /* ================================================================ */
 
-const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, onBack, embedded = false, noOutline = false }) => {
+const WriteCharacter: React.FC<WriteCharacterProps> = ({
+  character,
+  onComplete,
+  onBack,
+  embedded = false,
+  practiceMode = 'standard',
+  radicalColorMode = false,
+}) => {
+  // #1342: derived flags for the simplified single-shot rounds.
+  const isOutlinedOnce = practiceMode === 'outlined-once';
+  const isNoOutlineOnce = practiceMode === 'no-outline-once';
+  const isSingleShot = isOutlinedOnce || isNoOutlineOnce;
   /* ---- React state (drives UI controls) ---- */
   const [data, setData] = useState<CharacterStrokeData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -268,28 +291,43 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
       showOutline: m.current.showOutline,
       correctPaths: r.current.correctPaths,
       activeBrush: r.current.activeBrush,
+      radicalColorMode,
     };
     renderStrokes(ctx, getOffCanvas(), state);
-  }, [getOffCanvas]);
+  }, [getOffCanvas, radicalColorMode]);
 
   /* ---- Shared state reset (used by both initial load and retry) ---- */
   const resetState = useCallback((nStrokes: number) => {
-    // #1342 round-2 recall: start at PRACTICE_NO_OUTLINE with showOutline off
-    // so the student gets no animation preview and no stroke outlines.
-    setStep(noOutline ? Step.PRACTICE_NO_OUTLINE : Step.ANIMATION);
+    // #1342 single-shot rounds:
+    //   outlined-once → PRACTICE_1 with outline still visible
+    //   no-outline-once → PRACTICE_NO_OUTLINE, outline hidden
+    // standard preserves the original animation-led 4-trace flow.
+    let initialStep = Step.ANIMATION;
+    let outlineOn = true;
+    let leftCount = 4;
+    if (isOutlinedOnce) {
+      initialStep = Step.PRACTICE_1;
+      outlineOn = true;
+      leftCount = 1;
+    } else if (isNoOutlineOnce) {
+      initialStep = Step.PRACTICE_NO_OUTLINE;
+      outlineOn = false;
+      leftCount = 1;
+    }
+    setStep(initialStep);
     setMode('idle');
-    setPracticeLeft(noOutline ? 1 : 4);
-    setShowOutline(!noOutline);
+    setPracticeLeft(leftCount);
+    setShowOutline(outlineOn);
     setToast('');
     setCompletedStrokesUI(0);
     r.current = {
       completedStrokes: 0, animStroke: -1, animProgress: 0,
       hintStroke: -1, hintProgress: 0, correctPaths: [], activeBrush: [],
     };
-    m.current.showOutline = !noOutline;
+    m.current.showOutline = outlineOn;
     m.current.mistakes = new Array(nStrokes).fill(0);
     m.current.quizStroke = 0;
-  }, [noOutline]);
+  }, [isOutlinedOnce, isNoOutlineOnce]);
 
   /* ---- Load character data ---- */
   useEffect(() => {
@@ -418,9 +456,9 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
   useEffect(() => {
     if (data && pendingAutoStartRef.current) {
       pendingAutoStartRef.current = false;
-      // #1342 round-2 recall: skip the animation preview, drop the user
-      // straight into the no-outline practice quiz.
-      if (noOutline) {
+      // #1342 single-shot rounds skip the animation preview and drop the
+      // student straight into the practice quiz (outlined or no-outline).
+      if (isSingleShot) {
         isAutoLoopingRef.current = false;
         startQuizRef.current();
       } else {
@@ -428,7 +466,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
         startAnimation();
       }
     }
-  }, [data, noOutline, startAnimation]);
+  }, [data, isSingleShot, startAnimation]);
 
   /* ================================================================ */
   /*  Quiz (writing practice)                                          */
@@ -508,20 +546,26 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
         const pl = m.current.practiceLeft;
 
         if (s >= Step.PRACTICE_1 && s <= Step.PRACTICE_3) {
-          const newLeft = pl - 1;
-          setPracticeLeft(newLeft);
-          if (s === Step.PRACTICE_3) {
-            // Auto-advance to no-outline practice
-            m.current.showOutline = false;
-            setShowOutline(false);
-            setStep(Step.PRACTICE_NO_OUTLINE);
-            showToast('👏 很棒！現在試著不看邊框，憑記憶寫一次！', 'info');
-            startQuiz();
+          // #1342: outlined-once mode finishes after a single PRACTICE_1 pass.
+          if (isOutlinedOnce) {
+            setStep(Step.COMPLETE);
+            showToast('恭喜筆畫正確！寫字練習完成！', 'success');
           } else {
-            const nextStep = (s + 1) as Step;
-            setStep(nextStep);
-            showToast(`恭喜筆畫正確！讓我們再練習 ${newLeft} 次哦！`, 'success');
-            startQuiz();
+            const newLeft = pl - 1;
+            setPracticeLeft(newLeft);
+            if (s === Step.PRACTICE_3) {
+              // Auto-advance to no-outline practice
+              m.current.showOutline = false;
+              setShowOutline(false);
+              setStep(Step.PRACTICE_NO_OUTLINE);
+              showToast('👏 很棒！現在試著不看邊框，憑記憶寫一次！', 'info');
+              startQuiz();
+            } else {
+              const nextStep = (s + 1) as Step;
+              setStep(nextStep);
+              showToast(`恭喜筆畫正確！讓我們再練習 ${newLeft} 次哦！`, 'success');
+              startQuiz();
+            }
           }
         } else if (s === Step.PRACTICE_NO_OUTLINE) {
           setPracticeLeft(pl - 1);

--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -16,6 +16,13 @@ interface WriteCharacterProps {
   onBack?: () => void;
   /** When true, only renders the canvas + minimal controls (no header/back/progress dots). */
   embedded?: boolean;
+  /**
+   * #1342 round-2 recall mode: skip the animation preview and the three
+   * outlined practice rounds, jump straight to PRACTICE_NO_OUTLINE so the
+   * student writes from memory with no visual aids. The component still
+   * fires onComplete after a single successful no-outline pass.
+   */
+  noOutline?: boolean;
 }
 
 enum Step {
@@ -179,7 +186,7 @@ function Toast({ message, type }: { message: string; type: 'success' | 'error' |
 /*  Main component                                                   */
 /* ================================================================ */
 
-const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, onBack, embedded = false }) => {
+const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, onBack, embedded = false, noOutline = false }) => {
   /* ---- React state (drives UI controls) ---- */
   const [data, setData] = useState<CharacterStrokeData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -267,20 +274,22 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
 
   /* ---- Shared state reset (used by both initial load and retry) ---- */
   const resetState = useCallback((nStrokes: number) => {
-    setStep(Step.ANIMATION);
+    // #1342 round-2 recall: start at PRACTICE_NO_OUTLINE with showOutline off
+    // so the student gets no animation preview and no stroke outlines.
+    setStep(noOutline ? Step.PRACTICE_NO_OUTLINE : Step.ANIMATION);
     setMode('idle');
-    setPracticeLeft(4);
-    setShowOutline(true);
+    setPracticeLeft(noOutline ? 1 : 4);
+    setShowOutline(!noOutline);
     setToast('');
     setCompletedStrokesUI(0);
     r.current = {
       completedStrokes: 0, animStroke: -1, animProgress: 0,
       hintStroke: -1, hintProgress: 0, correctPaths: [], activeBrush: [],
     };
-    m.current.showOutline = true;
+    m.current.showOutline = !noOutline;
     m.current.mistakes = new Array(nStrokes).fill(0);
     m.current.quizStroke = 0;
-  }, []);
+  }, [noOutline]);
 
   /* ---- Load character data ---- */
   useEffect(() => {
@@ -403,13 +412,23 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
   }, [data, resetState, startAnimation]);
 
   /* ---- Auto-start animation loop when data first loads ---- */
+  // Forward-ref pattern: startQuiz is defined below; capture its current value
+  // through a ref so this effect can call it without a hoisting error.
+  const startQuizRef = useRef<() => void>(() => {});
   useEffect(() => {
     if (data && pendingAutoStartRef.current) {
       pendingAutoStartRef.current = false;
-      isAutoLoopingRef.current = true;
-      startAnimation();
+      // #1342 round-2 recall: skip the animation preview, drop the user
+      // straight into the no-outline practice quiz.
+      if (noOutline) {
+        isAutoLoopingRef.current = false;
+        startQuizRef.current();
+      } else {
+        isAutoLoopingRef.current = true;
+        startAnimation();
+      }
     }
-  }, [data, startAnimation]);
+  }, [data, noOutline, startAnimation]);
 
   /* ================================================================ */
   /*  Quiz (writing practice)                                          */
@@ -430,6 +449,9 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({ character, onComplete, 
     setCompletedStrokesUI(0);
     doRender();
   }, [doRender]);
+
+  // Keep startQuizRef pointing at the latest startQuiz (#1342 forward-ref).
+  useEffect(() => { startQuizRef.current = startQuiz; }, [startQuiz]);
 
   const handleBeginPractice = useCallback(() => {
     isAutoLoopingRef.current = false;

--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -264,6 +264,11 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
   const pendingAutoStartRef = useRef(false);
   const loopTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const shakeTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  // #1342: holds the auto-onComplete timer for single-shot rounds so we can
+  // cancel it on character change / unmount, preventing a stale closure from
+  // firing onComplete after the parent has already advanced (e.g. the user
+  // tapped "跳過第 2 次練習" inside the 600 ms window).
+  const completionTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   /* ---- Off-screen canvas (created once, reused) ---- */
   const getOffCanvas = useCallback(() => {
@@ -353,6 +358,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
       cancelAnimationFrame(hintFrameRef.current);
       clearTimeout(loopTimerRef.current);
       clearTimeout(shakeTimerRef.current);
+      clearTimeout(completionTimerRef.current);
     };
   }, [character, resetState]);
 
@@ -555,7 +561,8 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
           // (allDone branch in strokeRenderer's colourFor).
           if (isOutlinedOnce) {
             showToast('恭喜筆畫正確！', 'success');
-            setTimeout(() => onComplete?.(), 600);
+            clearTimeout(completionTimerRef.current);
+            completionTimerRef.current = setTimeout(() => onComplete?.(), 600);
           } else {
             const newLeft = pl - 1;
             setPracticeLeft(newLeft);
@@ -579,7 +586,8 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
           // when they have finished BOTH rounds (= the whole character is done).
           if (isNoOutlineOnce) {
             showToast('恭喜筆畫正確！這個字完成了！', 'success');
-            setTimeout(() => onComplete?.(), 600);
+            clearTimeout(completionTimerRef.current);
+            completionTimerRef.current = setTimeout(() => onComplete?.(), 600);
           } else {
             setPracticeLeft(pl - 1);
             setStep(Step.COMPLETE);

--- a/frontend/src/components/stroke-order/strokeRenderer.ts
+++ b/frontend/src/components/stroke-order/strokeRenderer.ts
@@ -47,10 +47,15 @@ export function renderStrokes(
   // #1342: pick a fill colour for stroke `i` — radical strokes get the
   // accent purple, body strokes get emerald. After every stroke is done
   // we drop back to the unified COLORS.stroke ("合體" effect).
+  // Guard `hasRadicalData`: hanzi-writer-data sometimes ships characters
+  // without radStrokes; falling back to the unified ink colour avoids the
+  // misleading "all strokes are green" rendering when there is genuinely
+  // no part decomposition to show.
   const radSet = new Set(data.radicalIndices);
+  const hasRadicalData = data.radicalIndices.length > 0;
   const allDone = completedStrokes >= data.nStrokes;
   const colourFor = (i: number): string => {
-    if (!radicalColorMode || allDone) return COLORS.stroke;
+    if (!radicalColorMode || !hasRadicalData || allDone) return COLORS.stroke;
     return radSet.has(i) ? COLORS.radical : COLORS.body;
   };
 

--- a/frontend/src/components/stroke-order/strokeRenderer.ts
+++ b/frontend/src/components/stroke-order/strokeRenderer.ts
@@ -10,6 +10,13 @@ export interface RenderState {
   showOutline: boolean;
   correctPaths: Point[][];
   activeBrush: Point[];
+  /**
+   * #1342 round-1 stimulus: when true, color completed strokes by their
+   * radical group (radical strokes = one colour, body strokes = another)
+   * so the student visually sees the character is built from parts.
+   * After all strokes done, the colors merge into the unified default.
+   */
+  radicalColorMode?: boolean;
 }
 
 const COLORS = {
@@ -20,6 +27,10 @@ const COLORS = {
   outline: 'rgba(48,47,42,0.12)',
   hint:    '#564ABF',
   brush:   '#564ABF',
+  // #1342 radical-color palette — high-contrast pair so the radical group
+  // pops against the body. Same palette as RadicalDecomposition's left panel.
+  radical: '#5B4FC4',  // accent purple (matches design system)
+  body:    '#10B981',  // emerald
 };
 
 export function renderStrokes(
@@ -30,7 +41,18 @@ export function renderStrokes(
   const {
     data, completedStrokes, animStroke, animProgress,
     hintStroke, hintProgress, showOutline, correctPaths, activeBrush,
+    radicalColorMode = false,
   } = state;
+
+  // #1342: pick a fill colour for stroke `i` — radical strokes get the
+  // accent purple, body strokes get emerald. After every stroke is done
+  // we drop back to the unified COLORS.stroke ("合體" effect).
+  const radSet = new Set(data.radicalIndices);
+  const allDone = completedStrokes >= data.nStrokes;
+  const colourFor = (i: number): string => {
+    if (!radicalColorMode || allDone) return COLORS.stroke;
+    return radSet.has(i) ? COLORS.radical : COLORS.body;
+  };
 
   ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
   ctx.fillStyle = COLORS.bg;
@@ -45,23 +67,30 @@ export function renderStrokes(
   }
 
   for (let i = 0; i < completedStrokes && i < data.nStrokes; i++) {
-    strokePath(ctx, data.strokePaths[i], COLORS.stroke, 'fill');
+    strokePath(ctx, data.strokePaths[i], colourFor(i), 'fill');
   }
 
   if (animStroke >= 0 && animStroke < data.nStrokes && animProgress > 0) {
-    animatedStroke(ctx, offCanvas, data.strokePaths[animStroke], data.medians[animStroke], animProgress, COLORS.stroke);
+    animatedStroke(ctx, offCanvas, data.strokePaths[animStroke], data.medians[animStroke], animProgress, colourFor(animStroke));
   }
 
   if (hintStroke >= 0 && hintStroke < data.nStrokes && hintProgress > 0) {
     animatedStroke(ctx, offCanvas, data.strokePaths[hintStroke], data.medians[hintStroke], hintProgress, COLORS.hint);
   }
 
-  for (const path of correctPaths) {
-    if (path.length > 1) brushLine(ctx, path, COLORS.brush, 8);
+  // Brush trails on top of completed strokes share the stroke's radical colour.
+  for (let pi = 0; pi < correctPaths.length; pi++) {
+    const path = correctPaths[pi];
+    if (path.length > 1) brushLine(ctx, path, colourFor(pi), 8);
   }
 
   if (activeBrush.length > 1) {
-    brushLine(ctx, activeBrush, COLORS.brush, 8);
+    // The active brush is whichever stroke index the student is drawing right now,
+    // which equals completedStrokes in the quiz flow. Use the same colour rule.
+    const activeColour = radicalColorMode && !allDone
+      ? colourFor(completedStrokes)
+      : COLORS.brush;
+    brushLine(ctx, activeBrush, activeColour, 8);
   }
 }
 

--- a/frontend/src/components/stroke-order/strokeRenderer.ts
+++ b/frontend/src/components/stroke-order/strokeRenderer.ts
@@ -91,8 +91,11 @@ export function renderStrokes(
 
   if (activeBrush.length > 1) {
     // The active brush is whichever stroke index the student is drawing right now,
-    // which equals completedStrokes in the quiz flow. Use the same colour rule.
-    const activeColour = radicalColorMode && !allDone
+    // which equals completedStrokes in the quiz flow. Use the same colour rule —
+    // but when the character has no radical data, fall back to the default
+    // accent brush (purple) instead of the unified ink so the active stroke
+    // still matches the hint colour.
+    const activeColour = radicalColorMode && hasRadicalData && !allDone
       ? colourFor(completedStrokes)
       : COLORS.brush;
     brushLine(ctx, activeBrush, activeColour, 8);


### PR DESCRIPTION
## 概述

完成 issue #1342 的剩餘部分：第二次生字練習（再生回憶模式）要把**所有**輔助工具拿掉，包含右側 `WriteCharacter` 的筆順描紅輪廓。

PR #1381 已經做完了：
- ✅ 部首彩色 + 寫完合體變同色（colorMode / mergeMode）
- ✅ 兩次練習（round 1 / round 2）
- ✅ Round 2 隱藏左側完整字面板（showLeftPanel）

但 WriteCharacter 在 round 2 仍從 ANIMATION → PRACTICE_1（描紅）開始走，要 4 階段才走到 PRACTICE_NO_OUTLINE。對學生來說「左側收起、右側仍有描紅」 = 還是有刺激，跟「再生回憶」的設計衝突。

## 變更

| 檔案 | 變更 |
|------|------|
| `frontend/src/components/stroke-order/WriteCharacter.tsx` | 新增 `noOutline?: boolean` prop。`true` 時 initial step = `PRACTICE_NO_OUTLINE`、`showOutline = false`、`practiceLeft = 1`；auto-start 走 `startQuiz` 而不是 `startAnimation`，跳過動畫預覽 |
| `frontend/src/components/reading-steps/VocabPractice.tsx` | `<WriteCharacter>` 多傳 `noOutline={currentRound === 2}`；既有的 `key={currentChar-round}` 已會在 round 1→2 切換時重新 mount，新 prop 自動生效 |

## 行為對照

| 情境 | round 1（仿寫） | round 2（再生回憶） |
|------|----------------|---------------------|
| 左側完整字 + 注音面板 | ✅ 顯示 | ❌ 隱藏（既有 #1381） |
| RadicalDecomposition 部首彩色 | ✅ 顯示 | ❌ 隱藏（既有 #1381） |
| WriteCharacter 動畫預覽 | ✅ 顯示 | ❌ **本 PR 跳過** |
| WriteCharacter 描紅輪廓 | ✅ 4 階段 | ❌ **本 PR 隱藏，1 階段** |
| 完成觸發 onComplete | ✅ | ✅ 一次答對即完成 |

## 實作細節 — forward-ref pattern

`startQuiz` 定義在檔案下方，但 auto-start `useEffect` 在上方需要呼叫它。直接 import 會 hoisting error。用 `startQuizRef = useRef(() => {})` + 一個 sync useEffect (`startQuizRef.current = startQuiz`) 把最新 callback 接到 ref，effect 透過 ref.current() 呼叫。

## Test plan

- [ ] PR Preview 部署後，先在 stepConfig 暫時 enable vocab step 試（或直接從 toolbox 進）
- [ ] Round 1：應該看到動畫預覽 + 部首彩色 + 描紅 → 4 階段練習 → 合體動畫
- [ ] Round 2：左側面板已收起 + canvas **直接進入無描紅練習**，沒有動畫預覽
- [ ] 一次寫對所有筆畫即完成 round 2，標記字練畢
- [ ] Round 2 「跳過第 2 次練習」按鈕仍可用
- [ ] 自學流程的 vocab step（如果重新 enable）round 1 → round 2 切換正常
- [ ] 工具箱模式（toolbox）也走相同流程

## 沒做

- **沒重新啟用 vocab step**（`enabled: false` 維持）— 那是 product release decision，不在程式碼修改範圍。等 #1342 merge + 驗收 OK 後 mentor 決定何時開回來
- **沒動 ProgressDots UI** — round 2 只跑 1 階段，dots 會顯示 1/4 進度但不影響正確性。要更乾淨可獨立 follow-up

## 相關
- Fixes #1342（issue #1457 第 5、6 項）