### PR TITLE
fix(stepper): 頂部步驟列依 lesson step_sequence 動態顯示 (#1634)

### DIFF
--- a/frontend/src/components/StepperNav.tsx
+++ b/frontend/src/components/StepperNav.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useMemo } from 'react';
 import { AppView, Story, LearningSession } from '../types';
-import { ACTIVE_STEPS, STEP_CATEGORY_COLORS } from '../config/stepConfig';
+import { resolveActiveSteps, STEP_CATEGORY_COLORS } from '../config/stepConfig';
 
 interface StepperNavProps {
   currentView: AppView;
@@ -14,32 +14,18 @@ type StepStatus = 'disabled' | 'idle' | 'active' | 'completed';
 interface StepDef {
   step: number;
   label: string;
+  displayChar: string;
   view: AppView;
   needsStory: boolean;
   category: 'reading' | 'comprehension' | 'practice' | 'report';
 }
-
-/**
- * Steps are derived from the central ACTIVE_STEPS config so that reordering
- * or adding steps only requires editing stepConfig.ts.
- */
-const steps: StepDef[] = ACTIVE_STEPS.map((s, i) => ({
-  step: i + 1,
-  label: s.label,
-  view: s.view,
-  needsStory: s.needsStory,
-  category: s.category,
-}));
-
-const VIEW_TO_STEP_ID: Record<string, string> = Object.fromEntries(
-  ACTIVE_STEPS.map((s) => [s.view, s.id]),
-);
 
 function getStepStatus(
   stepDef: StepDef,
   currentView: AppView,
   session: LearningSession | null,
   selectedStory: Story | null,
+  viewToStepId: Record<string, string>,
 ): StepStatus {
   if (currentView === stepDef.view) return 'active';
   if (stepDef.needsStory && !selectedStory) return 'disabled';
@@ -48,7 +34,7 @@ function getStepStatus(
   const isCompleted = (() => {
     if (!session) return false;
     const completedSet = new Set(session.completedSteps ?? []);
-    const stepId = VIEW_TO_STEP_ID[stepDef.view];
+    const stepId = viewToStepId[stepDef.view];
     if (stepId && completedSet.has(stepId)) return true;
     switch (stepDef.view) {
       case AppView.INTRO:                    return session.introCompleted;
@@ -119,6 +105,31 @@ const StepperNav: React.FC<StepperNavProps> = ({
 }) => {
   const scrollRef = useRef<HTMLElement>(null);
 
+  /* #1634: derive steps from this lesson's step_sequence (yaml-driven), so
+   * lessons that omit reading / vocab / etc. don't expose dead steps in the
+   * top stepper. Falls back to DEFAULT_STEP_SEQUENCE when the lesson lacks
+   * a step_sequence field. */
+  const activeSteps = useMemo(
+    () => resolveActiveSteps(selectedStory?.stepSequence),
+    [selectedStory?.stepSequence],
+  );
+  const steps: StepDef[] = useMemo(
+    () =>
+      activeSteps.map((s, i) => ({
+        step: i + 1,
+        label: s.label,
+        displayChar: s.displayChar,
+        view: s.view,
+        needsStory: s.needsStory,
+        category: s.category,
+      })),
+    [activeSteps],
+  );
+  const viewToStepId = useMemo(
+    () => Object.fromEntries(activeSteps.map((s) => [s.view, s.id])) as Record<string, string>,
+    [activeSteps],
+  );
+
   // Auto-scroll the active step into view
   useEffect(() => {
     const container = scrollRef.current;
@@ -147,7 +158,7 @@ const StepperNav: React.FC<StepperNavProps> = ({
 
         {/* Step pills */}
         {steps.map((stepDef) => {
-          const status = getStepStatus(stepDef, currentView, session, selectedStory);
+          const status = getStepStatus(stepDef, currentView, session, selectedStory, viewToStepId);
           const isActive = status === 'active';
           const isDisabled = status === 'disabled';
           const categoryColors = STEP_CATEGORY_COLORS[stepDef.category];


### PR DESCRIPTION
# Issue #1634 修正說明

## 問題摘要

學習頁面頂部的 StepperNav (圓點導覽列) 從 module load 時就用了
`ACTIVE_STEPS` 這個 **靜態** 預設清單，所以無論進到哪一課都畫出
12 個圓點。八哥課 (G7-L30) 紙本學習單根本沒有朗讀環節，但學生看到
StepperNav 仍然顯示「逐段朗讀／全文朗讀」步驟，被引導去念一篇本來
就不該念的課文。

## 根因

YAML `step_sequence` 欄位與後端解析（`lesson_loader.py` → API 回傳
`stepSequence`）都已就位，`AppShell.tsx`（步驟導航 + 下一關按鈕）與
`Intro.tsx`（簡介頁面的數位學習步驟卡片）都已改用 `useStepSequence` /
`resolveActiveSteps(story.stepSequence)`。

**唯一漏掉的地方**：`StepperNav.tsx` 在 module 載入時就 `const steps =
ACTIVE_STEPS.map(...)`，整段是靜態常數，跟 lesson 完全脫鉤。

```tsx
// Before (#1634 之前)
import { ACTIVE_STEPS, ... } from '../config/stepConfig';
const steps = ACTIVE_STEPS.map((s, i) => ({ ... }));  // 12 個全部寫死
```

`resolveActiveSteps()` 在 `stepConfig.ts:325-326` 的 docstring 就明白寫著：

> This is the single resolution function — StepperNav and LearningLayout
> should call this (or the `useStepSequence` hook) rather than importing
> ACTIVE_STEPS.

但 StepperNav 沒有照做。

## 修正策略

把 `steps` / `VIEW_TO_STEP_ID` 從 module-level 搬進 component 內部，
用 `useMemo + resolveActiveSteps(selectedStory?.stepSequence)` 隨著 lesson
切換重新計算。`getStepStatus` 改成接收 `viewToStepId` 參數而不是 closure
外部變數。

順手補上 `StepDef.displayChar` 型別欄位（line 170 早就在用 `stepDef.displayChar`
但 `StepDef` interface 一直沒宣告，是 staging 既有的 TS error）。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/components/StepperNav.tsx` | 改用 `resolveActiveSteps(selectedStory?.stepSequence)` 動態取得 step list；補 `StepDef.displayChar`；getStepStatus 改吃外部傳入的 viewToStepId。 |

## 7 課現況驗證

驗證方法：
1. **資料欄位比對**：用腳本掃每一課 yml，檢查 step_sequence 列出的每個 step
   對應的資料欄位（如 reading-strategy ↔ `strategy_exercise`/`strategy_exercises`、
   story-structure ↔ `story_structure_table`、comprehension ↔ `multiple_choice`、
   knowledge-station ↔ `video_links`）是否實際有內容。
2. **紙本 PDF 對照**：抽 G7-L29 + G7-L30 兩課人工讀完整 PDF 對照
   step_sequence；其餘 5 課靠資料欄位齊全推斷正確。

| 課 | step_sequence | 步驟數 | 紙本章節對應 | 狀態 |
|---|---|---|---|---|
| G6-L22 | intro / reading-annotation / tutor / full-reading / vocab-definition / vocab-application / reading-strategy / story-structure / comprehension / vocab-word-search / knowledge-station / report | 12 | 一般 12 環節（摘要策略） | ✓ |
| G6-L23 | 同上 | 12 | 同上 | ✓ |
| G6-L24 | 同上（knowledge-station 提前到第 3） | 12 | 同上 | ✓ |
| G6-L25 | 同 L22/L23 | 12 | 同上 | ✓ |
| G7-L28 | intro / reading-annotation / reading-strategy / knowledge-station / story-structure / comprehension / report | 7 | 讀全文 / 聚光燈 / 知識補給站 / 閱讀理解（圖文整合，**無朗讀**） | ✓ |
| G7-L29 | intro / reading-annotation / reading-strategy / knowledge-station / comprehension / report | 6 | 讀全文 / 聚光燈（四張圖）/ 知識補給站 / 閱讀理解（**無朗讀、無 structure**） | ✓ |
| G7-L30 八哥 | intro / reading-annotation / knowledge-station / reading-strategy / story-structure / comprehension / report | 7 | 讀全文（含表一二）/ 知識補給站 / 聚光燈（圖文表整合）/ 閱讀理解（**無朗讀**） | ✓ |

**結論**：7 課的 `step_sequence` YAML 設定都正確，問題出在 frontend
StepperNav 沒有 consume `step_sequence`。

## 測試方式

修正後預期：

1. 進 G7-L30（八哥課）→ 頂部 StepperNav 只應顯示 **7 個**圓點：
   簡 → 記 → 識 → 光 → 構 → 解 → 報（不再有 段/讀）
2. 進 G7-L29 → 只顯示 **6 個**圓點（連 story-structure 也沒有）
3. 進 G6-L22~L25 → 仍顯示 **12 個**圓點（一般課）
4. 進舊 lesson（無 step_sequence 欄位）→ fallback 到 DEFAULT_STEP_SEQUENCE

## 迴歸測試

- AppShell 步驟導航 (上一關 / 下一關按鈕計數) 跟 StepperNav 用同源資料，
  數字應一致
- Intro 頁面數位學習步驟卡片 (Intro.tsx:304-306) 也用 `resolveActiveSteps`
  本來就對的上
- KnowledgeStation 註解提到 G7-L30 把它排在第 3 step (`step_sequence`
  順序非預設)，本次改完依然能正確顯示在第 3 個圓點
- Stepper 的「completed / active / disabled」狀態判斷靠 `viewToStepId`
  從動態 step list 重新計算，跨 lesson 切換時不會殘留舊的對映