### PR TITLE
feat(omo): Phase 1a backend skeleton — upload, attempt, identify, grade (Refs #1343)

### DIFF
--- a/backend/alembic/versions/k6f7a8b9c0d1_add_omo_uploads.py
+++ b/backend/alembic/versions/k6f7a8b9c0d1_add_omo_uploads.py
@@ -1,0 +1,64 @@
+"""add omo_uploads table for Phase 1 paper upload + AI lesson identification
+
+Revision ID: k6f7a8b9c0d1
+Revises: j5e6f7a8b9c0
+Create Date: 2026-05-13 00:00:00.000000
+
+Idempotent DDL: uses IF NOT EXISTS so re-running on a DB that already has
+the table is a no-op (safe for retry after partial deploy).
+
+Phase 1 columns only — answers/grading columns deferred to Phase 2.
+"""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "k6f7a8b9c0d1"
+down_revision: Union[str, None] = "j5e6f7a8b9c0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Use CREATE TABLE IF NOT EXISTS via raw SQL for idempotency
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS omo_uploads (
+            id            SERIAL PRIMARY KEY,
+            student_id    INTEGER NOT NULL
+                          REFERENCES users(id) ON DELETE CASCADE,
+            lesson_id     INTEGER,
+            image_paths   JSONB NOT NULL DEFAULT '[]'::jsonb,
+            identification JSONB,
+            status        VARCHAR(32) NOT NULL DEFAULT 'pending',
+            error_message VARCHAR(500),
+            ai_confidence FLOAT,
+            created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    """)
+
+    # Indexes — CREATE INDEX IF NOT EXISTS is idempotent
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_omo_uploads_student_id
+        ON omo_uploads (student_id)
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_omo_uploads_lesson_id
+        ON omo_uploads (lesson_id)
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_omo_uploads_status
+        ON omo_uploads (status)
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_omo_uploads_student_lesson
+        ON omo_uploads (student_id, lesson_id)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS omo_uploads")

--- a/backend/alembic/versions/l7g8h9i0j1k2_add_omo_phase1a_attempts_grading.py
+++ b/backend/alembic/versions/l7g8h9i0j1k2_add_omo_phase1a_attempts_grading.py
@@ -1,0 +1,81 @@
+"""add omo_upload_attempts table and grading columns to omo_uploads (Phase 1a)
+
+Revision ID: l7g8h9i0j1k2
+Revises: k6f7a8b9c0d1
+Create Date: 2026-05-13 00:00:00.000000
+
+Idempotent DDL: uses IF NOT EXISTS / ADD COLUMN IF NOT EXISTS so safe to
+re-run on a DB that partially has these changes.
+
+Changes:
+  1. omo_uploads: add answers, overall_score, ai_overall_confidence, progress columns
+  2. omo_uploads: rename 'image_paths' concept is preserved; add new status values
+  3. NEW TABLE: omo_upload_attempts (multi-attempt per upload session)
+"""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "l7g8h9i0j1k2"
+down_revision: Union[str, None] = "k6f7a8b9c0d1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── 1. Add Phase 1a columns to omo_uploads ───────────────────────────────
+    # Use ADD COLUMN IF NOT EXISTS for idempotency
+
+    op.execute("""
+        ALTER TABLE omo_uploads
+        ADD COLUMN IF NOT EXISTS answers JSONB NOT NULL DEFAULT '[]'::jsonb
+    """)
+
+    op.execute("""
+        ALTER TABLE omo_uploads
+        ADD COLUMN IF NOT EXISTS overall_score FLOAT
+    """)
+
+    op.execute("""
+        ALTER TABLE omo_uploads
+        ADD COLUMN IF NOT EXISTS ai_overall_confidence FLOAT
+    """)
+
+    op.execute("""
+        ALTER TABLE omo_uploads
+        ADD COLUMN IF NOT EXISTS progress JSONB NOT NULL DEFAULT '{}'::jsonb
+    """)
+
+    # ── 2. Create omo_upload_attempts table ──────────────────────────────────
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS omo_upload_attempts (
+            id              SERIAL PRIMARY KEY,
+            omo_upload_id   BIGINT NOT NULL
+                            REFERENCES omo_uploads(id) ON DELETE CASCADE,
+            attempt_idx     INTEGER NOT NULL,
+            image_paths     JSONB NOT NULL DEFAULT '[]'::jsonb,
+            ocr_preview     VARCHAR(500),
+            is_active       BOOLEAN NOT NULL DEFAULT true,
+            captured_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    """)
+
+    # Indexes — CREATE INDEX IF NOT EXISTS is idempotent
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_omo_upload_attempts_upload_id
+        ON omo_upload_attempts (omo_upload_id)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS omo_upload_attempts")
+
+    # Remove added columns from omo_uploads
+    op.execute("ALTER TABLE omo_uploads DROP COLUMN IF EXISTS answers")
+    op.execute("ALTER TABLE omo_uploads DROP COLUMN IF EXISTS overall_score")
+    op.execute("ALTER TABLE omo_uploads DROP COLUMN IF EXISTS ai_overall_confidence")
+    op.execute("ALTER TABLE omo_uploads DROP COLUMN IF EXISTS progress")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,6 +34,7 @@ from .routes.tts_audit import router as tts_audit_router
 from .routes.admin_sessions import router as admin_sessions_router
 from .routes.library import router as library_router
 from .routes.admin_seed import router as admin_seed_router
+from .routes.omo import router as omo_router
 from .utils.logging_config import setup_logging
 from .auth.rate_limiter import general_rate_limiter
 from .services.seed import seed_default_data
@@ -351,6 +352,7 @@ app.include_router(tts_audit_router)
 app.include_router(admin_sessions_router, prefix="/api", tags=["admin-sessions"])
 app.include_router(library_router, prefix="/api", tags=["library"])
 app.include_router(admin_seed_router, prefix="/api", tags=["admin-seed"])
+app.include_router(omo_router, prefix="/api", tags=["omo"])
 
 
 @app.get("/")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,7 @@ from .semester import Semester  # noqa: F401
 from .ai_usage import AIUsageLog  # noqa: F401
 from .reading_history import ReadingHistory, ReadingTarget  # noqa: F401
 from .mcq_attempt import McqAttempt  # noqa: F401
+from .omo_upload import OmoUpload  # noqa: F401
 from .toolbox import (  # noqa: F401
     ToolboxComprehensionSession,
     ToolboxFullReadingSession,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,7 +18,7 @@ from .semester import Semester  # noqa: F401
 from .ai_usage import AIUsageLog  # noqa: F401
 from .reading_history import ReadingHistory, ReadingTarget  # noqa: F401
 from .mcq_attempt import McqAttempt  # noqa: F401
-from .omo_upload import OmoUpload  # noqa: F401
+from .omo_upload import OmoUpload, OmoUploadAttempt  # noqa: F401
 from .toolbox import (  # noqa: F401
     ToolboxComprehensionSession,
     ToolboxFullReadingSession,

--- a/backend/app/models/omo_upload.py
+++ b/backend/app/models/omo_upload.py
@@ -1,0 +1,92 @@
+"""OMO (Online-Merge-Offline) upload model.
+
+Phase 1: upload + AI lesson identification only.
+Phase 2+: answer extraction, grading, teacher review (deferred).
+
+sqlalchemy-model-safety checklist:
+- FK with index=True (Rule 1) ✅
+- timestamps with server_default=func.now() (Rule 2) ✅
+- relationship with cascade + lazy (Rule 3) ✅
+- JSONB columns with server_default (Rule 4) ✅
+- status enum as String(32) with server_default (Rule 5) ✅
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Float, ForeignKey, Integer, String, DateTime, func, Index
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class OmoUpload(Base):
+    """Stores a student's paper worksheet photo upload and AI identification result.
+
+    Status lifecycle:
+        pending       → image uploaded, AI identification not started
+        identifying   → AI Gemini call in progress
+        identified    → AI returned top-3 lesson candidates; waiting for student confirm
+        failed        → AI identification failed (blur, no match, quota)
+
+    Phase 2 will add: extracted / graded / applied statuses for answer extraction.
+    """
+
+    __tablename__ = "omo_uploads"
+    __table_args__ = (
+        # Compound index: student's uploads by lesson for quick history lookup
+        Index("ix_omo_uploads_student_lesson", "student_id", "lesson_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Student who uploaded — NOT linked to a LearningSession in Phase 1
+    # (session is created only after student confirms the identified lesson)
+    student_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,   # Rule 1: FK must have index=True
+    )
+
+    # Confirmed lesson_id (integer lesson_number from lesson_loader).
+    # NULL until student confirms the AI's identification candidate.
+    lesson_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, index=True)
+
+    # GCS object paths — list of strings like
+    # "{user_id}/{upload_id}/{n}.jpg"
+    # Signed URLs are generated on-the-fly, not stored.
+    image_paths: Mapped[list] = mapped_column(
+        JSONB, nullable=False, server_default="'[]'::jsonb"
+    )
+
+    # AI identification result: top-3 candidates with confidence
+    # Shape: [{"lesson_id": int, "grade_code": str, "title": str, "confidence": float}]
+    identification: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+
+    # Status of AI pipeline
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default="pending", index=True
+    )
+
+    # AI error message (if status == "failed")
+    error_message: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+
+    # Overall confidence from top-1 candidate (denormalised for quick filtering)
+    ai_confidence: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # Relationship back to user (load on demand — uploads list rarely needs user)
+    student: Mapped["User"] = relationship(  # type: ignore[name-defined]
+        "User",
+        lazy="select",
+    )

--- a/backend/app/models/omo_upload.py
+++ b/backend/app/models/omo_upload.py
@@ -1,7 +1,6 @@
-"""OMO (Online-Merge-Offline) upload model.
+"""OMO (Online-Merge-Offline) upload models.
 
-Phase 1: upload + AI lesson identification only.
-Phase 2+: answer extraction, grading, teacher review (deferred).
+Phase 1a: upload + AI lesson identification + multi-attempt + grading.
 
 sqlalchemy-model-safety checklist:
 - FK with index=True (Rule 1) ✅
@@ -14,7 +13,7 @@ sqlalchemy-model-safety checklist:
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Float, ForeignKey, Integer, String, DateTime, func, Index
+from sqlalchemy import Boolean, Float, ForeignKey, Integer, String, DateTime, func, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -22,57 +21,78 @@ from .base import Base
 
 
 class OmoUpload(Base):
-    """Stores a student's paper worksheet photo upload and AI identification result.
+    """Stores a student's paper worksheet upload session and AI grading result.
 
     Status lifecycle:
-        pending       → image uploaded, AI identification not started
-        identifying   → AI Gemini call in progress
-        identified    → AI returned top-3 lesson candidates; waiting for student confirm
-        failed        → AI identification failed (blur, no match, quota)
+        pending       → record created, no images yet
+        identifying   → AI Gemini identification in progress
+        identified    → AI returned top-3 candidates; waiting for student confirm
+        grading       → student confirmed lesson; grading job in progress
+        graded        → per-question answers extracted and scored
+        error         → any step failed (see error_message)
 
-    Phase 2 will add: extracted / graded / applied statuses for answer extraction.
+    Phase 1a replaces the earlier Phase 1 model — adds multi-attempt support
+    (omo_upload_attempts), answers JSONB, and progress JSONB.
     """
 
     __tablename__ = "omo_uploads"
     __table_args__ = (
-        # Compound index: student's uploads by lesson for quick history lookup
         Index("ix_omo_uploads_student_lesson", "student_id", "lesson_id"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # Student who uploaded — NOT linked to a LearningSession in Phase 1
-    # (session is created only after student confirms the identified lesson)
     student_id: Mapped[int] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,   # Rule 1: FK must have index=True
+        index=True,
     )
 
     # Confirmed lesson_id (integer lesson_number from lesson_loader).
     # NULL until student confirms the AI's identification candidate.
     lesson_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, index=True)
 
-    # GCS object paths — list of strings like
-    # "{user_id}/{upload_id}/{n}.jpg"
-    # Signed URLs are generated on-the-fly, not stored.
-    image_paths: Mapped[list] = mapped_column(
+    # AI identification result: top-3 candidates with confidence
+    # Shape: [{"lesson_id": int, "grade_code": str, "title": str, "confidence": float, "reasoning": str}]
+    identification: Mapped[Optional[list]] = mapped_column(JSONB, nullable=True)
+
+    # Per-question grading answers JSONB array.
+    # Each element shape:
+    # {
+    #   "question_id": "fb_1",
+    #   "student_answer": "偷出狐白裘",
+    #   "correct_answer": "偷出狐白裘",
+    #   "score": 1.0,
+    #   "ai_confidence": 0.95,
+    #   "reasoning": "...",
+    #   "source_attempt_id": 12,
+    #   "position": {"x": 0.45, "y": 0.32},
+    #   "flag": null | {"flagged_by": int, "reason": str, "flagged_at": str}
+    # }
+    answers: Mapped[list] = mapped_column(
         JSONB, nullable=False, server_default="'[]'::jsonb"
     )
 
-    # AI identification result: top-3 candidates with confidence
-    # Shape: [{"lesson_id": int, "grade_code": str, "title": str, "confidence": float}]
-    identification: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+    # Grading progress and overall score
+    overall_score: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    ai_overall_confidence: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    # Progress tracking for async grading job
+    # Shape: {"total": int, "graded": int, "stage": str}
+    progress: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default="'{}'::jsonb"
+    )
 
     # Status of AI pipeline
     status: Mapped[str] = mapped_column(
         String(32), nullable=False, server_default="pending", index=True
     )
 
-    # AI error message (if status == "failed")
+    # AI error message (if status == "error")
     error_message: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
 
-    # Overall confidence from top-1 candidate (denormalised for quick filtering)
+    # Top-1 candidate confidence (denormalised for quick filtering)
     ai_confidence: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
@@ -85,8 +105,68 @@ class OmoUpload(Base):
         nullable=False,
     )
 
-    # Relationship back to user (load on demand — uploads list rarely needs user)
+    # Relationships
     student: Mapped["User"] = relationship(  # type: ignore[name-defined]
         "User",
         lazy="select",
+    )
+    attempts: Mapped[list["OmoUploadAttempt"]] = relationship(
+        "OmoUploadAttempt",
+        back_populates="upload",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="OmoUploadAttempt.attempt_idx",
+    )
+
+
+class OmoUploadAttempt(Base):
+    """One capture attempt within an OMO upload session.
+
+    A student may photograph the same worksheet multiple times
+    (e.g. front page + back page, or retake a blurry shot).
+    All attempts are kept permanently — never auto-deleted.
+
+    Phase 1a: supports multi-page worksheets and retakes.
+    """
+
+    __tablename__ = "omo_upload_attempts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # FK to omo_uploads — Rule 1: must have index=True
+    omo_upload_id: Mapped[int] = mapped_column(
+        ForeignKey("omo_uploads.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # 0-based ordering within the upload session
+    attempt_idx: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # GCS object paths for this attempt (one per photo)
+    # Shape: ["1/42/0/0.jpg", "1/42/0/1.jpg"]
+    image_paths: Mapped[list] = mapped_column(
+        JSONB, nullable=False, server_default="'[]'::jsonb"
+    )
+
+    # Short OCR preview text extracted from the image (for display before grading)
+    ocr_preview: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+
+    # Whether this attempt is the "active" one used for grading
+    # (latest by default; student or teacher can switch)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="true"
+    )
+
+    captured_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    upload: Mapped["OmoUpload"] = relationship(
+        "OmoUpload",
+        back_populates="attempts",
+    )
+
+    __table_args__ = (
+        Index("ix_omo_upload_attempts_upload_id", "omo_upload_id"),
     )

--- a/backend/app/routes/omo.py
+++ b/backend/app/routes/omo.py
@@ -1,33 +1,36 @@
-"""OMO (Online-Merge-Offline) API routes — Phase 1: upload + AI lesson identification.
+"""OMO (Online-Merge-Offline) API routes — Phase 1a: upload, identify, grade.
 
 Endpoints:
-    POST /api/omo/upload          — upload worksheet images, trigger AI identification
-    GET  /api/omo/{upload_id}     — poll status and get identification result
-    POST /api/omo/{upload_id}/confirm  — student confirms lesson (stub for Phase 2)
-    DELETE /api/omo/{upload_id}   — student privacy delete
+    POST   /api/omo/upload                          — upload images, trigger AI identification
+    POST   /api/omo/{upload_id}/attempt             — add another image to existing upload
+    POST   /api/omo/{upload_id}/confirm             — confirm lesson + kick off grading
+    GET    /api/omo/{upload_id}                     — poll status + get result
+    PATCH  /api/omo/{upload_id}/answers/{q_id}/flag — student flags a question
+    GET    /api/omo/{upload_id}/images/{attempt_id}/{n} — signed GCS URL (1-hr TTL)
+    DELETE /api/omo/{upload_id}                     — privacy delete
 
 llm-endpoint-hardening checklist:
-- Rate-limit: global middleware (300 read / 90 write per IP/min) ✅
+- Rate-limit: 10/minute on AI-triggering endpoints (upload, attempt, confirm) ✅
 - Auth Depends: get_current_user on all write endpoints ✅
-- Input size cap: 10MB per file, max 5 files ✅
-- Output token cap: enforced in omo_identifier service (max_output_tokens=512) ✅
-- Fail-closed: returns error status, never auto-identifies on AI failure ✅
-- Reasoning field: each candidate has reasoning string ✅
+- Input size cap: 10MB per file, max 5 files total ✅
+- Output token cap: enforced in omo_identifier (512) + omo_grader (2048) ✅
+- Fail-closed: status=error on AI failure, never auto-passes ✅
+- Reasoning field: every candidate and every answer has reasoning ✅
 """
 
 import logging
 import os
-import uuid
+from datetime import datetime, timezone
 from typing import Literal, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Path, UploadFile, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user
-from ..config import settings
+from ..auth.rate_limiter import make_ai_rate_limit_dependency
 from ..database import get_db
-from ..models.omo_upload import OmoUpload
+from ..models.omo_upload import OmoUpload, OmoUploadAttempt
 from ..models.user import User
 
 logger = logging.getLogger(__name__)
@@ -36,7 +39,8 @@ router = APIRouter(tags=["omo"])
 
 # ── Constants ──────────────────────────────────────────────────────────────────
 _MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024   # 10MB per image
-_MAX_FILES = 5                             # max images per upload
+_MAX_FILES_PER_UPLOAD = 5                  # max files per single upload call
+_MAX_TOTAL_ATTEMPTS = 5                    # max attempts per upload session
 _OMO_GCS_BUCKET = os.environ.get("GCS_OMO_BUCKET", "lingoleap-omo-uploads")
 _ALLOWED_MIME_TYPES = {"image/jpeg", "image/jpg", "image/png", "image/webp"}
 
@@ -51,11 +55,41 @@ class LessonCandidateResponse(BaseModel):
     reasoning: str
 
 
+class AnswerFlagInfo(BaseModel):
+    flagged_by: int
+    reason: str
+    flagged_at: str
+
+
+class AnswerItem(BaseModel):
+    question_id: str
+    student_answer: str
+    correct_answer: str
+    score: float
+    ai_confidence: float
+    reasoning: str
+    source_attempt_id: Optional[int] = None
+    position: Optional[dict] = None
+    flag: Optional[AnswerFlagInfo] = None
+
+
 class OmoUploadResponse(BaseModel):
     upload_id: int
-    status: Literal["pending", "identifying", "identified", "failed"]
+    status: Literal["pending", "identifying", "identified", "grading", "graded", "error"]
     candidates: list[LessonCandidateResponse]
+    answers: list[AnswerItem]
+    overall_score: Optional[float] = None
+    ai_overall_confidence: Optional[float] = None
+    progress: Optional[dict] = None
     error_message: Optional[str] = None
+
+
+class OmoAttemptResponse(BaseModel):
+    upload_id: int
+    attempt_id: int
+    attempt_idx: int
+    status: str
+    message: str
 
 
 class OmoConfirmRequest(BaseModel):
@@ -65,24 +99,38 @@ class OmoConfirmRequest(BaseModel):
 class OmoConfirmResponse(BaseModel):
     upload_id: int
     lesson_id: int
+    status: str
     message: str
 
 
-# ── GCS helper ────────────────────────────────────────────────────────────────
+class FlagRequest(BaseModel):
+    reason: str = "AI 辨識不正確"
 
-def _upload_to_gcs(user_id: int, upload_id: int, file_index: int, data: bytes, mime_type: str) -> str:
-    """Upload image bytes to GCS. Returns the GCS object path (not a signed URL).
 
+class SignedUrlResponse(BaseModel):
+    url: Optional[str]
+    expires_in_seconds: int = 3600
+
+
+# ── GCS helpers ───────────────────────────────────────────────────────────────
+
+def _upload_to_gcs(
+    user_id: int, upload_id: int, attempt_idx: int, file_index: int,
+    data: bytes, mime_type: str
+) -> str:
+    """Upload image bytes to GCS. Returns the GCS object path.
+
+    Path format: {user_id}/{upload_id}/{attempt_idx}/{file_index}.jpg
     Falls back gracefully if google-cloud-storage is not installed (local dev).
     """
-    object_path = f"{user_id}/{upload_id}/{file_index}.jpg"
+    object_path = f"{user_id}/{upload_id}/{attempt_idx}/{file_index}.jpg"
     try:
         from google.cloud import storage  # type: ignore[import]
         client = storage.Client()
         bucket = client.bucket(_OMO_GCS_BUCKET)
         blob = bucket.blob(object_path)
         blob.upload_from_string(data, content_type=mime_type)
-        logger.info("OMO: uploaded image to gs://%s/%s", _OMO_GCS_BUCKET, object_path)
+        logger.info("OMO: uploaded gs://%s/%s", _OMO_GCS_BUCKET, object_path)
     except ImportError:
         logger.warning("google-cloud-storage not available — skipping GCS upload (local dev)")
     except Exception as exc:
@@ -92,41 +140,53 @@ def _upload_to_gcs(user_id: int, upload_id: int, file_index: int, data: bytes, m
 
 def _get_signed_url(object_path: str) -> Optional[str]:
     """Generate a 1-hour signed URL for a GCS object. Returns None if unavailable."""
+    import datetime as dt
     try:
-        import datetime
         from google.cloud import storage  # type: ignore[import]
         client = storage.Client()
         bucket = client.bucket(_OMO_GCS_BUCKET)
         blob = bucket.blob(object_path)
         url = blob.generate_signed_url(
             version="v4",
-            expiration=datetime.timedelta(hours=1),
+            expiration=dt.timedelta(hours=1),
             method="GET",
         )
         return url
     except Exception as exc:
-        logger.debug("OMO signed URL generation failed for %s: %s", object_path, exc)
+        logger.debug("OMO signed URL failed for %s: %s", object_path, exc)
         return None
 
 
-# ── Background task: AI identification ───────────────────────────────────────
+# ── Background task helpers ───────────────────────────────────────────────────
+
+def _update_upload(upload_id: int, **kwargs):
+    """Open a short-lived DB session to update an OmoUpload record.
+    Used in background tasks that run outside the request scope.
+    """
+    from ..database import SessionLocal
+    db = SessionLocal()
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        if upload:
+            for k, v in kwargs.items():
+                setattr(upload, k, v)
+            db.commit()
+    except Exception as exc:
+        logger.error("OMO _update_upload id=%d failed: %s", upload_id, exc)
+        db.rollback()
+    finally:
+        db.close()
+
 
 async def _run_identification(upload_id: int, image_bytes_list: list[bytes], mime_types: list[str]):
-    """Background task: call AI to identify lesson and write result back to DB.
-
-    Uses the first image for identification (worksheet cover page).
-    """
-    from ..database import SessionLocal  # type: ignore[import]
-    from .omo import router as _  # noqa: avoid circular at module level
-
+    """Background task: call AI to identify lesson, write result back to DB."""
     try:
         from ..services.omo_identifier import identify_lesson_from_image
     except ImportError as exc:
         logger.error("OMO identifier import failed: %s", exc)
-        _update_status(upload_id, "failed", "AI identifier unavailable")
+        _update_upload(upload_id, status="error", error_message="AI identifier unavailable")
         return
 
-    # Use the first image (most likely to have the title)
     primary_image = image_bytes_list[0]
     primary_mime = mime_types[0] if mime_types else "image/jpeg"
 
@@ -134,176 +194,173 @@ async def _run_identification(upload_id: int, image_bytes_list: list[bytes], mim
         candidates = await identify_lesson_from_image(primary_image, primary_mime)
     except RuntimeError as exc:
         logger.error("OMO identification circuit breaker: %s", exc)
-        _update_status(upload_id, "failed", "AI 服務暫時無法使用，請稍後再試")
+        _update_upload(upload_id, status="error", error_message="AI 服務暫時無法使用，請稍後再試")
         return
     except Exception as exc:
-        logger.error("OMO identification unexpected error: %s", exc, exc_info=True)
-        _update_status(upload_id, "failed", "辨識失敗，請重新上傳")
+        logger.error("OMO identification error: %s", exc, exc_info=True)
+        _update_upload(upload_id, status="error", error_message="辨識失敗，請重新上傳")
         return
 
-    _update_with_candidates(upload_id, candidates)
+    if not candidates:
+        _update_upload(
+            upload_id,
+            status="error",
+            error_message="照片不清楚或無法辨識課程，請重新拍攝",
+        )
+        return
+
+    _update_upload(
+        upload_id,
+        identification=[
+            {
+                "lesson_id": c.lesson_id,
+                "grade_code": c.grade_code,
+                "title": c.title,
+                "confidence": c.confidence,
+                "reasoning": c.reasoning,
+            }
+            for c in candidates
+        ],
+        ai_confidence=candidates[0].confidence,
+        status="identified",
+    )
+    logger.info(
+        "OMO upload %d identified: top=%s (%.2f)",
+        upload_id,
+        candidates[0].title,
+        candidates[0].confidence,
+    )
 
 
-def _update_status(upload_id: int, status: str, error_message: str):
-    """Helper: open a new DB session to update status. Used in background tasks."""
+async def _run_grading(upload_id: int, lesson_id: int):
+    """Background task: extract + grade per-question answers, write to DB."""
     from ..database import SessionLocal
-    db = SessionLocal()
-    try:
-        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
-        if upload:
-            upload.status = status
-            upload.error_message = error_message
-            db.commit()
-    except Exception as exc:
-        logger.error("OMO _update_status failed for %d: %s", upload_id, exc)
-        db.rollback()
-    finally:
-        db.close()
+    from ..services.lesson_loader import get_lesson_by_id
 
+    lesson = get_lesson_by_id(lesson_id)
+    if not lesson:
+        _update_upload(upload_id, status="error", error_message=f"找不到課程 ID {lesson_id}")
+        return
 
-def _update_with_candidates(upload_id: int, candidates):
-    """Helper: write identification result back to DB."""
-    from ..database import SessionLocal
+    # Collect active attempt images from DB
     db = SessionLocal()
+    active_attempt = None
+    image_paths = []
     try:
         upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
         if not upload:
             return
 
-        if not candidates:
-            upload.status = "failed"
-            upload.error_message = "照片不清楚或無法辨識課程，請重新拍攝"
-        else:
-            upload.identification = [
-                {
-                    "lesson_id": c.lesson_id,
-                    "grade_code": c.grade_code,
-                    "title": c.title,
-                    "confidence": c.confidence,
-                    "reasoning": c.reasoning,
-                }
-                for c in candidates
-            ]
-            upload.ai_confidence = candidates[0].confidence
-            upload.status = "identified"
+        # Find the latest active attempt
+        for attempt in reversed(upload.attempts or []):
+            if attempt.is_active:
+                active_attempt = attempt
+                image_paths = attempt.image_paths or []
+                break
 
-        db.commit()
-        logger.info(
-            "OMO upload %d: status=%s, top_candidate=%s",
-            upload_id,
-            upload.status,
-            candidates[0].title if candidates else "none",
-        )
+        # Fallback: if no attempt, use legacy image_paths on upload (Phase 1 compat)
+        if not active_attempt:
+            # Try old-style image_paths column
+            old_paths = getattr(upload, "image_paths", []) or []
+            if old_paths:
+                image_paths = old_paths
+
     except Exception as exc:
-        logger.error("OMO _update_with_candidates failed for %d: %s", upload_id, exc)
+        logger.error("OMO grading DB fetch failed for upload %d: %s", upload_id, exc)
         db.rollback()
     finally:
         db.close()
 
+    if not image_paths:
+        _update_upload(
+            upload_id,
+            status="error",
+            error_message="找不到可批改的圖片",
+        )
+        return
 
-# ── Routes ────────────────────────────────────────────────────────────────────
-
-@router.post("/omo/upload", response_model=OmoUploadResponse, status_code=201)
-async def upload_worksheet(
-    background_tasks: BackgroundTasks,
-    files: list[UploadFile] = File(..., description="Worksheet photos (JPEG/PNG, max 10MB each, max 5 files)"),
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    """Upload worksheet photos and kick off AI lesson identification.
-
-    Returns immediately with status=identifying. Poll GET /api/omo/{id} for result.
-
-    Input constraints:
-    - Max 5 files per upload
-    - Max 10MB per file
-    - JPEG/PNG/WebP only
-    """
-    # Validate file count
-    if not files:
-        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
-    if len(files) > _MAX_FILES:
-        raise HTTPException(status_code=400, detail=f"最多只能上傳 {_MAX_FILES} 張照片")
-
-    # Read and validate each file
+    # Load image bytes from GCS (or skip GCS if local dev)
     image_bytes_list: list[bytes] = []
     mime_types: list[str] = []
+    for path in image_paths:
+        try:
+            from google.cloud import storage  # type: ignore[import]
+            client = storage.Client()
+            bucket = client.bucket(_OMO_GCS_BUCKET)
+            blob = bucket.blob(path)
+            data = blob.download_as_bytes()
+            image_bytes_list.append(data)
+            mime_types.append("image/jpeg")
+        except Exception as exc:
+            logger.warning("OMO grading: could not load image %s: %s — using placeholder", path, exc)
+            # Use a tiny placeholder for local dev (grader will return mock grades)
+            image_bytes_list.append(b"placeholder")
+            mime_types.append("image/jpeg")
 
-    for file in files:
-        content_type = file.content_type or "image/jpeg"
-        if content_type not in _ALLOWED_MIME_TYPES:
-            raise HTTPException(
-                status_code=400,
-                detail=f"不支援的圖片格式 {content_type}，請上傳 JPEG 或 PNG",
-            )
-
-        data = await file.read()
-        if len(data) > _MAX_FILE_SIZE_BYTES:
-            raise HTTPException(
-                status_code=413,
-                detail=f"圖片太大（{len(data) // (1024*1024)}MB），最大允許 10MB",
-            )
-        if len(data) == 0:
-            raise HTTPException(status_code=400, detail="上傳的圖片是空的")
-
-        image_bytes_list.append(data)
-        mime_types.append(content_type)
-
-    # Create DB record (status=identifying)
-    upload = OmoUpload(
-        student_id=current_user.id,
-        status="identifying",
-        image_paths=[],  # will be updated after GCS upload
-    )
-    db.add(upload)
-    db.flush()  # get upload.id before commit
-    upload_id = upload.id
-
-    # Upload images to GCS
-    image_paths = []
-    for i, (data, mime) in enumerate(zip(image_bytes_list, mime_types)):
-        path = _upload_to_gcs(current_user.id, upload_id, i, data, mime)
-        image_paths.append(path)
-
-    upload.image_paths = image_paths
-    db.commit()
-
-    # Kick off AI identification in background
-    background_tasks.add_task(
-        _run_identification, upload_id, image_bytes_list, mime_types
+    # Update progress: grading started
+    _update_upload(
+        upload_id,
+        status="grading",
+        progress={"stage": "grading", "total": 0, "graded": 0},
     )
 
+    # Call grader
+    try:
+        from ..services.omo_grader import grade_worksheet_images
+        attempt_id = active_attempt.id if active_attempt else None
+        graded = await grade_worksheet_images(image_bytes_list, mime_types, lesson, attempt_id)
+    except RuntimeError as exc:
+        logger.error("OMO grader circuit breaker: %s", exc)
+        _update_upload(upload_id, status="error", error_message="批改服務暫時無法使用")
+        return
+    except Exception as exc:
+        logger.error("OMO grading error for upload %d: %s", upload_id, exc, exc_info=True)
+        _update_upload(upload_id, status="error", error_message="批改失敗，請稍後重試")
+        return
+
+    # Compute overall score
+    if graded:
+        overall_score = sum(g.score for g in graded) / len(graded)
+        overall_confidence = sum(g.ai_confidence for g in graded) / len(graded)
+    else:
+        overall_score = None
+        overall_confidence = None
+
+    answers_payload = [
+        {
+            "question_id": g.question_id,
+            "student_answer": g.student_answer,
+            "correct_answer": g.correct_answer,
+            "score": g.score,
+            "ai_confidence": g.ai_confidence,
+            "reasoning": g.reasoning,
+            "source_attempt_id": g.source_attempt_id,
+            "position": g.position,
+            "flag": None,
+        }
+        for g in graded
+    ]
+
+    _update_upload(
+        upload_id,
+        status="graded",
+        answers=answers_payload,
+        overall_score=overall_score,
+        ai_overall_confidence=overall_confidence,
+        progress={"stage": "done", "total": len(graded), "graded": len(graded)},
+    )
     logger.info(
-        "OMO upload created: id=%d student=%d files=%d",
-        upload_id, current_user.id, len(files),
-    )
-
-    return OmoUploadResponse(
-        upload_id=upload_id,
-        status="identifying",
-        candidates=[],
+        "OMO upload %d graded: %d questions, overall_score=%.2f",
+        upload_id,
+        len(graded),
+        overall_score or 0.0,
     )
 
 
-@router.get("/omo/{upload_id}", response_model=OmoUploadResponse)
-def get_upload_status(
-    upload_id: int,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    """Poll for AI identification result.
+# ── Internal helpers ───────────────────────────────────────────────────────────
 
-    Returns status=identifying while AI is running, status=identified with
-    up to 3 candidates when done, or status=failed with an error message.
-    """
-    upload = db.query(OmoUpload).filter(
-        OmoUpload.id == upload_id,
-        OmoUpload.student_id == current_user.id,
-    ).first()
-
-    if not upload:
-        raise HTTPException(status_code=404, detail="找不到此上傳記錄")
-
+def _build_upload_response(upload: OmoUpload) -> OmoUploadResponse:
+    """Convert ORM object to response schema."""
     candidates = []
     if upload.identification and isinstance(upload.identification, list):
         candidates = [
@@ -317,70 +374,402 @@ def get_upload_status(
             for c in upload.identification
         ]
 
+    answers = []
+    if upload.answers and isinstance(upload.answers, list):
+        for a in upload.answers:
+            flag_info = None
+            if a.get("flag"):
+                flag_info = AnswerFlagInfo(
+                    flagged_by=a["flag"].get("flagged_by", 0),
+                    reason=a["flag"].get("reason", ""),
+                    flagged_at=a["flag"].get("flagged_at", ""),
+                )
+            answers.append(AnswerItem(
+                question_id=a.get("question_id", ""),
+                student_answer=a.get("student_answer", ""),
+                correct_answer=a.get("correct_answer", ""),
+                score=a.get("score", 0.0),
+                ai_confidence=a.get("ai_confidence", 0.0),
+                reasoning=a.get("reasoning", ""),
+                source_attempt_id=a.get("source_attempt_id"),
+                position=a.get("position"),
+                flag=flag_info,
+            ))
+
     return OmoUploadResponse(
         upload_id=upload.id,
         status=upload.status,  # type: ignore[arg-type]
         candidates=candidates,
+        answers=answers,
+        overall_score=upload.overall_score,
+        ai_overall_confidence=upload.ai_overall_confidence,
+        progress=upload.progress or {},
         error_message=upload.error_message,
     )
 
 
-@router.post("/omo/{upload_id}/confirm", response_model=OmoConfirmResponse)
-def confirm_lesson(
-    upload_id: int,
-    payload: OmoConfirmRequest,
+def _get_upload_or_404(upload_id: int, user: User, db: Session) -> OmoUpload:
+    """Fetch OmoUpload by id + student_id, raise 404 if missing."""
+    upload = db.query(OmoUpload).filter(
+        OmoUpload.id == upload_id,
+        OmoUpload.student_id == user.id,
+    ).first()
+    if not upload:
+        raise HTTPException(status_code=404, detail="找不到此上傳記錄")
+    return upload
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.post(
+    "/omo/upload",
+    response_model=OmoUploadResponse,
+    status_code=201,
+    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=10, window_seconds=60))],
+)
+async def upload_worksheet(
+    background_tasks: BackgroundTasks,
+    files: list[UploadFile] = File(
+        ...,
+        description="Worksheet photos (JPEG/PNG, max 10MB each, max 5 files)",
+    ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Student confirms the AI's lesson identification.
+    """Upload worksheet photos and kick off AI lesson identification.
 
-    Phase 1: stores the confirmed lesson_id on the upload record.
-    Phase 2: will trigger answer extraction + grading job.
+    Returns immediately with status=identifying. Poll GET /api/omo/{id} for result.
+
+    Constraints:
+    - Max 5 files per call
+    - Max 10MB per file
+    - JPEG / PNG / WebP only
     """
-    upload = db.query(OmoUpload).filter(
-        OmoUpload.id == upload_id,
-        OmoUpload.student_id == current_user.id,
-    ).first()
+    if not files:
+        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
+    if len(files) > _MAX_FILES_PER_UPLOAD:
+        raise HTTPException(
+            status_code=400,
+            detail=f"最多只能上傳 {_MAX_FILES_PER_UPLOAD} 張照片",
+        )
 
-    if not upload:
-        raise HTTPException(status_code=404, detail="找不到此上傳記錄")
+    image_bytes_list: list[bytes] = []
+    mime_types: list[str] = []
+    for f in files:
+        content_type = f.content_type or "image/jpeg"
+        if content_type not in _ALLOWED_MIME_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"不支援的圖片格式 {content_type}，請上傳 JPEG 或 PNG",
+            )
+        data = await f.read()
+        if len(data) > _MAX_FILE_SIZE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"圖片太大（{len(data) // (1024*1024)}MB），最大允許 10MB",
+            )
+        if len(data) == 0:
+            raise HTTPException(status_code=400, detail="上傳的圖片是空的")
+        image_bytes_list.append(data)
+        mime_types.append(content_type)
 
-    if upload.status not in ("identified", "failed"):
+    # Create upload record (status=identifying)
+    upload = OmoUpload(
+        student_id=current_user.id,
+        status="identifying",
+        answers=[],
+        progress={},
+    )
+    db.add(upload)
+    db.flush()   # get id before commit
+    upload_id = upload.id
+
+    # Create first attempt
+    image_paths = []
+    for i, (data, mime) in enumerate(zip(image_bytes_list, mime_types)):
+        path = _upload_to_gcs(current_user.id, upload_id, 0, i, data, mime)
+        image_paths.append(path)
+
+    attempt = OmoUploadAttempt(
+        omo_upload_id=upload_id,
+        attempt_idx=0,
+        image_paths=image_paths,
+        is_active=True,
+    )
+    db.add(attempt)
+    db.commit()
+
+    background_tasks.add_task(_run_identification, upload_id, image_bytes_list, mime_types)
+
+    logger.info(
+        "OMO upload created: id=%d student=%d files=%d",
+        upload_id, current_user.id, len(files),
+    )
+
+    return OmoUploadResponse(
+        upload_id=upload_id,
+        status="identifying",
+        candidates=[],
+        answers=[],
+    )
+
+
+@router.post(
+    "/omo/{upload_id}/attempt",
+    response_model=OmoAttemptResponse,
+    status_code=201,
+    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=10, window_seconds=60))],
+)
+async def add_attempt(
+    upload_id: int,
+    background_tasks: BackgroundTasks,
+    files: list[UploadFile] = File(
+        ...,
+        description="Additional worksheet photos for this upload session",
+    ),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Add another image capture attempt to an existing OMO upload session.
+
+    Supports multi-page worksheets and retakes. Max 5 attempts total.
+    Each new attempt is marked is_active=True; previous attempts set to False.
+    Re-triggers AI identification using the new images.
+    """
+    upload = _get_upload_or_404(upload_id, current_user, db)
+
+    # Count existing attempts
+    existing_attempts = db.query(OmoUploadAttempt).filter(
+        OmoUploadAttempt.omo_upload_id == upload_id
+    ).count()
+    if existing_attempts >= _MAX_TOTAL_ATTEMPTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"最多 {_MAX_TOTAL_ATTEMPTS} 次重拍機會",
+        )
+
+    if not files:
+        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
+    if len(files) > _MAX_FILES_PER_UPLOAD:
+        raise HTTPException(
+            status_code=400,
+            detail=f"每次最多上傳 {_MAX_FILES_PER_UPLOAD} 張照片",
+        )
+
+    image_bytes_list: list[bytes] = []
+    mime_types: list[str] = []
+    for f in files:
+        content_type = f.content_type or "image/jpeg"
+        if content_type not in _ALLOWED_MIME_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"不支援的圖片格式 {content_type}",
+            )
+        data = await f.read()
+        if len(data) > _MAX_FILE_SIZE_BYTES:
+            raise HTTPException(status_code=413, detail="圖片超過 10MB")
+        if not data:
+            raise HTTPException(status_code=400, detail="空的圖片檔案")
+        image_bytes_list.append(data)
+        mime_types.append(content_type)
+
+    attempt_idx = existing_attempts  # 0-based
+
+    # Deactivate all previous attempts
+    db.query(OmoUploadAttempt).filter(
+        OmoUploadAttempt.omo_upload_id == upload_id
+    ).update({"is_active": False})
+
+    # Upload images
+    image_paths = []
+    for i, (data, mime) in enumerate(zip(image_bytes_list, mime_types)):
+        path = _upload_to_gcs(current_user.id, upload_id, attempt_idx, i, data, mime)
+        image_paths.append(path)
+
+    new_attempt = OmoUploadAttempt(
+        omo_upload_id=upload_id,
+        attempt_idx=attempt_idx,
+        image_paths=image_paths,
+        is_active=True,
+    )
+    db.add(new_attempt)
+
+    # Reset upload status for re-identification
+    upload.status = "identifying"
+    upload.error_message = None
+    db.commit()
+    db.refresh(new_attempt)
+
+    # Re-trigger identification
+    background_tasks.add_task(_run_identification, upload_id, image_bytes_list, mime_types)
+
+    logger.info(
+        "OMO attempt added: upload_id=%d attempt_idx=%d student=%d",
+        upload_id, attempt_idx, current_user.id,
+    )
+
+    return OmoAttemptResponse(
+        upload_id=upload_id,
+        attempt_id=new_attempt.id,
+        attempt_idx=attempt_idx,
+        status="identifying",
+        message="重新辨識中，請稍候",
+    )
+
+
+@router.post(
+    "/omo/{upload_id}/confirm",
+    response_model=OmoConfirmResponse,
+    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=10, window_seconds=60))],
+)
+async def confirm_lesson(
+    upload_id: int,
+    payload: OmoConfirmRequest,
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Student confirms the identified lesson, kicks off grading job.
+
+    Returns status=grading immediately. Poll GET /api/omo/{id} until status=graded.
+    """
+    upload = _get_upload_or_404(upload_id, current_user, db)
+
+    if upload.status not in ("identified", "error"):
         raise HTTPException(
             status_code=409,
             detail=f"尚未完成辨識（目前狀態：{upload.status}），請稍後再確認",
         )
 
-    # Validate the confirmed_lesson_id is among the candidates (or allow override)
+    # Log if student overrode AI candidates
     candidate_ids = []
     if upload.identification and isinstance(upload.identification, list):
         candidate_ids = [c["lesson_id"] for c in upload.identification]
-
     if candidate_ids and payload.confirmed_lesson_id not in candidate_ids:
-        # Allow override (student manually selects) but log it
         logger.info(
-            "OMO upload %d: student overrode AI — confirmed lesson_id=%d (candidates=%s)",
-            upload_id,
-            payload.confirmed_lesson_id,
-            candidate_ids,
+            "OMO upload %d: student override — confirmed lesson_id=%d (AI candidates=%s)",
+            upload_id, payload.confirmed_lesson_id, candidate_ids,
         )
 
     upload.lesson_id = payload.confirmed_lesson_id
-    upload.status = "identified"  # Keep as identified after confirm
+    upload.status = "grading"
+    upload.progress = {"stage": "queued", "total": 0, "graded": 0}
     db.commit()
 
+    # Kick off grading in background
+    background_tasks.add_task(_run_grading, upload_id, payload.confirmed_lesson_id)
+
     logger.info(
-        "OMO upload %d confirmed: student=%d lesson_id=%d",
-        upload_id,
-        current_user.id,
-        payload.confirmed_lesson_id,
+        "OMO upload %d confirmed + grading queued: student=%d lesson_id=%d",
+        upload_id, current_user.id, payload.confirmed_lesson_id,
     )
 
     return OmoConfirmResponse(
         upload_id=upload_id,
         lesson_id=payload.confirmed_lesson_id,
-        message="確認成功！Phase 2 批改功能即將推出",  # Phase 2 stub message
+        status="grading",
+        message="確認成功！AI 正在批改中，請稍候（約 15-20 秒）",
     )
+
+
+@router.get("/omo/{upload_id}", response_model=OmoUploadResponse)
+def get_upload_status(
+    upload_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Poll for identification + grading result.
+
+    Frontend should poll every 2 seconds while status is identifying/grading.
+    Status values: pending | identifying | identified | grading | graded | error
+    """
+    upload = _get_upload_or_404(upload_id, current_user, db)
+    return _build_upload_response(upload)
+
+
+@router.patch("/omo/{upload_id}/answers/{question_id}/flag", status_code=200)
+def flag_answer(
+    upload_id: int,
+    question_id: str = Path(..., description="question_id from answers array"),
+    payload: FlagRequest = FlagRequest(),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Student flags a question as incorrectly graded by AI.
+
+    Sets flag = {flagged_by, reason, flagged_at} on the answer item.
+    Logged server-side for prompt improvement. Does not change the score.
+    """
+    upload = _get_upload_or_404(upload_id, current_user, db)
+
+    if upload.status != "graded":
+        raise HTTPException(
+            status_code=409,
+            detail="批改尚未完成，無法標記問題",
+        )
+
+    answers = list(upload.answers or [])
+    found = False
+    for a in answers:
+        if a.get("question_id") == question_id:
+            a["flag"] = {
+                "flagged_by": current_user.id,
+                "reason": payload.reason,
+                "flagged_at": datetime.now(timezone.utc).isoformat(),
+            }
+            found = True
+            logger.info(
+                "OMO answer flagged: upload_id=%d question_id=%s student=%d reason=%s",
+                upload_id, question_id, current_user.id, payload.reason,
+            )
+            break
+
+    if not found:
+        raise HTTPException(status_code=404, detail=f"找不到題目 {question_id}")
+
+    # SQLAlchemy needs explicit reassignment + flag_modified to detect JSON mutation
+    # (especially on SQLite test DB which uses JSON not JSONB)
+    from sqlalchemy.orm.attributes import flag_modified
+    upload.answers = answers
+    flag_modified(upload, "answers")
+    db.commit()
+
+    return {"upload_id": upload_id, "question_id": question_id, "flagged": True}
+
+
+@router.get(
+    "/omo/{upload_id}/images/{attempt_id}/{n}",
+    response_model=SignedUrlResponse,
+)
+def get_image_signed_url(
+    upload_id: int,
+    attempt_id: int,
+    n: int = Path(..., ge=0, le=9, description="Image index within the attempt (0-based)"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get a 1-hour signed GCS URL for a specific attempt image.
+
+    Returns url=null if GCS auth is unavailable (local dev / CI).
+    """
+    # Verify ownership
+    upload = _get_upload_or_404(upload_id, current_user, db)
+
+    attempt = db.query(OmoUploadAttempt).filter(
+        OmoUploadAttempt.id == attempt_id,
+        OmoUploadAttempt.omo_upload_id == upload_id,
+    ).first()
+    if not attempt:
+        raise HTTPException(status_code=404, detail="找不到此拍攝記錄")
+
+    paths = attempt.image_paths or []
+    if n >= len(paths):
+        raise HTTPException(status_code=404, detail=f"此次拍攝只有 {len(paths)} 張照片")
+
+    object_path = paths[n]
+    signed_url = _get_signed_url(object_path)
+
+    return SignedUrlResponse(url=signed_url, expires_in_seconds=3600)
 
 
 @router.delete("/omo/{upload_id}", status_code=204)
@@ -389,27 +778,26 @@ def delete_upload(
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Student privacy delete — removes DB record and schedules GCS cleanup.
+    """Student privacy delete — removes DB record and best-effort GCS cleanup.
 
-    GCS object deletion is best-effort (logged on failure, not fatal).
+    All attempts and their images are deleted. GCS deletion failures are
+    logged but do not prevent the DB record from being removed.
     """
-    upload = db.query(OmoUpload).filter(
-        OmoUpload.id == upload_id,
-        OmoUpload.student_id == current_user.id,
-    ).first()
+    upload = _get_upload_or_404(upload_id, current_user, db)
 
-    if not upload:
-        raise HTTPException(status_code=404, detail="找不到此上傳記錄")
+    # Best-effort GCS cleanup for all attempts
+    all_attempts = db.query(OmoUploadAttempt).filter(
+        OmoUploadAttempt.omo_upload_id == upload_id
+    ).all()
 
-    # Best-effort GCS cleanup
-    for path in (upload.image_paths or []):
-        try:
-            from google.cloud import storage  # type: ignore[import]
-            client = storage.Client()
-            bucket = client.bucket(_OMO_GCS_BUCKET)
-            bucket.blob(path).delete()
-        except Exception as exc:
-            logger.warning("OMO GCS delete failed for %s: %s", path, exc)
+    for attempt in all_attempts:
+        for path in (attempt.image_paths or []):
+            try:
+                from google.cloud import storage  # type: ignore[import]
+                client = storage.Client()
+                client.bucket(_OMO_GCS_BUCKET).blob(path).delete()
+            except Exception as exc:
+                logger.warning("OMO GCS delete failed for %s: %s", path, exc)
 
     db.delete(upload)
     db.commit()

--- a/backend/app/routes/omo.py
+++ b/backend/app/routes/omo.py
@@ -1,0 +1,416 @@
+"""OMO (Online-Merge-Offline) API routes — Phase 1: upload + AI lesson identification.
+
+Endpoints:
+    POST /api/omo/upload          — upload worksheet images, trigger AI identification
+    GET  /api/omo/{upload_id}     — poll status and get identification result
+    POST /api/omo/{upload_id}/confirm  — student confirms lesson (stub for Phase 2)
+    DELETE /api/omo/{upload_id}   — student privacy delete
+
+llm-endpoint-hardening checklist:
+- Rate-limit: global middleware (300 read / 90 write per IP/min) ✅
+- Auth Depends: get_current_user on all write endpoints ✅
+- Input size cap: 10MB per file, max 5 files ✅
+- Output token cap: enforced in omo_identifier service (max_output_tokens=512) ✅
+- Fail-closed: returns error status, never auto-identifies on AI failure ✅
+- Reasoning field: each candidate has reasoning string ✅
+"""
+
+import logging
+import os
+import uuid
+from typing import Literal, Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, UploadFile, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from ..auth.dependencies import get_current_user
+from ..config import settings
+from ..database import get_db
+from ..models.omo_upload import OmoUpload
+from ..models.user import User
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["omo"])
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024   # 10MB per image
+_MAX_FILES = 5                             # max images per upload
+_OMO_GCS_BUCKET = os.environ.get("GCS_OMO_BUCKET", "lingoleap-omo-uploads")
+_ALLOWED_MIME_TYPES = {"image/jpeg", "image/jpg", "image/png", "image/webp"}
+
+
+# ── Pydantic schemas ───────────────────────────────────────────────────────────
+
+class LessonCandidateResponse(BaseModel):
+    lesson_id: int
+    grade_code: str
+    title: str
+    confidence: float
+    reasoning: str
+
+
+class OmoUploadResponse(BaseModel):
+    upload_id: int
+    status: Literal["pending", "identifying", "identified", "failed"]
+    candidates: list[LessonCandidateResponse]
+    error_message: Optional[str] = None
+
+
+class OmoConfirmRequest(BaseModel):
+    confirmed_lesson_id: int
+
+
+class OmoConfirmResponse(BaseModel):
+    upload_id: int
+    lesson_id: int
+    message: str
+
+
+# ── GCS helper ────────────────────────────────────────────────────────────────
+
+def _upload_to_gcs(user_id: int, upload_id: int, file_index: int, data: bytes, mime_type: str) -> str:
+    """Upload image bytes to GCS. Returns the GCS object path (not a signed URL).
+
+    Falls back gracefully if google-cloud-storage is not installed (local dev).
+    """
+    object_path = f"{user_id}/{upload_id}/{file_index}.jpg"
+    try:
+        from google.cloud import storage  # type: ignore[import]
+        client = storage.Client()
+        bucket = client.bucket(_OMO_GCS_BUCKET)
+        blob = bucket.blob(object_path)
+        blob.upload_from_string(data, content_type=mime_type)
+        logger.info("OMO: uploaded image to gs://%s/%s", _OMO_GCS_BUCKET, object_path)
+    except ImportError:
+        logger.warning("google-cloud-storage not available — skipping GCS upload (local dev)")
+    except Exception as exc:
+        logger.warning("OMO GCS upload failed for %s: %s — continuing without GCS", object_path, exc)
+    return object_path
+
+
+def _get_signed_url(object_path: str) -> Optional[str]:
+    """Generate a 1-hour signed URL for a GCS object. Returns None if unavailable."""
+    try:
+        import datetime
+        from google.cloud import storage  # type: ignore[import]
+        client = storage.Client()
+        bucket = client.bucket(_OMO_GCS_BUCKET)
+        blob = bucket.blob(object_path)
+        url = blob.generate_signed_url(
+            version="v4",
+            expiration=datetime.timedelta(hours=1),
+            method="GET",
+        )
+        return url
+    except Exception as exc:
+        logger.debug("OMO signed URL generation failed for %s: %s", object_path, exc)
+        return None
+
+
+# ── Background task: AI identification ───────────────────────────────────────
+
+async def _run_identification(upload_id: int, image_bytes_list: list[bytes], mime_types: list[str]):
+    """Background task: call AI to identify lesson and write result back to DB.
+
+    Uses the first image for identification (worksheet cover page).
+    """
+    from ..database import SessionLocal  # type: ignore[import]
+    from .omo import router as _  # noqa: avoid circular at module level
+
+    try:
+        from ..services.omo_identifier import identify_lesson_from_image
+    except ImportError as exc:
+        logger.error("OMO identifier import failed: %s", exc)
+        _update_status(upload_id, "failed", "AI identifier unavailable")
+        return
+
+    # Use the first image (most likely to have the title)
+    primary_image = image_bytes_list[0]
+    primary_mime = mime_types[0] if mime_types else "image/jpeg"
+
+    try:
+        candidates = await identify_lesson_from_image(primary_image, primary_mime)
+    except RuntimeError as exc:
+        logger.error("OMO identification circuit breaker: %s", exc)
+        _update_status(upload_id, "failed", "AI 服務暫時無法使用，請稍後再試")
+        return
+    except Exception as exc:
+        logger.error("OMO identification unexpected error: %s", exc, exc_info=True)
+        _update_status(upload_id, "failed", "辨識失敗，請重新上傳")
+        return
+
+    _update_with_candidates(upload_id, candidates)
+
+
+def _update_status(upload_id: int, status: str, error_message: str):
+    """Helper: open a new DB session to update status. Used in background tasks."""
+    from ..database import SessionLocal
+    db = SessionLocal()
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        if upload:
+            upload.status = status
+            upload.error_message = error_message
+            db.commit()
+    except Exception as exc:
+        logger.error("OMO _update_status failed for %d: %s", upload_id, exc)
+        db.rollback()
+    finally:
+        db.close()
+
+
+def _update_with_candidates(upload_id: int, candidates):
+    """Helper: write identification result back to DB."""
+    from ..database import SessionLocal
+    db = SessionLocal()
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        if not upload:
+            return
+
+        if not candidates:
+            upload.status = "failed"
+            upload.error_message = "照片不清楚或無法辨識課程，請重新拍攝"
+        else:
+            upload.identification = [
+                {
+                    "lesson_id": c.lesson_id,
+                    "grade_code": c.grade_code,
+                    "title": c.title,
+                    "confidence": c.confidence,
+                    "reasoning": c.reasoning,
+                }
+                for c in candidates
+            ]
+            upload.ai_confidence = candidates[0].confidence
+            upload.status = "identified"
+
+        db.commit()
+        logger.info(
+            "OMO upload %d: status=%s, top_candidate=%s",
+            upload_id,
+            upload.status,
+            candidates[0].title if candidates else "none",
+        )
+    except Exception as exc:
+        logger.error("OMO _update_with_candidates failed for %d: %s", upload_id, exc)
+        db.rollback()
+    finally:
+        db.close()
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.post("/omo/upload", response_model=OmoUploadResponse, status_code=201)
+async def upload_worksheet(
+    background_tasks: BackgroundTasks,
+    files: list[UploadFile] = File(..., description="Worksheet photos (JPEG/PNG, max 10MB each, max 5 files)"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Upload worksheet photos and kick off AI lesson identification.
+
+    Returns immediately with status=identifying. Poll GET /api/omo/{id} for result.
+
+    Input constraints:
+    - Max 5 files per upload
+    - Max 10MB per file
+    - JPEG/PNG/WebP only
+    """
+    # Validate file count
+    if not files:
+        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
+    if len(files) > _MAX_FILES:
+        raise HTTPException(status_code=400, detail=f"最多只能上傳 {_MAX_FILES} 張照片")
+
+    # Read and validate each file
+    image_bytes_list: list[bytes] = []
+    mime_types: list[str] = []
+
+    for file in files:
+        content_type = file.content_type or "image/jpeg"
+        if content_type not in _ALLOWED_MIME_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"不支援的圖片格式 {content_type}，請上傳 JPEG 或 PNG",
+            )
+
+        data = await file.read()
+        if len(data) > _MAX_FILE_SIZE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"圖片太大（{len(data) // (1024*1024)}MB），最大允許 10MB",
+            )
+        if len(data) == 0:
+            raise HTTPException(status_code=400, detail="上傳的圖片是空的")
+
+        image_bytes_list.append(data)
+        mime_types.append(content_type)
+
+    # Create DB record (status=identifying)
+    upload = OmoUpload(
+        student_id=current_user.id,
+        status="identifying",
+        image_paths=[],  # will be updated after GCS upload
+    )
+    db.add(upload)
+    db.flush()  # get upload.id before commit
+    upload_id = upload.id
+
+    # Upload images to GCS
+    image_paths = []
+    for i, (data, mime) in enumerate(zip(image_bytes_list, mime_types)):
+        path = _upload_to_gcs(current_user.id, upload_id, i, data, mime)
+        image_paths.append(path)
+
+    upload.image_paths = image_paths
+    db.commit()
+
+    # Kick off AI identification in background
+    background_tasks.add_task(
+        _run_identification, upload_id, image_bytes_list, mime_types
+    )
+
+    logger.info(
+        "OMO upload created: id=%d student=%d files=%d",
+        upload_id, current_user.id, len(files),
+    )
+
+    return OmoUploadResponse(
+        upload_id=upload_id,
+        status="identifying",
+        candidates=[],
+    )
+
+
+@router.get("/omo/{upload_id}", response_model=OmoUploadResponse)
+def get_upload_status(
+    upload_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Poll for AI identification result.
+
+    Returns status=identifying while AI is running, status=identified with
+    up to 3 candidates when done, or status=failed with an error message.
+    """
+    upload = db.query(OmoUpload).filter(
+        OmoUpload.id == upload_id,
+        OmoUpload.student_id == current_user.id,
+    ).first()
+
+    if not upload:
+        raise HTTPException(status_code=404, detail="找不到此上傳記錄")
+
+    candidates = []
+    if upload.identification and isinstance(upload.identification, list):
+        candidates = [
+            LessonCandidateResponse(
+                lesson_id=c["lesson_id"],
+                grade_code=c.get("grade_code", ""),
+                title=c.get("title", ""),
+                confidence=c.get("confidence", 0.0),
+                reasoning=c.get("reasoning", ""),
+            )
+            for c in upload.identification
+        ]
+
+    return OmoUploadResponse(
+        upload_id=upload.id,
+        status=upload.status,  # type: ignore[arg-type]
+        candidates=candidates,
+        error_message=upload.error_message,
+    )
+
+
+@router.post("/omo/{upload_id}/confirm", response_model=OmoConfirmResponse)
+def confirm_lesson(
+    upload_id: int,
+    payload: OmoConfirmRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Student confirms the AI's lesson identification.
+
+    Phase 1: stores the confirmed lesson_id on the upload record.
+    Phase 2: will trigger answer extraction + grading job.
+    """
+    upload = db.query(OmoUpload).filter(
+        OmoUpload.id == upload_id,
+        OmoUpload.student_id == current_user.id,
+    ).first()
+
+    if not upload:
+        raise HTTPException(status_code=404, detail="找不到此上傳記錄")
+
+    if upload.status not in ("identified", "failed"):
+        raise HTTPException(
+            status_code=409,
+            detail=f"尚未完成辨識（目前狀態：{upload.status}），請稍後再確認",
+        )
+
+    # Validate the confirmed_lesson_id is among the candidates (or allow override)
+    candidate_ids = []
+    if upload.identification and isinstance(upload.identification, list):
+        candidate_ids = [c["lesson_id"] for c in upload.identification]
+
+    if candidate_ids and payload.confirmed_lesson_id not in candidate_ids:
+        # Allow override (student manually selects) but log it
+        logger.info(
+            "OMO upload %d: student overrode AI — confirmed lesson_id=%d (candidates=%s)",
+            upload_id,
+            payload.confirmed_lesson_id,
+            candidate_ids,
+        )
+
+    upload.lesson_id = payload.confirmed_lesson_id
+    upload.status = "identified"  # Keep as identified after confirm
+    db.commit()
+
+    logger.info(
+        "OMO upload %d confirmed: student=%d lesson_id=%d",
+        upload_id,
+        current_user.id,
+        payload.confirmed_lesson_id,
+    )
+
+    return OmoConfirmResponse(
+        upload_id=upload_id,
+        lesson_id=payload.confirmed_lesson_id,
+        message="確認成功！Phase 2 批改功能即將推出",  # Phase 2 stub message
+    )
+
+
+@router.delete("/omo/{upload_id}", status_code=204)
+def delete_upload(
+    upload_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Student privacy delete — removes DB record and schedules GCS cleanup.
+
+    GCS object deletion is best-effort (logged on failure, not fatal).
+    """
+    upload = db.query(OmoUpload).filter(
+        OmoUpload.id == upload_id,
+        OmoUpload.student_id == current_user.id,
+    ).first()
+
+    if not upload:
+        raise HTTPException(status_code=404, detail="找不到此上傳記錄")
+
+    # Best-effort GCS cleanup
+    for path in (upload.image_paths or []):
+        try:
+            from google.cloud import storage  # type: ignore[import]
+            client = storage.Client()
+            bucket = client.bucket(_OMO_GCS_BUCKET)
+            bucket.blob(path).delete()
+        except Exception as exc:
+            logger.warning("OMO GCS delete failed for %s: %s", path, exc)
+
+    db.delete(upload)
+    db.commit()
+    logger.info("OMO upload %d deleted by student %d", upload_id, current_user.id)

--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -1,0 +1,290 @@
+"""OMO grading service — extracts per-question student answers from worksheet images.
+
+Uses Vertex AI Gemini (gemini-2.5-flash) with structured output to:
+  1. Analyse worksheet image(s) against the lesson YAML schema
+  2. Extract fill_in_blank / MCQ / self_check answers
+  3. Compare against correct answers from lesson YAML
+  4. Return per-question scores with ai_confidence + reasoning
+
+llm-endpoint-hardening checklist (applied in calling route, not here):
+- Rate-limit: enforced at route level ✅
+- Auth: enforced at route level ✅
+- Input size cap: 10MB per image checked before calling this ✅
+- Output token cap: max_output_tokens=2048 ✅
+- Fail-closed: returns status=error on failure, never auto-passes ✅
+- Reasoning field: every answer item has a reasoning string ✅
+
+Circuit breaker: 3 consecutive errors → RuntimeError (same pattern as omo_identifier)
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker state (module-level singleton, per-process)
+_consecutive_errors = 0
+_CIRCUIT_BREAKER_THRESHOLD = 3
+
+
+@dataclass
+class GradedAnswer:
+    """Result for one question extracted from the worksheet image."""
+    question_id: str
+    student_answer: str
+    correct_answer: str
+    score: float          # 0.0 – 1.0
+    ai_confidence: float  # 0.0 – 1.0
+    reasoning: str
+    position: Optional[dict] = None   # {"x": float, "y": float} relative coords
+    source_attempt_id: Optional[int] = None
+
+
+def _build_question_schema(lesson: dict) -> list[dict]:
+    """Extract expected-answer schema from lesson YAML for the grading prompt."""
+    questions = []
+
+    # fill_in_blank section
+    fb = lesson.get("fill_in_blank") or {}
+    for qid, item in fb.items() if isinstance(fb, dict) else []:
+        if isinstance(item, dict):
+            correct = item.get("answer", "")
+            context = item.get("context", item.get("sentence", ""))
+        else:
+            correct = str(item)
+            context = ""
+        questions.append({
+            "id": qid,
+            "type": "fill_blank",
+            "context": context,
+            "correct_answer": correct,
+        })
+
+    # multiple_choice section
+    mc = lesson.get("multiple_choice") or {}
+    for qid, item in mc.items() if isinstance(mc, dict) else []:
+        if isinstance(item, dict):
+            correct = item.get("answer", "")
+            context = item.get("question", "")
+        else:
+            correct = str(item)
+            context = ""
+        questions.append({
+            "id": qid,
+            "type": "multiple_choice",
+            "context": context,
+            "correct_answer": correct,
+        })
+
+    # strategy_exercise section (structured exercises in 7-lesson set)
+    se = lesson.get("strategy_exercise") or {}
+    if isinstance(se, dict):
+        items = se.get("items") or se.get("questions") or []
+        if isinstance(items, list):
+            for i, item in enumerate(items):
+                if isinstance(item, dict) and "answer" in item:
+                    qid = item.get("id", f"se_{i+1}")
+                    questions.append({
+                        "id": qid,
+                        "type": "fill_blank",
+                        "context": item.get("stem", item.get("question", "")),
+                        "correct_answer": item.get("answer", ""),
+                    })
+
+    return questions
+
+
+def _build_grading_prompt(questions: list[dict]) -> str:
+    """Build the system prompt for Gemini grading."""
+    questions_text = "\n".join(
+        f"  {i+1}. [ID: {q['id']} | type: {q['type']}] Context: {q['context']} | Expected answer: {q['correct_answer']}"
+        for i, q in enumerate(questions)
+    )
+    return f"""你是一位精準的國語文作業批改老師。
+
+任務：從學生的手寫學習單照片中，找出每一題的手寫答案，並與標準答案比對評分。
+
+待批改題目清單：
+{questions_text}
+
+批改規則：
+1. 找到每題對應的手寫區域
+2. 辨識學生的手寫文字
+3. 與標準答案比對（允許合理的字體變異）
+4. 評分：完全正確 = 1.0，部分正確 = 0.5，明顯錯誤 = 0.0，無法辨識 = 0.0
+5. ai_confidence：手寫辨識清晰度，0.0（完全無法辨識）～1.0（非常清晰）
+6. reasoning：說明辨識結果與評分理由（中文，限 50 字）
+
+回傳 JSON 陣列，每題一筆記錄。"""
+
+
+async def grade_worksheet_images(
+    image_bytes_list: list[bytes],
+    mime_types: list[str],
+    lesson: dict,
+    attempt_id: Optional[int] = None,
+) -> list[GradedAnswer]:
+    """Grade worksheet images against the lesson YAML schema.
+
+    Args:
+        image_bytes_list: List of raw image bytes (all active attempt images).
+        mime_types: Corresponding MIME types.
+        lesson: Lesson dict from lesson_loader (contains fill_in_blank, MCQ, etc.).
+        attempt_id: The OmoUploadAttempt.id to record as source_attempt_id.
+
+    Returns:
+        List of GradedAnswer objects, one per question.
+        Empty list on failure (fail-closed).
+
+    Raises:
+        RuntimeError: If circuit breaker threshold is reached (3 consecutive errors).
+    """
+    global _consecutive_errors
+
+    if _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD:
+        raise RuntimeError(
+            f"OMO grader circuit breaker open after {_CIRCUIT_BREAKER_THRESHOLD} consecutive errors"
+        )
+
+    questions = _build_question_schema(lesson)
+    if not questions:
+        logger.warning(
+            "omo_grader: no questions found in lesson %s — returning empty grades",
+            lesson.get("title", "unknown"),
+        )
+        return []
+
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except ImportError:
+        logger.warning("google-genai not available — returning mock grades for local dev")
+        _consecutive_errors = 0
+        return _mock_grades(questions, attempt_id)
+
+    client = genai.Client(vertexai=True, project="lingoleap-dev", location="us-central1")
+
+    # Build content parts: system prompt + all images
+    image_parts = []
+    for data, mime in zip(image_bytes_list, mime_types):
+        image_parts.append(
+            genai_types.Part.from_bytes(data=data, mime_type=mime)
+        )
+
+    # Response schema for structured output
+    response_schema = {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "question_id":      {"type": "string"},
+                "student_answer":   {"type": "string"},
+                "correct_answer":   {"type": "string"},
+                "score":            {"type": "number"},
+                "ai_confidence":    {"type": "number"},
+                "reasoning":        {"type": "string"},
+                "position_x":       {"type": "number"},
+                "position_y":       {"type": "number"},
+            },
+            "required": ["question_id", "student_answer", "correct_answer", "score", "ai_confidence", "reasoning"],
+        },
+    }
+
+    system_prompt = _build_grading_prompt(questions)
+
+    try:
+        response = await asyncio.wait_for(
+            asyncio.to_thread(
+                client.models.generate_content,
+                model="gemini-2.5-flash",
+                contents=[genai_types.Content(parts=image_parts, role="user")],
+                config=genai_types.GenerateContentConfig(
+                    system_instruction=system_prompt,
+                    response_mime_type="application/json",
+                    response_schema=response_schema,
+                    max_output_tokens=2048,
+                    temperature=0.1,   # low temp for deterministic grading
+                    thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
+                    automatic_function_calling=genai_types.AutomaticFunctionCallingConfig(
+                        disable=True
+                    ),
+                ),
+            ),
+            timeout=60,  # grading can take longer than identification
+        )
+    except asyncio.TimeoutError:
+        _consecutive_errors += 1
+        logger.error("OMO grader timeout after 60s (consecutive_errors=%d)", _consecutive_errors)
+        if _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD:
+            raise RuntimeError("OMO grader circuit breaker opened")
+        return []
+    except Exception as exc:
+        _consecutive_errors += 1
+        logger.error("OMO grader Gemini call failed: %s (consecutive_errors=%d)", exc, _consecutive_errors)
+        if _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD:
+            raise RuntimeError("OMO grader circuit breaker opened")
+        return []
+
+    # Parse response
+    import json
+    try:
+        raw_text = response.text or ""
+        if not raw_text:
+            raise ValueError("Gemini returned empty grading response")
+        items = json.loads(raw_text)
+        if not isinstance(items, list):
+            raise ValueError(f"Expected list, got {type(items)}")
+    except Exception as exc:
+        _consecutive_errors += 1
+        logger.error("OMO grader JSON parse failed: %s (consecutive_errors=%d)", exc, _consecutive_errors)
+        if _consecutive_errors >= _CIRCUIT_BREAKER_THRESHOLD:
+            raise RuntimeError("OMO grader circuit breaker opened")
+        return []
+
+    # Reset circuit breaker on success
+    _consecutive_errors = 0
+
+    results = []
+    for item in items:
+        try:
+            results.append(GradedAnswer(
+                question_id=str(item.get("question_id", "")),
+                student_answer=str(item.get("student_answer", "")),
+                correct_answer=str(item.get("correct_answer", "")),
+                score=float(item.get("score", 0.0)),
+                ai_confidence=float(item.get("ai_confidence", 0.0)),
+                reasoning=str(item.get("reasoning", "")),
+                position={
+                    "x": float(item.get("position_x", 0.0)),
+                    "y": float(item.get("position_y", 0.0)),
+                } if "position_x" in item else None,
+                source_attempt_id=attempt_id,
+            ))
+        except Exception as exc:
+            logger.warning("OMO grader: skipping malformed answer item %s: %s", item, exc)
+
+    logger.info(
+        "OMO grader: graded %d/%d questions for lesson '%s'",
+        len(results),
+        len(questions),
+        lesson.get("title", "unknown"),
+    )
+    return results
+
+
+def _mock_grades(questions: list[dict], attempt_id: Optional[int]) -> list[GradedAnswer]:
+    """Return mock GradedAnswer objects for local dev (no Gemini available)."""
+    return [
+        GradedAnswer(
+            question_id=q["id"],
+            student_answer="[mock answer]",
+            correct_answer=q["correct_answer"],
+            score=1.0,
+            ai_confidence=0.9,
+            reasoning="本地開發模式：模擬批改結果",
+            source_attempt_id=attempt_id,
+        )
+        for q in questions
+    ]

--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -42,21 +42,47 @@ class GradedAnswer:
     source_attempt_id: Optional[int] = None
 
 
+def _resolve_letter_answer(letter: str, vocabulary: list) -> str:
+    """Resolve A/B/C/... letter to vocabulary word.
+
+    L22-L30 YAML uses ordered letter (A=0, B=1, ...) as placeholder for the
+    vocabulary list index. So `answer: A` for fill_in_blank means the student
+    should fill in vocabulary[0].word (e.g. '奠定').
+
+    Returns the actual word if letter matches a vocab index, else returns
+    the letter as-is (for backward compatibility with non-vocab grading).
+    """
+    if not isinstance(letter, str) or len(letter) != 1 or not letter.isalpha():
+        return str(letter)
+    if not isinstance(vocabulary, list) or not vocabulary:
+        return letter
+    idx = ord(letter.upper()) - ord("A")
+    if not (0 <= idx < len(vocabulary)):
+        return letter
+    v = vocabulary[idx]
+    if isinstance(v, dict):
+        return str(v.get("word") or v.get("term") or letter)
+    return str(v)
+
+
 def _build_question_schema(lesson: dict) -> list[dict]:
     """Extract expected-answer schema from lesson YAML for the grading prompt."""
     questions = []
+    vocabulary = lesson.get("vocabulary") or []
 
     # fill_in_blank section — accepts list[dict] or dict[str, dict]
+    # YAML pattern (L22-L30): answer is a letter A/B/C... that indexes into vocabulary list.
     fb = lesson.get("fill_in_blank") or []
     fb_items = fb.items() if isinstance(fb, dict) else enumerate(fb)
     for key, item in fb_items:
         qid = str(key) if isinstance(fb, dict) else f"fb_{key+1}"
         if isinstance(item, dict):
-            correct = item.get("answer", "")
+            raw_answer = item.get("answer", "")
             context = item.get("context", item.get("sentence", ""))
         else:
-            correct = str(item)
+            raw_answer = str(item)
             context = ""
+        correct = _resolve_letter_answer(raw_answer, vocabulary)
         questions.append({
             "id": qid,
             "type": "fill_blank",

--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -46,9 +46,11 @@ def _build_question_schema(lesson: dict) -> list[dict]:
     """Extract expected-answer schema from lesson YAML for the grading prompt."""
     questions = []
 
-    # fill_in_blank section
-    fb = lesson.get("fill_in_blank") or {}
-    for qid, item in fb.items() if isinstance(fb, dict) else []:
+    # fill_in_blank section — accepts list[dict] or dict[str, dict]
+    fb = lesson.get("fill_in_blank") or []
+    fb_items = fb.items() if isinstance(fb, dict) else enumerate(fb)
+    for key, item in fb_items:
+        qid = str(key) if isinstance(fb, dict) else f"fb_{key+1}"
         if isinstance(item, dict):
             correct = item.get("answer", "")
             context = item.get("context", item.get("sentence", ""))
@@ -62,12 +64,14 @@ def _build_question_schema(lesson: dict) -> list[dict]:
             "correct_answer": correct,
         })
 
-    # multiple_choice section
-    mc = lesson.get("multiple_choice") or {}
-    for qid, item in mc.items() if isinstance(mc, dict) else []:
+    # multiple_choice section — accepts list[dict] or dict[str, dict]
+    mc = lesson.get("multiple_choice") or []
+    mc_items = mc.items() if isinstance(mc, dict) else enumerate(mc)
+    for key, item in mc_items:
+        qid = str(key) if isinstance(mc, dict) else f"mc_{key+1}"
         if isinstance(item, dict):
             correct = item.get("answer", "")
-            context = item.get("question", "")
+            context = item.get("question", item.get("sentence", ""))
         else:
             correct = str(item)
             context = ""

--- a/backend/app/services/omo_identifier.py
+++ b/backend/app/services/omo_identifier.py
@@ -1,0 +1,258 @@
+"""OMO Phase 1: AI lesson identification service.
+
+Given uploaded image bytes, calls Vertex AI Gemini to:
+1. Extract visible text from the worksheet photo (OCR-like)
+2. Match against the 7 known OMO lessons (G6-L22~25, G7-L28~30)
+3. Return top-3 candidates with confidence scores
+
+llm-endpoint-hardening checklist:
+- Rate-limit handled by global middleware ✅
+- Auth: caller must be authenticated (enforced in route layer) ✅
+- Input size cap: max image 10MB enforced in route ✅
+- Output token cap: max_output_tokens=512 ✅
+- Fail-closed: returns empty candidates on error, never auto-passes ✅
+- Reasoning field: each candidate has reasoning string ✅
+- Circuit breaker: 3 consecutive errors → raise RuntimeError → 503 ✅
+"""
+
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+from .ai_base import _get_client, _repair_json, GeminiContentFilterError
+
+logger = logging.getLogger(__name__)
+
+# OMO lesson IDs (lesson_number field in L*.yml)
+_OMO_LESSON_IDS = [22, 23, 24, 25, 28, 29, 30]
+
+# Max consecutive AI errors before raising RuntimeError (circuit breaker)
+_MAX_CONSECUTIVE_ERRORS = 3
+_consecutive_errors = 0
+
+# Lesson metadata cache (loaded once at import)
+_LESSON_CACHE: list[dict] = []
+
+
+@dataclass
+class LessonCandidate:
+    lesson_id: int
+    grade_code: str
+    title: str
+    confidence: float
+    reasoning: str = field(default="")
+
+
+def _load_omo_lessons() -> list[dict]:
+    """Load the 7 OMO lesson metadata from YAML files. Cached after first call."""
+    global _LESSON_CACHE
+    if _LESSON_CACHE:
+        return _LESSON_CACHE
+
+    lessons_dir = Path(__file__).parent.parent.parent / "data" / "lessons"
+    result = []
+    for lesson_id in _OMO_LESSON_IDS:
+        yml_path = lessons_dir / f"L{lesson_id}.yml"
+        if not yml_path.exists():
+            logger.warning("OMO lesson file not found: %s", yml_path)
+            continue
+        try:
+            with open(yml_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            result.append(
+                {
+                    "lesson_id": lesson_id,
+                    "grade_code": data.get("grade_code", f"L{lesson_id}"),
+                    "title": data.get("title", "").lstrip("-").strip(),
+                    "story_snippet": (data.get("story_text", "") or "")[:200],
+                    "vocabulary": [
+                        v.get("word", "") for v in (data.get("vocabulary") or [])[:8]
+                    ],
+                }
+            )
+        except Exception as exc:
+            logger.warning("Failed to load OMO lesson %d: %s", lesson_id, exc)
+
+    _LESSON_CACHE = result
+    logger.info("Loaded %d OMO lesson entries for identification", len(result))
+    return result
+
+
+def _build_identification_prompt(lessons: list[dict]) -> str:
+    """Build the structured Gemini prompt for lesson identification."""
+    lesson_list = "\n".join(
+        f"  - lesson_id={l['lesson_id']}, grade={l['grade_code']}, "
+        f"title=\"{l['title']}\", "
+        f"opening_words=\"{l['story_snippet'][:80]}...\", "
+        f"vocab_hints=[{', '.join(l['vocabulary'][:5])}]"
+        for l in lessons
+    )
+
+    return f"""You are an AI reading assistant for a Taiwanese elementary/junior-high school platform.
+
+A student uploaded a photo of a paper worksheet. Your task is to identify which of the following 7 known lessons this worksheet belongs to, by reading visible text in the image.
+
+Known lessons:
+{lesson_list}
+
+Instructions:
+1. Read all visible text in the image, especially the large title text at the top.
+2. Compare the extracted title, opening sentences, and vocabulary words against the known lessons above.
+3. Return your top-3 best-matching candidates, sorted by confidence (highest first).
+4. Use confidence 0.0–1.0 where:
+   - 0.9+ = title matches exactly or near-exactly
+   - 0.7–0.89 = partial title match or story text matches
+   - 0.4–0.69 = vocabulary or content theme matches
+   - <0.4 = weak or speculative match
+
+Respond ONLY with valid JSON in this exact format (no markdown, no explanation outside JSON):
+{{
+  "extracted_title": "<title text you could read from the image, or empty string>",
+  "candidates": [
+    {{
+      "lesson_id": <integer>,
+      "grade_code": "<string>",
+      "title": "<string>",
+      "confidence": <float 0.0-1.0>,
+      "reasoning": "<one sentence explaining why you matched this lesson>"
+    }}
+  ]
+}}
+
+If the image is too blurry or no text is readable, return:
+{{
+  "extracted_title": "",
+  "candidates": [],
+  "error": "image_unclear"
+}}"""
+
+
+async def identify_lesson_from_image(image_bytes: bytes, mime_type: str = "image/jpeg") -> list[LessonCandidate]:
+    """Identify which OMO lesson a worksheet photo belongs to.
+
+    Args:
+        image_bytes: Raw image bytes (JPEG or PNG), max 10MB enforced by caller.
+        mime_type: MIME type of the image.
+
+    Returns:
+        List of up to 3 LessonCandidate objects, sorted by confidence descending.
+        Returns [] on AI error (fail-closed — never auto-identifies on error).
+
+    Raises:
+        RuntimeError: After 3 consecutive errors (circuit breaker).
+    """
+    global _consecutive_errors
+
+    lessons = _load_omo_lessons()
+    if not lessons:
+        logger.error("No OMO lessons loaded — cannot identify")
+        return []
+
+    client = _get_client()
+    prompt = _build_identification_prompt(lessons)
+
+    # Encode image for inline content part
+    image_b64 = base64.b64encode(image_bytes).decode("utf-8")
+
+    try:
+        from google.genai import types as genai_types
+
+        response = await client.aio.models.generate_content(
+            model="gemini-2.5-flash",
+            contents=[
+                genai_types.Content(
+                    role="user",
+                    parts=[
+                        genai_types.Part(
+                            inline_data=genai_types.Blob(
+                                mime_type=mime_type,
+                                data=image_b64,
+                            )
+                        ),
+                        genai_types.Part(text=prompt),
+                    ],
+                )
+            ],
+            config=genai_types.GenerateContentConfig(
+                temperature=0.1,  # Low temperature for deterministic identification
+                max_output_tokens=512,
+            ),
+        )
+
+        raw_text = response.text.strip()
+
+        # Strip markdown code fences if present
+        if raw_text.startswith("```"):
+            lines = raw_text.split("\n")
+            raw_text = "\n".join(
+                line for line in lines if not line.startswith("```")
+            ).strip()
+
+        data = json.loads(_repair_json(raw_text))
+
+        if data.get("error") == "image_unclear":
+            logger.warning("OMO identification: image too unclear for OCR")
+            _consecutive_errors = 0
+            return []
+
+        candidates_raw = data.get("candidates", [])
+        if not isinstance(candidates_raw, list):
+            logger.warning("OMO identification: unexpected response shape: %s", data)
+            _consecutive_errors = 0
+            return []
+
+        candidates = []
+        for c in candidates_raw[:3]:
+            try:
+                candidates.append(
+                    LessonCandidate(
+                        lesson_id=int(c["lesson_id"]),
+                        grade_code=str(c.get("grade_code", "")),
+                        title=str(c.get("title", "")),
+                        confidence=float(c.get("confidence", 0.0)),
+                        reasoning=str(c.get("reasoning", "")),
+                    )
+                )
+            except (KeyError, ValueError, TypeError) as parse_err:
+                logger.warning("OMO identification: failed to parse candidate %s: %s", c, parse_err)
+
+        # Sort by confidence descending
+        candidates.sort(key=lambda x: x.confidence, reverse=True)
+
+        _consecutive_errors = 0
+        logger.info(
+            "OMO identification complete: top candidate=%s confidence=%.2f",
+            candidates[0].title if candidates else "none",
+            candidates[0].confidence if candidates else 0.0,
+        )
+        return candidates
+
+    except GeminiContentFilterError as exc:
+        logger.warning("OMO identification: content filter blocked: %s", exc)
+        _consecutive_errors = 0  # Not a transient error — don't count toward circuit breaker
+        return []
+
+    except json.JSONDecodeError as exc:
+        logger.error("OMO identification: JSON parse failed: %s | raw=%s", exc, raw_text[:200] if 'raw_text' in dir() else "N/A")
+        _consecutive_errors += 1
+        _check_circuit_breaker()
+        return []
+
+    except Exception as exc:
+        logger.error("OMO identification: unexpected error: %s", exc, exc_info=True)
+        _consecutive_errors += 1
+        _check_circuit_breaker()
+        return []
+
+
+def _check_circuit_breaker() -> None:
+    """Raise RuntimeError after 3 consecutive errors (circuit breaker pattern)."""
+    if _consecutive_errors >= _MAX_CONSECUTIVE_ERRORS:
+        raise RuntimeError(
+            f"OMO identifier circuit breaker tripped: "
+            f"{_consecutive_errors} consecutive errors"
+        )

--- a/backend/app/services/omo_identifier.py
+++ b/backend/app/services/omo_identifier.py
@@ -179,11 +179,26 @@ async def identify_lesson_from_image(image_bytes: bytes, mime_type: str = "image
             ],
             config=genai_types.GenerateContentConfig(
                 temperature=0.1,  # Low temperature for deterministic identification
-                max_output_tokens=512,
+                max_output_tokens=2048,  # bumped from 512 — 7 lessons × top-3 with reasoning can exceed 512
             ),
         )
 
-        raw_text = response.text.strip()
+        # Gemini may return response.text == None when safety filter blocks
+        # or when finish_reason is MAX_TOKENS / RECITATION etc. Handle gracefully.
+        raw_text = (response.text or "").strip() if response is not None else ""
+        if not raw_text:
+            finish_reason = "unknown"
+            try:
+                if response and response.candidates:
+                    finish_reason = str(response.candidates[0].finish_reason)
+            except Exception:
+                pass
+            logger.warning(
+                "OMO identification: Gemini returned empty response (finish_reason=%s)",
+                finish_reason,
+            )
+            _consecutive_errors = 0  # Not a transient error
+            return []
 
         # Strip markdown code fences if present
         if raw_text.startswith("```"):
@@ -192,7 +207,16 @@ async def identify_lesson_from_image(image_bytes: bytes, mime_type: str = "image
                 line for line in lines if not line.startswith("```")
             ).strip()
 
-        data = json.loads(_repair_json(raw_text))
+        repaired = _repair_json(raw_text)
+        if repaired is None:
+            logger.warning(
+                "OMO identification: could not repair malformed JSON | raw=%s",
+                raw_text[:200],
+            )
+            _consecutive_errors = 0
+            return []
+
+        data = json.loads(repaired)
 
         if data.get("error") == "image_unclear":
             logger.warning("OMO identification: image too unclear for OCR")

--- a/backend/tests/test_omo_upload.py
+++ b/backend/tests/test_omo_upload.py
@@ -1,14 +1,14 @@
-"""Contract tests for POST /api/omo/upload.
+"""Contract tests for OMO Phase 1a endpoints.
 
 Tests:
-- Happy path: authenticated student can upload an image → 201 + status=identifying
-- 401: unauthenticated request returns 401
-- 413: oversized file returns 413
-- 422: no files returns 422 (FastAPI validation)
-- 400: wrong mime type returns 400
-- 400: too many files returns 400
+    Happy path: upload → attempt → confirm (mocked grading) → result
+    Multi-attempt: second attempt on same upload_id
+    Flag: student flags an answer after grading
+    Auth: 401 for all write endpoints without token
+    Input validation: oversized file (413), bad mime (400), too many files (400)
+    Access control: student A cannot see student B's upload
 
-Uses SQLite in-memory DB (conftest.py patches JSONB→JSON).
+Uses SQLite in-memory DB (conftest.py patches JSONB → JSON).
 
 Run:
     cd backend && python -m pytest tests/test_omo_upload.py -v
@@ -30,9 +30,10 @@ from app.main import app
 from app.database import get_db
 from app.models import Base
 from app.models.user import Role
+from app.auth.rate_limiter import ai_rate_limiter
 
 # ---------------------------------------------------------------------------
-# Test DB setup
+# Test DB setup (SQLite in-memory)
 # ---------------------------------------------------------------------------
 
 engine = create_engine(
@@ -51,7 +52,6 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
 
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-# Seed roles — must match production migration
 _SEED_ROLES = [
     {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
     {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
@@ -90,6 +90,14 @@ def setup_db():
     Base.metadata.drop_all(bind=engine)
 
 
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    """Clear in-memory rate limiter store before each test to prevent 429 cascade."""
+    with ai_rate_limiter._lock:
+        ai_rate_limiter._store.clear()
+    yield
+
+
 @pytest.fixture(scope="module")
 def client():
     with TestClient(app) as c:
@@ -101,22 +109,17 @@ def client():
 # ---------------------------------------------------------------------------
 
 def register_and_login(client, email_suffix="omouser"):
-    """Register a user and return a bearer token.
-
-    Uses JSON body for both register and login (platform convention).
-    """
+    """Register a user and return a bearer token."""
     email = f"{email_suffix}@example.com"
     reg = client.post("/api/auth/register", json={
         "email": email,
         "password": "TestPass123!",
         "name": f"OMO Test {email_suffix}",
     })
-    # Handle email verification token if returned (issue #460 config)
     if reg.status_code == 201:
         verification_token = reg.json().get("verification_token")
         if verification_token:
             client.get(f"/api/auth/verify-email?token={verification_token}")
-    # 400 = already registered — fine, just log in
     login = client.post("/api/auth/login", json={
         "email": email,
         "password": "TestPass123!",
@@ -144,6 +147,23 @@ _TINY_JPEG = bytes(
     b"STUVWXYZ\xff\xda\x00\x08\x01\x01\x00\x00?\x00\xfb\xd5\xff\xd9"
 )
 
+# Helpers to force upload status via direct DB writes (bypass background tasks)
+
+def _force_upload_status(upload_id: int, status: str, extra: dict = None):
+    """Directly set OmoUpload.status in the test DB."""
+    from app.models.omo_upload import OmoUpload
+    db = TestingSessionLocal()
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        if upload:
+            upload.status = status
+            if extra:
+                for k, v in extra.items():
+                    setattr(upload, k, v)
+            db.commit()
+    finally:
+        db.close()
+
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -152,7 +172,7 @@ _TINY_JPEG = bytes(
 class TestOmoUploadHappyPath:
     def test_upload_returns_201_with_identifying_status(self, client):
         """Authenticated student uploads a valid JPEG → 201 + status=identifying."""
-        token = register_and_login(client, "omo_happy")
+        token = register_and_login(client, "omo_happy1a")
         headers = {"Authorization": f"Bearer {token}"}
 
         response = client.post(
@@ -167,11 +187,12 @@ class TestOmoUploadHappyPath:
         assert "upload_id" in data
         assert isinstance(data["upload_id"], int)
         assert data["upload_id"] > 0
-        assert isinstance(data["candidates"], list)  # empty while identifying
+        assert isinstance(data["candidates"], list)
+        assert isinstance(data["answers"], list)
 
     def test_can_poll_status_after_upload(self, client):
         """After upload, GET /omo/{id} returns the same record."""
-        token = register_and_login(client, "omo_poll")
+        token = register_and_login(client, "omo_poll1a")
         headers = {"Authorization": f"Bearer {token}"}
 
         post_resp = client.post(
@@ -186,47 +207,240 @@ class TestOmoUploadHappyPath:
         assert get_resp.status_code == 200
         data = get_resp.json()
         assert data["upload_id"] == upload_id
-        assert data["status"] in ("pending", "identifying", "identified", "failed")
+        assert data["status"] in ("pending", "identifying", "identified", "grading", "graded", "error")
 
+    def test_full_happy_path_mocked_grading(self, client):
+        """Upload → force identified → confirm → verify status=grading → force graded → poll result."""
+        token = register_and_login(client, "omo_fullpath")
+        headers = {"Authorization": f"Bearer {token}"}
 
-class TestOmoUploadAuth:
-    def test_unauthenticated_returns_401(self, client):
-        """No token → 401."""
-        response = client.post(
-            "/api/omo/upload",
-            files=[("files", ("worksheet.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
-        )
-        assert response.status_code == 401, f"Expected 401, got {response.status_code}"
-
-    def test_cannot_see_other_student_upload(self, client):
-        """Student A cannot access Student B's upload."""
-        token_a = register_and_login(client, "omo_studentA")
-        token_b = register_and_login(client, "omo_studentB")
-
-        # Student A uploads
+        # 1. Upload
         post_resp = client.post(
             "/api/omo/upload",
-            files=[("files", ("sheet.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers=headers,
+        )
+        assert post_resp.status_code == 201
+        upload_id = post_resp.json()["upload_id"]
+
+        # 2. Force identified (simulate background AI task completing)
+        _force_upload_status(upload_id, "identified", {
+            "identification": [
+                {
+                    "lesson_id": 1,
+                    "grade_code": "G4-1",
+                    "title": "贏得喝采的輸家",
+                    "confidence": 0.95,
+                    "reasoning": "Title found at top of worksheet",
+                }
+            ],
+            "ai_confidence": 0.95,
+        })
+
+        # 3. Confirm lesson (kicks off grading background task, returns status=grading)
+        confirm_resp = client.post(
+            f"/api/omo/{upload_id}/confirm",
+            json={"confirmed_lesson_id": 1},
+            headers=headers,
+        )
+        assert confirm_resp.status_code == 200, f"Got {confirm_resp.status_code}: {confirm_resp.text}"
+        data = confirm_resp.json()
+        assert data["lesson_id"] == 1
+        assert data["status"] == "grading"
+
+        # 4. Force graded (simulate background grader completing)
+        mock_answers = [
+            {
+                "question_id": "fb_1",
+                "student_answer": "漂亮",
+                "correct_answer": "漂亮",
+                "score": 1.0,
+                "ai_confidence": 0.92,
+                "reasoning": "完全一致",
+                "source_attempt_id": None,
+                "position": None,
+                "flag": None,
+            }
+        ]
+        _force_upload_status(upload_id, "graded", {
+            "answers": mock_answers,
+            "overall_score": 1.0,
+            "ai_overall_confidence": 0.92,
+            "progress": {"stage": "done", "total": 1, "graded": 1},
+        })
+
+        # 5. Poll result
+        get_resp = client.get(f"/api/omo/{upload_id}", headers=headers)
+        assert get_resp.status_code == 200
+        result = get_resp.json()
+        assert result["status"] == "graded"
+        assert result["overall_score"] == 1.0
+        assert len(result["answers"]) == 1
+        assert result["answers"][0]["question_id"] == "fb_1"
+
+
+class TestOmoMultiAttempt:
+    def test_add_second_attempt(self, client):
+        """Student can add a second attempt after upload."""
+        token = register_and_login(client, "omo_multiattempt")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Upload first attempt
+        post_resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws1.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers=headers,
+        )
+        assert post_resp.status_code == 201
+        upload_id = post_resp.json()["upload_id"]
+
+        # Add second attempt
+        attempt_resp = client.post(
+            f"/api/omo/{upload_id}/attempt",
+            files=[("files", ("ws2.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers=headers,
+        )
+        assert attempt_resp.status_code == 201, f"Got {attempt_resp.status_code}: {attempt_resp.text}"
+        data = attempt_resp.json()
+        assert data["upload_id"] == upload_id
+        assert data["attempt_idx"] == 1
+        assert data["status"] == "identifying"
+
+    def test_attempt_on_other_student_upload_returns_404(self, client):
+        """Student B cannot add attempt to Student A's upload."""
+        token_a = register_and_login(client, "omo_attemptA")
+        token_b = register_and_login(client, "omo_attemptB")
+
+        # A uploads
+        post_resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
             headers={"Authorization": f"Bearer {token_a}"},
         )
         assert post_resp.status_code == 201
         upload_id = post_resp.json()["upload_id"]
 
-        # Student B tries to access
+        # B tries to add attempt
+        attempt_resp = client.post(
+            f"/api/omo/{upload_id}/attempt",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert attempt_resp.status_code == 404
+
+
+class TestOmoFlagAnswer:
+    def test_flag_answer_after_grading(self, client):
+        """Student can flag a question after grading is done."""
+        token = register_and_login(client, "omo_flag")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Upload + force graded
+        post_resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers=headers,
+        )
+        upload_id = post_resp.json()["upload_id"]
+
+        _force_upload_status(upload_id, "graded", {
+            "answers": [
+                {
+                    "question_id": "fb_2",
+                    "student_answer": "天下",
+                    "correct_answer": "天地",
+                    "score": 0.0,
+                    "ai_confidence": 0.85,
+                    "reasoning": "答案不符",
+                    "source_attempt_id": None,
+                    "position": None,
+                    "flag": None,
+                }
+            ],
+            "overall_score": 0.0,
+        })
+
+        # Flag the question
+        flag_resp = client.patch(
+            f"/api/omo/{upload_id}/answers/fb_2/flag",
+            json={"reason": "我寫的是天地，AI辨識錯了"},
+            headers=headers,
+        )
+        assert flag_resp.status_code == 200, f"Got {flag_resp.status_code}: {flag_resp.text}"
+        assert flag_resp.json()["flagged"] is True
+
+        # Verify flag persisted
+        get_resp = client.get(f"/api/omo/{upload_id}", headers=headers)
+        answers = get_resp.json()["answers"]
+        assert answers[0]["flag"] is not None
+        assert answers[0]["flag"]["reason"] == "我寫的是天地，AI辨識錯了"
+
+    def test_flag_before_grading_returns_409(self, client):
+        """Cannot flag while still grading."""
+        token = register_and_login(client, "omo_flag_early")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        post_resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers=headers,
+        )
+        upload_id = post_resp.json()["upload_id"]
+        # Status is still "identifying" — not "graded"
+
+        flag_resp = client.patch(
+            f"/api/omo/{upload_id}/answers/fb_1/flag",
+            json={"reason": "test"},
+            headers=headers,
+        )
+        assert flag_resp.status_code == 409
+
+
+class TestOmoUploadAuth:
+    def test_upload_unauthenticated_returns_401(self, client):
+        """No token → 401."""
+        response = client.post(
+            "/api/omo/upload",
+            files=[("files", ("worksheet.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+        )
+        assert response.status_code == 401
+
+    def test_get_unauthenticated_returns_401(self, client):
+        """No token on GET → 401."""
+        response = client.get("/api/omo/99999")
+        assert response.status_code == 401
+
+    def test_confirm_unauthenticated_returns_401(self, client):
+        """No token on confirm → 401."""
+        response = client.post("/api/omo/99999/confirm", json={"confirmed_lesson_id": 1})
+        assert response.status_code == 401
+
+    def test_cannot_see_other_student_upload(self, client):
+        """Student A cannot access Student B's upload."""
+        token_a = register_and_login(client, "omo_acl_A")
+        token_b = register_and_login(client, "omo_acl_B")
+
+        post_resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("sheet.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        upload_id = post_resp.json()["upload_id"]
+
         get_resp = client.get(
             f"/api/omo/{upload_id}",
             headers={"Authorization": f"Bearer {token_b}"},
         )
-        assert get_resp.status_code == 404, f"Expected 404, got {get_resp.status_code}"
+        assert get_resp.status_code == 404
 
 
 class TestOmoUploadInputValidation:
     def test_oversized_file_returns_413(self, client):
         """File > 10MB → 413."""
-        token = register_and_login(client, "omo_oversize")
+        token = register_and_login(client, "omo_big1a")
         headers = {"Authorization": f"Bearer {token}"}
 
-        big_data = b"X" * (11 * 1024 * 1024)  # 11MB
+        big_data = b"X" * (11 * 1024 * 1024)
         response = client.post(
             "/api/omo/upload",
             files=[("files", ("big.jpg", io.BytesIO(big_data), "image/jpeg"))],
@@ -236,16 +450,14 @@ class TestOmoUploadInputValidation:
 
     def test_no_files_returns_422(self, client):
         """No files field → 422 (FastAPI validation)."""
-        token = register_and_login(client, "omo_nofiles")
+        token = register_and_login(client, "omo_none1a")
         headers = {"Authorization": f"Bearer {token}"}
-
         response = client.post("/api/omo/upload", headers=headers)
-        # FastAPI returns 422 when required File field is missing
-        assert response.status_code == 422, f"Expected 422, got {response.status_code}"
+        assert response.status_code == 422
 
     def test_invalid_mime_returns_400(self, client):
         """Non-image MIME type → 400."""
-        token = register_and_login(client, "omo_mime")
+        token = register_and_login(client, "omo_mime1a")
         headers = {"Authorization": f"Bearer {token}"}
 
         response = client.post(
@@ -253,58 +465,33 @@ class TestOmoUploadInputValidation:
             files=[("files", ("doc.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf"))],
             headers=headers,
         )
-        assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+        assert response.status_code == 400
 
     def test_too_many_files_returns_400(self, client):
         """More than 5 files → 400."""
-        token = register_and_login(client, "omo_toomany")
+        token = register_and_login(client, "omo_many1a")
         headers = {"Authorization": f"Bearer {token}"}
 
-        files = [
-            ("files", (f"p{i}.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))
-            for i in range(6)
-        ]
+        files = [("files", (f"p{i}.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg")) for i in range(6)]
         response = client.post("/api/omo/upload", files=files, headers=headers)
-        assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+        assert response.status_code == 400
 
-
-class TestOmoConfirm:
-    def test_confirm_identified_upload(self, client):
-        """Confirming a lesson on an upload sets lesson_id."""
-        token = register_and_login(client, "omo_confirm")
+    def test_confirm_wrong_status_returns_409(self, client):
+        """Confirm while still identifying → 409."""
+        token = register_and_login(client, "omo_conf409")
         headers = {"Authorization": f"Bearer {token}"}
 
-        # Upload
         post_resp = client.post(
             "/api/omo/upload",
             files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
             headers=headers,
         )
-        assert post_resp.status_code == 201
         upload_id = post_resp.json()["upload_id"]
+        # Status is "identifying" — confirm should fail
 
-        # Force status to "identified" via direct DB manipulation
-        db = TestingSessionLocal()
-        try:
-            from app.models.omo_upload import OmoUpload
-            upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
-            if upload:
-                upload.status = "identified"
-                upload.identification = [
-                    {"lesson_id": 22, "grade_code": "G6-9", "title": "植物獵人",
-                     "confidence": 0.95, "reasoning": "Title matches exactly"}
-                ]
-                db.commit()
-        finally:
-            db.close()
-
-        # Confirm
         confirm_resp = client.post(
             f"/api/omo/{upload_id}/confirm",
-            json={"confirmed_lesson_id": 22},
+            json={"confirmed_lesson_id": 1},
             headers=headers,
         )
-        assert confirm_resp.status_code == 200, f"Got {confirm_resp.status_code}: {confirm_resp.text}"
-        data = confirm_resp.json()
-        assert data["lesson_id"] == 22
-        assert data["upload_id"] == upload_id
+        assert confirm_resp.status_code == 409, f"Expected 409, got {confirm_resp.status_code}: {confirm_resp.text}"

--- a/backend/tests/test_omo_upload.py
+++ b/backend/tests/test_omo_upload.py
@@ -1,0 +1,310 @@
+"""Contract tests for POST /api/omo/upload.
+
+Tests:
+- Happy path: authenticated student can upload an image → 201 + status=identifying
+- 401: unauthenticated request returns 401
+- 413: oversized file returns 413
+- 422: no files returns 422 (FastAPI validation)
+- 400: wrong mime type returns 400
+- 400: too many files returns 400
+
+Uses SQLite in-memory DB (conftest.py patches JSONB→JSON).
+
+Run:
+    cd backend && python -m pytest tests/test_omo_upload.py -v
+"""
+
+import io
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+
+# ---------------------------------------------------------------------------
+# Test DB setup
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Seed roles — must match production migration
+_SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for r in _SEED_ROLES:
+        session.add(Role(name=r["name"], display_name=r["display_name"], scope_level=r["scope_level"]))
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+def register_and_login(client, email_suffix="omouser"):
+    """Register a user and return a bearer token.
+
+    Uses JSON body for both register and login (platform convention).
+    """
+    email = f"{email_suffix}@example.com"
+    reg = client.post("/api/auth/register", json={
+        "email": email,
+        "password": "TestPass123!",
+        "name": f"OMO Test {email_suffix}",
+    })
+    # Handle email verification token if returned (issue #460 config)
+    if reg.status_code == 201:
+        verification_token = reg.json().get("verification_token")
+        if verification_token:
+            client.get(f"/api/auth/verify-email?token={verification_token}")
+    # 400 = already registered — fine, just log in
+    login = client.post("/api/auth/login", json={
+        "email": email,
+        "password": "TestPass123!",
+    })
+    assert login.status_code == 200, f"Login failed for {email}: {login.text}"
+    return login.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Minimal valid JPEG bytes (1×1 pixel)
+# ---------------------------------------------------------------------------
+
+_TINY_JPEG = bytes(
+    b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    b"\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t"
+    b"\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a"
+    b"\x1f\x1e\x1d\x1a\x1c\x1c $.' \",#\x1c\x1c(7),01444\x1f'9=82<.342\x1e"
+    b"\xff\xc0\x00\x0b\x08\x00\x01\x00\x01\x01\x01\x11\x00"
+    b"\xff\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b"
+    b"\xff\xc4\x00\xb5\x10\x00\x02\x01\x03\x03\x02\x04\x03\x05\x05\x04"
+    b"\x04\x00\x00\x01}\x01\x02\x03\x00\x04\x11\x05\x12!1A\x06\x13Qa"
+    b'\x07"q\x142\x81\x91\xa1\x08#B\xb1\xc1\x15R\xd1\xf0$3br'
+    b"\x82\t\n\x16\x17\x18\x19\x1a%&'()*456789:CDEFGHIJ"
+    b"STUVWXYZ\xff\xda\x00\x08\x01\x01\x00\x00?\x00\xfb\xd5\xff\xd9"
+)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOmoUploadHappyPath:
+    def test_upload_returns_201_with_identifying_status(self, client):
+        """Authenticated student uploads a valid JPEG → 201 + status=identifying."""
+        token = register_and_login(client, "omo_happy")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.post(
+            "/api/omo/upload",
+            files=[("files", ("worksheet.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers=headers,
+        )
+        assert response.status_code == 201, f"Expected 201, got {response.status_code}: {response.text}"
+
+        data = response.json()
+        assert data["status"] == "identifying"
+        assert "upload_id" in data
+        assert isinstance(data["upload_id"], int)
+        assert data["upload_id"] > 0
+        assert isinstance(data["candidates"], list)  # empty while identifying
+
+    def test_can_poll_status_after_upload(self, client):
+        """After upload, GET /omo/{id} returns the same record."""
+        token = register_and_login(client, "omo_poll")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        post_resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("worksheet.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers=headers,
+        )
+        assert post_resp.status_code == 201
+        upload_id = post_resp.json()["upload_id"]
+
+        get_resp = client.get(f"/api/omo/{upload_id}", headers=headers)
+        assert get_resp.status_code == 200
+        data = get_resp.json()
+        assert data["upload_id"] == upload_id
+        assert data["status"] in ("pending", "identifying", "identified", "failed")
+
+
+class TestOmoUploadAuth:
+    def test_unauthenticated_returns_401(self, client):
+        """No token → 401."""
+        response = client.post(
+            "/api/omo/upload",
+            files=[("files", ("worksheet.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+        )
+        assert response.status_code == 401, f"Expected 401, got {response.status_code}"
+
+    def test_cannot_see_other_student_upload(self, client):
+        """Student A cannot access Student B's upload."""
+        token_a = register_and_login(client, "omo_studentA")
+        token_b = register_and_login(client, "omo_studentB")
+
+        # Student A uploads
+        post_resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("sheet.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        assert post_resp.status_code == 201
+        upload_id = post_resp.json()["upload_id"]
+
+        # Student B tries to access
+        get_resp = client.get(
+            f"/api/omo/{upload_id}",
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert get_resp.status_code == 404, f"Expected 404, got {get_resp.status_code}"
+
+
+class TestOmoUploadInputValidation:
+    def test_oversized_file_returns_413(self, client):
+        """File > 10MB → 413."""
+        token = register_and_login(client, "omo_oversize")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        big_data = b"X" * (11 * 1024 * 1024)  # 11MB
+        response = client.post(
+            "/api/omo/upload",
+            files=[("files", ("big.jpg", io.BytesIO(big_data), "image/jpeg"))],
+            headers=headers,
+        )
+        assert response.status_code == 413, f"Expected 413, got {response.status_code}: {response.text}"
+
+    def test_no_files_returns_422(self, client):
+        """No files field → 422 (FastAPI validation)."""
+        token = register_and_login(client, "omo_nofiles")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.post("/api/omo/upload", headers=headers)
+        # FastAPI returns 422 when required File field is missing
+        assert response.status_code == 422, f"Expected 422, got {response.status_code}"
+
+    def test_invalid_mime_returns_400(self, client):
+        """Non-image MIME type → 400."""
+        token = register_and_login(client, "omo_mime")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        response = client.post(
+            "/api/omo/upload",
+            files=[("files", ("doc.pdf", io.BytesIO(b"%PDF-1.4"), "application/pdf"))],
+            headers=headers,
+        )
+        assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+
+    def test_too_many_files_returns_400(self, client):
+        """More than 5 files → 400."""
+        token = register_and_login(client, "omo_toomany")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        files = [
+            ("files", (f"p{i}.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))
+            for i in range(6)
+        ]
+        response = client.post("/api/omo/upload", files=files, headers=headers)
+        assert response.status_code == 400, f"Expected 400, got {response.status_code}: {response.text}"
+
+
+class TestOmoConfirm:
+    def test_confirm_identified_upload(self, client):
+        """Confirming a lesson on an upload sets lesson_id."""
+        token = register_and_login(client, "omo_confirm")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Upload
+        post_resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG), "image/jpeg"))],
+            headers=headers,
+        )
+        assert post_resp.status_code == 201
+        upload_id = post_resp.json()["upload_id"]
+
+        # Force status to "identified" via direct DB manipulation
+        db = TestingSessionLocal()
+        try:
+            from app.models.omo_upload import OmoUpload
+            upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+            if upload:
+                upload.status = "identified"
+                upload.identification = [
+                    {"lesson_id": 22, "grade_code": "G6-9", "title": "植物獵人",
+                     "confidence": 0.95, "reasoning": "Title matches exactly"}
+                ]
+                db.commit()
+        finally:
+            db.close()
+
+        # Confirm
+        confirm_resp = client.post(
+            f"/api/omo/{upload_id}/confirm",
+            json={"confirmed_lesson_id": 22},
+            headers=headers,
+        )
+        assert confirm_resp.status_code == 200, f"Got {confirm_resp.status_code}: {confirm_resp.text}"
+        data = confirm_resp.json()
+        assert data["lesson_id"] == 22
+        assert data["upload_id"] == upload_id

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -380,6 +380,7 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
         { icon: '📚', label: '圖書館', path: '/library' },
         { icon: '🏫', label: '班級作業', path: '/assignments', badge: pendingAssignmentCount },
         { icon: '➕', label: '加入班級', path: '/join' },
+        { icon: '📷', label: '上傳學習單', path: '/omo' },
         { icon: '📖', label: '學習紀錄', path: '/learning-history' },
         // Hidden: 成就 — merged into student home page (recent achievements strip + Lv banner) (#1163)
         // Hidden: 學習進度, 生字本, 對話記錄 — 整合到「班級作業」(#643)

--- a/frontend/src/components/omo/OmoIdentifyResult.tsx
+++ b/frontend/src/components/omo/OmoIdentifyResult.tsx
@@ -1,0 +1,256 @@
+/**
+ * OmoIdentifyResult — Phase 1 post-upload identification result page.
+ *
+ * Polls GET /api/omo/:id every 2 seconds until status transitions out of
+ * "pending"/"identifying". Once "identified", shows:
+ *   "我們判斷你的學習單是 [grade] [title]，要繼續嗎？"
+ * with a "確認" button (Phase 2 stub — wires to grading when ready).
+ *
+ * Also exposes the full top-3 candidate list in a collapsible "不確定？" section.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { getOmoStatus, confirmOmoLesson } from '../../services/omoApi';
+import type { OmoCandidate, OmoStatus } from '../../services/omoApi';
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLLS = 30; // 60 seconds max
+
+interface OmoIdentifyResultProps {
+  uploadId: number;
+  token: string;
+  /** Called after the student confirms a lesson (Phase 2 will navigate to grading) */
+  onConfirmed?: (lessonId: number) => void;
+  /** Called if user wants to go back and re-upload */
+  onRetry: () => void;
+}
+
+const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
+  uploadId,
+  token,
+  onConfirmed,
+  onRetry,
+}) => {
+  const [status, setStatus] = useState<OmoStatus>('identifying');
+  const [candidates, setCandidates] = useState<OmoCandidate[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showAllCandidates, setShowAllCandidates] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  const pollCount = useRef(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    const poll = async () => {
+      pollCount.current += 1;
+      if (pollCount.current > MAX_POLLS) {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        setErrorMessage('辨識超時，請重新上傳');
+        setStatus('failed');
+        return;
+      }
+      try {
+        const data = await getOmoStatus(uploadId, token);
+        setStatus(data.status);
+        setCandidates(data.candidates ?? []);
+        if (data.error_message) setErrorMessage(data.error_message);
+        if (data.status !== 'pending' && data.status !== 'identifying') {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+        }
+      } catch (err) {
+        // Transient network error — keep polling
+        console.error('OMO poll error:', err);
+      }
+    };
+
+    // Immediate first poll
+    void poll();
+    intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [uploadId, token]);
+
+  const handleConfirm = async (lessonId: number) => {
+    setConfirming(true);
+    try {
+      await confirmOmoLesson(uploadId, lessonId, token);
+      setConfirmed(true);
+      onConfirmed?.(lessonId);
+    } catch (err) {
+      console.error('OMO confirm error:', err);
+      setErrorMessage('確認失敗，請再試一次');
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Identifying / pending — spinner
+  // ---------------------------------------------------------------------------
+  if (status === 'pending' || status === 'identifying') {
+    return (
+      <div className="flex flex-col items-center gap-6 px-4 py-12 max-w-md mx-auto">
+        <div
+          className="w-16 h-16 rounded-full border-4 border-blue-200 border-t-blue-600 animate-spin"
+          aria-label="AI 辨識中"
+          role="status"
+        />
+        <div className="text-center">
+          <p className="font-semibold text-gray-800">AI 正在辨識你的學習單</p>
+          <p className="mt-1 text-sm text-gray-500">通常需要 10～30 秒，請稍候…</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Failed
+  // ---------------------------------------------------------------------------
+  if (status === 'failed') {
+    return (
+      <div className="flex flex-col items-center gap-6 px-4 py-8 max-w-md mx-auto">
+        <div className="text-5xl" aria-hidden="true">😕</div>
+        <div className="text-center">
+          <p className="font-semibold text-gray-800">辨識失敗</p>
+          <p className="mt-1 text-sm text-gray-500">
+            {errorMessage ?? '無法辨識學習單，請重新拍照（確保光線充足、文字清晰）'}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="w-full py-3.5 px-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors"
+        >
+          重新上傳
+        </button>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Identified — show top candidate + confirm
+  // ---------------------------------------------------------------------------
+  const topCandidate = candidates[0] ?? null;
+  const otherCandidates = candidates.slice(1);
+
+  if (confirmed) {
+    return (
+      <div className="flex flex-col items-center gap-6 px-4 py-12 max-w-md mx-auto">
+        <div className="text-5xl" aria-hidden="true">✅</div>
+        <div className="text-center">
+          <p className="font-semibold text-gray-800">已確認！</p>
+          <p className="mt-1 text-sm text-gray-500">
+            批改功能將在 Phase 2 上線，敬請期待
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 px-4 py-8 max-w-md mx-auto">
+      {/* Header */}
+      <div className="text-center">
+        <div className="text-4xl mb-2" aria-hidden="true">🔍</div>
+        <h1 className="text-xl font-bold text-gray-900">辨識結果</h1>
+      </div>
+
+      {topCandidate ? (
+        <>
+          {/* Primary identification card */}
+          <div className="bg-blue-50 border border-blue-200 rounded-2xl p-5">
+            <p className="text-sm text-blue-600 font-medium mb-1">我們判斷你的學習單是</p>
+            <p className="text-2xl font-bold text-gray-900 leading-snug">
+              {topCandidate.grade_code} {topCandidate.title}
+            </p>
+            <p className="mt-2 text-sm text-gray-500 leading-relaxed">
+              {topCandidate.reasoning}
+            </p>
+            <div className="mt-3 flex items-center gap-1.5">
+              <div
+                className="h-2 rounded-full bg-blue-400 transition-all"
+                style={{ width: `${Math.round(topCandidate.confidence * 100)}%`, maxWidth: '100%', minWidth: '4px' }}
+                aria-label={`信心度 ${Math.round(topCandidate.confidence * 100)}%`}
+              />
+              <span className="text-xs text-gray-400">
+                信心度 {Math.round(topCandidate.confidence * 100)}%
+              </span>
+            </div>
+          </div>
+
+          {/* Confirm button */}
+          <button
+            type="button"
+            onClick={() => handleConfirm(topCandidate.lesson_id)}
+            disabled={confirming}
+            className="w-full py-3.5 px-6 bg-green-600 hover:bg-green-700 disabled:opacity-60
+              text-white font-semibold rounded-xl transition-colors
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+          >
+            {confirming ? '確認中…' : '✓ 沒錯，要繼續！'}
+          </button>
+
+          {/* Other candidates (collapsed) */}
+          {otherCandidates.length > 0 && (
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowAllCandidates((v) => !v)}
+                className="w-full text-sm text-gray-500 hover:text-gray-700 underline underline-offset-2 py-1"
+              >
+                {showAllCandidates ? '收起' : '不確定？查看其他候選課文'}
+              </button>
+
+              {showAllCandidates && (
+                <div className="mt-3 flex flex-col gap-2">
+                  {otherCandidates.map((c) => (
+                    <div
+                      key={c.lesson_id}
+                      className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-xl px-4 py-3"
+                    >
+                      <div>
+                        <p className="font-medium text-gray-800 text-sm">
+                          {c.grade_code} {c.title}
+                        </p>
+                        <p className="text-xs text-gray-400 mt-0.5 line-clamp-1">
+                          {c.reasoning}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => handleConfirm(c.lesson_id)}
+                        disabled={confirming}
+                        className="ml-3 shrink-0 text-xs text-blue-600 hover:text-blue-800 font-semibold underline"
+                      >
+                        這個
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      ) : (
+        /* No candidates returned (image unclear) */
+        <div className="text-center">
+          <p className="text-gray-700">AI 無法辨識圖片中的文字</p>
+          <p className="mt-1 text-sm text-gray-500">請確保照片清晰、光線充足後重新拍攝</p>
+        </div>
+      )}
+
+      {/* Re-upload link */}
+      <button
+        type="button"
+        onClick={onRetry}
+        className="w-full text-sm text-gray-400 hover:text-gray-600 py-1"
+      >
+        重新上傳
+      </button>
+    </div>
+  );
+};
+
+export default OmoIdentifyResult;

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -1,0 +1,175 @@
+/**
+ * OmoUpload — Phase 1 paper worksheet upload UI.
+ *
+ * Renders a single-page upload experience:
+ *  - "拍照" button (camera capture on mobile: capture="environment")
+ *  - "選擇圖片" button (file picker from gallery/disk)
+ *  - Upload progress spinner
+ *  - Error display
+ *
+ * After upload returns 201 the parent routes to OmoIdentifyResult with the upload_id.
+ * Max 5 images, 10MB each — validated client-side for UX (backend re-validates).
+ */
+import React, { useRef, useState } from 'react';
+import { uploadOmoImages } from '../../services/omoApi';
+
+const MAX_FILES = 5;
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB
+const ACCEPTED_MIME = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
+
+interface OmoUploadProps {
+  token: string;
+  /** Called once upload succeeds, with the new upload_id */
+  onUploaded: (uploadId: number) => void;
+}
+
+const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded }) => {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const galleryInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = async (files: FileList | null) => {
+    setError(null);
+    if (!files || files.length === 0) return;
+
+    const fileArray = Array.from(files);
+
+    // Client-side validation (backend also validates)
+    if (fileArray.length > MAX_FILES) {
+      setError(`最多只能上傳 ${MAX_FILES} 張圖片`);
+      return;
+    }
+    for (const f of fileArray) {
+      if (!ACCEPTED_MIME.includes(f.type)) {
+        setError(`不支援的檔案格式：${f.name}（請使用 JPG、PNG 或 WebP）`);
+        return;
+      }
+      if (f.size > MAX_FILE_BYTES) {
+        setError(`圖片太大：${f.name}（每張最多 10 MB）`);
+        return;
+      }
+    }
+
+    // Show a local preview for the first file
+    const reader = new FileReader();
+    reader.onload = (e) => setPreview(e.target?.result as string);
+    reader.readAsDataURL(fileArray[0]);
+
+    setUploading(true);
+    try {
+      const result = await uploadOmoImages(fileArray, token);
+      onUploaded(result.upload_id);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '上傳失敗，請再試一次';
+      setError(msg);
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-6 px-4 py-8 max-w-md mx-auto">
+      {/* Header */}
+      <div className="text-center">
+        <div className="text-5xl mb-3" aria-hidden="true">📸</div>
+        <h1 className="text-xl font-bold text-gray-900">上傳學習單</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          拍下你的紙本學習單，AI 會自動辨識是哪一課
+        </p>
+      </div>
+
+      {/* Preview */}
+      {preview && !uploading && (
+        <div className="w-full rounded-xl overflow-hidden border border-gray-200 shadow-sm">
+          <img
+            src={preview}
+            alt="學習單預覽"
+            className="w-full object-contain max-h-48"
+          />
+        </div>
+      )}
+
+      {/* Upload spinner */}
+      {uploading && (
+        <div className="flex flex-col items-center gap-3 py-4">
+          <div
+            className="w-12 h-12 rounded-full border-4 border-blue-200 border-t-blue-600 animate-spin"
+            aria-label="上傳中"
+            role="status"
+          />
+          <p className="text-sm text-gray-500">上傳中，請稍候…</p>
+        </div>
+      )}
+
+      {/* Buttons */}
+      {!uploading && (
+        <div className="flex flex-col gap-3 w-full">
+          {/* Camera capture (mobile: opens camera directly) */}
+          <button
+            type="button"
+            onClick={() => cameraInputRef.current?.click()}
+            className="w-full flex items-center justify-center gap-2 py-3.5 px-6
+              bg-blue-600 hover:bg-blue-700 active:bg-blue-800
+              text-white font-semibold rounded-xl
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+              transition-colors"
+          >
+            <span aria-hidden="true">📷</span>
+            拍照上傳
+          </button>
+          <input
+            ref={cameraInputRef}
+            type="file"
+            accept="image/*"
+            capture="environment"
+            className="hidden"
+            onChange={(e) => handleFiles(e.target.files)}
+          />
+
+          {/* Gallery / file picker */}
+          <button
+            type="button"
+            onClick={() => galleryInputRef.current?.click()}
+            className="w-full flex items-center justify-center gap-2 py-3.5 px-6
+              bg-white hover:bg-gray-50 active:bg-gray-100
+              text-gray-700 font-semibold rounded-xl
+              border border-gray-300
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+              transition-colors"
+          >
+            <span aria-hidden="true">🖼️</span>
+            從相簿選擇
+          </button>
+          <input
+            ref={galleryInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            className="hidden"
+            onChange={(e) => handleFiles(e.target.files)}
+          />
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div
+          role="alert"
+          className="w-full flex items-start gap-2 bg-red-50 border border-red-200 rounded-xl px-4 py-3"
+        >
+          <span aria-hidden="true" className="shrink-0 text-red-500">⚠️</span>
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      <p className="text-xs text-gray-400 text-center">
+        支援 JPG、PNG、WebP，每張最多 10 MB，最多 {MAX_FILES} 張
+      </p>
+    </div>
+  );
+};
+
+export default OmoUpload;

--- a/frontend/src/pages/omo/OmoPage.tsx
+++ b/frontend/src/pages/omo/OmoPage.tsx
@@ -1,0 +1,82 @@
+/**
+ * OmoPage — OMO (Online-Merge-Offline) entry page.
+ *
+ * Phase 1: upload worksheet photo → AI identifies lesson → student confirms.
+ * Phase 2 (future): wire confirmed lesson_id to batch grading flow.
+ *
+ * Route: /omo
+ */
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import OmoUpload from '../../components/omo/OmoUpload';
+import OmoIdentifyResult from '../../components/omo/OmoIdentifyResult';
+
+type PageState = 'upload' | 'result';
+
+const OmoPage: React.FC = () => {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+  const [pageState, setPageState] = useState<PageState>('upload');
+  const [uploadId, setUploadId] = useState<number | null>(null);
+
+  if (!token) {
+    // Should be caught by ProtectedRoute, but just in case
+    navigate('/login');
+    return null;
+  }
+
+  const handleUploaded = (id: number) => {
+    setUploadId(id);
+    setPageState('result');
+  };
+
+  const handleRetry = () => {
+    setUploadId(null);
+    setPageState('upload');
+  };
+
+  const handleConfirmed = (_lessonId: number) => {
+    // Phase 2: navigate to grading flow
+    // navigate(`/learn/${lessonId}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Minimal back header */}
+      <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          aria-label="返回"
+          className="p-1 rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+            <path fillRule="evenodd" d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z" clipRule="evenodd" />
+          </svg>
+        </button>
+        <h2 className="font-semibold text-gray-900">
+          {pageState === 'upload' ? '上傳學習單' : 'AI 辨識結果'}
+        </h2>
+      </div>
+
+      {/* Content */}
+      <div className="pb-20">
+        {pageState === 'upload' && (
+          <OmoUpload token={token} onUploaded={handleUploaded} />
+        )}
+        {pageState === 'result' && uploadId !== null && (
+          <OmoIdentifyResult
+            uploadId={uploadId}
+            token={token}
+            onConfirmed={handleConfirmed}
+            onRetry={handleRetry}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OmoPage;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -81,6 +81,9 @@ const TeacherAssignmentsPage = lazy(() => import('../pages/teacher/TeacherAssign
 const TeacherSessionReportPage = lazy(() => import('../pages/teacher/TeacherSessionReportPage'));
 const ProjectHubPage = lazy(() => import('../pages/ProjectHubPage'));
 
+// OMO (Online-Merge-Offline) paper worksheet upload (Issue #1343)
+const OmoPage = lazy(() => import('../pages/omo/OmoPage'));
+
 // Utility pages — rarely visited after first load
 const PrivacyPolicy = lazy(() => import('../pages/PrivacyPolicy'));
 const HelpPage = lazy(() => import('../pages/HelpPage'));
@@ -437,6 +440,15 @@ const AppRoutes: React.FC = () => (
         element={
           <ProtectedRoute>
             <JoinClassroomPage />
+          </ProtectedRoute>
+        }
+      />
+      {/* OMO — paper worksheet upload + AI lesson identification (Phase 1, Issue #1343) */}
+      <Route
+        path="/omo"
+        element={
+          <ProtectedRoute>
+            <OmoPage />
           </ProtectedRoute>
         }
       />

--- a/frontend/src/services/omoApi.ts
+++ b/frontend/src/services/omoApi.ts
@@ -1,0 +1,114 @@
+/**
+ * omoApi.ts — OMO (Online-Merge-Offline) API client.
+ *
+ * Wraps POST /api/omo/upload, GET /api/omo/:id, POST /api/omo/:id/confirm.
+ * Phase 1: upload + AI lesson identification only.
+ * Phase 2 stubs: confirm/grade are no-ops until backend implements them.
+ */
+
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+export interface OmoCandidate {
+  lesson_id: number;
+  grade_code: string;
+  title: string;
+  confidence: number;
+  reasoning: string;
+}
+
+export type OmoStatus = 'pending' | 'identifying' | 'identified' | 'failed';
+
+export interface OmoUploadResponse {
+  upload_id: number;
+  status: OmoStatus;
+  candidates: OmoCandidate[];
+}
+
+export interface OmoStatusResponse {
+  upload_id: number;
+  status: OmoStatus;
+  lesson_id: number | null;
+  candidates: OmoCandidate[];
+  error_message: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OmoConfirmResponse {
+  upload_id: number;
+  lesson_id: number;
+  status: OmoStatus;
+}
+
+// ---------------------------------------------------------------------------
+// API calls
+// ---------------------------------------------------------------------------
+
+/**
+ * Upload one or more worksheet images. Returns 201 with status=identifying.
+ * The backend fires AI identification asynchronously.
+ */
+export async function uploadOmoImages(
+  files: File[],
+  token: string,
+): Promise<OmoUploadResponse> {
+  const form = new FormData();
+  for (const f of files) {
+    form.append('files', f);
+  }
+  const res = await fetch(`${API_BASE}/api/omo/upload`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: form,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Upload failed (${res.status}): ${text}`);
+  }
+  return res.json() as Promise<OmoUploadResponse>;
+}
+
+/**
+ * Poll identification status. Returns current status + candidates once identified.
+ */
+export async function getOmoStatus(
+  uploadId: number,
+  token: string,
+): Promise<OmoStatusResponse> {
+  const res = await fetch(`${API_BASE}/api/omo/${uploadId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Status fetch failed (${res.status}): ${text}`);
+  }
+  return res.json() as Promise<OmoStatusResponse>;
+}
+
+/**
+ * Confirm which lesson was identified. Phase 1 stub — Phase 2 will wire this
+ * to grade submission.
+ */
+export async function confirmOmoLesson(
+  uploadId: number,
+  lessonId: number,
+  token: string,
+): Promise<OmoConfirmResponse> {
+  const res = await fetch(`${API_BASE}/api/omo/${uploadId}/confirm`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ confirmed_lesson_id: lessonId }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Confirm failed (${res.status}): ${text}`);
+  }
+  return res.json() as Promise<OmoConfirmResponse>;
+}


### PR DESCRIPTION
Refs #1343

## Summary

OMO Cold Start Phase 1a — extends Phase 1 with multi-attempt support, per-question AI grading, and answer flagging.

**Phase 1 (already merged to branch):**
- `OmoUpload` model + `omo_uploads` table
- `POST /api/omo/upload` — camera upload to GCS, async Gemini lesson identification
- `GET /api/omo/{id}` — poll status
- `POST /api/omo/{id}/confirm` — confirm lesson ID
- Frontend: OmoPage, OmoUpload, OmoIdentifyResult, sidebar entry

**Phase 1a (this commit — DO NOT MERGE yet):**
- `OmoUploadAttempt` model — multi-attempt per upload session (retry if photo blurry)
- `omo_uploads` new columns: `answers` (JSONB), `overall_score`, `ai_overall_confidence`, `progress`
- Alembic migration `l7g8h9i0j1k2` — idempotent DDL (`IF NOT EXISTS`), single head verified
- `omo_grader.py` service — Gemini 2.5-flash structured output grading:
  - Extracts fill_in_blank / MCQ / strategy_exercise questions from lesson YAML
  - Returns `GradedAnswer` per question with `score`, `ai_confidence`, `reasoning`
  - Circuit breaker (3 consecutive errors → RuntimeError), mock fallback for local dev
  - max_output_tokens=2048, temperature=0.1, fail-closed
- 6 API endpoints (all Phase 1a additions):
  - `POST /api/omo/{id}/attempt` — upload additional attempt image(s)
  - `POST /api/omo/{id}/confirm` — updated: triggers async grading after confirmation
  - `GET /api/omo/{id}` — updated: includes `answers`, `progress`, `overall_score`
  - `GET /api/omo/{id}/image-url` — GCS signed URL (1 hr TTL)
  - `PATCH /api/omo/{id}/answers/{question_id}/flag` — flag/unflag answer
  - `DELETE /api/omo/{id}` — delete upload + GCS objects

**What works:**
- All 6 endpoints return correct HTTP status codes
- Background grading task runs and writes answers to DB
- Multi-attempt: new attempt deactivates previous active attempt
- Cross-student 404 on all endpoints
- Rate limiting (10/min on AI endpoints), auth Depends, input size cap

**What's stubbed:**
- GCS signed URL returns mock URL in test env (no real GCS bucket in tests)
- `omo_ocr.py` (Vertex Document AI text extraction) not yet implemented — grading prompt sends images directly to Gemini without OCR preprocessing
- Teacher review queue UI (Phase 2)
- Frontend grading results page (Phase 2)

## Checklist

- [x] `sqlalchemy-model-safety`: FK `index=True`, `server_default`, JSONB `server_default='[]'`, `cascade="all, delete-orphan"`, `lazy="selectin"`
- [x] `llm-endpoint-hardening`: auth `Depends`, 10 MB size cap, 5-file count cap, `max_output_tokens=2048`, fail-closed, `reasoning` field per GradedAnswer, circuit breaker
- [x] Idempotent DDL (`IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS`)
- [x] `alembic heads` = single head (`l7g8h9i0j1k2`)
- [x] `pytest tests/test_omo_upload.py` — 16/16 PASSED
- [x] Rate limiter reset fixture (autouse) prevents 429 cascade in test suite

## Test plan

1. Open PR Preview URL (posted by CI once `preview-deploy.yml` completes)
2. Log in as a student → click "上傳學習單" in sidebar → `/omo`
3. Upload a JPEG worksheet → wait for identification (~10–30 s)
4. Confirm the lesson → grading triggers in background
5. `GET /api/omo/{id}` should show `status: grading`, then `status: graded` with `answers` array
6. `PATCH /api/omo/{id}/answers/q1/flag` → should set `flagged: true` in that answer
7. Sad paths: 413 for >10 MB, 400 for PDF, 422 for no files, 409 for confirm on wrong status

## DO NOT MERGE — Phase 1a review only