### PR TITLE
refactor(llm): TTS rate limit + socratic async wrap (Fixes #1773, Fixes #1774)

### DIFF
--- a/backend/app/routes/tts.py
+++ b/backend/app/routes/tts.py
@@ -35,6 +35,7 @@ from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 from ..auth.dependencies import get_current_user, require_role
+from ..auth.rate_limiter import make_ai_rate_limit_dependency
 from ..models.user import User
 from ..services.tts_service import (
     TTSError,
@@ -54,7 +55,10 @@ class TTSRequest(BaseModel):
     text: str = Field(..., min_length=1, max_length=5000, description="Plain text to synthesise (zh-TW)")
 
 
-@router.post("/synthesize")
+@router.post(
+    "/synthesize",
+    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=30, window_seconds=60))],
+)
 async def synthesize(
     req: TTSRequest,
     _current_user: User = Depends(get_current_user),
@@ -64,12 +68,17 @@ async def synthesize(
     Requires authentication (any active user).  Anonymous requests are rejected
     with 401 to prevent bill-washing attacks on the Azure/GCP TTS quota.
 
+    Rate-limited to 30 requests / 60 s per user: TTS fires per paragraph so
+    bursts are expected, but with TTS_PROVIDER=gemini31 each cache miss is an
+    LLM call — 30 RPM balances UX (≤ 30 paragraphs/minute) with cost safety.
+
     Runs in a thread pool via asyncio.to_thread() so the FastAPI event loop is
     not blocked during the 8–15 s remote TTS call (Azure / Google / Gemini).
 
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
         401  application/json — not authenticated.
+        429  application/json — rate limit exceeded.
         503  application/json — TTS unavailable; client should fall back
              to Web Speech API.
     """
@@ -93,7 +102,10 @@ async def synthesize(
     )
 
 
-@router.post("/synthesize-sentence")
+@router.post(
+    "/synthesize-sentence",
+    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=30, window_seconds=60))],
+)
 async def synthesize_sentence_endpoint(
     req: TTSRequest,
     _current_user: User = Depends(get_current_user),
@@ -103,6 +115,8 @@ async def synthesize_sentence_endpoint(
     Requires authentication (any active user).  Anonymous requests are rejected
     with 401 to prevent bill-washing attacks via the pre-generated sentence cache.
 
+    Rate-limited to 30 requests / 60 s per user (same budget as /synthesize).
+
     Stores audio under azure/sentences/ GCS path for sentence-level caching.
     Functionally identical to /synthesize but semantically scoped to sentences.
     Runs in a thread pool via asyncio.to_thread() to avoid blocking the event loop.
@@ -110,6 +124,7 @@ async def synthesize_sentence_endpoint(
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
         401  application/json — not authenticated.
+        429  application/json — rate limit exceeded.
         503  application/json — TTS unavailable.
     """
     try:
@@ -165,7 +180,13 @@ def get_tts_mapping(lesson_id: int) -> dict:
     return build_lesson_tts_mapping(lesson)
 
 
-@router.post("/regenerate", dependencies=[require_role("system_admin")])
+@router.post(
+    "/regenerate",
+    dependencies=[
+        require_role("system_admin"),
+        Depends(make_ai_rate_limit_dependency(max_requests=10, window_seconds=60)),
+    ],
+)
 async def regenerate(req: TTSRequest) -> dict:
     """Delete cached audio for *text* and re-synthesise from scratch (Issue #765).
 

--- a/backend/app/services/ai_comprehension.py
+++ b/backend/app/services/ai_comprehension.py
@@ -2,6 +2,7 @@
 AI comprehension evaluation — Socratic dialogue and comprehension scoring.
 """
 
+import asyncio
 import logging
 
 from google.genai import types as genai_types
@@ -104,15 +105,24 @@ async def generate_socratic_question(
         )
 
     client, _model = _get_client_for_task("socratic_question")
-    response = client.models.generate_content(
-        model=_model,
-        contents=contents,
-        config=genai_types.GenerateContentConfig(
-            system_instruction=system_prompt,
-            max_output_tokens=128,
-            temperature=0.7,
-            thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
+    # Wrap the synchronous SDK call in a thread so it does not block the
+    # FastAPI event loop (Issue #1774).  A 30-second timeout guards against
+    # hung connections — Gemini's max_output_tokens=128 should respond in
+    # well under 10 s in practice.
+    response = await asyncio.wait_for(
+        asyncio.to_thread(
+            lambda: client.models.generate_content(
+                model=_model,
+                contents=contents,
+                config=genai_types.GenerateContentConfig(
+                    system_instruction=system_prompt,
+                    max_output_tokens=128,
+                    temperature=0.7,
+                    thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
+                ),
+            )
         ),
+        timeout=30,
     )
     # Guard against safety filter before accessing response.text (#526)
     _check_safety_filter(response)

--- a/backend/tests/test_tts_service.py
+++ b/backend/tests/test_tts_service.py
@@ -886,6 +886,13 @@ class TestDeleteTtsCache:
 class TestRegenerateEndpoint:
     """POST /api/tts/regenerate must delete cache and re-synthesise."""
 
+    def setup_method(self):
+        # Reset the shared in-memory rate-limiter singleton so state from
+        # earlier tests (e.g. synthesize calls in other test classes) does not
+        # cause this class's first request to be throttled (Issue #1773 fix).
+        from app.auth.rate_limiter import ai_rate_limiter
+        ai_rate_limiter.reset()
+
     def _make_app(self):
         return _make_tts_test_app()
 


### PR DESCRIPTION
Fixes #1773
Fixes #1774

## Summary

- **#1773** `backend/app/routes/tts.py` — Added `make_ai_rate_limit_dependency` to three TTS endpoints that hit the provider. With `TTS_PROVIDER=gemini31` (current prod config) every cache miss is an LLM call. Limits: `/synthesize` + `/synthesize-sentence` → 30 req/60 s (matches per-paragraph burst pattern); `/regenerate` → 10 req/60 s (admin-only but still cost-sensitive).
- **#1774** `backend/app/services/ai_comprehension.py` — `generate_socratic_question()` was calling `client.models.generate_content()` synchronously inside an `async` function, blocking the FastAPI event loop. Wrapped in `asyncio.wait_for(asyncio.to_thread(...), timeout=30)` — minimal change preserving all existing logic, error handling, and usage telemetry.
- **Test fix** `backend/tests/test_tts_service.py` — Added `setup_method` to `TestRegenerateEndpoint` to reset the shared `ai_rate_limiter` singleton, preventing cross-test state leakage that would cause false 429s.

## Test plan

- [ ] `pytest backend/tests/test_tts_auth.py backend/tests/test_tts_service.py backend/tests/test_llm_rate_limits.py` → 74 passed (verified locally)
- [ ] CI backend build passes
- [ ] `curl /api/health` on staging preview returns 200
- [ ] Manual: hit `/api/tts/synthesize` 31x in 60 s → 31st returns 429