### PR TITLE
refactor(learning-layout): extract 3 hooks from LearningLayout.tsx (Related to #1824)

### DIFF
--- a/frontend/src/hooks/useLearningSessionBootstrap.ts
+++ b/frontend/src/hooks/useLearningSessionBootstrap.ts
@@ -1,0 +1,292 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { NavigateFunction } from 'react-router-dom';
+import type { AuthUser } from '../services/authApi';
+import { fetchStory, saveActiveSession } from '../services/api';
+import type { LearningSession, Story } from '../types';
+import { STEP_PATH_TO_NUMBER } from '../config/stepConfig';
+import { isToolboxMode } from '../services/learningStorageScope';
+import type { AssignmentReadingGoals } from '../layouts/LearningLayout';
+
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:8000';
+const ACTIVE_ASSIGNMENT_CONTEXT_KEY = 'activeAssignmentContext';
+const LEGACY_DB_SESSION_KEY_PREFIX = 'db-session-';
+const ASSIGNMENT_DB_SESSION_KEY_PREFIX = 'assignment-db-session-';
+const SELF_DB_SESSION_KEY_PREFIX = 'self-db-session-';
+
+interface AssignmentContext {
+  assignmentId?: number;
+  userId?: string | null;
+  storyKey?: string | null;
+}
+
+interface UseLearningSessionBootstrapOptions {
+  storyId: string | undefined;
+  user: AuthUser | null;
+  token: string | null;
+  navigate: NavigateFunction;
+}
+
+interface UseLearningSessionBootstrapReturn {
+  isAssignmentFlow: boolean;
+  isToolboxFlow: boolean;
+  assignmentContext: AssignmentContext | null;
+  assignmentReadingGoals: AssignmentReadingGoals | null;
+  dbSessionId: number | null;
+  isLoading: boolean;
+  error: string | null;
+  selectedStory: Story | null;
+  session: LearningSession | null;
+  setSession: React.Dispatch<React.SetStateAction<LearningSession | null>>;
+  setSelectedStory: React.Dispatch<React.SetStateAction<Story | null>>;
+  ensureDbSession: () => void;
+}
+
+function readAssignmentContext(): AssignmentContext | null {
+  try {
+    const raw = sessionStorage.getItem(ACTIVE_ASSIGNMENT_CONTEXT_KEY);
+    return raw ? (JSON.parse(raw) as AssignmentContext) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function useLearningSessionBootstrap({
+  storyId,
+  user,
+  token,
+  navigate,
+}: UseLearningSessionBootstrapOptions): UseLearningSessionBootstrapReturn {
+  const [selectedStory, setSelectedStory] = useState<Story | null>(null);
+  const [session, setSession] = useState<LearningSession | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dbSessionId, setDbSessionId] = useState<number | null>(null);
+  const [assignmentContext, setAssignmentContext] = useState<AssignmentContext | null>(() => readAssignmentContext());
+  const [assignmentReadingGoals] = useState<AssignmentReadingGoals | null>(() => {
+    try {
+      const raw = sessionStorage.getItem('activeAssignmentGoals');
+      return raw ? (JSON.parse(raw) as AssignmentReadingGoals) : null;
+    } catch {
+      return null;
+    }
+  });
+  const isCreatingSession = useRef(false);
+  const isToolboxFlow = isToolboxMode();
+
+  useEffect(() => {
+    setAssignmentContext(readAssignmentContext());
+  }, [storyId, user]);
+
+  const isAssignmentFlow = useMemo(() => {
+    if (!storyId) return false;
+    try {
+      const assignmentId = sessionStorage.getItem('activeAssignmentId');
+      if (!assignmentId) return false;
+      if (!assignmentContext) return true;
+      const storyMatch = String(assignmentContext.storyKey ?? '') === String(storyId);
+      const userMatch = !assignmentContext.userId || !user || String(assignmentContext.userId) === String(user.id);
+      return storyMatch && userMatch;
+    } catch {
+      return false;
+    }
+  }, [assignmentContext, storyId, user]);
+
+  const activeDbSessionStorageKey = useMemo(() => {
+    if (!storyId) return null;
+    if (isAssignmentFlow) {
+      const assignmentId = sessionStorage.getItem('activeAssignmentId');
+      if (assignmentId) {
+        return `${ASSIGNMENT_DB_SESSION_KEY_PREFIX}${assignmentId}-${storyId}`;
+      }
+      return `${ASSIGNMENT_DB_SESSION_KEY_PREFIX}${storyId}`;
+    }
+    return `${SELF_DB_SESSION_KEY_PREFIX}${storyId}`;
+  }, [isAssignmentFlow, storyId]);
+
+  const legacyDbSessionStorageKey = useMemo(() => {
+    if (!storyId) return null;
+    return `${LEGACY_DB_SESSION_KEY_PREFIX}${storyId}`;
+  }, [storyId]);
+
+  const storeSessionId = useCallback(
+    (id: number) => {
+      setDbSessionId(id);
+      if (activeDbSessionStorageKey) {
+        try { sessionStorage.setItem(activeDbSessionStorageKey, String(id)); } catch { /* non-fatal */ }
+      }
+      if (legacyDbSessionStorageKey) {
+        try { sessionStorage.removeItem(legacyDbSessionStorageKey); } catch { /* non-fatal */ }
+      }
+    },
+    [activeDbSessionStorageKey, legacyDbSessionStorageKey],
+  );
+
+  useEffect(() => {
+    if (isToolboxMode()) {
+      setDbSessionId(null);
+      return;
+    }
+
+    if (!storyId || !activeDbSessionStorageKey) {
+      setDbSessionId(null);
+      return;
+    }
+
+    try {
+      const directRaw = sessionStorage.getItem(activeDbSessionStorageKey);
+      const legacyRaw = legacyDbSessionStorageKey
+        ? sessionStorage.getItem(legacyDbSessionStorageKey)
+        : null;
+      const chosenRaw = directRaw ?? legacyRaw;
+      if (!chosenRaw) {
+        setDbSessionId(null);
+        return;
+      }
+      const parsed = parseInt(chosenRaw, 10);
+      if (Number.isNaN(parsed)) {
+        setDbSessionId(null);
+        return;
+      }
+      setDbSessionId(parsed);
+      if (!directRaw && legacyRaw) {
+        sessionStorage.setItem(activeDbSessionStorageKey, String(parsed));
+      }
+    } catch {
+      setDbSessionId(null);
+    }
+  }, [storyId, activeDbSessionStorageKey, legacyDbSessionStorageKey]);
+
+  useEffect(() => {
+    if (!storyId) {
+      navigate('/library', { replace: true });
+      return;
+    }
+
+    if (selectedStory?.id === storyId) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    fetchStory(storyId)
+      .then((story) => {
+        setSelectedStory(story);
+        setSession((prev) => {
+          if (prev && prev.storyId === storyId) return prev;
+          return {
+            storyId: story.id,
+            startedAt: Date.now(),
+            introCompleted: false,
+            readingAttempt: null,
+            comprehensionResult: null,
+            vocabResult: null,
+            dictationResult: null,
+            fullReadingResult: null,
+          };
+        });
+        if (user) {
+          saveActiveSession(String(user.id), {
+            sessionId: 0,
+            storyId,
+            currentStep: STEP_PATH_TO_NUMBER['reading-annotation'],
+            timestamp: Date.now(),
+          });
+        }
+      })
+      .catch((err) => {
+        setError(err.message || 'Failed to load story');
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [storyId, selectedStory?.id, navigate]);
+
+  const ensureDbSession = useCallback(() => {
+    if (isToolboxMode()) return;
+    if (!token || !storyId || dbSessionId !== null) return;
+    if (isCreatingSession.current) return;
+
+    isCreatingSession.current = true;
+
+    fetch(`${API_BASE}/api/learning/sessions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ story_slug: storyId }),
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data?.id) {
+          storeSessionId(data.id);
+        }
+      })
+      .catch(() => {
+        // Non-fatal — dialogue won't be persisted but learning still works
+      })
+      .finally(() => {
+        isCreatingSession.current = false;
+      });
+  }, [token, storyId, dbSessionId, storeSessionId]);
+
+  useEffect(() => {
+    if (isToolboxMode()) return;
+    if (!token || !storyId || dbSessionId !== null || isLoading) return;
+    if (isCreatingSession.current) return;
+
+    isCreatingSession.current = true;
+
+    fetch(`${API_BASE}/api/learning/sessions?story_slug=${encodeURIComponent(storyId)}&status=in_progress&limit=1`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        const existing = data?.items?.[0];
+        if (existing?.id) {
+          storeSessionId(existing.id);
+          return null;
+        }
+        return fetch(`${API_BASE}/api/learning/sessions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ story_slug: storyId }),
+        });
+      })
+      .then((res) => {
+        if (!res) return null;
+        return res.ok ? res.json() : null;
+      })
+      .then((data) => {
+        if (data?.id) {
+          storeSessionId(data.id);
+        }
+      })
+      .catch(() => {
+        // Non-fatal: local progress still works without DB.
+      })
+      .finally(() => {
+        isCreatingSession.current = false;
+      });
+  }, [token, storyId, dbSessionId, isLoading, storeSessionId]);
+
+  return {
+    isAssignmentFlow,
+    isToolboxFlow,
+    assignmentContext,
+    assignmentReadingGoals,
+    dbSessionId,
+    isLoading,
+    error,
+    selectedStory,
+    session,
+    setSession,
+    setSelectedStory,
+    ensureDbSession,
+  };
+}

--- a/frontend/src/hooks/useLearningStepNavigation.ts
+++ b/frontend/src/hooks/useLearningStepNavigation.ts
@@ -1,0 +1,520 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { NavigateFunction } from 'react-router-dom';
+import type { AuthUser } from '../services/authApi';
+import { completeSelfPracticeSession, SessionExpiredError, type StepProgressData } from '../services/learningApi';
+import { submitAssignment } from '../services/assignmentApi';
+import { STEP_PATH_TO_NUMBER } from '../config/stepConfig';
+import { isToolboxMode } from '../services/learningStorageScope';
+import type { ListeningResult } from '../components/reading-steps/ListeningPractice';
+import type { AnnotationSummary } from '../components/reading-steps/ReadingAnnotation';
+import type { VocabApplicationResult } from '../components/reading-steps/VocabApplication';
+import type { VocabDefinitionMatchResult } from '../components/reading-steps/VocabDefinitionMatch';
+import type {
+  ComprehensionResult,
+  DictationResult,
+  FullReadingResult,
+  LearningSession,
+  ReadingAttempt,
+  Story,
+  VocabResult,
+} from '../types';
+
+const ACTIVE_ASSIGNMENT_CONTEXT_KEY = 'activeAssignmentContext';
+const SELF_PRACTICE_COMPLETED_KEY_PREFIX = 'self-practice-completed-';
+
+interface PersistStepProgressOptions {
+  currentStep?: string | null;
+  completeStep?: string;
+  stepDataPatch?: Record<string, unknown>;
+}
+
+interface UseLearningStepNavigationOptions {
+  storyId: string | undefined;
+  selectedStory: Story | null;
+  token: string | null;
+  user: AuthUser | null;
+  dbSessionId: number | null;
+  hasActiveAssignment: boolean;
+  isAssignmentReadyForSubmit: boolean;
+  navigate: NavigateFunction;
+  setSession: Dispatch<SetStateAction<LearningSession | null>>;
+  setLastAttempt: Dispatch<SetStateAction<ReadingAttempt | null>>;
+  setSelectedStory: Dispatch<SetStateAction<Story | null>>;
+  persistStepProgressState: (opts: PersistStepProgressOptions, immediate: boolean) => void;
+  persistStep: (step: number) => void;
+  clearPersistedSession: () => void;
+  ensureDbSession: () => void;
+}
+
+interface UseLearningStepNavigationReturn {
+  handleStartReading: () => void;
+  handleFinishReading: (attempt: ReadingAttempt) => void;
+  handleFinishComprehension: (result: ComprehensionResult) => void;
+  handleFinishStoryStructure: () => void;
+  handleFinishReadingStrategy: () => void;
+  handleFinishVocab: (result: VocabResult) => void;
+  handleFinishDictation: (result: DictationResult) => void;
+  handleFinishFullReading: (result: FullReadingResult) => void;
+  handleFinishListening: (result: ListeningResult) => void;
+  handleFinishReadingAnnotation: (summary: AnnotationSummary) => void;
+  handleFinishVocabDefinitionMatch: (result: VocabDefinitionMatchResult) => void;
+  handleFinishVocabApplication: (result: VocabApplicationResult) => void;
+  handleFinishSentencePractice: () => void;
+  handleFinishVocabWordSearch: (elapsedSeconds: number) => void;
+  handleFinishKnowledgeStation: () => void;
+  handleRetry: () => void;
+  handleSessionComplete: () => void;
+  handleNextStep: () => void;
+  handlePrevStep: () => void;
+  handleComplete: () => void;
+  handleStepClick: (step: { id: string }) => void;
+}
+
+export function useLearningStepNavigation({
+  storyId,
+  selectedStory,
+  token,
+  user,
+  dbSessionId,
+  hasActiveAssignment,
+  isAssignmentReadyForSubmit,
+  navigate,
+  setSession,
+  setLastAttempt,
+  setSelectedStory,
+  persistStepProgressState,
+  persistStep,
+  clearPersistedSession,
+  ensureDbSession,
+}: UseLearningStepNavigationOptions): UseLearningStepNavigationReturn {
+  const sessionCompletedRef = useRef(false);
+  const completionApiCalledRef = useRef(false);
+
+  useEffect(() => {
+    sessionCompletedRef.current = false;
+    completionApiCalledRef.current = false;
+  }, [storyId]);
+
+  const handleStartReading = useCallback(() => {
+    setSession((prev) => {
+      if (prev) return { ...prev, introCompleted: true };
+      if (selectedStory) {
+        return {
+          storyId: selectedStory.id,
+          startedAt: Date.now(),
+          introCompleted: true,
+          readingAttempt: null,
+          comprehensionResult: null,
+          vocabResult: null,
+          dictationResult: null,
+          fullReadingResult: null,
+        };
+      }
+      return null;
+    });
+    persistStep(STEP_PATH_TO_NUMBER['reading-annotation']);
+    ensureDbSession();
+    navigate(isToolboxMode() ? '/tools' : `/learn/${storyId}/reading-annotation`);
+  }, [storyId, selectedStory, navigate, persistStep, ensureDbSession, setSession]);
+
+  const navigateAfterFinish = useCallback(
+    (nextStep: string) => {
+      if (isToolboxMode()) {
+        navigate('/tools');
+        return;
+      }
+      navigate(`/learn/${storyId}/${nextStep}`);
+    },
+    [navigate, storyId],
+  );
+
+  const handleFinishReading = useCallback(
+    (attempt: ReadingAttempt) => {
+      setLastAttempt(attempt);
+      setSession((prev) => (prev ? { ...prev, readingAttempt: attempt } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'tutor',
+          currentStep: 'full-reading',
+          stepDataPatch: {
+            tutor: { readingAttempt: attempt },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['full-reading']);
+      navigateAfterFinish('full-reading');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setLastAttempt, setSession],
+  );
+
+  const handleFinishComprehension = useCallback(
+    (result: ComprehensionResult) => {
+      setSession((prev) => (prev ? { ...prev, comprehensionResult: result } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'comprehension',
+          currentStep: 'vocab-word-search',
+          stepDataPatch: {
+            comprehension: { result },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['vocab-word-search']);
+      navigateAfterFinish('vocab-word-search');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setSession],
+  );
+
+  const handleFinishVocab = useCallback(
+    (result: VocabResult) => {
+      setSession((prev) => (prev ? { ...prev, vocabResult: result } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'vocab',
+          currentStep: 'vocab-definition',
+          stepDataPatch: {
+            vocab: { result },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['vocab-definition']);
+      navigateAfterFinish('vocab-definition');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setSession],
+  );
+
+  const handleFinishDictation = useCallback(
+    (result: DictationResult) => {
+      setSession((prev) => (prev ? { ...prev, dictationResult: result } : null));
+      persistStep(STEP_PATH_TO_NUMBER['vocab-word-search']);
+      navigateAfterFinish('vocab-word-search');
+    },
+    [navigateAfterFinish, persistStep, setSession],
+  );
+
+  const handleFinishFullReading = useCallback(
+    (result: FullReadingResult) => {
+      setSession((prev) => (prev ? { ...prev, fullReadingResult: result } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'full-reading',
+          stepDataPatch: {
+            'full-reading': { result },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['listening']);
+      navigateAfterFinish('listening');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setSession],
+  );
+
+  const handleFinishListening = useCallback(
+    (result: ListeningResult) => {
+      persistStepProgressState(
+        {
+          completeStep: 'listening',
+          currentStep: 'vocab',
+          stepDataPatch: {
+            listening: { completed: true, score: result.score, feedback: result.feedback },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['vocab']);
+      navigateAfterFinish('vocab');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState],
+  );
+
+  const handleFinishReadingAnnotation = useCallback(
+    (_summary: AnnotationSummary) => {
+      setSession((prev) => (prev ? { ...prev, readingAnnotationCompleted: true } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'reading-annotation',
+          currentStep: 'tutor',
+          stepDataPatch: {
+            'reading-annotation': { completed: true },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['tutor']);
+      navigateAfterFinish('tutor');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setSession],
+  );
+
+  const handleFinishVocabDefinitionMatch = useCallback(
+    (result: VocabDefinitionMatchResult) => {
+      setSession((prev) => (prev ? { ...prev, vocabDefinitionMatchCompleted: true } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'vocab-definition',
+          currentStep: 'vocab-application',
+          stepDataPatch: {
+            'vocab-definition': { completed: true, result },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['vocab-application']);
+      navigateAfterFinish('vocab-application');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setSession],
+  );
+
+  const handleFinishVocabApplication = useCallback(
+    (_result: VocabApplicationResult) => {
+      setSession((prev) => (prev ? { ...prev, vocabApplicationCompleted: true } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'vocab-application',
+          currentStep: 'story-structure',
+          stepDataPatch: {
+            'vocab-application': { completed: true },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['story-structure']);
+      navigateAfterFinish('story-structure');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setSession],
+  );
+
+  const handleFinishStoryStructure = useCallback(
+    () => {
+      persistStepProgressState(
+        {
+          completeStep: 'story-structure',
+          currentStep: 'reading-strategy',
+          stepDataPatch: {
+            'story-structure': { completed: true },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['reading-strategy']);
+      navigateAfterFinish('reading-strategy');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState],
+  );
+
+  const handleFinishReadingStrategy = useCallback(
+    () => {
+      persistStepProgressState(
+        {
+          completeStep: 'reading-strategy',
+          currentStep: 'comprehension',
+          stepDataPatch: {
+            'reading-strategy': { completed: true },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['comprehension']);
+      navigateAfterFinish('comprehension');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState],
+  );
+
+  const handleFinishSentencePractice = useCallback(
+    () => {
+      persistStepProgressState(
+        {
+          completeStep: 'sentence-practice',
+          currentStep: 'vocab-definition',
+          stepDataPatch: {
+            'sentence-practice': { completed: true },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['sentence-practice']);
+      navigateAfterFinish('vocab-definition');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState],
+  );
+
+  const handleFinishVocabWordSearch = useCallback(
+    (_elapsedSeconds: number) => {
+      setSession((prev) => (prev ? { ...prev, vocabWordSearchCompleted: true } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'vocab-word-search',
+          currentStep: 'knowledge-station',
+          stepDataPatch: {
+            'vocab-word-search': { completed: true },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['knowledge-station']);
+      navigateAfterFinish('knowledge-station');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setSession],
+  );
+
+  const handleFinishKnowledgeStation = useCallback(
+    () => {
+      setSession((prev) => (prev ? { ...prev, knowledgeStationCompleted: true } : null));
+      persistStepProgressState(
+        {
+          completeStep: 'knowledge-station',
+          currentStep: 'report',
+          stepDataPatch: {
+            'knowledge-station': { completed: true },
+          },
+        },
+        true,
+      );
+      persistStep(STEP_PATH_TO_NUMBER['report']);
+      navigateAfterFinish('report');
+    },
+    [navigateAfterFinish, persistStep, persistStepProgressState, setSession],
+  );
+
+  const handleRetry = useCallback(() => {
+    clearPersistedSession();
+    setSession(null);
+    setLastAttempt(null);
+    setSelectedStory(null);
+    navigate(isToolboxMode() ? '/tools' : '/library');
+  }, [navigate, clearPersistedSession, setSession, setLastAttempt, setSelectedStory]);
+
+  const handleSessionComplete = useCallback(() => {
+    const assignmentIdStr = sessionStorage.getItem('activeAssignmentId');
+    const contextRaw = sessionStorage.getItem(ACTIVE_ASSIGNMENT_CONTEXT_KEY);
+
+    let shouldSubmit = false;
+    let assignmentId: number | null = null;
+    if (assignmentIdStr) {
+      const parsed = parseInt(assignmentIdStr, 10);
+      if (!isNaN(parsed)) assignmentId = parsed;
+    }
+
+    if (assignmentId != null && contextRaw && token && user && storyId) {
+      try {
+        const context = JSON.parse(contextRaw) as {
+          assignmentId?: number;
+          userId?: string | null;
+          storyKey?: string | null;
+        };
+        shouldSubmit = (
+          context.assignmentId === assignmentId
+          && String(context.userId ?? '') === String(user.id)
+          && String(context.storyKey ?? '') === String(storyId)
+          && isAssignmentReadyForSubmit
+        );
+      } catch {
+        shouldSubmit = false;
+      }
+    }
+
+    if (assignmentId != null && !shouldSubmit) {
+      return;
+    }
+
+    if (!hasActiveAssignment && storyId && dbSessionId !== null && token && !completionApiCalledRef.current) {
+      completionApiCalledRef.current = true;
+      completeSelfPracticeSession(dbSessionId, token).catch((err) => {
+        if (err instanceof SessionExpiredError) {
+          console.warn('[LearningLayout] completeSelfPracticeSession: token expired, session not marked complete in DB');
+        } else {
+          console.warn('[LearningLayout] completeSelfPracticeSession failed:', err);
+        }
+      });
+    }
+
+    if (sessionCompletedRef.current) return;
+    sessionCompletedRef.current = true;
+
+    if (!hasActiveAssignment && storyId) {
+      try {
+        localStorage.setItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${storyId}`, '1');
+      } catch {
+        // non-fatal
+      }
+    }
+
+    clearPersistedSession();
+
+    sessionStorage.removeItem('activeAssignmentId');
+    sessionStorage.removeItem('activeAssignmentGoals');
+    sessionStorage.removeItem(ACTIVE_ASSIGNMENT_CONTEXT_KEY);
+
+    if (shouldSubmit && token && assignmentId != null) {
+      submitAssignment(token, assignmentId).catch((err) => {
+        console.warn('[LearningLayout] Auto-submit assignment failed:', err);
+      });
+    }
+  }, [
+    clearPersistedSession,
+    token,
+    user,
+    storyId,
+    isAssignmentReadyForSubmit,
+    hasActiveAssignment,
+    dbSessionId,
+  ]);
+
+  const handleStepClick = useCallback(
+    (step: { id: string }) => {
+      if (!storyId) return;
+      persistStep(STEP_PATH_TO_NUMBER[step.id]);
+      navigate(`/learn/${storyId}/${step.id}`);
+    },
+    [navigate, persistStep, storyId],
+  );
+
+  const handleComplete = useCallback(() => {
+    handleSessionComplete();
+  }, [handleSessionComplete]);
+
+  const handleNextStep = useCallback(() => {
+    const current = window.location.pathname.split('/').filter(Boolean).at(-1);
+    const stepIds = Object.keys(STEP_PATH_TO_NUMBER);
+    const idx = current ? stepIds.indexOf(current) : -1;
+    const next = idx >= 0 ? stepIds[idx + 1] : null;
+    if (next) handleStepClick({ id: next });
+  }, [handleStepClick]);
+
+  const handlePrevStep = useCallback(() => {
+    const current = window.location.pathname.split('/').filter(Boolean).at(-1);
+    const stepIds = Object.keys(STEP_PATH_TO_NUMBER);
+    const idx = current ? stepIds.indexOf(current) : -1;
+    const prev = idx > 0 ? stepIds[idx - 1] : null;
+    if (prev) handleStepClick({ id: prev });
+  }, [handleStepClick]);
+
+  return {
+    handleStartReading,
+    handleFinishReading,
+    handleFinishComprehension,
+    handleFinishStoryStructure,
+    handleFinishReadingStrategy,
+    handleFinishVocab,
+    handleFinishDictation,
+    handleFinishFullReading,
+    handleFinishListening,
+    handleFinishReadingAnnotation,
+    handleFinishVocabDefinitionMatch,
+    handleFinishVocabApplication,
+    handleFinishSentencePractice,
+    handleFinishVocabWordSearch,
+    handleFinishKnowledgeStation,
+    handleRetry,
+    handleSessionComplete,
+    handleNextStep,
+    handlePrevStep,
+    handleComplete,
+    handleStepClick,
+  };
+}

--- a/frontend/src/hooks/useStepProgressPersistence.ts
+++ b/frontend/src/hooks/useStepProgressPersistence.ts
@@ -1,0 +1,365 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import type { AuthUser } from '../services/authApi';
+import { clearActiveSession, saveActiveSession } from '../services/api';
+import { resolveActiveSteps, STEP_PATH_TO_NUMBER } from '../config/stepConfig';
+import { useProgressSync } from './useProgressSync';
+import type { StepProgressData } from '../services/learningApi';
+import type {
+  ComprehensionResult,
+  FullReadingResult,
+  LearningSession,
+  ReadingAttempt,
+  Story,
+  VocabResult,
+} from '../types';
+import { scopedStepStorageKey } from '../services/learningStorageScope';
+
+const LEGACY_DB_SESSION_KEY_PREFIX = 'db-session-';
+const ASSIGNMENT_DB_SESSION_KEY_PREFIX = 'assignment-db-session-';
+const SELF_DB_SESSION_KEY_PREFIX = 'self-db-session-';
+
+const STEP_NUMBER_TO_PATH: Record<number, string> = Object.fromEntries(
+  Object.entries(STEP_PATH_TO_NUMBER).map(([path, n]) => [n, path]),
+);
+
+interface PersistStepProgressOptions {
+  currentStep?: string | null;
+  completeStep?: string;
+  stepDataPatch?: Record<string, unknown>;
+}
+
+interface SaveStepProgressPatchOptions {
+  stepId: string;
+  stepData: Record<string, unknown>;
+  currentStep?: string | null;
+  markCompleted?: boolean;
+  immediate?: boolean;
+}
+
+interface UseStepProgressPersistenceOptions {
+  storyId: string | undefined;
+  user: AuthUser | null;
+  token: string | null;
+  dbSessionId: number | null;
+  selectedStory: Story | null;
+  isAssignmentFlow: boolean;
+  setSession: Dispatch<SetStateAction<LearningSession | null>>;
+}
+
+interface UseStepProgressPersistenceReturn {
+  stepProgressState: StepProgressData;
+  persistStepProgressState: (opts: PersistStepProgressOptions, immediate: boolean) => void;
+  persistStep: (step: number) => void;
+  saveStepProgressPatch: (opts: SaveStepProgressPatchOptions) => void;
+  clearPersistedSession: () => void;
+  completedParagraphsSet: Set<number>;
+  setCompletedParagraphsSet: Dispatch<SetStateAction<Set<number>>>;
+  handleParagraphComplete: (paragraphIndex: number) => void;
+  lessonActiveSteps: ReturnType<typeof resolveActiveSteps>;
+  completedStepsSet: Set<string>;
+  missingAssignmentSteps: Array<{ id: string; label: string }>;
+  isAssignmentReadyForSubmit: boolean;
+  firstIncompleteStepPath: string;
+  hasActiveAssignment: boolean;
+  syncProgress: (data: StepProgressData) => void;
+  flushProgress: (data: StepProgressData) => void;
+}
+
+export function useStepProgressPersistence({
+  storyId,
+  user,
+  token,
+  dbSessionId,
+  selectedStory,
+  isAssignmentFlow,
+  setSession,
+}: UseStepProgressPersistenceOptions): UseStepProgressPersistenceReturn {
+  const activeDbSessionStorageKey = useMemo(() => {
+    if (!storyId) return null;
+    if (isAssignmentFlow) {
+      const assignmentId = sessionStorage.getItem('activeAssignmentId');
+      if (assignmentId) {
+        return `${ASSIGNMENT_DB_SESSION_KEY_PREFIX}${assignmentId}-${storyId}`;
+      }
+      return `${ASSIGNMENT_DB_SESSION_KEY_PREFIX}${storyId}`;
+    }
+    return `${SELF_DB_SESSION_KEY_PREFIX}${storyId}`;
+  }, [isAssignmentFlow, storyId]);
+
+  const tutorCompletedStorageKey = useMemo(() => {
+    if (!storyId) return null;
+    return scopedStepStorageKey('tutor_completed_', storyId);
+  }, [storyId, isAssignmentFlow]);
+
+  const liveTutorProgressStorageKey = useMemo(() => {
+    if (!storyId) return null;
+    return scopedStepStorageKey('liveTutor_progress_', storyId);
+  }, [storyId, isAssignmentFlow]);
+
+  const legacyDbSessionStorageKey = useMemo(() => {
+    if (!storyId) return null;
+    return `${LEGACY_DB_SESSION_KEY_PREFIX}${storyId}`;
+  }, [storyId]);
+
+  const [completedParagraphsSet, setCompletedParagraphsSet] = useState<Set<number>>(() => {
+    const scopedTutorKey = storyId ? scopedStepStorageKey('tutor_completed_', storyId) : null;
+    const scopedLiveTutorKey = storyId ? scopedStepStorageKey('liveTutor_progress_', storyId) : null;
+    try {
+      const raw = scopedTutorKey ? localStorage.getItem(scopedTutorKey) : null;
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && (parsed as number[]).length > 0) {
+          return new Set<number>(parsed as number[]);
+        }
+      }
+    } catch {
+      // Non-fatal — continue to fallback
+    }
+    try {
+      const liveTutorRaw = scopedLiveTutorKey ? localStorage.getItem(scopedLiveTutorKey) : null;
+      if (liveTutorRaw) {
+        const liveTutorParsed = JSON.parse(liveTutorRaw) as {
+          completedParagraphs?: unknown;
+        };
+        if (
+          Array.isArray(liveTutorParsed.completedParagraphs) &&
+          (liveTutorParsed.completedParagraphs as number[]).length > 0
+        ) {
+          return new Set<number>(liveTutorParsed.completedParagraphs as number[]);
+        }
+      }
+    } catch {
+      // Non-fatal — start fresh
+    }
+    return new Set<number>();
+  });
+
+  const [stepProgressState, setStepProgressState] = useState<StepProgressData>({
+    current_step: null,
+    steps_completed: [],
+    step_data: {},
+  });
+
+  const lessonActiveSteps = useMemo(
+    () => resolveActiveSteps(selectedStory?.stepSequence),
+    [selectedStory?.stepSequence],
+  );
+
+  const requiredAssignmentSteps = useMemo(
+    () => lessonActiveSteps.filter((s) => s.id !== 'report').map((s) => ({ id: s.id, label: s.label })),
+    [lessonActiveSteps],
+  );
+  const completedStepsSet = useMemo(
+    () => new Set(stepProgressState.steps_completed ?? []),
+    [stepProgressState.steps_completed],
+  );
+  const missingAssignmentSteps = useMemo(
+    () => requiredAssignmentSteps.filter((s) => !completedStepsSet.has(s.id)),
+    [requiredAssignmentSteps, completedStepsSet],
+  );
+  const isAssignmentReadyForSubmit = missingAssignmentSteps.length === 0;
+  const firstIncompleteStepPath = missingAssignmentSteps[0]?.id ?? 'reading-annotation';
+  const hasActiveAssignment = useMemo(() => {
+    try {
+      return isAssignmentFlow;
+    } catch {
+      return false;
+    }
+  }, [isAssignmentFlow]);
+
+  const { syncProgress, flushProgress } = useProgressSync({
+    token: token ?? null,
+    dbSessionId,
+    onProgressLoaded: (data) => {
+      const loadedCompleted = Array.isArray(data.steps_completed) ? data.steps_completed : [];
+      const loadedStepData = (data.step_data ?? {}) as Record<string, unknown>;
+
+      setStepProgressState({
+        current_step: data.current_step ?? null,
+        steps_completed: loadedCompleted,
+        step_data: loadedStepData,
+      });
+
+      if (loadedStepData.tutor) {
+        const tutorData = loadedStepData.tutor as Record<string, unknown>;
+        const completedIdxs = tutorData.completedParagraphs;
+        if (Array.isArray(completedIdxs)) {
+          setCompletedParagraphsSet(new Set(completedIdxs as number[]));
+        }
+      }
+
+      setSession((prev) => {
+        if (!prev) return prev;
+        const tutorData = (loadedStepData.tutor ?? {}) as Record<string, unknown>;
+        const fullReadingData = (loadedStepData['full-reading'] ?? {}) as Record<string, unknown>;
+        const vocabData = (loadedStepData.vocab ?? {}) as Record<string, unknown>;
+        const comprehensionData = (loadedStepData.comprehension ?? {}) as Record<string, unknown>;
+        const readingAnnotationData = (loadedStepData['reading-annotation'] ?? {}) as Record<string, unknown>;
+        const vocabDefinitionData = (loadedStepData['vocab-definition'] ?? {}) as Record<string, unknown>;
+        const vocabApplicationData = (loadedStepData['vocab-application'] ?? {}) as Record<string, unknown>;
+        const vocabWordSearchData = (loadedStepData['vocab-word-search'] ?? {}) as Record<string, unknown>;
+        const knowledgeStationData = (loadedStepData['knowledge-station'] ?? {}) as Record<string, unknown>;
+
+        return {
+          ...prev,
+          completedSteps: loadedCompleted,
+          readingAttempt: (tutorData.readingAttempt as ReadingAttempt | undefined) ?? prev.readingAttempt,
+          fullReadingResult: (fullReadingData.result as FullReadingResult | undefined) ?? prev.fullReadingResult,
+          vocabResult: (vocabData.result as VocabResult | undefined) ?? prev.vocabResult,
+          comprehensionResult: (comprehensionData.result as ComprehensionResult | undefined) ?? prev.comprehensionResult,
+          readingAnnotationCompleted:
+            (readingAnnotationData.completed as boolean | undefined) ?? loadedCompleted.includes('reading-annotation') ?? prev.readingAnnotationCompleted,
+          vocabDefinitionMatchCompleted:
+            (vocabDefinitionData.completed as boolean | undefined) ?? loadedCompleted.includes('vocab-definition') ?? prev.vocabDefinitionMatchCompleted,
+          vocabApplicationCompleted:
+            (vocabApplicationData.completed as boolean | undefined) ?? loadedCompleted.includes('vocab-application') ?? prev.vocabApplicationCompleted,
+          vocabWordSearchCompleted:
+            (vocabWordSearchData.completed as boolean | undefined) ?? loadedCompleted.includes('vocab-word-search') ?? prev.vocabWordSearchCompleted,
+          knowledgeStationCompleted:
+            (knowledgeStationData.completed as boolean | undefined) ?? loadedCompleted.includes('knowledge-station') ?? prev.knowledgeStationCompleted,
+        };
+      });
+    },
+  });
+
+  const persistStepProgressState = useCallback(
+    (opts: PersistStepProgressOptions, immediate: boolean) => {
+      setStepProgressState((prev) => {
+        const completed = new Set<string>(prev.steps_completed);
+        if (opts.completeStep) completed.add(opts.completeStep);
+
+        const next: StepProgressData = {
+          current_step: opts.currentStep ?? prev.current_step,
+          steps_completed: Array.from(completed),
+          step_data: {
+            ...prev.step_data,
+            ...(opts.stepDataPatch ?? {}),
+          },
+        };
+
+        const prevSig = JSON.stringify(prev);
+        const nextSig = JSON.stringify(next);
+        if (prevSig === nextSig) {
+          return prev;
+        }
+
+        if (immediate) {
+          flushProgress(next);
+        } else {
+          syncProgress(next);
+        }
+
+        setSession((prevSession) => {
+          if (!prevSession) return prevSession;
+          return {
+            ...prevSession,
+            completedSteps: Array.from(completed),
+          };
+        });
+        return next;
+      });
+    },
+    [flushProgress, syncProgress, setSession],
+  );
+
+  const saveStepProgressPatch = useCallback(
+    (opts: SaveStepProgressPatchOptions) => {
+      persistStepProgressState(
+        {
+          currentStep: opts.currentStep,
+          completeStep: opts.markCompleted ? opts.stepId : undefined,
+          stepDataPatch: {
+            [opts.stepId]: {
+              ...opts.stepData,
+            },
+          },
+        },
+        opts.immediate ?? false,
+      );
+    },
+    [persistStepProgressState],
+  );
+
+  const persistStep = useCallback(
+    (step: number) => {
+      if (!user || !storyId) return;
+      saveActiveSession(String(user.id), {
+        sessionId: 0,
+        storyId,
+        currentStep: step,
+        timestamp: Date.now(),
+      });
+      persistStepProgressState(
+        { currentStep: STEP_NUMBER_TO_PATH[step] ?? null },
+        false,
+      );
+    },
+    [user, storyId, persistStepProgressState],
+  );
+
+  const clearPersistedSession = useCallback(() => {
+    if (!user) return;
+    clearActiveSession(String(user.id));
+    if (activeDbSessionStorageKey) {
+      try { sessionStorage.removeItem(activeDbSessionStorageKey); } catch { /* non-fatal */ }
+    }
+    if (legacyDbSessionStorageKey) {
+      try { sessionStorage.removeItem(legacyDbSessionStorageKey); } catch { /* non-fatal */ }
+    }
+    if (tutorCompletedStorageKey) {
+      try { localStorage.removeItem(tutorCompletedStorageKey); } catch { /* non-fatal */ }
+    }
+    if (liveTutorProgressStorageKey) {
+      try { localStorage.removeItem(liveTutorProgressStorageKey); } catch { /* non-fatal */ }
+    }
+  }, [
+    user,
+    activeDbSessionStorageKey,
+    legacyDbSessionStorageKey,
+    tutorCompletedStorageKey,
+    liveTutorProgressStorageKey,
+  ]);
+
+  const handleParagraphComplete = useCallback((paragraphIndex: number) => {
+    setCompletedParagraphsSet((prev) => {
+      if (prev.has(paragraphIndex)) return prev;
+      const updated = new Set(prev);
+      updated.add(paragraphIndex);
+      if (tutorCompletedStorageKey) {
+        try {
+          localStorage.setItem(tutorCompletedStorageKey, JSON.stringify(Array.from(updated)));
+        } catch {
+          // Non-fatal — in-memory state still updated
+        }
+      }
+      return updated;
+    });
+    setSession((prev) => {
+      if (!prev) return prev;
+      const existing = new Set(prev.completedParagraphs ?? []);
+      if (existing.has(paragraphIndex)) return prev;
+      existing.add(paragraphIndex);
+      return { ...prev, completedParagraphs: Array.from(existing) };
+    });
+  }, [setSession, tutorCompletedStorageKey]);
+
+  return {
+    stepProgressState,
+    persistStepProgressState,
+    persistStep,
+    saveStepProgressPatch,
+    clearPersistedSession,
+    completedParagraphsSet,
+    setCompletedParagraphsSet,
+    handleParagraphComplete,
+    lessonActiveSteps,
+    completedStepsSet,
+    missingAssignmentSteps,
+    isAssignmentReadyForSubmit,
+    firstIncompleteStepPath,
+    hasActiveAssignment,
+    syncProgress,
+    flushProgress,
+  };
+}


### PR DESCRIPTION
Related to #1824

## Summary
Phase 1 of the LearningLayout refactor: extract 3 focused hooks from the 1236-line god component.

## Hooks extracted
| Hook | Responsibility | Lines |
|------|----------------|-------|
| `useLearningSessionBootstrap.ts` | Session bootstrap, mode detection (assignment/self/toolbox), DB session creation, loading/error | 292 |
| `useStepProgressPersistence.ts` | Step progress state, DB+localStorage persistence, clearPersistedSession, completedParagraphsSet, lessonActiveSteps | 365 |
| `useLearningStepNavigation.ts` | handleNextStep, handlePrevStep, handleComplete, assignment completion check | 520 |

## Phase 2 (remaining)
LearningLayout.tsx still has original code (1236 lines). Phase 2 requires wiring the 3 hooks into LearningLayout to reduce to <600 lines — tracked in #1824, needs careful integration testing.

## Test plan
- [x] All 3 hooks typecheck (0 new TS errors)
- [x] Vite build passes (6.85s)
- [ ] CI frontend deploy green
- [ ] Preview frontend loads without regression