### PR TITLE
fix(ai): thinking_budget=0 prod patch (Fixes #1738)

### DIFF
--- a/backend/app/services/ai_comprehension.py
+++ b/backend/app/services/ai_comprehension.py
@@ -111,6 +111,7 @@ async def generate_socratic_question(
             system_instruction=system_prompt,
             max_output_tokens=128,
             temperature=0.7,
+            thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
         ),
     )
     # Guard against safety filter before accessing response.text (#526)

--- a/backend/app/services/omo_identifier.py
+++ b/backend/app/services/omo_identifier.py
@@ -372,6 +372,7 @@ async def identify_lesson_from_image(image_bytes: bytes, mime_type: str = "image
             config=genai_types.GenerateContentConfig(
                 temperature=0.1,  # Low temperature for deterministic identification
                 max_output_tokens=3072,  # bumped 2048→3072: terse prompt still needs buffer for 158-lesson corpus
+                thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
             ),
         )
 

--- a/backend/app/services/tts_service.py
+++ b/backend/app/services/tts_service.py
@@ -611,6 +611,7 @@ def _synthesize_gemini(text: str) -> bytes:
             contents=tts_contents,
             config=genai_types.GenerateContentConfig(
                 response_modalities=["AUDIO"],
+                thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
                 speech_config=genai_types.SpeechConfig(
                     voice_config=genai_types.VoiceConfig(
                         prebuilt_voice_config=genai_types.PrebuiltVoiceConfig(


### PR DESCRIPTION
## Part A — Prod patch (this PR)

Add `thinking_config=ThinkingConfig(thinking_budget=0)` to 3 prod `generate_content` call sites that were missing it. Reference correct pattern in `ai_base.py:343` and `omo_grader.py:488`.

Files patched:
- `backend/app/services/ai_comprehension.py:114` (generate_socratic_question)
- `backend/app/services/omo_identifier.py:374` (identify_lesson_from_image)
- `backend/app/services/tts_service.py:613` (_synthesize_gemini)

## Why this matters

Without `thinking_budget=0`, gemini-2.5-flash silently burns visible-output tokens on hidden thinking. socratic_question evidence (max_tokens=128):

| Config | thoughts_tok | candidates_tok | visible text |
|---|---:|---:|---|
| default thinking | 120 | 4 | "各位同學好！我是" (8 char) |
| thinking_budget=0 | — | 128 | full 207 char ✅ |

These 3 files use `gemini-2.5-flash` (identifier per #1729 prior swap, now reverted) → student-facing quality silently degraded before this patch.

## Part B — Fair A/B re-run (already done locally, no code change needed)

socratic_question fair re-run (`private/omo-real-samples/2026-05-20-systematic-ab/socratic_question_fair.json`):

| Metric | 2.5 Flash (fair) | flash-lite | Δ |
|---|---:|---:|---|
| Output tokens | 384 (full) | 384 (full) | tie ✅ quality |
| Avg latency | 3372ms | **2272ms** | flash-lite -33% |
| Total cost | $0.001042 | **$0.000644** | flash-lite -38% |

Verdict: flash-lite **still wins** socratic_question — but quality is **TIE** not "2.5-flash truncated". Previous A/B was unfair; conclusion (use flash-lite) unchanged.

Other 7 JSON tasks used `call_json()` which already had `thinking_budget=0` at line 116 — those A/B results were already fair.

→ `llm_models.py` unchanged.

## Test plan

- [x] pytest backend/tests/ no regression
- [ ] Staging deploy SUCCESS
- [ ] Curl socratic chat endpoint with 小明 demo — verify non-truncated 中文 response
- [ ] grep verify all 5 GenerateContentConfig sites now have thinking_budget=0

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex