### PR TITLE
fix(enrollment): unhide 加入班級 sidebar entry for students (Fixes #1542)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -379,11 +379,11 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
         { icon: '🏠', label: '主頁', path: '/student' },
         { icon: '📚', label: '圖書館', path: '/library' },
         { icon: '🏫', label: '班級作業', path: '/assignments', badge: pendingAssignmentCount },
+        { icon: '➕', label: '加入班級', path: '/join' },
         { icon: '📖', label: '學習紀錄', path: '/learning-history' },
         // Hidden: 成就 — merged into student home page (recent achievements strip + Lv banner) (#1163)
         // Hidden: 學習進度, 生字本, 對話記錄 — 整合到「班級作業」(#643)
         // Hidden: 我的班級 — merged into /assignments (#1146)
-        // Hidden: 加入班級 — students join via invite code, not sidebar (#838)
       ]
     : [];
 


### PR DESCRIPTION
## Summary
Unhides the existing Sidebar「加入班級」item so students with existing
classrooms can discover the join flow.

## Root cause
Backend /api/classrooms/join + /join page + joinClassroomByCode all
already exist. The Sidebar entry was hidden, leaving no nav path for
students who already have a class.

## Scope
Sidebar.tsx line ~386: unhide the existing join item

## Test plan
- [x] npm run build passes
- [ ] Manual: 小明 (already in 三年甲班・七年甲班) sees 加入班級 in sidebar
- [ ] Manual: click → /join page
- [ ] Manual: join "Audit Test 2026-05-11" via code → see new assignments

## Unblocks
- #1544 (bulk submissions verification)