### PR TITLE
feat(omo): 3-tier confidence confirm UX + GET /api/omo/lessons (Related to #1585)

### DIFF
--- a/backend/app/routes/omo.py
+++ b/backend/app/routes/omo.py
@@ -1,6 +1,7 @@
-"""OMO (Online-Merge-Offline) API routes — Phase 1b: dedup + regrade.
+"""OMO (Online-Merge-Offline) API routes — Phase 1b: dedup + regrade + 3-tier UX.
 
 Endpoints:
+    GET    /api/omo/lessons                         — list of OMO-eligible lessons (for manual picker)
     POST   /api/omo/upload                          — upload images, trigger AI identification
                                                        (Phase 1b: SHA-256 dedup → skip Gemini if cached)
     POST   /api/omo/{upload_id}/attempt             — add another image to existing upload
@@ -49,6 +50,13 @@ _ALLOWED_MIME_TYPES = {"image/jpeg", "image/jpg", "image/png", "image/webp"}
 
 
 # ── Pydantic schemas ───────────────────────────────────────────────────────────
+
+class LessonSummaryResponse(BaseModel):
+    """Simplified lesson entry for the manual picker in the 3-tier confidence UX."""
+    lesson_id: int
+    grade_code: str
+    title: str
+
 
 class LessonCandidateResponse(BaseModel):
     lesson_id: int
@@ -428,6 +436,38 @@ def _get_upload_or_404(upload_id: int, user: User, db: Session) -> OmoUpload:
 
 
 # ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.get(
+    "/omo/lessons",
+    response_model=list[LessonSummaryResponse],
+)
+def list_omo_lessons(
+    current_user: User = Depends(get_current_user),
+):
+    """Return all lessons available for the OMO manual picker.
+
+    Called when AI identification returns low confidence and the student
+    wants to pick the lesson manually.
+
+    Returns grade_code + title for each lesson, sorted by grade then title.
+    """
+    from ..services.lesson_loader import get_all_lessons
+    lessons = get_all_lessons()
+    result = []
+    for lesson in lessons:
+        lesson_id = lesson.get("id") or lesson.get("lesson_number")
+        grade_code = lesson.get("lesson_code") or lesson.get("grade_code", "")
+        title = lesson.get("title", "")
+        if lesson_id and title:
+            result.append(LessonSummaryResponse(
+                lesson_id=int(lesson_id),
+                grade_code=str(grade_code),
+                title=title,
+            ))
+    # Sort by grade_code then title for a predictable picker order
+    result.sort(key=lambda x: (x.grade_code, x.title))
+    return result
+
 
 @router.post(
     "/omo/upload",

--- a/frontend/src/components/omo/OmoIdentifyResult.tsx
+++ b/frontend/src/components/omo/OmoIdentifyResult.tsx
@@ -1,16 +1,20 @@
 /**
- * OmoIdentifyResult — Phase 1 post-upload identification result page.
+ * OmoIdentifyResult — Phase 1b post-upload identification result page.
  *
- * Polls GET /api/omo/:id every 2 seconds until status transitions out of
- * "pending"/"identifying". Once "identified", shows:
- *   "我們判斷你的學習單是 [grade] [title]，要繼續嗎？"
- * with a "確認" button (Phase 2 stub — wires to grading when ready).
+ * 3-tier confidence UX:
+ *   conf >= 0.9 (HIGH):   single prominent confirm button + smaller "不是這個"
+ *   0.4 <= conf < 0.9:    top-3 candidate cards, all clickable
+ *   conf < 0.4 OR empty:  "看不清楚 😅" + retake + manual-pick modal
  *
- * Also exposes the full top-3 candidate list in a collapsible "不確定？" section.
+ * Also handles:
+ *   - from_cache=true + already_graded=true: "already graded" modal
+ *   - /regrade endpoint for intentional re-grade
+ *   - Polls through grading state until status=graded
  */
 import React, { useEffect, useRef, useState } from 'react';
-import { getOmoStatus, confirmOmoLesson } from '../../services/omoApi';
-import type { OmoCandidate, OmoStatus } from '../../services/omoApi';
+import { getOmoStatus, confirmOmoLesson, regradeOmo, getOmoLessons } from '../../services/omoApi';
+import type { OmoCandidate, OmoStatus, OmoLessonSummary } from '../../services/omoApi';
+import { OMO_CONF_HIGH, OMO_CONF_MEDIUM } from './omoConfidenceThresholds';
 
 const POLL_INTERVAL_MS = 2000;
 const MAX_POLLS = 30; // 60 seconds max
@@ -18,29 +22,49 @@ const MAX_POLLS = 30; // 60 seconds max
 interface OmoIdentifyResultProps {
   uploadId: number;
   token: string;
-  /** Called after the student confirms a lesson (Phase 2 will navigate to grading) */
+  /** Set to true if backend returned from_cache=true AND already_graded=true */
+  alreadyGraded?: boolean;
+  /** The already-graded overall_score (if alreadyGraded=true) */
+  cachedScore?: number | null;
+  /** Called after the student confirms a lesson (and grading kicked off) */
   onConfirmed?: (lessonId: number) => void;
   /** Called if user wants to go back and re-upload */
   onRetry: () => void;
+  /** Called when grading completes (status=graded) */
+  onGraded?: (uploadId: number) => void;
 }
 
 const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
   uploadId,
   token,
+  alreadyGraded = false,
+  cachedScore = null,
   onConfirmed,
   onRetry,
+  onGraded,
 }) => {
   const [status, setStatus] = useState<OmoStatus>('identifying');
   const [candidates, setCandidates] = useState<OmoCandidate[]>([]);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [showAllCandidates, setShowAllCandidates] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [confirmed, setConfirmed] = useState(false);
+  const [regrading, setRegrading] = useState(false);
+  const [showAlreadyGraded, setShowAlreadyGraded] = useState(alreadyGraded);
+
+  // Manual picker state (for low-confidence / unclear case)
+  const [showManualPicker, setShowManualPicker] = useState(false);
+  const [lessons, setLessons] = useState<OmoLessonSummary[]>([]);
+  const [loadingLessons, setLoadingLessons] = useState(false);
 
   const pollCount = useRef(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // ---------------------------------------------------------------------------
+  // Polling
+  // ---------------------------------------------------------------------------
   useEffect(() => {
+    if (alreadyGraded) return; // skip polling for cache hits
+
     const poll = async () => {
       pollCount.current += 1;
       if (pollCount.current > MAX_POLLS) {
@@ -54,30 +78,37 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
         setStatus(data.status);
         setCandidates(data.candidates ?? []);
         if (data.error_message) setErrorMessage(data.error_message);
-        if (data.status !== 'pending' && data.status !== 'identifying') {
+        if (data.status === 'graded') {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          onGraded?.(uploadId);
+        } else if (
+          data.status !== 'pending' &&
+          data.status !== 'identifying' &&
+          data.status !== 'grading'
+        ) {
           if (intervalRef.current) clearInterval(intervalRef.current);
         }
-      } catch (err) {
+      } catch {
         // Transient network error — keep polling
-        console.error('OMO poll error:', err);
       }
     };
 
-    // Immediate first poll
     void poll();
     intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
+  }, [uploadId, token, alreadyGraded, onGraded]);
 
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [uploadId, token]);
-
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
   const handleConfirm = async (lessonId: number) => {
     setConfirming(true);
+    setShowManualPicker(false);
     try {
       await confirmOmoLesson(uploadId, lessonId, token);
       setConfirmed(true);
       onConfirmed?.(lessonId);
+      setStatus('grading');
     } catch (err) {
       console.error('OMO confirm error:', err);
       setErrorMessage('確認失敗，請再試一次');
@@ -86,19 +117,108 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
     }
   };
 
+  const handleRegrade = async () => {
+    setRegrading(true);
+    setShowAlreadyGraded(false);
+    try {
+      await regradeOmo(uploadId, token);
+      setStatus('grading');
+      pollCount.current = 0;
+      intervalRef.current = setInterval(async () => {
+        pollCount.current += 1;
+        if (pollCount.current > MAX_POLLS) {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          setErrorMessage('批改超時，請稍後重試');
+          return;
+        }
+        try {
+          const data = await getOmoStatus(uploadId, token);
+          setStatus(data.status);
+          if (data.status === 'graded') {
+            if (intervalRef.current) clearInterval(intervalRef.current);
+            onGraded?.(uploadId);
+          }
+        } catch { /* ignore transient */ }
+      }, POLL_INTERVAL_MS);
+    } catch (err) {
+      console.error('OMO regrade error:', err);
+      setErrorMessage('重新批改失敗，請稍後再試');
+    } finally {
+      setRegrading(false);
+    }
+  };
+
+  const handleOpenManualPicker = async () => {
+    setShowManualPicker(true);
+    if (lessons.length === 0) {
+      setLoadingLessons(true);
+      try {
+        const list = await getOmoLessons(token);
+        setLessons(list);
+      } catch {
+        setErrorMessage('無法載入課程清單，請重試');
+      } finally {
+        setLoadingLessons(false);
+      }
+    }
+  };
+
   // ---------------------------------------------------------------------------
-  // Identifying / pending — spinner
+  // Already-graded modal
   // ---------------------------------------------------------------------------
-  if (status === 'pending' || status === 'identifying') {
+  if (showAlreadyGraded) {
+    const scoreDisplay =
+      cachedScore !== null && cachedScore !== undefined
+        ? `${Math.round(cachedScore * 100)} 分`
+        : null;
+
+    return (
+      <div className="flex flex-col items-center gap-6 px-4 py-12 max-w-md mx-auto">
+        <div className="text-5xl" aria-hidden="true">📋</div>
+        <div className="text-center">
+          <h1 className="text-xl font-bold text-gray-900">這張學習單已批改過</h1>
+          {scoreDisplay && (
+            <p className="mt-2 text-3xl font-bold text-green-600">{scoreDisplay}</p>
+          )}
+          <p className="mt-2 text-sm text-gray-500">要查看上次結果，或重新批改？</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onGraded?.(uploadId)}
+          className="w-full py-3.5 px-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors"
+        >
+          看上次結果
+        </button>
+        <button
+          type="button"
+          onClick={handleRegrade}
+          disabled={regrading}
+          className="w-full py-3.5 px-6 border border-gray-300 hover:bg-gray-50 text-gray-700 font-semibold rounded-xl transition-colors disabled:opacity-60"
+        >
+          {regrading ? '重新批改中…' : '重新批改'}
+        </button>
+        <button type="button" onClick={onRetry} className="text-sm text-gray-400 hover:text-gray-600 py-1">
+          上傳其他學習單
+        </button>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Spinner states
+  // ---------------------------------------------------------------------------
+  if (status === 'pending' || status === 'identifying' || (status === 'grading' && !confirmed)) {
     return (
       <div className="flex flex-col items-center gap-6 px-4 py-12 max-w-md mx-auto">
         <div
           className="w-16 h-16 rounded-full border-4 border-blue-200 border-t-blue-600 animate-spin"
-          aria-label="AI 辨識中"
+          aria-label={status === 'grading' ? 'AI 批改中' : 'AI 辨識中'}
           role="status"
         />
         <div className="text-center">
-          <p className="font-semibold text-gray-800">AI 正在辨識你的學習單</p>
+          <p className="font-semibold text-gray-800">
+            {status === 'grading' ? 'AI 正在批改你的學習單' : 'AI 正在辨識你的學習單'}
+          </p>
           <p className="mt-1 text-sm text-gray-500">通常需要 10～30 秒，請稍候…</p>
         </div>
       </div>
@@ -106,9 +226,9 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
   }
 
   // ---------------------------------------------------------------------------
-  // Failed
+  // Error / failed
   // ---------------------------------------------------------------------------
-  if (status === 'failed') {
+  if (status === 'failed' || status === 'error') {
     return (
       <div className="flex flex-col items-center gap-6 px-4 py-8 max-w-md mx-auto">
         <div className="text-5xl" aria-hidden="true">😕</div>
@@ -118,11 +238,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
             {errorMessage ?? '無法辨識學習單，請重新拍照（確保光線充足、文字清晰）'}
           </p>
         </div>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="w-full py-3.5 px-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors"
-        >
+        <button type="button" onClick={onRetry} className="w-full py-3.5 px-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors">
           重新上傳
         </button>
       </div>
@@ -130,123 +246,237 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
   }
 
   // ---------------------------------------------------------------------------
-  // Identified — show top candidate + confirm
+  // Graded — brief flash before parent navigates
   // ---------------------------------------------------------------------------
-  const topCandidate = candidates[0] ?? null;
-  const otherCandidates = candidates.slice(1);
-
-  if (confirmed) {
+  if (status === 'graded') {
     return (
       <div className="flex flex-col items-center gap-6 px-4 py-12 max-w-md mx-auto">
         <div className="text-5xl" aria-hidden="true">✅</div>
         <div className="text-center">
-          <p className="font-semibold text-gray-800">已確認！</p>
-          <p className="mt-1 text-sm text-gray-500">
-            批改功能將在 Phase 2 上線，敬請期待
-          </p>
+          <p className="font-semibold text-gray-800">批改完成！</p>
+          <p className="mt-1 text-sm text-gray-500">正在載入結果…</p>
         </div>
       </div>
     );
   }
 
-  return (
-    <div className="flex flex-col gap-6 px-4 py-8 max-w-md mx-auto">
-      {/* Header */}
-      <div className="text-center">
-        <div className="text-4xl mb-2" aria-hidden="true">🔍</div>
-        <h1 className="text-xl font-bold text-gray-900">辨識結果</h1>
+  // ---------------------------------------------------------------------------
+  // Confirmed + waiting for grading
+  // ---------------------------------------------------------------------------
+  if (confirmed) {
+    return (
+      <div className="flex flex-col items-center gap-6 px-4 py-12 max-w-md mx-auto">
+        <div
+          className="w-16 h-16 rounded-full border-4 border-blue-200 border-t-blue-600 animate-spin"
+          aria-label="批改中"
+          role="status"
+        />
+        <div className="text-center">
+          <p className="font-semibold text-gray-800">AI 正在批改中</p>
+          <p className="mt-1 text-sm text-gray-500">通常需要 15～20 秒…</p>
+        </div>
       </div>
+    );
+  }
 
-      {topCandidate ? (
-        <>
-          {/* Primary identification card */}
-          <div className="bg-blue-50 border border-blue-200 rounded-2xl p-5">
-            <p className="text-sm text-blue-600 font-medium mb-1">我們判斷你的學習單是</p>
-            <p className="text-2xl font-bold text-gray-900 leading-snug">
-              {topCandidate.grade_code} {topCandidate.title}
-            </p>
-            <p className="mt-2 text-sm text-gray-500 leading-relaxed">
-              {topCandidate.reasoning}
-            </p>
-            <div className="mt-3 flex items-center gap-1.5">
-              <div
-                className="h-2 rounded-full bg-blue-400 transition-all"
-                style={{ width: `${Math.round(topCandidate.confidence * 100)}%`, maxWidth: '100%', minWidth: '4px' }}
-                aria-label={`信心度 ${Math.round(topCandidate.confidence * 100)}%`}
-              />
-              <span className="text-xs text-gray-400">
-                信心度 {Math.round(topCandidate.confidence * 100)}%
-              </span>
-            </div>
-          </div>
-
-          {/* Confirm button */}
+  // ---------------------------------------------------------------------------
+  // Manual picker modal overlay
+  // ---------------------------------------------------------------------------
+  if (showManualPicker) {
+    return (
+      <div className="flex flex-col gap-4 px-4 py-8 max-w-md mx-auto">
+        <div className="flex items-center gap-3 mb-2">
           <button
             type="button"
-            onClick={() => handleConfirm(topCandidate.lesson_id)}
-            disabled={confirming}
-            className="w-full py-3.5 px-6 bg-green-600 hover:bg-green-700 disabled:opacity-60
-              text-white font-semibold rounded-xl transition-colors
-              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+            onClick={() => setShowManualPicker(false)}
+            className="p-1 rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100"
+            aria-label="返回"
           >
-            {confirming ? '確認中…' : '✓ 沒錯，要繼續！'}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5" aria-hidden="true">
+              <path fillRule="evenodd" d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z" clipRule="evenodd" />
+            </svg>
           </button>
-
-          {/* Other candidates (collapsed) */}
-          {otherCandidates.length > 0 && (
-            <div>
-              <button
-                type="button"
-                onClick={() => setShowAllCandidates((v) => !v)}
-                className="w-full text-sm text-gray-500 hover:text-gray-700 underline underline-offset-2 py-1"
-              >
-                {showAllCandidates ? '收起' : '不確定？查看其他候選課文'}
-              </button>
-
-              {showAllCandidates && (
-                <div className="mt-3 flex flex-col gap-2">
-                  {otherCandidates.map((c) => (
-                    <div
-                      key={c.lesson_id}
-                      className="flex items-center justify-between bg-gray-50 border border-gray-200 rounded-xl px-4 py-3"
-                    >
-                      <div>
-                        <p className="font-medium text-gray-800 text-sm">
-                          {c.grade_code} {c.title}
-                        </p>
-                        <p className="text-xs text-gray-400 mt-0.5 line-clamp-1">
-                          {c.reasoning}
-                        </p>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => handleConfirm(c.lesson_id)}
-                        disabled={confirming}
-                        className="ml-3 shrink-0 text-xs text-blue-600 hover:text-blue-800 font-semibold underline"
-                      >
-                        這個
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-        </>
-      ) : (
-        /* No candidates returned (image unclear) */
-        <div className="text-center">
-          <p className="text-gray-700">AI 無法辨識圖片中的文字</p>
-          <p className="mt-1 text-sm text-gray-500">請確保照片清晰、光線充足後重新拍攝</p>
+          <h1 className="font-bold text-gray-900">手動選課文</h1>
         </div>
-      )}
+        <p className="text-sm text-gray-500">這是哪一課的學習單？</p>
 
-      {/* Re-upload link */}
+        {loadingLessons ? (
+          <div className="flex justify-center py-8">
+            <div className="w-8 h-8 rounded-full border-4 border-blue-200 border-t-blue-600 animate-spin" role="status" aria-label="載入中" />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {lessons.length === 0 && (
+              <p className="text-sm text-gray-400 text-center py-4">目前沒有可選的課文</p>
+            )}
+            {lessons.map((lesson) => (
+              <button
+                key={lesson.lesson_id}
+                type="button"
+                disabled={confirming}
+                onClick={() => handleConfirm(lesson.lesson_id)}
+                className="flex items-center gap-3 w-full bg-white border border-gray-200 hover:border-blue-400 hover:bg-blue-50 rounded-xl px-4 py-3 text-left transition-colors disabled:opacity-60"
+              >
+                <span className="shrink-0 text-xs font-semibold text-blue-600 bg-blue-100 rounded-lg px-2 py-1">
+                  {lesson.grade_code}
+                </span>
+                <span className="font-medium text-gray-800 text-sm">{lesson.title}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // 3-tier confidence logic
+  // ---------------------------------------------------------------------------
+  const topCandidate = candidates[0] ?? null;
+  const topConfidence = topCandidate?.confidence ?? 0;
+
+  // Tier 3: no candidates OR low confidence
+  if (!topCandidate || topConfidence < OMO_CONF_MEDIUM) {
+    return (
+      <div className="flex flex-col items-center gap-6 px-4 py-8 max-w-md mx-auto">
+        <div className="text-5xl" aria-hidden="true">😅</div>
+        <div className="text-center">
+          <h1 className="text-xl font-bold text-gray-900">看不清楚</h1>
+          <p className="mt-2 text-sm text-gray-500">
+            AI 無法確認是哪一課（信心度太低）
+            <br />請重新拍攝，或手動選課文。
+          </p>
+        </div>
+
+        <button
+          type="button"
+          onClick={onRetry}
+          className="w-full py-3.5 px-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors"
+        >
+          重拍
+        </button>
+
+        <button
+          type="button"
+          onClick={handleOpenManualPicker}
+          className="w-full py-3.5 px-6 border border-gray-300 hover:bg-gray-50 text-gray-700 font-semibold rounded-xl transition-colors"
+        >
+          手動選課
+        </button>
+      </div>
+    );
+  }
+
+  // Tier 1: high confidence
+  if (topConfidence >= OMO_CONF_HIGH) {
+    return (
+      <div className="flex flex-col gap-6 px-4 py-8 max-w-md mx-auto">
+        <div className="text-center">
+          <div className="text-4xl mb-2" aria-hidden="true">🎯</div>
+          <h1 className="text-xl font-bold text-gray-900">辨識結果</h1>
+        </div>
+
+        <div className="bg-blue-50 border-2 border-blue-300 rounded-2xl p-5">
+          <p className="text-sm text-blue-600 font-medium mb-1">我們認為你的學習單是</p>
+          <p className="text-2xl font-bold text-gray-900 leading-snug">
+            {topCandidate.grade_code} {topCandidate.title}
+          </p>
+          <p className="mt-2 text-sm text-gray-500">{topCandidate.reasoning}</p>
+          <div className="mt-3 flex items-center gap-1.5">
+            <div
+              className="h-2 rounded-full bg-blue-500 transition-all"
+              style={{ width: `${Math.round(topConfidence * 100)}%`, maxWidth: '100%', minWidth: '4px' }}
+            />
+            <span className="text-xs text-gray-400">信心度 {Math.round(topConfidence * 100)}%</span>
+          </div>
+        </div>
+
+        {/* Prominent confirm */}
+        <button
+          type="button"
+          onClick={() => handleConfirm(topCandidate.lesson_id)}
+          disabled={confirming}
+          className="w-full py-4 px-6 bg-green-600 hover:bg-green-700 disabled:opacity-60
+            text-white font-bold text-lg rounded-xl transition-colors
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:ring-offset-2"
+        >
+          {confirming ? '確認中…' : '對，是這個！'}
+        </button>
+
+        {/* Smaller "not this" */}
+        <button
+          type="button"
+          disabled={confirming}
+          onClick={handleOpenManualPicker}
+          className="w-full py-2 px-4 text-sm text-gray-500 hover:text-gray-700 underline underline-offset-2 disabled:opacity-60"
+        >
+          不是這個，手動選課
+        </button>
+
+        <button type="button" onClick={onRetry} className="text-xs text-gray-400 hover:text-gray-600 py-1 text-center">
+          重新上傳
+        </button>
+      </div>
+    );
+  }
+
+  // Tier 2: medium confidence — show top-3 cards
+  const topThree = candidates.slice(0, 3);
+  return (
+    <div className="flex flex-col gap-6 px-4 py-8 max-w-md mx-auto">
+      <div className="text-center">
+        <div className="text-4xl mb-2" aria-hidden="true">🤔</div>
+        <h1 className="text-xl font-bold text-gray-900">可能是哪一課？</h1>
+        <p className="mt-1 text-sm text-gray-500">AI 有點不確定，請選正確的課文</p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {topThree.map((c, idx) => (
+          <button
+            key={c.lesson_id}
+            type="button"
+            disabled={confirming}
+            onClick={() => handleConfirm(c.lesson_id)}
+            className={`
+              flex items-start gap-3 w-full rounded-2xl px-4 py-4 text-left transition-all
+              border-2 hover:border-blue-400 hover:bg-blue-50
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
+              disabled:opacity-60
+              ${idx === 0 ? 'border-blue-200 bg-white' : 'border-gray-200 bg-white'}
+            `}
+          >
+            <div className="shrink-0 mt-0.5">
+              <span className={`text-xs font-semibold rounded-lg px-2 py-1 ${idx === 0 ? 'bg-blue-100 text-blue-600' : 'bg-gray-100 text-gray-500'}`}>
+                {c.grade_code}
+              </span>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className={`font-semibold text-gray-900 ${idx === 0 ? 'text-base' : 'text-sm'}`}>
+                {c.title}
+              </p>
+              <p className="text-xs text-gray-400 mt-0.5 line-clamp-1">{c.reasoning}</p>
+              <div className="mt-2 flex items-center gap-1.5">
+                <div
+                  className="h-1.5 rounded-full bg-blue-300"
+                  style={{ width: `${Math.round(c.confidence * 100)}%`, maxWidth: '80px', minWidth: '4px' }}
+                />
+                <span className="text-xs text-gray-400">{Math.round(c.confidence * 100)}%</span>
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+
       <button
         type="button"
-        onClick={onRetry}
-        className="w-full text-sm text-gray-400 hover:text-gray-600 py-1"
+        disabled={confirming}
+        onClick={handleOpenManualPicker}
+        className="w-full text-sm text-gray-500 hover:text-gray-700 underline underline-offset-2 py-1 disabled:opacity-60"
       >
+        都不是，手動選課
+      </button>
+
+      <button type="button" onClick={onRetry} className="text-xs text-gray-400 hover:text-gray-600 py-1 text-center">
         重新上傳
       </button>
     </div>

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -19,8 +19,13 @@ const ACCEPTED_MIME = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
 
 interface OmoUploadProps {
   token: string;
-  /** Called once upload succeeds, with the new upload_id */
-  onUploaded: (uploadId: number) => void;
+  /** Called once upload succeeds, with the new upload_id.
+   *  Phase 1b: opts contains alreadyGraded + cachedScore for dedup cache hits.
+   */
+  onUploaded: (
+    uploadId: number,
+    opts?: { alreadyGraded?: boolean; cachedScore?: number | null },
+  ) => void;
 }
 
 const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded }) => {
@@ -61,7 +66,10 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded }) => {
     setUploading(true);
     try {
       const result = await uploadOmoImages(fileArray, token);
-      onUploaded(result.upload_id);
+      onUploaded(result.upload_id, {
+        alreadyGraded: result.already_graded ?? false,
+        cachedScore: result.overall_score ?? null,
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : '上傳失敗，請再試一次';
       setError(msg);

--- a/frontend/src/components/omo/omoConfidenceThresholds.ts
+++ b/frontend/src/components/omo/omoConfidenceThresholds.ts
@@ -1,0 +1,16 @@
+/**
+ * omoConfidenceThresholds.ts
+ *
+ * Confidence tier constants for the OMO 3-tier identification UX.
+ *
+ * Tier logic:
+ *   conf >= HIGH  → show prominent single-candidate confirm
+ *   conf >= MED   → show top-3 candidate cards (all clickable)
+ *   conf < MED    → "unclear image" prompt with retake / manual-pick options
+ */
+
+/** High confidence: AI is very sure — show single primary confirm button */
+export const OMO_CONF_HIGH = 0.9;
+
+/** Medium confidence: show top-3 clickable candidate cards */
+export const OMO_CONF_MEDIUM = 0.4;

--- a/frontend/src/pages/omo/OmoPage.tsx
+++ b/frontend/src/pages/omo/OmoPage.tsx
@@ -1,8 +1,8 @@
 /**
  * OmoPage — OMO (Online-Merge-Offline) entry page.
  *
- * Phase 1: upload worksheet photo → AI identifies lesson → student confirms.
- * Phase 2 (future): wire confirmed lesson_id to batch grading flow.
+ * Phase 1b: handles from_cache/already_graded dedup flow + grading result.
+ * Phase 2 (future): full result page at /omo/result/:id
  *
  * Route: /omo
  */
@@ -12,33 +12,47 @@ import { useAuth } from '../../contexts/AuthContext';
 import OmoUpload from '../../components/omo/OmoUpload';
 import OmoIdentifyResult from '../../components/omo/OmoIdentifyResult';
 
-type PageState = 'upload' | 'result';
+type PageState = 'upload' | 'result' | 'graded';
 
 const OmoPage: React.FC = () => {
   const { token } = useAuth();
   const navigate = useNavigate();
   const [pageState, setPageState] = useState<PageState>('upload');
   const [uploadId, setUploadId] = useState<number | null>(null);
+  const [alreadyGraded, setAlreadyGraded] = useState(false);
+  const [cachedScore, setCachedScore] = useState<number | null>(null);
+  const [gradedUploadId, setGradedUploadId] = useState<number | null>(null);
 
   if (!token) {
-    // Should be caught by ProtectedRoute, but just in case
     navigate('/login');
     return null;
   }
 
-  const handleUploaded = (id: number) => {
+  const handleUploaded = (
+    id: number,
+    opts?: { alreadyGraded?: boolean; cachedScore?: number | null },
+  ) => {
     setUploadId(id);
+    setAlreadyGraded(opts?.alreadyGraded ?? false);
+    setCachedScore(opts?.cachedScore ?? null);
     setPageState('result');
   };
 
   const handleRetry = () => {
     setUploadId(null);
+    setAlreadyGraded(false);
+    setCachedScore(null);
     setPageState('upload');
   };
 
   const handleConfirmed = (_lessonId: number) => {
-    // Phase 2: navigate to grading flow
-    // navigate(`/learn/${lessonId}`);
+    // OmoIdentifyResult continues polling until graded
+  };
+
+  const handleGraded = (id: number) => {
+    setGradedUploadId(id);
+    setPageState('graded');
+    // Phase 2: navigate(`/omo/result/${id}`)
   };
 
   return (
@@ -57,7 +71,11 @@ const OmoPage: React.FC = () => {
           </svg>
         </button>
         <h2 className="font-semibold text-gray-900">
-          {pageState === 'upload' ? '上傳學習單' : 'AI 辨識結果'}
+          {pageState === 'upload'
+            ? '上傳學習單'
+            : pageState === 'graded'
+            ? '批改結果'
+            : 'AI 辨識結果'}
         </h2>
       </div>
 
@@ -70,9 +88,30 @@ const OmoPage: React.FC = () => {
           <OmoIdentifyResult
             uploadId={uploadId}
             token={token}
+            alreadyGraded={alreadyGraded}
+            cachedScore={cachedScore}
             onConfirmed={handleConfirmed}
             onRetry={handleRetry}
+            onGraded={handleGraded}
           />
+        )}
+        {pageState === 'graded' && gradedUploadId !== null && (
+          <div className="flex flex-col items-center gap-6 px-4 py-12 max-w-md mx-auto">
+            <div className="text-5xl" aria-hidden="true">🎉</div>
+            <div className="text-center">
+              <p className="font-semibold text-gray-800">批改完成！</p>
+              <p className="mt-2 text-sm text-gray-500">
+                詳細結果頁面即將上線
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="w-full py-3.5 px-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors"
+            >
+              上傳另一張
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/services/omoApi.ts
+++ b/frontend/src/services/omoApi.ts
@@ -1,9 +1,8 @@
 /**
  * omoApi.ts — OMO (Online-Merge-Offline) API client.
  *
- * Wraps POST /api/omo/upload, GET /api/omo/:id, POST /api/omo/:id/confirm.
- * Phase 1: upload + AI lesson identification only.
- * Phase 2 stubs: confirm/grade are no-ops until backend implements them.
+ * Phase 1b: upload + dedup (from_cache/already_graded) + regrade.
+ * Phase 2 stubs: full result page wiring.
  */
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
@@ -20,28 +19,70 @@ export interface OmoCandidate {
   reasoning: string;
 }
 
-export type OmoStatus = 'pending' | 'identifying' | 'identified' | 'failed';
+/** Summary entry returned by GET /api/omo/lessons — for manual picker */
+export interface OmoLessonSummary {
+  lesson_id: number;
+  grade_code: string;
+  title: string;
+}
+
+export type OmoStatus =
+  | 'pending'
+  | 'identifying'
+  | 'identified'
+  | 'grading'
+  | 'graded'
+  | 'error'
+  | 'failed'; // frontend-only timeout sentinel
+
+export interface OmoAnswerItem {
+  question_id: string;
+  student_answer: string;
+  correct_answer: string;
+  score: number;
+  ai_confidence: number;
+  reasoning: string;
+  source_attempt_id?: number | null;
+  position?: { x: number; y: number } | null;
+  flag?: { flagged_by: number; reason: string; flagged_at: string } | null;
+}
 
 export interface OmoUploadResponse {
   upload_id: number;
   status: OmoStatus;
   candidates: OmoCandidate[];
+  answers: OmoAnswerItem[];
+  overall_score?: number | null;
+  ai_overall_confidence?: number | null;
+  progress?: Record<string, unknown> | null;
+  error_message?: string | null;
+  /** Phase 1b: true if this response is from a dedup cache hit (same image hash) */
+  from_cache?: boolean;
+  /** Phase 1b: true if the cached upload has already been graded */
+  already_graded?: boolean;
 }
 
-export interface OmoStatusResponse {
-  upload_id: number;
-  status: OmoStatus;
-  lesson_id: number | null;
-  candidates: OmoCandidate[];
-  error_message: string | null;
-  created_at: string;
-  updated_at: string;
-}
+export type OmoStatusResponse = OmoUploadResponse & {
+  lesson_id?: number | null;
+};
 
 export interface OmoConfirmResponse {
   upload_id: number;
   lesson_id: number;
-  status: OmoStatus;
+  status: string;
+  message: string;
+}
+
+export interface OmoRegradeResponse {
+  upload_id: number;
+  status: string;
+  message: string;
+}
+
+export interface OmoFlagResponse {
+  upload_id: number;
+  question_id: string;
+  flagged: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -50,7 +91,8 @@ export interface OmoConfirmResponse {
 
 /**
  * Upload one or more worksheet images. Returns 201 with status=identifying.
- * The backend fires AI identification asynchronously.
+ * Phase 1b: if same hash exists for this user, returns the existing record
+ * with from_cache=true (and possibly already_graded=true if status=graded).
  */
 export async function uploadOmoImages(
   files: File[],
@@ -73,7 +115,7 @@ export async function uploadOmoImages(
 }
 
 /**
- * Poll identification status. Returns current status + candidates once identified.
+ * Poll identification + grading status.
  */
 export async function getOmoStatus(
   uploadId: number,
@@ -90,8 +132,8 @@ export async function getOmoStatus(
 }
 
 /**
- * Confirm which lesson was identified. Phase 1 stub — Phase 2 will wire this
- * to grade submission.
+ * Confirm which lesson was identified. Kicks off grading job.
+ * Phase 1b: returns 409 if status=grading or status=graded (use regradeOmo instead).
  */
 export async function confirmOmoLesson(
   uploadId: number,
@@ -111,4 +153,65 @@ export async function confirmOmoLesson(
     throw new Error(`Confirm failed (${res.status}): ${text}`);
   }
   return res.json() as Promise<OmoConfirmResponse>;
+}
+
+/**
+ * Re-trigger grading for an already-graded upload.
+ * Phase 1b: student-initiated intentional re-grade.
+ */
+export async function regradeOmo(
+  uploadId: number,
+  token: string,
+): Promise<OmoRegradeResponse> {
+  const res = await fetch(`${API_BASE}/api/omo/${uploadId}/regrade`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Regrade failed (${res.status}): ${text}`);
+  }
+  return res.json() as Promise<OmoRegradeResponse>;
+}
+
+/**
+ * Flag a question as incorrectly graded.
+ */
+export async function flagOmoAnswer(
+  uploadId: number,
+  questionId: string,
+  reason: string,
+  token: string,
+): Promise<OmoFlagResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/omo/${uploadId}/answers/${encodeURIComponent(questionId)}/flag`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ reason }),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Flag failed (${res.status}): ${text}`);
+  }
+  return res.json() as Promise<OmoFlagResponse>;
+}
+
+/**
+ * Get the list of OMO-eligible lessons for the manual picker.
+ * Returns a simplified summary: lesson_id, grade_code, title.
+ */
+export async function getOmoLessons(token: string): Promise<OmoLessonSummary[]> {
+  const res = await fetch(`${API_BASE}/api/omo/lessons`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Lessons fetch failed (${res.status}): ${text}`);
+  }
+  return res.json() as Promise<OmoLessonSummary[]>;
 }


### PR DESCRIPTION
Related to #1585 | Part of OMO Phase 1b umbrella #1583

## Summary

- **omoConfidenceThresholds.ts**: Centralised HIGH=0.9, MEDIUM=0.4 constants
- **OmoIdentifyResult.tsx** (full rewrite):
  - Tier 3 (conf < 0.4 or no candidates): "看不清楚" + retake + manual pick buttons
  - Tier 1 (conf >= 0.9): prominent single confirm + "手動選課" escape link
  - Tier 2 (0.4–0.9): top-3 clickable candidate cards with confidence bars
  - Manual picker overlay: calls `GET /api/omo/lessons`, scrollable lesson list
  - Already-graded modal (`from_cache + already_graded`): view last result or regrade
  - Regrade flow: calls `regradeOmo`, resumes status polling
- **omoApi.ts**: Added `OmoLessonSummary`, `getOmoLessons`, `regradeOmo`, `flagOmoAnswer`, extended `OmoStatus` type
- **Backend `GET /api/omo/lessons`**: Auth-gated endpoint returning simplified lesson summaries (lesson_id, grade_code, title)

## Test plan

1. Upload worksheet image with high-confidence match (>0.9) — verify prominent single confirm
2. Upload with medium confidence (0.4–0.9) — verify top-3 candidate cards appear
3. Upload with low/no confidence — verify "看不清楚" screen with retake + manual pick
4. Use manual picker — verify lesson list loads and clicking a lesson triggers confirm
5. Upload same image twice — verify already-graded modal appears with regrade option
6. Click regrade — verify polling resumes until status=graded

## Files changed

- `frontend/src/components/omo/omoConfidenceThresholds.ts` (new)
- `frontend/src/components/omo/OmoIdentifyResult.tsx` (rewrite)
- `frontend/src/components/omo/OmoUpload.tsx` (minor)
- `frontend/src/pages/omo/OmoPage.tsx` (Phase 1b wiring)
- `frontend/src/services/omoApi.ts` (extended)
- `backend/app/routes/omo.py` (added GET /api/omo/lessons)