### PR TITLE
feat(reading-trend): 預設 4 筆 + 載入更多 + 最新在上 + 自我評估第 N 次 (#1633)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -545,7 +545,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
                 history={dedicatedHistory}
               />
 
-              {/* ── Issue #1386: Self-assessment + 4-attempt progress chart ── */}
+              {/* ── Issue #1386: Self-assessment + 4-attempt progress chart ──
+                  #1633: dedicatedHistory may not yet contain the in-flight
+                  current attempt (save runs in parallel with the UI render),
+                  so use max(history.length, 1) — first render after submit is
+                  always 「第 1 次」 at minimum. */}
               <SelfAssessment
                 onSelect={(rating) => {
                   setSelfRating(rating);
@@ -554,6 +558,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
                 selectedRating={selfRating}
                 aiRating={aiRating}
                 showComparison={showComparison}
+                attemptNumber={Math.max(dedicatedHistory.length, 1)}
               />
 
               {fullReadingAttempts.length > 0 && (

--- a/frontend/src/components/reading-steps/full-reading/ReadingMetricsCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/ReadingMetricsCard.tsx
@@ -10,7 +10,7 @@
  * - Style: amber/blue cards matching existing design system
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { ReadingHistoryItem } from '../../../services/readingHistoryApi';
 import ReadingTrendChart from './ReadingTrendChart';
 
@@ -19,19 +19,26 @@ interface ReadingMetricsCardProps {
   accuracy: number;
   /** 語速 字/分鐘 */
   cpm: number;
-  /** Past attempts (ordered newest-first from caller) — optional */
+  /** Past attempts — caller passes API order (oldest-first); this component
+   *  re-orders to newest-first for display (#1633). */
   history?: ReadingHistoryItem[];
 }
+
+const HISTORY_DEFAULT_ROWS = 4;
 
 const ReadingMetricsCard: React.FC<ReadingMetricsCardProps> = ({ accuracy, cpm, history }) => {
   const roundedAccuracy = Math.round(accuracy);
   const roundedCpm = Math.round(cpm);
 
-  // History: show at most 5, newest first (skip the very first call since the
-  // current attempt may not have been saved yet when the component first mounts).
-  const displayHistory = history && history.length > 0
-    ? [...history].reverse().slice(0, 5)
-    : null;
+  /* #1633: table shows newest at the top, defaults to 4 rows with 「載入更多」
+   * to progressively unfold older attempts. */
+  const newestFirst = history && history.length > 0 ? [...history].reverse() : [];
+  const [expanded, setExpanded] = useState(false);
+  const visibleRowCount = expanded
+    ? newestFirst.length
+    : Math.min(newestFirst.length, HISTORY_DEFAULT_ROWS);
+  const displayHistory = newestFirst.slice(0, visibleRowCount);
+  const remaining = newestFirst.length - visibleRowCount;
 
   return (
     <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 space-y-4">
@@ -71,8 +78,9 @@ const ReadingMetricsCard: React.FC<ReadingMetricsCardProps> = ({ accuracy, cpm, 
         </div>
       </div>
 
-      {/* History table — only when we have ≥ 2 past attempts */}
-      {displayHistory && displayHistory.length >= 2 && (
+      {/* History table — only when we have ≥ 2 past attempts. Newest at the
+          top (#1633), default 4 rows then 「載入更多」. */}
+      {newestFirst.length >= 2 && (
         <div>
           <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-2">
             歷史紀錄
@@ -98,6 +106,15 @@ const ReadingMetricsCard: React.FC<ReadingMetricsCardProps> = ({ accuracy, cpm, 
               );
             })}
           </div>
+          {remaining > 0 && (
+            <button
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="w-full mt-2 text-xs font-headline text-on-surface-variant bg-surface-container-low hover:bg-surface-container rounded-full py-2 transition-colors"
+            >
+              載入更多（還有 {remaining} 筆）
+            </button>
+          )}
         </div>
       )}
 

--- a/frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx
+++ b/frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx
@@ -106,8 +106,13 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
     );
   }
 
-  const expandable = effectiveVisible < Math.min(totalAttempts, MAX_POINTS);
-  const remaining = Math.min(totalAttempts, MAX_POINTS) - effectiveVisible;
+  const totalDisplayable = Math.min(totalAttempts, MAX_POINTS);
+  const expandable = effectiveVisible < totalDisplayable;
+  const remaining = totalDisplayable - effectiveVisible;
+  const cappedByMax = totalAttempts > MAX_POINTS;
+  /* Only show the count hint when something is actually hidden — for ≤ 4
+   * attempts every point is visible, so 「顯示最近 N 次」 reads awkwardly. */
+  const showCountHint = totalAttempts > DEFAULT_POINTS;
 
   return (
     <div className="space-y-2">
@@ -115,10 +120,12 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
         <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider">
           進步趨勢
         </p>
-        <span className="text-[10px] text-on-surface-variant">
-          顯示最近 {effectiveVisible} 次
-          {totalAttempts > MAX_POINTS && `（共 ${totalAttempts} 次，最多顯示 ${MAX_POINTS} 次）`}
-        </span>
+        {showCountHint && (
+          <span className="text-[10px] text-on-surface-variant">
+            顯示最近 {effectiveVisible} 次
+            {cappedByMax && `（共 ${totalAttempts} 次，最多顯示 ${MAX_POINTS} 次）`}
+          </span>
+        )}
       </div>
       <div className="h-48 w-full">
         <ResponsiveContainer width="100%" height="100%">
@@ -173,7 +180,7 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
           onClick={() => setVisiblePoints((v) => Math.min(v + DEFAULT_POINTS, MAX_POINTS))}
           className="w-full text-xs font-headline text-on-surface-variant bg-surface-container-low hover:bg-surface-container rounded-full py-2 transition-colors"
         >
-          載入更多（還有 {remaining} 筆）
+          載入更多（還有 {remaining} 筆{cappedByMax ? `，圖表最多顯示 ${MAX_POINTS} 筆` : ''}）
         </button>
       )}
     </div>

--- a/frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx
+++ b/frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx
@@ -3,10 +3,15 @@
  *
  * Young 5/8 ask: 「累積自己跟自己比的那個排行榜...一個那個線圖，就是慢慢
  * 上去都可以的」. Renders dual-axis line chart of accuracy (%) + CPM over
- * attempts so students see their own progression. Caps to the most recent
- * 20 points for chart readability (older points still appear in the table).
+ * attempts so students see their own progression.
+ *
+ * #1633: default to the most recent DEFAULT_POINTS attempts (curve was getting
+ * too crowded after 10+ practices). Students can press 「載入更多」 to
+ * progressively expand back into history. MAX_POINTS still caps the absolute
+ * maximum so the chart stays readable. X-axis numbers always reflect the
+ * actual attempt position in full history (e.g. attempt #37 → labelled 37).
  */
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   LineChart,
   Line,
@@ -32,19 +37,26 @@ interface ChartPoint {
   fullDate: string;
 }
 
+const DEFAULT_POINTS = 4;
 const MAX_POINTS = 20;
 
-function buildChartData(history: ReadingHistoryItem[]): ChartPoint[] {
+function buildChartData(
+  history: ReadingHistoryItem[],
+  visiblePoints: number,
+): ChartPoint[] {
   const sorted = [...history].sort(
     (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
   );
-  const points = sorted.slice(-MAX_POINTS);
+  const totalAttempts = sorted.length;
+  const sliceCount = Math.min(visiblePoints, totalAttempts);
+  const points = sorted.slice(-sliceCount);
+  const firstAttemptNo = totalAttempts - sliceCount + 1;
   return points.map((item, i) => {
     const date = new Date(item.created_at);
     const dateLabel = `${date.getMonth() + 1}/${date.getDate()}`;
     const fullDate = `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
     return {
-      attempt: i + 1,
+      attempt: firstAttemptNo + i,
       accuracy: Math.round(item.accuracy),
       cpm: Math.round(item.cpm),
       dateLabel,
@@ -77,7 +89,14 @@ function CustomTooltip({ active, payload }: TooltipProps) {
 }
 
 const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
-  const data = useMemo(() => buildChartData(history), [history]);
+  const totalAttempts = history.length;
+  /* #1633: start with the latest 4 attempts; 「載入更多」 unlocks more. */
+  const [visiblePoints, setVisiblePoints] = useState(DEFAULT_POINTS);
+  const effectiveVisible = Math.min(visiblePoints, totalAttempts, MAX_POINTS);
+  const data = useMemo(
+    () => buildChartData(history, effectiveVisible),
+    [history, effectiveVisible],
+  );
 
   if (data.length < 2) {
     return (
@@ -87,7 +106,8 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
     );
   }
 
-  const truncated = history.length > MAX_POINTS;
+  const expandable = effectiveVisible < Math.min(totalAttempts, MAX_POINTS);
+  const remaining = Math.min(totalAttempts, MAX_POINTS) - effectiveVisible;
 
   return (
     <div className="space-y-2">
@@ -95,9 +115,10 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
         <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider">
           進步趨勢
         </p>
-        {truncated && (
-          <span className="text-[10px] text-on-surface-variant">最近 {MAX_POINTS} 次</span>
-        )}
+        <span className="text-[10px] text-on-surface-variant">
+          顯示最近 {effectiveVisible} 次
+          {totalAttempts > MAX_POINTS && `（共 ${totalAttempts} 次，最多顯示 ${MAX_POINTS} 次）`}
+        </span>
       </div>
       <div className="h-48 w-full">
         <ResponsiveContainer width="100%" height="100%">
@@ -146,6 +167,15 @@ const ReadingTrendChart: React.FC<ReadingTrendChartProps> = ({ history }) => {
           </LineChart>
         </ResponsiveContainer>
       </div>
+      {expandable && (
+        <button
+          type="button"
+          onClick={() => setVisiblePoints((v) => Math.min(v + DEFAULT_POINTS, MAX_POINTS))}
+          className="w-full text-xs font-headline text-on-surface-variant bg-surface-container-low hover:bg-surface-container rounded-full py-2 transition-colors"
+        >
+          載入更多（還有 {remaining} 筆）
+        </button>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/full-reading/SelfAssessment.tsx
+++ b/frontend/src/components/reading-steps/full-reading/SelfAssessment.tsx
@@ -16,6 +16,10 @@ interface SelfAssessmentProps {
   aiRating?: AssessmentRating;
   /** Whether to show comparison (true after student has selected) */
   showComparison?: boolean;
+  /** Which practice attempt this self-assessment is for (1-indexed).
+   *  Per #1633: self-assessment overwrites, so only the latest one is kept —
+   *  the attempt number provides the missing context. */
+  attemptNumber?: number;
 }
 
 const RATING_CONFIG: Record<AssessmentRating, { label: string; icon: string; bg: string; border: string; text: string }> = {
@@ -89,14 +93,22 @@ const SelfAssessment: React.FC<SelfAssessmentProps> = ({
   selectedRating,
   aiRating,
   showComparison = false,
+  attemptNumber,
 }) => {
   const ratings: AssessmentRating[] = ['low', 'mid', 'high'];
 
   return (
     <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
-      <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-1">
-        自我評估
-      </p>
+      <div className="flex items-center justify-between mb-1">
+        <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider">
+          自我評估
+        </p>
+        {attemptNumber && attemptNumber > 0 && (
+          <span className="text-[10px] font-headline text-on-surface-variant">
+            第 {attemptNumber} 次練習
+          </span>
+        )}
+      </div>
       <p className="text-base font-headline text-on-surface mb-4">
         你覺得這次讀得怎麼樣？
       </p>


### PR DESCRIPTION
# Issue #1633 修正說明

## 問題摘要

5/15 週會 QA 反饋（PR #1600 朗讀歷史趨勢圖）：

1. 雙 Y 軸對學生不直覺
2. 練 10+ 次後曲線過長、看不出重點
3. 表格順序需明確：最新在上、最舊在下
4. 自我評估只需記一次（不展開歷史，但要看得出「這是第幾次」）

本次按 Done definition 進行 UX 調整：預設顯示 4 筆 + 載入更多展開 +
表格最新在上 + 自我評估標註「第 N 次練習」。雙 Y 軸保留（issue 註記
「靖杭判斷」，本次以好讀的「預設限縮 + 漸進展開」為主，不做拆軸的
大改動）。

## 修正策略

把「預設只看最近一段、想看更多再點開」這個 pattern 套到三個地方：

- **趨勢圖**：useState 控制可見點數，預設 4 → 點「載入更多」 +4，
  上限保留 `MAX_POINTS = 20`。X 軸 attempt 編號改成反映「總體第幾次」
  而不是「畫面第幾筆」，這樣學生點「載入更多」之後，新加進來的點
  才能和原本的點接續。
- **歷史表格**：同樣 useState 預設 4，點「載入更多」一次展開全部。
  原本 `[...history].reverse().slice(0, 5)` 已是新→舊，順序維持。
- **自我評估**：UI 本體維持單次（覆蓋式，無歷史 list），title 右側
  加 `第 N 次練習` 小標，N = `dedicatedHistory.length`（按 issue 描述
  「讀 history.length」）。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/components/reading-steps/full-reading/ReadingTrendChart.tsx` | 加 `DEFAULT_POINTS = 4` 與 `visiblePoints` state；`buildChartData` 接受 `visiblePoints` 並讓 X 軸 attempt 從實際順位算起；加「載入更多」按鈕。 |
| `frontend/src/components/reading-steps/full-reading/ReadingMetricsCard.tsx` | 歷史表格預設 4 列；加 `expanded` state 與「載入更多」按鈕；註解標明 caller 是 API order（oldest-first）由本元件 reverse 為 newest-first。 |
| `frontend/src/components/reading-steps/full-reading/SelfAssessment.tsx` | 新增 `attemptNumber` prop；title 右側顯示「第 N 次練習」。 |
| `frontend/src/components/reading-steps/FullReading.tsx` | 把 `Math.max(dedicatedHistory.length, 1)` 傳給 SelfAssessment 的 `attemptNumber`。 |

## 修正內容詳述

### ReadingTrendChart

**Before**

```tsx
const MAX_POINTS = 20;

function buildChartData(history: ReadingHistoryItem[]): ChartPoint[] {
  const sorted = [...history].sort(...);
  const points = sorted.slice(-MAX_POINTS);
  return points.map((item, i) => ({ attempt: i + 1, ... }));
}

const ReadingTrendChart = ({ history }) => {
  const data = useMemo(() => buildChartData(history), [history]);
  // 直接畫整段
};
```

**After**

```tsx
const DEFAULT_POINTS = 4;
const MAX_POINTS = 20;

function buildChartData(history, visiblePoints): ChartPoint[] {
  const sorted = [...history].sort(...);
  const totalAttempts = sorted.length;
  const sliceCount = Math.min(visiblePoints, totalAttempts);
  const points = sorted.slice(-sliceCount);
  const firstAttemptNo = totalAttempts - sliceCount + 1;
  return points.map((item, i) => ({
    attempt: firstAttemptNo + i,    // ← 反映實際順位
    ...
  }));
}

const ReadingTrendChart = ({ history }) => {
  const [visiblePoints, setVisiblePoints] = useState(DEFAULT_POINTS);
  const effectiveVisible = Math.min(visiblePoints, totalAttempts, MAX_POINTS);
  const data = useMemo(() => buildChartData(history, effectiveVisible), [history, effectiveVisible]);

  // 圖下方：
  // {expandable && <button onClick={...}>載入更多（還有 N 筆）</button>}
};
```

### ReadingMetricsCard

**Before**

```tsx
const displayHistory = history && history.length > 0
  ? [...history].reverse().slice(0, 5)
  : null;

// 表格直接 render displayHistory
```

**After**

```tsx
const HISTORY_DEFAULT_ROWS = 4;

const newestFirst = history && history.length > 0 ? [...history].reverse() : [];
const [expanded, setExpanded] = useState(false);
const visibleRowCount = expanded ? newestFirst.length : Math.min(newestFirst.length, HISTORY_DEFAULT_ROWS);
const displayHistory = newestFirst.slice(0, visibleRowCount);
const remaining = newestFirst.length - visibleRowCount;

// 表格下方：
// {remaining > 0 && <button onClick={() => setExpanded(true)}>載入更多（還有 N 筆）</button>}
```

### SelfAssessment

新增 `attemptNumber?: number` prop，在 title 右側 render：

```tsx
<div className="flex items-center justify-between mb-1">
  <p className="...">自我評估</p>
  {attemptNumber && attemptNumber > 0 && (
    <span className="text-[10px] ...">第 {attemptNumber} 次練習</span>
  )}
</div>
```

### FullReading 接線

```tsx
<SelfAssessment
  ...
  attemptNumber={Math.max(dedicatedHistory.length, 1)}
/>
```

`Math.max(_, 1)` 用來蓋住 history 還沒回來的 race window，避免顯示「第 0 次」。

## 測試方式

1. 第一次練朗讀：完成後看到「第 1 次練習」標籤；歷史表格 / 趨勢圖
   都還沒出現（< 2 筆）。
2. 第二次練：歷史表格出現 2 列，最新在上；趨勢圖兩個點。
3. 連練 6 次：歷史表格預設只顯示最新 4 列、下方有「載入更多（還有
   2 筆）」；趨勢圖預設顯示最後 4 個點、下方有「載入更多」。
4. 點「載入更多」：表格展開全部 6 列；圖上多 4 個點（最多到
   `MAX_POINTS = 20`）。
5. 連練 25 次：圖上預設最新 4 點；連點「載入更多」直到展開到 20 點，
   不再顯示按鈕；表格可一次展開全部 25 列。
6. 自我評估區：每一次回到結果頁，標籤都顯示「第 N 次練習」（N =
   到目前為止的總練習次數）；按鈕仍是單次覆蓋，不顯示歷史 list。

## 對應 Done definition

- [x] 預設顯示 4 筆，超過用「載入更多」展開（表格 + 圖兩處）
- [x] 最新在上、最舊在下（表格 `[...history].reverse()`）
- [x] 自我評估只顯示一次（不展開歷史），旁邊標「第 N 次練習」

## 迴歸測試

- < 2 筆時：趨勢圖維持原本的 「再多練幾次就會出現趨勢圖 🚀」 空狀態
- ReadingHistoryItem caller 順序：backend `order_by(created_at.asc())`
  維持不變，前端自行 reverse / sort，互不影響
- Issue #1632 的修正：本次未碰 `submitReading` / `saveReadingHistory`
  邏輯，趨勢圖不會再因為 re-mount 多一筆假紀錄
- FluencyProgressChart（Issue #1386，session 內 4 次練習）不受影響
- Self-assessment 比對訊息（match / mismatch）顯示邏輯不變