### PR TITLE
fix(layout): G7 圖文三欄擁擠改為左疊圖文+右題目 (Fixes #1504)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -13,6 +13,7 @@ import FloatingAIHelper from './FloatingAIHelper';
 import StrategyExercise from './StrategyExercise';
 import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStorageScope';
 import ToolboxCompletionActions from '../tools/ToolboxCompletionActions';
+import ZoomableImage from '../ui/ZoomableImage';
 
 interface ComprehensionChatProps {
   story: Story;
@@ -270,9 +271,11 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   const totalTabs = [hasMcq, true, hasStrategy].filter(Boolean).length;
   const progressPercent = totalTabs > 0 ? Math.round((completedCount / totalTabs) * 100) : 0;
 
-  // ── #1341 Plugin pattern dispatch: graphic-text mode adds a middle image pane ──
-  // For G7-L28~30 (圖文整合策略): 3-pane layout (text 4 / images 4 / tabs 4)
-  // For other lessons (layout_mode=standard or undefined): 2-pane (text 7 / tabs 5)
+  // ── #1504 layout decongestion: graphic-text now stacks 課文 + 圖文 in the
+  // left column instead of a third middle panel (Young 5/8 review: "電梯超
+  // 載"). Right panel takes col-span-7 so the tabs have breathing room while
+  // answering. Click any image to open a fullscreen zoom modal.
+  // #1341 introduced the 3-pane variant this replaces.
   const isGraphicText = story.layout_mode === 'graphic-text';
   const storyImages = story.images ?? [];
   const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
@@ -283,12 +286,14 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
     >
       {/* ── Main content area — fills viewport, no page scroll ──── */}
       <div className="flex-1 min-h-0 px-4 md:px-6 py-6 md:py-8">
-        <div className={`w-full h-full grid grid-cols-1 ${isGraphicText ? 'lg:grid-cols-12' : 'md:grid-cols-12'} gap-6`}>
+        <div className="w-full h-full grid grid-cols-1 md:grid-cols-12 gap-6">
 
-          {/* ── Left: Story text card ────────────────────────────── */}
-          <div className={`${isGraphicText ? 'lg:col-span-4' : 'md:col-span-7 lg:col-span-7'} min-h-0 flex`}>
+          {/* ── Left column ──────────────────────────────────────── */
+          /* graphic-text: text top + images bottom (stacked, 60/40)   */
+          /* standard:     text only, col-span-7                       */}
+          <div className={`${isGraphicText ? 'md:col-span-5' : 'md:col-span-7 lg:col-span-7'} min-h-0 flex flex-col gap-4`}>
 
-            <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full">
+            <div className={`bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full min-h-0 ${isGraphicText ? 'flex-[3]' : 'flex-1'}`}>
               <div className="flex items-center gap-2 mb-4 shrink-0">
                 <span className="material-symbols-outlined text-accent text-xl">menu_book</span>
                 <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">參考課文</span>
@@ -325,53 +330,52 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
                 </div>
               </div>
             </div>
-          </div>
 
-          {/* ── Middle: Image gallery (graphic-text mode only) ─────── #1341 */}
-          {isGraphicText && (
-            <div data-testid="graphic-text-image-pane" className="lg:col-span-4 min-h-0 flex">
-              <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full">
-                <div className="flex items-center gap-2 mb-4 shrink-0">
-                  <span className="material-symbols-outlined text-accent text-xl">photo_library</span>
-                  <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">圖文對照</span>
+            {/* Image strip (graphic-text only) — horizontally scrollable, click to zoom */}
+            {isGraphicText && (
+              <div
+                data-testid="graphic-text-image-pane"
+                className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5 flex flex-col w-full min-h-0 flex-[2]"
+              >
+                <div className="flex items-center gap-2 mb-3 shrink-0">
+                  <span className="material-symbols-outlined text-accent text-lg">photo_library</span>
+                  <span className="font-headline font-bold text-on-surface text-xs uppercase tracking-wider">圖文對照</span>
                   <span className="text-xs text-on-surface-variant ml-2">{storyImages.length} 張</span>
+                  <span className="text-[11px] text-on-surface-variant ml-auto hidden md:inline">點圖可放大</span>
                 </div>
-                <div className="flex-1 min-h-0 overflow-y-auto pr-2 custom-scrollbar">
-                  {storyImages.length === 0 ? (
-                    <div className="flex items-center justify-center h-48 text-on-surface-variant text-sm">
-                      暫無圖片
-                    </div>
-                  ) : (
-                    <div className="grid grid-cols-1 gap-4">
+                {storyImages.length === 0 ? (
+                  <div className="flex-1 min-h-0 flex items-center justify-center text-on-surface-variant text-sm">
+                    暫無圖片
+                  </div>
+                ) : (
+                  <div className="flex-1 min-h-0 overflow-x-auto custom-scrollbar">
+                    <div className="flex gap-3 h-full pr-2">
                       {storyImages.map((img, idx) => (
-                        <figure key={idx} className="space-y-2">
-                          <img
-                            src={`${GCS_IMAGE_BASE}/${story.lesson_code}/${img.filename}`}
-                            alt={img.caption ?? `圖 ${idx + 1}`}
-                            loading="lazy"
-                            className="w-full rounded-lg border border-outline-variant bg-surface"
-                            onError={(e) => {
-                              // Graceful fallback: hide broken image
-                              const el = e.currentTarget;
-                              el.style.display = 'none';
-                            }}
-                          />
+                        <figure key={idx} className="flex flex-col items-stretch shrink-0 h-full" style={{ width: 'clamp(180px, 22vw, 260px)' }}>
+                          <div className="flex-1 min-h-0">
+                            <ZoomableImage
+                              src={`${GCS_IMAGE_BASE}/${story.lesson_code}/${img.filename.split('/').pop()}`}
+                              alt={img.caption ?? `圖 ${idx + 1}`}
+                              caption={img.caption}
+                              className="h-full"
+                            />
+                          </div>
                           {img.caption && (
-                            <figcaption className="text-xs text-on-surface-variant">
+                            <figcaption className="text-[11px] text-on-surface-variant mt-1.5 line-clamp-2 shrink-0">
                               {img.caption}
                             </figcaption>
                           )}
                         </figure>
                       ))}
                     </div>
-                  )}
-                </div>
+                  </div>
+                )}
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
           {/* ── Right: Exercise panel ─────────────────────────────── */}
-          <div className={`${isGraphicText ? 'lg:col-span-4' : 'md:col-span-5 lg:col-span-5'} min-h-0 flex flex-col`}>
+          <div className={`${isGraphicText ? 'md:col-span-7' : 'md:col-span-5 lg:col-span-5'} min-h-0 flex flex-col`}>
 
             <div className="shrink-0">{renderTabs()}</div>
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex-1 min-h-0 overflow-y-auto custom-scrollbar">

--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -15,6 +15,7 @@ import React, { useMemo } from 'react';
 import { Story } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import FloatingAIHelper from './FloatingAIHelper';
+import ZoomableImage from '../ui/ZoomableImage';
 
 interface ComprehensionLayoutProps {
   story: Story;
@@ -43,10 +44,11 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
 
   const storyText = useMemo(() => story.content.join('\n'), [story.content]);
 
-  // ── #1341 plugin-pattern dispatch: graphic-text adds middle image pane ────
-  // For G7-L28~30 (圖文整合策略): 3-pane (story 4 / images 4 / exercise 4)
-  // For other lessons: 2-pane (story 7 / exercise 5) — unchanged
-  // #1416 basename fix needs frontend rebuild (detect-changes skipped prior staging deploys)
+  // ── #1504 layout decongestion: graphic-text now stacks 課文 + 圖文 in the
+  // left column instead of a third middle panel (Young 5/8 review: "電梯超
+  // 載"). Right panel takes col-span-7 so the structure table has breathing
+  // room while answering. Click any image to open a fullscreen zoom modal.
+  // #1341 introduced the 3-pane variant this replaces.
   const isGraphicText = story.layout_mode === 'graphic-text';
   const storyImages = story.images ?? [];
   const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
@@ -62,10 +64,13 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
         */}
         <div className="w-full h-full grid grid-cols-1 md:grid-cols-12 grid-rows-[1fr] gap-6">
 
-          {/* ── Left: Story text card ─────────────────────────────────────────── */}
-          <div className={`${isGraphicText ? 'md:col-span-4' : 'md:col-span-7'} min-h-0 flex`}>
+          {/* ── Left column ──────────────────────────────────────────────────── */
+          /* graphic-text: text top + images bottom (stacked, 60/40 split)        */
+          /* standard:     text only, col-span-7                                  */}
+          <div className={`${isGraphicText ? 'md:col-span-5' : 'md:col-span-7'} min-h-0 flex flex-col gap-4`}>
 
-            <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full min-h-0">
+            {/* Story text card */}
+            <div className={`bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full min-h-0 ${isGraphicText ? 'flex-[3]' : 'flex-1'}`}>
               <div className="flex items-center gap-2 mb-4 shrink-0">
                 <span className="material-symbols-outlined text-accent text-xl">menu_book</span>
                 <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">
@@ -110,55 +115,54 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
                 </div>
               )}
             </div>
-          </div>
 
-          {/* ── Right: Exercise panel ─────────────────────────────────────────── */}
-          {/* ── Middle: Image gallery (graphic-text mode only) ─────── #1341 */}
-          {isGraphicText && (
-            <div data-testid="graphic-text-image-pane" className="md:col-span-4 min-h-0 flex">
-              <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full min-h-0">
-                <div className="flex items-center gap-2 mb-4 shrink-0">
-                  <span className="material-symbols-outlined text-accent text-xl">photo_library</span>
-                  <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">
+            {/* Image strip (graphic-text only) — horizontally scrollable, click to zoom */}
+            {isGraphicText && (
+              <div
+                data-testid="graphic-text-image-pane"
+                className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5 flex flex-col w-full min-h-0 flex-[2]"
+              >
+                <div className="flex items-center gap-2 mb-3 shrink-0">
+                  <span className="material-symbols-outlined text-accent text-lg">photo_library</span>
+                  <span className="font-headline font-bold text-on-surface text-xs uppercase tracking-wider">
                     圖文對照
                   </span>
                   <span className="text-xs text-on-surface-variant ml-2">{storyImages.length} 張</span>
+                  <span className="text-[11px] text-on-surface-variant ml-auto hidden md:inline">點圖可放大</span>
                 </div>
-                <div className="flex-1 min-h-0 overflow-y-auto pr-2 custom-scrollbar">
-                  {storyImages.length === 0 ? (
-                    <div className="flex items-center justify-center h-48 text-on-surface-variant text-sm">
-                      暫無圖片
-                    </div>
-                  ) : (
-                    <div className="grid grid-cols-1 gap-4">
+                {storyImages.length === 0 ? (
+                  <div className="flex-1 min-h-0 flex items-center justify-center text-on-surface-variant text-sm">
+                    暫無圖片
+                  </div>
+                ) : (
+                  <div className="flex-1 min-h-0 overflow-x-auto custom-scrollbar">
+                    <div className="flex gap-3 h-full pr-2">
                       {storyImages.map((img, idx) => (
-                        <figure key={idx} className="space-y-2">
-                          <img
-                            src={`${GCS_IMAGE_BASE}/${story.lesson_code}/${img.filename.split('/').pop()}`}
-                            alt={img.caption ?? `圖 ${idx + 1}`}
-                            loading="lazy"
-                            className="w-full rounded-lg border border-outline-variant bg-surface"
-                            onError={(e) => {
-                              const el = e.currentTarget;
-                              el.style.display = 'none';
-                            }}
-                          />
+                        <figure key={idx} className="flex flex-col items-stretch shrink-0 h-full" style={{ width: 'clamp(180px, 22vw, 260px)' }}>
+                          <div className="flex-1 min-h-0">
+                            <ZoomableImage
+                              src={`${GCS_IMAGE_BASE}/${story.lesson_code}/${img.filename.split('/').pop()}`}
+                              alt={img.caption ?? `圖 ${idx + 1}`}
+                              caption={img.caption}
+                              className="h-full"
+                            />
+                          </div>
                           {img.caption && (
-                            <figcaption className="text-xs text-on-surface-variant">
+                            <figcaption className="text-[11px] text-on-surface-variant mt-1.5 line-clamp-2 shrink-0">
                               {img.caption}
                             </figcaption>
                           )}
                         </figure>
                       ))}
                     </div>
-                  )}
-                </div>
+                  </div>
+                )}
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
           {/* ── Right: Exercise panel ─────────────────────────────────────────── */}
-          <div className={`${isGraphicText ? 'md:col-span-4' : 'md:col-span-5'} min-h-0 flex flex-col`}>
+          <div className={`${isGraphicText ? 'md:col-span-7' : 'md:col-span-5'} min-h-0 flex flex-col`}>
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex-1 min-h-0 overflow-y-auto custom-scrollbar">
               {children}
             </div>

--- a/frontend/src/components/ui/ZoomableImage.tsx
+++ b/frontend/src/components/ui/ZoomableImage.tsx
@@ -1,0 +1,91 @@
+/**
+ * ZoomableImage — thumbnail that opens a fullscreen modal on click.
+ *
+ * Used by graphic-text comprehension layouts (#1504) so cramped image
+ * thumbnails stay viewable while answering on the right, then can be
+ * inspected at full size on demand.
+ *
+ * Esc + backdrop click close the modal. Body scroll is locked while open.
+ */
+import React, { useEffect, useState } from 'react';
+
+interface ZoomableImageProps {
+  src: string;
+  alt: string;
+  caption?: string;
+  className?: string;
+}
+
+const ZoomableImage: React.FC<ZoomableImageProps> = ({ src, alt, caption, className }) => {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('keydown', onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className={`group relative block w-full overflow-hidden rounded-lg border border-outline-variant bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${className ?? ''}`}
+        aria-label={`放大圖片：${alt}`}
+      >
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          className="w-full h-full object-contain transition-transform duration-200 group-hover:scale-[1.02]"
+          onError={(e) => { e.currentTarget.style.display = 'none'; }}
+        />
+        <span className="pointer-events-none absolute top-1.5 right-1.5 inline-flex items-center justify-center w-7 h-7 rounded-full bg-on-surface/60 text-white opacity-0 group-hover:opacity-100 transition-opacity">
+          <span className="material-symbols-outlined text-base">zoom_in</span>
+        </span>
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={alt}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 p-4 md:p-8 animate-fade-in"
+          onClick={() => setOpen(false)}
+        >
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setOpen(false); }}
+            className="absolute top-4 right-4 w-11 h-11 rounded-full bg-white/15 hover:bg-white/25 text-white flex items-center justify-center transition-colors"
+            aria-label="關閉"
+          >
+            <span className="material-symbols-outlined">close</span>
+          </button>
+          <figure
+            className="max-w-6xl w-full max-h-full flex flex-col items-center gap-3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img
+              src={src}
+              alt={alt}
+              className="max-h-[80vh] w-auto max-w-full object-contain rounded-lg shadow-2xl"
+            />
+            {caption && (
+              <figcaption className="text-sm text-white/90 text-center max-w-3xl">
+                {caption}
+              </figcaption>
+            )}
+          </figure>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ZoomableImage;

--- a/frontend/src/components/ui/ZoomableImage.tsx
+++ b/frontend/src/components/ui/ZoomableImage.tsx
@@ -7,7 +7,8 @@
  *
  * Esc + backdrop click close the modal. Body scroll is locked while open.
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 
 interface ZoomableImageProps {
   src: string;
@@ -18,6 +19,11 @@ interface ZoomableImageProps {
 
 const ZoomableImage: React.FC<ZoomableImageProps> = ({ src, alt, caption, className }) => {
   const [open, setOpen] = useState(false);
+  const [imgError, setImgError] = useState(false);
+
+  // WAI-ARIA Dialog focus management — trap Tab inside modal, restore focus on close.
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, open);
 
   useEffect(() => {
     if (!open) return;
@@ -35,24 +41,35 @@ const ZoomableImage: React.FC<ZoomableImageProps> = ({ src, alt, caption, classN
     <>
       <button
         type="button"
-        onClick={() => setOpen(true)}
-        className={`group relative block w-full overflow-hidden rounded-lg border border-outline-variant bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${className ?? ''}`}
-        aria-label={`放大圖片：${alt}`}
+        onClick={() => { if (!imgError) setOpen(true); }}
+        disabled={imgError}
+        className={`group relative block w-full overflow-hidden rounded-lg border border-outline-variant bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed ${className ?? ''}`}
+        aria-label={imgError ? `${alt}（圖片載入失敗）` : `放大圖片：${alt}`}
       >
-        <img
-          src={src}
-          alt={alt}
-          loading="lazy"
-          className="w-full h-full object-contain transition-transform duration-200 group-hover:scale-[1.02]"
-          onError={(e) => { e.currentTarget.style.display = 'none'; }}
-        />
-        <span className="pointer-events-none absolute top-1.5 right-1.5 inline-flex items-center justify-center w-7 h-7 rounded-full bg-on-surface/60 text-white opacity-0 group-hover:opacity-100 transition-opacity">
-          <span className="material-symbols-outlined text-base">zoom_in</span>
-        </span>
+        {imgError ? (
+          <div className="w-full h-full min-h-[80px] flex flex-col items-center justify-center gap-1 text-on-surface-variant/50">
+            <span className="material-symbols-outlined text-3xl">broken_image</span>
+            <span className="text-[10px]">圖片載入失敗</span>
+          </div>
+        ) : (
+          <>
+            <img
+              src={src}
+              alt={alt}
+              loading="lazy"
+              className="w-full h-full object-contain transition-transform duration-200 group-hover:scale-[1.02]"
+              onError={() => setImgError(true)}
+            />
+            <span className="pointer-events-none absolute top-1.5 right-1.5 inline-flex items-center justify-center w-7 h-7 rounded-full bg-on-surface/60 text-white opacity-0 group-hover:opacity-100 transition-opacity">
+              <span className="material-symbols-outlined text-base">zoom_in</span>
+            </span>
+          </>
+        )}
       </button>
 
       {open && (
         <div
+          ref={dialogRef}
           role="dialog"
           aria-modal="true"
           aria-label={alt}


### PR DESCRIPTION
## Summary

5/8 會議實機 walkthrough G7-L29 `/learn/1109/story-structure` 發現「課文 + 圖文 + 重點表」三欄各占 col-span-4 過擠（Young 比喻「電梯超載」），圖太小、捲動時看不到、文字被擠壓。教授核心需求：寫題時要**同時看到分開的文字與圖片**，但目前題目欄也被壓縮。

採方案 **C + B**：

- **2 欄取代 3 欄**：左 col-span-5、右 col-span-7
- **左欄上下分屏**：上 課文 (~60%)、下 圖文橫向滑動條 (~40%)；題目右側獨占 col-span-7 不被擠
- **圖片放大 modal**：新增 `ZoomableImage`（點圖開全螢幕，Esc / 背景點擊關閉，鎖定 body scroll）

影響範圍：`ComprehensionLayout`（story-structure / strategy-exercise）+ `ComprehensionChat`（課文理解 chat tabs）。standard layout 不變。

## 變更檔案

| 檔案 | 內容 |
|------|------|
| `frontend/src/components/ui/ZoomableImage.tsx` | 新增：縮圖+全螢幕 modal，含 Esc / 背景點擊關閉、body scroll lock |
| `frontend/src/components/reading-steps/ComprehensionLayout.tsx` | graphic-text 模式改 2 欄；左欄垂直分上下（課文 + 圖文 strip）；col-span 4-4-4 → 5-7 |
| `frontend/src/components/reading-steps/ComprehensionChat.tsx` | 同上模式套到 chat tabs 版本 |

## Acceptance（issue #1504）

- [x] 學生在 G7-L29 寫題時能同時看見圖 + 文不擠壓 — 圖文移到左下，題目獨佔右側 col-span-7
- [x] Mobile / desktop 都不出現雙重捲軸 — 左欄 inner-scroll；圖文 strip 改 overflow-x-auto；行動裝置 `< md` 自動降為單欄直疊
- [ ] 教授實機 demo 確認可用 — 待 preview 部署後 demo

## Test plan

- [ ] 進 `/learn/1109/story-structure`（G7-L29）：左上看到課文、左下看到 4 張圖橫向 strip、右側為文章重點表（明顯比之前寬）
- [ ] 點任一張圖 → 開啟全螢幕 modal，按 Esc / 點背景關閉
- [ ] 切到同課的 strategy-exercise / 課文理解 chat，layout 一致
- [ ] 切到非 graphic-text 課文（如 G3-L01）：layout 維持 7-5 不變
- [ ] 手機尺寸（< md）：所有區塊直疊單欄，無水平捲軸
- [ ] 沒有 \`story.images\` 的 graphic-text 課文（理論上不該存在）：圖文區顯示「暫無圖片」

Refs #1504, #1341 (3-pane 由本 PR 取代)

🤖 Generated with [Claude Code](https://claude.com/claude-code)