### PR TITLE
refactor(perf): fix 3 N+1 queries in assignments + feedback (Fixes #1766 #1767 #1768)

### DIFF
--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -88,29 +88,46 @@ def _resolve_story_slug_for_assignment(assignment: Assignment) -> str | None:
     return None
 
 
-def _assignment_to_response(assignment: Assignment, db: Session) -> AssignmentResponse:
-    """Convert an Assignment ORM object to an AssignmentResponse."""
+def _assignment_to_response(
+    assignment: Assignment,
+    db: Session,
+    *,
+    precomputed_counts: dict | None = None,
+) -> AssignmentResponse:
+    """Convert an Assignment ORM object to an AssignmentResponse.
+
+    precomputed_counts — optional dict keyed by assignment.id with keys:
+      assigned_student_count, submitted_student_count, total_attempts.
+    When provided (bulk list path) the per-row COUNT queries are skipped,
+    eliminating the N+1 pattern (Issue #1766).
+    """
     story_title = _resolve_title_for_assignment(assignment, db)
 
-    # Issue #1764 Fix 3: precise student counts
-    assigned_student_count: int = (
-        db.query(func.count(func.distinct(ClassroomStudent.student_id)))
-        .filter(ClassroomStudent.classroom_id == assignment.classroom_id)
-        .scalar() or 0
-    )
-    submitted_student_count: int = (
-        db.query(func.count(func.distinct(AssignmentSubmission.student_id)))
-        .filter(
-            AssignmentSubmission.assignment_id == assignment.id,
-            AssignmentSubmission.status.in_(["submitted", "graded"]),
+    if precomputed_counts is not None and assignment.id in precomputed_counts:
+        counts = precomputed_counts[assignment.id]
+        assigned_student_count: int = counts["assigned_student_count"]
+        submitted_student_count: int = counts["submitted_student_count"]
+        total_attempts: int = counts["total_attempts"]
+    else:
+        # Single-assignment path: fall back to per-row queries (Issue #1764 Fix 3)
+        assigned_student_count = (
+            db.query(func.count(func.distinct(ClassroomStudent.student_id)))
+            .filter(ClassroomStudent.classroom_id == assignment.classroom_id)
+            .scalar() or 0
         )
-        .scalar() or 0
-    )
-    total_attempts: int = (
-        db.query(func.count(AssignmentSubmission.id))
-        .filter(AssignmentSubmission.assignment_id == assignment.id)
-        .scalar() or 0
-    )
+        submitted_student_count = (
+            db.query(func.count(func.distinct(AssignmentSubmission.student_id)))
+            .filter(
+                AssignmentSubmission.assignment_id == assignment.id,
+                AssignmentSubmission.status.in_(["submitted", "graded"]),
+            )
+            .scalar() or 0
+        )
+        total_attempts = (
+            db.query(func.count(AssignmentSubmission.id))
+            .filter(AssignmentSubmission.assignment_id == assignment.id)
+            .scalar() or 0
+        )
 
     return AssignmentResponse(
         id=assignment.id,
@@ -176,15 +193,27 @@ def _extract_reading_metrics(
 
     Returns (reading_accuracy, reading_cpm, reading_error_chars).
     All values are None/[] when no session exists or data hasn't been recorded yet.
+
+    Issue #1767: uses sub.session (already eager-loaded via joinedload in
+    get_assignment_detail) when available, avoiding a per-row DB query.
+    Falls back to an explicit query for callers that did not eager-load.
     """
     if sub.session_id is None:
         return None, None, []
 
-    session = (
-        db.query(LearningSession)
-        .filter(LearningSession.id == sub.session_id)
-        .first()
-    )
+    # Use already-loaded relationship value if present (avoids N+1)
+    from sqlalchemy.orm.base import instance_state
+    state = instance_state(sub)
+    if "session" in state.dict:
+        # relationship was eager-loaded
+        session = sub.session
+    else:
+        session = (
+            db.query(LearningSession)
+            .filter(LearningSession.id == sub.session_id)
+            .first()
+        )
+
     if session is None:
         return None, None, []
 
@@ -571,8 +600,58 @@ def list_classroom_assignments(
 
     assignments = query.order_by(Assignment.created_at.desc()).all()
 
+    if not assignments:
+        return AssignmentListResponse(items=[], total=0)
+
+    assignment_ids = [a.id for a in assignments]
+
+    # ── Issue #1766: bulk-precompute counts to avoid N+1 ──────────────────────
+    # assigned_student_count: classroom-level (same for all assignments in classroom)
+    enrolled_count: int = (
+        db.query(func.count(func.distinct(ClassroomStudent.student_id)))
+        .filter(ClassroomStudent.classroom_id == classroom_id)
+        .scalar() or 0
+    )
+
+    # submitted_student_count per assignment
+    submitted_rows = (
+        db.query(
+            AssignmentSubmission.assignment_id,
+            func.count(func.distinct(AssignmentSubmission.student_id)).label("cnt"),
+        )
+        .filter(
+            AssignmentSubmission.assignment_id.in_(assignment_ids),
+            AssignmentSubmission.status.in_(["submitted", "graded"]),
+        )
+        .group_by(AssignmentSubmission.assignment_id)
+        .all()
+    )
+    submitted_map: dict[int, int] = {row.assignment_id: row.cnt for row in submitted_rows}
+
+    # total_attempts per assignment
+    attempts_rows = (
+        db.query(
+            AssignmentSubmission.assignment_id,
+            func.count(AssignmentSubmission.id).label("cnt"),
+        )
+        .filter(AssignmentSubmission.assignment_id.in_(assignment_ids))
+        .group_by(AssignmentSubmission.assignment_id)
+        .all()
+    )
+    attempts_map: dict[int, int] = {row.assignment_id: row.cnt for row in attempts_rows}
+
+    precomputed: dict[int, dict] = {
+        a_id: {
+            "assigned_student_count": enrolled_count,
+            "submitted_student_count": submitted_map.get(a_id, 0),
+            "total_attempts": attempts_map.get(a_id, 0),
+        }
+        for a_id in assignment_ids
+    }
+    # ─────────────────────────────────────────────────────────────────────────
+
     return AssignmentListResponse(
-        items=[_assignment_to_response(a, db) for a in assignments],
+        items=[_assignment_to_response(a, db, precomputed_counts=precomputed) for a in assignments],
         total=len(assignments),
     )
 
@@ -596,15 +675,23 @@ def get_assignment_detail(
     # Build base response
     base = _assignment_to_response(assignment, db)
 
-    # Build submissions list
+    # Issue #1767: eager-load student + session to avoid per-row N+1 queries.
+    # joinedload(AssignmentSubmission.student) eliminates per-row User lookups.
+    # joinedload(AssignmentSubmission.session) eliminates per-row LearningSession
+    # lookups inside _extract_reading_metrics.
     submissions = (
         db.query(AssignmentSubmission)
+        .options(
+            joinedload(AssignmentSubmission.student),
+            joinedload(AssignmentSubmission.session),
+        )
         .filter(AssignmentSubmission.assignment_id == assignment_id)
         .all()
     )
     submission_responses = []
     for sub in submissions:
-        student = db.query(User).filter(User.id == sub.student_id).first()
+        # student already loaded via joinedload — no extra query
+        student = sub.student
         r_accuracy, r_cpm, r_error_chars = _extract_reading_metrics(sub, db)
         submission_responses.append(
             SubmissionResponse(
@@ -631,7 +718,8 @@ def get_assignment_detail(
 
     groups: list[StudentAttemptGroup] = []
     for student_id, subs in student_subs.items():
-        student = db.query(User).filter(User.id == student_id).first()
+        # student already loaded via joinedload — no extra query
+        student = subs[0].student
         subs_sorted = sorted(subs, key=lambda s: s.attempt_number, reverse=True)
         latest = subs_sorted[0]
         attempt_list: list[AttemptResponse] = []

--- a/backend/app/routes/feedback.py
+++ b/backend/app/routes/feedback.py
@@ -9,7 +9,7 @@ Endpoints:
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from ..auth.dependencies import get_current_user, get_user_org_ids, require_role
 from ..database import get_db
@@ -133,8 +133,11 @@ def list_feedback(
         query = query.filter(Feedback.status == status_filter)
 
     total = query.count()
+    # Issue #1768: joinedload(Feedback.user) avoids per-row lazy User query in
+    # _feedback_to_response, which accesses feedback.user.name.
     items = (
-        query.order_by(Feedback.created_at.desc())
+        query.options(joinedload(Feedback.user))
+        .order_by(Feedback.created_at.desc())
         .offset((page - 1) * page_size)
         .limit(page_size)
         .all()


### PR DESCRIPTION
Fixes #1766
Fixes #1767
Fixes #1768

## Summary

Three teacher-facing endpoints had the same lazy-loading N+1 pattern. All three are fixed in a single PR because the root cause and pattern are identical (lazy-loaded SQLAlchemy relationships triggering per-row DB queries).

- **#1766 `list_classroom_assignments`**: `_assignment_to_response()` was firing 3 COUNT queries per assignment row (assigned_student_count, submitted_student_count, total_attempts). Fixed by pre-computing all three counts in 3 bulk queries before the loop, then passing a `precomputed_counts` dict to `_assignment_to_response()`. N assignments: `1+3N → 1+3` queries.

- **#1767 `get_assignment_detail`**: two N+1 patterns — per-submission `User` lookup (`db.query(User)`) + per-submission `LearningSession` lookup inside `_extract_reading_metrics`. Fixed by adding `joinedload(AssignmentSubmission.student)` + `joinedload(AssignmentSubmission.session)` to the submissions query. `_extract_reading_metrics` updated to use the already-loaded `sub.session` relationship when available (via SQLAlchemy instance state check), falling back to explicit query for other callers.

- **#1768 `list_feedback`**: `_feedback_to_response()` accessed `feedback.user.name` which triggers a lazy User query per row. Fixed by adding `.options(joinedload(Feedback.user))` to the paginated fetch query.

## Files changed

- `backend/app/routes/assignments.py`
- `backend/app/routes/feedback.py`

## Test plan

- [x] `pytest tests/test_assignments.py tests/test_feedback.py` — 66 passed, 13 pre-existing failures (JWT env not set locally), identical to staging HEAD — zero regressions
- [x] Diff is minimal: only the 3 N+1 fix sites, no unrelated changes
- [x] Backward compatible: `_assignment_to_response` signature extended with optional kwarg, all existing callers not passing `precomputed_counts` continue to use the fallback per-row path

🤖 Generated with [Claude Code](https://claude.com/claude-code)