### PR TITLE
fix(vocab-application): normalize fill_in_blank schema → sentence (Fixes #1559)

### DIFF
--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -55,6 +55,24 @@ def _halfwidth(code: str) -> str:
     )
 
 
+def _normalize_fill_in_blank_item(item: dict) -> dict:
+    """Normalize a fill_in_blank item to always carry a 'sentence' field.
+
+    New-format YAMLs (5/1 batch onwards) use context_before/context_after
+    instead of a pre-composed sentence string.  FillInBlankExercise.tsx
+    expects item.sentence; missing 'sentence' → undefined → runtime crash
+    (caught by StepErrorBoundary, shows ERR-* error screen).
+
+    Synthesis rule: sentence = context_before + "（　　）" + context_after
+    The blank placeholder matches what renderSentence() splits on (Issue #1559).
+    """
+    if "sentence" not in item and "context_before" in item:
+        before = item.get("context_before") or ""
+        after = item.get("context_after") or ""
+        item = {**item, "sentence": f"{before}（　　）{after}"}
+    return item
+
+
 _GENRE_TO_CATEGORY = {
     "記敘文": "Fable",
     "說明文": "Science",
@@ -198,7 +216,7 @@ def _load_layer1_lessons() -> list[dict]:
             ),
             "vocabulary": data.get("vocabulary") or [],
             "fill_in_blank": [
-                {**item, "answer": _halfwidth(item.get("answer", ""))}
+                {**_normalize_fill_in_blank_item(item), "answer": _halfwidth(item.get("answer", ""))}
                 for item in (data.get("fill_in_blank") or [])
             ] or None,
             "multiple_choice": data.get("multiple_choice"),
@@ -326,7 +344,7 @@ def _load_layer2_lessons(
             ),
             "vocabulary": vocabulary,
             "fill_in_blank": [
-                {**item, "answer": _halfwidth(item.get("answer", ""))}
+                {**_normalize_fill_in_blank_item(item), "answer": _halfwidth(item.get("answer", ""))}
                 for item in (data.get("fill_in_blank") or [])
             ] or None,
             "multiple_choice": data.get("multiple_choice"),

--- a/backend/tests/test_fill_in_blank_normalization.py
+++ b/backend/tests/test_fill_in_blank_normalization.py
@@ -1,0 +1,78 @@
+"""Tests for fill_in_blank schema normalization in lesson_loader.
+
+Issue #1559: New YAML lessons (5/1 batch) use context_before/context_after
+instead of a pre-composed `sentence` field.  FillInBlankExercise.tsx expects
+`sentence`, so items missing it cause a runtime crash caught by StepErrorBoundary.
+
+The fix is in lesson_loader._normalize_fill_in_blank_item which synthesizes
+`sentence` from context_before + blank placeholder + context_after.
+"""
+
+import pytest
+from app.services.lesson_loader import _normalize_fill_in_blank_item
+
+
+class TestNormalizeFillInBlankItem:
+    def test_old_schema_passthrough(self):
+        """Items already having 'sentence' must be returned unchanged."""
+        item = {"sentence": "孟嘗君（　　）逃離秦國。", "answer": "A"}
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "孟嘗君（　　）逃離秦國。"
+        assert result["answer"] == "A"
+
+    def test_new_schema_synthesizes_sentence(self):
+        """Items with context_before/context_after but no sentence get sentence synthesized."""
+        item = {
+            "id": 1,
+            "answer": "模仿雞叫",
+            "context_before": "孟嘗君的食客",
+            "context_after": "，引來附近公雞也一起叫。",
+            "context_paragraph_idx": 4,
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert "sentence" in result
+        assert result["sentence"] == "孟嘗君的食客（　　），引來附近公雞也一起叫。"
+
+    def test_new_schema_preserves_all_original_fields(self):
+        """Original fields (id, context_before, context_after, etc.) must be preserved."""
+        item = {
+            "id": 3,
+            "answer": "狗",
+            "context_before": "食客中有一位會模仿",
+            "context_after": "的樣子和動作潛入家戶偷東西。",
+            "context_paragraph_idx": 5,
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["id"] == 3
+        assert result["context_before"] == "食客中有一位會模仿"
+        assert result["context_after"] == "的樣子和動作潛入家戶偷東西。"
+        assert result["context_paragraph_idx"] == 5
+
+    def test_empty_context_fields(self):
+        """Handles empty context_before or context_after gracefully."""
+        item = {"answer": "A", "context_before": "", "context_after": "後面的文字。"}
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "（　　）後面的文字。"
+
+    def test_both_empty_context(self):
+        """Handles both context fields empty — produces a standalone blank."""
+        item = {"answer": "A", "context_before": "", "context_after": ""}
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "（　　）"
+
+    def test_no_context_fields_no_sentence_unchanged(self):
+        """Items with neither sentence nor context fields are returned unchanged (edge case)."""
+        item = {"answer": "A"}
+        result = _normalize_fill_in_blank_item(item)
+        assert "sentence" not in result
+
+    def test_sentence_wins_over_context(self):
+        """If 'sentence' already exists, don't overwrite even if context fields also present."""
+        item = {
+            "sentence": "已有的句子（　　）不應被覆蓋。",
+            "answer": "B",
+            "context_before": "不應使用",
+            "context_after": "這段文字",
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "已有的句子（　　）不應被覆蓋。"


### PR DESCRIPTION
Fixes #1559

## Summary

- New YAML lessons ingested 2026-05-01 (G6-L22~25, G7-L28~L30) use `context_before`/`context_after` schema in `fill_in_blank` instead of the existing `sentence` field
- Backend `lesson_loader.py` passed items through unchanged
- Frontend `FillInBlankExercise` calls `currentSentence.sentence` which was `undefined` for these items → `renderSentence(undefined)` threw a TypeError → `StepErrorBoundary` caught it and rendered the ERR-* error screen

## Fix

Added `_normalize_fill_in_blank_item()` in `backend/app/services/lesson_loader.py`:
- If item has `context_before`/`context_after` but no `sentence`, synthesize: `sentence = context_before + "（　　）" + context_after`
- If item already has `sentence`, pass through unchanged (backward compatible)
- Applied at both Layer-1 and Layer-2 `fill_in_blank` list comprehensions

## Affected stories (all fixed)

| story_id | grade_code | fill_in_blank count |
|----------|------------|---------------------|
| 1076 | G6-L22 | 8 |
| 1077 | G6-L23 | 8 |
| 1078 | G6-L24 | 5 |
| 1079 | G6-L25 | 5 |
| 1108 | G7-L28 | 15 |
| 1110 | G7-L30 | 1 |

## Test plan

- [ ] Open preview URL → navigate to story 1076 vocab-application step
- [ ] Confirm 語詞應用 exercise renders (fill-in-blank cards visible, no error screen)
- [ ] Confirm answer selection + confirm button works
- [ ] Check story 1077, 1078, 1079, 1108, 1110 same step also renders
- [ ] Confirm existing stories (e.g. story 22 with old schema) still work
- [ ] 7 unit tests pass: `pytest tests/test_fill_in_blank_normalization.py`

## Changed files

- `backend/app/services/lesson_loader.py` — added `_normalize_fill_in_blank_item()` helper + applied at 2 sites (lines ~58–78, ~219, ~347)
- `backend/tests/test_fill_in_blank_normalization.py` — 7 unit tests (new file)