### PR TITLE
fix(storage): 抽 authToken / safeStorage helper，5 處 token key 統一 (#1786)

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { login as apiLogin, register as apiRegister, getMe, acceptTerms as apiAcceptTerms, googleLogin as apiGoogleLogin, junyiLogin as apiJunyiLogin, AuthUser, AuthError, RegisterResponse } from '../services/authApi';
 import { SESSION_UNAUTHORIZED_EVENT } from '../services/sessionGuard';
+import { authToken, safeStorage } from '../utils/storage';
 
-const TOKEN_KEY = 'lingoleap_token';
 const ACTIVE_ASSIGNMENT_CONTEXT_KEY = 'activeAssignmentContext';
 // Set when user logs in via Junyi SSO (#1260). Read on logout to also clear
 // Junyi-side cookies via redirect to https://www.junyiacademy.org/logout —
@@ -51,7 +51,7 @@ export function useAuth(): AuthContextValue {
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<AuthUser | null>(null);
-  const [token, setToken] = useState<string | null>(() => localStorage.getItem(TOKEN_KEY));
+  const [token, setToken] = useState<string | null>(() => authToken.get());
   const [isLoading, setIsLoading] = useState(true);
   const [mustChangePassword, setMustChangePassword] = useState(false);
   const [loginPassword, setLoginPassword] = useState<string | null>(null);
@@ -86,7 +86,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       .catch(() => {
         // Token is invalid or expired — clear it
         if (!cancelled) {
-          localStorage.removeItem(TOKEN_KEY);
+          authToken.remove();
           setToken(null);
           setUser(null);
         }
@@ -115,10 +115,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // causing a duplicate /api/users/me on every login (Issue #1156).
     const userData = await getMe(newToken);
 
-    localStorage.setItem(TOKEN_KEY, newToken);
+    authToken.set(newToken);
     // Email/password login is not Junyi — clear any stale Junyi flag from a
     // prior session in another tab to avoid logout() redirecting to Junyi.
-    localStorage.removeItem(JUNYI_SESSION_FLAG);
+    safeStorage.local.remove(JUNYI_SESSION_FLAG);
     setUser(userData);
     setToken(newToken);
 
@@ -142,9 +142,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // Same ordering as login(): fetch user first, then set user before token so
     // the token-change useEffect skips its redundant /me call (Issue #1156).
     const userData = await getMe(newToken);
-    localStorage.setItem(TOKEN_KEY, newToken);
+    authToken.set(newToken);
     // Google login is not Junyi — clear any stale Junyi flag.
-    localStorage.removeItem(JUNYI_SESSION_FLAG);
+    safeStorage.local.remove(JUNYI_SESSION_FLAG);
     setUser(userData);
     setToken(newToken);
     return { isNewUser: response.is_new_user };
@@ -156,9 +156,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // Same ordering as loginWithGoogle: pre-fetch user so token-change useEffect
     // sees user !== null and skips the redundant /me call (Issue #1156).
     const userData = await getMe(newToken);
-    localStorage.setItem(TOKEN_KEY, newToken);
+    authToken.set(newToken);
     // Mark session as Junyi-sourced so logout() also clears Junyi cookies (#1260).
-    localStorage.setItem(JUNYI_SESSION_FLAG, '1');
+    safeStorage.local.set(JUNYI_SESSION_FLAG, '1');
     setUser(userData);
     setToken(newToken);
     return { isNewUser: response.is_new_user };
@@ -169,10 +169,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // round-trip through Junyi /logout (clears their cookies via Set-Cookie).
     // skipJunyiRedirect is set by the SESSION_UNAUTHORIZED auto-logout path so
     // expired-token recovery doesn't yank the user mid-page through Junyi.
-    const wasJunyiSession = localStorage.getItem(JUNYI_SESSION_FLAG) === '1';
+    const wasJunyiSession = safeStorage.local.get(JUNYI_SESSION_FLAG) === '1';
     const shouldRedirectToJunyi = wasJunyiSession && !options?.skipJunyiRedirect;
-    localStorage.removeItem(TOKEN_KEY);
-    localStorage.removeItem(JUNYI_SESSION_FLAG);
+    authToken.remove();
+    safeStorage.local.remove(JUNYI_SESSION_FLAG);
     try {
       sessionStorage.removeItem('activeAssignmentId');
       sessionStorage.removeItem('activeAssignmentGoals');
@@ -228,7 +228,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const refreshUser = useCallback(async () => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
+    const storedToken = authToken.get();
     if (!storedToken) return;
     try {
       const userData = await getMe(storedToken);

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -1,17 +1,11 @@
 import { useState, useRef, useCallback } from 'react';
 import { cancelTts, cleanForTts, pauseCurrentTts, resumeCurrentTts, speakTextWithProgress, TtsProgressInfo } from '../services/ttsApi';
+import { authToken } from '../utils/storage';
 
-// Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
-const _TTS_TOKEN_KEY = 'lingoleap_token';
-
-/** Read JWT token from localStorage and return Authorization header if present. */
+/** Read JWT token via storage helper and return Authorization header if present.
+ *  #1786: previously duplicated TOKEN_KEY locally → centralised in authToken. */
 function _ttsAuthHeaders(): Record<string, string> {
-  try {
-    const token = localStorage.getItem(_TTS_TOKEN_KEY);
-    return token ? { Authorization: `Bearer ${token}` } : {};
-  } catch {
-    return {};
-  }
+  return authToken.authHeader();
 }
 
 /**

--- a/frontend/src/services/feedbackApi.ts
+++ b/frontend/src/services/feedbackApi.ts
@@ -1,6 +1,7 @@
 /**
  * Feedback API service — in-app feedback submission.
  */
+import { authToken } from '../utils/storage';
 
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
@@ -34,11 +35,9 @@ export interface FeedbackListResponse {
 }
 
 function getAuthHeaders(): Record<string, string> {
-  // #1777: AuthContext stores JWT under 'lingoleap_token', not 'token'.
-  // This used to silently return no Authorization header → all feedback 401.
-  const token = localStorage.getItem('lingoleap_token');
-  if (!token) return {};
-  return { Authorization: `Bearer ${token}` };
+  // #1786: token key centralised in authToken — guards against #1777-style
+  // regressions where this file hardcoded 'token' instead of 'lingoleap_token'.
+  return authToken.authHeader();
 }
 
 /**

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -7,6 +7,7 @@
 
 import type { ReadingEvaluateResponse } from '../types';
 import { SessionExpiredError } from './api';
+import { authToken } from '../utils/storage';
 
 // Re-export so consumers can import SessionExpiredError from learningApi without
 // needing to know it lives in api.ts.
@@ -617,12 +618,9 @@ export interface DictionaryBatchResponse {
   results: DictionaryEntry[];
 }
 
-// Token key must match AuthContext TOKEN_KEY
-const _DICT_TOKEN_KEY = 'lingoleap_token';
-
+// #1786: TOKEN_KEY centralised in utils/storage; this helper now delegates.
 function _getDictAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem(_DICT_TOKEN_KEY);
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  return authToken.authHeader();
 }
 
 /** Look up a single Chinese character from the MOE dictionary (cached). Requires auth. */

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -14,24 +14,14 @@
  *   cancelTts();   // stop any in-progress playback
  */
 
+import { authToken } from '../utils/storage';
+
 const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
 
-// Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
-const TOKEN_KEY = 'lingoleap_token';
-
-/** Read the JWT token from localStorage (same source as AuthContext). */
-function _getAuthToken(): string | null {
-  try {
-    return localStorage.getItem(TOKEN_KEY);
-  } catch {
-    return null;
-  }
-}
-
-/** Build Authorization header if a token is available. */
+/** Build Authorization header if a token is available.
+ *  #1786: previously duplicated TOKEN_KEY locally → centralised in authToken. */
 function _authHeaders(): Record<string, string> {
-  const token = _getAuthToken();
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  return authToken.authHeader();
 }
 
 // In-memory URL cache: sentence text → blob URL.

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,0 +1,100 @@
+/**
+ * storage.ts — typed, safe wrappers around localStorage / sessionStorage.
+ *
+ * #1786: previously 31+ files read/wrote storage directly, each with its own
+ * ad-hoc try/catch (or none), and the auth-token key was hardcoded in 5+ places
+ * (#1777 was caused by one of those copies using `'token'` instead of
+ * `'lingoleap_token'`). This module centralises:
+ *  - graceful degradation when storage is unavailable (private browsing,
+ *    Safari ITP quota, disabled cookies)
+ *  - the auth-token key (single source of truth)
+ *  - typed JSON read/write
+ *
+ * Callers should NOT touch `localStorage` / `sessionStorage` directly. Add a
+ * helper here instead.
+ */
+
+/* ─── primitives ─────────────────────────────────────────────────────────── */
+
+function safeGet(area: Storage | null, key: string): string | null {
+  if (!area) return null;
+  try {
+    return area.getItem(key);
+  } catch {
+    // Private browsing / cookies disabled / quota exceeded
+    return null;
+  }
+}
+
+function safeSet(area: Storage | null, key: string, value: string): boolean {
+  if (!area) return false;
+  try {
+    area.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function safeRemove(area: Storage | null, key: string): void {
+  if (!area) return;
+  try {
+    area.removeItem(key);
+  } catch {
+    /* swallow — storage unavailable */
+  }
+}
+
+const _localStorage: Storage | null =
+  typeof window !== 'undefined' && 'localStorage' in window ? window.localStorage : null;
+const _sessionStorage: Storage | null =
+  typeof window !== 'undefined' && 'sessionStorage' in window ? window.sessionStorage : null;
+
+export const safeStorage = {
+  local: {
+    get: (key: string): string | null => safeGet(_localStorage, key),
+    set: (key: string, value: string): boolean => safeSet(_localStorage, key, value),
+    remove: (key: string): void => safeRemove(_localStorage, key),
+  },
+  session: {
+    get: (key: string): string | null => safeGet(_sessionStorage, key),
+    set: (key: string, value: string): boolean => safeSet(_sessionStorage, key, value),
+    remove: (key: string): void => safeRemove(_sessionStorage, key),
+  },
+};
+
+/* ─── typed JSON helpers ─────────────────────────────────────────────────── */
+
+export function readJSON<T>(area: 'local' | 'session', key: string): T | null {
+  const raw = safeStorage[area].get(key);
+  if (raw == null) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    // Corrupted value — treat as missing.
+    return null;
+  }
+}
+
+export function writeJSON(area: 'local' | 'session', key: string, value: unknown): boolean {
+  try {
+    return safeStorage[area].set(key, JSON.stringify(value));
+  } catch {
+    return false;
+  }
+}
+
+/* ─── auth token (single source of truth, replaces hardcoded keys) ───────── */
+
+export const AUTH_TOKEN_KEY = 'lingoleap_token';
+
+export const authToken = {
+  get: (): string | null => safeStorage.local.get(AUTH_TOKEN_KEY),
+  set: (token: string): boolean => safeStorage.local.set(AUTH_TOKEN_KEY, token),
+  remove: (): void => safeStorage.local.remove(AUTH_TOKEN_KEY),
+  /** Build an Authorization header from the stored token. Empty object if not present. */
+  authHeader: (): Record<string, string> => {
+    const t = safeStorage.local.get(AUTH_TOKEN_KEY);
+    return t ? { Authorization: `Bearer ${t}` } : {};
+  },
+};

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -45,10 +45,24 @@ function safeRemove(area: Storage | null, key: string): void {
   }
 }
 
-const _localStorage: Storage | null =
-  typeof window !== 'undefined' && 'localStorage' in window ? window.localStorage : null;
-const _sessionStorage: Storage | null =
-  typeof window !== 'undefined' && 'sessionStorage' in window ? window.sessionStorage : null;
+/* The `window.localStorage` property access itself can throw `SecurityError`
+ * in Firefox when "block all cookies" is set, even though `'localStorage' in
+ * window` returns true. Wrap each lookup in try/catch so this module can be
+ * imported safely under any privacy setting. */
+const _localStorage: Storage | null = (() => {
+  try {
+    return typeof window !== 'undefined' ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+})();
+const _sessionStorage: Storage | null = (() => {
+  try {
+    return typeof window !== 'undefined' ? window.sessionStorage : null;
+  } catch {
+    return null;
+  }
+})();
 
 export const safeStorage = {
   local: {
@@ -90,11 +104,22 @@ export const AUTH_TOKEN_KEY = 'lingoleap_token';
 
 export const authToken = {
   get: (): string | null => safeStorage.local.get(AUTH_TOKEN_KEY),
-  set: (token: string): boolean => safeStorage.local.set(AUTH_TOKEN_KEY, token),
+  set: (token: string): boolean => {
+    const ok = safeStorage.local.set(AUTH_TOKEN_KEY, token);
+    if (!ok && import.meta.env.DEV) {
+      // Surface storage failures in dev (private mode / quota) — silent in
+      // prod so we don't pollute users' consoles with a known degraded mode.
+      // eslint-disable-next-line no-console
+      console.warn('[storage] authToken.set failed — session will not persist across reload');
+    }
+    return ok;
+  },
   remove: (): void => safeStorage.local.remove(AUTH_TOKEN_KEY),
-  /** Build an Authorization header from the stored token. Empty object if not present. */
+  /** Build an Authorization header from the stored token. Empty object if not present.
+   *  Goes through `authToken.get()` so any future logic added to get (refresh /
+   *  expiry check) propagates here automatically. */
   authHeader: (): Record<string, string> => {
-    const t = safeStorage.local.get(AUTH_TOKEN_KEY);
+    const t = authToken.get();
     return t ? { Authorization: `Bearer ${t}` } : {};
   },
 };


### PR DESCRIPTION
# Issue #1786 修正說明

## 問題摘要

`localStorage` / `sessionStorage` 直接呼叫散在 31+ 檔案：
- **auth token key 硬編 5 處**（`AuthContext`、`useTtsPlayback`、
  `ttsApi`、`learningApi`、`feedbackApi`），#1777 就是因為 `feedbackApi.ts`
  寫錯成 `'token'` 害所有 feedback API 401
- 大部分 storage 呼叫沒 `try/catch`，**無痕模式 / Safari ITP 配額爆掉
  直接拋例外，使用者看到白畫面**
- 學習進度 / scope key 各自為政，未來改 key 名就會「升級後莫名被登出」
  或「作業/自學進度混在一起」

## 修正策略

**本次先做 critical 路徑：建 helper + 統一 5 個 auth token 讀寫點。**
其餘 26 個散落點留到 follow-up PR 分批遷移（避免單一 PR 動 31 檔太大）。

新增 `frontend/src/utils/storage.ts`：
- `safeStorage.local` / `safeStorage.session` — 包 try/catch 的 get/set/remove，
  無痕 / quota 失敗 graceful degrade（return null / false，不拋）
- `readJSON<T>` / `writeJSON` — typed JSON 序列化
- `AUTH_TOKEN_KEY = 'lingoleap_token'` — single source of truth
- `authToken` — 統一的 token 操作介面（含 `authHeader()` 直接給 fetch 用）

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/utils/storage.ts` | **新檔**：safeStorage / readJSON / writeJSON / authToken helper。 |
| `frontend/src/contexts/AuthContext.tsx` | 刪本地 `TOKEN_KEY`；所有 token 操作改 `authToken.get/set/remove`；`JUNYI_SESSION_FLAG` 改用 `safeStorage.local`。 |
| `frontend/src/services/ttsApi.ts` | 刪本地 `TOKEN_KEY` + `_getAuthToken`，`_authHeaders` 改 `authToken.authHeader()`。 |
| `frontend/src/hooks/useTtsPlayback.ts` | 刪 `_TTS_TOKEN_KEY`，`_ttsAuthHeaders` 改 `authToken.authHeader()`。 |
| `frontend/src/services/learningApi.ts` | 刪 `_DICT_TOKEN_KEY`，`_getDictAuthHeaders` 改 `authToken.authHeader()`。 |
| `frontend/src/services/feedbackApi.ts` | 刪硬編 `localStorage.getItem('lingoleap_token')`，`getAuthHeaders` 改 `authToken.authHeader()`；註解標明這裡是 #1777 ground zero，未來重構不能再 hardcode。 |

## 修正內容詳述

### 新檔：`utils/storage.ts`

提供四組 API：

```ts
// 1. raw safe access — primitive get/set/remove
safeStorage.local.get(key);     // string | null（無痕回 null）
safeStorage.local.set(key, value); // boolean（true = 成功）
safeStorage.local.remove(key);
safeStorage.session.*           // 同 local 但對應 sessionStorage

// 2. typed JSON
readJSON<T>('local', key);      // T | null（JSON parse 失敗 → null）
writeJSON('local', key, value); // boolean

// 3. auth token — single source of truth
authToken.get();
authToken.set(token);
authToken.remove();
authToken.authHeader();         // { Authorization: 'Bearer xxx' } 或 {}

// 4. exported constant for tests / migration scripts
AUTH_TOKEN_KEY;
```

### Before / After 對照

**ttsApi.ts**

```ts
// Before — 第二處硬編 TOKEN_KEY
const TOKEN_KEY = 'lingoleap_token';
function _getAuthToken(): string | null {
  try { return localStorage.getItem(TOKEN_KEY); } catch { return null; }
}
function _authHeaders(): Record<string, string> {
  const token = _getAuthToken();
  return token ? { Authorization: `Bearer ${token}` } : {};
}
```

```ts
// After
import { authToken } from '../utils/storage';
function _authHeaders(): Record<string, string> {
  return authToken.authHeader();
}
```

**feedbackApi.ts**（#1777 ground zero）

```ts
// Before
const token = localStorage.getItem('lingoleap_token');  // 之前曾誤寫 'token'
if (!token) return {};
return { Authorization: `Bearer ${token}` };
```

```ts
// After
return authToken.authHeader();   // 不可能再寫錯 key
```

## 測試方式

1. **登入流程**（驗證 5 個檔同源）
   - 正常登入 → token 寫入；refresh 後仍登入；登出 → token 清空
   - 試 Junyi SSO、Google、email/password 三條路徑都正常
2. **#1777 regression 防護**
   - 提交 feedback、用 TTS、查字典、reading practice 都會帶 Authorization
     header（curl 觀察 Network tab）
3. **無痕模式 / 隱私模式**
   - Chrome incognito 開站 → 不應白畫面或 crash
   - 操作 functional 但 token 不會持久（refresh 後要重 login，預期行為）
4. **localStorage 配額爆掉模擬**
   - DevTools 把 quota 設超小 → `safeStorage.set` 回 false，UI 不該拋例外

## 迴歸測試

- AuthContext useEffect 觸發路徑不變（mount 讀 token、token change re-fetch
  /me）
- Logout 流程不變（Junyi flag 仍能正確 redirect、sessionStorage 掃描清除）
- TTS playback / 字典查詢 / learning history / feedback submit 4 條
  API 路徑跟原本一樣帶 Bearer
- 全站搜尋 `'lingoleap_token'` literal：只剩 `utils/storage.ts:89` (single
  source) 與 `feedbackApi.ts:39` 的註解，其餘無
- `localStorage.getItem(TOKEN_KEY)` / `localStorage.setItem(TOKEN_KEY, ...)`
  全消失，無重複硬編

## 後續 follow-up（不在本次 scope）

- learning step progress keys（reading-steps 內 ~10 處 localStorage）
- `ACTIVE_ASSIGNMENT_CONTEXT_KEY`、`db-session-*`、`assignment-db-session-*`、
  `self-db-session-*` 等 scope key（AuthContext 內 sessionStorage 掃描）
- 把 `safeStorage` / `readJSON` 推廣到 reading-steps（FullReading 的
  localStorage 進度持久化、LiveTutor 的 transcript 暫存等）

這些都不影響登入/權限，無痕模式失敗範圍也小，獨立 PR 處理更安全。