### PR TITLE
fix(story-structure): VITE_API_URL fallback 改用 ?? 與專案 convention 一致 (Fixes #1533)

### DIFF
--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -223,7 +223,7 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
   const [submitting, setSubmitting] = useState(false);
   const [gradeResult, setGradeResult] = useState<GradeResult | null>(null);
 
-  const API_BASE = import.meta.env.VITE_API_URL || '';
+  const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
   useEffect(() => {
     setLoading(true);


### PR DESCRIPTION
Fixes #1533

## Root cause

`StoryStructureTable.tsx:226` 使用 `||` 而非 `??`，當本地未設定 `VITE_API_URL`（預期狀態）時，空字串 fallback 導致 fetch 打到 frontend dev server（port 3000）而非 backend（port 8000）→ 404 → 顯示錯誤訊息。

## 修改內容

```diff
- const API_BASE = import.meta.env.VITE_API_URL || '';
+ const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
```

與專案其他 24 個檔案（`api.ts`, `authApi.ts`, `teacherApi.ts` 等）的 convention 一致。

## 雲端影響

- **不受影響**：Cloud Run staging / production 的 `VITE_API_URL` 一定有設，`??` 右側的 fallback 不會生效。
- **本地開發修復**：未設 `VITE_API_URL` 時，正確 fallback 到 `http://localhost:8000`。

## Scope

只改 `StoryStructureTable.tsx` 一行，不動其他檔案（`PrivacyPolicy.tsx` / `teacherTextsApi.ts` 的同類問題另開 issue 處理）。

## Build

`npm run build` 成功，2605 modules transformed，0 errors。