### PR TITLE
feat(content): G9 step_sequence — 5 課 (Refs #1655)

### DIFF
--- a/backend/data/lessons/_parsed_2026-05-01/G9-L10.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L10.yml
@@ -3,6 +3,18 @@ grade: 9
 grade_code: G9-L10
 reading_strategy: ''
 reading_strategy_type: general
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G9-L10高地訓練有助於運動表現嗎？.docx
 parsed_at: '2026-05-01T21:10:44'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L11.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L11.yml
@@ -3,6 +3,19 @@ grade: 9
 grade_code: G9-L11
 reading_strategy: 摘要策略-科學探究文本結構
 reading_strategy_type: summary
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G9-L11長喙天蛾見前人所未見（摘要策略-科學探究文本結構）.docx
 parsed_at: '2026-05-01T21:10:44'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L12.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L12.yml
@@ -3,6 +3,19 @@ grade: 9
 grade_code: G9-L12
 reading_strategy: 摘要策略-小標題的作用：找細節
 reading_strategy_type: summary
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G9-L12臺灣的太空之眼（摘要策略-小標題的作用：找細節）.docx
 parsed_at: '2026-05-01T21:10:45'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L13.yml
@@ -3,6 +3,19 @@ grade: 9
 grade_code: G9-L13
 reading_strategy: 正向思考-學習樂觀思考
 reading_strategy_type: general
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G9-L13樂觀者勝：向NBA球員學習「詮釋失敗」的智慧（正向思考-學習樂觀思考）.docx
 parsed_at: '2026-05-01T21:10:45'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G9-L14.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G9-L14.yml
@@ -3,6 +3,19 @@ grade: 9
 grade_code: G9-L14
 reading_strategy: 正向思考-培養心理韌性
 reading_strategy_type: general
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G9-L14焚而不毀的倫敦（正向思考-培養心理韌性）.docx
 parsed_at: '2026-05-01T21:10:45'
 flags: []


### PR DESCRIPTION
Refs #1655 (round 2 sequential start)

## Summary

Per-lesson `step_sequence` for **G9 (5 lessons with PDF)** — 嚴格對齊紙本章節順序 (option-a)。

寫到 Layer-2 content yml `backend/data/lessons/_parsed_2026-05-01/G9-L{10..14}.yml`，frontend `Story.stepSequence` 從這讀（round 1 PR #1653 已驗證機制，不動 code）。

## Per-lesson step_sequence

| Lesson | 紙本章節 | step_sequence | Count |
|---|---|---|---|
| G9-L10 高地訓練 | 讀全文 → 念順順 → 語詞 → 語詞應用 → 重點表 → 閱讀理解 → 詞語複習 → 知識補給站 | intro · reading-annotation · tutor · full-reading · vocab-definition · vocab-application · story-structure · comprehension · vocab-word-search · knowledge-station · report | **11** |
| G9-L11 長喙天蛾 | 讀全文 → 念順順 → 語詞 → 語詞應用 → **聚光燈** → 重點表 → 閱讀理解 → 詞語複習 → 知識補給站 | intro · reading-annotation · tutor · full-reading · vocab-definition · vocab-application · reading-strategy · story-structure · comprehension · vocab-word-search · knowledge-station · report | 12 |
| G9-L12 太空之眼 | (同 L11 順序) | (同 L11) | 12 |
| G9-L13 樂觀者勝 | 讀全文 → 念順順 → 語詞 → 語詞應用 → **重點表** → 品格聚光燈 → 閱讀理解 → 詞語複習 → 知識補給站 | intro · reading-annotation · tutor · full-reading · vocab-definition · vocab-application · story-structure · reading-strategy · comprehension · vocab-word-search · knowledge-station · report | 12 |
| G9-L14 焚而不毀的倫敦 | (同 L13 順序) | (同 L13) | 12 |

### 關鍵差異

- **G9-L10** 目標策略 = 「無」→ **不加** `reading-strategy` step (11 step，唯一 11 step 的課)
- **L11/L12** 紙本順序：五 閱讀聚光燈 → 六 文章重點表（reading-strategy 在 story-structure 前）
- **L13/L14** 紙本順序：五 文章重點表 → 六 品格聚光燈（story-structure 在 reading-strategy 前）— 反過來
- 所有 5 課紙本皆含「念順順 + 計時朗讀紀錄表」→ **保留** `tutor` + `full-reading`

## Invariants

- ✅ `intro` 永遠第一步
- ✅ `report` 永遠最後一步
- ✅ 不寫 disabled steps: listening / vocab(生字) / sentence-practice / dictation
- ✅ 所有 step IDs 對應 `STEP_REGISTRY` (frontend/src/config/stepConfig.ts)
- ✅ 嚴格對齊紙本章節順序 (Young 5/16 拍板 option-a)

## Smoke test

```python
from app.services.lesson_loader import get_lesson_by_code
for code in ['G9-L10','G9-L11','G9-L12','G9-L13','G9-L14']:
    l = get_lesson_by_code(code)
    print(code, l['step_sequence'])
# All 5 return correct step_sequence — verified locally
```

## Test plan

- [ ] CI preview deploy (preview-deploy.yml)
- [ ] PR Preview `/qa` 抽樣 2 課 (L10 無策略 vs L11 有策略) 驗 stepper bar
  - L10 預期 stepper 顯示 **11 step**，無 ` 光`（reading-strategy 圖標）
  - L11 預期 stepper 顯示 **12 step**，含 `光` 在 `重` 之前
- [ ] 截圖兩課 stepper bar 貼 PR comment

## Out of scope (剩 round 2 budget)

- G4 (23 課) / G5 (16 課) / G6 (9 課) / G7 (17 課) / G8 (5 暫緩 — audit found PDF mismatch)
- 第三輪：66 課無 PDF (等 PDF 上 GCS)

接 G9 ✅ → 下一批 G6 (9 課)。

## Token usage

待補（commit 完後總結）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)