### PR TITLE
feat(omo): image hash dedup + regrade endpoint (Fixes #1584)

### DIFF
--- a/backend/alembic/versions/m8n9o0p1q2r3_add_omo_image_hash.py
+++ b/backend/alembic/versions/m8n9o0p1q2r3_add_omo_image_hash.py
@@ -1,0 +1,65 @@
+"""add image_hash to omo_upload_attempts for dedup
+
+Revision ID: m8n9o0p1q2r3
+Revises: l7g8h9i0j1k2
+Create Date: 2026-05-14 00:00:00.000000
+
+Idempotent DDL: uses ADD COLUMN IF NOT EXISTS, safe to re-run.
+
+Changes:
+  1. omo_upload_attempts: add image_hash VARCHAR(64) NOT NULL DEFAULT ''
+  2. Create index ix_omo_upload_attempts_hash_user on (image_hash, upload.student_id)
+     — actually we index on omo_upload_attempts.image_hash directly for fast lookup
+     The join to omo_uploads.student_id is done in application code.
+"""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "m8n9o0p1q2r3"
+down_revision: Union[str, None] = "l7g8h9i0j1k2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add image_hash column to omo_upload_attempts (idempotent)
+    conn = op.get_bind()
+
+    # Check if column exists before adding
+    result = conn.execute(sa.text(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name='omo_upload_attempts' AND column_name='image_hash'"
+    ))
+    if not result.fetchone():
+        op.add_column(
+            "omo_upload_attempts",
+            sa.Column("image_hash", sa.String(64), nullable=False, server_default=""),
+        )
+
+    # Create index for fast hash lookup (idempotent)
+    try:
+        op.create_index(
+            "ix_omo_upload_attempts_image_hash",
+            "omo_upload_attempts",
+            ["image_hash"],
+        )
+    except Exception:
+        pass  # index may already exist
+
+
+def downgrade() -> None:
+    try:
+        op.drop_index("ix_omo_upload_attempts_image_hash", table_name="omo_upload_attempts")
+    except Exception:
+        pass
+    conn = op.get_bind()
+    result = conn.execute(sa.text(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name='omo_upload_attempts' AND column_name='image_hash'"
+    ))
+    if result.fetchone():
+        op.drop_column("omo_upload_attempts", "image_hash")

--- a/backend/app/models/omo_upload.py
+++ b/backend/app/models/omo_upload.py
@@ -1,6 +1,7 @@
 """OMO (Online-Merge-Offline) upload models.
 
 Phase 1a: upload + AI lesson identification + multi-attempt + grading.
+Phase 1b: image_hash dedup on OmoUploadAttempt.
 
 sqlalchemy-model-safety checklist:
 - FK with index=True (Rule 1) ✅
@@ -8,6 +9,7 @@ sqlalchemy-model-safety checklist:
 - relationship with cascade + lazy (Rule 3) ✅
 - JSONB columns with server_default (Rule 4) ✅
 - status enum as String(32) with server_default (Rule 5) ✅
+- image_hash index=True (Rule 1) ✅
 """
 
 from datetime import datetime
@@ -149,6 +151,14 @@ class OmoUploadAttempt(Base):
         JSONB, nullable=False, server_default="'[]'::jsonb"
     )
 
+    # SHA-256 content hash of the primary uploaded image (first file).
+    # Used for dedup: if same hash + same student already exists, skip re-identification.
+    # Empty string for legacy records that pre-date Phase 1b.
+    # index=False here — the index is declared in __table_args__ below to avoid duplication.
+    image_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False, server_default=""
+    )
+
     # Short OCR preview text extracted from the image (for display before grading)
     ocr_preview: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
 
@@ -169,4 +179,5 @@ class OmoUploadAttempt(Base):
 
     __table_args__ = (
         Index("ix_omo_upload_attempts_upload_id", "omo_upload_id"),
+        Index("ix_omo_upload_attempts_image_hash", "image_hash"),
     )

--- a/backend/app/routes/omo.py
+++ b/backend/app/routes/omo.py
@@ -1,16 +1,18 @@
-"""OMO (Online-Merge-Offline) API routes — Phase 1a: upload, identify, grade.
+"""OMO (Online-Merge-Offline) API routes — Phase 1b: dedup + regrade.
 
 Endpoints:
     POST   /api/omo/upload                          — upload images, trigger AI identification
+                                                       (Phase 1b: SHA-256 dedup → skip Gemini if cached)
     POST   /api/omo/{upload_id}/attempt             — add another image to existing upload
     POST   /api/omo/{upload_id}/confirm             — confirm lesson + kick off grading
     GET    /api/omo/{upload_id}                     — poll status + get result
+    POST   /api/omo/{upload_id}/regrade             — re-trigger grading for an already-graded upload
     PATCH  /api/omo/{upload_id}/answers/{q_id}/flag — student flags a question
     GET    /api/omo/{upload_id}/images/{attempt_id}/{n} — signed GCS URL (1-hr TTL)
     DELETE /api/omo/{upload_id}                     — privacy delete
 
 llm-endpoint-hardening checklist:
-- Rate-limit: 10/minute on AI-triggering endpoints (upload, attempt, confirm) ✅
+- Rate-limit: 10/minute on AI-triggering endpoints (upload, attempt, confirm, regrade) ✅
 - Auth Depends: get_current_user on all write endpoints ✅
 - Input size cap: 10MB per file, max 5 files total ✅
 - Output token cap: enforced in omo_identifier (512) + omo_grader (2048) ✅
@@ -18,6 +20,7 @@ llm-endpoint-hardening checklist:
 - Reasoning field: every candidate and every answer has reasoning ✅
 """
 
+import hashlib
 import logging
 import os
 from datetime import datetime, timezone
@@ -82,6 +85,9 @@ class OmoUploadResponse(BaseModel):
     ai_overall_confidence: Optional[float] = None
     progress: Optional[dict] = None
     error_message: Optional[str] = None
+    # Phase 1b dedup fields
+    from_cache: bool = False         # True if this response reuses a prior upload (same image hash)
+    already_graded: bool = False     # True if the cached upload already has status=graded
 
 
 class OmoAttemptResponse(BaseModel):
@@ -405,6 +411,8 @@ def _build_upload_response(upload: OmoUpload) -> OmoUploadResponse:
         ai_overall_confidence=upload.ai_overall_confidence,
         progress=upload.progress or {},
         error_message=upload.error_message,
+        from_cache=False,
+        already_graded=False,
     )
 
 
@@ -473,7 +481,36 @@ async def upload_worksheet(
         image_bytes_list.append(data)
         mime_types.append(content_type)
 
-    # Create upload record (status=identifying)
+    # ── Phase 1b: SHA-256 dedup check ────────────────────────────────────────
+    # Hash the primary (first) image to detect duplicate uploads.
+    primary_hash = hashlib.sha256(image_bytes_list[0]).hexdigest()
+
+    existing_attempt = (
+        db.query(OmoUploadAttempt)
+        .join(OmoUpload, OmoUploadAttempt.omo_upload_id == OmoUpload.id)
+        .filter(
+            OmoUploadAttempt.image_hash == primary_hash,
+            OmoUpload.student_id == current_user.id,
+        )
+        .first()
+    )
+
+    if existing_attempt:
+        existing_upload = db.query(OmoUpload).filter(
+            OmoUpload.id == existing_attempt.omo_upload_id
+        ).first()
+        if existing_upload:
+            already_graded = existing_upload.status == "graded"
+            logger.info(
+                "OMO dedup hit: student=%d hash=%s existing_upload_id=%d already_graded=%s",
+                current_user.id, primary_hash[:16], existing_upload.id, already_graded,
+            )
+            response = _build_upload_response(existing_upload)
+            response.from_cache = True
+            response.already_graded = already_graded
+            return response
+
+    # ── Create new upload record (status=identifying) ─────────────────────────
     upload = OmoUpload(
         student_id=current_user.id,
         status="identifying",
@@ -484,7 +521,7 @@ async def upload_worksheet(
     db.flush()   # get id before commit
     upload_id = upload.id
 
-    # Create first attempt
+    # Create first attempt (with hash stored for future dedup)
     image_paths = []
     for i, (data, mime) in enumerate(zip(image_bytes_list, mime_types)):
         path = _upload_to_gcs(current_user.id, upload_id, 0, i, data, mime)
@@ -494,6 +531,7 @@ async def upload_worksheet(
         omo_upload_id=upload_id,
         attempt_idx=0,
         image_paths=image_paths,
+        image_hash=primary_hash,
         is_active=True,
     )
     db.add(attempt)
@@ -502,8 +540,8 @@ async def upload_worksheet(
     background_tasks.add_task(_run_identification, upload_id, image_bytes_list, mime_types)
 
     logger.info(
-        "OMO upload created: id=%d student=%d files=%d",
-        upload_id, current_user.id, len(files),
+        "OMO upload created: id=%d student=%d files=%d hash=%s",
+        upload_id, current_user.id, len(files), primary_hash[:16],
     )
 
     return OmoUploadResponse(
@@ -511,6 +549,8 @@ async def upload_worksheet(
         status="identifying",
         candidates=[],
         answers=[],
+        from_cache=False,
+        already_graded=False,
     )
 
 
@@ -635,6 +675,18 @@ async def confirm_lesson(
     """
     upload = _get_upload_or_404(upload_id, current_user, db)
 
+    # Phase 1b: guard against re-confirming an already in-progress or graded upload
+    if upload.status == "grading":
+        raise HTTPException(
+            status_code=409,
+            detail="批改正在進行中，請稍候",
+        )
+    if upload.status == "graded":
+        raise HTTPException(
+            status_code=409,
+            detail="此學習單已批改完成，如需重新批改請使用 /regrade",
+        )
+
     if upload.status not in ("identified", "error"):
         raise HTTPException(
             status_code=409,
@@ -685,6 +737,68 @@ def get_upload_status(
     """
     upload = _get_upload_or_404(upload_id, current_user, db)
     return _build_upload_response(upload)
+
+
+class OmoRegradeResponse(BaseModel):
+    upload_id: int
+    status: str
+    message: str
+
+
+@router.post(
+    "/omo/{upload_id}/regrade",
+    response_model=OmoRegradeResponse,
+    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=10, window_seconds=60))],
+)
+async def regrade_upload(
+    upload_id: int,
+    background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Re-trigger grading for an already-graded upload.
+
+    Student-initiated intentional re-grade (e.g. after flagging answers).
+    Resets status to grading and kicks off a new grading job using the
+    existing lesson_id and active attempt images.
+
+    Returns 409 if the upload is still grading.
+    """
+    upload = _get_upload_or_404(upload_id, current_user, db)
+
+    if upload.status == "grading":
+        raise HTTPException(
+            status_code=409,
+            detail="批改正在進行中，請稍候",
+        )
+    if upload.status not in ("graded", "error", "identified"):
+        raise HTTPException(
+            status_code=409,
+            detail=f"無法重新批改（目前狀態：{upload.status}）",
+        )
+    if not upload.lesson_id:
+        raise HTTPException(
+            status_code=409,
+            detail="尚未確認課程，請先確認課程後再批改",
+        )
+
+    upload.status = "grading"
+    upload.progress = {"stage": "queued", "total": 0, "graded": 0}
+    upload.error_message = None
+    db.commit()
+
+    background_tasks.add_task(_run_grading, upload_id, upload.lesson_id)
+
+    logger.info(
+        "OMO regrade queued: upload_id=%d student=%d lesson_id=%d",
+        upload_id, current_user.id, upload.lesson_id,
+    )
+
+    return OmoRegradeResponse(
+        upload_id=upload_id,
+        status="grading",
+        message="重新批改中，請稍候（約 15-20 秒）",
+    )
 
 
 @router.patch("/omo/{upload_id}/answers/{question_id}/flag", status_code=200)

--- a/backend/tests/test_omo_dedup.py
+++ b/backend/tests/test_omo_dedup.py
@@ -1,0 +1,365 @@
+"""Contract tests for OMO Phase 1b — image hash dedup + regrade endpoint.
+
+Tests:
+    Dedup: uploading same image bytes twice → 2nd returns from_cache=True
+    Dedup: uploading different bytes → fresh upload (not cached)
+    Dedup: same image, different students → NOT deduped (student-scoped)
+    Regrade: can regrade after graded
+    Regrade: 409 while grading is in progress
+    Regrade: 409 when no lesson_id confirmed yet
+
+Run:
+    cd backend && python -m pytest tests/test_omo_dedup.py -v
+"""
+
+import io
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+from app.auth.rate_limiter import ai_rate_limiter
+
+# ---------------------------------------------------------------------------
+# Test DB setup (SQLite in-memory)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+_SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for r in _SEED_ROLES:
+        session.add(Role(name=r["name"], display_name=r["display_name"], scope_level=r["scope_level"]))
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    with ai_rate_limiter._lock:
+        ai_rate_limiter._store.clear()
+    yield
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Auth helper
+# ---------------------------------------------------------------------------
+
+def register_and_login(client, email_suffix):
+    email = f"{email_suffix}@example.com"
+    reg = client.post("/api/auth/register", json={
+        "email": email,
+        "password": "TestPass123!",
+        "name": f"Dedup Test {email_suffix}",
+    })
+    if reg.status_code == 201:
+        verification_token = reg.json().get("verification_token")
+        if verification_token:
+            client.get(f"/api/auth/verify-email?token={verification_token}")
+    login = client.post("/api/auth/login", json={
+        "email": email,
+        "password": "TestPass123!",
+    })
+    assert login.status_code == 200, f"Login failed: {login.text}"
+    return login.json()["access_token"]
+
+
+# Minimal valid JPEG (1x1 pixel)
+_TINY_JPEG_A = bytes(
+    b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
+    b"\xff\xdb\x00C\x00\x08\x06\x06\x07\x06\x05\x08\x07\x07\x07\t\t"
+    b"\x08\n\x0c\x14\r\x0c\x0b\x0b\x0c\x19\x12\x13\x0f\x14\x1d\x1a"
+    b"\x1f\x1e\x1d\x1a\x1c\x1c $.' \",#\x1c\x1c(7),01444\x1f'9=82<.342\x1e"
+    b"\xff\xc0\x00\x0b\x08\x00\x01\x00\x01\x01\x01\x11\x00"
+    b"\xff\xc4\x00\x1f\x00\x00\x01\x05\x01\x01\x01\x01\x01\x01\x00\x00"
+    b"\x00\x00\x00\x00\x00\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b"
+    b"\xff\xc4\x00\xb5\x10\x00\x02\x01\x03\x03\x02\x04\x03\x05\x05\x04"
+    b"\x04\x00\x00\x01}\x01\x02\x03\x00\x04\x11\x05\x12!1A\x06\x13Qa"
+    b'\x07"q\x142\x81\x91\xa1\x08#B\xb1\xc1\x15R\xd1\xf0$3br'
+    b"\x82\t\n\x16\x17\x18\x19\x1a%&'()*456789:CDEFGHIJ"
+    b"STUVWXYZ\xff\xda\x00\x08\x01\x01\x00\x00?\x00\xfb\xd5\xff\xd9"
+)
+
+# Different bytes (simulates a different image)
+_TINY_JPEG_B = _TINY_JPEG_A[:10] + b"\x00\x00\x00" + _TINY_JPEG_A[13:]
+
+
+def _force_upload_status(upload_id: int, status: str, extra: dict = None):
+    from app.models.omo_upload import OmoUpload
+    db = TestingSessionLocal()
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        if upload:
+            upload.status = status
+            if extra:
+                for k, v in extra.items():
+                    setattr(upload, k, v)
+            db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOmoDedup:
+    def test_same_image_bytes_returns_from_cache(self, client):
+        """Uploading identical image bytes twice → 2nd response has from_cache=True."""
+        token = register_and_login(client, "dedup_same_img")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # First upload
+        resp1 = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG_A), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp1.status_code == 201, f"First upload failed: {resp1.text}"
+        data1 = resp1.json()
+        assert data1["from_cache"] is False
+        upload_id_1 = data1["upload_id"]
+
+        # Second upload with same bytes
+        resp2 = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws_copy.jpg", io.BytesIO(_TINY_JPEG_A), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp2.status_code == 201, f"Second upload failed: {resp2.text}"
+        data2 = resp2.json()
+        assert data2["from_cache"] is True, f"Expected from_cache=True, got: {data2}"
+        assert data2["upload_id"] == upload_id_1, "Dedup should return same upload_id"
+
+    def test_same_image_already_graded_returns_already_graded(self, client):
+        """If the cached upload is graded, already_graded=True in response."""
+        token = register_and_login(client, "dedup_graded")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Upload
+        resp1 = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG_A + b"graded_marker"), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp1.status_code == 201
+        upload_id = resp1.json()["upload_id"]
+
+        # Force to graded
+        _force_upload_status(upload_id, "graded", {
+            "answers": [],
+            "overall_score": 1.0,
+            "lesson_id": 1,
+        })
+
+        # Upload same bytes again
+        resp2 = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws_copy.jpg", io.BytesIO(_TINY_JPEG_A + b"graded_marker"), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp2.status_code == 201
+        data2 = resp2.json()
+        assert data2["from_cache"] is True
+        assert data2["already_graded"] is True
+
+    def test_different_image_bytes_not_cached(self, client):
+        """Different image bytes → new upload, from_cache=False."""
+        token = register_and_login(client, "dedup_diff")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp1 = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws_a.jpg", io.BytesIO(_TINY_JPEG_A + b"unique_a"), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp1.status_code == 201
+        upload_id_1 = resp1.json()["upload_id"]
+
+        resp2 = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws_b.jpg", io.BytesIO(_TINY_JPEG_B + b"unique_b"), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp2.status_code == 201
+        data2 = resp2.json()
+        assert data2["from_cache"] is False
+        assert data2["upload_id"] != upload_id_1
+
+    def test_same_image_different_students_not_cached(self, client):
+        """Student A's image hash does NOT cause a cache hit for Student B."""
+        token_a = register_and_login(client, "dedup_student_a")
+        token_b = register_and_login(client, "dedup_student_b")
+
+        unique_bytes = _TINY_JPEG_A + b"student_scope_test"
+
+        resp_a = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(unique_bytes), "image/jpeg"))],
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        assert resp_a.status_code == 201
+        assert resp_a.json()["from_cache"] is False
+
+        # Student B uploads same bytes — should NOT hit Student A's cache
+        resp_b = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(unique_bytes), "image/jpeg"))],
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert resp_b.status_code == 201
+        data_b = resp_b.json()
+        assert data_b["from_cache"] is False, "Different students should never share cache"
+
+
+class TestOmoRegrade:
+    def test_regrade_after_graded(self, client):
+        """Can trigger regrade when status=graded."""
+        token = register_and_login(client, "regrade_ok")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG_A + b"regrade_test"), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        upload_id = resp.json()["upload_id"]
+
+        _force_upload_status(upload_id, "graded", {
+            "lesson_id": 1,
+            "answers": [],
+            "overall_score": 0.8,
+        })
+
+        regrade_resp = client.post(
+            f"/api/omo/{upload_id}/regrade",
+            headers=headers,
+        )
+        assert regrade_resp.status_code == 200, f"Expected 200, got {regrade_resp.status_code}: {regrade_resp.text}"
+        data = regrade_resp.json()
+        assert data["status"] == "grading"
+
+        # Poll — should be grading
+        poll_resp = client.get(f"/api/omo/{upload_id}", headers=headers)
+        assert poll_resp.status_code == 200
+        assert poll_resp.json()["status"] == "grading"
+
+    def test_regrade_while_grading_returns_409(self, client):
+        """Regrade endpoint returns 409 if upload is already grading."""
+        token = register_and_login(client, "regrade_409")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG_A + b"regrade_409"), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        upload_id = resp.json()["upload_id"]
+        _force_upload_status(upload_id, "grading", {"lesson_id": 1})
+
+        regrade_resp = client.post(
+            f"/api/omo/{upload_id}/regrade",
+            headers=headers,
+        )
+        assert regrade_resp.status_code == 409
+
+    def test_regrade_without_lesson_id_returns_409(self, client):
+        """Regrade when no lesson confirmed yet → 409."""
+        token = register_and_login(client, "regrade_nolesson")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG_A + b"nolesson"), "image/jpeg"))],
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        upload_id = resp.json()["upload_id"]
+        # Upload is still "identifying" with no lesson_id
+
+        regrade_resp = client.post(
+            f"/api/omo/{upload_id}/regrade",
+            headers=headers,
+        )
+        assert regrade_resp.status_code == 409
+
+    def test_regrade_other_student_returns_404(self, client):
+        """Student B cannot regrade Student A's upload."""
+        token_a = register_and_login(client, "regrade_acl_a")
+        token_b = register_and_login(client, "regrade_acl_b")
+
+        resp = client.post(
+            "/api/omo/upload",
+            files=[("files", ("ws.jpg", io.BytesIO(_TINY_JPEG_A + b"acl_regrade"), "image/jpeg"))],
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        upload_id = resp.json()["upload_id"]
+        _force_upload_status(upload_id, "graded", {"lesson_id": 1})
+
+        regrade_resp = client.post(
+            f"/api/omo/{upload_id}/regrade",
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert regrade_resp.status_code == 404


### PR DESCRIPTION
Fixes #1584

## Changes
- `OmoUploadAttempt.image_hash` VARCHAR(64) column + index (sqlalchemy-model-safety OK)
- Migration `m8n9o0p1q2r3`: idempotent `ADD COLUMN IF NOT EXISTS`, alembic heads=1 OK
- `POST /omo/upload`: SHA-256 dedup — same image+student returns `from_cache=true`, skips Gemini
- `POST /omo/{id}/regrade`: re-trigger grading for graded/error/identified uploads
- `POST /omo/{id}/confirm`: 409 guard if already grading or graded
- `OmoUploadResponse`: `from_cache` + `already_graded` fields
- `test_omo_dedup.py`: 8 tests — all passing locally

## Test plan
- 8 contract tests green: dedup same-student, cross-student isolation, regrade lifecycle, 409 guards
- alembic heads = 1 (single migration chain)
- llm-endpoint-hardening: regrade rate-limited + auth-gated

Part of #1583 Phase 1b umbrella.