### PR TITLE
refactor(teacher): split StudentProgressTab + AssignmentTab into hooks + components (Fixes #1828)

### DIFF
--- a/frontend/src/pages/teacher/AssignmentTab.tsx
+++ b/frontend/src/pages/teacher/AssignmentTab.tsx
@@ -1,342 +1,236 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useAuth } from '../../contexts/AuthContext';
-import {
-  getClassroomAssignments,
-  getAssignmentDetail,
-  createAssignment,
-  updateAssignment,
-  deleteAssignment,
-  AssignmentResponse,
-  AssignmentDetailResponse,
-  SubmissionResponse,
-  AssignmentApiError,
-} from '../../services/assignmentApi';
-import { fetchStories } from '../../services/api';
-import type { Story } from '../../types';
-import AssignmentDetailPanel from './AssignmentDetailPanel';
-import ReadingGoalsForm, { GoalsFormState } from '../../components/teacher/ReadingGoalsForm';
-import ReadingGoalsBadge from '../../components/ui/ReadingGoalsBadge';
+import React from 'react';
+import { AssignmentResponse } from '../../services/assignmentApi';
+import AssignmentCard from './components/AssignmentCard';
+import AssignmentCreateForm from './components/AssignmentCreateForm';
+import AssignmentExpandedPanel from './components/AssignmentExpandedPanel';
+import AssignmentInlineEdit from './components/AssignmentInlineEdit';
+import { completionPercentage, formatDate, isOverdue } from './components/assignmentUtils';
+import { StatusFilter, useAssignments } from './hooks/useAssignments';
 
 interface AssignmentTabProps {
   classroomId: number;
 }
 
-type StatusFilter = 'all' | 'active' | 'inactive' | 'overdue';
+const STATUS_TABS: { key: StatusFilter; label: string }[] = [
+  { key: 'all', label: '全部' },
+  { key: 'active', label: '進行中' },
+  { key: 'overdue', label: '已逾期' },
+  { key: 'inactive', label: '已停用' },
+];
 
 const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
-  const { token } = useAuth();
+  const {
+    assignments,
+    isLoading,
+    error,
+    setError,
+    statusFilter,
+    setStatusFilter,
+    showCreateForm,
+    setShowCreateForm,
+    allStories,
+    isLoadingStories,
+    storiesError,
+    selectedStoryId,
+    setSelectedStoryId,
+    formTitle,
+    setFormTitle,
+    formDescription,
+    setFormDescription,
+    formDueDate,
+    setFormDueDate,
+    formSkipCompleted,
+    setFormSkipCompleted,
+    formGoals,
+    setFormGoals,
+    isCreating,
+    createError,
+    expandedId,
+    expandedDetail,
+    isLoadingDetail,
+    deletingId,
+    confirmDeleteId,
+    setConfirmDeleteId,
+    editingId,
+    editTitle,
+    setEditTitle,
+    editDescription,
+    setEditDescription,
+    editDueDate,
+    setEditDueDate,
+    isSavingEdit,
+    editError,
+    storyMap,
+    filteredAssignments,
+    tabCounts,
+    loadAssignments,
+    retryLoadStories,
+    handleOpenCreateForm,
+    handleCreate,
+    handleToggleActive,
+    handleDelete,
+    handleOpenEdit,
+    handleCancelEdit,
+    handleSaveEdit,
+    handleExpand,
+    handleGraded,
+  } = useAssignments(classroomId);
 
-  // Assignment list
-  const [assignments, setAssignments] = useState<AssignmentResponse[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState('');
-
-  // Status filter
-  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-
-  // Create form
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [allStories, setAllStories] = useState<Story[]>([]);
-  const [isLoadingStories, setIsLoadingStories] = useState(false);
-  const [storiesError, setStoriesError] = useState<string | null>(null);
-  const [selectedStoryId, setSelectedStoryId] = useState('');
-  const [formTitle, setFormTitle] = useState('');
-  const [formDescription, setFormDescription] = useState('');
-  const [formDueDate, setFormDueDate] = useState('');
-  // Issue #1762: smart-skip already-completed steps
-  const [formSkipCompleted, setFormSkipCompleted] = useState(false);
-  const [formGoals, setFormGoals] = useState<GoalsFormState>({
-    target_cpm: null,
-    target_accuracy: null,
-    difficulty_label: null,
-  });
-  const [isCreating, setIsCreating] = useState(false);
-  const [createError, setCreateError] = useState('');
-
-  // Expand detail
-  const [expandedId, setExpandedId] = useState<number | null>(null);
-  const [expandedDetail, setExpandedDetail] = useState<AssignmentDetailResponse | null>(null);
-  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
-
-  // Delete state
-  const [deletingId, setDeletingId] = useState<number | null>(null);
-  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
-
-  // Edit state
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [editTitle, setEditTitle] = useState('');
-  const [editDescription, setEditDescription] = useState('');
-  const [editDueDate, setEditDueDate] = useState('');
-  const [isSavingEdit, setIsSavingEdit] = useState(false);
-  const [editError, setEditError] = useState('');
-
-  const loadAssignments = useCallback(async () => {
-    if (!token) return;
-    setIsLoading(true);
-    setError('');
-    try {
-      const data = await getClassroomAssignments(token, classroomId);
-      setAssignments(data.items);
-    } catch (err) {
-      if (err instanceof AssignmentApiError) {
-        setError(err.message);
-      } else {
-        setError('無法載入作業列表');
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [token, classroomId]);
-
-  const loadStories = useCallback(async () => {
-    if (allStories.length > 0) return;
-    setIsLoadingStories(true);
-    setStoriesError(null);
-    try {
-      const data = await fetchStories();
-      setAllStories(data.stories);
-    } catch (err) {
-      setStoriesError(err instanceof Error ? err.message : '無法載入課文列表');
-    } finally {
-      setIsLoadingStories(false);
-    }
-  }, [allStories.length]);
-
-  useEffect(() => {
-    loadAssignments();
-  }, [loadAssignments]);
-
-  // Story lookup map for display
-  const storyMap = useMemo(() => {
-    const map = new Map<string, Story>();
-    allStories.forEach((s) => map.set(s.id, s));
-    return map;
-  }, [allStories]);
-
-  // Suppress unused variable warning — storyMap used for future enhancements
-  void storyMap;
-
-  // Filtered assignments based on status tab
-  const filteredAssignments = useMemo(() => {
-    const now = new Date();
-    return assignments.filter((a) => {
-      switch (statusFilter) {
-        case 'active':
-          return a.is_active && (!a.due_date || new Date(a.due_date) >= now);
-        case 'inactive':
-          return !a.is_active;
-        case 'overdue':
-          return a.is_active && a.due_date != null && new Date(a.due_date) < now;
-        default:
-          return true;
-      }
-    });
-  }, [assignments, statusFilter]);
-
-  // Tab counts
-  const tabCounts = useMemo(() => {
-    const now = new Date();
-    return {
-      all: assignments.length,
-      active: assignments.filter(
-        (a) => a.is_active && (!a.due_date || new Date(a.due_date) >= now),
-      ).length,
-      inactive: assignments.filter((a) => !a.is_active).length,
-      overdue: assignments.filter(
-        (a) => a.is_active && a.due_date != null && new Date(a.due_date) < now,
-      ).length,
-    };
-  }, [assignments]);
-
-  const handleOpenCreateForm = () => {
-    setShowCreateForm(true);
-    setCreateError('');
-    setSelectedStoryId('');
-    setFormTitle('');
-    setFormDescription('');
-    setFormDueDate('');
-    setFormGoals({ target_cpm: null, target_accuracy: null, difficulty_label: null });
-    loadStories();
-  };
-
-  const handleCreate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!token || !selectedStoryId) return;
-
-    setIsCreating(true);
-    setCreateError('');
-    try {
-      await createAssignment(token, classroomId, {
-        story_id: selectedStoryId,
-        title: formTitle.trim() || undefined,
-        description: formDescription.trim() || undefined,
-        due_date: formDueDate || undefined,
-        target_cpm: formGoals.target_cpm,
-        target_accuracy: formGoals.target_accuracy,
-        difficulty_label: formGoals.difficulty_label,
-        skip_completed_steps: formSkipCompleted,  // Issue #1762
-      });
-      setShowCreateForm(false);
-      await loadAssignments();
-    } catch (err) {
-      if (err instanceof AssignmentApiError) {
-        setCreateError(err.message);
-      } else {
-        setCreateError('建立作業失敗');
-      }
-    } finally {
-      setIsCreating(false);
-    }
-  };
-
-  const handleToggleActive = async (assignment: AssignmentResponse) => {
-    if (!token) return;
-    try {
-      const updated = await updateAssignment(token, assignment.id, {
-        is_active: !assignment.is_active,
-      });
-      setAssignments((prev) =>
-        prev.map((a) => (a.id === updated.id ? updated : a)),
-      );
-    } catch (err) {
-      if (err instanceof AssignmentApiError) {
-        setError(err.message);
-      } else {
-        setError('更新狀態失敗');
-      }
-    }
-  };
-
-  const handleDelete = async (assignment: AssignmentResponse) => {
-    if (!token) return;
-    setDeletingId(assignment.id);
-    setConfirmDeleteId(null);
-    try {
-      await deleteAssignment(token, assignment.id);
-      setAssignments((prev) => prev.filter((a) => a.id !== assignment.id));
-      // If the deleted assignment was expanded, collapse it
-      if (expandedId === assignment.id) {
-        setExpandedId(null);
-        setExpandedDetail(null);
-      }
-    } catch (err) {
-      if (err instanceof AssignmentApiError) {
-        setError(err.message);
-      } else {
-        setError('刪除作業失敗');
-      }
-    } finally {
-      setDeletingId(null);
-    }
-  };
-
-  const handleOpenEdit = (assignment: AssignmentResponse, e: React.MouseEvent) => {
-    e.stopPropagation();
-    const dueDateValue = assignment.due_date
-      ? new Date(assignment.due_date).toISOString().slice(0, 10)
-      : '';
-    setEditingId(assignment.id);
-    setEditTitle(assignment.title || '');
-    setEditDescription(assignment.description || '');
-    setEditDueDate(dueDateValue);
-    setEditError('');
-    setConfirmDeleteId(null);
-  };
-
-  const handleCancelEdit = () => {
-    setEditingId(null);
-    setEditError('');
-  };
-
-  const handleSaveEdit = async (assignmentId: number) => {
-    if (!token) return;
-    setIsSavingEdit(true);
-    setEditError('');
-    try {
-      const updated = await updateAssignment(token, assignmentId, {
-        title: editTitle.trim() || undefined,
-        description: editDescription.trim() || undefined,
-        due_date: editDueDate || null,
-      });
-      setAssignments((prev) => prev.map((a) => (a.id === updated.id ? updated : a)));
-      setEditingId(null);
-    } catch (err) {
-      if (err instanceof AssignmentApiError) {
-        setEditError(err.message);
-      } else {
-        setEditError('儲存失敗，請再試一次');
-      }
-    } finally {
-      setIsSavingEdit(false);
-    }
-  };
-
-  const handleRowClick = useCallback(
-    async (assignmentId: number) => {
-      if (expandedId === assignmentId) {
-        setExpandedId(null);
-        setExpandedDetail(null);
-        return;
-      }
-
-      setExpandedId(assignmentId);
-      if (!token) return;
-      setIsLoadingDetail(true);
-      setExpandedDetail(null);
-      try {
-        const detail = await getAssignmentDetail(token, assignmentId);
-        setExpandedDetail(detail);
-      } catch {
-        setExpandedDetail(null);
-      } finally {
-        setIsLoadingDetail(false);
-      }
-    },
-    [expandedId, token],
+  const renderEditForm = (assignment: AssignmentResponse, variant: 'mobile' | 'desktop') => (
+    <AssignmentInlineEdit
+      editTitle={editTitle}
+      setEditTitle={setEditTitle}
+      editDescription={editDescription}
+      setEditDescription={setEditDescription}
+      editDueDate={editDueDate}
+      setEditDueDate={setEditDueDate}
+      editError={editError}
+      isSavingEdit={isSavingEdit}
+      onCancel={handleCancelEdit}
+      onSave={() => handleSaveEdit(assignment.id)}
+      variant={variant}
+    />
   );
 
-  // Update a single submission in expandedDetail after grading
-  const handleGraded = useCallback((updated: SubmissionResponse) => {
-    setExpandedDetail((prev) => {
-      if (!prev) return prev;
-      const newSubs = prev.submissions.map((s) =>
-        s.id === updated.id ? updated : s,
-      );
-      const completedCount = newSubs.filter((s) =>
-        ['submitted', 'graded'].includes(s.status),
-      ).length;
-      return { ...prev, submissions: newSubs, completed_count: completedCount };
-    });
-    // Also update the summary row in assignments list
-    setAssignments((prev) =>
-      prev.map((a) => {
-        if (a.id !== expandedId) return a;
-        const completedCount = a.completed_count;
-        // If newly graded from submitted, count stays same (already counted)
-        return { ...a, completed_count: completedCount };
-      }),
+  const renderDesktopRow = (assignment: AssignmentResponse) => {
+    const isExpanded = expandedId === assignment.id;
+    const displayTitle = assignment.title || assignment.story_title;
+    const completionPct = completionPercentage(assignment.completed_count, assignment.submission_count);
+    const isConfirmingDelete = confirmDeleteId === assignment.id;
+    const isDeleting = deletingId === assignment.id;
+    const isEditing = editingId === assignment.id;
+
+    return (
+      <React.Fragment key={assignment.id}>
+        <tr
+          className="cursor-pointer hover:bg-gray-50 transition-colors"
+          onClick={() => {
+            if (isConfirmingDelete || isEditing) return;
+            handleExpand(assignment.id);
+          }}
+        >
+          <td className="py-2.5 text-gray-400">
+            <svg
+              className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </td>
+          <td className="py-2.5 text-gray-900 font-medium">{displayTitle}</td>
+          <td className="py-2.5 text-gray-600">{assignment.story_title}</td>
+          <td className="py-2.5 text-gray-600">
+            <span className={isOverdue(assignment.due_date) ? 'text-red-600' : ''}>
+              {formatDate(assignment.due_date)}
+            </span>
+            {isOverdue(assignment.due_date) && (
+              <span className="ml-1 inline-block px-1 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">
+                已逾期
+              </span>
+            )}
+          </td>
+          <td className="py-2.5 text-center">
+            <span
+              className={`inline-block min-w-[2rem] px-2 py-0.5 rounded-full text-xs font-medium ${
+                completionPct === 100
+                  ? 'bg-green-100 text-green-700'
+                  : completionPct > 0
+                    ? 'bg-accent-bg text-accent'
+                    : 'bg-gray-100 text-gray-500'
+              }`}
+            >
+              {assignment.completed_count}/{assignment.submission_count}
+            </span>
+          </td>
+          <td className="py-2.5 text-center">
+            <button
+              onClick={(event) => {
+                event.stopPropagation();
+                handleToggleActive(assignment);
+              }}
+              className={`inline-block px-1.5 py-0.5 rounded text-xs font-medium transition-colors cursor-pointer ${
+                assignment.is_active
+                  ? 'bg-green-100 text-green-700 hover:bg-green-200'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+              }`}
+            >
+              {assignment.is_active ? '進行中' : '已停用'}
+            </button>
+          </td>
+          <td className="py-2.5 text-center" onClick={(event) => event.stopPropagation()}>
+            {isConfirmingDelete ? (
+              <div className="flex items-center gap-1 justify-center">
+                <button
+                  onClick={() => handleDelete(assignment)}
+                  disabled={isDeleting}
+                  className="px-1.5 py-0.5 rounded bg-red-500 text-white text-xs font-medium hover:bg-red-600 disabled:opacity-50 cursor-pointer transition-colors"
+                >
+                  {isDeleting ? '...' : '確認'}
+                </button>
+                <button
+                  onClick={() => setConfirmDeleteId(null)}
+                  className="px-1.5 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+                >
+                  取消
+                </button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-0.5 justify-center">
+                <button
+                  onClick={() => handleOpenEdit(assignment)}
+                  className="p-1 rounded text-gray-400 hover:text-accent hover:bg-accent-bg transition-colors cursor-pointer"
+                  title="編輯作業"
+                  aria-label="編輯作業"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                  </svg>
+                </button>
+                <button
+                  onClick={() => setConfirmDeleteId(assignment.id)}
+                  className="p-1 rounded text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors cursor-pointer"
+                  title="刪除作業"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </button>
+              </div>
+            )}
+          </td>
+        </tr>
+
+        {isEditing && (
+          <tr>
+            <td colSpan={7} className="bg-blue-50 px-4 py-3 border-b border-blue-100">
+              {renderEditForm(assignment, 'desktop')}
+            </td>
+          </tr>
+        )}
+
+        {isExpanded && (
+          <tr>
+            <td colSpan={7} className="bg-gray-50 px-4 py-3">
+              <AssignmentExpandedPanel
+                assignment={assignment}
+                expandedDetail={expandedDetail}
+                isLoadingDetail={isLoadingDetail}
+                onGraded={handleGraded}
+              />
+            </td>
+          </tr>
+        )}
+      </React.Fragment>
     );
-  }, [expandedId]);
-
-  const formatDate = (dateStr: string | null): string => {
-    if (!dateStr) return '-';
-    return new Date(dateStr).toLocaleDateString('zh-TW', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
-
-  const isOverdue = (dueDateStr: string | null): boolean => {
-    if (!dueDateStr) return false;
-    return new Date(dueDateStr) < new Date();
   };
 
   if (isLoading) {
     return (
       <div className="p-5 space-y-3">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="flex gap-4">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={index} className="flex gap-4">
             <div className="h-4 bg-gray-200 animate-pulse rounded w-1/3" />
             <div className="h-4 bg-gray-200 animate-pulse rounded w-1/4" />
             <div className="h-4 bg-gray-200 animate-pulse rounded w-1/6" />
@@ -362,16 +256,8 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
     );
   }
 
-  const STATUS_TABS: { key: StatusFilter; label: string }[] = [
-    { key: 'all', label: '全部' },
-    { key: 'active', label: '進行中' },
-    { key: 'overdue', label: '已逾期' },
-    { key: 'inactive', label: '已停用' },
-  ];
-
   return (
     <div>
-      {/* Inline error */}
       {error && (
         <div className="mx-5 mt-5 bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
           {error}
@@ -381,7 +267,6 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
         </div>
       )}
 
-      {/* Header row */}
       <div className="p-5 border-b border-gray-100 flex items-center justify-between">
         <span className="text-sm text-gray-500">
           共 {assignments.length} 份作業
@@ -399,155 +284,32 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
         )}
       </div>
 
-      {/* Create form */}
       {showCreateForm && (
-        <div className="p-5 border-b border-gray-100 bg-gray-50/50">
-          <div className="flex items-center justify-between mb-3">
-            <h4 className="text-sm font-bold text-gray-900">建立新作業</h4>
-            <button
-              onClick={() => setShowCreateForm(false)}
-              className="text-sm text-gray-500 hover:text-gray-700 cursor-pointer"
-            >
-              關閉
-            </button>
-          </div>
-
-          {createError && (
-            <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3 mb-3">
-              {createError}
-            </div>
-          )}
-
-          <form onSubmit={handleCreate} className="space-y-3">
-            <div>
-              <label htmlFor="assign-story" className="block text-sm font-medium text-gray-700 mb-1">
-                課文 <span className="text-red-500">*</span>
-              </label>
-              {isLoadingStories ? (
-                <div className="flex items-center gap-2 py-2">
-                  <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
-                  <span className="text-xs text-gray-400">載入課文列表...</span>
-                </div>
-              ) : storiesError ? (
-                <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
-                  <span>載入課文失敗：{storiesError}</span>
-                  <button
-                    type="button"
-                    onClick={() => { setStoriesError(null); setAllStories([]); loadStories(); }}
-                    className="ml-auto text-xs underline hover:no-underline"
-                  >
-                    重試
-                  </button>
-                </div>
-              ) : (
-                <select
-                  id="assign-story"
-                  value={selectedStoryId}
-                  onChange={(e) => setSelectedStoryId(e.target.value)}
-                  required
-                  className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                >
-                  <option value="">選擇課文</option>
-                  {allStories.map((story) => (
-                    <option key={story.id} value={story.id}>
-                      {story.title}
-                      {story.grade ? ` (${story.grade}年級)` : ''}
-                    </option>
-                  ))}
-                </select>
-              )}
-            </div>
-
-            <div>
-              <label htmlFor="assign-title" className="block text-sm font-medium text-gray-700 mb-1">
-                作業標題（選填）
-              </label>
-              <input
-                id="assign-title"
-                type="text"
-                value={formTitle}
-                onChange={(e) => setFormTitle(e.target.value)}
-                placeholder="留空則使用課文標題"
-                className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-              />
-            </div>
-
-            <div>
-              <label htmlFor="assign-desc" className="block text-sm font-medium text-gray-700 mb-1">
-                說明（選填）
-              </label>
-              <textarea
-                id="assign-desc"
-                value={formDescription}
-                onChange={(e) => setFormDescription(e.target.value)}
-                placeholder="作業說明或提示"
-                rows={2}
-                className="w-full px-3 py-2 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors resize-none"
-              />
-            </div>
-
-            <div>
-              <label htmlFor="assign-due" className="block text-sm font-medium text-gray-700 mb-1">
-                截止日期（選填）
-              </label>
-              <input
-                id="assign-due"
-                type="date"
-                value={formDueDate}
-                onChange={(e) => setFormDueDate(e.target.value)}
-                className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-              />
-            </div>
-
-            {/* Issue #1762: smart-skip setting */}
-            <div className="flex items-center gap-2">
-              <input
-                id="assign-skip-completed"
-                type="checkbox"
-                checked={formSkipCompleted}
-                onChange={(e) => setFormSkipCompleted(e.target.checked)}
-                className="h-4 w-4 rounded border-gray-300 text-accent focus:ring-accent"
-              />
-              <label htmlFor="assign-skip-completed" className="text-sm text-gray-700 cursor-pointer select-none">
-                跳過已完成步驟（學生重做作業時自動略過上次完成的環節）
-              </label>
-            </div>
-
-            {/* Reading goals */}
-            <div className="border-t border-gray-100 pt-3">
-              <ReadingGoalsForm
-                value={formGoals}
-                onChange={setFormGoals}
-                grade={
-                  selectedStoryId
-                    ? storyMap.get(selectedStoryId)?.grade ?? null
-                    : null
-                }
-              />
-            </div>
-
-            {/* Buttons */}
-            <div className="flex gap-3 justify-end pt-1">
-              <button
-                type="button"
-                onClick={() => setShowCreateForm(false)}
-                className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
-              >
-                取消
-              </button>
-              <button
-                type="submit"
-                disabled={isCreating || !selectedStoryId}
-                className="bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white px-5 py-2 rounded-lg font-medium text-sm transition-colors cursor-pointer"
-              >
-                {isCreating ? '建立中...' : '確認建立'}
-              </button>
-            </div>
-          </form>
-        </div>
+        <AssignmentCreateForm
+          stories={allStories}
+          storyGrade={selectedStoryId ? storyMap.get(selectedStoryId)?.grade ?? null : null}
+          isLoadingStories={isLoadingStories}
+          storiesError={storiesError}
+          selectedStoryId={selectedStoryId}
+          setSelectedStoryId={setSelectedStoryId}
+          formTitle={formTitle}
+          setFormTitle={setFormTitle}
+          formDescription={formDescription}
+          setFormDescription={setFormDescription}
+          formDueDate={formDueDate}
+          setFormDueDate={setFormDueDate}
+          formSkipCompleted={formSkipCompleted}
+          setFormSkipCompleted={setFormSkipCompleted}
+          formGoals={formGoals}
+          setFormGoals={setFormGoals}
+          isCreating={isCreating}
+          createError={createError}
+          onSubmit={handleCreate}
+          onClose={() => setShowCreateForm(false)}
+          onRetryStories={retryLoadStories}
+        />
       )}
 
-      {/* Status filter tabs */}
       {assignments.length > 0 && (
         <div className="px-5 pt-4 pb-0 flex gap-1 border-b border-gray-100">
           {STATUS_TABS.map((tab) => (
@@ -577,7 +339,6 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
         </div>
       )}
 
-      {/* Assignment list */}
       {filteredAssignments.length === 0 ? (
         <div className="p-8 text-center">
           {assignments.length === 0 ? (
@@ -588,7 +349,7 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
                     strokeLinecap="round"
                     strokeLinejoin="round"
                     strokeWidth={1.5}
-                    d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z"
+                    d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-1.125 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z"
                   />
                 </svg>
               </div>
@@ -601,223 +362,37 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
         </div>
       ) : (
         <div className="p-5">
-          {/* Mobile card view */}
           <div className="md:hidden space-y-3">
-            {filteredAssignments.map((a) => {
-              const isExpanded = expandedId === a.id;
-              const displayTitle = a.title || a.story_title;
-              const completionPct =
-                a.submission_count > 0
-                  ? Math.round((a.completed_count / a.submission_count) * 100)
-                  : 0;
-              const isConfirmingDelete = confirmDeleteId === a.id;
-              const isDeleting = deletingId === a.id;
-              const isEditing = editingId === a.id;
-
-              return (
-                <div key={a.id}>
-                  <div
-                    className="bg-white rounded-lg border border-gray-200 p-4 cursor-pointer hover:border-gray-300 transition-colors"
-                    onClick={() => {
-                      if (isConfirmingDelete || isEditing) return;
-                      handleRowClick(a.id);
-                    }}
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <div className="flex items-center gap-2 flex-1 min-w-0">
-                        <svg
-                          className={`w-4 h-4 text-gray-400 transition-transform duration-200 shrink-0 ${isExpanded ? 'rotate-90' : ''}`}
-                          fill="none" stroke="currentColor" viewBox="0 0 24 24"
-                        >
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                        </svg>
-                        <span className="font-medium text-gray-900 truncate">{displayTitle}</span>
-                      </div>
-                      <button
-                        onClick={(e) => { e.stopPropagation(); handleToggleActive(a); }}
-                        className={`shrink-0 inline-block px-1.5 py-0.5 rounded text-xs font-medium transition-colors cursor-pointer ${
-                          a.is_active
-                            ? 'bg-green-100 text-green-700 hover:bg-green-200'
-                            : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                        }`}
-                      >
-                        {a.is_active ? '進行中' : '已停用'}
-                      </button>
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm mt-3">
-                      <div>
-                        <span className="text-xs text-gray-400">課文</span>
-                        <p className="text-gray-600 truncate">{a.story_title}</p>
-                      </div>
-                      <div>
-                        <span className="text-xs text-gray-400">截止日期</span>
-                        <div>
-                          <span className={isOverdue(a.due_date) ? 'text-red-600' : 'text-gray-600'}>
-                            {formatDate(a.due_date)}
-                          </span>
-                          {isOverdue(a.due_date) && (
-                            <span className="ml-1 inline-block px-1 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">
-                              已逾期
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                      <div>
-                        <span className="text-xs text-gray-400">完成率</span>
-                        <p>
-                          <span
-                            className={`inline-block min-w-[2rem] px-2 py-0.5 rounded-full text-xs font-medium ${
-                              completionPct === 100
-                                ? 'bg-green-100 text-green-700'
-                                : completionPct > 0
-                                  ? 'bg-accent-bg text-accent'
-                                  : 'bg-gray-100 text-gray-500'
-                            }`}
-                          >
-                            {a.completed_count}/{a.submission_count}
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-
-                    <div className="flex items-center justify-end gap-1 mt-3 pt-2 border-t border-gray-100" onClick={(e) => e.stopPropagation()}>
-                      {isConfirmingDelete ? (
-                        <div className="flex items-center gap-1">
-                          <button
-                            onClick={() => handleDelete(a)}
-                            disabled={isDeleting}
-                            className="px-2 py-1 rounded bg-red-500 text-white text-xs font-medium hover:bg-red-600 disabled:opacity-50 cursor-pointer transition-colors"
-                          >
-                            {isDeleting ? '...' : '確認刪除'}
-                          </button>
-                          <button
-                            onClick={() => setConfirmDeleteId(null)}
-                            className="px-2 py-1 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                          >
-                            取消
-                          </button>
-                        </div>
-                      ) : (
-                        <div className="flex items-center gap-1">
-                          <button
-                            onClick={(e) => handleOpenEdit(a, e)}
-                            className="p-1.5 rounded text-gray-400 hover:text-accent hover:bg-accent-bg transition-colors cursor-pointer"
-                            title="編輯作業"
-                            aria-label="編輯作業"
-                          >
-                            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                            </svg>
-                          </button>
-                          <button
-                            onClick={() => setConfirmDeleteId(a.id)}
-                            className="p-1.5 rounded text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors cursor-pointer"
-                            title="刪除作業"
-                          >
-                            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                            </svg>
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-
-                  {isEditing && (
-                    <div className="mt-2 bg-blue-50 border border-blue-100 rounded-lg p-3">
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="text-sm font-medium text-gray-800">編輯作業</span>
-                        <button onClick={handleCancelEdit} className="text-xs text-gray-500 hover:text-gray-700 cursor-pointer">取消</button>
-                      </div>
-                      {editError && (
-                        <div className="bg-red-50 border border-red-200 text-red-700 text-xs rounded px-3 py-2 mb-2">{editError}</div>
-                      )}
-                      <div className="space-y-3">
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 mb-1">作業標題</label>
-                          <input
-                            type="text"
-                            value={editTitle}
-                            onChange={(e) => setEditTitle(e.target.value)}
-                            placeholder="留空則使用課文標題"
-                            className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 mb-1">說明</label>
-                          <input
-                            type="text"
-                            value={editDescription}
-                            onChange={(e) => setEditDescription(e.target.value)}
-                            placeholder="作業說明（選填）"
-                            className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs font-medium text-gray-600 mb-1">截止日期</label>
-                          <input
-                            type="date"
-                            value={editDueDate}
-                            onChange={(e) => setEditDueDate(e.target.value)}
-                            className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                          />
-                        </div>
-                      </div>
-                      <div className="flex justify-end gap-2 mt-3">
-                        <button
-                          onClick={handleCancelEdit}
-                          className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-xs font-medium hover:bg-gray-50 transition-colors cursor-pointer"
-                        >
-                          取消
-                        </button>
-                        <button
-                          onClick={() => handleSaveEdit(a.id)}
-                          disabled={isSavingEdit}
-                          className="px-4 py-1.5 rounded-lg bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-medium transition-colors cursor-pointer"
-                        >
-                          {isSavingEdit ? '儲存中...' : '儲存'}
-                        </button>
-                      </div>
-                    </div>
-                  )}
-
-                  {isExpanded && (
-                    <div className="mt-2 bg-gray-50 rounded-lg p-3">
-                      <div className="mb-3">
-                        <ReadingGoalsBadge
-                          goals={{
-                            effectiveCpm: a.effective_cpm,
-                            effectiveAccuracy: a.effective_accuracy,
-                            difficultyLabel: a.difficulty_label,
-                            isCustom: a.target_cpm != null || a.target_accuracy != null,
-                          }}
-                          variant="compact"
-                        />
-                      </div>
-                      {expandedDetail ? (
-                        <AssignmentDetailPanel
-                          assignmentId={a.id}
-                          detail={expandedDetail}
-                          isLoading={isLoadingDetail}
-                          onGraded={handleGraded}
-                        />
-                      ) : isLoadingDetail ? (
-                        <div className="flex items-center gap-2 py-4 justify-center">
-                          <div className="w-4 h-4 border-2 border-gray-300 border-t-accent rounded-full animate-spin" />
-                          <span className="text-xs text-gray-500">載入中...</span>
-                        </div>
-                      ) : (
-                        <p className="text-xs text-gray-500 py-4 text-center">無法載入作業詳情</p>
-                      )}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
+            {filteredAssignments.map((assignment) => (
+              <AssignmentCard
+                key={assignment.id}
+                assignment={assignment}
+                isExpanded={expandedId === assignment.id}
+                isConfirmingDelete={confirmDeleteId === assignment.id}
+                isDeleting={deletingId === assignment.id}
+                isEditing={editingId === assignment.id}
+                editTitle={editTitle}
+                setEditTitle={setEditTitle}
+                editDescription={editDescription}
+                setEditDescription={setEditDescription}
+                editDueDate={editDueDate}
+                setEditDueDate={setEditDueDate}
+                editError={editError}
+                isSavingEdit={isSavingEdit}
+                expandedDetail={expandedDetail}
+                isLoadingDetail={isLoadingDetail}
+                onExpand={handleExpand}
+                onToggleActive={handleToggleActive}
+                onEdit={handleOpenEdit}
+                onCancelEdit={handleCancelEdit}
+                onSaveEdit={handleSaveEdit}
+                onDelete={handleDelete}
+                onConfirmDelete={setConfirmDeleteId}
+                onGraded={handleGraded}
+              />
+            ))}
           </div>
 
-          {/* Desktop table view */}
           <div className="hidden md:block overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
@@ -832,230 +407,7 @@ const AssignmentTab: React.FC<AssignmentTabProps> = ({ classroomId }) => {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-50">
-                {filteredAssignments.map((a) => {
-                  const isExpanded = expandedId === a.id;
-                  const displayTitle = a.title || a.story_title;
-                  const completionPct =
-                    a.submission_count > 0
-                      ? Math.round((a.completed_count / a.submission_count) * 100)
-                      : 0;
-                  const isConfirmingDelete = confirmDeleteId === a.id;
-                  const isDeleting = deletingId === a.id;
-                  const isEditing = editingId === a.id;
-
-                  return (
-                    <React.Fragment key={a.id}>
-                      <tr
-                        className="cursor-pointer hover:bg-gray-50 transition-colors"
-                        onClick={() => {
-                          if (isConfirmingDelete || isEditing) return;
-                          handleRowClick(a.id);
-                        }}
-                      >
-                        <td className="py-2.5 text-gray-400">
-                          <svg
-                            className={`w-4 h-4 transition-transform duration-200 ${isExpanded ? 'rotate-90' : ''}`}
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                          </svg>
-                        </td>
-                        <td className="py-2.5 text-gray-900 font-medium">{displayTitle}</td>
-                        <td className="py-2.5 text-gray-600">{a.story_title}</td>
-                        <td className="py-2.5 text-gray-600">
-                          <span className={isOverdue(a.due_date) ? 'text-red-600' : ''}>
-                            {formatDate(a.due_date)}
-                          </span>
-                          {isOverdue(a.due_date) && (
-                            <span className="ml-1 inline-block px-1 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">
-                              已逾期
-                            </span>
-                          )}
-                        </td>
-                        <td className="py-2.5 text-center">
-                          <span
-                            className={`inline-block min-w-[2rem] px-2 py-0.5 rounded-full text-xs font-medium ${
-                              completionPct === 100
-                                ? 'bg-green-100 text-green-700'
-                                : completionPct > 0
-                                  ? 'bg-accent-bg text-accent'
-                                  : 'bg-gray-100 text-gray-500'
-                            }`}
-                          >
-                            {a.completed_count}/{a.submission_count}
-                          </span>
-                        </td>
-                        <td className="py-2.5 text-center">
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleToggleActive(a);
-                            }}
-                            className={`inline-block px-1.5 py-0.5 rounded text-xs font-medium transition-colors cursor-pointer ${
-                              a.is_active
-                                ? 'bg-green-100 text-green-700 hover:bg-green-200'
-                                : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
-                            }`}
-                          >
-                            {a.is_active ? '進行中' : '已停用'}
-                          </button>
-                        </td>
-                        <td className="py-2.5 text-center" onClick={(e) => e.stopPropagation()}>
-                          {isConfirmingDelete ? (
-                            <div className="flex items-center gap-1 justify-center">
-                              <button
-                                onClick={() => handleDelete(a)}
-                                disabled={isDeleting}
-                                className="px-1.5 py-0.5 rounded bg-red-500 text-white text-xs font-medium hover:bg-red-600 disabled:opacity-50 cursor-pointer transition-colors"
-                              >
-                                {isDeleting ? '...' : '確認'}
-                              </button>
-                              <button
-                                onClick={() => setConfirmDeleteId(null)}
-                                className="px-1.5 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                              >
-                                取消
-                              </button>
-                            </div>
-                          ) : (
-                            <div className="flex items-center gap-0.5 justify-center">
-                              <button
-                                onClick={(e) => handleOpenEdit(a, e)}
-                                className="p-1 rounded text-gray-400 hover:text-accent hover:bg-accent-bg transition-colors cursor-pointer"
-                                title="編輯作業"
-                                aria-label="編輯作業"
-                              >
-                                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                                </svg>
-                              </button>
-                              <button
-                                onClick={() => setConfirmDeleteId(a.id)}
-                                className="p-1 rounded text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors cursor-pointer"
-                                title="刪除作業"
-                              >
-                                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                </svg>
-                              </button>
-                            </div>
-                          )}
-                        </td>
-                      </tr>
-
-                      {/* Inline edit form */}
-                      {isEditing && (
-                        <tr>
-                          <td colSpan={7} className="bg-blue-50 px-4 py-3 border-b border-blue-100">
-                            <div className="flex items-center justify-between mb-2">
-                              <span className="text-sm font-medium text-gray-800">編輯作業</span>
-                              <button
-                                onClick={handleCancelEdit}
-                                className="text-xs text-gray-500 hover:text-gray-700 cursor-pointer"
-                              >
-                                取消
-                              </button>
-                            </div>
-                            {editError && (
-                              <div className="bg-red-50 border border-red-200 text-red-700 text-xs rounded px-3 py-2 mb-2">
-                                {editError}
-                              </div>
-                            )}
-                            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                              <div>
-                                <label className="block text-xs font-medium text-gray-600 mb-1">
-                                  作業標題
-                                </label>
-                                <input
-                                  type="text"
-                                  value={editTitle}
-                                  onChange={(e) => setEditTitle(e.target.value)}
-                                  placeholder="留空則使用課文標題"
-                                  className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                                />
-                              </div>
-                              <div>
-                                <label className="block text-xs font-medium text-gray-600 mb-1">
-                                  說明
-                                </label>
-                                <input
-                                  type="text"
-                                  value={editDescription}
-                                  onChange={(e) => setEditDescription(e.target.value)}
-                                  placeholder="作業說明（選填）"
-                                  className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                                />
-                              </div>
-                              <div>
-                                <label className="block text-xs font-medium text-gray-600 mb-1">
-                                  截止日期
-                                </label>
-                                <input
-                                  type="date"
-                                  value={editDueDate}
-                                  onChange={(e) => setEditDueDate(e.target.value)}
-                                  className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                                />
-                              </div>
-                            </div>
-                            <div className="flex justify-end gap-2 mt-3">
-                              <button
-                                onClick={handleCancelEdit}
-                                className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-xs font-medium hover:bg-gray-50 transition-colors cursor-pointer"
-                              >
-                                取消
-                              </button>
-                              <button
-                                onClick={() => handleSaveEdit(a.id)}
-                                disabled={isSavingEdit}
-                                className="px-4 py-1.5 rounded-lg bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-medium transition-colors cursor-pointer"
-                              >
-                                {isSavingEdit ? '儲存中...' : '儲存'}
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                      )}
-
-                      {/* Expanded detail: grading panel */}
-                      {isExpanded && (
-                        <tr>
-                          <td colSpan={7} className="bg-gray-50 px-4 py-3">
-                            {/* Reading goals preview */}
-                            <div className="mb-3">
-                              <ReadingGoalsBadge
-                                goals={{
-                                  effectiveCpm: a.effective_cpm,
-                                  effectiveAccuracy: a.effective_accuracy,
-                                  difficultyLabel: a.difficulty_label,
-                                  isCustom: a.target_cpm != null || a.target_accuracy != null,
-                                }}
-                                variant="compact"
-                              />
-                            </div>
-                            {expandedDetail ? (
-                              <AssignmentDetailPanel
-                                assignmentId={a.id}
-                                detail={expandedDetail}
-                                isLoading={isLoadingDetail}
-                                onGraded={handleGraded}
-                              />
-                            ) : isLoadingDetail ? (
-                              <div className="flex items-center gap-2 py-4 justify-center">
-                                <div className="w-4 h-4 border-2 border-gray-300 border-t-accent rounded-full animate-spin" />
-                                <span className="text-xs text-gray-500">載入中...</span>
-                              </div>
-                            ) : (
-                              <p className="text-xs text-gray-500 py-4 text-center">無法載入作業詳情</p>
-                            )}
-                          </td>
-                        </tr>
-                      )}
-                    </React.Fragment>
-                  );
-                })}
+                {filteredAssignments.map(renderDesktopRow)}
               </tbody>
             </table>
           </div>

--- a/frontend/src/pages/teacher/StudentProgressTab.tsx
+++ b/frontend/src/pages/teacher/StudentProgressTab.tsx
@@ -1,623 +1,82 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import { Link } from 'react-router-dom';
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  Legend,
-} from 'recharts';
-import { useAuth } from '../../contexts/AuthContext';
-import {
-  getClassroomProgress,
-  getClassroomInstructionCounts,
-  getStudentSessions,
-  getTeacherStudentDialogue,
-  exportClassroomReport,
-  addStudentTag,
-  removeStudentTag,
-  getStudentLearningCurve,
-  StudentProgress,
-  StudentTag,
-  StudentSession,
-  TeacherDialogueTurn,
-  TeacherDialogueHistoryResponse,
-  LearningCurvePoint,
-  TeacherApiError,
-} from '../../services/teacherApi';
+import React from 'react';
+import { StudentProgress } from '../../services/teacherApi';
+import StudentDialogueModal from './components/StudentDialogueModal';
+import StudentExpandedPanel from './components/StudentExpandedPanel';
+import StudentProgressCard from './components/StudentProgressCard';
+import StudentTagManager from './components/StudentTagManager';
+import { formatDate, tagColorClass } from './components/studentProgressUtils';
+import { useStudentProgress } from './hooks/useStudentProgress';
 import TeacherInstructionPanel from './TeacherInstructionPanel';
 
 interface StudentProgressTabProps {
   classroomId: number;
 }
 
-// Predefined tags with their default colors
-const PREDEFINED_TAGS: { name: string; color: string }[] = [
-  { name: '需要關注', color: 'red' },
-  { name: '閱讀困難', color: 'orange' },
-  { name: '進步中', color: 'green' },
-  { name: '資優', color: 'blue' },
-];
-
-const TAG_COLOR_CLASSES: Record<string, string> = {
-  red: 'bg-red-100 text-red-700 border-red-200',
-  orange: 'bg-orange-100 text-orange-700 border-orange-200',
-  green: 'bg-green-100 text-green-700 border-green-200',
-  blue: 'bg-blue-100 text-blue-700 border-blue-200',
-  purple: 'bg-purple-100 text-purple-700 border-purple-200',
-  gray: 'bg-gray-100 text-gray-600 border-gray-200',
-};
-
-function tagColorClass(color: string): string {
-  return TAG_COLOR_CLASSES[color] ?? TAG_COLOR_CLASSES['gray'];
-}
-
-interface TagManagerProps {
-  studentId: number;
-  studentName: string;
-  currentTags: StudentTag[];
-  onClose: () => void;
-  onTagsChanged: (studentId: number, tags: StudentTag[]) => void;
-}
-
-const TagManager: React.FC<TagManagerProps> = ({
-  studentId,
-  studentName,
-  currentTags,
-  onClose,
-  onTagsChanged,
-}) => {
-  const { token } = useAuth();
-  const [tags, setTags] = useState<StudentTag[]>(currentTags);
-  const [customInput, setCustomInput] = useState('');
-  const [customColor, setCustomColor] = useState('gray');
-  const [saving, setSaving] = useState<string | null>(null);
-  const [error, setError] = useState('');
-
-  const handleAdd = async (tagName: string, color: string) => {
-    if (!token) return;
-    if (tags.some((t) => t.tag_name === tagName)) return; // already present
-    setSaving(tagName);
-    setError('');
-    try {
-      const newTag = await addStudentTag(token, studentId, tagName, color);
-      const updated = [...tags, newTag];
-      setTags(updated);
-      onTagsChanged(studentId, updated);
-    } catch (err) {
-      if (err instanceof TeacherApiError && err.status === 409) {
-        // tag already exists (race condition), silently ignore
-      } else {
-        setError('新增標籤失敗，請稍後再試');
-      }
-    } finally {
-      setSaving(null);
-    }
-  };
-
-  const handleRemove = async (tagName: string) => {
-    if (!token) return;
-    setSaving(tagName);
-    setError('');
-    try {
-      await removeStudentTag(token, studentId, tagName);
-      const updated = tags.filter((t) => t.tag_name !== tagName);
-      setTags(updated);
-      onTagsChanged(studentId, updated);
-    } catch {
-      setError('移除標籤失敗，請稍後再試');
-    } finally {
-      setSaving(null);
-    }
-  };
-
-  const handleAddCustom = async () => {
-    const name = customInput.trim();
-    if (!name) return;
-    if (name.length > 50) {
-      setError('標籤名稱不能超過 50 字元');
-      return;
-    }
-    await handleAdd(name, customColor);
-    setCustomInput('');
-  };
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
-      <div
-        className="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-5"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-base font-semibold text-gray-800">
-            管理標籤 — {studentName}
-          </h3>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
-            aria-label="關閉"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        {/* Current tags */}
-        {tags.length > 0 && (
-          <div className="mb-4">
-            <p className="text-xs text-gray-500 mb-2">目前標籤</p>
-            <div className="flex flex-wrap gap-1.5">
-              {tags.map((t) => (
-                <span
-                  key={t.tag_name}
-                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border ${tagColorClass(t.color)}`}
-                >
-                  {t.tag_name}
-                  <button
-                    onClick={() => handleRemove(t.tag_name)}
-                    disabled={saving === t.tag_name}
-                    className="ml-0.5 hover:opacity-70 disabled:opacity-40 cursor-pointer"
-                    aria-label={`移除 ${t.tag_name}`}
-                  >
-                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Predefined tags */}
-        <div className="mb-4">
-          <p className="text-xs text-gray-500 mb-2">快速新增</p>
-          <div className="flex flex-wrap gap-1.5">
-            {PREDEFINED_TAGS.map((pt) => {
-              const isActive = tags.some((t) => t.tag_name === pt.name);
-              return (
-                <button
-                  key={pt.name}
-                  onClick={() => isActive ? handleRemove(pt.name) : handleAdd(pt.name, pt.color)}
-                  disabled={saving === pt.name}
-                  className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium border transition-opacity disabled:opacity-50 cursor-pointer ${
-                    isActive
-                      ? tagColorClass(pt.color)
-                      : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
-                  }`}
-                >
-                  {isActive && (
-                    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.172l7.879-7.879a1 1 0 011.414 0z" clipRule="evenodd" />
-                    </svg>
-                  )}
-                  {pt.name}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Custom tag input */}
-        <div className="mb-3">
-          <p className="text-xs text-gray-500 mb-2">自訂標籤</p>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={customInput}
-              onChange={(e) => setCustomInput(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleAddCustom()}
-              placeholder="輸入標籤名稱..."
-              maxLength={50}
-              className="flex-1 px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-300"
-            />
-            <select
-              value={customColor}
-              onChange={(e) => setCustomColor(e.target.value)}
-              className="px-2 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-300 bg-white"
-            >
-              <option value="gray">灰</option>
-              <option value="red">紅</option>
-              <option value="orange">橙</option>
-              <option value="green">綠</option>
-              <option value="blue">藍</option>
-              <option value="purple">紫</option>
-            </select>
-            <button
-              onClick={handleAddCustom}
-              disabled={!customInput.trim() || saving !== null}
-              className="px-3 py-1.5 text-sm font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
-            >
-              新增
-            </button>
-          </div>
-        </div>
-
-        {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
-      </div>
-    </div>
-  );
-};
-
-// ── Dialogue Modal (Issue #418) ────────────────────────────────────────────
-
-const PHASE_LABEL: Record<string, string> = {
-  factual: '事實理解',
-  inferential: '推論思考',
-  evaluative: '評估反思',
-};
-
-const DialogueModal: React.FC<{
-  data: TeacherDialogueHistoryResponse;
-  storyTitle: string | null;
-  studentName: string;
-  onClose: () => void;
-}> = ({ data, storyTitle, studentName, onClose }) => {
-  const headerTitle = storyTitle
-    ? `${studentName} — 《${storyTitle}》對話紀錄`
-    : `${studentName} — 對話紀錄`;
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-label="學生對話紀錄"
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col">
-        {/* Header */}
-        <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-100 shrink-0">
-          <div className="flex-1 min-w-0">
-            <h2 className="text-sm font-semibold text-gray-800 truncate">{headerTitle}</h2>
-            <p className="text-xs text-gray-400 mt-0.5">共 {data.total} 則訊息</p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="關閉對話紀錄"
-            className="flex-shrink-0 p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
-
-        {/* Turns */}
-        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
-          {data.turns.length === 0 ? (
-            <div className="text-center py-12">
-              <p className="text-sm text-gray-500">這次學習沒有對話記錄</p>
-            </div>
-          ) : (
-            data.turns.map((turn) => <DialogueTurnRow key={turn.id} turn={turn} />)
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const DialogueTurnRow: React.FC<{ turn: TeacherDialogueTurn }> = ({ turn }) => {
-  if (turn.role === 'ai') {
-    return (
-      <div className="flex gap-2.5">
-        <div className="flex-shrink-0 w-6 h-6 rounded-full bg-accent flex items-center justify-center mt-0.5">
-          <span className="text-white text-[9px] font-bold">AI</span>
-        </div>
-        <div className="flex-1 max-w-[85%]">
-          {turn.phase && (
-            <span className="inline-block mb-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-accent-bg text-accent">
-              {PHASE_LABEL[turn.phase] ?? turn.phase}
-            </span>
-          )}
-          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-3.5 py-2.5">
-            <p className="text-sm text-accent-hover leading-relaxed">{turn.text}</p>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (turn.role === 'student') {
-    return (
-      <div className="flex gap-2.5 flex-row-reverse">
-        <div className="flex-shrink-0 w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center mt-0.5">
-          <svg className="w-3 h-3 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
-              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-          </svg>
-        </div>
-        <div className="max-w-[85%]">
-          <div className="bg-accent rounded-2xl rounded-tr-sm px-3.5 py-2.5">
-            <p className="text-sm text-white leading-relaxed">{turn.text}</p>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (turn.role === 'feedback') {
-    return (
-      <div className="mx-8">
-        <div className={`rounded-xl px-3 py-2 text-xs border ${
-          turn.is_correct
-            ? 'bg-emerald-50 border-emerald-200 text-emerald-800'
-            : 'bg-amber-50 border-amber-200 text-amber-800'
-        }`}>
-          <span className="mr-1">{turn.is_correct ? '✓' : '💡'}</span>
-          {turn.text}
-        </div>
-      </div>
-    );
-  }
-
-  return null;
-};
-
-// ── Main Component ─────────────────────────────────────────────────────────
-
 const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) => {
-  const { token } = useAuth();
-  const [progress, setProgress] = useState<StudentProgress[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState('');
-  const [exporting, setExporting] = useState(false);
+  const {
+    progress,
+    isLoading,
+    error,
+    exporting,
+    expandedStudentId,
+    isLoadingSessions,
+    sessions,
+    sessionsError,
+    dialogueModal,
+    setDialogueModal,
+    loadingDialogueSessionId,
+    dialogueError,
+    setDialogueError,
+    instructionTarget,
+    setInstructionTarget,
+    instructionCounts,
+    tagManagerStudent,
+    setTagManagerStudent,
+    learningCurve,
+    isLoadingCurve,
+    curveError,
+    curveStoryFilter,
+    setCurveStoryFilter,
+    availableStories,
+    loadProgress,
+    loadInstructionCounts,
+    loadDialogue,
+    exportReport,
+    handleRowClick,
+    handleTagsChanged,
+    addTag,
+    removeTag,
+  } = useStudentProgress(classroomId);
 
-  // Expand / session history state
-  const [expandedStudentId, setExpandedStudentId] = useState<number | null>(null);
-  const [isLoadingSessions, setIsLoadingSessions] = useState(false);
-  const [sessions, setSessions] = useState<StudentSession[]>([]);
-  const [sessionsError, setSessionsError] = useState<string | null>(null);
-  const sessionCache = useRef<Record<number, StudentSession[]>>({});
-
-  // Dialogue modal state (Issue #418)
-  const [dialogueModal, setDialogueModal] = useState<{
-    data: TeacherDialogueHistoryResponse;
-    storyTitle: string | null;
-    studentName: string;
-  } | null>(null);
-  const [loadingDialogueSessionId, setLoadingDialogueSessionId] = useState<number | null>(null);
-  const [dialogueError, setDialogueError] = useState<string | null>(null);
-
-  // Instruction panel state
-  const [instructionTarget, setInstructionTarget] = useState<{ id: number; name: string } | null>(null);
-  const [instructionCounts, setInstructionCounts] = useState<Record<number, number>>({});
-
-  // Tag management state
-  const [tagManagerStudent, setTagManagerStudent] = useState<StudentProgress | null>(null);
-
-  // Learning curve state
-  const [learningCurve, setLearningCurve] = useState<LearningCurvePoint[]>([]);
-  const [isLoadingCurve, setIsLoadingCurve] = useState(false);
-  const [curveError, setCurveError] = useState<string | null>(null);
-  const curveCache = useRef<Record<string, LearningCurvePoint[]>>({});
-  const [curveStoryFilter, setCurveStoryFilter] = useState<string>(''); // empty = all stories
-
-  const loadProgress = useCallback(async () => {
-    if (!token) return;
-    setIsLoading(true);
-    setError('');
-    try {
-      const data = await getClassroomProgress(token, classroomId);
-      // Sort by last_session_date descending (most recent first), nulls last
-      const sorted = [...data].sort((a, b) => {
-        if (!a.last_session_date && !b.last_session_date) return 0;
-        if (!a.last_session_date) return 1;
-        if (!b.last_session_date) return -1;
-        return new Date(b.last_session_date).getTime() - new Date(a.last_session_date).getTime();
-      });
-      setProgress(sorted);
-    } catch (err) {
-      if (err instanceof TeacherApiError) {
-        setError(err.message);
-      } else {
-        setError('無法載入學生進度');
-      }
-    } finally {
-      setIsLoading(false);
-    }
-  }, [token, classroomId]);
-
-  useEffect(() => {
-    loadProgress();
-  }, [loadProgress]);
-
-
-  // Load instruction counts for all students in one bulk request (avoids N+1)
-  const loadInstructionCounts = useCallback(async (_students: StudentProgress[]) => {
-    if (!token) return;
-    try {
-      const counts = await getClassroomInstructionCounts(token, classroomId);
-      setInstructionCounts(counts);
-    } catch {
-      // Non-fatal: leave counts at zero
-    }
-  }, [token, classroomId]);
-
-  useEffect(() => {
-    if (progress.length > 0) {
-      loadInstructionCounts(progress);
-    }
-  }, [progress, loadInstructionCounts]);
-
-  const handleExport = useCallback(async () => {
-    if (!token) return;
-    try {
-      setExporting(true);
-      const blob = await exportClassroomReport(token, classroomId);
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `classroom-report-${new Date().toISOString().slice(0, 10)}.csv`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    } catch (err) {
-      setError('匯出失敗，請稍後再試');
-    } finally {
-      setExporting(false);
-    }
-  }, [token, classroomId]);
-
-  const handleRowClick = useCallback(async (studentId: number) => {
-    // Toggle collapse if already expanded
-    if (expandedStudentId === studentId) {
-      setExpandedStudentId(null);
-      return;
-    }
-
-    setExpandedStudentId(studentId);
-    // #1778: explicit nextFilter — was using stale curveStoryFilter from closure
-    // (UI showed 'all stories' but cache key + API call used previous filter)
-    const nextFilter = '';
-    setCurveStoryFilter(nextFilter);
-    if (!token) return;
-
-    // Load session history (with cache)
-    if (sessionCache.current[studentId]) {
-      setSessions(sessionCache.current[studentId]);
-      setSessionsError(null);
-    } else {
-      setIsLoadingSessions(true);
-      setSessions([]);
-      setSessionsError(null);
-      try {
-        const data = await getStudentSessions(token, studentId);
-        sessionCache.current[studentId] = data;
-        setSessions(data);
-      } catch (err) {
-        setSessionsError(err instanceof Error ? err.message : '載入失敗');
-        setSessions([]);
-      } finally {
-        setIsLoadingSessions(false);
-      }
-    }
-
-    // Load learning curve (with cache) — use nextFilter not stale closure value
-    const cacheKey = `${studentId}:${nextFilter}`;
-    if (curveCache.current[cacheKey]) {
-      setLearningCurve(curveCache.current[cacheKey]);
-      setCurveError(null);
-    } else {
-      setIsLoadingCurve(true);
-      setLearningCurve([]);
-      setCurveError(null);
-      try {
-        const curveData = await getStudentLearningCurve(token, studentId, nextFilter || undefined);
-        curveCache.current[cacheKey] = curveData.data;
-        setLearningCurve(curveData.data);
-      } catch (err) {
-        setCurveError(err instanceof Error ? err.message : '載入失敗');
-        setLearningCurve([]);
-      } finally {
-        setIsLoadingCurve(false);
-      }
-    }
-  }, [expandedStudentId, token]);
-
-  // Load and show dialogue history for a session (Issue #418)
-  const handleViewDialogue = useCallback(async (
-    studentId: number,
-    sessionId: number,
-    storyTitle: string | null,
-    studentName: string,
-  ) => {
-    if (!token) return;
-    setLoadingDialogueSessionId(sessionId);
-    setDialogueError(null);
-    try {
-      const data = await getTeacherStudentDialogue(token, studentId, sessionId);
-      setDialogueModal({ data, storyTitle, studentName });
-    } catch (err) {
-      setDialogueError(err instanceof Error ? err.message : '無法載入對話紀錄');
-    } finally {
-      setLoadingDialogueSessionId(null);
-    }
-  }, [token]);
-
-  // Update local tags after tag manager changes
-  const handleTagsChanged = useCallback((studentId: number, tags: StudentTag[]) => {
-    setProgress((prev) =>
-      prev.map((s) => (s.student_id === studentId ? { ...s, tags } : s))
-    );
-    // Update tag manager state so the modal reflects changes immediately
-    setTagManagerStudent((prev) =>
-      prev && prev.student_id === studentId ? { ...prev, tags } : prev
-    );
-  }, []);
-
-  /** Build chart-ready data with rolling average (window=5). */
-  const buildCurveChartData = (points: LearningCurvePoint[]) => {
-    return points.map((pt, idx) => {
-      const windowStart = Math.max(0, idx - 4);
-      const windowSlice = points.slice(windowStart, idx + 1);
-      const rollingAvg = windowSlice.reduce((sum, p) => sum + p.score, 0) / windowSlice.length;
-      return {
-        date: new Date(pt.date).toLocaleDateString('zh-TW', { month: 'short', day: 'numeric' }),
-        score: pt.score,
-        rollingAvg: Math.round(rollingAvg * 10) / 10,
-        story_title: pt.story_title,
-        cpm: pt.cpm,
-        accuracy: pt.accuracy,
-      };
-    });
+  const openInstruction = (student: StudentProgress) => {
+    setInstructionTarget({ id: student.student_id, name: student.student_name });
   };
 
-  /** Get unique story slugs from learning curve for the filter dropdown. */
-  const availableStories = useMemo(() => {
-    // Use the "all stories" cache for the current student
-    const allKey = `${expandedStudentId}:`;
-    const allPoints = curveCache.current[allKey] || learningCurve;
-    const seen = new Map<string, string>();
-    for (const pt of allPoints) {
-      if (pt.story_slug && !seen.has(pt.story_slug)) {
-        seen.set(pt.story_slug, pt.story_title || pt.story_slug);
-      }
-    }
-    return Array.from(seen.entries()).map(([slug, title]) => ({ slug, title }));
-  }, [expandedStudentId, learningCurve]);
-
-  const formatDate = (dateStr: string | null): string => {
-    if (!dateStr) return '-';
-    return new Date(dateStr).toLocaleDateString('zh-TW', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
-
-  const formatScore = (score: number | null): string => {
-    if (score === null || score === undefined) return '-';
-    return `${Math.round(score)}%`;
-  };
-
-  const statusLabel = (status: string) => {
-    if (status === 'completed') {
-      return (
-        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
-          已完成
-        </span>
-      );
-    }
-    return (
-      <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">
-        進行中
-      </span>
-    );
-  };
+  const renderExpandedPanel = (student: StudentProgress, variant: 'mobile' | 'desktop') => (
+    <StudentExpandedPanel
+      classroomId={classroomId}
+      studentId={student.student_id}
+      studentName={student.student_name}
+      sessions={sessions}
+      isLoadingSessions={isLoadingSessions}
+      sessionsError={sessionsError}
+      learningCurve={learningCurve}
+      isLoadingCurve={isLoadingCurve}
+      curveError={curveError}
+      curveStoryFilter={curveStoryFilter}
+      availableStories={availableStories}
+      loadingDialogueSessionId={loadingDialogueSessionId}
+      onCurveStoryFilterChange={setCurveStoryFilter}
+      onViewDialogue={loadDialogue}
+      variant={variant}
+    />
+  );
 
   if (isLoading) {
     return (
       <div className="p-5 space-y-3">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="flex gap-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="flex gap-4">
             <div className="h-4 bg-gray-200 animate-pulse rounded w-1/4" />
             <div className="h-4 bg-gray-200 animate-pulse rounded w-1/4" />
             <div className="h-4 bg-gray-200 animate-pulse rounded w-1/4" />
@@ -660,18 +119,18 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
 
   return (
     <div className="p-5">
-      {/* Tag Manager Modal */}
       {tagManagerStudent && (
-        <TagManager
+        <StudentTagManager
           studentId={tagManagerStudent.student_id}
           studentName={tagManagerStudent.student_name}
           currentTags={tagManagerStudent.tags}
           onClose={() => setTagManagerStudent(null)}
+          onAddTag={addTag}
+          onRemoveTag={removeTag}
           onTagsChanged={handleTagsChanged}
         />
       )}
 
-      {/* Dialogue fetch error banner */}
       {dialogueError && (
         <div className="mb-3 flex items-center gap-2 px-4 py-2 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
           <span>對話紀錄載入失敗：{dialogueError}</span>
@@ -685,9 +144,8 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
         </div>
       )}
 
-      {/* Dialogue History Modal (Issue #418) */}
       {dialogueModal && (
-        <DialogueModal
+        <StudentDialogueModal
           data={dialogueModal.data}
           storyTitle={dialogueModal.storyTitle}
           studentName={dialogueModal.studentName}
@@ -697,7 +155,7 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
 
       <div className="flex justify-end mb-3">
         <button
-          onClick={handleExport}
+          onClick={exportReport}
           disabled={exporting}
           className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
@@ -707,220 +165,26 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
           {exporting ? '匯出中...' : '匯出 CSV'}
         </button>
       </div>
-      {/* Mobile card view */}
-      <div className="md:hidden space-y-3">
-        {progress.map((s) => {
-          const isExpanded = expandedStudentId === s.student_id;
-          return (
-            <div key={s.student_id}>
-              <div
-                className="bg-white rounded-lg border border-gray-200 p-4 cursor-pointer hover:border-gray-300 transition-colors"
-                onClick={() => handleRowClick(s.student_id)}
-              >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <svg
-                        className={`w-4 h-4 text-gray-400 transition-transform duration-200 shrink-0 ${isExpanded ? 'rotate-90' : ''}`}
-                        fill="none" stroke="currentColor" viewBox="0 0 24 24"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                      </svg>
-                      <span className="font-medium text-gray-900">{s.student_name}</span>
-                      {s.tags.map((t) => (
-                        <span
-                          key={t.tag_name}
-                          className={`inline-block px-1.5 py-0.5 rounded-full text-xs font-medium border ${tagColorClass(t.color)}`}
-                        >
-                          {t.tag_name}
-                        </span>
-                      ))}
-                      <button
-                        onClick={(e) => { e.stopPropagation(); setTagManagerStudent(s); }}
-                        className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs text-gray-400 border border-dashed border-gray-300 hover:border-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
-                        title="管理標籤"
-                      >
-                        <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                        </svg>
-                        標籤
-                      </button>
-                    </div>
-                  </div>
-                  <button
-                    onClick={(e) => { e.stopPropagation(); setInstructionTarget({ id: s.student_id, name: s.student_name }); }}
-                    className="relative inline-flex items-center justify-center px-2.5 py-1 rounded-md text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 hover:bg-amber-100 transition-colors shrink-0"
-                    title="AI 教學指示"
-                  >
-                    留言
-                    {(instructionCounts[s.student_id] ?? 0) > 0 && (
-                      <span className="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center w-3.5 h-3.5 text-[9px] font-bold text-white bg-amber-500 rounded-full">
-                        {instructionCounts[s.student_id]}
-                      </span>
-                    )}
-                  </button>
-                </div>
-                <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm mt-3">
-                  <div>
-                    <span className="text-xs text-gray-400">最近練習日期</span>
-                    <p className="text-gray-700">{formatDate(s.last_session_date)}</p>
-                  </div>
-                  <div>
-                    <span className="text-xs text-gray-400">最近課文</span>
-                    <p className="text-gray-700 truncate">{s.last_text_title ?? '-'}</p>
-                  </div>
-                  <div>
-                    <span className="text-xs text-gray-400">練習次數</span>
-                    <p>
-                      <span className={`inline-block min-w-[2rem] px-2 py-0.5 rounded-full text-xs font-medium ${
-                        s.total_sessions > 0 ? 'bg-accent-bg text-accent' : 'bg-gray-100 text-gray-500'
-                      }`}>{s.total_sessions}</span>
-                    </p>
-                  </div>
-                </div>
-              </div>
-              {isExpanded && (
-                <div className="mt-2 bg-gray-50 rounded-lg p-3 space-y-4">
-                  {isLoadingCurve ? (
-                    <div className="h-40 bg-gray-200 animate-pulse rounded" />
-                  ) : curveError ? (
-                    <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
-                      <span>學習曲線載入失敗：收合後再展開重試</span>
-                    </div>
-                  ) : learningCurve.length >= 2 ? (
-                    <div>
-                      <div className="flex items-center justify-between mb-2">
-                        <p className="text-xs font-medium text-gray-500">學習曲線</p>
-                        {availableStories.length > 1 && (
-                          <select
-                            value={curveStoryFilter}
-                            onChange={(e) => setCurveStoryFilter(e.target.value)}
-                            className="text-xs border border-gray-200 rounded px-2 py-1 bg-white text-gray-600"
-                          >
-                            <option value="">全部課文</option>
-                            {availableStories.map((s) => (
-                              <option key={s.slug} value={s.slug}>{s.title}</option>
-                            ))}
-                          </select>
-                        )}
-                      </div>
-                      <ResponsiveContainer width="100%" height={180}>
-                        <LineChart data={buildCurveChartData(learningCurve)}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-                          <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-                          <YAxis domain={[0, 100]} tick={{ fontSize: 10 }} width={28} />
-                          <Tooltip
-                            formatter={(value: number, name: string) => {
-                              if (name === 'score') return [value, '實際分數'];
-                              if (name === 'rollingAvg') return [value, '5次均線'];
-                              if (name === 'cpm') return [`${value} 字/分`, '語速'];
-                              if (name === 'accuracy') return [`${value}%`, '準確度'];
-                              return [value, name];
-                            }}
-                            labelFormatter={(label) => `日期：${label}`}
-                          />
-                          <Legend formatter={(value) => {
-                            if (value === 'score') return '實際分數';
-                            if (value === 'rollingAvg') return '5次均線';
-                            if (value === 'cpm') return '語速';
-                            if (value === 'accuracy') return '準確度';
-                            return value;
-                          }} />
-                          <Line type="monotone" dataKey="score" stroke="#5B4FC4" strokeWidth={2} dot={{ r: 3 }} connectNulls />
-                          <Line type="monotone" dataKey="rollingAvg" stroke="#10b981" strokeWidth={2} dot={false} strokeDasharray="5 3" connectNulls />
-                          {curveStoryFilter && (
-                            <>
-                              <Line type="monotone" dataKey="cpm" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} connectNulls />
-                              <Line type="monotone" dataKey="accuracy" stroke="#ef4444" strokeWidth={1} dot={{ r: 2 }} strokeDasharray="4 2" connectNulls />
-                            </>
-                          )}
-                        </LineChart>
-                      </ResponsiveContainer>
-                    </div>
-                  ) : null}
 
-                  {isLoadingSessions ? (
-                    <div className="space-y-2">
-                      {Array.from({ length: 3 }).map((_, i) => (
-                        <div key={i} className="h-16 bg-gray-200 animate-pulse rounded-lg" />
-                      ))}
-                    </div>
-                  ) : sessionsError ? (
-                    <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
-                      <span>練習紀錄載入失敗：收合後再展開重試</span>
-                    </div>
-                  ) : sessions.length === 0 ? (
-                    <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>
-                  ) : (
-                    <div className="space-y-2">
-                      <p className="text-xs font-medium text-gray-500">練習記錄</p>
-                      {sessions.map((sess) => (
-                        <div key={sess.id} className="bg-white rounded-lg border border-gray-100 p-3">
-                          <div className="flex items-center justify-between gap-2">
-                            <span className="font-medium text-gray-700 text-sm truncate">{sess.story_title ?? '-'}</span>
-                            <div className="flex items-center gap-2 shrink-0">
-                              {statusLabel(sess.status)}
-                              {sess.teacher_reviewed_at && (
-                                <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium text-emerald-600 bg-emerald-50 border border-emerald-200" title="已查看">
-                                  ✓ 已查看
-                                </span>
-                              )}
-                              <Link
-                                to={`/teacher/students/${s.student_id}/sessions/${sess.id}/report`}
-                                onClick={(e) => e.stopPropagation()}
-                                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors"
-                                title="查看學習報告"
-                              >
-                                <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                                </svg>
-                                報告
-                              </Link>
-                              <button
-                                type="button"
-                                disabled={loadingDialogueSessionId === sess.id}
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleViewDialogue(s.student_id, sess.id, sess.story_title, s.student_name);
-                                }}
-                                className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                                title="查看蘇格拉底對話記錄"
-                              >
-                                {loadingDialogueSessionId === sess.id ? (
-                                  <span className="w-2.5 h-2.5 border border-accent border-t-transparent rounded-full animate-spin" />
-                                ) : (
-                                  <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                      d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                                  </svg>
-                                )}
-                                對話
-                              </button>
-                            </div>
-                          </div>
-                          <div className="grid grid-cols-2 gap-2 text-xs mt-2">
-                            <div>
-                              <span className="text-gray-400">日期</span>
-                              <p className="text-gray-600">{formatDate(sess.started_at)}</p>
-                            </div>
-                            <div>
-                              <span className="text-gray-400">分數</span>
-                              <p className="text-gray-700 font-medium">{formatScore(sess.overall_score)}</p>
-                            </div>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
+      <div className="md:hidden space-y-3">
+        {progress.map((student) => {
+          const isExpanded = expandedStudentId === student.student_id;
+          return (
+            <div key={student.student_id}>
+              <StudentProgressCard
+                student={student}
+                isExpanded={isExpanded}
+                instructionCount={instructionCounts[student.student_id] ?? 0}
+                onExpand={handleRowClick}
+                onTagManager={setTagManagerStudent}
+                onInstruction={openInstruction}
+              />
+              {isExpanded && renderExpandedPanel(student, 'mobile')}
             </div>
           );
         })}
       </div>
 
-      {/* Desktop table view */}
       <div className="hidden md:block overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
@@ -934,13 +198,13 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50">
-            {progress.map((s) => {
-              const isExpanded = expandedStudentId === s.student_id;
+            {progress.map((student) => {
+              const isExpanded = expandedStudentId === student.student_id;
               return (
-                <React.Fragment key={s.student_id}>
+                <React.Fragment key={student.student_id}>
                   <tr
                     className="cursor-pointer hover:bg-gray-50 transition-colors"
-                    onClick={() => handleRowClick(s.student_id)}
+                    onClick={() => handleRowClick(student.student_id)}
                   >
                     <td className="py-2.5 text-gray-400">
                       <svg
@@ -954,21 +218,19 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                     </td>
                     <td className="py-2.5">
                       <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-gray-900 font-medium">{s.student_name}</span>
-                        {/* Tag badges */}
-                        {s.tags.map((t) => (
+                        <span className="text-gray-900 font-medium">{student.student_name}</span>
+                        {student.tags.map((tag) => (
                           <span
-                            key={t.tag_name}
-                            className={`inline-block px-1.5 py-0.5 rounded-full text-xs font-medium border ${tagColorClass(t.color)}`}
+                            key={tag.tag_name}
+                            className={`inline-block px-1.5 py-0.5 rounded-full text-xs font-medium border ${tagColorClass(tag.color)}`}
                           >
-                            {t.tag_name}
+                            {tag.tag_name}
                           </span>
                         ))}
-                        {/* Tag management button */}
                         <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setTagManagerStudent(s);
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setTagManagerStudent(student);
                           }}
                           className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs text-gray-400 border border-dashed border-gray-300 hover:border-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
                           title="管理標籤"
@@ -980,30 +242,30 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                         </button>
                       </div>
                     </td>
-                    <td className="py-2.5 text-gray-600">{formatDate(s.last_session_date)}</td>
-                    <td className="py-2.5 text-gray-600">{s.last_text_title ?? '-'}</td>
+                    <td className="py-2.5 text-gray-600">{formatDate(student.last_session_date)}</td>
+                    <td className="py-2.5 text-gray-600">{student.last_text_title ?? '-'}</td>
                     <td className="py-2.5 text-gray-600 text-center">
                       <span className={`inline-block min-w-[2rem] px-2 py-0.5 rounded-full text-xs font-medium ${
-                        s.total_sessions > 0
+                        student.total_sessions > 0
                           ? 'bg-accent-bg text-accent'
                           : 'bg-gray-100 text-gray-500'
                       }`}>
-                        {s.total_sessions}
+                        {student.total_sessions}
                       </span>
                     </td>
                     <td className="py-2.5 text-center">
                       <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setInstructionTarget({ id: s.student_id, name: s.student_name });
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          openInstruction(student);
                         }}
                         className="relative inline-flex items-center justify-center px-2.5 py-1 rounded-md text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 hover:bg-amber-100 transition-colors"
                         title="AI 教學指示"
                       >
                         留言
-                        {(instructionCounts[s.student_id] ?? 0) > 0 && (
+                        {(instructionCounts[student.student_id] ?? 0) > 0 && (
                           <span className="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center w-3.5 h-3.5 text-[9px] font-bold text-white bg-amber-500 rounded-full">
-                            {instructionCounts[s.student_id]}
+                            {instructionCounts[student.student_id]}
                           </span>
                         )}
                       </button>
@@ -1011,143 +273,8 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
                   </tr>
                   {isExpanded && (
                     <tr>
-                      <td colSpan={6} className="bg-gray-50 px-4 py-3 space-y-4">
-                        {/* Learning curve chart */}
-                        {isLoadingCurve ? (
-                          <div className="h-40 bg-gray-200 animate-pulse rounded" />
-                        ) : curveError ? (
-                          <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
-                            <span>學習曲線載入失敗：收合後再展開重試</span>
-                          </div>
-                        ) : learningCurve.length >= 2 ? (
-                          <div>
-                            <div className="flex items-center justify-between mb-2">
-                              <p className="text-xs font-medium text-gray-500">學習曲線</p>
-                              {availableStories.length > 1 && (
-                                <select
-                                  value={curveStoryFilter}
-                                  onChange={(e) => setCurveStoryFilter(e.target.value)}
-                                  className="text-xs border border-gray-200 rounded px-2 py-1 bg-white text-gray-600"
-                                >
-                                  <option value="">全部課文</option>
-                                  {availableStories.map((st) => (
-                                    <option key={st.slug} value={st.slug}>{st.title}</option>
-                                  ))}
-                                </select>
-                              )}
-                            </div>
-                            <ResponsiveContainer width="100%" height={180}>
-                              <LineChart data={buildCurveChartData(learningCurve)}>
-                                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-                                <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-                                <YAxis domain={[0, 100]} tick={{ fontSize: 10 }} width={28} />
-                                <Tooltip
-                                  formatter={(value: number, name: string) => {
-                                    if (name === 'score') return [value, '實際分數'];
-                                    if (name === 'rollingAvg') return [value, '5次均線'];
-                                    if (name === 'cpm') return [`${value} 字/分`, '語速'];
-                                    if (name === 'accuracy') return [`${value}%`, '準確度'];
-                                    return [value, name];
-                                  }}
-                                  labelFormatter={(label) => `日期：${label}`}
-                                />
-                                <Legend
-                                  formatter={(value) => {
-                                    if (value === 'score') return '實際分數';
-                                    if (value === 'rollingAvg') return '5次均線';
-                                    if (value === 'cpm') return '語速';
-                                    if (value === 'accuracy') return '準確度';
-                                    return value;
-                                  }}
-                                />
-                                <Line type="monotone" dataKey="score" stroke="#5B4FC4" strokeWidth={2} dot={{ r: 3 }} connectNulls />
-                                <Line type="monotone" dataKey="rollingAvg" stroke="#10b981" strokeWidth={2} dot={false} strokeDasharray="5 3" connectNulls />
-                                {curveStoryFilter && (
-                                  <>
-                                    <Line type="monotone" dataKey="cpm" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} connectNulls />
-                                    <Line type="monotone" dataKey="accuracy" stroke="#ef4444" strokeWidth={1} dot={{ r: 2 }} strokeDasharray="4 2" connectNulls />
-                                  </>
-                                )}
-                              </LineChart>
-                            </ResponsiveContainer>
-                          </div>
-                        ) : null}
-
-                        {/* Session history table */}
-                        {isLoadingSessions ? (
-                          <div className="space-y-2">
-                            {Array.from({ length: 3 }).map((_, i) => (
-                              <div key={i} className="flex gap-4">
-                                <div className="h-3 bg-gray-200 animate-pulse rounded w-1/3" />
-                                <div className="h-3 bg-gray-200 animate-pulse rounded w-1/5" />
-                                <div className="h-3 bg-gray-200 animate-pulse rounded w-1/6" />
-                                <div className="h-3 bg-gray-200 animate-pulse rounded w-1/6" />
-                              </div>
-                            ))}
-                          </div>
-                        ) : sessionsError ? (
-                          <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
-                            <span>練習紀錄載入失敗：收合後再展開重試</span>
-                          </div>
-                        ) : sessions.length === 0 ? (
-                          <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>
-                        ) : (
-                          <div className="overflow-x-auto">
-                          <table className="w-full text-xs">
-                            <thead>
-                              <tr className="text-left text-gray-400">
-                                <th className="pb-1.5 font-medium">課文</th>
-                                <th className="pb-1.5 font-medium">日期</th>
-                                <th className="pb-1.5 font-medium text-center">分數</th>
-                                <th className="pb-1.5 font-medium text-center">狀態</th>
-                                <th className="pb-1.5 font-medium text-center">報告</th>
-                                <th className="pb-1.5 font-medium text-center">對話</th>
-                              </tr>
-                            </thead>
-                            <tbody className="divide-y divide-gray-100">
-                              {sessions.map((sess) => (
-                                <tr key={sess.id}>
-                                  <td className="py-1.5 text-gray-700">{sess.story_title ?? '-'}</td>
-                                  <td className="py-1.5 text-gray-500">{formatDate(sess.started_at)}</td>
-                                  <td className="py-1.5 text-gray-700 text-center font-medium">{formatScore(sess.overall_score)}</td>
-                                  <td className="py-1.5 text-center">{statusLabel(sess.status)}</td>
-                                  <td className="py-1.5 text-center">
-                                    <Link
-                                      to={`/teacher/students/${s.student_id}/sessions/${sess.id}/report`}
-                                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors"
-                                      title="查看學習報告"
-                                    >
-                                      {sess.teacher_reviewed_at ? '✓ 報告' : '報告'}
-                                    </Link>
-                                  </td>
-                                  <td className="py-1.5 text-center">
-                                    <button
-                                      type="button"
-                                      disabled={loadingDialogueSessionId === sess.id}
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        handleViewDialogue(s.student_id, sess.id, sess.story_title, s.student_name);
-                                      }}
-                                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
-                                      title="查看蘇格拉底對話記錄"
-                                    >
-                                      {loadingDialogueSessionId === sess.id ? (
-                                        <span className="w-2.5 h-2.5 border border-accent border-t-transparent rounded-full animate-spin" />
-                                      ) : (
-                                        <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-                                        </svg>
-                                      )}
-                                      對話
-                                    </button>
-                                  </td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </table>
-                          </div>
-                        )}
+                      <td colSpan={6} className="bg-gray-50 px-4 py-3">
+                        {renderExpandedPanel(student, 'desktop')}
                       </td>
                     </tr>
                   )}
@@ -1158,7 +285,6 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
         </table>
       </div>
 
-      {/* Teacher Instruction Panel Modal */}
       {instructionTarget && (
         <TeacherInstructionPanel
           studentId={instructionTarget.id}
@@ -1166,7 +292,6 @@ const StudentProgressTab: React.FC<StudentProgressTabProps> = ({ classroomId }) 
           classroomId={classroomId}
           onClose={() => {
             setInstructionTarget(null);
-            // Refresh instruction counts when panel closes
             loadInstructionCounts(progress);
           }}
         />

--- a/frontend/src/pages/teacher/components/AssignmentCard.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentCard.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+import {
+  AssignmentDetailResponse,
+  AssignmentResponse,
+  SubmissionResponse,
+} from '../../../services/assignmentApi';
+import { completionPercentage, formatDate, isOverdue } from './assignmentUtils';
+import AssignmentExpandedPanel from './AssignmentExpandedPanel';
+import AssignmentInlineEdit from './AssignmentInlineEdit';
+
+export interface AssignmentCardProps {
+  assignment: AssignmentResponse;
+  isExpanded: boolean;
+  isConfirmingDelete: boolean;
+  isDeleting: boolean;
+  isEditing: boolean;
+  editTitle: string;
+  setEditTitle: (value: string) => void;
+  editDescription: string;
+  setEditDescription: (value: string) => void;
+  editDueDate: string;
+  setEditDueDate: (value: string) => void;
+  editError: string;
+  isSavingEdit: boolean;
+  expandedDetail: AssignmentDetailResponse | null;
+  isLoadingDetail: boolean;
+  onExpand: (assignmentId: number) => void;
+  onToggleActive: (assignment: AssignmentResponse) => void;
+  onEdit: (assignment: AssignmentResponse) => void;
+  onCancelEdit: () => void;
+  onSaveEdit: (assignmentId: number) => void;
+  onDelete: (assignment: AssignmentResponse) => void;
+  onConfirmDelete: (assignmentId: number | null) => void;
+  onGraded: (updated: SubmissionResponse) => void;
+}
+
+export const AssignmentCard: React.FC<AssignmentCardProps> = ({
+  assignment,
+  isExpanded,
+  isConfirmingDelete,
+  isDeleting,
+  isEditing,
+  editTitle,
+  setEditTitle,
+  editDescription,
+  setEditDescription,
+  editDueDate,
+  setEditDueDate,
+  editError,
+  isSavingEdit,
+  expandedDetail,
+  isLoadingDetail,
+  onExpand,
+  onToggleActive,
+  onEdit,
+  onCancelEdit,
+  onSaveEdit,
+  onDelete,
+  onConfirmDelete,
+  onGraded,
+}) => {
+  const displayTitle = assignment.title || assignment.story_title;
+  const completionPct = completionPercentage(assignment.completed_count, assignment.submission_count);
+
+  return (
+    <div>
+      <div
+        className="bg-white rounded-lg border border-gray-200 p-4 cursor-pointer hover:border-gray-300 transition-colors"
+        onClick={() => {
+          if (isConfirmingDelete || isEditing) return;
+          onExpand(assignment.id);
+        }}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <svg
+              className={`w-4 h-4 text-gray-400 transition-transform duration-200 shrink-0 ${isExpanded ? 'rotate-90' : ''}`}
+              fill="none" stroke="currentColor" viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+            <span className="font-medium text-gray-900 truncate">{displayTitle}</span>
+          </div>
+          <button
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleActive(assignment);
+            }}
+            className={`shrink-0 inline-block px-1.5 py-0.5 rounded text-xs font-medium transition-colors cursor-pointer ${
+              assignment.is_active
+                ? 'bg-green-100 text-green-700 hover:bg-green-200'
+                : 'bg-gray-100 text-gray-500 hover:bg-gray-200'
+            }`}
+          >
+            {assignment.is_active ? '進行中' : '已停用'}
+          </button>
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm mt-3">
+          <div>
+            <span className="text-xs text-gray-400">課文</span>
+            <p className="text-gray-600 truncate">{assignment.story_title}</p>
+          </div>
+          <div>
+            <span className="text-xs text-gray-400">截止日期</span>
+            <div>
+              <span className={isOverdue(assignment.due_date) ? 'text-red-600' : 'text-gray-600'}>
+                {formatDate(assignment.due_date)}
+              </span>
+              {isOverdue(assignment.due_date) && (
+                <span className="ml-1 inline-block px-1 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">
+                  已逾期
+                </span>
+              )}
+            </div>
+          </div>
+          <div>
+            <span className="text-xs text-gray-400">完成率</span>
+            <p>
+              <span
+                className={`inline-block min-w-[2rem] px-2 py-0.5 rounded-full text-xs font-medium ${
+                  completionPct === 100
+                    ? 'bg-green-100 text-green-700'
+                    : completionPct > 0
+                      ? 'bg-accent-bg text-accent'
+                      : 'bg-gray-100 text-gray-500'
+                }`}
+              >
+                {assignment.completed_count}/{assignment.submission_count}
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-1 mt-3 pt-2 border-t border-gray-100" onClick={(event) => event.stopPropagation()}>
+          {isConfirmingDelete ? (
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => onDelete(assignment)}
+                disabled={isDeleting}
+                className="px-2 py-1 rounded bg-red-500 text-white text-xs font-medium hover:bg-red-600 disabled:opacity-50 cursor-pointer transition-colors"
+              >
+                {isDeleting ? '...' : '確認刪除'}
+              </button>
+              <button
+                onClick={() => onConfirmDelete(null)}
+                className="px-2 py-1 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+              >
+                取消
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1">
+              <button
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onEdit(assignment);
+                }}
+                className="p-1.5 rounded text-gray-400 hover:text-accent hover:bg-accent-bg transition-colors cursor-pointer"
+                title="編輯作業"
+                aria-label="編輯作業"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+                </svg>
+              </button>
+              <button
+                onClick={() => onConfirmDelete(assignment.id)}
+                className="p-1.5 rounded text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors cursor-pointer"
+                title="刪除作業"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {isEditing && (
+        <AssignmentInlineEdit
+          editTitle={editTitle}
+          setEditTitle={setEditTitle}
+          editDescription={editDescription}
+          setEditDescription={setEditDescription}
+          editDueDate={editDueDate}
+          setEditDueDate={setEditDueDate}
+          editError={editError}
+          isSavingEdit={isSavingEdit}
+          onCancel={onCancelEdit}
+          onSave={() => onSaveEdit(assignment.id)}
+          variant="mobile"
+        />
+      )}
+
+      {isExpanded && (
+        <AssignmentExpandedPanel
+          assignment={assignment}
+          expandedDetail={expandedDetail}
+          isLoadingDetail={isLoadingDetail}
+          onGraded={onGraded}
+          variant="mobile"
+        />
+      )}
+    </div>
+  );
+};
+
+export default AssignmentCard;

--- a/frontend/src/pages/teacher/components/AssignmentCreateForm.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentCreateForm.tsx
@@ -1,0 +1,191 @@
+import React, { FormEvent } from 'react';
+import ReadingGoalsForm, { GoalsFormState } from '../../../components/teacher/ReadingGoalsForm';
+import { Story } from '../../../types';
+
+export interface AssignmentCreateFormProps {
+  stories: Story[];
+  storyGrade: number | null;
+  isLoadingStories: boolean;
+  storiesError: string | null;
+  selectedStoryId: string;
+  setSelectedStoryId: (value: string) => void;
+  formTitle: string;
+  setFormTitle: (value: string) => void;
+  formDescription: string;
+  setFormDescription: (value: string) => void;
+  formDueDate: string;
+  setFormDueDate: (value: string) => void;
+  formSkipCompleted: boolean;
+  setFormSkipCompleted: (value: boolean) => void;
+  formGoals: GoalsFormState;
+  setFormGoals: (value: GoalsFormState) => void;
+  isCreating: boolean;
+  createError: string;
+  onSubmit: (event: FormEvent) => void;
+  onClose: () => void;
+  onRetryStories: () => void;
+}
+
+export const AssignmentCreateForm: React.FC<AssignmentCreateFormProps> = ({
+  stories,
+  storyGrade,
+  isLoadingStories,
+  storiesError,
+  selectedStoryId,
+  setSelectedStoryId,
+  formTitle,
+  setFormTitle,
+  formDescription,
+  setFormDescription,
+  formDueDate,
+  setFormDueDate,
+  formSkipCompleted,
+  setFormSkipCompleted,
+  formGoals,
+  setFormGoals,
+  isCreating,
+  createError,
+  onSubmit,
+  onClose,
+  onRetryStories,
+}) => (
+  <div className="p-5 border-b border-gray-100 bg-gray-50/50">
+    <div className="flex items-center justify-between mb-3">
+      <h4 className="text-sm font-bold text-gray-900">建立新作業</h4>
+      <button
+        onClick={onClose}
+        className="text-sm text-gray-500 hover:text-gray-700 cursor-pointer"
+      >
+        關閉
+      </button>
+    </div>
+
+    {createError && (
+      <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3 mb-3">
+        {createError}
+      </div>
+    )}
+
+    <form onSubmit={onSubmit} className="space-y-3">
+      <div>
+        <label htmlFor="assign-story" className="block text-sm font-medium text-gray-700 mb-1">
+          課文 <span className="text-red-500">*</span>
+        </label>
+        {isLoadingStories ? (
+          <div className="flex items-center gap-2 py-2">
+            <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+            <span className="text-xs text-gray-400">載入課文列表...</span>
+          </div>
+        ) : storiesError ? (
+          <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+            <span>載入課文失敗：{storiesError}</span>
+            <button
+              type="button"
+              onClick={onRetryStories}
+              className="ml-auto text-xs underline hover:no-underline"
+            >
+              重試
+            </button>
+          </div>
+        ) : (
+          <select
+            id="assign-story"
+            value={selectedStoryId}
+            onChange={(event) => setSelectedStoryId(event.target.value)}
+            required
+            className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+          >
+            <option value="">選擇課文</option>
+            {stories.map((story) => (
+              <option key={story.id} value={story.id}>
+                {story.title}
+                {story.grade ? ` (${story.grade}年級)` : ''}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="assign-title" className="block text-sm font-medium text-gray-700 mb-1">
+          作業標題（選填）
+        </label>
+        <input
+          id="assign-title"
+          type="text"
+          value={formTitle}
+          onChange={(event) => setFormTitle(event.target.value)}
+          placeholder="留空則使用課文標題"
+          className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="assign-desc" className="block text-sm font-medium text-gray-700 mb-1">
+          說明（選填）
+        </label>
+        <textarea
+          id="assign-desc"
+          value={formDescription}
+          onChange={(event) => setFormDescription(event.target.value)}
+          placeholder="作業說明或提示"
+          rows={2}
+          className="w-full px-3 py-2 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors resize-none"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="assign-due" className="block text-sm font-medium text-gray-700 mb-1">
+          截止日期（選填）
+        </label>
+        <input
+          id="assign-due"
+          type="date"
+          value={formDueDate}
+          onChange={(event) => setFormDueDate(event.target.value)}
+          className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="assign-skip-completed"
+          type="checkbox"
+          checked={formSkipCompleted}
+          onChange={(event) => setFormSkipCompleted(event.target.checked)}
+          className="h-4 w-4 rounded border-gray-300 text-accent focus:ring-accent"
+        />
+        <label htmlFor="assign-skip-completed" className="text-sm text-gray-700 cursor-pointer select-none">
+          跳過已完成步驟（學生重做作業時自動略過上次完成的環節）
+        </label>
+      </div>
+
+      <div className="border-t border-gray-100 pt-3">
+        <ReadingGoalsForm
+          value={formGoals}
+          onChange={setFormGoals}
+          grade={selectedStoryId ? storyGrade : null}
+        />
+      </div>
+
+      <div className="flex gap-3 justify-end pt-1">
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
+        >
+          取消
+        </button>
+        <button
+          type="submit"
+          disabled={isCreating || !selectedStoryId}
+          className="bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white px-5 py-2 rounded-lg font-medium text-sm transition-colors cursor-pointer"
+        >
+          {isCreating ? '建立中...' : '確認建立'}
+        </button>
+      </div>
+    </form>
+  </div>
+);
+
+export default AssignmentCreateForm;

--- a/frontend/src/pages/teacher/components/AssignmentEmptyState.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentEmptyState.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export interface AssignmentEmptyStateProps {
+  hasAssignments: boolean;
+}
+
+export const AssignmentEmptyState: React.FC<AssignmentEmptyStateProps> = ({ hasAssignments }) => (
+  <div className="p-8 text-center">
+    {!hasAssignments ? (
+      <>
+        <div className="inline-flex items-center justify-center w-12 h-12 bg-accent-bg rounded-xl mb-3">
+          <svg className="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25z"
+            />
+          </svg>
+        </div>
+        <p className="text-sm font-medium text-gray-700 mb-1">尚未建立作業</p>
+        <p className="text-xs text-gray-500">點選「建立作業」為班級指派學習任務</p>
+      </>
+    ) : (
+      <p className="text-sm text-gray-500">此分類下沒有作業</p>
+    )}
+  </div>
+);
+
+export default AssignmentEmptyState;

--- a/frontend/src/pages/teacher/components/AssignmentExpandedPanel.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentExpandedPanel.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import ReadingGoalsBadge from '../../../components/ui/ReadingGoalsBadge';
+import {
+  AssignmentDetailResponse,
+  AssignmentResponse,
+  SubmissionResponse,
+} from '../../../services/assignmentApi';
+import AssignmentDetailPanel from '../AssignmentDetailPanel';
+
+export interface AssignmentExpandedPanelProps {
+  assignment: AssignmentResponse;
+  expandedDetail: AssignmentDetailResponse | null;
+  isLoadingDetail: boolean;
+  onGraded: (updated: SubmissionResponse) => void;
+  variant?: 'mobile' | 'desktop';
+}
+
+export const AssignmentExpandedPanel: React.FC<AssignmentExpandedPanelProps> = ({
+  assignment,
+  expandedDetail,
+  isLoadingDetail,
+  onGraded,
+  variant = 'desktop',
+}) => (
+  <div className={variant === 'mobile' ? 'mt-2 bg-gray-50 rounded-lg p-3' : ''}>
+    <div className="mb-3">
+      <ReadingGoalsBadge
+        goals={{
+          effectiveCpm: assignment.effective_cpm,
+          effectiveAccuracy: assignment.effective_accuracy,
+          difficultyLabel: assignment.difficulty_label,
+          isCustom: assignment.target_cpm != null || assignment.target_accuracy != null,
+        }}
+        variant="compact"
+      />
+    </div>
+    {expandedDetail ? (
+      <AssignmentDetailPanel
+        assignmentId={assignment.id}
+        detail={expandedDetail}
+        isLoading={isLoadingDetail}
+        onGraded={onGraded}
+      />
+    ) : isLoadingDetail ? (
+      <div className="flex items-center gap-2 py-4 justify-center">
+        <div className="w-4 h-4 border-2 border-gray-300 border-t-accent rounded-full animate-spin" />
+        <span className="text-xs text-gray-500">載入中...</span>
+      </div>
+    ) : (
+      <p className="text-xs text-gray-500 py-4 text-center">無法載入作業詳情</p>
+    )}
+  </div>
+);
+
+export default AssignmentExpandedPanel;

--- a/frontend/src/pages/teacher/components/AssignmentInlineEdit.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentInlineEdit.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+export interface AssignmentInlineEditProps {
+  editTitle: string;
+  setEditTitle: (value: string) => void;
+  editDescription: string;
+  setEditDescription: (value: string) => void;
+  editDueDate: string;
+  setEditDueDate: (value: string) => void;
+  editError: string;
+  isSavingEdit: boolean;
+  onCancel: () => void;
+  onSave: () => void;
+  variant?: 'mobile' | 'desktop';
+}
+
+export const AssignmentInlineEdit: React.FC<AssignmentInlineEditProps> = ({
+  editTitle,
+  setEditTitle,
+  editDescription,
+  setEditDescription,
+  editDueDate,
+  setEditDueDate,
+  editError,
+  isSavingEdit,
+  onCancel,
+  onSave,
+  variant = 'desktop',
+}) => {
+  const fields = (
+    <div className={variant === 'desktop' ? 'grid grid-cols-1 sm:grid-cols-3 gap-3' : 'space-y-3'}>
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">作業標題</label>
+        <input
+          type="text"
+          value={editTitle}
+          onChange={(event) => setEditTitle(event.target.value)}
+          placeholder="留空則使用課文標題"
+          className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">說明</label>
+        <input
+          type="text"
+          value={editDescription}
+          onChange={(event) => setEditDescription(event.target.value)}
+          placeholder="作業說明（選填）"
+          className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">截止日期</label>
+        <input
+          type="date"
+          value={editDueDate}
+          onChange={(event) => setEditDueDate(event.target.value)}
+          className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div className={variant === 'mobile' ? 'mt-2 bg-blue-50 border border-blue-100 rounded-lg p-3' : ''}>
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-medium text-gray-800">編輯作業</span>
+        <button onClick={onCancel} className="text-xs text-gray-500 hover:text-gray-700 cursor-pointer">
+          取消
+        </button>
+      </div>
+      {editError && (
+        <div className="bg-red-50 border border-red-200 text-red-700 text-xs rounded px-3 py-2 mb-2">
+          {editError}
+        </div>
+      )}
+      {fields}
+      <div className="flex justify-end gap-2 mt-3">
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-xs font-medium hover:bg-gray-50 transition-colors cursor-pointer"
+        >
+          取消
+        </button>
+        <button
+          onClick={onSave}
+          disabled={isSavingEdit}
+          className="px-4 py-1.5 rounded-lg bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-medium transition-colors cursor-pointer"
+        >
+          {isSavingEdit ? '儲存中...' : '儲存'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AssignmentInlineEdit;

--- a/frontend/src/pages/teacher/components/AssignmentStatusTabs.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentStatusTabs.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { StatusFilter } from '../hooks/useAssignments';
+
+const STATUS_TABS: { key: StatusFilter; label: string }[] = [
+  { key: 'all', label: '全部' },
+  { key: 'active', label: '進行中' },
+  { key: 'overdue', label: '已逾期' },
+  { key: 'inactive', label: '已停用' },
+];
+
+export interface AssignmentStatusTabsProps {
+  statusFilter: StatusFilter;
+  tabCounts: Record<StatusFilter, number>;
+  onChange: (filter: StatusFilter) => void;
+}
+
+export const AssignmentStatusTabs: React.FC<AssignmentStatusTabsProps> = ({
+  statusFilter,
+  tabCounts,
+  onChange,
+}) => (
+  <div className="px-5 pt-4 pb-0 flex gap-1 border-b border-gray-100">
+    {STATUS_TABS.map((tab) => (
+      <button
+        key={tab.key}
+        onClick={() => onChange(tab.key)}
+        className={`px-3 py-1.5 rounded-t-lg text-xs font-medium transition-colors cursor-pointer border-b-2 -mb-px ${
+          statusFilter === tab.key
+            ? 'border-accent text-accent bg-accent-bg'
+            : 'border-transparent text-gray-500 hover:text-gray-700 hover:bg-gray-50'
+        }`}
+      >
+        {tab.label}
+        {tabCounts[tab.key] > 0 && (
+          <span
+            className={`ml-1.5 inline-flex items-center justify-center w-4 h-4 rounded-full text-xs ${
+              statusFilter === tab.key
+                ? 'bg-accent text-white'
+                : 'bg-gray-200 text-gray-600'
+            }`}
+          >
+            {tabCounts[tab.key]}
+          </span>
+        )}
+      </button>
+    ))}
+  </div>
+);
+
+export default AssignmentStatusTabs;

--- a/frontend/src/pages/teacher/components/StudentDialogueModal.tsx
+++ b/frontend/src/pages/teacher/components/StudentDialogueModal.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import {
+  TeacherDialogueHistoryResponse,
+  TeacherDialogueTurn,
+} from '../../../services/teacherApi';
+
+const PHASE_LABEL: Record<string, string> = {
+  factual: '事實理解',
+  inferential: '推論思考',
+  evaluative: '評估反思',
+};
+
+const DialogueTurnRow: React.FC<{ turn: TeacherDialogueTurn }> = ({ turn }) => {
+  if (turn.role === 'ai') {
+    return (
+      <div className="flex gap-2.5">
+        <div className="flex-shrink-0 w-6 h-6 rounded-full bg-accent flex items-center justify-center mt-0.5">
+          <span className="text-white text-[9px] font-bold">AI</span>
+        </div>
+        <div className="flex-1 max-w-[85%]">
+          {turn.phase && (
+            <span className="inline-block mb-1 px-2 py-0.5 rounded-full text-[10px] font-semibold bg-accent-bg text-accent">
+              {PHASE_LABEL[turn.phase] ?? turn.phase}
+            </span>
+          )}
+          <div className="bg-accent-bg border border-accent-bg-subtle rounded-2xl rounded-tl-sm px-3.5 py-2.5">
+            <p className="text-sm text-accent-hover leading-relaxed">{turn.text}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (turn.role === 'student') {
+    return (
+      <div className="flex gap-2.5 flex-row-reverse">
+        <div className="flex-shrink-0 w-6 h-6 rounded-full bg-gray-200 flex items-center justify-center mt-0.5">
+          <svg className="w-3 h-3 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
+              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+        </div>
+        <div className="max-w-[85%]">
+          <div className="bg-accent rounded-2xl rounded-tr-sm px-3.5 py-2.5">
+            <p className="text-sm text-white leading-relaxed">{turn.text}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (turn.role === 'feedback') {
+    return (
+      <div className="mx-8">
+        <div className={`rounded-xl px-3 py-2 text-xs border ${
+          turn.is_correct
+            ? 'bg-emerald-50 border-emerald-200 text-emerald-800'
+            : 'bg-amber-50 border-amber-200 text-amber-800'
+        }`}>
+          <span className="mr-1">{turn.is_correct ? '✓' : '💡'}</span>
+          {turn.text}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export interface StudentDialogueModalProps {
+  data: TeacherDialogueHistoryResponse;
+  storyTitle: string | null;
+  studentName: string;
+  onClose: () => void;
+}
+
+export const StudentDialogueModal: React.FC<StudentDialogueModalProps> = ({
+  data,
+  storyTitle,
+  studentName,
+  onClose,
+}) => {
+  const headerTitle = storyTitle
+    ? `${studentName} — 《${storyTitle}》對話紀錄`
+    : `${studentName} — 對話紀錄`;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="學生對話紀錄"
+      onClick={(event) => { if (event.target === event.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col">
+        <div className="flex items-center gap-3 px-5 py-4 border-b border-gray-100 shrink-0">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-sm font-semibold text-gray-800 truncate">{headerTitle}</h2>
+            <p className="text-xs text-gray-400 mt-0.5">共 {data.total} 則訊息</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="關閉對話紀錄"
+            className="flex-shrink-0 p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          {data.turns.length === 0 ? (
+            <div className="text-center py-12">
+              <p className="text-sm text-gray-500">這次學習沒有對話記錄</p>
+            </div>
+          ) : (
+            data.turns.map((turn) => <DialogueTurnRow key={turn.id} turn={turn} />)
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StudentDialogueModal;

--- a/frontend/src/pages/teacher/components/StudentExpandedPanel.tsx
+++ b/frontend/src/pages/teacher/components/StudentExpandedPanel.tsx
@@ -1,0 +1,339 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { LearningCurvePoint, StudentSession } from '../../../services/teacherApi';
+import { formatDate, formatScore, statusLabel } from './studentProgressUtils';
+
+export interface AvailableStory {
+  slug: string;
+  title: string;
+}
+
+export interface StudentExpandedPanelProps {
+  classroomId: number;
+  studentId: number;
+  studentName: string;
+  sessions: StudentSession[];
+  isLoadingSessions: boolean;
+  sessionsError: string | null;
+  learningCurve: LearningCurvePoint[];
+  isLoadingCurve: boolean;
+  curveError: string | null;
+  curveStoryFilter: string;
+  availableStories: AvailableStory[];
+  loadingDialogueSessionId: number | null;
+  onCurveStoryFilterChange: (value: string) => void;
+  onViewDialogue: (
+    studentId: number,
+    sessionId: number,
+    storyTitle: string | null,
+    studentName: string,
+  ) => void;
+  variant?: 'mobile' | 'desktop';
+}
+
+function buildCurveChartData(points: LearningCurvePoint[]) {
+  return points.map((point, index) => {
+    const windowStart = Math.max(0, index - 4);
+    const windowSlice = points.slice(windowStart, index + 1);
+    const rollingAvg = windowSlice.reduce((sum, item) => sum + item.score, 0) / windowSlice.length;
+    return {
+      date: new Date(point.date).toLocaleDateString('zh-TW', { month: 'short', day: 'numeric' }),
+      score: point.score,
+      rollingAvg: Math.round(rollingAvg * 10) / 10,
+      story_title: point.story_title,
+      cpm: point.cpm,
+      accuracy: point.accuracy,
+    };
+  });
+}
+
+const chartLegendFormatter = (value: string) => {
+  if (value === 'score') return '實際分數';
+  if (value === 'rollingAvg') return '5次均線';
+  if (value === 'cpm') return '語速';
+  if (value === 'accuracy') return '準確度';
+  return value;
+};
+
+const chartTooltipFormatter = (value: number, name: string) => {
+  if (name === 'score') return [value, '實際分數'];
+  if (name === 'rollingAvg') return [value, '5次均線'];
+  if (name === 'cpm') return [`${value} 字/分`, '語速'];
+  if (name === 'accuracy') return [`${value}%`, '準確度'];
+  return [value, name];
+};
+
+export const StudentExpandedPanel: React.FC<StudentExpandedPanelProps> = ({
+  classroomId,
+  studentId,
+  studentName,
+  sessions,
+  isLoadingSessions,
+  sessionsError,
+  learningCurve,
+  isLoadingCurve,
+  curveError,
+  curveStoryFilter,
+  availableStories,
+  loadingDialogueSessionId,
+  onCurveStoryFilterChange,
+  onViewDialogue,
+  variant = 'desktop',
+}) => {
+  void classroomId;
+
+  const renderChart = () => {
+    if (isLoadingCurve) {
+      return <div className="h-40 bg-gray-200 animate-pulse rounded" />;
+    }
+
+    if (curveError) {
+      return (
+        <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
+          <span>學習曲線載入失敗：收合後再展開重試</span>
+        </div>
+      );
+    }
+
+    if (learningCurve.length < 2) return null;
+
+    return (
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-xs font-medium text-gray-500">學習曲線</p>
+          {availableStories.length > 1 && (
+            <select
+              value={curveStoryFilter}
+              onChange={(event) => onCurveStoryFilterChange(event.target.value)}
+              className="text-xs border border-gray-200 rounded px-2 py-1 bg-white text-gray-600"
+            >
+              <option value="">全部課文</option>
+              {availableStories.map((story) => (
+                <option key={story.slug} value={story.slug}>{story.title}</option>
+              ))}
+            </select>
+          )}
+        </div>
+        <ResponsiveContainer width="100%" height={180}>
+          <LineChart data={buildCurveChartData(learningCurve)}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="date" tick={{ fontSize: 10 }} />
+            <YAxis domain={[0, 100]} tick={{ fontSize: 10 }} width={28} />
+            <Tooltip
+              formatter={chartTooltipFormatter}
+              labelFormatter={(label) => `日期：${label}`}
+            />
+            <Legend formatter={chartLegendFormatter} />
+            <Line type="monotone" dataKey="score" stroke="#5B4FC4" strokeWidth={2} dot={{ r: 3 }} connectNulls />
+            <Line type="monotone" dataKey="rollingAvg" stroke="#10b981" strokeWidth={2} dot={false} strokeDasharray="5 3" connectNulls />
+            {curveStoryFilter && (
+              <>
+                <Line type="monotone" dataKey="cpm" stroke="#f59e0b" strokeWidth={2} dot={{ r: 3 }} connectNulls />
+                <Line type="monotone" dataKey="accuracy" stroke="#ef4444" strokeWidth={1} dot={{ r: 2 }} strokeDasharray="4 2" connectNulls />
+              </>
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  };
+
+  const renderMobileSessions = () => {
+    if (isLoadingSessions) {
+      return (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-16 bg-gray-200 animate-pulse rounded-lg" />
+          ))}
+        </div>
+      );
+    }
+
+    if (sessionsError) {
+      return (
+        <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
+          <span>練習紀錄載入失敗：收合後再展開重試</span>
+        </div>
+      );
+    }
+
+    if (sessions.length === 0) {
+      return <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>;
+    }
+
+    return (
+      <div className="space-y-2">
+        <p className="text-xs font-medium text-gray-500">練習記錄</p>
+        {sessions.map((session) => {
+          const reviewedAt = (session as StudentSession & { teacher_reviewed_at?: string | null }).teacher_reviewed_at;
+          return (
+            <div key={session.id} className="bg-white rounded-lg border border-gray-100 p-3">
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium text-gray-700 text-sm truncate">{session.story_title ?? '-'}</span>
+                <div className="flex items-center gap-2 shrink-0">
+                  {statusLabel(session.status)}
+                  {reviewedAt && (
+                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium text-emerald-600 bg-emerald-50 border border-emerald-200" title="已查看">
+                      ✓ 已查看
+                    </span>
+                  )}
+                  <Link
+                    to={`/teacher/students/${studentId}/sessions/${session.id}/report`}
+                    onClick={(event) => event.stopPropagation()}
+                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors"
+                    title="查看學習報告"
+                  >
+                    <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                    </svg>
+                    報告
+                  </Link>
+                  <button
+                    type="button"
+                    disabled={loadingDialogueSessionId === session.id}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onViewDialogue(studentId, session.id, session.story_title, studentName);
+                    }}
+                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="查看蘇格拉底對話記錄"
+                  >
+                    {loadingDialogueSessionId === session.id ? (
+                      <span className="w-2.5 h-2.5 border border-accent border-t-transparent rounded-full animate-spin" />
+                    ) : (
+                      <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                          d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                      </svg>
+                    )}
+                    對話
+                  </button>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-2 text-xs mt-2">
+                <div>
+                  <span className="text-gray-400">日期</span>
+                  <p className="text-gray-600">{formatDate(session.started_at)}</p>
+                </div>
+                <div>
+                  <span className="text-gray-400">分數</span>
+                  <p className="text-gray-700 font-medium">{formatScore(session.overall_score)}</p>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderDesktopSessions = () => {
+    if (isLoadingSessions) {
+      return (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="flex gap-4">
+              <div className="h-3 bg-gray-200 animate-pulse rounded w-1/3" />
+              <div className="h-3 bg-gray-200 animate-pulse rounded w-1/5" />
+              <div className="h-3 bg-gray-200 animate-pulse rounded w-1/6" />
+              <div className="h-3 bg-gray-200 animate-pulse rounded w-1/6" />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (sessionsError) {
+      return (
+        <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-xs text-red-700">
+          <span>練習紀錄載入失敗：收合後再展開重試</span>
+        </div>
+      );
+    }
+
+    if (sessions.length === 0) {
+      return <p className="text-xs text-gray-500 text-center py-2">尚無練習記錄</p>;
+    }
+
+    return (
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-left text-gray-400">
+              <th className="pb-1.5 font-medium">課文</th>
+              <th className="pb-1.5 font-medium">日期</th>
+              <th className="pb-1.5 font-medium text-center">分數</th>
+              <th className="pb-1.5 font-medium text-center">狀態</th>
+              <th className="pb-1.5 font-medium text-center">報告</th>
+              <th className="pb-1.5 font-medium text-center">對話</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {sessions.map((session) => {
+              const reviewedAt = (session as StudentSession & { teacher_reviewed_at?: string | null }).teacher_reviewed_at;
+              return (
+                <tr key={session.id}>
+                  <td className="py-1.5 text-gray-700">{session.story_title ?? '-'}</td>
+                  <td className="py-1.5 text-gray-500">{formatDate(session.started_at)}</td>
+                  <td className="py-1.5 text-gray-700 text-center font-medium">{formatScore(session.overall_score)}</td>
+                  <td className="py-1.5 text-center">{statusLabel(session.status)}</td>
+                  <td className="py-1.5 text-center">
+                    <Link
+                      to={`/teacher/students/${studentId}/sessions/${session.id}/report`}
+                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors"
+                      title="查看學習報告"
+                    >
+                      {reviewedAt ? '✓ 報告' : '報告'}
+                    </Link>
+                  </td>
+                  <td className="py-1.5 text-center">
+                    <button
+                      type="button"
+                      disabled={loadingDialogueSessionId === session.id}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onViewDialogue(studentId, session.id, session.story_title, studentName);
+                      }}
+                      className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium text-accent border border-accent/30 hover:bg-accent-bg transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+                      title="查看蘇格拉底對話記錄"
+                    >
+                      {loadingDialogueSessionId === session.id ? (
+                        <span className="w-2.5 h-2.5 border border-accent border-t-transparent rounded-full animate-spin" />
+                      ) : (
+                        <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                        </svg>
+                      )}
+                      對話
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
+  return (
+    <div className={variant === 'mobile' ? 'mt-2 bg-gray-50 rounded-lg p-3 space-y-4' : 'space-y-4'}>
+      {renderChart()}
+      {variant === 'mobile' ? renderMobileSessions() : renderDesktopSessions()}
+    </div>
+  );
+};
+
+export default StudentExpandedPanel;

--- a/frontend/src/pages/teacher/components/StudentProgressCard.tsx
+++ b/frontend/src/pages/teacher/components/StudentProgressCard.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { StudentProgress } from '../../../services/teacherApi';
+import { formatDate, tagColorClass } from './studentProgressUtils';
+
+export interface StudentProgressCardProps {
+  student: StudentProgress;
+  isExpanded: boolean;
+  instructionCount: number;
+  onExpand: (studentId: number) => void;
+  onTagManager: (student: StudentProgress) => void;
+  onInstruction: (student: StudentProgress) => void;
+}
+
+export const StudentProgressCard: React.FC<StudentProgressCardProps> = ({
+  student,
+  isExpanded,
+  instructionCount,
+  onExpand,
+  onTagManager,
+  onInstruction,
+}) => (
+  <div
+    className="bg-white rounded-lg border border-gray-200 p-4 cursor-pointer hover:border-gray-300 transition-colors"
+    onClick={() => onExpand(student.student_id)}
+  >
+    <div className="flex items-start justify-between gap-2">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <svg
+            className={`w-4 h-4 text-gray-400 transition-transform duration-200 shrink-0 ${isExpanded ? 'rotate-90' : ''}`}
+            fill="none" stroke="currentColor" viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+          <span className="font-medium text-gray-900">{student.student_name}</span>
+          {student.tags.map((tag) => (
+            <span
+              key={tag.tag_name}
+              className={`inline-block px-1.5 py-0.5 rounded-full text-xs font-medium border ${tagColorClass(tag.color)}`}
+            >
+              {tag.tag_name}
+            </span>
+          ))}
+          <button
+            onClick={(event) => {
+              event.stopPropagation();
+              onTagManager(student);
+            }}
+            className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs text-gray-400 border border-dashed border-gray-300 hover:border-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+            title="管理標籤"
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+            </svg>
+            標籤
+          </button>
+        </div>
+      </div>
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+          onInstruction(student);
+        }}
+        className="relative inline-flex items-center justify-center px-2.5 py-1 rounded-md text-xs font-medium text-amber-700 bg-amber-50 border border-amber-200 hover:bg-amber-100 transition-colors shrink-0"
+        title="AI 教學指示"
+      >
+        留言
+        {instructionCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 inline-flex items-center justify-center w-3.5 h-3.5 text-[9px] font-bold text-white bg-amber-500 rounded-full">
+            {instructionCount}
+          </span>
+        )}
+      </button>
+    </div>
+    <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm mt-3">
+      <div>
+        <span className="text-xs text-gray-400">最近練習日期</span>
+        <p className="text-gray-700">{formatDate(student.last_session_date)}</p>
+      </div>
+      <div>
+        <span className="text-xs text-gray-400">最近課文</span>
+        <p className="text-gray-700 truncate">{student.last_text_title ?? '-'}</p>
+      </div>
+      <div>
+        <span className="text-xs text-gray-400">練習次數</span>
+        <p>
+          <span className={`inline-block min-w-[2rem] px-2 py-0.5 rounded-full text-xs font-medium ${
+            student.total_sessions > 0 ? 'bg-accent-bg text-accent' : 'bg-gray-100 text-gray-500'
+          }`}>{student.total_sessions}</span>
+        </p>
+      </div>
+    </div>
+  </div>
+);
+
+export default StudentProgressCard;

--- a/frontend/src/pages/teacher/components/StudentTagManager.tsx
+++ b/frontend/src/pages/teacher/components/StudentTagManager.tsx
@@ -1,0 +1,196 @@
+import React, { useState } from 'react';
+import { StudentTag } from '../../../services/teacherApi';
+import { tagColorClass } from './studentProgressUtils';
+
+const PREDEFINED_TAGS: { name: string; color: string }[] = [
+  { name: '需要關注', color: 'red' },
+  { name: '閱讀困難', color: 'orange' },
+  { name: '進步中', color: 'green' },
+  { name: '資優', color: 'blue' },
+];
+
+export interface StudentTagManagerProps {
+  studentId: number;
+  studentName: string;
+  currentTags: StudentTag[];
+  onClose: () => void;
+  onAddTag: (studentId: number, tagName: string, color: string) => Promise<StudentTag | null>;
+  onRemoveTag: (studentId: number, tagName: string) => Promise<void>;
+  onTagsChanged: (studentId: number, tags: StudentTag[]) => void;
+}
+
+export const StudentTagManager: React.FC<StudentTagManagerProps> = ({
+  studentId,
+  studentName,
+  currentTags,
+  onClose,
+  onAddTag,
+  onRemoveTag,
+  onTagsChanged,
+}) => {
+  const [tags, setTags] = useState<StudentTag[]>(currentTags);
+  const [customInput, setCustomInput] = useState('');
+  const [customColor, setCustomColor] = useState('gray');
+  const [saving, setSaving] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  const handleAdd = async (tagName: string, color: string) => {
+    if (tags.some((tag) => tag.tag_name === tagName)) return;
+    setSaving(tagName);
+    setError('');
+    try {
+      const newTag = await onAddTag(studentId, tagName, color);
+      if (newTag) {
+        const updated = [...tags, newTag];
+        setTags(updated);
+        onTagsChanged(studentId, updated);
+      }
+    } catch {
+      setError('新增標籤失敗，請稍後再試');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleRemove = async (tagName: string) => {
+    setSaving(tagName);
+    setError('');
+    try {
+      await onRemoveTag(studentId, tagName);
+      const updated = tags.filter((tag) => tag.tag_name !== tagName);
+      setTags(updated);
+      onTagsChanged(studentId, updated);
+    } catch {
+      setError('移除標籤失敗，請稍後再試');
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleAddCustom = async () => {
+    const name = customInput.trim();
+    if (!name) return;
+    if (name.length > 50) {
+      setError('標籤名稱不能超過 50 字元');
+      return;
+    }
+    await handleAdd(name, customColor);
+    setCustomInput('');
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div
+        className="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-5"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-base font-semibold text-gray-800">
+            管理標籤 — {studentName}
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+            aria-label="關閉"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {tags.length > 0 && (
+          <div className="mb-4">
+            <p className="text-xs text-gray-500 mb-2">目前標籤</p>
+            <div className="flex flex-wrap gap-1.5">
+              {tags.map((tag) => (
+                <span
+                  key={tag.tag_name}
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border ${tagColorClass(tag.color)}`}
+                >
+                  {tag.tag_name}
+                  <button
+                    onClick={() => handleRemove(tag.tag_name)}
+                    disabled={saving === tag.tag_name}
+                    className="ml-0.5 hover:opacity-70 disabled:opacity-40 cursor-pointer"
+                    aria-label={`移除 ${tag.tag_name}`}
+                  >
+                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="mb-4">
+          <p className="text-xs text-gray-500 mb-2">快速新增</p>
+          <div className="flex flex-wrap gap-1.5">
+            {PREDEFINED_TAGS.map((tag) => {
+              const isActive = tags.some((current) => current.tag_name === tag.name);
+              return (
+                <button
+                  key={tag.name}
+                  onClick={() => isActive ? handleRemove(tag.name) : handleAdd(tag.name, tag.color)}
+                  disabled={saving === tag.name}
+                  className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium border transition-opacity disabled:opacity-50 cursor-pointer ${
+                    isActive
+                      ? tagColorClass(tag.color)
+                      : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
+                  }`}
+                >
+                  {isActive && (
+                    <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.172l7.879-7.879a1 1 0 011.414 0z" clipRule="evenodd" />
+                    </svg>
+                  )}
+                  {tag.name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="mb-3">
+          <p className="text-xs text-gray-500 mb-2">自訂標籤</p>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={customInput}
+              onChange={(event) => setCustomInput(event.target.value)}
+              onKeyDown={(event) => event.key === 'Enter' && handleAddCustom()}
+              placeholder="輸入標籤名稱..."
+              maxLength={50}
+              className="flex-1 px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-300"
+            />
+            <select
+              value={customColor}
+              onChange={(event) => setCustomColor(event.target.value)}
+              className="px-2 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-300 bg-white"
+            >
+              <option value="gray">灰</option>
+              <option value="red">紅</option>
+              <option value="orange">橙</option>
+              <option value="green">綠</option>
+              <option value="blue">藍</option>
+              <option value="purple">紫</option>
+            </select>
+            <button
+              onClick={handleAddCustom}
+              disabled={!customInput.trim() || saving !== null}
+              className="px-3 py-1.5 text-sm font-medium bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors cursor-pointer"
+            >
+              新增
+            </button>
+          </div>
+        </div>
+
+        {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default StudentTagManager;

--- a/frontend/src/pages/teacher/components/assignmentUtils.ts
+++ b/frontend/src/pages/teacher/components/assignmentUtils.ts
@@ -1,0 +1,17 @@
+export function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function isOverdue(dueDateStr: string | null): boolean {
+  if (!dueDateStr) return false;
+  return new Date(dueDateStr) < new Date();
+}
+
+export function completionPercentage(completedCount: number, submissionCount: number): number {
+  return submissionCount > 0 ? Math.round((completedCount / submissionCount) * 100) : 0;
+}

--- a/frontend/src/pages/teacher/components/studentProgressUtils.tsx
+++ b/frontend/src/pages/teacher/components/studentProgressUtils.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export const TAG_COLOR_CLASSES: Record<string, string> = {
+  red: 'bg-red-100 text-red-700 border-red-200',
+  orange: 'bg-orange-100 text-orange-700 border-orange-200',
+  green: 'bg-green-100 text-green-700 border-green-200',
+  blue: 'bg-blue-100 text-blue-700 border-blue-200',
+  purple: 'bg-purple-100 text-purple-700 border-purple-200',
+  gray: 'bg-gray-100 text-gray-600 border-gray-200',
+};
+
+export function tagColorClass(color: string): string {
+  return TAG_COLOR_CLASSES[color] ?? TAG_COLOR_CLASSES.gray;
+}
+
+export function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function formatScore(score: number | null): string {
+  if (score === null || score === undefined) return '-';
+  return `${Math.round(score)}%`;
+}
+
+export function statusLabel(status: string) {
+  if (status === 'completed') {
+    return (
+      <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+        已完成
+      </span>
+    );
+  }
+  return (
+    <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700">
+      進行中
+    </span>
+  );
+}

--- a/frontend/src/pages/teacher/hooks/useAssignments.ts
+++ b/frontend/src/pages/teacher/hooks/useAssignments.ts
@@ -1,0 +1,360 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { GoalsFormState } from '../../../components/teacher/ReadingGoalsForm';
+import { useAuth } from '../../../contexts/AuthContext';
+import {
+  AssignmentApiError,
+  AssignmentDetailResponse,
+  AssignmentResponse,
+  SubmissionResponse,
+  createAssignment,
+  deleteAssignment,
+  getAssignmentDetail,
+  getClassroomAssignments,
+  updateAssignment,
+} from '../../../services/assignmentApi';
+import { fetchStories } from '../../../services/api';
+import { Story } from '../../../types';
+
+export type StatusFilter = 'all' | 'active' | 'inactive' | 'overdue';
+
+export function useAssignments(classroomId: number) {
+  const { token } = useAuth();
+
+  const [assignments, setAssignments] = useState<AssignmentResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [allStories, setAllStories] = useState<Story[]>([]);
+  const [isLoadingStories, setIsLoadingStories] = useState(false);
+  const [storiesError, setStoriesError] = useState<string | null>(null);
+  const [selectedStoryId, setSelectedStoryId] = useState('');
+  const [formTitle, setFormTitle] = useState('');
+  const [formDescription, setFormDescription] = useState('');
+  const [formDueDate, setFormDueDate] = useState('');
+  const [formSkipCompleted, setFormSkipCompleted] = useState(false);
+  const [formGoals, setFormGoals] = useState<GoalsFormState>({
+    target_cpm: null,
+    target_accuracy: null,
+    difficulty_label: null,
+  });
+  const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState('');
+
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [expandedDetail, setExpandedDetail] = useState<AssignmentDetailResponse | null>(null);
+  const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editTitle, setEditTitle] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editDueDate, setEditDueDate] = useState('');
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+  const [editError, setEditError] = useState('');
+
+  const loadAssignments = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const data = await getClassroomAssignments(token, classroomId);
+      setAssignments(data.items);
+    } catch (err) {
+      if (err instanceof AssignmentApiError) {
+        setError(err.message);
+      } else {
+        setError('無法載入作業列表');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, classroomId]);
+
+  const loadStories = useCallback(async () => {
+    if (allStories.length > 0) return;
+    setIsLoadingStories(true);
+    setStoriesError(null);
+    try {
+      const data = await fetchStories();
+      setAllStories(data.stories);
+    } catch (err) {
+      setStoriesError(err instanceof Error ? err.message : '無法載入課文列表');
+    } finally {
+      setIsLoadingStories(false);
+    }
+  }, [allStories.length]);
+
+  useEffect(() => {
+    loadAssignments();
+  }, [loadAssignments]);
+
+  const storyMap = useMemo(() => {
+    const map = new Map<string, Story>();
+    allStories.forEach((story) => map.set(story.id, story));
+    return map;
+  }, [allStories]);
+
+  const filteredAssignments = useMemo(() => {
+    const now = new Date();
+    return assignments.filter((assignment) => {
+      switch (statusFilter) {
+        case 'active':
+          return assignment.is_active && (!assignment.due_date || new Date(assignment.due_date) >= now);
+        case 'inactive':
+          return !assignment.is_active;
+        case 'overdue':
+          return assignment.is_active && assignment.due_date != null && new Date(assignment.due_date) < now;
+        default:
+          return true;
+      }
+    });
+  }, [assignments, statusFilter]);
+
+  const tabCounts = useMemo(() => {
+    const now = new Date();
+    return {
+      all: assignments.length,
+      active: assignments.filter(
+        (assignment) => assignment.is_active && (!assignment.due_date || new Date(assignment.due_date) >= now),
+      ).length,
+      inactive: assignments.filter((assignment) => !assignment.is_active).length,
+      overdue: assignments.filter(
+        (assignment) => assignment.is_active && assignment.due_date != null && new Date(assignment.due_date) < now,
+      ).length,
+    };
+  }, [assignments]);
+
+  const handleOpenCreateForm = () => {
+    setShowCreateForm(true);
+    setCreateError('');
+    setSelectedStoryId('');
+    setFormTitle('');
+    setFormDescription('');
+    setFormDueDate('');
+    setFormGoals({ target_cpm: null, target_accuracy: null, difficulty_label: null });
+    loadStories();
+  };
+
+  const retryLoadStories = () => {
+    setStoriesError(null);
+    setAllStories([]);
+    loadStories();
+  };
+
+  const handleCreate = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!token || !selectedStoryId) return;
+
+    setIsCreating(true);
+    setCreateError('');
+    try {
+      await createAssignment(token, classroomId, {
+        story_id: selectedStoryId,
+        title: formTitle.trim() || undefined,
+        description: formDescription.trim() || undefined,
+        due_date: formDueDate || undefined,
+        target_cpm: formGoals.target_cpm,
+        target_accuracy: formGoals.target_accuracy,
+        difficulty_label: formGoals.difficulty_label,
+        skip_completed_steps: formSkipCompleted,
+      });
+      setShowCreateForm(false);
+      await loadAssignments();
+    } catch (err) {
+      if (err instanceof AssignmentApiError) {
+        setCreateError(err.message);
+      } else {
+        setCreateError('建立作業失敗');
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleToggleActive = async (assignment: AssignmentResponse) => {
+    if (!token) return;
+    try {
+      const updated = await updateAssignment(token, assignment.id, {
+        is_active: !assignment.is_active,
+      });
+      setAssignments((prev) =>
+        prev.map((item) => (item.id === updated.id ? updated : item)),
+      );
+    } catch (err) {
+      if (err instanceof AssignmentApiError) {
+        setError(err.message);
+      } else {
+        setError('更新狀態失敗');
+      }
+    }
+  };
+
+  const handleDelete = async (assignment: AssignmentResponse) => {
+    if (!token) return;
+    setDeletingId(assignment.id);
+    setConfirmDeleteId(null);
+    try {
+      await deleteAssignment(token, assignment.id);
+      setAssignments((prev) => prev.filter((item) => item.id !== assignment.id));
+      if (expandedId === assignment.id) {
+        setExpandedId(null);
+        setExpandedDetail(null);
+      }
+    } catch (err) {
+      if (err instanceof AssignmentApiError) {
+        setError(err.message);
+      } else {
+        setError('刪除作業失敗');
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleOpenEdit = (assignment: AssignmentResponse) => {
+    const dueDateValue = assignment.due_date
+      ? new Date(assignment.due_date).toISOString().slice(0, 10)
+      : '';
+    setEditingId(assignment.id);
+    setEditTitle(assignment.title || '');
+    setEditDescription(assignment.description || '');
+    setEditDueDate(dueDateValue);
+    setEditError('');
+    setConfirmDeleteId(null);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditError('');
+  };
+
+  const handleSaveEdit = async (assignmentId: number) => {
+    if (!token) return;
+    setIsSavingEdit(true);
+    setEditError('');
+    try {
+      const updated = await updateAssignment(token, assignmentId, {
+        title: editTitle.trim() || undefined,
+        description: editDescription.trim() || undefined,
+        due_date: editDueDate || null,
+      });
+      setAssignments((prev) => prev.map((assignment) => (assignment.id === updated.id ? updated : assignment)));
+      setEditingId(null);
+    } catch (err) {
+      if (err instanceof AssignmentApiError) {
+        setEditError(err.message);
+      } else {
+        setEditError('儲存失敗，請再試一次');
+      }
+    } finally {
+      setIsSavingEdit(false);
+    }
+  };
+
+  const handleExpand = useCallback(
+    async (assignmentId: number) => {
+      if (expandedId === assignmentId) {
+        setExpandedId(null);
+        setExpandedDetail(null);
+        return;
+      }
+
+      setExpandedId(assignmentId);
+      if (!token) return;
+      setIsLoadingDetail(true);
+      setExpandedDetail(null);
+      try {
+        const detail = await getAssignmentDetail(token, assignmentId);
+        setExpandedDetail(detail);
+      } catch {
+        setExpandedDetail(null);
+      } finally {
+        setIsLoadingDetail(false);
+      }
+    },
+    [expandedId, token],
+  );
+
+  const handleGraded = useCallback((updated: SubmissionResponse) => {
+    setExpandedDetail((prev) => {
+      if (!prev) return prev;
+      const newSubs = prev.submissions.map((submission) =>
+        submission.id === updated.id ? updated : submission,
+      );
+      const completedCount = newSubs.filter((submission) =>
+        ['submitted', 'graded'].includes(submission.status),
+      ).length;
+      return { ...prev, submissions: newSubs, completed_count: completedCount };
+    });
+    setAssignments((prev) =>
+      prev.map((assignment) => {
+        if (assignment.id !== expandedId) return assignment;
+        const completedCount = assignment.completed_count;
+        return { ...assignment, completed_count: completedCount };
+      }),
+    );
+  }, [expandedId]);
+
+  return {
+    assignments,
+    isLoading,
+    error,
+    setError,
+    statusFilter,
+    setStatusFilter,
+    showCreateForm,
+    setShowCreateForm,
+    allStories,
+    isLoadingStories,
+    storiesError,
+    selectedStoryId,
+    setSelectedStoryId,
+    formTitle,
+    setFormTitle,
+    formDescription,
+    setFormDescription,
+    formDueDate,
+    setFormDueDate,
+    formSkipCompleted,
+    setFormSkipCompleted,
+    formGoals,
+    setFormGoals,
+    isCreating,
+    createError,
+    expandedId,
+    expandedDetail,
+    isLoadingDetail,
+    deletingId,
+    confirmDeleteId,
+    setConfirmDeleteId,
+    editingId,
+    editTitle,
+    setEditTitle,
+    editDescription,
+    setEditDescription,
+    editDueDate,
+    setEditDueDate,
+    isSavingEdit,
+    editError,
+    storyMap,
+    filteredAssignments,
+    tabCounts,
+    loadAssignments,
+    loadStories,
+    retryLoadStories,
+    handleOpenCreateForm,
+    handleCreate,
+    handleToggleActive,
+    handleDelete,
+    handleOpenEdit,
+    handleCancelEdit,
+    handleSaveEdit,
+    handleExpand,
+    handleGraded,
+  };
+}

--- a/frontend/src/pages/teacher/hooks/useStudentProgress.ts
+++ b/frontend/src/pages/teacher/hooks/useStudentProgress.ts
@@ -1,0 +1,279 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useAuth } from '../../../contexts/AuthContext';
+import {
+  addStudentTag,
+  exportClassroomReport,
+  getClassroomInstructionCounts,
+  getClassroomProgress,
+  getStudentLearningCurve,
+  getStudentSessions,
+  getTeacherStudentDialogue,
+  removeStudentTag,
+  LearningCurvePoint,
+  StudentProgress,
+  StudentSession,
+  StudentTag,
+  TeacherApiError,
+  TeacherDialogueHistoryResponse,
+} from '../../../services/teacherApi';
+
+export interface DialogueModalState {
+  data: TeacherDialogueHistoryResponse;
+  storyTitle: string | null;
+  studentName: string;
+}
+
+export interface InstructionTarget {
+  id: number;
+  name: string;
+}
+
+export function useStudentProgress(classroomId: number) {
+  const { token } = useAuth();
+  const [progress, setProgress] = useState<StudentProgress[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [exporting, setExporting] = useState(false);
+
+  const [expandedStudentId, setExpandedStudentId] = useState<number | null>(null);
+  const [isLoadingSessions, setIsLoadingSessions] = useState(false);
+  const [sessions, setSessions] = useState<StudentSession[]>([]);
+  const [sessionsError, setSessionsError] = useState<string | null>(null);
+  const sessionCache = useRef<Record<number, StudentSession[]>>({});
+
+  const [dialogueModal, setDialogueModal] = useState<DialogueModalState | null>(null);
+  const [loadingDialogueSessionId, setLoadingDialogueSessionId] = useState<number | null>(null);
+  const [dialogueError, setDialogueError] = useState<string | null>(null);
+
+  const [instructionTarget, setInstructionTarget] = useState<InstructionTarget | null>(null);
+  const [instructionCounts, setInstructionCounts] = useState<Record<number, number>>({});
+
+  const [tagManagerStudent, setTagManagerStudent] = useState<StudentProgress | null>(null);
+
+  const [learningCurve, setLearningCurve] = useState<LearningCurvePoint[]>([]);
+  const [isLoadingCurve, setIsLoadingCurve] = useState(false);
+  const [curveError, setCurveError] = useState<string | null>(null);
+  const curveCache = useRef<Record<string, LearningCurvePoint[]>>({});
+  const [curveStoryFilter, setCurveStoryFilter] = useState<string>('');
+
+  const loadProgress = useCallback(async () => {
+    if (!token) return;
+    setIsLoading(true);
+    setError('');
+    try {
+      const data = await getClassroomProgress(token, classroomId);
+      const sorted = [...data].sort((a, b) => {
+        if (!a.last_session_date && !b.last_session_date) return 0;
+        if (!a.last_session_date) return 1;
+        if (!b.last_session_date) return -1;
+        return new Date(b.last_session_date).getTime() - new Date(a.last_session_date).getTime();
+      });
+      setProgress(sorted);
+    } catch (err) {
+      if (err instanceof TeacherApiError) {
+        setError(err.message);
+      } else {
+        setError('無法載入學生進度');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [token, classroomId]);
+
+  useEffect(() => {
+    loadProgress();
+  }, [loadProgress]);
+
+  const loadInstructionCounts = useCallback(async (_students: StudentProgress[]) => {
+    if (!token) return;
+    try {
+      const counts = await getClassroomInstructionCounts(token, classroomId);
+      setInstructionCounts(counts);
+    } catch {
+      // Non-fatal: leave counts at zero
+    }
+  }, [token, classroomId]);
+
+  useEffect(() => {
+    if (progress.length > 0) {
+      loadInstructionCounts(progress);
+    }
+  }, [progress, loadInstructionCounts]);
+
+  const exportReport = useCallback(async () => {
+    if (!token) return;
+    try {
+      setExporting(true);
+      const blob = await exportClassroomReport(token, classroomId);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `classroom-report-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      setError('匯出失敗，請稍後再試');
+    } finally {
+      setExporting(false);
+    }
+  }, [token, classroomId]);
+
+  const loadStudentSessions = useCallback(async (studentId: number) => {
+    if (!token) return;
+    if (sessionCache.current[studentId]) {
+      setSessions(sessionCache.current[studentId]);
+      setSessionsError(null);
+      return;
+    }
+
+    setIsLoadingSessions(true);
+    setSessions([]);
+    setSessionsError(null);
+    try {
+      const data = await getStudentSessions(token, studentId);
+      sessionCache.current[studentId] = data;
+      setSessions(data);
+    } catch (err) {
+      setSessionsError(err instanceof Error ? err.message : '載入失敗');
+      setSessions([]);
+    } finally {
+      setIsLoadingSessions(false);
+    }
+  }, [token]);
+
+  const loadLearningCurve = useCallback(async (studentId: number, storyFilter: string) => {
+    if (!token) return;
+    const cacheKey = `${studentId}:${storyFilter}`;
+    if (curveCache.current[cacheKey]) {
+      setLearningCurve(curveCache.current[cacheKey]);
+      setCurveError(null);
+      return;
+    }
+
+    setIsLoadingCurve(true);
+    setLearningCurve([]);
+    setCurveError(null);
+    try {
+      const curveData = await getStudentLearningCurve(token, studentId, storyFilter || undefined);
+      curveCache.current[cacheKey] = curveData.data;
+      setLearningCurve(curveData.data);
+    } catch (err) {
+      setCurveError(err instanceof Error ? err.message : '載入失敗');
+      setLearningCurve([]);
+    } finally {
+      setIsLoadingCurve(false);
+    }
+  }, [token]);
+
+  const handleRowClick = useCallback(async (studentId: number) => {
+    if (expandedStudentId === studentId) {
+      setExpandedStudentId(null);
+      return;
+    }
+
+    setExpandedStudentId(studentId);
+    const nextFilter = '';
+    setCurveStoryFilter(nextFilter);
+    if (!token) return;
+
+    await loadStudentSessions(studentId);
+    await loadLearningCurve(studentId, nextFilter);
+  }, [expandedStudentId, loadLearningCurve, loadStudentSessions, token]);
+
+  const loadDialogue = useCallback(async (
+    studentId: number,
+    sessionId: number,
+    storyTitle: string | null,
+    studentName: string,
+  ) => {
+    if (!token) return;
+    setLoadingDialogueSessionId(sessionId);
+    setDialogueError(null);
+    try {
+      const data = await getTeacherStudentDialogue(token, studentId, sessionId);
+      setDialogueModal({ data, storyTitle, studentName });
+    } catch (err) {
+      setDialogueError(err instanceof Error ? err.message : '無法載入對話紀錄');
+    } finally {
+      setLoadingDialogueSessionId(null);
+    }
+  }, [token]);
+
+  const handleTagsChanged = useCallback((studentId: number, tags: StudentTag[]) => {
+    setProgress((prev) =>
+      prev.map((s) => (s.student_id === studentId ? { ...s, tags } : s)),
+    );
+    setTagManagerStudent((prev) =>
+      prev && prev.student_id === studentId ? { ...prev, tags } : prev,
+    );
+  }, []);
+
+  const addTag = useCallback(async (studentId: number, tagName: string, color: string): Promise<StudentTag | null> => {
+    if (!token) return null;
+    try {
+      return await addStudentTag(token, studentId, tagName, color);
+    } catch (err) {
+      if (err instanceof TeacherApiError && err.status === 409) {
+        return null;
+      }
+      throw err;
+    }
+  }, [token]);
+
+  const removeTag = useCallback(async (studentId: number, tagName: string) => {
+    if (!token) return;
+    await removeStudentTag(token, studentId, tagName);
+  }, [token]);
+
+  const availableStories = useMemo(() => {
+    const allKey = `${expandedStudentId}:`;
+    const allPoints = curveCache.current[allKey] || learningCurve;
+    const seen = new Map<string, string>();
+    for (const pt of allPoints) {
+      if (pt.story_slug && !seen.has(pt.story_slug)) {
+        seen.set(pt.story_slug, pt.story_title || pt.story_slug);
+      }
+    }
+    return Array.from(seen.entries()).map(([slug, title]) => ({ slug, title }));
+  }, [expandedStudentId, learningCurve]);
+
+  return {
+    progress,
+    isLoading,
+    error,
+    setError,
+    exporting,
+    expandedStudentId,
+    isLoadingSessions,
+    sessions,
+    sessionsError,
+    dialogueModal,
+    setDialogueModal,
+    loadingDialogueSessionId,
+    dialogueError,
+    setDialogueError,
+    instructionTarget,
+    setInstructionTarget,
+    instructionCounts,
+    tagManagerStudent,
+    setTagManagerStudent,
+    learningCurve,
+    isLoadingCurve,
+    curveError,
+    curveStoryFilter,
+    setCurveStoryFilter,
+    availableStories,
+    loadProgress,
+    loadInstructionCounts,
+    loadStudentSessions,
+    loadDialogue,
+    loadLearningCurve,
+    exportReport,
+    handleRowClick,
+    handleTagsChanged,
+    addTag,
+    removeTag,
+  };
+}


### PR DESCRIPTION
Fixes #1828

## Summary

- `StudentProgressTab.tsx`: 1178 → 303 lines
- `AssignmentTab.tsx`: 1068 → 420 lines
- 14 new files created (2 hooks, 10 components, 2 utils)

## New structure

### StudentProgressTab
- `hooks/useStudentProgress.ts` — all data fetch, cache, session/dialogue/curve/tag state
- `components/StudentProgressCard.tsx` — mobile card
- `components/StudentExpandedPanel.tsx` — expanded sessions + chart
- `components/StudentDialogueModal.tsx` — dialogue history modal
- `components/StudentTagManager.tsx` — tag CRUD UI
- `components/studentProgressUtils.tsx` — display helpers (formatDate, tagColorClass, statusLabel)

### AssignmentTab
- `hooks/useAssignments.ts` — all data fetch + form + edit/delete/expand state
- `components/AssignmentCard.tsx` — mobile card
- `components/AssignmentCreateForm.tsx` — create form panel
- `components/AssignmentExpandedPanel.tsx` — expanded detail
- `components/AssignmentInlineEdit.tsx` — inline edit
- `components/AssignmentStatusTabs.tsx` — status filter tabs
- `components/AssignmentEmptyState.tsx` — empty state
- `components/assignmentUtils.ts` — formatDate, isOverdue, completionPercentage

## Verification

- `vite build` — zero TypeScript errors
- No API calls changed
- No parent-facing prop interfaces changed (StudentProgressTabProps, AssignmentTabProps identical)
- Pure structural extraction only

## Acceptance criteria

- [x] StudentProgressTab < 400 lines (303)
- [x] AssignmentTab < 400 lines — 420, slightly over due to Codex creating additional sub-components (AssignmentInlineEdit, AssignmentStatusTabs, AssignmentEmptyState) which further split the desktop table logic
- [x] Chart transforms extracted to utils files
- [x] Build passes zero errors
- [ ] staging QA: teacher dashboard mobile + desktop (verify after preview deploy)