### PR TITLE
feat(omo): swap identifier to gemini-flash-lite-latest (Fixes #1729)

### DIFF
--- a/backend/app/services/omo_identifier.py
+++ b/backend/app/services/omo_identifier.py
@@ -351,7 +351,7 @@ async def identify_lesson_from_image(image_bytes: bytes, mime_type: str = "image
         from google.genai import types as genai_types
 
         response = await client.aio.models.generate_content(
-            model="gemini-2.5-flash",
+            model="gemini-flash-lite-latest",
             contents=[
                 genai_types.Content(
                     role="user",


### PR DESCRIPTION
Fixes #1729

## Summary
- `omo_identifier.py` line 354: `gemini-2.5-flash` → `gemini-flash-lite-latest`
- No region change needed — `_get_client()` in `ai_base.py` already uses `location="global"`
- `omo_grader.py` untouched (scope-locked to this file only)

## Why safe
- 5/18 batch test: 3 sample pages × 2 models — both 15/16 hit rate at confidence 0.95-1.0
- Simple JSON output schema (title + confidence + reasoning) — no complex grading logic
- Lower per-token cost vs gemini-2.5-flash baseline

## Test plan
- [ ] `pytest backend/tests/test_omo_crop_provenance.py backend/tests/test_omo_lessons.py` — no regression
- [ ] Backend `/api/health` 200 after staging deploy
- [ ] Cloud Run revision updated
- [ ] OMO grader unchanged: `grep "gemini-2.5-flash" omo_grader.py` ≥1 hit