### PR TITLE
fix(data): align 57 content yml + catalog with 教授 5/1 新版 (Fixes #1620)

### DIFF
--- a/backend/data/curriculum/lessons/G7-L09.yml
+++ b/backend/data/curriculum/lessons/G7-L09.yml
@@ -1,7 +1,7 @@
 lesson_code: G7-L09
 display_order: 88
 original_order: 33
-title: 吐瓦魯：逐漸被淹没的島國
+title: 吐瓦魯：逐漸被淹沒的島國
 grade: 7
 genre: 説明文
 text_type: 單

--- a/backend/data/curriculum/lessons/G9-L05.yml
+++ b/backend/data/curriculum/lessons/G9-L05.yml
@@ -1,7 +1,7 @@
 lesson_code: G9-L05
 display_order: 134
 original_order: 50
-title: ＃MeToo運動與我們的權利
+title: #MeToo運動與我們的權利
 grade: 9
 genre: 說明文
 text_type: 單

--- a/backend/data/curriculum/lessons/文-L01.yml
+++ b/backend/data/curriculum/lessons/文-L01.yml
@@ -1,0 +1,15 @@
+lesson_code: 文-L01
+display_order: 1
+original_order: 1
+title: 假新聞？鞭虎救弟記
+grade: 8
+genre: 說明文
+text_type: 單
+unit_topic: 文言文
+applicable_grade: 7-9
+strategy_id: null
+strategy_name: 數位閱讀與論證方法(提問、合理質疑、找證據、下結論)
+strategy_dependency: null
+strategy_relation: null
+classical_chinese: true
+video_links:

--- a/backend/data/curriculum/lessons/文-L02.yml
+++ b/backend/data/curriculum/lessons/文-L02.yml
@@ -1,0 +1,15 @@
+lesson_code: 文-L02
+display_order: 2
+original_order: 2
+title: 文言文怎麼讀？以鞭虎救弟記為例
+grade: 8
+genre: 說明文
+text_type: 單
+unit_topic: 文言文
+applicable_grade: 7-9
+strategy_id: null
+strategy_name: 以狐假虎威故事示範如何讀懂文言文(找代名詞、猜詞意、全句翻譯、讀出作者意圖)
+strategy_dependency: null
+strategy_relation: null
+classical_chinese: true
+video_links:

--- a/backend/data/curriculum/lessons/文-L03.yml
+++ b/backend/data/curriculum/lessons/文-L03.yml
@@ -1,0 +1,15 @@
+lesson_code: 文-L03
+display_order: 3
+original_order: 3
+title: 不量田
+grade: 8
+genre: 文言文
+text_type: 單
+unit_topic: 文言文
+applicable_grade: 7-9
+strategy_id: null
+strategy_name: 文言文－判讀主語
+strategy_dependency: null
+strategy_relation: null
+classical_chinese: true
+video_links:

--- a/backend/data/curriculum/lessons/文-L04.yml
+++ b/backend/data/curriculum/lessons/文-L04.yml
@@ -1,0 +1,15 @@
+lesson_code: 文-L04
+display_order: 4
+original_order: 4
+title: 陸公買硯
+grade: 8
+genre: 文言文
+text_type: 單
+unit_topic: 文言文
+applicable_grade: 7-9
+strategy_id: null
+strategy_name: 文言文－斷句及判讀主語II
+strategy_dependency: null
+strategy_relation: null
+classical_chinese: true
+video_links:

--- a/backend/data/curriculum/lessons/文-L08.yml
+++ b/backend/data/curriculum/lessons/文-L08.yml
@@ -1,0 +1,15 @@
+lesson_code: 文-L08
+display_order: 8
+original_order: 8
+title: 愛讀書的顧寧人
+grade: 8
+genre: 文言文
+text_type: 單
+unit_topic: 文言文
+applicable_grade: 7-9
+strategy_id: null
+strategy_name: 文言文－一字多義：少
+strategy_dependency: null
+strategy_relation: null
+classical_chinese: true
+video_links:

--- a/backend/data/curriculum/lessons/文-L09.yml
+++ b/backend/data/curriculum/lessons/文-L09.yml
@@ -1,0 +1,15 @@
+lesson_code: 文-L09
+display_order: 9
+original_order: 9
+title: 從天才跌為凡人的神童
+grade: 8
+genre: 文言文
+text_type: 單
+unit_topic: 文言文
+applicable_grade: 7-9
+strategy_id: null
+strategy_name: 文言文－一字多義：聞
+strategy_dependency: null
+strategy_relation: null
+classical_chinese: true
+video_links:

--- a/backend/data/lessons/L01.yml
+++ b/backend/data/lessons/L01.yml
@@ -1,6 +1,6 @@
 lesson_number: 1
 grade: 4
-grade_code: G4-1
+grade_code: G4-L01
 title: 贏得喝采的輸家
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L02.yml
+++ b/backend/data/lessons/L02.yml
@@ -1,6 +1,6 @@
 lesson_number: 2
 grade: 4
-grade_code: G4-2
+grade_code: G4-L02
 title: 十秒的背後
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L03.yml
+++ b/backend/data/lessons/L03.yml
@@ -1,6 +1,6 @@
 lesson_number: 3
 grade: 4
-grade_code: G4-3
+grade_code: G4-L03
 title: 長高的祕密
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L04.yml
+++ b/backend/data/lessons/L04.yml
@@ -1,6 +1,6 @@
 lesson_number: 4
 grade: 4
-grade_code: G4-4
+grade_code: G4-L04
 title: 運動科學
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L05.yml
+++ b/backend/data/lessons/L05.yml
@@ -1,6 +1,6 @@
 lesson_number: 5
 grade: 4
-grade_code: G4-5
+grade_code: G4-L05
 title: 穿越極限的跑者
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L06.yml
+++ b/backend/data/lessons/L06.yml
@@ -1,6 +1,6 @@
 lesson_number: 6
 grade: 4
-grade_code: G4-6
+grade_code: G4-L13
 title: 第一百碗麵
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L07.yml
+++ b/backend/data/lessons/L07.yml
@@ -1,6 +1,6 @@
 lesson_number: 7
-grade: 5
-grade_code: G5-1
+grade: 6
+grade_code: G6-L07
 title: 黑猩猩的守護者
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L08.yml
+++ b/backend/data/lessons/L08.yml
@@ -1,6 +1,6 @@
 lesson_number: 8
 grade: 5
-grade_code: G5-2
+grade_code: G5-L08
 title: 奧運銀牌的自我鍛鍊
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L09.yml
+++ b/backend/data/lessons/L09.yml
@@ -1,7 +1,7 @@
 lesson_number: 9
 grade: 5
-grade_code: G5-3
-title: 周天成的一天-頂尖選手的養成
+grade_code: G5-L09
+title: 周天成的一天──頂尖選手的養成
 genre: 記敘文
 text_type: 單
 reading_strategy: 推論人物特質－由課文句子推論人物特質(給支持理由及勾選特質)

--- a/backend/data/lessons/L10.yml
+++ b/backend/data/lessons/L10.yml
@@ -1,6 +1,6 @@
 lesson_number: 10
 grade: 5
-grade_code: G5-4
+grade_code: G5-L10
 title: 從童工到大學教授之路
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L11.yml
+++ b/backend/data/lessons/L11.yml
@@ -1,7 +1,7 @@
 lesson_number: 11
 grade: 5
-grade_code: G5-5
-title: 拳力出擊-陳念琴
+grade_code: G5-L11
+title: 拳力出擊──陳念琴
 genre: 記敘文
 text_type: 單
 reading_strategy: 推論人物特質－由改寫文章-田鼠阿飛推論人物特質(自行寫支持理由及特質)

--- a/backend/data/lessons/L12.yml
+++ b/backend/data/lessons/L12.yml
@@ -1,6 +1,6 @@
 lesson_number: 12
 grade: 5
-grade_code: G5-6
+grade_code: G5-L22
 title: 我有一個棒球夢
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L13.yml
+++ b/backend/data/lessons/L13.yml
@@ -1,6 +1,6 @@
 lesson_number: 13
 grade: 5
-grade_code: G5-7
+grade_code: G5-L12
 title: 六塊肌六塊雞
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L14.yml
+++ b/backend/data/lessons/L14.yml
@@ -1,6 +1,6 @@
 lesson_number: 14
 grade: 6
-grade_code: G6-1
+grade_code: G6-L01
 title: 運動傷害，怎麼辦
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L15.yml
+++ b/backend/data/lessons/L15.yml
@@ -1,6 +1,6 @@
 lesson_number: 15
 grade: 6
-grade_code: G6-2
+grade_code: G6-L04
 title: 兩千五百歲的酷老師
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L16.yml
+++ b/backend/data/lessons/L16.yml
@@ -1,6 +1,6 @@
 lesson_number: 16
 grade: 6
-grade_code: G6-3
+grade_code: G6-L05
 title: 卡通人氣王票選政見發表會
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L17.yml
+++ b/backend/data/lessons/L17.yml
@@ -1,7 +1,7 @@
 lesson_number: 17
 grade: 6
-grade_code: G6-4
-title: 心理出狀況，是壞事導致的嗎?
+grade_code: G6-L06
+title: 心理出狀況，是壞事導致的嗎？
 genre: 議論文
 text_type: 單
 reading_strategy: 推論段落主旨－由段落大意和關鍵語句推論段落主旨

--- a/backend/data/lessons/L18.yml
+++ b/backend/data/lessons/L18.yml
@@ -1,6 +1,6 @@
 lesson_number: 18
 grade: 6
-grade_code: G6-5
+grade_code: G6-L08
 title: 動物談情說愛的方式
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L19.yml
+++ b/backend/data/lessons/L19.yml
@@ -1,6 +1,6 @@
 lesson_number: 19
 grade: 6
-grade_code: G6-6
+grade_code: G6-L09
 title: 祝你好眠
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L20.yml
+++ b/backend/data/lessons/L20.yml
@@ -1,7 +1,7 @@
 lesson_number: 20
 grade: 6
-grade_code: G6-7
-title: -末日種子庫
+grade_code: G6-L10
+title: 末日種子庫
 genre: 說明文
 text_type: 單
 reading_strategy: 說明文結構(主題描述)－找小主題和細節(明示段落勾選)

--- a/backend/data/lessons/L21.yml
+++ b/backend/data/lessons/L21.yml
@@ -1,6 +1,6 @@
 lesson_number: 21
 grade: 6
-grade_code: G6-8
+grade_code: G6-L13
 title: 森林大軍的守護者
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L22.yml
+++ b/backend/data/lessons/L22.yml
@@ -1,7 +1,7 @@
 lesson_number: 22
 grade: 6
-grade_code: G6-9
-title: -植物獵人
+grade_code: G6-L14
+title: 植物獵人
 genre: 記敘文
 text_type: 單
 reading_strategy: 自我提問－問重要的問題(由文章重點表-記人轉化成重要問題)

--- a/backend/data/lessons/L23.yml
+++ b/backend/data/lessons/L23.yml
@@ -1,6 +1,6 @@
 lesson_number: 23
 grade: 6
-grade_code: G6-10
+grade_code: G6-L15
 title: 小藍鯨之死
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L24.yml
+++ b/backend/data/lessons/L24.yml
@@ -1,6 +1,6 @@
 lesson_number: 24
 grade: 6
-grade_code: G6-11
+grade_code: G6-L03
 title: 昆蟲會思考嗎？
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L25.yml
+++ b/backend/data/lessons/L25.yml
@@ -1,6 +1,6 @@
 lesson_number: 25
 grade: 6
-grade_code: G6-12
+grade_code: G6-L17
 title: 給神明發會診單
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L26.yml
+++ b/backend/data/lessons/L26.yml
@@ -1,6 +1,6 @@
 lesson_number: 26
 grade: 6
-grade_code: G6-13
+grade_code: G6-L16
 title: 奇蹟行動
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L27.yml
+++ b/backend/data/lessons/L27.yml
@@ -1,6 +1,6 @@
 lesson_number: 27
 grade: 6
-grade_code: G6-14
+grade_code: G6-L18
 title: 把手上的餅吃香一點
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L28.yml
+++ b/backend/data/lessons/L28.yml
@@ -1,6 +1,6 @@
 lesson_number: 28
 grade: 6
-grade_code: G6-15
+grade_code: G6-L19
 title: 紅領帶
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L29.yml
+++ b/backend/data/lessons/L29.yml
@@ -1,6 +1,6 @@
 lesson_number: 29
 grade: 7
-grade_code: G7-1
+grade_code: G7-L02
 title: 澳洲奧運金牌的X機密
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L30.yml
+++ b/backend/data/lessons/L30.yml
@@ -1,6 +1,6 @@
 lesson_number: 30
 grade: 7
-grade_code: G7-2
+grade_code: G7-L03
 title: 女性太空人登月
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L31.yml
+++ b/backend/data/lessons/L31.yml
@@ -1,6 +1,6 @@
 lesson_number: 31
 grade: 7
-grade_code: G7-3
+grade_code: G7-L06
 title: 奧運性別平等這條路
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L32.yml
+++ b/backend/data/lessons/L32.yml
@@ -1,6 +1,6 @@
 lesson_number: 32
 grade: 7
-grade_code: G7-4
+grade_code: G7-L08
 title: 科學怪人
 genre: 應用文
 text_type: 單

--- a/backend/data/lessons/L33.yml
+++ b/backend/data/lessons/L33.yml
@@ -1,6 +1,6 @@
 lesson_number: 33
 grade: 7
-grade_code: G7-5
+grade_code: G7-L09
 title: 吐瓦魯：逐漸被淹沒的島國
 genre: 説明文
 text_type: 單

--- a/backend/data/lessons/L34.yml
+++ b/backend/data/lessons/L34.yml
@@ -1,6 +1,6 @@
 lesson_number: 34
 grade: 7
-grade_code: G7-6
+grade_code: G7-L13
 title: 綠色賽事
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L35.yml
+++ b/backend/data/lessons/L35.yml
@@ -1,6 +1,6 @@
 lesson_number: 35
 grade: 7
-grade_code: G7-7
+grade_code: G7-L15
 title: 看到了嗎，然後呢
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L36.yml
+++ b/backend/data/lessons/L36.yml
@@ -1,6 +1,6 @@
 lesson_number: 36
 grade: 7
-grade_code: G7-8
+grade_code: G7-L16
 title: 果醬男孩
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L37.yml
+++ b/backend/data/lessons/L37.yml
@@ -1,6 +1,6 @@
 lesson_number: 37
 grade: 7
-grade_code: G7-9
+grade_code: G7-L17
 title: 用科學方法伸張正義的神探
 genre: 記敘文
 text_type: 單

--- a/backend/data/lessons/L38.yml
+++ b/backend/data/lessons/L38.yml
@@ -1,6 +1,6 @@
 lesson_number: 38
 grade: 7
-grade_code: G7-10
+grade_code: G7-L07
 title: 你看見時代的灰犀牛了嗎談人口負成長
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L39.yml
+++ b/backend/data/lessons/L39.yml
@@ -1,6 +1,6 @@
 lesson_number: 39
 grade: 7
-grade_code: G7-11
+grade_code: G7-L20
 title: 網紅的電子煙實驗：偽科學的陷阱
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L40.yml
+++ b/backend/data/lessons/L40.yml
@@ -1,6 +1,6 @@
 lesson_number: 40
 grade: 7
-grade_code: G7-12
+grade_code: G7-L21
 title: 別上「誘餌式標題」的鉤
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L41.yml
+++ b/backend/data/lessons/L41.yml
@@ -1,6 +1,6 @@
 lesson_number: 41
 grade: 7
-grade_code: G7-13
+grade_code: G7-L22
 title: 信眾與教主
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L42.yml
+++ b/backend/data/lessons/L42.yml
@@ -1,6 +1,6 @@
 lesson_number: 42
 grade: 8
-grade_code: G8-1
+grade_code: 文-L08
 title: 愛讀書的顧寧人
 genre: 文言文
 text_type: 單

--- a/backend/data/lessons/L43.yml
+++ b/backend/data/lessons/L43.yml
@@ -1,6 +1,6 @@
 lesson_number: 43
 grade: 8
-grade_code: G8-2
+grade_code: 文-L09
 title: 從天才跌為凡人的神童
 genre: 文言文
 text_type: 單

--- a/backend/data/lessons/L44.yml
+++ b/backend/data/lessons/L44.yml
@@ -1,6 +1,6 @@
 lesson_number: 44
 grade: 8
-grade_code: G8-3
+grade_code: 文-L01
 title: 假新聞？鞭虎救弟記
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L45.yml
+++ b/backend/data/lessons/L45.yml
@@ -1,6 +1,6 @@
 lesson_number: 45
 grade: 8
-grade_code: G8-4
+grade_code: 文-L02
 title: 文言文怎麼讀？以鞭虎救弟記為例
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L46.yml
+++ b/backend/data/lessons/L46.yml
@@ -1,6 +1,6 @@
 lesson_number: 46
 grade: 8
-grade_code: G8-5
+grade_code: 文-L03
 title: 不量田
 genre: 文言文
 text_type: 單

--- a/backend/data/lessons/L47.yml
+++ b/backend/data/lessons/L47.yml
@@ -1,6 +1,6 @@
 lesson_number: 47
 grade: 8
-grade_code: G8-6
+grade_code: 文-L04
 title: 陸公買硯
 genre: 文言文
 text_type: 單

--- a/backend/data/lessons/L48.yml
+++ b/backend/data/lessons/L48.yml
@@ -1,7 +1,7 @@
 lesson_number: 48
 grade: 9
-grade_code: G9-1
-title: 盡信書不如無書：從一件殺人案@談起
+grade_code: G9-L01
+title: 盡信書不如無書：從一件殺人案談起
 genre: 說明文
 text_type: 單
 reading_strategy: 假新聞訊息真偽思辨(假新聞解釋、背後目的以及如何辨識)

--- a/backend/data/lessons/L49.yml
+++ b/backend/data/lessons/L49.yml
@@ -1,6 +1,6 @@
 lesson_number: 49
 grade: 9
-grade_code: G9-2
+grade_code: G9-L04
 title: 預防近視？多點戶外活動就對了！
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L50.yml
+++ b/backend/data/lessons/L50.yml
@@ -1,6 +1,6 @@
 lesson_number: 50
 grade: 9
-grade_code: G9-3
+grade_code: G9-L05
 title: '#MeToo運動與我們的權利'
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L51.yml
+++ b/backend/data/lessons/L51.yml
@@ -1,6 +1,6 @@
 lesson_number: 51
 grade: 9
-grade_code: G9-4
+grade_code: G9-L06
 title: 靈異與科學
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L52.yml
+++ b/backend/data/lessons/L52.yml
@@ -1,6 +1,6 @@
 lesson_number: 52
 grade: 9
-grade_code: G9-5
+grade_code: G9-L07
 title: 從基因來的特別禮物
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L53.yml
+++ b/backend/data/lessons/L53.yml
@@ -1,6 +1,6 @@
 lesson_number: 53
 grade: 9
-grade_code: G9-6
+grade_code: G9-L08
 title: 臺灣學生的閱讀力：美麗與哀愁
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L54.yml
+++ b/backend/data/lessons/L54.yml
@@ -1,6 +1,6 @@
 lesson_number: 54
 grade: 9
-grade_code: G9-7
+grade_code: G9-L09
 title: 力與美表現的競技體操
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L55.yml
+++ b/backend/data/lessons/L55.yml
@@ -1,6 +1,6 @@
 lesson_number: 55
 grade: 9
-grade_code: G9-8
+grade_code: G9-L10
 title: 高地訓練有助於運動表現嗎？
 genre: 說明文
 text_type: 單

--- a/backend/data/lessons/L56.yml
+++ b/backend/data/lessons/L56.yml
@@ -1,6 +1,6 @@
 lesson_number: 56
 grade: 9
-grade_code: G9-9
+grade_code: G9-L15
 title: 多文本-未解之謎-巨石陣+摩艾石像
 genre: 說明文
 text_type: 多*2

--- a/backend/data/lessons/L58.yml
+++ b/backend/data/lessons/L58.yml
@@ -1,6 +1,6 @@
 lesson_number: 58
 grade: 9
-grade_code: G9-11
+grade_code: G9-L17
 title: 多文本-馬拉松王者+靠跑鞋破紀錄合理嗎+促成更高更快更遠的因素
 genre: 記敘文
 text_type: 多*3


### PR DESCRIPTION
Fixes #1620

## Summary

Aligned all 57 `backend/data/lessons/L*.yml` grade_code fields to the authoritative 教授 5/1 新版 (民國 115/04/15) lesson index. Also created 6 new 文言文 catalog entries and fixed 2 catalog drift issues.

### Changes

**Commit 1 — 57 content yml:**
- 43 lessons: grade_code order reassigned per 5/1 新版 docx index (e.g. L06 G4-6 → G4-L13)
- 7 lessons: format-only upgrade G4-1 → G4-L01 (add L prefix + zero-pad)
- 1 lesson: cross-grade L07 G5-1 → G6-L07, grade 5→6 (黑猩猩的守護者)
- 6 lessons: 文言文 L42-L47 grade_code G8-N → 文-L0N (grade kept as 8)
- 6 titles: 半全形 fix (── for -, ？ for ?, removed leading -)

**Commit 2 — 6 new 文-L* catalog yml:**
- 文-L01 假新聞？鞭虎救弟記
- 文-L02 文言文怎麼讀？以鞭虎救弟記為例
- 文-L03 不量田
- 文-L04 陸公買硯
- 文-L08 愛讀書的顧寧人
- 文-L09 從天才跌為凡人的神童
All: classical_chinese: true, grade: 8, applicable_grade: 7-9

**Commit 3 — Catalog drift:**
- G7-L09.yml: 淹没 → 淹沒
- G9-L05.yml: ＃MeToo → #MeToo

## No code changes

Only `backend/data/` files. Zero backend logic changes.

## Verification

- `git grep 'grade_code: G[0-9]-[0-9]' backend/data/lessons/` → 0 results
- 6 new 文-L* catalog yml confirmed present
- Source: `private/omo-real-samples/2026-05-14/yml-audit-report.md`

## Test plan

- [ ] Backend starts without errors (`/api/health` returns 200)
- [ ] Lesson list API returns lessons with new grade_codes (e.g. G4-L13 for 第一百碗麵)
- [ ] 文言文 lessons (L42-L47) returned with grade_code 文-L0N
- [ ] No orphaned catalog references

🤖 Generated with [Claude Code](https://claude.com/claude-code)