### PR TITLE
fix(schema): expose story_structure_table/rows in StoryDetail API (Fixes #1683 item 4)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -263,6 +263,11 @@ def get_story(story_id: str):
         worksheet_pdf_url=story.get("worksheet_pdf_url"),
         # 紙本表格 (#1685) — extracted tables for 圖文表整合 lessons; None for others
         tables=story.get("tables"),
+        # Story structure scaffold (#1683 item 4): YAML data for StoryStructure step.
+        # story_structure_table: list-of-lists from docx parser (G7-L28/L29/L30).
+        # story_structure_rows: AI-generated dict rows (richer shape). Both may be None.
+        story_structure_table=story.get("story_structure_table"),
+        story_structure_rows=story.get("story_structure_rows"),
     )
 
 

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -83,6 +83,12 @@ class StoryDetail(StoryListItem):
     # Used by 圖文表整合 lessons (G7-L28, G7-L30) where docx → yml parser dropped
     # table row data; frontend renders via TableDisplay component with zoom modal.
     tables: Optional[list[dict]] = None
+    # Story structure scaffold for StoryStructure step (#1683 item 4):
+    # story_structure_table — docx-parsed list-of-lists (ground truth for G7 graphic-text lessons)
+    # story_structure_rows — AI-generated dict rows (richer, with checkbox support)
+    # Both None for lessons without this step; StoryStructure endpoint uses whichever is present.
+    story_structure_table: Optional[list] = None
+    story_structure_rows: Optional[list] = None
 
 
 class StoryListResponse(BaseModel):


### PR DESCRIPTION
Fixes #1683

## Root Cause

`lesson_loader` correctly propagated `story_structure_table` and `story_structure_rows` from `_parsed_2026-05-01/G7-L28/L29/L30.yml` through Layer-2 enrichment. However:

1. **`StoryDetail` Pydantic schema** had no fields for `story_structure_table` or `story_structure_rows` — Pydantic silently dropped them from the serialized response
2. **`get_story()` route handler** never passed these fields when constructing `StoryDetail(...)`

So the API always returned `null`/empty for both fields regardless of what the loader returned.

## Fix (2 files)

- `backend/app/schemas/story.py` — Added `story_structure_table: Optional[list] = None` and `story_structure_rows: Optional[list] = None` to `StoryDetail`
- `backend/app/routes/stories.py` — Wired both fields through the `StoryDetail(...)` constructor in `get_story()`

## Verification

Local check before/after:
| Lesson | story_structure_table before | after |
|--------|------------------------------|-------|
| G7-L28 (1108) | 0 rows | **6 rows** |
| G7-L29 (1109) | 0 rows | **7 rows** |
| G7-L30 (1110) | 0 rows | **6 rows** |

Tests: `test_yaml_first_structure` + `test_strategy_exercise_schema` — 16/16 passed

## Test plan

After staging deploy:
```
curl -H "Authorization: Bearer <token>" \
  https://lingoleap-backend-staging-958347263320.asia-east1.run.app/api/stories/1110 \
  | jq '.story_structure_table | length, .story_structure_rows | length'
```
Expected: `6` and `0` (table present, rows not yet generated by AI).