### PR TITLE
fix(reading-trend): 朗讀紀錄改在完成事件儲存，避免 re-mount 重複寫入 (#1632)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -228,12 +228,6 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
       .catch(() => {});
   }, [token, user?.id, story.id, historyRefreshKey]);
 
-  /* ---- Save reading attempt to dedicated reading_history table (#909)
-   *   #1632: save is invoked inside submitReading (on actual completion),
-   *   NOT in a useEffect on `result` — because `result` is also rehydrated
-   *   from localStorage / initialResult on every re-mount, which previously
-   *   produced a duplicate fake record each time the user returned to the page. */
-
   /* ---- Audio recorder (for student playback review) ---- */
   const audioRecorder = useAudioRecorder(120);
 
@@ -338,6 +332,9 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
 
   /* ---- Submit & evaluate ---- */
   const submitReading = useCallback(() => {
+    /* #1632 double-click guard: stopSession() flips this to false synchronously,
+     * so a second click during the same tick exits before re-saving. */
+    if (!isSessionActiveRef.current) return;
     const transcript = currentTranscriptRef.current;
     const durationMs = Date.now() - startTimeRef.current;
     stopSession();

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -228,27 +228,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
       .catch(() => {});
   }, [token, user?.id, story.id, historyRefreshKey]);
 
-  /* ---- Save reading attempt to dedicated reading_history table (#909) ---- */
-  const savedResultRef = useRef(false);
-  useEffect(() => {
-    if (!result || savedResultRef.current || !token) return;
-    savedResultRef.current = true;
-    const durationSec = (result.durationMs || 0) / 1000;
-    if (durationSec > 0) {
-      saveReadingHistory(
-        {
-          lesson_id: String(story.id),
-          reading_type: 'full',
-          cpm: result.cpm || 0,
-          accuracy: Math.round((result.matchRate || 0) * 100),
-          duration_seconds: durationSec,
-        },
-        token,
-      )
-        .then(() => setHistoryRefreshKey(k => k + 1))
-        .catch((err) => console.error('Failed to save reading history:', err));
-    }
-  }, [result, token, story.id]);
+  /* ---- Save reading attempt to dedicated reading_history table (#909)
+   *   #1632: save is invoked inside submitReading (on actual completion),
+   *   NOT in a useEffect on `result` — because `result` is also rehydrated
+   *   from localStorage / initialResult on every re-mount, which previously
+   *   produced a duplicate fake record each time the user returned to the page. */
 
   /* ---- Audio recorder (for student playback review) ---- */
   const audioRecorder = useAudioRecorder(120);
@@ -374,7 +358,25 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
       errorBreakdown: fluency.errorBreakdown,
     });
     setStreamingTranscript(cleanChineseText(transcript));
-  }, [fullText, stopSession]);
+
+    /* #1632: persist this attempt to reading_history HERE — fired by the actual
+     * completion event, so re-mounts (page revisit) won't add fake rows. */
+    const durationSec = fluency.durationMs / 1000;
+    if (token && durationSec > 0) {
+      saveReadingHistory(
+        {
+          lesson_id: String(story.id),
+          reading_type: 'full',
+          cpm: fluency.cpm || 0,
+          accuracy: Math.round((fluency.accuracy || 0) * 100),
+          duration_seconds: durationSec,
+        },
+        token,
+      )
+        .then(() => setHistoryRefreshKey(k => k + 1))
+        .catch((err) => console.error('Failed to save reading history:', err));
+    }
+  }, [fullText, stopSession, token, story.id]);
 
   /* ---- Render paragraph text with optional KTV TTS highlighting ---- */
   const renderParagraph = (line: string, idx: number) => {
@@ -583,13 +585,13 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
           {result ? (
             inToolbox ? (
               <ToolboxCompletionActions
-                onRetry={() => { try { localStorage.removeItem(storageKey); } catch {} savedResultRef.current = false; setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); setSelfRating(undefined); setShowComparison(false); }}
+                onRetry={() => { try { localStorage.removeItem(storageKey); } catch {} setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); setSelfRating(undefined); setShowComparison(false); }}
                 className="w-full"
               />
             ) : (
               <>
                 <button
-                  onClick={() => { try { localStorage.removeItem(storageKey); } catch {} savedResultRef.current = false; setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); setSelfRating(undefined); setShowComparison(false); }}
+                  onClick={() => { try { localStorage.removeItem(storageKey); } catch {} setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); setSelfRating(undefined); setShowComparison(false); }}
                   className="w-full h-12 rounded-full font-headline font-bold text-base text-on-surface bg-surface-container-lowest shadow-editorial hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
                 >
                   <span className="material-symbols-outlined text-lg">refresh</span>


### PR DESCRIPTION
# Issue #1632 修正說明

## 問題摘要

朗讀歷史趨勢圖（PR #1600）每次返回頁面就會自動多一筆假紀錄。
使用者實際上沒有再練習，但因為 component re-mount 觸發副作用，
DB 裡的 `reading_history` 表就多一筆 row、趨勢線一路向上爬，
與 issue 描述「render 出來看到一條一直在增長的線」一致。

## 根因

`frontend/src/components/reading-steps/FullReading.tsx` 原本用一個
`useEffect` 監聽 `result`，只要 `result` 為 truthy 且 `savedResultRef.current`
為 false 就呼叫 `saveReadingHistory()`：

```tsx
const savedResultRef = useRef(false);
useEffect(() => {
  if (!result || savedResultRef.current || !token) return;
  savedResultRef.current = true;
  saveReadingHistory({...}, token).then(() => setHistoryRefreshKey(k => k + 1));
}, [result, token, story.id]);
```

問題在於：

1. Component 在 mount 時就會用 `getInitialResult()` 把 `result` 從
   `localStorage` 或 `initialResult` prop（DB 還原, Bug #1320）還原回來。
2. `useRef(false)` 也會在每次 mount 重新建立，所以 `savedResultRef.current`
   每次都是 `false`。
3. 條件全部成立 → 又寫一筆 → 又 `setHistoryRefreshKey(k => k + 1)` 重新
   抓 history → 線又長一格。

`useRef` 只能擋住「同一個 mount 內」的重複呼叫，無法擋「跨 mount」的重複呼叫。

## 修正策略

把儲存的時機從「`result` 變動」改成「使用者實際完成朗讀」——也就是
issue 修法方向裡建議的「掛在完成朗讀 callback，不能在 component mount /
useEffect 副作用裡呼叫」。

具體做法：把 `saveReadingHistory()` 從 `useEffect` 搬到 `submitReading`
callback 內，緊接在 `setResult({...})` 之後，使用同一份 `fluency` 結果。
這樣只有在使用者按下「結束朗讀」之後才會寫入，page revisit / route
切換 / 重新整理都不會觸發。

`savedResultRef` 與相關的重置邏輯（兩個 retry 按鈕的
`savedResultRef.current = false`）一併移除。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/components/reading-steps/FullReading.tsx` | 把 `saveReadingHistory` 移到 `submitReading` callback；移除 `savedResultRef` 與其 mount-side useEffect；清掉兩個 retry 按鈕內的 ref reset。 |

## 修正內容詳述

### Before

```tsx
/* ---- Save reading attempt to dedicated reading_history table (#909) ---- */
const savedResultRef = useRef(false);
useEffect(() => {
  if (!result || savedResultRef.current || !token) return;
  savedResultRef.current = true;
  const durationSec = (result.durationMs || 0) / 1000;
  if (durationSec > 0) {
    saveReadingHistory(
      {
        lesson_id: String(story.id),
        reading_type: 'full',
        cpm: result.cpm || 0,
        accuracy: Math.round((result.matchRate || 0) * 100),
        duration_seconds: durationSec,
      },
      token,
    )
      .then(() => setHistoryRefreshKey(k => k + 1))
      .catch((err) => console.error('Failed to save reading history:', err));
  }
}, [result, token, story.id]);

// submitReading：只 setResult，沒有寫入
const submitReading = useCallback(() => {
  // ...
  setResult({ matchRate: fluency.accuracy, ... });
  setStreamingTranscript(cleanChineseText(transcript));
}, [fullText, stopSession]);
```

### After

```tsx
/* ---- Save reading attempt to dedicated reading_history table (#909)
 *   #1632: save is invoked inside submitReading (on actual completion),
 *   NOT in a useEffect on `result` — because `result` is also rehydrated
 *   from localStorage / initialResult on every re-mount, which previously
 *   produced a duplicate fake record each time the user returned to the page. */

// submitReading：完成事件當下直接寫入
const submitReading = useCallback(() => {
  // ...
  setResult({ matchRate: fluency.accuracy, ... });
  setStreamingTranscript(cleanChineseText(transcript));

  const durationSec = fluency.durationMs / 1000;
  if (token && durationSec > 0) {
    saveReadingHistory(
      {
        lesson_id: String(story.id),
        reading_type: 'full',
        cpm: fluency.cpm || 0,
        accuracy: Math.round((fluency.accuracy || 0) * 100),
        duration_seconds: durationSec,
      },
      token,
    )
      .then(() => setHistoryRefreshKey(k => k + 1))
      .catch((err) => console.error('Failed to save reading history:', err));
  }
}, [fullText, stopSession, token, story.id]);
```

兩個「再讀一次」/`ToolboxCompletionActions` `onRetry` callback 內的
`savedResultRef.current = false;` 一併刪除。

## 測試方式

1. 登入學生帳號進入七課之一，選自學模式 → 走到全文朗讀步驟。
2. 完成一次朗讀（按結束）→ 觀察趨勢圖出現「1 個點」。
3. 切到其他 step 再回來 → 趨勢圖點數應維持「1」。
4. 連續離開／回到頁面 5 次 → 點數仍然是「1」。
5. 再完成一次朗讀 → 點數變「2」。
6. 開無痕模式重登 → DB 紀錄數應等於實際完成次數（2）。

對應 issue Done definition：
- [x] 連續返回頁面 5 次不會新增紀錄
- [x] 完成 1 次朗讀只新增 1 筆
- [x] 開無痕清 cache 重進，紀錄數與實際練習次數一致

## 迴歸測試

- 「再讀一次」按鈕：應正常清掉 `result` 與 localStorage，回到開始畫面。
- ToolboxCompletionActions「再做一次」：行為同上。
- `historyRefreshKey` 仍然在 `.then()` 內遞增，趨勢圖會在儲存完成後立即
  refetch 顯示最新資料。
- localStorage 持久化 useEffect（line 257-262）不受影響，重整後 UI 還是
  能還原朗讀結果。
- Bug #1320 跨瀏覽器還原（`initialResult` rehydrate）仍然有效，只是不再
  附帶副作用寫 DB。