### PR TITLE
docs(meeting): update 5/15 agenda with OMO final progress (Fixes #1618)

### DIFF
--- a/docs/meetings/2026-05-15.md
+++ b/docs/meetings/2026-05-15.md
@@ -50,8 +50,16 @@
   - Loading copy / error toasts / 前端 client-side image resize
 - ✅ **品質修正**：confidence < 0.4 candidate 過濾（#1581）、學生答案逐字相同強制 score=1（#1602）、上傳上限 5→20 張（#1606）
 - ✅ **Identify 涵蓋全課程**（#1607）— 對齊 168 課（curriculum catalog + content layer）
+- ✅ **Identify JSON repair + fuzzy title match**（#1611）— 26 個原 fail case 重跑 **26/26 PASS**
+- ✅ **Grader prompt 重寫 — 真實手寫資料 fix**（#1615 round 1 + #1617 round 2）— 真實學生 PDF 從 **14/15 假陽性 → 2/15**，學生手寫真實被讀出（飛翔/構成/被動/熟練/葉片），不再 echo YAML 標準答案
 - ✅ **Test coverage**（#1596）— 3-tier confirm UX contract + render tests
 - ✅ **Docs**（#1589 master docs + #1595 test plan）
+
+### 真實學生 PDF 測試（5/14）
+- ✅ 兩份真實學生學習單 PDF 歸檔 `private/omo-real-samples/2026-05-14/`（gitignored）
+- ✅ Identifier conf=0.99 命中 L24「昆蟲會思考嗎？」
+- ✅ Round 2 grader 讀真實手寫成功（14/15→2/15 false-positive 消除）
+- 🟡 168 全集 identifier 重跑驗證 fuzzy match（pre-fix 73%，預期 post-fix ≥90%）— **跑中**
 
 ### 環境分隔（Phase 1c env hardening）
 - ✅ **Staging ↔ Prod Cloud SQL 拆開**（#1579）— preview/staging 不再共用 prod DB


### PR DESCRIPTION
Fixes #1618

## Summary
- Identify JSON repair + fuzzy title match: 26/26 PASS (#1611)
- Grader round 2: 14→2 false-positives on real student PDF (#1617)
- Real student PDF test results (5/14 session)
- E2E API confirmed working with real handwriting

## Test plan
- [ ] Docs-only change, no code impact
- [ ] CI quick check passes