### PR TITLE
feat(curriculum): ingestion parser + drift detector + INGESTION_MANIFEST (Fixes #1624)

### DIFF
--- a/.github/workflows/curriculum-drift-check.yml
+++ b/.github/workflows/curriculum-drift-check.yml
@@ -1,0 +1,73 @@
+name: curriculum-drift-check
+
+# Detects drift between 教授 source (private/curriculum-source/) and
+# backend/data/ parser-managed fields. See docs/curriculum-pipeline.md.
+#
+# Runs:
+#   - Weekly cron (Mondays 09:00 UTC = 17:00 Taipei)
+#   - Manual workflow_dispatch
+#   - PRs touching backend/data/lessons/ or curriculum/lessons/
+#
+# NOTE: This workflow requires private/curriculum-source/ which is gitignored.
+# It will skip gracefully if source is not available in the runner.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'backend/data/lessons/**'
+      - 'backend/data/curriculum/lessons/**'
+      - 'backend/data/curriculum/INGESTION_MANIFEST.yml'
+      - 'scripts/ingest_curriculum.py'
+      - 'scripts/check_curriculum_drift.py'
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install python-docx openpyxl pyyaml
+
+      - name: Check curriculum source availability
+        id: source_check
+        run: |
+          MANIFEST_PATH="backend/data/curriculum/INGESTION_MANIFEST.yml"
+          if [ ! -f "$MANIFEST_PATH" ]; then
+            echo "MANIFEST not found - skipping drift check"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          SOURCE_DIR=$(python -c "import yaml,sys; print(yaml.safe_load(open(sys.argv[1]))['source_dir'])" "$MANIFEST_PATH")
+          if [ ! -d "$SOURCE_DIR" ]; then
+            echo "Source dir not present in runner (private/ is gitignored)"
+            echo "Drift check requires access to teacher source - skipping in CI"
+            echo "Run locally: python scripts/check_curriculum_drift.py"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run drift detector
+        if: steps.source_check.outputs.skip != 'true'
+        run: |
+          python scripts/check_curriculum_drift.py
+
+      - name: Report skipped
+        if: steps.source_check.outputs.skip == 'true'
+        run: |
+          echo "::notice::Drift check skipped - private/curriculum-source/ not available in CI runner. Run locally."

--- a/backend/data/curriculum/INGESTION_MANIFEST.yml
+++ b/backend/data/curriculum/INGESTION_MANIFEST.yml
@@ -1,0 +1,41 @@
+active_version: '2026-05-01'
+source_dir: private/curriculum-source/2026-05-01/1.L1-158新版完成學習單1150415
+source_excel: 自學教材清單.xlsx
+parsed_at: '2026-05-14T16:25:55Z'
+parser_version: 1.0.0
+stats:
+  total_lessons: 157
+  catalog_yml_count: 157
+  content_yml_count: 157
+  docx_matched: 140
+  missing_docx: 17
+  missing_story_text: 0
+  白話: 147
+  文言文: 10
+schema_note: MANIFEST tracks the active 教授 source version. Use scripts/check_curriculum_drift.py to verify backend/data/ matches what parser would generate from this source.
+parser_managed_catalog_fields:
+- lesson_code
+- display_order
+- original_order
+- title
+- grade
+- genre
+- text_type
+- unit_topic
+- applicable_grade
+- strategy_name
+- classical_chinese
+- vocab
+parser_managed_content_fields:
+- lesson_number
+- grade
+- grade_code
+- title
+- genre
+- text_type
+- reading_strategy
+- story_text
+- paragraphs
+- paragraph_count
+- char_count
+- vocab_keywords

--- a/docs/curriculum-pipeline.md
+++ b/docs/curriculum-pipeline.md
@@ -1,0 +1,170 @@
+# Curriculum Ingestion Pipeline
+
+> Auto-sync 教授 source (xlsx + docx) → backend/data/ yml, with drift detection.
+> Issue: #1624
+
+## Goal
+
+Treat curriculum as **data**, not hand-edited yml. Every time 教授 ships a new edition (5/1 v1 → 8/15 v2 → ...):
+
+1. Drop the new source under `private/curriculum-source/{date}/`
+2. Run parser → catalog yml + content yml + INGESTION_MANIFEST refresh
+3. Drift detector enforces the invariant `backend/data/ ≡ parser(source)` for parser-managed fields
+
+Prevents the class of bugs in #1620 / #1621 (manual yml align after edition change).
+
+---
+
+## Source layout (教授 ships)
+
+```
+private/curriculum-source/
+├── 2026-05-01/
+│   └── 1.L1-158新版完成學習單1150415/
+│       ├── 自學教材清單.xlsx                    # master index: 新課次 / 原課次 / 年級 / 課名 / 策略 / 語詞
+│       ├── 1-1教師版(L1~122)/                  # teacher version (has story text in table[0])
+│       │   ├── 4年級/G4-L01贏得喝采的輸家.docx
+│       │   └── ...
+│       ├── 2-1學生版(L1~122)/                  # student worksheet (no story)
+│       │   └── ...
+│       └── 第三階段(L123開始~L157)差學生版/    # phase 3 (student only)
+│           └── ...
+└── 2026-XX-XX/   # next edition
+```
+
+---
+
+## Identity model (important)
+
+| Field | Source | Meaning | Stability |
+|-------|--------|---------|-----------|
+| `lesson_code` | derived | `G{grade}-L{NN}` where NN is **per-grade sequential** in new edition (G4 L01..L27) | Changes between editions |
+| `display_order` | xlsx 新課次 | Global ordering (1..158) | Changes between editions |
+| `original_order` | xlsx 原課次 | Original (pre-5/1) numbering | **Stable across editions** — used as content yml stem |
+| Content yml stem | `L{original_order:02d}` | e.g. `L01.yml`, `L126.yml` | Stable — downstream AI-generated content (story_structure, fill_in_blank, etc.) keyed by this |
+
+**Why two yml namespaces**: `curriculum/lessons/G{grade}-L{NN}.yml` is the catalog (per-edition view); `lessons/L{NN}.yml` is the content (stable identity for AI-generated assets).
+
+---
+
+## Files
+
+| File | Role |
+|------|------|
+| `scripts/ingest_curriculum.py` | Parser: xlsx + docx → yml |
+| `scripts/check_curriculum_drift.py` | Drift detector: re-parse + diff vs backend/data/ |
+| `backend/data/curriculum/INGESTION_MANIFEST.yml` | Active version + parser-managed field list |
+| `.github/workflows/curriculum-drift-check.yml` | Weekly cron + PR gate |
+| `docs/curriculum-pipeline.md` | This doc |
+
+---
+
+## Parser-managed fields
+
+Only these fields are owned by the parser. Drift detector ignores everything else (AI-generated story_structure, hand-curated vocab_bank, fill_in_blank, multiple_choice are **NOT** clobbered).
+
+### Catalog yml (`curriculum/lessons/{code}.yml`)
+- `lesson_code`, `display_order`, `original_order`, `title`, `grade`, `genre`,
+  `text_type`, `unit_topic`, `applicable_grade`, `strategy_name`,
+  `classical_chinese`, `vocab`
+
+### Content yml (`lessons/L{NN}.yml`)
+- `lesson_number`, `grade`, `grade_code`, `title`, `genre`, `text_type`,
+  `reading_strategy`, `story_text`, `paragraphs`, `paragraph_count`,
+  `char_count`, `vocab_keywords`
+
+To change scope, edit `parser_managed_*_fields` in `backend/data/curriculum/INGESTION_MANIFEST.yml`.
+
+---
+
+## SOP: 教授 ships a new edition
+
+1. **Drop source** under `private/curriculum-source/{YYYY-MM-DD}/`. Should contain `自學教材清單.xlsx` + docx dirs (same shape as 5/1).
+
+2. **Dry-run parser** to inspect output:
+   ```bash
+   python scripts/ingest_curriculum.py \
+     --source private/curriculum-source/{YYYY-MM-DD}/... \
+     --target /tmp/curriculum-new/
+   # (no --write = dry-run; just prints stats)
+   ```
+
+3. **Generate to staging-tmp** + diff against current backend/data/:
+   ```bash
+   python scripts/ingest_curriculum.py \
+     --source private/curriculum-source/{YYYY-MM-DD}/... \
+     --target /tmp/curriculum-new/ --write
+
+   diff -r /tmp/curriculum-new/curriculum/lessons backend/data/curriculum/lessons | head -100
+   ```
+
+4. **Review the diff manually**. Expected changes:
+   - New display_order (新課次 changed) → fine, parser is the source of truth
+   - New lesson_code per-grade sequential → fine
+   - story_text changed → fine, teacher edited
+   - vocab list changed → fine
+   - **Unexpected**: AI-generated downstream fields lost → BAD; parser shouldn't touch those, file a bug
+
+5. **Open issue** `feat(curriculum): align with 教授 {date} edition` and let the parser overwrite yml:
+   ```bash
+   python scripts/ingest_curriculum.py \
+     --source private/curriculum-source/{YYYY-MM-DD}/... \
+     --target backend/data/ --write
+   ```
+
+6. **Update INGESTION_MANIFEST**:
+   ```bash
+   # Edit backend/data/curriculum/INGESTION_MANIFEST.yml → bump active_version
+   # (parser auto-writes INGESTION_MANIFEST when --target = backend/data; just verify)
+   ```
+
+7. **Run drift detector** to confirm clean state:
+   ```bash
+   python scripts/check_curriculum_drift.py
+   # Exit 0 = no drift
+   ```
+
+8. **Commit** + PR to staging.
+
+---
+
+## Drift detector
+
+Run anytime to verify backend/data/ matches the active source:
+
+```bash
+python scripts/check_curriculum_drift.py
+```
+
+Exit codes:
+- `0` = no drift (parser-managed fields match exactly)
+- `1` = drift found (report printed)
+- `2` = parser/INGESTION_MANIFEST error
+
+CI runs this weekly + on every PR touching `backend/data/lessons/` or `curriculum/lessons/`.
+
+---
+
+## Anti-patterns
+
+- ❌ Hand-edit `backend/data/lessons/*.yml` parser-managed fields → next drift check will fail
+- ❌ Hand-edit `backend/data/curriculum/lessons/*.yml` catalog → same
+- ❌ Re-run parser without updating `INGESTION_MANIFEST.active_version` → INGESTION_MANIFEST becomes lying record
+- ❌ Touch private/curriculum-source/ source files → 教授 ships read-only; only Young copies new editions in
+- ❌ Add new "parser-managed" field without updating INGESTION_MANIFEST.parser_managed_*_fields
+
+---
+
+## Future iterations
+
+- Phase 3 + classical docx filename matchers (current parser misses ~17 files)
+- AI-generated downstream pipeline (story_structure, fill_in_blank) as separate `enrich_curriculum.py` script with its own INGESTION_MANIFEST
+- Schema validation against `backend/data/schemas/lesson-content-v2.schema.json`
+
+---
+
+## References
+
+- Issue #1624 — parser + INGESTION_MANIFEST + drift detector
+- Issue #1620, #1621 — manual yml align (the bugs this pipeline prevents)
+- `backend/data/schemas/lesson-content-v2.schema.json` — downstream content schema

--- a/scripts/check_curriculum_drift.py
+++ b/scripts/check_curriculum_drift.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Curriculum drift detector — verify backend/data/ matches 教授 source.
+
+Workflow:
+  1. Read backend/data/curriculum/INGESTION_MANIFEST.yml → active_version + source_dir
+  2. Re-run scripts/ingest_curriculum.py to /tmp/curriculum-regenerated/
+  3. Diff /tmp/curriculum-regenerated/ vs backend/data/ (parser-managed fields only)
+  4. Exit 0 if no drift, exit 1 if drift found (prints report)
+
+Used by:
+  - pre-commit hook (block commit if drift)
+  - .github/workflows/curriculum-drift-check.yml (weekly cron)
+  - manual: python scripts/check_curriculum_drift.py
+
+Owner: Young / LingoLeap | Issue: #1624
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("ERROR: pyyaml required\n")
+    sys.exit(2)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BACKEND_DATA = REPO_ROOT / "backend" / "data"
+DEFAULT_MANIFEST = DEFAULT_BACKEND_DATA / "curriculum" / "INGESTION_MANIFEST.yml"
+LEGACY_MANIFEST_NAME = "manifest.yml"  # do not confuse with INGESTION_MANIFEST.yml; legacy is consumed by lesson_loader.py
+DEFAULT_PARSER = REPO_ROOT / "scripts" / "ingest_curriculum.py"
+
+
+def load_yaml(path: Path) -> Any:
+    if not path.exists():
+        return None
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def filter_managed_fields(data: dict, fields: list[str]) -> dict:
+    """Return subset of data keyed by `fields` (parser-managed only)."""
+    if data is None:
+        return {}
+    return {k: data.get(k) for k in fields if k in data}
+
+
+def diff_lesson(generated: dict, existing: dict, managed_fields: list[str]) -> list[str]:
+    """Compare parser-managed fields. Returns list of human-readable diff lines."""
+    diffs: list[str] = []
+    g = filter_managed_fields(generated, managed_fields)
+    e = filter_managed_fields(existing, managed_fields)
+    for k in managed_fields:
+        gv = g.get(k)
+        ev = e.get(k)
+        if gv != ev:
+            gv_repr = str(gv)[:80]
+            ev_repr = str(ev)[:80]
+            diffs.append(f"    {k}: generated={gv_repr!r} != existing={ev_repr!r}")
+    return diffs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Check curriculum drift")
+    ap.add_argument("--backend-data", type=Path, default=DEFAULT_BACKEND_DATA,
+                    help="Path to backend/data/ (default: repo/backend/data)")
+    ap.add_argument("--manifest", type=Path, default=None,
+                    help="Path to INGESTION_MANIFEST.yml (default: <backend-data>/curriculum/INGESTION_MANIFEST.yml)")
+    ap.add_argument("--parser", type=Path, default=DEFAULT_PARSER,
+                    help="Path to ingest_curriculum.py")
+    ap.add_argument("--source", type=Path, default=None,
+                    help="Override source dir (default: read from MANIFEST.source_dir)")
+    ap.add_argument("--keep-regen", action="store_true",
+                    help="Keep regenerated dir for inspection")
+    ap.add_argument("--max-show", type=int, default=20,
+                    help="Max number of drifted lessons to display in detail")
+    args = ap.parse_args()
+
+    backend_data: Path = args.backend_data.resolve()
+    manifest_path: Path = (args.manifest or backend_data / "curriculum" / "INGESTION_MANIFEST.yml").resolve()
+
+    if not manifest_path.exists():
+        sys.stderr.write(f"ERROR: MANIFEST not found: {manifest_path}\n")
+        sys.stderr.write("Hint: run scripts/ingest_curriculum.py --write first.\n")
+        return 2
+
+    manifest = load_yaml(manifest_path)
+    if not manifest:
+        sys.stderr.write(f"ERROR: failed to load MANIFEST: {manifest_path}\n")
+        return 2
+
+    source_dir = args.source or Path(manifest.get("source_dir", ""))
+    if not source_dir.is_absolute():
+        source_dir = REPO_ROOT / source_dir
+    if not source_dir.exists():
+        sys.stderr.write(f"ERROR: source dir not found: {source_dir}\n")
+        sys.stderr.write(f"  (from MANIFEST.source_dir or --source)\n")
+        return 2
+
+    catalog_fields = manifest.get("parser_managed_catalog_fields", [])
+    content_fields = manifest.get("parser_managed_content_fields", [])
+    if not catalog_fields or not content_fields:
+        sys.stderr.write("ERROR: MANIFEST missing parser_managed_*_fields\n")
+        return 2
+
+    print(f"[drift] MANIFEST: {manifest_path}")
+    print(f"[drift] active_version: {manifest.get('active_version')}")
+    print(f"[drift] source: {source_dir}")
+
+    # Step 1: regenerate to tmp
+    regen_dir = Path(tempfile.mkdtemp(prefix="curriculum-regen-"))
+    print(f"[drift] regenerating to: {regen_dir}")
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(args.parser),
+                "--source", str(source_dir),
+                "--target", str(regen_dir),
+                "--write",
+                "--version", manifest.get("active_version", "unknown"),
+            ],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        if result.returncode != 0:
+            sys.stderr.write(f"ERROR: parser failed:\n{result.stderr}\n")
+            return 2
+        print(f"[drift] parser output: {result.stdout.splitlines()[-2] if result.stdout else 'n/a'}")
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("ERROR: parser timeout\n")
+        return 2
+
+    # Step 2: diff
+    drift_count = 0
+    missing_in_existing = 0
+    missing_in_regen = 0
+    all_drift_details: list[str] = []
+
+    # Catalog yml diff
+    regen_catalog_dir = regen_dir / "curriculum" / "lessons"
+    existing_catalog_dir = backend_data / "curriculum" / "lessons"
+
+    for regen_file in sorted(regen_catalog_dir.glob("*.yml")):
+        existing_file = existing_catalog_dir / regen_file.name
+        if not existing_file.exists():
+            missing_in_existing += 1
+            all_drift_details.append(f"  [missing in existing] catalog: {regen_file.name}")
+            drift_count += 1
+            continue
+        regen_data = load_yaml(regen_file)
+        existing_data = load_yaml(existing_file)
+        diffs = diff_lesson(regen_data, existing_data, catalog_fields)
+        if diffs:
+            drift_count += 1
+            all_drift_details.append(f"  [catalog drift] {regen_file.name}:")
+            all_drift_details.extend(diffs)
+
+    # Files in existing but not regenerated
+    for existing_file in sorted(existing_catalog_dir.glob("*.yml")):
+        regen_file = regen_catalog_dir / existing_file.name
+        if not regen_file.exists():
+            missing_in_regen += 1
+            all_drift_details.append(f"  [missing in regen] catalog: {existing_file.name}")
+
+    # Content yml diff (parser-managed fields only — story_text/paragraphs etc.)
+    regen_content_dir = regen_dir / "lessons"
+    existing_content_dir = backend_data / "lessons"
+
+    for regen_file in sorted(regen_content_dir.glob("*.yml")):
+        existing_file = existing_content_dir / regen_file.name
+        if not existing_file.exists():
+            all_drift_details.append(f"  [missing in existing] content: {regen_file.name}")
+            drift_count += 1
+            continue
+        regen_data = load_yaml(regen_file)
+        existing_data = load_yaml(existing_file)
+        diffs = diff_lesson(regen_data, existing_data, content_fields)
+        if diffs:
+            drift_count += 1
+            all_drift_details.append(f"  [content drift] {regen_file.name}:")
+            all_drift_details.extend(diffs)
+
+    # Print summary
+    print(f"\n[drift] === REPORT ===")
+    print(f"[drift] drifted lessons: {drift_count}")
+    print(f"[drift] missing in existing (regen has, existing doesn't): {missing_in_existing}")
+    print(f"[drift] missing in regen (existing has, regen doesn't): {missing_in_regen}")
+
+    if all_drift_details:
+        print(f"\n[drift] details (showing up to {args.max_show * 2} lines):")
+        for line in all_drift_details[: args.max_show * 2]:
+            print(line)
+        if len(all_drift_details) > args.max_show * 2:
+            print(f"  ... and {len(all_drift_details) - args.max_show * 2} more lines")
+
+    # Cleanup
+    if not args.keep_regen:
+        shutil.rmtree(regen_dir, ignore_errors=True)
+    else:
+        print(f"\n[drift] kept regen dir: {regen_dir}")
+
+    if drift_count > 0 or missing_in_regen > 0:
+        print(f"\n[drift] FAIL: drift detected")
+        return 1
+    else:
+        print(f"\n[drift] PASS: no drift")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest_curriculum.py
+++ b/scripts/ingest_curriculum.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""
+Curriculum ingestion parser — auto-sync from 教授 source to backend/data/.
+
+Reads:
+  - <source>/自學教材清單.xlsx (master index, sheet 總表 + 文言文)
+  - <source>/1-1教師版(L1~122)/{grade}/G{grade}-L{NN}*.docx (teacher version)
+  - <source>/2-1學生版(L1~122)/{grade}/G{grade}-SL{NN}*.docx (student version)
+  - <source>/第三階段(L123開始~L157)差學生版/G{grade}-L{NN}*.docx (phase 3)
+
+Writes (to --target):
+  - curriculum/lessons/G{grade}-L{NN}.yml  (catalog metadata, per-grade NN)
+  - lessons/L{original_order}.yml          (content yml, keyed by 原課次)
+  - curriculum/MANIFEST.yml                (active_version + provenance)
+
+Identity model (important!):
+  - lesson_code = G{grade}-L{NN} where NN is per-grade sequential (new edition)
+  - display_order = global 新課次 (1..158)
+  - original_order = 原課次 from xlsx (used as content yml stem)
+  - Content yml stems (L01..L158) are STABLE across editions — downstream
+    AI-generated fields (story_structure, fill_in_blank, etc.) keyed by these stems
+
+Parser writes catalog yml in full + content yml minimal subset
+(lesson_number, grade, grade_code, title, story_text, paragraphs, vocab).
+Downstream AI-generated fields are NOT clobbered (drift detector compares
+parser-managed subset only).
+
+Usage:
+  python scripts/ingest_curriculum.py \\
+    --source private/curriculum-source/2026-05-01/1.L1-158新版完成學習單1150415/ \\
+    --target /tmp/parsed-from-source/ --write
+
+Owner: Young / LingoLeap | Issue: #1624
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import signal
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from docx import Document
+except ImportError:
+    sys.stderr.write("ERROR: python-docx required. pip install python-docx\n")
+    sys.exit(2)
+
+try:
+    import openpyxl
+except ImportError:
+    sys.stderr.write("ERROR: openpyxl required. pip install openpyxl\n")
+    sys.exit(2)
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("ERROR: pyyaml required. pip install pyyaml\n")
+    sys.exit(2)
+
+
+# ----------------------------------------------------------------------
+# Constants
+# ----------------------------------------------------------------------
+
+DOCX_PARSE_TIMEOUT_SECONDS = 60
+PARSER_VERSION = "1.0.0"
+EXCEL_DATE_BASE = dt.datetime(2025, 4, 1)
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _parse_grade(val: Any) -> int | str | None:
+    if val is None or val == "無" or val == "":
+        return None
+    if isinstance(val, (int, float)):
+        return int(val)
+    s = str(val).strip()
+    if s.isdigit():
+        return int(s)
+    return None
+
+
+def _normalize_str(val: Any) -> str:
+    if val is None:
+        return ""
+    return str(val).strip()
+
+
+def _decode_new_order(raw: Any) -> int | None:
+    """Excel auto-converted 新課次 1 → 2025-04-01. Reverse it."""
+    if raw is None:
+        return None
+    if isinstance(raw, dt.datetime):
+        return (raw - EXCEL_DATE_BASE).days + 1
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    s = _normalize_str(raw)
+    if s.isdigit():
+        return int(s)
+    return None
+
+
+def _lesson_code(grade: Any, per_grade_seq: int) -> str:
+    if isinstance(grade, int):
+        return f"G{grade}-L{per_grade_seq:02d}"
+    return f"文-L{per_grade_seq:02d}"
+
+
+def _content_yml_stem(original_order: int) -> str:
+    if original_order is None:
+        return None
+    return f"L{original_order:02d}" if original_order < 100 else f"L{original_order}"
+
+
+# ----------------------------------------------------------------------
+# Step A: parse master xlsx
+# ----------------------------------------------------------------------
+
+
+def parse_master_xlsx(xlsx_path: Path) -> list[dict]:
+    """Parse 自學教材清單.xlsx → list of lesson records (ordered by new_order).
+
+    Returns records with: new_order, original_order, grade (int|'文'),
+    title, genre, text_type, unit_topic, applicable_grade, strategy_name,
+    vocab[], classical_chinese, per_grade_seq.
+    """
+    wb = openpyxl.load_workbook(xlsx_path, read_only=True, data_only=True)
+    lessons: list[dict] = []
+
+    # --- 總表 sheet (白話) ---
+    ws = wb["總表"]
+    header = [_normalize_str(c) for c in next(ws.iter_rows(min_row=1, max_row=1, values_only=True))]
+    vocab_col_idx = [i for i, h in enumerate(header) if h.startswith("語詞")]
+
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        if not row or row[0] is None:
+            continue
+        new_order = _decode_new_order(row[0])
+        if new_order is None:
+            continue
+
+        try:
+            original_order = int(row[1]) if row[1] is not None else None
+        except (ValueError, TypeError):
+            original_order = None
+
+        grade = _parse_grade(row[2])
+        title = _normalize_str(row[3])
+        if not title or grade is None:
+            continue
+
+        genre = _normalize_str(row[4])
+        strategy_name = _normalize_str(row[6]) or "無"
+        unit_topic = _normalize_str(row[8]) or None
+        text_type = _normalize_str(row[10])
+
+        vocab = []
+        for vi in vocab_col_idx:
+            if vi < len(row) and row[vi]:
+                v = _normalize_str(row[vi])
+                if v and v != "無":
+                    vocab.append(v)
+
+        lessons.append(
+            {
+                "new_order": new_order,
+                "original_order": original_order,
+                "grade": grade,
+                "title": title,
+                "genre": genre,
+                "text_type": text_type,
+                "unit_topic": unit_topic,
+                "applicable_grade": None,
+                "strategy_name": strategy_name,
+                "vocab": vocab,
+                "classical_chinese": False,
+            }
+        )
+
+    # --- 文言文 sheet ---
+    if "文言文" in wb.sheetnames:
+        ws = wb["文言文"]
+        header = [_normalize_str(c) for c in next(ws.iter_rows(min_row=1, max_row=1, values_only=True))]
+        vocab_col_idx = [i for i, h in enumerate(header) if h.startswith("語詞")]
+
+        for row in ws.iter_rows(min_row=2, values_only=True):
+            if not row or row[0] is None:
+                continue
+            try:
+                new_order = int(row[0])
+            except (ValueError, TypeError):
+                continue
+            try:
+                original_order = int(row[1]) if row[1] is not None else None
+            except (ValueError, TypeError):
+                original_order = None
+
+            applicable_grade = _normalize_str(row[2]) or None
+            title = _normalize_str(row[3])
+            if not title:
+                continue
+            genre = _normalize_str(row[4])
+            unit_topic = _normalize_str(row[6]) or None
+            strategy_name = _normalize_str(row[8]) or "無"
+            text_type = _normalize_str(row[10])
+
+            vocab = []
+            for vi in vocab_col_idx:
+                if vi < len(row) and row[vi]:
+                    v = _normalize_str(row[vi])
+                    if v and v != "無":
+                        vocab.append(v)
+
+            lessons.append(
+                {
+                    "new_order": new_order,
+                    "original_order": original_order,
+                    "grade": "文",
+                    "title": title,
+                    "genre": genre,
+                    "text_type": text_type,
+                    "unit_topic": unit_topic,
+                    "applicable_grade": applicable_grade,
+                    "strategy_name": strategy_name,
+                    "vocab": vocab,
+                    "classical_chinese": True,
+                }
+            )
+
+    wb.close()
+    lessons.sort(key=lambda x: x["new_order"])
+
+    # Compute per-grade sequential (G4 L01, L02, ... independently per grade)
+    per_grade_counter: dict[Any, int] = {}
+    for L in lessons:
+        g = L["grade"]
+        per_grade_counter[g] = per_grade_counter.get(g, 0) + 1
+        L["per_grade_seq"] = per_grade_counter[g]
+
+    return lessons
+
+
+# ----------------------------------------------------------------------
+# Step B + C: scan docx + extract story_text
+# ----------------------------------------------------------------------
+
+
+def scan_docx_files(source_root: Path) -> dict[str, dict[str, Path]]:
+    """Build map: lesson_code (e.g. 'G4-L17') → {teacher: Path, student: Path}."""
+    teacher_dir = source_root / "1-1教師版(L1~122)"
+    student_dir = source_root / "2-1學生版(L1~122)"
+    phase3_dir = source_root / "第三階段(L123開始~L157)差學生版"
+    classical_dir_marker = "文言文"  # subdir in both teacher/student
+
+    found: dict[str, dict[str, Path]] = {}
+
+    def _scan(root: Path, role: str) -> None:
+        if not root.exists():
+            return
+        for docx in root.rglob("*.docx"):
+            if docx.name.startswith("~$"):
+                continue
+            # Match G{grade}-L{NN} or G{grade}-SL{NN} (also G{grade}-L{NN}-{MM} for multi-lesson)
+            m = re.match(r"G(\d+)-S?L(\d+)(?:-\d+)?", docx.name)
+            if m:
+                grade_num = int(m.group(1))
+                lesson_num = int(m.group(2))
+                code = f"G{grade_num}-L{lesson_num:02d}"
+            else:
+                # Classical: filenames like "1假新聞？鞭虎救弟記.docx" or similar
+                m2 = re.match(r"(\d+)", docx.name)
+                if not m2:
+                    continue
+                # Use per-grade-seq from classical dir
+                if classical_dir_marker not in str(docx):
+                    continue
+                lesson_num = int(m2.group(1))
+                code = f"文-L{lesson_num:02d}"
+            found.setdefault(code, {})[role] = docx
+
+    _scan(teacher_dir, "teacher")
+    _scan(student_dir, "student")
+    _scan(phase3_dir, "student")
+    return found
+
+
+def _docx_timeout_handler(signum, frame):
+    raise TimeoutError("docx parsing timeout")
+
+
+def extract_story_from_docx(docx_path: Path) -> tuple[str, list[str]]:
+    """Extract story_text from a teacher docx.
+
+    Strategy: scan tables for the largest text cell > 100 chars (heuristic
+    verified on G4-L1 sample — story in table[0][2,1]).
+    """
+    signal.signal(signal.SIGALRM, _docx_timeout_handler)
+    signal.alarm(DOCX_PARSE_TIMEOUT_SECONDS)
+    try:
+        doc = Document(docx_path)
+        candidate: tuple[int, str] = (0, "")
+        for table in doc.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    text = cell.text.strip()
+                    # Skip obvious non-story cells
+                    if len(text) > candidate[0] and not _looks_like_metadata(text):
+                        candidate = (len(text), text)
+
+        if candidate[0] < 100:
+            return "", []
+
+        story = candidate[1]
+        chunks = re.split(r"\n\s*\n|\n(?=　)", story)
+        paragraphs = [c.strip() for c in chunks if c.strip()]
+        full_text = "\n".join(paragraphs)
+        return full_text, paragraphs
+    except TimeoutError:
+        sys.stderr.write(f"WARN: timeout parsing {docx_path.name} — skipped\n")
+        return "", []
+    except Exception as e:
+        sys.stderr.write(f"WARN: failed to parse {docx_path.name}: {e}\n")
+        return "", []
+    finally:
+        signal.alarm(0)
+
+
+def _looks_like_metadata(text: str) -> bool:
+    """Filter out non-story cells (vocab banks, video lists, instructions)."""
+    head = text[:30]
+    for marker in ("第", "計時", "影片", "請", "□", "◎", "A.", "B.", "C.", "D.", "E.", "F.", "G.", "H."):
+        if head.startswith(marker):
+            return True
+    return False
+
+
+# ----------------------------------------------------------------------
+# Step D + E: render yml
+# ----------------------------------------------------------------------
+
+
+def render_catalog_yml(lesson: dict) -> dict:
+    code = _lesson_code(lesson["grade"], lesson["per_grade_seq"])
+    grade_field = lesson["grade"] if isinstance(lesson["grade"], int) else None
+    content_stem = _content_yml_stem(lesson["original_order"])
+    return {
+        "lesson_code": code,
+        "display_order": lesson["new_order"],
+        "original_order": lesson["original_order"],
+        "title": lesson["title"],
+        "grade": grade_field,
+        "genre": lesson["genre"],
+        "text_type": lesson["text_type"],
+        "unit_topic": lesson["unit_topic"],
+        "applicable_grade": lesson.get("applicable_grade"),
+        "strategy_id": None,
+        "strategy_name": lesson["strategy_name"],
+        "strategy_dependency": None,
+        "strategy_relation": None,
+        "classical_chinese": lesson["classical_chinese"],
+        "video_links": [],
+        "vocab": lesson["vocab"],
+        "existing_content_yaml": f"{content_stem}.yml" if content_stem else None,
+        "notes": None,
+    }
+
+
+def render_content_yml_minimal(lesson: dict, story_text: str, paragraphs: list[str]) -> dict:
+    """Minimal content yml — only parser-managed fields.
+
+    Drift detector compares ONLY these fields. Downstream-managed fields
+    (vocabulary, vocab_bank, fill_in_blank, multiple_choice, story_structure, etc.)
+    are NOT touched.
+    """
+    grade_field = lesson["grade"] if isinstance(lesson["grade"], int) else None
+    code = _lesson_code(lesson["grade"], lesson["per_grade_seq"])
+    return {
+        "lesson_number": lesson["original_order"],
+        "grade": grade_field,
+        "grade_code": code,
+        "title": lesson["title"],
+        "genre": lesson["genre"],
+        "text_type": lesson["text_type"],
+        "reading_strategy": lesson["strategy_name"],
+        "story_text": story_text,
+        "paragraphs": paragraphs,
+        "paragraph_count": len(paragraphs),
+        "char_count": len(story_text),
+        "vocab_keywords": lesson["vocab"],
+    }
+
+
+# ----------------------------------------------------------------------
+# Step F: MANIFEST
+# ----------------------------------------------------------------------
+
+
+def write_manifest(target_root: Path, source_root: Path, version: str, stats: dict) -> Path:
+    # Use INGESTION_MANIFEST.yml to avoid case-collision with existing manifest.yml
+    # (macOS is case-insensitive — the legacy manifest.yml is loaded by lesson_loader.py)
+    manifest_path = target_root / "curriculum" / "INGESTION_MANIFEST.yml"
+    try:
+        rel_source = str(source_root.relative_to(Path.cwd()))
+    except ValueError:
+        rel_source = str(source_root)
+    manifest = {
+        "active_version": version,
+        "source_dir": rel_source,
+        "source_excel": "自學教材清單.xlsx",
+        "parsed_at": dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "parser_version": PARSER_VERSION,
+        "stats": stats,
+        "schema_note": (
+            "MANIFEST tracks the active 教授 source version. "
+            "Use scripts/check_curriculum_drift.py to verify backend/data/ "
+            "matches what parser would generate from this source."
+        ),
+        "parser_managed_catalog_fields": [
+            "lesson_code", "display_order", "original_order", "title", "grade",
+            "genre", "text_type", "unit_topic", "applicable_grade",
+            "strategy_name", "classical_chinese", "vocab",
+        ],
+        "parser_managed_content_fields": [
+            "lesson_number", "grade", "grade_code", "title", "genre", "text_type",
+            "reading_strategy", "story_text", "paragraphs", "paragraph_count",
+            "char_count", "vocab_keywords",
+        ],
+    }
+    return _write_yaml(manifest_path, manifest)
+
+
+def _write_yaml(path: Path, data: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False, width=10000)
+    return path
+
+
+# ----------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Ingest curriculum source → backend/data yml")
+    ap.add_argument("--source", required=True, type=Path,
+                    help="教授 source root (contains 自學教材清單.xlsx)")
+    ap.add_argument("--target", required=True, type=Path,
+                    help="Output root (writes curriculum/lessons/ + lessons/ + curriculum/MANIFEST.yml)")
+    ap.add_argument("--version", default=None,
+                    help="Version label (default: auto-detect from source parent dir)")
+    ap.add_argument("--write", action="store_true",
+                    help="Actually write files (default: dry-run, no write)")
+    ap.add_argument("--limit", type=int, default=None,
+                    help="Limit to first N lessons (for testing)")
+    args = ap.parse_args()
+
+    source_root: Path = args.source.resolve()
+    target_root: Path = args.target.resolve()
+
+    if not source_root.exists():
+        sys.stderr.write(f"ERROR: source not found: {source_root}\n")
+        return 2
+
+    xlsx = source_root / "自學教材清單.xlsx"
+    if not xlsx.exists():
+        sys.stderr.write(f"ERROR: master xlsx not found: {xlsx}\n")
+        return 2
+
+    version = args.version or _infer_version(source_root)
+    print(f"[ingest] source: {source_root}", flush=True)
+    print(f"[ingest] target: {target_root} ({'WRITE' if args.write else 'DRY-RUN'})", flush=True)
+    print(f"[ingest] version: {version}", flush=True)
+
+    print(f"[ingest] Step A: parsing master xlsx...", flush=True)
+    lessons = parse_master_xlsx(xlsx)
+    print(f"[ingest]   loaded {len(lessons)} lesson records", flush=True)
+
+    print(f"[ingest] Step B: scanning docx files...", flush=True)
+    docx_map = scan_docx_files(source_root)
+    print(f"[ingest]   found docx for {len(docx_map)} lesson codes", flush=True)
+
+    print(f"[ingest] Step C-E: extracting stories + rendering yml...", flush=True)
+    catalog_written = 0
+    content_written = 0
+    missing_story = 0
+    missing_docx = 0
+    matched_docx = 0
+
+    iter_lessons = lessons[: args.limit] if args.limit else lessons
+
+    for i, lesson in enumerate(iter_lessons, 1):
+        if i % 25 == 0:
+            print(f"[ingest]   progress: {i}/{len(iter_lessons)}", flush=True)
+
+        code = _lesson_code(lesson["grade"], lesson["per_grade_seq"])
+        docx_paths = docx_map.get(code, {})
+        teacher_docx = docx_paths.get("teacher")
+        student_docx = docx_paths.get("student")
+
+        story_text = ""
+        paragraphs: list[str] = []
+        if teacher_docx and teacher_docx.exists():
+            story_text, paragraphs = extract_story_from_docx(teacher_docx)
+            matched_docx += 1
+        elif student_docx and student_docx.exists():
+            story_text, paragraphs = extract_story_from_docx(student_docx)
+            matched_docx += 1
+        else:
+            missing_docx += 1
+
+        if docx_paths and not story_text:
+            missing_story += 1
+
+        catalog = render_catalog_yml(lesson)
+        content = render_content_yml_minimal(lesson, story_text, paragraphs)
+
+        content_stem = _content_yml_stem(lesson["original_order"])
+        catalog_path = target_root / "curriculum" / "lessons" / f"{code}.yml"
+        content_path = target_root / "lessons" / f"{content_stem}.yml" if content_stem else None
+
+        if args.write:
+            _write_yaml(catalog_path, catalog)
+            if content_path:
+                _write_yaml(content_path, content)
+        catalog_written += 1
+        if content_path:
+            content_written += 1
+
+    stats = {
+        "total_lessons": len(iter_lessons),
+        "catalog_yml_count": catalog_written,
+        "content_yml_count": content_written,
+        "docx_matched": matched_docx,
+        "missing_docx": missing_docx,
+        "missing_story_text": missing_story,
+        "白話": sum(1 for L in iter_lessons if not L["classical_chinese"]),
+        "文言文": sum(1 for L in iter_lessons if L["classical_chinese"]),
+    }
+    if args.write:
+        manifest_path = write_manifest(target_root, source_root, version, stats)
+        print(f"[ingest] wrote MANIFEST: {manifest_path}", flush=True)
+
+    print(f"\n[ingest] DONE", flush=True)
+    print(f"[ingest] stats: {json.dumps(stats, ensure_ascii=False)}", flush=True)
+    if not args.write:
+        print(f"[ingest] (dry-run — no files written; pass --write to commit)", flush=True)
+    return 0
+
+
+def _infer_version(source_root: Path) -> str:
+    for part in reversed(source_root.parts):
+        m = re.match(r"^(\d{4}-\d{2}-\d{2})$", part)
+        if m:
+            return m.group(1)
+    return dt.date.today().strftime("%Y-%m-%d")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Parser** (`scripts/ingest_curriculum.py`): reads 教授 source (`自學教材清單.xlsx` + docx) → generates catalog yml (`G{grade}-L{NN}.yml`) + content yml (`L{NN}.yml`) + INGESTION_MANIFEST.
- **Drift detector** (`scripts/check_curriculum_drift.py`): re-runs parser to /tmp/ and diffs vs `backend/data/` parser-managed fields. Exit 1 if drift.
- **INGESTION_MANIFEST.yml** at `backend/data/curriculum/`: tracks `active_version: 2026-05-01` + source dir + parser-managed field allowlist. **Named to avoid case-collision with legacy `manifest.yml`** (loaded by `lesson_loader.py`).
- **Docs** (`docs/curriculum-pipeline.md`): SOP for next 教授 edition + identity model (display_order vs original_order vs lesson_code).
- **CI workflow** (`.github/workflows/curriculum-drift-check.yml`): weekly cron + PR gate; skips gracefully if `private/curriculum-source/` not in runner.

## Why this PR

14 days, 4 manual-align PRs (#1620 / #1621 / #1622 / #1623) to re-sync yml every time 教授 ships a new edition. This PR introduces curriculum-as-data tooling so the next edition is a one-shot regenerate + drift check.

## Dry-run on 5/1 source

```
total_lessons: 157
catalog_yml_count: 157
content_yml_count: 157
docx_matched: 140
missing_docx: 17  (phase 3 + classical naming variations)
missing_story_text: 0
白話: 147 / 文言文: 10
```

Drift detector flagged 283 lessons drifted between parser output and current `backend/data/` — **informational baseline, not regressions**. Surfaces real schema inconsistencies (e.g. `applicable_grade` field in staging yml carries strategy names instead of grade hints, `display_order` off-by-3 for G5+). Future PRs can use this to drive cleanup.

## Scope

- ✅ Added: 5 new files (scripts + manifest + docs + workflow)
- ❌ **NOT touched**: any yml in `backend/data/lessons/` or `backend/data/curriculum/lessons/` (left for #1620/#1621/#1622/#1623 to handle; this PR is tooling-only)
- ❌ **NOT touched**: backend code (lesson_loader.py, omo_*.py), legacy `manifest.yml`

## Test plan

- [x] Parser runs end-to-end on 5/1 source (157 lessons in ~60s)
- [x] Drift detector exits 1 when drift exists, prints report
- [x] INGESTION_MANIFEST.yml schema validates (parser_managed_*_fields lists)
- [x] Legacy `manifest.yml` untouched (verified `git status` + lesson_loader.py path unchanged)
- [ ] CI workflow runs on PR (will see when GH Actions kicks in)
- [ ] Local: `python scripts/check_curriculum_drift.py` → prints baseline drift report

## Next steps (out of scope, future PRs)

1. Decide on parser semantics for `applicable_grade` (read from xlsx 適用年級 vs use strategy_name as historical fallback)
2. Investigate G5+ `display_order` off-by-3 (parser counts 157 lessons globally; staging yml may have used different sequencing)
3. Phase 3 + classical docx filename matchers (currently 17/157 unmatched)
4. Eventually: bump MANIFEST.parser_managed_*_fields to cover more yml fields once drift is reconciled

🤖 Generated with [Claude Code](https://claude.com/claude-code)