### PR TITLE
feat(omo): 上傳學習單按鈕移到課文頁面 Intro (Fixes #1637)

### DIFF
--- a/backend/app/routes/omo.py
+++ b/backend/app/routes/omo.py
@@ -27,7 +27,7 @@ import os
 from datetime import datetime, timezone
 from typing import Literal, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Path, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Path, UploadFile, status
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -192,8 +192,59 @@ def _update_upload(upload_id: int, **kwargs):
         db.close()
 
 
-async def _run_identification(upload_id: int, image_bytes_list: list[bytes], mime_types: list[str]):
-    """Background task: call AI to identify lesson, write result back to DB."""
+async def _run_identification(
+    upload_id: int,
+    image_bytes_list: list[bytes],
+    mime_types: list[str],
+    lesson_code_hint: Optional[str] = None,
+):
+    """Background task: identify lesson and write result back to DB.
+
+    If ``lesson_code_hint`` is provided (student uploaded from within a lesson
+    page), use the fast hint path (no AI call, conf=1.0).  Otherwise fall back
+    to the Gemini-powered fuzzy-match path.
+    """
+    # ── Hint path: lesson is already known, skip AI identification ────────────
+    if lesson_code_hint:
+        try:
+            from ..services.omo_identifier import identify_lesson_from_hint
+            candidates = identify_lesson_from_hint(lesson_code_hint)
+        except ImportError as exc:
+            logger.error("OMO identifier import failed: %s", exc)
+            candidates = []
+
+        if not candidates:
+            logger.warning(
+                "OMO hint path: lesson_code=%r not found — falling back to AI",
+                lesson_code_hint,
+            )
+            # Fall through to AI path below
+        else:
+            _update_upload(
+                upload_id,
+                identification=[
+                    {
+                        "lesson_id": c.lesson_id,
+                        "grade_code": c.grade_code,
+                        "title": c.title,
+                        "confidence": c.confidence,
+                        "reasoning": c.reasoning,
+                    }
+                    for c in candidates
+                ],
+                ai_confidence=candidates[0].confidence,
+                status="identified",
+            )
+            logger.info(
+                "OMO upload %d hint-identified: lesson_code=%r title=%s conf=%.2f",
+                upload_id,
+                lesson_code_hint,
+                candidates[0].title,
+                candidates[0].confidence,
+            )
+            return
+
+    # ── AI path: fuzzy match via Gemini ──────────────────────────────────────
     try:
         from ..services.omo_identifier import identify_lesson_from_image
     except ImportError as exc:
@@ -481,10 +532,19 @@ async def upload_worksheet(
         ...,
         description="Worksheet photos (JPEG/PNG, max 10MB each, max 5 files)",
     ),
+    lesson_code_hint: Optional[str] = Form(
+        default=None,
+        description=(
+            "Optional lesson code hint (e.g. 'G5-L25'). "
+            "When provided (student uploads from within a lesson page), "
+            "skips AI fuzzy-match and resolves directly — faster + cheaper. "
+            "Without hint, falls back to full Gemini identification."
+        ),
+    ),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    """Upload worksheet photos and kick off AI lesson identification.
+    """Upload worksheet photos and kick off lesson identification.
 
     Returns immediately with status=identifying. Poll GET /api/omo/{id} for result.
 
@@ -492,6 +552,10 @@ async def upload_worksheet(
     - Max 5 files per call
     - Max 10MB per file
     - JPEG / PNG / WebP only
+
+    Hint path (#1637): if ``lesson_code_hint`` is supplied, identification
+    completes synchronously in the background task without any AI call
+    (confidence=1.0, ~0 latency vs 6-24 s for Gemini).
     """
     if not files:
         raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
@@ -577,11 +641,14 @@ async def upload_worksheet(
     db.add(attempt)
     db.commit()
 
-    background_tasks.add_task(_run_identification, upload_id, image_bytes_list, mime_types)
+    background_tasks.add_task(
+        _run_identification, upload_id, image_bytes_list, mime_types, lesson_code_hint
+    )
 
     logger.info(
-        "OMO upload created: id=%d student=%d files=%d hash=%s",
+        "OMO upload created: id=%d student=%d files=%d hash=%s hint=%s",
         upload_id, current_user.id, len(files), primary_hash[:16],
+        lesson_code_hint or "none",
     )
 
     return OmoUploadResponse(

--- a/backend/app/services/omo_identifier.py
+++ b/backend/app/services/omo_identifier.py
@@ -508,3 +508,52 @@ def _check_circuit_breaker() -> None:
             f"OMO identifier circuit breaker tripped: "
             f"{_consecutive_errors} consecutive errors"
         )
+
+
+def identify_lesson_from_hint(lesson_code: str) -> list[LessonCandidate]:
+    """Resolve a lesson by its known lesson_code (hint path — skips AI fuzzy match).
+
+    Used when the student uploads from within a lesson reading page, so the
+    system already knows which lesson they're working on.  The upload route
+    uses this function when ``lesson_code_hint`` is provided in the request,
+    saving ~6-24 s of Vertex AI latency and ~$0.0003 per call.
+
+    Args:
+        lesson_code: Canonical lesson code from the YAML catalog (e.g. "G5-L25").
+
+    Returns:
+        A single LessonCandidate with confidence=1.0, or [] if the code is not
+        found in the curriculum catalog.
+    """
+    curriculum = _load_curriculum_titles()
+    if not curriculum:
+        logger.warning("identify_lesson_from_hint: curriculum cache empty")
+        return []
+
+    info = curriculum.get(lesson_code)
+    if not info:
+        logger.warning(
+            "identify_lesson_from_hint: lesson_code=%r not found in catalog", lesson_code
+        )
+        return []
+
+    try:
+        lesson_id = int(lesson_code.split("-L")[1])
+    except (IndexError, ValueError):
+        lesson_id = 0
+
+    logger.info(
+        "identify_lesson_from_hint: lesson_code=%r → id=%d title=%r (hint path, no AI call)",
+        lesson_code,
+        lesson_id,
+        info["title"],
+    )
+    return [
+        LessonCandidate(
+            lesson_id=lesson_id,
+            grade_code=info["grade_code"],
+            title=info["title"],
+            confidence=1.0,
+            reasoning="user-provided lesson hint (課文頁面內上傳)",
+        )
+    ]

--- a/backend/tests/test_omo_hint_1637.py
+++ b/backend/tests/test_omo_hint_1637.py
@@ -1,0 +1,222 @@
+"""Tests for Issue #1637 — lesson_code_hint path in OMO upload.
+
+Covers:
+    T3: Backend accepts optional lesson_code_hint field in multipart upload
+    T4: With valid hint → identify_lesson_from_hint returns conf=1.0, skips AI
+    T4b: With unknown hint → falls back gracefully (AI path)
+    T6: Without hint → existing fuzzy-match path unaffected (backward compat)
+
+Run:
+    cd backend && python -m pytest tests/test_omo_hint_1637.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for identify_lesson_from_hint (pure function, no DB/GCS needed)
+# ---------------------------------------------------------------------------
+
+class TestIdentifyLessonFromHint:
+    """Unit-test the hint path function directly."""
+
+    def _mock_curriculum(self):
+        """Minimal curriculum dict for testing."""
+        return {
+            "G5-L25": {"title": "北風與太陽", "grade_code": "G5-L25"},
+            "G6-L22": {"title": "小石潭記", "grade_code": "G6-L22"},
+        }
+
+    def test_known_lesson_code_returns_confidence_1(self):
+        """T4: valid hint returns single candidate with confidence=1.0."""
+        from app.services.omo_identifier import identify_lesson_from_hint
+
+        with patch(
+            "app.services.omo_identifier._load_curriculum_titles",
+            return_value=self._mock_curriculum(),
+        ):
+            candidates = identify_lesson_from_hint("G5-L25")
+
+        assert len(candidates) == 1
+        c = candidates[0]
+        assert c.confidence == 1.0
+        assert c.title == "北風與太陽"
+        assert c.grade_code == "G5-L25"
+        assert c.lesson_id == 25
+        assert "hint" in c.reasoning.lower() or "user-provided" in c.reasoning.lower()
+
+    def test_second_known_lesson_code(self):
+        """T4: another valid lesson_code also resolves correctly."""
+        from app.services.omo_identifier import identify_lesson_from_hint
+
+        with patch(
+            "app.services.omo_identifier._load_curriculum_titles",
+            return_value=self._mock_curriculum(),
+        ):
+            candidates = identify_lesson_from_hint("G6-L22")
+
+        assert len(candidates) == 1
+        assert candidates[0].title == "小石潭記"
+        assert candidates[0].confidence == 1.0
+
+    def test_unknown_lesson_code_returns_empty(self):
+        """T4b: unknown lesson_code → returns [] so caller falls back to AI."""
+        from app.services.omo_identifier import identify_lesson_from_hint
+
+        with patch(
+            "app.services.omo_identifier._load_curriculum_titles",
+            return_value=self._mock_curriculum(),
+        ):
+            candidates = identify_lesson_from_hint("G9-L99")
+
+        assert candidates == []
+
+    def test_empty_curriculum_returns_empty(self):
+        """T4b: if curriculum failed to load, returns [] gracefully."""
+        from app.services.omo_identifier import identify_lesson_from_hint
+
+        with patch(
+            "app.services.omo_identifier._load_curriculum_titles",
+            return_value={},
+        ):
+            candidates = identify_lesson_from_hint("G5-L25")
+
+        assert candidates == []
+
+    def test_lesson_id_parsed_from_code(self):
+        """lesson_id is the numeric part after '-L'."""
+        from app.services.omo_identifier import identify_lesson_from_hint
+
+        curriculum = {"G4-L10": {"title": "春天來了", "grade_code": "G4-L10"}}
+        with patch(
+            "app.services.omo_identifier._load_curriculum_titles",
+            return_value=curriculum,
+        ):
+            candidates = identify_lesson_from_hint("G4-L10")
+
+        assert candidates[0].lesson_id == 10
+
+    def test_malformed_code_lesson_id_defaults_to_zero(self):
+        """If code has no '-L' part, lesson_id defaults to 0 (no crash)."""
+        from app.services.omo_identifier import identify_lesson_from_hint
+
+        curriculum = {"NOGRAMMAR": {"title": "測試", "grade_code": "NOGRAMMAR"}}
+        with patch(
+            "app.services.omo_identifier._load_curriculum_titles",
+            return_value=curriculum,
+        ):
+            candidates = identify_lesson_from_hint("NOGRAMMAR")
+
+        assert len(candidates) == 1
+        assert candidates[0].lesson_id == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration-style test: _run_identification background task routing
+# ---------------------------------------------------------------------------
+
+class TestRunIdentificationRouting:
+    """Verify that _run_identification routes hint vs AI correctly."""
+
+    @pytest.mark.asyncio
+    async def test_hint_path_skips_ai_call(self):
+        """T4: with valid hint, identify_lesson_from_image is NEVER called."""
+        from app.routes.omo import _run_identification
+
+        mock_candidate = MagicMock()
+        mock_candidate.lesson_id = 25
+        mock_candidate.grade_code = "G5-L25"
+        mock_candidate.title = "北風與太陽"
+        mock_candidate.confidence = 1.0
+        mock_candidate.reasoning = "user-provided lesson hint"
+
+        with patch(
+            "app.routes.omo._update_upload"
+        ) as mock_update, patch(
+            "app.services.omo_identifier.identify_lesson_from_hint",
+            return_value=[mock_candidate],
+        ) as mock_hint, patch(
+            "app.services.omo_identifier.identify_lesson_from_image",
+        ) as mock_ai:
+            await _run_identification(
+                upload_id=999,
+                image_bytes_list=[b"fake"],
+                mime_types=["image/jpeg"],
+                lesson_code_hint="G5-L25",
+            )
+
+        # hint function was used
+        mock_hint.assert_called_once_with("G5-L25")
+        # AI was NOT called
+        mock_ai.assert_not_called()
+        # DB update was called with status=identified
+        update_calls = mock_update.call_args_list
+        assert any(
+            call.kwargs.get("status") == "identified" or
+            (len(call.args) > 1 and "identified" in str(call.args))
+            for call in update_calls
+        ), f"Expected status=identified in update calls: {update_calls}"
+
+    @pytest.mark.asyncio
+    async def test_no_hint_uses_ai_path(self):
+        """T6: without hint, identify_lesson_from_image IS called (backward compat)."""
+        from app.routes.omo import _run_identification
+
+        mock_candidate = MagicMock()
+        mock_candidate.lesson_id = 25
+        mock_candidate.grade_code = "G5-L25"
+        mock_candidate.title = "北風與太陽"
+        mock_candidate.confidence = 0.95
+        mock_candidate.reasoning = "fuzzy match"
+
+        with patch(
+            "app.routes.omo._update_upload"
+        ), patch(
+            "app.services.omo_identifier.identify_lesson_from_image",
+            return_value=[mock_candidate],
+        ) as mock_ai:
+            await _run_identification(
+                upload_id=998,
+                image_bytes_list=[b"fake"],
+                mime_types=["image/jpeg"],
+                lesson_code_hint=None,
+            )
+
+        mock_ai.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_hint_not_found_falls_back_to_ai(self):
+        """T4b: if hint lookup returns [], AI path is used as fallback."""
+        from app.routes.omo import _run_identification
+
+        mock_candidate = MagicMock()
+        mock_candidate.lesson_id = 25
+        mock_candidate.grade_code = "G5-L25"
+        mock_candidate.title = "北風與太陽"
+        mock_candidate.confidence = 0.9
+        mock_candidate.reasoning = "fuzzy"
+
+        with patch(
+            "app.routes.omo._update_upload"
+        ), patch(
+            "app.services.omo_identifier.identify_lesson_from_hint",
+            return_value=[],  # hint lookup failed
+        ), patch(
+            "app.services.omo_identifier.identify_lesson_from_image",
+            return_value=[mock_candidate],
+        ) as mock_ai:
+            await _run_identification(
+                upload_id=997,
+                image_bytes_list=[b"fake"],
+                mime_types=["image/jpeg"],
+                lesson_code_hint="G9-L99",  # unknown code
+            )
+
+        # Falls back to AI
+        mock_ai.assert_called_once()

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -38,6 +38,12 @@ interface OmoUploadProps {
   token: string;
   /** Called once upload succeeds, with the new upload_id */
   onUploaded: (uploadId: number) => void;
+  /**
+   * Issue #1637: optional lesson code hint (e.g. "G5-L25") passed when the
+   * student uploads from within a lesson reading page.  Forwarded to the
+   * backend so it can skip Gemini fuzzy-match (faster + cheaper).
+   */
+  lessonCodeHint?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -126,7 +132,7 @@ function useLoadingMessage(active: boolean): string {
 // OmoUpload component
 // ---------------------------------------------------------------------------
 
-const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded }) => {
+const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint }) => {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
@@ -169,8 +175,8 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded }) => {
       // ── Client-side resize ────────────────────────────────────────────────
       const resized = await Promise.all(fileArray.map(resizeImage));
 
-      // ── Upload ────────────────────────────────────────────────────────────
-      const result = await uploadOmoImages(resized, token);
+      // ── Upload (pass lesson hint if available — Issue #1637) ─────────────
+      const result = await uploadOmoImages(resized, token, lessonCodeHint);
       onUploaded(result.upload_id);
     } catch (err) {
       const raw = err instanceof Error ? err.message : '';

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Story } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
@@ -24,8 +25,19 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
   const [showWorksheetModal, setShowWorksheetModal] = useState(false);
   const { zhuyinActive, processZhuyin } = useZhuyin();
   const worksheetModalRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
 
   useFocusTrap(worksheetModalRef, showWorksheetModal);
+
+  /**
+   * Issue #1637: navigate to /omo with lesson_code query param so OmoPage
+   * can pass it as a hint to the backend (skip Gemini fuzzy-match).
+   */
+  const handleUploadWorksheet = useCallback(() => {
+    const lessonCode = story.lesson_code ?? '';
+    const params = lessonCode ? `?lesson_code=${encodeURIComponent(lessonCode)}` : '';
+    navigate(`/omo${params}`);
+  }, [navigate, story.lesson_code]);
 
   useEffect(() => {
     if (!showWorksheetModal) return;
@@ -148,20 +160,38 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
 
           {/* 知識補給站 YouTube embed was removed — intro page shows course intro only */}
 
-          {/* 紙本學習單 PDF button (#1444) — only shown when a matching PDF exists */}
-          {story.worksheetPdfUrl && (
-            <div className="flex justify-start">
-              <button
-                type="button"
-                onClick={() => setShowWorksheetModal(true)}
-                className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-bold border border-blue-300 bg-blue-50 hover:bg-blue-100 text-blue-700 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-1"
-                aria-label="查看紙本學習單 PDF"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                </svg>
-                查看紙本學習單
-              </button>
+          {/* 紙本學習單 PDF button (#1444) + 上傳學習單 button (#1637) */}
+          {(story.worksheetPdfUrl || story.lesson_code) && (
+            <div className="flex flex-wrap items-center gap-2">
+              {/* PDF view button — only when a PDF is available */}
+              {story.worksheetPdfUrl && (
+                <button
+                  type="button"
+                  onClick={() => setShowWorksheetModal(true)}
+                  className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-bold border border-blue-300 bg-blue-50 hover:bg-blue-100 text-blue-700 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-1"
+                  aria-label="查看紙本學習單 PDF"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  查看紙本學習單
+                </button>
+              )}
+
+              {/* Upload button — #1637: available for any lesson with a lesson_code */}
+              {story.lesson_code && (
+                <button
+                  type="button"
+                  onClick={handleUploadWorksheet}
+                  className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-bold border border-green-300 bg-green-50 hover:bg-green-100 text-green-700 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-1"
+                  aria-label="上傳學習單"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+                  </svg>
+                  上傳學習單
+                </button>
+              )}
             </div>
           )}
 

--- a/frontend/src/pages/omo/OmoPage.tsx
+++ b/frontend/src/pages/omo/OmoPage.tsx
@@ -5,10 +5,14 @@
  *   upload  → result (AI identify + confirm + grading poll)
  *          → graded (per-question result page)
  *
+ * Issue #1637: when navigated from a lesson reading page, `?lesson_code=G5-L25`
+ * is appended to the URL.  OmoPage reads this query param and forwards it to
+ * OmoUpload → uploadOmoImages so the backend can skip Gemini fuzzy-match.
+ *
  * Route: /omo
  */
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import OmoUpload from '../../components/omo/OmoUpload';
 import OmoIdentifyResult from '../../components/omo/OmoIdentifyResult';
@@ -20,6 +24,9 @@ type PageState = 'upload' | 'result' | 'graded';
 const OmoPage: React.FC = () => {
   const { token } = useAuth();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  /** Lesson code hint supplied by the lesson reading page (Issue #1637). */
+  const lessonCodeHint = searchParams.get('lesson_code') ?? undefined;
   const [pageState, setPageState] = useState<PageState>('upload');
   const [uploadId, setUploadId] = useState<number | null>(null);
   const [lessonTitle, setLessonTitle] = useState<string | undefined>(undefined);
@@ -93,7 +100,11 @@ const OmoPage: React.FC = () => {
       {/* Content */}
       <div className="pb-20">
         {pageState === 'upload' && (
-          <OmoUpload token={token} onUploaded={handleUploaded} />
+          <OmoUpload
+            token={token}
+            onUploaded={handleUploaded}
+            lessonCodeHint={lessonCodeHint}
+          />
         )}
 
         {pageState === 'result' && uploadId !== null && (

--- a/frontend/src/services/omoApi.ts
+++ b/frontend/src/services/omoApi.ts
@@ -93,14 +93,23 @@ export interface OmoFlagResponse {
  * Upload one or more worksheet images. Returns 201 with status=identifying.
  * Phase 1b: if same hash exists for this user, returns the existing record
  * with from_cache=true (and possibly already_graded=true if status=graded).
+ *
+ * Issue #1637: when `lessonCodeHint` is provided (student uploads from within
+ * a lesson reading page), the backend skips Gemini fuzzy-match and resolves
+ * the lesson directly — faster (~0 latency vs 6-24 s) and cheaper (~$0 vs
+ * ~$0.0003 per call).
  */
 export async function uploadOmoImages(
   files: File[],
   token: string,
+  lessonCodeHint?: string,
 ): Promise<OmoUploadResponse> {
   const form = new FormData();
   for (const f of files) {
     form.append('files', f);
+  }
+  if (lessonCodeHint) {
+    form.append('lesson_code_hint', lessonCodeHint);
   }
   const res = await fetch(`${API_BASE}/api/omo/upload`, {
     method: 'POST',


### PR DESCRIPTION
Fixes #1637

## Summary

- Add green 上傳學習單 button to lesson Intro page (next to 查看紙本學習單)
- When clicked, navigates to `/omo?lesson_code={code}` — system already knows which lesson
- Backend: `POST /api/omo/upload` accepts optional `lesson_code_hint` Form field
- Backend: `identify_lesson_from_hint()` in `omo_identifier.py` resolves lesson from catalog cache — **no Gemini call**, conf=1.0, ~0 latency vs 6-24 s + ~$0.0003 saved per upload
- Sidebar `上傳學習單` entry preserved (issue spec: keep until new entry is stable)

## Changes

| File | Change |
|------|--------|
| `frontend/src/components/reading-steps/Intro.tsx` | Add 上傳學習單 button; `useNavigate` to `/omo?lesson_code=` |
| `frontend/src/pages/omo/OmoPage.tsx` | Read `lesson_code` from query string via `useSearchParams`; pass to OmoUpload |
| `frontend/src/components/omo/OmoUpload.tsx` | Accept `lessonCodeHint` prop; forward to `uploadOmoImages` |
| `frontend/src/services/omoApi.ts` | `uploadOmoImages` accepts optional `lessonCodeHint`; appends `lesson_code_hint` form field |
| `backend/app/routes/omo.py` | `POST /omo/upload` accepts `lesson_code_hint: Optional[str] = Form(None)`; passes to background task |
| `backend/app/services/omo_identifier.py` | Add `identify_lesson_from_hint(lesson_code)` → `LessonCandidate(conf=1.0)` from catalog cache |
| `backend/tests/test_omo_hint_1637.py` | 9 unit tests (T3/T4/T4b/T6) — all pass |

## Test plan

- [ ] T1: Intro page renders 上傳學習單 button for lessons with `lesson_code`
- [ ] T2: Click navigates to `/omo?lesson_code=G5-L25` (lesson code in URL)
- [ ] T3: `POST /api/omo/upload` with `lesson_code_hint` field accepted (9 unit tests pass locally)
- [ ] T4: With hint → conf=1.0, no AI call (unit tests pass)
- [ ] T5: Sidebar `上傳學習單` entry still visible (preserved per issue spec)
- [ ] T6: Direct `/omo` entry without hint still works (existing tests pass)
- [ ] T7: `pytest backend/tests/` — 9 new pass, 29 existing pass (1 pre-existing fail: `test_too_many_files` — unrelated, MAX set to 20)
- [ ] T8: Staging deploy SUCCESS → curl `/api/omo/upload` with `lesson_code_hint=G5-L25` returns `status=identified`
- [ ] T9: Manual staging walkthrough on all 7 target lessons

## Deviation from brief

- Brief: remove Sidebar `上傳學習單` entry. **Issue body (authoritative)**: keep it ("暫時保留入口，避免破壞已知測試流程"). Sidebar entry preserved per issue body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)