### PR TITLE
feat(reading): 朗讀歷史趨勢線圖 — 自己跟自己比 (Fixes #1597)

### DIFF
--- a/frontend/src/components/reading-steps/__tests__/ReadingTrendChart.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/ReadingTrendChart.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ReadingTrendChart from '../full-reading/ReadingTrendChart';
+import type { ReadingHistoryItem } from '../../../services/readingHistoryApi';
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const makeItem = (id: number, accuracy: number, cpm: number, daysAgo: number): ReadingHistoryItem => ({
+  id,
+  student_id: 1,
+  lesson_id: '1109',
+  paragraph_index: null,
+  reading_type: 'full',
+  cpm,
+  accuracy,
+  duration_seconds: 60,
+  created_at: new Date(Date.now() - daysAgo * 86400_000).toISOString(),
+});
+
+describe('ReadingTrendChart', () => {
+  it('shows encouragement when fewer than 2 attempts', () => {
+    render(<ReadingTrendChart history={[makeItem(1, 80, 150, 0)]} />);
+    expect(screen.getByText(/再多練幾次/)).toBeTruthy();
+  });
+
+  it('shows encouragement when history is empty', () => {
+    render(<ReadingTrendChart history={[]} />);
+    expect(screen.getByText(/再多練幾次/)).toBeTruthy();
+  });
+
+  it('renders chart with at least 2 attempts', () => {
+    const history = [makeItem(1, 70, 140, 5), makeItem(2, 80, 150, 0)];
+    render(<ReadingTrendChart history={history} />);
+    expect(screen.getByText('進步趨勢')).toBeTruthy();
+    expect(screen.queryByText(/再多練幾次/)).toBeNull();
+  });
+
+  it('caps at 20 points and shows "最近 20 次" label when exceeded', () => {
+    const history = Array.from({ length: 25 }, (_, i) =>
+      makeItem(i + 1, 60 + i, 100 + i * 2, 25 - i),
+    );
+    render(<ReadingTrendChart history={history} />);
+    expect(screen.getByText('最近 20 次')).toBeTruthy();
+  });
+
+  it('does NOT show "最近 20 次" label when within the cap', () => {
+    const history = Array.from({ length: 5 }, (_, i) =>
+      makeItem(i + 1, 70 + i, 130 + i, 5 - i),
+    );
+    render(<ReadingTrendChart history={history} />);
+    expect(screen.queryByText('最近 20 次')).toBeNull();
+  });
+});

--- a/frontend/src/components/reading-steps/full-reading/ReadingMetricsCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/ReadingMetricsCard.tsx
@@ -12,6 +12,7 @@
 
 import React from 'react';
 import type { ReadingHistoryItem } from '../../../services/readingHistoryApi';
+import ReadingTrendChart from './ReadingTrendChart';
 
 interface ReadingMetricsCardProps {
   /** 正確率 0–100 (integer %) */
@@ -99,6 +100,11 @@ const ReadingMetricsCard: React.FC<ReadingMetricsCardProps> = ({ accuracy, cpm, 
           </div>
         </div>
       )}
+
+      {/* #1597 Trend chart — all-history dual-axis line. Renders an inline
+          encouragement message when < 2 points (the chart component handles
+          its own empty state). */}
+      {history && history.length > 0 && <ReadingTrendChart history={history} />}
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx
+++ b/frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx
@@ -1,0 +1,153 @@
+/**
+ * ReadingTrendChart — 朗讀歷史趨勢線圖 (#1597, Refs #1505).
+ *
+ * Young 5/8 ask: 「累積自己跟自己比的那個排行榜...一個那個線圖，就是慢慢
+ * 上去都可以的」. Renders dual-axis line chart of accuracy (%) + CPM over
+ * attempts so students see their own progression. Caps to the most recent
+ * 20 points for chart readability (older points still appear in the table).
+ */
+import React, { useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import type { ReadingHistoryItem } from '../../../services/readingHistoryApi';
+
+interface ReadingTrendChartProps {
+  /** Reading history items — order from caller is preserved internally. */
+  history: ReadingHistoryItem[];
+}
+
+interface ChartPoint {
+  attempt: number;
+  accuracy: number;
+  cpm: number;
+  dateLabel: string;
+  fullDate: string;
+}
+
+const MAX_POINTS = 20;
+
+function buildChartData(history: ReadingHistoryItem[]): ChartPoint[] {
+  const sorted = [...history].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  );
+  const points = sorted.slice(-MAX_POINTS);
+  return points.map((item, i) => {
+    const date = new Date(item.created_at);
+    const dateLabel = `${date.getMonth() + 1}/${date.getDate()}`;
+    const fullDate = `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+    return {
+      attempt: i + 1,
+      accuracy: Math.round(item.accuracy),
+      cpm: Math.round(item.cpm),
+      dateLabel,
+      fullDate,
+    };
+  });
+}
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: ChartPoint }>;
+}
+
+function CustomTooltip({ active, payload }: TooltipProps) {
+  if (!active || !payload || payload.length === 0) return null;
+  const p = payload[0].payload;
+  return (
+    <div className="bg-surface-container-lowest border border-surface-container-high rounded-lg shadow-md px-3 py-2 text-xs">
+      <div className="font-headline font-bold text-on-surface mb-1">第 {p.attempt} 次 · {p.fullDate}</div>
+      <div className="flex items-center gap-2 text-amber-700">
+        <span className="w-2 h-2 rounded-full bg-amber-500" />
+        正確率：<span className="font-bold">{p.accuracy}%</span>
+      </div>
+      <div className="flex items-center gap-2 text-blue-700">
+        <span className="w-2 h-2 rounded-full bg-blue-500" />
+        語速：<span className="font-bold">{p.cpm} 字/分</span>
+      </div>
+    </div>
+  );
+}
+
+const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
+  const data = useMemo(() => buildChartData(history), [history]);
+
+  if (data.length < 2) {
+    return (
+      <div className="bg-surface-container-low rounded-2xl py-6 px-4 text-center text-xs text-on-surface-variant">
+        再多練幾次就會出現趨勢圖，可以看到自己慢慢進步 🚀
+      </div>
+    );
+  }
+
+  const truncated = history.length > MAX_POINTS;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider">
+          進步趨勢
+        </p>
+        {truncated && (
+          <span className="text-[10px] text-on-surface-variant">最近 {MAX_POINTS} 次</span>
+        )}
+      </div>
+      <div className="h-48 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis dataKey="attempt" tick={{ fontSize: 10 }} stroke="#9ca3af" />
+            <YAxis
+              yAxisId="accuracy"
+              orientation="left"
+              domain={[0, 100]}
+              tick={{ fontSize: 10 }}
+              stroke="#d97706"
+              tickFormatter={(v) => `${v}%`}
+              width={32}
+            />
+            <YAxis
+              yAxisId="cpm"
+              orientation="right"
+              domain={['auto', 'auto']}
+              tick={{ fontSize: 10 }}
+              stroke="#2563eb"
+              width={32}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend wrapperStyle={{ fontSize: 10 }} iconSize={8} />
+            <Line
+              yAxisId="accuracy"
+              type="monotone"
+              dataKey="accuracy"
+              name="正確率 %"
+              stroke="#d97706"
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              activeDot={{ r: 5 }}
+            />
+            <Line
+              yAxisId="cpm"
+              type="monotone"
+              dataKey="cpm"
+              name="語速 字/分"
+              stroke="#2563eb"
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              activeDot={{ r: 5 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default ReadingTrendChart;


### PR DESCRIPTION
## Summary

Young 5/8 ask：「累積自己跟自己比的那個排行榜...一個那個線圖，就是慢慢上去都可以的」。PR #1519 已有 history table（last 5），這次補上學生可以「自己跟自己比」的時間趨勢線圖。

## 變更檔案

| 檔案 | 改動 |
|------|------|
| `frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx` | 新增 — recharts dual-axis line chart |
| `frontend/src/components/reading-steps/full-reading/ReadingMetricsCard.tsx` | 在 history table 下方掛入趨勢圖 |
| `frontend/src/components/reading-steps/__tests__/ReadingTrendChart.test.tsx` | 新增 — 5 個 unit tests |

## 設計細節

- **雙 Y 軸**：左 amber 正確率 (0–100%)、右 blue 語速 (auto domain) — 與 metric pills 配色一致
- **X 軸**：第 N 次練習（按 `created_at` 升序）
- **Tooltip**：完整時間戳 + accuracy + cpm
- **資料上限**：最多顯示最近 20 點，超過則顯示「最近 20 次」標籤
- **Empty state**：< 2 點時顯示「再多練幾次就會出現趨勢圖，可以看到自己慢慢進步 🚀」（沒有圖）

不需 caller 改動 — `ReadingMetricsCard` 已 mount 在 FullReading + LiveTutor，自動套用。

## 後端影響

無。`/api/reading-history/{student_id}/{lesson_id}?reading_type=full` 已存在（PR #1519 引用，#909 落地），回傳完整歷史，前端自己 sort + cap。

## Test plan

- [ ] 第 1 次練習完，下方看到 metric pills + 「再多練幾次」鼓勵訊息（沒圖）
- [ ] 第 2 次練習完，顯示趨勢圖：2 個點，amber 線（正確率）+ blue 線（語速）
- [ ] 練超過 20 次，顯示「最近 20 次」標籤，圖只畫最近 20 點
- [ ] hover 任一點 → tooltip 顯示「第 N 次 · YYYY/MM/DD HH:MM」+ 正確率 + 語速
- [ ] LiveTutor 完成所有段落也看到一致 UI
- [ ] mobile 375px 圖可讀
- [ ] `npm test ReadingTrendChart` 5/5 pass ✅

## Acceptance（issue #1597）

- [x] FullReading 完成練習後看到 history table + 折線圖兩個區塊
- [x] LiveTutor 完成所有段落後同樣顯示
- [x] 第 1 次：不顯示 chart，顯示「再練幾次就有趨勢圖了」訊息
- [x] 第 2 次以上：chart 顯示對應筆數
- [x] tooltip 顯示日期 + 時間 + 正確率 + 語速

Refs #1597, #1505 (history table 由 #1519 落地), #1386 (4-attempt chart pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)