### PR TITLE
fix(spotlight): persist essay answers across step navigation (Fixes #1506)

### DIFF
--- a/frontend/src/components/reading-steps/StrategyExercise.tsx
+++ b/frontend/src/components/reading-steps/StrategyExercise.tsx
@@ -8,7 +8,7 @@
  *
  * Designed to feel like part of the existing worksheet (matches MCQ / StoryStructure UI).
  */
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { StrategyExercise as StrategyExerciseType, StrategyExerciseOrderingItem } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { fontForZhuyin } from '../../constants/fonts';
@@ -16,6 +16,8 @@ import { fontForZhuyin } from '../../constants/fonts';
 interface Props {
   exercise: StrategyExerciseType;
   onComplete?: () => void;
+  onChange?: (exerciseState: Record<string, unknown>) => void;
+  initialState?: Record<string, unknown>;
 }
 
 // ── Shared helpers ──────────────────────────────────────────────────────────
@@ -323,18 +325,28 @@ function TraitInferenceExercise({
 function GuidedStepsExercise({
   exercise,
   onComplete,
+  onChange,
+  initialState,
 }: {
   exercise: StrategyExerciseType;
   onComplete?: () => void;
+  onChange?: (exerciseState: Record<string, unknown>) => void;
+  initialState?: Record<string, unknown>;
 }) {
   const steps = exercise.steps ?? [];
   const [answers, setAnswers] = useState<(string | number | null)[]>(
-    () => steps.map(() => null),
+    () => (initialState?.answers as (string | number | null)[]) ?? steps.map(() => null),
   );
   const [stepFeedback, setStepFeedback] = useState<(boolean | null)[]>(
-    () => steps.map(() => null),
+    () => (initialState?.stepFeedback as (boolean | null)[]) ?? steps.map(() => null),
   );
-  const [allDone, setAllDone] = useState(false);
+  const [allDone, setAllDone] = useState(
+    () => !!(initialState?.allDone as boolean),
+  );
+
+  useEffect(() => {
+    onChange?.({ answers, stepFeedback, allDone, exerciseType: 'guided_steps' });
+  }, [answers, stepFeedback, allDone]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleTextChange = (stepIdx: number, value: string) => {
     if (stepFeedback[stepIdx] !== null) return;
@@ -501,7 +513,7 @@ function GuidedStepsExercise({
 
 // ── Main Component ──────────────────────────────────────────────────────────
 
-const StrategyExercise: React.FC<Props> = ({ exercise, onComplete }) => {
+const StrategyExercise: React.FC<Props> = ({ exercise, onComplete, onChange, initialState }) => {
   const { zhuyinActive, processZhuyin } = useZhuyin();
   const zhuyinFont = fontForZhuyin(zhuyinActive);
 
@@ -512,7 +524,7 @@ const StrategyExercise: React.FC<Props> = ({ exercise, onComplete }) => {
   const content = (() => {
     if (exercise.type === 'ordering') return <OrderingExercise exercise={exercise} onComplete={handleComplete} />;
     if (exercise.type === 'trait_inference') return <TraitInferenceExercise exercise={exercise} onComplete={handleComplete} />;
-    if (exercise.type === 'guided_steps') return <GuidedStepsExercise exercise={exercise} onComplete={handleComplete} />;
+    if (exercise.type === 'guided_steps') return <GuidedStepsExercise exercise={exercise} onComplete={handleComplete} onChange={onChange} initialState={initialState} />;
     return <div className="p-4 text-on-surface-variant text-sm text-center">不支援的練習類型：{exercise.type}</div>;
   })();
 

--- a/frontend/src/pages/learning/StrategyExercisePage.tsx
+++ b/frontend/src/pages/learning/StrategyExercisePage.tsx
@@ -19,9 +19,12 @@ const StrategyExercisePage: React.FC = () => {
     handleFinishReadingStrategy,
     dbSessionId,
     saveStepProgressPatch,
+    stepProgressData,
   } = useLearningContext();
 
-  const [strategyDone, setStrategyDone] = useState(false);
+  const savedStrategyData = stepProgressData.step_data?.['reading-strategy'] as Record<string, unknown> | undefined;
+
+  const [strategyDone, setStrategyDone] = useState(() => !!(savedStrategyData?.allDone));
 
   const handleProgressChange = useCallback(
     (stepData: Record<string, unknown>, immediate = false) => {
@@ -33,6 +36,13 @@ const StrategyExercisePage: React.FC = () => {
       });
     },
     [saveStepProgressPatch],
+  );
+
+  const handleAnswerChange = useCallback(
+    (exerciseState: Record<string, unknown>) => {
+      handleProgressChange(exerciseState, false);
+    },
+    [handleProgressChange],
   );
 
   const handleStrategyComplete = useCallback(() => {
@@ -58,6 +68,8 @@ const StrategyExercisePage: React.FC = () => {
           <StrategyExercise
             exercise={selectedStory.strategyExercise!}
             onComplete={handleStrategyComplete}
+            onChange={handleAnswerChange}
+            initialState={savedStrategyData}
           />
           {/* Show "下一關" once the strategy exercise is done (or always allow skip) */}
           <div className="mt-6 shrink-0">


### PR DESCRIPTION
Fixes #1506

## Summary

- **Root cause**: `GuidedStepsExercise` stored all answer state in plain `useState` with no persistence. Switching steps unmounts the component, wiping all answers. `saveStepProgressPatch` was only called on "下一關" click and only saved `{ completed: true }`, never the actual answers.
- **Fix part A** (`StrategyExercisePage.tsx`): Read `savedStrategyData` from `stepProgressData` context (same pattern as `ComprehensionPage`, `VocabDefinitionMatchPage`); seed `strategyDone` from `initialState.allDone`; add `handleAnswerChange` that calls `saveStepProgressPatch` (debounced 5 s via existing `useProgressSync`) on every answer change.
- **Fix part B** (`StrategyExercise.tsx`): Add `onChange` + `initialState` props to component and `GuidedStepsExercise`; seed `answers`, `stepFeedback`, `allDone` from `initialState` on mount; fire `onChange` via `useEffect` whenever any of those state values change.

No backend changes. No new API endpoints. Uses existing `step_data` JSONB key `reading-strategy`.

## LOC

- `StrategyExercise.tsx`: +22 / -6 lines
- `StrategyExercisePage.tsx`: +14 / -1 lines
- **Total: 31 insertions, 7 deletions (net +24 LOC vs estimate of +26)**

## Test plan

- [ ] Type text in a `free_text` step → wait 6 s (past 5 s debounce) → switch to another step → return → verify text is restored
- [ ] Select an option in a `select` step → switch away → return → verify selection is restored
- [ ] Complete all steps (`allDone=true`) → switch away → return → verify "全部步驟完成！" banner shows and "下一關" button is enabled
- [ ] Reload page mid-essay → verify answers restored from DB
- [ ] Lesson with no `strategyExercise` — placeholder + skip button still works (no regression)
- [ ] Build passes: `npm run build` ✅