### PR TITLE
fix(layout): inline image/table in paragraph order (Fixes #1692)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -17,6 +17,14 @@ import { useZhuyin } from '../../context/ZhuyinContext';
 import FloatingAIHelper from './FloatingAIHelper';
 import GraphicTextImageStrip from './GraphicTextImageStrip';
 import TableDisplay from './TableDisplay';
+import InlineImageCard from './InlineImageCard';
+import InlineTableCard from './InlineTableCard';
+import {
+  detectImageMarker,
+  detectTableMarker,
+  resolveImageIndex,
+  resolveTableIndex,
+} from '../../utils/paragraphMarkers';
 
 interface ComprehensionLayoutProps {
   story: Story;
@@ -55,7 +63,54 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
   // text card (standard). Currently used by G7-L28 (文章重點表) and G7-L30
   // (異同比較表 + 族群變化表). Tables are missing from yml.paragraphs because
   // the docx → yml parser dropped row data; this surfaces them properly.
-  const hasTables = !!(story.tables && story.tables.length > 0);
+
+  // Inline figure/table placement (#1692): if a paragraph is a 圖 N / 表 N
+  // caption row, the matching image/table renders right after that paragraph
+  // inside the scrollable text card. Un-referenced assets fall back to the
+  // strip + table block under the card (preserves G7-L29 behavior where no
+  // captions appear in body paragraphs).
+  const { inlineImageIdxByPara, inlineTableIdxByPara, usedImageIdx, usedTableIdx } = useMemo(() => {
+    const imgMap = new Map<number, number>();
+    const tblMap = new Map<number, number>();
+    const usedImg = new Set<number>();
+    const usedTbl = new Set<number>();
+    story.content.forEach((para, paraIdx) => {
+      const imgN = detectImageMarker(para);
+      if (imgN !== null) {
+        const imgIdx = resolveImageIndex(story.images, imgN);
+        if (imgIdx !== null && !usedImg.has(imgIdx)) {
+          imgMap.set(paraIdx, imgIdx);
+          usedImg.add(imgIdx);
+        }
+      }
+      const tblN = detectTableMarker(para);
+      if (tblN !== null) {
+        const tblIdx = resolveTableIndex(story.tables, tblN);
+        if (tblIdx !== null && !usedTbl.has(tblIdx)) {
+          tblMap.set(paraIdx, tblIdx);
+          usedTbl.add(tblIdx);
+        }
+      }
+    });
+    return {
+      inlineImageIdxByPara: imgMap,
+      inlineTableIdxByPara: tblMap,
+      usedImageIdx: usedImg,
+      usedTableIdx: usedTbl,
+    };
+  }, [story.content, story.images, story.tables]);
+
+  const fallbackImages = useMemo(
+    () => (story.images ?? []).filter((_, i) => !usedImageIdx.has(i)),
+    [story.images, usedImageIdx],
+  );
+  const fallbackTables = useMemo(
+    () => (story.tables ?? []).filter((_, i) => !usedTableIdx.has(i)),
+    [story.tables, usedTableIdx],
+  );
+
+  const hasFallbackImages = fallbackImages.length > 0;
+  const hasFallbackTables = fallbackTables.length > 0;
 
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden bg-surface relative">
@@ -81,22 +136,43 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
                   參考課文
                 </span>
               </div>
-              {/* Scrollable story content — overflow-y-auto on the inner div only */}
+              {/* Scrollable story content — overflow-y-auto on the inner div only.
+                  Inline images/tables (#1692) appear right after their caption
+                  paragraph to match the printed worksheet's reading order. */}
               <div className="flex-1 min-h-0 overflow-y-auto pr-2 custom-scrollbar space-y-6">
-                {story.content.map((line, idx) => (
-                  <div key={idx} className="flex gap-3 items-start">
-                    <span className="text-xs font-headline font-bold text-on-surface-variant/30 pt-1 select-none shrink-0 w-5 text-right">
-                      {String(idx + 1).padStart(2, '0')}
-                    </span>
-                    <p
-                      className={`text-lg md:text-xl text-on-surface leading-[2rem] md:leading-[2.2rem] ${
-                        zhuyinActive ? 'tracking-[0.15em]' : ''
-                      }`}
-                    >
-                      {zhuyinLines ? zhuyinLines[idx] : line}
-                    </p>
-                  </div>
-                ))}
+                {story.content.map((line, idx) => {
+                  const inlineImgIdx = inlineImageIdxByPara.get(idx);
+                  const inlineTblIdx = inlineTableIdxByPara.get(idx);
+                  return (
+                    <React.Fragment key={idx}>
+                      <div className="flex gap-3 items-start">
+                        <span className="text-xs font-headline font-bold text-on-surface-variant/30 pt-1 select-none shrink-0 w-5 text-right">
+                          {String(idx + 1).padStart(2, '0')}
+                        </span>
+                        <p
+                          className={`text-lg md:text-xl text-on-surface leading-[2rem] md:leading-[2.2rem] ${
+                            zhuyinActive ? 'tracking-[0.15em]' : ''
+                          }`}
+                        >
+                          {zhuyinLines ? zhuyinLines[idx] : line}
+                        </p>
+                      </div>
+                      {inlineImgIdx !== undefined && story.images?.[inlineImgIdx] && (
+                        <div data-testid={`comprehension-inline-image-after-para-${idx}`}>
+                          <InlineImageCard
+                            image={story.images[inlineImgIdx]}
+                            lessonCode={story.lesson_code}
+                          />
+                        </div>
+                      )}
+                      {inlineTblIdx !== undefined && story.tables?.[inlineTblIdx] && (
+                        <div data-testid={`comprehension-inline-table-after-para-${idx}`}>
+                          <InlineTableCard table={story.tables[inlineTblIdx]} />
+                        </div>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
               </div>
 
               {/* Progress bar — only shown when progressPercent >= 0 */}
@@ -120,20 +196,22 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
               )}
             </div>
 
-            {/* Image strip (graphic-text only) — horizontally scrollable, click to zoom */}
-            {isGraphicText && (story.images?.length ?? 0) > 0 && (
+            {/* Fallback image strip — only un-referenced images. Preserves the
+                graphic-text bottom strip for lessons whose body sentences mention
+                圖 N without dedicated caption rows (e.g. G7-L29). */}
+            {isGraphicText && hasFallbackImages && (
               <div className="h-64 md:h-72 flex shrink-0">
                 <GraphicTextImageStrip
-                  images={story.images ?? []}
+                  images={fallbackImages}
                   lessonCode={story.lesson_code}
                 />
               </div>
             )}
 
-            {/* 紙本表格 (#1685) — appears for 圖文表整合 lessons (e.g. G7-L28, G7-L30). */}
-            {hasTables && (
+            {/* Fallback 紙本表格 — only un-referenced tables. */}
+            {hasFallbackTables && (
               <div className="shrink-0">
-                <TableDisplay tables={story.tables!} layout="stacked" />
+                <TableDisplay tables={fallbackTables} layout="stacked" />
               </div>
             )}
           </div>

--- a/frontend/src/components/reading-steps/InlineImageCard.tsx
+++ b/frontend/src/components/reading-steps/InlineImageCard.tsx
@@ -1,0 +1,55 @@
+/**
+ * InlineImageCard — render a single image inline after its caption paragraph.
+ *
+ * Used by ReadingAnnotation + ComprehensionLayout when a paragraph is detected
+ * as a `圖 N` caption row. Mirrors GraphicTextImageStrip's visual styling
+ * (rounded card, shadow-editorial) so inline figures look consistent with the
+ * fallback strip rendered at the end of the article.
+ *
+ * Click-to-zoom is handled by ZoomableImage (same modal as GraphicTextImageStrip).
+ */
+import React from 'react';
+import ZoomableImage from '../ui/ZoomableImage';
+
+const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+
+interface InlineImageCardProps {
+  image: { filename: string; caption?: string };
+  lessonCode?: string;
+  /** Optional fallback alt-text label (e.g. `圖 1`). */
+  fallbackLabel?: string;
+}
+
+/** Derive lesson code from `images/G7-L28/G7-L28-08.jpg` style filename. */
+function deriveLessonCodeFromFilename(filename: string): string {
+  const parts = filename.split('/').filter(Boolean);
+  if (parts.length >= 2 && parts[0] === 'images') return parts[1];
+  if (parts.length >= 2) return parts[parts.length - 2];
+  return '';
+}
+
+const InlineImageCard: React.FC<InlineImageCardProps> = ({ image, lessonCode, fallbackLabel }) => {
+  const resolvedLessonCode = lessonCode || deriveLessonCodeFromFilename(image.filename);
+  const src = `${GCS_IMAGE_BASE}/${resolvedLessonCode}/${image.filename.split('/').pop()}`;
+  return (
+    <div
+      data-testid="inline-image-card"
+      className="bg-surface-container-lowest rounded-2xl shadow-editorial p-3 md:p-4 max-w-2xl mx-auto"
+      style={{ WebkitUserSelect: 'none', userSelect: 'none' } as React.CSSProperties}
+    >
+      <div className="w-full h-64 md:h-80">
+        <ZoomableImage
+          src={src}
+          alt={image.caption ?? fallbackLabel ?? '圖片'}
+          caption={image.caption}
+          className="h-full"
+        />
+      </div>
+      {image.caption && (
+        <p className="text-xs text-on-surface-variant mt-2 text-center">{image.caption}</p>
+      )}
+    </div>
+  );
+};
+
+export default InlineImageCard;

--- a/frontend/src/components/reading-steps/InlineTableCard.tsx
+++ b/frontend/src/components/reading-steps/InlineTableCard.tsx
@@ -1,0 +1,29 @@
+/**
+ * InlineTableCard — render a single table inline after its caption paragraph.
+ *
+ * Uses the same TableCard primitive as TableDisplay so click-to-zoom modal,
+ * compact styling, and notes rendering stay consistent. The bottom-of-article
+ * `TableDisplay` block still renders any tables NOT referenced by a caption
+ * row (with its own `data-testid="lesson-tables"` container).
+ */
+import React from 'react';
+import { LessonTable } from '../../types';
+import { TableCard } from './TableDisplay';
+
+interface InlineTableCardProps {
+  table: LessonTable;
+}
+
+const InlineTableCard: React.FC<InlineTableCardProps> = ({ table }) => {
+  return (
+    <div
+      data-testid="inline-table-card"
+      className="max-w-3xl mx-auto"
+      style={{ WebkitUserSelect: 'none', userSelect: 'none' } as React.CSSProperties}
+    >
+      <TableCard table={table} compact />
+    </div>
+  );
+};
+
+export default InlineTableCard;

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -11,6 +11,14 @@ import { scopedStepStorageKey } from '../../services/learningStorageScope';
 import { fontForZhuyin } from '../../constants/fonts';
 import GraphicTextImageStrip from './GraphicTextImageStrip';
 import TableDisplay from './TableDisplay';
+import InlineImageCard from './InlineImageCard';
+import InlineTableCard from './InlineTableCard';
+import {
+  detectImageMarker,
+  detectTableMarker,
+  resolveImageIndex,
+  resolveTableIndex,
+} from '../../utils/paragraphMarkers';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -136,6 +144,50 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     unknownCount: annotations.filter((a) => a.type === 'unknown').length,
     importantCount: annotations.filter((a) => a.type === 'important').length,
   }), [annotations]);
+
+  // Pre-compute which images/tables get rendered inline (caption-matched) so the
+  // fallback strip at the bottom only emits the un-referenced ones. Avoids the
+  // duplicate-render trap when a lesson labels every figure in its paragraphs.
+  // See utils/paragraphMarkers.ts for the caption rule.
+  const { inlineImageIdxByPara, inlineTableIdxByPara, usedImageIdx, usedTableIdx } = useMemo(() => {
+    const imgMap = new Map<number, number>();
+    const tblMap = new Map<number, number>();
+    const usedImg = new Set<number>();
+    const usedTbl = new Set<number>();
+    story.content.forEach((para, paraIdx) => {
+      const imgN = detectImageMarker(para);
+      if (imgN !== null) {
+        const imgIdx = resolveImageIndex(story.images, imgN);
+        if (imgIdx !== null && !usedImg.has(imgIdx)) {
+          imgMap.set(paraIdx, imgIdx);
+          usedImg.add(imgIdx);
+        }
+      }
+      const tblN = detectTableMarker(para);
+      if (tblN !== null) {
+        const tblIdx = resolveTableIndex(story.tables, tblN);
+        if (tblIdx !== null && !usedTbl.has(tblIdx)) {
+          tblMap.set(paraIdx, tblIdx);
+          usedTbl.add(tblIdx);
+        }
+      }
+    });
+    return {
+      inlineImageIdxByPara: imgMap,
+      inlineTableIdxByPara: tblMap,
+      usedImageIdx: usedImg,
+      usedTableIdx: usedTbl,
+    };
+  }, [story.content, story.images, story.tables]);
+
+  const fallbackImages = useMemo(
+    () => (story.images ?? []).filter((_, i) => !usedImageIdx.has(i)),
+    [story.images, usedImageIdx],
+  );
+  const fallbackTables = useMemo(
+    () => (story.tables ?? []).filter((_, i) => !usedTableIdx.has(i)),
+    [story.tables, usedTableIdx],
+  );
 
   const annotationsForPanel = useMemo<AnnotationWithText[]>(() => {
     return [...annotations]
@@ -581,63 +633,83 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
             </h1>
           </div>
 
-          {/* Article paragraphs */}
+          {/* Article paragraphs.
+              Images/tables whose captions appear inside paragraphs render inline
+              right after the caption row (#1692). Un-referenced assets fall back
+              to the strip/table block below the article. */}
           <article className="max-w-4xl mx-auto px-6 md:px-16 space-y-10">
             {story.content.map((rawPara, paraIdx) => {
               const displayText = zhuyinParagraphs?.[paraIdx] ?? rawPara;
+              const inlineImgIdx = inlineImageIdxByPara.get(paraIdx);
+              const inlineTblIdx = inlineTableIdxByPara.get(paraIdx);
               return (
-                <section key={paraIdx} className="relative group">
-                  {/* Paragraph number — lives outside the [data-para-idx] subtree
-                      so its text doesn't inflate selection offsets. */}
-                  <span
-                    aria-hidden="true"
-                    className="absolute -left-8 md:-left-12 top-2 text-sm font-headline font-bold text-on-surface-variant/30 select-none pointer-events-none"
-                  >
-                    {String(paraIdx + 1).padStart(2, '0')}
-                  </span>
-                  <p
-                    data-para-idx={paraIdx}
-                    className="text-on-surface/90"
-                    style={{
-                      fontSize: `${fontSizePx}px`,
-                      lineHeight: isZhuyinAny ? '2.4rem' : '1.6', /* ruby annotations need 2.4rem minimum to avoid clipping */
-                      letterSpacing: isZhuyinAny ? '0.15em' : '0',
-                    }}
-                  >
-                    {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}
-                  </p>
-                </section>
+                <React.Fragment key={paraIdx}>
+                  <section className="relative group">
+                    {/* Paragraph number — lives outside the [data-para-idx] subtree
+                        so its text doesn't inflate selection offsets. */}
+                    <span
+                      aria-hidden="true"
+                      className="absolute -left-8 md:-left-12 top-2 text-sm font-headline font-bold text-on-surface-variant/30 select-none pointer-events-none"
+                    >
+                      {String(paraIdx + 1).padStart(2, '0')}
+                    </span>
+                    <p
+                      data-para-idx={paraIdx}
+                      className="text-on-surface/90"
+                      style={{
+                        fontSize: `${fontSizePx}px`,
+                        lineHeight: isZhuyinAny ? '2.4rem' : '1.6', /* ruby annotations need 2.4rem minimum to avoid clipping */
+                        letterSpacing: isZhuyinAny ? '0.15em' : '0',
+                      }}
+                    >
+                      {renderAnnotatedParagraph(rawPara, displayText, paraIdx)}
+                    </p>
+                  </section>
+                  {inlineImgIdx !== undefined && story.images?.[inlineImgIdx] && (
+                    <div
+                      data-testid={`inline-image-after-para-${paraIdx}`}
+                      className="max-w-3xl mx-auto"
+                    >
+                      <InlineImageCard
+                        image={story.images[inlineImgIdx]}
+                        lessonCode={story.lesson_code}
+                      />
+                    </div>
+                  )}
+                  {inlineTblIdx !== undefined && story.tables?.[inlineTblIdx] && (
+                    <div data-testid={`inline-table-after-para-${paraIdx}`}>
+                      <InlineTableCard table={story.tables[inlineTblIdx]} />
+                    </div>
+                  )}
+                </React.Fragment>
               );
             })}
           </article>
 
-          {/* Graphic-text layout: images strip below the article (#1681).
-              Stacked layout (per Young 5/18 rule for ReadingAnnotation) — side
-              panel '我的記號' already occupies the right column, so images sit
-              under the text instead of beside it. */}
-          {story.layout_mode === 'graphic-text' && (story.images?.length ?? 0) > 0 && (
+          {/* Fallback image strip — only un-referenced images (no caption match).
+              Preserves G7-L29 behavior where paragraphs reference 圖 N inside body
+              sentences but never as standalone caption rows. */}
+          {story.layout_mode === 'graphic-text' && fallbackImages.length > 0 && (
             <div
               className="max-w-4xl mx-auto px-6 md:px-16 mt-10 h-72 md:h-80 flex"
               data-testid="reading-annotation-graphic-text-images"
               style={{ WebkitUserSelect: 'none', userSelect: 'none' } as React.CSSProperties}
             >
               <GraphicTextImageStrip
-                images={story.images ?? []}
+                images={fallbackImages}
                 lessonCode={story.lesson_code}
               />
             </div>
           )}
 
-          {/* 紙本表格 (#1685) — appears for 圖文表整合 lessons (G7-L28, G7-L30).
-              Stacked below images using the same max-width/padding rhythm so the
-              article + images + tables read top-down in paper order. */}
-          {(story.tables?.length ?? 0) > 0 && (
+          {/* Fallback tables — only un-referenced tables. */}
+          {fallbackTables.length > 0 && (
             <div
               className="max-w-4xl mx-auto px-6 md:px-16 mt-10"
               data-testid="reading-annotation-tables"
               style={{ WebkitUserSelect: 'none', userSelect: 'none' } as React.CSSProperties}
             >
-              <TableDisplay tables={story.tables!} layout="stacked" />
+              <TableDisplay tables={fallbackTables} layout="stacked" />
             </div>
           )}
 

--- a/frontend/src/components/reading-steps/TableDisplay.tsx
+++ b/frontend/src/components/reading-steps/TableDisplay.tsx
@@ -96,7 +96,7 @@ const TableBody: React.FC<{ table: LessonTable; compact?: boolean }> = ({ table,
 
 // ── Single-card with zoom modal ─────────────────────────────────────────────
 
-const TableCard: React.FC<{ table: LessonTable; compact?: boolean }> = ({ table, compact }) => {
+export const TableCard: React.FC<{ table: LessonTable; compact?: boolean }> = ({ table, compact }) => {
   const [open, setOpen] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(dialogRef, open);

--- a/frontend/src/components/reading-steps/__tests__/ComprehensionLayout.inline.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/ComprehensionLayout.inline.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * ComprehensionLayout — inline image/table placement (#1692).
+ *
+ * Verifies that lessons with 圖 N / 表 N caption paragraphs render the
+ * matching asset inline immediately after the caption, and that
+ * un-referenced assets still fall back to the bottom strip/table block.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ComprehensionLayout from '../ComprehensionLayout';
+import { Story } from '../../../types';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+vi.mock('../../../context/ZhuyinContext', () => ({
+  useZhuyin: () => ({
+    zhuyinActive: false,
+    processLines: (lines: string[]) => lines,
+  }),
+}));
+
+vi.mock('../FloatingAIHelper', () => ({
+  default: () => null,
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+const g7l30Story: Story = {
+  id: '1110',
+  title: '臺灣兩種八哥',
+  level: 7,
+  content: [
+    '段落零文字內容',
+    '圖一 白尾八哥（左）與 臺灣冠八哥（右）外形圖',
+    '表一比較了白尾八哥和臺灣冠八哥', // body — not a caption
+    '表一 白尾八哥與臺灣冠八哥比較異同表',
+    '表二則說明了兩種八哥近年族群數量的變化', // body — not a caption
+    '表二 近年兩種臺灣常見八哥之族群數量之變化',
+    '結尾段落',
+  ],
+  layout_mode: 'graphic-text',
+  lesson_code: 'G7-L30',
+  images: [
+    { filename: 'images/G7-L30/G7-L30-06.png', size_bytes: 0, image_hash: 'h', content_type: 'image/png' },
+  ],
+  tables: [
+    {
+      id: 'table-1',
+      title: '表一 白尾八哥與臺灣冠八哥比較異同表',
+      headers: ['項目', '白尾八哥'],
+      rows: [{ cells: ['體型', '小'] }],
+    },
+    {
+      id: 'table-2',
+      title: '表二 近年兩種臺灣常見八哥之族群數量之變化',
+      headers: ['年份', '數量'],
+      rows: [{ cells: ['2020', '100'] }],
+    },
+  ],
+} as unknown as Story;
+
+const g7l29NoCaptionsStory: Story = {
+  id: '1109',
+  title: '氣候變遷',
+  level: 7,
+  content: [
+    '一般段落',
+    '另一段',
+    '圖三進一步說明了一百多年來', // body, NOT a caption (no space after 圖三)
+    '結尾',
+  ],
+  layout_mode: 'graphic-text',
+  lesson_code: 'G7-L29',
+  images: [
+    { filename: 'images/G7-L29/G7-L29-02.png', size_bytes: 0, image_hash: 'h', content_type: 'image/png' },
+    { filename: 'images/G7-L29/G7-L29-05.png', size_bytes: 0, image_hash: 'h', content_type: 'image/png' },
+  ],
+} as unknown as Story;
+
+const standardLessonStory: Story = {
+  id: 'standard',
+  title: '一般課文',
+  level: 6,
+  content: ['段落一', '段落二'],
+  layout_mode: 'standard',
+} as unknown as Story;
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+describe('ComprehensionLayout inline image/table (#1692)', () => {
+  it('renders 圖一 inline right after paragraph[1] for G7-L30', () => {
+    render(
+      <ComprehensionLayout story={g7l30Story}>
+        <div>exercise panel</div>
+      </ComprehensionLayout>,
+    );
+    expect(screen.getByTestId('comprehension-inline-image-after-para-1')).toBeTruthy();
+  });
+
+  it('renders 表一 inline after paragraph[3] (the caption, not body sentence at [2])', () => {
+    render(
+      <ComprehensionLayout story={g7l30Story}>
+        <div />
+      </ComprehensionLayout>,
+    );
+    expect(screen.queryByTestId('comprehension-inline-table-after-para-2')).toBeNull(); // body
+    expect(screen.getByTestId('comprehension-inline-table-after-para-3')).toBeTruthy(); // caption
+  });
+
+  it('renders 表二 inline after paragraph[5] only', () => {
+    render(
+      <ComprehensionLayout story={g7l30Story}>
+        <div />
+      </ComprehensionLayout>,
+    );
+    expect(screen.queryByTestId('comprehension-inline-table-after-para-4')).toBeNull(); // body
+    expect(screen.getByTestId('comprehension-inline-table-after-para-5')).toBeTruthy(); // caption
+  });
+
+  it('falls back to bottom image strip when paragraphs have no caption rows (G7-L29 case)', () => {
+    render(
+      <ComprehensionLayout story={g7l29NoCaptionsStory}>
+        <div />
+      </ComprehensionLayout>,
+    );
+    // No inline image cards.
+    for (let i = 0; i < g7l29NoCaptionsStory.content.length; i += 1) {
+      expect(screen.queryByTestId(`comprehension-inline-image-after-para-${i}`)).toBeNull();
+    }
+    // Fallback strip rendered.
+    expect(screen.getByTestId('graphic-text-image-pane')).toBeTruthy();
+  });
+
+  it('does NOT render image strip or any inline asset for non-graphic-text lessons', () => {
+    render(
+      <ComprehensionLayout story={standardLessonStory}>
+        <div />
+      </ComprehensionLayout>,
+    );
+    expect(screen.queryByTestId('graphic-text-image-pane')).toBeNull();
+    expect(screen.queryByTestId('lesson-tables')).toBeNull();
+    expect(screen.queryByTestId('comprehension-inline-image-after-para-0')).toBeNull();
+  });
+
+  it('once an asset renders inline it is removed from the fallback block', () => {
+    render(
+      <ComprehensionLayout story={g7l30Story}>
+        <div />
+      </ComprehensionLayout>,
+    );
+    // G7-L30 has 1 image and 2 tables — all 3 captioned in paragraphs, so the
+    // fallback strip + bottom tables block must both be absent.
+    expect(screen.queryByTestId('graphic-text-image-pane')).toBeNull();
+    expect(screen.queryByTestId('lesson-tables')).toBeNull();
+  });
+});

--- a/frontend/src/utils/paragraphMarkers.test.ts
+++ b/frontend/src/utils/paragraphMarkers.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectImageMarker,
+  detectTableMarker,
+  resolveImageIndex,
+  resolveTableIndex,
+} from './paragraphMarkers';
+
+describe('detectImageMarker', () => {
+  it('matches G7-L30 caption "圖一 白尾八哥..."', () => {
+    expect(detectImageMarker('圖一 白尾八哥（左）與 臺灣冠八哥（右）外形圖')).toBe(1);
+  });
+
+  it('matches G7-L28 caption "圖一 巴斯德..."', () => {
+    expect(detectImageMarker('圖一 巴斯德鵝頸瓶實驗的設計與程序')).toBe(1);
+  });
+
+  it('matches 圖二/圖三/圖四', () => {
+    expect(detectImageMarker('圖二 something')).toBe(2);
+    expect(detectImageMarker('圖三 something')).toBe(3);
+    expect(detectImageMarker('圖四 something')).toBe(4);
+  });
+
+  it('does NOT match body sentences referencing 圖 N', () => {
+    expect(detectImageMarker('圖三進一步說明了一百多年來')).toBeNull();
+    expect(detectImageMarker('圖一比較了兩種八哥')).toBeNull();
+  });
+
+  it('returns null for non-marker text', () => {
+    expect(detectImageMarker('白尾八哥是一種外來種')).toBeNull();
+    expect(detectImageMarker('')).toBeNull();
+    expect(detectImageMarker('表一 something')).toBeNull(); // table marker, not image
+  });
+
+  it('tolerates CJK fullwidth space (U+3000)', () => {
+    expect(detectImageMarker('圖一　白尾八哥')).toBe(1);
+  });
+});
+
+describe('detectTableMarker', () => {
+  it('matches G7-L30 captions "表一 ..." and "表二 ..."', () => {
+    expect(detectTableMarker('表一 白尾八哥與臺灣冠八哥比較異同表')).toBe(1);
+    expect(detectTableMarker('表二 近年兩種臺灣常見八哥之族群數量之變化')).toBe(2);
+  });
+
+  it('does NOT match body sentences referencing 表 N', () => {
+    expect(detectTableMarker('表一比較了白尾八哥和臺灣冠八哥')).toBeNull();
+    expect(detectTableMarker('表二則說明了兩種八哥近年族群數量的變化')).toBeNull();
+    expect(detectTableMarker('從表二可知')).toBeNull();
+  });
+
+  it('returns null for non-marker text', () => {
+    expect(detectTableMarker('白尾八哥是一種外來種')).toBeNull();
+    expect(detectTableMarker('圖一 something')).toBeNull(); // image marker
+  });
+});
+
+describe('resolveImageIndex', () => {
+  it('returns positional index (markerNumber - 1)', () => {
+    const imgs = [{}, {}, {}, {}];
+    expect(resolveImageIndex(imgs, 1)).toBe(0);
+    expect(resolveImageIndex(imgs, 4)).toBe(3);
+  });
+
+  it('returns null when out of bounds or empty', () => {
+    expect(resolveImageIndex([], 1)).toBeNull();
+    expect(resolveImageIndex(undefined, 1)).toBeNull();
+    expect(resolveImageIndex([{}], 5)).toBeNull();
+  });
+});
+
+describe('resolveTableIndex', () => {
+  it('matches by title prefix when titles embed the marker', () => {
+    const tables = [
+      { title: '表一 白尾八哥與臺灣冠八哥比較異同表' },
+      { title: '表二 近年兩種臺灣常見八哥之族群數量之變化' },
+    ];
+    expect(resolveTableIndex(tables, 1)).toBe(0);
+    expect(resolveTableIndex(tables, 2)).toBe(1);
+  });
+
+  it('falls back to positional index when title has no marker', () => {
+    const tables = [
+      { title: '文章重點表 — 以實驗破解肉湯腐敗之謎' },
+    ];
+    expect(resolveTableIndex(tables, 1)).toBe(0);
+  });
+
+  it('returns null when out of bounds or empty', () => {
+    expect(resolveTableIndex([], 1)).toBeNull();
+    expect(resolveTableIndex(undefined, 1)).toBeNull();
+    expect(resolveTableIndex([{ title: '表一 X' }], 5)).toBeNull();
+  });
+});

--- a/frontend/src/utils/paragraphMarkers.ts
+++ b/frontend/src/utils/paragraphMarkers.ts
@@ -1,0 +1,97 @@
+/**
+ * paragraphMarkers — detect 紙本 caption rows inside paragraphs.
+ *
+ * Lessons like G7-L30 embed image/table captions as their own paragraph
+ * (e.g. `圖一 白尾八哥（左）...`). To render images/tables inline at the
+ * same place they appear in the printed worksheet (rather than dumped at
+ * the end of the article), we detect these caption paragraphs and emit
+ * the corresponding asset right after them.
+ *
+ * Caption rule
+ *   `^(圖|表)[一二三...十]\s+.+`
+ *
+ * The trailing whitespace is what distinguishes a caption row from a body
+ * sentence that happens to start with the marker, e.g.
+ *   - `表一 白尾八哥...`     → caption (whitespace after 表一)
+ *   - `表一比較了外形與習性` → body sentence (CJK char immediately after)
+ *
+ * G7-L30 verified manually:
+ *   paragraph[1] `圖一 ...`       → caption
+ *   paragraph[2] `表一比較了...`  → body, NOT a caption
+ *   paragraph[3] `表一 ...`       → caption
+ *   paragraph[4] `表二則說明...`  → body, NOT a caption
+ *   paragraph[5] `表二 ...`       → caption
+ */
+
+const CN_NUMERALS: Record<string, number> = {
+  一: 1, 二: 2, 三: 3, 四: 4, 五: 5,
+  六: 6, 七: 7, 八: 8, 九: 9, 十: 10,
+};
+
+const IMAGE_CAPTION_RE = /^圖([一二三四五六七八九十])[\s　]+\S/;
+const TABLE_CAPTION_RE = /^表([一二三四五六七八九十])[\s　]+\S/;
+
+/**
+ * Detect whether a paragraph is an image caption row.
+ * Returns the 1-based marker number (e.g. 1 for 圖一) or null.
+ */
+export function detectImageMarker(text: string): number | null {
+  if (!text) return null;
+  const m = text.match(IMAGE_CAPTION_RE);
+  if (!m) return null;
+  return CN_NUMERALS[m[1]] ?? null;
+}
+
+/**
+ * Detect whether a paragraph is a table caption row.
+ * Returns the 1-based marker number (e.g. 1 for 表一) or null.
+ */
+export function detectTableMarker(text: string): number | null {
+  if (!text) return null;
+  const m = text.match(TABLE_CAPTION_RE);
+  if (!m) return null;
+  return CN_NUMERALS[m[1]] ?? null;
+}
+
+/**
+ * Pick a table from the yml `tables[]` array for the given marker number.
+ *
+ * Strategy:
+ *   1. Match by title prefix — `表一 ...` caption → table whose title starts with `表一`.
+ *      Most robust because yml parser preserves the printed marker in `title`.
+ *   2. Fallback — use `markerNumber - 1` as array index. Works when titles don't
+ *      embed the marker (e.g. G7-L28's only table is `文章重點表 — ...`).
+ *
+ * Returns the matching table index, or null if neither strategy resolves.
+ */
+export function resolveTableIndex<T extends { title?: string }>(
+  tables: T[] | undefined,
+  markerNumber: number,
+): number | null {
+  if (!tables || tables.length === 0) return null;
+  const cnNumeral = Object.keys(CN_NUMERALS).find((k) => CN_NUMERALS[k] === markerNumber);
+  if (cnNumeral) {
+    const prefix = `表${cnNumeral}`;
+    const titleIdx = tables.findIndex((t) => (t.title ?? '').trim().startsWith(prefix));
+    if (titleIdx >= 0) return titleIdx;
+  }
+  // Fallback: positional
+  const fallback = markerNumber - 1;
+  if (fallback >= 0 && fallback < tables.length) return fallback;
+  return null;
+}
+
+/**
+ * Pick an image index for a `圖N` caption. Image yml `caption` rarely embeds the
+ * printed marker, so we use positional mapping. Verified for G7-L30 (1 image,
+ * marker 圖一 → index 0) and G7-L29 (4 images, 圖一-圖四 → index 0-3).
+ */
+export function resolveImageIndex<T>(
+  images: T[] | undefined,
+  markerNumber: number,
+): number | null {
+  if (!images || images.length === 0) return null;
+  const idx = markerNumber - 1;
+  if (idx >= 0 && idx < images.length) return idx;
+  return null;
+}


### PR DESCRIPTION
Fixes #1692

## Summary

Captioned 圖/表 now render inline right after their caption paragraph, matching the printed worksheet's reading order. Previously PR #1682 (images) and PR #1687 (tables) dumped all assets at the bottom of the article, breaking the reading flow Young requested 5/19.

## Detection rule

`^(圖|表)[一-十][\s　]+\S` — whitespace after the marker distinguishes a caption row (`表一 白尾八哥…`) from a body sentence that happens to start with the marker (`表一比較了…`). Verified against actual yml fixtures via 14 unit tests.

## Verified lessons (yml + test fixtures)

| Lesson | Caption rows | Result |
|--------|--------------|--------|
| G7-L30 | para[1]=圖一, para[3]=表一, para[5]=表二 | All 3 render inline; bottom fallback empty |
| G7-L28 | para[5]=圖一 | Inline; bottom fallback empty |
| G7-L29 | none (only body refs `圖三進一步說明…`) | All 4 images via fallback strip (unchanged) |
| Standard (G6-L22 etc.) | n/a | No images/tables → no change |

## Files

- `frontend/src/utils/paragraphMarkers.ts` — new util: `detectImageMarker` / `detectTableMarker` / `resolveImageIndex` / `resolveTableIndex`
- `frontend/src/components/reading-steps/InlineImageCard.tsx` — single-image inline card (reuses `ZoomableImage`)
- `frontend/src/components/reading-steps/InlineTableCard.tsx` — single-table inline card (reuses `TableCard`)
- `frontend/src/components/reading-steps/ReadingAnnotation.tsx` — caption-paragraph map + filtered fallback
- `frontend/src/components/reading-steps/ComprehensionLayout.tsx` — same logic, inside scrollable text card
- `frontend/src/components/reading-steps/TableDisplay.tsx` — `TableCard` exported for reuse

## Constraints respected

- bypass permissions (no destructive ops, no `--no-verify`)
- no commit secrets
- `stepConfig.ts` untouched
- yml untouched (pure frontend layout)
- click-to-zoom modal preserved (both image + table)
- Zhuyin / annotation logic untouched (offsets still computed on `story.content`, inline divs sit outside `[data-para-idx]`)

## Test plan

- [x] 14 new unit tests for `paragraphMarkers` (detection + index resolution)
- [x] 6 new integration tests for `ComprehensionLayout` inline placement (G7-L30 captions, G7-L29 fallback, standard lesson no-op, no-duplicate-render)
- [x] Full vitest run: 220 pass / 38 baseline pre-existing fail (same fail count as `staging` HEAD — no regressions)
- [x] `npm run build` succeeds
- [x] TypeScript clean for all touched files
- [ ] Staging smoke: G7-L30 reading-annotation order = para 1 → 圖一 → para 2-3 → 表一 → para 4-5 → 表二 → para 6+
- [ ] Staging smoke: G7-L30 comprehension layout shows same inline order in left text card
- [ ] Staging smoke: G7-L29 still shows 4 images in bottom strip (fallback path)
- [ ] Click-to-zoom modal opens for inline image and inline table

🤖 Generated with [Claude Code](https://claude.com/claude-code)