### PR TITLE
refactor(omo): explicit timeout + idempotency guard on background tasks (Fixes #1772)

### DIFF
--- a/backend/app/services/omo_jobs.py
+++ b/backend/app/services/omo_jobs.py
@@ -5,10 +5,36 @@ AnalysisBy: issue #1770 — routes/omo.py 1197-line refactor.
 
 Contains:
 - _update_upload(): short-lived DB session helper for background tasks
+- _fetch_upload_status(): lightweight status read for idempotency checks
 - _run_identification(): background task — lesson identification via hint or Gemini AI
 - _run_grading(): background task — per-question answer extraction + grading
+
+## Hardening (issue #1772)
+
+### Timeout policy
+- _run_identification: 90 s total task-level timeout (wraps entire body via asyncio.wait_for)
+- _run_grading:        120 s total task-level timeout (wraps entire body via asyncio.wait_for)
+- On asyncio.TimeoutError → upload.status = 'error' + Chinese error_message; no re-raise
+
+### Idempotency
+- Both tasks re-fetch upload.status from DB at entry via a fresh SessionLocal.
+- _run_identification: no-op if status already in {'identified', 'grading', 'graded'}
+- _run_grading:        no-op if status already in {'graded'}
+- Prevents double-processing on duplicate BackgroundTask enqueue or accidental
+  client retries without an explicit /regrade call.
+
+### Retry policy
+- No automatic retry.  Client must re-trigger via POST /api/omo/uploads/{id}/regrade.
+- Circuit breaker: 3 consecutive AI errors → RuntimeError → HTTP 503 (in
+  omo_identifier.py / omo_grader.py).
+
+### Memory bounds
+- 10 MB × 5 files hard cap enforced upstream at POST /api/omo/uploads
+  (backend/app/routes/omo.py).  This module does not re-validate; it relies on
+  the route-level guard being in place.
 """
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -16,6 +42,14 @@ from ..models.omo_upload import OmoUpload
 from .omo_storage import _OMO_GCS_BUCKET
 
 logger = logging.getLogger(__name__)
+
+# Statuses that indicate work is already done / in-flight — skip re-processing.
+_IDENTIFICATION_TERMINAL = frozenset({"identified", "grading", "graded"})
+_GRADING_TERMINAL = frozenset({"graded"})
+
+# Task-level wall-clock timeouts (seconds).
+_IDENTIFICATION_TIMEOUT = 90
+_GRADING_TIMEOUT = 120
 
 
 # ── DB update helper ──────────────────────────────────────────────────────────
@@ -39,6 +73,22 @@ def _update_upload(upload_id: int, **kwargs):
         db.close()
 
 
+def _fetch_upload_status(upload_id: int) -> Optional[str]:
+    """Return current upload.status without holding a session open.
+    Used at task entry for idempotency checks.
+    """
+    from ..database import SessionLocal
+    db = SessionLocal()
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        return upload.status if upload else None
+    except Exception as exc:
+        logger.error("OMO _fetch_upload_status id=%d failed: %s", upload_id, exc)
+        return None
+    finally:
+        db.close()
+
+
 # ── Background task: lesson identification ────────────────────────────────────
 
 async def _run_identification(
@@ -52,223 +102,282 @@ async def _run_identification(
     If ``lesson_code_hint`` is provided (student uploaded from within a lesson
     page), use the fast hint path (no AI call, conf=1.0).  Otherwise fall back
     to the Gemini-powered fuzzy-match path.
+
+    Task-level timeout: _IDENTIFICATION_TIMEOUT seconds.
+    Idempotency: no-op if status is already in _IDENTIFICATION_TERMINAL.
     """
-    # ── Hint path: lesson is already known, skip AI identification ────────────
-    if lesson_code_hint:
-        try:
-            from ..services.omo_identifier import identify_lesson_from_hint
-            candidates = identify_lesson_from_hint(lesson_code_hint)
-        except ImportError as exc:
-            logger.error("OMO identifier import failed: %s", exc)
-            candidates = []
-
-        if not candidates:
-            logger.warning(
-                "OMO hint path: lesson_code=%r not found — falling back to AI",
-                lesson_code_hint,
-            )
-            # Fall through to AI path below
-        else:
-            _update_upload(
-                upload_id,
-                identification=[
-                    {
-                        "lesson_id": c.lesson_id,
-                        "grade_code": c.grade_code,
-                        "title": c.title,
-                        "confidence": c.confidence,
-                        "reasoning": c.reasoning,
-                    }
-                    for c in candidates
-                ],
-                ai_confidence=candidates[0].confidence,
-                status="identified",
-            )
-            logger.info(
-                "OMO upload %d hint-identified: lesson_code=%r title=%s conf=%.2f",
-                upload_id,
-                lesson_code_hint,
-                candidates[0].title,
-                candidates[0].confidence,
-            )
-            return
-
-    # ── AI path: fuzzy match via Gemini ──────────────────────────────────────
-    try:
-        from ..services.omo_identifier import identify_lesson_from_image
-    except ImportError as exc:
-        logger.error("OMO identifier import failed: %s", exc)
-        _update_upload(upload_id, status="error", error_message="AI identifier unavailable")
-        return
-
-    primary_image = image_bytes_list[0]
-    primary_mime = mime_types[0] if mime_types else "image/jpeg"
-
-    try:
-        candidates = await identify_lesson_from_image(primary_image, primary_mime)
-    except RuntimeError as exc:
-        logger.error("OMO identification circuit breaker: %s", exc)
-        _update_upload(upload_id, status="error", error_message="AI 服務暫時無法使用，請稍後再試")
-        return
-    except Exception as exc:
-        logger.error("OMO identification error: %s", exc, exc_info=True)
-        _update_upload(upload_id, status="error", error_message="辨識失敗，請重新上傳")
-        return
-
-    if not candidates:
-        _update_upload(
+    # ── Idempotency guard — re-fetch status at task entry ─────────────────────
+    current_status = _fetch_upload_status(upload_id)
+    if current_status in _IDENTIFICATION_TERMINAL:
+        logger.info(
+            "OMO _run_identification skipped (idempotency): upload %d already status=%r",
             upload_id,
-            status="error",
-            error_message="照片不清楚或無法辨識課程，請重新拍攝",
+            current_status,
         )
         return
 
-    _update_upload(
-        upload_id,
-        identification=[
-            {
-                "lesson_id": c.lesson_id,
-                "grade_code": c.grade_code,
-                "title": c.title,
-                "confidence": c.confidence,
-                "reasoning": c.reasoning,
-            }
-            for c in candidates
-        ],
-        ai_confidence=candidates[0].confidence,
-        status="identified",
-    )
-    logger.info(
-        "OMO upload %d identified: top=%s (%.2f)",
-        upload_id,
-        candidates[0].title,
-        candidates[0].confidence,
-    )
+    async def _do_identify():
+        # ── Hint path: lesson is already known, skip AI identification ────────
+        if lesson_code_hint:
+            try:
+                from ..services.omo_identifier import identify_lesson_from_hint
+                candidates = identify_lesson_from_hint(lesson_code_hint)
+            except ImportError as exc:
+                logger.error("OMO identifier import failed: %s", exc)
+                candidates = []
+
+            if not candidates:
+                logger.warning(
+                    "OMO hint path: lesson_code=%r not found — falling back to AI",
+                    lesson_code_hint,
+                )
+                # Fall through to AI path below
+            else:
+                _update_upload(
+                    upload_id,
+                    identification=[
+                        {
+                            "lesson_id": c.lesson_id,
+                            "grade_code": c.grade_code,
+                            "title": c.title,
+                            "confidence": c.confidence,
+                            "reasoning": c.reasoning,
+                        }
+                        for c in candidates
+                    ],
+                    ai_confidence=candidates[0].confidence,
+                    status="identified",
+                )
+                logger.info(
+                    "OMO upload %d hint-identified: lesson_code=%r title=%s conf=%.2f",
+                    upload_id,
+                    lesson_code_hint,
+                    candidates[0].title,
+                    candidates[0].confidence,
+                )
+                return
+
+        # ── AI path: fuzzy match via Gemini ──────────────────────────────────
+        try:
+            from ..services.omo_identifier import identify_lesson_from_image
+        except ImportError as exc:
+            logger.error("OMO identifier import failed: %s", exc)
+            _update_upload(upload_id, status="error", error_message="AI identifier unavailable")
+            return
+
+        primary_image = image_bytes_list[0]
+        primary_mime = mime_types[0] if mime_types else "image/jpeg"
+
+        try:
+            candidates = await identify_lesson_from_image(primary_image, primary_mime)
+        except RuntimeError as exc:
+            logger.error("OMO identification circuit breaker: %s", exc)
+            _update_upload(upload_id, status="error", error_message="AI 服務暫時無法使用，請稍後再試")
+            return
+        except Exception as exc:
+            logger.error("OMO identification error: %s", exc, exc_info=True)
+            _update_upload(upload_id, status="error", error_message="辨識失敗，請重新上傳")
+            return
+
+        if not candidates:
+            _update_upload(
+                upload_id,
+                status="error",
+                error_message="照片不清楚或無法辨識課程，請重新拍攝",
+            )
+            return
+
+        _update_upload(
+            upload_id,
+            identification=[
+                {
+                    "lesson_id": c.lesson_id,
+                    "grade_code": c.grade_code,
+                    "title": c.title,
+                    "confidence": c.confidence,
+                    "reasoning": c.reasoning,
+                }
+                for c in candidates
+            ],
+            ai_confidence=candidates[0].confidence,
+            status="identified",
+        )
+        logger.info(
+            "OMO upload %d identified: top=%s (%.2f)",
+            upload_id,
+            candidates[0].title,
+            candidates[0].confidence,
+        )
+
+    # ── Task-level timeout wrapper ────────────────────────────────────────────
+    try:
+        await asyncio.wait_for(_do_identify(), timeout=_IDENTIFICATION_TIMEOUT)
+    except asyncio.TimeoutError:
+        logger.error(
+            "OMO _run_identification timed out after %ds for upload %d",
+            _IDENTIFICATION_TIMEOUT,
+            upload_id,
+        )
+        _update_upload(
+            upload_id,
+            status="error",
+            error_message=f"辨識任務超時 ({_IDENTIFICATION_TIMEOUT}s)，請重新上傳",
+        )
 
 
 # ── Background task: grading ─────────────────────────────────────────────────
 
 async def _run_grading(upload_id: int, lesson_id: int):
-    """Background task: extract + grade per-question answers, write to DB."""
-    from ..database import SessionLocal
-    from ..services.lesson_loader import get_lesson_by_id
+    """Background task: extract + grade per-question answers, write to DB.
 
-    lesson = get_lesson_by_id(lesson_id)
-    if not lesson:
-        _update_upload(upload_id, status="error", error_message=f"找不到課程 ID {lesson_id}")
-        return
-
-    # Collect active attempt images from DB
-    db = SessionLocal()
-    active_attempt = None
-    image_paths = []
-    try:
-        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
-        if not upload:
-            return
-
-        # Find the latest active attempt
-        for attempt in reversed(upload.attempts or []):
-            if attempt.is_active:
-                active_attempt = attempt
-                image_paths = attempt.image_paths or []
-                break
-
-        # Fallback: if no attempt, use legacy image_paths on upload (Phase 1 compat)
-        if not active_attempt:
-            # Try old-style image_paths column
-            old_paths = getattr(upload, "image_paths", []) or []
-            if old_paths:
-                image_paths = old_paths
-
-    except Exception as exc:
-        logger.error("OMO grading DB fetch failed for upload %d: %s", upload_id, exc)
-        db.rollback()
-    finally:
-        db.close()
-
-    if not image_paths:
-        _update_upload(
+    Task-level timeout: _GRADING_TIMEOUT seconds.
+    Idempotency: no-op if status is already in _GRADING_TERMINAL.
+    """
+    # ── Idempotency guard — re-fetch status at task entry ─────────────────────
+    current_status = _fetch_upload_status(upload_id)
+    if current_status in _GRADING_TERMINAL:
+        logger.info(
+            "OMO _run_grading skipped (idempotency): upload %d already status=%r",
             upload_id,
-            status="error",
-            error_message="找不到可批改的圖片",
+            current_status,
         )
         return
 
-    # Load image bytes from GCS (or skip GCS if local dev)
-    image_bytes_list: list[bytes] = []
-    mime_types: list[str] = []
-    for path in image_paths:
+    async def _do_grade():
+        from ..database import SessionLocal
+        from ..services.lesson_loader import get_lesson_by_id
+
+        lesson = get_lesson_by_id(lesson_id)
+        if not lesson:
+            _update_upload(upload_id, status="error", error_message=f"找不到課程 ID {lesson_id}")
+            return
+
+        # Collect active attempt images from DB
+        db = SessionLocal()
+        active_attempt = None
+        image_paths = []
         try:
-            from google.cloud import storage  # type: ignore[import]
-            client = storage.Client()
-            bucket = client.bucket(_OMO_GCS_BUCKET)
-            blob = bucket.blob(path)
-            data = blob.download_as_bytes()
-            image_bytes_list.append(data)
-            mime_types.append("image/jpeg")
+            upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+            if not upload:
+                return
+
+            # Find the latest active attempt
+            for attempt in reversed(upload.attempts or []):
+                if attempt.is_active:
+                    active_attempt = attempt
+                    image_paths = attempt.image_paths or []
+                    break
+
+            # Fallback: if no attempt, use legacy image_paths on upload (Phase 1 compat)
+            if not active_attempt:
+                # Try old-style image_paths column
+                old_paths = getattr(upload, "image_paths", []) or []
+                if old_paths:
+                    image_paths = old_paths
+
         except Exception as exc:
-            logger.warning("OMO grading: could not load image %s: %s — using placeholder", path, exc)
-            # Use a tiny placeholder for local dev (grader will return mock grades)
-            image_bytes_list.append(b"placeholder")
-            mime_types.append("image/jpeg")
+            logger.error("OMO grading DB fetch failed for upload %d: %s", upload_id, exc)
+            db.rollback()
+        finally:
+            db.close()
 
-    # Update progress: grading started
-    _update_upload(
-        upload_id,
-        status="grading",
-        progress={"stage": "grading", "total": 0, "graded": 0},
-    )
+        if not image_paths:
+            _update_upload(
+                upload_id,
+                status="error",
+                error_message="找不到可批改的圖片",
+            )
+            return
 
-    # Call grader
+        # Load image bytes from GCS (or skip GCS if local dev)
+        image_bytes_list: list[bytes] = []
+        mime_types: list[str] = []
+        for path in image_paths:
+            try:
+                from google.cloud import storage  # type: ignore[import]
+                client = storage.Client()
+                bucket = client.bucket(_OMO_GCS_BUCKET)
+                blob = bucket.blob(path)
+                data = blob.download_as_bytes()
+                image_bytes_list.append(data)
+                mime_types.append("image/jpeg")
+            except Exception as exc:
+                logger.warning("OMO grading: could not load image %s: %s — using placeholder", path, exc)
+                # Use a tiny placeholder for local dev (grader will return mock grades)
+                image_bytes_list.append(b"placeholder")
+                mime_types.append("image/jpeg")
+
+        # Update progress: grading started
+        _update_upload(
+            upload_id,
+            status="grading",
+            progress={"stage": "grading", "total": 0, "graded": 0},
+        )
+
+        # Call grader
+        try:
+            from ..services.omo_grader import grade_worksheet_images
+            attempt_id = active_attempt.id if active_attempt else None
+            graded = await grade_worksheet_images(image_bytes_list, mime_types, lesson, attempt_id, upload_id=upload_id)
+        except RuntimeError as exc:
+            logger.error("OMO grader circuit breaker: %s", exc)
+            _update_upload(upload_id, status="error", error_message="批改服務暫時無法使用")
+            return
+        except Exception as exc:
+            logger.error("OMO grading error for upload %d: %s", upload_id, exc, exc_info=True)
+            _update_upload(upload_id, status="error", error_message="批改失敗，請稍後重試")
+            return
+
+        # Compute overall score
+        if graded:
+            overall_score = sum(g.score for g in graded) / len(graded)
+            overall_confidence = sum(g.ai_confidence for g in graded) / len(graded)
+        else:
+            overall_score = None
+            overall_confidence = None
+
+        answers_payload = [
+            {
+                "question_id": g.question_id,
+                "student_answer": g.student_answer,
+                "correct_answer": g.correct_answer,
+                "score": g.score,
+                "ai_confidence": g.ai_confidence,
+                "reasoning": g.reasoning,
+                "source_attempt_id": g.source_attempt_id,
+                "position": g.position,
+                "crop_image_url": g.crop_image_url,
+                "flag": None,
+            }
+            for g in graded
+        ]
+
+        _update_upload(
+            upload_id,
+            status="graded",
+            answers=answers_payload,
+            overall_score=overall_score,
+            ai_overall_confidence=overall_confidence,
+            progress={"stage": "done", "total": len(graded), "graded": len(graded)},
+        )
+        logger.info(
+            "OMO upload %d graded: %d questions, overall_score=%.2f",
+            upload_id,
+            len(graded),
+            overall_score or 0.0,
+        )
+
+    # ── Task-level timeout wrapper ────────────────────────────────────────────
     try:
-        from ..services.omo_grader import grade_worksheet_images
-        attempt_id = active_attempt.id if active_attempt else None
-        graded = await grade_worksheet_images(image_bytes_list, mime_types, lesson, attempt_id, upload_id=upload_id)
-    except RuntimeError as exc:
-        logger.error("OMO grader circuit breaker: %s", exc)
-        _update_upload(upload_id, status="error", error_message="批改服務暫時無法使用")
-        return
-    except Exception as exc:
-        logger.error("OMO grading error for upload %d: %s", upload_id, exc, exc_info=True)
-        _update_upload(upload_id, status="error", error_message="批改失敗，請稍後重試")
-        return
-
-    # Compute overall score
-    if graded:
-        overall_score = sum(g.score for g in graded) / len(graded)
-        overall_confidence = sum(g.ai_confidence for g in graded) / len(graded)
-    else:
-        overall_score = None
-        overall_confidence = None
-
-    answers_payload = [
-        {
-            "question_id": g.question_id,
-            "student_answer": g.student_answer,
-            "correct_answer": g.correct_answer,
-            "score": g.score,
-            "ai_confidence": g.ai_confidence,
-            "reasoning": g.reasoning,
-            "source_attempt_id": g.source_attempt_id,
-            "position": g.position,
-            "crop_image_url": g.crop_image_url,
-            "flag": None,
-        }
-        for g in graded
-    ]
-
-    _update_upload(
-        upload_id,
-        status="graded",
-        answers=answers_payload,
-        overall_score=overall_score,
-        ai_overall_confidence=overall_confidence,
-        progress={"stage": "done", "total": len(graded), "graded": len(graded)},
-    )
-    logger.info(
-        "OMO upload %d graded: %d questions, overall_score=%.2f",
-        upload_id,
-        len(graded),
-        overall_score or 0.0,
-    )
+        await asyncio.wait_for(_do_grade(), timeout=_GRADING_TIMEOUT)
+    except asyncio.TimeoutError:
+        logger.error(
+            "OMO _run_grading timed out after %ds for upload %d",
+            _GRADING_TIMEOUT,
+            upload_id,
+        )
+        _update_upload(
+            upload_id,
+            status="error",
+            error_message=f"批改任務超時 ({_GRADING_TIMEOUT}s)，請稍後重試",
+        )

--- a/backend/tests/test_regression_omo_job_hardening_1772.py
+++ b/backend/tests/test_regression_omo_job_hardening_1772.py
@@ -1,0 +1,266 @@
+"""Regression tests for OMO background-task hardening (issue #1772).
+
+Tests:
+    Timeout:
+        _run_identification: asyncio.TimeoutError → status='error', Chinese message
+        _run_grading:        asyncio.TimeoutError → status='error', Chinese message
+    Idempotency:
+        _run_identification: no-op when status already in {'identified','grading','graded'}
+        _run_grading:        no-op when status already 'graded'
+    Module docstring:
+        asyncio imported
+        _IDENTIFICATION_TIMEOUT / _GRADING_TIMEOUT constants present
+        _IDENTIFICATION_TERMINAL / _GRADING_TERMINAL sets correct
+        _fetch_upload_status helper exported
+
+Run:
+    cd backend && python -m pytest tests/test_regression_omo_job_hardening_1772.py -v
+"""
+
+import asyncio
+import sys
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import module under test
+# ---------------------------------------------------------------------------
+
+from app.services import omo_jobs
+from app.services.omo_jobs import (
+    _run_identification,
+    _run_grading,
+    _IDENTIFICATION_TIMEOUT,
+    _GRADING_TIMEOUT,
+    _IDENTIFICATION_TERMINAL,
+    _GRADING_TERMINAL,
+    _fetch_upload_status,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TINY_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 12 + b"\xff\xd9"
+
+
+def _make_upload_mock(status: str):
+    """Return a MagicMock that behaves like an OmoUpload with the given status."""
+    obj = MagicMock()
+    obj.status = status
+    obj.id = 99
+    obj.attempts = []
+    obj.identification = None
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants check
+# ---------------------------------------------------------------------------
+
+class TestModuleConstants:
+    def test_identification_timeout_value(self):
+        assert _IDENTIFICATION_TIMEOUT == 90, "Expected 90s identification timeout"
+
+    def test_grading_timeout_value(self):
+        assert _GRADING_TIMEOUT == 120, "Expected 120s grading timeout"
+
+    def test_identification_terminal_set(self):
+        assert _IDENTIFICATION_TERMINAL == frozenset({"identified", "grading", "graded"})
+
+    def test_grading_terminal_set(self):
+        assert _GRADING_TERMINAL == frozenset({"graded"})
+
+    def test_asyncio_imported(self):
+        import inspect
+        src = inspect.getsource(omo_jobs)
+        assert "import asyncio" in src
+
+    def test_fetch_upload_status_callable(self):
+        assert callable(_fetch_upload_status)
+
+
+# ---------------------------------------------------------------------------
+# Timeout tests — _run_identification
+# ---------------------------------------------------------------------------
+
+class TestIdentificationTimeout:
+    @pytest.mark.asyncio
+    async def test_timeout_sets_error_status(self):
+        """When _do_identify hangs past 90s, status → 'error' with Chinese message."""
+        updated_calls = []
+
+        async def _slow_identify(*args, **kwargs):
+            await asyncio.sleep(200)  # Simulates a hung task
+
+        with (
+            patch("app.services.omo_jobs._fetch_upload_status", return_value="identifying"),
+            patch("app.services.omo_jobs._update_upload", side_effect=lambda upload_id, **kw: updated_calls.append(kw)),
+            patch("asyncio.wait_for", side_effect=asyncio.TimeoutError),
+        ):
+            await _run_identification(
+                upload_id=1,
+                image_bytes_list=[_TINY_JPEG],
+                mime_types=["image/jpeg"],
+            )
+
+        assert updated_calls, "Expected _update_upload to be called on timeout"
+        last_call = updated_calls[-1]
+        assert last_call.get("status") == "error"
+        msg = last_call.get("error_message", "")
+        assert "超時" in msg or "timeout" in msg.lower(), f"Expected timeout message, got: {msg!r}"
+        assert str(_IDENTIFICATION_TIMEOUT) in msg
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_reraise(self):
+        """TimeoutError must be caught — caller must NOT see an unhandled exception."""
+        with (
+            patch("app.services.omo_jobs._fetch_upload_status", return_value="identifying"),
+            patch("app.services.omo_jobs._update_upload"),
+            patch("asyncio.wait_for", side_effect=asyncio.TimeoutError),
+        ):
+            # Should complete without raising
+            await _run_identification(
+                upload_id=2,
+                image_bytes_list=[_TINY_JPEG],
+                mime_types=["image/jpeg"],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Timeout tests — _run_grading
+# ---------------------------------------------------------------------------
+
+class TestGradingTimeout:
+    @pytest.mark.asyncio
+    async def test_timeout_sets_error_status(self):
+        """When _do_grade hangs past 120s, status → 'error' with Chinese message."""
+        updated_calls = []
+
+        with (
+            patch("app.services.omo_jobs._fetch_upload_status", return_value="grading"),
+            patch("app.services.omo_jobs._update_upload", side_effect=lambda upload_id, **kw: updated_calls.append(kw)),
+            patch("asyncio.wait_for", side_effect=asyncio.TimeoutError),
+        ):
+            await _run_grading(upload_id=3, lesson_id=1)
+
+        assert updated_calls, "Expected _update_upload to be called on timeout"
+        last_call = updated_calls[-1]
+        assert last_call.get("status") == "error"
+        msg = last_call.get("error_message", "")
+        assert "超時" in msg or "timeout" in msg.lower(), f"Expected timeout message, got: {msg!r}"
+        assert str(_GRADING_TIMEOUT) in msg
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_reraise(self):
+        """TimeoutError must be caught — caller must NOT see an unhandled exception."""
+        with (
+            patch("app.services.omo_jobs._fetch_upload_status", return_value="grading"),
+            patch("app.services.omo_jobs._update_upload"),
+            patch("asyncio.wait_for", side_effect=asyncio.TimeoutError),
+        ):
+            await _run_grading(upload_id=4, lesson_id=1)
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tests — _run_identification
+# ---------------------------------------------------------------------------
+
+class TestIdentificationIdempotency:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("terminal_status", ["identified", "grading", "graded"])
+    async def test_skips_when_already_terminal(self, terminal_status):
+        """_run_identification is a no-op when upload is already in a terminal state."""
+        update_called = []
+
+        with (
+            patch("app.services.omo_jobs._fetch_upload_status", return_value=terminal_status),
+            patch("app.services.omo_jobs._update_upload", side_effect=lambda *a, **kw: update_called.append(kw)),
+        ):
+            await _run_identification(
+                upload_id=10,
+                image_bytes_list=[_TINY_JPEG],
+                mime_types=["image/jpeg"],
+            )
+
+        assert not update_called, (
+            f"Expected no DB writes when status={terminal_status!r}, "
+            f"but got: {update_called}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_proceeds_when_status_identifying(self):
+        """_run_identification proceeds (calls wait_for) when status='identifying'."""
+        wait_for_called = []
+
+        async def _fake_wait_for(coro, timeout):
+            wait_for_called.append(timeout)
+            # Drain the coroutine to avoid ResourceWarning
+            try:
+                await coro
+            except Exception:
+                pass
+
+        with (
+            patch("app.services.omo_jobs._fetch_upload_status", return_value="identifying"),
+            patch("app.services.omo_jobs._update_upload"),
+            patch("asyncio.wait_for", side_effect=_fake_wait_for),
+        ):
+            await _run_identification(
+                upload_id=11,
+                image_bytes_list=[_TINY_JPEG],
+                mime_types=["image/jpeg"],
+            )
+
+        assert wait_for_called, "Expected asyncio.wait_for to be called"
+        assert wait_for_called[0] == _IDENTIFICATION_TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# Idempotency tests — _run_grading
+# ---------------------------------------------------------------------------
+
+class TestGradingIdempotency:
+    @pytest.mark.asyncio
+    async def test_skips_when_already_graded(self):
+        """_run_grading is a no-op when upload is already 'graded'."""
+        update_called = []
+
+        with (
+            patch("app.services.omo_jobs._fetch_upload_status", return_value="graded"),
+            patch("app.services.omo_jobs._update_upload", side_effect=lambda *a, **kw: update_called.append(kw)),
+        ):
+            await _run_grading(upload_id=20, lesson_id=1)
+
+        assert not update_called, (
+            f"Expected no DB writes when status='graded', but got: {update_called}"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("non_terminal_status", ["identifying", "identified", "grading"])
+    async def test_proceeds_when_not_graded(self, non_terminal_status):
+        """_run_grading proceeds (calls wait_for) when status is not yet 'graded'."""
+        wait_for_called = []
+
+        async def _fake_wait_for(coro, timeout):
+            wait_for_called.append(timeout)
+            try:
+                await coro
+            except Exception:
+                pass
+
+        with (
+            patch("app.services.omo_jobs._fetch_upload_status", return_value=non_terminal_status),
+            patch("app.services.omo_jobs._update_upload"),
+            patch("asyncio.wait_for", side_effect=_fake_wait_for),
+        ):
+            await _run_grading(upload_id=21, lesson_id=1)
+
+        assert wait_for_called, f"Expected asyncio.wait_for to be called for status={non_terminal_status!r}"
+        assert wait_for_called[0] == _GRADING_TIMEOUT


### PR DESCRIPTION
Fixes #1772

## Summary

Minimal in-place hardening of `backend/app/services/omo_jobs.py` — no new infra, no schema changes.

- **Timeout**: `asyncio.wait_for` wraps entire task body — 90s for `_run_identification`, 120s for `_run_grading`. On `TimeoutError` → `upload.status='error'` + Chinese message, no re-raise to caller
- **Idempotency**: re-fetch `upload.status` at task entry via fresh `SessionLocal`; no-op if already in terminal set (`{'identified','grading','graded'}` for identify; `{'graded'}` for grade) — prevents double-processing on duplicate enqueue
- **Docstring**: timeout policy / idempotency / retry budget (client-initiated via `/regrade`) / memory bound all documented inline
- **`_fetch_upload_status()`**: new lightweight helper for the idempotency read

## NOT in scope
- Cloud Tasks migration (deferred — needs spec)
- `background_jobs` DB table (deferred)
- Worker process pool (deferred)

## Test plan
- 18 new regression tests in `test_regression_omo_job_hardening_1772.py`
  - Timeout → status='error' + correct message (identify + grade)
  - TimeoutError does not re-raise (identify + grade)
  - Idempotency: skip when terminal (3 statuses × identify, 1 × grade)
  - Proceeds normally when not terminal (1 × identify, 3 statuses × grade)
  - Module constants + imports verified
- Existing OMO tests: 39 passed, 1 pre-existing failure (`test_too_many_files_returns_400` fails on staging before this PR — unrelated)