### PR TITLE
fix(pitch): 投影片字體 2x + 修破圖 (Fixes #1565)

### DIFF
--- a/frontend/public/presentation/7-lessons-progress.html
+++ b/frontend/public/presentation/7-lessons-progress.html
@@ -9,7 +9,7 @@
 /* ── viewport base (per frontend-slides skill) ── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 html, body { overflow-x: hidden; }
-html { scroll-snap-type: y mandatory; scroll-behavior: smooth; height: 100%; }
+html { scroll-snap-type: y mandatory; scroll-behavior: smooth; height: 100%; font-size: 32px; }
 body { min-height: 100vh; }
 body {
   font-family: "Noto Serif TC", "Songti TC", serif;
@@ -93,7 +93,7 @@ body {
   flex-direction: column;
   justify-content: center;
   max-height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 /* ── slide 1 cover ── */
@@ -172,18 +172,9 @@ body {
   letter-spacing: 0.05em;
 }
 
-/* ── PDCA badge ── */
+/* ── PDCA badge (hidden — slide-step at top-right already conveys phase) ── */
 .pdca {
-  display: inline-block;
-  font-family: "Noto Sans TC", sans-serif;
-  font-size: 1rem;
-  font-weight: 700;
-  letter-spacing: 0.2em;
-  padding: 4px 14px;
-  border-radius: 999px;
-  background: var(--purple);
-  color: white;
-  margin-bottom: 1.5vh;
+  display: none;
 }
 .pdca.plan { background: var(--purple); }
 .pdca.do { background: var(--emerald); }


### PR DESCRIPTION
## Summary
- html base font-size 16px → 32px（rem 全部 ×2，視覺放大兩倍）
- .content overflow-y: auto（內部可 scroll，避免大字撐爆 100vh）
- .pdca: display: none（slide-step 右上已標階段，badge 多餘且重疊 slide-num）

## Test plan
- [ ] 預覽 URL 開 6 頁，字明顯放大、無破圖
- [ ] Slide 3 頂部不再有重疊綠色 bar
- [ ] 鍵盤 ↑↓ Space 翻頁正常
- [ ] 內容 overflow 時可 scroll

owner-acknowledged: Fixes #1565

🤖 Generated with [Claude Code](https://claude.com/claude-code)