### PR TITLE
docs(meeting): 2026-05-08 update — 今日 5 PR + 2 issues

### DIFF
--- a/docs/intern-training/interns/raymond.json
+++ b/docs/intern-training/interns/raymond.json
@@ -236,7 +236,7 @@
       "maxLevel": 5
     },
     "11": {
-      "level": 3,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
@@ -248,6 +248,11 @@
           "date": "2026-05-08",
           "level": 3,
           "reason": "PR #1465 toolbox Phase 2+3：useEffect mount-only（空 deps []）觸發後端 toolbox session 建立，同時用 useRef recordedRef 防止 #1464 完成畫面的 CTA 重複觸發寫入。兩個 hook 協同解決跨 PR 的設計衝突（#1463 需要 mount 時記錄，#1464 需要 completion 時記錄），展現對 useEffect 生命週期與 useRef 穩定性的組合應用，已超出 debounce 的單一 hook 場景"
+        },
+        {
+          "date": "2026-05-08",
+          "level": 4,
+          "reason": "PR #1499 VocabPractice multi-mode：新增 `practiceMode` prop（3 variants: standard/toolbox/quiz）+ `radicalColorMode` prop，Round 1 顯示筆順輪廓 + 部首顏色，Round 2 隱藏所有輔助。命名時刻意避免與元件內部 `mode` state 衝突，顯示對 prop vs internal state 邊界的清晰判斷。4 輪 @claude review 全部解決，含最後 brush color 一致性問題（commit 9bad640a）。已超出單純 useEffect/useRef，展現 prop 設計 + multi-mode 元件架構整合能力"
         }
       ]
     },
@@ -311,6 +316,11 @@
           "date": "2026-04-05",
           "level": 2,
           "reason": "PR #899 在修復 ReadingAnnotation 的同時更新 __tests__/ReadingAnnotation.test.tsx（+41/-6），不只修 bug 還同步維護測試，開始建立「改完要更新測試」的習慣。PR #805 也補寫 test_auth_api.py 測試家長角色登入被封鎖的情境（+48 行），涵蓋多個 test case"
+        },
+        {
+          "date": "2026-05-08",
+          "level": 2,
+          "reason": "PR #1498 G7-L29/L30 文章重點表重構：把 22 行純文字平鋪輸出拆解為 5 個結構化行（主題/觀察/推論/趨勢/反論/結論）+ fill-blank 格式，對應方大哥 #1388 的教學設計目標。2 輪 review 迭代（第一輪靖杭寫了「證據→趨勢」，Claude 指出語義不精準，第二輪改為「是否怕人」句式）。這是主動理解教學規格→轉換資料結構的問題拆解，而非機械式修改。level 維持 2，原因：目前是 1 個 YAML 的資料結構轉換，尚未見到跨多個複雜問題類型的拆解"
         }
       ]
     },
@@ -332,6 +342,17 @@
           "date": "2026-04-23",
           "level": 4,
           "reason": "PR #1144（跨裝置 session 復用）和 PR #1145（current_step 同步）是 P1 beta blocker issue #1073/#1074 的完整實作。兩個 PR 在 4/22 deadline 前 2 天提前 merge，後端新增 GET-first + dedup 邏輯，DB 加 partial unique index，前端守衛同步，形成完整的前後端 + DB 三層解決方案。這是靖杭首次獨立完成涉及 DB migration 的端對端功能"
+        }
+      ]
+    },
+    "17": {
+      "level": 1,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-05-08",
+          "level": 1,
+          "reason": "PR #1497 fix(csp)：閱讀 SecurityHeadersMiddleware 的 CSP header 建構邏輯，定位 `frame-src` directive 缺少 `https://storage.googleapis.com` 的根因（PDF iframe popup 被 CSP 封鎖），在正確位置加入白名單並附說明 CSP path-restriction limitation（GCS bucket 無法做到 path 級限制）。這是靖杭首次讀懂並修改 Python middleware 層的安全設定，Level 1：能在引導下讀懂既有 middleware 邏輯並做定點修改"
         }
       ]
     },
@@ -364,11 +385,12 @@
   },
   "recommendations": [
     "架構理解（#18）升到 level 4，首次獨立設計完整 feature 後端 API（toolbox POST/GET/PATCH）。下一步：嘗試為 toolbox API 補寫 contract test（pytest）驗證各 endpoint 的 status code + response schema，這是 level 5 的準備——不只能設計 API，也能用測試鎖定合約",
-    "React 進階（#11）升到 level 3（useEffect + useRef 跨 PR 協同）。下一步：在 #1190 或 #1186 中嘗試用 useMemo 快取計算結果，或抽取 custom hook，完成後 #11 有機會升到 level 4",
+    "React 進階（#11）升到 level 4（PR #1499 multi-mode prop 設計 + 命名衝突解決）。下一步：在 #1190 或 #1186 中嘗試用 useMemo 快取計算結果，或抽取 custom hook，完成後 #11 有機會升到 level 5",
     "元件設計（#13）已穩在 level 4。#1464 的 ToolboxCompletionActions 共用元件 + 9 個 reading-step 接入是好的證據。下一步挑戰：把 toolbox session 寫入邏輯抽成 useToolboxSession custom hook，這是 level 5 的證明",
-    "獨立開發（#16）已穩在 level 4。#1457 驗收簽結是好的 level 5 候選機會：完整經歷需求→設計→實作→現場驗收的全循環，且是跨 4 個 PR 的大型功能"
+    "獨立開發（#16）已穩在 level 4。#1457 驗收簽結是好的 level 5 候選機會：完整經歷需求→設計→實作→現場驗收的全循環，且是跨 4 個 PR 的大型功能",
+    "後端 Python 閱讀（#17）新增 level 1。下一步：在 #1494 silent-failure 修復中繼續讀懂 mcq_rescue_agent 的錯誤處理邏輯，這是 level 2 的機會（能獨立追蹤 middleware → route → service 的控制流）"
   ],
-  "summary": "5/4~5/8 共 4 個 PR merge，全部圍繞練習工具箱完整落地：Phase 1 Alembic 建 10 張 DB tables → per-tool CTA 共用元件 → Phase 2+3 後端 API + 前端 toolboxApi.ts + 學習紀錄頁整合。技術亮點：PR #1465 用 useEffect mount + useRef recordedRef 優雅解決 #1463 和 #1464 的設計衝突，展現跨 PR 架構思維。靖杭首次獨立設計後端 feature API（POST/GET/PATCH）並走完 DB → route → frontend 完整鏈路。技能升級：#11 React 進階（2→3）、#18 架構理解（3→4）。[5/7 補充] Young 補了 #1482（PR #1480 follow-up，is_correct=True 強制 suggestion=\"\"）+ #1485/#1487 meeting-prep skill 建立，靖杭本週無新 intern PR",
+  "summary": "5/4~5/8 共 7 個 PR merge（5/4~5/7: 4 個 toolbox PR；5/8 新增: #1497/#1498/#1499）。5/8 亮點：PR #1499 VocabPractice multi-mode（practiceMode + radicalColorMode 雙 prop，4 輪 review）展現跨 mode 元件架構設計；PR #1498 G7-L29/L30 文章重點表結構化重構（22 行平文字 → 5 行填空）；PR #1497 CSP middleware fix（首次讀懂並修改 Python security middleware）。技能升級：#11 React 進階（3→4，multi-mode prop 設計 + 命名邊界清晰）；#17 後端 Python 閱讀（新增 level 1）。技能 #14 質量提升（無升級，1498 證據待後續積累）。累計本週 7 PR，是歷週最高產之一",
   "issues": [
     {
       "id": "環境建置",
@@ -667,6 +689,49 @@
         "前後端 + DB 三層完整走完",
         "4 輪 @claude review 迭代"
       ]
+    },
+    {
+      "id": "#1496",
+      "title": "fix(csp): GCS frame-src 允許，解除 PDF popup 封鎖（PR #1497）",
+      "date": "2026-05-08",
+      "type": "bugfix",
+      "contribution": "閱讀 SecurityHeadersMiddleware 的 CSP header 建構邏輯，定位 frame-src 缺少 storage.googleapis.com，在正確位置加入白名單。說明了 CSP 無法做 GCS path-restriction 的限制，修改精準（+3/-1）",
+      "skillsLearned": [17],
+      "highlights": [
+        "首次讀懂並修改 Python middleware 安全設定",
+        "正確定位 CSP directive 在 header 建構中的位置",
+        "附說明 GCS path-restriction 限制，展現對 CSP 語意的理解"
+      ],
+      "linesChanged": "+3/-1"
+    },
+    {
+      "id": "#1388",
+      "title": "fix(content): G7-L29/L30 文章重點表結構化重構（PR #1498）",
+      "date": "2026-05-08",
+      "type": "bugfix",
+      "contribution": "將 G7-L29/L30 的文章重點表從 22 行純文字平鋪重構為 5 個結構化行（主題/觀察/推論/趨勢/反論）並加入 fill-blank 格式，符合方大哥 #1388 的教學設計規格。2 輪 review 迭代（改善「證據→趨勢」語意、「怕人→是否怕人」句式）",
+      "skillsLearned": [14],
+      "highlights": [
+        "主動理解教學規格，將平文字轉換為結構化填空",
+        "2 輪 review 迭代，精修欄位語意",
+        "staging 驗證 6 個填空格正確渲染（HTTP 200）"
+      ],
+      "linesChanged": "+35/-47"
+    },
+    {
+      "id": "#1342",
+      "title": "feat(vocab): 第二次練習隱藏輔助 + 部首顏色（PR #1499）",
+      "date": "2026-05-08",
+      "type": "feature",
+      "contribution": "VocabPractice 新增 practiceMode prop（standard/toolbox/quiz 三種）+ radicalColorMode prop，Round 1 顯示筆順輪廓 + 部首顏色標示，Round 2 隱藏所有輔助（筆順/注音/筆畫數）。命名刻意避免與元件內部 mode state 衝突，4 輪 @claude review 全部解決含最後 brush color 一致性",
+      "skillsLearned": [6, 11],
+      "highlights": [
+        "prop vs internal state 邊界設計清晰，避免命名衝突",
+        "3 variants + 雙 prop 的 multi-mode 元件架構",
+        "4 輪 @claude review 全部追蹤到底，含 commit 9bad640a brush color 修正",
+        "162+/32- 規模適中，設計乾淨"
+      ],
+      "linesChanged": "+162/-32"
     }
   ]
 }

--- a/docs/meetings/2026-05-08-agenda.md
+++ b/docs/meetings/2026-05-08-agenda.md
@@ -23,6 +23,11 @@
 | #1482 | Young | fix(ai): is_correct=true 時強制 suggestion="" | Fixes #1481 |
 | #1485 | Young | feat(skill): friday-meeting-prep skill 建立 | — |
 | #1487 | Young | feat(skill): 泛化 meeting-prep，不假設週五 | Fixes #1486 |
+| #1493 | Young/Claude | test(mcq-rescue): 28 contract tests for #1387 Phase 1 backend | Refs #1387 |
+| #1495 | Young/Claude | feat(data): infill 4 missing story_structure YAMLs + 2 worksheet PDFs → 208/208 coverage | Refs #1398 #1444 |
+| #1497 | 靖杭 | fix(csp): allow GCS frame-src to unblock 紙本學習單 PDF popup | Fixes #1496 |
+| #1498 | 靖杭 | fix(content): rewrite G7-L29/L30 文章重點表 from flat text to 5 structured rows | Refs #1388 |
+| #1499 | 靖杭 | feat(vocab): 第二次練習隱藏所有輔助 + 不同部首不同顏色 | Fixes #1342 |
 
 ---
 
@@ -42,13 +47,16 @@
 - ✅ PR #1461 — 10 個 toolbox session tables + AppShell `aria-label` toolbox-aware（feat #1460 Phase 1）
 - ✅ PR #1464 — `ToolboxCompletionActions` 共用元件 + 9 個 reading-step 接入（feat #1462）
 - ✅ PR #1465 — 後端 `toolbox.py` + 前端 `toolboxApi.ts` + 學習紀錄頁分區（feat #1463）
+- ✅ PR #1497 — CSP frame-src 加入 `storage.googleapis.com`，解除 GCS PDF popup 被瀏覽器封鎖（fix #1496）
+- ✅ PR #1498 — G7-L29/L30 文章重點表從 22 行純文字重構為 5 行結構化填空（主題/觀察/推論/趨勢/反論），refs #1388
+- ✅ PR #1499 — 生字第二次練習隱藏所有輔助（筆順輪廓/注音/筆畫數），加入部首顏色標示（Round 1 outlined+radical colors / Round 2 no-aids），fixes #1342
 
 ### 待驗收
 - 5/1 會議決議 #1457 — 字體/詞彙/簡介/教材整合整包驗收，PR #1459/#1461/#1464/#1465 全歸此 issue，需現場走過 staging 簽結
 
 ### 進行中
-- 🔧 #1190 — 進行中
-- 🔧 #1186 — 進行中
+- 🔧 #1190 — 進行中（下週建議聚焦）
+- 🔧 #1186 — 進行中（下週建議聚焦）
 - 🔧 9 個 `ai-qa-passed + intern-review` label 等實習生 final eye-check
 
 ### 待討論
@@ -91,6 +99,12 @@ PR #1480 修造句練習三個獨立問題：AI 評估語氣歧義（拆 is_corr
 ### 開發流程 Skill
 - ✅ PR #1485 — meeting-prep skill 首建：4 份文件自動產出（議程 + 貢獻 + 2 個 intern JSON），開 PR 到 staging
 - ✅ PR #1487 — 泛化為 `meeting-prep`（不假設週五）+ 加 AskUserQuestion 邏輯，回應 Young 「不一定週五」feedback
+
+### Test Coverage
+- ✅ PR #1493 — #1387 Phase 1 backend 28 contract tests（fail-closed 驗證、empty reasoning 偵測、start_session error path、blank resume），確保 mcq_rescue_agent 不是 test theatre
+
+### Data 補檔（5/8）
+- ✅ PR #1495 — infill 4 missing story_structure YAMLs（G5-L5 / G8-L8 / G9-L2 / 文-L10）+ 2 missing worksheet PDFs（G9-L15-16 / G9-L17-19）→ 208/208 coverage，refs #1398 #1444
 
 ---
 
@@ -146,19 +160,67 @@ PR #1482 已於 5/7 merge，`is_correct=True` 時 `suggestion=""` 防禦修正�
 
 ---
 
-## 五、7/1 Deadline 計數
+### 4.7 #1494 mcq_rescue_agent silent-failure follow-up（5/8 新開）
+
+**背景**：PR #1493 contract tests 過程中發現 Phase 1 scaffold 有 4 個 silent-failure risks
+- broad `except Exception` 吃掉所有錯誤不回報
+- reasoning field 可能空字串（Young/方大哥無法稽核）
+- `start_session` 無 error path，學生看不到錯誤提示
+- resume 回傳 blank state 時前端無 fallback
+
+**現況**：issue #1494 已開，P1，7/1 deadline，尚未 assign
+**需討論**：
+- [ ] assignee 誰接？（靖杭 / Young）
+- [ ] 預計本週或下週啟動
+
+---
+
+### 4.8 #1393 G7-L29/L30 圖文整合 YAML — 5/8 進度更新
+
+**5/8 今日進展**：
+- PR #1498 已 merge：G7-L29/L30 文章重點表已從 22 行純文字重構為 5 行結構化填空，staging 驗證 HTTP 200 + 6 個填空格正確渲染
+- PR #1495 data infill 已 merge：208/208 coverage
+
+**仍待解決（Claude 建議，等 Young 拍板）**：
+- (a) AI 助教直接吃完整 22 行，不修改 YAML 結構（最快）
+- (b) 開新 issue，做圖文 hotspot 互動（最佳體驗，但需 2 週）
+- (c) 先用 PR #1498 結構化 5 行填空作為過渡，圖片整合後期補
+
+---
+
+## 五、實習生進度（5/8 更新）
+
+### 靖杭 @if-else-master
+
+**本週 merged（5/8 新增）**：
+- ✅ PR #1497 — CSP fix（backend middleware + `frame-src` 白名單）
+- ✅ PR #1498 — G7-L29/L30 文章重點表結構化重構（2 輪 review 迭代，最終 5 行填空）
+- ✅ PR #1499 — VocabPractice 第二次練習 multi-mode：`practiceMode` prop + `radicalColorMode` prop，4 輪 @claude review（含最終 brush color consistency）
+
+**下週建議聚焦**：
+- #1190（進行中，已超過 1 週）
+- #1186（進行中，已超過 1 週）
+
+### 啟翔 @stgst
+
+**本週（5/8）**：無新 PR merge（最後一個 PR 為 #1480，已於上週 merge）
+**下週建議**：#1458 剩餘 scope 確認（課文理解 / 圖文整合）
+
+---
+
+## 七、7/1 Deadline 計數
 
 > 7/1 deadline 剩約 **8 週**。兩大模組必須完成：(A) 閱讀聚光燈 AI 助教、(B) 圖文整合 3 課學習單
 
 | 模組 | Issue | 現況 | 風險 |
 |------|-------|------|------|
 | 閱讀聚光燈 AI 助教 | #1387 | Phase 1 scaffold 存在，無 assignee | 🔴 高（尚未實質開工） |
-| 圖文整合 YAML + 呈現 | #1393 | YAML 已有，呈現 spec 待確認 | 🟡 中（spec 確認後可快速啟動） |
+| 圖文整合 YAML + 呈現 | #1393 | 文章重點表已結構化（PR #1498），圖片 hotspot 待討論 | 🟡 中（spec 確認後可快速啟動） |
 | G4-G5 剩餘 toolbox 整合 | #1463 follow-up | Phase 2+3 已 merge | 🟢 低 |
 
 ---
 
-## 六、Tech Debt Follow-up（#1473–#1477）
+## 八、Tech Debt Follow-up（#1473–#1477）
 
 Young 本週開的 5 個 toolbox tech-debt issues，低優先但本週安排認領避免積壓：
 
@@ -172,7 +234,7 @@ Young 本週開的 5 個 toolbox tech-debt issues，低優先但本週安排認�
 
 ---
 
-## 七、Action Items
+## 九、Action Items
 
 | # | Action | 負責 | 完成標準 | Deadline |
 |---|--------|------|---------|----------|

--- a/docs/meetings/team-contributions.md
+++ b/docs/meetings/team-contributions.md
@@ -25,6 +25,11 @@
 | Young | ✅ | PR #1482 fix(ai)（#1481）| is_correct=True 時強制 suggestion=""（ai_generation.py L292 一行 defensive fix，#1480 claude-bot L285 finding）|
 | Young | ✅ | PR #1485 feat(skill) | meeting-prep skill 首建：4 份文件自動產出 + worktree + PR 到 staging 全流程 |
 | Young | ✅ | PR #1487 feat(skill)（#1486）| 泛化 meeting-prep：不假設週五、AskUserQuestion 問日期、DOW_ZH case 支援週一到週日 |
+| Young | ✅ | PR #1493 test(mcq-rescue)（#1387）| 28 contract tests for Phase 1 backend：fail-closed 驗證、empty reasoning 偵測、start_session error path、blank resume fallback |
+| Young | ✅ | PR #1495 feat(data)（#1398 #1444）| infill 4 missing story_structure YAMLs（G5-L5/G8-L8/G9-L2/文-L10）+ 2 worksheet PDFs（G9-L15-16/G9-L17-19）→ 208/208 coverage |
+| 靖杭 | ✅ | PR #1497 fix(csp)（#1496）| SecurityHeadersMiddleware frame-src 加入 `storage.googleapis.com`，解除 GCS PDF popup 被 CSP 封鎖 |
+| 靖杭 | ✅ | PR #1498 fix(content)（#1388）| G7-L29/L30 文章重點表從 22 行平文字重構為 5 行結構化填空（主題/觀察/推論/趨勢/反論）+ fill-blanks，2 輪 review 精修 |
+| 靖杭 | ✅ | PR #1499 feat(vocab)（#1342）| VocabPractice `practiceMode` prop（3 variants）+ `radicalColorMode` prop，Round 1 outlined+radical colors / Round 2 no-aids，4 輪 @claude review |
 
 ---
 


### PR DESCRIPTION
## Summary

Today's (5/8) incremental update appended to the existing 2026-05-08 agenda. No rewrites — insert/append only.

### 5 Merged PRs added
- #1493 by Young/Claude — `test(mcq-rescue)`: 28 contract tests for #1387 Phase 1 backend
- #1495 by Young/Claude — `feat(data)`: infill 4 missing story_structure YAMLs + 2 worksheet PDFs → 208/208 coverage
- #1497 by 靖杭 — `fix(csp)`: allow GCS frame-src to unblock 紙本學習單 PDF popup
- #1498 by 靖杭 — `fix(content)`: rewrite G7-L29/L30 文章重點表 to 5 structured fill-blank rows
- #1499 by 靖杭 — `feat(vocab)`: 第二次練習 hidden aids + radical colors

### 2 New issues added to agenda (待討論)
- #1494 — mcq_rescue_agent silent-failure follow-up (P1, 7/1 deadline, unassigned)
- #1393 — G7-L29/L30 圖文整合 5/8 update (PR #1498 resolved table, hotspot still pending)

### Files changed
1. `docs/meetings/2026-05-08-agenda.md` — +~74 lines (5 PR rows, 靖杭 section, Young section, 4.7/4.8 discussion items, Section 五 intern progress, section renumbering)
2. `docs/meetings/team-contributions.md` — +5 rows to 5/4~5/8 table
3. `docs/intern-training/interns/raymond.json` — skill #11 3→4, skill #17 new level 1, skill #14 history entry, 3 new issues
4. `docs/intern-training/interns/xiung.json` — no changes (lastReview already 2026-05-08)

### Skill bumps applied (raymond.json)
- **#11 React 進階: 3 → 4** — PR #1499 multi-mode prop design (practiceMode + radicalColorMode, naming boundary clarity, 4-round review)
- **#17 後端 Python 閱讀: new → 1** — PR #1497 CSP middleware read/fix (first time reading Python security middleware)
- **#14 問題拆解: level 2 maintained** — PR #1498 quality evidence added, not enough for bump yet

## Test plan
- [ ] jq validates raymond.json (confirmed: valid)
- [ ] jq validates xiung.json (confirmed: valid)
- [ ] Agenda sections read cleanly (no broken tables, no duplicate numbering)
- [ ] team-contributions rows match PR details

🤖 Generated with [Claude Code](https://claude.com/claude-code)