### PR TITLE
feat: unify learning-step progress storage via step_progress (#1549)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -235,9 +235,11 @@ class GlobalRateLimitMiddleware:
     _EXEMPT_PATHS = ("/health", "/docs", "/redoc", "/openapi.json", "/")
     # Read operations are much burstier during UI navigation (route mounts,
     # parallel data loaders, prefetch). Keep write operations stricter.
-    READ_LIMIT = 300
-    WRITE_LIMIT = 90
-    WINDOW = 60  # seconds
+    # Allow env overrides so local dev (React StrictMode double-invocations,
+    # HMR replays) doesn't trip the global limiter while debugging.
+    READ_LIMIT = int(os.getenv("RATE_LIMIT_READ", "300"))
+    WRITE_LIMIT = int(os.getenv("RATE_LIMIT_WRITE", "90"))
+    WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))  # seconds
 
     def __init__(self, app):
         self.app = app

--- a/backend/app/routes/teacher/teacher_schemas.py
+++ b/backend/app/routes/teacher/teacher_schemas.py
@@ -401,6 +401,10 @@ class TeacherSessionReportResponse(BaseModel):
     teacher_reviewed_at: datetime | None
     started_at: datetime
     completed_at: datetime | None
+    # Issue #1549 — unified per-step progress. Contains current_step,
+    # steps_completed, and step_data (one entry per stepId: intro / tutor /
+    # comprehension / vocab / dictation / full-reading / report).
+    step_progress: dict | None = None
 
     model_config = {"from_attributes": True}
 

--- a/frontend/src/components/reading-steps/DictationPractice.tsx
+++ b/frontend/src/components/reading-steps/DictationPractice.tsx
@@ -3,6 +3,7 @@ import { Story } from '../../types';
 import { speakText as cloudSpeakText, cancelTts } from '../../services/ttsApi';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { fontForZhuyin } from '../../constants/fonts';
+import type { DictationStepData } from '../../types/stepProgress';
 
 export interface DictationResult {
   totalWords: number;
@@ -17,12 +18,17 @@ interface WordResult {
   studentAnswer: string;
   isCorrect: boolean;
   skipped: boolean;
+  durationMs?: number;
 }
 
 interface DictationPracticeProps {
   story: Story;
   onFinish: (result: DictationResult) => void;
   onBack: () => void;
+  /** Rehydrate from previously saved step_progress.step_data['dictation']. */
+  initialProgress?: DictationStepData;
+  /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
+  onProgressChange?: (stepData: DictationStepData, immediate?: boolean) => void;
 }
 
 type Phase = 'intro' | 'practice' | 'results';
@@ -103,21 +109,48 @@ const SpeakerIcon: React.FC<{ animate: boolean }> = ({ animate }) => (
 
 // ---- Main component ----
 
-const DictationPractice: React.FC<DictationPracticeProps> = ({ story, onFinish, onBack }) => {
+const DictationPractice: React.FC<DictationPracticeProps> = ({
+  story,
+  onFinish,
+  onBack,
+  initialProgress,
+  onProgressChange,
+}) => {
   const { zhuyinActive } = useZhuyin();
   const zhuyinFont = fontForZhuyin(zhuyinActive);
   const words = React.useMemo(() => extractDictationWords(story), [story]);
 
-  const [phase, setPhase] = useState<Phase>('intro');
-  const [currentIndex, setCurrentIndex] = useState(0);
+  // Rehydrate from DB-loaded step_data['dictation'] when available.
+  // Only resume mid-flight if a) we have results, b) we hadn't already finished.
+  const canResume = !!initialProgress
+    && Array.isArray(initialProgress.word_results)
+    && initialProgress.word_results.length > 0
+    && initialProgress.phase !== 'results';
+
+  const initialResults: WordResult[] = canResume
+    ? (initialProgress!.word_results as DictationStepData['word_results']).map((r) => ({
+        word: r.word,
+        studentAnswer: r.user_answer,
+        isCorrect: r.correct,
+        skipped: r.user_answer === '' && !r.correct,
+        durationMs: r.duration_ms,
+      }))
+    : [];
+
+  const [phase, setPhase] = useState<Phase>(canResume ? 'practice' : 'intro');
+  const [currentIndex, setCurrentIndex] = useState(
+    canResume ? Math.min(initialProgress!.current_index ?? 0, words.length - 1) : 0,
+  );
   const [answer, setAnswer] = useState('');
   const [isSpeaking, setIsSpeaking] = useState(false);
-  const [wordResults, setWordResults] = useState<WordResult[]>([]);
+  const [wordResults, setWordResults] = useState<WordResult[]>(initialResults);
   const [ttsSupported, setTtsSupported] = useState(true);
   const [voicesLoaded, setVoicesLoaded] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   // IME composition guard (#1206): Enter during 注音選字 should not submit.
   const isComposingRef = useRef(false);
+  // Track when the current word was first shown so we can record duration.
+  const wordStartTsRef = useRef<number>(Date.now());
 
   // Cloud TTS is always ready immediately; mark voicesLoaded true on mount.
   // Web Speech API voice loading is handled inside ttsApi fallback.
@@ -154,6 +187,13 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({ story, onFinish, 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [phase, currentIndex, voicesLoaded]);
 
+  // Reset per-word timer when phase enters practice or the word advances.
+  useEffect(() => {
+    if (phase === 'practice') {
+      wordStartTsRef.current = Date.now();
+    }
+  }, [phase, currentIndex]);
+
   const handleStartPractice = () => {
     setPhase('practice');
     setCurrentIndex(0);
@@ -161,28 +201,57 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({ story, onFinish, 
     setWordResults([]);
   };
 
+  const buildStepData = useCallback(
+    (results: WordResult[], nextIndex: number, nextPhase: Phase): DictationStepData => ({
+      word_results: results.map((r) => ({
+        word: r.word,
+        user_answer: r.studentAnswer,
+        correct: r.isCorrect,
+        attempts: 1,
+        duration_ms: r.durationMs,
+      })),
+      current_index: nextIndex,
+      phase: nextPhase,
+    }),
+    [],
+  );
+
   const submitAnswer = useCallback(
     (skipped = false) => {
       const word = words[currentIndex];
       const trimmed = answer.trim();
       const isCorrect = !skipped && trimmed === word;
+      const durationMs = Math.max(0, Date.now() - wordStartTsRef.current);
 
       const result: WordResult = {
         word,
         studentAnswer: skipped ? '' : trimmed,
         isCorrect,
         skipped,
+        durationMs,
       };
 
       const updatedResults = [...wordResults, result];
       setWordResults(updatedResults);
 
-      if (currentIndex + 1 >= words.length) {
-        // Done — show results
+      const isLast = currentIndex + 1 >= words.length;
+      if (isLast) {
         cancelTts();
         const correct = updatedResults.filter((r) => r.isCorrect).length;
         const skippedCount = updatedResults.filter((r) => r.skipped).length;
         const incorrect = updatedResults.length - correct - skippedCount;
+        // Final flush to DB (immediate) — include summary so the report view
+        // and teacher dashboard can read it directly from step_data.
+        const finalStepData: DictationStepData = {
+          ...buildStepData(updatedResults, currentIndex, 'results'),
+          result: {
+            total_words: words.length,
+            correct_count: correct,
+            incorrect_count: incorrect,
+            skipped_count: skippedCount,
+          },
+        };
+        onProgressChange?.(finalStepData, true);
         onFinish({
           totalWords: words.length,
           correctCount: correct,
@@ -192,11 +261,13 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({ story, onFinish, 
         });
         setPhase('results');
       } else {
+        // Mid-flight: debounced DB write.
+        onProgressChange?.(buildStepData(updatedResults, currentIndex + 1, 'practice'), false);
         setCurrentIndex((i) => i + 1);
         setAnswer('');
       }
     },
-    [words, currentIndex, answer, wordResults, onFinish],
+    [words, currentIndex, answer, wordResults, onFinish, onProgressChange, buildStepData],
   );
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/frontend/src/components/reading-steps/DictationPractice.tsx
+++ b/frontend/src/components/reading-steps/DictationPractice.tsx
@@ -121,13 +121,24 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({
   const words = React.useMemo(() => extractDictationWords(story), [story]);
 
   // Rehydrate from DB-loaded step_data['dictation'] when available.
-  // Only resume mid-flight if a) we have results, b) we hadn't already finished.
-  const canResume = !!initialProgress
+  // Three cases:
+  //   - phase === 'results' + matching word_results → show the prior summary so
+  //     the student can review or redo (Issue #1549 P1 fix from PR review)
+  //   - phase === 'practice' with partial word_results → resume mid-flight
+  //   - otherwise → fresh start at intro
+  // We guard against course-content drift: if the stored word_results length
+  // doesn't match the current `words.length`, fall back to fresh start to
+  // avoid showing a stale summary that no longer corresponds to the lesson.
+  const hasPriorResults = !!initialProgress
     && Array.isArray(initialProgress.word_results)
-    && initialProgress.word_results.length > 0
-    && initialProgress.phase !== 'results';
+    && initialProgress.word_results.length > 0;
+  const priorMatchesWords = hasPriorResults
+    && initialProgress!.word_results!.length === words.length
+    && initialProgress!.word_results!.every((r, i) => r.word === words[i]);
+  const canShowResults = priorMatchesWords && initialProgress!.phase === 'results';
+  const canResume = hasPriorResults && priorMatchesWords && initialProgress!.phase !== 'results';
 
-  const initialResults: WordResult[] = canResume
+  const initialResults: WordResult[] = (canResume || canShowResults)
     ? (initialProgress!.word_results as DictationStepData['word_results']).map((r) => ({
         word: r.word,
         studentAnswer: r.user_answer,
@@ -137,7 +148,9 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({
       }))
     : [];
 
-  const [phase, setPhase] = useState<Phase>(canResume ? 'practice' : 'intro');
+  const [phase, setPhase] = useState<Phase>(
+    canShowResults ? 'results' : canResume ? 'practice' : 'intro',
+  );
   const [currentIndex, setCurrentIndex] = useState(
     canResume ? Math.min(initialProgress!.current_index ?? 0, words.length - 1) : 0,
   );
@@ -441,12 +454,91 @@ const DictationPractice: React.FC<DictationPracticeProps> = ({
     );
   }
 
-  // ---- Phase: results (summary shown internally, then onFinish is called) ----
-  // This phase is reached only momentarily; the parent navigates away via onFinish.
-  // We show a brief "loading" state while onFinish fires.
+  // ---- Phase: results ----
+  // Two entry paths:
+  //   1. submitAnswer finished the last word → onFinish has already fired and
+  //      the parent typically navigates away; this view is transient.
+  //   2. Re-mount after the student returned to this step from elsewhere
+  //      (rehydrated via canShowResults). They see the saved summary plus a
+  //      "重做" button to start over and a "繼續下一關" button to advance.
+  const correctCount = wordResults.filter((r) => r.isCorrect).length;
+  const skippedCount = wordResults.filter((r) => r.skipped).length;
+  const incorrectCount = wordResults.length - correctCount - skippedCount;
+  const handleRedo = () => {
+    setPhase('intro');
+    setCurrentIndex(0);
+    setAnswer('');
+    setWordResults([]);
+  };
+  const handleContinue = () => {
+    onFinish({
+      totalWords: words.length,
+      correctCount,
+      incorrectCount,
+      skippedCount,
+      results: wordResults,
+    });
+  };
   return (
-    <div className="flex-1 flex items-center justify-center bg-amber-50">
-      <div className="w-8 h-8 border-4 border-accent border-t-transparent rounded-full animate-spin" />
+    <div className="flex-1 flex flex-col bg-amber-50 overflow-hidden">
+      <div className="flex-1 flex flex-col items-center justify-start px-6 py-8 gap-6 max-w-lg mx-auto w-full overflow-y-auto">
+        <div className="text-center space-y-2">
+          <h2 className="text-2xl font-bold text-gray-900">聽寫成績</h2>
+          <p className="text-sm text-gray-500">共 {words.length} 字</p>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3 w-full">
+          <div className="rounded-2xl bg-emerald-50 border border-emerald-200 p-4 text-center">
+            <div className="text-2xl font-bold text-emerald-700">{correctCount}</div>
+            <div className="text-xs text-emerald-700/70 mt-1">答對</div>
+          </div>
+          <div className="rounded-2xl bg-red-50 border border-red-200 p-4 text-center">
+            <div className="text-2xl font-bold text-red-700">{incorrectCount}</div>
+            <div className="text-xs text-red-700/70 mt-1">答錯</div>
+          </div>
+          <div className="rounded-2xl bg-gray-100 border border-gray-200 p-4 text-center">
+            <div className="text-2xl font-bold text-gray-700">{skippedCount}</div>
+            <div className="text-xs text-gray-700/70 mt-1">跳過</div>
+          </div>
+        </div>
+
+        <div className="w-full space-y-2">
+          {wordResults.map((r, i) => (
+            <div
+              key={i}
+              className={`flex items-center justify-between rounded-xl px-4 py-3 border ${
+                r.skipped
+                  ? 'bg-gray-50 border-gray-200'
+                  : r.isCorrect
+                    ? 'bg-emerald-50 border-emerald-200'
+                    : 'bg-red-50 border-red-200'
+              }`}
+            >
+              <span className={`text-xl font-bold ${zhuyinFont}`}>{r.word}</span>
+              <span className={`text-sm ${
+                r.skipped ? 'text-gray-500' : r.isCorrect ? 'text-emerald-700' : 'text-red-700'
+              }`}>
+                {r.skipped ? '跳過' : r.isCorrect ? '✓ 正確' : `你寫：${r.studentAnswer || '(空白)'}`}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        <div className="w-full flex flex-col gap-2 mt-2">
+          <button
+            onClick={handleContinue}
+            className="w-full py-3 rounded-2xl bg-accent text-white font-semibold hover:bg-accent-hover transition-colors"
+          >
+            繼續下一關
+          </button>
+          <button
+            onClick={handleRedo}
+            className="w-full py-3 rounded-2xl bg-white text-gray-700 border border-gray-300 font-semibold hover:bg-gray-50 transition-colors"
+          >
+            重做聽寫
+          </button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/FloatingAIHelper.tsx
+++ b/frontend/src/components/reading-steps/FloatingAIHelper.tsx
@@ -6,7 +6,11 @@
  * Uses the existing /api/comprehension/chat endpoint for AI responses.
  */
 import React, { useCallback, useRef, useState, useEffect } from 'react';
-import { sendComprehensionChat, SessionExpiredError } from '../../services/learningApi';
+import {
+  sendComprehensionChat,
+  SessionExpiredError,
+  fetchDialogueHistory,
+} from '../../services/learningApi';
 import { useAuth } from '../../contexts/AuthContext';
 import VoiceInputButton from '../ui/VoiceInputButton';
 
@@ -34,12 +38,40 @@ const FloatingAIHelper: React.FC<FloatingAIHelperProps> = ({
   const [messages, setMessages] = useState<HelperMessage[]>([]);
   const [inputText, setInputText] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isHistoryLoading, setIsHistoryLoading] = useState(false);
   const [sessionId] = useState(() =>
     dbSessionId ? `helper-${dbSessionId}` : `helper-${crypto.randomUUID()}`
   );
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const isComposingRef = useRef(false);
+
+  // Rehydrate dialogue history on mount (Issue #1549) — when the student
+  // re-enters a course/session, we pull existing dialogue_turns so the chat
+  // panel resumes from where they left off instead of showing an empty box.
+  //
+  // Race guard: if the user opens the helper and sends a message before this
+  // GET resolves, `messages.length > 0` means we'd clobber their new message.
+  // Use a ref so the guard sees the latest length without re-running the effect.
+  const userHasInteractedRef = useRef(false);
+  useEffect(() => {
+    if (!token || !dbSessionId) return;
+    setIsHistoryLoading(true);
+    fetchDialogueHistory(token, dbSessionId)
+      .then((res) => {
+        if (userHasInteractedRef.current) return;
+        const restored: HelperMessage[] = res.turns
+          .slice()
+          .sort((a, b) => a.turn_order - b.turn_order)
+          .filter((t) => t.role === 'ai' || t.role === 'student')
+          .map((t) => ({ role: t.role as 'ai' | 'student', text: t.text }));
+        if (restored.length > 0) setMessages(restored);
+      })
+      .catch(() => {
+        // Silent — first-time learners simply see an empty chat
+      })
+      .finally(() => setIsHistoryLoading(false));
+  }, [token, dbSessionId]);
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -57,6 +89,7 @@ const FloatingAIHelper: React.FC<FloatingAIHelperProps> = ({
     const text = inputText.trim();
     if (!text || isLoading) return;
 
+    userHasInteractedRef.current = true;
     const studentMsg: HelperMessage = { role: 'student', text };
     setMessages(prev => [...prev, studentMsg]);
     setInputText('');
@@ -133,7 +166,13 @@ const FloatingAIHelper: React.FC<FloatingAIHelperProps> = ({
 
           {/* Messages */}
           <div className="flex-1 min-h-0 overflow-y-auto p-3 space-y-3 bg-gray-50">
-            {messages.length === 0 && (
+            {isHistoryLoading && messages.length === 0 && (
+              <div className="flex items-center justify-center py-8">
+                <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+              </div>
+            )}
+
+            {!isHistoryLoading && messages.length === 0 && (
               <div className="text-center text-gray-400 text-xs py-8">
                 <p>對課文有疑問嗎？</p>
                 <p className="mt-1">輸入你的問題，AI 會幫你解答</p>

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -34,9 +34,21 @@ interface FullReadingProps {
   initialResult?: FullReadingResult | null;
   /** All reading attempts for this session from DB (Issue #1386 — 4-attempt progress chart). */
   fullReadingAttempts?: FullReadingAttempt[];
+  /** Full step_data['full-reading'] snapshot from DB (Issue #1549) — provides selfRating + transcript. */
+  initialProgress?: FullReadingStepData;
+  /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
+  onProgressChange?: (stepData: FullReadingStepData, immediate?: boolean) => void;
 }
 
-const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, initialResult, fullReadingAttempts = [] }) => {
+const FullReading: React.FC<FullReadingProps> = ({
+  story,
+  onFinish,
+  onBack,
+  initialResult,
+  fullReadingAttempts = [],
+  initialProgress,
+  onProgressChange,
+}) => {
   const { token, user } = useAuth();
   const storageKey = scopedStepStorageKey('fullReading_progress_', story.id);
   // #1462: in toolbox mode, completion screen shows 重做/回工具箱 instead of 下一關.
@@ -57,7 +69,10 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
   });
 
   /* ---- Self-assessment for current attempt (Issue #1386) ---- */
-  const [selfRating, setSelfRating] = useState<AssessmentRating | undefined>(undefined);
+  // Issue #1549 — rehydrate selfRating from DB-loaded step_data when available.
+  const [selfRating, setSelfRating] = useState<AssessmentRating | undefined>(
+    () => (initialProgress?.self_rating as AssessmentRating | undefined) ?? undefined
+  );
   const [showComparison, setShowComparison] = useState(false);
 
   /* ---- Parsed benchmark for progress chart (Issue #1386) ---- */
@@ -166,6 +181,29 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
   // Raw Web Speech gray-text preview replaces the punctuation-insertion path.
   // Reason: enhanceLiveTranscript ran on every STT partial → visible flicker.
   // Gemini provides accurate punctuation post-submission (no live re-insertion needed).
+
+  /* ---- Issue #1549 — persist to step_progress (DB).
+   *      We only push to DB after a result is committed; transcript and
+   *      selfRating updates ride along so teachers see them too. The handler
+   *      is debounced upstream (5 s) so rapid selfRating clicks don't spam. */
+  useEffect(() => {
+    if (!result || !onProgressChange) return;
+    onProgressChange(
+      {
+        result: {
+          matchRate: result.matchRate,
+          feedback: result.feedback,
+          diffTokens: result.diffTokens,
+          cpm: result.cpm,
+          durationMs: result.durationMs,
+          errorBreakdown: result.errorBreakdown,
+        },
+        self_rating: selfRating,
+        transcript: streamingTranscript,
+      },
+      false,
+    );
+  }, [result, selfRating, streamingTranscript, onProgressChange]);
 
   const zhuyinLines = useMemo(
     () => processLinesSelective(story.content, vocabWords),

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -10,7 +10,7 @@
  *  - Skip button for round 2 (tracked but not blocking)
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Story, ReadingAttempt, VocabResult } from '../../types';
 import { hasStrokeData } from '../stroke-order/strokeData';
 import WriteCharacter from '../stroke-order/WriteCharacter';
@@ -20,22 +20,45 @@ import RadicalDecomposition from './RadicalDecomposition';
 import { getDecomposition, initGeneratedDecompositions, initRadicalMeanings } from '../../data/radicals';
 import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStorageScope';
 import ToolboxCompletionActions from '../tools/ToolboxCompletionActions';
+import type { VocabStepData } from '../../types/stepProgress';
 
 interface VocabPracticeProps {
   story: Story;
   attempt: ReadingAttempt | null;
   onFinish: (result: VocabResult) => void;
   onBack: () => void;
+  /** Rehydrate from previously saved step_progress.step_data['vocab']. */
+  initialProgress?: VocabStepData;
+  /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
+  onProgressChange?: (stepData: VocabStepData, immediate?: boolean) => void;
 }
 
 /** Per-character practice round state */
 type CharRound = 1 | 2 | 'done';
 
+/** Convert in-memory round state to wire format (1=round1, 2=round2, 3=done). */
+function roundToCode(r: CharRound): number {
+  return r === 'done' ? 3 : r;
+}
+
+function codeToRound(c: number): CharRound {
+  if (c === 3) return 'done';
+  if (c === 2) return 2;
+  return 1;
+}
+
 /* ================================================================ */
 /*  Main component                                                   */
 /* ================================================================ */
 
-const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish, onBack }) => {
+const VocabPractice: React.FC<VocabPracticeProps> = ({
+  story,
+  attempt,
+  onFinish,
+  onBack,
+  initialProgress,
+  onProgressChange,
+}) => {
   // Load generated decomposition data
   const [decompReady, setDecompReady] = useState(false);
   useEffect(() => {
@@ -43,34 +66,66 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   }, []);
 
   const storageKey = scopedStepStorageKey('vocabPractice_progress_', story.id);
-  const loadSaved = () => {
+
+  // Rehydration order: DB-loaded initialProgress → localStorage → empty (Issue #1549).
+  const loadFromLocalStorage = () => {
     try {
       const raw = localStorage.getItem(storageKey);
       if (!raw) return null;
       return JSON.parse(raw) as { practicedChars: string[]; currentIndex: number };
     } catch { return null; }
   };
-  const savedProgress = useRef(loadSaved());
+  const savedProgress = useRef(loadFromLocalStorage());
 
-  const [practicedChars, setPracticedChars] = useState<Set<string>>(
-    () => new Set(savedProgress.current?.practicedChars ?? [])
-  );
-  const [currentIndex, setCurrentIndex] = useState(savedProgress.current?.currentIndex ?? 0);
+  const [practicedChars, setPracticedChars] = useState<Set<string>>(() => {
+    if (initialProgress?.practiced_chars?.length) return new Set(initialProgress.practiced_chars);
+    return new Set(savedProgress.current?.practicedChars ?? []);
+  });
+  const [currentIndex, setCurrentIndex] = useState(() => {
+    if (typeof initialProgress?.current_index === 'number') return initialProgress.current_index;
+    return savedProgress.current?.currentIndex ?? 0;
+  });
 
   // ── #1342: per-character round tracking ──────────────────────────
   // charRounds maps char → current round. Characters start at round 1.
   // "done" = both rounds completed (or round 2 skipped).
-  const [charRounds, setCharRounds] = useState<Map<string, CharRound>>(new Map());
+  const [charRounds, setCharRounds] = useState<Map<string, CharRound>>(() => {
+    const m = new Map<string, CharRound>();
+    if (initialProgress?.char_rounds) {
+      for (const [ch, code] of Object.entries(initialProgress.char_rounds)) {
+        m.set(ch, codeToRound(code as number));
+      }
+    }
+    return m;
+  });
 
   // Whether the "合體" merge animation is playing between round 1 → 2
   const [showMergeAnimation, setShowMergeAnimation] = useState(false);
 
   // Tracks which chars had round 2 skipped (for analytics / reporting)
-  const skippedRecallRef = useRef<Set<string>>(new Set());
+  const skippedRecallRef = useRef<Set<string>>(
+    new Set(initialProgress?.skipped_recall ?? [])
+  );
 
   const { zhuyinActive, processZhuyin } = useZhuyin();
 
-  // Persist progress
+  // Build the step_data payload from current state — pure, called by the persist effect.
+  const buildStepData = useCallback(
+    (overrides?: Partial<VocabStepData>): VocabStepData => {
+      const charRoundsObj: Record<string, number> = {};
+      charRounds.forEach((r, ch) => { charRoundsObj[ch] = roundToCode(r); });
+      return {
+        practiced_chars: Array.from(practicedChars),
+        current_index: currentIndex,
+        char_rounds: charRoundsObj,
+        skipped_recall: Array.from(skippedRecallRef.current),
+        ...(overrides ?? {}),
+      };
+    },
+    [practicedChars, currentIndex, charRounds],
+  );
+
+  // Persist progress — localStorage (immediate) + DB (debounced).
   useEffect(() => {
     try {
       localStorage.setItem(storageKey, JSON.stringify({
@@ -78,7 +133,8 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
         currentIndex,
       }));
     } catch {}
-  }, [practicedChars, currentIndex, storageKey]);
+    onProgressChange?.(buildStepData(), false);
+  }, [practicedChars, currentIndex, charRounds, storageKey, onProgressChange, buildStepData]);
 
   // Characters to practice
   const displayChars = useMemo(() => {
@@ -191,6 +247,12 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
   })();
 
   const handleFinish = () => {
+    // Immediate flush with the result summary so teacher dashboard can read it
+    // directly from step_data['vocab'].result (Issue #1549).
+    onProgressChange?.(
+      buildStepData({ result: { practiced_words: vocabWords, total_words: vocabWords.length } }),
+      true,
+    );
     onFinish({ practicedWords: vocabWords, totalWords: vocabWords.length });
   };
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -64,6 +64,10 @@ interface LiveTutorProps {
   onParagraphComplete?: (completedParagraphIndex: number) => void;
   /** Initial set of completed paragraph indices (for session resume). */
   initialCompletedParagraphs?: Set<number>;
+  /** Rehydrate from previously saved step_progress.step_data['tutor'] (Issue #1549). */
+  initialProgress?: TutorStepData;
+  /** Persist incremental progress to LearningSession.step_progress (Issue #1549). */
+  onProgressChange?: (stepData: TutorStepData, immediate?: boolean) => void;
 }
 
 const LiveTutor: React.FC<LiveTutorProps> = ({
@@ -74,6 +78,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   onCancel: _onCancel,
   onParagraphComplete,
   initialCompletedParagraphs,
+  initialProgress,
+  onProgressChange,
 }) => {
   const { px: fontSizePx } = useFontSize();
   const { isZhuyinAny, processLinesSelective } = useZhuyin();

--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -78,6 +78,14 @@ export function useProgressSync({
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const isProgressLoading = !!token && dbSessionId !== null && !hasLoadedOnce;
 
+  // Stash onProgressLoaded behind a ref so the doSave / syncProgress / flushProgress
+  // identities don't change every render when the caller passes an inline arrow.
+  // Without this, every LearningLayout re-render minted new callback references,
+  // which propagated through useOutletContext → child useEffect deps → fired the
+  // step-data sync on every render, bursting the rate-limited PUT endpoint.
+  const onProgressLoadedRef = useRef(onProgressLoaded);
+  useEffect(() => { onProgressLoadedRef.current = onProgressLoaded; }, [onProgressLoaded]);
+
   const readStoredVersion = (data: StepProgressData | null | undefined): number => {
     const v = data?.version;
     return typeof v === 'number' && v >= 0 ? v : 0;
@@ -96,7 +104,7 @@ export function useProgressSync({
         const stepProgress = res.step_progress;
         if (stepProgress) {
           lastServerVersionRef.current = readStoredVersion(stepProgress);
-          if (onProgressLoaded) onProgressLoaded(stepProgress);
+          onProgressLoadedRef.current?.(stepProgress);
         }
       })
       .catch(() => {
@@ -128,14 +136,14 @@ export function useProgressSync({
             lastServerVersionRef.current = err.storedVersion;
             loadStepProgress(token, dbSessionId)
               .then((res) => {
-                if (res.step_progress && onProgressLoaded) onProgressLoaded(res.step_progress);
+                if (res.step_progress) onProgressLoadedRef.current?.(res.step_progress);
               })
               .catch(() => {});
           }
           // Other errors: non-fatal — localStorage already has the data
         });
     },
-    [token, dbSessionId, onProgressLoaded],
+    [token, dbSessionId],
   );
 
   // Keep a ref to the latest doSave so unmount cleanup always uses the current version

--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -151,9 +151,15 @@ export function useProgressSync({
     [doSave],
   );
 
-  // Flush pending data on page unload (refresh / close / navigate away)
+  // Flush pending data on page unload (refresh / close / navigate away / tab hide).
+  //
+  // We listen to three events because no single one is reliable across browsers:
+  //   - beforeunload : desktop refresh / close (ignored on iOS Safari)
+  //   - pagehide     : reliable replacement for beforeunload on mobile + bfcache
+  //   - visibilitychange→hidden : fires when user switches apps on mobile
+  //     (the only signal an iOS Safari → home-screen transition produces)
   useEffect(() => {
-    const handleBeforeUnload = () => {
+    const flushBeacon = () => {
       if (!latestDataRef.current || !debounceTimerRef.current) return;
 
       clearTimeout(debounceTimerRef.current);
@@ -167,9 +173,17 @@ export function useProgressSync({
       }
     };
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flushBeacon();
+    };
+
+    window.addEventListener('beforeunload', flushBeacon);
+    window.addEventListener('pagehide', flushBeacon);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('beforeunload', flushBeacon);
+      window.removeEventListener('pagehide', flushBeacon);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [token, dbSessionId]);
 

--- a/frontend/src/hooks/useProgressSync.ts
+++ b/frontend/src/hooks/useProgressSync.ts
@@ -18,7 +18,7 @@
  *
  * API failures are fully non-blocking — localStorage still functions.
  */
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   saveStepProgress,
   saveStepProgressBeacon,
@@ -49,6 +49,13 @@ export interface UseProgressSyncReturn {
   syncProgress: (data: StepProgressData) => void;
   /** Force an immediate DB save (e.g. on step completion). */
   flushProgress: (data: StepProgressData) => void;
+  /**
+   * True while the initial load from DB is in flight (Issue #1549).
+   * Caller should gate child renders that depend on step_progress so they
+   * don't initialise local state from an empty stepProgressData and then
+   * fail to re-init once the async load completes.
+   */
+  isProgressLoading: boolean;
 }
 
 export function useProgressSync({
@@ -60,6 +67,16 @@ export function useProgressSync({
   const latestDataRef = useRef<StepProgressData | null>(null);
   // Monotonic version tracking (#1187): last-known server version + in-flight client bump
   const lastServerVersionRef = useRef<number>(0);
+  // Issue #1549 — derive "loading" synchronously from a one-shot
+  // `hasLoadedOnce` flag plus the input props. We do NOT use a separate
+  // setIsLoading state, because doing so would lag one render behind the
+  // dbSessionId transition and let children mount with an empty snapshot.
+  //
+  // isProgressLoading is true whenever we *would* be loading from DB
+  // (both token and dbSessionId present) but the first load hasn't yet
+  // resolved. The flag flips on first .finally() of the load effect.
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const isProgressLoading = !!token && dbSessionId !== null && !hasLoadedOnce;
 
   const readStoredVersion = (data: StepProgressData | null | undefined): number => {
     const v = data?.version;
@@ -70,6 +87,10 @@ export function useProgressSync({
   useEffect(() => {
     if (!token || dbSessionId === null) return;
 
+    // If we're loading for a fresh session (e.g. dbSessionId just transitioned
+    // from null → id), reset the loaded flag so isProgressLoading flips back
+    // to true synchronously on the next render.
+    setHasLoadedOnce(false);
     loadStepProgress(token, dbSessionId)
       .then((res) => {
         const stepProgress = res.step_progress;
@@ -80,7 +101,8 @@ export function useProgressSync({
       })
       .catch(() => {
         // Non-fatal: fallback to localStorage handled by caller
-      });
+      })
+      .finally(() => setHasLoadedOnce(true));
     // Only run once when dbSessionId first becomes available
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dbSessionId, token]);
@@ -201,5 +223,5 @@ export function useProgressSync({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { syncProgress, flushProgress };
+  return { syncProgress, flushProgress, isProgressLoading };
 }

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -331,9 +331,25 @@ const LearningLayout: React.FC = () => {
     hasActiveAssignment,
   };
 
+  // Issue #1549 — when a DB session exists but step_progress is still loading,
+  // delay child render so pages don't initialise local state from an empty
+  // snapshot. Without this gate the async DB load lands after the child has
+  // already useState-initialised with undefined, and the rehydrated answers
+  // never appear in the UI even though they're stored correctly.
+  const waitingForProgress = dbSessionId !== null && isProgressLoading;
+
   return (
     <>
-      <Outlet context={ctx} />
+      {waitingForProgress ? (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3">
+            <div className="w-8 h-8 border-3 border-accent border-t-transparent rounded-full animate-spin" />
+            <span className="text-sm text-gray-400">載入學習進度中...</span>
+          </div>
+        </div>
+      ) : (
+        <Outlet context={ctx} />
+      )}
       <SessionTimeoutWarning
         visible={showTimeoutWarning}
         countdownSeconds={WARNING_COUNTDOWN_SECONDS}

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -261,6 +261,8 @@ const LearningLayout: React.FC = () => {
   // ── Loading / error states ────────────────────────────────────────────────
 
 
+
+
   if (isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center">

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -260,6 +260,7 @@ const LearningLayout: React.FC = () => {
 
   // ── Loading / error states ────────────────────────────────────────────────
 
+
   if (isLoading) {
     return (
       <div className="flex-1 flex items-center justify-center">

--- a/frontend/src/layouts/LearningLayout.tsx
+++ b/frontend/src/layouts/LearningLayout.tsx
@@ -98,10 +98,15 @@ export interface LearningContext {
   /**
    * Merge a per-step progress payload into step_progress and persist it.
    * Use this for in-step process/history persistence (e.g. dialogue turns).
+   *
+   * `stepData` is typed as `object` (not `Record<string, unknown>`) so the
+   * strict per-step shapes from `types/stepProgress.ts` are assignable
+   * without a cast at every call site. Runtime behaviour is unchanged — the
+   * payload is spread into `step_data[stepId]` JSONB regardless of shape.
    */
   saveStepProgressPatch: (opts: {
     stepId: string;
-    stepData: Record<string, unknown>;
+    stepData: object;
     currentStep?: string | null;
     markCompleted?: boolean;
     immediate?: boolean;
@@ -291,45 +296,86 @@ const LearningLayout: React.FC = () => {
     );
   }
 
-  // ── Context assembly ─────────────────────────────────────────────────────
-
-  const ctx: LearningContext = {
-    selectedStory,
-    session,
-    lastAttempt,
-    rightPanelWidth,
-    setRightPanelWidth,
-    handleStartReading,
-    handleFinishReading,
-    handleFinishComprehension,
-    handleFinishStoryStructure,
-    handleFinishReadingStrategy,
-    handleFinishVocab,
-    handleFinishDictation,
-    handleFinishFullReading,
-    handleFinishListening,
-    handleFinishReadingAnnotation,
-    handleFinishVocabDefinitionMatch,
-    handleFinishVocabApplication,
-    handleFinishSentencePractice,
-    handleFinishVocabWordSearch,
-    handleFinishKnowledgeStation,
-    handleRetry,
-    handleSessionComplete,
-    emptyAttempt: EMPTY_ATTEMPT,
-    dbSessionId,
-    completedParagraphsSet,
-    handleParagraphComplete,
-    assignmentReadingGoals,
-    syncProgress,
-    flushProgress,
-    stepProgressData: stepProgressState,
-    saveStepProgressPatch,
-    isAssignmentReadyForSubmit,
-    missingAssignmentSteps,
-    firstIncompleteStepPath,
-    hasActiveAssignment,
-  };
+  // Memoise the outlet-context object so the Outlet (and any child component
+  // destructuring via useLearningContext) sees a stable reference when no
+  // dependency actually changed. Without useMemo, each LearningLayout render
+  // minted a fresh object; child useEffect hooks that depend on context
+  // identity (rather than individual fields) would needlessly re-run.
+  const ctx: LearningContext = useMemo(
+    () => ({
+      selectedStory,
+      session,
+      lastAttempt,
+      rightPanelWidth,
+      setRightPanelWidth,
+      handleStartReading,
+      handleFinishReading,
+      handleFinishComprehension,
+      handleFinishStoryStructure,
+      handleFinishReadingStrategy,
+      handleFinishVocab,
+      handleFinishDictation,
+      handleFinishFullReading,
+      handleFinishListening,
+      handleFinishReadingAnnotation,
+      handleFinishVocabDefinitionMatch,
+      handleFinishVocabApplication,
+      handleFinishSentencePractice,
+      handleFinishVocabWordSearch,
+      handleFinishKnowledgeStation,
+      handleRetry,
+      handleSessionComplete,
+      emptyAttempt: EMPTY_ATTEMPT,
+      dbSessionId,
+      completedParagraphsSet,
+      handleParagraphComplete,
+      assignmentReadingGoals,
+      syncProgress,
+      flushProgress,
+      stepProgressData: stepProgressState,
+      saveStepProgressPatch,
+      isAssignmentReadyForSubmit,
+      missingAssignmentSteps,
+      firstIncompleteStepPath,
+      hasActiveAssignment,
+    }),
+    [
+      selectedStory,
+      session,
+      lastAttempt,
+      rightPanelWidth,
+      setRightPanelWidth,
+      handleStartReading,
+      handleFinishReading,
+      handleFinishComprehension,
+      handleFinishStoryStructure,
+      handleFinishReadingStrategy,
+      handleFinishVocab,
+      handleFinishDictation,
+      handleFinishFullReading,
+      handleFinishListening,
+      handleFinishReadingAnnotation,
+      handleFinishVocabDefinitionMatch,
+      handleFinishVocabApplication,
+      handleFinishSentencePractice,
+      handleFinishVocabWordSearch,
+      handleFinishKnowledgeStation,
+      handleRetry,
+      handleSessionComplete,
+      dbSessionId,
+      completedParagraphsSet,
+      handleParagraphComplete,
+      assignmentReadingGoals,
+      syncProgress,
+      flushProgress,
+      stepProgressState,
+      saveStepProgressPatch,
+      isAssignmentReadyForSubmit,
+      missingAssignmentSteps,
+      firstIncompleteStepPath,
+      hasActiveAssignment,
+    ],
+  );
 
   // Issue #1549 — when a DB session exists but step_progress is still loading,
   // delay child render so pages don't initialise local state from an empty

--- a/frontend/src/pages/learning/DictationPage.tsx
+++ b/frontend/src/pages/learning/DictationPage.tsx
@@ -1,12 +1,30 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import DictationPractice from '../../components/reading-steps/DictationPractice';
 import { useLearningContext } from '../../layouts/LearningLayout';
+import type { DictationStepData } from '../../types/stepProgress';
 
 const DictationPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
-  const { selectedStory, handleFinishDictation } = useLearningContext();
+  const {
+    selectedStory,
+    handleFinishDictation,
+    stepProgressData,
+    saveStepProgressPatch,
+  } = useLearningContext();
   const navigate = useNavigate();
+
+  const handleProgressChange = useCallback(
+    (stepData: DictationStepData, immediate = false) => {
+      saveStepProgressPatch({
+        stepId: 'dictation',
+        stepData,
+        currentStep: 'dictation',
+        immediate,
+      });
+    },
+    [saveStepProgressPatch],
+  );
 
   if (!selectedStory) return null;
 
@@ -15,6 +33,8 @@ const DictationPage: React.FC = () => {
       story={selectedStory}
       onFinish={handleFinishDictation}
       onBack={() => navigate(`/learn/${storyId}/vocab`)}
+      initialProgress={stepProgressData.step_data?.dictation as DictationStepData | undefined}
+      onProgressChange={handleProgressChange}
     />
   );
 };

--- a/frontend/src/pages/learning/FullReadingPage.tsx
+++ b/frontend/src/pages/learning/FullReadingPage.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import FullReading from '../../components/reading-steps/FullReading';
 import { useLearningContext } from '../../layouts/LearningLayout';
+import type { FullReadingStepData } from '../../types/stepProgress';
 
 const FullReadingPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
@@ -9,8 +10,22 @@ const FullReadingPage: React.FC = () => {
     selectedStory,
     handleFinishFullReading,
     session,
+    stepProgressData,
+    saveStepProgressPatch,
   } = useLearningContext();
   const navigate = useNavigate();
+
+  const handleProgressChange = useCallback(
+    (stepData: FullReadingStepData, immediate = false) => {
+      saveStepProgressPatch({
+        stepId: 'full-reading',
+        stepData,
+        currentStep: 'full-reading',
+        immediate,
+      });
+    },
+    [saveStepProgressPatch],
+  );
 
   if (!selectedStory) return null;
 
@@ -20,6 +35,8 @@ const FullReadingPage: React.FC = () => {
       onFinish={handleFinishFullReading}
       onBack={() => navigate(`/learn/${storyId}/tutor`)}
       initialResult={session?.fullReadingResult ?? null}
+      initialProgress={stepProgressData.step_data?.['full-reading'] as FullReadingStepData | undefined}
+      onProgressChange={handleProgressChange}
     />
   );
 };

--- a/frontend/src/pages/learning/ReportPage.tsx
+++ b/frontend/src/pages/learning/ReportPage.tsx
@@ -24,9 +24,30 @@ const ReportPage: React.FC = () => {
     missingAssignmentSteps,
     firstIncompleteStepPath,
     hasActiveAssignment,
+    saveStepProgressPatch,
   } = useLearningContext();
   const { user, token } = useAuth();
   const navigate = useNavigate();
+
+  // Issue #1549 — mark report as viewed in step_progress on mount, so the
+  // teacher dashboard can confirm the student reached the final report.
+  // Runs once per (story, dbSessionId) pair.
+  const reportMarkedRef = React.useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedStory?.id) return;
+    const key = `${selectedStory.id}-${dbSessionId ?? 'no-session'}`;
+    if (reportMarkedRef.current === key) return;
+    reportMarkedRef.current = key;
+    saveStepProgressPatch({
+      stepId: 'report',
+      stepData: {
+        viewed_at: new Date().toISOString(),
+        exit_ticket_id: null,
+      },
+      markCompleted: true,
+      immediate: true,
+    });
+  }, [selectedStory?.id, dbSessionId, saveStepProgressPatch]);
 
   const [xpResult, setXpResult] = useState<XPAwardResult | null>(null);
   const [showXpToast, setShowXpToast] = useState(false);

--- a/frontend/src/pages/learning/TutorPage.tsx
+++ b/frontend/src/pages/learning/TutorPage.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import LiveTutor from '../../components/reading-steps/LiveTutor';
 import { useLearningContext } from '../../layouts/LearningLayout';
+import type { TutorStepData } from '../../types/stepProgress';
 
 const TutorPage: React.FC = () => {
   const {
@@ -11,8 +12,22 @@ const TutorPage: React.FC = () => {
     handleFinishReading,
     completedParagraphsSet,
     handleParagraphComplete,
+    stepProgressData,
+    saveStepProgressPatch,
   } = useLearningContext();
   const navigate = useNavigate();
+
+  const handleProgressChange = useCallback(
+    (stepData: TutorStepData, immediate = false) => {
+      saveStepProgressPatch({
+        stepId: 'tutor',
+        stepData,
+        currentStep: 'tutor',
+        immediate,
+      });
+    },
+    [saveStepProgressPatch],
+  );
 
   if (!selectedStory) return null;
 
@@ -25,6 +40,8 @@ const TutorPage: React.FC = () => {
       onCancel={() => navigate('/library')}
       onParagraphComplete={handleParagraphComplete}
       initialCompletedParagraphs={completedParagraphsSet}
+      initialProgress={stepProgressData.step_data?.tutor as TutorStepData | undefined}
+      onProgressChange={handleProgressChange}
     />
   );
 };

--- a/frontend/src/pages/learning/VocabPage.tsx
+++ b/frontend/src/pages/learning/VocabPage.tsx
@@ -1,12 +1,32 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import VocabPractice from '../../components/reading-steps/VocabPractice';
 import { useLearningContext } from '../../layouts/LearningLayout';
+import type { VocabStepData } from '../../types/stepProgress';
 
 const VocabPage: React.FC = () => {
   const { storyId } = useParams<{ storyId: string }>();
-  const { selectedStory, lastAttempt, handleFinishVocab, emptyAttempt } = useLearningContext();
+  const {
+    selectedStory,
+    lastAttempt,
+    handleFinishVocab,
+    emptyAttempt,
+    stepProgressData,
+    saveStepProgressPatch,
+  } = useLearningContext();
   const navigate = useNavigate();
+
+  const handleProgressChange = useCallback(
+    (stepData: VocabStepData, immediate = false) => {
+      saveStepProgressPatch({
+        stepId: 'vocab',
+        stepData,
+        currentStep: 'vocab',
+        immediate,
+      });
+    },
+    [saveStepProgressPatch],
+  );
 
   if (!selectedStory) return null;
 
@@ -16,6 +36,8 @@ const VocabPage: React.FC = () => {
       attempt={lastAttempt ?? emptyAttempt}
       onFinish={handleFinishVocab}
       onBack={() => navigate(`/learn/${storyId}/comprehension`)}
+      initialProgress={stepProgressData.step_data?.vocab as VocabStepData | undefined}
+      onProgressChange={handleProgressChange}
     />
   );
 };

--- a/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
+++ b/frontend/src/pages/teacher/TeacherSessionReportPage.tsx
@@ -257,6 +257,24 @@ const TeacherSessionReportPage: React.FC = () => {
           readOnly
         />
       )}
+
+      {/* Issue #1549 — raw step_progress placeholder. A proper per-step
+          breakdown UI (vocab chars practiced, dictation answers, etc.) is
+          tracked in a follow-up issue; for now we expose the JSON so the
+          data wiring is verifiable end-to-end. */}
+      {report?.step_progress && (
+        <details className="mt-8 bg-white border border-gray-200 rounded-xl overflow-hidden">
+          <summary className="cursor-pointer px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50">
+            學習步驟細節（原始資料）
+            <span className="ml-2 text-xs text-gray-400">
+              {(report.step_progress.steps_completed?.length ?? 0)} 步已完成
+            </span>
+          </summary>
+          <pre className="px-4 py-3 text-xs text-gray-800 bg-gray-50 overflow-x-auto whitespace-pre-wrap break-words border-t border-gray-200">
+            {JSON.stringify(report.step_progress, null, 2)}
+          </pre>
+        </details>
+      )}
     </div>
   );
 };

--- a/frontend/src/services/teacherApi.ts
+++ b/frontend/src/services/teacherApi.ts
@@ -320,6 +320,13 @@ export interface TeacherSessionReport {
   teacher_reviewed_at: string | null;
   started_at: string;
   completed_at: string | null;
+  /** Issue #1549 — unified per-step progress (current_step, steps_completed, step_data). */
+  step_progress: {
+    current_step: string | null;
+    steps_completed: string[];
+    step_data: Record<string, unknown>;
+    version?: number;
+  } | null;
 }
 
 // ════════════════════════════════════════════════════════════════════════════════

--- a/frontend/src/types/stepProgress.ts
+++ b/frontend/src/types/stepProgress.ts
@@ -43,10 +43,15 @@ export interface ComprehensionStepData {
 export interface VocabStepData {
   practiced_chars: string[];
   current_index: number;
-  /** Map of character → completed round number (1-3). */
+  /** Map of character → round-state code: 1 = round 1, 2 = round 2, 3 = done. */
   char_rounds?: Record<string, number>;
   /** Characters the learner skipped during recall round (round 2). */
   skipped_recall?: string[];
+  /** Summary written on completion. */
+  result?: {
+    practiced_words: string[];
+    total_words: number;
+  };
 }
 
 /** Step 5 — DictationPractice (听写). */

--- a/frontend/src/types/stepProgress.ts
+++ b/frontend/src/types/stepProgress.ts
@@ -16,15 +16,27 @@ export interface IntroStepData {
 /** Step 2 — LiveTutor (per-paragraph reading evaluation). */
 export interface TutorParagraphSummary {
   paragraph_index: number;
-  cpm: number | null;
-  accuracy: number | null;
+  /** Cumulative attempts on this paragraph. */
   attempts: number;
-  completed_at?: string;
+  /** Match-rate of the latest attempt (0..1). */
+  match_rate: number;
+  cpm: number;
+  duration_ms: number;
 }
 
 export interface TutorStepData {
   completed_paragraphs: number[];
   paragraph_summaries: TutorParagraphSummary[];
+  /** Current paragraph the learner is on (for resume). */
+  current_line_index?: number;
+  /** Final reading attempt summary, written when the whole flow finishes. */
+  reading_attempt?: {
+    storyId: string;
+    accuracy: number;
+    cpm: number;
+    transcription?: string;
+    timestamp: number;
+  };
 }
 
 /** Step 3 — Comprehension (multi-tab chat / mcq / strategy). */

--- a/frontend/src/types/stepProgress.ts
+++ b/frontend/src/types/stepProgress.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-step shape definitions for `LearningSession.step_progress.step_data[stepId]`.
+ * Backend stores this as JSONB (Issue #1549); these types are the contract used by
+ * each reading-step component when calling `saveStepProgressPatch({ stepId, stepData })`.
+ *
+ * Step IDs match `STEP_REGISTRY` keys in `config/stepConfig.ts`.
+ */
+
+/** Step 1 — Intro: just a "visited" marker so teachers can see the student entered the lesson. */
+export interface IntroStepData {
+  visited: true;
+  started_at: string;
+  pdf_opened?: boolean;
+}
+
+/** Step 2 — LiveTutor (per-paragraph reading evaluation). */
+export interface TutorParagraphSummary {
+  paragraph_index: number;
+  cpm: number | null;
+  accuracy: number | null;
+  attempts: number;
+  completed_at?: string;
+}
+
+export interface TutorStepData {
+  completed_paragraphs: number[];
+  paragraph_summaries: TutorParagraphSummary[];
+}
+
+/** Step 3 — Comprehension (multi-tab chat / mcq / strategy). */
+export interface ComprehensionStepData {
+  tab_completion?: {
+    structureVisited?: boolean;
+    mcqDone?: boolean;
+    strategyDone?: boolean;
+  };
+  active_tab?: 'mcq' | 'structure' | 'strategy' | string;
+  mcq_score?: number;
+  mcq_total?: number;
+}
+
+/** Step 4 — VocabPractice (stroke-order + recall). */
+export interface VocabStepData {
+  practiced_chars: string[];
+  current_index: number;
+  /** Map of character → completed round number (1-3). */
+  char_rounds?: Record<string, number>;
+  /** Characters the learner skipped during recall round (round 2). */
+  skipped_recall?: string[];
+}
+
+/** Step 5 — DictationPractice (听写). */
+export interface DictationWordResult {
+  word: string;
+  user_answer: string;
+  correct: boolean;
+  attempts: number;
+  duration_ms?: number;
+}
+
+export interface DictationStepData {
+  word_results: DictationWordResult[];
+  current_index: number;
+  phase: 'intro' | 'practice' | 'results';
+  result?: {
+    total_words: number;
+    correct_count: number;
+    incorrect_count: number;
+    skipped_count: number;
+  };
+}
+
+/** Step 6 — FullReading (whole-text reading + self-rating). */
+export interface FullReadingResult {
+  matchRate?: number;
+  feedback?: string;
+  diffTokens?: unknown[];
+  cpm?: number;
+  durationMs?: number;
+  accuracy?: number;
+  errorBreakdown?: Record<string, unknown>;
+  audioUrl?: string;
+}
+
+export interface FullReadingStepData {
+  result?: FullReadingResult;
+  /** Student self-rating 1-5 (Issue #1386). */
+  self_rating?: number;
+  /** Raw streaming transcript captured during evaluation. */
+  transcript?: string;
+}
+
+/** Step 7 — AssessmentReport. */
+export interface ReportStepData {
+  viewed_at: string;
+  exit_ticket_id?: number | null;
+}
+
+/** Discriminated map from stepId → expected stepData shape. */
+export interface StepDataMap {
+  intro: IntroStepData;
+  tutor: TutorStepData;
+  comprehension: ComprehensionStepData;
+  vocab: VocabStepData;
+  dictation: DictationStepData;
+  'full-reading': FullReadingStepData;
+  report: ReportStepData;
+}
+
+export type StepId = keyof StepDataMap;


### PR DESCRIPTION
## Summary

Closes #1549. 統一 7 個學習步驟的進度儲存路徑，全部寫入 `LearningSession.step_progress.step_data`，讓老師端能讀到學生完整學習紀錄。

之前各步驟各自為政：DictationPractice 零持久化、VocabPractice 只寫 localStorage、LiveTutor 細節只在 localStorage，老師看不到。現在改用 `saveStepProgressPatch` 寫進統一 JSONB 欄位。

- 沒有 schema migration（`step_progress` JSONB 已可容納）
- `reading_history` 表（CPM 進步曲線）維持不動，與 step_progress 互補
- localStorage 從 source of truth 降格為 L1 快取

## Changes

### 基礎工程
- `frontend/src/types/stepProgress.ts` — 7 個 stepId 的 TypeScript shape
- `frontend/src/hooks/useProgressSync.ts` — 補 `pagehide` + `visibilitychange→hidden` flush（iOS Safari 不觸發 beforeunload）

### 各步驟接 DB 寫入
| Step | 改動 |
|---|---|
| 1 Intro | `handleStartReading` 寫 `{ visited, started_at }` + markCompleted |
| 2 LiveTutor | 細節（completed_paragraphs / paragraph_summaries / current_line_index / reading_attempt）寫進 step_data；`handleFinishReading` 不再覆蓋 |
| 3 Comprehension | 已實作（無改動） |
| 4 VocabPractice | dual-write localStorage + DB；practiced_chars / current_index / char_rounds / skipped_recall / result |
| 5 DictationPractice | 從零持久化 → 完整持久化（word_results / phase / result） |
| 6 FullReading | 補 selfRating + transcript 進 step_data；`handleFinishFullReading` 不再覆蓋 |
| 7 AssessmentReport | ReportPage 加 viewed_at + markCompleted |

### 老師端
- `TeacherSessionReportResponse.step_progress` 新增欄位
- `GET /api/teacher/students/{student_id}/sessions/{session_id}/report` 回傳 step_progress
- `TeacherSessionReportPage` 加可摺疊 JSON 佔位（完整 per-step UI 留下一個 issue）

## Test plan

- [ ] DictationPractice：練習中按返回 → 回到 Dictation → 看到剛剛的進度
- [ ] VocabPractice：練幾個字 → 重整 → 從相同位置繼續
- [ ] LiveTutor：完成 2 段 → 重整 → 解鎖狀態保留
- [ ] FullReading：朗讀後給 selfRating → 換瀏覽器/清 localStorage → DB 仍有 selfRating
- [ ] 走完 7 步驟 → 老師端 `/teacher/students/{id}/sessions/{id}/report` 「學習步驟細節（原始資料）」摺疊區看到 7 個 step_data key
- [ ] `reading_history` 表 CPM 曲線不受影響（LiveTutor / FullReading 仍照常寫 reading_history）
- [ ] CI lint + build + typecheck 通過
- [ ] Preview 部署 URL 上跑一輪確認沒回歸

🤖 Generated with [Claude Code](https://claude.com/claude-code)
