### PR TITLE
fix(tts): 穩定 useTtsPlayback return ref + 凍住 caller 端 inline callback (#1780)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -34,6 +34,12 @@ function getFullReadingEncouragement(matchRate: number): { stars: number; text: 
   return { stars: tier.stars, text: tier.text, color: tier.color };
 }
 
+/* #1780: module-level noop so useTtsPlayback receives a stable callback ref
+ * across renders. Inline `() => {}` would be a new function every render,
+ * which invalidates the hook's useCallback deps and re-creates speakText,
+ * defeating the memoized return value's reference stability. */
+const NOOP = () => {};
+
 /* ------------------------------------------------------------------ */
 
 interface FullReadingProps {
@@ -166,7 +172,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
   /* ---- TTS playback (Cloud TTS + cursor animation, same as LiveTutor) ---- */
   const [speakingProgress, setSpeakingProgress] = useState(0);
   const [currentTtsParagraph, setCurrentTtsParagraph] = useState(-1);
-  const tts = useTtsPlayback(setSpeakingProgress, () => {});
+  const tts = useTtsPlayback(setSpeakingProgress, NOOP);
 
   /* Speak paragraph by paragraph to track which paragraph is highlighted */
   const ttsQueueRef = useRef<string[]>([]);

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -189,7 +189,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     setCurrentTtsParagraph(idx);
     setSpeakingProgress(0);
     tts.speakText(queue[idx]);
-  }, [tts]);
+  }, [tts.speakText]);
 
   const speakFullStory = useCallback(() => {
     ttsQueueRef.current = [...story.content];
@@ -213,7 +213,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     ttsQueueIdxRef.current = 0;
     setCurrentTtsParagraph(-1);
     setSpeakingProgress(0);
-  }, [tts]);
+  }, [tts.stopTts]);
 
   const isTtsPlaying = tts.isTtsSpeaking || currentTtsParagraph >= 0;
 

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -154,7 +154,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     async () => { throw new Error('handleSentenceRetryEval called before initialization'); }
   );
 
-  /* ---- TTS playback hook ---- */
+  /* ---- TTS playback hook ----
+   * #1780: pass stable callback refs so the hook's internal useCallback deps
+   * don't churn every render. setSpeakingProgress is already stable (React
+   * setter); the diff-clear closure is wrapped in useCallback. */
+  const handleRealtimeDiffClear = useCallback(() => setRealtimeDiffTokens(null), []);
   const {
     isTtsSpeaking,
     isTtsPaused,
@@ -168,10 +172,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     pauseTts,
     resumeTts,
     stopTts,
-  } = useTtsPlayback(
-    (pos) => setSpeakingProgress(pos),
-    () => setRealtimeDiffTokens(null),
-  );
+  } = useTtsPlayback(setSpeakingProgress, handleRealtimeDiffClear);
 
   /** Use Cloud TTS to read the current paragraph aloud.
    *  Passes lessonId + paragraphIdx so the TTS hook fetches canonical v2 sentences

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useMemo } from 'react';
 import { cancelTts, cleanForTts, pauseCurrentTts, resumeCurrentTts, speakTextWithProgress, TtsProgressInfo } from '../services/ttsApi';
 
 // Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
@@ -348,18 +348,26 @@ export function useTtsPlayback(
     setTtsError(null);
   }, []);
 
-  return {
-    isTtsSpeaking,
-    isTtsPaused,
-    isTtsLoading,
-    ttsError,
-    setIsTtsSpeaking,
-    setIsTtsPaused,
-    utteranceRef,
-    ttsRafRef,
-    speakText,
-    pauseTts,
-    resumeTts,
-    stopTts,
-  };
+  /* #1780: wrap the return value in useMemo so consumers can put the whole
+   * `tts` object in a useEffect/useCallback dep array without re-firing every
+   * render. The underlying callbacks (speakText / pauseTts / resumeTts /
+   * stopTts) are already useCallback'd; the only thing that changes between
+   * renders without this memo is the object literal itself. */
+  return useMemo(
+    () => ({
+      isTtsSpeaking,
+      isTtsPaused,
+      isTtsLoading,
+      ttsError,
+      setIsTtsSpeaking,
+      setIsTtsPaused,
+      utteranceRef,
+      ttsRafRef,
+      speakText,
+      pauseTts,
+      resumeTts,
+      stopTts,
+    }),
+    [isTtsSpeaking, isTtsPaused, isTtsLoading, ttsError, speakText, pauseTts, resumeTts, stopTts],
+  );
 }


### PR DESCRIPTION
# Issue #1780 修正說明

## 問題摘要

`useTtsPlayback` hook 每次 render 都回傳新的 `{ ... }` 物件，下游
`FullReading` 與 `LiveTutor` 把整個 `tts` 物件放進 `useCallback` /
`useEffect` deps 陣列，導致 `speakNextInQueue` 每次 render 被重建、
"TTS 講完跳下一段" 的 useEffect 過度觸發。學生會感受到朗讀流程
卡頓、自動跳段時序錯亂。

## 修正策略

兩層修正缺一不可：

**(1) Hook 端**：用 `useMemo` 把 return object 包起來，object reference
跨 render 穩定。但這只解決 object literal 的問題。

**(2) Caller 端**：把 inline `() => {}` / `(pos) => setX(pos)` 換成
stable refs。原因：hook 內 `speakText` 的 `useCallback` deps 包含
`onSpeakingProgress` / `onRealtimeDiffTokensClear`，如果 caller 每次
render 都傳新的 inline 箭頭，`speakText` 還是會被重建，連帶讓 (1) 的
`useMemo` deps 失效。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/hooks/useTtsPlayback.ts` | return statement 改用 `useMemo`，deps 是個別 state + 已 memo 的 callbacks。 |
| `frontend/src/components/reading-steps/FullReading.tsx` | 把 inline `() => {}` 換成 module-level `NOOP` 常數。 |
| `frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx` | 第一個 callback 直接傳 `setSpeakingProgress`（React setter 本來就穩）；第二個用 `useCallback` 包 `setRealtimeDiffTokens(null)`。 |

## 修正內容詳述

### useTtsPlayback.ts

**Before**

```ts
return {
  isTtsSpeaking,
  isTtsPaused,
  isTtsLoading,
  ttsError,
  setIsTtsSpeaking,
  setIsTtsPaused,
  utteranceRef,
  ttsRafRef,
  speakText,
  pauseTts,
  resumeTts,
  stopTts,
};
```

**After**

```ts
return useMemo(
  () => ({
    isTtsSpeaking,
    isTtsPaused,
    isTtsLoading,
    ttsError,
    setIsTtsSpeaking,
    setIsTtsPaused,
    utteranceRef,
    ttsRafRef,
    speakText,
    pauseTts,
    resumeTts,
    stopTts,
  }),
  [isTtsSpeaking, isTtsPaused, isTtsLoading, ttsError, speakText, pauseTts, resumeTts, stopTts],
);
```

### FullReading.tsx

**Before**

```tsx
const tts = useTtsPlayback(setSpeakingProgress, () => {});  // ← 新 fn ref / render
```

**After**

```tsx
// module-level
const NOOP = () => {};

// in component
const tts = useTtsPlayback(setSpeakingProgress, NOOP);
```

### LiveTutor.tsx

**Before**

```tsx
const { /* ... */ } = useTtsPlayback(
  (pos) => setSpeakingProgress(pos),    // ← 新 fn ref / render
  () => setRealtimeDiffTokens(null),    // ← 新 fn ref / render
);
```

**After**

```tsx
const handleRealtimeDiffClear = useCallback(() => setRealtimeDiffTokens(null), []);
const { /* ... */ } = useTtsPlayback(setSpeakingProgress, handleRealtimeDiffClear);
```

## 測試方式

1. 進入 G6-L1 之類有逐段朗讀的課
2. 點 LiveTutor 自動朗讀，觀察 paragraph 一段段跳過去：
   - **預期**：每段 TTS 結束剛好跳下一段，沒有提早跳/重複跳/卡頓
3. 在 FullReading 全文朗讀按播放：
   - **預期**：朗讀順暢、cursor 動畫不抖
4. React DevTools Profiler 對 FullReading 元件做一次 record：
   - **預期**：TTS 中途的 render 次數應該明顯下降（之前每個 timeupdate
     都觸發 effect 連鎖重建，現在只有 isTtsSpeaking / state 真變才會跑）

## 迴歸測試

- LiveTutor 暫停 / 恢復 / 停止按鈕仍正常作用
- FullReading 重做（再讀一次）按鈕仍正常重置
- `tts.speakText(...)` 仍能用，cursor 動畫與 onSpeakingProgress 仍正常
- `tts.stopTts()` 從外部呼叫仍能 cancel 進行中的播放
- `useTtsPlayback` 的兩個 caller 之外沒有其他地方用，影響範圍清晰