### PR TITLE
fix(data): wire worksheet_pdf_url to active lesson ymls (Fixes #1639)

### DIFF
--- a/backend/data/curriculum/lessons/G4-L01.yml
+++ b/backend/data/curriculum/lessons/G4-L01.yml
@@ -30,3 +30,4 @@ vocab:
 - 摸不著頭緒
 existing_content_yaml: L01.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L01.pdf

--- a/backend/data/curriculum/lessons/G4-L02.yml
+++ b/backend/data/curriculum/lessons/G4-L02.yml
@@ -30,3 +30,4 @@ vocab:
 - 經年累月
 existing_content_yaml: L02.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L02.pdf

--- a/backend/data/curriculum/lessons/G4-L03.yml
+++ b/backend/data/curriculum/lessons/G4-L03.yml
@@ -30,3 +30,4 @@ vocab:
 - 根據
 existing_content_yaml: L03.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L03.pdf

--- a/backend/data/curriculum/lessons/G4-L04.yml
+++ b/backend/data/curriculum/lessons/G4-L04.yml
@@ -30,3 +30,4 @@ vocab:
 - 差之毫釐，失之千里
 existing_content_yaml: L04.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L04.pdf

--- a/backend/data/curriculum/lessons/G4-L05.yml
+++ b/backend/data/curriculum/lessons/G4-L05.yml
@@ -30,3 +30,4 @@ vocab:
 - 痛快淋漓
 existing_content_yaml: L05.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L05.pdf

--- a/backend/data/curriculum/lessons/G4-L07.yml
+++ b/backend/data/curriculum/lessons/G4-L07.yml
@@ -33,3 +33,4 @@ vocab:
 - 帥氣挺拔
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L07.pdf

--- a/backend/data/curriculum/lessons/G4-L08.yml
+++ b/backend/data/curriculum/lessons/G4-L08.yml
@@ -31,3 +31,4 @@ vocab:
 - 老神在在
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L08.pdf

--- a/backend/data/curriculum/lessons/G4-L09.yml
+++ b/backend/data/curriculum/lessons/G4-L09.yml
@@ -33,3 +33,4 @@ vocab:
 - 前兆
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L09.pdf

--- a/backend/data/curriculum/lessons/G4-L10.yml
+++ b/backend/data/curriculum/lessons/G4-L10.yml
@@ -28,3 +28,4 @@ vocab:
 - 路見不平
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L10.pdf

--- a/backend/data/curriculum/lessons/G4-L11.yml
+++ b/backend/data/curriculum/lessons/G4-L11.yml
@@ -27,3 +27,4 @@ vocab:
 - 反芻
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L11.pdf

--- a/backend/data/curriculum/lessons/G4-L12.yml
+++ b/backend/data/curriculum/lessons/G4-L12.yml
@@ -29,3 +29,4 @@ vocab:
 - 忐忑不安
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L12.pdf

--- a/backend/data/curriculum/lessons/G4-L13.yml
+++ b/backend/data/curriculum/lessons/G4-L13.yml
@@ -26,3 +26,4 @@ vocab:
 - 暈󠇡黃
 existing_content_yaml: L06.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L13.pdf

--- a/backend/data/curriculum/lessons/G4-L14.yml
+++ b/backend/data/curriculum/lessons/G4-L14.yml
@@ -32,3 +32,4 @@ vocab:
 - 奄奄一󠇢息
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L14.pdf

--- a/backend/data/curriculum/lessons/G4-L15.yml
+++ b/backend/data/curriculum/lessons/G4-L15.yml
@@ -24,3 +24,4 @@ vocab:
 - 目光
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L15.pdf

--- a/backend/data/curriculum/lessons/G4-L16.yml
+++ b/backend/data/curriculum/lessons/G4-L16.yml
@@ -26,3 +26,4 @@ vocab:
 - 一󠇢言一󠇢行
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L16.pdf

--- a/backend/data/curriculum/lessons/G4-L17.yml
+++ b/backend/data/curriculum/lessons/G4-L17.yml
@@ -30,3 +30,4 @@ vocab:
 - 孤注一擲
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L17.pdf

--- a/backend/data/curriculum/lessons/G4-L18.yml
+++ b/backend/data/curriculum/lessons/G4-L18.yml
@@ -31,3 +31,4 @@ vocab:
 - 兼顧
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L18.pdf

--- a/backend/data/curriculum/lessons/G4-L19.yml
+++ b/backend/data/curriculum/lessons/G4-L19.yml
@@ -32,3 +32,4 @@ vocab:
 - 訓練有素
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L19.pdf

--- a/backend/data/curriculum/lessons/G4-L23.yml
+++ b/backend/data/curriculum/lessons/G4-L23.yml
@@ -29,3 +29,4 @@ vocab:
 - 心理素質
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L23.pdf

--- a/backend/data/curriculum/lessons/G4-L24.yml
+++ b/backend/data/curriculum/lessons/G4-L24.yml
@@ -29,3 +29,4 @@ vocab:
 - 使喚
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L24.pdf

--- a/backend/data/curriculum/lessons/G4-L25.yml
+++ b/backend/data/curriculum/lessons/G4-L25.yml
@@ -32,3 +32,4 @@ vocab:
 - 本錢
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L25.pdf

--- a/backend/data/curriculum/lessons/G4-L26.yml
+++ b/backend/data/curriculum/lessons/G4-L26.yml
@@ -28,3 +28,4 @@ vocab:
 - 懊悔
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L26.pdf

--- a/backend/data/curriculum/lessons/G4-L27.yml
+++ b/backend/data/curriculum/lessons/G4-L27.yml
@@ -27,3 +27,4 @@ vocab:
 - 酸言酸語
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L27.pdf

--- a/backend/data/curriculum/lessons/G5-L01.yml
+++ b/backend/data/curriculum/lessons/G5-L01.yml
@@ -31,3 +31,4 @@ vocab:
 - 演化
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L01.pdf

--- a/backend/data/curriculum/lessons/G5-L10.yml
+++ b/backend/data/curriculum/lessons/G5-L10.yml
@@ -31,3 +31,4 @@ vocab:
 - 心力交瘁
 existing_content_yaml: L10.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L10.pdf

--- a/backend/data/curriculum/lessons/G5-L12.yml
+++ b/backend/data/curriculum/lessons/G5-L12.yml
@@ -26,3 +26,4 @@ vocab:
 - 欲速則不達
 existing_content_yaml: L13.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L12.pdf

--- a/backend/data/curriculum/lessons/G5-L13.yml
+++ b/backend/data/curriculum/lessons/G5-L13.yml
@@ -34,3 +34,4 @@ vocab:
 - 壓力鍋
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L13.pdf

--- a/backend/data/curriculum/lessons/G5-L14.yml
+++ b/backend/data/curriculum/lessons/G5-L14.yml
@@ -27,3 +27,4 @@ vocab:
 - 無傷大雅
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L14.pdf

--- a/backend/data/curriculum/lessons/G5-L15.yml
+++ b/backend/data/curriculum/lessons/G5-L15.yml
@@ -33,3 +33,4 @@ vocab:
 - 緣起
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L15.pdf

--- a/backend/data/curriculum/lessons/G5-L16.yml
+++ b/backend/data/curriculum/lessons/G5-L16.yml
@@ -29,3 +29,4 @@ vocab:
 - 先驅
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L16.pdf

--- a/backend/data/curriculum/lessons/G5-L17.yml
+++ b/backend/data/curriculum/lessons/G5-L17.yml
@@ -33,3 +33,4 @@ vocab:
 - 繁殖
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L17.pdf

--- a/backend/data/curriculum/lessons/G5-L18.yml
+++ b/backend/data/curriculum/lessons/G5-L18.yml
@@ -31,3 +31,4 @@ vocab:
 - 契機
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L18.pdf

--- a/backend/data/curriculum/lessons/G5-L19.yml
+++ b/backend/data/curriculum/lessons/G5-L19.yml
@@ -24,3 +24,4 @@ vocab:
 - 漣漪
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L19.pdf

--- a/backend/data/curriculum/lessons/G5-L20.yml
+++ b/backend/data/curriculum/lessons/G5-L20.yml
@@ -25,3 +25,4 @@ vocab:
 - 坦然
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L20.pdf

--- a/backend/data/curriculum/lessons/G5-L21.yml
+++ b/backend/data/curriculum/lessons/G5-L21.yml
@@ -32,3 +32,4 @@ vocab:
 - 蠢蠢欲動
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L21.pdf

--- a/backend/data/curriculum/lessons/G5-L22.yml
+++ b/backend/data/curriculum/lessons/G5-L22.yml
@@ -27,3 +27,4 @@ vocab:
 - 想方設法
 existing_content_yaml: L12.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L22.pdf

--- a/backend/data/curriculum/lessons/G5-L23.yml
+++ b/backend/data/curriculum/lessons/G5-L23.yml
@@ -31,3 +31,4 @@ vocab:
 - 座無虛席
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L23.pdf

--- a/backend/data/curriculum/lessons/G5-L26.yml
+++ b/backend/data/curriculum/lessons/G5-L26.yml
@@ -27,3 +27,4 @@ vocab:
 - 年齡層
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L26.pdf

--- a/backend/data/curriculum/lessons/G5-L27.yml
+++ b/backend/data/curriculum/lessons/G5-L27.yml
@@ -25,3 +25,4 @@ vocab:
 - 工作記憶
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L27.pdf

--- a/backend/data/curriculum/lessons/G6-L10.yml
+++ b/backend/data/curriculum/lessons/G6-L10.yml
@@ -31,3 +31,4 @@ vocab:
 - 殃及池魚
 existing_content_yaml: L20.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L10.pdf

--- a/backend/data/curriculum/lessons/G6-L11.yml
+++ b/backend/data/curriculum/lessons/G6-L11.yml
@@ -30,3 +30,4 @@ vocab:
 - 口耳相傳
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L11.pdf

--- a/backend/data/curriculum/lessons/G6-L12.yml
+++ b/backend/data/curriculum/lessons/G6-L12.yml
@@ -29,3 +29,4 @@ vocab:
 - 相去無幾
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L12.pdf

--- a/backend/data/curriculum/lessons/G6-L13.yml
+++ b/backend/data/curriculum/lessons/G6-L13.yml
@@ -33,3 +33,4 @@ vocab:
 - 拋家棄子
 existing_content_yaml: L21.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L13.pdf

--- a/backend/data/curriculum/lessons/G6-L14.yml
+++ b/backend/data/curriculum/lessons/G6-L14.yml
@@ -36,3 +36,4 @@ vocab:
 - 悄然無息
 existing_content_yaml: L22.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L14.pdf

--- a/backend/data/curriculum/lessons/G6-L15.yml
+++ b/backend/data/curriculum/lessons/G6-L15.yml
@@ -32,3 +32,4 @@ vocab:
 - 燃燒殆盡
 existing_content_yaml: L23.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L15.pdf

--- a/backend/data/curriculum/lessons/G6-L16.yml
+++ b/backend/data/curriculum/lessons/G6-L16.yml
@@ -32,3 +32,4 @@ vocab:
 - 充飢
 existing_content_yaml: L26.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L16.pdf

--- a/backend/data/curriculum/lessons/G6-L17.yml
+++ b/backend/data/curriculum/lessons/G6-L17.yml
@@ -32,3 +32,4 @@ vocab:
 - 惡版印象
 existing_content_yaml: L25.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L17.pdf

--- a/backend/data/curriculum/lessons/G6-L19.yml
+++ b/backend/data/curriculum/lessons/G6-L19.yml
@@ -28,3 +28,4 @@ vocab:
 - 蜿蜒凶險
 existing_content_yaml: L28.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L19.pdf

--- a/backend/data/curriculum/lessons/G6-L20.yml
+++ b/backend/data/curriculum/lessons/G6-L20.yml
@@ -26,3 +26,4 @@ vocab:
 - 遲疑
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L20.pdf

--- a/backend/data/curriculum/lessons/G6-L21.yml
+++ b/backend/data/curriculum/lessons/G6-L21.yml
@@ -26,3 +26,4 @@ vocab:
 - 酸澀
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L21.pdf

--- a/backend/data/curriculum/lessons/G6-L22.yml
+++ b/backend/data/curriculum/lessons/G6-L22.yml
@@ -34,3 +34,4 @@ vocab:
 - 投奔
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L22.pdf

--- a/backend/data/curriculum/lessons/G6-L23.yml
+++ b/backend/data/curriculum/lessons/G6-L23.yml
@@ -31,3 +31,4 @@ vocab:
 - 鍥而不捨
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L23.pdf

--- a/backend/data/curriculum/lessons/G7-L10.yml
+++ b/backend/data/curriculum/lessons/G7-L10.yml
@@ -28,3 +28,4 @@ vocab:
 - 簽署
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L10.pdf

--- a/backend/data/curriculum/lessons/G7-L11.yml
+++ b/backend/data/curriculum/lessons/G7-L11.yml
@@ -30,3 +30,4 @@ vocab:
 - 磨難
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L11.pdf

--- a/backend/data/curriculum/lessons/G7-L12.yml
+++ b/backend/data/curriculum/lessons/G7-L12.yml
@@ -29,3 +29,4 @@ vocab:
 - 死纏爛打
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L12.pdf

--- a/backend/data/curriculum/lessons/G7-L13.yml
+++ b/backend/data/curriculum/lessons/G7-L13.yml
@@ -33,3 +33,4 @@ vocab:
 - 因應而生
 existing_content_yaml: L34.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L13.pdf

--- a/backend/data/curriculum/lessons/G7-L14.yml
+++ b/backend/data/curriculum/lessons/G7-L14.yml
@@ -30,3 +30,4 @@ vocab:
 - 內化
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L14.pdf

--- a/backend/data/curriculum/lessons/G7-L16.yml
+++ b/backend/data/curriculum/lessons/G7-L16.yml
@@ -30,3 +30,4 @@ vocab:
 - 大為嘆服
 existing_content_yaml: L36.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L16.pdf

--- a/backend/data/curriculum/lessons/G7-L17.yml
+++ b/backend/data/curriculum/lessons/G7-L17.yml
@@ -29,3 +29,4 @@ vocab:
 - 兵貴神速
 existing_content_yaml: L37.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L17.pdf

--- a/backend/data/curriculum/lessons/G7-L18.yml
+++ b/backend/data/curriculum/lessons/G7-L18.yml
@@ -29,3 +29,4 @@ vocab:
 - 秋祺
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L18.pdf

--- a/backend/data/curriculum/lessons/G7-L19.yml
+++ b/backend/data/curriculum/lessons/G7-L19.yml
@@ -33,3 +33,4 @@ vocab:
 - 笨拙
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L19.pdf

--- a/backend/data/curriculum/lessons/G7-L20.yml
+++ b/backend/data/curriculum/lessons/G7-L20.yml
@@ -31,3 +31,4 @@ vocab:
 - 指鹿為馬
 existing_content_yaml: L39.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L20.pdf

--- a/backend/data/curriculum/lessons/G7-L21.yml
+++ b/backend/data/curriculum/lessons/G7-L21.yml
@@ -33,3 +33,4 @@ vocab:
 - 眼花撩亂
 existing_content_yaml: L40.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L21.pdf

--- a/backend/data/curriculum/lessons/G7-L22.yml
+++ b/backend/data/curriculum/lessons/G7-L22.yml
@@ -25,3 +25,4 @@ vocab:
 - 衝鋒陷陣
 existing_content_yaml: L41.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L22.pdf

--- a/backend/data/curriculum/lessons/G7-L23.yml
+++ b/backend/data/curriculum/lessons/G7-L23.yml
@@ -19,3 +19,4 @@ vocab:
 - 無
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L23.pdf

--- a/backend/data/curriculum/lessons/G7-L24.yml
+++ b/backend/data/curriculum/lessons/G7-L24.yml
@@ -30,3 +30,4 @@ vocab:
 - 雞皮疙瘩
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L24.pdf

--- a/backend/data/curriculum/lessons/G7-L25.yml
+++ b/backend/data/curriculum/lessons/G7-L25.yml
@@ -36,3 +36,4 @@ vocab:
 - 有憑有據
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L25.pdf

--- a/backend/data/curriculum/lessons/G7-L26.yml
+++ b/backend/data/curriculum/lessons/G7-L26.yml
@@ -20,3 +20,4 @@ video_links:
 vocab: null
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L26.pdf

--- a/backend/data/curriculum/lessons/G7-L27.yml
+++ b/backend/data/curriculum/lessons/G7-L27.yml
@@ -16,3 +16,4 @@ video_links: null
 vocab: null
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L27.pdf

--- a/backend/data/curriculum/lessons/G7-L28.yml
+++ b/backend/data/curriculum/lessons/G7-L28.yml
@@ -21,3 +21,4 @@ vocab:
 - 無
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L28.pdf

--- a/backend/data/curriculum/lessons/G7-L29.yml
+++ b/backend/data/curriculum/lessons/G7-L29.yml
@@ -20,3 +20,4 @@ video_links:
 vocab: null
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L29.pdf

--- a/backend/data/curriculum/lessons/G7-L30.yml
+++ b/backend/data/curriculum/lessons/G7-L30.yml
@@ -21,3 +21,4 @@ vocab:
 - 無
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L30.pdf

--- a/backend/data/curriculum/lessons/G8-L02.yml
+++ b/backend/data/curriculum/lessons/G8-L02.yml
@@ -30,3 +30,4 @@ vocab:
 - 經濟蕭條
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L2.pdf

--- a/backend/data/curriculum/lessons/G8-L10.yml
+++ b/backend/data/curriculum/lessons/G8-L10.yml
@@ -29,3 +29,4 @@ vocab:
 - 一目了󠇡然
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L10.pdf

--- a/backend/data/curriculum/lessons/G8-L13.yml
+++ b/backend/data/curriculum/lessons/G8-L13.yml
@@ -32,3 +32,4 @@ vocab:
 - 莫衷一是
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L13.pdf

--- a/backend/data/curriculum/lessons/G8-L14.yml
+++ b/backend/data/curriculum/lessons/G8-L14.yml
@@ -32,3 +32,4 @@ vocab:
 - 緩不濟急
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L14.pdf

--- a/backend/data/curriculum/lessons/G8-L15.yml
+++ b/backend/data/curriculum/lessons/G8-L15.yml
@@ -30,3 +30,4 @@ vocab:
 - 權衡
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L15.pdf

--- a/backend/data/curriculum/lessons/G9-L10.yml
+++ b/backend/data/curriculum/lessons/G9-L10.yml
@@ -28,3 +28,4 @@ vocab:
 - 凝血現象
 existing_content_yaml: L55.yml
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G9-L10.pdf

--- a/backend/data/curriculum/lessons/G9-L11.yml
+++ b/backend/data/curriculum/lessons/G9-L11.yml
@@ -28,3 +28,4 @@ vocab:
 - 機制
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G9-L11.pdf

--- a/backend/data/curriculum/lessons/G9-L12.yml
+++ b/backend/data/curriculum/lessons/G9-L12.yml
@@ -30,3 +30,4 @@ vocab:
 - 休戚與共
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G9-L12.pdf

--- a/backend/data/curriculum/lessons/G9-L13.yml
+++ b/backend/data/curriculum/lessons/G9-L13.yml
@@ -29,3 +29,4 @@ vocab:
 - 否󠇡極泰來
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G9-L13.pdf

--- a/backend/data/curriculum/lessons/G9-L14.yml
+++ b/backend/data/curriculum/lessons/G9-L14.yml
@@ -20,3 +20,4 @@ video_links:
 vocab: null
 existing_content_yaml: null
 notes: null
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G9-L14.pdf

--- a/backend/data/lessons/L01.yml
+++ b/backend/data/lessons/L01.yml
@@ -219,3 +219,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L01.pdf

--- a/backend/data/lessons/L02.yml
+++ b/backend/data/lessons/L02.yml
@@ -222,3 +222,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L02.pdf

--- a/backend/data/lessons/L03.yml
+++ b/backend/data/lessons/L03.yml
@@ -225,3 +225,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L03.pdf

--- a/backend/data/lessons/L04.yml
+++ b/backend/data/lessons/L04.yml
@@ -228,3 +228,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L04.pdf

--- a/backend/data/lessons/L05.yml
+++ b/backend/data/lessons/L05.yml
@@ -236,3 +236,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L05.pdf

--- a/backend/data/lessons/L06.yml
+++ b/backend/data/lessons/L06.yml
@@ -243,3 +243,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L13.pdf

--- a/backend/data/lessons/L10.yml
+++ b/backend/data/lessons/L10.yml
@@ -255,3 +255,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L10.pdf

--- a/backend/data/lessons/L12.yml
+++ b/backend/data/lessons/L12.yml
@@ -231,3 +231,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L22.pdf

--- a/backend/data/lessons/L13.yml
+++ b/backend/data/lessons/L13.yml
@@ -233,3 +233,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G5-L12.pdf

--- a/backend/data/lessons/L20.yml
+++ b/backend/data/lessons/L20.yml
@@ -264,3 +264,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L10.pdf

--- a/backend/data/lessons/L21.yml
+++ b/backend/data/lessons/L21.yml
@@ -268,3 +268,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L13.pdf

--- a/backend/data/lessons/L22.yml
+++ b/backend/data/lessons/L22.yml
@@ -287,3 +287,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L14.pdf

--- a/backend/data/lessons/L23.yml
+++ b/backend/data/lessons/L23.yml
@@ -232,3 +232,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L15.pdf

--- a/backend/data/lessons/L25.yml
+++ b/backend/data/lessons/L25.yml
@@ -304,3 +304,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L17.pdf

--- a/backend/data/lessons/L26.yml
+++ b/backend/data/lessons/L26.yml
@@ -286,3 +286,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L16.pdf

--- a/backend/data/lessons/L28.yml
+++ b/backend/data/lessons/L28.yml
@@ -263,3 +263,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L19.pdf

--- a/backend/data/lessons/L34.yml
+++ b/backend/data/lessons/L34.yml
@@ -265,3 +265,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L13.pdf

--- a/backend/data/lessons/L36.yml
+++ b/backend/data/lessons/L36.yml
@@ -272,3 +272,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L16.pdf

--- a/backend/data/lessons/L37.yml
+++ b/backend/data/lessons/L37.yml
@@ -287,3 +287,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L17.pdf

--- a/backend/data/lessons/L39.yml
+++ b/backend/data/lessons/L39.yml
@@ -227,3 +227,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L20.pdf

--- a/backend/data/lessons/L40.yml
+++ b/backend/data/lessons/L40.yml
@@ -274,3 +274,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L21.pdf

--- a/backend/data/lessons/L41.yml
+++ b/backend/data/lessons/L41.yml
@@ -258,3 +258,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L22.pdf

--- a/backend/data/lessons/L55.yml
+++ b/backend/data/lessons/L55.yml
@@ -190,3 +190,4 @@ worksheet_section_order:
 - number: 十一
   name: 報告
   type: report
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G9-L10.pdf


### PR DESCRIPTION
Fixes #1639

## Summary

- Added `worksheet_pdf_url` field to 82 catalog YMLs (`backend/data/curriculum/lessons/G*-L*.yml`)
- Added `worksheet_pdf_url` field to 23 active lesson YMLs (`backend/data/lessons/L*.yml`)
- Source of truth: GCS `gs://lingoleap-assets/worksheets/` (90 validated single-lesson PDFs)
- Excluded: 22 title-mismatch entries + 4 multi-lesson codes (e.g. G4-L20-22)

## Why data-only

Backend already reads `worksheet_pdf_url` from YMLs and exposes it via `/api/stories/{lesson}`. Frontend `Intro.tsx` already has the conditional button. The field just wasn't populated in any active YML.

## Validation

- yaml.safe_load verified on 3 random catalog YMLs (G4-L01, G5-L10, G7-L28) — field present + valid URL
- Active L01.yml: `grade_code: G4-L01`, `worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L01.pdf`
- GCS PDF HTTP 200: `curl -s -o /dev/null -w "%{http_code}" https://storage.googleapis.com/lingoleap-assets/worksheets/G4-L01.pdf` → **200**

## Test plan

- After staging deploy: `curl https://lingoleap-backend-staging-xxx.run.app/api/stories/L01` → `worksheet_pdf_url` should be non-null
- Open staging frontend → Intro step for any of the 23 active lessons → 查看紙本學習單 button should appear