### PR TITLE
refactor(models): add index=True to FK columns (Fixes #1769)

### DIFF
--- a/backend/app/models/ai_usage.py
+++ b/backend/app/models/ai_usage.py
@@ -12,7 +12,7 @@ class AIUsageLog(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    student_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    student_id = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
     user_role = Column(String(20))
     endpoint = Column(String(80))
     action = Column(String(30))

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -9,7 +9,7 @@ class Feedback(Base):
     __tablename__ = "feedbacks"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     category: Mapped[str] = mapped_column(String(50), nullable=False)  # "bug", "feature", "question", "other"
     title: Mapped[str] = mapped_column(String(200), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/parent_link.py
+++ b/backend/app/models/parent_link.py
@@ -34,11 +34,11 @@ class ParentInviteCode(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     code: Mapped[str] = mapped_column(String(12), unique=True, nullable=False, index=True)
-    student_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
-    created_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    student_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    created_by: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     used: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
-    used_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    used_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
     used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -61,8 +61,8 @@ class ParentStudentLink(Base):
     __table_args__ = (UniqueConstraint("parent_id", "student_id"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    parent_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
-    student_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    parent_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    student_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     linked_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/points_log.py
+++ b/backend/app/models/points_log.py
@@ -10,7 +10,7 @@ class OrganizationPointsLog(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     organization_id: Mapped[str] = mapped_column(String(36), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True)
-    user_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"), nullable=True)
+    user_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("users.id"), nullable=True, index=True)
     points_used: Mapped[int] = mapped_column(Integer, nullable=False)
     feature_type: Mapped[str] = mapped_column(String(50), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/models/school.py
+++ b/backend/app/models/school.py
@@ -25,13 +25,13 @@ class School(Base):
     name: Mapped[str] = mapped_column(String(200), nullable=False)
     domain: Mapped[str | None] = mapped_column(String(255), nullable=True, unique=True, index=True)
     organization_id: Mapped[str | None] = mapped_column(
-        ForeignKey("organizations.id"), nullable=True
+        ForeignKey("organizations.id"), nullable=True, index=True
     )
     display_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
     address: Mapped[str | None] = mapped_column(String(500), nullable=True)
     phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
     admin_user_id: Mapped[int | None] = mapped_column(
-        ForeignKey("users.id"), nullable=True
+        ForeignKey("users.id"), nullable=True, index=True
     )
     join_code: Mapped[str | None] = mapped_column(String(20), unique=True, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
@@ -59,7 +59,7 @@ class Classroom(Base):
     __tablename__ = "classrooms"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    school_id: Mapped[int] = mapped_column(ForeignKey("schools.id"), nullable=False)
+    school_id: Mapped[int] = mapped_column(ForeignKey("schools.id"), nullable=False, index=True)
     teacher_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     grade: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -109,9 +109,9 @@ class ClassroomTeacher(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     classroom_id: Mapped[int] = mapped_column(
-        ForeignKey("classrooms.id", ondelete="CASCADE"), nullable=False
+        ForeignKey("classrooms.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    teacher_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    teacher_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     # "primary" = owner (Classroom.teacher_id), "assistant" = co-teacher
     role: Mapped[str] = mapped_column(String(20), nullable=False, default="assistant")
     invited_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
@@ -131,11 +131,11 @@ class ClassroomText(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     classroom_id: Mapped[int] = mapped_column(
-        ForeignKey("classrooms.id", ondelete="CASCADE"), nullable=False
+        ForeignKey("classrooms.id", ondelete="CASCADE"), nullable=False, index=True
     )
     text_id: Mapped[str] = mapped_column(String(50), nullable=False)
     assigned_by: Mapped[int | None] = mapped_column(
-        ForeignKey("users.id"), nullable=True
+        ForeignKey("users.id"), nullable=True, index=True
     )
     assigned_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -106,7 +106,7 @@ class LearningSession(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     student_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False, index=True)
     text_id: Mapped[int | None] = mapped_column(ForeignKey("texts.id"), nullable=True, index=True)
-    classroom_id: Mapped[int | None] = mapped_column(ForeignKey("classrooms.id"), nullable=True)
+    classroom_id: Mapped[int | None] = mapped_column(ForeignKey("classrooms.id"), nullable=True, index=True)
     # DEPRECATED (#1188): story_slug is the legacy string key.  text_id FK is the
     # canonical source of truth.  Use story_slug_derived hybrid property for reads.
     # DO NOT write story_slug without also setting text_id.  Column will be dropped

--- a/backend/app/models/teacher_instruction.py
+++ b/backend/app/models/teacher_instruction.py
@@ -15,9 +15,9 @@ class TeacherInstruction(Base):
     __tablename__ = "teacher_instructions"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    teacher_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    student_id = Column(Integer, ForeignKey("users.id"), nullable=False)
-    classroom_id = Column(Integer, ForeignKey("classrooms.id"), nullable=False)
+    teacher_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    student_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    classroom_id = Column(Integer, ForeignKey("classrooms.id"), nullable=False, index=True)
     instruction_type = Column(String(50), default="general")  # general, reading, comprehension, vocabulary
     content = Column(Text, nullable=False)
     is_active = Column(Boolean, default=True)

--- a/backend/app/models/text.py
+++ b/backend/app/models/text.py
@@ -91,21 +91,21 @@ class Text(Base):
         index=True,
     )
     school_id: Mapped[int | None] = mapped_column(
-        ForeignKey("schools.id"), nullable=True
+        ForeignKey("schools.id"), nullable=True, index=True
     )
     class_id: Mapped[int | None] = mapped_column(
-        ForeignKey("classrooms.id"), nullable=True
+        ForeignKey("classrooms.id"), nullable=True, index=True
     )
     teacher_id: Mapped[int | None] = mapped_column(
-        ForeignKey("users.id"), nullable=True
+        ForeignKey("users.id"), nullable=True, index=True
     )
     created_by_id: Mapped[int | None] = mapped_column(
-        ForeignKey("users.id"), nullable=True
+        ForeignKey("users.id"), nullable=True, index=True
     )
 
     # === Fork/Copy ===
     forked_from_id: Mapped[int | None] = mapped_column(
-        ForeignKey("texts.id"), nullable=True
+        ForeignKey("texts.id"), nullable=True, index=True
     )
 
     # === Status ===

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -78,11 +78,11 @@ class UserRole(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
-    role_id: Mapped[int] = mapped_column(ForeignKey("roles.id"), nullable=False)
+    role_id: Mapped[int] = mapped_column(ForeignKey("roles.id"), nullable=False, index=True)
     scope_type: Mapped[str] = mapped_column(String(20), nullable=False)  # platform | organization | school
     scope_id: Mapped[str | None] = mapped_column(String(100), nullable=True)  # org UUID or school ID; platform = NULL
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
-    granted_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    granted_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True, index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
@@ -103,7 +103,7 @@ class StudentProfile(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), unique=True, nullable=False)
-    school_id: Mapped[int] = mapped_column(ForeignKey("schools.id"), nullable=False)
+    school_id: Mapped[int] = mapped_column(ForeignKey("schools.id"), nullable=False, index=True)
     student_number: Mapped[str | None] = mapped_column(String(20), nullable=True)
     birthdate: Mapped[date | None] = mapped_column(Date, nullable=True)
     password_changed: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)


### PR DESCRIPTION
Fixes #1769

## Summary

- Adds `index=True` to 27 ForeignKey columns across 9 model files to align SQLAlchemy ORM metadata with the DB indexes already created by migration `fk01idx02add03`
- No new migration needed — the DB indexes already exist; this is a model declaration correctness fix
- Alembic head remains single: `705ba7c6b659` (verified)

## Files changed

| File | Columns fixed |
|------|--------------|
| `ai_usage.py` | `student_id` |
| `feedback.py` | `user_id` |
| `parent_link.py` | `student_id`, `created_by`, `used_by`, `parent_id`, `student_id` |
| `points_log.py` | `user_id` |
| `school.py` | `organization_id`, `admin_user_id`, `school_id`, `classroom_id`, `teacher_id`, `assigned_by` |
| `session.py` | `classroom_id` |
| `teacher_instruction.py` | `teacher_id`, `student_id`, `classroom_id` |
| `text.py` | `school_id`, `class_id`, `teacher_id`, `created_by_id`, `forked_from_id` |
| `user.py` | `role_id`, `granted_by`, `school_id` |

## Test plan

- [x] `python3 -c "from app.models import Base; print(len(Base.metadata.tables), 'tables')"` → 47 tables loaded OK
- [x] `alembic heads` → single head `705ba7c6b659`
- [x] 123 tests passed across model-touching test files (teacher_instructions, feedback, parent_portal, classrooms, schools)
- [x] Pre-existing failures confirmed unrelated to this change (test_admin_api, test_ai_analysis — both fail on staging too)