### PR TITLE
fix(deploy): inject PROD_JWT_SECRET_KEY for prod (unblocks 41-commit release)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
             --max-instances=3 \
             --timeout=300s \
             --add-cloudsql-instances=lingoleap-dev:asia-east1:lingoleap-db \
-            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=production::ENABLE_TEST_SEED=false::GCS_OMO_BUCKET=lingoleap-omo-uploads-prod"
+            --set-env-vars="^::^ALLOWED_ORIGINS=https://lingoleap-frontend-958347263320.asia-east1.run.app,https://lingoleap-prod.web.app::DATABASE_URL=${{ secrets.DATABASE_URL }}::RUN_MIGRATIONS=true::AZURE_SPEECH_KEY=${{ secrets.AZURE_SPEECH_KEY }}::AZURE_SPEECH_REGION=eastus::TTS_PROVIDER=gemini31::ENVIRONMENT=production::ENABLE_TEST_SEED=false::JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}::GCS_OMO_BUCKET=lingoleap-omo-uploads-prod"
 
       - name: Verify backend health
         run: |


### PR DESCRIPTION
Hotfix for failed prod deploy 25961682628. Backend startup rejects dev-default JWT secret. New secret PROD_JWT_SECRET_KEY set via gh secret. After merge, prod backend will roll forward to fdbb41b7, promoting today's 41 commits including 7-lesson vocab schema normalization, AI analysis deprecation, dictionary hide, teacher join_code UI. All prod users will need to re-login (acceptable for security fix — old revision ran on public dev-default JWT secret).