### PR TITLE
fix(tts): classroom rate-limit failure — re-key user_id + scope ai:tts: bucket + cache-before-limit + frontend 429 handler (Fixes #1808)

### DIFF
--- a/backend/app/auth/rate_limiter.py
+++ b/backend/app/auth/rate_limiter.py
@@ -173,3 +173,33 @@ ai_limit_10_per_min = make_ai_rate_limit_dependency(max_requests=10, window_seco
 ai_limit_5_per_min = make_ai_rate_limit_dependency(max_requests=5, window_seconds=60)
 # General API: 100 requests / minute per IP
 general_limit_100_per_min = make_general_rate_limit_dependency(max_requests=100, window_seconds=60)
+
+
+# ---------------------------------------------------------------------------
+# TTS-specific rate limiter (Issue #1808)
+# ---------------------------------------------------------------------------
+
+# Dedicated in-memory limiter for TTS — isolated from the shared ai_rate_limiter
+# so that TTS bursts do NOT consume the socratic/comprehension/reading quota.
+tts_rate_limiter = InMemoryRateLimiter()
+
+# TTS limits per user_id (not IP — avoids classroom NAT collapse problem).
+TTS_MAX_REQUESTS = 30
+TTS_WINDOW_SECONDS = 60
+
+
+def tts_rate_limit(user_id: int) -> RateLimitInfo:
+    """Check TTS rate limit for *user_id* using the dedicated TTS bucket.
+
+    Key: ``ai:tts:user:{user_id}`` — completely separate from the shared
+    ``ai:`` bucket so TTS bursts cannot starve socratic/comprehension quota.
+
+    Args:
+        user_id: The authenticated user's integer ID.
+
+    Returns:
+        RateLimitInfo with allowed=True if under limit, False if exceeded.
+        When allowed=False, retry_after contains seconds until the window resets.
+    """
+    key = f"ai:tts:user:{user_id}"
+    return tts_rate_limiter.check_with_info(key, TTS_MAX_REQUESTS, TTS_WINDOW_SECONDS)

--- a/backend/app/routes/tts.py
+++ b/backend/app/routes/tts.py
@@ -35,11 +35,13 @@ from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 from ..auth.dependencies import get_current_user, require_role
+from ..auth.rate_limiter import tts_rate_limit
 from ..models.user import User
 from ..services.tts_service import (
     TTSError,
     build_lesson_tts_mapping,
     delete_tts_cache,
+    get_cached_tts,
     synthesize_sentence,
     synthesize_speech,
 )
@@ -57,12 +59,20 @@ class TTSRequest(BaseModel):
 @router.post("/synthesize")
 async def synthesize(
     req: TTSRequest,
-    _current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> Response:
     """Synthesise *text* to MP3 audio using Azure TTS (primary) or Cloud TTS (fallback).
 
     Requires authentication (any active user).  Anonymous requests are rejected
     with 401 to prevent bill-washing attacks on the Azure/GCP TTS quota.
+
+    Rate limiting (Issue #1808):
+    - Cache check happens FIRST — a cache hit returns immediately without
+      touching the rate limiter, so repeated classroom sentences are free.
+    - Rate limit is keyed on user_id (not IP) — avoids entire classroom sharing
+      one 30 RPM bucket when behind a school NAT.
+    - Uses a dedicated ai:tts:user:{id} bucket, separate from the shared ai:
+      bucket, so TTS bursts cannot starve socratic/comprehension quota.
 
     Runs in a thread pool via asyncio.to_thread() so the FastAPI event loop is
     not blocked during the 8–15 s remote TTS call (Azure / Google / Gemini).
@@ -70,9 +80,30 @@ async def synthesize(
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
         401  application/json — not authenticated.
+        429  application/json — rate limit exceeded; Retry-After header present.
         503  application/json — TTS unavailable; client should fall back
              to Web Speech API.
     """
+    # Fix #3: Check L1 cache BEFORE rate limit — cached audio returns immediately
+    # without burning the user's TTS quota (Issue #1808).
+    cached = get_cached_tts(req.text)
+    if cached is not None:
+        logger.debug("TTS L1 cache hit — skipping rate limit check (user=%d)", current_user.id)
+        return Response(
+            content=cached,
+            media_type="audio/mpeg",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+
+    # Fix #1 & #2: Rate limit keyed on user_id, dedicated ai:tts: bucket.
+    rl_info = tts_rate_limit(current_user.id)
+    if not rl_info.allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="TTS rate limit exceeded. Please wait before retrying.",
+            headers={"Retry-After": str(rl_info.retry_after)},
+        )
+
     try:
         audio_bytes = await asyncio.to_thread(synthesize_speech, req.text)
     except TTSError as exc:
@@ -96,12 +127,15 @@ async def synthesize(
 @router.post("/synthesize-sentence")
 async def synthesize_sentence_endpoint(
     req: TTSRequest,
-    _current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> Response:
     """Synthesise a single sentence to MP3 audio (Issue #667).
 
     Requires authentication (any active user).  Anonymous requests are rejected
     with 401 to prevent bill-washing attacks via the pre-generated sentence cache.
+
+    Applies the same cache-before-rate-limit and user_id-keyed rate limiting
+    as /synthesize (Issue #1808 fix).
 
     Stores audio under azure/sentences/ GCS path for sentence-level caching.
     Functionally identical to /synthesize but semantically scoped to sentences.
@@ -110,8 +144,28 @@ async def synthesize_sentence_endpoint(
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
         401  application/json — not authenticated.
+        429  application/json — rate limit exceeded; Retry-After header present.
         503  application/json — TTS unavailable.
     """
+    # Fix #3: Cache check BEFORE rate limit (Issue #1808).
+    cached = get_cached_tts(req.text)
+    if cached is not None:
+        logger.debug("TTS L1 cache hit (sentence) — skipping rate limit (user=%d)", current_user.id)
+        return Response(
+            content=cached,
+            media_type="audio/mpeg",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+
+    # Fix #1 & #2: Per-user TTS rate limit (Issue #1808).
+    rl_info = tts_rate_limit(current_user.id)
+    if not rl_info.allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="TTS rate limit exceeded. Please wait before retrying.",
+            headers={"Retry-After": str(rl_info.retry_after)},
+        )
+
     try:
         audio_bytes = await asyncio.to_thread(synthesize_sentence, req.text)
     except TTSError as exc:

--- a/backend/app/services/tts_service.py
+++ b/backend/app/services/tts_service.py
@@ -752,6 +752,27 @@ def _l1_put(key: str, audio_bytes: bytes) -> None:
     _TTS_CACHE[key] = audio_bytes
 
 
+def get_cached_tts(text: str) -> Optional[bytes]:
+    """Return cached audio bytes for *text* without touching the rate limiter.
+
+    Checks L1 (in-memory) only — the fast synchronous path the route uses to
+    short-circuit rate-limit checks before doing any I/O.  GCS (L2) is checked
+    later inside :func:`synthesize_speech` when this returns None.
+
+    This is intentionally L1-only so the cache check stays synchronous and
+    non-blocking (no thread pool needed).  A GCS hit will still save the remote
+    TTS API call; only the L1 warm-up round-trip is skipped.
+
+    Args:
+        text: The exact text to look up (hashed identically to synthesize_speech).
+
+    Returns:
+        Audio bytes if an L1 cache entry exists, otherwise None.
+    """
+    key = _cache_key(text)
+    return _TTS_CACHE.get(key)
+
+
 def delete_tts_cache(text: str) -> dict:
     """Delete cached audio for *text* from L1 and GCS (both azure and google paths).
 

--- a/backend/tests/test_regression_tts_rate_limit_1808.py
+++ b/backend/tests/test_regression_tts_rate_limit_1808.py
@@ -1,0 +1,313 @@
+"""
+Regression tests for Issue #1808 — TTS classroom rate-limit failure modes.
+
+Four tests:
+
+1. test_same_user_shares_bucket:
+   30 concurrent requests from the SAME user_id pass within the bucket;
+   the 31st gets 429 with Retry-After: 60 header.
+
+2. test_different_users_have_separate_buckets:
+   30 requests from two DIFFERENT user_ids (15 each) — both user_ids pass
+   independently (bucket is not shared).
+
+3. test_cached_request_does_not_decrement_bucket:
+   A pre-warmed L1 cache entry returns 200 without consuming the rate-limit
+   bucket (i.e. 31 requests where the first warms the cache and the following
+   30 are cache hits → all 31 succeed).
+
+4. test_429_response_has_retry_after_60:
+   When the rate limit is exceeded the response contains the header
+   Retry-After: 60.
+
+Run:
+    cd /path/to/chinese-literacy-platform/backend
+    pytest tests/test_regression_tts_rate_limit_1808.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+from app.auth.rate_limiter import tts_rate_limiter  # dedicated TTS limiter
+
+# ---------------------------------------------------------------------------
+# Test DB (SQLite in-memory, isolated from production)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):  # noqa: ANN001
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session) -> None:  # noqa: ANN001
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db() -> Generator:
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_and_login(client) -> dict:  # noqa: ANN001
+    """Register a fresh user and return {'email', 'token', 'user_id'}."""
+    unique = uuid.uuid4().hex[:8]
+    email = f"rl1808_{unique}@example.com"
+    password = "SecurePass123!"
+
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": f"RL Test {unique}",
+    })
+    assert resp.status_code == 201, resp.text
+
+    verification_token = resp.json().get("verification_token")
+    if verification_token is not None:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
+
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    token = login_resp.json()["access_token"]
+
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).first()
+        user_id = user.id
+    finally:
+        db.close()
+
+    return {"email": email, "token": token, "user_id": user_id}
+
+
+FAKE_AUDIO = b"FAKE_AUDIO_BYTES_1808"
+
+
+def _patch_tts():
+    """Patch synthesize_speech so tests don't hit Azure/GCP."""
+    return patch.multiple(
+        "app.routes.tts",
+        synthesize_speech=MagicMock(return_value=FAKE_AUDIO),
+        synthesize_sentence=MagicMock(return_value=FAKE_AUDIO),
+        # get_cached_tts returns None by default — no L1 hit unless overridden
+        get_cached_tts=MagicMock(return_value=None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reset_tts_limiter() -> None:
+    """Clear the TTS rate limiter between tests to avoid cross-test bleed."""
+    tts_rate_limiter.reset()
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Same user shares bucket — 30 pass, 31st is 429
+# ---------------------------------------------------------------------------
+
+class TestSameUserSharesBucket:
+    def test_30_requests_pass_31st_is_429(self, client):
+        """30 requests from the same user_id all succeed; the 31st gets 429."""
+        _reset_tts_limiter()
+        user = _register_and_login(client)
+        token = user["token"]
+
+        with _patch_tts():
+            # First 30 — all should succeed
+            for i in range(30):
+                resp = client.post(
+                    "/api/tts/synthesize",
+                    json={"text": f"測試句子 {i}"},  # unique text → no L1 cache
+                    headers=_auth(token),
+                )
+                assert resp.status_code == 200, (
+                    f"Request #{i + 1} expected 200, got {resp.status_code}: {resp.text}"
+                )
+
+            # 31st — must be rate-limited
+            resp_31 = client.post(
+                "/api/tts/synthesize",
+                json={"text": "測試句子 THIRTY_ONE"},
+                headers=_auth(token),
+            )
+
+        assert resp_31.status_code == 429, (
+            f"Expected 429 for 31st request, got {resp_31.status_code}: {resp_31.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Different users have separate buckets
+# ---------------------------------------------------------------------------
+
+class TestDifferentUsersHaveSeparateBuckets:
+    def test_15_each_both_pass(self, client):
+        """15 requests from user_A and 15 from user_B both succeed independently."""
+        _reset_tts_limiter()
+        user_a = _register_and_login(client)
+        user_b = _register_and_login(client)
+
+        with _patch_tts():
+            for i in range(15):
+                resp_a = client.post(
+                    "/api/tts/synthesize",
+                    json={"text": f"用戶甲 {i}"},
+                    headers=_auth(user_a["token"]),
+                )
+                resp_b = client.post(
+                    "/api/tts/synthesize",
+                    json={"text": f"用戶乙 {i}"},
+                    headers=_auth(user_b["token"]),
+                )
+                assert resp_a.status_code == 200, (
+                    f"User A request #{i + 1}: expected 200, got {resp_a.status_code}"
+                )
+                assert resp_b.status_code == 200, (
+                    f"User B request #{i + 1}: expected 200, got {resp_b.status_code}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Cached request does NOT decrement the bucket
+# ---------------------------------------------------------------------------
+
+class TestCachedRequestDoesNotDecrementBucket:
+    def test_cache_hit_bypasses_rate_limit(self, client):
+        """
+        31 requests where the L1 cache returns audio — all 31 should succeed
+        because cache hits skip the rate-limit check entirely.
+        """
+        _reset_tts_limiter()
+        user = _register_and_login(client)
+        token = user["token"]
+
+        # Patch get_cached_tts to always return FAKE_AUDIO (L1 hit)
+        with patch.multiple(
+            "app.routes.tts",
+            get_cached_tts=MagicMock(return_value=FAKE_AUDIO),
+            synthesize_speech=MagicMock(return_value=FAKE_AUDIO),
+        ):
+            for i in range(31):
+                resp = client.post(
+                    "/api/tts/synthesize",
+                    json={"text": "共同句子（全部都在快取中）"},
+                    headers=_auth(token),
+                )
+                assert resp.status_code == 200, (
+                    f"Cache-hit request #{i + 1} expected 200, "
+                    f"got {resp.status_code}: {resp.text}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: 429 response includes Retry-After: 60 header
+# ---------------------------------------------------------------------------
+
+class TestRetryAfterHeader:
+    def test_429_has_retry_after_header(self, client):
+        """When rate-limited, the response includes Retry-After: 60."""
+        _reset_tts_limiter()
+        user = _register_and_login(client)
+        token = user["token"]
+
+        with _patch_tts():
+            # Exhaust the bucket
+            for i in range(30):
+                client.post(
+                    "/api/tts/synthesize",
+                    json={"text": f"排光配額 {i}"},
+                    headers=_auth(token),
+                )
+
+            # 31st request should return 429 with Retry-After
+            resp = client.post(
+                "/api/tts/synthesize",
+                json={"text": "配額已排光"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 429, (
+            f"Expected 429, got {resp.status_code}: {resp.text}"
+        )
+        retry_after = resp.headers.get("retry-after")
+        assert retry_after is not None, "Retry-After header missing from 429 response"
+        assert retry_after == "60" or int(retry_after) > 0, (
+            f"Retry-After expected ≥1, got '{retry_after}'"
+        )

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -49,6 +49,51 @@ let _currentAudio: HTMLAudioElement | null = null;
 // Flag to signal cancellation mid-sequence
 let _cancelRequested = false;
 
+// ---------------------------------------------------------------------------
+// Issue #1808: 429 rate-limit state
+// ---------------------------------------------------------------------------
+
+/**
+ * When the backend returns 429, we pause the TTS queue until Retry-After elapses.
+ * _rateLimitUntil holds the timestamp (ms) after which requests can resume.
+ * 0 = not rate-limited.
+ */
+let _rateLimitUntil = 0;
+
+/**
+ * Optional callback invoked when TTS hits a 429 rate limit.
+ * Callers (e.g. useTtsPlayback) can use this to show a toast / disable the
+ * play button without needing to catch an exception.
+ * Receives the number of seconds until the limit resets.
+ */
+let _onRateLimit: ((retryAfterSeconds: number) => void) | null = null;
+
+/**
+ * Register a callback to be called when TTS is rate-limited (429).
+ *
+ * Usage:
+ *   setTtsRateLimitCallback((secs) => showToast(`AI 助教暫時忙線，請 ${secs} 秒後再試`, 'warning'));
+ */
+export function setTtsRateLimitCallback(cb: ((retryAfterSeconds: number) => void) | null): void {
+  _onRateLimit = cb;
+}
+
+/**
+ * Return true if TTS requests are currently paused due to a 429 response.
+ * Useful for disabling the play button in the UI.
+ */
+export function isTtsRateLimited(): boolean {
+  return Date.now() < _rateLimitUntil;
+}
+
+/**
+ * Remaining seconds until the TTS rate limit resets, or 0 if not limited.
+ */
+export function ttsRateLimitRemainingSeconds(): number {
+  const remaining = _rateLimitUntil - Date.now();
+  return remaining > 0 ? Math.ceil(remaining / 1000) : 0;
+}
+
 /**
  * Stop any TTS currently in progress.
  */
@@ -148,6 +193,8 @@ export const cleanForTts = _cleanForTts;
 export const _testInternals = {
   reset() {
     _cancelRequested = false;
+    _rateLimitUntil = 0;
+    _onRateLimit = null;
     _urlCache.clear();
     _mappingCache.clear();
   },
@@ -254,14 +301,42 @@ async function _fetchLessonSentences(
 // Private: backend sequential playback
 // ---------------------------------------------------------------------------
 
-async function _fetchAudioUrl(sentence: string): Promise<string> {
+/**
+ * Fetch audio URL for a sentence, or null if rate-limited (429).
+ *
+ * On 429 (Issue #1808):
+ * - Reads Retry-After header (default 60s).
+ * - Sets _rateLimitUntil so subsequent sentences in the queue skip fetching.
+ * - Fires _onRateLimit callback so the UI can show a toast.
+ * - Returns null — callers skip playback for this sentence instead of throwing.
+ *
+ * On any other error: throws (existing behaviour, caught by outer try/catch in
+ * speakText callers or surfaced to the user as a silent skip).
+ */
+async function _fetchAudioUrl(sentence: string): Promise<string | null> {
   let audioUrl = _urlCache.get(sentence);
   if (!audioUrl) {
+    // If still within a rate-limit window, skip this sentence silently.
+    if (isTtsRateLimited()) {
+      return null;
+    }
+
     const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ text: sentence }),
     });
+
+    // Issue #1808 Fix #3: Handle 429 gracefully — pause queue, notify UI.
+    if (response.status === 429) {
+      const retryAfterHeader = response.headers.get('Retry-After');
+      const retryAfterSeconds = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 60;
+      _rateLimitUntil = Date.now() + retryAfterSeconds * 1000;
+      if (_onRateLimit) {
+        _onRateLimit(retryAfterSeconds);
+      }
+      return null; // don't throw — caller skips playback for this sentence
+    }
 
     if (!response.ok) {
       throw new Error(`TTS backend responded ${response.status}`);
@@ -302,6 +377,8 @@ async function _speakViaBackend(
     if (!sentence.trim()) continue;
 
     const audioUrl = await _fetchAudioUrl(sentence);
+    // null = 429 rate-limited — skip this sentence (toast already fired)
+    if (audioUrl === null) continue;
     if (_cancelRequested) break;
     await _playSingleAudio(audioUrl);
   }
@@ -346,7 +423,7 @@ async function _speakViaBackendWithProgress(
   // Bug 2 (#1211): prefetch next sentence's audio URL while current plays
   // so 100-500ms inter-sentence fetch doesn't freeze the highlight.
   const firstIdx = sentences.findIndex((s) => s?.trim());
-  let pending: { idx: number; promise: Promise<string> } | null =
+  let pending: { idx: number; promise: Promise<string | null> } | null =
     firstIdx >= 0
       ? { idx: firstIdx, promise: _fetchAudioUrl(sentences[firstIdx]) }
       : null;
@@ -365,6 +442,8 @@ async function _speakViaBackendWithProgress(
     const audioUrl = pending && pending.idx === i
       ? await pending.promise
       : await _fetchAudioUrl(sentence);
+    // null = 429 rate-limited — skip playback for this sentence
+    if (audioUrl === null) continue;
     if (_cancelRequested) break;
 
     // Start prefetch for next non-empty sentence BEFORE awaiting playback.


### PR DESCRIPTION
Fixes #1808

## Summary

- **Fix 1 & 2 — Rate limit keyed on user_id, dedicated ai:tts: bucket**: `rate_limiter.py` adds `tts_rate_limiter` singleton + `tts_rate_limit(user_id: int)` using key `ai:tts:user:{id}`. Isolated from shared `ai:` bucket. TTS bursts cannot starve socratic/comprehension quota.

- **Fix 3 — Cache-check BEFORE rate limit**: `tts_service.py` exposes `get_cached_tts(text)` (L1 synchronous lookup). Both endpoints call it first — L1 hit returns audio without consuming quota.

- **Fix 4 — Frontend 429 handling**: `ttsApi.ts` `_fetchAudioUrl()` returns `string | null`. On 429: reads `Retry-After`, sets `_rateLimitUntil` pause window, fires `_onRateLimit` callback for UI toast, returns null (no throw). Exports: `setTtsRateLimitCallback`, `isTtsRateLimited`, `ttsRateLimitRemainingSeconds`.

## Test plan

- [x] 4/4 regression tests pass: `pytest tests/test_regression_tts_rate_limit_1808.py`
- [x] 70/70 existing TTS tests pass (zero regression)
- [ ] Staging verify after CI: first req 200, 31st rapid req 429 w/ Retry-After, cached repeat 200 no quota hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)