### PR TITLE
chore(sidebar): remove 上傳學習單 entry — moved to lesson Intro page (Related to #1637)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -380,7 +380,7 @@ const Sidebar: React.FC<SidebarProps> = ({ pendingAssignmentCount }) => {
         { icon: '📚', label: '圖書館', path: '/library' },
         { icon: '🏫', label: '班級作業', path: '/assignments', badge: pendingAssignmentCount },
         { icon: '➕', label: '加入班級', path: '/join' },
-        { icon: '📷', label: '上傳學習單', path: '/omo' },
+        // Hidden: 上傳學習單 — moved to lesson Intro page (#1637) — passes lesson_code_hint to backend, skips fuzzy-match Vertex AI call
         { icon: '📖', label: '學習紀錄', path: '/learning-history' },
         // Hidden: 成就 — merged into student home page (recent achievements strip + Lv banner) (#1163)
         // Hidden: 學習進度, 生字本, 對話記錄 — 整合到「班級作業」(#643)


### PR DESCRIPTION
## Summary

Follow-up to PR #1684 — remove the now-obsolete sidebar `上傳學習單` entry.

PR #1684 added an in-lesson upload button (`Intro.tsx`) that passes `lesson_code_hint` to the backend, skipping the fuzzy-match Vertex AI call. The sidebar duplicate added user confusion + bypassed the hint short-circuit when clicked.

## Files

- `frontend/src/components/layout/Sidebar.tsx:383` — replace entry line with `// Hidden:` comment (same pattern as #1638 字典查詢 removal)

Backend `/api/omo/*` + frontend `/omo` route preserved.

## Test plan

- [x] Sidebar grep no longer matches `上傳學習單`
- [ ] Staging deploy SUCCESS
- [ ] Staging UI `/student` — sidebar no longer shows upload entry
- [ ] Lesson page Intro step still has upload button (PR #1684)

🤖 Generated with [Claude Code](https://claude.com/claude-code)