### PR TITLE
fix(comprehension): remove duplicated title in image/table panels (Fixes #1705)

### DIFF
--- a/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
+++ b/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
@@ -32,14 +32,8 @@ const GraphicTextImageStrip: React.FC<GraphicTextImageStripProps> = ({ images, l
       data-testid="graphic-text-image-pane"
       className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5 flex flex-col w-full min-h-0 flex-[2]"
     >
-      <div className="flex items-center gap-2 mb-3 shrink-0">
-        <span className="material-symbols-outlined text-accent text-lg">photo_library</span>
-        <span className="font-headline font-bold text-on-surface text-xs uppercase tracking-wider">
-          圖文對照
-        </span>
-        <span className="text-xs text-on-surface-variant ml-2">{images.length} 張</span>
-        <span className="text-[11px] text-on-surface-variant ml-auto hidden md:inline">點圖可放大</span>
-      </div>
+      {/* #1706: header removed — collapsible parent shows icon/title/count. */}
+      <div className="text-[11px] text-on-surface-variant text-right mb-2 shrink-0 hidden md:block">點圖可放大</div>
       {images.length === 0 ? (
         <div className="flex-1 min-h-0 flex items-center justify-center text-on-surface-variant text-sm">
           暫無圖片

--- a/frontend/src/components/reading-steps/TableDisplay.tsx
+++ b/frontend/src/components/reading-steps/TableDisplay.tsx
@@ -185,14 +185,8 @@ const TableDisplay: React.FC<TableDisplayProps> = ({ tables, layout = 'stacked' 
       data-testid="lesson-tables"
       className={`bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5 flex flex-col w-full min-h-0 ${layout === 'strip' ? 'flex-[2]' : ''}`}
     >
-      <div className="flex items-center gap-2 mb-3 shrink-0">
-        <span className="material-symbols-outlined text-accent text-lg">table_view</span>
-        <span className="font-headline font-bold text-on-surface text-xs uppercase tracking-wider">
-          紙本表格
-        </span>
-        <span className="text-xs text-on-surface-variant ml-2">{tables.length} 張</span>
-        <span className="text-[11px] text-on-surface-variant ml-auto hidden md:inline">點表可放大</span>
-      </div>
+      {/* #1706: header removed — collapsible parent shows icon/title/count. */}
+      <div className="text-[11px] text-on-surface-variant text-right mb-2 shrink-0 hidden md:block">點表可放大</div>
       <div className={`flex-1 min-h-0 ${layout === 'strip' ? 'overflow-x-auto custom-scrollbar' : 'overflow-y-auto custom-scrollbar'}`}>
         <div className={`${layout === 'strip' ? 'flex gap-3 pr-2' : 'flex flex-col gap-3 pr-2'}`}>
           {tables.map((t) => (


### PR DESCRIPTION
移除 GraphicTextImageStrip + TableDisplay 內部 header。Closes #1705