### PR TITLE
feat(vocab): 還原筆順示範動畫 + 部首多色 (Fixes #1529)

### DIFF
--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -391,6 +391,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
                 //   round 2 再生回憶 → one no-outline practice, no aids
                 practiceMode={currentRound === 2 ? 'no-outline-once' : 'outlined-once'}
                 radicalColorMode={currentRound === 1}
+                componentCount={decomp?.components.length ?? 2}
               />
             </div>
 

--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -30,11 +30,17 @@ interface WriteCharacterProps {
    */
   practiceMode?: 'standard' | 'outlined-once' | 'no-outline-once';
   /**
-   * #1342: colour completed strokes by their radical group on the canvas
-   * (radical strokes = accent purple, body strokes = emerald). Once every
-   * stroke is done the colours unify into the default ink colour ("合體").
+   * #1342: colour completed strokes by their component group on the canvas.
+   * Once every stroke is done the colours unify into the default ink colour
+   * ("合體"). Number of distinct colours is driven by `componentCount` below.
    */
   radicalColorMode?: boolean;
+  /**
+   * #1529: number of components for this character (from getDecomposition).
+   * One colour per component, up to the palette length (5). Defaults to 2
+   * (primary radical + body) when omitted, matching the previous behaviour.
+   */
+  componentCount?: number;
 }
 
 enum Step {
@@ -205,11 +211,13 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
   embedded = false,
   practiceMode = 'standard',
   radicalColorMode = false,
+  componentCount = 2,
 }) => {
-  // #1342: derived flags for the simplified single-shot rounds.
+  // #1342 / #1529: derived flags for the simplified single-shot rounds.
+  // outlined-once still plays the animation preview (#1529); only the recall
+  // round (no-outline-once) skips it.
   const isOutlinedOnce = practiceMode === 'outlined-once';
   const isNoOutlineOnce = practiceMode === 'no-outline-once';
-  const isSingleShot = isOutlinedOnce || isNoOutlineOnce;
   /* ---- React state (drives UI controls) ---- */
   const [data, setData] = useState<CharacterStrokeData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -297,21 +305,25 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
       correctPaths: r.current.correctPaths,
       activeBrush: r.current.activeBrush,
       radicalColorMode,
+      componentCount,
     };
     renderStrokes(ctx, getOffCanvas(), state);
-  }, [getOffCanvas, radicalColorMode]);
+  }, [getOffCanvas, radicalColorMode, componentCount]);
 
   /* ---- Shared state reset (used by both initial load and retry) ---- */
   const resetState = useCallback((nStrokes: number) => {
-    // #1342 single-shot rounds:
-    //   outlined-once → PRACTICE_1 with outline still visible
-    //   no-outline-once → PRACTICE_NO_OUTLINE, outline hidden
+    // #1342 / #1529 single-shot rounds:
+    //   outlined-once → ANIMATION first (preview stroke order), then a single
+    //     PRACTICE_1 trace once the student clicks 開始練習. Restored in #1529
+    //     so children see the correct stroke order before writing — without
+    //     having to wait the full animation out (skip button stays available).
+    //   no-outline-once → PRACTICE_NO_OUTLINE, outline hidden, no preview.
     // standard preserves the original animation-led 4-trace flow.
     let initialStep = Step.ANIMATION;
     let outlineOn = true;
     let leftCount = 4;
     if (isOutlinedOnce) {
-      initialStep = Step.PRACTICE_1;
+      initialStep = Step.ANIMATION;
       outlineOn = true;
       leftCount = 1;
     } else if (isNoOutlineOnce) {
@@ -462,9 +474,10 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
   useEffect(() => {
     if (data && pendingAutoStartRef.current) {
       pendingAutoStartRef.current = false;
-      // #1342 single-shot rounds skip the animation preview and drop the
-      // student straight into the practice quiz (outlined or no-outline).
-      if (isSingleShot) {
+      // #1529: only the recall round (no-outline-once) skips the animation.
+      // outlined-once now plays the stroke-order preview (with a 開始 button)
+      // so children see the correct stroke order before writing.
+      if (isNoOutlineOnce) {
         isAutoLoopingRef.current = false;
         startQuizRef.current();
       } else {
@@ -472,7 +485,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         startAnimation();
       }
     }
-  }, [data, isSingleShot, startAnimation]);
+  }, [data, isNoOutlineOnce, startAnimation]);
 
   /* ================================================================ */
   /*  Quiz (writing practice)                                          */

--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -323,8 +323,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
     let outlineOn = true;
     let leftCount = 4;
     if (isOutlinedOnce) {
-      initialStep = Step.ANIMATION;
-      outlineOn = true;
       leftCount = 1;
     } else if (isNoOutlineOnce) {
       initialStep = Step.PRACTICE_NO_OUTLINE;

--- a/frontend/src/components/stroke-order/strokeRenderer.ts
+++ b/frontend/src/components/stroke-order/strokeRenderer.ts
@@ -12,11 +12,17 @@ export interface RenderState {
   activeBrush: Point[];
   /**
    * #1342 round-1 stimulus: when true, color completed strokes by their
-   * radical group (radical strokes = one colour, body strokes = another)
-   * so the student visually sees the character is built from parts.
-   * After all strokes done, the colors merge into the unified default.
+   * component (radical) group so the student visually sees the character
+   * is built from parts. After every stroke is done the palette unifies
+   * into the default ink ("合體" effect).
    */
   radicalColorMode?: boolean;
+  /**
+   * #1529 multi-component coloring: number of components in this character
+   * from getDecomposition. Defaults to 2 (primary radical + body) when not
+   * passed. We support up to RADICAL_PALETTE.length colours.
+   */
+  componentCount?: number;
 }
 
 const COLORS = {
@@ -27,11 +33,21 @@ const COLORS = {
   outline: 'rgba(48,47,42,0.12)',
   hint:    '#564ABF',
   brush:   '#564ABF',
-  // #1342 radical-color palette — high-contrast pair so the radical group
-  // pops against the body. Same palette as RadicalDecomposition's left panel.
-  radical: '#5B4FC4',  // accent purple (matches design system)
-  body:    '#10B981',  // emerald
 };
+
+/**
+ * #1529: per-component palette. Hex values match the Tailwind classes used
+ * by RadicalDecomposition.tsx (emerald-700, blue-700, amber-700, rose-700,
+ * violet-700) so the canvas colors visually match the left-side panel.
+ * WCAG AAA contrast against the white canvas, color-blind friendly order.
+ */
+const RADICAL_PALETTE: readonly string[] = [
+  '#047857',  // position 0 — emerald (primary radical / first component)
+  '#1D4ED8',  // position 1 — blue
+  '#B45309',  // position 2 — amber
+  '#BE123C',  // position 3 — rose
+  '#6D28D9',  // position 4 — violet
+];
 
 export function renderStrokes(
   ctx: CanvasRenderingContext2D,
@@ -42,21 +58,51 @@ export function renderStrokes(
     data, completedStrokes, animStroke, animProgress,
     hintStroke, hintProgress, showOutline, correctPaths, activeBrush,
     radicalColorMode = false,
+    componentCount = 2,
   } = state;
 
-  // #1342: pick a fill colour for stroke `i` — radical strokes get the
-  // accent purple, body strokes get emerald. After every stroke is done
-  // we drop back to the unified COLORS.stroke ("合體" effect).
+  // #1342 / #1529: pick a fill colour for stroke `i` — assign each stroke to
+  // its component (0 = primary radical from radStrokes, 1..N-1 = body parts
+  // distributed in stroke order across the remaining components). After every
+  // stroke is done we drop back to the unified COLORS.stroke ("合體" effect).
+  //
   // Guard `hasRadicalData`: hanzi-writer-data sometimes ships characters
   // without radStrokes; falling back to the unified ink colour avoids the
-  // misleading "all strokes are green" rendering when there is genuinely
-  // no part decomposition to show.
+  // misleading "all body" rendering when there is genuinely no part
+  // decomposition to show.
   const radSet = new Set(data.radicalIndices);
   const hasRadicalData = data.radicalIndices.length > 0;
   const allDone = completedStrokes >= data.nStrokes;
+  const N = Math.min(Math.max(componentCount, 1), RADICAL_PALETTE.length);
+
+  // Pre-compute body stroke order for each non-radical stroke, then bucket
+  // them into N-1 sequential groups.
+  const bodyTotal = data.nStrokes - radSet.size;
+  const bodyOrder = new Array<number>(data.nStrokes).fill(-1);
+  {
+    let order = 0;
+    for (let i = 0; i < data.nStrokes; i++) {
+      if (!radSet.has(i)) {
+        bodyOrder[i] = order;
+        order++;
+      }
+    }
+  }
+  const remainingComponents = Math.max(N - 1, 1);
+  const perComponent = Math.max(1, Math.ceil(bodyTotal / remainingComponents));
+
+  const componentForStroke = (i: number): number => {
+    if (N <= 1) return 0;
+    if (radSet.has(i)) return 0;
+    if (N === 2) return 1;
+    const bo = bodyOrder[i];
+    if (bo < 0) return 0;
+    return 1 + Math.min(remainingComponents - 1, Math.floor(bo / perComponent));
+  };
+
   const colourFor = (i: number): string => {
     if (!radicalColorMode || !hasRadicalData || allDone) return COLORS.stroke;
-    return radSet.has(i) ? COLORS.radical : COLORS.body;
+    return RADICAL_PALETTE[componentForStroke(i)];
   };
 
   ctx.clearRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);


### PR DESCRIPTION
## Summary

修正 PR #1499 後遺留的兩個生字書寫問題：

- **筆順示範動畫回歸**：第 1 輪 (`outlined-once`) 改回從 `Step.ANIMATION` 開始，學生先看完整筆順示範再按「開始練習」進入仿寫（保留隨時跳過示範的能力）。第 2 輪 (`no-outline-once`) 維持原本行為，直接進入無框默寫。
- **部首多色**：用 hanzi-writer 的 `radStrokes`（主部首筆畫）+ 剩餘筆畫依筆順切成 N-1 等份的 heuristic，分配到最多 5 色 palette（emerald / blue / amber / rose / violet），與左側 `RadicalDecomposition` 面板配色一致。componentCount 從 `getDecomposition(currentChar).components.length` 取得，預設 2。

## 變更檔案

| 檔案 | 內容 |
|------|------|
| `frontend/src/components/stroke-order/WriteCharacter.tsx` | outlined-once 改回 ANIMATION → PRACTICE_1；auto-start 只在 no-outline-once 時跳過示範；新增 `componentCount` prop |
| `frontend/src/components/stroke-order/strokeRenderer.ts` | 移除 COLORS.radical/body；新增 `RADICAL_PALETTE` (5 色) 與 `componentForStroke` heuristic；`colourFor` 全程使用 palette |
| `frontend/src/components/reading-steps/VocabPractice.tsx` | 把 `decomp?.components.length ?? 2` 傳給 `WriteCharacter` |

## Test plan

- [ ] 進工具箱 → 選課文 → 選「生字書寫」
- [ ] 第 1 輪：看到筆順示範動畫（可按「開始練習」中斷）
- [ ] 寫對 → 600ms 後自動進入第 2 輪
- [ ] 第 2 輪：無筆順示範、無框線
- [ ] 多部件字（3+ components）右側 canvas 顯示對應顏色數量
- [ ] 寫完所有筆畫後合體變黑（既有 allDone 行為）
- [ ] 沒有 `radStrokes` 資料時 fallback 為統一墨色（不誤畫成 emerald）

Refs #1529 (Fixes), #1499, #1342

🤖 Generated with [Claude Code](https://claude.com/claude-code)