### PR TITLE
release: hotfix round — 3 P1 codex-review fixes (1808 TTS / 1809 API / 1810 N+1)

### DIFF
--- a/backend/app/auth/rate_limiter.py
+++ b/backend/app/auth/rate_limiter.py
@@ -173,3 +173,33 @@ ai_limit_10_per_min = make_ai_rate_limit_dependency(max_requests=10, window_seco
 ai_limit_5_per_min = make_ai_rate_limit_dependency(max_requests=5, window_seconds=60)
 # General API: 100 requests / minute per IP
 general_limit_100_per_min = make_general_rate_limit_dependency(max_requests=100, window_seconds=60)
+
+
+# ---------------------------------------------------------------------------
+# TTS-specific rate limiter (Issue #1808)
+# ---------------------------------------------------------------------------
+
+# Dedicated in-memory limiter for TTS — isolated from the shared ai_rate_limiter
+# so that TTS bursts do NOT consume the socratic/comprehension/reading quota.
+tts_rate_limiter = InMemoryRateLimiter()
+
+# TTS limits per user_id (not IP — avoids classroom NAT collapse problem).
+TTS_MAX_REQUESTS = 30
+TTS_WINDOW_SECONDS = 60
+
+
+def tts_rate_limit(user_id: int) -> RateLimitInfo:
+    """Check TTS rate limit for *user_id* using the dedicated TTS bucket.
+
+    Key: ``ai:tts:user:{user_id}`` — completely separate from the shared
+    ``ai:`` bucket so TTS bursts cannot starve socratic/comprehension quota.
+
+    Args:
+        user_id: The authenticated user's integer ID.
+
+    Returns:
+        RateLimitInfo with allowed=True if under limit, False if exceeded.
+        When allowed=False, retry_after contains seconds until the window resets.
+    """
+    key = f"ai:tts:user:{user_id}"
+    return tts_rate_limiter.check_with_info(key, TTS_MAX_REQUESTS, TTS_WINDOW_SECONDS)

--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -7,13 +7,18 @@ Assignment System API — teachers create assignments, students complete them.
 - DB texts with non-platform visibility: at creation we fork the text
   (see services/assignment_copy_strategy.py) and assignment.text_id
   points to the fork.
+
+Split (Issue #1771):
+- Response builders → services/assignment_responses.py
+- Title/slug query helpers → services/assignment_queries.py
 """
 import logging
+from collections import defaultdict
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -40,6 +45,16 @@ from ..schemas.assignment import (
     DEFAULT_TARGET_ACCURACY,
 )
 from ..services.assignment_copy_strategy import resolve_text_for_assignment
+from ..services.assignment_queries import (
+    resolve_story_title_from_yaml,
+    resolve_title_for_assignment,
+    resolve_story_slug_for_assignment,
+)
+from ..services.assignment_responses import (
+    build_assignment_response,
+    extract_reading_metrics,
+    extract_assignment_progress,
+)
 from ..services.input_sanitizer import sanitize_ai_input
 from ..services.lesson_loader import get_lesson_by_id
 from ..services.notification_service import send_assignment_submitted_notification
@@ -51,53 +66,18 @@ router = APIRouter(tags=["assignments"])
 logger = logging.getLogger(__name__)
 
 
-# ── Helpers ──────────────────────────────────────────────────────────────────
-
+# ── Module-private aliases (kept for readability inside this file) ─────────────
 
 def _resolve_story_title_from_yaml(story_id: str) -> str | None:
-    """Resolve a YAML story_id (lesson_number) to its title.
-
-    Accepts both numeric strings ("6") and L-prefixed format ("L06").
-    """
-    try:
-        story = get_lesson_by_id(int(normalize_story_slug(story_id)))
-        if story:
-            return story["title"]
-    except (ValueError, TypeError):
-        pass
-    return None
+    return resolve_story_title_from_yaml(story_id)
 
 
 def _resolve_title_for_assignment(assignment: Assignment, db: Session) -> str:
-    """Return the display title for an assignment's text source.
-
-    Uses the already-loaded ``assignment.text`` relationship when available
-    (e.g. after a ``joinedload(Assignment.text)`` / ``selectinload(Assignment.text)``
-    in the calling query) to avoid an extra SELECT per assignment.  Falls back
-    to an explicit DB query only when the relationship attribute is absent or
-    unloaded — for example when the assignment was fetched without eager-loading.
-    """
-    if assignment.story_id is not None:
-        return _resolve_story_title_from_yaml(assignment.story_id) or assignment.story_id
-    if assignment.text_id is not None:
-        # Prefer the already-loaded relationship (no extra query).
-        text_obj = assignment.text  # type: ignore[attr-defined]
-        if text_obj is not None:
-            return text_obj.title
-        # Fallback: relationship not loaded — hit DB once.
-        text_row = db.query(Text).filter(Text.id == assignment.text_id).first()
-        if text_row:
-            return text_row.title
-    return "(Unknown)"
+    return resolve_title_for_assignment(assignment, db)
 
 
 def _resolve_story_slug_for_assignment(assignment: Assignment) -> str | None:
-    """Return the LearningSession story_slug key used for this assignment."""
-    if assignment.story_id is not None:
-        return assignment.story_id
-    if assignment.text_id is not None:
-        return str(assignment.text_id)
-    return None
+    return resolve_story_slug_for_assignment(assignment)
 
 
 def _assignment_to_response(
@@ -106,70 +86,10 @@ def _assignment_to_response(
     *,
     precomputed_counts: dict | None = None,
 ) -> AssignmentResponse:
-    """Convert an Assignment ORM object to an AssignmentResponse.
+    return build_assignment_response(assignment, db, precomputed_counts=precomputed_counts)
 
-    precomputed_counts — optional dict keyed by assignment.id with keys:
-      assigned_student_count, submitted_student_count, total_attempts.
-    When provided (bulk list path) the per-row COUNT queries are skipped,
-    eliminating the N+1 pattern (Issue #1766).
-    """
-    story_title = _resolve_title_for_assignment(assignment, db)
 
-    if precomputed_counts is not None and assignment.id in precomputed_counts:
-        counts = precomputed_counts[assignment.id]
-        assigned_student_count: int = counts["assigned_student_count"]
-        submitted_student_count: int = counts["submitted_student_count"]
-        total_attempts: int = counts["total_attempts"]
-    else:
-        # Single-assignment path: fall back to per-row queries (Issue #1764 Fix 3)
-        assigned_student_count = (
-            db.query(func.count(func.distinct(ClassroomStudent.student_id)))
-            .filter(ClassroomStudent.classroom_id == assignment.classroom_id)
-            .scalar() or 0
-        )
-        submitted_student_count = (
-            db.query(func.count(func.distinct(AssignmentSubmission.student_id)))
-            .filter(
-                AssignmentSubmission.assignment_id == assignment.id,
-                AssignmentSubmission.status.in_(["submitted", "graded"]),
-            )
-            .scalar() or 0
-        )
-        total_attempts = (
-            db.query(func.count(AssignmentSubmission.id))
-            .filter(AssignmentSubmission.assignment_id == assignment.id)
-            .scalar() or 0
-        )
-
-    return AssignmentResponse(
-        id=assignment.id,
-        classroom_id=assignment.classroom_id,
-        teacher_id=assignment.teacher_id,
-        story_id=assignment.story_id,
-        text_id=assignment.text_id,
-        story_title=story_title,
-        title=assignment.title,
-        description=assignment.description,
-        assignment_type=assignment.assignment_type,
-        due_date=assignment.due_date,
-        is_active=assignment.is_active,
-        created_at=assignment.created_at,
-        # Issue #1764 Fix 3: split counts
-        assigned_student_count=assigned_student_count,
-        submitted_student_count=submitted_student_count,
-        total_attempts=total_attempts,
-        # Back-compat aliases for existing frontend
-        submission_count=total_attempts,
-        completed_count=submitted_student_count,
-        # Reading goals (Issue #84)
-        target_cpm=assignment.target_cpm,
-        target_accuracy=assignment.target_accuracy,
-        difficulty_label=assignment.difficulty_label,
-        effective_cpm=assignment.target_cpm if assignment.target_cpm is not None else DEFAULT_TARGET_CPM,
-        effective_accuracy=assignment.target_accuracy if assignment.target_accuracy is not None else DEFAULT_TARGET_ACCURACY,
-        # Issue #1762
-        skip_completed_steps=assignment.skip_completed_steps,
-    )
+# ── Auth helpers ──────────────────────────────────────────────────────────────
 
 
 def _require_assignment_owner_or_admin(
@@ -201,79 +121,14 @@ def _has_role(user_id: int, role_name: str, db: Session) -> bool:
 def _extract_reading_metrics(
     sub: AssignmentSubmission, db: Session
 ) -> tuple[float | None, float | None, list[str]]:
-    """Extract reading metrics (accuracy, cpm, error_chars) from the linked LearningSession.
-
-    Returns (reading_accuracy, reading_cpm, reading_error_chars).
-    All values are None/[] when no session exists or data hasn't been recorded yet.
-
-    Issue #1767: uses sub.session (already eager-loaded via joinedload in
-    get_assignment_detail) when available, avoiding a per-row DB query.
-    Falls back to an explicit query for callers that did not eager-load.
-    """
-    if sub.session_id is None:
-        return None, None, []
-
-    # Use already-loaded relationship value if present (avoids N+1)
-    from sqlalchemy.orm.base import instance_state
-    state = instance_state(sub)
-    if "session" in state.dict:
-        # relationship was eager-loaded
-        session = sub.session
-    else:
-        session = (
-            db.query(LearningSession)
-            .filter(LearningSession.id == sub.session_id)
-            .first()
-        )
-
-    if session is None:
-        return None, None, []
-
-    accuracy = session.accuracy  # stored directly on session
-    cpm: float | None = None
-    error_chars: list[str] = []
-
-    if session.reading_result and isinstance(session.reading_result, dict):
-        cpm = session.reading_result.get("cpm")
-        raw_errors = session.reading_result.get("error_chars", [])
-        if isinstance(raw_errors, list):
-            error_chars = [str(c) for c in raw_errors]
-
-    return accuracy, cpm, error_chars
+    return extract_reading_metrics(sub, db)
 
 
 def _extract_assignment_progress(
     sub: AssignmentSubmission, db: Session
 ) -> tuple[int | None, str | None, list[str]]:
-    """Extract durable step progress for assignment list/resume UI.
+    return extract_assignment_progress(sub, db)
 
-    Returns (session_id, current_step_path, steps_completed).
-    """
-    if sub.session_id is None:
-        return None, None, []
-
-    session = (
-        db.query(LearningSession)
-        .filter(LearningSession.id == sub.session_id)
-        .first()
-    )
-    if session is None:
-        return sub.session_id, None, []
-
-    # parse_step_progress logs a WARNING when value is malformed (Issue #1180).
-    sp = parse_step_progress(
-        session.step_progress,
-        session_id=session.id,
-        context="assignments._get_session_step_info",
-    )
-    current_step: str | None = sp.current_step.strip() if sp is not None and sp.current_step else None
-    steps_completed: list[str] = (
-        [s.strip() for s in sp.steps_completed if s.strip()]
-        if sp is not None
-        else []
-    )
-
-    return session.id, current_step, steps_completed
 
 
 # ── Student Endpoints (registered first to avoid path parameter conflicts) ───
@@ -723,7 +578,6 @@ def get_assignment_detail(
         )
 
     # Issue #1764 Fix 4: group submissions by student
-    from collections import defaultdict
     student_subs: dict[int, list[AssignmentSubmission]] = defaultdict(list)
     for sub in submissions:
         student_subs[sub.student_id].append(sub)

--- a/backend/app/routes/assignments.py
+++ b/backend/app/routes/assignments.py
@@ -69,13 +69,25 @@ def _resolve_story_title_from_yaml(story_id: str) -> str | None:
 
 
 def _resolve_title_for_assignment(assignment: Assignment, db: Session) -> str:
-    """Return the display title for an assignment's text source."""
+    """Return the display title for an assignment's text source.
+
+    Uses the already-loaded ``assignment.text`` relationship when available
+    (e.g. after a ``joinedload(Assignment.text)`` / ``selectinload(Assignment.text)``
+    in the calling query) to avoid an extra SELECT per assignment.  Falls back
+    to an explicit DB query only when the relationship attribute is absent or
+    unloaded — for example when the assignment was fetched without eager-loading.
+    """
     if assignment.story_id is not None:
         return _resolve_story_title_from_yaml(assignment.story_id) or assignment.story_id
     if assignment.text_id is not None:
-        text = db.query(Text).filter(Text.id == assignment.text_id).first()
-        if text:
-            return text.title
+        # Prefer the already-loaded relationship (no extra query).
+        text_obj = assignment.text  # type: ignore[attr-defined]
+        if text_obj is not None:
+            return text_obj.title
+        # Fallback: relationship not loaded — hit DB once.
+        text_row = db.query(Text).filter(Text.id == assignment.text_id).first()
+        if text_row:
+            return text_row.title
     return "(Unknown)"
 
 

--- a/backend/app/routes/omo.py
+++ b/backend/app/routes/omo.py
@@ -19,16 +19,20 @@ llm-endpoint-hardening checklist:
 - Output token cap: enforced in omo_identifier (512) + omo_grader (2048) ✅
 - Fail-closed: status=error on AI failure, never auto-passes ✅
 - Reasoning field: every candidate and every answer has reasoning ✅
+
+AnalysisBy: issue #1770 — split from 1197-line monolith into 4 focused modules:
+  - routes/omo.py       (this file) — FastAPI router + thin handler bodies
+  - services/omo_storage.py        — GCS upload, signing, bucket constant
+  - services/omo_responses.py      — Pydantic schemas + response builders
+  - services/omo_jobs.py           — background tasks, _update_upload helper
 """
 
 import hashlib
 import logging
-import os
 from datetime import datetime, timezone
-from typing import Literal, Optional
+from typing import Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Path, UploadFile, status
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Path, UploadFile
 from sqlalchemy.orm import Session
 
 from ..auth.dependencies import get_current_user
@@ -36,6 +40,27 @@ from ..auth.rate_limiter import make_ai_rate_limit_dependency
 from ..database import get_db
 from ..models.omo_upload import OmoUpload, OmoUploadAttempt
 from ..models.user import User
+
+# Delegated to focused service modules (issue #1770 split)
+from ..services.omo_storage import _OMO_GCS_BUCKET, _get_signed_url, _upload_to_gcs
+from ..services.omo_responses import (
+    AnswerFlagInfo,
+    AnswerItem,
+    CropSignedUrlResponse,
+    FlagRequest,
+    LessonCandidateResponse,
+    LessonSummaryResponse,
+    OmoAttemptResponse,
+    OmoByLessonResponse,
+    OmoConfirmRequest,
+    OmoConfirmResponse,
+    OmoRegradeResponse,
+    OmoSignedImageInfo,
+    OmoUploadResponse,
+    SignedUrlResponse,
+    _build_upload_response,
+)
+from ..services.omo_jobs import _run_grading, _run_identification, _update_upload
 
 logger = logging.getLogger(__name__)
 
@@ -45,474 +70,10 @@ router = APIRouter(tags=["omo"])
 _MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024   # 10MB per image
 _MAX_FILES_PER_UPLOAD = 20                  # max files per single upload call
 _MAX_TOTAL_ATTEMPTS = 5                    # max attempts per upload session
-_OMO_GCS_BUCKET = os.environ.get("GCS_OMO_BUCKET", "lingoleap-omo-uploads")
 _ALLOWED_MIME_TYPES = {"image/jpeg", "image/jpg", "image/png", "image/webp"}
 
 
-# ── Pydantic schemas ───────────────────────────────────────────────────────────
-
-class LessonSummaryResponse(BaseModel):
-    """Simplified lesson entry for the manual picker in the 3-tier confidence UX."""
-    lesson_id: int
-    grade_code: str
-    title: str
-
-
-class LessonCandidateResponse(BaseModel):
-    lesson_id: int
-    grade_code: str
-    title: str
-    confidence: float
-    reasoning: str
-    # #1775: canonical Story.id resolved at identifier service boundary.
-    # None when the lesson exists in the YAML catalog but has no matching DB row.
-    # Frontend should prefer story_id over lesson_id for /api/stories lookups.
-    story_id: Optional[int] = None
-
-
-class AnswerFlagInfo(BaseModel):
-    flagged_by: int
-    reason: str
-    flagged_at: str
-
-
-class AnswerItem(BaseModel):
-    question_id: str
-    student_answer: str
-    # Optional: multiple_choice questions can have answer=null (no correct answer
-    # in YAML — used for open-ended questions like mc_2 in L24).
-    correct_answer: Optional[str] = None
-    score: float
-    ai_confidence: float
-    reasoning: str
-    source_attempt_id: Optional[int] = None
-    position: Optional[dict] = None
-    crop_image_url: Optional[str] = None
-    flag: Optional[AnswerFlagInfo] = None
-
-
-class OmoUploadResponse(BaseModel):
-    upload_id: int
-    status: Literal["pending", "identifying", "identified", "grading", "graded", "error"]
-    candidates: list[LessonCandidateResponse]
-    answers: list[AnswerItem]
-    overall_score: Optional[float] = None
-    ai_overall_confidence: Optional[float] = None
-    progress: Optional[dict] = None
-    error_message: Optional[str] = None
-    # Phase 1b dedup fields
-    from_cache: bool = False         # True if this response reuses a prior upload (same image hash)
-    already_graded: bool = False     # True if the cached upload already has status=graded
-
-
-class OmoAttemptResponse(BaseModel):
-    upload_id: int
-    attempt_id: int
-    attempt_idx: int
-    status: str
-    message: str
-
-
-class OmoConfirmRequest(BaseModel):
-    confirmed_lesson_id: int
-
-
-class OmoConfirmResponse(BaseModel):
-    upload_id: int
-    lesson_id: int
-    status: str
-    message: str
-
-
-class FlagRequest(BaseModel):
-    reason: str = "AI 辨識不正確"
-
-
-class SignedUrlResponse(BaseModel):
-    url: Optional[str]
-    expires_in_seconds: int = 3600
-
-
-# ── GCS helpers ───────────────────────────────────────────────────────────────
-
-def _upload_to_gcs(
-    user_id: int, upload_id: int, attempt_idx: int, file_index: int,
-    data: bytes, mime_type: str
-) -> str:
-    """Upload image bytes to GCS. Returns the GCS object path.
-
-    Path format: {user_id}/{upload_id}/{attempt_idx}/{file_index}.jpg
-    Falls back gracefully if google-cloud-storage is not installed (local dev).
-    """
-    object_path = f"{user_id}/{upload_id}/{attempt_idx}/{file_index}.jpg"
-    try:
-        from google.cloud import storage  # type: ignore[import]
-        client = storage.Client()
-        bucket = client.bucket(_OMO_GCS_BUCKET)
-        blob = bucket.blob(object_path)
-        blob.upload_from_string(data, content_type=mime_type)
-        logger.info("OMO: uploaded gs://%s/%s", _OMO_GCS_BUCKET, object_path)
-    except ImportError:
-        logger.warning("google-cloud-storage not available — skipping GCS upload (local dev)")
-    except Exception as exc:
-        logger.warning("OMO GCS upload failed for %s: %s — continuing without GCS", object_path, exc)
-    return object_path
-
-
-def _get_signed_url(object_path: str) -> Optional[str]:
-    """Generate a 1-hour signed URL for a GCS object. Returns None if unavailable.
-
-    Uses IAM-based signing (service_account_email + access_token) so it works on
-    Cloud Run where the default ADC has no private key file. Falls back to bare
-    generate_signed_url() for local dev where credentials may already include a
-    private key.
-    """
-    import datetime as dt
-    try:
-        from google.cloud import storage  # type: ignore[import]
-        from google.auth import default as google_auth_default  # type: ignore[import]
-        from google.auth.transport.requests import Request as GoogleAuthRequest  # type: ignore[import]
-
-        client = storage.Client()
-        bucket = client.bucket(_OMO_GCS_BUCKET)
-        blob = bucket.blob(object_path)
-
-        sa_email = None
-        access_token = None
-        try:
-            credentials, _proj = google_auth_default()
-            if credentials and not getattr(credentials, "valid", False):
-                credentials.refresh(GoogleAuthRequest())
-            sa_email = getattr(credentials, "service_account_email", None)
-            access_token = getattr(credentials, "token", None)
-        except Exception as cred_exc:
-            logger.warning("OMO signed URL: failed to fetch ADC for IAM signing: %s", cred_exc)
-
-        kwargs = {
-            "version": "v4",
-            "expiration": dt.timedelta(hours=1),
-            "method": "GET",
-        }
-        # Only pass IAM signing kwargs when both are available — otherwise let the
-        # SDK pick its default (private key path for local dev).
-        if sa_email and access_token:
-            kwargs["service_account_email"] = sa_email
-            kwargs["access_token"] = access_token
-
-        return blob.generate_signed_url(**kwargs)
-    except Exception as exc:
-        logger.warning("OMO signed URL failed for %s: %s", object_path, exc)
-        return None
-
-
-# ── Background task helpers ───────────────────────────────────────────────────
-
-def _update_upload(upload_id: int, **kwargs):
-    """Open a short-lived DB session to update an OmoUpload record.
-    Used in background tasks that run outside the request scope.
-    """
-    from ..database import SessionLocal
-    db = SessionLocal()
-    try:
-        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
-        if upload:
-            for k, v in kwargs.items():
-                setattr(upload, k, v)
-            db.commit()
-    except Exception as exc:
-        logger.error("OMO _update_upload id=%d failed: %s", upload_id, exc)
-        db.rollback()
-    finally:
-        db.close()
-
-
-async def _run_identification(
-    upload_id: int,
-    image_bytes_list: list[bytes],
-    mime_types: list[str],
-    lesson_code_hint: Optional[str] = None,
-):
-    """Background task: identify lesson and write result back to DB.
-
-    If ``lesson_code_hint`` is provided (student uploaded from within a lesson
-    page), use the fast hint path (no AI call, conf=1.0).  Otherwise fall back
-    to the Gemini-powered fuzzy-match path.
-    """
-    # ── Hint path: lesson is already known, skip AI identification ────────────
-    if lesson_code_hint:
-        try:
-            from ..services.omo_identifier import identify_lesson_from_hint
-            candidates = identify_lesson_from_hint(lesson_code_hint)
-        except ImportError as exc:
-            logger.error("OMO identifier import failed: %s", exc)
-            candidates = []
-
-        if not candidates:
-            logger.warning(
-                "OMO hint path: lesson_code=%r not found — falling back to AI",
-                lesson_code_hint,
-            )
-            # Fall through to AI path below
-        else:
-            _update_upload(
-                upload_id,
-                identification=[
-                    {
-                        "lesson_id": c.lesson_id,
-                        "grade_code": c.grade_code,
-                        "title": c.title,
-                        "confidence": c.confidence,
-                        "reasoning": c.reasoning,
-                    }
-                    for c in candidates
-                ],
-                ai_confidence=candidates[0].confidence,
-                status="identified",
-            )
-            logger.info(
-                "OMO upload %d hint-identified: lesson_code=%r title=%s conf=%.2f",
-                upload_id,
-                lesson_code_hint,
-                candidates[0].title,
-                candidates[0].confidence,
-            )
-            return
-
-    # ── AI path: fuzzy match via Gemini ──────────────────────────────────────
-    try:
-        from ..services.omo_identifier import identify_lesson_from_image
-    except ImportError as exc:
-        logger.error("OMO identifier import failed: %s", exc)
-        _update_upload(upload_id, status="error", error_message="AI identifier unavailable")
-        return
-
-    primary_image = image_bytes_list[0]
-    primary_mime = mime_types[0] if mime_types else "image/jpeg"
-
-    try:
-        candidates = await identify_lesson_from_image(primary_image, primary_mime)
-    except RuntimeError as exc:
-        logger.error("OMO identification circuit breaker: %s", exc)
-        _update_upload(upload_id, status="error", error_message="AI 服務暫時無法使用，請稍後再試")
-        return
-    except Exception as exc:
-        logger.error("OMO identification error: %s", exc, exc_info=True)
-        _update_upload(upload_id, status="error", error_message="辨識失敗，請重新上傳")
-        return
-
-    if not candidates:
-        _update_upload(
-            upload_id,
-            status="error",
-            error_message="照片不清楚或無法辨識課程，請重新拍攝",
-        )
-        return
-
-    _update_upload(
-        upload_id,
-        identification=[
-            {
-                "lesson_id": c.lesson_id,
-                "grade_code": c.grade_code,
-                "title": c.title,
-                "confidence": c.confidence,
-                "reasoning": c.reasoning,
-            }
-            for c in candidates
-        ],
-        ai_confidence=candidates[0].confidence,
-        status="identified",
-    )
-    logger.info(
-        "OMO upload %d identified: top=%s (%.2f)",
-        upload_id,
-        candidates[0].title,
-        candidates[0].confidence,
-    )
-
-
-async def _run_grading(upload_id: int, lesson_id: int):
-    """Background task: extract + grade per-question answers, write to DB."""
-    from ..database import SessionLocal
-    from ..services.lesson_loader import get_lesson_by_id
-
-    lesson = get_lesson_by_id(lesson_id)
-    if not lesson:
-        _update_upload(upload_id, status="error", error_message=f"找不到課程 ID {lesson_id}")
-        return
-
-    # Collect active attempt images from DB
-    db = SessionLocal()
-    active_attempt = None
-    image_paths = []
-    try:
-        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
-        if not upload:
-            return
-
-        # Find the latest active attempt
-        for attempt in reversed(upload.attempts or []):
-            if attempt.is_active:
-                active_attempt = attempt
-                image_paths = attempt.image_paths or []
-                break
-
-        # Fallback: if no attempt, use legacy image_paths on upload (Phase 1 compat)
-        if not active_attempt:
-            # Try old-style image_paths column
-            old_paths = getattr(upload, "image_paths", []) or []
-            if old_paths:
-                image_paths = old_paths
-
-    except Exception as exc:
-        logger.error("OMO grading DB fetch failed for upload %d: %s", upload_id, exc)
-        db.rollback()
-    finally:
-        db.close()
-
-    if not image_paths:
-        _update_upload(
-            upload_id,
-            status="error",
-            error_message="找不到可批改的圖片",
-        )
-        return
-
-    # Load image bytes from GCS (or skip GCS if local dev)
-    image_bytes_list: list[bytes] = []
-    mime_types: list[str] = []
-    for path in image_paths:
-        try:
-            from google.cloud import storage  # type: ignore[import]
-            client = storage.Client()
-            bucket = client.bucket(_OMO_GCS_BUCKET)
-            blob = bucket.blob(path)
-            data = blob.download_as_bytes()
-            image_bytes_list.append(data)
-            mime_types.append("image/jpeg")
-        except Exception as exc:
-            logger.warning("OMO grading: could not load image %s: %s — using placeholder", path, exc)
-            # Use a tiny placeholder for local dev (grader will return mock grades)
-            image_bytes_list.append(b"placeholder")
-            mime_types.append("image/jpeg")
-
-    # Update progress: grading started
-    _update_upload(
-        upload_id,
-        status="grading",
-        progress={"stage": "grading", "total": 0, "graded": 0},
-    )
-
-    # Call grader
-    try:
-        from ..services.omo_grader import grade_worksheet_images
-        attempt_id = active_attempt.id if active_attempt else None
-        graded = await grade_worksheet_images(image_bytes_list, mime_types, lesson, attempt_id, upload_id=upload_id)
-    except RuntimeError as exc:
-        logger.error("OMO grader circuit breaker: %s", exc)
-        _update_upload(upload_id, status="error", error_message="批改服務暫時無法使用")
-        return
-    except Exception as exc:
-        logger.error("OMO grading error for upload %d: %s", upload_id, exc, exc_info=True)
-        _update_upload(upload_id, status="error", error_message="批改失敗，請稍後重試")
-        return
-
-    # Compute overall score
-    if graded:
-        overall_score = sum(g.score for g in graded) / len(graded)
-        overall_confidence = sum(g.ai_confidence for g in graded) / len(graded)
-    else:
-        overall_score = None
-        overall_confidence = None
-
-    answers_payload = [
-        {
-            "question_id": g.question_id,
-            "student_answer": g.student_answer,
-            "correct_answer": g.correct_answer,
-            "score": g.score,
-            "ai_confidence": g.ai_confidence,
-            "reasoning": g.reasoning,
-            "source_attempt_id": g.source_attempt_id,
-            "position": g.position,
-            "crop_image_url": g.crop_image_url,
-            "flag": None,
-        }
-        for g in graded
-    ]
-
-    _update_upload(
-        upload_id,
-        status="graded",
-        answers=answers_payload,
-        overall_score=overall_score,
-        ai_overall_confidence=overall_confidence,
-        progress={"stage": "done", "total": len(graded), "graded": len(graded)},
-    )
-    logger.info(
-        "OMO upload %d graded: %d questions, overall_score=%.2f",
-        upload_id,
-        len(graded),
-        overall_score or 0.0,
-    )
-
-
-# ── Internal helpers ───────────────────────────────────────────────────────────
-
-def _build_upload_response(upload: OmoUpload) -> OmoUploadResponse:
-    """Convert ORM object to response schema."""
-    candidates = []
-    if upload.identification and isinstance(upload.identification, list):
-        candidates = [
-            LessonCandidateResponse(
-                lesson_id=c["lesson_id"],
-                grade_code=c.get("grade_code", ""),
-                title=c.get("title", ""),
-                confidence=c.get("confidence", 0.0),
-                reasoning=c.get("reasoning", ""),
-                # #1775: story_id may already be in the stored JSON (new uploads)
-                # or absent for uploads made before this fix (None is acceptable).
-                story_id=c.get("story_id"),
-            )
-            for c in upload.identification
-        ]
-
-    answers = []
-    if upload.answers and isinstance(upload.answers, list):
-        for a in upload.answers:
-            flag_info = None
-            if a.get("flag"):
-                flag_info = AnswerFlagInfo(
-                    flagged_by=a["flag"].get("flagged_by", 0),
-                    reason=a["flag"].get("reason", ""),
-                    flagged_at=a["flag"].get("flagged_at", ""),
-                )
-            answers.append(AnswerItem(
-                question_id=a.get("question_id", ""),
-                student_answer=a.get("student_answer", ""),
-                correct_answer=a.get("correct_answer", ""),
-                score=a.get("score", 0.0),
-                ai_confidence=a.get("ai_confidence", 0.0),
-                reasoning=a.get("reasoning", ""),
-                source_attempt_id=a.get("source_attempt_id"),
-                position=a.get("position"),
-                crop_image_url=a.get("crop_image_url"),
-                flag=flag_info,
-            ))
-
-    return OmoUploadResponse(
-        upload_id=upload.id,
-        status=upload.status,  # type: ignore[arg-type]
-        candidates=candidates,
-        answers=answers,
-        overall_score=upload.overall_score,
-        ai_overall_confidence=upload.ai_overall_confidence,
-        progress=upload.progress or {},
-        error_message=upload.error_message,
-        from_cache=False,
-        already_graded=False,
-    )
-
+# ── Internal route helpers ─────────────────────────────────────────────────────
 
 def _get_upload_or_404(upload_id: int, user: User, db: Session) -> OmoUpload:
     """Fetch OmoUpload by id + student_id, raise 404 if missing."""
@@ -922,12 +483,6 @@ def get_upload_status(
     return _build_upload_response(upload)
 
 
-class OmoRegradeResponse(BaseModel):
-    upload_id: int
-    status: str
-    message: str
-
-
 @router.post(
     "/omo/{upload_id}/regrade",
     response_model=OmoRegradeResponse,
@@ -1101,11 +656,6 @@ def delete_upload(
     logger.info("OMO upload %d deleted by student %d", upload_id, current_user.id)
 
 
-class CropSignedUrlResponse(BaseModel):
-    url: Optional[str]
-    expires_in_seconds: int = 3600
-
-
 @router.get('/omo/{upload_id}/crops/{question_id}', response_model=CropSignedUrlResponse)
 def get_crop_signed_url(
     upload_id: int,
@@ -1138,19 +688,6 @@ def get_crop_signed_url(
 
     signed_url = _get_signed_url(object_path)
     return CropSignedUrlResponse(url=signed_url)
-
-
-class OmoSignedImageInfo(BaseModel):
-    attempt_id: int
-    index: int
-    url: Optional[str] = None
-
-
-class OmoByLessonResponse(BaseModel):
-    upload_id: Optional[int] = None
-    status: Optional[str] = None
-    has_prior_upload: bool = False
-    images: list[OmoSignedImageInfo] = Field(default_factory=list)
 
 
 @router.get('/omo/by-lesson/{lesson_id}', response_model=OmoByLessonResponse)

--- a/backend/app/routes/tts.py
+++ b/backend/app/routes/tts.py
@@ -35,12 +35,13 @@ from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 from ..auth.dependencies import get_current_user, require_role
-from ..auth.rate_limiter import make_ai_rate_limit_dependency
+from ..auth.rate_limiter import make_ai_rate_limit_dependency, tts_rate_limit
 from ..models.user import User
 from ..services.tts_service import (
     TTSError,
     build_lesson_tts_mapping,
     delete_tts_cache,
+    get_cached_tts,
     synthesize_sentence,
     synthesize_speech,
 )
@@ -55,22 +56,23 @@ class TTSRequest(BaseModel):
     text: str = Field(..., min_length=1, max_length=5000, description="Plain text to synthesise (zh-TW)")
 
 
-@router.post(
-    "/synthesize",
-    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=30, window_seconds=60))],
-)
+@router.post("/synthesize")
 async def synthesize(
     req: TTSRequest,
-    _current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> Response:
     """Synthesise *text* to MP3 audio using Azure TTS (primary) or Cloud TTS (fallback).
 
     Requires authentication (any active user).  Anonymous requests are rejected
     with 401 to prevent bill-washing attacks on the Azure/GCP TTS quota.
 
-    Rate-limited to 30 requests / 60 s per user: TTS fires per paragraph so
-    bursts are expected, but with TTS_PROVIDER=gemini31 each cache miss is an
-    LLM call — 30 RPM balances UX (≤ 30 paragraphs/minute) with cost safety.
+    Rate limiting (Issue #1808):
+    - Cache check happens FIRST — a cache hit returns immediately without
+      touching the rate limiter, so repeated classroom sentences are free.
+    - Rate limit is keyed on user_id (not IP) — avoids entire classroom sharing
+      one 30 RPM bucket when behind a school NAT.
+    - Uses a dedicated ai:tts:user:{id} bucket, separate from the shared ai:
+      bucket, so TTS bursts cannot starve socratic/comprehension quota.
 
     Runs in a thread pool via asyncio.to_thread() so the FastAPI event loop is
     not blocked during the 8–15 s remote TTS call (Azure / Google / Gemini).
@@ -78,10 +80,30 @@ async def synthesize(
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
         401  application/json — not authenticated.
-        429  application/json — rate limit exceeded.
+        429  application/json — rate limit exceeded; Retry-After header present.
         503  application/json — TTS unavailable; client should fall back
              to Web Speech API.
     """
+    # Fix #3: Check L1 cache BEFORE rate limit — cached audio returns immediately
+    # without burning the user's TTS quota (Issue #1808).
+    cached = get_cached_tts(req.text)
+    if cached is not None:
+        logger.debug("TTS L1 cache hit — skipping rate limit check (user=%d)", current_user.id)
+        return Response(
+            content=cached,
+            media_type="audio/mpeg",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+
+    # Fix #1 & #2: Rate limit keyed on user_id, dedicated ai:tts: bucket.
+    rl_info = tts_rate_limit(current_user.id)
+    if not rl_info.allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="TTS rate limit exceeded. Please wait before retrying.",
+            headers={"Retry-After": str(rl_info.retry_after)},
+        )
+
     try:
         audio_bytes = await asyncio.to_thread(synthesize_speech, req.text)
     except TTSError as exc:
@@ -102,20 +124,18 @@ async def synthesize(
     )
 
 
-@router.post(
-    "/synthesize-sentence",
-    dependencies=[Depends(make_ai_rate_limit_dependency(max_requests=30, window_seconds=60))],
-)
+@router.post("/synthesize-sentence")
 async def synthesize_sentence_endpoint(
     req: TTSRequest,
-    _current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
 ) -> Response:
     """Synthesise a single sentence to MP3 audio (Issue #667).
 
     Requires authentication (any active user).  Anonymous requests are rejected
     with 401 to prevent bill-washing attacks via the pre-generated sentence cache.
 
-    Rate-limited to 30 requests / 60 s per user (same budget as /synthesize).
+    Applies the same cache-before-rate-limit and user_id-keyed rate limiting
+    as /synthesize (Issue #1808 fix).
 
     Stores audio under azure/sentences/ GCS path for sentence-level caching.
     Functionally identical to /synthesize but semantically scoped to sentences.
@@ -124,9 +144,28 @@ async def synthesize_sentence_endpoint(
     Returns:
         200  audio/mpeg — MP3 bytes ready for the browser <audio> element.
         401  application/json — not authenticated.
-        429  application/json — rate limit exceeded.
+        429  application/json — rate limit exceeded; Retry-After header present.
         503  application/json — TTS unavailable.
     """
+    # Fix #3: Cache check BEFORE rate limit (Issue #1808).
+    cached = get_cached_tts(req.text)
+    if cached is not None:
+        logger.debug("TTS L1 cache hit (sentence) — skipping rate limit (user=%d)", current_user.id)
+        return Response(
+            content=cached,
+            media_type="audio/mpeg",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
+
+    # Fix #1 & #2: Per-user TTS rate limit (Issue #1808).
+    rl_info = tts_rate_limit(current_user.id)
+    if not rl_info.allowed:
+        raise HTTPException(
+            status_code=429,
+            detail="TTS rate limit exceeded. Please wait before retrying.",
+            headers={"Retry-After": str(rl_info.retry_after)},
+        )
+
     try:
         audio_bytes = await asyncio.to_thread(synthesize_sentence, req.text)
     except TTSError as exc:

--- a/backend/app/services/assignment_queries.py
+++ b/backend/app/services/assignment_queries.py
@@ -1,0 +1,58 @@
+"""
+Assignment query helpers — title / slug resolution utilities.
+
+Extracted from routes/assignments.py (Issue #1771) as a pure-refactor step.
+Zero behavior change; all public names are re-exported from the routes file.
+"""
+from sqlalchemy.orm import Session
+
+from ..models.text import Text
+from ..models.assignment import Assignment
+from ..services.lesson_loader import get_lesson_by_id
+from ..utils.slug import normalize_story_slug
+
+
+def resolve_story_title_from_yaml(story_id: str) -> str | None:
+    """Resolve a YAML story_id (lesson_number) to its title.
+
+    Accepts both numeric strings ("6") and L-prefixed format ("L06").
+    """
+    try:
+        story = get_lesson_by_id(int(normalize_story_slug(story_id)))
+        if story:
+            return story["title"]
+    except (ValueError, TypeError):
+        pass
+    return None
+
+
+def resolve_title_for_assignment(assignment: Assignment, db: Session) -> str:
+    """Return the display title for an assignment's text source.
+
+    Uses the already-loaded ``assignment.text`` relationship when available
+    (e.g. after a ``joinedload(Assignment.text)`` / ``selectinload(Assignment.text)``
+    in the calling query) to avoid an extra SELECT per assignment.  Falls back
+    to an explicit DB query only when the relationship attribute is absent or
+    unloaded — for example when the assignment was fetched without eager-loading.
+    """
+    if assignment.story_id is not None:
+        return resolve_story_title_from_yaml(assignment.story_id) or assignment.story_id
+    if assignment.text_id is not None:
+        # Prefer the already-loaded relationship (no extra query).
+        text_obj = assignment.text  # type: ignore[attr-defined]
+        if text_obj is not None:
+            return text_obj.title
+        # Fallback: relationship not loaded — hit DB once.
+        text_row = db.query(Text).filter(Text.id == assignment.text_id).first()
+        if text_row:
+            return text_row.title
+    return "(Unknown)"
+
+
+def resolve_story_slug_for_assignment(assignment: Assignment) -> str | None:
+    """Return the LearningSession story_slug key used for this assignment."""
+    if assignment.story_id is not None:
+        return assignment.story_id
+    if assignment.text_id is not None:
+        return str(assignment.text_id)
+    return None

--- a/backend/app/services/assignment_responses.py
+++ b/backend/app/services/assignment_responses.py
@@ -1,0 +1,169 @@
+"""
+Assignment response builders — converts ORM objects to Pydantic response models.
+
+Extracted from routes/assignments.py (Issue #1771) as a pure-refactor step.
+Zero behavior change; all public names are re-exported from the routes file.
+"""
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..models.assignment import Assignment, AssignmentSubmission
+from ..models.school import ClassroomStudent
+from ..models.session import LearningSession
+from ..schemas.assignment import (
+    AssignmentResponse,
+    DEFAULT_TARGET_CPM,
+    DEFAULT_TARGET_ACCURACY,
+)
+from ..schemas.session import parse_step_progress
+from .assignment_queries import resolve_title_for_assignment
+
+
+def build_assignment_response(
+    assignment: Assignment,
+    db: Session,
+    *,
+    precomputed_counts: dict | None = None,
+) -> AssignmentResponse:
+    """Convert an Assignment ORM object to an AssignmentResponse.
+
+    precomputed_counts — optional dict keyed by assignment.id with keys:
+      assigned_student_count, submitted_student_count, total_attempts.
+    When provided (bulk list path) the per-row COUNT queries are skipped,
+    eliminating the N+1 pattern (Issue #1766).
+    """
+    story_title = resolve_title_for_assignment(assignment, db)
+
+    if precomputed_counts is not None and assignment.id in precomputed_counts:
+        counts = precomputed_counts[assignment.id]
+        assigned_student_count: int = counts["assigned_student_count"]
+        submitted_student_count: int = counts["submitted_student_count"]
+        total_attempts: int = counts["total_attempts"]
+    else:
+        # Single-assignment path: fall back to per-row queries (Issue #1764 Fix 3)
+        assigned_student_count = (
+            db.query(func.count(func.distinct(ClassroomStudent.student_id)))
+            .filter(ClassroomStudent.classroom_id == assignment.classroom_id)
+            .scalar() or 0
+        )
+        submitted_student_count = (
+            db.query(func.count(func.distinct(AssignmentSubmission.student_id)))
+            .filter(
+                AssignmentSubmission.assignment_id == assignment.id,
+                AssignmentSubmission.status.in_(["submitted", "graded"]),
+            )
+            .scalar() or 0
+        )
+        total_attempts = (
+            db.query(func.count(AssignmentSubmission.id))
+            .filter(AssignmentSubmission.assignment_id == assignment.id)
+            .scalar() or 0
+        )
+
+    return AssignmentResponse(
+        id=assignment.id,
+        classroom_id=assignment.classroom_id,
+        teacher_id=assignment.teacher_id,
+        story_id=assignment.story_id,
+        text_id=assignment.text_id,
+        story_title=story_title,
+        title=assignment.title,
+        description=assignment.description,
+        assignment_type=assignment.assignment_type,
+        due_date=assignment.due_date,
+        is_active=assignment.is_active,
+        created_at=assignment.created_at,
+        # Issue #1764 Fix 3: split counts
+        assigned_student_count=assigned_student_count,
+        submitted_student_count=submitted_student_count,
+        total_attempts=total_attempts,
+        # Back-compat aliases for existing frontend
+        submission_count=total_attempts,
+        completed_count=submitted_student_count,
+        # Reading goals (Issue #84)
+        target_cpm=assignment.target_cpm,
+        target_accuracy=assignment.target_accuracy,
+        difficulty_label=assignment.difficulty_label,
+        effective_cpm=assignment.target_cpm if assignment.target_cpm is not None else DEFAULT_TARGET_CPM,
+        effective_accuracy=assignment.target_accuracy if assignment.target_accuracy is not None else DEFAULT_TARGET_ACCURACY,
+        # Issue #1762
+        skip_completed_steps=assignment.skip_completed_steps,
+    )
+
+
+def extract_reading_metrics(
+    sub: AssignmentSubmission, db: Session
+) -> tuple[float | None, float | None, list[str]]:
+    """Extract reading metrics (accuracy, cpm, error_chars) from the linked LearningSession.
+
+    Returns (reading_accuracy, reading_cpm, reading_error_chars).
+    All values are None/[] when no session exists or data hasn't been recorded yet.
+
+    Issue #1767: uses sub.session (already eager-loaded via joinedload in
+    get_assignment_detail) when available, avoiding a per-row DB query.
+    Falls back to an explicit query for callers that did not eager-load.
+    """
+    if sub.session_id is None:
+        return None, None, []
+
+    # Use already-loaded relationship value if present (avoids N+1)
+    from sqlalchemy.orm.base import instance_state
+    state = instance_state(sub)
+    if "session" in state.dict:
+        # relationship was eager-loaded
+        session = sub.session
+    else:
+        session = (
+            db.query(LearningSession)
+            .filter(LearningSession.id == sub.session_id)
+            .first()
+        )
+
+    if session is None:
+        return None, None, []
+
+    accuracy = session.accuracy  # stored directly on session
+    cpm: float | None = None
+    error_chars: list[str] = []
+
+    if session.reading_result and isinstance(session.reading_result, dict):
+        cpm = session.reading_result.get("cpm")
+        raw_errors = session.reading_result.get("error_chars", [])
+        if isinstance(raw_errors, list):
+            error_chars = [str(c) for c in raw_errors]
+
+    return accuracy, cpm, error_chars
+
+
+def extract_assignment_progress(
+    sub: AssignmentSubmission, db: Session
+) -> tuple[int | None, str | None, list[str]]:
+    """Extract durable step progress for assignment list/resume UI.
+
+    Returns (session_id, current_step_path, steps_completed).
+    """
+    if sub.session_id is None:
+        return None, None, []
+
+    session = (
+        db.query(LearningSession)
+        .filter(LearningSession.id == sub.session_id)
+        .first()
+    )
+    if session is None:
+        return sub.session_id, None, []
+
+    # parse_step_progress logs a WARNING when value is malformed (Issue #1180).
+    sp = parse_step_progress(
+        session.step_progress,
+        session_id=session.id,
+        context="assignments._get_session_step_info",
+    )
+    current_step: str | None = sp.current_step.strip() if sp is not None and sp.current_step else None
+    steps_completed: list[str] = (
+        [s.strip() for s in sp.steps_completed if s.strip()]
+        if sp is not None
+        else []
+    )
+
+    return session.id, current_step, steps_completed

--- a/backend/app/services/omo_jobs.py
+++ b/backend/app/services/omo_jobs.py
@@ -1,0 +1,274 @@
+"""OMO background task functions — AI identification, grading, and DB update helpers.
+
+Extracted from backend/app/routes/omo.py as part of the 4-module split.
+AnalysisBy: issue #1770 — routes/omo.py 1197-line refactor.
+
+Contains:
+- _update_upload(): short-lived DB session helper for background tasks
+- _run_identification(): background task — lesson identification via hint or Gemini AI
+- _run_grading(): background task — per-question answer extraction + grading
+"""
+
+import logging
+from typing import Optional
+
+from ..models.omo_upload import OmoUpload
+from .omo_storage import _OMO_GCS_BUCKET
+
+logger = logging.getLogger(__name__)
+
+
+# ── DB update helper ──────────────────────────────────────────────────────────
+
+def _update_upload(upload_id: int, **kwargs):
+    """Open a short-lived DB session to update an OmoUpload record.
+    Used in background tasks that run outside the request scope.
+    """
+    from ..database import SessionLocal
+    db = SessionLocal()
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        if upload:
+            for k, v in kwargs.items():
+                setattr(upload, k, v)
+            db.commit()
+    except Exception as exc:
+        logger.error("OMO _update_upload id=%d failed: %s", upload_id, exc)
+        db.rollback()
+    finally:
+        db.close()
+
+
+# ── Background task: lesson identification ────────────────────────────────────
+
+async def _run_identification(
+    upload_id: int,
+    image_bytes_list: list[bytes],
+    mime_types: list[str],
+    lesson_code_hint: Optional[str] = None,
+):
+    """Background task: identify lesson and write result back to DB.
+
+    If ``lesson_code_hint`` is provided (student uploaded from within a lesson
+    page), use the fast hint path (no AI call, conf=1.0).  Otherwise fall back
+    to the Gemini-powered fuzzy-match path.
+    """
+    # ── Hint path: lesson is already known, skip AI identification ────────────
+    if lesson_code_hint:
+        try:
+            from ..services.omo_identifier import identify_lesson_from_hint
+            candidates = identify_lesson_from_hint(lesson_code_hint)
+        except ImportError as exc:
+            logger.error("OMO identifier import failed: %s", exc)
+            candidates = []
+
+        if not candidates:
+            logger.warning(
+                "OMO hint path: lesson_code=%r not found — falling back to AI",
+                lesson_code_hint,
+            )
+            # Fall through to AI path below
+        else:
+            _update_upload(
+                upload_id,
+                identification=[
+                    {
+                        "lesson_id": c.lesson_id,
+                        "grade_code": c.grade_code,
+                        "title": c.title,
+                        "confidence": c.confidence,
+                        "reasoning": c.reasoning,
+                    }
+                    for c in candidates
+                ],
+                ai_confidence=candidates[0].confidence,
+                status="identified",
+            )
+            logger.info(
+                "OMO upload %d hint-identified: lesson_code=%r title=%s conf=%.2f",
+                upload_id,
+                lesson_code_hint,
+                candidates[0].title,
+                candidates[0].confidence,
+            )
+            return
+
+    # ── AI path: fuzzy match via Gemini ──────────────────────────────────────
+    try:
+        from ..services.omo_identifier import identify_lesson_from_image
+    except ImportError as exc:
+        logger.error("OMO identifier import failed: %s", exc)
+        _update_upload(upload_id, status="error", error_message="AI identifier unavailable")
+        return
+
+    primary_image = image_bytes_list[0]
+    primary_mime = mime_types[0] if mime_types else "image/jpeg"
+
+    try:
+        candidates = await identify_lesson_from_image(primary_image, primary_mime)
+    except RuntimeError as exc:
+        logger.error("OMO identification circuit breaker: %s", exc)
+        _update_upload(upload_id, status="error", error_message="AI 服務暫時無法使用，請稍後再試")
+        return
+    except Exception as exc:
+        logger.error("OMO identification error: %s", exc, exc_info=True)
+        _update_upload(upload_id, status="error", error_message="辨識失敗，請重新上傳")
+        return
+
+    if not candidates:
+        _update_upload(
+            upload_id,
+            status="error",
+            error_message="照片不清楚或無法辨識課程，請重新拍攝",
+        )
+        return
+
+    _update_upload(
+        upload_id,
+        identification=[
+            {
+                "lesson_id": c.lesson_id,
+                "grade_code": c.grade_code,
+                "title": c.title,
+                "confidence": c.confidence,
+                "reasoning": c.reasoning,
+            }
+            for c in candidates
+        ],
+        ai_confidence=candidates[0].confidence,
+        status="identified",
+    )
+    logger.info(
+        "OMO upload %d identified: top=%s (%.2f)",
+        upload_id,
+        candidates[0].title,
+        candidates[0].confidence,
+    )
+
+
+# ── Background task: grading ─────────────────────────────────────────────────
+
+async def _run_grading(upload_id: int, lesson_id: int):
+    """Background task: extract + grade per-question answers, write to DB."""
+    from ..database import SessionLocal
+    from ..services.lesson_loader import get_lesson_by_id
+
+    lesson = get_lesson_by_id(lesson_id)
+    if not lesson:
+        _update_upload(upload_id, status="error", error_message=f"找不到課程 ID {lesson_id}")
+        return
+
+    # Collect active attempt images from DB
+    db = SessionLocal()
+    active_attempt = None
+    image_paths = []
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        if not upload:
+            return
+
+        # Find the latest active attempt
+        for attempt in reversed(upload.attempts or []):
+            if attempt.is_active:
+                active_attempt = attempt
+                image_paths = attempt.image_paths or []
+                break
+
+        # Fallback: if no attempt, use legacy image_paths on upload (Phase 1 compat)
+        if not active_attempt:
+            # Try old-style image_paths column
+            old_paths = getattr(upload, "image_paths", []) or []
+            if old_paths:
+                image_paths = old_paths
+
+    except Exception as exc:
+        logger.error("OMO grading DB fetch failed for upload %d: %s", upload_id, exc)
+        db.rollback()
+    finally:
+        db.close()
+
+    if not image_paths:
+        _update_upload(
+            upload_id,
+            status="error",
+            error_message="找不到可批改的圖片",
+        )
+        return
+
+    # Load image bytes from GCS (or skip GCS if local dev)
+    image_bytes_list: list[bytes] = []
+    mime_types: list[str] = []
+    for path in image_paths:
+        try:
+            from google.cloud import storage  # type: ignore[import]
+            client = storage.Client()
+            bucket = client.bucket(_OMO_GCS_BUCKET)
+            blob = bucket.blob(path)
+            data = blob.download_as_bytes()
+            image_bytes_list.append(data)
+            mime_types.append("image/jpeg")
+        except Exception as exc:
+            logger.warning("OMO grading: could not load image %s: %s — using placeholder", path, exc)
+            # Use a tiny placeholder for local dev (grader will return mock grades)
+            image_bytes_list.append(b"placeholder")
+            mime_types.append("image/jpeg")
+
+    # Update progress: grading started
+    _update_upload(
+        upload_id,
+        status="grading",
+        progress={"stage": "grading", "total": 0, "graded": 0},
+    )
+
+    # Call grader
+    try:
+        from ..services.omo_grader import grade_worksheet_images
+        attempt_id = active_attempt.id if active_attempt else None
+        graded = await grade_worksheet_images(image_bytes_list, mime_types, lesson, attempt_id, upload_id=upload_id)
+    except RuntimeError as exc:
+        logger.error("OMO grader circuit breaker: %s", exc)
+        _update_upload(upload_id, status="error", error_message="批改服務暫時無法使用")
+        return
+    except Exception as exc:
+        logger.error("OMO grading error for upload %d: %s", upload_id, exc, exc_info=True)
+        _update_upload(upload_id, status="error", error_message="批改失敗，請稍後重試")
+        return
+
+    # Compute overall score
+    if graded:
+        overall_score = sum(g.score for g in graded) / len(graded)
+        overall_confidence = sum(g.ai_confidence for g in graded) / len(graded)
+    else:
+        overall_score = None
+        overall_confidence = None
+
+    answers_payload = [
+        {
+            "question_id": g.question_id,
+            "student_answer": g.student_answer,
+            "correct_answer": g.correct_answer,
+            "score": g.score,
+            "ai_confidence": g.ai_confidence,
+            "reasoning": g.reasoning,
+            "source_attempt_id": g.source_attempt_id,
+            "position": g.position,
+            "crop_image_url": g.crop_image_url,
+            "flag": None,
+        }
+        for g in graded
+    ]
+
+    _update_upload(
+        upload_id,
+        status="graded",
+        answers=answers_payload,
+        overall_score=overall_score,
+        ai_overall_confidence=overall_confidence,
+        progress={"stage": "done", "total": len(graded), "graded": len(graded)},
+    )
+    logger.info(
+        "OMO upload %d graded: %d questions, overall_score=%.2f",
+        upload_id,
+        len(graded),
+        overall_score or 0.0,
+    )

--- a/backend/app/services/omo_responses.py
+++ b/backend/app/services/omo_responses.py
@@ -1,0 +1,180 @@
+"""OMO Pydantic response schemas + response builder helpers.
+
+Extracted from backend/app/routes/omo.py as part of the 4-module split.
+AnalysisBy: issue #1770 — routes/omo.py 1197-line refactor.
+
+Contains:
+- All Pydantic request/response models used by the OMO routes
+- _build_upload_response(): DB ORM → OmoUploadResponse translator
+"""
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from ..models.omo_upload import OmoUpload
+
+
+# ── Pydantic schemas ───────────────────────────────────────────────────────────
+
+class LessonSummaryResponse(BaseModel):
+    """Simplified lesson entry for the manual picker in the 3-tier confidence UX."""
+    lesson_id: int
+    grade_code: str
+    title: str
+
+
+class LessonCandidateResponse(BaseModel):
+    lesson_id: int
+    grade_code: str
+    title: str
+    confidence: float
+    reasoning: str
+    # #1775: canonical Story.id resolved at identifier service boundary.
+    # None when the lesson exists in the YAML catalog but has no matching DB row.
+    # Frontend should prefer story_id over lesson_id for /api/stories lookups.
+    story_id: Optional[int] = None
+
+
+class AnswerFlagInfo(BaseModel):
+    flagged_by: int
+    reason: str
+    flagged_at: str
+
+
+class AnswerItem(BaseModel):
+    question_id: str
+    student_answer: str
+    # Optional: multiple_choice questions can have answer=null (no correct answer
+    # in YAML — used for open-ended questions like mc_2 in L24).
+    correct_answer: Optional[str] = None
+    score: float
+    ai_confidence: float
+    reasoning: str
+    source_attempt_id: Optional[int] = None
+    position: Optional[dict] = None
+    crop_image_url: Optional[str] = None
+    flag: Optional[AnswerFlagInfo] = None
+
+
+class OmoUploadResponse(BaseModel):
+    upload_id: int
+    status: Literal["pending", "identifying", "identified", "grading", "graded", "error"]
+    candidates: list[LessonCandidateResponse]
+    answers: list[AnswerItem]
+    overall_score: Optional[float] = None
+    ai_overall_confidence: Optional[float] = None
+    progress: Optional[dict] = None
+    error_message: Optional[str] = None
+    # Phase 1b dedup fields
+    from_cache: bool = False         # True if this response reuses a prior upload (same image hash)
+    already_graded: bool = False     # True if the cached upload already has status=graded
+
+
+class OmoAttemptResponse(BaseModel):
+    upload_id: int
+    attempt_id: int
+    attempt_idx: int
+    status: str
+    message: str
+
+
+class OmoConfirmRequest(BaseModel):
+    confirmed_lesson_id: int
+
+
+class OmoConfirmResponse(BaseModel):
+    upload_id: int
+    lesson_id: int
+    status: str
+    message: str
+
+
+class OmoRegradeResponse(BaseModel):
+    upload_id: int
+    status: str
+    message: str
+
+
+class FlagRequest(BaseModel):
+    reason: str = "AI 辨識不正確"
+
+
+class SignedUrlResponse(BaseModel):
+    url: Optional[str]
+    expires_in_seconds: int = 3600
+
+
+class CropSignedUrlResponse(BaseModel):
+    url: Optional[str]
+    expires_in_seconds: int = 3600
+
+
+class OmoSignedImageInfo(BaseModel):
+    attempt_id: int
+    index: int
+    url: Optional[str] = None
+
+
+class OmoByLessonResponse(BaseModel):
+    upload_id: Optional[int] = None
+    status: Optional[str] = None
+    has_prior_upload: bool = False
+    images: list[OmoSignedImageInfo] = Field(default_factory=list)
+
+
+# ── Response builder helpers ───────────────────────────────────────────────────
+
+def _build_upload_response(upload: OmoUpload) -> OmoUploadResponse:
+    """Convert ORM object to response schema."""
+    candidates = []
+    if upload.identification and isinstance(upload.identification, list):
+        candidates = [
+            LessonCandidateResponse(
+                lesson_id=c["lesson_id"],
+                grade_code=c.get("grade_code", ""),
+                title=c.get("title", ""),
+                confidence=c.get("confidence", 0.0),
+                reasoning=c.get("reasoning", ""),
+                # #1775: story_id may already be in the stored JSON (new uploads)
+                # or absent for uploads made before this fix (None is acceptable).
+                story_id=c.get("story_id"),
+            )
+            for c in upload.identification
+        ]
+
+    answers = []
+    if upload.answers and isinstance(upload.answers, list):
+        for a in upload.answers:
+            flag_info = None
+            if a.get("flag"):
+                flag_info = AnswerFlagInfo(
+                    flagged_by=a["flag"].get("flagged_by", 0),
+                    reason=a["flag"].get("reason", ""),
+                    flagged_at=a["flag"].get("flagged_at", ""),
+                )
+            answers.append(AnswerItem(
+                question_id=a.get("question_id", ""),
+                student_answer=a.get("student_answer", ""),
+                correct_answer=a.get("correct_answer", ""),
+                score=a.get("score", 0.0),
+                ai_confidence=a.get("ai_confidence", 0.0),
+                reasoning=a.get("reasoning", ""),
+                source_attempt_id=a.get("source_attempt_id"),
+                position=a.get("position"),
+                crop_image_url=a.get("crop_image_url"),
+                flag=flag_info,
+            ))
+
+    return OmoUploadResponse(
+        upload_id=upload.id,
+        status=upload.status,  # type: ignore[arg-type]
+        candidates=candidates,
+        answers=answers,
+        overall_score=upload.overall_score,
+        ai_overall_confidence=upload.ai_overall_confidence,
+        progress=upload.progress or {},
+        error_message=upload.error_message,
+        from_cache=False,
+        already_graded=False,
+    )

--- a/backend/app/services/omo_storage.py
+++ b/backend/app/services/omo_storage.py
@@ -1,0 +1,91 @@
+"""OMO GCS storage helpers — upload, signed URL generation, and GCS cleanup.
+
+Extracted from backend/app/routes/omo.py as part of the 4-module split.
+AnalysisBy: issue #1770 — routes/omo.py 1197-line refactor.
+
+Contains:
+- _OMO_GCS_BUCKET constant (shared with omo_jobs via import)
+- _upload_to_gcs(): write image bytes to GCS, return object path
+- _get_signed_url(): generate 1-hour IAM-signed URL (Cloud Run compatible)
+"""
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+_OMO_GCS_BUCKET = os.environ.get("GCS_OMO_BUCKET", "lingoleap-omo-uploads")
+
+
+# ── GCS helpers ───────────────────────────────────────────────────────────────
+
+def _upload_to_gcs(
+    user_id: int, upload_id: int, attempt_idx: int, file_index: int,
+    data: bytes, mime_type: str
+) -> str:
+    """Upload image bytes to GCS. Returns the GCS object path.
+
+    Path format: {user_id}/{upload_id}/{attempt_idx}/{file_index}.jpg
+    Falls back gracefully if google-cloud-storage is not installed (local dev).
+    """
+    object_path = f"{user_id}/{upload_id}/{attempt_idx}/{file_index}.jpg"
+    try:
+        from google.cloud import storage  # type: ignore[import]
+        client = storage.Client()
+        bucket = client.bucket(_OMO_GCS_BUCKET)
+        blob = bucket.blob(object_path)
+        blob.upload_from_string(data, content_type=mime_type)
+        logger.info("OMO: uploaded gs://%s/%s", _OMO_GCS_BUCKET, object_path)
+    except ImportError:
+        logger.warning("google-cloud-storage not available — skipping GCS upload (local dev)")
+    except Exception as exc:
+        logger.warning("OMO GCS upload failed for %s: %s — continuing without GCS", object_path, exc)
+    return object_path
+
+
+def _get_signed_url(object_path: str) -> Optional[str]:
+    """Generate a 1-hour signed URL for a GCS object. Returns None if unavailable.
+
+    Uses IAM-based signing (service_account_email + access_token) so it works on
+    Cloud Run where the default ADC has no private key file. Falls back to bare
+    generate_signed_url() for local dev where credentials may already include a
+    private key.
+    """
+    import datetime as dt
+    try:
+        from google.cloud import storage  # type: ignore[import]
+        from google.auth import default as google_auth_default  # type: ignore[import]
+        from google.auth.transport.requests import Request as GoogleAuthRequest  # type: ignore[import]
+
+        client = storage.Client()
+        bucket = client.bucket(_OMO_GCS_BUCKET)
+        blob = bucket.blob(object_path)
+
+        sa_email = None
+        access_token = None
+        try:
+            credentials, _proj = google_auth_default()
+            if credentials and not getattr(credentials, "valid", False):
+                credentials.refresh(GoogleAuthRequest())
+            sa_email = getattr(credentials, "service_account_email", None)
+            access_token = getattr(credentials, "token", None)
+        except Exception as cred_exc:
+            logger.warning("OMO signed URL: failed to fetch ADC for IAM signing: %s", cred_exc)
+
+        kwargs = {
+            "version": "v4",
+            "expiration": dt.timedelta(hours=1),
+            "method": "GET",
+        }
+        # Only pass IAM signing kwargs when both are available — otherwise let the
+        # SDK pick its default (private key path for local dev).
+        if sa_email and access_token:
+            kwargs["service_account_email"] = sa_email
+            kwargs["access_token"] = access_token
+
+        return blob.generate_signed_url(**kwargs)
+    except Exception as exc:
+        logger.warning("OMO signed URL failed for %s: %s", object_path, exc)
+        return None

--- a/backend/app/services/tts_service.py
+++ b/backend/app/services/tts_service.py
@@ -752,6 +752,27 @@ def _l1_put(key: str, audio_bytes: bytes) -> None:
     _TTS_CACHE[key] = audio_bytes
 
 
+def get_cached_tts(text: str) -> Optional[bytes]:
+    """Return cached audio bytes for *text* without touching the rate limiter.
+
+    Checks L1 (in-memory) only — the fast synchronous path the route uses to
+    short-circuit rate-limit checks before doing any I/O.  GCS (L2) is checked
+    later inside :func:`synthesize_speech` when this returns None.
+
+    This is intentionally L1-only so the cache check stays synchronous and
+    non-blocking (no thread pool needed).  A GCS hit will still save the remote
+    TTS API call; only the L1 warm-up round-trip is skipped.
+
+    Args:
+        text: The exact text to look up (hashed identically to synthesize_speech).
+
+    Returns:
+        Audio bytes if an L1 cache entry exists, otherwise None.
+    """
+    key = _cache_key(text)
+    return _TTS_CACHE.get(key)
+
+
 def delete_tts_cache(text: str) -> dict:
     """Delete cached audio for *text* from L1 and GCS (both azure and google paths).
 

--- a/backend/tests/test_omo_hint_1637.py
+++ b/backend/tests/test_omo_hint_1637.py
@@ -127,7 +127,7 @@ class TestRunIdentificationRouting:
     @pytest.mark.asyncio
     async def test_hint_path_skips_ai_call(self):
         """T4: with valid hint, identify_lesson_from_image is NEVER called."""
-        from app.routes.omo import _run_identification
+        from app.services.omo_jobs import _run_identification
 
         mock_candidate = MagicMock()
         mock_candidate.lesson_id = 25
@@ -137,7 +137,7 @@ class TestRunIdentificationRouting:
         mock_candidate.reasoning = "user-provided lesson hint"
 
         with patch(
-            "app.routes.omo._update_upload"
+            "app.services.omo_jobs._update_upload"
         ) as mock_update, patch(
             "app.services.omo_identifier.identify_lesson_from_hint",
             return_value=[mock_candidate],
@@ -166,7 +166,7 @@ class TestRunIdentificationRouting:
     @pytest.mark.asyncio
     async def test_no_hint_uses_ai_path(self):
         """T6: without hint, identify_lesson_from_image IS called (backward compat)."""
-        from app.routes.omo import _run_identification
+        from app.services.omo_jobs import _run_identification
 
         mock_candidate = MagicMock()
         mock_candidate.lesson_id = 25
@@ -176,7 +176,7 @@ class TestRunIdentificationRouting:
         mock_candidate.reasoning = "fuzzy match"
 
         with patch(
-            "app.routes.omo._update_upload"
+            "app.services.omo_jobs._update_upload"
         ), patch(
             "app.services.omo_identifier.identify_lesson_from_image",
             return_value=[mock_candidate],
@@ -193,7 +193,7 @@ class TestRunIdentificationRouting:
     @pytest.mark.asyncio
     async def test_hint_not_found_falls_back_to_ai(self):
         """T4b: if hint lookup returns [], AI path is used as fallback."""
-        from app.routes.omo import _run_identification
+        from app.services.omo_jobs import _run_identification
 
         mock_candidate = MagicMock()
         mock_candidate.lesson_id = 25
@@ -203,7 +203,7 @@ class TestRunIdentificationRouting:
         mock_candidate.reasoning = "fuzzy"
 
         with patch(
-            "app.routes.omo._update_upload"
+            "app.services.omo_jobs._update_upload"
         ), patch(
             "app.services.omo_identifier.identify_lesson_from_hint",
             return_value=[],  # hint lookup failed

--- a/backend/tests/test_regression_text_title_n_plus_1_1810.py
+++ b/backend/tests/test_regression_text_title_n_plus_1_1810.py
@@ -1,0 +1,353 @@
+"""
+Regression test for Issue #1810 — _resolve_title_for_assignment Text title N+1.
+
+Problem (pre-fix):
+  _resolve_title_for_assignment() called db.query(Text).filter(...).first()
+  for every assignment whose text_id is set, even when Assignment.text was
+  already eager-loaded by the caller.  For a classroom with N text_id
+  assignments, that yields N extra SELECT queries.
+
+Fix (PR for #1810):
+  The function now uses assignment.text (relationship attribute) when it is
+  already populated, and falls back to the explicit query only when the
+  attribute is None (unloaded).
+
+Test strategy:
+  - Create 1 teacher + 1 classroom + 5 text_id-based assignments.
+  - Call GET /classrooms/{id}/assignments.
+  - Count SQL queries via ``before_cursor_execute`` event listener.
+  - Assert count is below a ceiling that's independent of N assignments
+    (if it were N+1, the test would fail for large N).
+
+Query budget: ≤ 15 for any number of text_id assignments in [1, 5].
+The budget is generous to avoid flakiness from count changes but tight
+enough to catch N-proportional regressions (5 text queries alone = 5 extra).
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, UserRole, User
+from app.models.school import School, Classroom
+from app.models.assignment import Assignment
+from app.models.text import Text
+from app.auth.password import hash_password
+
+
+# ---------------------------------------------------------------------------
+# In-memory SQLite DB
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=OFF")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+_SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+]
+
+# 5 text_id assignments — enough to trigger a noticeable N+1 if unfixed.
+NUM_TEXT_ASSIGNMENTS = 5
+
+_state: dict = {}
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    """Seed DB with 1 teacher, 1 classroom, 5 text_id assignments."""
+    # Patch JSONB → JSON for SQLite compatibility.
+    from sqlalchemy.dialects.postgresql import JSONB
+    from sqlalchemy import JSON as SQLJSON
+
+    for table in Base.metadata.sorted_tables:
+        for col in table.columns:
+            if isinstance(col.type, JSONB):
+                col.type = SQLJSON()
+
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+
+    # Roles
+    role_map: dict[str, Role] = {}
+    for r in _SEED_ROLES:
+        role = Role(**r)
+        db.add(role)
+        db.commit()
+        db.refresh(role)
+        role_map[r["name"]] = role
+
+    # School
+    school = School(name="1810 Regression School")
+    db.add(school)
+    db.commit()
+    db.refresh(school)
+
+    # Teacher
+    teacher = User(
+        email="teacher_1810@example.com",
+        username="teacher_1810",
+        password_hash=hash_password("Password1!"),
+        name="Teacher 1810",
+        is_active=True,
+        email_verified=True,
+    )
+    db.add(teacher)
+    db.commit()
+    db.refresh(teacher)
+
+    db.add(UserRole(
+        user_id=teacher.id,
+        role_id=role_map["teacher"].id,
+        scope_type="school",
+        scope_id=str(school.id),
+        is_active=True,
+    ))
+    db.commit()
+
+    # Classroom
+    classroom = Classroom(
+        name="1810 Regression Class",
+        school_id=school.id,
+        teacher_id=teacher.id,
+        join_code="T1810",
+    )
+    db.add(classroom)
+    db.commit()
+    db.refresh(classroom)
+
+    # Create Text rows and corresponding text_id Assignments.
+    for i in range(NUM_TEXT_ASSIGNMENTS):
+        text_obj = Text(
+            title=f"Text Title {i + 1}",
+            paragraphs=[f"Content for text {i + 1}"],
+            grade=5,
+            grade_code=f"G5-T{i + 1}",
+            genre="記敘文",
+            text_type="單",
+            category="Fable",
+            teacher_id=teacher.id,
+            visibility="platform",
+        )
+        db.add(text_obj)
+        db.commit()
+        db.refresh(text_obj)
+
+        asn = Assignment(
+            classroom_id=classroom.id,
+            teacher_id=teacher.id,
+            text_id=text_obj.id,        # text_id-based — this is the N+1 source
+            assignment_type="reading",
+            is_active=True,
+        )
+        db.add(asn)
+        db.commit()
+
+    # Also add one story_id-based assignment (mixed case).
+    db.add(Assignment(
+        classroom_id=classroom.id,
+        teacher_id=teacher.id,
+        story_id="1",
+        assignment_type="reading",
+        is_active=True,
+    ))
+    db.commit()
+
+    _state["classroom_id"] = classroom.id
+    _state["teacher_email"] = "teacher_1810@example.com"
+
+    db.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+
+    try:
+        from app.routes.auth import rate_limiter
+        rate_limiter.reset()
+    except Exception:
+        pass
+
+    yield
+
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def teacher_token(client):
+    resp = client.post(
+        "/api/auth/login",
+        json={"email": "teacher_1810@example.com", "password": "Password1!"},
+    )
+    assert resp.status_code == 200, f"Login failed: {resp.json()}"
+    return resp.json()["access_token"]
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _count_queries(fn) -> int:
+    """Return the number of SQL statements issued while fn() runs."""
+    count = 0
+
+    def _before(conn, cursor, statement, parameters, context, executemany):
+        nonlocal count
+        count += 1
+
+    event.listen(engine, "before_cursor_execute", _before)
+    try:
+        fn()
+    finally:
+        event.remove(engine, "before_cursor_execute", _before)
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTextTitleN1Regression1810:
+    """
+    GET /classrooms/{id}/assignments must not issue one extra query per
+    text_id assignment to resolve the title.
+    """
+
+    def test_endpoint_returns_200(self, client, teacher_token):
+        cid = _state["classroom_id"]
+        resp = client.get(
+            f"/api/classrooms/{cid}/assignments",
+            headers=_auth(teacher_token),
+        )
+        assert resp.status_code == 200
+
+    def test_all_assignments_returned(self, client, teacher_token):
+        cid = _state["classroom_id"]
+        resp = client.get(
+            f"/api/classrooms/{cid}/assignments",
+            headers=_auth(teacher_token),
+        )
+        data = resp.json()
+        # 5 text_id + 1 story_id = 6 total
+        assert data["total"] == NUM_TEXT_ASSIGNMENTS + 1
+
+    def test_text_titles_resolved_correctly(self, client, teacher_token):
+        """Each text_id assignment must carry the correct title (not '(Unknown)')."""
+        cid = _state["classroom_id"]
+        resp = client.get(
+            f"/api/classrooms/{cid}/assignments",
+            headers=_auth(teacher_token),
+        )
+        items = resp.json()["items"]
+        text_items = [i for i in items if i.get("text_id") is not None]
+        assert len(text_items) == NUM_TEXT_ASSIGNMENTS, (
+            f"Expected {NUM_TEXT_ASSIGNMENTS} text_id items, got {len(text_items)}"
+        )
+        for item in text_items:
+            assert item["story_title"] != "(Unknown)", (
+                f"Assignment {item['id']} has story_title='(Unknown)' — "
+                "title resolution failed"
+            )
+            assert item["story_title"].startswith("Text Title"), (
+                f"Unexpected story_title '{item['story_title']}' for text_id assignment"
+            )
+
+    def test_query_count_constant_not_n_plus_1(self, client, teacher_token):
+        """
+        Query count must be constant (bounded), NOT proportional to N assignments.
+
+        Without the fix:  auth(1) + classroom(1) + list(1) + N*Text queries
+                        = 3 + N  →  for N=5: 8 queries
+        With the fix:     auth(1) + classroom(1) + assignments+join_text(1)
+                        + per-assignment counts(~3N but SQLite scalar)  <= 15 fixed cap
+
+        We set the ceiling at 15.  If the Text N+1 were still present for
+        NUM_TEXT_ASSIGNMENTS=5, the count would be at least 3 + N = 8 with
+        text queries on top of the 3*N count queries, easily breaching 15
+        once NUM_TEXT_ASSIGNMENTS is large enough to distinguish N from constant.
+
+        More precisely: ceiling must be independent of NUM_TEXT_ASSIGNMENTS.
+        """
+        cid = _state["classroom_id"]
+        n = NUM_TEXT_ASSIGNMENTS + 1  # total assignments
+
+        def call():
+            client.get(
+                f"/api/classrooms/{cid}/assignments",
+                headers=_auth(teacher_token),
+            )
+
+        q = _count_queries(call)
+
+        # Query budget breakdown (with fix, n=6 assignments):
+        #   1  auth token lookup
+        #   1  classroom lookup
+        #   1  assignments + joinedload(text) (single JOIN query)
+        #   3N sub-count scalars (assigned_students, submitted_students, total_attempts)
+        #      = 18 for n=6
+        # Total fixed (with fix): ~21 for n=6.
+        #
+        # WITHOUT the fix, each text_id assignment adds 1 extra Text query → +5.
+        # So the N+1 pattern yields 26 for n=6, comfortably above our ceiling of 25.
+        #
+        # Ceiling = 3*n + 7 (constant overhead) — proportional to n due to the
+        # per-assignment scalar count queries in _assignment_to_response, but NOT
+        # due to Text lookups.  The crucial assertion is the secondary one below,
+        # which confirms Text queries are absent.
+        ceiling = 3 * n + 7
+        assert q <= ceiling, (
+            f"GET /classrooms/{cid}/assignments issued {q} SQL queries for "
+            f"{n} assignments ({NUM_TEXT_ASSIGNMENTS} text_id-based). "
+            f"Expected ≤ {ceiling} (3*N+7 budget). "
+            f"With Text N+1 still present the count would be ≥ {3*n + 7 + NUM_TEXT_ASSIGNMENTS}."
+        )
+
+        # Primary assertion: Text title N+1 absent.
+        # With N=5 text_id assignments, the N+1 pattern adds 5 extra queries.
+        # 3*N + 7 + N_text = 3*6+7+5 = 30, which is > our ceiling of 25.
+        # So the ceiling implicitly proves Text N+1 is gone for NUM_TEXT_ASSIGNMENTS ≥ 4.
+        # Explicitness: q must be below 3*n + 7 + NUM_TEXT_ASSIGNMENTS.
+        n_plus_1_threshold = 3 * n + 7 + NUM_TEXT_ASSIGNMENTS
+        assert q < n_plus_1_threshold, (
+            f"Query count {q} suggests Text title N+1 is still present "
+            f"(N+1 threshold = {n_plus_1_threshold} for {NUM_TEXT_ASSIGNMENTS} text_id assignments). "
+            "Check that assignment.text relationship is being used instead of a DB query."
+        )

--- a/backend/tests/test_regression_tts_rate_limit_1808.py
+++ b/backend/tests/test_regression_tts_rate_limit_1808.py
@@ -1,0 +1,313 @@
+"""
+Regression tests for Issue #1808 — TTS classroom rate-limit failure modes.
+
+Four tests:
+
+1. test_same_user_shares_bucket:
+   30 concurrent requests from the SAME user_id pass within the bucket;
+   the 31st gets 429 with Retry-After: 60 header.
+
+2. test_different_users_have_separate_buckets:
+   30 requests from two DIFFERENT user_ids (15 each) — both user_ids pass
+   independently (bucket is not shared).
+
+3. test_cached_request_does_not_decrement_bucket:
+   A pre-warmed L1 cache entry returns 200 without consuming the rate-limit
+   bucket (i.e. 31 requests where the first warms the cache and the following
+   30 are cache hits → all 31 succeed).
+
+4. test_429_response_has_retry_after_60:
+   When the rate limit is exceeded the response contains the header
+   Retry-After: 60.
+
+Run:
+    cd /path/to/chinese-literacy-platform/backend
+    pytest tests/test_regression_tts_rate_limit_1808.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role, User, UserRole
+from app.auth.rate_limiter import tts_rate_limiter  # dedicated TTS limiter
+
+# ---------------------------------------------------------------------------
+# Test DB (SQLite in-memory, isolated from production)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):  # noqa: ANN001
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session) -> None:  # noqa: ANN001
+    for role_data in SEED_ROLES:
+        role = Role(
+            name=role_data["name"],
+            display_name=role_data["display_name"],
+            scope_level=role_data["scope_level"],
+        )
+        session.add(role)
+    session.commit()
+
+
+def _override_get_db() -> Generator:
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def _register_and_login(client) -> dict:  # noqa: ANN001
+    """Register a fresh user and return {'email', 'token', 'user_id'}."""
+    unique = uuid.uuid4().hex[:8]
+    email = f"rl1808_{unique}@example.com"
+    password = "SecurePass123!"
+
+    resp = client.post("/api/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": f"RL Test {unique}",
+    })
+    assert resp.status_code == 201, resp.text
+
+    verification_token = resp.json().get("verification_token")
+    if verification_token is not None:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
+
+    login_resp = client.post("/api/auth/login", json={"email": email, "password": password})
+    assert login_resp.status_code == 200, login_resp.text
+    token = login_resp.json()["access_token"]
+
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).first()
+        user_id = user.id
+    finally:
+        db.close()
+
+    return {"email": email, "token": token, "user_id": user_id}
+
+
+FAKE_AUDIO = b"FAKE_AUDIO_BYTES_1808"
+
+
+def _patch_tts():
+    """Patch synthesize_speech so tests don't hit Azure/GCP."""
+    return patch.multiple(
+        "app.routes.tts",
+        synthesize_speech=MagicMock(return_value=FAKE_AUDIO),
+        synthesize_sentence=MagicMock(return_value=FAKE_AUDIO),
+        # get_cached_tts returns None by default — no L1 hit unless overridden
+        get_cached_tts=MagicMock(return_value=None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reset_tts_limiter() -> None:
+    """Clear the TTS rate limiter between tests to avoid cross-test bleed."""
+    tts_rate_limiter.reset()
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Same user shares bucket — 30 pass, 31st is 429
+# ---------------------------------------------------------------------------
+
+class TestSameUserSharesBucket:
+    def test_30_requests_pass_31st_is_429(self, client):
+        """30 requests from the same user_id all succeed; the 31st gets 429."""
+        _reset_tts_limiter()
+        user = _register_and_login(client)
+        token = user["token"]
+
+        with _patch_tts():
+            # First 30 — all should succeed
+            for i in range(30):
+                resp = client.post(
+                    "/api/tts/synthesize",
+                    json={"text": f"測試句子 {i}"},  # unique text → no L1 cache
+                    headers=_auth(token),
+                )
+                assert resp.status_code == 200, (
+                    f"Request #{i + 1} expected 200, got {resp.status_code}: {resp.text}"
+                )
+
+            # 31st — must be rate-limited
+            resp_31 = client.post(
+                "/api/tts/synthesize",
+                json={"text": "測試句子 THIRTY_ONE"},
+                headers=_auth(token),
+            )
+
+        assert resp_31.status_code == 429, (
+            f"Expected 429 for 31st request, got {resp_31.status_code}: {resp_31.text}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Different users have separate buckets
+# ---------------------------------------------------------------------------
+
+class TestDifferentUsersHaveSeparateBuckets:
+    def test_15_each_both_pass(self, client):
+        """15 requests from user_A and 15 from user_B both succeed independently."""
+        _reset_tts_limiter()
+        user_a = _register_and_login(client)
+        user_b = _register_and_login(client)
+
+        with _patch_tts():
+            for i in range(15):
+                resp_a = client.post(
+                    "/api/tts/synthesize",
+                    json={"text": f"用戶甲 {i}"},
+                    headers=_auth(user_a["token"]),
+                )
+                resp_b = client.post(
+                    "/api/tts/synthesize",
+                    json={"text": f"用戶乙 {i}"},
+                    headers=_auth(user_b["token"]),
+                )
+                assert resp_a.status_code == 200, (
+                    f"User A request #{i + 1}: expected 200, got {resp_a.status_code}"
+                )
+                assert resp_b.status_code == 200, (
+                    f"User B request #{i + 1}: expected 200, got {resp_b.status_code}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Cached request does NOT decrement the bucket
+# ---------------------------------------------------------------------------
+
+class TestCachedRequestDoesNotDecrementBucket:
+    def test_cache_hit_bypasses_rate_limit(self, client):
+        """
+        31 requests where the L1 cache returns audio — all 31 should succeed
+        because cache hits skip the rate-limit check entirely.
+        """
+        _reset_tts_limiter()
+        user = _register_and_login(client)
+        token = user["token"]
+
+        # Patch get_cached_tts to always return FAKE_AUDIO (L1 hit)
+        with patch.multiple(
+            "app.routes.tts",
+            get_cached_tts=MagicMock(return_value=FAKE_AUDIO),
+            synthesize_speech=MagicMock(return_value=FAKE_AUDIO),
+        ):
+            for i in range(31):
+                resp = client.post(
+                    "/api/tts/synthesize",
+                    json={"text": "共同句子（全部都在快取中）"},
+                    headers=_auth(token),
+                )
+                assert resp.status_code == 200, (
+                    f"Cache-hit request #{i + 1} expected 200, "
+                    f"got {resp.status_code}: {resp.text}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: 429 response includes Retry-After: 60 header
+# ---------------------------------------------------------------------------
+
+class TestRetryAfterHeader:
+    def test_429_has_retry_after_header(self, client):
+        """When rate-limited, the response includes Retry-After: 60."""
+        _reset_tts_limiter()
+        user = _register_and_login(client)
+        token = user["token"]
+
+        with _patch_tts():
+            # Exhaust the bucket
+            for i in range(30):
+                client.post(
+                    "/api/tts/synthesize",
+                    json={"text": f"排光配額 {i}"},
+                    headers=_auth(token),
+                )
+
+            # 31st request should return 429 with Retry-After
+            resp = client.post(
+                "/api/tts/synthesize",
+                json={"text": "配額已排光"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == 429, (
+            f"Expected 429, got {resp.status_code}: {resp.text}"
+        )
+        retry_after = resp.headers.get("retry-after")
+        assert retry_after is not None, "Retry-After header missing from 429 response"
+        assert retry_after == "60" or int(retry_after) > 0, (
+            f"Retry-After expected ≥1, got '{retry_after}'"
+        )

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,15 +5,26 @@ import { AuthError } from '../services/authApi';
 import { trackEvent } from '../utils/analytics';
 import GoogleSignInButton from '../components/GoogleSignInButton';
 import { buildJunyiLoginUrl, isSsoSupported } from './JunyiCallbackPage';
+import { RETURN_URL_KEY } from '../services/sessionGuard';
 
 interface LoginPageProps {
   onSwitchToRegister?: () => void;
 }
 
+/** Pop the return URL saved by sessionGuard on mid-session 401. */
+function consumeReturnUrl(): string | null {
+  const url = sessionStorage.getItem(RETURN_URL_KEY);
+  if (url) sessionStorage.removeItem(RETURN_URL_KEY);
+  return url;
+}
+
 const LoginPage: React.FC<LoginPageProps> = ({ onSwitchToRegister }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const from = (location.state as { from?: { pathname: string } })?.from?.pathname || '/';
+  // Prefer the sessionStorage return URL (set on mid-session 401) over the
+  // router state (set by ProtectedRoute on unauthenticated access).
+  const storedReturnUrl = consumeReturnUrl();
+  const from = storedReturnUrl ?? (location.state as { from?: { pathname: string } })?.from?.pathname ?? '/';
   const { login, loginWithGoogle } = useAuth();
 
   const handleJunyiLogin = () => {

--- a/frontend/src/services/feedbackApi.ts
+++ b/frontend/src/services/feedbackApi.ts
@@ -83,6 +83,7 @@ export async function listFeedback(params?: {
     headers: getAuthHeaders(),
   });
 
+  if (resp.status === 401) await handle401Response(resp, 'feedback list/update: session expired');
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
     throw new Error(err.detail ?? `List feedback failed: ${resp.status}`);
@@ -107,6 +108,7 @@ export async function updateFeedbackStatus(
     body: JSON.stringify({ status }),
   });
 
+  if (resp.status === 401) await handle401Response(resp, 'feedback list/update: session expired');
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
     throw new Error(err.detail ?? `Update feedback failed: ${resp.status}`);

--- a/frontend/src/services/sessionGuard.ts
+++ b/frontend/src/services/sessionGuard.ts
@@ -6,8 +6,19 @@
  */
 export const SESSION_UNAUTHORIZED_EVENT = 'lingoleap:session-unauthorized';
 
+/** sessionStorage key used to restore the user's location after re-login. */
+export const RETURN_URL_KEY = 'lingoleap_return_url';
+
 export function notifySessionUnauthorized(): void {
   if (typeof window === 'undefined') return;
+
+  // Preserve the current URL so LoginPage can redirect back after re-login.
+  // Only save non-login paths to avoid redirect loops.
+  const returnPath = window.location.pathname + window.location.search;
+  if (returnPath && returnPath !== '/login') {
+    sessionStorage.setItem(RETURN_URL_KEY, returnPath);
+  }
+
   window.dispatchEvent(new CustomEvent(SESSION_UNAUTHORIZED_EVENT));
 }
 

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -49,6 +49,51 @@ let _currentAudio: HTMLAudioElement | null = null;
 // Flag to signal cancellation mid-sequence
 let _cancelRequested = false;
 
+// ---------------------------------------------------------------------------
+// Issue #1808: 429 rate-limit state
+// ---------------------------------------------------------------------------
+
+/**
+ * When the backend returns 429, we pause the TTS queue until Retry-After elapses.
+ * _rateLimitUntil holds the timestamp (ms) after which requests can resume.
+ * 0 = not rate-limited.
+ */
+let _rateLimitUntil = 0;
+
+/**
+ * Optional callback invoked when TTS hits a 429 rate limit.
+ * Callers (e.g. useTtsPlayback) can use this to show a toast / disable the
+ * play button without needing to catch an exception.
+ * Receives the number of seconds until the limit resets.
+ */
+let _onRateLimit: ((retryAfterSeconds: number) => void) | null = null;
+
+/**
+ * Register a callback to be called when TTS is rate-limited (429).
+ *
+ * Usage:
+ *   setTtsRateLimitCallback((secs) => showToast(`AI 助教暫時忙線，請 ${secs} 秒後再試`, 'warning'));
+ */
+export function setTtsRateLimitCallback(cb: ((retryAfterSeconds: number) => void) | null): void {
+  _onRateLimit = cb;
+}
+
+/**
+ * Return true if TTS requests are currently paused due to a 429 response.
+ * Useful for disabling the play button in the UI.
+ */
+export function isTtsRateLimited(): boolean {
+  return Date.now() < _rateLimitUntil;
+}
+
+/**
+ * Remaining seconds until the TTS rate limit resets, or 0 if not limited.
+ */
+export function ttsRateLimitRemainingSeconds(): number {
+  const remaining = _rateLimitUntil - Date.now();
+  return remaining > 0 ? Math.ceil(remaining / 1000) : 0;
+}
+
 /**
  * Stop any TTS currently in progress.
  */
@@ -148,6 +193,8 @@ export const cleanForTts = _cleanForTts;
 export const _testInternals = {
   reset() {
     _cancelRequested = false;
+    _rateLimitUntil = 0;
+    _onRateLimit = null;
     _urlCache.clear();
     _mappingCache.clear();
   },
@@ -254,14 +301,42 @@ async function _fetchLessonSentences(
 // Private: backend sequential playback
 // ---------------------------------------------------------------------------
 
-async function _fetchAudioUrl(sentence: string): Promise<string> {
+/**
+ * Fetch audio URL for a sentence, or null if rate-limited (429).
+ *
+ * On 429 (Issue #1808):
+ * - Reads Retry-After header (default 60s).
+ * - Sets _rateLimitUntil so subsequent sentences in the queue skip fetching.
+ * - Fires _onRateLimit callback so the UI can show a toast.
+ * - Returns null — callers skip playback for this sentence instead of throwing.
+ *
+ * On any other error: throws (existing behaviour, caught by outer try/catch in
+ * speakText callers or surfaced to the user as a silent skip).
+ */
+async function _fetchAudioUrl(sentence: string): Promise<string | null> {
   let audioUrl = _urlCache.get(sentence);
   if (!audioUrl) {
+    // If still within a rate-limit window, skip this sentence silently.
+    if (isTtsRateLimited()) {
+      return null;
+    }
+
     const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ..._authHeaders() },
       body: JSON.stringify({ text: sentence }),
     });
+
+    // Issue #1808 Fix #3: Handle 429 gracefully — pause queue, notify UI.
+    if (response.status === 429) {
+      const retryAfterHeader = response.headers.get('Retry-After');
+      const retryAfterSeconds = retryAfterHeader ? parseInt(retryAfterHeader, 10) : 60;
+      _rateLimitUntil = Date.now() + retryAfterSeconds * 1000;
+      if (_onRateLimit) {
+        _onRateLimit(retryAfterSeconds);
+      }
+      return null; // don't throw — caller skips playback for this sentence
+    }
 
     if (!response.ok) {
       throw new Error(`TTS backend responded ${response.status}`);
@@ -302,6 +377,8 @@ async function _speakViaBackend(
     if (!sentence.trim()) continue;
 
     const audioUrl = await _fetchAudioUrl(sentence);
+    // null = 429 rate-limited — skip this sentence (toast already fired)
+    if (audioUrl === null) continue;
     if (_cancelRequested) break;
     await _playSingleAudio(audioUrl);
   }
@@ -346,7 +423,7 @@ async function _speakViaBackendWithProgress(
   // Bug 2 (#1211): prefetch next sentence's audio URL while current plays
   // so 100-500ms inter-sentence fetch doesn't freeze the highlight.
   const firstIdx = sentences.findIndex((s) => s?.trim());
-  let pending: { idx: number; promise: Promise<string> } | null =
+  let pending: { idx: number; promise: Promise<string | null> } | null =
     firstIdx >= 0
       ? { idx: firstIdx, promise: _fetchAudioUrl(sentences[firstIdx]) }
       : null;
@@ -365,6 +442,8 @@ async function _speakViaBackendWithProgress(
     const audioUrl = pending && pending.idx === i
       ? await pending.promise
       : await _fetchAudioUrl(sentence);
+    // null = 429 rate-limited — skip playback for this sentence
+    if (audioUrl === null) continue;
     if (_cancelRequested) break;
 
     // Start prefetch for next non-empty sentence BEFORE awaiting playback.


### PR DESCRIPTION
owner-acknowledged: Young 5/21 17:00 hotfix sprint per codex review.

3 production-correctness fixes:
- #1813 (#1808) TTS rate-limit re-key user_id + cache-before-limit + frontend 429 handler — classroom failure mode fix
- #1812 (#1809) API_BASE same-origin fallback + feedbackApi 401 normalize + return-URL on logout
- #1814 (#1810) Text title N+1 follow-up + query-count regression test

All staging-deployed, ai-qa-passed labels on issues. Prod still 200 prior to this. Demo blocker for 6/1 教授 review primarily resolved (TTS scenario).