### PR TITLE
refactor(auth): centralize classroom/student auth policies (Fixes #1822)

### DIFF
--- a/backend/app/auth/policies.py
+++ b/backend/app/auth/policies.py
@@ -1,0 +1,102 @@
+"""Centralized authorization policies for LingoLeap.
+
+Single source of truth for classroom/student access control.
+All route modules should import from here instead of implementing their own checks.
+"""
+import logging
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ..models.school import Classroom, ClassroomStudent, ClassroomTeacher
+from ..models.user import Role, User, UserRole
+
+logger = logging.getLogger(__name__)
+
+
+def is_admin(user_id: int, db: Session) -> bool:
+    """Return True if user has system_admin or org_admin role."""
+    return (
+        db.query(UserRole)
+        .join(Role)
+        .filter(
+            UserRole.user_id == user_id,
+            UserRole.is_active == True,
+            Role.name.in_(["system_admin", "org_admin"]),
+        )
+        .first()
+    ) is not None
+
+
+def require_classroom_owner(classroom: Classroom, user: User, db: Session) -> None:
+    """Allow classroom primary teacher OR system/org admin. Raise 403 otherwise.
+
+    Use for write operations (update, delete, assign).
+    Co-teachers (assistants) are NOT allowed for write ops.
+    """
+    if classroom.teacher_id == user.id:
+        return
+    if is_admin(user.id, db):
+        return
+    raise HTTPException(status_code=403, detail="Not your classroom")
+
+
+def require_classroom_member(classroom: Classroom, user: User, db: Session) -> None:
+    """Allow classroom owner, co-teachers, or system/org admins. Raise 403 otherwise.
+
+    Use for read operations (view students, progress).
+    """
+    if classroom.teacher_id == user.id:
+        return
+    ct = (
+        db.query(ClassroomTeacher)
+        .filter(
+            ClassroomTeacher.classroom_id == classroom.id,
+            ClassroomTeacher.teacher_id == user.id,
+        )
+        .first()
+    )
+    if ct:
+        return
+    if is_admin(user.id, db):
+        return
+    raise HTTPException(status_code=403, detail="Not your classroom")
+
+
+def require_student_visible_to_teacher(student_id: int, user: User, db: Session) -> None:
+    """Verify teacher (primary or co-teacher) has access to a student, OR user is admin.
+
+    A student is visible to a teacher if:
+    - The teacher owns a classroom containing the student (primary teacher), OR
+    - The teacher is a co-teacher of a classroom containing the student, OR
+    - The user is a system/org admin
+
+    Raises 403 if none of the above.
+    """
+    if is_admin(user.id, db):
+        return
+
+    # Check if student is in any classroom where user is primary teacher or co-teacher
+    enrollment = (
+        db.query(ClassroomStudent)
+        .join(Classroom, ClassroomStudent.classroom_id == Classroom.id)
+        .filter(ClassroomStudent.student_id == student_id)
+        .filter(
+            (Classroom.teacher_id == user.id)
+            | (
+                db.query(ClassroomTeacher.classroom_id)
+                .filter(
+                    ClassroomTeacher.classroom_id == ClassroomStudent.classroom_id,
+                    ClassroomTeacher.teacher_id == user.id,
+                )
+                .correlate(ClassroomStudent)
+                .exists()
+            )
+        )
+        .first()
+    )
+    if not enrollment:
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to access this student's data",
+        )

--- a/backend/app/routes/classrooms/helpers.py
+++ b/backend/app/routes/classrooms/helpers.py
@@ -8,6 +8,11 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from ...auth.dependencies import get_current_user  # noqa: F401 — re-exported for convenience
+from ...auth.policies import (
+    is_admin as _is_admin_policy,
+    require_classroom_member as _require_classroom_member,
+    require_classroom_owner as _require_classroom_owner,
+)
 from ...models.assignment import Assignment, AssignmentSubmission
 from ...models.school import Classroom, ClassroomStudent, ClassroomTeacher
 from ...models.user import Role, User, UserRole
@@ -58,71 +63,18 @@ def get_classroom_or_404(classroom_id: int, db: Session) -> Classroom:
 
 
 def require_owner_or_admin(classroom: Classroom, current_user: User, db: Session) -> None:
-    """Allow classroom teacher (primary) OR system/org admin. Raise 403 otherwise.
-
-    For co-teachers (assistants) use require_member_or_admin which also allows assistants.
-    """
-    if classroom.teacher_id == current_user.id:
-        return
-    admin_role = (
-        db.query(UserRole)
-        .join(Role)
-        .filter(
-            UserRole.user_id == current_user.id,
-            UserRole.is_active == True,
-            Role.name.in_(["system_admin", "org_admin"]),
-        )
-        .first()
-    )
-    if admin_role:
-        return
-    raise HTTPException(status_code=403, detail="Not your classroom")
+    """Delegate to centralized policies. Kept for backwards compatibility."""
+    _require_classroom_owner(classroom, current_user, db)
 
 
 def require_member_or_admin(classroom: Classroom, current_user: User, db: Session) -> None:
-    """Allow classroom owner, co-teachers (assistants), or system/org admins.
-
-    Used for read-only endpoints like viewing student progress.
-    """
-    if classroom.teacher_id == current_user.id:
-        return
-    ct = (
-        db.query(ClassroomTeacher)
-        .filter(
-            ClassroomTeacher.classroom_id == classroom.id,
-            ClassroomTeacher.teacher_id == current_user.id,
-        )
-        .first()
-    )
-    if ct:
-        return
-    admin_role = (
-        db.query(UserRole)
-        .join(Role)
-        .filter(
-            UserRole.user_id == current_user.id,
-            UserRole.is_active == True,
-            Role.name.in_(["system_admin", "org_admin"]),
-        )
-        .first()
-    )
-    if admin_role:
-        return
-    raise HTTPException(status_code=403, detail="Not your classroom")
+    """Delegate to centralized policies. Kept for backwards compatibility."""
+    _require_classroom_member(classroom, current_user, db)
 
 
 def is_admin(user_id: int, db: Session) -> bool:
-    """Check if a user has system_admin or org_admin role."""
-    return (
-        db.query(UserRole)
-        .join(Role)
-        .filter(
-            UserRole.user_id == user_id,
-            UserRole.is_active == True,
-            Role.name.in_(["system_admin", "org_admin"]),
-        )
-        .first()
-    ) is not None
+    """Delegate to centralized policies. Kept for backwards compatibility."""
+    return _is_admin_policy(user_id, db)
 
 
 # ── Email Helpers ─────────────────────────────────────────────────────────────

--- a/backend/app/routes/teacher/teacher_students.py
+++ b/backend/app/routes/teacher/teacher_students.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.orm import Session, joinedload
 
 from ...auth.dependencies import get_current_user
+from ...auth.policies import require_student_visible_to_teacher
 from ...auth.rate_limiter import ai_limit_5_per_min
 from ...database import get_db
 from ...dependencies.tenant import _check_classroom_access
@@ -41,21 +42,11 @@ logger = logging.getLogger(__name__)
 def _require_teacher_owns_student(
     teacher_id: int, student_id: int, db: Session
 ) -> None:
-    """Raise 403 if the teacher does not own any classroom that contains this student."""
-    enrollment = (
-        db.query(ClassroomStudent)
-        .join(Classroom, ClassroomStudent.classroom_id == Classroom.id)
-        .filter(
-            ClassroomStudent.student_id == student_id,
-            Classroom.teacher_id == teacher_id,
-        )
-        .first()
-    )
-    if not enrollment:
-        raise HTTPException(
-            status_code=403,
-            detail="Not authorized to manage tags for this student",
-        )
+    """Deprecated: Use require_student_visible_to_teacher from auth.policies instead."""
+    user = db.query(User).filter(User.id == teacher_id).first()
+    if user is None:
+        raise HTTPException(status_code=403, detail="Teacher not found")
+    require_student_visible_to_teacher(student_id, user, db)
 
 
 @router.get(
@@ -72,18 +63,7 @@ def get_student_sessions(
 
     Teacher must own a classroom that contains this student.
     """
-    # Verify teacher owns a classroom containing this student
-    enrollment = (
-        db.query(ClassroomStudent)
-        .join(Classroom, ClassroomStudent.classroom_id == Classroom.id)
-        .filter(
-            ClassroomStudent.student_id == student_id,
-            Classroom.teacher_id == current_user.id,
-        )
-        .first()
-    )
-    if not enrollment:
-        raise HTTPException(status_code=403, detail="Not authorized to view this student's sessions")
+    require_student_visible_to_teacher(student_id, current_user, db)
 
     audit_log_endpoint(
         request=request,
@@ -141,18 +121,7 @@ def get_teacher_student_dialogue(
     The requesting teacher must own a classroom that contains the student.
     Returns an empty turns list if the session exists but has no recorded dialogue.
     """
-    # Verify teacher owns a classroom containing this student
-    enrollment = (
-        db.query(ClassroomStudent)
-        .join(Classroom, ClassroomStudent.classroom_id == Classroom.id)
-        .filter(
-            ClassroomStudent.student_id == student_id,
-            Classroom.teacher_id == current_user.id,
-        )
-        .first()
-    )
-    if not enrollment:
-        raise HTTPException(status_code=403, detail="Not authorized to view this student's sessions")
+    require_student_visible_to_teacher(student_id, current_user, db)
 
     audit_log_endpoint(
         request=request,
@@ -300,18 +269,7 @@ def get_student_learning_curve(
     Optionally filter by story_slug to see reading progress for a specific text.
     Teacher must own a classroom containing this student.
     """
-    # Verify teacher access
-    enrollment = (
-        db.query(ClassroomStudent)
-        .join(Classroom, ClassroomStudent.classroom_id == Classroom.id)
-        .filter(
-            ClassroomStudent.student_id == student_id,
-            Classroom.teacher_id == current_user.id,
-        )
-        .first()
-    )
-    if not enrollment:
-        raise HTTPException(status_code=403, detail="Not authorized to view this student's data")
+    require_student_visible_to_teacher(student_id, current_user, db)
 
     audit_log_endpoint(
         request=request,


### PR DESCRIPTION
Fixes #1822

## Summary

- Create `backend/app/auth/policies.py` as single source of truth for classroom/student authorization
- **Bug fix**: `teacher_students.py` was missing admin and co-teacher exemptions — admin could not see student sessions/dialogue/curve data
- `classrooms/helpers.py` existing functions now delegate to `policies.py` (backward-compatible, no callers need changes)
- `teacher_students.py` now calls `require_student_visible_to_teacher()` which supports admin + co-teacher

## New policy functions

| Function | Purpose | Who passes |
|---|---|---|
| `require_classroom_owner()` | Write ops | Primary teacher + admin |
| `require_classroom_member()` | Read ops | Primary teacher + co-teacher + admin |
| `require_student_visible_to_teacher()` | Student-level read | Primary teacher + co-teacher + admin |
| `is_admin()` | Shared helper | — |

## Verification

- Import smoke tests: all pass (policies.py, helpers.py, teacher_students.py, assignments.py, full app)
- `pytest tests/` — 37 pass, 1 pre-existing failure confirmed on staging baseline before this PR
- No new test failures introduced

## Acceptance criteria

- [x] `backend/app/auth/policies.py` built with 4 policy functions
- [x] Three drift points delegate to policies (classrooms/helpers.py × 2 functions, teacher_students.py × 3 call sites + deprecated wrapper)
- [x] grep audit done — remaining `Classroom.teacher_id == current_user.id` in gamification/learning are data-listing filters, not auth guards (out of scope per issue)
- [ ] Admin can see teacher_students endpoints — needs deploy + manual verify
- [ ] Co-teacher can see student progress — needs deploy + manual verify

## Test plan (after merge to staging)

1. Log in as system_admin
2. `GET /api/teacher/students/{student_id}/sessions` — expect 200 (was 403)
3. Log in as co-teacher of a classroom with that student
4. Same endpoint — expect 200 (was 403)