### PR TITLE
feat(infra): separate staging Cloud SQL from prod (Fixes #1578)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -80,8 +80,8 @@ jobs:
             --min-instances=0 \
             --max-instances=1 \
             --timeout=300s \
-            --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=staging::GCS_OMO_BUCKET=lingoleap-omo-uploads-staging"
+            --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-staging-db \
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-staging-958347263320.asia-east1.run.app,https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-staging.web.app,https://lingoleap-dev.web.app::DATABASE_URL=${{ secrets.STAGING_DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=staging::GCS_OMO_BUCKET=lingoleap-omo-uploads-staging"
 
       - name: Promote backend traffic to latest revision (Fixes #1449)
         run: |


### PR DESCRIPTION
Fixes #1578

## Problem

Staging and prod shared the same Cloud SQL instance (`lingoleap-db`). PR #1576 (which disabled demo accounts in prod) also broke staging quick-login as an unintended side effect.

## Changes

**1 file, 2 lines changed** in `.github/workflows/staging-deploy.yml`:

| Field | Before | After |
|-------|--------|-------|
| `--add-cloudsql-instances` | `lingoleap-dev:asia-east1:lingoleap-db` | `lingoleap-dev:asia-east1:lingoleap-staging-db` |
| `DATABASE_URL` secret | `secrets.DATABASE_URL` (prod's) | `secrets.STAGING_DATABASE_URL` (new, staging-only) |

## Infrastructure already done (out-of-band, before this PR)

- Created `lingoleap-staging-db` (PostgreSQL 15, db-f1-micro, asia-east1-b)
- Created database `lingoleap` + user `lingoleap` on new instance
- Ran `alembic upgrade head` — all 37 migrations applied successfully
- Seeded 6 demo accounts (admin/teacher/teacher2/student/student2/student3@test.com)
- Set GitHub secret `STAGING_DATABASE_URL` (Unix socket format, staging instance)
- Prod `lingoleap-db` is untouched

## Test plan

- [ ] Merge this PR → staging-deploy.yml CI triggers
- [ ] After deploy: login as student@test.com on staging frontend → returns access_token
- [ ] Verify prod: admin@test.com login still rejected ("Invalid email or password")
- [ ] `gcloud sql instances list` shows both `lingoleap-db` (prod) and `lingoleap-staging-db` (staging)

## Deferred

- No automated backups on `lingoleap-staging-db` (cost control, staging is expendable)
- No read replica on staging
- Periodic staging DB reset script (nice to have, not blocking)

---
DO NOT MERGE — Young verifies smoke test first.