### PR TITLE
feat(content): G6 step_sequence — 11 課 (Refs #1655)

### DIFF
--- a/backend/data/lessons/_parsed_2026-05-01/G6-L10.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L10.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L10
 reading_strategy: 摘要策略-從關鍵句找小主題與細節
 reading_strategy_type: summary
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L10末日種子庫（摘要策略-從關鍵句找小主題與細節）.docx
 parsed_at: '2026-05-01T21:10:37'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L11.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L11.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L11
 reading_strategy: 摘要策略-從關鍵句找小主題與細節
 reading_strategy_type: summary
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L11古代畫家心中的仙境（摘要策略-從關鍵句找小主題與細節）.docx
 parsed_at: '2026-05-01T21:10:37'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L12.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L12.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L12
 reading_strategy: 摘要策略-從段落找主題句
 reading_strategy_type: summary
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L12愛冒險逞強的雄性動物（摘要策略-從段落找主題句）.docx
 parsed_at: '2026-05-01T21:10:37'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L13.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L13
 reading_strategy: 自我提問-問好奇、疑惑的問題
 reading_strategy_type: self_questioning
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L13森林大軍的守護者（自我提問-問好奇、疑惑的問題）.docx
 parsed_at: '2026-05-01T21:10:37'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L14.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L14.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L14
 reading_strategy: 自我提問-問重要的問題
 reading_strategy_type: self_questioning
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L14植物獵人（自我提問-問重要的問題）.docx
 parsed_at: '2026-05-01T21:10:37'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L15.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L15.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L15
 reading_strategy: 自我提問-4F思考法自我提問
 reading_strategy_type: self_questioning
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L15小藍鯨之死（自我提問-4F思考法自我提問）.docx
 parsed_at: '2026-05-01T21:10:37'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L16.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L16.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L16
 reading_strategy: 生活素養-野外求生技能
 reading_strategy_type: general
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L16奇蹟行動（生活素養-野外求生技能）.docx
 parsed_at: '2026-05-01T21:10:37'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L17.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L17.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L17
 reading_strategy: 跨文化接納理解
 reading_strategy_type: general
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L17給神明發會診單（跨文化接納理解）.docx
 parsed_at: '2026-05-01T21:10:38'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L19.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L19.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L19
 reading_strategy: 正向思考-特定句型的轉念練習
 reading_strategy_type: general
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L19紅領帶（正向思考-特定句型的轉念練習）.docx
 parsed_at: '2026-05-01T21:10:38'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L20.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L20.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L20
 reading_strategy: 負責任的決定-區辨控制圈
 reading_strategy_type: general
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L20感情小日記5──我該告白嗎？（負責任的決定-區辨控制圈）.docx
 parsed_at: '2026-05-01T21:10:38'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L21.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L21.yml
@@ -3,6 +3,19 @@ grade: 6
 grade_code: G6-L21
 reading_strategy: 情緒管理-悲傷五階段
 reading_strategy_type: general
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G6-L21感情小日記6──我失戀了（情緒管理-悲傷五階段）.docx
 parsed_at: '2026-05-01T21:10:38'
 flags: []


### PR DESCRIPTION
Refs #1655

## Summary

Round 2 G6 batch — adds `step_sequence` to **11 G6 content yml's** under `backend/data/lessons/_parsed_2026-05-01/` (Layer-2, where `lesson_loader.get_lesson_by_id()` actually reads).

**Lessons (11)**: G6-L10, L11, L12, L13, L14, L15, L16, L17, L19, L20, L21

Excluded per coordinator directive: L22, L23, L24, L25 (round 1 scope).
Skipped (no PDF): L18 (no worksheet_pdf_url on staging).

> Note: original brief said "9 課"; actual count after auditing staging is **11** (L10-L17 are 8 + L19/L20/L21 are 3). All 11 have PDF + lack step_sequence in content yml. Documented for transparency.

## Patterns (per paper section order)

Each PDF was read in full, then step_sequence was designed strictly per the paper's actual章節 order:

- **Pattern A** (L10, L11): paper has 五閱讀聚光燈 → 六文章重點表
  → `reading-strategy` BEFORE `story-structure`
- **Pattern B** (L12, L13, L14, L15, L16, L17, L19, L20, L21): paper has 五文章重點表 → 六閱讀聚光燈/品格聚光燈
  → `story-structure` BEFORE `reading-strategy`

All 11 lessons follow the same paper section pattern (一讀全文 / 二念順順 / 三語詞我最棒 / 四語詞應用 / 五↔六 聚光燈↔重點表 / 七閱讀理解 / 八詞語複習 / 九知識補給站), giving the same 12-step skeleton with the聚光燈/重點表 swap.

### Step mapping

| 紙本章節 | Step |
|---|---|
| (always first) | `intro` |
| 一讀全文-做記號 | `reading-annotation` |
| 二念順順 | `tutor` + `full-reading` |
| 三語詞我最棒 | `vocab-definition` |
| 四語詞應用 | `vocab-application` |
| 五/六 閱讀聚光燈 | `reading-strategy` |
| 五/六 文章重點表 | `story-structure` |
| 七閱讀理解 | `comprehension` |
| 八詞語複習 | `vocab-word-search` |
| 九知識補給站 | `knowledge-station` |
| (always last) | `report` |

Disabled steps (NOT added — not present in paper): `listening` / `vocab` (生字) / `sentence-practice` / `dictation`.

## Self-checks

- [x] All 11 step_sequence start with `intro`, end with `report`
- [x] YAML parses cleanly (validated with `yaml.safe_load`)
- [x] All step names in allowed set
- [x] Each lesson's sequence matches the lesson's actual PDF章節 order
- [x] No catalog yml edits (only `_parsed_2026-05-01/` content yml)
- [x] No frontend / stepConfig.ts / other grade files touched

## Test plan

- [ ] PR Preview deploys (CI: preview-deploy.yml on `feat/issue-` branch)
- [ ] Spot-check 2 lessons on staging Preview URL after merge (Pattern A + Pattern B)
- [ ] Open one Pattern A lesson (e.g. G6-L10 末日種子庫): verify stepper shows 聚光燈 before 重點表
- [ ] Open one Pattern B lesson (e.g. G6-L13 森林大軍的守護者): verify stepper shows 重點表 before 聚光燈
- [ ] Verify no disabled steps (聽寫 / 生字 / 造句) appear in the stepper for any of the 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)