### PR TITLE
fix(auth): staging register skip 'check email' screen — auto-verified

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -161,8 +161,9 @@ def register(req: RegisterRequest, request: Request, db: Session = Depends(get_d
             verification_token=verification_token if settings.is_dev else None,
         )
     return RegisterResponse(
-        message="註冊成功！",
+        message="註冊成功！此環境帳號已自動驗證，請直接登入。",
         verification_token=None,
+        auto_verified=True,
     )
 
 

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -36,6 +36,10 @@ class RegisterResponse(BaseModel):
     # Dev/staging mode: token returned directly so the flow can be tested without email.
     # In production this field would be omitted and the token sent via email only.
     verification_token: str | None = None
+    # True when REQUIRE_EMAIL_VERIFICATION=false (staging/preview) — account is
+    # auto-verified and user can log in immediately. Frontend uses this to skip
+    # the "check your email" waiting screen (no email pipeline implemented yet).
+    auto_verified: bool = False
 
 
 class ResendVerificationRequest(BaseModel):

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -59,7 +59,13 @@ const RegisterPage: React.FC<RegisterPageProps> = ({ onSwitchToLogin }) => {
     setIsSubmitting(true);
     try {
       const result = await register(email.trim(), password, name.trim());
-      // Registration successful — user must verify email before logging in (issue #460)
+      // Staging/preview auto_verified=true → skip "check your email" screen, go straight to login
+      // (no email pipeline exists; account is already verified server-side)
+      if (result.auto_verified) {
+        navigate('/login', { replace: true, state: { autoVerifiedEmail: email.trim() } });
+        return;
+      }
+      // Production flow: user must verify email before logging in (issue #460)
       setRegisteredEmail(email.trim());
       if (result.verification_token) {
         setDevToken(result.verification_token);

--- a/frontend/src/services/authApi.ts
+++ b/frontend/src/services/authApi.ts
@@ -99,6 +99,8 @@ export interface RegisterResponse {
   message: string;
   /** Dev/staging mode only: token returned directly for testing. Null in production. */
   verification_token: string | null;
+  /** True when REQUIRE_EMAIL_VERIFICATION=false (staging/preview) — skip verify screen. */
+  auto_verified?: boolean;
 }
 
 export async function register(


### PR DESCRIPTION
Jay教授 5/21 註冊後說沒收到驗證信。Root cause: staging 環境沒實作 email pipeline，REQUIRE_EMAIL_VERIFICATION=false → 帳號 auto-verified 但 UI 仍顯示「請檢查信箱」誤導 user。

## Change
- Backend RegisterResponse 加 auto_verified: bool
- Auto-verified path 設 auto_verified=true + message 更新
- Frontend 直接 redirect /login（passing email in state）
- Production flow 不變