### PR TITLE
fix(g7-layout): graphic-text column ratio to 2:1 left-right (Fixes #1552)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -65,7 +65,7 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
           {/* ── Left column ──────────────────────────────────────────────────── */
           /* graphic-text: text top + images bottom (stacked, 60/40 split)        */
           /* standard:     text only, col-span-7                                  */}
-          <div className={`${isGraphicText ? 'md:col-span-5' : 'md:col-span-7'} min-h-0 flex flex-col gap-4`}>
+          <div className={`${isGraphicText ? 'md:col-span-8' : 'md:col-span-7'} min-h-0 flex flex-col gap-4`}>
 
             {/* Story text card */}
             <div className={`bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full min-h-0 ${isGraphicText ? 'flex-[3]' : 'flex-1'}`}>
@@ -124,7 +124,7 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
           </div>
 
           {/* ── Right: Exercise panel ─────────────────────────────────────────── */}
-          <div className={`${isGraphicText ? 'md:col-span-7' : 'md:col-span-5'} min-h-0 flex flex-col`}>
+          <div className={`${isGraphicText ? 'md:col-span-4' : 'md:col-span-5'} min-h-0 flex flex-col`}>
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex-1 min-h-0 overflow-y-auto custom-scrollbar">
               {children}
             </div>


### PR DESCRIPTION
Fixes #1552

## Summary
- **Root cause**: PR #1531 set graphic-text left column to `col-span-5` and right column to `col-span-7`, which is inverted — course text + image strip ended up narrower than the question panel
- **Fix**: swap to `col-span-8` (left, 2/3) and `col-span-4` (right, 1/3) for graphic-text mode only
- Standard layout (`col-span-7` / `col-span-5`) is unchanged
- Mobile single-column stack preserved (no md: prefix = unaffected)

## Changed class
| Location | Before | After |
|----------|--------|-------|
| Left col (課文+圖文, line 68) | `md:col-span-5` | `md:col-span-8` |
| Right col (題目, line 127) | `md:col-span-7` | `md:col-span-4` |

## Test plan
- [ ] Open PR Preview URL at 1440px viewport
- [ ] Navigate to G7-L29 圖文整合 comprehension step
- [ ] Verify left panel (課文 + 圖文 strip) occupies ~2/3 width
- [ ] Verify right panel (題目) occupies ~1/3 width
- [ ] Resize to mobile (375px) — both panels stack vertically
- [ ] Confirm non-graphic-text lessons (standard layout) unaffected

Refs #1531 #1539