### PR TITLE
fix(story-structure): move renderCellContent useCallback before early returns (Fixes #1536)

### DIFF
--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -342,26 +342,8 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
   const gradeResults = gradeResult?.results ?? [];
   const score = gradeResult?.score ?? 0;
 
-  // ── Render ─────────────────────────────────────────────────────────────────
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center p-8 text-gray-400 text-sm">
-        <span className="animate-spin mr-2">⏳</span> 正在整理文章重點…
-      </div>
-    );
-  }
-
-  if (fetchError || !structure) {
-    return (
-      <div className="p-4 text-sm text-red-500 text-center">
-        無法載入文章重點表，請重新整理頁面
-      </div>
-    );
-  }
-
-  const { rows } = structure;
-
+  // renderCellContent must be declared BEFORE any early returns to satisfy Rules of Hooks.
+  // When loading=true or structure=null, this hook still runs but is never called.
   const renderCellContent = useCallback(
     (
       cell: StructureRow | StructureSubRow,
@@ -397,6 +379,26 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
     },
     [answers, submitted, gradeResults, setAnswer],
   );
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8 text-gray-400 text-sm">
+        <span className="animate-spin mr-2">⏳</span> 正在整理文章重點…
+      </div>
+    );
+  }
+
+  if (fetchError || !structure) {
+    return (
+      <div className="p-4 text-sm text-red-500 text-center">
+        無法載入文章重點表，請重新整理頁面
+      </div>
+    );
+  }
+
+  const { rows } = structure;
 
   return (
     <div className="overflow-hidden rounded-xl border-2 border-gray-300 shadow-sm max-w-2xl mx-auto">


### PR DESCRIPTION
Fixes #1536

## Root cause

PR #1535 (see second commit "apply review feedback") wrapped `renderCellContent` in `useCallback` as requested in code review, but placed it **after** the two early returns:

```tsx
if (loading) { return ... }                    // early return ← line 347
if (fetchError || !structure) { return ... }   // early return ← line 355

const { rows } = structure;
const renderCellContent = useCallback(...)     // BUG: hook after conditional return
```

React's Rules of Hooks require hooks to be called in the same order on every render. With the hook after early returns:
- Render 1: `loading=true` → early exit → `useCallback` **not** called → 0 hooks at this position
- Render 2: `loading=false` → `useCallback` **called** → 1 hook at this position
- Result: React error #310 (Rendered more hooks than during the previous render) → step 8 crashes

## Fix (Option A)

Move `renderCellContent = useCallback(...)` to **before** `if (loading)`. The closure over `answers`/`submitted`/`gradeResults` is still valid — these values are correctly initialized even when `loading=true`. The callback is never *called* during the loading/error render path, so there is no behavioral impact.

Hook order after fix:
```
useEffect          ← line 228
setAnswer          ← line 245  (useCallback)
buildAnswerPayload ← line 250  (useCallback)
handleSubmit       ← line 295  (useCallback)
renderCellContent  ← line 347  (useCallback) ← moved here
if (loading)       ← line 385  (early return)
if (fetchError)    ← line 393  (early return)
```

## Test plan

- [ ] Open any G7 lesson → step 8 文章重點表 loads without React error #310
- [ ] Fill in answers + submit → grading works correctly
- [ ] Verify step 8 renders on first load (no retry needed)
- [ ] `npm run build` passes with no TypeScript errors

## Changes

- `frontend/src/components/reading-steps/StoryStructureTable.tsx` — move `renderCellContent useCallback` 22 lines up, before early returns. Zero logic change.

## Verification

- `npm run build` ✅ (vite build clean, 65 modules, no TS errors)
- Hook order manually verified: all 4 `useCallback` before both early returns

Refs: #1535 (introduced the bug in "apply review feedback" commit)