### PR TITLE
fix(backend): Layer-2 enrichment merge — 14 課 step_sequence shadowed (Fixes #1666)

### DIFF
--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -415,6 +415,65 @@ def _load_lessons() -> list[dict]:
     # Layer 2: new parsed lessons
     layer2 = _load_layer2_lessons(manifest_index, layer1_titles)
 
+    # Merge Layer-2 enrichment into Layer-1 entries with matching title (#1666).
+    #
+    # Problem: when a curriculum slot has BOTH a Layer-1 L*.yml (legacy, no
+    # step_sequence) AND a Layer-2 _parsed_/G*-L*.yml (new SOT with
+    # step_sequence + worksheet_* + lesson_intro + layout_mode), `_load_layer2_lessons`
+    # skips the Layer-2 entry on title match to avoid duplicate cards. Result:
+    # /api/stories/G6-L10 resolves to Layer-1 entry with step_sequence=null.
+    #
+    # Fix: build a title→Layer-2 lookup from _parsed_ files (regardless of
+    # whether the Layer-2 entry was kept after dedup), then copy the enrichment
+    # fields onto matching Layer-1 entries. Layer-1 keeps its id/lesson_number
+    # /title/paragraphs (preserves DB Text FK + session.story_slug back-compat).
+    #
+    # Enrichment fields inherited from Layer-2 (when source has a non-None value):
+    #   - step_sequence (#1374)
+    #   - worksheet_section_order, worksheet_intro (#1434)
+    #   - lesson_intro (#1443)
+    #   - worksheet_pdf_url (#1444)
+    #   - layout_mode, reading_strategy_type (#1404)
+    #   - images (#1341)
+    #   - strategy_exercise (#1418, structured Gemini output — Layer-2 richer)
+    #   - story_structure_table, story_structure_rows
+    layer2_by_title: dict[str, dict] = {}
+    if _PARSED_DIR.exists():
+        for yml_path in _PARSED_DIR.glob("*.yml"):
+            with open(yml_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if not data:
+                continue
+            title = data.get("title", "")
+            if title:
+                layer2_by_title[title] = data
+
+    _ENRICHMENT_FIELDS = (
+        "step_sequence",
+        "worksheet_section_order",
+        "worksheet_intro",
+        "lesson_intro",
+        "worksheet_pdf_url",
+        "layout_mode",
+        "reading_strategy_type",
+        "images",
+        "strategy_exercise",
+        "story_structure_table",
+        "story_structure_rows",
+    )
+
+    for lesson in layer1:
+        l2_data = layer2_by_title.get(lesson["title"])
+        if not l2_data:
+            continue
+        for field in _ENRICHMENT_FIELDS:
+            l2_value = l2_data.get(field)
+            # strategy_exercise: Layer-2 may use plural key (legacy G7 圖文整合)
+            if field == "strategy_exercise" and l2_value is None:
+                l2_value = l2_data.get("strategy_exercises")
+            if l2_value:  # only override when Layer-2 has a truthy value
+                lesson[field] = l2_value
+
     all_lessons = layer1 + layer2
 
     # Sort: Layer-1 by lesson_number, Layer-2 by display_order, then mix

--- a/backend/tests/test_slug_grade_code.py
+++ b/backend/tests/test_slug_grade_code.py
@@ -81,3 +81,55 @@ def test_publisher_slug_unchanged():
 
 def test_empty_or_falsy_slug():
     assert normalize_story_slug("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Bug #1666 — Layer-2 enrichment shadow
+# ---------------------------------------------------------------------------
+
+
+def test_shadowed_grade_codes_inherit_layer2_step_sequence():
+    """Layer-1 lessons with matching-title Layer-2 yml must inherit step_sequence.
+
+    Before #1666: _load_layer2_lessons skipped Layer-2 entries when title matched
+    a Layer-1 lesson, leaving the catalogue with Layer-1 entry only (no
+    step_sequence). API returned step_sequence=null for 14+ lessons.
+
+    Fix: _load_lessons now merges Layer-2 enrichment fields (step_sequence,
+    worksheet_*, lesson_intro, layout_mode, etc.) into matching Layer-1 entries.
+    """
+    # Sample 3 known-shadowed codes from the #1666 audit
+    shadowed_codes = ["G6-L10", "G4-L13", "G6-L13"]
+    for code in shadowed_codes:
+        lesson = get_lesson_by_code(code)
+        assert lesson is not None, f"{code} must exist in catalogue"
+        assert lesson.get("step_sequence"), (
+            f"{code} (Layer-1 id={lesson['id']}, title={lesson['title']!r}) "
+            f"must inherit step_sequence from Layer-2 _parsed_ yml. "
+            f"Got: {lesson.get('step_sequence')!r}"
+        )
+        # Sanity: Layer-1 id preserved (DB FK back-compat)
+        assert lesson["id"] < 1000, (
+            f"{code} should keep Layer-1 id (< 1000) for session FK compat, "
+            f"got id={lesson['id']}"
+        )
+
+
+def test_layer2_only_lessons_still_resolve():
+    """Layer-2-only lessons (no Layer-1 equivalent) must still work post-fix."""
+    # G7-L30 (八哥, Layer-2 only) — verified by #1654 test, but re-check
+    lesson = get_lesson_by_code("G7-L30")
+    assert lesson is not None
+    assert lesson["id"] == 1110
+    assert lesson.get("step_sequence"), "Layer-2 G7-L30 must have step_sequence"
+
+
+def test_no_duplicate_titles_after_merge():
+    """Merging Layer-2 enrichment into Layer-1 must not cause duplicate catalogue entries."""
+    from app.services.lesson_loader import get_all_lessons
+    from collections import Counter
+
+    titles = [l["title"] for l in get_all_lessons() if l.get("title")]
+    counts = Counter(titles)
+    duplicates = {t: c for t, c in counts.items() if c > 1}
+    assert not duplicates, f"Duplicate titles after merge: {duplicates}"


### PR DESCRIPTION
## Bug

當 grade_code 同時存在 Layer-1 (`backend/data/lessons/L*.yml`) 和 Layer-2 (`backend/data/lessons/_parsed_2026-05-01/G*-L*.yml`) 且 title 相同時，`_load_layer2_lessons` line 322-324 跳過 Layer-2 entry → Layer-2 yml 的 `step_sequence` (#1374)、`worksheet_*` (#1434/#1444)、`lesson_intro` (#1443)、`layout_mode` (#1404)、`images` (#1341) 等 enrichment 全部 ignored。

API 回傳 step_sequence=null，前端 fallback 走 DEFAULT_STEP_SEQUENCE，紙本學習單章節順序錯亂。

## Reproduce (before)

```bash
curl -s "https://lingoleap-backend-staging-958347263320.asia-east1.run.app/api/stories/G6-L10" | python3 -c "import sys,json;d=json.load(sys.stdin);print(f'id={d[\"id\"]}, step_sequence={d.get(\"step_sequence\")}')"
# id=20, step_sequence=None  ❌ should be 12 items
```

## Audit Scope

14 課 shadowed（Layer-2 有 step_sequence、Layer-1 沒有、title 相同）：

G4-L13 / G6-L10 / G6-L13 / G6-L14 / G6-L15 / G6-L16 / G6-L17 / G6-L19 / G7-L13 / G7-L16 / G7-L17 / G7-L20 / G7-L21 / G7-L22

外加 2 課 (G5-L10, G5-L22) 兩 layer 都有 step_sequence — 也同步切到 Layer-2 (newer，含 worksheet/lesson_intro 等)。

## Root Cause (5-Why)

1. `/api/stories/G6-L10` → `normalize_story_slug` → `get_lesson_by_code` → `_LESSONS_BY_CODE["G6-L10"]` → Layer-1 entry
2. Layer-1 L20.yml `grade_code: G6-L10` 進 `_LESSONS_BY_CODE` (line 437-439)
3. Layer-2 `_parsed_/G6-L10.yml` 被 `_load_layer2_lessons` line 322-324 `if title in layer1_titles: continue` 跳過
4. 舊設計（避免重複卡片）→ 但 Layer-2 是新 SOT，含 #1374 #1404 #1434 #1443 #1444 增強欄位
5. Layer-1 entry 必須保留（DB Text FK + legacy session story_slug 整數 ID 依賴），所以正解是 **merge** 而非 replace

## Fix

`backend/app/services/lesson_loader.py` `_load_lessons` 加 merge step：
- title 同 Layer-2 yml 的 enrichment fields → copy 進 Layer-1 entry
- 保留 Layer-1 `id` / `lesson_number` / `title` / `paragraphs` / `full_text` / `vocabulary`（DB FK back-compat）
- Layer-2 entry 仍 skip 避免重複卡片

Enrichment fields:
- `step_sequence` (#1374)
- `worksheet_section_order`, `worksheet_intro` (#1434)
- `lesson_intro` (#1443)
- `worksheet_pdf_url` (#1444)
- `layout_mode`, `reading_strategy_type` (#1404)
- `images` (#1341)
- `strategy_exercise` (#1418 + plural legacy key fallback)
- `story_structure_table`, `story_structure_rows`

## Verify (local catalogue)

| Code | Before | After | Layer-1 ID preserved |
|------|--------|-------|----------------------|
| G6-L10 | step_sequence=null | 12 items + worksheet_pdf | ✅ id=20 |
| G4-L13 | step_sequence=null | 12 items + worksheet_pdf | ✅ id=6 |
| G6-L13 | step_sequence=null | 12 items | ✅ id=21 |
| G6-L14 | step_sequence=null | 12 items + lesson_intro | ✅ id=22 |
| G7-L13 | step_sequence=null | 12 items | ✅ id=34 |
| G7-L16 | step_sequence=null | 12 items | ✅ id=36 |
| G7-L30 | 7 items (Layer-2) | 7 items unchanged | ✅ id=1110 |
| G5-L13 | 12 items (Layer-2) | 12 items unchanged | ✅ id=1040 |

- `get_lesson_by_id(20)` 仍回傳 末日種子庫（legacy session FK OK）
- Total lessons: 160，duplicate titles: 0
- 18 pre-existing test failures 仍存在（stale 57-count assumption，與本 fix 無關）

## Tests

- 7 existing slug tests pass
- 3 new regression tests added:
  - `test_shadowed_grade_codes_inherit_layer2_step_sequence` — 驗證 G6-L10 / G4-L13 / G6-L13 有 step_sequence + id < 1000
  - `test_layer2_only_lessons_still_resolve` — G7-L30 不 regress
  - `test_no_duplicate_titles_after_merge` — 0 duplicate cards

## Refs

- Fixes #1666
- Related #1654 (slug grade_code routing)
- Related #1655 (round 2 step_sequence parent)

## Test plan

- [ ] Preview deploy 起來
- [ ] `curl /api/stories/G6-L10` → step_sequence=12 items
- [ ] `curl /api/stories/G4-L13` → step_sequence=12 items
- [ ] `curl /api/stories/G7-L30` → step_sequence=7 items (no regression)