### PR TITLE
fix(story-structure): 文章重點表黃/灰標籤改橫向 banner (Fixes #1534)

### DIFF
--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -366,38 +366,41 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
   // Renders a value/input for either a top-level row or a sub_row. Extracted
   // so the new card layout can reuse the same logic for both shapes without
   // the prior table colSpan branching.
-  const renderCellContent = (
-    cell: StructureRow | StructureSubRow,
-    rowIdx: number,
-    subIdx?: number,
-  ) => {
-    if (cell.interactive_type === 'display') {
-      return <span className="text-gray-800 leading-relaxed">{cell.value}</span>;
-    }
-    const key = answerKey(rowIdx, subIdx);
-    const gradeItem = submitted ? findGradeItem(gradeResults, rowIdx, subIdx) : undefined;
-    if (cell.interactive_type === 'checkbox') {
+  const renderCellContent = useCallback(
+    (
+      cell: StructureRow | StructureSubRow,
+      rowIdx: number,
+      subIdx?: number,
+    ) => {
+      if (cell.interactive_type === 'display') {
+        return <span className="text-gray-800 leading-relaxed">{cell.value}</span>;
+      }
+      const key = answerKey(rowIdx, subIdx);
+      const gradeItem = submitted ? findGradeItem(gradeResults, rowIdx, subIdx) : undefined;
+      if (cell.interactive_type === 'checkbox') {
+        return (
+          <CheckboxCell
+            options={cell.options ?? []}
+            selected={Array.isArray(answers[key]) ? (answers[key] as number[]) : []}
+            onChange={(v) => setAnswer(key, v)}
+            submitted={submitted}
+            gradeItem={gradeItem}
+            correctOptions={cell.correct_options}
+          />
+        );
+      }
       return (
-        <CheckboxCell
-          options={cell.options ?? []}
-          selected={Array.isArray(answers[key]) ? (answers[key] as number[]) : []}
+        <FillBlankCell
+          hint={cell.hint}
+          value={typeof answers[key] === 'string' ? (answers[key] as string) : ''}
           onChange={(v) => setAnswer(key, v)}
           submitted={submitted}
           gradeItem={gradeItem}
-          correctOptions={cell.correct_options}
         />
       );
-    }
-    return (
-      <FillBlankCell
-        hint={cell.hint}
-        value={typeof answers[key] === 'string' ? (answers[key] as string) : ''}
-        onChange={(v) => setAnswer(key, v)}
-        submitted={submitted}
-        gradeItem={gradeItem}
-      />
-    );
-  };
+    },
+    [answers, submitted, gradeResults, setAnswer],
+  );
 
   return (
     <div className="overflow-hidden rounded-xl border-2 border-gray-300 shadow-sm max-w-2xl mx-auto">
@@ -434,10 +437,10 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
         {rows.map((row, rowIdx) => {
           const hasSubRows = !!(row.sub_rows && row.sub_rows.length > 0);
           const topLevelEmptyDisplay =
-            !hasSubRows && row.interactive_type === 'display' && !row.value;
+            !hasSubRows && row.interactive_type === 'display' && !row.value?.trim();
 
           return (
-            <section key={rowIdx}>
+            <section key={`${rowIdx}-${row.label}`}>
               {/* Yellow header — row.label as horizontal banner */}
               <div className="bg-amber-50 px-4 py-2.5 font-bold text-gray-800 leading-snug">
                 {row.label}
@@ -445,7 +448,7 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
 
               {hasSubRows ? (
                 <div className="divide-y divide-gray-200">
-                  {row.sub_rows!.map((sub, subIdx) => (
+                  {(row.sub_rows ?? []).map((sub, subIdx) => (
                     <div key={subIdx}>
                       {/* Gray sub-label — horizontal banner */}
                       <div className="bg-gray-50 px-4 py-2 text-sm font-semibold text-gray-600 leading-snug">

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -362,10 +362,6 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
 
   const { rows } = structure;
 
-  // ── Cell renderer (#1534) ─────────────────────────────────────────────────
-  // Renders a value/input for either a top-level row or a sub_row. Extracted
-  // so the new card layout can reuse the same logic for both shapes without
-  // the prior table colSpan branching.
   const renderCellContent = useCallback(
     (
       cell: StructureRow | StructureSubRow,
@@ -420,19 +416,7 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
         )}
       </div>
 
-      {/* Rows — card layout (#1534) ───────────────────────────────────────
-          Replaces the prior <table> with `w-20` / `w-16` label columns,
-          which squeezed Chinese labels into single-character vertical
-          stacks. Each top-level row is now a stacked card:
-            - Yellow banner: row.label (full width, horizontal)
-            - Body (per sub_row if any, else single section):
-                · Gray banner: sub.label (only for sub_rows)
-                · Value / input area
-          A top-level row that is `display` with empty value AND no
-          sub_rows renders only the yellow banner — used for section
-          intro / leading question — so we don't leave a huge empty
-          value area below it (the original bug).
-      */}
+      {/* #1534: card layout — yellow row banner + per-sub_row body; bare banner when display with empty value (avoids huge blank cell). */}
       <div className="divide-y-2 divide-gray-200 text-base">
         {rows.map((row, rowIdx) => {
           const hasSubRows = !!(row.sub_rows && row.sub_rows.length > 0);
@@ -449,7 +433,7 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
               {hasSubRows ? (
                 <div className="divide-y divide-gray-200">
                   {(row.sub_rows ?? []).map((sub, subIdx) => (
-                    <div key={subIdx}>
+                    <div key={`${subIdx}-${sub.label}`}>
                       {/* Gray sub-label — horizontal banner */}
                       <div className="bg-gray-50 px-4 py-2 text-sm font-semibold text-gray-600 leading-snug">
                         {sub.label}

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -362,6 +362,43 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
 
   const { rows } = structure;
 
+  // ── Cell renderer (#1534) ─────────────────────────────────────────────────
+  // Renders a value/input for either a top-level row or a sub_row. Extracted
+  // so the new card layout can reuse the same logic for both shapes without
+  // the prior table colSpan branching.
+  const renderCellContent = (
+    cell: StructureRow | StructureSubRow,
+    rowIdx: number,
+    subIdx?: number,
+  ) => {
+    if (cell.interactive_type === 'display') {
+      return <span className="text-gray-800 leading-relaxed">{cell.value}</span>;
+    }
+    const key = answerKey(rowIdx, subIdx);
+    const gradeItem = submitted ? findGradeItem(gradeResults, rowIdx, subIdx) : undefined;
+    if (cell.interactive_type === 'checkbox') {
+      return (
+        <CheckboxCell
+          options={cell.options ?? []}
+          selected={Array.isArray(answers[key]) ? (answers[key] as number[]) : []}
+          onChange={(v) => setAnswer(key, v)}
+          submitted={submitted}
+          gradeItem={gradeItem}
+          correctOptions={cell.correct_options}
+        />
+      );
+    }
+    return (
+      <FillBlankCell
+        hint={cell.hint}
+        value={typeof answers[key] === 'string' ? (answers[key] as string) : ''}
+        onChange={(v) => setAnswer(key, v)}
+        submitted={submitted}
+        gradeItem={gradeItem}
+      />
+    );
+  };
+
   return (
     <div className="overflow-hidden rounded-xl border-2 border-gray-300 shadow-sm max-w-2xl mx-auto">
       {/* Header */}
@@ -380,125 +417,55 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
         )}
       </div>
 
-      {/* Table */}
-      <table className="w-full text-base" style={{ borderCollapse: 'collapse' }}>
-        <tbody>
-          {rows.map((row, rowIdx) =>
-            row.sub_rows && row.sub_rows.length > 0 ? (
-              row.sub_rows.map((sub, subIdx) => {
-                const key = answerKey(rowIdx, subIdx);
-                const gradeItem = submitted
-                  ? findGradeItem(gradeResults, rowIdx, subIdx)
-                  : undefined;
+      {/* Rows — card layout (#1534) ───────────────────────────────────────
+          Replaces the prior <table> with `w-20` / `w-16` label columns,
+          which squeezed Chinese labels into single-character vertical
+          stacks. Each top-level row is now a stacked card:
+            - Yellow banner: row.label (full width, horizontal)
+            - Body (per sub_row if any, else single section):
+                · Gray banner: sub.label (only for sub_rows)
+                · Value / input area
+          A top-level row that is `display` with empty value AND no
+          sub_rows renders only the yellow banner — used for section
+          intro / leading question — so we don't leave a huge empty
+          value area below it (the original bug).
+      */}
+      <div className="divide-y-2 divide-gray-200 text-base">
+        {rows.map((row, rowIdx) => {
+          const hasSubRows = !!(row.sub_rows && row.sub_rows.length > 0);
+          const topLevelEmptyDisplay =
+            !hasSubRows && row.interactive_type === 'display' && !row.value;
 
-                return (
-                  <tr
-                    key={`${rowIdx}-${subIdx}`}
-                    style={{ borderBottom: '1.5px solid #d1d5db' }}
-                  >
-                    {subIdx === 0 && (
-                      <td
-                        rowSpan={row.sub_rows!.length}
-                        className="bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center align-middle w-20"
-                        style={{ borderRight: '1.5px solid #d1d5db' }}
-                      >
-                        {row.label}
-                      </td>
-                    )}
-                    <td
-                      className="bg-gray-50 px-3 py-3 font-semibold text-gray-600 text-center w-16"
-                      style={{ borderRight: '1.5px solid #d1d5db' }}
-                    >
-                      {sub.label}
-                    </td>
-                    <td className="px-4 py-3 text-gray-800 leading-relaxed">
-                      {sub.interactive_type === 'display' ? (
-                        <span>{sub.value}</span>
-                      ) : sub.interactive_type === 'checkbox' ? (
-                        <CheckboxCell
-                          options={sub.options ?? []}
-                          selected={
-                            Array.isArray(answers[key])
-                              ? (answers[key] as number[])
-                              : []
-                          }
-                          onChange={(v) => setAnswer(key, v)}
-                          submitted={submitted}
-                          gradeItem={gradeItem}
-                          correctOptions={sub.correct_options}
-                        />
-                      ) : (
-                        <FillBlankCell
-                          hint={sub.hint}
-                          value={
-                            typeof answers[key] === 'string'
-                              ? (answers[key] as string)
-                              : ''
-                          }
-                          onChange={(v) => setAnswer(key, v)}
-                          submitted={submitted}
-                          gradeItem={gradeItem}
-                        />
-                      )}
-                    </td>
-                  </tr>
-                );
-              })
-            ) : (
-              <tr key={rowIdx} style={{ borderBottom: '1.5px solid #d1d5db' }}>
-                <td
-                  className="bg-amber-50 px-4 py-3 font-bold text-gray-800 text-center w-20"
-                  style={{ borderRight: '1.5px solid #d1d5db' }}
-                >
-                  {row.label}
-                </td>
-                {row.interactive_type === 'display' ? (
-                  <td colSpan={2} className="px-5 py-3 text-gray-800 leading-relaxed">
-                    {row.value}
-                  </td>
-                ) : (
-                  <td colSpan={2} className="px-4 py-3">
-                    {row.interactive_type === 'checkbox' ? (
-                      <CheckboxCell
-                        options={row.options ?? []}
-                        selected={
-                          Array.isArray(answers[answerKey(rowIdx)])
-                            ? (answers[answerKey(rowIdx)] as number[])
-                            : []
-                        }
-                        onChange={(v) => setAnswer(answerKey(rowIdx), v)}
-                        submitted={submitted}
-                        gradeItem={
-                          submitted
-                            ? findGradeItem(gradeResults, rowIdx)
-                            : undefined
-                        }
-                        correctOptions={row.correct_options}
-                      />
-                    ) : (
-                      <FillBlankCell
-                        hint={row.hint}
-                        value={
-                          typeof answers[answerKey(rowIdx)] === 'string'
-                            ? (answers[answerKey(rowIdx)] as string)
-                            : ''
-                        }
-                        onChange={(v) => setAnswer(answerKey(rowIdx), v)}
-                        submitted={submitted}
-                        gradeItem={
-                          submitted
-                            ? findGradeItem(gradeResults, rowIdx)
-                            : undefined
-                        }
-                      />
-                    )}
-                  </td>
-                )}
-              </tr>
-            ),
-          )}
-        </tbody>
-      </table>
+          return (
+            <section key={rowIdx}>
+              {/* Yellow header — row.label as horizontal banner */}
+              <div className="bg-amber-50 px-4 py-2.5 font-bold text-gray-800 leading-snug">
+                {row.label}
+              </div>
+
+              {hasSubRows ? (
+                <div className="divide-y divide-gray-200">
+                  {row.sub_rows!.map((sub, subIdx) => (
+                    <div key={subIdx}>
+                      {/* Gray sub-label — horizontal banner */}
+                      <div className="bg-gray-50 px-4 py-2 text-sm font-semibold text-gray-600 leading-snug">
+                        {sub.label}
+                      </div>
+                      <div className="px-4 py-3">
+                        {renderCellContent(sub, rowIdx, subIdx)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : topLevelEmptyDisplay ? null : (
+                <div className="px-4 py-3">
+                  {renderCellContent(row, rowIdx)}
+                </div>
+              )}
+            </section>
+          );
+        })}
+      </div>
 
       {/* Submit / Result bar */}
       <div className="px-5 py-4 border-t-2 border-gray-200 bg-gray-50">


### PR DESCRIPTION
## Summary

PR #1531 把 \`/learn/.../story-structure\` 右欄改 \`col-span-7\` 後，內層 StoryStructureTable 用 \`<table>\` 配 \`w-20\` (80px) 黃色 label + \`w-16\` (64px) 灰色 sub-label 直欄，中文長標題（如「都是八哥，為什麼命運不一樣？」14 字）在 80px 寬被擠成**單字直排**極難閱讀。最上面那一格無 sub_rows 時 \`colSpan=2\` 又留下空白超大 value 區，視覺比例失衡。

改寫為 **card 化堆疊佈局**：每個 row 是一個 \`<section>\`，黃色 banner 在上（橫向、佔滿欄寬），sub_rows 各自有灰色子標 + value/input 區。**無 sub_rows + display + 空 value 的 row 只渲染 banner**（標題型 row 不再留下空白）。

## 變更檔案

| 檔案 | 內容 |
|------|------|
| \`frontend/src/components/reading-steps/StoryStructureTable.tsx\` | \`<table>\` → \`<div>\`-based card 堆疊；抽出 \`renderCellContent\` helper 共用 display/checkbox/fill_blank 分支 |

## 範圍

- 純前端 layout 改寫
- API / data shape（\`row.sub_rows\` / \`interactive_type\`）完全相容
- 既有 score / submit / grade / fill_blank / checkbox 行為不動
- \`max-w-2xl mx-auto\` 包裝保留
- 適用所有 genre（記敘文 / 說明文 / 詩 / 古文）的 structure 模板

## Acceptance（issue #1534）

- [x] 黃色 / 灰色標籤改為橫向 banner — \`bg-amber-50\` / \`bg-gray-50\` 佔滿全寬
- [x] top row 無 sub_rows + display + empty value 時不顯示空白 value 區 — \`topLevelEmptyDisplay\` 早退邏輯
- [x] 所有 genre 的 StoryStructure 視覺一致 — 統一 card 規則
- [ ] 既有 \`StoryStructureTable.test.tsx\` 測試 — 本來就因 useAuth 沒包 AuthProvider 全部 fail（pre-existing，與本 PR 無關，已用 \`git stash\` 對比驗證）
- [x] PR #1531 的橫向 col-span-7 仍生效（不互相干擾）— layout 元件分層獨立

## Test plan

- [ ] 進 \`/learn/<G7-L29 storyId>/story-structure\`：所有 row 黃色 banner 橫向、長中文標題不再直排
- [ ] top row「從四張圖，看地球暖化的現象」只顯示黃色 banner，沒有底下空白區
- [ ] 主題 row：黃色「主題」banner → 灰色「文章探討的核心問題是什麼？」banner → 下方 fill_blank 輸入框
- [ ] checkbox 題型仍可勾選
- [ ] 提交後分數 / feedback / correct mark 正確顯示
- [ ] 其他 genre 課文（如記敘文、詩）也視覺一致
- [ ] TypeScript build pass — vite build 5.13s ✅

Refs #1534, #1531, #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)