### PR TITLE
feat(content): G8 step_sequence + catalog↔PDF mismatch 修正 (Related to #1655)

### DIFF
--- a/backend/data/curriculum/lessons/G8-L10.yml
+++ b/backend/data/curriculum/lessons/G8-L10.yml
@@ -29,4 +29,4 @@ vocab:
 - 一目了󠇡然
 existing_content_yaml: null
 notes: null
-worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L10.pdf
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L13.pdf

--- a/backend/data/curriculum/lessons/G8-L13.yml
+++ b/backend/data/curriculum/lessons/G8-L13.yml
@@ -32,4 +32,4 @@ vocab:
 - 莫衷一是
 existing_content_yaml: null
 notes: null
-worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L13.pdf
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L17.pdf

--- a/backend/data/curriculum/lessons/G8-L14.yml
+++ b/backend/data/curriculum/lessons/G8-L14.yml
@@ -32,4 +32,4 @@ vocab:
 - 緩不濟急
 existing_content_yaml: null
 notes: null
-worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L14.pdf
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L18.pdf

--- a/backend/data/curriculum/lessons/G8-L15.yml
+++ b/backend/data/curriculum/lessons/G8-L15.yml
@@ -30,4 +30,4 @@ vocab:
 - 權衡
 existing_content_yaml: null
 notes: null
-worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L15.pdf
+worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G8-L19.pdf

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L13.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L13.yml
@@ -3,6 +3,18 @@ grade: 8
 grade_code: G8-L13
 reading_strategy: 解決問題-科學探究法
 reading_strategy_type: problem_solving
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G8-L13《構樹：南島祖先「出台灣說」的植物證據》（解決問題-科學探究法）.docx
 parsed_at: '2026-05-01T21:10:43'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L17.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L17.yml
@@ -3,6 +3,19 @@ grade: 8
 grade_code: G8-L17
 reading_strategy: 比較多元觀點
 reading_strategy_type: compare_contrast
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G8-L17我能不能選擇告別方式0225(比較多元觀點).docx
 parsed_at: '2026-05-01T21:10:43'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L18.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L18.yml
@@ -3,6 +3,19 @@ grade: 8
 grade_code: G8-L18
 reading_strategy: 比較多元觀點
 reading_strategy_type: compare_contrast
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G8-L18石虎保育：遷移與否的兩難（比較多元觀點）.docx
 parsed_at: '2026-05-01T21:10:43'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L19.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L19.yml
@@ -3,6 +3,18 @@ grade: 8
 grade_code: G8-L19
 reading_strategy: 比較多元觀點
 reading_strategy_type: compare_contrast
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-application
+- reading-strategy
+- story-structure
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G8-L19核能的兩難抉擇（比較多元觀點）.docx
 parsed_at: '2026-05-01T21:10:43'
 flags: []

--- a/backend/data/lessons/_parsed_2026-05-01/G8-L2.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G8-L2.yml
@@ -3,6 +3,19 @@ grade: 8
 grade_code: G8-L2
 reading_strategy: 寫作手法：對比-從對比歸納作者意圖
 reading_strategy_type: writing_technique
+step_sequence:
+- intro
+- reading-annotation
+- tutor
+- full-reading
+- vocab-definition
+- vocab-application
+- story-structure
+- reading-strategy
+- comprehension
+- vocab-word-search
+- knowledge-station
+- report
 source_file: G8-L2爸爸的恩人們（寫作手法：對比-從對比歸納作者意圖）.docx
 parsed_at: '2026-05-01T21:10:43'
 flags: []


### PR DESCRIPTION
Related to #1655 — G8 round 2 of 6.

## TL;DR

1. **2 課實際生效**：寫 step_sequence 到 Layer-2 yml，runtime 會讀
   - `G8-L2.yml` 爸爸的恩人們 (12 steps)
   - `G8-L13.yml` 構樹 (11 steps，無 story-structure)
2. **3 課寫了但 inert**：`G8-L17/L18/L19.yml` (告別/石虎/核能) — Layer-2 yml 有 step_sequence 但 manifest 沒對應 entry → 不曝光。等將來修 manifest 後自動 activate。
3. **4 catalog yml `worksheet_pdf_url` 修正**：cosmetic（catalog yml 不被 runtime 讀），讓 title ↔ PDF 對齊正確。

## Investigation summary（為何只有 2 課實際生效）

G8 因為 `a/b` 拆分（L03a/b、L06a/b、L09a/b、L12a/b），catalog code 與 Layer-2 chapter number 不對齊：

| Catalog code | Catalog title | Manifest 號碼 → Layer-2 lookup | Layer-2 yml title | Production 顯示 |
|---|---|---|---|---|
| G8-L02 | 爸爸恩人 | G8-L2 | 爸爸恩人 ✓ | 爸爸恩人 ✓ |
| G8-L10 | 構樹 | G8-L10 | 按讚 ✗ | 按讚 (Layer-2 title 取代 catalog) |
| G8-L13 | 告別 | G8-L13 | 構樹 ✗ | 構樹 |
| G8-L14 | 石虎 | G8-L14 | 蝴蝶蘭 ✗ | 蝴蝶蘭 |
| G8-L15 | 核能 | G8-L15 | 球場指揮家 ✗ | 球場指揮家 |
| — | 我的阿嬤 | (manifest G8-L12b → 拿 G8-L12a→fallback G8-L12) | 語言足跡 | 不曝光 |
| — | 告別/石虎/核能 | 沒對應 manifest entry | 告別/石虎/核能 | 不曝光 |

`lesson_loader._load_layer2_lessons()` 用 manifest 作 iterator，所以 Layer-2 `G8-L16/L17/L18/L19` (我的阿嬤/告別/石虎/核能) 沒進 runtime — 即使有 step_sequence 也 inert。

驗證指令：
\`\`\`bash
curl -s 'https://lingoleap-backend-958347263320.asia-east1.run.app/api/stories?grade=8' | jq '.[].grade_code'
# 結果：G8-L1 到 G8-L15（用 Layer-2 codes、Layer-2 titles）— 告別/石虎/核能/阿嬤 都沒有
\`\`\`

## Decision matrix

| Lesson | step_sequence 寫到 | 生效? | 為什麼 |
|---|---|---|---|
| 爸爸恩人 | Layer-2 G8-L2.yml | ✅ Yes | manifest G8-L2 → Layer-2 G8-L2 |
| 構樹 | Layer-2 G8-L13.yml | ✅ Yes | manifest G8-L10 → Layer-2 G8-L10 (按讚)... 但 runtime 顯示 G8-L13 = 構樹（Layer-2 title）。step_sequence 在 G8-L13 = 構樹 lesson record |
| 告別 | Layer-2 G8-L17.yml | ⏸️ Inert | manifest 沒 G8-L17 entry |
| 石虎 | Layer-2 G8-L18.yml | ⏸️ Inert | manifest 沒 G8-L18 entry |
| 核能 | Layer-2 G8-L19.yml | ⏸️ Inert | manifest 沒 G8-L19 entry |

## Per-lesson step_sequence (依紙本章節順序)

### G8-L2 爸爸的恩人們 (12 steps)
紙本：讀全文 → 念順順 → 語詞我最棒 → 語詞應用 → **文章重點表** → **閱讀聚光燈** → 閱讀理解 → 詞語複習 → 知識補給站

(注意：story-structure 在 reading-strategy 前 — 這課比較特別)

\`\`\`yaml
step_sequence:
- intro
- reading-annotation
- tutor
- full-reading
- vocab-definition
- vocab-application
- story-structure
- reading-strategy
- comprehension
- vocab-word-search
- knowledge-station
- report
\`\`\`

### G8-L13 構樹 (11 steps，無 story-structure)
紙本：讀全文 → 念順順 → 語詞我最棒 → 語詞應用 → 閱讀聚光燈 → 閱讀理解 → 詞語複習 → 知識補給站
(紙本沒有「文章重點表」段，省 story-structure)

\`\`\`yaml
step_sequence:
- intro
- reading-annotation
- tutor
- full-reading
- vocab-definition
- vocab-application
- reading-strategy
- comprehension
- vocab-word-search
- knowledge-station
- report
\`\`\`

### G8-L17 告別 (12 steps, inert)
\`\`\`yaml
- intro · reading-annotation · tutor · full-reading
- vocab-definition · vocab-application
- reading-strategy · story-structure
- comprehension · vocab-word-search · knowledge-station · report
\`\`\`

### G8-L18 石虎 (12 steps, inert — 同 L17 結構)

### G8-L19 核能 (11 steps, inert — 無 vocab-definition)
紙本：讀全文 → 念順順 → **(無語詞我最棒)** → 語詞應用 → 閱讀聚光燈 → 文章重點表 → 閱讀理解 → 詞語複習 → 知識補給站
\`\`\`yaml
- intro · reading-annotation · tutor · full-reading
- vocab-application
- reading-strategy · story-structure
- comprehension · vocab-word-search · knowledge-station · report
\`\`\`

## Catalog `worksheet_pdf_url` 修正 (cosmetic)

`backend/data/curriculum/lessons/` 是 manifest layer，**lesson_loader 不讀**這個欄位（PR #1640 寫的，被 wired 但實際 runtime 用 Layer-2 yml 的 `worksheet_pdf_url`）。修正 catalog yml 為了：
1. catalog title ↔ PDF content 對齊（將來若有程式真讀此欄位，會正確）
2. 答覆 audit 提的「catalog 指向錯 PDF」問題

PDF 內容已逐一 `pdftotext` 驗證：

| Catalog yml | Title | 修前 PDF（內容） | 修後 PDF（內容） |
|---|---|---|---|
| G8-L10.yml | 構樹 | G8-L10.pdf（按讚 ✗） | G8-L13.pdf（構樹 ✓） |
| G8-L13.yml | 告別 | G8-L13.pdf（構樹 ✗） | G8-L17.pdf（告別 ✓） |
| G8-L14.yml | 石虎 | G8-L14.pdf（蝴蝶蘭 ✗） | G8-L18.pdf（石虎 ✓） |
| G8-L15.yml | 核能 | G8-L15.pdf（指揮家 ✗） | G8-L19.pdf（核能 ✓） |

G8-L02.yml `worksheet_pdf_url=G8-L2.pdf` 不動（已正確指爸爸恩人 PDF）。

## 已知更大問題（待後續 issue）

⚠️ G8 manifest ↔ Layer-2 lesson_code 不對齊：

| Manifest code | Manifest title (catalog 認知) | Layer-2 lookup gets | Runtime 實際顯示 |
|---|---|---|---|
| G8-L4 | 玻璃娃娃 | Layer-2 G8-L4 (植物肉) | 植物肉 |
| G8-L5 | 戲院賭場 | Layer-2 G8-L5 (玻璃娃娃) | 玻璃娃娃 |
| G8-L7 | 黑猩猩 | Layer-2 G8-L7 (甜蜜) | 甜蜜 |
| G8-L8 | 按讚 | Layer-2 G8-L8 (隱形) | 隱形 |
| G8-L10 | 構樹 | Layer-2 G8-L10 (按讚) | 按讚 |
| G8-L11 | 蝴蝶蘭 | Layer-2 G8-L11 (虎襲) | 虎襲 |
| G8-L12a | 球場指揮家 | Layer-2 G8-L12 fallback (語言足跡) | 語言足跡 |
| G8-L13 | 告別 | Layer-2 G8-L13 (構樹) | 構樹 |
| G8-L14 | 石虎 | Layer-2 G8-L14 (蝴蝶蘭) | 蝴蝶蘭 |
| G8-L15 | 核能 | Layer-2 G8-L15 (球場指揮家) | 球場指揮家 |

= 10 個 manifest code 顯示的 lesson 跟 manifest title 不符。
+ 4 個 Layer-2 lesson (我的阿嬤/告別/石虎/核能) 完全不曝光。

**根因**：G8 catalog 有 a/b 拆分（L03a/L03b 等），總 catalog slots 19；但 Layer-2 也是 19 個檔案，且使用原始章節編號。manifest 把 catalog code 直接 normalize 後當 Layer-2 lookup key — 在 G8-L03a/b 之後就 drift 4 個（每組 a/b 多 1 個 slot，4 組 = +4 偏移）。

**建議下一步**：開新 issue 修 manifest ↔ Layer-2 mapping (e.g. manifest 加 `content_lesson_code` field 指向實際 Layer-2 lesson_code)。本 PR 不修——超出 round 2 scope。

## What's NOT in this PR

- ❌ 修 manifest mapping（10 個 G8 lesson title 跟 manifest title 不符 — 上面那張表的問題）
- ❌ 把告別/石虎/核能/阿嬤 4 個 Layer-2 lesson 接進 manifest（讓他們在 runtime 曝光）
- ❌ Rename GCS PDFs to use catalog-code naming
- ❌ stepConfig.ts 改動

## Invariants

- ✅ `intro` 永遠第一步
- ✅ `report` 永遠最後一步
- ✅ 不含 disabled steps (listening / vocab / sentence-practice / dictation)
- ✅ Step IDs 對應 STEP_REGISTRY (frontend/src/config/stepConfig.ts:83-)
- ✅ stepConfig.ts `resolveActiveSteps()` 會用 yml step_sequence 覆寫 DEFAULT
- ✅ YAML lint pass (9 個 yml)
- ✅ `lesson_loader._load_layer2_lessons()` smoke test pass

## Test plan

- [x] YAML lint 9 個檔案 pass
- [x] lesson_loader smoke test: G8-L2 picks up 12-step seq, G8-L13 picks up 11-step seq
- [ ] CI preview deploy（等 GitHub Actions）
- [ ] PR Preview /qa 或 /browse 開：
  - G8-L2 stepper 顯示 12 step（簡 · 記 · 段 · 讀 · 詞 · 應 · 重 · 光 · 解 · 字 · 補 · 報）
  - G8-L13 stepper 顯示 11 step（簡 · 記 · 段 · 讀 · 詞 · 應 · 光 · 解 · 字 · 補 · 報）—**無**重點表
- [ ] 截兩課 stepper bar

## Files changed (9)

\`\`\`
M backend/data/curriculum/lessons/G8-L10.yml         (-1/+1)
M backend/data/curriculum/lessons/G8-L13.yml         (-1/+1)
M backend/data/curriculum/lessons/G8-L14.yml         (-1/+1)
M backend/data/curriculum/lessons/G8-L15.yml         (-1/+1)
M backend/data/lessons/_parsed_2026-05-01/G8-L2.yml  (+13)
M backend/data/lessons/_parsed_2026-05-01/G8-L13.yml (+12)
M backend/data/lessons/_parsed_2026-05-01/G8-L17.yml (+13)  ← inert until manifest fixed
M backend/data/lessons/_parsed_2026-05-01/G8-L18.yml (+13)  ← inert until manifest fixed
M backend/data/lessons/_parsed_2026-05-01/G8-L19.yml (+12)  ← inert until manifest fixed
\`\`\`

## Refs

- Round 1 PR #1653 (G6/G7 7 priority lessons, merged)
- Round 2 sibling PRs: G4 / G5 / G6 / G7 / G9 (all open / running)
- Audit report: `/tmp/catalog-pdf-audit-2026-05-17.md` + Issue #1655 comment
- Round 3 follow-up: 66 課沒 PDF（等 PDF 上 GCS）
- Future follow-up: G8 manifest ↔ Layer-2 mapping 修正（10 個 title mismatch + 4 個 orphaned Layer-2 lesson）

🤖 Generated with [Claude Code](https://claude.com/claude-code)