### PR TITLE
fix(vocab-application): filter new-format fill_in_blank to prevent crash (Fixes #1563)

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -53,7 +53,10 @@ interface ApiStoryListItem {
 interface ApiStoryDetail extends ApiStoryListItem {
   paragraphs: string[];
   vocabulary: ApiVocabItem[] | null;
-  fill_in_blank: Array<{ sentence: string; answer: string }> | null;
+  // New-format items (5/1 curriculum batch) use context_before/context_after instead of sentence.
+  // Both schemas coexist; normalization in apiDetailToStory filters to legacy-format only (#1563).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fill_in_blank: Array<Record<string, any>> | null;
   multiple_choice: Array<{ question: string; options: string[]; answer: string | null; explanation: string | null }> | null;
   vocab_bank: Record<string, string> | null;
   knowledge_video_url: string | null;
@@ -128,7 +131,14 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     vocabulary: detail.vocabulary ?? undefined,
     charCount: detail.char_count,
     readingBenchmark: detail.reading_benchmark ?? undefined,
-    fillInBlank: detail.fill_in_blank ?? undefined,
+    // Filter to legacy-format items only (those with a `sentence` field).
+    // New-format items from the 5/1 curriculum batch use context_before/context_after
+    // which FillInBlankExercise does not yet support — passing them causes a TypeError
+    // crash when the component accesses `.sentence` (#1563).
+    // Filtering to [] causes VocabApplication.hasData to return false → NoDataFallback.
+    fillInBlank: detail.fill_in_blank
+      ? detail.fill_in_blank.filter((item) => typeof item['sentence'] === 'string') as Array<{ sentence: string; answer: string }>
+      : undefined,
     multipleChoice: detail.multiple_choice ?? undefined,
     vocabBank: detail.vocab_bank ?? undefined,
     knowledgeVideoUrl: detail.knowledge_video_url ?? undefined,


### PR DESCRIPTION
Fixes #1563

## Root Cause

G6-L22 (and other new 5/1 curriculum lessons) use a new `fill_in_blank` schema:

```json
{ "id": 1, "answer": "模仿雞叫", "context_before": "...", "context_after": "..." }
```

`FillInBlankExercise` expects the legacy schema (`{ sentence, answer }`), so `currentSentence.sentence` is `undefined` → TypeError → StepErrorBoundary catches → grey error screen with code ERR-mp3pdicj-50gq.

## Fix

Single-line filter in `apiDetailToStory` (`frontend/src/services/api.ts`):

```ts
fillInBlank: detail.fill_in_blank
  ? detail.fill_in_blank.filter((item) => typeof item['sentence'] === 'string') as ...
  : undefined,
```

New-format items are filtered out → `VocabApplication.hasData` returns `false` → graceful `NoDataFallback` renders ("本課尚無語詞應用題目") with a skip button.

## Safety

- **Old-format stories unchanged** — filter only removes items without `sentence`
- **No component logic touched** — normalization at the API mapping layer only
- **`npm run build` passes** — 0 TypeScript errors

## Test Plan

1. Open story 1076 vocab-application step on PR Preview URL
2. Confirm step loads (no error screen) — shows "本課尚無語詞應用題目" + "繼續下一步" button
3. Open any legacy story (e.g. story with old-format fill_in_blank like L41) — confirm exercise still works normally
4. Click "繼續下一步" on 1076 — confirm navigation to next step works