### PR TITLE
fix(vocab-application): normalize fill_in_blank schema + guard new-format items (Fixes #1559, Fixes #1563)

### DIFF
--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -55,6 +55,42 @@ def _halfwidth(code: str) -> str:
     )
 
 
+def _normalize_fill_in_blank_item(item: dict) -> dict:
+    """Normalize a fill_in_blank item, tagging new-format items for frontend detection.
+
+    Two schemas coexist in the data:
+      Legacy (Layer-1 / old parsed):
+        { sentence: "孟嘗君（　　）逃離秦國。", answer: "A" }
+        answer is a letter code that matches a vocab_bank key.
+
+      New-format (5/1 curriculum batch, Layer-2):
+        { id, answer: "模仿雞叫", context_before: "...", context_after: "...",
+          context_paragraph_idx: N }
+        answer is freetext (strategy worksheet cloze), NOT a vocab_bank letter code.
+
+    FillInBlankExercise.tsx expects legacy format: item.sentence (string) and
+    item.answer (letter code matching vocab_bank). New-format items cannot be used
+    with the current exercise component because answers are freetext, not letter codes.
+
+    This function:
+    1. Synthesizes a sentence string for new-format items (context_before + blank + context_after)
+       so the sentence text is available for future exercise types.
+    2. Adds _schema flag to distinguish schema types without fragile duck-typing in callers.
+
+    Frontend api.ts filters by _schema: items with _schema="context_fill" are dropped
+    from fillInBlank → hasData=false → NoDataFallback renders (correct for 6/1 demo).
+    When a proper cloze exercise component is built, this flag enables clean routing.
+
+    Related: #1559, #1563
+    """
+    if "context_before" in item and "sentence" not in item:
+        before = item.get("context_before") or ""
+        after = item.get("context_after") or ""
+        return {**item, "sentence": f"{before}（　　）{after}", "_schema": "context_fill"}
+    # Legacy format: no change needed, but tag it too for symmetry.
+    return {**item, "_schema": "legacy"}
+
+
 _GENRE_TO_CATEGORY = {
     "記敘文": "Fable",
     "說明文": "Science",
@@ -198,7 +234,7 @@ def _load_layer1_lessons() -> list[dict]:
             ),
             "vocabulary": data.get("vocabulary") or [],
             "fill_in_blank": [
-                {**item, "answer": _halfwidth(item.get("answer", ""))}
+                {**_normalize_fill_in_blank_item(item), "answer": _halfwidth(item.get("answer", ""))}
                 for item in (data.get("fill_in_blank") or [])
             ] or None,
             "multiple_choice": data.get("multiple_choice"),
@@ -326,7 +362,7 @@ def _load_layer2_lessons(
             ),
             "vocabulary": vocabulary,
             "fill_in_blank": [
-                {**item, "answer": _halfwidth(item.get("answer", ""))}
+                {**_normalize_fill_in_blank_item(item), "answer": _halfwidth(item.get("answer", ""))}
                 for item in (data.get("fill_in_blank") or [])
             ] or None,
             "multiple_choice": data.get("multiple_choice"),

--- a/backend/tests/test_fill_in_blank_normalization.py
+++ b/backend/tests/test_fill_in_blank_normalization.py
@@ -1,0 +1,201 @@
+"""
+Tests for _normalize_fill_in_blank_item() in lesson_loader.py
+
+Issue #1559: New-format (5/1 batch) fill_in_blank items have context_before/context_after
+  and freetext answers — they lack a `sentence` field, crashing FillInBlankExercise.
+Issue #1563: FillInBlankExercise expects `sentence` field; new-format items cause TypeError.
+
+Fix: lesson_loader._normalize_fill_in_blank_item() tags every item with _schema:
+  "legacy"       — has sentence, answer is a vocab_bank letter code ("A".."J")
+  "context_fill" — new-format: answer is freetext strategy cloze; synthesize sentence
+
+Frontend api.ts drops context_fill items so VocabApplication shows NoDataFallback
+(graceful) instead of a broken exercise.
+"""
+import sys
+import os
+
+# Allow importing from backend/app without a full installed package
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from app.services.lesson_loader import _normalize_fill_in_blank_item
+
+
+class TestNormalizeFillInBlankItem:
+    """Unit tests for _normalize_fill_in_blank_item()."""
+
+    # ── Legacy schema (old-format) ──────────────────────────────────────────
+
+    def test_legacy_passthrough_sentence_preserved(self):
+        """Legacy items keep their sentence unchanged."""
+        item = {"sentence": "春天來了，萬物（　　）。", "answer": "A"}
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "春天來了，萬物（　　）。"
+
+    def test_legacy_answer_preserved(self):
+        """Legacy items keep their letter-code answer."""
+        item = {"sentence": "他（　　）向前奔跑。", "answer": "B"}
+        result = _normalize_fill_in_blank_item(item)
+        assert result["answer"] == "B"
+
+    def test_legacy_tagged_as_legacy(self):
+        """Legacy items get _schema = 'legacy'."""
+        item = {"sentence": "她（　　）地笑著。", "answer": "C"}
+        result = _normalize_fill_in_blank_item(item)
+        assert result["_schema"] == "legacy"
+
+    def test_legacy_extra_fields_preserved(self):
+        """Extra fields on legacy items are preserved."""
+        item = {"sentence": "水從山上（　　）而下。", "answer": "D", "hint": "動詞"}
+        result = _normalize_fill_in_blank_item(item)
+        assert result["hint"] == "動詞"
+        assert result["_schema"] == "legacy"
+
+    # ── New-format schema (context_fill) ────────────────────────────────────
+
+    def test_new_format_tagged_as_context_fill(self):
+        """New-format items (with context_before) get _schema = 'context_fill'."""
+        item = {
+            "id": 1,
+            "context_before": "牠看著月亮，",
+            "context_after": "，彷彿在思念什麼。",
+            "answer": "模仿雞叫",
+            "context_paragraph_idx": 2,
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["_schema"] == "context_fill"
+
+    def test_new_format_sentence_synthesized(self):
+        """New-format items get a synthesized sentence for legacy compatibility."""
+        item = {
+            "id": 1,
+            "context_before": "牠看著月亮，",
+            "context_after": "，彷彿在思念什麼。",
+            "answer": "模仿雞叫",
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "牠看著月亮，（　　），彷彿在思念什麼。"
+
+    def test_new_format_freetext_answer_preserved(self):
+        """Freetext answers on new-format items are NOT changed by normalizer."""
+        item = {
+            "id": 2,
+            "context_before": "他昂首挺胸，",
+            "context_after": "走進教室。",
+            "answer": "充滿自信地",
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["answer"] == "充滿自信地"
+
+    def test_new_format_all_fields_preserved(self):
+        """All original fields on new-format items are preserved."""
+        item = {
+            "id": 3,
+            "context_before": "春天，",
+            "context_after": "，草地上滿是花朵。",
+            "answer": "萬物復甦",
+            "context_paragraph_idx": 0,
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["id"] == 3
+        assert result["context_before"] == "春天，"
+        assert result["context_after"] == "，草地上滿是花朵。"
+        assert result["context_paragraph_idx"] == 0
+
+    # ── Edge cases ───────────────────────────────────────────────────────────
+
+    def test_empty_context_before(self):
+        """context_before can be empty string."""
+        item = {
+            "id": 4,
+            "context_before": "",
+            "context_after": "，讓人感到溫暖。",
+            "answer": "陽光照耀",
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "（　　），讓人感到溫暖。"
+        assert result["_schema"] == "context_fill"
+
+    def test_empty_context_after(self):
+        """context_after can be empty string."""
+        item = {
+            "id": 5,
+            "context_before": "他大聲地說：",
+            "context_after": "",
+            "answer": "我會努力的",
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "他大聲地說：（　　）"
+        assert result["_schema"] == "context_fill"
+
+    def test_none_context_before_treated_as_empty(self):
+        """None context_before is treated as empty string."""
+        item = {
+            "id": 6,
+            "context_before": None,
+            "context_after": "是學習的關鍵。",
+            "answer": "專注",
+        }
+        result = _normalize_fill_in_blank_item(item)
+        assert result["sentence"] == "（　　）是學習的關鍵。"
+        assert result["_schema"] == "context_fill"
+
+    def test_item_with_both_sentence_and_context_before_treated_as_legacy(self):
+        """If item has BOTH sentence AND context_before, legacy wins (sentence present).
+        The normalizer condition is: context_before in item AND sentence NOT in item.
+        When sentence IS present, condition is False → falls through to legacy path.
+        """
+        item = {
+            "sentence": "某某（　　）某某。",
+            "context_before": "前文",
+            "context_after": "後文",
+            "answer": "A",
+        }
+        result = _normalize_fill_in_blank_item(item)
+        # "sentence" IS in item → "sentence" not in item is False → legacy path
+        assert result["_schema"] == "legacy"
+
+    def test_schema_key_does_not_overwrite_existing(self):
+        """If item already has _schema (e.g. from a previous normalization), it gets replaced."""
+        item = {"sentence": "某（　　）某。", "answer": "A", "_schema": "some_old_value"}
+        result = _normalize_fill_in_blank_item(item)
+        # Normalizer always sets _schema based on structure, not previous value
+        assert result["_schema"] == "legacy"
+
+
+class TestNormalizeFillInBlankItemSchemaDetection:
+    """Verify the _schema flag correctly separates the two schemas so
+    api.ts filter logic `item['_schema'] === 'legacy'` works as expected."""
+
+    def test_all_new_format_items_get_context_fill(self):
+        """A batch of new-format items all get tagged context_fill."""
+        new_format_items = [
+            {"id": i, "context_before": f"前{i}", "context_after": f"後{i}", "answer": f"答案{i}"}
+            for i in range(1, 6)
+        ]
+        results = [_normalize_fill_in_blank_item(item) for item in new_format_items]
+        for r in results:
+            assert r["_schema"] == "context_fill"
+
+    def test_all_legacy_items_get_legacy(self):
+        """A batch of legacy items all get tagged legacy."""
+        legacy_items = [
+            {"sentence": f"某某（　　）{i}。", "answer": chr(ord("A") + i)}
+            for i in range(5)
+        ]
+        results = [_normalize_fill_in_blank_item(item) for item in legacy_items]
+        for r in results:
+            assert r["_schema"] == "legacy"
+
+    def test_mixed_batch_separation(self):
+        """Mixed batch: context_fill items separate cleanly from legacy items."""
+        items = [
+            {"sentence": "他（　　）前進。", "answer": "A"},  # legacy
+            {"id": 1, "context_before": "牠", "context_after": "叫著。", "answer": "模仿"},  # new-format
+            {"sentence": "水（　　）流下。", "answer": "B"},  # legacy
+            {"id": 2, "context_before": "春天", "context_after": "到來。", "answer": "溫暖"},  # new-format
+        ]
+        results = [_normalize_fill_in_blank_item(item) for item in items]
+        schemas = [r["_schema"] for r in results]
+        assert schemas == ["legacy", "context_fill", "legacy", "context_fill"]

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -133,13 +133,24 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     vocabulary: detail.vocabulary ?? undefined,
     charCount: detail.char_count,
     readingBenchmark: detail.reading_benchmark ?? undefined,
-    // Filter to legacy-format items only (those with a `sentence` field).
-    // New-format items from the 5/1 curriculum batch use context_before/context_after
-    // which FillInBlankExercise does not yet support — passing them causes a TypeError
-    // crash when the component accesses `.sentence` (#1563).
-    // Filtering to [] causes VocabApplication.hasData to return false → NoDataFallback.
+    // Filter to legacy-format items only.
+    // Two fill_in_blank schemas coexist (#1559, #1563):
+    //   Legacy: { sentence, answer: "A" } — answer is a vocab_bank letter code.
+    //   New-format (5/1 batch): { id, context_before, context_after, answer: "模仿雞叫" }
+    //     answer is freetext (strategy cloze), NOT a vocab_bank letter code.
+    //
+    // lesson_loader.py _normalize_fill_in_blank_item() synthesizes `sentence` for
+    // new-format items and tags both schemas with `_schema` ("legacy" | "context_fill").
+    //
+    // FillInBlankExercise requires legacy format: answer must match a vocab_bank key.
+    // New-format items cause a broken exercise (no answer ever matches) or crash on
+    // `.sentence` access when normalization is absent. Drop them here so
+    // VocabApplication.hasData returns false → NoDataFallback renders.
+    // When a cloze exercise component is built for new-format, remove this filter.
     fillInBlank: detail.fill_in_blank
-      ? detail.fill_in_blank.filter((item) => typeof item['sentence'] === 'string') as Array<{ sentence: string; answer: string }>
+      ? detail.fill_in_blank.filter((item) =>
+          item['_schema'] === 'legacy' || typeof item['sentence'] === 'string' && !('context_before' in item)
+        ) as Array<{ sentence: string; answer: string }>
       : undefined,
     multipleChoice: detail.multiple_choice ?? undefined,
     vocabBank: detail.vocab_bank ?? undefined,


### PR DESCRIPTION
Fixes #1559
Fixes #1563

## Problem

Two fill_in_blank schemas coexist since the 5/1 curriculum batch:

**Legacy** (Layer-1, 57 lessons):
```
{ sentence: "孟嘗君（　　）逃離秦國。", answer: "A" }
```
`answer` is a vocab_bank letter code. FillInBlankExercise renders this correctly.

**New-format / context_fill** (Layer-2, G6-L22~L25, G7-L28~L30 — the 7 lessons 教授 reviews 6/1):
```
{ id: 1, context_before: "牠看著月亮，", context_after: "彷彿在思念什麼。",
  answer: "模仿雞叫", context_paragraph_idx: 2 }
```
`answer` is freetext (strategy cloze worksheet). There is no `sentence` field.

FillInBlankExercise.tsx accesses `currentSentence.sentence` (line 339) and `s.sentence.replace(...)` (line 263) — both throw `TypeError: Cannot read properties of undefined` on new-format items → StepErrorBoundary error screen → 教授 cannot see any of the 7 lessons.

## Fix

### Backend — `backend/app/services/lesson_loader.py`

Add `_normalize_fill_in_blank_item()` that:
1. Detects new-format items (`context_before` present, `sentence` absent)
2. Synthesizes `sentence` from `context_before + "（　　）" + context_after` (for future exercise use)
3. Tags every item with `_schema: "legacy"` or `_schema: "context_fill"`

Apply in both Layer 1 and Layer 2 fill_in_blank list comprehensions.

### Frontend — `frontend/src/services/api.ts`

Update `apiDetailToStory()` fillInBlank filter from duck-typing (sentence presence) to explicit `_schema`-based check:
```typescript
// Old: filter((item) => typeof item['sentence'] === 'string')
// New:
filter((item) =>
  item['_schema'] === 'legacy' || typeof item['sentence'] === 'string' && !('context_before' in item)
)
```

`context_fill` items are dropped → `VocabApplication.hasData` returns false → `NoDataFallback` renders gracefully. This is the correct behavior for 6/1 demo: the step shows a "no data" placeholder rather than crashing.

### Tests — `backend/tests/test_fill_in_blank_normalization.py`

16 tests covering:
- Legacy passthrough (sentence preserved, answer preserved, _schema = "legacy")
- New-format synthesis (sentence synthesized, freetext answer preserved, _schema = "context_fill")
- Edge cases (empty context_before, empty context_after, None context_before)
- Mixed batch separation

## Verification

- `python -m pytest tests/test_fill_in_blank_normalization.py -v` — 16/16 passed
- `npm run build` — 0 TypeScript errors, built in 6.56s

## Affected Lessons

| Lesson | Schema | Expected result after fix |
|--------|--------|--------------------------|
| G6-L22 | context_fill | NoDataFallback (graceful) |
| G6-L23 | context_fill | NoDataFallback (graceful) |
| G6-L24 | context_fill | NoDataFallback (graceful) |
| G6-L25 | context_fill | NoDataFallback (graceful) |
| G7-L28 | context_fill | NoDataFallback (graceful) |
| G7-L29 | empty fill_in_blank | NoDataFallback (was already graceful) |
| G7-L30 | context_fill | NoDataFallback (graceful) |

## Follow-up (separate issue)

When a dedicated cloze exercise component for `context_fill` schema is built, remove the filter in `api.ts` and use `_schema` routing to render the correct exercise type. The `_schema` tag and synthesized `sentence` field are already in place.