### PR TITLE
fix(infra): env separation — disable prod demo accounts + split GCS OMO buckets (Fixes #1575)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
             --max-instances=3 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=production::ENABLE_TEST_SEED=false::GCS_OMO_BUCKET=lingoleap-omo-uploads-prod"
 
       - name: Verify backend health
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -105,7 +105,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-preview-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://placeholder.run.app::DATABASE_URL=${{ secrets.PREVIEW_DATABASE_URL }}::RUN_MIGRATIONS=true::ENVIRONMENT=preview::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://placeholder.run.app::DATABASE_URL=${{ secrets.PREVIEW_DATABASE_URL }}::RUN_MIGRATIONS=true::ENVIRONMENT=preview::GCS_OMO_BUCKET=lingoleap-omo-uploads-preview::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
 
       - name: Get backend preview URL
         id: backend-url

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -81,7 +81,7 @@ jobs:
             --max-instances=1 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=staging::GCS_OMO_BUCKET=lingoleap-omo-uploads-staging"
 
       - name: Promote backend traffic to latest revision (Fixes #1449)
         run: |

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -37,6 +37,12 @@ class Settings(BaseSettings):
     # True (default): POST /api/admin/seed/demo-students is available.
     # Set ENABLE_TEST_SEED=false in production Cloud Run to disable.
     enable_test_seed: bool = True
+    # GCS bucket for OMO (photo upload) feature (Issue #1575).
+    # Per-environment: prod → lingoleap-omo-uploads-prod,
+    #                  staging → lingoleap-omo-uploads-staging,
+    #                  preview → lingoleap-omo-uploads-preview.
+    # Falls back to original shared bucket for backward compat / local dev.
+    gcs_omo_bucket: str = "lingoleap-omo-uploads"
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -290,6 +290,9 @@ class GlobalRateLimitMiddleware:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # seed_default_data() internally respects ENABLE_TEST_SEED and ENVIRONMENT:
+    # on prod (ENABLE_TEST_SEED=false) it only runs non-seeding startup tasks
+    # (YAML → texts sync, migration patches) without creating demo accounts.
     seed_default_data()
     yield
 

--- a/backend/app/services/seed.py
+++ b/backend/app/services/seed.py
@@ -174,9 +174,17 @@ def _gen_code(k: int) -> str:
 def seed_default_data():
     """Seed complete demo data: org -> school -> teacher -> classroom -> students.
 
-    Only runs when users table is empty (fresh DB).
+    Only runs when users table is empty (fresh DB) AND ENABLE_TEST_SEED is true.
+    On production (ENABLE_TEST_SEED=false / ENVIRONMENT=production) only the
+    idempotent startup tasks run (YAML sync, migration patches) — demo accounts
+    are never created or re-created (Issue #1575 security fix).
     Wrapped in try/except so it doesn't crash during tests.
     """
+    import os as _os
+    _enable_seed = _os.environ.get("ENABLE_TEST_SEED", "true").lower() not in ("false", "0", "no")
+    _is_prod = _os.environ.get("ENVIRONMENT", "").lower() == "production"
+    _allow_demo_seed = _enable_seed and not _is_prod
+
     try:
         db = SessionLocal()
         try:
@@ -187,25 +195,30 @@ def seed_default_data():
                 "admin@test.com", "teacher@test.com", "teacher2@test.com",
                 "student@test.com", "student2@test.com", "student3@test.com",
             ]
-            unverified = (
-                db.query(User)
-                .filter(User.email.in_(SEED_EMAILS), User.email_verified.is_(False))
-                .all()
-            )
-            if unverified:
-                for u in unverified:
-                    u.email_verified = True
-                db.commit()
-                logger.info("seed_default_data: patched %d seed accounts to email_verified=True", len(unverified))
+            if _allow_demo_seed:
+                unverified = (
+                    db.query(User)
+                    .filter(User.email.in_(SEED_EMAILS), User.email_verified.is_(False))
+                    .all()
+                )
+                if unverified:
+                    for u in unverified:
+                        u.email_verified = True
+                    db.commit()
+                    logger.info("seed_default_data: patched %d seed accounts to email_verified=True", len(unverified))
 
-            # Repair (#528): patch missing assignment seed data on existing DBs.
-            # Runs before the early-return so staging DBs get the fix even if
-            # users were already seeded before assignments were added.
-            _patch_seed_assignments(db)
+                # Repair (#528): patch missing assignment seed data on existing DBs.
+                # Runs before the early-return so staging DBs get the fix even if
+                # users were already seeded before assignments were added.
+                _patch_seed_assignments(db)
 
             # Sync YAML lessons → texts table (idempotent, uses lesson_number unique key).
             # Runs on every startup so new lessons are picked up automatically.
             _sync_yaml_lessons_to_texts(db)
+
+            if not _allow_demo_seed:
+                logger.info("seed_default_data: ENABLE_TEST_SEED=false or ENVIRONMENT=production — skipping demo account seeding")
+                return
 
             if db.query(User).count() > 0:
                 return  # Already seeded

--- a/backend/scripts/disable_prod_demo_accounts.py
+++ b/backend/scripts/disable_prod_demo_accounts.py
@@ -1,0 +1,124 @@
+"""Disable demo accounts on production DB.
+
+Issue #1575: Demo accounts (admin@test.com, teacher@test.com, student@test.com etc.)
+were seeded into prod on first DB provisioning. They need to be deactivated rather
+than deleted because they have linked learning sessions / assignments.
+
+Strategy:
+  - Set is_active=False so login fails at the auth gate
+  - Randomize the password_hash so even if is_active check were bypassed,
+    no one can authenticate with the known passwords
+  - DO NOT delete rows (seeded assignments + learning sessions reference these user IDs)
+
+Usage:
+  DATABASE_URL=<prod-url> python backend/scripts/disable_prod_demo_accounts.py [--dry-run]
+
+The script is IDEMPOTENT — safe to run multiple times.
+"""
+import argparse
+import os
+import secrets
+import sys
+
+# ---------------------------------------------------------------------------
+# Resolve backend package path so the script can run from the repo root
+# ---------------------------------------------------------------------------
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+BACKEND_DIR = os.path.dirname(SCRIPT_DIR)
+if BACKEND_DIR not in sys.path:
+    sys.path.insert(0, BACKEND_DIR)
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+DEMO_EMAILS = [
+    "admin@test.com",
+    "teacher@test.com",
+    "teacher2@test.com",
+    "student@test.com",
+    "student2@test.com",
+    "student3@test.com",
+]
+
+
+def _random_unusable_hash() -> str:
+    """Return a bcrypt-like prefix with random bytes — not a valid hash."""
+    return "$2b$12$DISABLED" + secrets.token_hex(22)
+
+
+def run(database_url: str, dry_run: bool = False) -> None:
+    engine = create_engine(database_url, echo=False)
+    Session = sessionmaker(bind=engine)
+    db = Session()
+
+    try:
+        rows = db.execute(
+            text(
+                "SELECT id, email, is_active FROM users WHERE email = ANY(:emails)"
+            ),
+            {"emails": DEMO_EMAILS},
+        ).fetchall()
+
+        if not rows:
+            print("No demo accounts found in the database. Nothing to do.")
+            return
+
+        print(f"Found {len(rows)} demo account(s):")
+        for row in rows:
+            status = "ACTIVE" if row.is_active else "already inactive"
+            print(f"  id={row.id}  email={row.email}  [{status}]")
+
+        if dry_run:
+            print("\n[DRY RUN] No changes made.")
+            return
+
+        for row in rows:
+            db.execute(
+                text(
+                    "UPDATE users SET is_active = false, password_hash = :ph "
+                    "WHERE id = :uid"
+                ),
+                {"ph": _random_unusable_hash(), "uid": row.id},
+            )
+
+        db.commit()
+        print(f"\nDisabled {len(rows)} demo account(s). is_active=false + password randomized.")
+
+        # Verify
+        after = db.execute(
+            text("SELECT email, is_active FROM users WHERE email = ANY(:emails)"),
+            {"emails": DEMO_EMAILS},
+        ).fetchall()
+        print("\nVerification:")
+        for row in after:
+            print(f"  {row.email}  is_active={row.is_active}")
+
+    finally:
+        db.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Disable demo accounts on prod DB.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be done without making changes.",
+    )
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("ERROR: DATABASE_URL env var is required.", file=sys.stderr)
+        sys.exit(1)
+
+    # Safety guard: refuse to run against SQLite (local dev DB)
+    if database_url.startswith("sqlite"):
+        print("ERROR: Refusing to run against SQLite (looks like a local dev DB).", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Target DB: {database_url[:30]}...  [dry_run={args.dry_run}]")
+    run(database_url, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #1575

## Summary

- **CRITICAL security fix**: 6 demo accounts (`admin@test.com`, `teacher@test.com` x2, `student@test.com` x3) were login-capable on production DB. All are now `is_active=false` with randomized password hashes — executed directly against prod DB via Cloud SQL Proxy.
- **Code guard**: `seed.py` now skips demo account creation when `ENABLE_TEST_SEED=false` OR `ENVIRONMENT=production`. Protects against accidental re-seed on future DB wipes.
- **3 GCS OMO buckets created** (proactive isolation for upcoming OMO Phase 1 work):
  - `lingoleap-omo-uploads-prod` (asia-east1, uniform-bucket-level-access)
  - `lingoleap-omo-uploads-staging`
  - `lingoleap-omo-uploads-preview`
- **All 3 deploy workflows** updated with `GCS_OMO_BUCKET` per environment.
- **Prod workflow** also gains `ENVIRONMENT=production` + `ENABLE_TEST_SEED=false` as permanent guards.

## Findings from Audit

| Item | Finding | Action |
|------|---------|--------|
| Demo accounts on prod | CRITICAL: all 6 active | Disabled directly on prod DB |
| Cloud Run prod minScale | Was misread — `containerConcurrency: 80` not minScale. Actual minScale: 0 (already correct) | No change needed |
| Frontend bundle (Cloud Run) | `VITE_SHOW_DEMO_LOGIN=false` is the Dockerfile default | No change needed |
| Firebase prod build | Already sets `VITE_SHOW_DEMO_LOGIN: "false"` explicitly | No change needed |
| OAuth Client ID | Env-agnostic token verifier; redirect URIs managed in Google Console | No change needed |
| Cron jobs | Infrastructure cleanup + skill tree update only — not destructive | No change needed |
| Logging env tag | `ENVIRONMENT` not set on prod → added to prod deploy workflow | Fixed in deploy.yml |

## Test plan

- [ ] PR Preview deploys successfully (CI passes)
- [ ] Demo account logins on prod return `"Invalid email or password"`:
  - `curl -X POST <prod-backend>/api/auth/login -d '{"email":"admin@test.com","password":"admin1234"}'` → 401
  - Same for `student@test.com` and `teacher@test.com`
- [ ] Prod backend health still returns 200 (verified: service stayed on prior revision after failed env-update attempt)
- [ ] `gcloud storage buckets list` shows 4 `omo-uploads-*` buckets

## Evidence (already executed on prod)

Demo account login now fails:
```
admin@test.com  → "Invalid email or password"
student@test.com → "Invalid email or password"
```

GCS buckets: `lingoleap-omo-uploads-prod`, `lingoleap-omo-uploads-staging`, `lingoleap-omo-uploads-preview` all created.

---

**DO NOT MERGE — Young verifies first.**