### PR TITLE
docs(meeting): append 5/9 sprint outcomes (Fixes #1524)

### DIFF
--- a/docs/meetings/2026-05-08-record.md
+++ b/docs/meetings/2026-05-08-record.md
@@ -868,3 +868,52 @@ AI 引導是什麼樣的意思？
 ### STATUS
 
 **DONE** — 9 PRs all verified live on staging, 0 critical/high bugs introduced.
+
+---
+
+## 2026-05-09 Sprint outcomes (post-meeting issues 從會議抽出)
+
+> Following 5/8 meeting walkthrough, 8 issues opened (#1504-#1511). 7 PRs landed during 5/9 sprint to address 4 of them.
+
+### Quick wins delivered
+
+| Issue | PR | Status | Summary |
+|---|---|---|---|
+| #1511 step order bug | #1517 | ✅ CLOSED | DEFAULT_STEP_SEQUENCE swap reading-strategy + story-structure (聚光燈 → 重點表) |
+| #1508 Intro digital steps | #1518 | ✅ CLOSED | Intro page reads `step_sequence` not `worksheetSectionOrder` |
+| #1505 朗讀 metrics | #1519 | ✅ CLOSED | Student-side ReadingMetricsCard 顯示 正確率 + 語速 + 歷史 |
+| #1506 essay persist | #1523 | ⚠️ **QA FAILED, OPEN** | Fix shipped but staging QA shows essay still cleared on step navigation. PATCH didn't fire — likely textarea is not `GuidedStepsExercise` for G6-L22 |
+
+### Specs framework drafted (no code, await educator review)
+
+| Issue | PR | Doc | Notes |
+|---|---|---|---|
+| #1509 content schema | #1520 | `docs/specs/content-schema-2026-05-09.md` + JSON Schema | learning_goal / lesson_intro / step_sequence canonical forms |
+| #1506 essay investigation | #1521 | `docs/specs/issue-1506-essay-record-investigation.md` | Root cause + 26-LOC fix sketch (turned out incomplete in #1523) |
+| #1507 AI guidance UX | #1522 | `docs/specs/ai-guidance-ux-2026-05-09.md` | Modal A 推薦 + 3 教授決策待回 |
+
+### Open work (待後續 sprint)
+
+- #1504 G7 三欄佈局擁擠 — 需 Design Pipeline 5 stages
+- #1506 essay persist — #1523 fix 未解，需更深 investigation
+- #1507 AI 引導 implementation — blocked on 教授 input (3 questions)
+- #1509 content schema implementation — Pydantic + UI work after spec approval
+- #1510 教師功能 epic — 3-4 週工程，6/1~7/1 開發
+
+### 教授必答（6/1 review 前）
+
+來自 #1507 spec：
+1. **連錯幾題強制 AI 引導？** N=1 影響課堂節奏
+2. **5 步驟 progress 顯示？** 顯示匿名 ●○○○○ vs 完全隱藏
+3. **課文段落高亮？** AI 提示時是否同步高亮對應段落
+
+### Final staging state at 5/9 EOD
+
+- Cloud Run backend: `lingoleap-backend-staging-00679-mgf`
+- Cloud Run frontend: `lingoleap-frontend-staging-00761-vt5`
+- Today total: 7 PRs landed (#1517 #1518 #1519 #1520 #1521 #1522 #1523)
+- Open: #1506 (QA fail) + #1504 #1507 #1509 #1510
+
+### STATUS
+
+**DONE_WITH_CONCERNS** — 4/8 meeting issues addressed (3 closed + 3 specs). #1506 fix did not pass staging QA, needs deeper investigation. 4 issues remain open as planned (待教授 / 大型工程).


### PR DESCRIPTION
Fixes #1524

## Summary
- Appends `## 2026-05-09 Sprint outcomes` section to end of `docs/meetings/2026-05-08-record.md`
- Documents 7 PRs landed (#1517–#1523), 3 issues closed, 3 specs drafted, #1506 QA fail status
- No existing content modified — append only

## Test plan
- [ ] Verify existing content above the new section is untouched
- [ ] Verify new section appears at end of file (line 811 onward)