### PR TITLE
fix(teacher-dashboard): route 查看報告 to classroom selector with intent banner (Fixes #1545)

### DIFF
--- a/frontend/src/pages/teacher/TeacherDashboard.tsx
+++ b/frontend/src/pages/teacher/TeacherDashboard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import {
@@ -18,6 +19,9 @@ interface TeacherDashboardProps {
 const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }) => {
   const { token, user } = useAuth();
   const { activeSchoolId: teacherSchoolId, hasMultipleSchools } = useWorkspace();
+  const location = useLocation();
+  // Fix #1545: detect intent:'reports' navigation from TeacherHome quick-action
+  const isReportsIntent = (location.state as { intent?: string } | null)?.intent === 'reports';
   const [classrooms, setClassrooms] = useState<ClassroomResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
@@ -128,7 +132,9 @@ const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }
         {/* Page header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">班級管理</h1>
+            <h1 className="text-2xl font-bold text-gray-900">
+              {isReportsIntent ? '查看學習報告' : '班級管理'}
+            </h1>
             {isLoading ? (
               <Skeleton className="mt-2 h-4 w-28 rounded" />
             ) : (
@@ -146,6 +152,21 @@ const TeacherDashboard: React.FC<TeacherDashboardProps> = ({ onSelectClassroom }
             </button>
           </div>
         </div>
+
+        {/* Fix #1545: Reports intent banner — shown when navigating from "查看報告" quick-action */}
+        {isReportsIntent && (
+          <div
+            data-testid="reports-intent-banner"
+            className="flex items-start gap-3 bg-purple-50 border border-purple-200 rounded-xl px-4 py-3"
+            role="status"
+          >
+            <span className="text-xl shrink-0" aria-hidden="true">📊</span>
+            <div>
+              <p className="text-sm font-semibold text-purple-800">選擇班級以查看報告</p>
+              <p className="text-xs text-purple-600 mt-0.5">點擊下方班級卡片，即可進入該班級的學習報告</p>
+            </div>
+          </div>
+        )}
 
         {/* Search & sort */}
         {!isLoading && classrooms.length > 0 && (

--- a/frontend/src/pages/teacher/TeacherHome.tsx
+++ b/frontend/src/pages/teacher/TeacherHome.tsx
@@ -7,6 +7,9 @@
  * - Quick action cards: 管理班級, 建立作業, 查看報告
  *
  * Route: /teacher-home
+ *
+ * Fix #1545: 查看報告 now navigates to /teacher with state { intent: 'reports' }
+ * so TeacherDashboard renders a "請選擇班級以查看報告" selection banner.
  */
 
 import React, { useEffect, useState } from 'react';
@@ -32,7 +35,10 @@ interface QuickAction {
   icon: string;
   label: string;
   description: string;
+  /** Navigation path for this action */
   path: string;
+  /** Optional router state to pass with navigation (e.g. { intent: 'reports' }) */
+  state?: Record<string, unknown>;
   colorClass: string;
 }
 
@@ -54,8 +60,10 @@ const QUICK_ACTIONS: QuickAction[] = [
   {
     icon: '📊',
     label: '查看報告',
-    description: '了解學生的學習狀況',
+    description: '選擇班級以查看學生學習報告',
     path: '/teacher',
+    // Fix #1545: pass intent so TeacherDashboard shows a report-selection banner
+    state: { intent: 'reports' },
     colorClass: 'bg-purple-50 hover:bg-purple-100 border-purple-200 text-purple-700',
   },
 ];
@@ -250,7 +258,11 @@ const TeacherHome: React.FC = () => {
               <button
                 key={action.label}
                 type="button"
-                onClick={() => navigate(action.path)}
+                onClick={() =>
+                  action.state
+                    ? navigate(action.path, { state: action.state })
+                    : navigate(action.path)
+                }
                 aria-label={`${action.label}：${action.description}`}
                 className={`
                   flex items-center gap-4 p-4 rounded-xl border text-left transition-colors

--- a/frontend/src/pages/teacher/__tests__/TeacherHome.routing.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/TeacherHome.routing.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Issue #1545 — TeacherHome routing tests
+ *
+ * Verifies that the 查看報告 quick-action card navigates to /teacher
+ * with state { intent: 'reports' } so TeacherDashboard can show the
+ * "選擇班級以查看報告" banner.
+ *
+ * Regression guard: 管理班級 and 建立作業 must navigate to /teacher
+ * WITHOUT the reports intent flag.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    // useLocation is NOT mocked here — we use MemoryRouter initialEntries to control it
+  };
+});
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 1, name: '李老師' },
+    token: 'test-token',
+  }),
+}));
+
+vi.mock('../../../contexts/WorkspaceContext', () => ({
+  useWorkspace: () => ({
+    activeSchoolId: null,
+    hasMultipleSchools: false,
+    teacherSchoolIds: [],
+    studentSchoolIds: [],
+    activeView: 'teacher',
+    setActiveView: vi.fn(),
+    setActiveSchoolId: vi.fn(),
+    availableViews: ['teacher'],
+  }),
+}));
+
+vi.mock('../../../services/classroomApi', () => ({
+  listMyClassrooms: vi.fn().mockResolvedValue({
+    items: [
+      { id: 1, name: '三年甲班', grade: 3, student_count: 20, school_id: 1, teacher_id: 1, is_active: true, created_at: '2026-01-01T00:00:00Z' },
+      { id: 2, name: '五年乙班', grade: 5, student_count: 25, school_id: 1, teacher_id: 1, is_active: true, created_at: '2026-01-02T00:00:00Z' },
+    ],
+    total: 2,
+  }),
+}));
+
+import TeacherHome from '../TeacherHome';
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+function renderTeacherHome() {
+  return render(
+    <MemoryRouter initialEntries={['/teacher-home']}>
+      <TeacherHome />
+    </MemoryRouter>
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('TeacherHome — 查看報告 routing (issue #1545)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the 查看報告 quick-action card', async () => {
+    renderTeacherHome();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /查看報告/i })).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to /teacher with intent:"reports" when 查看報告 is clicked', async () => {
+    renderTeacherHome();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /查看報告/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /查看報告/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/teacher', { state: { intent: 'reports' } });
+  });
+
+  it('navigates to /teacher WITHOUT intent state when 管理班級 is clicked', async () => {
+    renderTeacherHome();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /管理班級/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /管理班級/i }));
+
+    // Should navigate to /teacher but NOT with intent:'reports'
+    expect(mockNavigate).toHaveBeenCalledWith('/teacher');
+    expect(mockNavigate).not.toHaveBeenCalledWith('/teacher', { state: { intent: 'reports' } });
+  });
+
+  it('classroom list items navigate to /teacher/classroom/:id', async () => {
+    renderTeacherHome();
+
+    // Wait for classrooms to load
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /前往 三年甲班/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /前往 三年甲班/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/teacher/classroom/1');
+  });
+});
+
+describe('TeacherDashboard — reports banner (issue #1545)', () => {
+  it('renders reports-intent banner when location.state.intent is "reports"', async () => {
+    const { default: TeacherDashboard } = await import('../TeacherDashboard');
+    const mockOnSelectClassroom = vi.fn();
+
+    // Use MemoryRouter with initial state containing intent:'reports'
+    const { container } = render(
+      <MemoryRouter
+        initialEntries={[{ pathname: '/teacher', state: { intent: 'reports' } }]}
+      >
+        <TeacherDashboard onSelectClassroom={mockOnSelectClassroom} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      // Banner should appear with text indicating report-selection mode
+      const banner = container.querySelector('[data-testid="reports-intent-banner"]');
+      expect(banner).toBeInTheDocument();
+      expect(banner?.textContent).toMatch(/選擇班級以查看報告/);
+    });
+  });
+
+  it('does NOT render reports-intent banner when navigating without intent state', async () => {
+    const { default: TeacherDashboard } = await import('../TeacherDashboard');
+    const mockOnSelectClassroom = vi.fn();
+
+    const { container } = render(
+      <MemoryRouter initialEntries={[{ pathname: '/teacher', state: null }]}>
+        <TeacherDashboard onSelectClassroom={mockOnSelectClassroom} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const banner = container.querySelector('[data-testid="reports-intent-banner"]');
+      expect(banner).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1545

## Summary

- `TeacherHome.tsx`: `QUICK_ACTIONS[2]` (查看報告) now calls `navigate('/teacher', { state: { intent: 'reports' } })` instead of `navigate('/teacher')` — the route target is identical but router state is now passed to communicate intent.
- `TeacherDashboard.tsx`: reads `location.state?.intent === 'reports'`; when present:
  - Changes page `<h1>` from "班級管理" to "查看學習報告"
  - Shows a purple banner "選擇班級以查看報告 / 點擊下方班級卡片，即可進入該班級的學習報告" (`data-testid="reports-intent-banner"`)
- No new routes, no backend changes needed — clicking a classroom card already navigates to `/teacher/classroom/{id}` which shows analytics.

## Design Choice

**Option B (state-driven intent)** chosen over Option A (auto-pick most-recent classroom):
- Seed data has 2+ classrooms; auto-picking "most-recent" is ambiguous and error-prone.
- Single deliberate click (pick classroom) is predictable UX.
- Zero new routes or backend endpoints — pure routing state signal.

## Test Plan

- [ ] Login as teacher (李老師 demo account)
- [ ] Click "查看報告" quick-action card on TeacherHome (`/teacher-home`)
- [ ] Verify: lands on `/teacher` with **purple banner** "選擇班級以查看報告" at top
- [ ] Verify: page `h1` shows "查看學習報告" (not "班級管理")
- [ ] Click a classroom card → verify navigates to `/teacher/classroom/{id}` (analytics page)
- [ ] Click "管理班級" quick-action → verify banner does NOT appear (plain classroom list)
- [ ] Check browser console for zero new errors

## Tests Added

6 vitest tests in `frontend/src/pages/teacher/__tests__/TeacherHome.routing.test.tsx`:
- `TeacherHome` suite: renders card, correct navigate call with intent, regression for 管理班級 without intent, classroom list navigation
- `TeacherDashboard` suite: banner shows with intent state, banner absent without intent state

All 6 pass: `npm run test -- --run` ✅