### PR TITLE
docs(meeting): sync 5/8 record — 8 PRs / 6 closed / 8 new issues (Fixes #1513)

### DIFF
--- a/docs/meetings/2026-05-08-record.md
+++ b/docs/meetings/2026-05-08-record.md
@@ -6,23 +6,39 @@ participants:
   - 靖杭 @if-else-master (intern)
   - 啟翔 @stgst (intern)
 agenda_ref: docs/meetings/2026-05-08-agenda.md
-related_issues:
-  - "#1457 (intern QA batch — 靖杭)"
-  - "#1458 (intern QA batch — 啟翔)"
-  - "#1340 (AI 助教 + 語音互動)"
-  - "#1387 (閱讀聚光燈 AI 助教 implementation Phase 1 backend)"
-  - "#1393 (G7-L29/L30 圖文整合 redesign)"
-  - "#1498 (G7-L29/L30 文章重點表 內容)"
-  - "#1499 (Vocab Round 2 + 部首顏色)"
-related_prs:
-  - "#1493 mcq-rescue contract tests"
-  - "#1495 4 yamls + 2 PDFs"
-  - "#1497 CSP frame-src GCS"
-  - "#1498 G7-L29/L30 文章重點表"
-  - "#1499 Vocab Round 2"
+related_issues_open:
+  - "#1457 (intern QA batch — 靖杭, OPEN)"
+  - "#1458 (intern QA batch — 啟翔, OPEN)"
+  - "#1340 (AI 助教 + 語音互動 — Phase 2 voice tracker, OPEN)"
+related_issues_closed_today:
+  - "#1387 (閱讀聚光燈 AI 助教 Phase 1 backend, CLOSED 5/8)"
+  - "#1393 (G7-L29/L30 圖文整合 redesign — resolved by #1498, CLOSED 5/8)"
+  - "#1455 (docs QA checklist — checklist file shipped, CLOSED 5/8)"
+  - "#1494 (mcq_rescue silent-failure 4 bugs — fixed by #1512, CLOSED 5/8)"
+  - "#1496 (CSP popup blocked — fixed by #1497, CLOSED 5/8)"
+  - "#1502 (meeting record archive tracking, CLOSED 5/8)"
+related_issues_opened_today:
+  - "#1504 [7/1] G7 三欄佈局擁擠排版優化"
+  - "#1505 [7/1] 學生端顯示朗讀正確率 + 語速"
+  - "#1506 [bug] 閱讀聚光燈申論題記錄跳關卡會清空"
+  - "#1507 [7/1] AI 引導 UI/UX redesign"
+  - "#1508 [7/1] Intro 顯示數位學習步驟而非紙本"
+  - "#1509 [7/1] 內容標準化 schema 定義"
+  - "#1510 [7/1 epic] 教師功能初版 MVP（6/1~7/1）"
+  - "#1511 [bug] DEFAULT_STEP_SEQUENCE 順序錯誤"
+related_prs_merged:
+  - "#1493 mcq-rescue contract tests (28 tests)"
+  - "#1495 4 yamls + 2 worksheet PDFs (#1398/#1444)"
+  - "#1497 CSP frame-src GCS (Fixes #1496)"
+  - "#1498 G7-L29/L30 文章重點表 (Refs #1388)"
+  - "#1499 Vocab Round 2 + 部首顏色 (Fixes #1342)"
   - "#1500 5/8 agenda update"
+  - "#1503 meeting record archive (Fixes #1502)"
+  - "#1512 mcq_rescue silent-failure 4 bugs + 32 tests (Refs #1494)"
 key_decisions_count: 13
 deadline: 2026-06-01 教授 review / 2026-07-01 product launch
+final_staging_revision: lingoleap-backend-staging-00675-p6m
+session_outcome: 8 PRs landed, 6 issues closed, 8 issues opened
 ---
 
 # 2026-05-08 週會記錄


### PR DESCRIPTION
Fixes #1513

## Summary
- Replaces flat `related_issues` + `related_prs` blocks with 5 structured blocks: `related_issues_open`, `related_issues_closed_today`, `related_issues_opened_today`, `related_prs_merged`
- Adds `final_staging_revision` and `session_outcome` summary fields
- Body content (transcript + AI summary) unchanged — only YAML frontmatter modified

## Changes
- `related_issues_open`: 3 still-open issues
- `related_issues_closed_today`: 6 issues closed on 5/8 (#1387, #1393, #1455, #1494, #1496, #1502)
- `related_issues_opened_today`: 8 new issues opened on 5/8 (#1504–#1511)
- `related_prs_merged`: 8 PRs landed on 5/8 (#1493, #1495, #1497–#1500, #1503, #1512)
- `final_staging_revision`: lingoleap-backend-staging-00675-p6m
- `session_outcome`: 8 PRs landed, 6 issues closed, 8 issues opened

## Test plan
- [ ] File line count >= 810 (body intact): 826 lines confirmed
- [ ] YAML frontmatter parses cleanly (no duplicate keys)
- [ ] Body starts with `# 2026-05-08 週會記錄` immediately after closing `---`