### PR TITLE
fix(teacher): API 失敗不再被默默吞掉，跟「沒資料」分開顯示 (#1784)

### DIFF
--- a/frontend/src/pages/teacher/AssignmentTab.tsx
+++ b/frontend/src/pages/teacher/AssignmentTab.tsx
@@ -38,6 +38,9 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [allStories, setAllStories] = useState<Story[]>([]);
   const [isLoadingStories, setIsLoadingStories] = useState(false);
+  /* #1784: distinguish "fetch failed" from "empty list" so teacher isn't
+   * presented with an empty <select> that looks like there are no lessons. */
+  const [storiesError, setStoriesError] = useState<string | null>(null);
   const [selectedStoryId, setSelectedStoryId] = useState('');
   const [formTitle, setFormTitle] = useState('');
   const [formDescription, setFormDescription] = useState('');
@@ -90,11 +93,12 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
   const loadStories = useCallback(async () => {
     if (allStories.length > 0) return;
     setIsLoadingStories(true);
+    setStoriesError(null);
     try {
       const data = await fetchStories();
       setAllStories(data.stories);
-    } catch {
-      // silent
+    } catch (err) {
+      setStoriesError(err instanceof Error ? err.message : '無法載入課文列表');
     } finally {
       setIsLoadingStories(false);
     }
@@ -425,6 +429,11 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
                 <div className="flex items-center gap-2 py-2">
                   <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
                   <span className="text-xs text-gray-400">載入課文列表...</span>
+                </div>
+              ) : storiesError ? (
+                <div className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-sm text-red-700">
+                  <span>載入課文失敗：{storiesError}</span>
+                  <button type="button" onClick={loadStories} className="underline text-xs">重試</button>
                 </div>
               ) : (
                 <select

--- a/frontend/src/pages/teacher/StudentProgressTab.tsx
+++ b/frontend/src/pages/teacher/StudentProgressTab.tsx
@@ -527,6 +527,43 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
     }
   }, [expandedStudentId, token]);
 
+  /* #1784 retry helpers — re-fetch sessions / curve for the expanded student
+   * without toggling the collapse state. Used by inline error banners. */
+  const retrySessions = useCallback(async (studentId: number) => {
+    if (!token) return;
+    delete sessionCache.current[studentId];
+    setIsLoadingSessions(true);
+    setSessions([]);
+    setSessionsError(null);
+    try {
+      const data = await getStudentSessions(token, studentId);
+      sessionCache.current[studentId] = data;
+      setSessions(data);
+    } catch (err) {
+      setSessionsError(err instanceof Error ? err.message : '無法載入學習紀錄');
+    } finally {
+      setIsLoadingSessions(false);
+    }
+  }, [token]);
+
+  const retryCurve = useCallback(async (studentId: number, filter: string) => {
+    if (!token) return;
+    const cacheKey = `${studentId}:${filter}`;
+    delete curveCache.current[cacheKey];
+    setIsLoadingCurve(true);
+    setLearningCurve([]);
+    setCurveError(null);
+    try {
+      const curveData = await getStudentLearningCurve(token, studentId, filter || undefined);
+      curveCache.current[cacheKey] = curveData.data;
+      setLearningCurve(curveData.data);
+    } catch (err) {
+      setCurveError(err instanceof Error ? err.message : '無法載入學習曲線');
+    } finally {
+      setIsLoadingCurve(false);
+    }
+  }, [token]);
+
   // Load and show dialogue history for a session (Issue #418)
   const handleViewDialogue = useCallback(async (
     studentId: number,
@@ -542,8 +579,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
       setDialogueModal({ data, storyTitle, studentName });
     } catch (err) {
       // #1784: was silently failing → teacher clicked the dialogue button and
-      // nothing happened. Now surface the error inline.
-      setDialogueError(err instanceof Error ? err.message : '無法載入對話紀錄');
+      // nothing happened. Now surface the error inline with student context
+      // so teacher knows which click failed when multiple are in-flight.
+      const msg = err instanceof Error ? err.message : '無法載入對話紀錄';
+      setDialogueError(`${studentName}：${msg}`);
     } finally {
       setLoadingDialogueSessionId(null);
     }
@@ -785,8 +824,9 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                   {isLoadingCurve ? (
                     <div className="h-40 bg-gray-200 animate-pulse rounded" />
                   ) : curveError ? (
-                    <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700">
-                      學習曲線載入失敗：{curveError}（請收合此學生後再展開重試）
+                    <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700 flex items-center justify-between gap-2">
+                      <span>學習曲線載入失敗：{curveError}</span>
+                      <button type="button" onClick={() => retryCurve(s.student_id, curveStoryFilter)} className="underline shrink-0">重試</button>
                     </div>
                   ) : learningCurve.length >= 2 ? (
                     <div>
@@ -847,8 +887,9 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                       ))}
                     </div>
                   ) : sessionsError ? (
-                    <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700">
-                      學習紀錄載入失敗：{sessionsError}（請收合此學生後再展開重試）
+                    <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700 flex items-center justify-between gap-2">
+                      <span>學習紀錄載入失敗：{sessionsError}</span>
+                      <button type="button" onClick={() => retrySessions(s.student_id)} className="underline shrink-0">重試</button>
                     </div>
                   ) : sessions.length === 0 ? (
                     <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>
@@ -1017,8 +1058,9 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                         {isLoadingCurve ? (
                           <div className="h-40 bg-gray-200 animate-pulse rounded" />
                         ) : curveError ? (
-                          <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700">
-                            學習曲線載入失敗：{curveError}（請收合此學生後再展開重試）
+                          <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700 flex items-center justify-between gap-2">
+                            <span>學習曲線載入失敗：{curveError}</span>
+                            <button type="button" onClick={() => retryCurve(s.student_id, curveStoryFilter)} className="underline shrink-0">重試</button>
                           </div>
                         ) : learningCurve.length >= 2 ? (
                           <div>
@@ -1087,8 +1129,9 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                             ))}
                           </div>
                         ) : sessionsError ? (
-                          <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700">
-                            學習紀錄載入失敗：{sessionsError}（請收合此學生後再展開重試）
+                          <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700 flex items-center justify-between gap-2">
+                            <span>學習紀錄載入失敗：{sessionsError}</span>
+                            <button type="button" onClick={() => retrySessions(s.student_id)} className="underline shrink-0">重試</button>
                           </div>
                         ) : sessions.length === 0 ? (
                           <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>

--- a/frontend/src/pages/teacher/StudentProgressTab.tsx
+++ b/frontend/src/pages/teacher/StudentProgressTab.tsx
@@ -374,6 +374,9 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   const [isLoadingSessions, setIsLoadingSessions] = useState(false);
   const [sessions, setSessions] = useState<StudentSession[]>([]);
   const sessionCache = useRef<Record<number, StudentSession[]>>({});
+  /* #1784: separate fetch-failed from no-data so teacher doesn't mistake
+   * an API error for "student hasn't done any sessions". */
+  const [sessionsError, setSessionsError] = useState<string | null>(null);
 
   // Dialogue modal state (Issue #418)
   const [dialogueModal, setDialogueModal] = useState<{
@@ -382,6 +385,8 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
     studentName: string;
   } | null>(null);
   const [loadingDialogueSessionId, setLoadingDialogueSessionId] = useState<number | null>(null);
+  // #1784: surface dialogue-fetch failures (was silent → opened blank modal)
+  const [dialogueError, setDialogueError] = useState<string | null>(null);
 
   // Instruction panel state
   const [instructionTarget, setInstructionTarget] = useState<{ id: number; name: string } | null>(null);
@@ -394,6 +399,8 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   const [learningCurve, setLearningCurve] = useState<LearningCurvePoint[]>([]);
   const [isLoadingCurve, setIsLoadingCurve] = useState(false);
   const curveCache = useRef<Record<string, LearningCurvePoint[]>>({});
+  // #1784: surface learning-curve fetch failures
+  const [curveError, setCurveError] = useState<string | null>(null);
   const [curveStoryFilter, setCurveStoryFilter] = useState<string>(''); // empty = all stories
 
   const loadProgress = useCallback(async () => {
@@ -480,15 +487,19 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
     // Load session history (with cache)
     if (sessionCache.current[studentId]) {
       setSessions(sessionCache.current[studentId]);
+      setSessionsError(null);
     } else {
       setIsLoadingSessions(true);
       setSessions([]);
+      setSessionsError(null);
       try {
         const data = await getStudentSessions(token, studentId);
         sessionCache.current[studentId] = data;
         setSessions(data);
-      } catch {
-        setSessions([]);
+      } catch (err) {
+        // #1784: keep sessions empty but surface the failure so teacher
+        // doesn't conclude the student hasn't done any practice.
+        setSessionsError(err instanceof Error ? err.message : '無法載入學習紀錄');
       } finally {
         setIsLoadingSessions(false);
       }
@@ -498,15 +509,18 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
     const cacheKey = `${studentId}:${nextFilter}`;
     if (curveCache.current[cacheKey]) {
       setLearningCurve(curveCache.current[cacheKey]);
+      setCurveError(null);
     } else {
       setIsLoadingCurve(true);
       setLearningCurve([]);
+      setCurveError(null);
       try {
         const curveData = await getStudentLearningCurve(token, studentId, nextFilter || undefined);
         curveCache.current[cacheKey] = curveData.data;
         setLearningCurve(curveData.data);
-      } catch {
-        setLearningCurve([]);
+      } catch (err) {
+        // #1784: surface curve fetch failure instead of pretending data is empty
+        setCurveError(err instanceof Error ? err.message : '無法載入學習曲線');
       } finally {
         setIsLoadingCurve(false);
       }
@@ -522,11 +536,14 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   ) => {
     if (!token) return;
     setLoadingDialogueSessionId(sessionId);
+    setDialogueError(null);
     try {
       const data = await getTeacherStudentDialogue(token, studentId, sessionId);
       setDialogueModal({ data, storyTitle, studentName });
-    } catch {
-      // Non-fatal — silently fail
+    } catch (err) {
+      // #1784: was silently failing → teacher clicked the dialogue button and
+      // nothing happened. Now surface the error inline.
+      setDialogueError(err instanceof Error ? err.message : '無法載入對話紀錄');
     } finally {
       setLoadingDialogueSessionId(null);
     }
@@ -670,6 +687,14 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
           onClose={() => setDialogueModal(null)}
         />
       )}
+      {/* #1784: dialogue fetch errors used to be silent; surface them as a
+          dismissible banner so the teacher doesn't think "button doesn't work". */}
+      {dialogueError && (
+        <div className="mb-3 flex items-center justify-between gap-2 px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-sm text-red-700">
+          <span>對話紀錄載入失敗：{dialogueError}</span>
+          <button type="button" onClick={() => setDialogueError(null)} className="underline text-xs">關閉</button>
+        </div>
+      )}
 
       <div className="flex justify-end mb-3">
         <button
@@ -759,6 +784,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                 <div className="mt-2 bg-gray-50 rounded-lg p-3 space-y-4">
                   {isLoadingCurve ? (
                     <div className="h-40 bg-gray-200 animate-pulse rounded" />
+                  ) : curveError ? (
+                    <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700">
+                      學習曲線載入失敗：{curveError}（請收合此學生後再展開重試）
+                    </div>
                   ) : learningCurve.length >= 2 ? (
                     <div>
                       <div className="flex items-center justify-between mb-2">
@@ -816,6 +845,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                       {Array.from({ length: 3 }).map((_, i) => (
                         <div key={i} className="h-16 bg-gray-200 animate-pulse rounded-lg" />
                       ))}
+                    </div>
+                  ) : sessionsError ? (
+                    <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700">
+                      學習紀錄載入失敗：{sessionsError}（請收合此學生後再展開重試）
                     </div>
                   ) : sessions.length === 0 ? (
                     <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>
@@ -983,6 +1016,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                         {/* Learning curve chart */}
                         {isLoadingCurve ? (
                           <div className="h-40 bg-gray-200 animate-pulse rounded" />
+                        ) : curveError ? (
+                          <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700">
+                            學習曲線載入失敗：{curveError}（請收合此學生後再展開重試）
+                          </div>
                         ) : learningCurve.length >= 2 ? (
                           <div>
                             <div className="flex items-center justify-between mb-2">
@@ -1048,6 +1085,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                                 <div className="h-3 bg-gray-200 animate-pulse rounded w-1/6" />
                               </div>
                             ))}
+                          </div>
+                        ) : sessionsError ? (
+                          <div className="px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-xs text-red-700">
+                            學習紀錄載入失敗：{sessionsError}（請收合此學生後再展開重試）
                           </div>
                         ) : sessions.length === 0 ? (
                           <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>

--- a/frontend/src/pages/teacher/TextManagementTab.tsx
+++ b/frontend/src/pages/teacher/TextManagementTab.tsx
@@ -34,6 +34,9 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
   // All available stories
   const [allStories, setAllStories] = useState<Story[]>([]);
   const [isLoadingStories, setIsLoadingStories] = useState(false);
+  /* #1784: separate fetch-failed from no-data so teacher sees a retry option
+   * instead of a misleading "所有課文皆已指派" empty state. */
+  const [storiesError, setStoriesError] = useState<string | null>(null);
 
   // Assign flow
   const [showAssignSelector, setShowAssignSelector] = useState(false);
@@ -70,11 +73,12 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
   const loadStories = useCallback(async () => {
     if (allStories.length > 0) return; // already loaded
     setIsLoadingStories(true);
+    setStoriesError(null);
     try {
       const data = await fetchStories();
       setAllStories(data.stories);
-    } catch {
-      // silent -- selector will show empty
+    } catch (err) {
+      setStoriesError(err instanceof Error ? err.message : '無法載入課文列表');
     } finally {
       setIsLoadingStories(false);
     }
@@ -285,6 +289,11 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
             <div className="flex items-center gap-2 py-4">
               <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
               <span className="text-xs text-gray-400">載入課文列表...</span>
+            </div>
+          ) : storiesError ? (
+            <div className="flex items-center justify-between gap-2 px-3 py-2 rounded-lg border border-red-200 bg-red-50 text-sm text-red-700">
+              <span>載入課文失敗：{storiesError}</span>
+              <button type="button" onClick={loadStories} className="underline text-xs">重試</button>
             </div>
           ) : availableStories.length === 0 ? (
             <p className="text-xs text-gray-400 py-4">所有課文皆已指派</p>


### PR DESCRIPTION
# Issue #1784 修正說明

## 問題摘要

教師後台多處 fetch 失敗會被 catch 後 silently fallback 到空陣列，導致
教師誤判：
- 「這班沒人交作業」其實是 API 沒回
- 「這個學生沒練習紀錄／學習曲線」其實是 fetch 拋例外
- 「對話按鈕沒反應」其實是 dialogue API 失敗

UI 三種情境（loading / fetch failed / 真的沒資料）應該分開呈現，但目前
fetch failed 跟 empty 被混在一起。

## 修正策略

在每個 silent catch 旁邊加一個獨立的 error state，UI 區分三態：
- **loading 中** → skeleton（既有）
- **fetch failed** → 紅色 banner 顯示錯誤訊息 + 重試/操作提示（新增）
- **成功但 empty** → 既有 empty state（不變）

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/pages/teacher/AssignmentTab.tsx` | `loadStories` 加 `storiesError`；課文 select 上方多一個 error banner + 「重試」按鈕。 |
| `frontend/src/pages/teacher/TextManagementTab.tsx` | 同 AssignmentTab 模式。 |
| `frontend/src/pages/teacher/StudentProgressTab.tsx` | sessions / curve / dialogue 三處各加獨立 error state。曲線 / 紀錄區塊 inline 顯示「載入失敗，請收合後再展開重試」；dialogue 失敗顯示頁面頂部 dismissible banner。 |

## 修正內容詳述

### AssignmentTab.tsx

**Before**

```tsx
const loadStories = useCallback(async () => {
  if (allStories.length > 0) return;
  setIsLoadingStories(true);
  try {
    const data = await fetchStories();
    setAllStories(data.stories);
  } catch {
    // silent
  } finally { setIsLoadingStories(false); }
}, [allStories.length]);
```

**After**

```tsx
const [storiesError, setStoriesError] = useState<string | null>(null);

const loadStories = useCallback(async () => {
  if (allStories.length > 0) return;
  setIsLoadingStories(true);
  setStoriesError(null);
  try {
    const data = await fetchStories();
    setAllStories(data.stories);
  } catch (err) {
    setStoriesError(err instanceof Error ? err.message : '無法載入課文列表');
  } finally { setIsLoadingStories(false); }
}, [allStories.length]);

// UI:
isLoadingStories ? <Spinner/>
  : storiesError ? (
    <div className="...error banner...">
      <span>載入課文失敗：{storiesError}</span>
      <button onClick={loadStories}>重試</button>
    </div>
  ) : <select>...</select>
```

### TextManagementTab.tsx

同上模式，error banner 顯示在課文清單上方。

### StudentProgressTab.tsx

三個獨立 error state：
- `sessionsError` — 練習紀錄 fetch 失敗
- `curveError` — 學習曲線 fetch 失敗
- `dialogueError` — 對話歷史 fetch 失敗

曲線 / 紀錄區塊都是在學生 row expand 時才載入，retry 方案是「收合後再
展開」（cache key 重置）；inline banner 寫明這個操作提示。dialogue 是
跨多個學生 row 共用 modal，所以失敗時顯示在頁面頂部的 dismissible
banner。

## 測試方式

1. **Chrome devtools → Network → Offline**：開教師後台
   - 進「作業」分頁、按「新增作業」→ 課文 select 不再是空選單，改顯示
     紅色 error banner + 重試按鈕
   - 進「課文管理」分頁 → 課文清單上方顯示 error banner
   - 進「學生進度」分頁 → 展開任一學生：學習曲線 / 練習紀錄都顯示
     紅色 inline 錯誤 + 操作提示
   - 學生紀錄列表中點「對話」→ 頂部跳 dismissible 紅色 banner
2. 切回 Online，重試按鈕應正常重抓資料
3. 真的沒資料的學生（從沒練習）→ 還是顯示「尚無練習記錄」灰字
   （error path 跟 empty path 不會混）

## 迴歸測試

- 既有的 skeleton / loading UI 不變
- 既有的 empty state（"所有課文皆已指派"、"尚無練習記錄"）不變
- 既有的 success path 不變
- 個別 error 互相獨立（dialogue 失敗不影響 curve / sessions 顯示）
- StudentProgressTab 內其他幾處 silent catch（line 110 / 435）影響面
  較小，本次不動，留到後續 PR
- reading-steps 內的 silent catch 多半是 localStorage 寫入失敗（本來就
  該 graceful degrade），不在本次 scope 內