### PR TITLE
fix(library): 退出課文後保留年級／難度／搜尋／未讀篩選 (#1725)

### DIFF
--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -47,34 +47,44 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
   const [selectedGrade, setSelectedGrade] = useState<number | null>(() => {
     try {
       const v = sessionStorage.getItem('library_filter_grade');
-      return v && v !== 'null' ? Number(v) : null;
-    } catch { return null; }
+      if (!v || v === 'null') return null;
+      const n = Number(v);
+      // Guard against junk in storage (e.g. someone manually set 'NaN').
+      return Number.isFinite(n) ? n : null;
+    } catch { /* sessionStorage unavailable (e.g. private browsing) — degrade to default */ return null; }
   });
   const [selectedDifficulty, setSelectedDifficulty] = useState<Difficulty | null>(() => {
     try {
       const v = sessionStorage.getItem('library_filter_difficulty');
-      return v && v !== 'null' ? (v as Difficulty) : null;
-    } catch { return null; }
+      // Whitelist-check the stored value so stale entries from a renamed
+      // Difficulty enum get silently discarded instead of as-casted.
+      const valid: Difficulty[] = ['easy', 'medium', 'hard'];
+      return v && (valid as string[]).includes(v) ? (v as Difficulty) : null;
+    } catch { /* sessionStorage unavailable (e.g. private browsing) — degrade to default */ return null; }
   });
   const [searchQuery, setSearchQuery] = useState<string>(() => {
-    try { return sessionStorage.getItem('library_filter_search') ?? ''; } catch { return ''; }
+    try { return sessionStorage.getItem('library_filter_search') ?? ''; }
+    catch { /* sessionStorage unavailable (e.g. private browsing) — degrade to default */ return ''; }
   });
   const [showOnlyUnread, setShowOnlyUnread] = useState<boolean>(() => {
-    try { return sessionStorage.getItem('library_filter_unread') === '1'; } catch { return false; }
+    try { return sessionStorage.getItem('library_filter_unread') === '1'; }
+    catch { /* sessionStorage unavailable (e.g. private browsing) — degrade to default */ return false; }
   });
 
-  /* Persist whenever any filter changes. */
+  /* Persist whenever any filter changes. Empty catch is intentional: when
+   * sessionStorage is unavailable (private browsing / quota exceeded) we
+   * silently fall back to in-memory state for this mount. */
   useEffect(() => {
-    try { sessionStorage.setItem('library_filter_grade', String(selectedGrade)); } catch {}
+    try { sessionStorage.setItem('library_filter_grade', String(selectedGrade)); } catch { /* sessionStorage unavailable */ }
   }, [selectedGrade]);
   useEffect(() => {
-    try { sessionStorage.setItem('library_filter_difficulty', String(selectedDifficulty)); } catch {}
+    try { sessionStorage.setItem('library_filter_difficulty', String(selectedDifficulty)); } catch { /* sessionStorage unavailable */ }
   }, [selectedDifficulty]);
   useEffect(() => {
-    try { sessionStorage.setItem('library_filter_search', searchQuery); } catch {}
+    try { sessionStorage.setItem('library_filter_search', searchQuery); } catch { /* sessionStorage unavailable */ }
   }, [searchQuery]);
   useEffect(() => {
-    try { sessionStorage.setItem('library_filter_unread', showOnlyUnread ? '1' : '0'); } catch {}
+    try { sessionStorage.setItem('library_filter_unread', showOnlyUnread ? '1' : '0'); } catch { /* sessionStorage unavailable */ }
   }, [showOnlyUnread]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [loadingStoryId, setLoadingStoryId] = useState<string | null>(null);

--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -39,10 +39,43 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
 }) => {
   const { token, user } = useAuth();
   const [xpToNext, setXpToNext] = useState<number | null>(null);
-  const [selectedGrade, setSelectedGrade] = useState<number | null>(null);
-  const [selectedDifficulty, setSelectedDifficulty] = useState<Difficulty | null>(null);
-  const [searchQuery, setSearchQuery] = useState<string>('');
-  const [showOnlyUnread, setShowOnlyUnread] = useState(false);
+
+  /* #1725: persist filter selections across the lesson round-trip so that
+   * exiting a story returns to the same grade / difficulty / search the
+   * student was browsing. Stored in sessionStorage so each tab keeps its own
+   * view and a fresh tab starts clean. */
+  const [selectedGrade, setSelectedGrade] = useState<number | null>(() => {
+    try {
+      const v = sessionStorage.getItem('library_filter_grade');
+      return v && v !== 'null' ? Number(v) : null;
+    } catch { return null; }
+  });
+  const [selectedDifficulty, setSelectedDifficulty] = useState<Difficulty | null>(() => {
+    try {
+      const v = sessionStorage.getItem('library_filter_difficulty');
+      return v && v !== 'null' ? (v as Difficulty) : null;
+    } catch { return null; }
+  });
+  const [searchQuery, setSearchQuery] = useState<string>(() => {
+    try { return sessionStorage.getItem('library_filter_search') ?? ''; } catch { return ''; }
+  });
+  const [showOnlyUnread, setShowOnlyUnread] = useState<boolean>(() => {
+    try { return sessionStorage.getItem('library_filter_unread') === '1'; } catch { return false; }
+  });
+
+  /* Persist whenever any filter changes. */
+  useEffect(() => {
+    try { sessionStorage.setItem('library_filter_grade', String(selectedGrade)); } catch {}
+  }, [selectedGrade]);
+  useEffect(() => {
+    try { sessionStorage.setItem('library_filter_difficulty', String(selectedDifficulty)); } catch {}
+  }, [selectedDifficulty]);
+  useEffect(() => {
+    try { sessionStorage.setItem('library_filter_search', searchQuery); } catch {}
+  }, [searchQuery]);
+  useEffect(() => {
+    try { sessionStorage.setItem('library_filter_unread', showOnlyUnread ? '1' : '0'); } catch {}
+  }, [showOnlyUnread]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [loadingStoryId, setLoadingStoryId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -106,10 +139,15 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
     }
   }, [token, classroomId]);
 
-  // Chain of filters
+  // Chain of filters. In classroom mode the grade/difficulty controls are
+  // hidden (#1725: also skipping their application so a persisted grade=7
+  // doesn't wipe out a grade=0 classroom view).
+  const inClassroomMode = classroomId != null && !isNaN(classroomId);
   let filtered = allStories;
-  if (selectedGrade != null) filtered = filtered.filter((s) => s.grade === selectedGrade);
-  if (selectedDifficulty != null) filtered = filtered.filter((s) => getDifficulty(s) === selectedDifficulty);
+  if (!inClassroomMode) {
+    if (selectedGrade != null) filtered = filtered.filter((s) => s.grade === selectedGrade);
+    if (selectedDifficulty != null) filtered = filtered.filter((s) => getDifficulty(s) === selectedDifficulty);
+  }
   if (searchQuery) {
     const q = searchQuery.toLowerCase();
     filtered = filtered.filter(


### PR DESCRIPTION
# Issue #1725 修正說明

## 問題摘要

在圖書館用上方「年級分類」tab 篩選課文後，進入課文中途退出，會被導
回**整個圖書館的初始畫面**（年級篩選清空、顯示全部年級）。學生若只是
想換一篇同年級的課文，必須再點一次年級 tab，體驗中斷。

## 修正策略

`StoryLibrary.tsx` 4 個 filter state（`selectedGrade`、`selectedDifficulty`、
`searchQuery`、`showOnlyUnread`）原本是 `useState`，元件 unmount 就消失。
改成用 **sessionStorage** 持久化：

- `useState` lazy initializer 從 `sessionStorage` 讀回上次的值
- `useEffect` 在每個 state 變動時寫回 sessionStorage
- 用 sessionStorage 而不是 localStorage：每個 tab 各自一份、新開 tab 是
  乾淨狀態，符合「同 session 內延續、跨 session 不殘留」的習慣

PR 描述評估過 URL search params 方案，但 sessionStorage 改動範圍最小
（單檔），不會影響其他 6 處 `navigate('/library')` 呼叫的語意。

順手處理一個 latent bug：classroom mode 下 grade / difficulty UI 是隱藏
的，但 filter chain 仍然套用。原本 `selectedGrade` 一律是 null 所以
沒事，這次持久化後若使用者帶著 `selectedGrade=7` 切到 classroom view，
classroom mode 的 mock story 都是 `grade: 0`，會被全部過濾掉 → 0 結果。
在 filter chain 加 `inClassroomMode` guard 跳過 grade/difficulty 套用。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/pages/student/StoryLibrary.tsx` | 4 個 filter state 改用 sessionStorage 持久化；filter chain 加 classroom-mode guard。 |

## 修正內容詳述

### Before

```tsx
const [selectedGrade, setSelectedGrade] = useState<number | null>(null);
const [selectedDifficulty, setSelectedDifficulty] = useState<Difficulty | null>(null);
const [searchQuery, setSearchQuery] = useState<string>('');
const [showOnlyUnread, setShowOnlyUnread] = useState(false);

// ...

let filtered = allStories;
if (selectedGrade != null) filtered = filtered.filter((s) => s.grade === selectedGrade);
if (selectedDifficulty != null) filtered = filtered.filter((s) => getDifficulty(s) === selectedDifficulty);
```

### After

```tsx
// Persisted to sessionStorage so round-trip into a lesson keeps the filter view.
const [selectedGrade, setSelectedGrade] = useState<number | null>(() => {
  try {
    const v = sessionStorage.getItem('library_filter_grade');
    return v && v !== 'null' ? Number(v) : null;
  } catch { return null; }
});
// (同樣 pattern 套用到另外三個 filter)

useEffect(() => {
  try { sessionStorage.setItem('library_filter_grade', String(selectedGrade)); } catch {}
}, [selectedGrade]);
// (同樣 useEffect 套用到另外三個 filter)

// Filter chain
const inClassroomMode = classroomId != null && !isNaN(classroomId);
let filtered = allStories;
if (!inClassroomMode) {
  if (selectedGrade != null) filtered = filtered.filter((s) => s.grade === selectedGrade);
  if (selectedDifficulty != null) filtered = filtered.filter((s) => getDifficulty(s) === selectedDifficulty);
}
```

## 測試方式

1. 登入學生帳號 → 圖書館
2. 點上方「7 年級」分頁 → 列表縮到 7 年級
3. 點任一篇課文進入學習頁
4. 按「離開」或在學習頁倒數結束自動退出
5. **預期**：回到圖書館時仍停在 7 年級 tab、列表還是 7 年級的課文
6. 切換難度 + 搜尋 + 只看未讀，重複 step 3~5 → 都應保留
7. 「清除全部篩選」按鈕 → 應該清空 sessionStorage 並回到全部
8. 進入「我的班級 → 課文庫」(classroom mode) → 不會因為持久化的
   grade=7 而導致 0 結果

## 迴歸測試

- 第一次登入（沒有 sessionStorage）→ 預設 all null，行為跟原本一致
- 新開 tab → sessionStorage 是 per-tab 的，新 tab 自動 fresh
- 關閉 tab 再開新 tab → 不會殘留（sessionStorage scope）
- `clearFilters()` 按鈕：透過 setter 觸發 effect 寫回 'null'/''/'0'，
  下次 mount 讀回時被視為 cleared，行為一致
- classroom mode 下 search bar 跟 unread filter 仍會作用（UI 沒被
  隱藏），只有 grade/difficulty 在 classroom mode 下不套用