### PR TITLE
fix(learning): deprecate no-cache AI analysis endpoint (Fixes #1648)

### DIFF
--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -231,19 +231,31 @@ async def get_ai_analysis(
     "/learning/ai-analysis",
     response_model=AIAnalysisResponse,
     dependencies=[Depends(ai_limit_5_per_min)],
+    deprecated=True,
 )
 async def get_ai_analysis_standalone(
     payload: AIAnalysisRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Generate AI reading diagnosis without requiring a backend session.
+    """DEPRECATED — will be removed in a future release.
 
-    This endpoint is for the frontend learning flow which manages sessions
-    in-memory. No caching — analysis is generated fresh each call.
+    Use the session-scoped endpoint instead:
+        POST /api/learning/sessions/{session_id}/ai-analysis
+
+    This endpoint was the fallback for frontend flows without a DB session ID.
+    All callers have been updated to use the session-scoped cached endpoint (Issue #1648).
+
+    Original: Generate AI reading diagnosis without requiring a backend session.
+    No caching — analysis is generated fresh each call.
 
     Rate limited: 5 requests per minute per user/IP.
     """
+    logger.warning(
+        "DEPRECATED: /api/learning/ai-analysis called — frontend should use "
+        "/api/learning/sessions/{id}/ai-analysis instead. (Issue #1648)"
+    )
+
     # Sanitize user-provided text before sending to AI
     safe_story_title, _ = sanitize_ai_input(payload.story_title, user_id=str(current_user.id))
 

--- a/backend/tests/test_ai_analysis_deprecation_1648.py
+++ b/backend/tests/test_ai_analysis_deprecation_1648.py
@@ -1,0 +1,239 @@
+"""
+Issue #1648: Deprecation of standalone /api/learning/ai-analysis endpoint.
+
+Tests:
+- Standalone endpoint logs a DEPRECATED warning on every call
+- Standalone endpoint still returns 200 (backward-compatible, not removed)
+- Deprecation warning message contains the issue number and migration path
+"""
+
+import logging
+import sys
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+
+
+# ---------------------------------------------------------------------------
+# Test DB setup (same pattern as test_ai_analysis.py)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+MOCK_ANALYSIS = {
+    "analysis_summary": "你的朗讀表現整體不錯",
+    "strengths": ["發音清晰"],
+    "areas_for_improvement": ["注意多音字"],
+    "practice_suggestions": ["每天練習 10 分鐘"],
+    "encouragement_message": "加油！",
+}
+
+ANALYSIS_PAYLOAD = {
+    "story_title": "玉山之美",
+    "accuracy": 85.0,
+    "cpm": 120.0,
+    "error_chars": ["山"],
+    "total_characters": 200,
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    from app.auth.rate_limiter import ai_rate_limiter
+    ai_rate_limiter.reset()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_and_login(client, suffix=None):
+    unique = suffix or uuid.uuid4().hex[:8]
+    email = f"depr_user_{unique}@example.com"
+    password = "SecurePass123!"
+    name = f"Depr User {unique}"
+    resp = client.post("/api/auth/register", json={"email": email, "password": password, "name": name})
+    assert resp.status_code == 201, resp.text
+    verification_token = resp.json().get("verification_token")
+    if verification_token:
+        resp = client.post("/api/auth/verify-email", json={"token": verification_token})
+        assert resp.status_code == 200, resp.text
+    resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["access_token"]
+
+
+@pytest.fixture(scope="module")
+def token(client):
+    return _register_and_login(client, "depr_a")
+
+
+def auth_header(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStandaloneEndpointDeprecation:
+    """Verify the deprecation warning is emitted on every call to the standalone endpoint."""
+
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
+    def test_deprecated_warning_logged_on_standalone_call(self, mock_gen, client, token, caplog):
+        """Every call to /api/learning/ai-analysis must emit a DEPRECATED warning log."""
+        mock_gen.return_value = MOCK_ANALYSIS
+
+        with caplog.at_level(logging.WARNING, logger="app.routes.learning.learning_reading"):
+            resp = client.post(
+                "/api/learning/ai-analysis",
+                json=ANALYSIS_PAYLOAD,
+                headers=auth_header(token),
+            )
+
+        assert resp.status_code == 200, resp.text
+
+        # The DEPRECATED warning must be present in the log
+        deprecated_logs = [r for r in caplog.records if "DEPRECATED" in r.message]
+        assert len(deprecated_logs) >= 1, (
+            f"Expected at least 1 DEPRECATED warning, got: {[r.message for r in caplog.records]}"
+        )
+
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
+    def test_deprecated_warning_mentions_issue_1648(self, mock_gen, client, token, caplog):
+        """The deprecation warning message must reference Issue #1648."""
+        mock_gen.return_value = MOCK_ANALYSIS
+
+        with caplog.at_level(logging.WARNING, logger="app.routes.learning.learning_reading"):
+            client.post(
+                "/api/learning/ai-analysis",
+                json=ANALYSIS_PAYLOAD,
+                headers=auth_header(token),
+            )
+
+        deprecated_logs = [r for r in caplog.records if "DEPRECATED" in r.message]
+        assert any("#1648" in r.message for r in deprecated_logs), (
+            f"Deprecation log should mention #1648. Got: {[r.message for r in deprecated_logs]}"
+        )
+
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
+    def test_deprecated_warning_mentions_session_scoped_endpoint(self, mock_gen, client, token, caplog):
+        """The deprecation warning must mention the replacement session-scoped endpoint."""
+        mock_gen.return_value = MOCK_ANALYSIS
+
+        with caplog.at_level(logging.WARNING, logger="app.routes.learning.learning_reading"):
+            client.post(
+                "/api/learning/ai-analysis",
+                json=ANALYSIS_PAYLOAD,
+                headers=auth_header(token),
+            )
+
+        deprecated_logs = [r for r in caplog.records if "DEPRECATED" in r.message]
+        assert any("sessions/" in r.message and "ai-analysis" in r.message for r in deprecated_logs), (
+            f"Deprecation log should mention sessions/{{id}}/ai-analysis. Got: {[r.message for r in deprecated_logs]}"
+        )
+
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
+    def test_standalone_still_returns_200_backward_compatible(self, mock_gen, client, token):
+        """Endpoint is deprecated but NOT removed — must still return 200 for backward compat."""
+        mock_gen.return_value = MOCK_ANALYSIS
+
+        resp = client.post(
+            "/api/learning/ai-analysis",
+            json=ANALYSIS_PAYLOAD,
+            headers=auth_header(token),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["analysis_summary"] == MOCK_ANALYSIS["analysis_summary"]
+
+    @patch("app.routes.learning.learning_reading.generate_reading_analysis", new_callable=AsyncMock)
+    def test_deprecated_warning_logged_on_each_call(self, mock_gen, client, token, caplog):
+        """Warning must fire on EVERY call, not just the first one."""
+        mock_gen.return_value = MOCK_ANALYSIS
+
+        with caplog.at_level(logging.WARNING, logger="app.routes.learning.learning_reading"):
+            client.post("/api/learning/ai-analysis", json=ANALYSIS_PAYLOAD, headers=auth_header(token))
+            call_1_count = len([r for r in caplog.records if "DEPRECATED" in r.message])
+
+            client.post("/api/learning/ai-analysis", json=ANALYSIS_PAYLOAD, headers=auth_header(token))
+            call_2_count = len([r for r in caplog.records if "DEPRECATED" in r.message])
+
+        assert call_2_count > call_1_count, (
+            "Second call should also emit DEPRECATED warning. "
+            f"call_1_count={call_1_count}, call_2_count={call_2_count}"
+        )

--- a/frontend/src/components/reading-steps/AIAnalysisSection.tsx
+++ b/frontend/src/components/reading-steps/AIAnalysisSection.tsx
@@ -42,6 +42,11 @@ const AIAnalysisSection: React.FC<AIAnalysisSectionProps> = ({
 
   const fetchAnalysis = useCallback(async () => {
     if (!token) return;
+    // Issue #1648: dbSessionId must be a valid number to use the session-scoped
+    // cached endpoint. If null/undefined (error/reset state), do not call any
+    // AI endpoint — the deprecated standalone no-cache endpoint is removed from
+    // this call site.
+    if (dbSessionId === null || dbSessionId === undefined) return;
     setLoading(true);
     setError(null);
     try {
@@ -59,7 +64,7 @@ const AIAnalysisSection: React.FC<AIAnalysisSectionProps> = ({
           dictationCorrectCount,
           dictationTotalCount,
         },
-        dbSessionId ?? undefined,
+        dbSessionId,
       );
       setAnalysis(result);
     } catch (err) {
@@ -74,6 +79,22 @@ const AIAnalysisSection: React.FC<AIAnalysisSectionProps> = ({
     return (
       <div className="p-6 bg-gray-50 rounded-2xl text-center">
         <p className="text-sm text-gray-400">請先登入以使用 AI 分析功能</p>
+      </div>
+    );
+  }
+
+  // Issue #1648: No session ID — show graceful empty state instead of calling
+  // the deprecated no-cache standalone endpoint. This state occurs when the
+  // DB session hasn't been created yet or was reset (error/lesson-switch).
+  if (dbSessionId === null || dbSessionId === undefined) {
+    return (
+      <div
+        data-testid="ai-analysis-no-session"
+        className="p-6 bg-gray-50 rounded-2xl text-center"
+      >
+        <p className="text-sm text-gray-400">
+          分析資料載入中...若持續顯示請重新整理頁面
+        </p>
       </div>
     );
   }

--- a/frontend/src/components/reading-steps/__tests__/AIAnalysisSection.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/AIAnalysisSection.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Tests for AIAnalysisSection — Issue #1648
+ *
+ * Covers:
+ * - When dbSessionId is null, no API call fires and graceful empty state renders
+ * - When dbSessionId is a valid number, the session-based cached endpoint is called
+ * - Normal analysis render when data comes back
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import AIAnalysisSection from '../AIAnalysisSection';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetAIAnalysis = vi.fn();
+
+vi.mock('../../../services/learningApi', () => ({
+  getAIAnalysis: (...args: unknown[]) => mockGetAIAnalysis(...args),
+}));
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token-abc' }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_PROPS = {
+  storyTitle: '玉山之美',
+  accuracy: 85,
+  cpm: 120,
+  errorChars: ['山', '雪'],
+  totalCharacters: 200,
+};
+
+const MOCK_ANALYSIS = {
+  analysis_summary: '整體表現不錯',
+  strengths: ['發音清晰'],
+  areas_for_improvement: ['注意多音字'],
+  practice_suggestions: ['每天練習 10 分鐘'],
+  encouragement_message: '加油！',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AIAnalysisSection — Issue #1648', () => {
+  beforeEach(() => {
+    mockGetAIAnalysis.mockReset();
+  });
+
+  describe('when dbSessionId is null (error/reset state)', () => {
+    it('does NOT call getAIAnalysis when user clicks generate', async () => {
+      render(<AIAnalysisSection {...BASE_PROPS} dbSessionId={null} />);
+
+      // The generate button might not even appear — but if it does, clicking
+      // should not call the API
+      const btn = screen.queryByText('產生 AI 分析');
+      if (btn) {
+        fireEvent.click(btn);
+        // Even after click, API should not be called
+        expect(mockGetAIAnalysis).not.toHaveBeenCalled();
+      }
+    });
+
+    it('shows graceful empty state message when dbSessionId is null', () => {
+      render(<AIAnalysisSection {...BASE_PROPS} dbSessionId={null} />);
+
+      // Should show a message indicating session is not ready
+      const container = screen.getByTestId('ai-analysis-no-session');
+      expect(container).toBeTruthy();
+      expect(container.textContent).toContain('分析資料載入中');
+    });
+
+    it('does NOT fire any fetch/API call on mount when dbSessionId is null', () => {
+      render(<AIAnalysisSection {...BASE_PROPS} dbSessionId={null} />);
+      expect(mockGetAIAnalysis).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when dbSessionId is a valid number', () => {
+    it('calls getAIAnalysis with the session ID when user clicks generate', async () => {
+      mockGetAIAnalysis.mockResolvedValueOnce(MOCK_ANALYSIS);
+
+      render(<AIAnalysisSection {...BASE_PROPS} dbSessionId={42} />);
+
+      const btn = screen.getByText('產生 AI 分析');
+      fireEvent.click(btn);
+
+      await waitFor(() => {
+        expect(mockGetAIAnalysis).toHaveBeenCalledOnce();
+        // Second arg is the session ID
+        expect(mockGetAIAnalysis).toHaveBeenCalledWith(
+          'test-token-abc',
+          expect.objectContaining({ storyTitle: '玉山之美' }),
+          42,
+        );
+      });
+    });
+
+    it('renders analysis result after successful fetch', async () => {
+      mockGetAIAnalysis.mockResolvedValueOnce(MOCK_ANALYSIS);
+
+      render(<AIAnalysisSection {...BASE_PROPS} dbSessionId={42} />);
+
+      fireEvent.click(screen.getByText('產生 AI 分析'));
+
+      await waitFor(() => {
+        expect(screen.getByText('整體表現不錯')).toBeTruthy();
+        expect(screen.getByText('加油！')).toBeTruthy();
+      });
+    });
+
+    it('never passes sessionId=undefined to getAIAnalysis (ensures cached endpoint)', async () => {
+      mockGetAIAnalysis.mockResolvedValueOnce(MOCK_ANALYSIS);
+
+      render(<AIAnalysisSection {...BASE_PROPS} dbSessionId={99} />);
+
+      fireEvent.click(screen.getByText('產生 AI 分析'));
+
+      await waitFor(() => {
+        const [, , sessionIdArg] = mockGetAIAnalysis.mock.calls[0];
+        // Must be the numeric ID, never undefined (which would trigger standalone endpoint)
+        expect(typeof sessionIdArg).toBe('number');
+        expect(sessionIdArg).toBe(99);
+      });
+    });
+  });
+});

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -208,10 +208,14 @@ export interface AIAnalysisResponse {
 }
 
 /**
- * Fetch AI reading analysis. Uses session-based endpoint when sessionId is
- * available (with server-side caching), otherwise the standalone endpoint.
+ * Fetch AI reading analysis using the session-scoped cached endpoint.
  *
  * Issue #415: accepts optional comprehension/vocab data for richer analysis.
+ * Issue #1648: sessionId is now required — always uses the session-scoped
+ * endpoint with server-side caching. The no-cache standalone endpoint
+ * /api/learning/ai-analysis is deprecated and must not be called from here.
+ * Callers (AIAnalysisSection) must guard against null dbSessionId before
+ * calling this function.
  */
 export async function getAIAnalysis(
   token: string,
@@ -227,11 +231,9 @@ export async function getAIAnalysis(
     dictationCorrectCount?: number | null;
     dictationTotalCount?: number | null;
   },
-  sessionId?: number,
+  sessionId: number,
 ): Promise<AIAnalysisResponse> {
-  const url = sessionId
-    ? `${API_BASE}/api/learning/sessions/${sessionId}/ai-analysis`
-    : `${API_BASE}/api/learning/ai-analysis`;
+  const url = `${API_BASE}/api/learning/sessions/${sessionId}/ai-analysis`;
   const res = await fetch(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Fixes #1648

## Summary

- **Backend**: Added `deprecated=True` to FastAPI router decorator and `logger.warning("DEPRECATED: /api/learning/ai-analysis called — frontend should use /api/learning/sessions/{id}/ai-analysis instead. (Issue #1648)")` on every call to the standalone endpoint. Endpoint is kept alive for one release cycle (backward compat). Updated docstring to say DEPRECATED.
- **Frontend `AIAnalysisSection.tsx`**: Added early-return guard when `dbSessionId === null/undefined` — shows graceful empty state ("分析資料載入中...") instead of ever reaching the deprecated standalone endpoint. Removed `dbSessionId ?? undefined` conversion that was the source of the anti-pattern.
- **Frontend `learningApi.ts`**: Changed `sessionId` from `optional (?: number)` to `required (: number)`. Removed the ternary URL fallback to `/api/learning/ai-analysis`. Always uses `/api/learning/sessions/${sessionId}/ai-analysis`.

## No DB migration required

The `LearningSession.ai_analysis` column already exists. No schema changes.

## Test plan

### TDD — all tests green before this PR
- `backend/tests/test_ai_analysis_deprecation_1648.py` — 5 tests: deprecation log fires, mentions #1648, mentions sessions/ endpoint, returns 200, fires on every call
- `frontend/src/components/reading-steps/__tests__/AIAnalysisSection.test.tsx` — 6 tests: null sessionId = no API call, graceful state renders, valid sessionId calls correct endpoint, analysis renders

### Verify deprecation warning in production logs
Search Cloud Run backend logs for:
```
DEPRECATED: /api/learning/ai-analysis called
```
After merge, this message should appear zero times in normal user flow (student completes lesson → report step). If it appears, it identifies a caller that wasn't updated.

### E2E verification steps
1. Login as student demo account
2. Navigate to a lesson, complete reading steps until step 7 (報告)
3. Verify AIAnalysisSection renders and "產生 AI 分析" button appears
4. Click button — verify AI analysis text appears (cached endpoint path)
5. Check backend Cloud Run logs — zero DEPRECATED warnings during normal flow