### PR TITLE
chore: hide dictionary entry from sidebar (Fixes #1638)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -389,10 +389,11 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
     : [];
 
   // Targeted practice tools — shown at the BOTTOM of the student sidebar, separated by a divider (#1165)
+  // Hidden: 字典查詢 — removed from sidebar per 5/15 meeting (Issue #1638).
+  // Backend DictionaryService and /api/dictionary/* endpoints are preserved.
   const toolsItems: NavItem[] = activeView === 'student'
     ? [
         { icon: '🧰', label: '練習工具箱', path: '/tools' },
-        { icon: '📖', label: '字典查詢', path: '/dictionary' },
       ]
     : [];
 

--- a/frontend/src/components/layout/__tests__/Sidebar.dictionary.test.ts
+++ b/frontend/src/components/layout/__tests__/Sidebar.dictionary.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Test: 字典查詢 must NOT appear in Sidebar toolsItems (Issue #1638)
+ *
+ * This is a pure unit test on the config array — no DOM render needed.
+ * After the fix, the sidebar nav should not expose the /dictionary route.
+ * The route itself remains in AppRoutes.tsx (backend preserved).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// We test the exported constant directly so the test is fast and deterministic.
+// If the component ever extracts toolsItems to a separate module this import path
+// should be updated to point to that module.
+
+// Dynamic import to get the raw module without React context setup
+describe('Sidebar toolsItems — 字典查詢 hidden (Issue #1638)', () => {
+  it('QUICK_CARDS in QuickPracticeStrip does not contain 字典查詢', async () => {
+    // Import the module source to verify the static config array
+    const module = await import('../../../components/student/QuickPracticeStrip');
+    // We can't directly access QUICK_CARDS since it's not exported,
+    // but we can check the rendered output via string inspection of the module
+    // Instead we use a simpler contract: grep the module text for the entry.
+    // This test is intentionally checking the contract at the config layer.
+
+    // Since QUICK_CARDS is not exported, we use a different approach:
+    // render the component and verify "字典查詢" is not in the DOM.
+    const { render, screen } = await import('@testing-library/react');
+    const { MemoryRouter } = await import('react-router-dom');
+    const { default: QuickPracticeStrip } = module;
+
+    const { createElement } = await import('react');
+
+    render(
+      createElement(MemoryRouter, null,
+        createElement(QuickPracticeStrip, null)
+      )
+    );
+
+    // After fix: "字典查詢" text should NOT be present
+    expect(screen.queryByText('字典查詢')).toBeNull();
+  });
+});

--- a/frontend/src/components/student/QuickPracticeStrip.tsx
+++ b/frontend/src/components/student/QuickPracticeStrip.tsx
@@ -8,7 +8,8 @@
  *   - 筆順字帖  → /write          (no story needed)
  *   - 聽寫挑戰  → /library        (needs story — goes to library first)
  *   - 造句練習  → /library        (needs story)
- *   - 字典查詢  → /dictionary     (no story needed, Issue #1230)
+ * Hidden (Issue #1638): 字典查詢 removed from UI per 5/15 meeting.
+ *   Backend DictionaryService preserved; /dictionary route still accessible directly.
  *
  * "看更多 →" links to /tools (PracticeToolbox page, Issue #1153).
  *
@@ -48,12 +49,9 @@ const QUICK_CARDS: PracticeCard[] = [
     route: '/library',
     needsStory: true,
   },
-  {
-    icon: '📖',
-    title: '字典查詢',
-    description: '查字義、注音、例句',
-    route: '/dictionary',
-  },
+  // Hidden: 字典查詢 — removed from UI per 5/15 meeting (Issue #1638).
+  // Backend DictionaryService and /api/dictionary/* endpoints are preserved.
+  // The /dictionary route in AppRoutes.tsx is also preserved for direct access.
 ];
 
 const QuickPracticeStrip: React.FC = () => {


### PR DESCRIPTION
Fixes #1638

## Summary

- Remove `字典查詢` entry from `Sidebar.tsx` `toolsItems` (student sidebar nav)
- Remove `字典查詢` card from `QuickPracticeStrip.tsx` `QUICK_CARDS` (StudentHome 「想練點什麼？」strip)
- Add comments citing 5/15 meeting decision and Issue #1638

## Backend Safety

The following are **NOT changed** and continue to work normally:

| Component | Status |
|-----------|--------|
| `backend/app/services/dictionary_service.py` | Preserved |
| `backend/app/routes/` dictionary endpoints | Preserved |
| `frontend/src/pages/student/DictionaryPage.tsx` | Preserved (route still accessible directly) |
| `ZhuyinPhoneticGame.tsx` — calls MOE dictionary API | Unaffected |
| `VocabDefinitionMatch.tsx` — uses dictionary icon | Unaffected |
| `FillInBlankExercise.tsx`, `FullReading.tsx`, `LiveTutor.tsx` | Unaffected |

## Test Plan

- [x] TDD: `Sidebar.dictionary.test.ts` — asserts `字典查詢` is absent from `QuickPracticeStrip` render (1/1 Green)
- [x] No new test failures introduced (pre-existing 38 failures unchanged on staging)
- [ ] Preview URL: verify sidebar no longer shows 字典查詢 entry
- [ ] Verify other learning steps (LiveTutor, VocabDefinitionMatch, FillInBlank) still load without errors