### PR TITLE
fix(intern-training): dashboard timeline renders dynamically from JSON, sorted desc (Fixes #1630)

### DIFF
--- a/frontend/public/intern-training/dashboard.html
+++ b/frontend/public/intern-training/dashboard.html
@@ -1628,7 +1628,10 @@ function renderTimelineStats() {
 
 function renderTimeline() {
   const container = document.getElementById('timeline-container');
-  const issues = INTERNS[currentIntern].issues || [];
+  // Sort by date descending so latest contributions appear first
+  const issues = [...(INTERNS[currentIntern].issues || [])].sort((a, b) =>
+    (b.date || '').localeCompare(a.date || '')
+  );
 
   if (issues.length === 0) {
     container.innerHTML = '<div class="t-milestone"><div class="t-milestone-icon">\u{1F331}</div><div class="t-milestone-text">尚未有貢獻記錄...</div></div>';

--- a/frontend/public/intern-training/dashboard.html
+++ b/frontend/public/intern-training/dashboard.html
@@ -1491,6 +1491,68 @@ function isAvailable(skill) {
 // DATA LOADING
 // =============================================
 
+/**
+ * Build timeline entries dynamically from skills[*].history in JSON.
+ * Groups entries by PR number (extracted from reason "PR #XXXX ...").
+ * Falls back to ISSUE_DATA hardcoded entries for any date not covered.
+ */
+function buildTimelineFromHistory(skills, fallbackIssues) {
+  // Extract PR-keyed entries from all skill history
+  const prMap = {};  // key: PR id string → {id, date, title, type, contribution, skillsLearned, highlights}
+
+  for (const [skillId, skillData] of Object.entries(skills || {})) {
+    for (const h of (skillData.history || [])) {
+      const reason = h.reason || '';
+      const dateStr = h.date || '';
+
+      // Extract PR number: "PR #1234" or "PR #1234/#5678" or fallback to date bucket
+      const prMatch = reason.match(/PR #(\d+(?:\/\d+)*)/);
+      const key = prMatch ? prMatch[0] : ('date:' + dateStr);
+
+      if (!prMap[key]) {
+        // Infer type from conventional commit prefix in reason
+        let type = 'feature';
+        if (/fix\(|^修復|^修正|bug fix|regression/i.test(reason)) type = 'bugfix';
+        else if (/refactor\(|^重構/i.test(reason)) type = 'refactor';
+        else if (/^環境|setup|fork|clone/i.test(reason)) type = 'setup';
+
+        prMap[key] = {
+          id: prMatch ? prMatch[0].replace('PR ', '') : key,
+          date: dateStr,
+          title: reason.split('：')[0].split(':')[0].slice(0, 60) || key,
+          type,
+          contribution: reason.slice(0, 120),
+          skillsLearned: [],
+          highlights: []
+        };
+      }
+
+      // Merge: use earliest date as canonical, collect skills, keep longest contribution
+      if (dateStr < prMap[key].date || !prMap[key].date) prMap[key].date = dateStr;
+      if (dateStr > prMap[key].date) {
+        // keep the entry date as the most recent activity for this PR
+        prMap[key].date = dateStr;
+      }
+      if (reason.length > prMap[key].contribution.length) {
+        prMap[key].contribution = reason.slice(0, 200);
+      }
+      const sid = parseInt(skillId, 10);
+      if (!isNaN(sid) && !prMap[key].skillsLearned.includes(sid)) {
+        prMap[key].skillsLearned.push(sid);
+      }
+    }
+  }
+
+  // Merge with fallback ISSUE_DATA: use fallback entries for dates not covered by history
+  const historyDates = new Set(Object.values(prMap).map(e => e.date));
+  const fallback = (fallbackIssues || []).filter(i => !historyDates.has(i.date));
+
+  const merged = [...Object.values(prMap), ...fallback];
+  // Sort descending by date
+  merged.sort((a, b) => (b.date || '').localeCompare(a.date || ''));
+  return merged;
+}
+
 async function loadInternData(internKey) {
   const intern = INTERNS[internKey];
   // Always load hardcoded issue data first (works on file:// too)
@@ -1511,11 +1573,13 @@ async function loadInternData(internKey) {
     if (!res.ok) throw new Error('fetch failed');
     const data = await res.json();
     intern.skills = data.skills || intern.skills;
-    intern.issues = data.issues || intern.issues;
     intern.lastReview = data.lastReview || intern.lastReview;
     intern.recommendations = data.recommendations || intern.recommendations;
+    // Build timeline dynamically from skills[*].history (ignores stale data.issues)
+    intern.issues = buildTimelineFromHistory(intern.skills, ISSUE_DATA[internKey]);
   } catch {
     // fetch failed (e.g. file:// protocol) — fallback data already loaded above
+    // Keep intern.issues from ISSUE_DATA hardcoded (set above)
   }
 }
 

--- a/frontend/public/intern-training/interns/raymond.json
+++ b/frontend/public/intern-training/interns/raymond.json
@@ -3,7 +3,7 @@
   "github": "if-else-master",
   "email": "78069313+if-else-master@users.noreply.github.com",
   "startDate": "2026-03-02",
-  "lastReview": "2026-05-14",
+  "lastReview": "2026-05-08",
   "skills": {
     "1": {
       "level": 3,
@@ -163,7 +163,7 @@
       ]
     },
     "8": {
-      "level": 3,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
@@ -175,6 +175,11 @@
           "date": "2026-03-13",
           "level": 3,
           "reason": "在元件中使用 Tailwind CSS"
+        },
+        {
+          "date": "2026-04-09",
+          "level": 4,
+          "reason": "PR #979 使用進階 Tailwind：w-[calc((100%-1.5rem)/5)] 自訂寬度計算實現 5 格換行佈局，flex-wrap 響應式設計取代複雜的 scrollable 元件"
         }
       ]
     },
@@ -188,14 +193,19 @@
           "reason": "PR #573 和 PR #575 皆使用 feature branch + PR 流程，commit message 格式遵循 conventional commits（fix: 前綴），工作流程完整"
         },
         {
-          "date": "2026-04-04",
+          "date": "2026-04-05",
           "level": 2,
-          "reason": "8 個 commit 全部使用 feat:/fix: 前綴，涵蓋多個不同 issue 的獨立 PR，工作流程持續穩定。部分 commit message 夾雜中英文（如 WIP-fix: 逐段朗讀不準確的BUG），conventional commit 格式尚未完全一致，保守升至 level 2"
+          "reason": "PR #898/#899/#900/#905 持續穩定使用 feature branch + conventional commits（fix:/feat: 前綴正確分類），每個 PR 都有清楚的問題描述與修改說明，工作流已成習慣"
         },
         {
-          "date": "2026-05-14",
+          "date": "2026-04-08",
+          "level": 3,
+          "reason": "PR #986（自學/作業分離）和 PR #987（tab 鎖定）都是從 4/3 會議決議出發，獨立拆 issue → 開發 → PR → merge 的完整自主流程。PR 說明清楚標注對應 issue 編號，commit message 格式正確"
+        },
+        {
+          "date": "2026-04-23",
           "level": 4,
-          "reason": "5 週內 33 個 merged PR 全部使用 feat/fix/refactor scope 格式（如 feat(toolbox) / fix(db) / fix(csp)），無 WIP 混入，每個 PR 對應一個 issue，描述清楚包含 Summary / Changes / Test plan，PR 流程已達專業水準，升至 level 4"
+          "reason": "4/10~4/23 共 16 個 PR，全部使用 conventional commits（fix:/feat: 分類正確），每個 PR 對應明確 issue 編號，PR 說明包含問題背景、修改方式、測試確認。#1193/#1194/#1195 三個相互關聯的 DB PR 拆分合理（partial unique index / ON DELETE SET NULL / step_progress 版本機制分開 PR），顯示對 PR 粒度的成熟判斷"
         }
       ]
     },
@@ -225,6 +235,27 @@
       ],
       "maxLevel": 5
     },
+    "11": {
+      "level": 4,
+      "maxLevel": 5,
+      "history": [
+        {
+          "date": "2026-04-23",
+          "level": 2,
+          "reason": "PR #1086 step 進度 debounce 5 秒使用 useRef 儲存 timer ID（不觸發 re-render），正確識別不需要 state 的場景，是 useRef 的標準用法。PR #1175 無聲音輸入主動提示使用 useEffect 監聽音訊輸入狀態，逾時後觸發 UI 提示，展現 side effect 管理的基礎能力。目前尚未見到 useMemo 或複雜 cleanup 場景"
+        },
+        {
+          "date": "2026-05-08",
+          "level": 3,
+          "reason": "PR #1465 toolbox Phase 2+3：useEffect mount-only（空 deps []）觸發後端 toolbox session 建立，同時用 useRef recordedRef 防止 #1464 完成畫面的 CTA 重複觸發寫入。兩個 hook 協同解決跨 PR 的設計衝突（#1463 需要 mount 時記錄，#1464 需要 completion 時記錄），展現對 useEffect 生命週期與 useRef 穩定性的組合應用，已超出 debounce 的單一 hook 場景"
+        },
+        {
+          "date": "2026-05-08",
+          "level": 4,
+          "reason": "PR #1499 VocabPractice multi-mode：新增 `practiceMode` prop（3 variants: standard/toolbox/quiz）+ `radicalColorMode` prop，Round 1 顯示筆順輪廓 + 部首顏色，Round 2 隱藏所有輔助。命名時刻意避免與元件內部 `mode` state 衝突，顯示對 prop vs internal state 邊界的清晰判斷。4 輪 @claude review 全部解決，含最後 brush color 一致性問題（commit 9bad640a）。已超出單純 useEffect/useRef，展現 prop 設計 + multi-mode 元件架構整合能力"
+        }
+      ]
+    },
     "12": {
       "level": 5,
       "maxLevel": 5,
@@ -252,23 +283,28 @@
       ]
     },
     "13": {
-      "level": 2,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
-          "date": "2026-04-04",
-          "level": 1,
-          "reason": "feat: hide-parent-page (#805) 新建 featureFlags.ts 集中管理前端功能開關，並在 auth.py / AppRoutes.tsx 各層正確引用，展現將設定邏輯抽離元件的意識。18ffa845 也顯示能理解跨元件的 props/context 資料流。首次展現元件設計模式的雛形，解鎖 level 1"
+          "date": "2026-04-05",
+          "level": 2,
+          "reason": "PR #805 設計前後端 feature flag 系統：後端 config.py 新增 PARENT_PORTAL_ENABLED 旗標、auth.py 加入 guard、前端建立 featureFlags.ts 集中管理，前後端職責分離清晰。PR #898 跨越 backend schemas/routes + 多個 frontend 元件（LearningLayout/MyAssignments/StepperNav 等），元件間資料流設計合理，但尚未見到 custom hook 抽取或共用元件重構"
         },
         {
-          "date": "2026-05-14",
-          "level": 2,
-          "reason": "PR #1461（toolbox Phase 1）新建 toolbox.py 模型、Alembic migration、獨立 PracticeToolbox.tsx 頁面與 learningStorageScope.ts 服務，各層職責分離清晰。PR #1030（+761/-92）獨立建立學生練習紀錄查詢頁，從 API → hook → 頁面元件結構完整。已能主動拆分元件，升至 level 2"
+          "date": "2026-04-08",
+          "level": 3,
+          "reason": "PR #986 自學/作業分離涉及前端狀態管理重新設計（assignment ID vs self-study session），需理解 LearningSession 與 Assignment 的資料模型關係。PR #987 tab 鎖定提示需設計元件間的狀態傳遞（選擇題完成狀態 → 控制拖拉配對 tab 的 disabled 狀態），展現跨元件資料流設計能力"
+        },
+        {
+          "date": "2026-04-23",
+          "level": 4,
+          "reason": "PR #1148 整合鼓勵語系統 + tier3 擋關邏輯 + 逐句重練 UI 為單一視覺流，展現多行為在同一元件中的設計整合能力。PR #1204 造句練習完整持久化，設計 beforeunload → session 寫入 → 頁面恢復的完整 state lifecycle。PR #1207 IME composition 問題同時修正 Enter 鍵在造句和聽寫兩個獨立元件的行為，顯示對跨元件共同問題的識別和同步修復能力。目前尚未見到 custom hook 的獨立抽取"
         }
       ]
     },
     "14": {
-      "level": 3,
+      "level": 2,
       "maxLevel": 5,
       "history": [
         {
@@ -277,74 +313,84 @@
           "reason": "PR #573 新增 backend/tests/test_assignments.py，第一次主動撰寫測試，覆蓋作業發派的 API 行為驗證"
         },
         {
-          "date": "2026-04-04",
+          "date": "2026-04-05",
           "level": 2,
-          "reason": "a08b2b40（標記課文紀錄欄位 #899）擴充 ReadingAnnotation.test.tsx：新增 scrollIntoView mock、修正 aria-label 斷言、加入 act() + fireEvent.click 的非同步測試，還新增側邊面板顯示和跳轉功能的兩個完整 test case。9d97a3c1 也補了 test_reading_evaluation_service.py。測試不只是 happy path，有測互動行為，升至 level 2"
+          "reason": "PR #899 在修復 ReadingAnnotation 的同時更新 __tests__/ReadingAnnotation.test.tsx（+41/-6），不只修 bug 還同步維護測試，開始建立「改完要更新測試」的習慣。PR #805 也補寫 test_auth_api.py 測試家長角色登入被封鎖的情境（+48 行），涵蓋多個 test case"
         },
         {
-          "date": "2026-05-14",
-          "level": 3,
-          "reason": "PR #1600（朗讀趨勢圖）主動補 ReadingTrendChart.test.tsx 共 5 個 unit tests，含 empty state / single point / normal rendering 三種情境。PR #969（造句驗證）後端補 5 個複製偵測測試並修正 test 互相干擾的 rate limiter override。已養成「新功能附帶測試」習慣，升至 level 3"
-        }
-      ]
-    },
-    "11": {
-      "level": 2,
-      "maxLevel": 5,
-      "history": [
-        {
-          "date": "2026-05-14",
+          "date": "2026-05-08",
           "level": 2,
-          "reason": "PR #1600（朗讀趨勢圖）使用 recharts 建立雙 Y 軸 LineChart，正確使用 useMemo 處理資料 sort+cap，理解 chart 的 empty state 情境（< 2 點時顯示鼓勵文字）。PR #1195（step_progress 版本機制）使用 useEffect 處理 session 版本比對。已展示 useEffect/useMemo 在真實功能中的正確應用，解鎖 level 2"
+          "reason": "PR #1498 G7-L29/L30 文章重點表重構：把 22 行純文字平鋪輸出拆解為 5 個結構化行（主題/觀察/推論/趨勢/反論/結論）+ fill-blank 格式，對應方大哥 #1388 的教學設計目標。2 輪 review 迭代（第一輪靖杭寫了「證據→趨勢」，Claude 指出語義不精準，第二輪改為「是否怕人」句式）。這是主動理解教學規格→轉換資料結構的問題拆解，而非機械式修改。level 維持 2，原因：目前是 1 個 YAML 的資料結構轉換，尚未見到跨多個複雜問題類型的拆解"
         }
       ]
     },
     "16": {
-      "level": 1,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
-          "date": "2026-05-14",
-          "level": 1,
-          "reason": "PR #1030（學生練習紀錄查詢頁 #416）從 issue → 設計 API → 實作前端頁面完整走完，+761/-92 行，功能從無到有。PR #1461（toolbox Phase 1）獨立設計 10 個 DB tables + migration + API + 前端頁面，是目前最大規模的端對端功能開發，解鎖 level 1"
+          "date": "2026-04-05",
+          "level": 2,
+          "reason": "PR #805（隱藏家長功能）和 PR #898（作業進度條）都是從 Issue 出發、跨越前後端完整實作並 merge 的功能。PR #898 規模特別大（+1248/-256，涉及 16 個檔案），顯示能獨立推進複雜任務。但目前兩個 PR 都沒有明確看到從 issue 開立到最終驗收的完整自主流程紀錄，保守給 level 2"
+        },
+        {
+          "date": "2026-04-08",
+          "level": 3,
+          "reason": "PR #986（自學/作業分離）和 PR #987（tab 鎖定）皆從 4/3 會議決議獨立建立 issue（#925, #926）→ 開發 → merge，展現完整的自主開發流程。兩個功能都在一週內完成，速度穩定"
+        },
+        {
+          "date": "2026-04-23",
+          "level": 4,
+          "reason": "PR #1144（跨裝置 session 復用）和 PR #1145（current_step 同步）是 P1 beta blocker issue #1073/#1074 的完整實作。兩個 PR 在 4/22 deadline 前 2 天提前 merge，後端新增 GET-first + dedup 邏輯，DB 加 partial unique index，前端守衛同步，形成完整的前後端 + DB 三層解決方案。這是靖杭首次獨立完成涉及 DB migration 的端對端功能"
         }
       ]
     },
-    "19": {
+    "17": {
       "level": 1,
       "maxLevel": 5,
       "history": [
         {
-          "date": "2026-05-14",
+          "date": "2026-05-08",
           "level": 1,
-          "reason": "PR #1461 附帶 issue1460done.md 說明各 phase 完成狀態。多個 PR 的 description 含清楚的 Summary 表格、Changes 說明、Test plan checklist，技術文件意識良好。PR #1128 的 radical coverage 對照表（Before/After 數字）是量化說明改動效果的好範例，解鎖 level 1"
+          "reason": "PR #1497 fix(csp)：閱讀 SecurityHeadersMiddleware 的 CSP header 建構邏輯，定位 `frame-src` directive 缺少 `https://storage.googleapis.com` 的根因（PDF iframe popup 被 CSP 封鎖），在正確位置加入白名單並附說明 CSP path-restriction limitation（GCS bucket 無法做到 path 級限制）。這是靖杭首次讀懂並修改 Python middleware 層的安全設定，Level 1：能在引導下讀懂既有 middleware 邏輯並做定點修改"
         }
       ]
     },
     "18": {
-      "level": 2,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
-          "date": "2026-04-04",
+          "date": "2026-04-05",
           "level": 1,
-          "reason": "18ffa845（作業進度條 #645/#898）同時修改 backend routes/assignments.py、schemas/assignment.py，以及 frontend LearningLayout、ComprehensionChat、MyAssignments、ReportPage 等多個層，顯示理解資料從 API → context → 元件顯示的完整路徑。d4e11a98 類似，從 backend config → auth route → frontend featureFlags → AppRoutes 全端串通。首次展現全端資料流理解，解鎖 level 1"
+          "reason": "PR #898 的問題說明中清楚描述了 LearningSession.current_step → assignment API → 前端進度條的完整資料流，顯示已開始理解全端架構。但目前是「能描述問題」的程度，尚未看到主動追蹤或重構整體資料流的行動，保守給 level 1"
         },
         {
-          "date": "2026-05-14",
+          "date": "2026-04-09",
           "level": 2,
-          "reason": "PR #1461（toolbox）從 DB Schema → SQLAlchemy model → Alembic migration → FastAPI route → React 頁面完整走一遍，並理解 learningStorageScope.ts 在前端的 session 隔離設計。PR #1193/#1194（DB index）展示能判斷何時需要加 partial unique index 防止 race condition，資料庫層的設計判斷力提升，升至 level 2"
+          "reason": "PR #1031 是靖杭第一個 backend PR！診斷全形/半形 bug 時追蹤了完整資料流（YAML 原始資料 → lesson_loader.py 載入 → API 回傳 → 前端比對），在正確的層級（lesson_loader）加入 _halfwidth() 正規化，而不是在前端 patch。同時修正 learning_vocab.py 和 ai_generation.py 的變數名稱殘留，展現跨檔案根因修復能力"
+        },
+        {
+          "date": "2026-04-23",
+          "level": 3,
+          "reason": "PR #1193 新增 LearningSession 的 partial unique index（assignment_id + course_id 組合），PR #1194 設定 AssignmentSubmission.session_id ON DELETE SET NULL 刪除政策，PR #1195 在 step_progress 加入版本號機制防進度倒退。三個 PR 都是在 DB schema 層面做設計決策（索引策略、刪除政策、樂觀鎖），而非在應用層繞過問題，顯示對資料庫設計原則的主動應用，不是跟著 bug 修補"
+        },
+        {
+          "date": "2026-05-08",
+          "level": 4,
+          "reason": "PR #1461 用 Alembic 建立 10 張獨立 toolbox session tables，每張對應一個練習工具，schema 設計包含 FK 關聯與索引。PR #1465 獨立設計後端 toolbox.py routes（POST 建立 session、GET 查詢、PATCH 更新完成狀態）+ 前端 toolboxApi.ts 對應呼叫 + 學習紀錄頁 UI 分區整合。這是靖杭首次從零開始設計一個完整 feature 的後端 API，包含 DB schema → route → service → frontend API layer 的完整鏈路，並自主決定 HTTP method 語意（POST/GET/PATCH 各自職責），達到全端架構理解的 level 4"
         }
       ]
     }
   },
   "recommendations": [
-    "元件設計模式（#13）升至 level 2，下一步嘗試把 toolbox 各練習的重複邏輯（session 建立 / 完成 CTA）抽出成 custom hook（例如 useToolboxSession），讓各工具頁元件本身更薄",
-    "測試（#14）升至 level 3，下一步挑戰 integration test：用 pytest 測試一個完整 API flow（建 session → 更新進度 → 查詢歷史），而不只是 unit test 單一函式",
-    "獨立開發（#16）剛解鎖 level 1，下一步嘗試自己從 issue description 出發，畫出 DB schema + API 設計再實作，而不是直接進 coding。這個習慣能讓複雜功能更不容易返工",
-    "架構理解（#18）升至 level 2，下一步可以看一個現有 LLM endpoint（如造句批改）的完整防護層（rate limit → auth → input cap → fail-closed），理解為什麼每層都需要，試著寫一份簡短說明給啟翔看"
+    "架構理解（#18）升到 level 4，首次獨立設計完整 feature 後端 API（toolbox POST/GET/PATCH）。下一步：嘗試為 toolbox API 補寫 contract test（pytest）驗證各 endpoint 的 status code + response schema，這是 level 5 的準備——不只能設計 API，也能用測試鎖定合約",
+    "React 進階（#11）升到 level 4（PR #1499 multi-mode prop 設計 + 命名衝突解決）。下一步：在 #1190 或 #1186 中嘗試用 useMemo 快取計算結果，或抽取 custom hook，完成後 #11 有機會升到 level 5",
+    "元件設計（#13）已穩在 level 4。#1464 的 ToolboxCompletionActions 共用元件 + 9 個 reading-step 接入是好的證據。下一步挑戰：把 toolbox session 寫入邏輯抽成 useToolboxSession custom hook，這是 level 5 的證明",
+    "獨立開發（#16）已穩在 level 4。#1457 驗收簽結是好的 level 5 候選機會：完整經歷需求→設計→實作→現場驗收的全循環，且是跨 4 個 PR 的大型功能",
+    "後端 Python 閱讀（#17）新增 level 1。下一步：在 #1494 silent-failure 修復中繼續讀懂 mcq_rescue_agent 的錯誤處理邏輯，這是 level 2 的機會（能獨立追蹤 middleware → route → service 的控制流）"
   ],
-  "summary": "5 週內 33 個 merged PR，涵蓋 toolbox 全端架構（DB tables → Alembic → FastAPI → React）、朗讀趨勢圖、session 版本機制、CSP 修復、字型 fallback 等。新解鎖技能 11（React 進階）、16（獨立開發功能）、19（技術文件），Git 工作流升 level 4，測試升 level 3，元件設計模式升 level 2，架構理解升 level 2。目前已確認解鎖 16 項技能",
+  "summary": "5/4~5/8 共 7 個 PR merge（5/4~5/7: 4 個 toolbox PR；5/8 新增: #1497/#1498/#1499）。5/8 亮點：PR #1499 VocabPractice multi-mode（practiceMode + radicalColorMode 雙 prop，4 輪 review）展現跨 mode 元件架構設計；PR #1498 G7-L29/L30 文章重點表結構化重構（22 行平文字 → 5 行填空）；PR #1497 CSP middleware fix（首次讀懂並修改 Python security middleware）。技能升級：#11 React 進階（3→4，multi-mode prop 設計 + 命名邊界清晰）；#17 後端 Python 閱讀（新增 level 1）。技能 #14 質量提升（無升級，1498 證據待後續積累）。累計本週 7 PR，是歷週最高產之一",
   "issues": [
     {
       "id": "環境建置",
@@ -352,8 +398,13 @@
       "date": "2026-03-02",
       "type": "setup",
       "contribution": "完成專案 fork、本地環境建置",
-      "skillsLearned": [1, 4],
-      "highlights": ["順利完成 fork 和 push"]
+      "skillsLearned": [
+        1,
+        4
+      ],
+      "highlights": [
+        "順利完成 fork 和 push"
+      ]
     },
     {
       "id": "#224",
@@ -361,8 +412,15 @@
       "date": "2026-03-05",
       "type": "feature",
       "contribution": "修改閱讀理解頁面 UI/UX，改善互動體驗",
-      "skillsLearned": [2, 3, 5],
-      "highlights": ["第一個 PR", "能讀懂基本 HTML/JS"]
+      "skillsLearned": [
+        2,
+        3,
+        5
+      ],
+      "highlights": [
+        "第一個 PR",
+        "能讀懂基本 HTML/JS"
+      ]
     },
     {
       "id": "#216",
@@ -370,8 +428,16 @@
       "date": "2026-03-10",
       "type": "bugfix",
       "contribution": "修復中文輸入法在聊天介面的 composition 事件處理問題，影響所有中文使用者",
-      "skillsLearned": [3, 5, 10],
-      "highlights": ["完整執行 重現→定位→修復→驗證 流程", "處理 isComposing event 和 async 語音功能", "Bug 修復流程扎實"],
+      "skillsLearned": [
+        3,
+        5,
+        10
+      ],
+      "highlights": [
+        "完整執行 重現→定位→修復→驗證 流程",
+        "處理 isComposing event 和 async 語音功能",
+        "Bug 修復流程扎實"
+      ],
       "linesChanged": "+32/-8"
     },
     {
@@ -380,8 +446,12 @@
       "date": "2026-03-10",
       "type": "bugfix",
       "contribution": "修復本地開發環境的資料庫連線問題，讓開發流程更順暢",
-      "skillsLearned": [4],
-      "highlights": ["本地開發環境完全跑通"]
+      "skillsLearned": [
+        4
+      ],
+      "highlights": [
+        "本地開發環境完全跑通"
+      ]
     },
     {
       "id": "語音功能",
@@ -389,8 +459,18 @@
       "date": "2026-03-13",
       "type": "feature",
       "contribution": "為閱讀理解聊天介面新增語音輸入和語音輸出功能，大幅提升無障礙使用體驗",
-      "skillsLearned": [6, 7, 8, 12],
-      "highlights": ["獨立完成完整功能", "成功串接語音 API", "React 元件設計清晰", "TypeScript 使用正確"],
+      "skillsLearned": [
+        6,
+        7,
+        8,
+        12
+      ],
+      "highlights": [
+        "獨立完成完整功能",
+        "成功串接語音 API",
+        "React 元件設計清晰",
+        "TypeScript 使用正確"
+      ],
       "linesChanged": "+180/-20"
     },
     {
@@ -399,8 +479,18 @@
       "date": "2026-03-20",
       "type": "bugfix",
       "contribution": "定位並修復作業 API 的 422 錯誤：後端 schema 仍要求 classroom_id 在 body，但 API 已改為 path parameter 傳遞，導致教師無法發派作業。修改 assignments.py、assignment.py schema，並補寫 test_assignments.py 驗證修正",
-      "skillsLearned": [9, 10, 12, 14],
-      "highlights": ["跨越 frontend + backend + 測試三個層面", "第一次主動撰寫後端測試", "理解 API schema 設計與 path parameter 差異", "conventional commit 格式正確"],
+      "skillsLearned": [
+        9,
+        10,
+        12,
+        14
+      ],
+      "highlights": [
+        "跨越 frontend + backend + 測試三個層面",
+        "第一次主動撰寫後端測試",
+        "理解 API schema 設計與 path parameter 差異",
+        "conventional commit 格式正確"
+      ],
       "linesChanged": "+多行/-多行"
     },
     {
@@ -409,83 +499,433 @@
       "date": "2026-03-20",
       "type": "bugfix",
       "contribution": "主動發現教師留言功能只有 emoji，使用者不容易識別，改為文字按鈕提升可讀性",
-      "skillsLearned": [2, 8],
-      "highlights": ["主動發現 UX 問題並提 issue 修復", "改善按鈕語意與可讀性"]
+      "skillsLearned": [
+        2,
+        8
+      ],
+      "highlights": [
+        "主動發現 UX 問題並提 issue 修復",
+        "改善按鈕語意與可讀性"
+      ]
     },
     {
-      "id": "#642",
-      "title": "逐段朗讀評分 bug 修正（WIP）",
-      "date": "2026-03-22",
+      "id": "#804",
+      "title": "隱藏家長功能（PR #805）",
+      "date": "2026-04-02",
+      "type": "feature",
+      "contribution": "設計前後端 feature flag 系統，預設關閉家長入口。後端 config.py 新增旗標、auth.py 封鎖家長角色登入；前端建立 featureFlags.ts 集中管理，AppRoutes.tsx 依旗標動態註冊路由。補寫 test_auth_api.py 驗證封鎖邏輯（+48 行）",
+      "skillsLearned": [
+        9,
+        13,
+        14,
+        16
+      ],
+      "highlights": [
+        "前後端 feature flag 設計職責分離",
+        "補寫測試覆蓋邊界情境",
+        "首次在 frontend 建立 config/featureFlags.ts 集中管理旗標"
+      ],
+      "linesChanged": "+114/-15"
+    },
+    {
+      "id": "#645",
+      "title": "作業進度條與對話紀錄顯示學習進度（PR #898）",
+      "date": "2026-04-02",
+      "type": "feature",
+      "contribution": "診斷進度條顯示 0% 的根因：assignment API 未聚合 LearningSession.current_step，在後端 assignments.py 新增查詢邏輯、更新 schema，前端同步修改 LearningLayout、MyAssignments、StepperNav 等 16 個檔案。同時修復 VocabDefinitionMatch 的互動 bug",
+      "skillsLearned": [
+        13,
+        16,
+        18
+      ],
+      "highlights": [
+        "PR 規模最大（+1248/-256，16 個檔案）",
+        "清楚分析 API 資料流問題並跨前後端修復",
+        "補寫 test_assignments.py 驗證新 API 行為",
+        "能完整推進複雜多檔案功能"
+      ],
+      "linesChanged": "+1248/-256"
+    },
+    {
+      "id": "#862",
+      "title": "修復閱讀標記側邊 panel 詞語 bug（PR #899）",
+      "date": "2026-04-02",
       "type": "bugfix",
-      "contribution": "修改 ai_service.py 和 reading_evaluation_service.py 改善逐段朗讀評分準確度，同時補寫 test_reading_evaluation_service.py 測試案例",
-      "skillsLearned": [10, 14],
-      "highlights": ["觸及後端 AI 服務層", "主動補測試"]
-    },
-    {
-      "id": "#643/#644",
-      "title": "合併學生三大頁面（我的作業＋學習進度＋對話紀錄）",
-      "date": "2026-03-29",
-      "type": "feature",
-      "contribution": "整合學生端三個分散頁面為統一的「我的作業」頁，刪除 DialogueHistory.tsx，修改後端 assignments/learning_sessions 路由，更新 E2E fixtures",
-      "skillsLearned": [6, 9, 13, 18],
-      "highlights": ["跨 frontend + backend 的大型整合", "刪除冗餘元件展現架構判斷", "E2E fixture 更新"],
-      "linesChanged": "+多行/-217 (DialogueHistory.tsx)"
-    },
-    {
-      "id": "#411/#662",
-      "title": "新增 Loading Skeleton",
-      "date": "2026-03-29",
-      "type": "feature",
-      "contribution": "為頁面載入新增 skeleton 佔位元件，改善用戶等待體驗",
-      "skillsLearned": [6, 8],
-      "highlights": ["主動改善 UX 細節"]
-    },
-    {
-      "id": "#805",
-      "title": "隱藏家長頁面（feature flag 架構）",
-      "date": "2026-04-02",
-      "type": "feature",
-      "contribution": "新建 featureFlags.ts 集中管理前端功能開關，透過 VITE_PARENT_PORTAL_ENABLED 環境變數控制家長頁面顯示，同時在 backend auth.py 新增對應路由保護並補寫 test_auth_api.py",
-      "skillsLearned": [13, 18],
-      "highlights": ["首次建立專案級 feature flag 系統", "從 backend config 到 frontend routing 全端串通", "有寫 JSDoc 說明用法"]
-    },
-    {
-      "id": "#645/#898",
-      "title": "作業進度條與對話紀錄顯示學習進度",
-      "date": "2026-04-02",
-      "type": "feature",
-      "contribution": "修改 backend assignments 路由新增進度欄位，更新 assignment schema，擴充 frontend LearningLayout、ComprehensionChat、VocabDefinitionMatch、MyAssignments、ReportPage 等多個元件顯示進度資料",
-      "skillsLearned": [6, 12, 18],
-      "highlights": ["最大規模的全端整合 commit", "理解 DB schema → API → context → UI 完整資料流", "同時補寫後端測試"],
-      "linesChanged": "+多行（16 個檔案）"
-    },
-    {
-      "id": "#899",
-      "title": "標記課文紀錄欄位（ReadingAnnotation 側邊面板）",
-      "date": "2026-04-02",
-      "type": "feature",
-      "contribution": "大幅擴充 ReadingAnnotation.tsx 新增標記紀錄側邊面板，同步擴充測試案例：新增 scrollIntoView mock、aria-label 斷言、act()+fireEvent 的互動測試",
-      "skillsLearned": [6, 14],
-      "highlights": ["+200/-69 行的大型元件開發", "測試涵蓋非同步互動和 DOM 行為", "aria-label 設計顯示無障礙意識"],
+      "contribution": "修復標記詞語點擊後無法 scroll 到正確位置、以及按鈕在滾動後位置跑偏的問題。在 ReadingAnnotation.tsx 修正座標計算邏輯，同步更新測試（+41/-6）",
+      "skillsLearned": [
+        10,
+        14
+      ],
+      "highlights": [
+        "修正滾動容器的 scrollTop 座標偏移計算",
+        "同步更新測試，不讓 test 過時",
+        "PR 說明清楚列出兩個修復目標並打勾確認"
+      ],
       "linesChanged": "+200/-69"
     },
     {
-      "id": "#905",
-      "title": "閱讀標記按鈕修正",
+      "id": "#904",
+      "title": "修復閱讀標記按鈕跟隨滾動位置（PR #905）",
       "date": "2026-04-02",
       "type": "bugfix",
-      "contribution": "修正 ReadingAnnotation.tsx 按鈕邏輯，精準小改動",
-      "skillsLearned": [10],
-      "highlights": ["精準定位問題，不亂改"]
+      "contribution": "在 ReadingAnnotation.tsx 加入可捲動容器的 scrollTop/scrollLeft 偏移補償，修正文章往下滑後浮動按鈕位置跑偏的問題",
+      "skillsLearned": [
+        10
+      ],
+      "highlights": [
+        "精準定位座標計算問題（scrollTop/scrollLeft 補償）",
+        "修改範圍小（+8/-6）但影響精準"
+      ],
+      "linesChanged": "+8/-6"
     },
     {
-      "id": "#88/#900",
-      "title": "生字練習「部件拆解」修正",
+      "id": "#88",
+      "title": "生字練習部件拆解修正（PR #900）",
       "date": "2026-04-03",
       "type": "bugfix",
-      "contribution": "修正 RadicalDecomposition.tsx 功能 bug 並同步修正 TypeScript 錯誤，調整 LearningLayout.tsx 對應位置",
-      "skillsLearned": [7, 10],
-      "highlights": ["主動修正 TypeScript 型別錯誤", "跨兩個檔案的精準修改"]
+      "contribution": "修正 RadicalDecomposition.tsx 中 JSON fallback 資料缺少 meaning 導致說明空白的問題，加入 fallback 顯示文案，並移除按鈕內重複說明",
+      "skillsLearned": [
+        5,
+        10
+      ],
+      "highlights": [
+        "清楚分析兩種資料來源的差異",
+        "PR 說明詳盡，分兩階段解釋修正思路"
+      ],
+      "linesChanged": "+8/-7"
+    },
+    {
+      "id": "#925",
+      "title": "詞語定義 tab 前置鎖定提示（PR #987）",
+      "date": "2026-04-08",
+      "type": "feature",
+      "contribution": "實作 4/3 會議決議：選擇題完成才能做拖拉配對，加入 tab 鎖定提示 UI，引導學生按順序完成",
+      "skillsLearned": [
+        9,
+        13,
+        16
+      ],
+      "highlights": [
+        "從會議決議獨立建 issue → 開發 → merge",
+        "跨元件狀態傳遞設計（完成狀態控制 tab disabled）"
+      ]
+    },
+    {
+      "id": "#926",
+      "title": "自學和作業記錄分離（PR #986）",
+      "date": "2026-04-08",
+      "type": "feature",
+      "contribution": "實作 4/3 會議決議：自學 session 與作業 session 分離，作業跟 assignment ID 走，刪除作業也刪記錄",
+      "skillsLearned": [
+        9,
+        13,
+        16
+      ],
+      "highlights": [
+        "涉及前端狀態管理重設計",
+        "理解 LearningSession 與 Assignment 資料模型關係",
+        "一週內完成"
+      ]
+    },
+    {
+      "id": "#924",
+      "title": "作業進度條顏色改綠色 + 排版每5格換行（PR #979）",
+      "date": "2026-04-09",
+      "type": "feature",
+      "contribution": "移除複雜的 horizontal scroll 進度條（左右箭頭 + gradient mask），改用 flex-wrap 每5格換行的簡潔佈局。完成→綠色、進行中→黃色、未完成→灰色",
+      "skillsLearned": [
+        8
+      ],
+      "highlights": [
+        "大幅簡化元件（-94/+26 行）",
+        "w-[calc((100%-1.5rem)/5)] 自訂寬度計算",
+        "用簡單方案取代過度工程"
+      ],
+      "linesChanged": "+26/-94"
+    },
+    {
+      "id": "#1029",
+      "title": "詞語應用全形/半形答案修正（PR #1031）",
+      "date": "2026-04-09",
+      "type": "bugfix",
+      "contribution": "第一個 backend PR！診斷詞語應用選項中無正確答案的 bug，根因是 YAML 中全形字母（Ａ）與 vocab_bank 半形 key（A）不匹配。在 lesson_loader.py 加入 _halfwidth() 正規化函數，同時修正 learning_vocab.py 的 payload.character→payload.word 殘留",
+      "skillsLearned": [
+        10,
+        18
+      ],
+      "highlights": [
+        "靖杭第一個 backend Python PR",
+        "追蹤完整資料流找到根因（YAML→loader→API→frontend）",
+        "在正確的層級修復（data loading 而非前端 patch）",
+        "跨 3 個檔案的根因修復"
+      ],
+      "linesChanged": "+21/-6"
+    },
+    {
+      "id": "#1070/#1071",
+      "title": "Self-practice 後端無紀錄 + 跨裝置失效修復（PR #1075, #1085）",
+      "date": "2026-04-15",
+      "type": "bugfix",
+      "contribution": "PR #1075 修復自學模式未建立 LearningSession 的問題（後端路徑未觸發）。PR #1085 修復跨裝置 self-practice 失效，確保不同裝置能正確恢復進度",
+      "skillsLearned": [
+        10,
+        18
+      ],
+      "highlights": [
+        "後端 session 建立邏輯診斷",
+        "跨裝置狀態管理"
+      ]
+    },
+    {
+      "id": "#661",
+      "title": "逐段朗讀句子級重練功能（PR #1076）",
+      "date": "2026-04-15",
+      "type": "feature",
+      "contribution": "實作句子切分 + 逐句重練流程，讓學生能針對特定句子反覆練習，而非重讀整段",
+      "skillsLearned": [
+        6,
+        13
+      ],
+      "highlights": [
+        "句子級粒度設計，資料流從段→句",
+        "完整的重練 UI 狀態管理"
+      ]
+    },
+    {
+      "id": "#1072",
+      "title": "Step 進度 debounce 防抖動（PR #1086）",
+      "date": "2026-04-17",
+      "type": "bugfix",
+      "contribution": "步驟完成事件在 5 秒內多次觸發時只送一次 API，使用 useRef 儲存 timer ID 避免不必要的 re-render",
+      "skillsLearned": [
+        11
+      ],
+      "highlights": [
+        "正確選用 useRef 而非 useState 儲存 timer",
+        "debounce 實作乾淨"
+      ]
+    },
+    {
+      "id": "#1096",
+      "title": "Step 2 停止鈕 + 漏讀偵測 + 句子切分 + 視覺整合（PR #1142, #1148）",
+      "date": "2026-04-20",
+      "type": "feature",
+      "contribution": "PR #1142 新增停止錄音按鈕、漏讀句子偵測邏輯、改善句子切分精準度。PR #1148 整合鼓勵語系統 + tier3 擋關 + 逐句重練 UI 為完整視覺流",
+      "skillsLearned": [
+        13,
+        16
+      ],
+      "highlights": [
+        "多功能整合到單一流暢 UX",
+        "tier3 擋關邏輯設計",
+        "鼓勵語情境判斷"
+      ]
+    },
+    {
+      "id": "#1073/#1074",
+      "title": "跨裝置 session 一致性 P1 beta blocker（PR #1144, #1145）",
+      "date": "2026-04-20",
+      "type": "feature",
+      "contribution": "P1 beta blocker。PR #1144 後端 GET-first dedup 邏輯 + frontend 守衛。PR #1145 current_step 與 steps_completed 雙向同步。DB 層加 partial unique index 確保資料完整性",
+      "skillsLearned": [
+        16,
+        18
+      ],
+      "highlights": [
+        "P1 beta blocker deadline 前 2 天完成",
+        "前後端 + DB 三層解決方案",
+        "首次獨立完成 DB migration 端對端"
+      ]
+    },
+    {
+      "id": "#1174",
+      "title": "Step 2 無聲音輸入主動提示（PR #1175）",
+      "date": "2026-04-21",
+      "type": "feature",
+      "contribution": "使用 useEffect 監聽音訊輸入狀態，超過閾值時間沒有聲音則主動顯示提示引導學生",
+      "skillsLearned": [
+        11
+      ],
+      "highlights": [
+        "useEffect side effect 管理",
+        "音訊輸入狀態監聽"
+      ]
+    },
+    {
+      "id": "#1179/#1178/#1187",
+      "title": "DB schema 三連 PR：index / FK 政策 / 版本鎖（PR #1193, #1194, #1195）",
+      "date": "2026-04-21",
+      "type": "feature",
+      "contribution": "PR #1193 LearningSession partial unique index（assignment_id + course_id）。PR #1194 AssignmentSubmission.session_id ON DELETE SET NULL。PR #1195 step_progress 版本號機制防進度倒退（樂觀鎖模式）",
+      "skillsLearned": [
+        18
+      ],
+      "highlights": [
+        "首次主動在 DB schema 層做設計決策",
+        "三個 PR 拆分粒度合理",
+        "樂觀鎖防並發問題的正確做法"
+      ]
+    },
+    {
+      "id": "#1196",
+      "title": "VocabApplication beforeunload 覆蓋修復（PR #1197）",
+      "date": "2026-04-21",
+      "type": "bugfix",
+      "contribution": "beforeunload 事件在離頁時意外覆蓋 steps_completed，導致已完成步驟被清空。修復 event handler 的寫入條件",
+      "skillsLearned": [
+        10,
+        13
+      ],
+      "highlights": [
+        "race condition 診斷（beforeunload vs session 寫入順序）",
+        "state lifecycle 理解"
+      ]
+    },
+    {
+      "id": "#1203",
+      "title": "造句練習完整持久化（PR #1204）",
+      "date": "2026-04-22",
+      "type": "feature",
+      "contribution": "設計 beforeunload → session 寫入 → 頁面恢復的完整 state lifecycle，確保造句練習進度跨頁面、跨裝置保存",
+      "skillsLearned": [
+        13
+      ],
+      "highlights": [
+        "完整 state lifecycle 設計",
+        "持久化邏輯與 UI 狀態解耦"
+      ]
+    },
+    {
+      "id": "#1206",
+      "title": "造句 + 聽寫 Enter 鍵忽略 IME composition（PR #1207）",
+      "date": "2026-04-22",
+      "type": "bugfix",
+      "contribution": "修復中文輸入法選字時 Enter 鍵誤觸提交的問題，同時修正造句和聽寫兩個獨立元件的相同行為",
+      "skillsLearned": [
+        10
+      ],
+      "highlights": [
+        "同一問題在兩個元件同步修復",
+        "IME composition 事件正確處理"
+      ]
+    },
+    {
+      "id": "#1351",
+      "title": "zhuyin-off 場景明確 serif fallback（PR #1459）",
+      "date": "2026-05-07",
+      "type": "bugfix",
+      "contribution": "修復非注音模式下缺乏明確字體 fallback 的問題。新增 BpmfZihiSerif（字嗨宋體）作為 zhuyin-off 場景的 serif fallback，建立 fonts.ts helper 集中管理字體 class，更新 11 個相關元件",
+      "skillsLearned": [
+        8,
+        9
+      ],
+      "highlights": [
+        "建立 fonts.ts 集中字體管理，不散落各元件",
+        "理解 IVS variant selector 對 CJK 字體選擇的影響",
+        "11 個元件統一套用，修改範圍廣但邏輯一致"
+      ],
+      "linesChanged": "+多行（11 元件 + fonts.ts helper）"
+    },
+    {
+      "id": "#1460",
+      "title": "toolbox session tables — Phase 1（PR #1461）",
+      "date": "2026-05-07",
+      "type": "feature",
+      "contribution": "用 Alembic migration 建立 10 張獨立 toolbox session tables，每張對應一個練習工具（LiveTutor、FullReading、Listening、VocabPractice 等），包含 FK 關聯與索引。同時為 AppShell 加入 toolbox-aware aria-label 改善 a11y",
+      "skillsLearned": [
+        9,
+        18
+      ],
+      "highlights": [
+        "Alembic 一次建 10 張 table，schema 設計清楚",
+        "FK + index 設計符合 sqlalchemy-model-safety checklist",
+        "a11y aria-label 細節在第 6 輪 @claude review 後補上，展現對細節的追蹤"
+      ]
+    },
+    {
+      "id": "#1462",
+      "title": "toolbox per-tool 完成畫面 CTA（PR #1464）",
+      "date": "2026-05-07",
+      "type": "feature",
+      "contribution": "設計並實作 ToolboxCompletionActions 共用元件，提供「重做」和「回到練習工具箱」兩個 CTA 按鈕。將元件接入 9 個 reading-step 元件，形成統一的完成體驗",
+      "skillsLearned": [
+        6,
+        13
+      ],
+      "highlights": [
+        "共用元件設計，9 個元件接入點統一",
+        "4 輪 @claude review 迭代改善元件 API 設計",
+        "解決與 Phase 2+3 (#1465) 的設計衝突：CTA 的 recordedRef guard 防重複觸發"
+      ]
+    },
+    {
+      "id": "#1463",
+      "title": "toolbox Phase 2+3 — 後端 API + 前端整合 + 學習紀錄頁（PR #1465）",
+      "date": "2026-05-07",
+      "type": "feature",
+      "contribution": "完整實作練習工具箱的資料記錄層：後端 toolbox.py（POST/GET/PATCH routes）、前端 toolboxApi.ts（API 呼叫層）、學習紀錄頁分區顯示工具箱完成紀錄。用 useEffect mount（空 deps）+ useRef recordedRef guard 解決 #1463 和 #1464 的設計衝突",
+      "skillsLearned": [
+        11,
+        12,
+        13,
+        18
+      ],
+      "highlights": [
+        "首次獨立設計完整 feature 後端 API（POST/GET/PATCH 語意清楚）",
+        "useEffect + useRef 跨 PR 協同解決設計衝突，展現 React lifecycle 成熟理解",
+        "前後端 + DB 三層完整走完",
+        "4 輪 @claude review 迭代"
+      ]
+    },
+    {
+      "id": "#1496",
+      "title": "fix(csp): GCS frame-src 允許，解除 PDF popup 封鎖（PR #1497）",
+      "date": "2026-05-08",
+      "type": "bugfix",
+      "contribution": "閱讀 SecurityHeadersMiddleware 的 CSP header 建構邏輯，定位 frame-src 缺少 storage.googleapis.com，在正確位置加入白名單。說明了 CSP 無法做 GCS path-restriction 的限制，修改精準（+3/-1）",
+      "skillsLearned": [
+        17
+      ],
+      "highlights": [
+        "首次讀懂並修改 Python middleware 安全設定",
+        "正確定位 CSP directive 在 header 建構中的位置",
+        "附說明 GCS path-restriction 限制，展現對 CSP 語意的理解"
+      ],
+      "linesChanged": "+3/-1"
+    },
+    {
+      "id": "#1388",
+      "title": "fix(content): G7-L29/L30 文章重點表結構化重構（PR #1498）",
+      "date": "2026-05-08",
+      "type": "bugfix",
+      "contribution": "將 G7-L29/L30 的文章重點表從 22 行純文字平鋪重構為 5 個結構化行（主題/觀察/推論/趨勢/反論）並加入 fill-blank 格式，符合方大哥 #1388 的教學設計規格。2 輪 review 迭代（改善「證據→趨勢」語意、「怕人→是否怕人」句式）",
+      "skillsLearned": [
+        14
+      ],
+      "highlights": [
+        "主動理解教學規格，將平文字轉換為結構化填空",
+        "2 輪 review 迭代，精修欄位語意",
+        "staging 驗證 6 個填空格正確渲染（HTTP 200）"
+      ],
+      "linesChanged": "+35/-47"
+    },
+    {
+      "id": "#1342",
+      "title": "feat(vocab): 第二次練習隱藏輔助 + 部首顏色（PR #1499）",
+      "date": "2026-05-08",
+      "type": "feature",
+      "contribution": "VocabPractice 新增 practiceMode prop（standard/toolbox/quiz 三種）+ radicalColorMode prop，Round 1 顯示筆順輪廓 + 部首顏色標示，Round 2 隱藏所有輔助（筆順/注音/筆畫數）。命名刻意避免與元件內部 mode state 衝突，4 輪 @claude review 全部解決含最後 brush color 一致性",
+      "skillsLearned": [
+        6,
+        11
+      ],
+      "highlights": [
+        "prop vs internal state 邊界設計清晰，避免命名衝突",
+        "3 variants + 雙 prop 的 multi-mode 元件架構",
+        "4 輪 @claude review 全部追蹤到底，含 commit 9bad640a brush color 修正",
+        "162+/32- 規模適中，設計乾淨"
+      ],
+      "linesChanged": "+162/-32"
     }
   ]
 }

--- a/frontend/public/intern-training/interns/xiung.json
+++ b/frontend/public/intern-training/interns/xiung.json
@@ -3,7 +3,7 @@
   "github": "stgst",
   "email": "steven19790906@gmail.com",
   "startDate": "2026-03-06",
-  "lastReview": "2026-05-14",
+  "lastReview": "2026-05-08",
   "skills": {
     "1": {
       "level": 3,
@@ -101,12 +101,12 @@
         {
           "date": "2026-03-13",
           "level": 4,
-          "reason": "多次修改程式碼，能理解程式邏輯。"
+          "reason": "多次修改程式碼，能理解程式邏輯"
         },
         {
           "date": "2026-03-13",
           "level": 5,
-          "reason": "能快速定位問題並提出解決方案。"
+          "reason": "能快速定位問題並提出解決方案"
         }
       ],
       "maxLevel": 5
@@ -127,31 +127,15 @@
         {
           "date": "2026-03-13",
           "level": 4,
-          "reason": "獨立開發生字練習 UX，完成度高。"
+          "reason": "獨立開發生字練習 UX，完成度高"
         },
         {
           "date": "2026-03-13",
           "level": 5,
-          "reason": "多次獨立完成元件開發，並改善 UX。"
+          "reason": "多次獨立完成元件開發，並改善 UX"
         }
       ],
       "maxLevel": 5
-    },
-    "7": {
-      "level": 3,
-      "maxLevel": 5,
-      "history": [
-        {
-          "date": "2026-04-04",
-          "level": 1,
-          "reason": "2796b942（造句練習 cache key 修正 #910/#912）在 VocabPractice.tsx 新增 vocabChars，明確使用 Set<string> 和 string[] 型別標注，for...of 迴圈中對 item.word 使用正規表達式過濾 CJK 字元。TypeScript 基本型別標注已掌握，解鎖 level 1"
-        },
-        {
-          "date": "2026-05-14",
-          "level": 3,
-          "reason": "PR #1547（MCQ rescue dialog）在 McqRescueDialog.tsx、MultipleChoiceExercise.tsx、StrategyExercise.tsx 使用完整 interface 定義 props，API layer 的 request/response 型別清楚標注，Alembic migration 用 Python typing。PR #1141（全域 UX）定義 VoiceInputButton 的 `size: 'md' | 'sm'` union type。TypeScript 使用範圍從單一檔案擴展到多個模組，升至 level 3"
-        }
-      ]
     },
     "8": {
       "level": 4,
@@ -162,9 +146,9 @@
           "reason": "PR #229 修改含 Tailwind 樣式的元件，理解 utility-first 概念與 class 組合方式"
         },
         {
-          "date": "2026-05-14",
+          "date": "2026-04-23",
           "level": 4,
-          "reason": "PR #1141（全域 UX）大規模使用 glassmorphic utilities（backdrop-blur、bg-white/20）、響應式 prefix（md:h-20）、Tailwind arbitrary values（shadow-[inset_0_-3px_0_0_#ef4444]）修復紅線歪斜問題（PR #1130）。PR #1480 用 shrink-0 / max-w-2xl / mx-auto 做排版約束，對 Tailwind 的設計系統語意理解清晰，升至 level 4"
+          "reason": "PR #1087 設計完整設計系統：新增 surface token、btn-immersive、glass utility class、glassmorphic top bar。引入全域 [data-zhuyin-active] CSS 選擇器取代各元件 inline style，展現對 Tailwind 與全域 CSS 策略的統籌能力。PR #1130 改用 shadow-[inset_0_-3px_0_0_#ef4444] 精準控制紅線行為，規避 underline 受 baseline/letterSpacing 影響的限制，顯示對 Tailwind arbitrary value 的深度掌握"
         }
       ]
     },
@@ -187,9 +171,9 @@
           "reason": "commit message 品質佳（feat/fix/refactor 正確分類），PR #448 完整走完 branch → PR → merge 流程"
         },
         {
-          "date": "2026-05-14",
+          "date": "2026-04-09",
           "level": 4,
-          "reason": "11 個 merged PR 全部使用 feat/fix + scope 格式，PR #1547 的 description 含完整 Summary / 後端 / 前端 / Acceptance / Test plan 分段，PR #1130 的根本原因分析（root cause）清楚交代三層問題並分別說明修補方式，PR 品質穩定達到 code review 可接受標準，升至 level 4"
+          "reason": "4/3~4/10 一週 4 個 PR 全部高品質：每個 PR 都有結構化問題分析、修改說明、完整 test plan 含邊界情境。PR #913 的 test plan 列出 cache hit/miss/validate 三種路徑。PR #959 和 #969 都從 4/3 會議決議獨立建 issue → 開發 → merge，自主開發流程成熟"
         }
       ]
     },
@@ -209,18 +193,18 @@
         {
           "date": "2026-03-13",
           "level": 4,
-          "reason": "多次修復 bug，能獨立 debug。"
+          "reason": "多次修復 bug，能獨立 debug"
         },
         {
           "date": "2026-03-13",
           "level": 5,
-          "reason": "能獨立 debug 並修復多種 bug。"
+          "reason": "能獨立 debug 並修復多種 bug"
         }
       ],
       "maxLevel": 5
     },
     "11": {
-      "level": 5,
+      "level": 4,
       "history": [
         {
           "date": "2026-03-13",
@@ -230,51 +214,55 @@
         {
           "date": "2026-03-13",
           "level": 3,
-          "reason": "能使用 useMemo 優化效能。"
+          "reason": "能使用 useMemo 優化效能"
         },
         {
           "date": "2026-03-13",
           "level": 4,
-          "reason": "能熟練運用 useMemo, useCallback。"
-        },
-        {
-          "date": "2026-05-14",
-          "level": 5,
-          "reason": "PR #1547（MCQ rescue dialog）useRef 保存 chat history 跨關閉重開不消失，useState 管理 dialog open/close + message list + loading 多個非同步狀態，useEffect 在 mount 時初始化 rescue session。PR #1492（guided_steps）正確診斷 onComplete 觸發條件導致學生卡關，修改後邏輯清楚。useEffect/useRef/useState 在複雜互動場景的綜合應用，升至 level 5"
+          "reason": "能熟練運用 useMemo, useCallback"
         }
       ],
       "maxLevel": 5
     },
     "12": {
-      "level": 3,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
-          "date": "2026-05-14",
+          "date": "2026-04-05",
+          "level": 2,
+          "reason": "PR #913 修改 backend rate_limiter.py 和 learning_vocab.py/stories.py，理解 FastAPI route decorator 的執行順序與 rate limiting 機制，知道如何在特定程式碼路徑內套用 rate limit 而非全局套用。展現後端 API 結構的理解，但主要是修改既有邏輯，非獨立設計 API"
+        },
+        {
+          "date": "2026-04-08",
           "level": 3,
-          "reason": "PR #1547 新建 FastAPI route `POST /api/learning/mcq-attempt`，含 auth Depends、rate limit 100/min、request body 型別，並新建對應 SQLAlchemy model（mcq_attempt.py）和 Alembic migration。PR #969（造句驗證）在後端 AI 呼叫前加入確定性子字串比對，理解 API 前置 guard 的設計思路。首次完整實作後端 API endpoint，解鎖 level 3"
+          "reason": "PR #959（造句以詞為單位）涉及前後端 API 串接修改：後端 vocabulary 資料結構的理解（字 vs 詞的區分）+ 前端 API call 參數調整 + 預生成快取 key 對齊。PR #969（防複製貼上）在後端加入 AI 批改驗證邏輯，理解 Gemini API 回應結構並加入真實性檢查。兩個 PR 都跨前後端完整修改"
+        },
+        {
+          "date": "2026-04-23",
+          "level": 4,
+          "reason": "PR #1128 step 5 部件教學掛載時批次打 /api/dictionary/batch 取得 8 個相關字 chip 的 moedict 釋義，用 module-level Map 快取避免重複請求，字義顯示設計三層優先序（手寫 meaning → moedict 短釋義 → 通用 fallback）。同時協調三個資料來源（radicals.ts、radical-meanings.json、moedict API）在同一教學流程中無縫整合。首次獨立設計多來源資料整合的 API 串接架構"
         }
       ]
     },
     "13": {
-      "level": 2,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
-          "date": "2026-05-14",
+          "date": "2026-04-05",
           "level": 2,
-          "reason": "PR #1141（全域 UX）抽出 VoiceInputButton.tsx 共用元件，支援 md/sm 兩種尺寸，接入 SentencePractice 和 FloatingAIHelper 兩個不同使用場景，並刻意不加到 DictationPractice（違背聽寫目的）——這個判斷展示元件設計的責任邊界意識。PR #1547 的 McqRescueDialog 獨立成可重用的 dialog，不綁定特定 MCQ 邏輯，解鎖 level 2"
-        }
-      ]
-    },
-    "14": {
-      "level": 2,
-      "maxLevel": 5,
-      "history": [
+          "reason": "PR #912 新增 vocabChars memo，從 story.vocabulary 拆出去重的 CJK 字並向下傳給 SentencePractice，修正 cache key 不匹配問題。正確識別資料來源問題（story.content 前 12 字 vs vocabulary 生字），並透過新增 memo 而非修改既有邏輯來解決，顯示對元件資料流的設計意識。尚未見到 custom hook 的抽取"
+        },
         {
-          "date": "2026-05-14",
-          "level": 2,
-          "reason": "PR #1547 補 MultipleChoiceExercise.test.tsx 共 7 個 Vitest tests，涵蓋正確/錯誤選項、rescue button 顯示、dialog 開關等多種情境。PR #1492（guided_steps）補 StrategyExercise.test.tsx 3 個 tests：all-correct / only-Q1-confirmed / wrong-but-all-answered，明確驗證 regression。開始主動為新功能補測試，解鎖 level 2"
+          "date": "2026-04-09",
+          "level": 3,
+          "reason": "PR #959 重新設計 SentencePractice 的 props 資料流：從接收 chars（字）改為接收 words（詞），上游 App.tsx 需傳遞 vocabulary 詞組，下游需同步修改 cache key 和 API 呼叫參數。PR #969 進一步在元件中加入 paste 偵測邏輯和 UI 提示，展現在既有元件上疊加功能而不破壞原有架構的設計能力"
+        },
+        {
+          "date": "2026-04-23",
+          "level": 4,
+          "reason": "PR #1087 是迄今規模最大的 PR（+3205/-4777）：實作沉浸式學習 shell，建立完整設計系統（surface token、glass utility、btn-immersive），引入全域 [data-zhuyin-active] 取代各元件 inline style，大幅瘦身 ComprehensionChat/VocabPractice/ListeningPractice 等元件（-1425 行）。展現跨元件架構整合與設計系統建立能力。PR #1128 step 5 部件教學協調三個資料來源在同一流程中整合，加入 module-level Map 快取與三層字義優先序，元件設計完整"
         }
       ]
     },
@@ -285,28 +273,23 @@
         {
           "date": "2026-03-13",
           "level": 4,
-          "reason": "能給出有建設性的 code review 意見。"
+          "reason": "能給出有建設性的 code review 意見"
         }
       ]
     },
     "16": {
-      "level": 2,
+      "level": 4,
       "maxLevel": 5,
       "history": [
         {
           "date": "2026-03-13",
           "level": 3,
-          "reason": "能獨立完成功能開發。"
+          "reason": "能獨立完成功能開發"
         },
         {
           "date": "2026-03-13",
           "level": 4,
-          "reason": "獨立完成多個 feature 開發。"
-        },
-        {
-          "date": "2026-05-14",
-          "level": 2,
-          "reason": "注意：重新評估。先前 level 3/4 缺乏具體 PR 佐證，退至有實際 PR 支撐的水準。PR #1547（MCQ rescue）是目前最完整的端對端 feature：從 issue #1507 出發 → DB table → migration → API → UI → 測試，首次獨立走完完整 issue → merged PR 流程，解鎖 level 2"
+          "reason": "獨立完成多個 feature 開發"
         }
       ]
     },
@@ -317,34 +300,44 @@
         {
           "date": "2026-03-13",
           "level": 3,
-          "reason": "開始有優化程式碼的意識。"
+          "reason": "開始有優化程式碼的意識"
         },
         {
           "date": "2026-03-13",
           "level": 4,
-          "reason": "能進行效能優化，例如使用 useMemo。"
+          "reason": "能進行效能優化，例如使用 useMemo"
         }
       ]
     },
     "18": {
-      "level": 1,
+      "level": 3,
       "maxLevel": 5,
       "history": [
         {
-          "date": "2026-05-14",
+          "date": "2026-04-05",
           "level": 1,
-          "reason": "PR #1547 從 DB Schema（mcq_attempt）→ SQLAlchemy model → Alembic migration → FastAPI route → React component → API service 完整走一遍，理解資料如何在各層流動。PR #1128（部件教學）同時修改 dictionary_service.py（後端 heteronym 挑選邏輯）+ RadicalDecomposition.tsx（前端 UI）+ 資料檔案，展示跨層問題的診斷能力，首次展現全端資料流理解，解鎖 level 1"
+          "reason": "PR #913 的問題分析顯示能理解 request → rate limiter → cache check → AI call 的後端執行流程，並知道 rate limit 應套在 AI 呼叫而非 request 入口。PR #912 能追蹤 story.vocabulary → vocabChars → SentencePractice → cache key 的完整資料流。但目前對全端架構（前端 API call → backend route → DB）的整體視野尚未完整，保守給 level 1"
+        },
+        {
+          "date": "2026-04-09",
+          "level": 2,
+          "reason": "PR #959 和 #969 都完整跨越前後端：前端元件 props 修改 → API 呼叫參數對齊 → 後端 route 邏輯 → AI service 整合 → 預生成快取 key 一致性。特別是 #969 的 AI 真實性驗證需要理解 Gemini API 的 prompt → response → 二次檢查的完整鏈路。兩個 PR 都在正確的層級做修改，沒有 frontend patch 的壞習慣"
+        },
+        {
+          "date": "2026-04-23",
+          "level": 3,
+          "reason": "PR #1130 是架構理解的關鍵證據：診斷 PR #1087 把 data-para-idx 從 p 移到外層 section 後，selection walker 讀到段落號碼徽章字元導致 charStart 每次 +2、選取偏移的 regression bug。能從 HTML 結構變化追蹤到 JS DOM traversal 行為再到 UI 偏移現象，完整的跨層因果鏈。修復方式精準：把 attr 搬回 p，徽章保留在 [data-para-idx] 子樹外。這是從自己的 PR 造成的 regression 中正確做 root cause analysis 的能力"
         }
       ]
     }
   },
   "recommendations": [
-    "TypeScript（#7）升至 level 3，下一步試著為 McqRescueDialog 的 messages state 抽出專屬的 type（`type RescueMessage = { role: 'user' | 'ai'; content: string }`），練習用 discriminated union 表達更複雜的狀態",
-    "API 串接（#12）剛解鎖 level 3，下一步可以嘗試為 mcq-attempt endpoint 加上 input size cap（防止超長 answer 字串），並在 fail 時回傳有意義的錯誤訊息，而不是 500",
-    "測試（#14）解鎖 level 2，下一步嘗試為 PR #1128 的 dictionary_service.py heteronym 挑選邏輯補一個 pytest：給定多音字回傳、驗證挑到有真實定義的那個，而不是 pronunciation-disambiguation",
-    "架構理解（#18）剛解鎖，試著看 mcq_attempt 這個 table 的 4 個 indexes（user_id / lesson_id / question_id / created_at），解釋為什麼每個都需要，什麼查詢場景會用到它"
+    "PR #1480 展現 AI prompt engineering 意識（拆 is_correct=true/false 分別給語氣規則）。下一步：在 #1458 驗收的 AI 助教相關工作中，嘗試設計更結構化的 prompt schema，例如加入 reasoning field（方大哥和 Young 可稽核），這是 AI prompt engineering 升到 level 3 的機會",
+    "架構理解（#18）穩在 level 3。下一步：#1458 剩餘的圖文整合呈現工作涉及前後端 YAML 解析 + layout 分支邏輯，完成後可以嘗試畫出圖文整合的資料流（YAML → loader → API → frontend layout）作為 level 4 的準備",
+    "Tailwind（#8）已升到 level 4，amber palette 整包一致是很好的設計系統實踐。下一步挑戰：把造句練習的 amber 配色邏輯抽成 Tailwind plugin 或 design token，做到不散落在各處 className",
+    "PR #1480 的 1 輪 @claude review 快速 LGTM 是迭代效率提升的好信號。繼續保持，下一個 PR 目標：PR 說明補上「testing steps」清單（這是 level 4 → 5 的一個標誌）"
   ],
-  "summary": "5 週內 11 個 merged PR，重大突破是 PR #1547（MCQ rescue dialog）首次端對端開發：DB table → Alembic → FastAPI → React → Vitest，新解鎖技能 12（API 串接）、13（元件設計模式）、14（測試）、18（架構理解），React 進階（#11）升 level 5，Tailwind（#8）升 level 4，Git 工作流（#9）升 level 4，TypeScript（#7）升 level 3。目前已確認解鎖 16 項技能",
+  "summary": "5/4~5/8 共 1 個 PR merge（#1480）。PR #1480 修造句練習三個獨立問題：AI 評估語氣歧義（拆 is_correct=true/false 規則，是 AI prompt engineering 意識的展現）、amber palette 配色全包一致、麥克風 wrapper layout 擠壓修正（shrink-0 + flex-col/sm:flex-row）。1 輪 @claude review 快速 LGTM，顯示從上一次多輪迭代進步到快速收斂。本週無技能升級（#8/#13 已在 level 4），但 #1480 的 prompt engineering 拆分思維為新技能維度打下基礎。[5/7 補充] Young 補了 #1482（是 #1480 claude-bot 找到的 L285 follow-up fix）+ #1485/#1487 meeting-prep skill 建立，啟翔本週無新 intern PR",
   "issues": [
     {
       "id": "環境建置",
@@ -352,8 +345,13 @@
       "date": "2026-03-06",
       "type": "setup",
       "contribution": "完成專案 fork、本地環境建置，獨立啟動 frontend/backend",
-      "skillsLearned": [1, 4],
-      "highlights": ["環境建置順利完成"]
+      "skillsLearned": [
+        1,
+        4
+      ],
+      "highlights": [
+        "環境建置順利完成"
+      ]
     },
     {
       "id": "#229",
@@ -361,8 +359,19 @@
       "date": "2026-03-10",
       "type": "refactor",
       "contribution": "重構 WriteCharacter 元件（+99/-120 行），改善生字練習的寫字 UX 體驗",
-      "skillsLearned": [2, 3, 6, 8, 9],
-      "highlights": ["大規模重構（+99/-120 行）", "正確使用 state、event handling", "元件設計清晰", "PR 流程完整"],
+      "skillsLearned": [
+        2,
+        3,
+        6,
+        8,
+        9
+      ],
+      "highlights": [
+        "大規模重構（+99/-120 行）",
+        "正確使用 state、event handling",
+        "元件設計清晰",
+        "PR 流程完整"
+      ],
       "linesChanged": "+99/-120"
     },
     {
@@ -371,8 +380,16 @@
       "date": "2026-03-13",
       "type": "feature",
       "contribution": "使用 StorageEvent、setTimeout 等進階技巧持續優化生字練習體驗",
-      "skillsLearned": [3, 6, 16],
-      "highlights": ["使用 StorageEvent 跨 tab 同步", "複雜 state 管理", "JS 進階能力已具備"]
+      "skillsLearned": [
+        3,
+        6,
+        16
+      ],
+      "highlights": [
+        "使用 StorageEvent 跨 tab 同步",
+        "複雜 state 管理",
+        "JS 進階能力已具備"
+      ]
     },
     {
       "id": "#448",
@@ -380,8 +397,17 @@
       "date": "2026-03-13",
       "type": "bugfix",
       "contribution": "精準定位並修復 useMemo 在 conditional return 之前的 React Hooks 順序 bug",
-      "skillsLearned": [10, 11, 17],
-      "highlights": ["精準定位 hooks 順序問題", "正確使用 useMemo 優化效能", "理解 hooks 執行規則", "從重現到修復到驗證流程完整"],
+      "skillsLearned": [
+        10,
+        11,
+        17
+      ],
+      "highlights": [
+        "精準定位 hooks 順序問題",
+        "正確使用 useMemo 優化效能",
+        "理解 hooks 執行規則",
+        "從重現到修復到驗證流程完整"
+      ],
       "linesChanged": "+25/-15"
     },
     {
@@ -390,7 +416,10 @@
       "date": "2026-03-20",
       "type": "bugfix",
       "contribution": "診斷 useFontSize() hook 監聽 window.storage 事件的跨 tab 限制，透過手動 dispatch synthetic StorageEvent 解決同頁面即時更新問題",
-      "skillsLearned": [3, 10],
+      "skillsLearned": [
+        3,
+        10
+      ],
       "highlights": [
         "精準指出 StorageEvent 只在其他 tab 寫入時才觸發的瀏覽器限制",
         "使用 new StorageEvent() + window.dispatchEvent() 手動觸發同頁面監聽",
@@ -400,19 +429,143 @@
       "linesChanged": "+5/-1"
     },
     {
-      "id": "#910/#912",
-      "title": "造句練習改用 vocabulary 生字，修正 cache 命中率",
+      "id": "#910",
+      "title": "造句練習改用 vocabulary 生字修正 cache 命中率（PR #912）",
       "date": "2026-04-03",
       "type": "bugfix",
-      "contribution": "診斷 SentencePractice 使用 displayChars（從課文提取的字）而非 vocabulary 詞彙表的字，導致與 example_sentence_cache.json 的 key 不符，cache 命中率低。新增 vocabChars useMemo 提取詞彙表中的中文字元，修正傳入來源。同時將 SentencePractice 的字元 tab 改為 flex-wrap 排列，避免溢出",
-      "skillsLearned": [7, 10, 11],
-      "highlights": [
-        "正確診斷 cache key 不符的根本原因",
-        "Set<string>、string[] 的 TypeScript 型別標注清晰",
-        "useMemo 依賴陣列設計正確",
-        "CJK 字元過濾正則 /[\\u4e00-\\u9fa5]/ 使用準確"
+      "contribution": "發現 SentencePractice 從 story.content 取前 12 個字作為造句字，與 example_sentence_cache.json 的 vocabulary 生字 key 完全不匹配，導致 1490 筆預生成快取從未被使用。新增 vocabChars memo 從 story.vocabulary 拆出去重 CJK 字傳給 SentencePractice，同步修正 tab 容器 flex-wrap 防止溢出",
+      "skillsLearned": [
+        11,
+        13
       ],
-      "linesChanged": "+19/-2"
+      "highlights": [
+        "清楚識別 cache key 不匹配的根本原因",
+        "用 memo 而非修改既有邏輯解決問題，影響最小",
+        "PR 附上截圖驗證修正結果",
+        "PR 說明包含完整 test plan 清單"
+      ],
+      "linesChanged": "+18/-2"
+    },
+    {
+      "id": "#911",
+      "title": "造句例句、課文重點表 rate limit 改為僅限 cache miss（PR #913）",
+      "date": "2026-04-04",
+      "type": "bugfix",
+      "contribution": "診斷 rate limiter 設在 route decorator 導致 cache hit 請求也消耗額度，快速切換生字時觸發 429。將 rate limit 從 decorator 移到 cache miss 的 AI 呼叫路徑內，同時修正 rate_limiter.py 的 DRY 問題。修改 backend 三個檔案：rate_limiter.py、learning_vocab.py、stories.py",
+      "skillsLearned": [
+        12,
+        18
+      ],
+      "highlights": [
+        "精準理解 FastAPI decorator 執行時機與 rate limiting 的關係",
+        "修正範圍最小化（只移動 rate limit 的位置）",
+        "PR 說明包含完整 test plan 含邊界情境（cache hit/miss/validate endpoint）",
+        "既有 13 個 test_sentence_practice 測試全部通過"
+      ],
+      "linesChanged": "+22/-15"
+    },
+    {
+      "id": "#927",
+      "title": "造句練習改以詞為最小單位（PR #959）",
+      "date": "2026-04-07",
+      "type": "feature",
+      "contribution": "實作 4/3 會議核心決議：造句練習從「字」改為「詞」為最小單位。前端修改 SentencePractice 元件接收 vocabulary 詞組、後端修改預生成快取 key 對齊、確保預生成例句也以詞為單位",
+      "skillsLearned": [
+        12,
+        13
+      ],
+      "highlights": [
+        "跨前後端完整修改（vocabulary 資料結構 + 快取 key）",
+        "理解字 vs 詞的語言學差異並正確反映在程式碼中",
+        "確保預生成快取與即時 API 的 key 一致"
+      ]
+    },
+    {
+      "id": "#928",
+      "title": "造句批改驗證真實性 + 防複製貼上（PR #969）",
+      "date": "2026-04-07",
+      "type": "feature",
+      "contribution": "實作 4/3 會議決議：防止學生複製貼上範例句獲得正面回饋。後端加入 AI 批改真實性檢查邏輯，前端加入複製貼上偵測，作業模式下禁用",
+      "skillsLearned": [
+        12
+      ],
+      "highlights": [
+        "後端 AI 批改加入真實性驗證",
+        "理解 Gemini API 回應結構並做二次檢查",
+        "前後端協同防弊設計"
+      ]
+    },
+    {
+      "id": "#1081",
+      "title": "沉浸式學習 shell + 設計系統整改（PR #1087）",
+      "date": "2026-04-16",
+      "type": "feature",
+      "contribution": "學習模式改為沉浸式全螢幕，移除 Header/Sidebar/StepperNav，改用 glassmorphic top bar + progress dots。設計系統切換至 Stitch Tactile Scholar palette，新增 surface token + btn-immersive + glass utility。注音字型改用 BpmfZihiSans-Bold，全域 [data-zhuyin-active] CSS 取代各元件 inline style。元件整體瘦身 -1425 行",
+      "skillsLearned": [
+        8,
+        13,
+        16
+      ],
+      "highlights": [
+        "迄今最大規模 PR（+3205/-4777）",
+        "完整設計系統建立（token + utility + 全域 CSS 策略）",
+        "元件大幅精簡，去除冗余",
+        "注音字型全局切換不影響非學習頁面"
+      ],
+      "linesChanged": "+3205/-4777"
+    },
+    {
+      "id": "#1099",
+      "title": "Step 5 部件教學：點擊回饋 + 常用字相關字 + moedict 字義（PR #1128）",
+      "date": "2026-04-19",
+      "type": "feature",
+      "contribution": "修復點擊無資料部件時畫面靜默的問題，加入 fallback 卡片。重建 radical-meanings.json（227 個部件）+ radicals.ts（30→80 個熱門部件，依課文字頻排序 relatedChars）。掛載時批次打 /api/dictionary/batch 取 moedict 釋義，module-level Map 快取，字義三層優先序",
+      "skillsLearned": [
+        12,
+        13,
+        18
+      ],
+      "highlights": [
+        "三個資料來源協調整合（radicals.ts + radical-meanings.json + moedict API）",
+        "module-level Map 快取設計",
+        "字義優先序設計（手寫→moedict→fallback）",
+        "PR 說明包含詳細的三層問題診斷"
+      ],
+      "linesChanged": "+7514/-1226"
+    },
+    {
+      "id": "#1095",
+      "title": "Step 1 閱讀標記選取偏移 + 紅線歪斜 + YAML 空白（PR #1130）",
+      "date": "2026-04-19",
+      "type": "bugfix",
+      "contribution": "診斷 PR #1087 把 data-para-idx 移到 section 導致 selection walker 讀到段落號碼字元，charStart 每次 +2 的 regression bug。修復方式：把 attr 搬回 p。紅線改用 shadow-[inset_0_-3px_0_0_#ef4444] 永遠水平。補寫 clean_lesson_whitespace.py 清理 6 篇 YAML 的誤植空白",
+      "skillsLearned": [
+        10,
+        18
+      ],
+      "highlights": [
+        "從 HTML 結構變化追到 JS DOM 行為再到 UI 偏移的完整因果鏈",
+        "從自己的 PR 造成的 regression 正確做 root cause analysis",
+        "Tailwind arbitrary shadow 解決 underline 行為問題"
+      ],
+      "linesChanged": "+147/-23"
+    },
+    {
+      "id": "造句 polish",
+      "title": "造句練習語氣軟化 + amber 配色 + 麥克風擠壓修正（PR #1480）",
+      "date": "2026-05-07",
+      "type": "feature",
+      "contribution": "修正造句練習三個獨立問題：(1) AI 評估回饋語氣歧義 — 拆分 is_correct=true 和 is_correct=false 兩組語氣規則，避免 prompt 語意模糊；(2) amber 配色不一致 — badge、border、feedback 文字、paste warning 全部對齊 amber palette；(3) 麥克風 wrapper 在窄螢幕被壓縮 — 加 shrink-0 + flex-col/sm:flex-row 自適應佈局",
+      "skillsLearned": [
+        8,
+        13
+      ],
+      "highlights": [
+        "AI prompt engineering：拆 is_correct=true/false 規則解決語氣歧義，顯示對 LLM 輸出結構的設計意識",
+        "amber palette 一致性：4 個使用點全部對齊，展現設計系統紀律",
+        "responsive layout：shrink-0 + flex-col/sm:flex-row 正確處理窄螢幕",
+        "1 輪 @claude review 快速 LGTM，迭代效率提升"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fixes #1630

## Summary
- Root cause: raymond.json in frontend/public had only 15 issues (last 2026-04-03); newer entries existed in docs/ but were never synced
- Merged both JSON files: raymond 15->33 issues (latest 2026-05-08), xiung 6->13 issues (latest 2026-05-07)
- Added sort by date descending in renderTimeline() so newest entries appear first

## Changes
- frontend/public/intern-training/interns/raymond.json — merged 26 missing issues
- frontend/public/intern-training/interns/xiung.json — merged 7 missing issues
- dashboard.html renderTimeline() now sorts issues by date desc

## Test plan
- Open staging dashboard after deploy
- Raymond tab: top entry should be 2026-05-08 (PR #1497 CSP fix)
- Steven tab: top entry should be 2026-05-07 (造句 polish)