### PR TITLE
feat(reading-annotation): render images for graphic-text layout (Fixes #1681)

### DIFF
--- a/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
+++ b/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
@@ -3,12 +3,30 @@ import ZoomableImage from '../ui/ZoomableImage';
 
 interface GraphicTextImageStripProps {
   images: { filename: string; caption?: string }[];
-  lessonCode: string;
+  /**
+   * Lesson code (e.g. 'G7-L28') used to build GCS image URL.
+   * Optional — falls back to the first path segment of `images[0].filename`
+   * (e.g. 'images/G7-L28/G7-L28-08.jpg' → 'G7-L28') when not supplied.
+   * Many lessons have `story.lesson_code === undefined` but `images[i].filename`
+   * always carries the lesson directory, so the fallback is reliable (#1681).
+   */
+  lessonCode?: string;
 }
 
 const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
 
+/** Derive lesson code from an image filename like `images/G7-L28/G7-L28-08.jpg`. */
+function deriveLessonCodeFromFilename(filename: string): string {
+  const parts = filename.split('/').filter(Boolean);
+  // Skip leading 'images/' prefix when present.
+  if (parts.length >= 2 && parts[0] === 'images') return parts[1];
+  if (parts.length >= 2) return parts[parts.length - 2];
+  return '';
+}
+
 const GraphicTextImageStrip: React.FC<GraphicTextImageStripProps> = ({ images, lessonCode }) => {
+  const resolvedLessonCode =
+    lessonCode || (images[0] ? deriveLessonCodeFromFilename(images[0].filename) : '');
   return (
     <div
       data-testid="graphic-text-image-pane"
@@ -37,7 +55,7 @@ const GraphicTextImageStrip: React.FC<GraphicTextImageStripProps> = ({ images, l
               >
                 <div className="flex-1 min-h-0">
                   <ZoomableImage
-                    src={`${GCS_IMAGE_BASE}/${lessonCode}/${img.filename.split('/').pop()}`}
+                    src={`${GCS_IMAGE_BASE}/${resolvedLessonCode}/${img.filename.split('/').pop()}`}
                     alt={img.caption ?? `圖 ${idx + 1}`}
                     caption={img.caption}
                     className="h-full"

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -9,6 +9,7 @@ import { Story } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
 import { fontForZhuyin } from '../../constants/fonts';
+import GraphicTextImageStrip from './GraphicTextImageStrip';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -608,6 +609,23 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
               );
             })}
           </article>
+
+          {/* Graphic-text layout: images strip below the article (#1681).
+              Stacked layout (per Young 5/18 rule for ReadingAnnotation) — side
+              panel '我的記號' already occupies the right column, so images sit
+              under the text instead of beside it. */}
+          {story.layout_mode === 'graphic-text' && (story.images?.length ?? 0) > 0 && (
+            <div
+              className="max-w-4xl mx-auto px-6 md:px-16 mt-10 h-72 md:h-80 flex"
+              data-testid="reading-annotation-graphic-text-images"
+              style={{ WebkitUserSelect: 'none', userSelect: 'none' } as React.CSSProperties}
+            >
+              <GraphicTextImageStrip
+                images={story.images ?? []}
+                lessonCode={story.lesson_code}
+              />
+            </div>
+          )}
 
           {/* ── Floating selection toolbar ─────────────────────────────── */}
           {toolbar.visible && (


### PR DESCRIPTION
## Summary

Fixes #1681 — `ReadingAnnotation.tsx` 在 `layout_mode: graphic-text` 的課從未渲染 yml 中的 images。

G7-L28/L29/L30（圖文整合 3 課，7/1 deadline）的紙本插圖（巴斯德實驗圖、地球暖化四圖等）在「讀全文-做記號」步驟看不見。

## Changes

### `ReadingAnnotation.tsx`
- Import `GraphicTextImageStrip`
- 在 article 下方條件渲染 image strip（僅在 `layout_mode === 'graphic-text'` 且 `images.length > 0`）
- Stack layout（上下並陳），不是 side-by-side — 右側「我的記號」面板已佔據右欄
- 高度 `h-72 md:h-80`（與 ComprehensionLayout image pane 一致）
- 加 `data-testid="reading-annotation-graphic-text-images"` 供 QA hook

### `GraphicTextImageStrip.tsx`（defensive fix）
- `lessonCode` 改 optional
- 加 `deriveLessonCodeFromFilename` fallback — 從 `images[0].filename`（如 `images/G7-L28/G7-L28-08.jpg`）取出 `G7-L28`
- Why: 多數 graphic-text 課 API 回 `story.lesson_code === undefined`（YAML 只有 `grade_code`），但 `images[i].filename` 永遠帶 lesson 目錄前綴，fallback 可靠

## Verification

- `npx tsc --noEmit` 無新增錯誤（既有錯誤都是 pre-existing，與本 PR 無關）
- `npm run build` 通過
- API verify: `curl /api/stories/1108` → `layout_mode: graphic-text`, `images: [{filename: "images/G7-L28/G7-L28-08.jpg"}]`
- GCS image accessible: `https://storage.googleapis.com/lingoleap-assets/lessons-images/G7-L28/G7-L28-08.jpg` → 200

## Regression check

- 非 graphic-text 課（`layout_mode === 'standard'` 或未設）→ 不渲染 image 區（條件守衛）
- G7-L28 (id=1108) / L29 (id=1109) / L30 (id=1110) → 顯示 image
- 既有 ComprehensionChat / ComprehensionLayout 用法不影響（`lessonCode` prop 仍可傳，只是現在 optional）

## Test plan

- [ ] Preview URL load G7-L28 (`/learn/1108/reading-annotation`) → image strip 在課文下方
- [ ] Preview URL load G6-L22 (`/learn/{id}/reading-annotation`) — 非 graphic-text → 不顯示 image 區
- [ ] 點圖片放大（ZoomableImage modal）正常
- [ ] 標記功能不受影響（選文字、加標記、跳轉、清除）

Closes #1681