### PR TITLE
refactor(zhuyin): split polyphonicProcessor.ts into 4 pure modules (Fixes #1843)

### DIFF
--- a/frontend/src/components/zhuyin/polyphonicPatternMatcher.ts
+++ b/frontend/src/components/zhuyin/polyphonicPatternMatcher.ts
@@ -1,0 +1,174 @@
+import type { PolyphonicData } from './bopomoConstants';
+
+const CHINESE_CHAR_REGEX = /[\u4e00-\u9fa5]/;
+
+/** Special set of three-char phrases ending with 地 that should read de5 */
+const PHRASES_ENDS_WITH_DI = new Set([
+  '一十地', '大方地', '大聲地', '小心地', '小聲地', '不休地', '不安地',
+  '不倦地', '不停地', '不堪地', '不絕地', '不諱地', '不斷地', '亢奮地',
+  '仔細地', '叨叨地', '可憐地', '巧妙地', '平整地', '正當地', '正經地',
+  '生氣地', '生動地', '示弱地', '交替地', '吁吁地', '合適地', '吐吐地',
+  '如實地', '安靜地', '忙碌地', '成功地', '有味地', '有效地', '自主地',
+  '自由地', '自在地', '自信地', '自然地', '下氣地', '低聲地', '克難地',
+  '冷漠地', '吾吾地', '均勻地', '完整地', '忘我地', '快速地', '快樂地',
+  '抖擻地', '決然地', '牢固地', '狂暴地', '狂熱地', '甫定地', '迅速地',
+  '屈膝地', '周到地', '呱呱地', '和藹地', '坦率地', '委婉地', '怯步地',
+  '所能地', '易舉地', '虎嚥地', '采烈地', '勇敢地', '思索地', '急速地',
+  '筍般地', '耐心地', '重複地', '飛快地', '容易地', '恣意地', '悄悄地',
+  '特別地', '特定地', '真實地', '秘密地', '虔誠地', '究柢地', '高興地',
+  '乾脆地', '停蹄地', '偷偷地', '堅定地', '堅強地', '堅毅地', '專注地',
+  '康康地', '強烈地', '得意地', '悠悠地', '悠揚地', '悠閒地', '情願地',
+  '授權地', '敏感地', '敏銳地', '淡寫地', '深刻地', '深深地', '清楚地',
+  '甜甜地', '細心地', '許可地', '尊敬地', '悲傷地', '惺忪地', '愉快地',
+  '無私地', '無償地', '猶豫地', '痛苦地', '絮絮地', '間斷地', '意外地',
+  '意料地', '準確地', '溫柔地', '煞氣地', '痴痴地', '經意地', '詳細地',
+  '誠意地', '誠懇地', '嘆氣地', '慢慢地', '慣性地', '漂亮地', '漸漸地',
+  '瘋狂地', '盡力地', '盡瘁地', '緊緊地', '輕盈地', '輕微地', '輕輕地',
+  '輕聲地', '遠遠地', '嘩啦地', '熟慮地', '熟練地', '熱心地', '熱情地',
+  '範圍地', '緩慢地', '緩緩地', '踏實地', '整齊地', '激動地', '興奮地',
+  '諱言地', '錯誤地', '隨意地', '靜靜地', '靦腆地', '默默地', '優雅地',
+  '翼翼地', '闊步地', '禮貌地', '簡單地', '謹慎地', '穩固地', '穩穩地',
+  '嚴厲地', '歡快地', '驕傲地', '驚恐地', '靈活地', '究底地', '大大地',
+]);
+
+/**
+ * Match polyphonic patterns for a character.
+ * Returns [matchIndex, skipNext, skipPrev]
+ */
+export function matchPolyphonicPattern(
+  character: string,
+  index: number,
+  patterns: string[],
+  text: string[],
+  skipPrev: boolean,
+  polyphonicData: PolyphonicData,
+): [number, boolean, boolean] {
+  let defaultIndex = -1;
+  const prev2Char = index > 1 ? text[index - 2] : '';
+  const prevChar = index > 0 ? text[index - 1] : '';
+  const threeCharPhrase = prev2Char + prevChar + character;
+  const nextChar = index + 1 < text.length ? text[index + 1] : '';
+  const isFirstChar = prevChar === '' || !isChineseCharacter(prevChar);
+  const isLastChar = nextChar === '' || !isChineseCharacter(nextChar);
+  const isStandalone = text.length === 1 || (isFirstChar && isLastChar);
+  let skipNext = false;
+
+  if (isStandalone) {
+    return [0, false, true];
+  }
+
+  // Special handle for '地' with 'de5' sound
+  if (character === '地') {
+    if (PHRASES_ENDS_WITH_DI.has(threeCharPhrase)) {
+      return [1, false, true]; // de5
+    } else {
+      return [0, false, true]; // di4
+    }
+  }
+
+  // Special handle for '著' (著作權)
+  if (character === '著') {
+    const secondLine = patterns.length > 1 ? patterns[1] : '';
+    if (index >= 0 && index + 2 < text.length) {
+      const prefix = character + text[index + 1] + text[index + 2];
+      if (prefix === '著作權') {
+        return [patterns.indexOf(secondLine), false, false];
+      }
+    }
+  }
+
+  // First pass: Checking all patterns for "any+*" or "any+*+any"
+  if (!isFirstChar && !skipPrev) {
+    for (let j = 0; j < patterns.length; j++) {
+      const combinedPattern = patterns[j];
+      const subPatterns = combinedPattern.split('/');
+
+      for (const pattern of subPatterns) {
+        if (pattern === '') {
+          defaultIndex = j;
+          continue;
+        }
+        if (pattern.startsWith('*')) continue; // Skip patterns starting with '*' in first pass
+        const pos = pattern.indexOf('*');
+        if (pos === -1) continue;
+
+        const start = index - pos;
+        const end = index - pos + pattern.length;
+        if (start < 0 || end > text.length) continue;
+
+        if (matchPattern(pattern, pos, start, end, text, character)) {
+          return [j, false, true];
+        }
+      }
+    }
+  }
+
+  // Second pass: Checking patterns for "*+any"
+  if (!isLastChar) {
+    for (let j = 0; j < patterns.length; j++) {
+      const combinedPattern = patterns[j];
+      const subPatterns = combinedPattern.split('/');
+
+      for (const pattern of subPatterns) {
+        if (pattern === '') {
+          defaultIndex = j;
+          continue;
+        }
+        if (!pattern.startsWith('*')) continue; // Only patterns starting with '*' in second pass
+        const pos = pattern.indexOf('*');
+        if (pos === -1) continue;
+
+        const start = index - pos;
+        const end = index - pos + pattern.length;
+        if (start < 0 || end > text.length) continue;
+
+        if (matchPattern(pattern, pos, start, end, text, character)) {
+          if (isPolyphonicChar(nextChar, polyphonicData)) {
+            skipNext = false;
+            skipPrev = false;
+          } else {
+            skipPrev = true;
+            skipNext = pattern.startsWith('*') && pos === 0;
+          }
+          if (isPolyphonicChar(nextChar, polyphonicData)) {
+            skipNext = false;
+            skipPrev = false;
+          } else {
+            skipPrev = true;
+            skipNext = pattern.startsWith('*') && pos === 0;
+          }
+          return [j, skipNext, skipPrev];
+        }
+      }
+    }
+  }
+
+  return [defaultIndex, false, false];
+}
+
+/** Check if a character is in the polyphonic data */
+function isPolyphonicChar(character: string, polyphonicData: PolyphonicData): boolean {
+  if (!isChineseCharacter(character)) return false;
+  return character in polyphonicData.data;
+}
+
+/** Match a pattern against text around the character position */
+function matchPattern(
+  pattern: string,
+  _pos: number,
+  start: number,
+  end: number,
+  text: string[],
+  character: string,
+): boolean {
+  let tmp = '';
+  for (let z = start; z < end; z++) {
+    tmp += text[z];
+  }
+  return tmp === pattern.replaceAll('*', character);
+}
+
+/** Check if a single character is a CJK unified ideograph */
+export function isChineseCharacter(char: string): boolean {
+  return CHINESE_CHAR_REGEX.test(char);
+}

--- a/frontend/src/components/zhuyin/polyphonicProcessor.test.ts
+++ b/frontend/src/components/zhuyin/polyphonicProcessor.test.ts
@@ -304,3 +304,232 @@ describe('一 tone sandhi regression tests (Issue #638)', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// 不 tone sandhi characterization tests (Issue #1843)
+// ---------------------------------------------------------------------------
+//
+// 不 tone sandhi rules:
+//   Before 4th tone → 2nd tone (ss01)  e.g. 不是 bú shì
+//   Before 1st/2nd/3rd/5th tone → remain 4th tone (0000)  e.g. 不知 bù zhī
+//   Special phrases: 不禁/不菲/不勝/不著/不了/不好/不假 → 0000 (unchanged)
+//   Special phrase: 不當 → ss01 (2nd tone)
+//   Standalone → 0000 (4th tone)
+
+describe('不 tone sandhi characterization tests (Issue #1843)', () => {
+  let proc: import('./polyphonicProcessor').PolyphonicProcessor;
+
+  beforeAll(async () => {
+    const { PolyphonicProcessor } = await import('./polyphonicProcessor');
+    (PolyphonicProcessor as unknown as { _instance: unknown })._instance = undefined;
+    proc = PolyphonicProcessor.instance;
+    (proc as unknown as { polyphonicData: unknown; _loaded: boolean }).polyphonicData = { data: {} };
+    (proc as unknown as { _loaded: boolean })._loaded = true;
+  });
+
+  const ssOfBu = (text: string) =>
+    proc.process(text).find(c => c.char === '不')?.styleSet;
+
+  it('standalone 不 → 0000 (4th tone)', () => {
+    expect(ssOfBu('不')).toBe('0000');
+  });
+
+  it('不是 → 0000 (是 is 4th tone but nextTone=4 → ss01, BUT 是 is in nextCharSet1 check? No — let test document actual)', () => {
+    // 是 is in nextCharSet1, so 一 before 是 is special-cased.
+    // For 不, we check specialBuCases first (是 not in it), then nextTone.
+    // getToneForChar('是') = 4, so → ss01
+    expect(getToneForChar('是')).toBe(4);
+    expect(ssOfBu('不是')).toBe('ss01');
+  });
+
+  it('不知 → 0000 (知 is 1st tone → remain 4th)', () => {
+    expect(getToneForChar('知')).toBe(1);
+    expect(ssOfBu('不知')).toBe('0000');
+  });
+
+  it('不同 → 0000 (同 is 2nd tone → remain 4th)', () => {
+    expect(getToneForChar('同')).toBe(2);
+    expect(ssOfBu('不同')).toBe('0000');
+  });
+
+  it('不好 → 0000 (specialBuCases: 好 → 0000)', () => {
+    expect(ssOfBu('不好')).toBe('0000');
+  });
+
+  it('不當 → ss01 (specialBuCases: 當 → ss01, 2nd tone)', () => {
+    expect(ssOfBu('不當')).toBe('ss01');
+  });
+
+  it('不禁 → 0000 (specialBuCases override)', () => {
+    expect(ssOfBu('不禁')).toBe('0000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 地 special phrase (de5) characterization tests (Issue #1843)
+// ---------------------------------------------------------------------------
+//
+// 地 is special-cased: PHRASES_ENDS_WITH_DI set determines de5 vs di4.
+// Three-char phrase = prev2Char + prevChar + '地'
+//   If phrase in PHRASES_ENDS_WITH_DI → ss01 (index=1, de5)
+//   Otherwise → 0000 (index=0, di4, the default)
+
+describe('地 de5/di4 characterization tests (Issue #1843)', () => {
+  let proc: import('./polyphonicProcessor').PolyphonicProcessor;
+
+  beforeAll(async () => {
+    const { PolyphonicProcessor } = await import('./polyphonicProcessor');
+    (PolyphonicProcessor as unknown as { _instance: unknown })._instance = undefined;
+    proc = PolyphonicProcessor.instance;
+    (proc as unknown as { polyphonicData: unknown; _loaded: boolean }).polyphonicData = {
+      data: {
+        '地': { s: 2, v: ['', '成功*'] },
+      },
+    };
+    (proc as unknown as { _loaded: boolean })._loaded = true;
+  });
+
+  it('大地 → 0000 (di4, not in PHRASES_ENDS_WITH_DI)', () => {
+    const result = proc.process('大地');
+    expect(result.find(c => c.char === '地')?.styleSet).toBe('0000');
+  });
+
+  it('快樂地 → ss01 (de5, in PHRASES_ENDS_WITH_DI)', () => {
+    const result = proc.process('快樂地');
+    expect(result.find(c => c.char === '地')?.styleSet).toBe('ss01');
+  });
+
+  it('靜靜地 → ss01 (de5, in PHRASES_ENDS_WITH_DI)', () => {
+    const result = proc.process('靜靜地');
+    expect(result.find(c => c.char === '地')?.styleSet).toBe('ss01');
+  });
+
+  it('走在地上 → 0000 (di4, 在地 not in PHRASES_ENDS_WITH_DI)', () => {
+    // prev2=在, prevChar=地, but we look at char=地: prev2=走, prevChar=在
+    // threeCharPhrase = '走在地' — not in set
+    const result = proc.process('走在地上');
+    expect(result.find(c => c.char === '地')?.styleSet).toBe('0000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// double-character special pairs characterization tests (Issue #1843)
+// ---------------------------------------------------------------------------
+//
+// SPECIAL_DOUBLE_CHARACTERS: pair → styleSet
+// Both chars in the pair get the SAME styleSet (or 0000 when ss00).
+// Context overrides exist for some pairs.
+
+describe('double-character special pairs (Issue #1843)', () => {
+  let proc: import('./polyphonicProcessor').PolyphonicProcessor;
+
+  beforeAll(async () => {
+    const { PolyphonicProcessor } = await import('./polyphonicProcessor');
+    (PolyphonicProcessor as unknown as { _instance: unknown })._instance = undefined;
+    proc = PolyphonicProcessor.instance;
+    (proc as unknown as { polyphonicData: unknown; _loaded: boolean }).polyphonicData = {
+      data: {
+        '重': { s: 2, v: ['', ''] },
+        '行': { s: 4, d: 1, v: ['流*', '銀*', '品*', '**如也'] },
+        '好': { s: 2, v: ['', ''] },
+        '數': { s: 2, v: ['', ''] },
+        '晃': { s: 2, v: ['', ''] },
+      },
+    };
+    (proc as unknown as { _loaded: boolean })._loaded = true;
+  });
+
+  it('重重 → both chars get ss01 (SPECIAL_DOUBLE_CHARACTERS default)', () => {
+    const result = proc.process('重重');
+    expect(result[0].char).toBe('重');
+    expect(result[0].styleSet).toBe('ss01');
+    expect(result[1].char).toBe('重');
+    expect(result[1].styleSet).toBe('ss01');
+  });
+
+  it('重重的 → both chars get 0000 (context override: nextChar=的)', () => {
+    const result = proc.process('重重的');
+    expect(result[0].char).toBe('重');
+    expect(result[0].styleSet).toBe('0000');
+    expect(result[1].char).toBe('重');
+    expect(result[1].styleSet).toBe('0000');
+  });
+
+  it('好好 → both chars get 0000 (ss00 in map → renders as 0000)', () => {
+    const result = proc.process('好好');
+    expect(result[0].char).toBe('好');
+    expect(result[0].styleSet).toBe('0000');
+    expect(result[1].char).toBe('好');
+    expect(result[1].styleSet).toBe('0000');
+  });
+
+  it('數數 → both chars get ss01', () => {
+    const result = proc.process('數數');
+    expect(result[0].char).toBe('數');
+    expect(result[0].styleSet).toBe('ss01');
+    expect(result[1].char).toBe('數');
+    expect(result[1].styleSet).toBe('ss01');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildZhuyinString PUA selector characterization tests (Issue #1843)
+// ---------------------------------------------------------------------------
+//
+// buildZhuyinString appends a PUA variant selector for non-default style sets.
+// Only ss01–ss05 trigger PUA (SS_MAPPING). '0000' = no selector appended.
+
+import { buildZhuyinString } from './polyphonicProcessor';
+import { SS_MAPPING } from './bopomoConstants';
+
+describe('buildZhuyinString PUA selector (Issue #1843)', () => {
+  it('0000 styleSet → no PUA selector appended', () => {
+    const result = buildZhuyinString([{ char: '行', styleSet: '0000' }]);
+    expect(result).toBe('行');
+    expect(result.length).toBe(1);
+  });
+
+  it('ss01 styleSet → PUA selector E01E1 appended after char', () => {
+    const result = buildZhuyinString([{ char: '行', styleSet: 'ss01' }]);
+    // U+E01E1 is above U+FFFF → surrogate pair (2 UTF-16 code units)
+    // result.length = 1 (行) + 2 (surrogate pair for U+E01E1) = 3
+    expect(result.length).toBe(3);
+    expect(result[0]).toBe('行');
+    expect(result.codePointAt(1)).toBe(parseInt(SS_MAPPING['ss01'], 16));
+  });
+
+  it('ss02 styleSet → PUA selector E01E2 appended', () => {
+    const result = buildZhuyinString([{ char: '著', styleSet: 'ss02' }]);
+    // U+E01E2 → surrogate pair → length 3
+    expect(result.length).toBe(3);
+    expect(result.codePointAt(1)).toBe(parseInt(SS_MAPPING['ss02'], 16));
+  });
+
+  it('mixed: 0000 + ss01 + 0000 → only middle char gets PUA', () => {
+    const result = buildZhuyinString([
+      { char: '銀', styleSet: '0000' },
+      { char: '行', styleSet: 'ss01' },
+      { char: '家', styleSet: '0000' },
+    ]);
+    // 銀(1) + 行(1) + PUA(1) + 家(1) = 4 code units
+    // But PUA is in supplementary plane (U+E01E1), so it's 2 UTF-16 code units
+    // result.length = 1 + 1 + 2 + 1 = 5? No: U+E01E1 is BMP? 0xE01E1 > 0xFFFF → surrogate pair → 2 code units
+    // Actually let's use codePointAt to verify
+    expect(result).toContain('銀');
+    expect(result).toContain('行');
+    expect(result).toContain('家');
+    // 銀 has no PUA
+    const yinIdx = result.indexOf('銀');
+    expect(result.codePointAt(yinIdx + 1)).toBe('行'.codePointAt(0)); // next is 行, not PUA
+    // 行 has PUA selector
+    const hangIdx = result.indexOf('行');
+    expect(result.codePointAt(hangIdx + 1)).toBe(parseInt(SS_MAPPING['ss01'], 16));
+  });
+
+  it('unknown styleSet (not in SS_MAPPING) → no PUA appended (graceful)', () => {
+    // 'ss00' is used internally as sentinel but not in SS_MAPPING
+    const result = buildZhuyinString([{ char: '行', styleSet: 'ss00' }]);
+    expect(result).toBe('行');
+    expect(result.length).toBe(1);
+  });
+});

--- a/frontend/src/components/zhuyin/polyphonicProcessor.ts
+++ b/frontend/src/components/zhuyin/polyphonicProcessor.ts
@@ -11,10 +11,12 @@
  *   - ButTaiwan/bpmfvs (bopomofo processing methods)
  */
 
-import { SS_MAPPING, ProcessedChar, PolyphonicData } from './bopomoConstants';
+import { ProcessedChar, PolyphonicData } from './bopomoConstants';
+import { matchPolyphonicPattern, isChineseCharacter } from './polyphonicPatternMatcher';
+import { variantIndexToStyleSet } from './styleSetMapper';
+import { getNewToneForYiBu } from './toneSandhi';
 import { getToneForChar } from './toneData';
-
-const CHINESE_CHAR_REGEX = /[\u4e00-\u9fa5]/;
+export { buildZhuyinString } from './zhuyinStringBuilder';
 
 /**
  * Singleton polyphonic processor.
@@ -104,306 +106,6 @@ export class PolyphonicProcessor {
       }
     }
     return filtered;
-  }
-
-  // ---------------------------------------------------------------------------
-  //  Tone sandhi for 一 and 不
-  // ---------------------------------------------------------------------------
-
-  /**
-   * 以下處理一、不的方法是基於 jeffreyxuan 的原始碼
-   * https://github.com/jeffreyxuan/toneoz-font-zhuyin/blob/main/src/js/ybtone.js
-   * 同時也請參考教育部國語辭典說明：https://dict.concised.moe.edu.tw/page.jsp?ID=55
-   *
-   * Returns [newSs, skipNext, skipPrev]
-   */
-  private getNewToneForYiBu(
-    prevChar: string | null,
-    currentChar: string,
-    nextChar: string | null,
-    prevTone: number | null,
-    nextTone: number | null,
-    skipPrev: boolean,
-  ): [string, boolean, boolean] {
-    const prevCharSet1 = new Set([
-      '第', '説', '说', '唯', '惟', '统', '統', '独', '獨', '劃', '划', '萬', '專', '某',
-      '十', '九', '八', '七', '六', '五', '四', '三', '二', '一', '〇', '零',
-    ]);
-
-    const nextCharSet1 = new Set([
-      '是', '日', '月', '的', '或', '物', '片', '系',
-      '十', '九', '八', '七', '六', '五', '四', '三', '二', '一', '〇', '零', '百', '千', '萬',
-      '元', '則', '節', '台', '同', '名', '回', '堂', '層', '幅', '幢', '年', '息', '成', '排',
-      '提', '搏', '擊', '擲', '旁', '時', '枚', '格', '條', '樓', '流', '環', '篇', '級', '群',
-      '言', '連', '門', '間',
-      '天', '經', '方', '對', '次', '家', '鳴', '命', '份', '件', '尊', '聲', '歲', '副', '本', '批',
-    ]);
-
-    // specialYiCases: nextChar → [newSs, skipNext, skipPrev]
-    const specialYiCases: Record<string, [string, boolean, boolean]> = {
-      '個': ['0000', false, false],
-      '个': ['0000', false, false],
-      '會': ['0000', false, false],
-      '切': ['0000', false, false],
-      '不': ['0000', true, true],
-    };
-
-    const specialBuCases: Record<string, [string, boolean, boolean]> = {
-      '禁': ['0000', false, false],
-      '菲': ['0000', false, false],
-      '勝': ['0000', false, false],
-      '著': ['0000', false, false],
-      '了': ['0000', false, false],
-      '好': ['0000', false, false],
-      '假': ['0000', false, false],
-      '當': ['ss01', false, false],
-    };
-
-    if (currentChar === '一') {
-      if (!skipPrev && (prevChar == null || prevCharSet1.has(prevChar))) {
-        return ['0000', false, true];
-      } else if (nextChar != null && nextChar in specialYiCases) {
-        return specialYiCases[nextChar]!;
-      } else if (nextChar == null || nextChar === '' || nextCharSet1.has(nextChar)) {
-        return ['0000', true, true];
-      } else if (prevChar === nextChar ||
-          ['看', '聽', '寫', '用', '說', '動', '搖', '問'].includes(nextChar ?? '')) {
-        return ['0000', true, true];
-      } else if (nextTone != null && (nextTone === 1 || nextTone === 2 || nextTone === 3)) {
-        return ['ss02', true, true]; // Fourth tone
-      } else if (nextTone != null && nextTone === 4) {
-        return ['ss01', true, true]; // Second tone
-      } else {
-        return ['0000', false, true];
-      }
-    } else if (currentChar === '不') {
-      if (nextChar != null && nextChar in specialBuCases) {
-        return specialBuCases[nextChar]!;
-      }
-      if (nextTone != null && (nextTone === 1 || nextTone === 2 || nextTone === 3 || nextTone === 5)) {
-        return ['0000', false, true]; // Remain 四聲
-      } else if (nextTone != null && nextTone === 4) {
-        return ['ss01', true, true]; // Change to second tone
-      } else {
-        return ['0000', false, true];
-      }
-    }
-
-    return ['0000', false, false]; // Default case
-  }
-
-  // ---------------------------------------------------------------------------
-  //  Pattern matching for polyphonic characters
-  // ---------------------------------------------------------------------------
-
-  /** Special set of three-char phrases ending with 地 that should read de5 */
-  private static readonly PHRASES_ENDS_WITH_DI = new Set([
-    '一十地', '大方地', '大聲地', '小心地', '小聲地', '不休地', '不安地',
-    '不倦地', '不停地', '不堪地', '不絕地', '不諱地', '不斷地', '亢奮地',
-    '仔細地', '叨叨地', '可憐地', '巧妙地', '平整地', '正當地', '正經地',
-    '生氣地', '生動地', '示弱地', '交替地', '吁吁地', '合適地', '吐吐地',
-    '如實地', '安靜地', '忙碌地', '成功地', '有味地', '有效地', '自主地',
-    '自由地', '自在地', '自信地', '自然地', '下氣地', '低聲地', '克難地',
-    '冷漠地', '吾吾地', '均勻地', '完整地', '忘我地', '快速地', '快樂地',
-    '抖擻地', '決然地', '牢固地', '狂暴地', '狂熱地', '甫定地', '迅速地',
-    '屈膝地', '周到地', '呱呱地', '和藹地', '坦率地', '委婉地', '怯步地',
-    '所能地', '易舉地', '虎嚥地', '采烈地', '勇敢地', '思索地', '急速地',
-    '筍般地', '耐心地', '重複地', '飛快地', '容易地', '恣意地', '悄悄地',
-    '特別地', '特定地', '真實地', '秘密地', '虔誠地', '究柢地', '高興地',
-    '乾脆地', '停蹄地', '偷偷地', '堅定地', '堅強地', '堅毅地', '專注地',
-    '康康地', '強烈地', '得意地', '悠悠地', '悠揚地', '悠閒地', '情願地',
-    '授權地', '敏感地', '敏銳地', '淡寫地', '深刻地', '深深地', '清楚地',
-    '甜甜地', '細心地', '許可地', '尊敬地', '悲傷地', '惺忪地', '愉快地',
-    '無私地', '無償地', '猶豫地', '痛苦地', '絮絮地', '間斷地', '意外地',
-    '意料地', '準確地', '溫柔地', '煞氣地', '痴痴地', '經意地', '詳細地',
-    '誠意地', '誠懇地', '嘆氣地', '慢慢地', '慣性地', '漂亮地', '漸漸地',
-    '瘋狂地', '盡力地', '盡瘁地', '緊緊地', '輕盈地', '輕微地', '輕輕地',
-    '輕聲地', '遠遠地', '嘩啦地', '熟慮地', '熟練地', '熱心地', '熱情地',
-    '範圍地', '緩慢地', '緩緩地', '踏實地', '整齊地', '激動地', '興奮地',
-    '諱言地', '錯誤地', '隨意地', '靜靜地', '靦腆地', '默默地', '優雅地',
-    '翼翼地', '闊步地', '禮貌地', '簡單地', '謹慎地', '穩固地', '穩穩地',
-    '嚴厲地', '歡快地', '驕傲地', '驚恐地', '靈活地', '究底地', '大大地',
-  ]);
-
-  /**
-   * Match polyphonic patterns for a character.
-   * Returns [matchIndex, skipNext, skipPrev]
-   */
-  private match(
-    character: string,
-    index: number,
-    patterns: string[],
-    text: string[],
-    skipPrev: boolean = false,
-  ): [number, boolean, boolean] {
-    let defaultIndex = -1;
-    const prev2Char = index > 1 ? text[index - 2] : '';
-    const prevChar = index > 0 ? text[index - 1] : '';
-    const threeCharPhrase = prev2Char + prevChar + character;
-    const nextChar = index + 1 < text.length ? text[index + 1] : '';
-    const isFirstChar = prevChar === '' || !this.isChineseCharacter(prevChar);
-    const isLastChar = nextChar === '' || !this.isChineseCharacter(nextChar);
-    const isStandalone = text.length === 1 || (isFirstChar && isLastChar);
-    let skipNext = false;
-
-    if (isStandalone) {
-      return [0, false, true];
-    }
-
-    // Special handle for '地' with 'de5' sound
-    if (character === '地') {
-      if (PolyphonicProcessor.PHRASES_ENDS_WITH_DI.has(threeCharPhrase)) {
-        return [1, false, true]; // de5
-      } else {
-        return [0, false, true]; // di4
-      }
-    }
-
-    // Special handle for '著' (著作權)
-    if (character === '著') {
-      const secondLine = patterns.length > 1 ? patterns[1] : '';
-      if (index >= 0 && index + 2 < text.length) {
-        const prefix = character + text[index + 1] + text[index + 2];
-        if (prefix === '著作權') {
-          return [patterns.indexOf(secondLine), false, false];
-        }
-      }
-    }
-
-    // First pass: Checking all patterns for "any+*" or "any+*+any"
-    if (!isFirstChar && !skipPrev) {
-      for (let j = 0; j < patterns.length; j++) {
-        const combinedPattern = patterns[j];
-        const subPatterns = combinedPattern.split('/');
-
-        for (const pattern of subPatterns) {
-          if (pattern === '') {
-            defaultIndex = j;
-            continue;
-          }
-          if (pattern.startsWith('*')) continue; // Skip patterns starting with '*' in first pass
-          const pos = pattern.indexOf('*');
-          if (pos === -1) continue;
-
-          const start = index - pos;
-          const end = index - pos + pattern.length;
-          if (start < 0 || end > text.length) continue;
-
-          if (this.matchPattern(pattern, pos, start, end, text, character)) {
-            return [j, false, true];
-          }
-        }
-      }
-    }
-
-    // Second pass: Checking patterns for "*+any"
-    if (!isLastChar) {
-      for (let j = 0; j < patterns.length; j++) {
-        const combinedPattern = patterns[j];
-        const subPatterns = combinedPattern.split('/');
-
-        for (const pattern of subPatterns) {
-          if (pattern === '') {
-            defaultIndex = j;
-            continue;
-          }
-          if (!pattern.startsWith('*')) continue; // Only patterns starting with '*' in second pass
-          const pos = pattern.indexOf('*');
-          if (pos === -1) continue;
-
-          const start = index - pos;
-          const end = index - pos + pattern.length;
-          if (start < 0 || end > text.length) continue;
-
-          if (this.matchPattern(pattern, pos, start, end, text, character)) {
-            if (this.isPolyphonicChar(nextChar)) {
-              skipNext = false;
-              skipPrev = false;
-            } else {
-              skipPrev = true;
-              skipNext = pattern.startsWith('*') && pos === 0;
-            }
-            if (this.isPolyphonicChar(nextChar)) {
-              skipNext = false;
-              skipPrev = false;
-            } else {
-              skipPrev = true;
-              skipNext = pattern.startsWith('*') && pos === 0;
-            }
-            return [j, skipNext, skipPrev];
-          }
-        }
-      }
-    }
-
-    return [defaultIndex, false, false];
-  }
-
-  /** Check if a character is in the polyphonic data */
-  private isPolyphonicChar(character: string): boolean {
-    if (!this.polyphonicData) return false;
-    if (!this.isChineseCharacter(character)) return false;
-    return character in this.polyphonicData.data;
-  }
-
-  /** Match a pattern against text around the character position */
-  private matchPattern(
-    pattern: string,
-    _pos: number,
-    start: number,
-    end: number,
-    text: string[],
-    character: string,
-  ): boolean {
-    let tmp = '';
-    for (let z = start; z < end; z++) {
-      tmp += text[z];
-    }
-    return tmp === pattern.replaceAll('*', character);
-  }
-
-  /** Check if a single character is a CJK unified ideograph */
-  private isChineseCharacter(char: string): boolean {
-    return CHINESE_CHAR_REGEX.test(char);
-  }
-
-  // ---------------------------------------------------------------------------
-  //  Style-set mapping
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Map a matched variant index returned by match() to the BpmfIansui font's
-   * stylistic-set code ('0000' = no selector = font default, 'ss01'..'ss05' = variants).
-   *
-   * @param matchIndex  Index j returned by match(): -1 means "no explicit pattern
-   *                    matched", 0..n means v[j] was the matched variant.
-   * @param defaultVariantIdx  The v[] index whose pronunciation the font renders
-   *                    by default ('0000').  Stored as `d` in poyin_db.json;
-   *                    defaults to 0 when the field is absent.
-   *
-   * Mapping rules:
-   *   j == -1              → treated as j=0 (no match falls back to v[0] reading)
-   *   j == defaultVariantIdx → '0000'  (explicit match on the default variant)
-   *   j <  defaultVariantIdx → 'ss0{j+1}'  (shift up to skip the default slot)
-   *   j >  defaultVariantIdx → 'ss0{j}'    (no shift needed)
-   *
-   * When defaultVariantIdx == 0 (the common case), this simplifies to:
-   *   j == -1 or j == 0  → '0000'
-   *   j > 0              → 'ss0{j}'
-   * which is identical to the original code.
-   */
-  private variantIndexToStyleSet(matchIndex: number, defaultVariantIdx: number): string {
-    // No explicit match: fall back to v[0] as the reading for unrecognized contexts.
-    const j = matchIndex === -1 ? 0 : matchIndex;
-
-    if (j === defaultVariantIdx) {
-      return '0000';
-    }
-    if (j < defaultVariantIdx) {
-      return `ss0${j + 1}`;
-    }
-    // j > defaultVariantIdx
-    return `ss0${j}`;
   }
 
   // ---------------------------------------------------------------------------
@@ -504,7 +206,7 @@ export class PolyphonicProcessor {
       skipPrev = false;
 
       // Non-Chinese character: pass through with default style
-      if (!CHINESE_CHAR_REGEX.test(character)) {
+      if (!isChineseCharacter(character)) {
         result.push({ char: character, styleSet: '0000' });
         skipPrev = true;
         continue;
@@ -560,7 +262,7 @@ export class PolyphonicProcessor {
         // General tone sandhi for 一 and 不
         const prevTone = i > 0 ? getToneForChar(prevChar) : 0;
         const nextTone = i + 1 < length ? getToneForChar(nextChar) : 0;
-        const [newSs, skipNext, newSkipPrev] = this.getNewToneForYiBu(
+        const [newSs, skipNext, newSkipPrev] = getNewToneForYiBu(
           prevChar || null,
           character,
           nextChar || null,
@@ -649,8 +351,8 @@ export class PolyphonicProcessor {
           const variations = charData.v;
           if (variations && variations.length > 0) {
             const patterns = variations.map(String);
-            const [matchIndex, skipNext, matchSkipPrev] = this.match(
-              character, i, patterns, characters, skipPrevTemp,
+            const [matchIndex, skipNext, matchSkipPrev] = matchPolyphonicPattern(
+              character, i, patterns, characters, skipPrevTemp, this.polyphonicData,
             );
             skipPrev = matchSkipPrev;
 
@@ -658,7 +360,7 @@ export class PolyphonicProcessor {
             // Stored as charData.d; falls back to 0 for characters where v[0]
             // is the font default (the vast majority of polyphonic chars).
             const defaultVariantIdx = charData.d ?? 0;
-            const newSs = this.variantIndexToStyleSet(matchIndex, defaultVariantIdx);
+            const newSs = variantIndexToStyleSet(matchIndex, defaultVariantIdx);
 
             result.push({ char: character, styleSet: newSs });
 
@@ -685,23 +387,4 @@ export class PolyphonicProcessor {
 
     return result;
   }
-}
-
-// ---------------------------------------------------------------------------
-//  Utility functions
-// ---------------------------------------------------------------------------
-
-/**
- * Convert ProcessedChar[] to a Unicode string suitable for BpmfIansui font rendering.
- * Characters with non-default style sets get a PUA variant selector appended.
- */
-export function buildZhuyinString(processed: ProcessedChar[]): string {
-  let result = '';
-  for (const { char, styleSet } of processed) {
-    result += char;
-    if (styleSet !== '0000' && styleSet in SS_MAPPING) {
-      result += String.fromCodePoint(parseInt(SS_MAPPING[styleSet], 16));
-    }
-  }
-  return result;
 }

--- a/frontend/src/components/zhuyin/styleSetMapper.ts
+++ b/frontend/src/components/zhuyin/styleSetMapper.ts
@@ -1,0 +1,34 @@
+/**
+ * Map a matched variant index returned by match() to the BpmfIansui font's
+ * stylistic-set code ('0000' = no selector = font default, 'ss01'..'ss05' = variants).
+ *
+ * @param matchIndex  Index j returned by match(): -1 means "no explicit pattern
+ *                    matched", 0..n means v[j] was the matched variant.
+ * @param defaultVariantIdx  The v[] index whose pronunciation the font renders
+ *                    by default ('0000').  Stored as `d` in poyin_db.json;
+ *                    defaults to 0 when the field is absent.
+ *
+ * Mapping rules:
+ *   j == -1              → treated as j=0 (no match falls back to v[0] reading)
+ *   j == defaultVariantIdx → '0000'  (explicit match on the default variant)
+ *   j <  defaultVariantIdx → 'ss0{j+1}'  (shift up to skip the default slot)
+ *   j >  defaultVariantIdx → 'ss0{j}'    (no shift needed)
+ *
+ * When defaultVariantIdx == 0 (the common case), this simplifies to:
+ *   j == -1 or j == 0  → '0000'
+ *   j > 0              → 'ss0{j}'
+ * which is identical to the original code.
+ */
+export function variantIndexToStyleSet(matchIndex: number, defaultVariantIdx: number): string {
+  // No explicit match: fall back to v[0] as the reading for unrecognized contexts.
+  const j = matchIndex === -1 ? 0 : matchIndex;
+
+  if (j === defaultVariantIdx) {
+    return '0000';
+  }
+  if (j < defaultVariantIdx) {
+    return `ss0${j + 1}`;
+  }
+  // j > defaultVariantIdx
+  return `ss0${j}`;
+}

--- a/frontend/src/components/zhuyin/toneSandhi.ts
+++ b/frontend/src/components/zhuyin/toneSandhi.ts
@@ -1,0 +1,82 @@
+import { getToneForChar } from './toneData';
+
+const prevCharSet1 = new Set([
+  '第', '説', '说', '唯', '惟', '统', '統', '独', '獨', '劃', '划', '萬', '專', '某',
+  '十', '九', '八', '七', '六', '五', '四', '三', '二', '一', '〇', '零',
+]);
+
+const nextCharSet1 = new Set([
+  '是', '日', '月', '的', '或', '物', '片', '系',
+  '十', '九', '八', '七', '六', '五', '四', '三', '二', '一', '〇', '零', '百', '千', '萬',
+  '元', '則', '節', '台', '同', '名', '回', '堂', '層', '幅', '幢', '年', '息', '成', '排',
+  '提', '搏', '擊', '擲', '旁', '時', '枚', '格', '條', '樓', '流', '環', '篇', '級', '群',
+  '言', '連', '門', '間',
+  '天', '經', '方', '對', '次', '家', '鳴', '命', '份', '件', '尊', '聲', '歲', '副', '本', '批',
+]);
+
+const specialYiCases: Record<string, [string, boolean, boolean]> = {
+  '個': ['0000', false, false],
+  '个': ['0000', false, false],
+  '會': ['0000', false, false],
+  '切': ['0000', false, false],
+  '不': ['0000', true, true],
+};
+
+const specialBuCases: Record<string, [string, boolean, boolean]> = {
+  '禁': ['0000', false, false],
+  '菲': ['0000', false, false],
+  '勝': ['0000', false, false],
+  '著': ['0000', false, false],
+  '了': ['0000', false, false],
+  '好': ['0000', false, false],
+  '假': ['0000', false, false],
+  '當': ['ss01', false, false],
+};
+
+/**
+ * 以下處理一、不的方法是基於 jeffreyxuan 的原始碼
+ * https://github.com/jeffreyxuan/toneoz-font-zhuyin/blob/main/src/js/ybtone.js
+ * 同時也請參考教育部國語辭典說明：https://dict.concised.moe.edu.tw/page.jsp?ID=55
+ *
+ * Returns [newSs, skipNext, skipPrev]
+ */
+export function getNewToneForYiBu(
+  prevChar: string | null,
+  currentChar: string,
+  nextChar: string | null,
+  prevTone: number | null,
+  nextTone: number | null,
+  skipPrev: boolean,
+): [string, boolean, boolean] {
+  if (currentChar === '一') {
+    if (!skipPrev && (prevChar == null || prevCharSet1.has(prevChar))) {
+      return ['0000', false, true];
+    } else if (nextChar != null && nextChar in specialYiCases) {
+      return specialYiCases[nextChar]!;
+    } else if (nextChar == null || nextChar === '' || nextCharSet1.has(nextChar)) {
+      return ['0000', true, true];
+    } else if (prevChar === nextChar ||
+        ['看', '聽', '寫', '用', '說', '動', '搖', '問'].includes(nextChar ?? '')) {
+      return ['0000', true, true];
+    } else if (nextTone != null && (nextTone === 1 || nextTone === 2 || nextTone === 3)) {
+      return ['ss02', true, true]; // Fourth tone
+    } else if (nextTone != null && nextTone === 4) {
+      return ['ss01', true, true]; // Second tone
+    } else {
+      return ['0000', false, true];
+    }
+  } else if (currentChar === '不') {
+    if (nextChar != null && nextChar in specialBuCases) {
+      return specialBuCases[nextChar]!;
+    }
+    if (nextTone != null && (nextTone === 1 || nextTone === 2 || nextTone === 3 || nextTone === 5)) {
+      return ['0000', false, true]; // Remain 四聲
+    } else if (nextTone != null && nextTone === 4) {
+      return ['ss01', true, true]; // Change to second tone
+    } else {
+      return ['0000', false, true];
+    }
+  }
+
+  return ['0000', false, false]; // Default case
+}

--- a/frontend/src/components/zhuyin/zhuyinStringBuilder.ts
+++ b/frontend/src/components/zhuyin/zhuyinStringBuilder.ts
@@ -1,0 +1,16 @@
+import { SS_MAPPING, type ProcessedChar } from './bopomoConstants';
+
+/**
+ * Convert ProcessedChar[] to a Unicode string suitable for BpmfIansui font rendering.
+ * Characters with non-default style sets get a PUA variant selector appended.
+ */
+export function buildZhuyinString(processed: ProcessedChar[]): string {
+  let result = '';
+  for (const { char, styleSet } of processed) {
+    result += char;
+    if (styleSet !== '0000' && styleSet in SS_MAPPING) {
+      result += String.fromCodePoint(parseInt(SS_MAPPING[styleSet], 16));
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Fixes #1843

## Summary

TDD-first refactor. 44 characterization tests written and verified BEFORE any code was moved.

Modules extracted from `polyphonicProcessor.ts` (707L → 390L):

- `toneSandhi.ts` — `getNewToneForYiBu()` + 一/不 Set constants (prevCharSet1, nextCharSet1, specialYiCases, specialBuCases)
- `polyphonicPatternMatcher.ts` — `match()`, `matchPattern()`, `isChineseCharacter()`, `PHRASES_ENDS_WITH_DI` set
- `styleSetMapper.ts` — `variantIndexToStyleSet()`
- `zhuyinStringBuilder.ts` — `buildZhuyinString()`

`polyphonicProcessor.ts` retains: singleton loader, `loadPolyphonicData()`, `process()`, `removeComments()`, `SPECIAL_DOUBLE_CHARACTERS`, `DUO_COMMON_PHRASES`. Re-exports `buildZhuyinString` for backward compat.

## TDD Evidence

Phase 1: 24 existing tests + 20 new characterization tests = **44/44 green on original code**  
Phase 2: Tautology check — broke PHRASES_ENDS_WITH_DI rule → 2 tests fail, restored → 44/44  
Phase 3: Refactor → **44/44 still green**, `vite build` zero TS errors

New test coverage added:
- 不 tone sandhi (standalone, before 1st/2nd/4th tone, specialBuCases)
- 地 de5/di4 (快樂地/靜靜地 → ss01, 走在地上 → 0000)
- Double-char pairs (重重, 重重的 override, 好好, 數數)
- buildZhuyinString PUA selector (0000=no PUA, ss01/ss02=surrogate pair, mixed, unknown=graceful)

## Constraints respected

- `ZhuyinPhoneticGame.tsx` — NOT touched
- No consumer component changes
- Zero behavior change (pure structural extraction)
- All 4 new files are in `src/components/zhuyin/`

## Test plan

1. CI vitest: 44/44 zhuyin tests green
2. CI vite build: zero errors
3. Staging deploy: verify zhuyin rendering identical to pre-refactor