### PR TITLE
feat(zhuyin): default to 無注音 on first visit (Fixes #1561)

### DIFF
--- a/frontend/src/context/ZhuyinContext.tsx
+++ b/frontend/src/context/ZhuyinContext.tsx
@@ -62,8 +62,9 @@ function readStoredMode(): ZhuyinMode {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw === 'none' || raw === 'difficult' || raw === 'all') return raw;
-    // Migrate from old boolean key
+    // Migrate from old boolean key (preserve returning users' existing choice)
     const legacy = localStorage.getItem(LEGACY_KEY);
+    if (legacy === 'true') return 'all';
     if (legacy === 'false') return 'none';
     // Default for first-time visitors: no annotation (cleaner reading surface)
     return 'none';

--- a/frontend/src/context/ZhuyinContext.tsx
+++ b/frontend/src/context/ZhuyinContext.tsx
@@ -65,9 +65,10 @@ function readStoredMode(): ZhuyinMode {
     // Migrate from old boolean key
     const legacy = localStorage.getItem(LEGACY_KEY);
     if (legacy === 'false') return 'none';
-    return 'all';
+    // Default for first-time visitors: no annotation (cleaner reading surface)
+    return 'none';
   } catch {
-    return 'all';
+    return 'none';
   }
 }
 
@@ -95,13 +96,13 @@ interface ZhuyinContextValue {
 }
 
 const ZhuyinContext = createContext<ZhuyinContextValue>({
-  zhuyinMode: 'all',
+  zhuyinMode: 'none',
   zhuyinReady: false,
   zhuyinActive: false,
   isZhuyinAny: false,
   isZhuyinAll: false,
-  isZhuyinNone: false,
-  zhuyinEnabled: true,
+  isZhuyinNone: true,
+  zhuyinEnabled: false,
   setZhuyinMode: () => {},
   setZhuyinEnabled: () => {},
   toggleZhuyin: () => {},


### PR DESCRIPTION
Fixes #1561

## Summary

- First-time visitors (no localStorage) now land on **無注音** instead of **全**
- Returning users with a stored preference (`zhuyin_mode_v2` key) see no change
- Legacy `zhuyin_enabled=false` migration path still works correctly

## Change

**One file, 4 lines changed:**

`frontend/src/context/ZhuyinContext.tsx`

| Location | Before | After |
|---|---|---|
| `readStoredMode()` no-storage fallback (line 68) | `return 'all'` | `return 'none'` |
| `readStoredMode()` exception fallback (line 70) | `return 'all'` | `return 'none'` |
| Context default `zhuyinMode` (line 98) | `'all'` | `'none'` |
| Context default `isZhuyinNone` / `zhuyinEnabled` (lines 103-104) | `false` / `true` | `true` / `false` |

## Test plan

1. Open any reading step in incognito (no prior localStorage) → toggle should show **無**
2. Toggle to **全** → refresh → toggle still shows **全** (persistence works)
3. Clear site data (DevTools > Application > Clear) → refresh → toggle back to **無**
4. Existing user with `localStorage.zhuyin_mode_v2 = 'all'` → no change on reload