### PR TITLE
docs+test: QA plan + 4 regression tests (Fixes #1757)

### DIFF
--- a/backend/tests/test_regression_fill_in_blank_schema_1675.py
+++ b/backend/tests/test_regression_fill_in_blank_schema_1675.py
@@ -1,0 +1,242 @@
+"""Regression tests for fill_in_blank schema alignment — Issue #1675 / PR #1678.
+
+Verifies the 6 specific lessons fixed by #1675 have coherent fill_in_blank data:
+  - answer letter codes match vocab_bank keys
+  - sentence and answer fields are present on legacy items
+  - _schema normalizer tag is applied to all items
+  - vocab_bank is present when legacy items reference it
+
+The 6 lessons fixed:
+  - L15.yml  → grade_code G6-L04 (兩千五百歲的酷老師) — Layer-1
+  - L24.yml  → grade_code G6-L03 (昆蟲會思考嗎?)   — Layer-1
+  - G6-L22.yml → 雞鳴狗盜 — Layer-2 priority demo
+  - G6-L23.yml → 老鷹紅豆 — Layer-2 priority demo
+  - G6-L24.yml → 白鯨救援 — Layer-2 priority demo
+  - G6-L25.yml → 荷蘭東印度 — Layer-2 priority demo
+
+Root cause of #1675: vocab_bank letter order + sentence text were AI-generated
+placeholders that did not match the printed worksheets. OMO grader scored 0.13/0.20
+because answer letter codes (e.g. 'A') pointed to wrong vocabulary words.
+
+Run:
+    cd backend && python -m pytest tests/test_regression_fill_in_blank_schema_1675.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from app.services.lesson_loader import get_lesson_by_code, get_all_lessons
+
+# The 6 lessons fixed by Issue #1675. Two are Layer-1 (by grade_code), four Layer-2.
+_FIXED_LESSON_CODES = [
+    "G6-L04",   # L15.yml (兩千五百歲的酷老師) — Layer-1
+    "G6-L03",   # L24.yml (昆蟲會思考嗎?) — Layer-1
+    "G6-L22",   # 雞鳴狗盜 — Layer-2
+    "G6-L23",   # 老鷹紅豆 — Layer-2
+    "G6-L24",   # 白鯨救援 — Layer-2
+    "G6-L25",   # 荷蘭東印度 — Layer-2
+]
+
+
+def _get_fixed_lessons():
+    """Load the 6 lessons fixed by Issue #1675."""
+    results = {}
+    for code in _FIXED_LESSON_CODES:
+        lesson = get_lesson_by_code(code)
+        if lesson is not None:
+            results[code] = lesson
+    return results
+
+
+class TestFixedLessonsHaveFillInBlankData:
+    """The 6 fixed lessons must have fill_in_blank data after the fix."""
+
+    @pytest.fixture(scope="class")
+    def fixed_lessons(self):
+        return _get_fixed_lessons()
+
+    def test_fixed_lessons_are_loadable(self, fixed_lessons):
+        """All 6 lesson codes from Issue #1675 must be loadable."""
+        missing = [code for code in _FIXED_LESSON_CODES if code not in fixed_lessons]
+        assert not missing, (
+            f"Lessons not found: {missing}. "
+            f"These were fixed in Issue #1675. "
+            f"Was the lesson YAML removed or the lesson_code changed?"
+        )
+
+    def test_fixed_lessons_have_fill_in_blank(self, fixed_lessons):
+        """Each of the 6 fixed lessons must have fill_in_blank data."""
+        failures = []
+        for code, lesson in fixed_lessons.items():
+            fib = lesson.get("fill_in_blank")
+            if not fib or len(fib) == 0:
+                failures.append(
+                    f"{code}: fill_in_blank is missing or empty. "
+                    f"Was the YAML fill_in_blank block removed?"
+                )
+        assert not failures, "\n".join(failures)
+
+    def test_fixed_lessons_have_vocab_bank(self, fixed_lessons):
+        """Each of the 6 fixed lessons must have a vocab_bank dict."""
+        failures = []
+        for code, lesson in fixed_lessons.items():
+            fib = lesson.get("fill_in_blank") or []
+            has_legacy = any(item.get("_schema") == "legacy" for item in fib)
+            if has_legacy and not lesson.get("vocab_bank"):
+                failures.append(
+                    f"{code}: has legacy fill_in_blank items but vocab_bank is missing. "
+                    f"Issue #1675 aligned vocab_bank — it was reverted."
+                )
+        assert not failures, "\n".join(failures)
+
+
+class TestFixedLessonsAnswerVocabBankCoherence:
+    """Core regression: answer letter codes must match vocab_bank keys."""
+
+    @pytest.fixture(scope="class")
+    def fixed_lessons(self):
+        return _get_fixed_lessons()
+
+    def test_legacy_answer_letters_in_vocab_bank(self, fixed_lessons):
+        """For each fixed lesson: every single-letter answer must be in vocab_bank.
+
+        This is the exact regression caught by Issue #1675:
+        answer='A' pointing to vocab_bank with no 'A' key → wrong word displayed.
+        """
+        failures = []
+        for code, lesson in fixed_lessons.items():
+            vocab_bank = lesson.get("vocab_bank") or {}
+            fib = lesson.get("fill_in_blank") or []
+            for i, item in enumerate(fib):
+                if item.get("_schema") != "legacy":
+                    continue
+                answer = item.get("answer", "")
+                # Only check single uppercase letter codes (not freetext answers)
+                if len(answer) == 1 and answer.isupper() and answer.isalpha():
+                    if answer not in vocab_bank:
+                        failures.append(
+                            f"{code} item[{i}]: answer={answer!r} not in "
+                            f"vocab_bank keys={sorted(vocab_bank.keys())}. "
+                            f"This was the exact bug fixed in Issue #1675 — "
+                            f"vocab_bank letter order must match answer codes."
+                        )
+        assert not failures, (
+            f"{len(failures)} answer-vocab_bank mismatches (Issue #1675 regression):\n"
+            + "\n".join(failures)
+        )
+
+    def test_vocab_bank_has_at_least_one_entry(self, fixed_lessons):
+        """vocab_bank must not be empty for lessons with letter-coded answers."""
+        failures = []
+        for code, lesson in fixed_lessons.items():
+            fib = lesson.get("fill_in_blank") or []
+            has_letter_coded = any(
+                item.get("_schema") == "legacy"
+                and len(item.get("answer", "")) == 1
+                and item.get("answer", "").isupper()
+                and item.get("answer", "").isalpha()
+                for item in fib
+            )
+            if has_letter_coded:
+                vocab_bank = lesson.get("vocab_bank") or {}
+                if len(vocab_bank) == 0:
+                    failures.append(f"{code}: vocab_bank is empty but has letter-coded answers")
+        assert not failures, "\n".join(failures)
+
+
+class TestNormalizerAppliedToAllItems:
+    """_normalize_fill_in_blank_item() must be applied to all loaded items."""
+
+    @pytest.fixture(scope="class")
+    def fixed_lessons(self):
+        return _get_fixed_lessons()
+
+    def test_all_fill_in_blank_items_have_schema_tag(self, fixed_lessons):
+        """Every fill_in_blank item in the 6 fixed lessons must have _schema tag."""
+        failures = []
+        for code, lesson in fixed_lessons.items():
+            for i, item in enumerate(lesson.get("fill_in_blank") or []):
+                if "_schema" not in item:
+                    failures.append(
+                        f"{code} item[{i}]: missing _schema tag. "
+                        f"lesson_loader normalizer not applied?"
+                    )
+        assert not failures, "\n".join(failures)
+
+    def test_legacy_items_have_sentence_field(self, fixed_lessons):
+        """Every legacy-schema item must have a sentence field."""
+        failures = []
+        for code, lesson in fixed_lessons.items():
+            for i, item in enumerate(lesson.get("fill_in_blank") or []):
+                if item.get("_schema") == "legacy" and not item.get("sentence"):
+                    failures.append(
+                        f"{code} item[{i}]: legacy item missing sentence field. "
+                        f"Item: {item}"
+                    )
+        assert not failures, "\n".join(failures)
+
+    def test_legacy_items_have_answer_field(self, fixed_lessons):
+        """Every legacy-schema item must have an answer field."""
+        failures = []
+        for code, lesson in fixed_lessons.items():
+            for i, item in enumerate(lesson.get("fill_in_blank") or []):
+                if item.get("_schema") == "legacy" and "answer" not in item:
+                    failures.append(
+                        f"{code} item[{i}]: legacy item missing answer field. "
+                        f"Item: {item}"
+                    )
+        assert not failures, "\n".join(failures)
+
+
+class TestGlobalNormalizerInvariant:
+    """_schema tag is applied globally across all Layer-1 lessons."""
+
+    def test_all_layer1_fib_items_have_schema_tag(self):
+        """All Layer-1 lessons' fill_in_blank items must have _schema tag.
+
+        This is a global normalizer invariant — if the normalizer is not called,
+        _schema would be absent and the frontend filter logic breaks.
+        """
+        lessons = get_all_lessons()
+        layer1 = [l for l in lessons if l.get("_layer") == 1 and l.get("fill_in_blank")]
+        failures = []
+        for lesson in layer1:
+            for i, item in enumerate(lesson["fill_in_blank"]):
+                if "_schema" not in item:
+                    failures.append(
+                        f"Lesson {lesson['lesson_code']} item[{i}]: missing _schema tag"
+                    )
+        assert not failures, (
+            f"{len(failures)} Layer-1 fill_in_blank items missing _schema:\n"
+            + "\n".join(failures[:5])
+        )
+
+    def test_layer1_items_are_predominantly_legacy_schema(self):
+        """Layer-1 fill_in_blank items should be predominantly 'legacy' schema (≥80%).
+
+        If most items are context_fill, the normalizer is miscategorizing.
+        (Layer-2 items that are primarily context_fill are expected.)
+        """
+        lessons = get_all_lessons()
+        layer1 = [l for l in lessons if l.get("_layer") == 1 and l.get("fill_in_blank")]
+        legacy_count = 0
+        context_fill_count = 0
+        for lesson in layer1:
+            for item in lesson["fill_in_blank"]:
+                schema = item.get("_schema")
+                if schema == "legacy":
+                    legacy_count += 1
+                elif schema == "context_fill":
+                    context_fill_count += 1
+
+        total = legacy_count + context_fill_count
+        assert total > 0, "No fill_in_blank items found in Layer-1 lessons."
+        legacy_pct = legacy_count / total * 100
+        assert legacy_pct >= 80, (
+            f"Only {legacy_pct:.1f}% of Layer-1 fill_in_blank items are 'legacy' schema. "
+            f"Expected ≥80%. legacy={legacy_count}, context_fill={context_fill_count}. "
+            f"Possible normalizer regression."
+        )

--- a/backend/tests/test_regression_layer2_shadow_merge_1666.py
+++ b/backend/tests/test_regression_layer2_shadow_merge_1666.py
@@ -1,0 +1,222 @@
+"""Regression tests for Layer-2 shadow merge in lesson_loader — Issue #1666.
+
+Verifies that:
+  1. get_lesson_by_code() returns Layer-2 lessons (not None)
+  2. Layer-2 lessons have expected structure (id, title, paragraphs, grade_code)
+  3. Layer-1 lessons still load correctly (Layer-2 doesn't shadow them)
+  4. The lesson loader loads both layers simultaneously (total count is reasonable)
+  5. Layer-2 lessons with step_sequence have the field set correctly
+
+Background:
+  Layer-1: backend/data/lessons/L*.yml (57 lessons, integer lesson_number)
+  Layer-2: backend/data/lessons/_parsed_2026-05-01/*.yml (151 parsed lessons)
+  Curriculum manifest: backend/data/curriculum/manifest.yml (158 entries)
+
+  Layer-2 lessons get synthetic integer IDs: display_order + 1000.
+  Layer-1 lessons take precedence when both cover the same curriculum slot.
+
+  Issue #1666 was the initial shadow-fix that made Layer-2 lessons accessible
+  via get_lesson_by_code() by building a code→lesson index.
+
+Run:
+    cd backend && python -m pytest tests/test_regression_layer2_shadow_merge_1666.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from app.services.lesson_loader import (
+    get_all_lessons,
+    get_lesson_by_code,
+    get_lesson_by_id,
+    get_lessons_by_grade,
+)
+
+_LAYER2_ID_OFFSET = 1000  # Layer-2 IDs = display_order + 1000
+
+
+class TestLayer2LessonsLoadCorrectly:
+    """Layer-2 lessons are accessible via get_lesson_by_code()."""
+
+    def test_total_lesson_count_is_reasonable(self):
+        """get_all_lessons() returns at least 57 (Layer-1) lessons.
+
+        After Layer-2 integration, expect 100+ lessons total.
+        If count drops below 57, the Layer-1 loader broke.
+        If count drops below 100, Layer-2 loader broke.
+        """
+        lessons = get_all_lessons()
+        assert len(lessons) >= 57, (
+            f"get_all_lessons() returned {len(lessons)} lessons. "
+            f"Expected at least 57 (Layer-1 minimum). Layer-1 loader may be broken."
+        )
+        assert len(lessons) >= 100, (
+            f"get_all_lessons() returned {len(lessons)} lessons. "
+            f"Expected at least 100 (Layer-1 + Layer-2). Layer-2 loader may be broken."
+        )
+
+    def test_layer1_and_layer2_both_present(self):
+        """Both _layer=1 and _layer=2 lessons exist in the combined result."""
+        lessons = get_all_lessons()
+        layer1 = [l for l in lessons if l.get("_layer") == 1]
+        layer2 = [l for l in lessons if l.get("_layer") == 2]
+        assert len(layer1) >= 50, (
+            f"Only {len(layer1)} Layer-1 lessons found. Expected ~57."
+        )
+        assert len(layer2) >= 50, (
+            f"Only {len(layer2)} Layer-2 lessons found. Expected ~100+."
+        )
+
+    def test_layer2_lesson_accessible_by_code(self):
+        """get_lesson_by_code() returns a Layer-2 lesson (G6-L11 is Layer-2 only)."""
+        # G6-L11 exists only in Layer-2 (_parsed_2026-05-01/) — not in L*.yml
+        lesson = get_lesson_by_code("G6-L11")
+        assert lesson is not None, (
+            "get_lesson_by_code('G6-L11') returned None. "
+            "Expected a Layer-2 lesson. "
+            "Was the Layer-2 loader broken or the shadow-fix reverted? (Issue #1666)"
+        )
+        assert lesson.get("_layer") == 2, (
+            f"G6-L11 should be _layer=2, got {lesson.get('_layer')}."
+        )
+
+    def test_layer2_lesson_has_required_fields(self):
+        """Layer-2 lessons have id, title, grade_code, paragraphs fields."""
+        lesson = get_lesson_by_code("G6-L11")
+        if lesson is None:
+            pytest.skip("G6-L11 not available — skipping field check")
+
+        assert "id" in lesson, "Layer-2 lesson missing 'id' field"
+        assert isinstance(lesson["id"], int), f"id must be int, got {type(lesson['id'])}"
+        assert lesson["id"] >= _LAYER2_ID_OFFSET, (
+            f"Layer-2 lesson id={lesson['id']} should be >= {_LAYER2_ID_OFFSET}. "
+            f"Synthetic ID formula: display_order + {_LAYER2_ID_OFFSET}."
+        )
+
+        assert "title" in lesson and lesson["title"], "Layer-2 lesson missing/empty 'title'"
+        assert "grade_code" in lesson and lesson["grade_code"], "Layer-2 lesson missing 'grade_code'"
+        assert "paragraphs" in lesson, "Layer-2 lesson missing 'paragraphs' field"
+
+    def test_layer1_lesson_still_accessible_by_code(self):
+        """Layer-1 lesson (G6-L10 has L*.yml) is still accessible after Layer-2 merge."""
+        # G6-L10 (末日種子庫) exists in backend/data/lessons/ as a Layer-1 YAML.
+        lesson = get_lesson_by_code("G6-L10")
+        assert lesson is not None, (
+            "get_lesson_by_code('G6-L10') returned None. "
+            "Layer-1 lesson access broken — shadow-fix may have overwritten Layer-1 index."
+        )
+        assert lesson.get("_layer") == 1, (
+            f"G6-L10 should be _layer=1 (takes precedence over Layer-2), "
+            f"got {lesson.get('_layer')}."
+        )
+
+    def test_layer1_takes_precedence_over_layer2(self):
+        """When both layers have the same curriculum slot, Layer-1 wins."""
+        # G6-L10 appears in both Layer-1 (L*.yml) and potentially Layer-2 (_parsed/).
+        # Layer-1 must win (dedup by title).
+        lesson = get_lesson_by_code("G6-L10")
+        if lesson is None:
+            pytest.skip("G6-L10 not found — skipping precedence check")
+        assert lesson.get("_layer") == 1, (
+            f"G6-L10 returned _layer={lesson.get('_layer')}. "
+            f"Layer-1 should always take precedence over Layer-2 for the same slot."
+        )
+
+
+class TestLayer2StepSequence:
+    """Layer-2 lessons respect step_sequence from YAML if present."""
+
+    def test_layer1_lesson_with_step_sequence_has_it(self):
+        """G6-L10 has step_sequence in its Layer-1 YAML (added by #1374)."""
+        lesson = get_lesson_by_code("G6-L10")
+        if lesson is None:
+            pytest.skip("G6-L10 not found")
+        # G6-L10 has step_sequence set in its YAML
+        seq = lesson.get("step_sequence")
+        assert seq is not None, (
+            "G6-L10 should have step_sequence from its Layer-1 YAML. "
+            "Was the YAML modified?"
+        )
+        assert isinstance(seq, list), f"step_sequence must be a list, got {type(seq)}"
+        assert len(seq) >= 5, (
+            f"step_sequence has only {len(seq)} steps. Expected at least 5."
+        )
+        # Intro must be first
+        assert seq[0] == "intro", f"step_sequence[0] should be 'intro', got {seq[0]!r}"
+
+    def test_layer2_lesson_step_sequence_is_none_or_list(self):
+        """Layer-2 lesson step_sequence is either None (default) or a valid list."""
+        lesson = get_lesson_by_code("G6-L11")
+        if lesson is None:
+            pytest.skip("G6-L11 not found")
+        seq = lesson.get("step_sequence")
+        # step_sequence can be None (frontend uses DEFAULT_STEP_SEQUENCE) or a list
+        assert seq is None or isinstance(seq, list), (
+            f"G6-L11 step_sequence must be None or list, got {type(seq)}: {seq}"
+        )
+
+
+class TestLessonLoaderBoundaryConditions:
+    """Edge cases in lesson loader that were fixed in Issue #1666."""
+
+    def test_get_lesson_by_code_unknown_returns_none(self):
+        """get_lesson_by_code() returns None for unknown codes."""
+        result = get_lesson_by_code("G99-L99")
+        assert result is None, (
+            f"get_lesson_by_code('G99-L99') should return None, got {result}"
+        )
+
+    def test_get_lesson_by_code_empty_string_returns_none(self):
+        """get_lesson_by_code('') returns None without crashing."""
+        result = get_lesson_by_code("")
+        assert result is None, (
+            f"get_lesson_by_code('') should return None, got {result}"
+        )
+
+    def test_layer2_lessons_have_synthetic_integer_ids(self):
+        """All Layer-2 lesson ids are integers >= 1001 (offset 1000 + display_order >= 1)."""
+        lessons = get_all_lessons()
+        layer2 = [l for l in lessons if l.get("_layer") == 2]
+        assert len(layer2) > 0, "No Layer-2 lessons found"
+        for lesson in layer2:
+            lesson_id = lesson.get("id")
+            assert isinstance(lesson_id, int), (
+                f"Layer-2 lesson {lesson.get('lesson_code')!r} has non-int id: {lesson_id!r}"
+            )
+            assert lesson_id >= _LAYER2_ID_OFFSET + 1, (
+                f"Layer-2 lesson {lesson.get('lesson_code')!r} has id={lesson_id}, "
+                f"expected >= {_LAYER2_ID_OFFSET + 1} (offset + min display_order 1)."
+            )
+
+    def test_no_more_than_ten_duplicate_lesson_codes(self):
+        """Duplicate lesson codes should be minimal (< 10).
+
+        Some Layer-1 / Layer-2 overlaps have slightly different titles
+        (e.g. punctuation differences: '拳力出擊' vs '「拳」力出擊')
+        which bypass the title-dedup logic. These are known and tracked.
+
+        This test guards against a mass regression (e.g. dedup logic broken
+        across all lessons) while tolerating the known small set of overlaps.
+        """
+        lessons = get_all_lessons()
+        codes = [l.get("lesson_code", "") for l in lessons if l.get("lesson_code")]
+        from collections import Counter
+        duplicates = [c for c, cnt in Counter(codes).items() if cnt > 1]
+        assert len(duplicates) < 10, (
+            f"Too many duplicate lesson codes ({len(duplicates)}): {duplicates}. "
+            f"Expected < 10 known overlaps. "
+            f"Layer-2 dedup-by-title logic may be broken."
+        )
+
+    def test_no_duplicate_lesson_ids(self):
+        """All lesson ids are unique across both layers."""
+        lessons = get_all_lessons()
+        ids = [l.get("id") for l in lessons if l.get("id") is not None]
+        duplicates = [i for i in set(ids) if ids.count(i) > 1]
+        assert not duplicates, (
+            f"Duplicate lesson id(s) found: {duplicates}. "
+            f"Layer-2 synthetic ID formula or Layer-1 lesson_number collision."
+        )

--- a/backend/tests/test_regression_llm_models_per_task_1734.py
+++ b/backend/tests/test_regression_llm_models_per_task_1734.py
@@ -1,0 +1,177 @@
+"""Regression tests for per-task LLM model config — Issue #1734 / PR #1735.
+
+Guards against accidental model reassignment in llm_models.py.
+
+Key decisions locked by these tests:
+  - omo_grader MUST stay on gemini-2.5-flash @ us-central1 (Issue #1730)
+    Reason: lettered-circle spatial reasoning accuracy 5/5 vs 1/5 with flash-lite
+  - omo_identifier moved to gemini-flash-lite-latest @ global (Issue #1729)
+    Reason: 15/16 accuracy parity with 2.5-flash, faster + cheaper
+  - 8 text/JSON generation tasks moved to gemini-2.5-flash-lite @ global (Issue #1744)
+    Reason: 3/3 complete quality parity, 29-49% faster, 22-46% cheaper
+
+Run:
+    cd backend && python -m pytest tests/test_regression_llm_models_per_task_1734.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from app.services.llm_models import TASK_MODELS, get_model_for_task
+
+
+class TestTaskModelsRegistry:
+    """TASK_MODELS dict must contain all expected tasks with correct assignments."""
+
+    EXPECTED_TASKS = [
+        "socratic_question",
+        "socratic_agent_process",
+        "comprehension_score",
+        "sentence_validate",
+        "exit_ticket_generate",
+        "example_sentences",
+        "story_structure",
+        "reading_analysis",
+        "teacher_comment",
+        "omo_identifier",
+        "omo_grader",
+    ]
+
+    def test_all_expected_tasks_registered(self):
+        """TASK_MODELS must contain all 11 expected tasks."""
+        for task in self.EXPECTED_TASKS:
+            assert task in TASK_MODELS, (
+                f"Task {task!r} missing from TASK_MODELS. "
+                f"This was added in Issue #1734 and must not be removed."
+            )
+
+    def test_task_count_is_at_least_11(self):
+        """TASK_MODELS must have at least 11 entries."""
+        assert len(TASK_MODELS) >= 11, (
+            f"TASK_MODELS has only {len(TASK_MODELS)} entries. "
+            f"Expected at least 11 (Issue #1734)."
+        )
+
+    def test_each_task_has_model_and_location(self):
+        """Every TASK_MODELS entry must be a (model, location) tuple with non-empty strings."""
+        for task, value in TASK_MODELS.items():
+            assert isinstance(value, tuple), f"Task {task!r}: value must be a tuple, got {type(value)}"
+            assert len(value) == 2, f"Task {task!r}: tuple must have exactly 2 elements (model, location)"
+            model, location = value
+            assert isinstance(model, str) and model, f"Task {task!r}: model must be non-empty string"
+            assert isinstance(location, str) and location, f"Task {task!r}: location must be non-empty string"
+
+
+class TestOmoGraderLock:
+    """omo_grader is LOCKED on gemini-2.5-flash @ us-central1 — Issue #1730.
+
+    DO NOT change this assignment. Spatial reasoning accuracy:
+      gemini-2.5-flash: lettered circles 5/5
+      gemini-flash-lite: lettered circles 1/5 (catastrophic failure)
+    """
+
+    def test_omo_grader_uses_gemini_25_flash(self):
+        """omo_grader must use gemini-2.5-flash (NOT flash-lite, NOT 3.x)."""
+        model, location = get_model_for_task("omo_grader")
+        assert model == "gemini-2.5-flash", (
+            f"omo_grader model is {model!r}. "
+            f"LOCKED on 'gemini-2.5-flash' per Issue #1730. "
+            f"DO NOT change — lettered circle accuracy drops from 5/5 to 1/5 with flash-lite."
+        )
+
+    def test_omo_grader_location_is_us_central1(self):
+        """omo_grader must be in us-central1 for Gemini 2.5 availability."""
+        model, location = get_model_for_task("omo_grader")
+        assert location == "us-central1", (
+            f"omo_grader location is {location!r}. "
+            f"Must be 'us-central1' per Issue #1730 (Gemini 2.5 Flash requires regional endpoint)."
+        )
+
+    def test_get_model_for_task_omo_grader_returns_correct_tuple(self):
+        """get_model_for_task('omo_grader') returns the locked tuple."""
+        result = get_model_for_task("omo_grader")
+        assert result == ("gemini-2.5-flash", "us-central1"), (
+            f"omo_grader returned {result!r}. Expected ('gemini-2.5-flash', 'us-central1')."
+        )
+
+
+class TestOmoIdentifierAssignment:
+    """omo_identifier moved to gemini-flash-lite-latest @ global — Issue #1729.
+
+    A/B test result: 15/16 accuracy parity with 2.5-flash.
+    """
+
+    def test_omo_identifier_uses_flash_lite_latest(self):
+        """omo_identifier must use gemini-flash-lite-latest."""
+        model, location = get_model_for_task("omo_identifier")
+        assert model == "gemini-flash-lite-latest", (
+            f"omo_identifier model is {model!r}. "
+            f"Expected 'gemini-flash-lite-latest' per Issue #1729 A/B result."
+        )
+
+    def test_omo_identifier_location_is_global(self):
+        """omo_identifier uses global endpoint (no regional routing needed for flash-lite)."""
+        model, location = get_model_for_task("omo_identifier")
+        assert location == "global", (
+            f"omo_identifier location is {location!r}. Expected 'global'."
+        )
+
+
+class TestTextGenerationTasksUseFlashLite:
+    """8 text/JSON generation tasks must use gemini-2.5-flash-lite @ global — Issue #1744.
+
+    Each task was A/B tested: 3/3 quality complete, 29-49% faster, 22-46% cheaper.
+    """
+
+    FLASH_LITE_TASKS = [
+        "socratic_question",
+        "socratic_agent_process",
+        "comprehension_score",
+        "sentence_validate",
+        "exit_ticket_generate",
+        "example_sentences",
+        "story_structure",
+        "reading_analysis",
+        "teacher_comment",
+    ]
+
+    def test_all_flash_lite_tasks_use_correct_model(self):
+        """All text/JSON generation tasks must use gemini-2.5-flash-lite."""
+        for task in self.FLASH_LITE_TASKS:
+            model, location = get_model_for_task(task)
+            assert model == "gemini-2.5-flash-lite", (
+                f"Task {task!r} model is {model!r}. "
+                f"Expected 'gemini-2.5-flash-lite' per Issue #1744 A/B result."
+            )
+
+    def test_all_flash_lite_tasks_use_global_location(self):
+        """All text/JSON generation tasks must use global endpoint."""
+        for task in self.FLASH_LITE_TASKS:
+            model, location = get_model_for_task(task)
+            assert location == "global", (
+                f"Task {task!r} location is {location!r}. Expected 'global'."
+            )
+
+
+class TestGetModelForTaskErrorHandling:
+    """get_model_for_task raises KeyError for unknown tasks."""
+
+    def test_unknown_task_raises_key_error(self):
+        """Unknown task must raise KeyError, not return None or default."""
+        with pytest.raises(KeyError) as exc_info:
+            get_model_for_task("unknown_task_that_does_not_exist")
+        assert "unknown_task_that_does_not_exist" in str(exc_info.value)
+
+    def test_empty_string_task_raises_key_error(self):
+        """Empty string task must raise KeyError."""
+        with pytest.raises(KeyError):
+            get_model_for_task("")
+
+    def test_typo_in_task_name_raises_key_error(self):
+        """Common typo variants must raise KeyError (not silently return wrong model)."""
+        for typo in ["socratic", "omo-grader", "OMO_GRADER", "comprehension"]:
+            with pytest.raises(KeyError):
+                get_model_for_task(typo)

--- a/backend/tests/test_regression_thinking_budget_1738.py
+++ b/backend/tests/test_regression_thinking_budget_1738.py
@@ -1,0 +1,159 @@
+"""Regression tests for thinking_budget=0 enforcement — Issue #1738 / PR #1739.
+
+Static analysis test: reads source files and asserts that
+thinking_budget=0 (or equivalent) is present in each production LLM call site.
+
+Why thinking_budget=0 matters:
+  Gemini 2.5 Flash (and Flash-Lite) have "thinking" enabled by default.
+  Thinking increases latency and token cost with no quality benefit for
+  structured JSON generation tasks (scored 3/3 equivalent without thinking).
+  Setting thinking_budget=0 disables extended thinking, saving ~30-50% cost.
+
+Files guarded by this test:
+  - ai_comprehension.py  (comprehension scoring, socratic questions)
+  - omo_identifier.py    (worksheet image identification)
+  - tts_service.py       (TTS generation config)
+  - ai_base.py           (base LLM call utility)
+  - omo_grader.py        (OMO answer grading)
+
+Run:
+    cd backend && python -m pytest tests/test_regression_thinking_budget_1738.py -v
+"""
+
+import sys
+import os
+import re
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Resolve the backend/app/services directory relative to this test file
+_SERVICES_DIR = Path(__file__).parent.parent / "app" / "services"
+
+# Files that must have thinking_budget=0 in their GenerateContentConfig calls.
+# Each entry: (relative_path, description_for_error_message)
+_GUARDED_FILES = [
+    ("ai_comprehension.py", "comprehension scoring / socratic question generation"),
+    ("omo_identifier.py", "OMO worksheet image identification"),
+    ("tts_service.py", "TTS content generation config"),
+    ("ai_base.py", "base LLM call utility used by most services"),
+    ("omo_grader.py", "OMO answer grading — Issue #1717"),
+]
+
+# Pattern that must appear in each file.
+# Matches: thinking_budget=0  OR  thinking_budget = 0
+_THINKING_BUDGET_PATTERN = re.compile(r"thinking_budget\s*=\s*0")
+
+# Pattern for GenerateContentConfig — confirms the file actually makes LLM calls.
+_GENERATE_CONTENT_CONFIG_PATTERN = re.compile(r"GenerateContentConfig")
+
+
+class TestThinkingBudgetEnforcement:
+    """thinking_budget=0 must be present in all production LLM call sites."""
+
+    def _read_service_file(self, filename: str) -> str:
+        path = _SERVICES_DIR / filename
+        assert path.exists(), (
+            f"Service file {filename!r} not found at {path}. "
+            f"Was it renamed or moved? Update this test."
+        )
+        return path.read_text(encoding="utf-8")
+
+    def test_ai_comprehension_has_thinking_budget_zero(self):
+        """ai_comprehension.py must set thinking_budget=0 in GenerateContentConfig."""
+        content = self._read_service_file("ai_comprehension.py")
+        assert _THINKING_BUDGET_PATTERN.search(content), (
+            "ai_comprehension.py does NOT contain thinking_budget=0. "
+            "This was fixed in Issue #1738. "
+            "Removing this causes extended thinking to run on every comprehension "
+            "scoring call, increasing latency and cost by ~30-50%."
+        )
+
+    def test_omo_identifier_has_thinking_budget_zero(self):
+        """omo_identifier.py must set thinking_budget=0 in GenerateContentConfig."""
+        content = self._read_service_file("omo_identifier.py")
+        assert _THINKING_BUDGET_PATTERN.search(content), (
+            "omo_identifier.py does NOT contain thinking_budget=0. "
+            "This was fixed in Issue #1738. "
+            "Extended thinking on identifier calls wastes tokens with no accuracy gain."
+        )
+
+    def test_tts_service_has_thinking_budget_zero(self):
+        """tts_service.py must set thinking_budget=0 in GenerateContentConfig."""
+        content = self._read_service_file("tts_service.py")
+        assert _THINKING_BUDGET_PATTERN.search(content), (
+            "tts_service.py does NOT contain thinking_budget=0. "
+            "This was fixed in Issue #1738. "
+            "TTS generation is deterministic and never benefits from thinking."
+        )
+
+    def test_ai_base_has_thinking_budget_zero(self):
+        """ai_base.py must set thinking_budget=0 in its GenerateContentConfig."""
+        content = self._read_service_file("ai_base.py")
+        assert _THINKING_BUDGET_PATTERN.search(content), (
+            "ai_base.py does NOT contain thinking_budget=0. "
+            "This was fixed in Issue #1738. "
+            "ai_base.py is the shared LLM call utility — missing this setting "
+            "would enable thinking for all tasks that use the base utility."
+        )
+
+    def test_omo_grader_has_thinking_budget_zero(self):
+        """omo_grader.py must set thinking_budget=0 (Issue #1717)."""
+        content = self._read_service_file("omo_grader.py")
+        assert _THINKING_BUDGET_PATTERN.search(content), (
+            "omo_grader.py does NOT contain thinking_budget=0. "
+            "This was fixed in Issue #1717 (predates #1738). "
+            "OMO grading uses vision — thinking does not improve spatial accuracy."
+        )
+
+
+class TestThinkingBudgetContext:
+    """Sanity checks: files actually make LLM calls (so thinking_budget matters)."""
+
+    def _read_service_file(self, filename: str) -> str:
+        path = _SERVICES_DIR / filename
+        return path.read_text(encoding="utf-8") if path.exists() else ""
+
+    def test_ai_comprehension_uses_generate_content_config(self):
+        """ai_comprehension.py uses GenerateContentConfig (confirms it makes LLM calls)."""
+        content = self._read_service_file("ai_comprehension.py")
+        assert _GENERATE_CONTENT_CONFIG_PATTERN.search(content), (
+            "ai_comprehension.py does not use GenerateContentConfig. "
+            "If the LLM call pattern changed, update this test."
+        )
+
+    def test_omo_identifier_uses_generate_content_config(self):
+        """omo_identifier.py uses GenerateContentConfig."""
+        content = self._read_service_file("omo_identifier.py")
+        assert _GENERATE_CONTENT_CONFIG_PATTERN.search(content), (
+            "omo_identifier.py does not use GenerateContentConfig."
+        )
+
+    def test_omo_grader_uses_generate_content_config(self):
+        """omo_grader.py uses GenerateContentConfig."""
+        content = self._read_service_file("omo_grader.py")
+        assert _GENERATE_CONTENT_CONFIG_PATTERN.search(content), (
+            "omo_grader.py does not use GenerateContentConfig."
+        )
+
+    def test_all_guarded_files_exist(self):
+        """All guarded service files must exist (catches file rename/deletion)."""
+        for filename, description in _GUARDED_FILES:
+            path = _SERVICES_DIR / filename
+            assert path.exists(), (
+                f"Service file {filename!r} ({description}) not found at {path}. "
+                f"If the file was renamed, update _GUARDED_FILES in this test."
+            )
+
+    def test_thinking_budget_count_per_file(self):
+        """Each guarded file should have at least 1 thinking_budget=0 occurrence."""
+        for filename, description in _GUARDED_FILES:
+            path = _SERVICES_DIR / filename
+            if not path.exists():
+                continue
+            content = path.read_text(encoding="utf-8")
+            matches = _THINKING_BUDGET_PATTERN.findall(content)
+            assert len(matches) >= 1, (
+                f"{filename} has 0 occurrences of thinking_budget=0. "
+                f"Expected at least 1 (Issue #1738)."
+            )

--- a/docs/qa/qa-plan.md
+++ b/docs/qa/qa-plan.md
@@ -1,0 +1,200 @@
+# LingoLeap QA Strategy Plan
+
+**Created**: 2026-05-20  
+**Issue**: #1757 — 固化功能 + 測試  
+**Scope**: Backend pytest suite. No frontend tests (low ROI per project memory). No `.github/workflows/` changes.
+
+---
+
+## Section 1: 3-Tier Testing Strategy
+
+Mirrors `~/.claude/rules/testing-strategy.md` adapted to this project.
+
+### Tier 1 — Type + Lint (pre-commit, seconds)
+
+| Tool | Config | When |
+|------|--------|------|
+| mypy | `backend/mypy.ini` (if present) or inline | pre-commit |
+| ruff | `backend/pyproject.toml` ruff section | pre-commit |
+| detect-secrets / gitleaks | `.gitleaks.toml` | pre-commit |
+
+**Cost**: ~5 s per run. Catches: typos, wrong argument types, secret leaks.  
+**Does NOT catch**: runtime schema errors, LLM config drift, lesson loader regressions.
+
+### Tier 2 — API Contract Tests + Unit Tests (pytest, CI gate)
+
+The primary automated quality layer for this project.
+
+**Two sub-types**:
+
+- **API contract tests** — spin up `TestClient(app)` with SQLite in-memory DB, assert HTTP status + JSON schema shape. Pattern: `test_omo_lessons.py`, `test_auth_api.py`.
+- **Unit/service tests** — call Python functions directly without HTTP. Pattern: `test_fill_in_blank_normalization.py`, new regression tests (this issue).
+
+**Run command**:
+```bash
+cd backend && python -m pytest tests/ -q --ignore=tests/test_omo_real_upload_integration.py --ignore=tests/test_omo_grader_real.py
+```
+
+**Baseline (2026-05-20)**:
+- 2182 tests collected
+- 1810 passed, 228 failed, 125 errors, 31 warnings
+- Runtime: ~632 s (10.5 min)
+- Pre-existing failures: `test_admin_api`, `test_step_progress_api`, `test_teacher_dashboard_n1` — NOT introduced by this issue
+
+### Tier 3 — AI Browser QA (gstack /qa or /browse, post-deploy)
+
+Run manually after each staging deploy using gstack `/qa` (automated test-fix-verify loop) or `/browse` (headless screenshot assertions).
+
+**Scope**: student reading flow end-to-end, OMO upload/grade cycle, teacher dashboard loading.  
+**NOT automated in CI** — per Young decision (E2E Playwright disabled, `e2e-tests.yml.disabled`).
+
+---
+
+## Section 2: Current Coverage Audit (2026-05-20)
+
+### Backend tests
+
+```
+pytest backend/tests/ --collect-only -q
+→ 2182 tests collected (113 test files, excluding 2 real-integration files)
+
+pytest backend/tests/ -q (full run)
+→ 1810 passed / 228 failed / 125 errors
+→ Runtime: 632 s
+```
+
+**Pre-existing failure categories** (not introduced by recent PRs):
+- `test_admin_api.py::TestGetUserDetail::test_get_detail_works_for_org_admin` — org-admin permission regression
+- `test_step_progress_api.py` — 8 errors (likely DB schema migration issue in SQLite env)
+- `test_teacher_dashboard_n1.py` — 6 errors (N+1 query fixture issue)
+
+### Frontend tests
+
+Per project memory: **low ROI — 866 commits only caught 2 bugs**. Not tracked in this plan. `e2e-tests.yml` is disabled by design.
+
+---
+
+## Section 3: Critical Path Coverage Matrix
+
+| Service Area | Coverage Status | Key Test Files |
+|---|---|---|
+| Auth (login / token / refresh / verify) | HAS-TEST | `test_auth_api.py`, `test_auth_token_gate.py`, `test_rate_limiting.py` |
+| LearningSession (CRUD / step_progress) | HAS-TEST (partial) | `test_learning_sessions_api.py`, `test_step_progress_parse.py` |
+| LearningSession step_progress API | PARTIAL (errors in test_step_progress_api.py) | `test_step_progress_api.py` — pre-existing errors |
+| Lessons Layer-1 (catalog / get_lesson_by_id) | HAS-TEST | `test_stories_api.py`, `test_story_crud.py` |
+| Lessons Layer-2 (shadow merge / get_lesson_by_code) | NO-TEST | **Gap — regression test added this PR** |
+| Fill-in-blank schema (legacy vs context_fill) | HAS-TEST | `test_fill_in_blank_normalization.py` |
+| Fill-in-blank alignment (sentence + answer + vocab_bank) | NO-TEST | **Gap — regression test added this PR** |
+| LLM per-task model config (`llm_models.py`) | NO-TEST | **Gap — regression test added this PR** |
+| LLM thinking_budget=0 enforcement | NO-TEST | **Gap — regression test added this PR** |
+| OMO upload / identify | HAS-TEST | `test_omo_upload.py`, `test_omo_dedup.py` |
+| OMO grader | HAS-TEST (real integration skipped) | `test_omo_grader_real.py` (real mark, skipped in CI) |
+| OMO lessons list | HAS-TEST | `test_omo_lessons.py` |
+| TTS (provider switch / Azure / Gemini) | HAS-TEST | `test_tts_service.py`, `test_tts_auth.py` |
+| Gamification (XP / achievements) | HAS-TEST | `test_gamification.py`, `test_points_system.py` |
+| Assignments / Classrooms | HAS-TEST | `test_assignments.py`, `test_classrooms_api.py` |
+| Teacher dashboard | HAS-TEST (partial, some errors) | `test_teacher_api.py`, `test_teacher_dashboard_n1.py` |
+| Privacy / Audit | HAS-TEST | `test_privacy_api.py`, `test_audit_logger.py` |
+| Security headers | HAS-TEST | `test_security_headers.py`, `test_security_fixes.py` |
+| Socratic agent (question / circuit breaker) | HAS-TEST | `test_ai_endpoints.py`, `test_ai_analysis.py` |
+| LLM rate limiting | HAS-TEST | `test_llm_rate_limits.py` |
+| JSON repair fallback | HAS-TEST | `test_json_repair.py` |
+
+**Summary**: 3 critical gaps identified — all addressed in Section 4.
+
+---
+
+## Section 4: Recent-Fix Regression Test Gaps
+
+The following PRs were merged recently. For each: does a regression test exist? If not, proposal.
+
+| PR / Issue | Description | Regression Test Exists? | Notes |
+|---|---|---|---|
+| #1675 / PR #1678 | fill_in_blank schema alignment (6 Layer-1 lessons) | PARTIAL — `test_fill_in_blank_normalization.py` tests normalizer logic but NOT actual YAML data values | **Gap**: no test that reads real YAML and asserts `sentence` + `answer` + vocab_bank coherence |
+| #1729 / PR #1733 | OMO identifier model swap to flash-lite | NO | Model config not tested anywhere |
+| #1730 | Grader spatial reasoning lock on 2.5-flash | NO | Same gap — `TASK_MODELS["omo_grader"]` never asserted |
+| #1734 / PR #1735 | Per-task `llm_models.py` config (11 tasks) | NO | **High risk**: anyone can accidentally change a model assignment |
+| #1738 / PR #1739 | `thinking_budget=0` on ai_comprehension, omo_identifier, tts_service | NO | Static regression: should fail if someone removes the setting |
+| #1744 / PR #1747 | 2.5-flash-lite swap for 8 text/JSON generation tasks | NO | Covered by #1734 regression test |
+| #1753 / PR #1754 | 127 Layer-2 fill_in_blank align (sentence + answer + vocab_bank) | NO | **Critical**: 127 lessons, any YAML corruption → broken exercise |
+
+**Tests added in this PR**: A (llm_models), B (thinking_budget), C (fill_in_blank schema), D (layer2 shadow merge) — covering 4 of the 5 gap areas.
+
+---
+
+## Section 5: 7-Day Test Addition Roadmap
+
+| Priority | Test File | What It Catches | Effort |
+|---|---|---|---|
+| P0 | `test_regression_llm_models_per_task_1734.py` | Model assignment drift for 11 tasks + omo_grader lock | 30 min — **added this PR** |
+| P0 | `test_regression_thinking_budget_1738.py` | thinking_budget=0 removal from 5 prod files | 20 min — **added this PR** |
+| P0 | `test_regression_fill_in_blank_schema_1675.py` | sentence/answer/vocab_bank coherence in Layer-1 YAMLs | 30 min — **added this PR** |
+| P0 | `test_regression_layer2_shadow_merge_1666.py` | Layer-2 lesson loading, get_lesson_by_code coverage | 30 min — **added this PR** |
+| P1 | `test_regression_layer2_fill_in_blank_1753.py` | 127 Layer-2 YAMLs fill_in_blank structure | 45 min — next sprint |
+| P1 | `test_regression_omo_model_lock.py` | OMO grader stays on 2.5-flash if future A/B changes omo_identifier | 20 min — next sprint |
+| P2 | Fix `test_step_progress_api.py` pre-existing errors | Step progress API reliability | 60 min — needs DB schema investigation |
+| P2 | `test_regression_socratic_circuit_breaker.py` | 3-error → RuntimeError → 503 (currently no contract test) | 45 min |
+| P3 | `test_regression_tts_provider_switch.py` | TTS provider fallback chain (Azure → Gemini → error) | 30 min |
+| P3 | Fix `test_admin_api.py` org-admin permission failure | Org-admin role scope regression | 45 min |
+
+---
+
+## Section 6: Definition of Done (Per Test Type)
+
+### API Contract Test
+- HTTP status code matches expected (200 / 401 / 403 / 422)
+- JSON response shape has required fields (not just non-null)
+- Types are correct (int, str, list, bool)
+- At least 1 item in list responses when data exists
+
+### Schema Validation Test (unit)
+- Required fields present in every item
+- Type assertions on each field
+- Cross-reference assertions (e.g. `answer` letter is a key in `vocab_bank`)
+- Sentinel values not present (e.g. `None` where string expected)
+
+### Regression Test
+- Test assertion **would fail** on the pre-fix codebase state
+- Test assertion **passes** on the post-fix codebase state
+- File name includes issue number: `test_regression_*_NNNN.py`
+- Self-contained: no network, no real DB, no LLM calls
+- Runs in < 5 s
+
+### Static Analysis Test
+- Reads source files via `open()` + regex / AST
+- Asserts presence of specific patterns
+- No import side effects from the tested module
+- Documents the exact line/pattern being guarded
+
+---
+
+## Section 7: Skip List (Low ROI — Won't Write)
+
+| Category | Reason |
+|---|---|
+| Unit tests for trivial getters / setters | Type checker catches these; AI development makes them maintenance burden |
+| Frontend visual diff tests | Use `/qa` screenshot for visual verification; 866 commits only caught 2 bugs |
+| Full E2E Playwright suite | Disabled by design (`e2e-tests.yml.disabled`); too slow for CI |
+| LLM-call integration tests (actual Gemini calls) | Non-deterministic, requires Vertex AI auth, slow — mock instead |
+| TTS audio quality tests | Subjective, requires audio playback; contract test on HTTP 200 sufficient |
+| Performance benchmark tests | Use `test_perf_sql_aggregates.py` pattern only for proven N+1 regressions |
+| Migration schema tests | Use `alembic check` in CI instead of pytest |
+
+---
+
+## Appendix: Running Regression Tests
+
+```bash
+# Run only new regression tests (fast, < 30 s)
+cd backend && python -m pytest tests/test_regression_*.py -v
+
+# Run full suite (skip real integration tests)
+cd backend && python -m pytest tests/ -q \
+  --ignore=tests/test_omo_real_upload_integration.py \
+  --ignore=tests/test_omo_grader_real.py
+
+# Run a specific test file
+cd backend && python -m pytest tests/test_regression_llm_models_per_task_1734.py -v
+```
+
+**Expected regression test runtime**: < 5 s per file, < 30 s total for all 4 files.


### PR DESCRIPTION
Fixes #1757

## Summary

- **\`docs/qa/qa-plan.md\`** (200 lines): 3-tier testing strategy, baseline audit (2182 tests / 1810 pass), critical path coverage matrix, gap analysis for 7 recent PRs, 7-day roadmap, skip list, and definition of done per test type
- **4 regression test files** (46 tests, 5.4 s total): guards against model assignment drift, thinking_budget removal, fill_in_blank data corruption, and Layer-2 lesson loader regression

## Test files added

| File | Tests | What it catches |
|---|---|---|
| \`test_regression_llm_models_per_task_1734.py\` | 13 | TASK_MODELS has all 11 tasks; omo_grader LOCKED on gemini-2.5-flash@us-central1 (#1730); omo_identifier on flash-lite-latest@global (#1729); 9 generation tasks on flash-lite@global (#1744); KeyError on unknown task |
| \`test_regression_thinking_budget_1738.py\` | 10 | Static analysis: all 5 prod service files have thinking_budget=0 in GenerateContentConfig. Catches future removal. |
| \`test_regression_fill_in_blank_schema_1675.py\` | 13 | The 6 lessons fixed by #1675 have answer letters matching vocab_bank keys; _schema normalizer tag applied; global Layer-1 invariant |
| \`test_regression_layer2_shadow_merge_1666.py\` | 10 | Layer-2 lessons accessible via get_lesson_by_code(); Layer-1 precedence holds; synthetic IDs correct; no mass duplicate codes |

## Baseline (pre-existing failures, not introduced here)

```
2182 tests collected
1810 passed / 228 failed / 125 errors
Pre-existing: test_admin_api, test_step_progress_api, test_teacher_dashboard_n1
```

## Constraints satisfied

- NO .github/workflows/ changes
- NO frontend test changes
- NO LLM-call integration tests (static / config dict only)
- NO refactoring of existing tests
- All 4 files: backend/tests/test_regression_*.py
- Single PR

🤖 Generated with Claude Code