### PR TITLE
feat(admin): shared primitives — AdminPageShell, AdminTable, DetailHeaderCard, EditSection, ConfirmDialog, hooks (Fixes #1847)

### DIFF
--- a/frontend/src/components/admin/AdminPageShell.tsx
+++ b/frontend/src/components/admin/AdminPageShell.tsx
@@ -1,0 +1,82 @@
+/**
+ * AdminPageShell — shared page wrapper for admin + teacher panels.
+ *
+ * Handles loading spinner, error banner, empty state, and consistent
+ * page title rendering so each panel doesn't repeat this boilerplate.
+ *
+ * Usage:
+ *   <AdminPageShell title="使用者管理" isLoading={isLoading} error={error}>
+ *     <MyContent />
+ *   </AdminPageShell>
+ */
+import React from 'react';
+
+export interface AdminPageShellProps {
+  /** Page heading displayed in the top bar. */
+  title: string;
+  /** Optional subtitle rendered below the title. */
+  subtitle?: string;
+  /** When true, replaces content with a centered spinner. */
+  isLoading?: boolean;
+  /** Non-empty string triggers an error banner instead of children. */
+  error?: string;
+  /** When true AND children is absent, shows the emptyMessage. */
+  isEmpty?: boolean;
+  /** Message shown when isEmpty is true. Defaults to '沒有資料'. */
+  emptyMessage?: string;
+  /** Optional action buttons rendered in the title bar (e.g. "+ 新增"). */
+  headerActions?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+const AdminPageShell: React.FC<AdminPageShellProps> = ({
+  title,
+  subtitle,
+  isLoading = false,
+  error,
+  isEmpty = false,
+  emptyMessage = '沒有資料',
+  headerActions,
+  children,
+}) => {
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      {/* ── Title bar ──────────────────────────────────────────────────── */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold text-gray-900">{title}</h1>
+          {subtitle && (
+            <p className="mt-0.5 text-sm text-gray-500">{subtitle}</p>
+          )}
+        </div>
+        {headerActions && <div className="flex items-center gap-2">{headerActions}</div>}
+      </div>
+
+      {/* ── States ─────────────────────────────────────────────────────── */}
+      {isLoading ? (
+        <div
+          role="status"
+          aria-label="載入中"
+          className="flex items-center justify-center py-16"
+        >
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-500 border-t-transparent" />
+        </div>
+      ) : error ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
+          {error}
+        </div>
+      ) : isEmpty ? (
+        <div className="flex items-center justify-center py-16 text-sm text-gray-400">
+          {emptyMessage}
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+};
+
+export default AdminPageShell;

--- a/frontend/src/components/admin/AdminTable.tsx
+++ b/frontend/src/components/admin/AdminTable.tsx
@@ -1,0 +1,127 @@
+/**
+ * AdminTable — generic responsive table with card fallback on mobile.
+ *
+ * On md+ screens: renders a <table>. On small screens: renders each row
+ * as a stacked card so the layout doesn't overflow.
+ *
+ * Usage:
+ *   const columns: ColumnDef<User>[] = [
+ *     { key: 'name', header: '名稱', render: (row) => row.name },
+ *     { key: 'email', header: 'Email' },
+ *   ];
+ *   <AdminTable columns={columns} rows={users} rowKey={(u) => u.id} />
+ */
+import React from 'react';
+
+export interface ColumnDef<T> {
+  /** Unique column key (used as React key). */
+  key: string;
+  /** Column header label. */
+  header: string;
+  /**
+   * Optional render function. When omitted the column key is used as a
+   * property accessor on the row object (requires T extends Record<string,unknown>).
+   */
+  render?: (row: T, index: number) => React.ReactNode;
+  /** Optional className applied to both <th> and <td> cells for this column. */
+  className?: string;
+}
+
+export interface AdminTableProps<T> {
+  columns: ColumnDef<T>[];
+  rows: T[];
+  /** Returns the unique React key for each row. */
+  rowKey: (row: T, index: number) => string | number;
+  /** Optional click handler for rows. */
+  onRowClick?: (row: T) => void;
+  /** Override card heading accessor — shown prominently in mobile card view. */
+  cardTitle?: (row: T) => React.ReactNode;
+  /** Extra className on the wrapping <div>. */
+  className?: string;
+}
+
+function getCellValue<T>(row: T, col: ColumnDef<T>, index: number): React.ReactNode {
+  if (col.render) return col.render(row, index);
+  // Fall back to property access by key
+  const value = (row as Record<string, unknown>)[col.key];
+  return value !== undefined && value !== null ? String(value) : '—';
+}
+
+function AdminTable<T>({
+  columns,
+  rows,
+  rowKey,
+  onRowClick,
+  cardTitle,
+  className = '',
+}: AdminTableProps<T>): React.ReactElement {
+  const clickable = Boolean(onRowClick);
+
+  return (
+    <div className={`w-full ${className}`}>
+      {/* ── Desktop table ──────────────────────────────────────────────── */}
+      <div className="hidden overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm md:block">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={col.key}
+                  scope="col"
+                  className={`px-4 py-3 text-left font-medium text-gray-600 ${col.className ?? ''}`}
+                >
+                  {col.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {rows.map((row, index) => (
+              <tr
+                key={rowKey(row, index)}
+                onClick={clickable ? () => onRowClick!(row) : undefined}
+                className={clickable ? 'cursor-pointer hover:bg-blue-50 transition-colors' : ''}
+              >
+                {columns.map((col) => (
+                  <td
+                    key={col.key}
+                    className={`px-4 py-3 text-gray-700 ${col.className ?? ''}`}
+                  >
+                    {getCellValue(row, col, index)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* ── Mobile cards ───────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-3 md:hidden">
+        {rows.map((row, index) => (
+          <div
+            key={rowKey(row, index)}
+            onClick={clickable ? () => onRowClick!(row) : undefined}
+            className={`rounded-xl border border-gray-200 bg-white p-4 shadow-sm ${
+              clickable ? 'cursor-pointer hover:bg-blue-50 transition-colors' : ''
+            }`}
+          >
+            {cardTitle && (
+              <div className="mb-2 font-medium text-gray-900">{cardTitle(row)}</div>
+            )}
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+              {columns.map((col) => (
+                <div key={col.key} className="flex flex-col">
+                  <dt className="text-xs text-gray-400">{col.header}</dt>
+                  <dd className="text-gray-700">{getCellValue(row, col, index)}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default AdminTable;

--- a/frontend/src/components/admin/ConfirmDialog.tsx
+++ b/frontend/src/components/admin/ConfirmDialog.tsx
@@ -1,0 +1,123 @@
+/**
+ * ConfirmDialog — modal confirm gate with optional destructive styling.
+ *
+ * Renders a simple overlay dialog asking the user to confirm an action.
+ * The confirm button turns red when variant="destructive".
+ *
+ * Usage:
+ *   <ConfirmDialog
+ *     open={showConfirm}
+ *     title="停用帳號"
+ *     message="確定要停用此帳號嗎？此操作可復原。"
+ *     variant="destructive"
+ *     onConfirm={handleDeactivate}
+ *     onCancel={() => setShowConfirm(false)}
+ *     isLoading={isDeactivating}
+ *   />
+ */
+import React, { useEffect, useRef } from 'react';
+
+export type ConfirmDialogVariant = 'default' | 'destructive';
+
+export interface ConfirmDialogProps {
+  /** Controls dialog visibility. */
+  open: boolean;
+  /** Dialog heading. */
+  title: string;
+  /** Body message or custom React node. */
+  message: React.ReactNode;
+  /** 'destructive' makes the confirm button red. Defaults to 'default'. */
+  variant?: ConfirmDialogVariant;
+  /** Label on the confirm button. Defaults to '確認'. */
+  confirmLabel?: string;
+  /** Label on the cancel button. Defaults to '取消'. */
+  cancelLabel?: string;
+  /** Called when user confirms. */
+  onConfirm: () => void;
+  /** Called when user cancels or clicks the backdrop. */
+  onCancel: () => void;
+  /** When true the confirm button shows a spinner and is disabled. */
+  isLoading?: boolean;
+}
+
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  title,
+  message,
+  variant = 'default',
+  confirmLabel = '確認',
+  cancelLabel = '取消',
+  onConfirm,
+  onCancel,
+  isLoading = false,
+}) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  const confirmCls =
+    variant === 'destructive'
+      ? 'bg-red-600 hover:bg-red-700 text-white'
+      : 'bg-blue-600 hover:bg-blue-700 text-white';
+
+  return (
+    /* Backdrop */
+    <div
+      role="presentation"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onCancel}
+    >
+      {/* Dialog panel — stop propagation so clicks inside don't close */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl"
+      >
+        <h2
+          id="confirm-dialog-title"
+          className="text-base font-semibold text-gray-900"
+        >
+          {title}
+        </h2>
+        <div className="mt-2 text-sm text-gray-600">{message}</div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 disabled:opacity-50 transition-colors"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isLoading}
+            className={`inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${confirmCls}`}
+          >
+            {isLoading && (
+              <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+            )}
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/frontend/src/components/admin/DetailHeaderCard.tsx
+++ b/frontend/src/components/admin/DetailHeaderCard.tsx
@@ -1,0 +1,80 @@
+/**
+ * DetailHeaderCard — entity header used at the top of detail panels.
+ *
+ * Displays a title, optional subtitle, a status badge, and action buttons.
+ *
+ * Usage:
+ *   <DetailHeaderCard
+ *     title={org.name}
+ *     subtitle={org.display_name}
+ *     badge={{ label: org.is_active ? '啟用' : '停用', variant: org.is_active ? 'green' : 'red' }}
+ *     actions={<button onClick={handleEdit}>編輯</button>}
+ *   />
+ */
+import React from 'react';
+
+export type BadgeVariant = 'green' | 'red' | 'blue' | 'yellow' | 'gray';
+
+const BADGE_STYLES: Record<BadgeVariant, string> = {
+  green: 'bg-green-100 text-green-700',
+  red: 'bg-red-100 text-red-700',
+  blue: 'bg-blue-100 text-blue-700',
+  yellow: 'bg-yellow-100 text-yellow-700',
+  gray: 'bg-gray-100 text-gray-600',
+};
+
+export interface BadgeProps {
+  label: string;
+  variant?: BadgeVariant;
+}
+
+export interface DetailHeaderCardProps {
+  /** Main entity name / title. */
+  title: string;
+  /** Optional secondary label (e.g. display name, email). */
+  subtitle?: string;
+  /** Status badge configuration. */
+  badge?: BadgeProps;
+  /** Action buttons rendered in the top-right corner. */
+  actions?: React.ReactNode;
+  /** Extra className on the card wrapper. */
+  className?: string;
+}
+
+const DetailHeaderCard: React.FC<DetailHeaderCardProps> = ({
+  title,
+  subtitle,
+  badge,
+  actions,
+  className = '',
+}) => {
+  return (
+    <div
+      className={`flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-4 shadow-sm sm:flex-row sm:items-start sm:justify-between ${className}`}
+    >
+      {/* ── Left: title + badge ────────────────────────────────────────── */}
+      <div className="flex flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+          {badge && (
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                BADGE_STYLES[badge.variant ?? 'gray']
+              }`}
+            >
+              {badge.label}
+            </span>
+          )}
+        </div>
+        {subtitle && <p className="text-sm text-gray-500">{subtitle}</p>}
+      </div>
+
+      {/* ── Right: actions ─────────────────────────────────────────────── */}
+      {actions && (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      )}
+    </div>
+  );
+};
+
+export default DetailHeaderCard;

--- a/frontend/src/components/admin/EditSection.tsx
+++ b/frontend/src/components/admin/EditSection.tsx
@@ -1,0 +1,114 @@
+/**
+ * EditSection — collapsible section with view/edit toggle and save/cancel.
+ *
+ * When isEditing=false the section header shows an "編輯" button.
+ * When isEditing=true the footer renders save + cancel buttons.
+ *
+ * The parent manages the edit state; this component is purely presentational.
+ *
+ * Usage:
+ *   <EditSection
+ *     title="基本資料"
+ *     isEditing={isEditing}
+ *     onEdit={() => setIsEditing(true)}
+ *     onSave={handleSave}
+ *     onCancel={() => setIsEditing(false)}
+ *     isSaving={isSaving}
+ *     error={saveError}
+ *   >
+ *     {isEditing ? <EditForm /> : <ReadView />}
+ *   </EditSection>
+ */
+import React from 'react';
+
+export interface EditSectionProps {
+  /** Section heading. */
+  title: string;
+  /** Controlled editing state. */
+  isEditing: boolean;
+  /** Called when user clicks "編輯". */
+  onEdit: () => void;
+  /** Called when user clicks "儲存". */
+  onSave: () => void;
+  /** Called when user clicks "取消". */
+  onCancel: () => void;
+  /** When true, the save button shows a spinner and is disabled. */
+  isSaving?: boolean;
+  /** Non-empty string shows an error message above the action row. */
+  error?: string;
+  /** Whether to show the Edit button (e.g. hide when permissions absent). */
+  canEdit?: boolean;
+  children: React.ReactNode;
+  /** Extra className on the outer wrapper. */
+  className?: string;
+}
+
+const EditSection: React.FC<EditSectionProps> = ({
+  title,
+  isEditing,
+  onEdit,
+  onSave,
+  onCancel,
+  isSaving = false,
+  error,
+  canEdit = true,
+  children,
+  className = '',
+}) => {
+  return (
+    <section
+      className={`rounded-xl border border-gray-200 bg-white shadow-sm ${className}`}
+    >
+      {/* ── Header ─────────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+        <h3 className="text-sm font-semibold text-gray-700">{title}</h3>
+        {!isEditing && canEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="text-sm font-medium text-blue-600 hover:text-blue-800 transition-colors"
+          >
+            編輯
+          </button>
+        )}
+      </div>
+
+      {/* ── Body ───────────────────────────────────────────────────────── */}
+      <div className="px-4 py-4">{children}</div>
+
+      {/* ── Footer (edit mode only) ────────────────────────────────────── */}
+      {isEditing && (
+        <div className="border-t border-gray-100 px-4 py-3">
+          {error && (
+            <p role="alert" className="mb-2 text-sm text-red-600">
+              {error}
+            </p>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={isSaving}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {isSaving && (
+                <span className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              )}
+              儲存
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={isSaving}
+              className="rounded-lg px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 disabled:opacity-50 transition-colors"
+            >
+              取消
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default EditSection;

--- a/frontend/src/components/admin/__tests__/AdminPageShell.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminPageShell.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Tests for AdminPageShell (Issue #1847)
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AdminPageShell from '../AdminPageShell';
+
+describe('AdminPageShell', () => {
+  it('renders the page title', () => {
+    render(<AdminPageShell title="使用者管理"><div>content</div></AdminPageShell>);
+    expect(screen.getByText('使用者管理')).toBeTruthy();
+  });
+
+  it('renders children when not loading and no error', () => {
+    render(
+      <AdminPageShell title="Test">
+        <p>My content</p>
+      </AdminPageShell>,
+    );
+    expect(screen.getByText('My content')).toBeTruthy();
+  });
+
+  it('shows spinner when isLoading=true instead of children', () => {
+    render(
+      <AdminPageShell title="Test" isLoading>
+        <p>Should not appear</p>
+      </AdminPageShell>,
+    );
+    expect(screen.getByRole('status')).toBeTruthy();
+    expect(screen.queryByText('Should not appear')).toBeNull();
+  });
+
+  it('shows error alert when error is set', () => {
+    render(
+      <AdminPageShell title="Test" error="載入失敗">
+        <p>hidden</p>
+      </AdminPageShell>,
+    );
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('載入失敗');
+    expect(screen.queryByText('hidden')).toBeNull();
+  });
+
+  it('shows emptyMessage when isEmpty=true', () => {
+    render(
+      <AdminPageShell title="Test" isEmpty emptyMessage="沒有使用者">
+        <p>hidden</p>
+      </AdminPageShell>,
+    );
+    expect(screen.getByText('沒有使用者')).toBeTruthy();
+    expect(screen.queryByText('hidden')).toBeNull();
+  });
+
+  it('renders subtitle when provided', () => {
+    render(<AdminPageShell title="T" subtitle="副標題"><span /></AdminPageShell>);
+    expect(screen.getByText('副標題')).toBeTruthy();
+  });
+
+  it('renders headerActions', () => {
+    render(
+      <AdminPageShell title="T" headerActions={<button>新增</button>}>
+        <span />
+      </AdminPageShell>,
+    );
+    expect(screen.getByRole('button', { name: '新增' })).toBeTruthy();
+  });
+});

--- a/frontend/src/components/admin/__tests__/AdminTable.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminTable.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for AdminTable (Issue #1847)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AdminTable, { ColumnDef } from '../AdminTable';
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+const USERS: User[] = [
+  { id: 1, name: '張三', email: 'test-user-a' },
+  { id: 2, name: '李四', email: 'test-user-b' },
+];
+
+const COLUMNS: ColumnDef<User>[] = [
+  { key: 'name', header: '姓名' },
+  { key: 'email', header: 'Email' },
+];
+
+describe('AdminTable', () => {
+  it('renders column headers', () => {
+    render(
+      <AdminTable
+        columns={COLUMNS}
+        rows={USERS}
+        rowKey={(u) => u.id}
+      />,
+    );
+    expect(screen.getAllByText('姓名').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Email').length).toBeGreaterThan(0);
+  });
+
+  it('renders row data', () => {
+    render(
+      <AdminTable
+        columns={COLUMNS}
+        rows={USERS}
+        rowKey={(u) => u.id}
+      />,
+    );
+    expect(screen.getAllByText('張三').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('李四').length).toBeGreaterThan(0);
+  });
+
+  it('calls onRowClick when a row is clicked', () => {
+    const onClick = vi.fn();
+    render(
+      <AdminTable
+        columns={COLUMNS}
+        rows={USERS}
+        rowKey={(u) => u.id}
+        onRowClick={onClick}
+      />,
+    );
+    // Click the first visible "張三" cell in the table (desktop view)
+    const cells = screen.getAllByText('張三');
+    fireEvent.click(cells[0].closest('tr')!);
+    expect(onClick).toHaveBeenCalledWith(USERS[0]);
+  });
+
+  it('uses custom render function for cells', () => {
+    const columns: ColumnDef<User>[] = [
+      { key: 'name', header: '姓名', render: (row) => <strong>{row.name}-custom</strong> },
+    ];
+    render(
+      <AdminTable columns={columns} rows={[USERS[0]]} rowKey={(u) => u.id} />,
+    );
+    expect(screen.getAllByText('張三-custom').length).toBeGreaterThan(0);
+  });
+
+  it('renders empty table with no rows without crashing', () => {
+    render(
+      <AdminTable columns={COLUMNS} rows={[]} rowKey={(u) => u.id} />,
+    );
+    expect(screen.getAllByText('姓名').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/admin/__tests__/ConfirmDialog.test.tsx
+++ b/frontend/src/components/admin/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for ConfirmDialog (Issue #1847)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConfirmDialog from '../ConfirmDialog';
+
+const BASE_PROPS = {
+  open: true,
+  title: '確認操作',
+  message: '你確定嗎？',
+  onConfirm: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('ConfirmDialog', () => {
+  it('renders nothing when open=false', () => {
+    render(<ConfirmDialog {...BASE_PROPS} open={false} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders dialog when open=true', () => {
+    render(<ConfirmDialog {...BASE_PROPS} />);
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('確認操作')).toBeTruthy();
+    expect(screen.getByText('你確定嗎？')).toBeTruthy();
+  });
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...BASE_PROPS} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: '確認' }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...BASE_PROPS} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole('button', { name: '取消' }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when backdrop is clicked', () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...BASE_PROPS} onCancel={onCancel} />);
+    // The backdrop is the outermost div with role="presentation"
+    fireEvent.click(screen.getByRole('presentation'));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('respects custom confirmLabel and cancelLabel', () => {
+    render(
+      <ConfirmDialog
+        {...BASE_PROPS}
+        confirmLabel="停用"
+        cancelLabel="返回"
+      />,
+    );
+    expect(screen.getByRole('button', { name: '停用' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '返回' })).toBeTruthy();
+  });
+
+  it('disables buttons when isLoading=true', () => {
+    render(<ConfirmDialog {...BASE_PROPS} isLoading />);
+    const confirmBtn = screen.getByRole('button', { name: /確認/ });
+    const cancelBtn = screen.getByRole('button', { name: '取消' });
+    expect(confirmBtn).toHaveProperty('disabled', true);
+    expect(cancelBtn).toHaveProperty('disabled', true);
+  });
+});

--- a/frontend/src/components/admin/__tests__/DetailHeaderCard.test.tsx
+++ b/frontend/src/components/admin/__tests__/DetailHeaderCard.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Tests for DetailHeaderCard (Issue #1847)
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DetailHeaderCard from '../DetailHeaderCard';
+
+describe('DetailHeaderCard', () => {
+  it('renders the title', () => {
+    render(<DetailHeaderCard title="測試機構" />);
+    expect(screen.getByText('測試機構')).toBeTruthy();
+  });
+
+  it('renders subtitle when provided', () => {
+    render(<DetailHeaderCard title="機構" subtitle="副名稱" />);
+    expect(screen.getByText('副名稱')).toBeTruthy();
+  });
+
+  it('renders badge with correct text', () => {
+    render(
+      <DetailHeaderCard
+        title="機構"
+        badge={{ label: '啟用', variant: 'green' }}
+      />,
+    );
+    expect(screen.getByText('啟用')).toBeTruthy();
+  });
+
+  it('renders actions slot', () => {
+    render(
+      <DetailHeaderCard
+        title="機構"
+        actions={<button>編輯</button>}
+      />,
+    );
+    expect(screen.getByRole('button', { name: '編輯' })).toBeTruthy();
+  });
+
+  it('renders without badge or actions without crashing', () => {
+    render(<DetailHeaderCard title="Simple" />);
+    expect(screen.getByText('Simple')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/admin/__tests__/EditSection.test.tsx
+++ b/frontend/src/components/admin/__tests__/EditSection.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for EditSection (Issue #1847)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EditSection from '../EditSection';
+
+const BASE_PROPS = {
+  title: '基本資料',
+  isEditing: false,
+  onEdit: vi.fn(),
+  onSave: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('EditSection', () => {
+  it('renders the section title', () => {
+    render(<EditSection {...BASE_PROPS}><span>view</span></EditSection>);
+    expect(screen.getByText('基本資料')).toBeTruthy();
+  });
+
+  it('shows "編輯" button when not editing', () => {
+    render(<EditSection {...BASE_PROPS}><span /></EditSection>);
+    expect(screen.getByRole('button', { name: '編輯' })).toBeTruthy();
+  });
+
+  it('calls onEdit when "編輯" is clicked', () => {
+    const onEdit = vi.fn();
+    render(<EditSection {...BASE_PROPS} onEdit={onEdit}><span /></EditSection>);
+    fireEvent.click(screen.getByRole('button', { name: '編輯' }));
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it('shows "儲存" and "取消" when isEditing=true', () => {
+    render(
+      <EditSection {...BASE_PROPS} isEditing>
+        <span />
+      </EditSection>,
+    );
+    expect(screen.getByRole('button', { name: /儲存/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '取消' })).toBeTruthy();
+    // "編輯" button should not be visible in edit mode
+    expect(screen.queryByRole('button', { name: '編輯' })).toBeNull();
+  });
+
+  it('calls onSave when "儲存" is clicked', () => {
+    const onSave = vi.fn();
+    render(
+      <EditSection {...BASE_PROPS} isEditing onSave={onSave}>
+        <span />
+      </EditSection>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /儲存/ }));
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it('calls onCancel when "取消" is clicked', () => {
+    const onCancel = vi.fn();
+    render(
+      <EditSection {...BASE_PROPS} isEditing onCancel={onCancel}>
+        <span />
+      </EditSection>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '取消' }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('displays error message in edit mode', () => {
+    render(
+      <EditSection {...BASE_PROPS} isEditing error="儲存失敗">
+        <span />
+      </EditSection>,
+    );
+    expect(screen.getByRole('alert').textContent).toContain('儲存失敗');
+  });
+
+  it('hides "編輯" button when canEdit=false', () => {
+    render(
+      <EditSection {...BASE_PROPS} canEdit={false}>
+        <span />
+      </EditSection>,
+    );
+    expect(screen.queryByRole('button', { name: '編輯' })).toBeNull();
+  });
+});

--- a/frontend/src/hooks/__tests__/useAsyncAction.test.ts
+++ b/frontend/src/hooks/__tests__/useAsyncAction.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for useAsyncAction (Issue #1847)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAsyncAction } from '../useAsyncAction';
+
+describe('useAsyncAction', () => {
+  it('initialises with isLoading=false and empty error', () => {
+    const { result } = renderHook(() => useAsyncAction());
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe('');
+  });
+
+  it('returns true when the function resolves successfully', async () => {
+    const { result } = renderHook(() => useAsyncAction());
+    let outcome: boolean | undefined;
+
+    await act(async () => {
+      outcome = await result.current.run(async () => {/* no-op */});
+    });
+
+    expect(outcome).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe('');
+  });
+
+  it('returns false and sets error when the function throws', async () => {
+    const { result } = renderHook(() => useAsyncAction());
+    let outcome: boolean | undefined;
+
+    await act(async () => {
+      outcome = await result.current.run(async () => {
+        throw new Error('API 失敗');
+      });
+    });
+
+    expect(outcome).toBe(false);
+    expect(result.current.error).toBe('API 失敗');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sets a generic error for non-Error throws', async () => {
+    const { result } = renderHook(() => useAsyncAction());
+
+    await act(async () => {
+      await result.current.run(async () => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'string error';
+      });
+    });
+
+    expect(result.current.error).toBe('發生錯誤，請稍後再試');
+  });
+
+  it('clears error via clearError', async () => {
+    const { result } = renderHook(() => useAsyncAction());
+
+    await act(async () => {
+      await result.current.run(async () => { throw new Error('oops'); });
+    });
+
+    expect(result.current.error).toBe('oops');
+
+    act(() => { result.current.clearError(); });
+
+    expect(result.current.error).toBe('');
+  });
+
+  it('sets isLoading=false after execution completes', async () => {
+    const { result } = renderHook(() => useAsyncAction());
+
+    // Before run, isLoading is false
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      await result.current.run(async () => {/* no-op */});
+    });
+
+    // After run, isLoading must be false again
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('isLoading resets to false even on error', async () => {
+    const { result } = renderHook(() => useAsyncAction());
+
+    await act(async () => {
+      await result.current.run(async () => { throw new Error('fail'); });
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/useDebouncedSearch.test.ts
+++ b/frontend/src/hooks/__tests__/useDebouncedSearch.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for useDebouncedSearch (Issue #1847)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebouncedSearch } from '../useDebouncedSearch';
+
+describe('useDebouncedSearch', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('initialises with empty query and page 0', () => {
+    const { result } = renderHook(() => useDebouncedSearch());
+    expect(result.current.query).toBe('');
+    expect(result.current.debouncedQuery).toBe('');
+    expect(result.current.page).toBe(0);
+  });
+
+  it('initialises with provided initialQuery', () => {
+    const { result } = renderHook(() =>
+      useDebouncedSearch({ initialQuery: 'hello' }),
+    );
+    expect(result.current.query).toBe('hello');
+  });
+
+  it('updates debouncedQuery after the delay', () => {
+    const { result } = renderHook(() => useDebouncedSearch({ delay: 300 }));
+
+    act(() => {
+      result.current.setQuery('abc');
+    });
+
+    // Still old value before delay
+    expect(result.current.debouncedQuery).toBe('');
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current.debouncedQuery).toBe('abc');
+  });
+
+  it('resets page to 0 when debouncedQuery changes', () => {
+    const { result } = renderHook(() => useDebouncedSearch({ delay: 200 }));
+
+    // Manually advance to initial debounce
+    act(() => { vi.advanceTimersByTime(200); });
+
+    // Set page to 2
+    act(() => { result.current.setPage(2); });
+    expect(result.current.page).toBe(2);
+
+    // Change query → debounce fires → page should reset
+    act(() => { result.current.setQuery('search'); });
+    act(() => { vi.advanceTimersByTime(200); });
+
+    expect(result.current.debouncedQuery).toBe('search');
+    expect(result.current.page).toBe(0);
+  });
+
+  it('allows manual page changes via setPage', () => {
+    const { result } = renderHook(() => useDebouncedSearch());
+    act(() => { result.current.setPage(5); });
+    expect(result.current.page).toBe(5);
+  });
+
+  it('debounces rapid keystrokes — only fires once after the delay', () => {
+    const { result } = renderHook(() => useDebouncedSearch({ delay: 400 }));
+
+    act(() => { vi.advanceTimersByTime(400); }); // flush initial mount
+
+    act(() => { result.current.setQuery('a'); });
+    act(() => { vi.advanceTimersByTime(100); });
+    act(() => { result.current.setQuery('ab'); });
+    act(() => { vi.advanceTimersByTime(100); });
+    act(() => { result.current.setQuery('abc'); });
+    act(() => { vi.advanceTimersByTime(400); }); // final debounce fires
+
+    expect(result.current.debouncedQuery).toBe('abc');
+  });
+});

--- a/frontend/src/hooks/useAsyncAction.ts
+++ b/frontend/src/hooks/useAsyncAction.ts
@@ -1,0 +1,58 @@
+/**
+ * useAsyncAction — thin wrapper for async actions with loading/error state.
+ *
+ * Replaces repetitive `isLoading / setIsLoading / setError / try-catch`
+ * blocks in admin panels.
+ *
+ * Usage:
+ *   const { run, isLoading, error, clearError } = useAsyncAction();
+ *
+ *   const handleSave = async () => {
+ *     const ok = await run(async () => {
+ *       await api.updateOrg(token, id, data);
+ *     });
+ *     if (ok) setIsEditing(false);
+ *   };
+ */
+import { useState, useCallback } from 'react';
+
+export interface UseAsyncActionResult {
+  /**
+   * Execute an async function.  Returns true if it resolved without throwing,
+   * false if it threw.  The caught error message is stored in `error`.
+   */
+  run: (fn: () => Promise<unknown>) => Promise<boolean>;
+  /** True while the wrapped function is executing. */
+  isLoading: boolean;
+  /** Error message from the last failed run, or '' when clear. */
+  error: string;
+  /** Manually clear the error state. */
+  clearError: () => void;
+}
+
+export function useAsyncAction(): UseAsyncActionResult {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const clearError = useCallback(() => setError(''), []);
+
+  const run = useCallback(async (fn: () => Promise<unknown>): Promise<boolean> => {
+    setIsLoading(true);
+    setError('');
+    try {
+      await fn();
+      return true;
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError('發生錯誤，請稍後再試');
+      }
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { run, isLoading, error, clearError };
+}

--- a/frontend/src/hooks/useDebouncedSearch.ts
+++ b/frontend/src/hooks/useDebouncedSearch.ts
@@ -1,0 +1,62 @@
+/**
+ * useDebouncedSearch — debounced query string with automatic page reset.
+ *
+ * Returns the raw query (bound to the input), the debounced query (used
+ * for API calls), and the current page index.  Whenever the debounced
+ * query changes the page resets to 0.
+ *
+ * Usage:
+ *   const { query, setQuery, debouncedQuery, page, setPage } =
+ *     useDebouncedSearch({ delay: 400 });
+ *
+ *   // Bind query to the input value, use debouncedQuery for API calls.
+ */
+import { useState, useEffect, useRef } from 'react';
+
+export interface UseDebouncedSearchOptions {
+  /** Initial query value. Defaults to ''. */
+  initialQuery?: string;
+  /** Debounce delay in milliseconds. Defaults to 400. */
+  delay?: number;
+}
+
+export interface UseDebouncedSearchResult {
+  /** Raw query — bind this to the search input. */
+  query: string;
+  setQuery: (q: string) => void;
+  /** Debounced query — use this for API / filter calls. */
+  debouncedQuery: string;
+  /** Current page index (0-based). Resets to 0 when debouncedQuery changes. */
+  page: number;
+  setPage: (p: number) => void;
+}
+
+export function useDebouncedSearch(
+  options: UseDebouncedSearchOptions = {},
+): UseDebouncedSearchResult {
+  const { initialQuery = '', delay = 400 } = options;
+
+  const [query, setQuery] = useState(initialQuery);
+  const [debouncedQuery, setDebouncedQuery] = useState(initialQuery);
+  const [page, setPage] = useState(0);
+
+  // Track whether this is the first render so we don't reset the page
+  // immediately on mount (only when the query actually changes).
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(query);
+      // Reset page to 0 only on user-driven query changes, not on mount.
+      if (!isFirstRender.current) {
+        setPage(0);
+      }
+    }, delay);
+
+    isFirstRender.current = false;
+
+    return () => clearTimeout(timer);
+  }, [query, delay]);
+
+  return { query, setQuery, debouncedQuery, page, setPage };
+}


### PR DESCRIPTION
Fixes #1847

## Summary

Additive-only PR creating 7 shared primitives that unblock #1848-#1854 (admin panels + teacher pages refactor):

**Components** (`frontend/src/components/admin/`):
- `AdminPageShell.tsx` — page wrapper with loading/error/empty/title states
- `AdminTable.tsx` — responsive table + mobile card layout, generic via `ColumnDef<T>` props
- `DetailHeaderCard.tsx` — entity header with title/badge/actions slot
- `EditSection.tsx` — collapsible section with view/edit toggle + save/cancel footer
- `ConfirmDialog.tsx` — confirm gate with destructive variant styling

**Hooks** (`frontend/src/hooks/`):
- `useDebouncedSearch.ts` — debounced query string + automatic page reset to 0
- `useAsyncAction.ts` — async wrapper with loading/error state, replaces repetitive try/catch boilerplate

## Verification gates

- [x] 45 vitest tests pass (7 new test files, all green)
- [x] 0 TS errors in new files (`tsc --noEmit` clean for admin/ and new hooks)
- [x] No consumer file changes (only new files — `git status` shows only additions)
- [x] Purely additive: 14 files added, 0 modified

## Test plan

1. CI runs on PR — check vitest + tsc steps pass
2. Spot-check: run `npx vitest run src/components/admin src/hooks/__tests__` locally → 45/45 pass
3. Confirm no existing admin panels were modified (`git diff --name-only origin/staging` = only new files)

🤖 Generated with Claude Code (claude-sonnet-4-6)