### PR TITLE
fix(omo): grader 真實手寫 100% 偽陽性 — 重寫 prompt + 移除 Safety override (Fixes #1614)

### DIFF
--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -127,27 +127,62 @@ def _build_question_schema(lesson: dict) -> list[dict]:
 
 
 def _build_grading_prompt(questions: list[dict]) -> str:
-    """Build the system prompt for Gemini grading."""
+    """Build the system prompt for Gemini grading.
+
+    Design principles (fixes 100% false-positive bug — Issue #1614):
+    - Expected answers are NOT shown inline per question to prevent Gemini from
+      copying them into student_answer. They are listed in a separate "grading
+      reference" section used only for comparison AFTER reading the handwriting.
+    - The opening instruction explicitly forbids referencing the expected answer
+      when extracting what the student wrote.
+    - Red-pen correction marks are treated as evidence the student was wrong;
+      the student's ORIGINAL (pre-correction) answer should be captured.
+    - If handwriting is unclear, return empty student_answer + score/confidence=0.
+    """
+    # Question list shown to Gemini: context only, NO correct_answer inline
     questions_text = "\n".join(
-        f"  {i+1}. [ID: {q['id']} | type: {q['type']}] Context: {q['context']} | Expected answer: {q['correct_answer']}"
+        f"  {i+1}. [ID: {q['id']} | type: {q['type']}] {q['context']}"
         for i, q in enumerate(questions)
     )
-    return f"""你是一位精準的國語文作業批改老師。
+    # Separate reference block — used for scoring comparison only
+    reference_text = "\n".join(
+        f"  {i+1}. [ID: {q['id']}] 標準答案：{q['correct_answer']}"
+        for i, q in enumerate(questions)
+    )
+    return f"""你是一位國語文作業批改老師。你的唯一任務是**讀取學生在學習單上的手寫筆跡**，然後與標準答案比對評分。
 
-任務：從學生的手寫學習單照片中，找出每一題的手寫答案，並與標準答案比對評分。
+== 絕對禁止 ==
+- 禁止把標準答案複製到 student_answer 欄位
+- 禁止猜測學生「應該」寫什麼、「可能」寫什麼
+- 如果你看不清楚學生手寫，必須回傳 student_answer="" 且 score=0.0 且 ai_confidence=0.0
+- 禁止把印刷文字（題目說明、選項文字）當作學生的作答
 
-待批改題目清單：
+== 手寫辨識規則 ==
+1. 只讀學生用鉛筆或原子筆填寫的手寫部分，忽略印刷文字
+2. 選擇題：報告學生用筆圈選的選項字母（A/B/C/D），不管哪個是正確答案
+3. 填充題：逐字辨識學生手寫的文字
+4. 如果看到紅筆批改痕跡（✗ 記號、紅筆劃線、紅筆覆寫）：
+   - 這表示老師已標記學生答錯
+   - student_answer 填學生的**原始手寫**（紅筆訂正前的字），不是老師的修改
+   - 直接給 score=0.0
+5. 作答欄位空白 → student_answer="" 且 score=0.0
+
+== 評分規則（比對標準答案後） ==
+- 完全正確（允許合理字體變異）= 1.0
+- 部分正確（答對概念但有筆誤）= 0.5
+- 明顯錯誤 = 0.0
+- 無法辨識 / 空白 = 0.0
+- ai_confidence：你對手寫辨識結果的信心（0.0=完全看不到筆跡，1.0=非常清晰）
+- reasoning（中文，限 50 字）：必須說明「看到什麼筆跡」例如「學生圈了 B」「答案欄空白」「字跡為『注目』但被紅筆畫掉」
+
+== 待批改題目（按題號對應學習單） ==
 {questions_text}
 
-批改規則：
-1. 找到每題對應的手寫區域
-2. 辨識學生的手寫文字
-3. 與標準答案比對（允許合理的字體變異）
-4. 評分：完全正確 = 1.0，部分正確 = 0.5，明顯錯誤 = 0.0，無法辨識 = 0.0
-5. ai_confidence：手寫辨識清晰度，0.0（完全無法辨識）～1.0（非常清晰）
-6. reasoning：說明辨識結果與評分理由（中文，限 50 字）
+== 標準答案參考（僅用於比對，不可複製到 student_answer） ==
+{reference_text}
 
-回傳 JSON 陣列，每題一筆記錄。"""
+回傳 JSON 陣列，每題一筆記錄，格式：
+[{{"question_id": "...", "student_answer": "學生實際寫的", "correct_answer": "標準答案", "score": 0.0, "ai_confidence": 0.0, "reasoning": "..."}}]"""
 
 
 async def grade_worksheet_images(
@@ -285,14 +320,10 @@ async def grade_worksheet_images(
             ai_conf = float(item.get("ai_confidence", 0.0))
             reasoning = str(item.get("reasoning", ""))
 
-            # Safety override: if Gemini gave score=0 but answers match literally,
-            # force score=1.0. Observed on messy handwriting where Gemini extracted
-            # the exact correct text but assigned conf=0 / score=0 inconsistently.
-            if student_ans and correct_ans and student_ans == correct_ans and score < 1.0:
-                score = 1.0
-                if ai_conf < 0.5:
-                    ai_conf = 0.95
-                reasoning = (reasoning + " [自動校正：學生答案與標準答案完全一致]").strip()
+            # NOTE: No "safety override" here. Matching student_answer == correct_answer
+            # does NOT prove correctness — Gemini may have copied the expected answer
+            # instead of reading the handwriting (Issue #1614 root cause).
+            # Trust Gemini's score as returned; the new prompt explicitly forbids copying.
 
             results.append(GradedAnswer(
                 question_id=str(item.get("question_id", "")),

--- a/backend/tests/test_omo_grader_real.py
+++ b/backend/tests/test_omo_grader_real.py
@@ -1,0 +1,388 @@
+"""Tests for omo_grader — prevents regression of Issue #1614 (100% false-positive).
+
+Ground truth from private/omo-real-samples/2026-05-14/test-report.md:
+
+L24「昆蟲會思考嗎？」PDF #1:
+  Multiple-choice (page 21):
+    mc_1: student circled A, correct=C  → score=0.0
+    mc_2: student circled B, correct=None → score=0.0
+    mc_3: student circled A, correct=D  → score=0.0
+    mc_4: student circled A, correct=B  → score=0.0
+    mc_5: student circled C, correct=B  → score=0.0  (only q5 student=C, correct=B: wrong)
+  Fill-in-blank (page 18, red-pen corrections):
+    fb_1 「尋找食物」: student wrote 寛食 (wrong radical), red-pen corrected → score=0.0
+    fb_9 「現況的變化」: student answer crossed out → score=0.0
+    fb_10「雷聲突然響起」: red ✗ mark → score=0.0
+
+Strategy:
+  All tests use mock Gemini responses (no real API calls, no quota usage).
+  @pytest.mark.real tests exist for manual local verification with real images.
+"""
+
+import asyncio
+import json
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_LESSON = {
+    "title": "昆蟲會思考嗎？",
+    "vocabulary": [
+        {"word": "奠定"},
+        {"word": "覓食"},
+        {"word": "迅雷不及掩耳"},
+        {"word": "臨機應變"},
+        {"word": "注目"},
+    ],
+    "fill_in_blank": [
+        {"answer": "B", "sentence": "尋找食物的本能"},           # fb_1 → 覓食
+        {"answer": "A", "sentence": "基礎穩固"},                  # fb_2 → 奠定
+        {"answer": "E", "sentence": "引人注意"},                  # fb_3 → 注目
+        {"answer": "D", "sentence": "靈活應對"},                  # fb_4 → 臨機應變
+        {"answer": "C", "sentence": "行動迅速"},                  # fb_5 → 迅雷不及掩耳
+        {"answer": "A", "sentence": ""},
+        {"answer": "B", "sentence": ""},
+        {"answer": "C", "sentence": ""},
+        {"answer": "D", "sentence": "現況的變化"},                # fb_9 → 臨機應變
+        {"answer": "C", "sentence": "雷聲突然響起"},              # fb_10 → 迅雷不及掩耳
+    ],
+    "multiple_choice": [
+        {"answer": "C", "question": "q1"},
+        {"answer": "",  "question": "q2"},
+        {"answer": "D", "question": "q3"},
+        {"answer": "B", "question": "q4"},
+        {"answer": "B", "question": "q5"},
+    ],
+}
+
+
+def _make_mock_response(items: list[dict]) -> MagicMock:
+    """Create a mock Gemini response with the given graded items."""
+    mock_resp = MagicMock()
+    mock_resp.text = json.dumps(items)
+    return mock_resp
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — prompt structure (no API calls)
+# ---------------------------------------------------------------------------
+
+class TestBuildGradingPrompt:
+    """Verify the new prompt design does not leak expected answers inline."""
+
+    def setup_method(self):
+        from app.services.omo_grader import _build_question_schema, _build_grading_prompt
+        self.questions = _build_question_schema(SAMPLE_LESSON)
+        self.prompt = _build_grading_prompt(self.questions)
+
+    def test_prompt_contains_handwriting_only_instruction(self):
+        assert "禁止把標準答案複製到 student_answer" in self.prompt, (
+            "Prompt must explicitly forbid copying expected answer into student_answer"
+        )
+
+    def test_expected_answers_not_inline(self):
+        """Each QUESTION line must NOT contain the correct_answer inline.
+
+        Old pattern:  '| Expected answer: 覓食'
+        New pattern:  correct answers only appear in the reference block at the bottom.
+
+        We identify question lines as those between the "待批改題目" header and the
+        "標準答案參考" header — the reference block is a separate section.
+        """
+        lines = self.prompt.split("\n")
+        # Find the section boundaries
+        in_questions_section = False
+        question_lines = []
+        for line in lines:
+            if "待批改題目" in line:
+                in_questions_section = True
+                continue
+            if "標準答案參考" in line:
+                in_questions_section = False
+                continue
+            if in_questions_section and line.strip():
+                question_lines.append(line)
+
+        assert len(question_lines) > 0, "Should find question lines in 待批改題目 section"
+        for line in question_lines:
+            assert "Expected answer:" not in line, (
+                f"Question line still contains 'Expected answer:': {line!r}"
+            )
+            assert "標準答案：" not in line, (
+                f"Question line still contains inline correct answer: {line!r}"
+            )
+
+    def test_reference_block_present(self):
+        assert "標準答案參考" in self.prompt, (
+            "Prompt must have a separate reference block for correct answers"
+        )
+
+    def test_red_pen_instruction_present(self):
+        assert "紅筆" in self.prompt, (
+            "Prompt must instruct Gemini how to handle red-pen correction marks"
+        )
+
+    def test_mc_instruction_present(self):
+        assert "圈選" in self.prompt or "選項字母" in self.prompt, (
+            "Prompt must tell Gemini to report which letter the student CIRCLED"
+        )
+
+    def test_blank_answer_instruction(self):
+        assert "空白" in self.prompt, (
+            "Prompt must handle blank answer slots (student_answer='', score=0.0)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — parsing logic with mock Gemini responses
+# ---------------------------------------------------------------------------
+
+class TestParsingWithMockResponses:
+    """Verify that the grader correctly parses Gemini responses representing
+    real student errors — no false-positive inflating to score=1.0."""
+
+    def _patch_and_run(self, mock_items: list[dict]) -> list:
+        """Patch Gemini and run grade_worksheet_images with a dummy image."""
+        import app.services.omo_grader as grader_mod
+
+        # Reset circuit breaker
+        grader_mod._consecutive_errors = 0
+
+        mock_response = _make_mock_response(mock_items)
+
+        # Build a minimal fake genai module
+        fake_genai = types.ModuleType("google.genai")
+        fake_types = types.ModuleType("google.genai.types")
+
+        class FakeContent:
+            def __init__(self, **kwargs): pass
+
+        class FakePart:
+            @staticmethod
+            def from_bytes(**kwargs): return FakePart()
+
+        class FakeThinkingConfig:
+            def __init__(self, **kwargs): pass
+
+        class FakeAutoFuncCallingConfig:
+            def __init__(self, **kwargs): pass
+
+        class FakeGenerateContentConfig:
+            def __init__(self, **kwargs): pass
+
+        class FakeClient:
+            def __init__(self, **kwargs): pass
+            class models:
+                @staticmethod
+                def generate_content(**kwargs):
+                    return mock_response
+
+        fake_types.Content = FakeContent
+        fake_types.Part = FakePart
+        fake_types.ThinkingConfig = FakeThinkingConfig
+        fake_types.AutomaticFunctionCallingConfig = FakeAutoFuncCallingConfig
+        fake_types.GenerateContentConfig = FakeGenerateContentConfig
+        fake_genai.Client = FakeClient
+
+        fake_google = types.ModuleType("google")
+        fake_google.genai = fake_genai
+
+        with patch.dict(sys.modules, {
+            "google": fake_google,
+            "google.genai": fake_genai,
+            "google.genai.types": fake_types,
+        }):
+            return _run(grader_mod.grade_worksheet_images(
+                image_bytes_list=[b"fake_image_bytes"],
+                mime_types=["image/jpeg"],
+                lesson=SAMPLE_LESSON,
+                attempt_id=None,
+            ))
+
+    def test_mc_all_wrong_student_answers_score_zero(self):
+        """Ground truth: 5 MC questions, student answered A/B/A/A/C, all wrong.
+        Gemini correctly reads handwriting and returns student answers ≠ correct answers."""
+        mock_items = [
+            {"question_id": "mc_1", "student_answer": "A", "correct_answer": "C",    "score": 0.0, "ai_confidence": 0.9, "reasoning": "學生圈了A"},
+            {"question_id": "mc_2", "student_answer": "B", "correct_answer": "",     "score": 0.0, "ai_confidence": 0.9, "reasoning": "學生圈了B"},
+            {"question_id": "mc_3", "student_answer": "A", "correct_answer": "D",    "score": 0.0, "ai_confidence": 0.9, "reasoning": "學生圈了A"},
+            {"question_id": "mc_4", "student_answer": "A", "correct_answer": "B",    "score": 0.0, "ai_confidence": 0.8, "reasoning": "學生圈了A"},
+            {"question_id": "mc_5", "student_answer": "C", "correct_answer": "B",    "score": 0.0, "ai_confidence": 0.85, "reasoning": "學生圈了C"},
+        ]
+        results = self._patch_and_run(mock_items)
+        assert len(results) > 0, "Should return graded results"
+        mc_results = [r for r in results if r.question_id.startswith("mc_")]
+        for r in mc_results:
+            assert r.score == 0.0, (
+                f"Question {r.question_id}: student_answer={r.student_answer!r} "
+                f"vs correct={r.correct_answer!r} — expected score=0.0 got {r.score}"
+            )
+
+    def test_fill_blank_red_pen_corrected_score_zero(self):
+        """Ground truth: fb_1 student wrote 寛食 (wrong radical), red-pen corrected.
+        Gemini reads original handwriting, sees red-pen, returns score=0.0."""
+        mock_items = [
+            {"question_id": "fb_1", "student_answer": "寛食", "correct_answer": "覓食",
+             "score": 0.0, "ai_confidence": 0.75, "reasoning": "學生寫寛食，紅筆已訂正"},
+        ]
+        results = self._patch_and_run(mock_items)
+        fb1 = next((r for r in results if r.question_id == "fb_1"), None)
+        assert fb1 is not None
+        assert fb1.score == 0.0, f"Red-pen corrected answer must score 0.0, got {fb1.score}"
+        assert fb1.student_answer == "寛食", f"Must capture original handwriting, got {fb1.student_answer!r}"
+
+    def test_no_safety_override_inflates_score(self):
+        """Verify removed Safety override: student_answer == correct_answer does NOT
+        force score=1.0 when Gemini returns score=0.0 (e.g. Gemini correctly reports
+        exact text but low confidence / zero score due to red-pen mark)."""
+        mock_items = [
+            # Simulate old bug scenario: Gemini returns correct_answer in student_answer
+            # but score=0 — old code would inflate this to 1.0
+            {"question_id": "mc_1", "student_answer": "C", "correct_answer": "C",
+             "score": 0.0, "ai_confidence": 0.1, "reasoning": "老師紅筆訂正為C，學生原答未知"},
+        ]
+        results = self._patch_and_run(mock_items)
+        mc1 = next((r for r in results if r.question_id == "mc_1"), None)
+        assert mc1 is not None
+        assert mc1.score == 0.0, (
+            f"Safety override must NOT inflate score when Gemini returns 0.0. Got {mc1.score}. "
+            "This was the root cause of Issue #1614 — student_answer==correct_answer was "
+            "being auto-promoted to 1.0 even when Gemini had copied the expected answer."
+        )
+
+    def test_blank_answer_stays_zero(self):
+        """Student left a fill-blank empty — should remain score=0.0."""
+        mock_items = [
+            {"question_id": "fb_9", "student_answer": "", "correct_answer": "臨機應變",
+             "score": 0.0, "ai_confidence": 0.0, "reasoning": "答案欄空白"},
+        ]
+        results = self._patch_and_run(mock_items)
+        fb9 = next((r for r in results if r.question_id == "fb_9"), None)
+        assert fb9 is not None
+        assert fb9.score == 0.0
+        assert fb9.student_answer == ""
+
+    def test_correct_answer_scores_one(self):
+        """Student actually got the right answer — should score=1.0."""
+        mock_items = [
+            {"question_id": "mc_5", "student_answer": "B", "correct_answer": "B",
+             "score": 1.0, "ai_confidence": 0.95, "reasoning": "學生圈了B，正確"},
+        ]
+        results = self._patch_and_run(mock_items)
+        mc5 = next((r for r in results if r.question_id == "mc_5"), None)
+        assert mc5 is not None
+        assert mc5.score == 1.0
+
+    def test_reasoning_field_present_in_all_results(self):
+        """Every result must have a non-empty reasoning field (llm-endpoint-hardening rule)."""
+        mock_items = [
+            {"question_id": "mc_1", "student_answer": "A", "correct_answer": "C",
+             "score": 0.0, "ai_confidence": 0.9, "reasoning": "學生圈了A，錯誤"},
+            {"question_id": "fb_1", "student_answer": "寛食", "correct_answer": "覓食",
+             "score": 0.0, "ai_confidence": 0.75, "reasoning": "字跡為寛食，部首錯誤"},
+        ]
+        results = self._patch_and_run(mock_items)
+        for r in results:
+            assert r.reasoning, f"question_id={r.question_id} has empty reasoning"
+
+
+# ---------------------------------------------------------------------------
+# Question schema tests
+# ---------------------------------------------------------------------------
+
+class TestBuildQuestionSchema:
+    def test_vocabulary_letter_resolution(self):
+        """fill_in_blank answer 'B' should resolve to vocabulary[1].word = '覓食'."""
+        from app.services.omo_grader import _build_question_schema
+        questions = _build_question_schema(SAMPLE_LESSON)
+        fb_questions = [q for q in questions if q["type"] == "fill_blank"]
+        assert fb_questions[0]["correct_answer"] == "覓食", (
+            f"fb_1 answer 'B' should resolve to vocabulary[1]='覓食', got {fb_questions[0]['correct_answer']!r}"
+        )
+
+    def test_mc_questions_extracted(self):
+        from app.services.omo_grader import _build_question_schema
+        questions = _build_question_schema(SAMPLE_LESSON)
+        mc_questions = [q for q in questions if q["type"] == "multiple_choice"]
+        assert len(mc_questions) == 5
+        assert mc_questions[0]["correct_answer"] == "C"
+        assert mc_questions[2]["correct_answer"] == "D"
+
+    def test_total_question_count(self):
+        from app.services.omo_grader import _build_question_schema
+        questions = _build_question_schema(SAMPLE_LESSON)
+        assert len(questions) == 15  # 10 fill_blank + 5 MC
+
+
+# ---------------------------------------------------------------------------
+# Real image test (skipped by default, run with: pytest -m real)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.real
+class TestRealImages:
+    """Manual verification with actual student images (requires Vertex AI ADC).
+
+    Run: pytest backend/tests/test_omo_grader_real.py -m real -v
+
+    Expected results based on ground truth (test-report.md):
+    - mc_1 through mc_5: all score=0.0 (student answered A/B/A/A/C, all wrong)
+    - fb_1: score=0.0 (寛食 with red-pen correction)
+    - fb_9: score=0.0 (red-pen crossed out)
+    - fb_10: score=0.0 (red ✗ mark)
+    """
+
+    def test_mc_questions_not_all_perfect(self):
+        import os
+        img_dir = "private/omo-real-samples/2026-05-14/images"
+        # MC questions are on page 5 of PDF1 (135902-p-5.jpg) or nearby
+        # Try pages 5-8 which cover the test section
+        images = []
+        for page in ["5", "6", "7", "8"]:
+            path = os.path.join(img_dir, f"135902-p-{page}.jpg")
+            if os.path.exists(path):
+                with open(path, "rb") as f:
+                    images.append((f.read(), "image/jpeg"))
+
+        if not images:
+            pytest.skip(f"Real images not found at {img_dir}")
+
+        from app.services.omo_grader import grade_worksheet_images
+        import asyncio
+
+        # Load real L24 lesson
+        import yaml
+        lesson_path = "backend/data/lessons/lesson_24.yaml"
+        if not os.path.exists(lesson_path):
+            pytest.skip(f"Lesson YAML not found at {lesson_path}")
+        with open(lesson_path) as f:
+            lesson = yaml.safe_load(f)
+
+        results = asyncio.get_event_loop().run_until_complete(
+            grade_worksheet_images(
+                image_bytes_list=[img for img, _ in images],
+                mime_types=[mime for _, mime in images],
+                lesson=lesson,
+            )
+        )
+
+        mc_results = [r for r in results if r.question_id.startswith("mc_")]
+        assert len(mc_results) > 0, "Should find MC questions in the images"
+
+        # Not all should be 1.0 — ground truth says 5 of 5 are wrong
+        perfect_scores = [r for r in mc_results if r.score == 1.0]
+        assert len(perfect_scores) < len(mc_results), (
+            f"REGRESSION: All {len(mc_results)} MC questions returned score=1.0 (100% false-positive). "
+            "The grader is still copying expected answers instead of reading handwriting.\n"
+            f"Results: {[(r.question_id, r.student_answer, r.correct_answer, r.score) for r in mc_results]}"
+        )


### PR DESCRIPTION
Fixes #1614

## Root Cause

`_build_grading_prompt()` 把 `Expected answer: {correct_answer}` 放在每題 inline，Gemini 沒有「必須讀手寫」的硬性指令，直接抄標準答案填到 `student_answer`。另有 Safety override（line 291）在 `student_answer == correct_answer` 時自動強升 score=1.0，進一步固化了這個問題。

## Changes

**`backend/app/services/omo_grader.py`**
- `_build_grading_prompt()` 重寫：expected answers 移到獨立的「標準答案參考」段落，題目列表不含正確答案
- Prompt 開頭加強制指令：「禁止把標準答案複製到 student_answer 欄位」
- 加紅筆批改處理規則：student_answer 保留原始手寫，score=0.0
- 加空白答案規則：student_answer="" 且 score=0.0
- 移除 Safety override（student_answer==correct_answer → score=1.0），這是加固偽陽性的關鍵

**`backend/tests/test_omo_grader_real.py`** (新增)
- 15 個 unit test（mock Gemini，不打 API）
- 驗證 prompt 結構：expected answer 不在 inline、有紅筆規則、有空白規則
- 驗證 parsing：5 題 MC 全答錯 → score=0.0；紅筆訂正 → score=0.0
- 驗證 Safety override 已移除：student_answer==correct_answer 不再自動 1.0
- `@pytest.mark.real` 測試集可手動 `pytest -m real` 用真實圖片驗

## Test Results

```
15 passed, 1 deselected (real tests skipped) in 0.35s
```

## Before vs After（ground truth：mc_1 學生圈 A，正解 C）

| | Before | After |
|---|---|---|
| student_answer | "C" (抄標準答案) | "A" (讀手寫) |
| score | 1.0 (偽陽性) | 0.0 (正確) |
| reasoning | 「學生答案與標準答案完全一致」 | 「學生圈了A，與正解C不符」 |