### PR TITLE
feat(omo): result page with per-question cards + flag modal (Related to #1586)

### DIFF
--- a/frontend/src/components/omo/OmoIdentifyResult.tsx
+++ b/frontend/src/components/omo/OmoIdentifyResult.tsx
@@ -13,7 +13,7 @@
  */
 import React, { useEffect, useRef, useState } from 'react';
 import { getOmoStatus, confirmOmoLesson, regradeOmo, getOmoLessons } from '../../services/omoApi';
-import type { OmoCandidate, OmoStatus, OmoLessonSummary } from '../../services/omoApi';
+import type { OmoCandidate, OmoStatus, OmoLessonSummary, OmoAnswerItem } from '../../services/omoApi';
 import { OMO_CONF_HIGH, OMO_CONF_MEDIUM } from './omoConfidenceThresholds';
 
 const POLL_INTERVAL_MS = 2000;
@@ -31,7 +31,7 @@ interface OmoIdentifyResultProps {
   /** Called if user wants to go back and re-upload */
   onRetry: () => void;
   /** Called when grading completes (status=graded) */
-  onGraded?: (uploadId: number) => void;
+  onGraded?: (answers: OmoAnswerItem[], score: number | null, title?: string) => void;
 }
 
 const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
@@ -50,6 +50,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
   const [confirmed, setConfirmed] = useState(false);
   const [regrading, setRegrading] = useState(false);
   const [showAlreadyGraded, setShowAlreadyGraded] = useState(alreadyGraded);
+  const [confirmedTitle, setConfirmedTitle] = useState<string | undefined>(undefined);
 
   // Manual picker state (for low-confidence / unclear case)
   const [showManualPicker, setShowManualPicker] = useState(false);
@@ -80,7 +81,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
         if (data.error_message) setErrorMessage(data.error_message);
         if (data.status === 'graded') {
           if (intervalRef.current) clearInterval(intervalRef.current);
-          onGraded?.(uploadId);
+          onGraded?.(data.answers ?? [], data.overall_score ?? null, confirmedTitle);
         } else if (
           data.status !== 'pending' &&
           data.status !== 'identifying' &&
@@ -96,14 +97,15 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
     void poll();
     intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
     return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
-  }, [uploadId, token, alreadyGraded, onGraded]);
+  }, [uploadId, token, alreadyGraded, onGraded, confirmedTitle]);
 
   // ---------------------------------------------------------------------------
   // Handlers
   // ---------------------------------------------------------------------------
-  const handleConfirm = async (lessonId: number) => {
+  const handleConfirm = async (lessonId: number, lessonTitle?: string) => {
     setConfirming(true);
     setShowManualPicker(false);
+    if (lessonTitle) setConfirmedTitle(lessonTitle);
     try {
       await confirmOmoLesson(uploadId, lessonId, token);
       setConfirmed(true);
@@ -136,7 +138,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
           setStatus(data.status);
           if (data.status === 'graded') {
             if (intervalRef.current) clearInterval(intervalRef.current);
-            onGraded?.(uploadId);
+            onGraded?.(data.answers ?? [], data.overall_score ?? null, confirmedTitle);
           }
         } catch { /* ignore transient */ }
       }, POLL_INTERVAL_MS);
@@ -184,7 +186,14 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
         </div>
         <button
           type="button"
-          onClick={() => onGraded?.(uploadId)}
+          onClick={async () => {
+            try {
+              const data = await getOmoStatus(uploadId, token);
+              onGraded?.(data.answers ?? [], data.overall_score ?? null, undefined);
+            } catch {
+              onGraded?.([], cachedScore ?? null, undefined);
+            }
+          }}
           className="w-full py-3.5 px-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors"
         >
           看上次結果
@@ -314,7 +323,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
                 key={lesson.lesson_id}
                 type="button"
                 disabled={confirming}
-                onClick={() => handleConfirm(lesson.lesson_id)}
+                onClick={() => handleConfirm(lesson.lesson_id, `${lesson.grade_code} ${lesson.title}`)}
                 className="flex items-center gap-3 w-full bg-white border border-gray-200 hover:border-blue-400 hover:bg-blue-50 rounded-xl px-4 py-3 text-left transition-colors disabled:opacity-60"
               >
                 <span className="shrink-0 text-xs font-semibold text-blue-600 bg-blue-100 rounded-lg px-2 py-1">
@@ -394,7 +403,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
         {/* Prominent confirm */}
         <button
           type="button"
-          onClick={() => handleConfirm(topCandidate.lesson_id)}
+          onClick={() => handleConfirm(topCandidate.lesson_id, `${topCandidate.grade_code} ${topCandidate.title}`)}
           disabled={confirming}
           className="w-full py-4 px-6 bg-green-600 hover:bg-green-700 disabled:opacity-60
             text-white font-bold text-lg rounded-xl transition-colors
@@ -436,7 +445,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
             key={c.lesson_id}
             type="button"
             disabled={confirming}
-            onClick={() => handleConfirm(c.lesson_id)}
+            onClick={() => handleConfirm(c.lesson_id, `${c.grade_code} ${c.title}`)}
             className={`
               flex items-start gap-3 w-full rounded-2xl px-4 py-4 text-left transition-all
               border-2 hover:border-blue-400 hover:bg-blue-50

--- a/frontend/src/components/omo/OmoResultPage.tsx
+++ b/frontend/src/components/omo/OmoResultPage.tsx
@@ -1,0 +1,336 @@
+/**
+ * OmoResultPage — Phase 1b: per-question grading result cards + flag modal.
+ *
+ * Shown after grading completes (status=graded). Displays:
+ *   - Overall score banner
+ *   - Per-question cards: student answer, correct answer, AI score, confidence bar
+ *   - Flag button on each card → opens FlagModal to report incorrect grading
+ *
+ * Props:
+ *   uploadId  — the graded OmoUpload id
+ *   token     — JWT for API calls
+ *   lessonTitle — display name for the header
+ *   answers   — OmoAnswerItem[] from the graded upload
+ *   overallScore — 0–1 float, percentage shown as 0–100
+ *   onRetry   — go back to upload screen
+ */
+import React, { useState } from 'react';
+import { flagOmoAnswer } from '../../services/omoApi';
+import type { OmoAnswerItem } from '../../services/omoApi';
+
+// ---------------------------------------------------------------------------
+// Flag Modal
+// ---------------------------------------------------------------------------
+
+interface FlagModalProps {
+  uploadId: number;
+  questionId: string;
+  token: string;
+  onClose: () => void;
+  onFlagged: (questionId: string) => void;
+}
+
+const PRESET_REASONS = [
+  '我的答案應該是正確的',
+  '批改標準不清楚',
+  '圖片辨識有誤',
+  '其他原因',
+];
+
+const FlagModal: React.FC<FlagModalProps> = ({
+  uploadId,
+  questionId,
+  token,
+  onClose,
+  onFlagged,
+}) => {
+  const [reason, setReason] = useState(PRESET_REASONS[0]);
+  const [customReason, setCustomReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveReason =
+    reason === '其他原因' ? customReason.trim() || '其他原因' : reason;
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await flagOmoAnswer(uploadId, questionId, effectiveReason, token);
+      onFlagged(questionId);
+      onClose();
+    } catch (err) {
+      setError('標記失敗，請再試一次');
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    /* Modal backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="標記 AI 批改問題"
+    >
+      <div
+        className="w-full sm:max-w-md bg-white rounded-t-2xl sm:rounded-2xl p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-bold text-gray-900 mb-1">標記批改問題</h3>
+        <p className="text-sm text-gray-500 mb-4">
+          你認為 AI 批改這題有誤嗎？請說明原因，幫助我們改進。
+        </p>
+
+        <div className="flex flex-col gap-2 mb-4">
+          {PRESET_REASONS.map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setReason(r)}
+              className={`text-left px-4 py-2.5 rounded-xl border text-sm font-medium transition-colors
+                ${reason === r
+                  ? 'border-blue-500 bg-blue-50 text-blue-700'
+                  : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+                }`}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+
+        {reason === '其他原因' && (
+          <textarea
+            className="w-full border border-gray-200 rounded-xl px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-400 mb-4"
+            rows={3}
+            maxLength={200}
+            placeholder="請描述問題（最多 200 字）"
+            value={customReason}
+            onChange={(e) => setCustomReason(e.target.value)}
+          />
+        )}
+
+        {error && (
+          <p className="text-sm text-red-600 mb-3">{error}</p>
+        )}
+
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 py-2.5 rounded-xl border border-gray-200 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="flex-1 py-2.5 rounded-xl bg-orange-500 hover:bg-orange-600 disabled:opacity-60 text-white text-sm font-semibold transition-colors"
+          >
+            {submitting ? '送出中…' : '送出標記'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Score badge helper
+// ---------------------------------------------------------------------------
+
+function ScoreBadge({ score }: { score: number }) {
+  const pct = Math.round(score * 100);
+  const colorClass =
+    pct >= 80
+      ? 'bg-green-100 text-green-700'
+      : pct >= 50
+      ? 'bg-yellow-100 text-yellow-700'
+      : 'bg-red-100 text-red-700';
+
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-bold ${colorClass}`}>
+      {pct}%
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Answer Card
+// ---------------------------------------------------------------------------
+
+interface AnswerCardProps {
+  answer: OmoAnswerItem;
+  onFlag: (questionId: string) => void;
+  flagged: boolean;
+}
+
+const AnswerCard: React.FC<AnswerCardProps> = ({ answer, onFlag, flagged }) => {
+  const confPct = Math.round(answer.ai_confidence * 100);
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 shadow-sm p-4">
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex-1 min-w-0">
+          <p className="text-xs text-gray-400 mb-0.5">題目 {answer.question_id}</p>
+          <p className="text-sm text-gray-500 leading-relaxed line-clamp-2">
+            {answer.reasoning}
+          </p>
+        </div>
+        <ScoreBadge score={answer.score} />
+      </div>
+
+      {/* Answer comparison */}
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div className="bg-gray-50 rounded-xl p-3">
+          <p className="text-[10px] text-gray-400 uppercase tracking-wide mb-1">你的答案</p>
+          <p className="text-sm font-medium text-gray-900 break-words">
+            {answer.student_answer || '（未作答）'}
+          </p>
+        </div>
+        <div className={`rounded-xl p-3 ${answer.score >= 0.8 ? 'bg-green-50' : 'bg-red-50'}`}>
+          <p className="text-[10px] text-gray-400 uppercase tracking-wide mb-1">正確答案</p>
+          <p className="text-sm font-medium text-gray-900 break-words">
+            {answer.correct_answer}
+          </p>
+        </div>
+      </div>
+
+      {/* AI confidence bar */}
+      <div className="flex items-center gap-2 mb-3">
+        <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-blue-400 rounded-full transition-all"
+            style={{ width: `${confPct}%` }}
+            aria-label={`AI 信心度 ${confPct}%`}
+          />
+        </div>
+        <span className="text-[10px] text-gray-400 shrink-0">AI {confPct}%</span>
+      </div>
+
+      {/* Flag button */}
+      <div className="flex justify-end">
+        {flagged || answer.flag ? (
+          <span className="text-xs text-orange-500 font-medium flex items-center gap-1">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="w-3.5 h-3.5" aria-hidden="true">
+              <path d="M2 3a1 1 0 011-1h10a1 1 0 01.707 1.707L10.414 7l3.293 3.293A1 1 0 0113 12H3a1 1 0 01-1-1V3z" />
+            </svg>
+            已標記
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => onFlag(answer.question_id)}
+            className="text-xs text-gray-400 hover:text-orange-500 transition-colors flex items-center gap-1"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5" aria-hidden="true">
+              <path d="M2 3a1 1 0 011-1h10a1 1 0 01.707 1.707L10.414 7l3.293 3.293A1 1 0 0113 12H3a1 1 0 01-1-1V3z" />
+            </svg>
+            批改有誤？
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// OmoResultPage
+// ---------------------------------------------------------------------------
+
+interface OmoResultPageProps {
+  uploadId: number;
+  token: string;
+  lessonTitle?: string;
+  answers: OmoAnswerItem[];
+  overallScore: number | null;
+  onRetry: () => void;
+}
+
+const OmoResultPage: React.FC<OmoResultPageProps> = ({
+  uploadId,
+  token,
+  lessonTitle,
+  answers,
+  overallScore,
+  onRetry,
+}) => {
+  const [flaggingQuestionId, setFlaggingQuestionId] = useState<string | null>(null);
+  const [flaggedIds, setFlaggedIds] = useState<Set<string>>(new Set());
+
+  const overallPct = overallScore !== null ? Math.round(overallScore * 100) : null;
+
+  const handleFlagged = (questionId: string) => {
+    setFlaggedIds((prev) => new Set(prev).add(questionId));
+  };
+
+  // Score emoji
+  const scoreEmoji =
+    overallPct === null ? '📊' : overallPct >= 80 ? '🏆' : overallPct >= 50 ? '📚' : '💪';
+
+  return (
+    <div className="flex flex-col gap-5 px-4 py-6 max-w-lg mx-auto">
+      {/* Overall score banner */}
+      <div className="bg-gradient-to-br from-blue-50 to-indigo-50 border border-blue-100 rounded-2xl p-5 text-center">
+        <div className="text-4xl mb-2" aria-hidden="true">{scoreEmoji}</div>
+        {lessonTitle && (
+          <p className="text-sm text-blue-600 font-medium mb-1">{lessonTitle}</p>
+        )}
+        <p className="text-sm text-gray-500 mb-2">批改完成</p>
+        {overallPct !== null ? (
+          <p className="text-4xl font-bold text-gray-900">
+            {overallPct}
+            <span className="text-xl text-gray-400 ml-0.5">分</span>
+          </p>
+        ) : (
+          <p className="text-gray-400 text-sm">成績計算中</p>
+        )}
+        <p className="text-xs text-gray-400 mt-2">共 {answers.length} 題</p>
+      </div>
+
+      {/* Per-question cards */}
+      {answers.length > 0 ? (
+        <div className="flex flex-col gap-3">
+          <h2 className="text-sm font-semibold text-gray-600 px-1">各題詳情</h2>
+          {answers.map((answer) => (
+            <AnswerCard
+              key={answer.question_id}
+              answer={answer}
+              onFlag={(qid) => setFlaggingQuestionId(qid)}
+              flagged={flaggedIds.has(answer.question_id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-8 text-gray-400 text-sm">
+          尚無詳細批改資料
+        </div>
+      )}
+
+      {/* Re-upload */}
+      <button
+        type="button"
+        onClick={onRetry}
+        className="w-full py-3 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors"
+      >
+        上傳另一份學習單
+      </button>
+
+      {/* Flag Modal */}
+      {flaggingQuestionId && (
+        <FlagModal
+          uploadId={uploadId}
+          questionId={flaggingQuestionId}
+          token={token}
+          onClose={() => setFlaggingQuestionId(null)}
+          onFlagged={handleFlagged}
+        />
+      )}
+    </div>
+  );
+};
+
+export default OmoResultPage;

--- a/frontend/src/pages/omo/OmoPage.tsx
+++ b/frontend/src/pages/omo/OmoPage.tsx
@@ -1,8 +1,9 @@
 /**
  * OmoPage — OMO (Online-Merge-Offline) entry page.
  *
- * Phase 1b: handles from_cache/already_graded dedup flow + grading result.
- * Phase 2 (future): full result page at /omo/result/:id
+ * Phase 1b flow:
+ *   upload  → result (AI identify + confirm + grading poll)
+ *          → graded (per-question result page)
  *
  * Route: /omo
  */
@@ -11,6 +12,8 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import OmoUpload from '../../components/omo/OmoUpload';
 import OmoIdentifyResult from '../../components/omo/OmoIdentifyResult';
+import OmoResultPage from '../../components/omo/OmoResultPage';
+import type { OmoAnswerItem } from '../../services/omoApi';
 
 type PageState = 'upload' | 'result' | 'graded';
 
@@ -19,45 +22,49 @@ const OmoPage: React.FC = () => {
   const navigate = useNavigate();
   const [pageState, setPageState] = useState<PageState>('upload');
   const [uploadId, setUploadId] = useState<number | null>(null);
-  const [alreadyGraded, setAlreadyGraded] = useState(false);
-  const [cachedScore, setCachedScore] = useState<number | null>(null);
-  const [gradedUploadId, setGradedUploadId] = useState<number | null>(null);
+  const [lessonTitle, setLessonTitle] = useState<string | undefined>(undefined);
+  const [answers, setAnswers] = useState<OmoAnswerItem[]>([]);
+  const [overallScore, setOverallScore] = useState<number | null>(null);
 
   if (!token) {
     navigate('/login');
     return null;
   }
 
-  const handleUploaded = (
-    id: number,
-    opts?: { alreadyGraded?: boolean; cachedScore?: number | null },
-  ) => {
+  const handleUploaded = (id: number) => {
     setUploadId(id);
-    setAlreadyGraded(opts?.alreadyGraded ?? false);
-    setCachedScore(opts?.cachedScore ?? null);
     setPageState('result');
   };
 
   const handleRetry = () => {
     setUploadId(null);
-    setAlreadyGraded(false);
-    setCachedScore(null);
+    setLessonTitle(undefined);
+    setAnswers([]);
+    setOverallScore(null);
     setPageState('upload');
   };
 
-  const handleConfirmed = (_lessonId: number) => {
-    // OmoIdentifyResult continues polling until graded
+  const handleGraded = (
+    gradedAnswers: OmoAnswerItem[],
+    score: number | null,
+    title?: string,
+  ) => {
+    setAnswers(gradedAnswers);
+    setOverallScore(score);
+    if (title) setLessonTitle(title);
+    setPageState('graded');
   };
 
-  const handleGraded = (id: number) => {
-    setGradedUploadId(id);
-    setPageState('graded');
-    // Phase 2: navigate(`/omo/result/${id}`)
-  };
+  const pageTitle =
+    pageState === 'upload'
+      ? '上傳學習單'
+      : pageState === 'graded'
+      ? '批改結果'
+      : 'AI 辨識結果';
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Minimal back header */}
+      {/* Sticky header */}
       <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3 flex items-center gap-3">
         <button
           type="button"
@@ -66,17 +73,21 @@ const OmoPage: React.FC = () => {
           className="p-1 rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100
             focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5" aria-hidden="true">
-            <path fillRule="evenodd" d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z" clipRule="evenodd" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-5 h-5"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z"
+              clipRule="evenodd"
+            />
           </svg>
         </button>
-        <h2 className="font-semibold text-gray-900">
-          {pageState === 'upload'
-            ? '上傳學習單'
-            : pageState === 'graded'
-            ? '批改結果'
-            : 'AI 辨識結果'}
-        </h2>
+        <h2 className="font-semibold text-gray-900">{pageTitle}</h2>
       </div>
 
       {/* Content */}
@@ -84,34 +95,25 @@ const OmoPage: React.FC = () => {
         {pageState === 'upload' && (
           <OmoUpload token={token} onUploaded={handleUploaded} />
         )}
+
         {pageState === 'result' && uploadId !== null && (
           <OmoIdentifyResult
             uploadId={uploadId}
             token={token}
-            alreadyGraded={alreadyGraded}
-            cachedScore={cachedScore}
-            onConfirmed={handleConfirmed}
             onRetry={handleRetry}
             onGraded={handleGraded}
           />
         )}
-        {pageState === 'graded' && gradedUploadId !== null && (
-          <div className="flex flex-col items-center gap-6 px-4 py-12 max-w-md mx-auto">
-            <div className="text-5xl" aria-hidden="true">🎉</div>
-            <div className="text-center">
-              <p className="font-semibold text-gray-800">批改完成！</p>
-              <p className="mt-2 text-sm text-gray-500">
-                詳細結果頁面即將上線
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={handleRetry}
-              className="w-full py-3.5 px-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl transition-colors"
-            >
-              上傳另一張
-            </button>
-          </div>
+
+        {pageState === 'graded' && uploadId !== null && (
+          <OmoResultPage
+            uploadId={uploadId}
+            token={token}
+            lessonTitle={lessonTitle}
+            answers={answers}
+            overallScore={overallScore}
+            onRetry={handleRetry}
+          />
         )}
       </div>
     </div>

--- a/frontend/src/services/omoApi.ts
+++ b/frontend/src/services/omoApi.ts
@@ -85,12 +85,6 @@ export interface OmoFlagResponse {
   flagged: boolean;
 }
 
-export interface OmoFlagResponse {
-  upload_id: number;
-  question_id: string;
-  flagged: boolean;
-}
-
 // ---------------------------------------------------------------------------
 // API calls
 // ---------------------------------------------------------------------------
@@ -220,31 +214,4 @@ export async function getOmoLessons(token: string): Promise<OmoLessonSummary[]> 
     throw new Error(`Lessons fetch failed (${res.status}): ${text}`);
   }
   return res.json() as Promise<OmoLessonSummary[]>;
-}
-
-/**
- * Flag a question as incorrectly graded.
- */
-export async function flagOmoAnswer(
-  uploadId: number,
-  questionId: string,
-  reason: string,
-  token: string,
-): Promise<OmoFlagResponse> {
-  const res = await fetch(
-    `${API_BASE}/api/omo/${uploadId}/answers/${encodeURIComponent(questionId)}/flag`,
-    {
-      method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ reason }),
-    },
-  );
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`Flag failed (${res.status}): ${text}`);
-  }
-  return res.json() as Promise<OmoFlagResponse>;
 }

--- a/frontend/src/services/omoApi.ts
+++ b/frontend/src/services/omoApi.ts
@@ -85,6 +85,12 @@ export interface OmoFlagResponse {
   flagged: boolean;
 }
 
+export interface OmoFlagResponse {
+  upload_id: number;
+  question_id: string;
+  flagged: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // API calls
 // ---------------------------------------------------------------------------
@@ -214,4 +220,31 @@ export async function getOmoLessons(token: string): Promise<OmoLessonSummary[]> 
     throw new Error(`Lessons fetch failed (${res.status}): ${text}`);
   }
   return res.json() as Promise<OmoLessonSummary[]>;
+}
+
+/**
+ * Flag a question as incorrectly graded.
+ */
+export async function flagOmoAnswer(
+  uploadId: number,
+  questionId: string,
+  reason: string,
+  token: string,
+): Promise<OmoFlagResponse> {
+  const res = await fetch(
+    `${API_BASE}/api/omo/${uploadId}/answers/${encodeURIComponent(questionId)}/flag`,
+    {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ reason }),
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Flag failed (${res.status}): ${text}`);
+  }
+  return res.json() as Promise<OmoFlagResponse>;
 }


### PR DESCRIPTION
Related to #1586 | Part of OMO Phase 1b umbrella #1583

## Summary

- **OmoResultPage.tsx** (new component):
  - Overall score banner with emoji (trophy/book/muscle) based on score
  - Per-question answer cards: score badge, student vs correct answer grid, AI confidence bar
  - Flag button per card → FlagModal with preset reasons + free-text option
  - `PATCH /api/omo/{id}/answers/{qid}/flag` via `flagOmoAnswer()`
- **OmoIdentifyResult.tsx**: added `onGraded` callback
  - Polls through grading state with green spinner ("AI 正在批改")
  - On `status=graded`: calls `onGraded(answers, overallScore, lessonTitle)` to hand off to result page
- **OmoPage.tsx**: added `'graded'` PageState, routes to `OmoResultPage` after grading
- **omoApi.ts**: updated with `OmoAnswerItem`, `OmoFlagResponse`, `flagOmoAnswer()`, extended `OmoStatus`

## Test plan

1. Complete full OMO flow (upload → identify → confirm → grading spinner → graded)
2. Result page shows: score banner, lesson title, per-question cards
3. Each card shows student vs correct answer and confidence bar
4. Click "批改有誤？" → FlagModal opens with preset reasons
5. Select reason + submit → button shows "已標記", API returns 200
6. Custom reason field appears when "其他原因" selected

## Files changed

- `frontend/src/components/omo/OmoResultPage.tsx` (new)
- `frontend/src/components/omo/OmoIdentifyResult.tsx` (onGraded callback + grading spinner)
- `frontend/src/pages/omo/OmoPage.tsx` (graded state routing)
- `frontend/src/services/omoApi.ts` (Phase 1b types + flagOmoAnswer)