### PR TITLE
refactor(frontend): centralize auth token + surface API errors (Fixes #1784 #1786)

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { login as apiLogin, register as apiRegister, getMe, acceptTerms as apiAcceptTerms, googleLogin as apiGoogleLogin, junyiLogin as apiJunyiLogin, AuthUser, AuthError, RegisterResponse } from '../services/authApi';
 import { SESSION_UNAUTHORIZED_EVENT } from '../services/sessionGuard';
+import { authToken, safeStorage } from '../utils/storage';
 
-const TOKEN_KEY = 'lingoleap_token';
 const ACTIVE_ASSIGNMENT_CONTEXT_KEY = 'activeAssignmentContext';
 // Set when user logs in via Junyi SSO (#1260). Read on logout to also clear
 // Junyi-side cookies via redirect to https://www.junyiacademy.org/logout —
@@ -51,7 +51,7 @@ export function useAuth(): AuthContextValue {
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<AuthUser | null>(null);
-  const [token, setToken] = useState<string | null>(() => localStorage.getItem(TOKEN_KEY));
+  const [token, setToken] = useState<string | null>(() => authToken.get());
   const [isLoading, setIsLoading] = useState(true);
   const [mustChangePassword, setMustChangePassword] = useState(false);
   const [loginPassword, setLoginPassword] = useState<string | null>(null);
@@ -86,7 +86,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       .catch(() => {
         // Token is invalid or expired — clear it
         if (!cancelled) {
-          localStorage.removeItem(TOKEN_KEY);
+          authToken.remove();
           setToken(null);
           setUser(null);
         }
@@ -115,10 +115,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // causing a duplicate /api/users/me on every login (Issue #1156).
     const userData = await getMe(newToken);
 
-    localStorage.setItem(TOKEN_KEY, newToken);
+    authToken.set(newToken);
     // Email/password login is not Junyi — clear any stale Junyi flag from a
     // prior session in another tab to avoid logout() redirecting to Junyi.
-    localStorage.removeItem(JUNYI_SESSION_FLAG);
+    safeStorage.local.remove(JUNYI_SESSION_FLAG);
     setUser(userData);
     setToken(newToken);
 
@@ -142,9 +142,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // Same ordering as login(): fetch user first, then set user before token so
     // the token-change useEffect skips its redundant /me call (Issue #1156).
     const userData = await getMe(newToken);
-    localStorage.setItem(TOKEN_KEY, newToken);
+    authToken.set(newToken);
     // Google login is not Junyi — clear any stale Junyi flag.
-    localStorage.removeItem(JUNYI_SESSION_FLAG);
+    safeStorage.local.remove(JUNYI_SESSION_FLAG);
     setUser(userData);
     setToken(newToken);
     return { isNewUser: response.is_new_user };
@@ -156,9 +156,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // Same ordering as loginWithGoogle: pre-fetch user so token-change useEffect
     // sees user !== null and skips the redundant /me call (Issue #1156).
     const userData = await getMe(newToken);
-    localStorage.setItem(TOKEN_KEY, newToken);
+    authToken.set(newToken);
     // Mark session as Junyi-sourced so logout() also clears Junyi cookies (#1260).
-    localStorage.setItem(JUNYI_SESSION_FLAG, '1');
+    safeStorage.local.set(JUNYI_SESSION_FLAG, '1');
     setUser(userData);
     setToken(newToken);
     return { isNewUser: response.is_new_user };
@@ -169,10 +169,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     // round-trip through Junyi /logout (clears their cookies via Set-Cookie).
     // skipJunyiRedirect is set by the SESSION_UNAUTHORIZED auto-logout path so
     // expired-token recovery doesn't yank the user mid-page through Junyi.
-    const wasJunyiSession = localStorage.getItem(JUNYI_SESSION_FLAG) === '1';
+    const wasJunyiSession = safeStorage.local.get(JUNYI_SESSION_FLAG) === '1';
     const shouldRedirectToJunyi = wasJunyiSession && !options?.skipJunyiRedirect;
-    localStorage.removeItem(TOKEN_KEY);
-    localStorage.removeItem(JUNYI_SESSION_FLAG);
+    authToken.remove();
+    safeStorage.local.remove(JUNYI_SESSION_FLAG);
     try {
       sessionStorage.removeItem('activeAssignmentId');
       sessionStorage.removeItem('activeAssignmentGoals');
@@ -228,7 +228,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   }, []);
 
   const refreshUser = useCallback(async () => {
-    const storedToken = localStorage.getItem(TOKEN_KEY);
+    const storedToken = authToken.get();
     if (!storedToken) return;
     try {
       const userData = await getMe(storedToken);

--- a/frontend/src/hooks/useTtsPlayback.ts
+++ b/frontend/src/hooks/useTtsPlayback.ts
@@ -1,17 +1,10 @@
 import { useState, useRef, useCallback } from 'react';
 import { cancelTts, cleanForTts, pauseCurrentTts, resumeCurrentTts, speakTextWithProgress, TtsProgressInfo } from '../services/ttsApi';
-
-// Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
-const _TTS_TOKEN_KEY = 'lingoleap_token';
+import { authToken } from '../utils/storage';
 
 /** Read JWT token from localStorage and return Authorization header if present. */
 function _ttsAuthHeaders(): Record<string, string> {
-  try {
-    const token = localStorage.getItem(_TTS_TOKEN_KEY);
-    return token ? { Authorization: `Bearer ${token}` } : {};
-  } catch {
-    return {};
-  }
+  return authToken.authHeader();
 }
 
 /**

--- a/frontend/src/pages/teacher/AssignmentTab.tsx
+++ b/frontend/src/pages/teacher/AssignmentTab.tsx
@@ -38,6 +38,7 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [allStories, setAllStories] = useState<Story[]>([]);
   const [isLoadingStories, setIsLoadingStories] = useState(false);
+  const [storiesError, setStoriesError] = useState<string | null>(null);
   const [selectedStoryId, setSelectedStoryId] = useState('');
   const [formTitle, setFormTitle] = useState('');
   const [formDescription, setFormDescription] = useState('');
@@ -90,11 +91,12 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
   const loadStories = useCallback(async () => {
     if (allStories.length > 0) return;
     setIsLoadingStories(true);
+    setStoriesError(null);
     try {
       const data = await fetchStories();
       setAllStories(data.stories);
-    } catch {
-      // silent
+    } catch (err) {
+      setStoriesError(err instanceof Error ? err.message : '無法載入課文列表');
     } finally {
       setIsLoadingStories(false);
     }
@@ -425,6 +427,17 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
                 <div className="flex items-center gap-2 py-2">
                   <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
                   <span className="text-xs text-gray-400">載入課文列表...</span>
+                </div>
+              ) : storiesError ? (
+                <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+                  <span>載入課文失敗：{storiesError}</span>
+                  <button
+                    type="button"
+                    onClick={() => { setStoriesError(null); setAllStories([]); loadStories(); }}
+                    className="ml-auto text-xs underline hover:no-underline"
+                  >
+                    重試
+                  </button>
                 </div>
               ) : (
                 <select

--- a/frontend/src/pages/teacher/StudentProgressTab.tsx
+++ b/frontend/src/pages/teacher/StudentProgressTab.tsx
@@ -373,6 +373,7 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   const [expandedStudentId, setExpandedStudentId] = useState<number | null>(null);
   const [isLoadingSessions, setIsLoadingSessions] = useState(false);
   const [sessions, setSessions] = useState<StudentSession[]>([]);
+  const [sessionsError, setSessionsError] = useState<string | null>(null);
   const sessionCache = useRef<Record<number, StudentSession[]>>({});
 
   // Dialogue modal state (Issue #418)
@@ -382,6 +383,7 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
     studentName: string;
   } | null>(null);
   const [loadingDialogueSessionId, setLoadingDialogueSessionId] = useState<number | null>(null);
+  const [dialogueError, setDialogueError] = useState<string | null>(null);
 
   // Instruction panel state
   const [instructionTarget, setInstructionTarget] = useState<{ id: number; name: string } | null>(null);
@@ -393,6 +395,7 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   // Learning curve state
   const [learningCurve, setLearningCurve] = useState<LearningCurvePoint[]>([]);
   const [isLoadingCurve, setIsLoadingCurve] = useState(false);
+  const [curveError, setCurveError] = useState<string | null>(null);
   const curveCache = useRef<Record<string, LearningCurvePoint[]>>({});
   const [curveStoryFilter, setCurveStoryFilter] = useState<string>(''); // empty = all stories
 
@@ -480,14 +483,17 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
     // Load session history (with cache)
     if (sessionCache.current[studentId]) {
       setSessions(sessionCache.current[studentId]);
+      setSessionsError(null);
     } else {
       setIsLoadingSessions(true);
       setSessions([]);
+      setSessionsError(null);
       try {
         const data = await getStudentSessions(token, studentId);
         sessionCache.current[studentId] = data;
         setSessions(data);
-      } catch {
+      } catch (err) {
+        setSessionsError(err instanceof Error ? err.message : '載入失敗');
         setSessions([]);
       } finally {
         setIsLoadingSessions(false);
@@ -498,14 +504,17 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
     const cacheKey = `${studentId}:${nextFilter}`;
     if (curveCache.current[cacheKey]) {
       setLearningCurve(curveCache.current[cacheKey]);
+      setCurveError(null);
     } else {
       setIsLoadingCurve(true);
       setLearningCurve([]);
+      setCurveError(null);
       try {
         const curveData = await getStudentLearningCurve(token, studentId, nextFilter || undefined);
         curveCache.current[cacheKey] = curveData.data;
         setLearningCurve(curveData.data);
-      } catch {
+      } catch (err) {
+        setCurveError(err instanceof Error ? err.message : '載入失敗');
         setLearningCurve([]);
       } finally {
         setIsLoadingCurve(false);
@@ -522,11 +531,12 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
   ) => {
     if (!token) return;
     setLoadingDialogueSessionId(sessionId);
+    setDialogueError(null);
     try {
       const data = await getTeacherStudentDialogue(token, studentId, sessionId);
       setDialogueModal({ data, storyTitle, studentName });
-    } catch {
-      // Non-fatal — silently fail
+    } catch (err) {
+      setDialogueError(err instanceof Error ? err.message : '無法載入對話紀錄');
     } finally {
       setLoadingDialogueSessionId(null);
     }
@@ -661,6 +671,20 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
         />
       )}
 
+      {/* Dialogue fetch error banner */}
+      {dialogueError && (
+        <div className="mb-3 flex items-center gap-2 px-4 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+          <span>對話紀錄載入失敗：{dialogueError}</span>
+          <button
+            type="button"
+            onClick={() => setDialogueError(null)}
+            className="ml-auto text-xs underline hover:no-underline"
+          >
+            關閉
+          </button>
+        </div>
+      )}
+
       {/* Dialogue History Modal (Issue #418) */}
       {dialogueModal && (
         <DialogueModal
@@ -759,6 +783,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                 <div className="mt-2 bg-gray-50 rounded-lg p-3 space-y-4">
                   {isLoadingCurve ? (
                     <div className="h-40 bg-gray-200 animate-pulse rounded" />
+                  ) : curveError ? (
+                    <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
+                      <span>學習曲線載入失敗：收合後再展開重試</span>
+                    </div>
                   ) : learningCurve.length >= 2 ? (
                     <div>
                       <div className="flex items-center justify-between mb-2">
@@ -816,6 +844,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                       {Array.from({ length: 3 }).map((_, i) => (
                         <div key={i} className="h-16 bg-gray-200 animate-pulse rounded-lg" />
                       ))}
+                    </div>
+                  ) : sessionsError ? (
+                    <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
+                      <span>練習紀錄載入失敗：收合後再展開重試</span>
                     </div>
                   ) : sessions.length === 0 ? (
                     <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>
@@ -983,6 +1015,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                         {/* Learning curve chart */}
                         {isLoadingCurve ? (
                           <div className="h-40 bg-gray-200 animate-pulse rounded" />
+                        ) : curveError ? (
+                          <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
+                            <span>學習曲線載入失敗：收合後再展開重試</span>
+                          </div>
                         ) : learningCurve.length >= 2 ? (
                           <div>
                             <div className="flex items-center justify-between mb-2">
@@ -1048,6 +1084,10 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                                 <div className="h-3 bg-gray-200 animate-pulse rounded w-1/6" />
                               </div>
                             ))}
+                          </div>
+                        ) : sessionsError ? (
+                          <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
+                            <span>練習紀錄載入失敗：收合後再展開重試</span>
                           </div>
                         ) : sessions.length === 0 ? (
                           <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>

--- a/frontend/src/pages/teacher/TextManagementTab.tsx
+++ b/frontend/src/pages/teacher/TextManagementTab.tsx
@@ -34,6 +34,7 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
   // All available stories
   const [allStories, setAllStories] = useState<Story[]>([]);
   const [isLoadingStories, setIsLoadingStories] = useState(false);
+  const [storiesError, setStoriesError] = useState<string | null>(null);
 
   // Assign flow
   const [showAssignSelector, setShowAssignSelector] = useState(false);
@@ -70,11 +71,12 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
   const loadStories = useCallback(async () => {
     if (allStories.length > 0) return; // already loaded
     setIsLoadingStories(true);
+    setStoriesError(null);
     try {
       const data = await fetchStories();
       setAllStories(data.stories);
-    } catch {
-      // silent -- selector will show empty
+    } catch (err) {
+      setStoriesError(err instanceof Error ? err.message : '無法載入課文列表');
     } finally {
       setIsLoadingStories(false);
     }
@@ -285,6 +287,17 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
             <div className="flex items-center gap-2 py-4">
               <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
               <span className="text-xs text-gray-400">載入課文列表...</span>
+            </div>
+          ) : storiesError ? (
+            <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+              <span>載入課文失敗：{storiesError}</span>
+              <button
+                type="button"
+                onClick={() => { setStoriesError(null); setAllStories([]); loadStories(); }}
+                className="ml-auto text-xs underline hover:no-underline"
+              >
+                重試
+              </button>
             </div>
           ) : availableStories.length === 0 ? (
             <p className="text-xs text-gray-400 py-4">所有課文皆已指派</p>

--- a/frontend/src/services/feedbackApi.ts
+++ b/frontend/src/services/feedbackApi.ts
@@ -4,6 +4,7 @@
 
 import { API_BASE } from './apiConfig';
 import { handle401Response } from './apiUnauthorized';
+import { authToken } from '../utils/storage';
 
 export type FeedbackCategory = 'bug' | 'feature' | 'question' | 'other';
 export type FeedbackStatus = 'open' | 'in_progress' | 'resolved' | 'closed';
@@ -35,11 +36,9 @@ export interface FeedbackListResponse {
 }
 
 function getAuthHeaders(): Record<string, string> {
-  // #1777: AuthContext stores JWT under 'lingoleap_token', not 'token'.
-  // This used to silently return no Authorization header → all feedback 401.
-  const token = localStorage.getItem('lingoleap_token');
-  if (!token) return {};
-  return { Authorization: `Bearer ${token}` };
+  // #1777 ground zero: previously hardcoded 'token' key → all feedback 401.
+  // #1786: migrated to authToken.authHeader() — cannot hardcode wrong key again.
+  return authToken.authHeader();
 }
 
 /**

--- a/frontend/src/services/learningApi.ts
+++ b/frontend/src/services/learningApi.ts
@@ -8,6 +8,7 @@
 import type { ReadingEvaluateResponse } from '../types';
 import { SessionExpiredError } from './api';
 import { API_BASE } from './apiConfig';
+import { authToken } from '../utils/storage';
 
 // Re-export so consumers can import SessionExpiredError from learningApi without
 // needing to know it lives in api.ts.
@@ -616,12 +617,8 @@ export interface DictionaryBatchResponse {
   results: DictionaryEntry[];
 }
 
-// Token key must match AuthContext TOKEN_KEY
-const _DICT_TOKEN_KEY = 'lingoleap_token';
-
 function _getDictAuthHeaders(): Record<string, string> {
-  const token = localStorage.getItem(_DICT_TOKEN_KEY);
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  return authToken.authHeader();
 }
 
 /** Look up a single Chinese character from the MOE dictionary (cached). Requires auth. */

--- a/frontend/src/services/ttsApi.ts
+++ b/frontend/src/services/ttsApi.ts
@@ -1,4 +1,5 @@
 import { API_BASE } from './apiConfig';
+import { authToken } from '../utils/storage';
 /**
  * ttsApi.ts — TTS client with sentence-level sequential playback (Issue #667)
  *
@@ -16,22 +17,9 @@ import { API_BASE } from './apiConfig';
  */
 
 
-// Token key must match AuthContext TOKEN_KEY ('lingoleap_token').
-const TOKEN_KEY = 'lingoleap_token';
-
-/** Read the JWT token from localStorage (same source as AuthContext). */
-function _getAuthToken(): string | null {
-  try {
-    return localStorage.getItem(TOKEN_KEY);
-  } catch {
-    return null;
-  }
-}
-
 /** Build Authorization header if a token is available. */
 function _authHeaders(): Record<string, string> {
-  const token = _getAuthToken();
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  return authToken.authHeader();
 }
 
 // In-memory URL cache: sentence text → blob URL.

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,0 +1,118 @@
+/**
+ * storage.ts — Typed localStorage/sessionStorage helpers.
+ *
+ * Issue #1786: Centralizes auth token access so the key is never hardcoded
+ * across files. Direct reads in AuthContext / ttsApi / useTtsPlayback /
+ * learningApi / feedbackApi are replaced by authToken.* helpers here.
+ *
+ * Provides:
+ *   - safeStorage.local / safeStorage.session  — try/catch-wrapped primitive ops
+ *   - readJSON<T> / writeJSON                   — typed JSON serialization
+ *   - AUTH_TOKEN_KEY                            — single source of truth for key name
+ *   - authToken                                 — token read/write/header helpers
+ *
+ * Graceful degrade: Private browsing / Safari ITP / quota errors return null/false
+ * instead of throwing, so callers never see a white screen from storage errors.
+ */
+
+// ---------------------------------------------------------------------------
+// Raw safe storage
+// ---------------------------------------------------------------------------
+
+export const safeStorage = {
+  local: {
+    get(key: string): string | null {
+      try {
+        return localStorage.getItem(key);
+      } catch {
+        return null;
+      }
+    },
+    set(key: string, value: string): boolean {
+      try {
+        localStorage.setItem(key, value);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    remove(key: string): void {
+      try {
+        localStorage.removeItem(key);
+      } catch {
+        // non-fatal
+      }
+    },
+  },
+  session: {
+    get(key: string): string | null {
+      try {
+        return sessionStorage.getItem(key);
+      } catch {
+        return null;
+      }
+    },
+    set(key: string, value: string): boolean {
+      try {
+        sessionStorage.setItem(key, value);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    remove(key: string): void {
+      try {
+        sessionStorage.removeItem(key);
+      } catch {
+        // non-fatal
+      }
+    },
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Typed JSON helpers
+// ---------------------------------------------------------------------------
+
+export function readJSON<T>(store: 'local' | 'session', key: string): T | null {
+  const raw = safeStorage[store].get(key);
+  if (raw === null) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function writeJSON(store: 'local' | 'session', key: string, value: unknown): boolean {
+  try {
+    return safeStorage[store].set(key, JSON.stringify(value));
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auth token — single source of truth
+// ---------------------------------------------------------------------------
+
+/** The localStorage key under which the JWT is stored. Exported for tests
+ *  and migration scripts; never duplicate this constant in other files. */
+export const AUTH_TOKEN_KEY = 'lingoleap_token';
+
+export const authToken = {
+  get(): string | null {
+    return safeStorage.local.get(AUTH_TOKEN_KEY);
+  },
+  set(token: string): void {
+    safeStorage.local.set(AUTH_TOKEN_KEY, token);
+  },
+  remove(): void {
+    safeStorage.local.remove(AUTH_TOKEN_KEY);
+  },
+  /** Returns `{ Authorization: 'Bearer <token>' }` or `{}` if no token. */
+  authHeader(): Record<string, string> {
+    const token = safeStorage.local.get(AUTH_TOKEN_KEY);
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  },
+};


### PR DESCRIPTION
Fixes #1784
Fixes #1786

Implementation per @if-else-master analysis on [#1784](https://github.com/Youngger9765/chinese-literacy-platform/issues/1784) and [#1786](https://github.com/Youngger9765/chinese-literacy-platform/issues/1786).

## Summary

### #1786 — Auth token centralization (5 critical sites)

- **New file**: `frontend/src/utils/storage.ts`
  - `safeStorage.local/session` — try/catch-wrapped primitive ops (private browsing safe)
  - `AUTH_TOKEN_KEY = 'lingoleap_token'` — single source of truth
  - `authToken.get/set/remove/authHeader()` — token helpers
- Migrated 5 auth token read/write sites to `authToken.*`:
  - `AuthContext.tsx` — login / loginWithGoogle / loginWithJunyi / logout / refreshUser
  - `ttsApi.ts` — removed local `TOKEN_KEY` + `_getAuthToken()`
  - `useTtsPlayback.ts` — removed local `_TTS_TOKEN_KEY`
  - `learningApi.ts` — removed local `_DICT_TOKEN_KEY`
  - `feedbackApi.ts` — annotated as #1777 ground zero; can never hardcode wrong key again
- `lingoleap_token` string literal now appears in **exactly 1 file** (`storage.ts`)

### #1784 — Visible error states on silent-failure fetch paths

- `AssignmentTab.tsx`: `storiesError` state + red banner + retry button on story selector fetch failure
- `TextManagementTab.tsx`: same pattern on story list fetch failure
- `StudentProgressTab.tsx`:
  - `sessionsError` — inline red banner on session history load failure
  - `curveError` — inline red banner on learning curve load failure
  - `dialogueError` — dismissible red banner at page top on dialogue fetch failure
- Teacher can now distinguish "fetch failed" from "no data" without guessing

## Test plan

- [ ] Login (email + Google + Junyi SSO) — token stored, re-hydrated on reload, cleared on logout
- [ ] TTS playback, dictionary lookup, feedback submit — all carry `Authorization` header (Network tab)
- [ ] Chrome DevTools → Network → Offline: AssignmentTab/TextManagementTab story selector shows red banner + retry; StudentProgressTab expanded row shows curve/session error banners; dialogue button shows dismissible banner
- [ ] Online retry — banner disappears, data loads
- [ ] Normal (no error) path unchanged — empty state still shows "尚無練習記錄" gray text
- [ ] `npm run build` — clean ✅ (verified locally, 7.10s)

## Grep evidence

```
rg "lingoleap_token" frontend/src
# → frontend/src/utils/storage.ts (1 file only)
```