### PR TITLE
fix(intern-training): cache-bust JSON fetch in dashboard.html (Fixes #1626)

### DIFF
--- a/frontend/public/intern-training/dashboard.html
+++ b/frontend/public/intern-training/dashboard.html
@@ -1507,7 +1507,7 @@ async function loadInternData(internKey) {
   }
   // Then try fetch for latest data (overrides fallback if successful)
   try {
-    const res = await fetch(intern.jsonFile);
+    const res = await fetch(intern.jsonFile + '?t=' + Date.now(), {cache: 'no-store'});
     if (!res.ok) throw new Error('fetch failed');
     const data = await res.json();
     intern.skills = data.skills || intern.skills;


### PR DESCRIPTION
Fixes #1626

## Summary
- `dashboard.html` line 1510: add `?t=Date.now()` + `{cache: 'no-store'}` to `fetch(intern.jsonFile)` so browser never serves stale JSON after intern data updates.

## Test plan
- Open `/intern-training/dashboard.html` on PR Preview
- Update a JSON file; reload page without hard-refresh → should show new data