### PR TITLE
refactor(comprehension): extract GraphicTextImageStrip shared component (Fixes #1532)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -13,7 +13,7 @@ import FloatingAIHelper from './FloatingAIHelper';
 import StrategyExercise from './StrategyExercise';
 import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStorageScope';
 import ToolboxCompletionActions from '../tools/ToolboxCompletionActions';
-import ZoomableImage from '../ui/ZoomableImage';
+import GraphicTextImageStrip from './GraphicTextImageStrip';
 
 interface ComprehensionChatProps {
   story: Story;
@@ -277,8 +277,6 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
   // answering. Click any image to open a fullscreen zoom modal.
   // #1341 introduced the 3-pane variant this replaces.
   const isGraphicText = story.layout_mode === 'graphic-text';
-  const storyImages = story.images ?? [];
-  const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
 
   return (
     <div
@@ -333,44 +331,10 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
             {/* Image strip (graphic-text only) — horizontally scrollable, click to zoom */}
             {isGraphicText && (
-              <div
-                data-testid="graphic-text-image-pane"
-                className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5 flex flex-col w-full min-h-0 flex-[2]"
-              >
-                <div className="flex items-center gap-2 mb-3 shrink-0">
-                  <span className="material-symbols-outlined text-accent text-lg">photo_library</span>
-                  <span className="font-headline font-bold text-on-surface text-xs uppercase tracking-wider">圖文對照</span>
-                  <span className="text-xs text-on-surface-variant ml-2">{storyImages.length} 張</span>
-                  <span className="text-[11px] text-on-surface-variant ml-auto hidden md:inline">點圖可放大</span>
-                </div>
-                {storyImages.length === 0 ? (
-                  <div className="flex-1 min-h-0 flex items-center justify-center text-on-surface-variant text-sm">
-                    暫無圖片
-                  </div>
-                ) : (
-                  <div className="flex-1 min-h-0 overflow-x-auto custom-scrollbar">
-                    <div className="flex gap-3 h-full pr-2">
-                      {storyImages.map((img, idx) => (
-                        <figure key={idx} className="flex flex-col items-stretch shrink-0 h-full" style={{ width: 'clamp(180px, 22vw, 260px)' }}>
-                          <div className="flex-1 min-h-0">
-                            <ZoomableImage
-                              src={`${GCS_IMAGE_BASE}/${story.lesson_code}/${img.filename.split('/').pop()}`}
-                              alt={img.caption ?? `圖 ${idx + 1}`}
-                              caption={img.caption}
-                              className="h-full"
-                            />
-                          </div>
-                          {img.caption && (
-                            <figcaption className="text-[11px] text-on-surface-variant mt-1.5 line-clamp-2 shrink-0">
-                              {img.caption}
-                            </figcaption>
-                          )}
-                        </figure>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
+              <GraphicTextImageStrip
+                images={story.images ?? []}
+                lessonCode={story.lesson_code}
+              />
             )}
           </div>
 

--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -15,7 +15,7 @@ import React, { useMemo } from 'react';
 import { Story } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import FloatingAIHelper from './FloatingAIHelper';
-import ZoomableImage from '../ui/ZoomableImage';
+import GraphicTextImageStrip from './GraphicTextImageStrip';
 
 interface ComprehensionLayoutProps {
   story: Story;
@@ -50,8 +50,6 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
   // room while answering. Click any image to open a fullscreen zoom modal.
   // #1341 introduced the 3-pane variant this replaces.
   const isGraphicText = story.layout_mode === 'graphic-text';
-  const storyImages = story.images ?? [];
-  const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
 
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden bg-surface relative">
@@ -118,46 +116,10 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
 
             {/* Image strip (graphic-text only) — horizontally scrollable, click to zoom */}
             {isGraphicText && (
-              <div
-                data-testid="graphic-text-image-pane"
-                className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5 flex flex-col w-full min-h-0 flex-[2]"
-              >
-                <div className="flex items-center gap-2 mb-3 shrink-0">
-                  <span className="material-symbols-outlined text-accent text-lg">photo_library</span>
-                  <span className="font-headline font-bold text-on-surface text-xs uppercase tracking-wider">
-                    圖文對照
-                  </span>
-                  <span className="text-xs text-on-surface-variant ml-2">{storyImages.length} 張</span>
-                  <span className="text-[11px] text-on-surface-variant ml-auto hidden md:inline">點圖可放大</span>
-                </div>
-                {storyImages.length === 0 ? (
-                  <div className="flex-1 min-h-0 flex items-center justify-center text-on-surface-variant text-sm">
-                    暫無圖片
-                  </div>
-                ) : (
-                  <div className="flex-1 min-h-0 overflow-x-auto custom-scrollbar">
-                    <div className="flex gap-3 h-full pr-2">
-                      {storyImages.map((img, idx) => (
-                        <figure key={idx} className="flex flex-col items-stretch shrink-0 h-full" style={{ width: 'clamp(180px, 22vw, 260px)' }}>
-                          <div className="flex-1 min-h-0">
-                            <ZoomableImage
-                              src={`${GCS_IMAGE_BASE}/${story.lesson_code}/${img.filename.split('/').pop()}`}
-                              alt={img.caption ?? `圖 ${idx + 1}`}
-                              caption={img.caption}
-                              className="h-full"
-                            />
-                          </div>
-                          {img.caption && (
-                            <figcaption className="text-[11px] text-on-surface-variant mt-1.5 line-clamp-2 shrink-0">
-                              {img.caption}
-                            </figcaption>
-                          )}
-                        </figure>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
+              <GraphicTextImageStrip
+                images={story.images ?? []}
+                lessonCode={story.lesson_code}
+              />
             )}
           </div>
 

--- a/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
+++ b/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import ZoomableImage from '../ui/ZoomableImage';
+
+interface GraphicTextImageStripProps {
+  images: { filename: string; caption?: string }[];
+  lessonCode: string;
+}
+
+const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+
+const GraphicTextImageStrip: React.FC<GraphicTextImageStripProps> = ({ images, lessonCode }) => {
+  return (
+    <div
+      data-testid="graphic-text-image-pane"
+      className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5 flex flex-col w-full min-h-0 flex-[2]"
+    >
+      <div className="flex items-center gap-2 mb-3 shrink-0">
+        <span className="material-symbols-outlined text-accent text-lg">photo_library</span>
+        <span className="font-headline font-bold text-on-surface text-xs uppercase tracking-wider">
+          圖文對照
+        </span>
+        <span className="text-xs text-on-surface-variant ml-2">{images.length} 張</span>
+        <span className="text-[11px] text-on-surface-variant ml-auto hidden md:inline">點圖可放大</span>
+      </div>
+      {images.length === 0 ? (
+        <div className="flex-1 min-h-0 flex items-center justify-center text-on-surface-variant text-sm">
+          暫無圖片
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-x-auto custom-scrollbar">
+          <div className="flex gap-3 h-full pr-2">
+            {images.map((img, idx) => (
+              <figure
+                key={idx}
+                className="flex flex-col items-stretch shrink-0 h-full"
+                style={{ width: 'clamp(180px, 22vw, 260px)' }}
+              >
+                <div className="flex-1 min-h-0">
+                  <ZoomableImage
+                    src={`${GCS_IMAGE_BASE}/${lessonCode}/${img.filename.split('/').pop()}`}
+                    alt={img.caption ?? `圖 ${idx + 1}`}
+                    caption={img.caption}
+                    className="h-full"
+                  />
+                </div>
+                {img.caption && (
+                  <figcaption className="text-[11px] text-on-surface-variant mt-1.5 line-clamp-2 shrink-0">
+                    {img.caption}
+                  </figcaption>
+                )}
+              </figure>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GraphicTextImageStrip;


### PR DESCRIPTION
## Summary
- Extract shared graphic-text image strip into `GraphicTextImageStrip` component
- Replace duplicated inline strip blocks in `ComprehensionLayout` and `ComprehensionChat`
- Keep behavior and UI unchanged while centralizing future strip tweaks in one place

## Test plan
- [x] `cd frontend && npm run build`

Refs #1504
Related PR #1531
