### PR TITLE
chore(meeting): 5/15 prep + intern skill trees 5週更新 + skill path SOT 修正 (Fixes #1612)

### DIFF
--- a/.claude/rules/catchup-intern-check.md
+++ b/.claude/rules/catchup-intern-check.md
@@ -33,8 +33,10 @@ python3 scripts/skill-tree-updater.py --intern all --days 7
 ```
 
 This updates:
-- `docs/intern-training/interns/raymond.json`（靖杭）
-- `docs/intern-training/interns/xiung.json`（啟翔）
+- `frontend/public/intern-training/interns/raymond.json`（靖杭，SOT — staging dashboard 從此讀）
+- `frontend/public/intern-training/interns/xiung.json`（啟翔）
+
+> ⚠️ `docs/intern-training/` 是舊版 mirror，**deprecated**。staging `https://lingoleap-frontend-staging-958347263320.asia-east1.run.app/intern-training/dashboard.html` 從 `frontend/public/intern-training/` 讀。寫錯 path = staging 看不到更新。
 
 If the script fails (e.g. no Vertex AI auth locally), manually review their recent PRs and update the JSON skill levels + history entries.
 

--- a/.claude/skills/friday-meeting-prep/SKILL.md
+++ b/.claude/skills/friday-meeting-prep/SKILL.md
@@ -96,8 +96,8 @@ gh issue list \
 ### 1d. 讀取 intern JSON 現狀
 
 ```bash
-cat docs/intern-training/interns/raymond.json | jq '{lastReview,skills_summary: (.skills | to_entries | map({(.key): .value.level}) | add)}'
-cat docs/intern-training/interns/xiung.json   | jq '{lastReview,skills_summary: (.skills | to_entries | map({(.key): .value.level}) | add)}'
+cat frontend/public/intern-training/interns/raymond.json | jq '{lastReview,skills_summary: (.skills | to_entries | map({(.key): .value.level}) | add)}'
+cat frontend/public/intern-training/interns/xiung.json   | jq '{lastReview,skills_summary: (.skills | to_entries | map({(.key): .value.level}) | add)}'
 ```
 
 ### 1e. 最近 agenda 範本
@@ -322,8 +322,8 @@ cd ../chinese-literacy-platform-issue-${ISSUE_NUM}
 git add \
   docs/meetings/${FRIDAY}-agenda.md \
   docs/meetings/team-contributions.md \
-  docs/intern-training/interns/raymond.json \
-  docs/intern-training/interns/xiung.json
+  frontend/public/intern-training/interns/raymond.json \
+  frontend/public/intern-training/interns/xiung.json
 
 git commit -m "docs(meeting): ${FRIDAY} agenda + contributions + skill trees (Related to #${ISSUE_NUM})"
 
@@ -332,8 +332,8 @@ git push -u origin "$BRANCH"
 
 **驗證 JSON 格式（push 前必跑）**：
 ```bash
-jq . docs/intern-training/interns/raymond.json > /dev/null && echo "raymond.json OK"
-jq . docs/intern-training/interns/xiung.json   > /dev/null && echo "xiung.json OK"
+jq . frontend/public/intern-training/interns/raymond.json > /dev/null && echo "raymond.json OK"
+jq . frontend/public/intern-training/interns/xiung.json   > /dev/null && echo "xiung.json OK"
 ```
 
 若 `jq` 報 parse error，先修再 push。
@@ -352,8 +352,8 @@ gh pr create \
 
 - Add \`docs/meetings/{FRIDAY}-agenda.md\` — agenda with 7/1 deadline risk table, action items
 - Update \`docs/meetings/team-contributions.md\` — prepend {WEEK_LABEL} week section
-- Update \`docs/intern-training/interns/raymond.json\` — lastReview + history entries + skill bumps (if evidence)
-- Update \`docs/intern-training/interns/xiung.json\` — lastReview + history entries + skill bumps (if evidence)
+- Update \`frontend/public/intern-training/interns/raymond.json\` — lastReview + history entries + skill bumps (if evidence)
+- Update \`frontend/public/intern-training/interns/xiung.json\` — lastReview + history entries + skill bumps (if evidence)
 
 ## Key agenda items
 
@@ -394,8 +394,8 @@ Issue #${ISSUE_NUM} / PR #{PR_NUM} 已開
 4 份文件：
 - docs/meetings/${FRIDAY}-agenda.md（新增）
 - docs/meetings/team-contributions.md（${WEEK_LABEL} 週區段插入）
-- docs/intern-training/interns/raymond.json（lastReview ${FRIDAY}）
-- docs/intern-training/interns/xiung.json（lastReview ${FRIDAY}）
+- frontend/public/intern-training/interns/raymond.json（lastReview ${FRIDAY}）
+- frontend/public/intern-training/interns/xiung.json（lastReview ${FRIDAY}）
 
 議程重點：{1 句總結本週最重要的議題}
 

--- a/.claude/skills/meeting-prep/SKILL.md
+++ b/.claude/skills/meeting-prep/SKILL.md
@@ -134,8 +134,8 @@ gh issue list \
 ### 1d. 讀取 intern JSON 現狀
 
 ```bash
-cat docs/intern-training/interns/raymond.json | jq '{lastReview,skills_summary: (.skills | to_entries | map({(.key): .value.level}) | add)}'
-cat docs/intern-training/interns/xiung.json   | jq '{lastReview,skills_summary: (.skills | to_entries | map({(.key): .value.level}) | add)}'
+cat frontend/public/intern-training/interns/raymond.json | jq '{lastReview,skills_summary: (.skills | to_entries | map({(.key): .value.level}) | add)}'
+cat frontend/public/intern-training/interns/xiung.json   | jq '{lastReview,skills_summary: (.skills | to_entries | map({(.key): .value.level}) | add)}'
 ```
 
 ### 1e. 最近 agenda 範本
@@ -360,8 +360,8 @@ cd ../chinese-literacy-platform-issue-${ISSUE_NUM}
 git add \
   docs/meetings/${MEETING_DATE}-agenda.md \
   docs/meetings/team-contributions.md \
-  docs/intern-training/interns/raymond.json \
-  docs/intern-training/interns/xiung.json
+  frontend/public/intern-training/interns/raymond.json \
+  frontend/public/intern-training/interns/xiung.json
 
 git commit -m "docs(meeting): ${MEETING_DATE} agenda + contributions + skill trees (Related to #${ISSUE_NUM})"
 
@@ -370,8 +370,8 @@ git push -u origin "$BRANCH"
 
 **驗證 JSON 格式（push 前必跑）**：
 ```bash
-jq . docs/intern-training/interns/raymond.json > /dev/null && echo "raymond.json OK"
-jq . docs/intern-training/interns/xiung.json   > /dev/null && echo "xiung.json OK"
+jq . frontend/public/intern-training/interns/raymond.json > /dev/null && echo "raymond.json OK"
+jq . frontend/public/intern-training/interns/xiung.json   > /dev/null && echo "xiung.json OK"
 ```
 
 若 `jq` 報 parse error，先修再 push。
@@ -390,8 +390,8 @@ gh pr create \
 
 - Add `docs/meetings/{MEETING_DATE}-agenda.md` — agenda with 7/1 deadline risk table, action items
 - Update `docs/meetings/team-contributions.md` — prepend {WEEK_LABEL} week section
-- Update `docs/intern-training/interns/raymond.json` — lastReview + history entries + skill bumps (if evidence)
-- Update `docs/intern-training/interns/xiung.json` — lastReview + history entries + skill bumps (if evidence)
+- Update `frontend/public/intern-training/interns/raymond.json` — lastReview + history entries + skill bumps (if evidence)
+- Update `frontend/public/intern-training/interns/xiung.json` — lastReview + history entries + skill bumps (if evidence)
 
 ## Key agenda items
 
@@ -432,8 +432,8 @@ Issue #${ISSUE_NUM} / PR #{PR_NUM} 已開
 4 份文件：
 - docs/meetings/${MEETING_DATE}-agenda.md（新增）
 - docs/meetings/team-contributions.md（${WEEK_LABEL} 週區段插入）
-- docs/intern-training/interns/raymond.json（lastReview ${MEETING_DATE}）
-- docs/intern-training/interns/xiung.json（lastReview ${MEETING_DATE}）
+- frontend/public/intern-training/interns/raymond.json（lastReview ${MEETING_DATE}）
+- frontend/public/intern-training/interns/xiung.json（lastReview ${MEETING_DATE}）
 
 議程重點：{1 句總結本週最重要的議題}
 

--- a/docs/meetings/2026-05-15.md
+++ b/docs/meetings/2026-05-15.md
@@ -1,0 +1,159 @@
+# 會議議程 2026-05-15（五）
+
+## 參與者
+- Young（lead dev）
+- 靖杭 @if-else-master（intern）
+- 啟翔 @stgst（intern）
+- 方大哥 @Shinjou（product owner，視出席狀況）
+
+---
+
+## 本週 Merged PRs 總覽（5/12 ~ 5/15）
+
+| PR | 作者 | 內容 | Issue |
+|----|------|------|-------|
+| #1547 | 啟翔 | feat(rescue): MCQ rescue dialog 重設計 + 接入聚光燈 + 紀錄 attempts | Refs #1387 |
+| #1573 | Young | feat(omo): Phase 1a backend skeleton — upload/attempt/identify/grade | Refs #1343 |
+| #1576 | Young | fix(infra): env 分隔 — prod demo accounts 關 + OMO GCS bucket 拆 | Fixes #1575 |
+| #1579 | Young | feat(infra): staging Cloud SQL 從 prod 拆出 | Fixes #1578 |
+| #1580 | Young | fix(infra): staging Cloud Run 注入 JWT_SECRET_KEY | — |
+| #1583 | Young | feat(omo): Phase 1b 學生 UX sprint umbrella | Refs #1582 |
+| #1588 | Young | feat(omo): image hash dedup + regrade endpoint | Fixes #1584 |
+| #1589 | Young | docs(omo): command center master docs | Refs #1343 |
+| #1590 | Young | feat(omo): 3-tier 信心度確認 UX + GET /api/omo/lessons | Refs #1585 |
+| #1592 | Young | feat(omo): 結果頁 per-question cards + flag modal | Refs #1586 |
+| #1593 | Young | feat(omo): loading copy + error toasts + 前端圖片 resize | Refs #1587 |
+| #1595 | Young | docs(omo): 測試計劃 | Refs #1343 |
+| #1596 | Young | test(omo): 3-tier confirm UX contract + render tests | Refs #1591 |
+| #1602 | Young | fix(omo): 學生答案逐字相同時強制 score=1 | Refs #1343 |
+| #1604 | Young | feat(infra): Phase 1c env hardening — logging tag + cron audit + OAuth docs | Fixes #1603 |
+| #1606 | Young | fix(omo): 單次上傳上限 5→20 張 | Refs #1343 |
+| #1607 | Young | fix(omo): identify 對齊全 168 課（curriculum + content）| — |
+| #1599 | 靖杭 | fix(intro): 課文簡介 AI 生成 + 學習策略獨立 hint 區 | Fixes #1598 |
+| #1600 | 靖杭 | feat(reading): 朗讀歷史趨勢線圖 — 自己跟自己比 | Fixes #1597 |
+
+**啟翔 open（待 review）**
+| PR | 內容 | Issue |
+|----|------|-------|
+| #1601 | feat: 統一 learning-step 進度儲存到 step_progress | Refs #1549 |
+
+---
+
+## 一、Young 本週成果（5/12 ~ 5/15）
+
+### OMO Phase 1 全 merged（7/1 demo 主軸）
+- ✅ **Backend skeleton**（#1573）— upload / attempt / identify / grade 4 個核心 endpoint
+- ✅ **Student UX sprint**（#1583 umbrella，#1588/#1590/#1592/#1593 子 PR）
+  - Image hash dedup + regrade endpoint
+  - 3-tier 信心度確認 UX（高/中/低 自動分流）+ GET /api/omo/lessons
+  - 結果頁：per-question cards + flag 回報 modal
+  - Loading copy / error toasts / 前端 client-side image resize
+- ✅ **品質修正**：confidence < 0.4 candidate 過濾（#1581）、學生答案逐字相同強制 score=1（#1602）、上傳上限 5→20 張（#1606）
+- ✅ **Identify 涵蓋全課程**（#1607）— 對齊 168 課（curriculum catalog + content layer）
+- ✅ **Test coverage**（#1596）— 3-tier confirm UX contract + render tests
+- ✅ **Docs**（#1589 master docs + #1595 test plan）
+
+### 環境分隔（Phase 1c env hardening）
+- ✅ **Staging ↔ Prod Cloud SQL 拆開**（#1579）— preview/staging 不再共用 prod DB
+- ✅ **Prod demo accounts 關 + OMO GCS bucket 拆**（#1576）
+- ✅ **JWT_SECRET_KEY 注入 staging Cloud Run**（#1580）
+- ✅ **Logging env tag + cron audit + OAuth docs**（#1604）
+
+### 158 → 168 課 auto-discovery 完成
+- ✅ OMO identify 從 hard-coded 範圍改為動態讀 curriculum catalog + content layer，全 168 課皆可辨識（#1607）
+
+### 保留給實習生：OMO 真機測試任務已開
+- 學生端真實流程（拍紙本 → 上傳 → 辨識 → 答題）需高中生實際走過驗收
+- 本週會議認領
+
+---
+
+## 二、靖杭進度報告
+
+> 📊 [技能樹儀表板](https://lingoleap-frontend-staging-958347263320.asia-east1.run.app/intern-training/dashboard.html) ｜ [貢獻紀錄](team-contributions.md)
+
+### 本週摘要
+本週 2 個 merged（#1599 / #1600）。聚焦在「課文簡介 AI 生成」和「朗讀歷史趨勢圖」兩個新功能線。從工具箱基礎建設轉向學生端體驗增強。
+
+### 本週完成（5/12 ~ 5/15）
+- ✅ PR #1599 — 課文簡介 AI 生成 + 學習策略獨立 hint 區（fixes #1598）
+- ✅ PR #1600 — 朗讀歷史趨勢線圖：自己跟自己比（fixes #1597）
+
+### 上週遺留 / 進行中
+- 🔧 #1190 進行中（已超過 2 週，本週需 status check）
+- 🔧 #1186 進行中（已超過 2 週，本週需 status check）
+- 🔧 9 個 `ai-qa-passed + intern-review` label 等實習生 final eye-check
+
+### 待討論
+- #1190 / #1186 卡住點
+
+---
+
+## 三、啟翔進度報告
+
+> 📊 [技能樹儀表板](https://lingoleap-frontend-staging-958347263320.asia-east1.run.app/intern-training/dashboard.html) ｜ [貢獻紀錄](team-contributions.md)
+
+### 本週摘要
+PR #1547 重要里程碑：MCQ rescue dialog 重設計 + 接入聚光燈 + log attempts，這是 #1387 閱讀聚光燈 AI 助教（7/1 deadline 大功能）的關鍵體驗組件。Open #1601 統一 step_progress 儲存模式為下一步基礎。
+
+### 本週完成（5/12 ~ 5/15）
+- ✅ PR #1547 — MCQ rescue dialog 重設計 + 接入聚光燈 + 紀錄 attempts（refs #1387）
+
+### Open PRs（待 review）
+- 🔧 PR #1601 — 統一 learning-step 進度儲存到 step_progress（refs #1549）
+
+### 待討論
+- #1547 是否完整覆蓋 #1387 Phase 1 體驗端？下一步 phase 接什麼
+- #1601 step_progress 統一是否影響既有 toolbox sessions
+
+---
+
+## 四、方大哥本週應該知道的事
+
+### 1. OMO Phase 1 全段落 merged 上 staging
+- 學生拍紙本學習單 → AI 辨識 → 自動批改回饋整條 pipeline 已通
+- 7/1 demo 主軸基礎完成（剩學生端真機壓測 + UX 微調）
+- Staging 可實測：上傳照片 → 看辨識信心度 → 看 per-question 結果頁
+- Master docs：`docs/omo/` + test plan（#1595）
+
+### 2. 158 → 168 課 auto-discovery 完成
+- OMO 辨識範圍從寫死改為動態對齊 curriculum catalog
+- 後續新增課程不需改 OMO code，自動納入
+- 進度：8 月 180 篇仍 on track
+
+### 3. 環境分隔已完成
+- Staging / Prod Cloud SQL 拆開（之前共用 prod 是潛在風險）
+- Prod demo accounts 已關，OMO GCS bucket 已分
+
+---
+
+## 五、待討論議題
+
+### 5.1 5/1 兩單元 7 課精緻化進度
+- A=G6-L22~25 摘要策略 4 課
+- B=G7-L28~30 圖文整合 3 課（7/1 必含）
+- **需確認**：本週是否能逐課跑 staging walk-through？哪些還有 blocking issues？
+
+### 5.2 OMO 學生真實測試時程
+- Phase 1 backend + UX 已上 staging，需安排：
+  - 高中生實習團隊真機測試（手機拍紙本 → 完整流程）
+  - 邀請少量教師 + 學生 beta 試用
+  - **問**：本週 / 下週可以排幾場？誰主導？
+
+### 5.3 #1387 閱讀聚光燈 AI 助教 — Phase 2 規劃
+- #1547 已交付 rescue dialog + spotlight wiring
+- 7/1 deadline 剩約 7 週，下一個 phase scope 待定
+- **需討論**：語音化 AI 助教 MVP（5/8 會議已提）下週啟動誰接？
+
+---
+
+## 六、Action Items
+
+| # | Action | 負責 | 完成標準 | Deadline |
+|---|--------|------|---------|----------|
+| A1 | ~~靖杭 PR #1599 / #1600 review + merge~~ ✅ 5/14 已 merge | — | — | — |
+| A2 | 啟翔 PR #1601 review + merge | Young + 啟翔 | merge 到 staging | 5/16 |
+| A3 | OMO 真機測試場次安排 | Young + 實習團隊 | 排定至少 1 場 / 列待測 checklist | 5/15 會議中 |
+| A4 | #1387 Phase 2（語音化）assignee + scope | Young + team | issue 有 assignee + MVP scope | 5/15 會議中 |
+| A5 | 5/1 七課精緻化逐課 staging walk-through | 靖杭 + 啟翔 | 列 blocking items 或簽結 | 5/22 前 |
+| A6 | #1190 / #1186 status check | 靖杭 | 仍在做 / 卡住 / 該關，明確回報 | 5/15 會議中 |

--- a/docs/meetings/team-contributions.md
+++ b/docs/meetings/team-contributions.md
@@ -8,6 +8,24 @@
 
 ---
 
+## 5/12 ~ 5/15
+
+| 人 | 狀態 | Issue / 項目 | 做了什麼 |
+|----|------|-------------|---------|
+| 啟翔 | ✅ | PR #1547 MCQ rescue（#1387）| MCQ rescue dialog 重設計 + 接入閱讀聚光燈 + log attempts，#1387 Phase 1 體驗端關鍵組件 |
+| 啟翔 | 🔧 | PR #1601 open（#1549）| 統一 learning-step 進度儲存到 step_progress，待 review |
+| 靖杭 | 🔧 | PR #1599 open（#1598）| 課文簡介 AI 生成 + 學習策略獨立 hint 區，待 review |
+| 靖杭 | 🔧 | PR #1600 open（#1597）| 朗讀歷史趨勢線圖 — 自己跟自己比，待 review |
+| Young | ✅ | OMO Phase 1a backend（#1573，refs #1343）| upload / attempt / identify / grade 4 個核心 endpoint，7/1 demo 主軸 |
+| Young | ✅ | OMO Phase 1b 學生 UX sprint（#1583 umbrella）| #1588 image hash dedup + regrade、#1590 3-tier 信心度確認 + GET /api/omo/lessons、#1592 結果頁 per-question + flag modal、#1593 loading/toast/image resize |
+| Young | ✅ | OMO 品質修正 | #1581 conf<0.4 過濾、#1602 逐字相同強制 score=1、#1606 上傳上限 5→20、#1607 identify 對齊全 168 課 |
+| Young | ✅ | OMO test + docs | #1596 3-tier confirm contract + render tests、#1589 master docs、#1595 test plan |
+| Young | ✅ | 環境分隔（Phase 1c env hardening）| #1579 staging Cloud SQL 從 prod 拆、#1576 prod demo accounts 關 + OMO GCS bucket 拆、#1580 staging JWT_SECRET_KEY 注入、#1604 logging env tag + cron audit + OAuth docs |
+| Young | ✅ | Pitch deck（5/13 評審用）| #1551/#1557/#1567/#1574 七課 7/1 deadline 進度簡報 + 字體 2x + 修破圖 |
+| Young | ✅ | UX 小修 | #1564 預設無注音、#1566 stepper 放大 + 首字 label、#1568 vocab-application filter、#1570/#1572 displayChar per step、#1546/#1548 stepper 單擊導航、#1555 G7 圖文 2:1 ratio |
+
+---
+
 ## 5/4 ~ 5/8
 
 | 人 | 狀態 | Issue / 項目 | 做了什麼 |

--- a/frontend/public/intern-training/CHEATSHEET.md
+++ b/frontend/public/intern-training/CHEATSHEET.md
@@ -7,35 +7,14 @@
 ## 📁 檔案結構
 
 ```
-docs/intern-training/
-├── skill-tree.html              ← 互動式技能樹（瀏覽器開啟）
-├── PBL-curriculum.md            ← PBL 課程綱要
+frontend/public/intern-training/   ← SOT（staging dashboard 從此讀）
+├── dashboard.html               ← 互動式技能樹儀表板（staging 可見）
 ├── CHEATSHEET.md                ← 本文件
-├── interns/
-│   ├── raymond.json             ← 靖杭進度 (completed, reviewNotes)
-│   └── xiung.json               ← 啟翔進度
-└── courses/                     ← 20 堂教材
-    ├── README.md                ← 教材索引
-    ├── tier1-git-basics.md
-    ├── tier1-html-css.md
-    ├── tier1-javascript.md
-    ├── tier1-dev-environment.md
-    ├── tier1-reading-code.md
-    ├── tier2-react-components.md
-    ├── tier2-typescript.md
-    ├── tier2-tailwind.md
-    ├── tier2-git-workflow.md
-    ├── tier2-bug-fixing.md
-    ├── tier3-react-advanced.md
-    ├── tier3-api-integration.md
-    ├── tier3-component-patterns.md
-    ├── tier3-testing.md
-    ├── tier3-code-review.md
-    ├── tier4-feature-development.md
-    ├── tier4-performance.md
-    ├── tier4-architecture.md
-    ├── tier4-documentation.md
-    └── tier4-mentoring.md
+└── interns/
+    ├── raymond.json             ← 靖杭進度 (skills, lastReview, history)
+    └── xiung.json               ← 啟翔進度
+
+docs/intern-training/            ← ⚠️ DEPRECATED（舊版 mirror，不要更新這裡）
 ```
 
 ---
@@ -135,33 +114,18 @@ open docs/intern-training/skill-tree.html
 
 ---
 
-## 👥 目前進度 (2026-03-13)
+## 👥 目前進度 (2026-05-14)
+
+> 最新進度請看 staging dashboard：
+> https://lingoleap-frontend-staging-958347263300.asia-east1.run.app/intern-training/dashboard.html
 
 ### Raymond (靖杭 @if-else-master)
 
-```
-已解鎖：6/20 (85 XP)
-Tier 1: ████████████████████ 5/5
-Tier 2: ██                   1/5 (#10 Bug修復)
-Tier 3: ─────────────────── 0/5
-Tier 4: ─────────────────── 0/5
-```
-
-**強項**：積極嘗試新功能、能獨立修 bug
-**建議**：學 React 元件開發 (#6)、改善 commit message 格式
+5 週 33 個 merged PR，新解鎖 #11（React 進階）、#16（獨立開發）、#19（技術文件），Git #9 升 level 4，測試 #14 升 level 3
 
 ### Steven (啟翔 @stgst)
 
-```
-已解鎖：10/20 (215 XP)
-Tier 1: ████████████████████ 5/5
-Tier 2: ████████████████     4/5 (缺 #7 TypeScript)
-Tier 3: ████                 1/5 (#11 React 進階)
-Tier 4: ─────────────────── 0/5
-```
-
-**強項**：程式碼品質高、React hooks 理解深、UX 改善有深度
-**建議**：學 TypeScript (#7)、嘗試 API 串接 (#12)
+5 週 11 個 merged PR，新解鎖 #12（API 串接）、#13（設計模式）、#14（測試）、#18（架構理解），React 進階 #11 升 level 5，Tailwind #8 升 level 4
 
 ---
 
@@ -177,20 +141,27 @@ Tier 4: ─────────────────── 0/5
 如果要手動調整（不透過 agent）：
 
 ```bash
-# 編輯靖杭的進度
-vim docs/intern-training/interns/raymond.json
+# SOT path（staging dashboard 從此讀）
+vim frontend/public/intern-training/interns/raymond.json
 
-# 編輯啟翔的進度
-vim docs/intern-training/interns/xiung.json
+# 啟翔
+vim frontend/public/intern-training/interns/xiung.json
 ```
 
-JSON 格式：
+JSON 格式（現行 schema）：
 ```json
 {
-  "completed": [1, 2, 3],       // 已完成的技能 ID
-  "lastReview": "2026-03-13",   // 上次評估日期
-  "reviewNotes": { "1": "證據" }, // 每個技能的通過證據
-  "recommendations": ["建議"]    // 下一步建議
+  "name": "Raymond",
+  "lastReview": "2026-05-14",   // 上次評估日期
+  "skills": {
+    "1": {
+      "level": 3,
+      "maxLevel": 5,
+      "history": [{ "date": "...", "level": 3, "reason": "..." }]
+    }
+  },
+  "recommendations": ["建議"],
+  "summary": "本次評估摘要"
 }
 ```
 

--- a/frontend/public/intern-training/interns/raymond.json
+++ b/frontend/public/intern-training/interns/raymond.json
@@ -3,7 +3,7 @@
   "github": "if-else-master",
   "email": "78069313+if-else-master@users.noreply.github.com",
   "startDate": "2026-03-02",
-  "lastReview": "2026-04-04",
+  "lastReview": "2026-05-14",
   "skills": {
     "1": {
       "level": 3,
@@ -179,7 +179,7 @@
       ]
     },
     "9": {
-      "level": 2,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
@@ -191,6 +191,11 @@
           "date": "2026-04-04",
           "level": 2,
           "reason": "8 個 commit 全部使用 feat:/fix: 前綴，涵蓋多個不同 issue 的獨立 PR，工作流程持續穩定。部分 commit message 夾雜中英文（如 WIP-fix: 逐段朗讀不準確的BUG），conventional commit 格式尚未完全一致，保守升至 level 2"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 4,
+          "reason": "5 週內 33 個 merged PR 全部使用 feat/fix/refactor scope 格式（如 feat(toolbox) / fix(db) / fix(csp)），無 WIP 混入，每個 PR 對應一個 issue，描述清楚包含 Summary / Changes / Test plan，PR 流程已達專業水準，升至 level 4"
         }
       ]
     },
@@ -247,18 +252,23 @@
       ]
     },
     "13": {
-      "level": 1,
+      "level": 2,
       "maxLevel": 5,
       "history": [
         {
           "date": "2026-04-04",
           "level": 1,
           "reason": "feat: hide-parent-page (#805) 新建 featureFlags.ts 集中管理前端功能開關，並在 auth.py / AppRoutes.tsx 各層正確引用，展現將設定邏輯抽離元件的意識。18ffa845 也顯示能理解跨元件的 props/context 資料流。首次展現元件設計模式的雛形，解鎖 level 1"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 2,
+          "reason": "PR #1461（toolbox Phase 1）新建 toolbox.py 模型、Alembic migration、獨立 PracticeToolbox.tsx 頁面與 learningStorageScope.ts 服務，各層職責分離清晰。PR #1030（+761/-92）獨立建立學生練習紀錄查詢頁，從 API → hook → 頁面元件結構完整。已能主動拆分元件，升至 level 2"
         }
       ]
     },
     "14": {
-      "level": 2,
+      "level": 3,
       "maxLevel": 5,
       "history": [
         {
@@ -270,28 +280,71 @@
           "date": "2026-04-04",
           "level": 2,
           "reason": "a08b2b40（標記課文紀錄欄位 #899）擴充 ReadingAnnotation.test.tsx：新增 scrollIntoView mock、修正 aria-label 斷言、加入 act() + fireEvent.click 的非同步測試，還新增側邊面板顯示和跳轉功能的兩個完整 test case。9d97a3c1 也補了 test_reading_evaluation_service.py。測試不只是 happy path，有測互動行為，升至 level 2"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 3,
+          "reason": "PR #1600（朗讀趨勢圖）主動補 ReadingTrendChart.test.tsx 共 5 個 unit tests，含 empty state / single point / normal rendering 三種情境。PR #969（造句驗證）後端補 5 個複製偵測測試並修正 test 互相干擾的 rate limiter override。已養成「新功能附帶測試」習慣，升至 level 3"
+        }
+      ]
+    },
+    "11": {
+      "level": 2,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-05-14",
+          "level": 2,
+          "reason": "PR #1600（朗讀趨勢圖）使用 recharts 建立雙 Y 軸 LineChart，正確使用 useMemo 處理資料 sort+cap，理解 chart 的 empty state 情境（< 2 點時顯示鼓勵文字）。PR #1195（step_progress 版本機制）使用 useEffect 處理 session 版本比對。已展示 useEffect/useMemo 在真實功能中的正確應用，解鎖 level 2"
+        }
+      ]
+    },
+    "16": {
+      "level": 1,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-05-14",
+          "level": 1,
+          "reason": "PR #1030（學生練習紀錄查詢頁 #416）從 issue → 設計 API → 實作前端頁面完整走完，+761/-92 行，功能從無到有。PR #1461（toolbox Phase 1）獨立設計 10 個 DB tables + migration + API + 前端頁面，是目前最大規模的端對端功能開發，解鎖 level 1"
+        }
+      ]
+    },
+    "19": {
+      "level": 1,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-05-14",
+          "level": 1,
+          "reason": "PR #1461 附帶 issue1460done.md 說明各 phase 完成狀態。多個 PR 的 description 含清楚的 Summary 表格、Changes 說明、Test plan checklist，技術文件意識良好。PR #1128 的 radical coverage 對照表（Before/After 數字）是量化說明改動效果的好範例，解鎖 level 1"
         }
       ]
     },
     "18": {
-      "level": 1,
+      "level": 2,
       "maxLevel": 5,
       "history": [
         {
           "date": "2026-04-04",
           "level": 1,
           "reason": "18ffa845（作業進度條 #645/#898）同時修改 backend routes/assignments.py、schemas/assignment.py，以及 frontend LearningLayout、ComprehensionChat、MyAssignments、ReportPage 等多個層，顯示理解資料從 API → context → 元件顯示的完整路徑。d4e11a98 類似，從 backend config → auth route → frontend featureFlags → AppRoutes 全端串通。首次展現全端資料流理解，解鎖 level 1"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 2,
+          "reason": "PR #1461（toolbox）從 DB Schema → SQLAlchemy model → Alembic migration → FastAPI route → React 頁面完整走一遍，並理解 learningStorageScope.ts 在前端的 session 隔離設計。PR #1193/#1194（DB index）展示能判斷何時需要加 partial unique index 防止 race condition，資料庫層的設計判斷力提升，升至 level 2"
         }
       ]
     }
   },
   "recommendations": [
-    "Git 工作流（#9）升至 level 2，下一步練習讓每個 PR 只包含單一 issue 的改動，commit message 全部統一用英文描述（例如 fix: reading annotation scroll behavior），避免 WIP- 前綴混入 main branch",
-    "測試（#14）升至 level 2，下一步挑戰 TDD 流程：先寫一個會 fail 的測試，再實作功能讓它通過。下一個 bug fix 可以從測試先寫起",
-    "元件設計模式（#13）剛解鎖，下一步可以嘗試把 18ffa845 裡的學習進度邏輯抽出成 custom hook（例如 useAssignmentProgress），讓元件本身更乾淨",
-    "架構理解（#18）剛解鎖，試著畫出一個功能的完整資料流圖（從 DB schema → API endpoint → frontend hook → UI），用文字或圖解說明，這會幫助你更快定位未來的 bug"
+    "元件設計模式（#13）升至 level 2，下一步嘗試把 toolbox 各練習的重複邏輯（session 建立 / 完成 CTA）抽出成 custom hook（例如 useToolboxSession），讓各工具頁元件本身更薄",
+    "測試（#14）升至 level 3，下一步挑戰 integration test：用 pytest 測試一個完整 API flow（建 session → 更新進度 → 查詢歷史），而不只是 unit test 單一函式",
+    "獨立開發（#16）剛解鎖 level 1，下一步嘗試自己從 issue description 出發，畫出 DB schema + API 設計再實作，而不是直接進 coding。這個習慣能讓複雜功能更不容易返工",
+    "架構理解（#18）升至 level 2，下一步可以看一個現有 LLM endpoint（如造句批改）的完整防護層（rate limit → auth → input cap → fail-closed），理解為什麼每層都需要，試著寫一份簡短說明給啟翔看"
   ],
-  "summary": "本期 8 個 commit 涵蓋全端：後端 AI 服務修正、feature flag 架構、作業進度全端串接、loading skeleton、閱讀標記測試擴充。新解鎖技能 13（元件設計模式）、18（架構理解），測試技能升至 level 2，Git 工作流升至 level 2。目前已確認解鎖 14 項技能",
+  "summary": "5 週內 33 個 merged PR，涵蓋 toolbox 全端架構（DB tables → Alembic → FastAPI → React）、朗讀趨勢圖、session 版本機制、CSP 修復、字型 fallback 等。新解鎖技能 11（React 進階）、16（獨立開發功能）、19（技術文件），Git 工作流升 level 4，測試升 level 3，元件設計模式升 level 2，架構理解升 level 2。目前已確認解鎖 16 項技能",
   "issues": [
     {
       "id": "環境建置",

--- a/frontend/public/intern-training/interns/xiung.json
+++ b/frontend/public/intern-training/interns/xiung.json
@@ -3,7 +3,7 @@
   "github": "stgst",
   "email": "steven19790906@gmail.com",
   "startDate": "2026-03-06",
-  "lastReview": "2026-04-04",
+  "lastReview": "2026-05-14",
   "skills": {
     "1": {
       "level": 3,
@@ -138,28 +138,38 @@
       "maxLevel": 5
     },
     "7": {
-      "level": 1,
+      "level": 3,
       "maxLevel": 5,
       "history": [
         {
           "date": "2026-04-04",
           "level": 1,
           "reason": "2796b942（造句練習 cache key 修正 #910/#912）在 VocabPractice.tsx 新增 vocabChars，明確使用 Set<string> 和 string[] 型別標注，for...of 迴圈中對 item.word 使用正規表達式過濾 CJK 字元。TypeScript 基本型別標注已掌握，解鎖 level 1"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 3,
+          "reason": "PR #1547（MCQ rescue dialog）在 McqRescueDialog.tsx、MultipleChoiceExercise.tsx、StrategyExercise.tsx 使用完整 interface 定義 props，API layer 的 request/response 型別清楚標注，Alembic migration 用 Python typing。PR #1141（全域 UX）定義 VoiceInputButton 的 `size: 'md' | 'sm'` union type。TypeScript 使用範圍從單一檔案擴展到多個模組，升至 level 3"
         }
       ]
     },
     "8": {
-      "level": 2,
+      "level": 4,
       "history": [
         {
           "date": "2026-03-10",
           "level": 2,
           "reason": "PR #229 修改含 Tailwind 樣式的元件，理解 utility-first 概念與 class 組合方式"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 4,
+          "reason": "PR #1141（全域 UX）大規模使用 glassmorphic utilities（backdrop-blur、bg-white/20）、響應式 prefix（md:h-20）、Tailwind arbitrary values（shadow-[inset_0_-3px_0_0_#ef4444]）修復紅線歪斜問題（PR #1130）。PR #1480 用 shrink-0 / max-w-2xl / mx-auto 做排版約束，對 Tailwind 的設計系統語意理解清晰，升至 level 4"
         }
       ]
     },
     "9": {
-      "level": 3,
+      "level": 4,
       "history": [
         {
           "date": "2026-03-08",
@@ -175,6 +185,11 @@
           "date": "2026-03-13",
           "level": 3,
           "reason": "commit message 品質佳（feat/fix/refactor 正確分類），PR #448 完整走完 branch → PR → merge 流程"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 4,
+          "reason": "11 個 merged PR 全部使用 feat/fix + scope 格式，PR #1547 的 description 含完整 Summary / 後端 / 前端 / Acceptance / Test plan 分段，PR #1130 的根本原因分析（root cause）清楚交代三層問題並分別說明修補方式，PR 品質穩定達到 code review 可接受標準，升至 level 4"
         }
       ]
     },
@@ -205,7 +220,7 @@
       "maxLevel": 5
     },
     "11": {
-      "level": 4,
+      "level": 5,
       "history": [
         {
           "date": "2026-03-13",
@@ -221,9 +236,47 @@
           "date": "2026-03-13",
           "level": 4,
           "reason": "能熟練運用 useMemo, useCallback。"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 5,
+          "reason": "PR #1547（MCQ rescue dialog）useRef 保存 chat history 跨關閉重開不消失，useState 管理 dialog open/close + message list + loading 多個非同步狀態，useEffect 在 mount 時初始化 rescue session。PR #1492（guided_steps）正確診斷 onComplete 觸發條件導致學生卡關，修改後邏輯清楚。useEffect/useRef/useState 在複雜互動場景的綜合應用，升至 level 5"
         }
       ],
       "maxLevel": 5
+    },
+    "12": {
+      "level": 3,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-05-14",
+          "level": 3,
+          "reason": "PR #1547 新建 FastAPI route `POST /api/learning/mcq-attempt`，含 auth Depends、rate limit 100/min、request body 型別，並新建對應 SQLAlchemy model（mcq_attempt.py）和 Alembic migration。PR #969（造句驗證）在後端 AI 呼叫前加入確定性子字串比對，理解 API 前置 guard 的設計思路。首次完整實作後端 API endpoint，解鎖 level 3"
+        }
+      ]
+    },
+    "13": {
+      "level": 2,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-05-14",
+          "level": 2,
+          "reason": "PR #1141（全域 UX）抽出 VoiceInputButton.tsx 共用元件，支援 md/sm 兩種尺寸，接入 SentencePractice 和 FloatingAIHelper 兩個不同使用場景，並刻意不加到 DictationPractice（違背聽寫目的）——這個判斷展示元件設計的責任邊界意識。PR #1547 的 McqRescueDialog 獨立成可重用的 dialog，不綁定特定 MCQ 邏輯，解鎖 level 2"
+        }
+      ]
+    },
+    "14": {
+      "level": 2,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-05-14",
+          "level": 2,
+          "reason": "PR #1547 補 MultipleChoiceExercise.test.tsx 共 7 個 Vitest tests，涵蓋正確/錯誤選項、rescue button 顯示、dialog 開關等多種情境。PR #1492（guided_steps）補 StrategyExercise.test.tsx 3 個 tests：all-correct / only-Q1-confirmed / wrong-but-all-answered，明確驗證 regression。開始主動為新功能補測試，解鎖 level 2"
+        }
+      ]
     },
     "15": {
       "level": 4,
@@ -237,7 +290,7 @@
       ]
     },
     "16": {
-      "level": 4,
+      "level": 2,
       "maxLevel": 5,
       "history": [
         {
@@ -249,6 +302,11 @@
           "date": "2026-03-13",
           "level": 4,
           "reason": "獨立完成多個 feature 開發。"
+        },
+        {
+          "date": "2026-05-14",
+          "level": 2,
+          "reason": "注意：重新評估。先前 level 3/4 缺乏具體 PR 佐證，退至有實際 PR 支撐的水準。PR #1547（MCQ rescue）是目前最完整的端對端 feature：從 issue #1507 出發 → DB table → migration → API → UI → 測試，首次獨立走完完整 issue → merged PR 流程，解鎖 level 2"
         }
       ]
     },
@@ -267,15 +325,26 @@
           "reason": "能進行效能優化，例如使用 useMemo。"
         }
       ]
+    },
+    "18": {
+      "level": 1,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-05-14",
+          "level": 1,
+          "reason": "PR #1547 從 DB Schema（mcq_attempt）→ SQLAlchemy model → Alembic migration → FastAPI route → React component → API service 完整走一遍，理解資料如何在各層流動。PR #1128（部件教學）同時修改 dictionary_service.py（後端 heteronym 挑選邏輯）+ RadicalDecomposition.tsx（前端 UI）+ 資料檔案，展示跨層問題的診斷能力，首次展現全端資料流理解，解鎖 level 1"
+        }
+      ]
     }
   },
   "recommendations": [
-    "TypeScript（#7）剛解鎖，下一步試著為 VocabPractice 的 props 介面加上明確型別定義（interface VocabPracticeProps），或為 vocabChars hook 抽出 custom hook 並標注回傳型別，進一步深化 TS 使用",
-    "本期只有 1 個 commit 被 merge，產出量明顯少於靖杭。PR #913（rate limit fix）還在 open 狀態，優先把它收尾 merge",
-    "測試（#14）還未解鎖，可以為 vocabChars 的邏輯撰寫一個 Vitest 單元測試：給定不同的 story.vocabulary 輸入，驗證重複字元被去除、非中文字元被過濾。這個邏輯很適合作為第一個 pure function 測試",
-    "架構理解（#18）還未解鎖，試著追蹤一個 API call 的完整路徑：從 SentencePractice 呼叫 API → backend route → cache 查詢 → 回應，用自己的話寫下來，這會幫助你更快診斷像 #910 這樣的 cache key 問題"
+    "TypeScript（#7）升至 level 3，下一步試著為 McqRescueDialog 的 messages state 抽出專屬的 type（`type RescueMessage = { role: 'user' | 'ai'; content: string }`），練習用 discriminated union 表達更複雜的狀態",
+    "API 串接（#12）剛解鎖 level 3，下一步可以嘗試為 mcq-attempt endpoint 加上 input size cap（防止超長 answer 字串），並在 fail 時回傳有意義的錯誤訊息，而不是 500",
+    "測試（#14）解鎖 level 2，下一步嘗試為 PR #1128 的 dictionary_service.py heteronym 挑選邏輯補一個 pytest：給定多音字回傳、驗證挑到有真實定義的那個，而不是 pronunciation-disambiguation",
+    "架構理解（#18）剛解鎖，試著看 mcq_attempt 這個 table 的 4 個 indexes（user_id / lesson_id / question_id / created_at），解釋為什麼每個都需要，什麼查詢場景會用到它"
   ],
-  "summary": "本期 1 個 commit merge（#910/#912），精準定位 SentencePractice 使用錯誤字元集導致 cache 命中率低的根本原因，用 useMemo 抽出 vocabChars 解決，展現對資料流的理解。首次使用明確 TypeScript 型別標注，解鎖技能 #7（TypeScript）。PR #913 仍 open 中。目前已確認解鎖 13 項技能",
+  "summary": "5 週內 11 個 merged PR，重大突破是 PR #1547（MCQ rescue dialog）首次端對端開發：DB table → Alembic → FastAPI → React → Vitest，新解鎖技能 12（API 串接）、13（元件設計模式）、14（測試）、18（架構理解），React 進階（#11）升 level 5，Tailwind（#8）升 level 4，Git 工作流（#9）升 level 4，TypeScript（#7）升 level 3。目前已確認解鎖 16 項技能",
   "issues": [
     {
       "id": "環境建置",


### PR DESCRIPTION
Fixes #1612

## Summary

- **Commit A**: `docs/meetings/2026-05-15.md` (new) — 5/15 meeting agenda with OMO Phase 1 results, 7/1 deadline table, intern progress snapshots, 6 action items. `docs/meetings/team-contributions.md` — prepend 5/12~5/15 week section.
- **Commit B**: `frontend/public/intern-training/interns/raymond.json` + `xiung.json` — 5-week skill tree review (lastReview 4/04 → 5/14). raymond: 33 merged PRs, new skills #11/#16/#19. xiung: 11 merged PRs, new skills #12/#13/#14/#18.
- **Commit C**: `.claude/skills/friday-meeting-prep/SKILL.md`, `.claude/skills/meeting-prep/SKILL.md`, `.claude/rules/catchup-intern-check.md`, `frontend/public/intern-training/CHEATSHEET.md` — all `docs/intern-training/` paths corrected to `frontend/public/intern-training/` (SOT). `docs/intern-training/` marked deprecated.

## Expected effect

After merge to staging: `curl staging/intern-training/interns/raymond.json | jq .lastReview` returns `"2026-05-14"`.

## Test plan

- [ ] `docs/meetings/2026-05-15.md` renders correctly in GitHub preview
- [ ] `team-contributions.md` has 5/12~5/15 section at top (after header)
- [ ] `raymond.json` valid JSON — `jq . raymond.json` passes; `lastReview = 2026-05-14`
- [ ] `xiung.json` valid JSON — `jq . xiung.json` passes; `lastReview = 2026-05-14`
- [ ] SKILL.md files reference `frontend/public/intern-training/` (not `docs/`)