### PR TITLE
fix(join): show actual classroom name in success message (Fixes #1646)

### DIFF
--- a/frontend/src/pages/JoinClassroomPage.tsx
+++ b/frontend/src/pages/JoinClassroomPage.tsx
@@ -42,7 +42,7 @@ const JoinClassroomPage: React.FC = () => {
     setIsSubmitting(true);
     try {
       const result = await joinClassroomByCode(token, joinCode);
-      setSuccessMessage(`成功加入「${result.classroom_name}」！`);
+      setSuccessMessage(`成功加入「${result.name}」！`);
     } catch (err) {
       if (err instanceof ClassroomApiError) {
         if (err.status === 404) {

--- a/frontend/src/pages/__tests__/JoinClassroomPage.test.tsx
+++ b/frontend/src/pages/__tests__/JoinClassroomPage.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for JoinClassroomPage success message — Issue #1646
+ * Verifies that the success message shows the actual classroom name
+ * (result.name from ClassroomResponse) instead of "undefined".
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import JoinClassroomPage from '../JoinClassroomPage';
+import * as classroomApi from '../../services/classroomApi';
+
+// --- Mocks ---
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', user: { id: 99, role: 'student' } }),
+}));
+
+vi.mock('../../services/classroomApi', () => ({
+  joinClassroomByCode: vi.fn(),
+  ClassroomApiError: class ClassroomApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+      this.name = 'ClassroomApiError';
+    }
+  },
+}));
+
+// --- Helpers ---
+
+function fillAndSubmit(code: string) {
+  const input = screen.getByPlaceholderText('輸入 6 碼加入代碼');
+  fireEvent.change(input, { target: { value: code } });
+  fireEvent.submit(input.closest('form')!);
+}
+
+// --- Tests ---
+
+describe('JoinClassroomPage — success message (Issue #1646)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the classroom name from result.name in success message', async () => {
+    // Backend returns ClassroomResponse which has `name` field (not classroom_name)
+    vi.mocked(classroomApi.joinClassroomByCode).mockResolvedValueOnce({
+      id: 42,
+      name: '測試班級 5A',
+      school_id: 1,
+      teacher_id: 7,
+      grade: 5,
+      join_code: 'ABC123',
+      is_active: true,
+      created_at: new Date().toISOString(),
+      student_count: 10,
+    } as any);
+
+    render(<JoinClassroomPage />);
+    fillAndSubmit('ABC123');
+
+    await waitFor(() => {
+      expect(screen.getByText(/成功加入「測試班級 5A」！/)).toBeInTheDocument();
+    });
+
+    // Must NOT show "undefined"
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument();
+  });
+
+  it('does NOT show "undefined" when classroom has a name', async () => {
+    vi.mocked(classroomApi.joinClassroomByCode).mockResolvedValueOnce({
+      id: 1,
+      name: 'Bulk驗證 2026-05-16',
+      school_id: 1,
+      teacher_id: 1,
+      grade: null,
+      join_code: 'XY9Z01',
+      is_active: true,
+      created_at: new Date().toISOString(),
+      student_count: 30,
+    } as any);
+
+    render(<JoinClassroomPage />);
+    fillAndSubmit('XY9Z01');
+
+    await waitFor(() => {
+      const msg = screen.queryByText(/undefined/);
+      expect(msg).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/成功加入「Bulk驗證 2026-05-16」！/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when join code is invalid (404)', async () => {
+    const { ClassroomApiError } = await import('../../services/classroomApi');
+    vi.mocked(classroomApi.joinClassroomByCode).mockRejectedValueOnce(
+      new ClassroomApiError('Not found', 404),
+    );
+
+    render(<JoinClassroomPage />);
+    fillAndSubmit('XXXXXX');
+
+    await waitFor(() => {
+      expect(screen.getByText(/找不到此加入代碼/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when already enrolled (409)', async () => {
+    const { ClassroomApiError } = await import('../../services/classroomApi');
+    vi.mocked(classroomApi.joinClassroomByCode).mockRejectedValueOnce(
+      new ClassroomApiError('Already enrolled', 409),
+    );
+
+    render(<JoinClassroomPage />);
+    fillAndSubmit('ABC123');
+
+    await waitFor(() => {
+      expect(screen.getByText(/你已經加入這個班級了/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/services/classroomApi.ts
+++ b/frontend/src/services/classroomApi.ts
@@ -203,13 +203,13 @@ export async function searchStudentsForClassroom(
 export async function joinClassroomByCode(
   token: string,
   joinCode: string,
-): Promise<{ message: string; classroom_id: number; classroom_name: string }> {
+): Promise<ClassroomResponse> {
   const res = await fetch(`${API_BASE}/api/classrooms/join`, {
     method: 'POST',
     headers: authHeaders(token),
     body: JSON.stringify({ join_code: joinCode }),
   });
-  return handleResponse<{ message: string; classroom_id: number; classroom_name: string }>(res);
+  return handleResponse<ClassroomResponse>(res);
 }
 
 // --- Batch create students ---


### PR DESCRIPTION
Fixes #1646

## Root Cause

`joinClassroomByCode` in `classroomApi.ts` declared its return type as `{ message: string; classroom_id: number; classroom_name: string }` but the backend `POST /api/classrooms/join` actually returns `ClassroomResponse` (field: `name`, not `classroom_name`). Reading a non-existent field produces `undefined`.

## Changes

- `frontend/src/services/classroomApi.ts` — align `joinClassroomByCode` return type to `ClassroomResponse` (matches backend schema)
- `frontend/src/pages/JoinClassroomPage.tsx` — read `result.name` instead of `result.classroom_name`
- `frontend/src/pages/__tests__/JoinClassroomPage.test.tsx` — new vitest tests (TDD): asserts success message shows actual name, asserts "undefined" never appears, covers 404/409 error paths

## Test plan

- [ ] 4/4 vitest unit tests pass (confirmed locally)
- [ ] PR preview deploys — navigate /join, enter valid code, verify success message shows classroom name
- [ ] Enter invalid code — error message still works
- [ ] Enter already-enrolled code — 409 error still works