### PR TITLE
feat(teacher): surface classroom join_code + copy/regenerate UI (Fixes #1643)

### DIFF
--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -6,6 +6,7 @@ import {
   addStudent,
   removeStudent,
   exportClassroomReport,
+  regenerateClassroomCode,
   ClassroomDetailResponse,
   StudentInClassroomResponse,
   ClassroomApiError,
@@ -64,6 +65,11 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
 
   // Remove confirmation
   const [removingStudentId, setRemovingStudentId] = useState<number | null>(null);
+
+  // Join code state
+  const [isCopied, setIsCopied] = useState(false);
+  const [showRegenConfirm, setShowRegenConfirm] = useState(false);
+  const [isRegenerating, setIsRegenerating] = useState(false);
 
   const loadClassroom = useCallback(async () => {
     if (!token) return;
@@ -193,6 +199,36 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
         setError('移除學生失敗');
       }
       setRemovingStudentId(null);
+    }
+  };
+
+  const handleCopyJoinCode = async () => {
+    if (!classroom?.join_code) return;
+    try {
+      await navigator.clipboard.writeText(classroom.join_code);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch {
+      // clipboard API unavailable (non-HTTPS dev env)
+      setIsCopied(false);
+    }
+  };
+
+  const handleRegenerateCode = async () => {
+    if (!token || !classroom) return;
+    setIsRegenerating(true);
+    setShowRegenConfirm(false);
+    try {
+      await regenerateClassroomCode(token, classroom.id);
+      await loadClassroom();
+    } catch (err) {
+      if (err instanceof ClassroomApiError) {
+        setError(err.message);
+      } else {
+        setError('重新產生代碼失敗');
+      }
+    } finally {
+      setIsRegenerating(false);
     }
   };
 
@@ -371,6 +407,95 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
             </div>
           )}
         </div>
+
+        {/* Join Code card */}
+        <div className="bg-white rounded-2xl shadow-card p-6">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div className="flex-1">
+              <h3 className="text-sm font-semibold text-gray-700 mb-1">加入代碼</h3>
+              {classroom.join_code ? (
+                <p className="font-mono text-2xl font-bold tracking-widest text-accent select-all">
+                  {classroom.join_code}
+                </p>
+              ) : (
+                <p className="font-mono text-2xl font-bold tracking-widest text-gray-300">—</p>
+              )}
+              <p className="text-xs text-gray-400 mt-1.5">
+                把此代碼給學生，他們從首頁「加入班級」輸入即可加入
+              </p>
+            </div>
+            <div className="flex gap-2 shrink-0">
+              <button
+                onClick={handleCopyJoinCode}
+                disabled={!classroom.join_code}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {isCopied ? (
+                  <>
+                    <svg className="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                    </svg>
+                    <span className="text-emerald-600">已複製</span>
+                  </>
+                ) : (
+                  <>
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                    </svg>
+                    複製代碼
+                  </>
+                )}
+              </button>
+              <button
+                onClick={() => setShowRegenConfirm(true)}
+                disabled={isRegenerating}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {isRegenerating ? (
+                  '產生中...'
+                ) : (
+                  <>
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    重生代碼
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Confirm regenerate dialog */}
+        {showRegenConfirm && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="regen-dialog-title"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          >
+            <div className="bg-white rounded-2xl shadow-xl p-6 max-w-sm w-full mx-4">
+              <h3 id="regen-dialog-title" className="text-base font-bold text-gray-900 mb-2">確認重新產生代碼？</h3>
+              <p className="text-sm text-gray-600 mb-6">
+                舊代碼將立即失效，學生需重新輸入新代碼才能加入此班級。
+              </p>
+              <div className="flex justify-end gap-3">
+                <button
+                  onClick={() => setShowRegenConfirm(false)}
+                  className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
+                >
+                  取消
+                </button>
+                <button
+                  onClick={handleRegenerateCode}
+                  className="px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium transition-colors cursor-pointer"
+                >
+                  確定
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Tabbed content card */}
         <div className="bg-white rounded-2xl shadow-card">

--- a/frontend/src/pages/teacher/__tests__/ClassroomDetail.joincode.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/ClassroomDetail.joincode.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Tests for ClassroomDetail join_code UI — Issue #1643
+ * Verifies:
+ *  1. join_code is rendered prominently in monospace
+ *  2. 複製代碼 button triggers clipboard.writeText
+ *  3. 重生代碼 button shows confirm dialog before calling API
+ *  4. After confirm, regenerateClassroomCode is called and UI updates
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ClassroomDetail from '../ClassroomDetail';
+import * as classroomApi from '../../../services/classroomApi';
+
+// --- Mocks ---
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', user: { id: 1, role: 'teacher' } }),
+}));
+
+// Mock all classroomApi calls we depend on
+vi.mock('../../../services/classroomApi', () => ({
+  getClassroomDetail: vi.fn(),
+  updateClassroom: vi.fn(),
+  addStudent: vi.fn(),
+  removeStudent: vi.fn(),
+  exportClassroomReport: vi.fn(),
+  regenerateClassroomCode: vi.fn(),
+  ClassroomApiError: class ClassroomApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'ClassroomApiError';
+      this.status = status;
+    }
+  },
+}));
+
+// Stub child tabs to avoid deep render
+vi.mock('../StudentProgressTab', () => ({ default: () => <div data-testid="student-progress-tab" /> }));
+vi.mock('../TextManagementTab', () => ({ default: () => <div data-testid="text-management-tab" /> }));
+vi.mock('../StudentListTab', () => ({ default: () => <div data-testid="student-list-tab" /> }));
+vi.mock('../ClassroomAnalytics', () => ({ default: () => <div data-testid="classroom-analytics" /> }));
+vi.mock('../CrossTextAnalytics', () => ({ default: () => <div data-testid="cross-text-analytics" /> }));
+vi.mock('../../components/teacher/AtRiskStudents', () => ({ default: () => <div data-testid="at-risk-students" /> }));
+vi.mock('../ErrorHeatmapTab', () => ({ default: () => <div data-testid="error-heatmap-tab" /> }));
+vi.mock('../CoTeachingTab', () => ({ default: () => <div data-testid="co-teaching-tab" /> }));
+
+const MOCK_CLASSROOM = {
+  id: 42,
+  name: '三年甲班',
+  school_id: 1,
+  teacher_id: 1,
+  grade: 3,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  student_count: 5,
+  students: [],
+  join_code: 'ABC123',
+  school_name: '測試國小',
+};
+
+function renderDetail() {
+  return render(<ClassroomDetail classroomId={42} onBack={vi.fn()} />);
+}
+
+describe('ClassroomDetail — join_code UI (#1643)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: getClassroomDetail resolves with join_code
+    vi.mocked(classroomApi.getClassroomDetail).mockResolvedValue(MOCK_CLASSROOM);
+
+    // Mock clipboard
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('1. renders join_code prominently in the classroom info card', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('ABC123')).toBeInTheDocument();
+    });
+    // Should be in a monospace or code-like element
+    const codeEl = screen.getByText('ABC123');
+    expect(codeEl.tagName.toLowerCase()).toMatch(/^(code|span|p|div)$/);
+  });
+
+  it('2. 複製代碼 button calls clipboard.writeText with the join_code', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('ABC123')).toBeInTheDocument();
+    });
+
+    const copyBtn = screen.getByRole('button', { name: /複製代碼/i });
+    await userEvent.click(copyBtn);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('ABC123');
+  });
+
+  it('3. 重生代碼 button shows a confirm dialog before calling the API', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('ABC123')).toBeInTheDocument();
+    });
+
+    const regenBtn = screen.getByRole('button', { name: /重生代碼/i });
+    await userEvent.click(regenBtn);
+
+    // Confirm dialog should appear
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // API must NOT be called yet
+    expect(classroomApi.regenerateClassroomCode).not.toHaveBeenCalled();
+  });
+
+  it('4. cancelling the confirm dialog does not call regenerateClassroomCode', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('ABC123')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /重生代碼/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Cancel
+    await userEvent.click(screen.getByRole('button', { name: /取消/i }));
+    expect(classroomApi.regenerateClassroomCode).not.toHaveBeenCalled();
+
+    // Dialog should disappear
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('5. confirming the dialog calls regenerateClassroomCode and updates displayed code', async () => {
+    vi.mocked(classroomApi.regenerateClassroomCode).mockResolvedValue({ join_code: 'XYZ789' });
+    // After regen, re-fetch returns the updated classroom
+    vi.mocked(classroomApi.getClassroomDetail)
+      .mockResolvedValueOnce(MOCK_CLASSROOM)         // initial load
+      .mockResolvedValueOnce({ ...MOCK_CLASSROOM, join_code: 'XYZ789' }); // after regen
+
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('ABC123')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /重生代碼/i }));
+    await userEvent.click(screen.getByRole('button', { name: /確定/i }));
+
+    await waitFor(() => {
+      expect(classroomApi.regenerateClassroomCode).toHaveBeenCalledWith('test-token', 42);
+    });
+
+    // UI updates with new code
+    await waitFor(() => {
+      expect(screen.getByText('XYZ789')).toBeInTheDocument();
+    });
+  });
+
+  it('6. renders help text below the join_code', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('ABC123')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/把此代碼給學生/i)).toBeInTheDocument();
+  });
+
+  it('7. classroom with null join_code still renders the section (no code yet)', async () => {
+    vi.mocked(classroomApi.getClassroomDetail).mockResolvedValue({
+      ...MOCK_CLASSROOM,
+      join_code: null,
+    });
+
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.queryByText('三年甲班')).toBeInTheDocument();
+    });
+
+    // The section header should still appear
+    expect(screen.getByText(/加入代碼/i)).toBeInTheDocument();
+    // Show a placeholder or "—" for null code
+    expect(screen.getByText(/—|尚未產生/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1643

## Scope correction

Issue #1643 was originally written as an epic-level "enrollment flow". A verify-first audit (5/11) found the entire backend + student-side enrollment is **already implemented**:
- `Classroom.join_code` field (String 8, auto-generated on classroom creation)
- `POST /api/classrooms/join` (student joins by code)
- `POST /api/classrooms/{id}/regenerate-code` (teacher regenerates)
- `JoinClassroomPage.tsx` + `/join` route + sidebar entry already exist for students

The only real gap: **teacher-side UI to view/copy/regenerate the join_code**. This PR closes that gap.

## Changes (frontend only — no backend touched)

- `frontend/src/pages/teacher/ClassroomDetail.tsx` — new "加入代碼" card in the classroom info section:
  - Monospace display of the join_code (visually distinct)
  - "複製代碼" button → `navigator.clipboard.writeText` + 2s success feedback
  - "重生代碼" button → confirm dialog (prevents accidental resets) → `POST regenerate-code` → UI refresh
  - Help text: 把此代碼給學生，他們從首頁「加入班級」輸入即可加入
  - Null-safe: shows `—` when join_code is null
- `frontend/src/pages/teacher/__tests__/ClassroomDetail.joincode.test.tsx` — 7 vitest tests (TDD Red→Green verified)

## Test plan

1. Login as teacher → go to any classroom detail page
2. Verify join_code panel appears below classroom info card
3. Click 複製代碼 → confirm clipboard gets the code + "已複製" feedback
4. Click 重生代碼 → confirm dialog appears → click 取消 → no change
5. Click 重生代碼 → click 確定 → new code appears
6. Use new code as student on /join → enrollment succeeds

## Unblocks

- Issue #1544 (bulk submissions audit) — teachers can now share codes, students can join new classrooms

🤖 Generated with Claude Code (git-issue-pr-flow agent)