### PR TITLE
fix(curriculum): align fill_in_blank to 紙本學習單 for 6 lessons (Fixes #1675)

### DIFF
--- a/backend/data/lessons/L15.yml
+++ b/backend/data/lessons/L15.yml
@@ -35,58 +35,49 @@ paragraphs:
 paragraph_count: 12
 char_count: 1112
 vocabulary:
-- word: 直率
-  definition: 性情直爽不虛偽。
-- word: 普及
-  definition: 普遍推行。
-- word: 遲疑
-  definition: 猶豫難以決定。
-- word: 富可敵國
-  definition: 個人擁有的財富可與國家財富相比。
-- word: 謙和
-  definition: 謙恭和藹。
-- word: 果斷
-  definition: 下決定很快。
-- word: 學問淵博
-  definition: 學識豐富。
-- word: 應󠇡對如流
-  definition: 思考敏捷、對答順暢流利。
-- word: 朽木不可雕也
-  definition: 腐朽的木頭不能雕刻。比喻一個人資質不好，不能培養成人才。
 - word: 名符其實
   definition: 名聲與實際相符合。
+- word: 富可敵國
+  definition: 個人擁有的財富可與國家財富相比。
+- word: 直率
+  definition: 性情直爽不虛偽。
+- word: 學問淵博
+  definition: 學識豐富。
+- word: 應對如流
+  definition: 思考敏捷、對答順暢流利。
+- word: 果斷
+  definition: 下決定很快。
+- word: 遲疑
+  definition: 猶豫難以決定。
+- word: 朽木不可雕也
+  definition: 腐朽的木頭不能雕刻。比喻一個人資質不好，不能培養成人才。
+- word: 普及
+  definition: 普遍推行。
+- word: 謙和
+  definition: 謙恭和藹。
 vocabulary_count: 10
 vocab_bank:
-  A: 直率
-  B: 普及
-  C: 遲疑
-  D: 富可敵國
-  E: 謙和
+  A: 名符其實
+  B: 富可敵國
+  C: 直率
+  D: 學問淵博
+  E: 應對如流
   F: 果斷
-  G: 學問淵博
-  I: 朽木不可雕也
-  J: 名符其實
+  G: 遲疑
+  H: 朽木不可雕也
 fill_in_blank:
-- sentence: 小明總是（　　）地說出自己的想法，從不拐彎抹角。
-  answer: A
-- sentence: 隨著科技發展，智慧型手機已在我們生活中（　　）。
-  answer: B
-- sentence: 面對兩個同樣誘人的選項，他（　　）了許久才做出決定。
-  answer: C
-- sentence: 那位商人累積了龐大的財富，據說他的個人資產甚至足以（　　）。
-  answer: D
-- sentence: 儘管王老師知識淵博，但他對待學生卻總是那麼（　　），從不擺架子。
-  answer: E
-- sentence: 隊長在緊急時刻展現出（　　）的判斷力，帶領大家脫離險境。
-  answer: F
-- sentence: 爺爺讀遍了古今中外許多書籍，什麼問題都難不倒他，真是（　　）。
-  answer: G
-- sentence: 辯論比賽中，小華面對對手的提問，總是（　　），讓評審印象深刻。
+- sentence: 面對多次勸說卻不聽的學生，老師不禁大嘆（　　）。
   answer: H
-- sentence: 老師苦口婆心勸導他，但他依然故我，真是（　　），讓人感到無奈。
-  answer: I
-- sentence: 這家餐廳的招牌菜果然美味，吃過之後才發現它（　　），廣受好評不是沒有原因的。
-  answer: J
+- sentence: 他熱心公益，樂於助人，真是（　　）的大善人。
+  answer: A
+- sentence: 因為事前準備充分，今天的口試我才能（　　）。
+  answer: E
+- sentence: 他個性（　　），從不拘泥小節，同學都喜歡和他一起做朋友。
+  answer: C
+- sentence: 我聽了價錢（　　）了一會兒，她卻沒有猶豫，＿的付錢了。
+  answer: G
+- sentence: 我聽了價錢＿了一會兒，她卻沒有猶豫，（　　）的付錢了。
+  answer: F
 multiple_choice:
 - question: 下列哪個詞語使用正確?
   options:

--- a/backend/data/lessons/L24.yml
+++ b/backend/data/lessons/L24.yml
@@ -44,59 +44,46 @@ paragraphs:
 paragraph_count: 9
 char_count: 994
 vocabulary:
-- word: 覓食
-  definition: 尋找食物。
-- word: 彷彿
-  definition: 似乎、好像。
-- word: 守株待兔
-  definition: 比喻不知變通或想要不勞而獲。在本課指等著目標自己送上門來。
-- word: 巧妙
-  definition: 神奇美妙的方式。
-- word: 葉苞
-  definition: 本文指將葉子捲成如同花苞的形狀。
-- word: 孵化
-  definition: 卵變成幼蟲或小動物的過程。
 - word: 依循
   definition: 依照遵循。
 - word: 規律
   definition: 事物或現象反覆出現的秩序。
-- word: 臨機應變
-  definition: 看現況的變化來做反應。
+- word: 彷彿
+  definition: 似乎、好像。
+- word: 覓食
+  definition: 尋找食物。
+- word: 巧妙
+  definition: 神奇美妙的方式。
+- word: 守株待兔
+  definition: 比喻不知變通或想要不勞而獲。在本課指等著目標自己送上門來。
 - word: 迅雷不及掩耳
   definition: 雷聲突然響起，來不及掩住耳朵。比喻行動迅速，來不及防範準備。
+- word: 葉苞
+  definition: 本文指將葉子捲成如同花苞的形狀。
+- word: 孵化
+  definition: 卵變成幼蟲或小動物的過程。
+- word: 臨機應變
+  definition: 看現況的變化來做反應。
 vocabulary_count: 10
 vocab_bank:
-  A: 覓食
-  B: 彷彿
-  C: 守株待兔
-  D: 巧妙
-  E: 葉苞
-  F: 孵化
-  G: 依循
-  H: 規律
-  I: 臨機應變
-  J: 迅雷不及掩耳
+  A: 依循
+  B: 規律
+  C: 彷彿
+  D: 覓食
+  E: 巧妙
+  F: 守株待兔
+  G: 迅雷不及掩耳
 fill_in_blank:
-- sentence: 小鳥在樹林裡四處（　　），希望能找到蟲子餵飽自己。
-  answer: A
-- sentence: 夕陽西下，天空被染成一片橘紅色，（　　）一幅美麗的油畫。
+- sentence: 他每週固定運動三天，（　　）的運動習慣，讓他能保持身體健康。
   answer: B
-- sentence: 老師提醒我們，學習不能（　　），要主動思考和探索新知。
-  answer: C
-- sentence: 魔術師用他（　　）的手法，變出了一朵又一朵的鮮花，讓觀眾驚呼連連。
-  answer: D
-- sentence: 清晨的露珠掛在（　　）上，晶瑩剔透，十分可愛。
+- sentence: 這本小說情節安排的很（　　），讓讀者在閱讀過程中驚喜連連。
   answer: E
-- sentence: 小雞從蛋殼裡鑽出來，完成了（　　）的過程，開始探索這個世界。
+- sentence: 他不去推銷，只希望客人上門，這是（　　），太異想天開了。
   answer: F
-- sentence: 我們必須（　　）交通規則，才能確保行車安全，避免意外發生。
+- sentence: 下課鐘聲一響，同學們以（　　）的速度衝向籃球場。
   answer: G
-- sentence: 大自然的變化有著一定的（　　），例如日出日落、潮起潮落。
-  answer: H
-- sentence: 比賽中遇到突發狀況，選手必須（　　），才能找到獲勝的機會。
-  answer: I
-- sentence: 警方（　　）地展開突襲行動，讓歹徒措手不及，順利將其逮捕。
-  answer: J
+- sentence: 飄動的雲朵，（　　）大自然的畫筆，在空中畫下一幅又一幅的畫作。
+  answer: C
 multiple_choice:
 - question: 根據這篇文章，請問下列哪個選項不是動物的本能?
   options:


### PR DESCRIPTION
## Summary

- Aligns lesson YAML `fill_in_blank` schema (sentence text + vocab letter ordering) to printed (紙本) student worksheets for 6 lessons
- Root cause traced via 5/18 OMO real-handwriting batch test — see `private/omo-real-samples/2026-05-18-batch-results/summary.md`
- Fixes OMO grader 0.13/0.20 avg score regression (was scoring against AI-generated placeholder sentences, not actual worksheet content)

## Files changed (6)

| File | Lesson | Source 紙本 |
|---|---|---|
| `backend/data/lessons/L15.yml` | G6-L04 兩千五百歲的酷老師 (Layer-1) | `G6-SL4...docx` |
| `backend/data/lessons/L24.yml` | G6-L03 昆蟲會思考嗎? (Layer-1) | `G6-SL3...docx` |
| `_parsed_2026-05-01/G6-L22.yml` | 雞鳴狗盜 (priority demo) | `G6-SL22...docx` |
| `_parsed_2026-05-01/G6-L23.yml` | 老鷹紅豆 (priority demo) | `G6-SL23...docx` |
| `_parsed_2026-05-01/G6-L24.yml` | 白鯨救援 (priority demo) | `G6-SL24...docx` |
| `_parsed_2026-05-01/G6-L25.yml` | 荷蘭東印度 (priority demo) | `G6-SL25...docx` |

## Test plan

- [x] `pytest backend/tests/test_fill_in_blank_normalization.py` — 7/7 pass
- [x] `pytest backend/tests/test_omo_lessons.py` — 6/6 pass
- [x] `pytest backend/tests/test_slug_grade_code.py` — 20/20 pass (no regression to slug/shadow/layer fixes)
- [ ] Staging deploy success
- [ ] Staging API `/api/stories/G6-L03` returns new vocab_bank order (A=依循 B=規律 C=彷彿 D=覓食 E=巧妙 F=守株待兔 G=迅雷不及掩耳)
- [ ] Staging API `/api/stories/G6-L22`~`G6-L25` return updated fill_in_blank sentences
- [ ] OMO grader re-run on PDF #1 (135902-*.jpg) using staging — target avg score ≥ 0.40 (was 0.13/0.20)

## Out of scope (separate issues)

- G7-L28~30 priority demo (printed worksheet 沒有「四 語詞應用」 section, schema mismatch by design)
- 158-course full alignment
- 紙本「三 語詞我最棒」單字格子 (different schema, requires grader prompt change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)