### PR TITLE
fix(g7-layout): graphic-text column ratio to 2:1 left-right (Fixes #1554)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -65,7 +65,7 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
           {/* ── Left column ──────────────────────────────────────────────────── */
           /* graphic-text: text top + images bottom (stacked, 60/40 split)        */
           /* standard:     text only, col-span-7                                  */}
-          <div className={`${isGraphicText ? 'md:col-span-5' : 'md:col-span-7'} min-h-0 flex flex-col gap-4`}>
+          <div className={`${isGraphicText ? 'md:col-span-8' : 'md:col-span-7'} min-h-0 flex flex-col gap-4`}>
 
             {/* Story text card */}
             <div className={`bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full min-h-0 ${isGraphicText ? 'flex-[3]' : 'flex-1'}`}>
@@ -124,7 +124,7 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
           </div>
 
           {/* ── Right: Exercise panel ─────────────────────────────────────────── */}
-          <div className={`${isGraphicText ? 'md:col-span-7' : 'md:col-span-5'} min-h-0 flex flex-col`}>
+          <div className={`${isGraphicText ? 'md:col-span-4' : 'md:col-span-5'} min-h-0 flex flex-col`}>
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex-1 min-h-0 overflow-y-auto custom-scrollbar">
               {children}
             </div>


### PR DESCRIPTION
Fixes #1554

## Summary

- **Root cause**: `ComprehensionLayout.tsx` had `isGraphicText` branch backwards — left column got `md:col-span-5` (42%) and right got `md:col-span-7` (58%), so 課文+圖文 strip was cramped while the question panel had excess space
- **Fix**: swap to `md:col-span-8` (67%) left / `md:col-span-4` (33%) right for graphic-text mode only
- **Standard layout** (non graphic-text): unchanged at col-span-7 / col-span-5
- **Mobile**: unchanged — single column stacked at `< md` breakpoint

## Class changes

| Element | Before | After |
|---------|--------|-------|
| Left col (graphic-text) | `md:col-span-5` | `md:col-span-8` |
| Right col (graphic-text) | `md:col-span-7` | `md:col-span-4` |
| Left col (standard) | `md:col-span-7` | `md:col-span-7` (no change) |
| Right col (standard) | `md:col-span-5` | `md:col-span-5` (no change) |

## Diff stat

1 file changed, 2 insertions(+), 2 deletions(-)

## Test plan

- Open PR Preview URL at 1440px viewport
- Navigate to G7-L29 comprehension step (lesson 1109)
- Verify left column (課文 + 圖文 strip) is visually ~2/3 wide
- Verify right column (題目) is visually ~1/3 wide
- Resize to mobile — verify single column stacked layout unchanged

## Refs

Related to 1504 — original graphic-text issue
Replaces ratio set in PR 1531