### PR TITLE
feat(content): per-lesson step_sequence for 7 priority lessons (Fixes #1652)

### DIFF
--- a/backend/data/lessons/_parsed_2026-05-01/G6-L22.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L22.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L22
 reading_strategy: 摘要策略-問題.解決.結果結構
 reading_strategy_type: summary_psr
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L22小兵立大功：雞鳴狗盜的故事（摘要策略-問題.解決.結果結構）.docx
 parsed_at: '2026-05-02T16:24:34'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L23.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L23.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L23
 reading_strategy: 摘要策略-問題.解決結構找重點
 reading_strategy_type: summary_psr
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L23老鷹紅豆的故事（摘要策略-問題.解決結構找重點）.docx
 parsed_at: '2026-05-02T16:24:34'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L24
 reading_strategy: 摘要策略-問題.解決結構找重點
 reading_strategy_type: summary_psr
+step_sequence:
+- intro
+- reading-annotation
+- knowledge-station
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- report
 source_file: G6-L24白鯨救援（摘要策略-問題.解決結構找重點）.docx
 parsed_at: '2026-05-02T16:24:34'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L25
 reading_strategy: 摘要策略-問題.解決結構找重點
 reading_strategy_type: summary_psr
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L25全世界第一張股票的誕生（摘要策略-問題.解決結構找重點）.docx
 parsed_at: '2026-05-02T16:24:34'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
@@ -7,8 +7,6 @@ layout_mode: graphic-text
 step_sequence:
 - intro
 - reading-annotation
-- tutor
-- full-reading
 - reading-strategy
 - knowledge-station
 - story-structure

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
@@ -4,6 +4,16 @@ grade_code: G7-L28
 reading_strategy: 圖文整合閱讀策略
 reading_strategy_type: graphic_text_integration
 layout_mode: graphic-text
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- reading-strategy
+- knowledge-station
+- story-structure
+- comprehension
+- report
 source_file: G7-L28看不見的兇手：以實驗破解肉湯腐敗之謎（圖文整合閱讀策略）.docx
 parsed_at: '2026-05-02T16:24:34'
 flags:

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
@@ -7,8 +7,6 @@ layout_mode: graphic-text
 step_sequence:
 - intro
 - reading-annotation
-- tutor
-- full-reading
 - reading-strategy
 - knowledge-station
 - comprehension

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
@@ -4,6 +4,15 @@ grade_code: G7-L29
 reading_strategy: 圖文整合閱讀策略
 reading_strategy_type: graphic_text_integration
 layout_mode: graphic-text
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- reading-strategy
+- knowledge-station
+- comprehension
+- report
 source_file: G7-L29四張圖看地球暖化（圖文整合閱讀策略）.docx
 parsed_at: '2026-05-02T16:24:34'
 flags:

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
@@ -4,6 +4,16 @@ grade_code: G7-L30
 reading_strategy: 圖文表整合閱讀策略
 reading_strategy_type: graphic_text_integration
 layout_mode: graphic-text
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- knowledge-station
+- reading-strategy
+- story-structure
+- comprehension
+- report
 source_file: G7-L30都是八哥為什麼命運不一樣（圖文表整合閱讀策略）.docx
 parsed_at: '2026-05-02T16:24:35'
 flags:

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
@@ -7,8 +7,6 @@ layout_mode: graphic-text
 step_sequence:
 - intro
 - reading-annotation
-- tutor
-- full-reading
 - knowledge-station
 - reading-strategy
 - story-structure


### PR DESCRIPTION
Fixes #1652

## 5/16 update — 嚴格對齊紙本（Young 拍板 option-a）

G7 三課紙本實際 audit 沒有「念順順 / 計時 1 分鐘朗讀紀錄表」章節 → 移除 `tutor` + `full-reading`。
G6 四課紙本含「念順順 + 計時朗讀紀錄表」→ 保留朗讀 step。

| Lesson | step 數量 (before → after) | tutor + full-reading |
|---|---|---|
| G6-L22 雞鳴狗盜 | 12 → 12 | ✅ 保留（紙本含計時朗讀）|
| G6-L23 老鷹紅豆 | 12 → 12 | ✅ 保留 |
| G6-L24 白鯨救援 | 12 → 12 | ✅ 保留 |
| G6-L25 荷蘭東印度公司 | 12 → 12 | ✅ 保留 |
| G7-L28 肉湯腐敗 | 9 → **7** | ❌ 移除（紙本無朗讀章節）|
| G7-L29 地球暖化 | 8 → **6** | ❌ 移除 |
| G7-L30 八哥 | 9 → **7** | ❌ 移除 |

## Summary

Sets `step_sequence` in 7 priority lesson YAML files to align UI step order with paper worksheet 章節順序. 6/1 教授 review 必含。

Backend reads `step_sequence` from Layer-2 content YAML (`backend/data/lessons/_parsed_2026-05-01/*.yml`) via `lesson_loader._load_layer2_lessons()` (line 386), passes to API, frontend resolves via `resolveActiveSteps()` (stepConfig.ts line 328).

**No code change** — mechanism (#1374) already exists. Only data edits in 7 yml files.

## Per-lesson step_sequence (最終版)

| Lesson | 紙本章節 | step_sequence | Count |
|---|---|---|---|
| G6-L22 雞鳴狗盜 | 讀全文 → 念順順 → 語詞 → 語詞應用 → 聚光燈+重點表 → 閱讀理解 → 詞語複習 → 知識補給站 | intro · reading-annotation · tutor · full-reading · vocab-definition · vocab-application · reading-strategy · story-structure · comprehension · vocab-word-search · knowledge-station · report | 12 |
| G6-L23 老鷹紅豆 | (同 L22) | (同 L22) | 12 |
| G6-L24 白鯨救援 | 讀全文 → **知識補給站** → 念順順 → 語詞 → 聚光燈+重點表 → 閱讀理解 | intro · reading-annotation · **knowledge-station** · tutor · full-reading · vocab-definition · vocab-application · reading-strategy · story-structure · comprehension · vocab-word-search · report | 12 |
| G6-L25 荷蘭東印度公司 | (同 L22) | (同 L22) | 12 |
| G7-L28 肉湯腐敗 | 讀全文 → 聚光燈 → 知識補給 → 重點表 → 閱讀理解 | intro · reading-annotation · reading-strategy · knowledge-station · story-structure · comprehension · report | **7** |
| G7-L29 地球暖化 | 讀全文 → 聚光燈 → 知識補給 → 閱讀理解 | intro · reading-annotation · reading-strategy · knowledge-station · comprehension · report | **6** |
| G7-L30 八哥 | 讀全文 → 知識補給 → 聚光燈(含表) → 閱讀理解 | intro · reading-annotation · knowledge-station · reading-strategy · story-structure · comprehension · report | **7** |

## Invariants

- ✅ `intro` 永遠第一步
- ✅ `report` 永遠最後一步
- ✅ 不寫 disabled steps: listening / vocab / sentence-practice / dictation
- ✅ Step IDs 全部對應 `STEP_REGISTRY` (frontend/src/config/stepConfig.ts)
- ✅ stepConfig.ts `resolveActiveSteps()` 會用 yml step_sequence 覆寫 DEFAULT (line 328-335)

## Where step_sequence is read

| Path | Role |
|---|---|
| `backend/data/lessons/_parsed_2026-05-01/G*-L*.yml` (Layer-2 content) | **SOT** — edited in this PR |
| `backend/app/services/lesson_loader.py:386` | `data.get(\"step_sequence\") or None` — passes to API |
| `backend/app/routes/stories.py:249` | API response includes `step_sequence` |
| `frontend/src/services/api.ts:159` | maps to lesson detail `stepSequence` |
| `frontend/src/config/stepConfig.ts:328` `resolveActiveSteps()` | resolves to ordered StepConfig[] for StepperNav |
| `backend/data/curriculum/lessons/G*-L*.yml` (catalog manifest) | NOT read by lesson_loader — not touched in this PR |

## Test plan

- [x] CI preview deploy
- [ ] /qa or /browse 打開 PR Preview URL：
  - G7-L30 stepper 顯示 7 step 順序：簡 · 記 · 補 · 光 · 重 · 解 · 報（**無朗讀**）
  - G6-L22 stepper 顯示含朗讀 step（簡 · 記 · 段 · 讀 · ...）
- [ ] 截圖兩課 stepper bar

## Out of scope (future issues)

- 75 課有 PDF 但無 step_sequence — 第二輪批量做
- 73 課沒 PDF — 第三輪等 PDF 上 GCS
- catalog yml (`backend/data/curriculum/lessons/`) — manifest layer，不被 lesson_loader 讀，不在此 PR scope