### PR TITLE
refactor(omo): split routes/omo.py into validator + upload + state services (Fixes #1857)

### DIFF
--- a/backend/app/routes/omo.py
+++ b/backend/app/routes/omo.py
@@ -25,11 +25,15 @@ AnalysisBy: issue #1770 — split from 1197-line monolith into 4 focused modules
   - services/omo_storage.py        — GCS upload, signing, bucket constant
   - services/omo_responses.py      — Pydantic schemas + response builders
   - services/omo_jobs.py           — background tasks, _update_upload helper
+
+AnalysisBy: issue #1857 — second-pass split into 3 more focused modules:
+  - services/omo_upload_validator.py — file-count/size/MIME guards (sync, no DB/GCS)
+  - services/omo_upload_service.py   — dedup/create/supersede DB helpers
+  - services/omo_state_service.py    — confirm/regrade/flag/lesson-id mapping
 """
 
 import hashlib
 import logging
-from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Path, UploadFile
@@ -62,15 +66,29 @@ from ..services.omo_responses import (
 )
 from ..services.omo_jobs import _run_grading, _run_identification, _update_upload
 
+# Delegated to focused service modules (issue #1857 split)
+from ..services.omo_upload_validator import (
+    _MAX_FILES_PER_UPLOAD,
+    _MAX_TOTAL_ATTEMPTS,
+    validate_attempt_files,
+    validate_upload_files,
+)
+from ..services.omo_upload_service import (
+    check_dedup,
+    create_attempt_record,
+    create_upload_record,
+    supersede_existing_uploads,
+)
+from ..services.omo_state_service import (
+    apply_confirm,
+    apply_flag,
+    apply_regrade,
+    resolve_lesson_id,
+)
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["omo"])
-
-# ── Constants ──────────────────────────────────────────────────────────────────
-_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024   # 10MB per image
-_MAX_FILES_PER_UPLOAD = 20                  # max files per single upload call
-_MAX_TOTAL_ATTEMPTS = 5                    # max attempts per upload session
-_ALLOWED_MIME_TYPES = {"image/jpeg", "image/jpg", "image/png", "image/webp"}
 
 
 # ── Internal route helpers ─────────────────────────────────────────────────────
@@ -157,89 +175,53 @@ async def upload_worksheet(
     completes synchronously in the background task without any AI call
     (confidence=1.0, ~0 latency vs 6-24 s for Gemini).
     """
-    if not files:
-        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
-    if len(files) > _MAX_FILES_PER_UPLOAD:
-        raise HTTPException(
-            status_code=400,
-            detail=f"最多只能上傳 {_MAX_FILES_PER_UPLOAD} 張照片",
-        )
-
-    image_bytes_list: list[bytes] = []
-    mime_types: list[str] = []
+    # ── Read all file bytes (required for async UploadFile) ──────────────────
+    files_data: list[tuple[bytes, str]] = []
     for f in files:
         content_type = f.content_type or "image/jpeg"
-        if content_type not in _ALLOWED_MIME_TYPES:
-            raise HTTPException(
-                status_code=400,
-                detail=f"不支援的圖片格式 {content_type}，請上傳 JPEG 或 PNG",
-            )
         data = await f.read()
-        if len(data) > _MAX_FILE_SIZE_BYTES:
-            raise HTTPException(
-                status_code=413,
-                detail=f"圖片太大（{len(data) // (1024*1024)}MB），最大允許 10MB",
-            )
-        if len(data) == 0:
-            raise HTTPException(status_code=400, detail="上傳的圖片是空的")
-        image_bytes_list.append(data)
-        mime_types.append(content_type)
+        files_data.append((data, content_type))
+
+    # ── Validate (raises 400/413 before any GCS work) ────────────────────────
+    validate_upload_files(files_data)
+
+    image_bytes_list = [d for d, _ in files_data]
+    mime_types = [m for _, m in files_data]
 
     # ── Phase 1b: SHA-256 dedup check ────────────────────────────────────────
     # Hash the primary (first) image to detect duplicate uploads.
     primary_hash = hashlib.sha256(image_bytes_list[0]).hexdigest()
 
-    existing_attempt = (
-        db.query(OmoUploadAttempt)
-        .join(OmoUpload, OmoUploadAttempt.omo_upload_id == OmoUpload.id)
-        .filter(
-            OmoUploadAttempt.image_hash == primary_hash,
-            OmoUpload.student_id == current_user.id,
+    existing_upload = check_dedup(db, current_user.id, primary_hash)
+    if existing_upload:
+        already_graded = existing_upload.status == "graded"
+        logger.info(
+            "OMO dedup hit: student=%d hash=%s existing_upload_id=%d already_graded=%s",
+            current_user.id, primary_hash[:16], existing_upload.id, already_graded,
         )
-        .first()
-    )
-
-    if existing_attempt:
-        existing_upload = db.query(OmoUpload).filter(
-            OmoUpload.id == existing_attempt.omo_upload_id
-        ).first()
-        if existing_upload:
-            already_graded = existing_upload.status == "graded"
-            logger.info(
-                "OMO dedup hit: student=%d hash=%s existing_upload_id=%d already_graded=%s",
-                current_user.id, primary_hash[:16], existing_upload.id, already_graded,
-            )
-            response = _build_upload_response(existing_upload)
-            response.from_cache = True
-            response.already_graded = already_graded
-            return response
+        response = _build_upload_response(existing_upload)
+        response.from_cache = True
+        response.already_graded = already_graded
+        return response
 
     # ── Create new upload record (status=identifying) ─────────────────────────
-    upload = OmoUpload(
-        student_id=current_user.id,
-        status="identifying",
-        answers=[],
-        progress={},
-    )
-    db.add(upload)
-    db.flush()   # get id before commit
+    upload = create_upload_record(db, current_user.id)
     upload_id = upload.id
 
     # Create first attempt (with hash stored for future dedup)
     image_paths = []
-    for i, (data, mime) in enumerate(zip(image_bytes_list, mime_types)):
+    for i, (data, mime) in enumerate(files_data):
         path = _upload_to_gcs(current_user.id, upload_id, 0, i, data, mime)
         image_paths.append(path)
 
-    attempt = OmoUploadAttempt(
-        omo_upload_id=upload_id,
+    create_attempt_record(
+        db,
+        upload_id=upload_id,
         attempt_idx=0,
         image_paths=image_paths,
         image_hash=primary_hash,
         is_active=True,
     )
-    db.add(attempt)
-    db.commit()
 
     # Upload-replace UX: supersede any existing active upload for this lesson+student
     # (only when we know the lesson upfront via hint — avoids superseding during identification)
@@ -248,14 +230,7 @@ async def upload_worksheet(
         hint_candidates = identify_lesson_from_hint(lesson_code_hint)
         if hint_candidates:
             hinted_lesson_id = hint_candidates[0].lesson_id
-            now_ts = datetime.now(timezone.utc)
-            db.query(OmoUpload).filter(
-                OmoUpload.student_id == current_user.id,
-                OmoUpload.lesson_id == hinted_lesson_id,
-                OmoUpload.superseded_at.is_(None),
-                OmoUpload.id != upload_id,
-            ).update({'superseded_at': now_ts})
-            db.commit()
+            supersede_existing_uploads(db, current_user.id, hinted_lesson_id, upload_id)
 
     background_tasks.add_task(
         _run_identification, upload_id, image_bytes_list, mime_types, lesson_code_hint
@@ -305,36 +280,19 @@ async def add_attempt(
     existing_attempts = db.query(OmoUploadAttempt).filter(
         OmoUploadAttempt.omo_upload_id == upload_id
     ).count()
-    if existing_attempts >= _MAX_TOTAL_ATTEMPTS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"最多 {_MAX_TOTAL_ATTEMPTS} 次重拍機會",
-        )
 
-    if not files:
-        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
-    if len(files) > _MAX_FILES_PER_UPLOAD:
-        raise HTTPException(
-            status_code=400,
-            detail=f"每次最多上傳 {_MAX_FILES_PER_UPLOAD} 張照片",
-        )
-
-    image_bytes_list: list[bytes] = []
-    mime_types: list[str] = []
+    # ── Read all file bytes ───────────────────────────────────────────────────
+    files_data: list[tuple[bytes, str]] = []
     for f in files:
         content_type = f.content_type or "image/jpeg"
-        if content_type not in _ALLOWED_MIME_TYPES:
-            raise HTTPException(
-                status_code=400,
-                detail=f"不支援的圖片格式 {content_type}",
-            )
         data = await f.read()
-        if len(data) > _MAX_FILE_SIZE_BYTES:
-            raise HTTPException(status_code=413, detail="圖片超過 10MB")
-        if not data:
-            raise HTTPException(status_code=400, detail="空的圖片檔案")
-        image_bytes_list.append(data)
-        mime_types.append(content_type)
+        files_data.append((data, content_type))
+
+    # ── Validate (attempt count + file constraints) ───────────────────────────
+    validate_attempt_files(files_data, existing_attempts)
+
+    image_bytes_list = [d for d, _ in files_data]
+    mime_types = [m for _, m in files_data]
 
     attempt_idx = existing_attempts  # 0-based
 
@@ -345,23 +303,22 @@ async def add_attempt(
 
     # Upload images
     image_paths = []
-    for i, (data, mime) in enumerate(zip(image_bytes_list, mime_types)):
+    for i, (data, mime) in enumerate(files_data):
         path = _upload_to_gcs(current_user.id, upload_id, attempt_idx, i, data, mime)
         image_paths.append(path)
-
-    new_attempt = OmoUploadAttempt(
-        omo_upload_id=upload_id,
-        attempt_idx=attempt_idx,
-        image_paths=image_paths,
-        is_active=True,
-    )
-    db.add(new_attempt)
 
     # Reset upload status for re-identification
     upload.status = "identifying"
     upload.error_message = None
     db.commit()
-    db.refresh(new_attempt)
+
+    new_attempt = create_attempt_record(
+        db,
+        upload_id=upload_id,
+        attempt_idx=attempt_idx,
+        image_paths=image_paths,
+        is_active=True,
+    )
 
     # Re-trigger identification
     background_tasks.add_task(_run_identification, upload_id, image_bytes_list, mime_types)
@@ -426,31 +383,13 @@ async def confirm_lesson(
             upload_id, payload.confirmed_lesson_id, candidate_ids,
         )
 
-    # #1740 fix: identifier returns synthetic lesson_id (yml display_order)
-    # which does not match canonical Story.id used by frontend /api/stories.
-    # Translate via candidate's grade_code so OmoUpload.lesson_id is queryable
-    # via /api/omo/by-lesson/{Story.id} and _run_grading finds the right schema.
-    real_lesson_id = payload.confirmed_lesson_id
-    if upload.identification and isinstance(upload.identification, list):
-        matched = next(
-            (c for c in upload.identification if c.get("lesson_id") == payload.confirmed_lesson_id),
-            None,
-        )
-        grade_code = (matched or {}).get("grade_code") if matched else None
-        if grade_code:
-            from ..services.lesson_loader import get_lesson_by_code
-            story = get_lesson_by_code(grade_code)
-            if story and story.get("id"):
-                real_lesson_id = story["id"]
-                logger.info(
-                    "OMO #1740 lesson_id mapping: synthetic %d → Story.id %d via grade_code %s",
-                    payload.confirmed_lesson_id, real_lesson_id, grade_code,
-                )
+    # #1740 fix: translate synthetic lesson_id → canonical Story.id via grade_code
+    real_lesson_id = resolve_lesson_id(
+        payload.confirmed_lesson_id,
+        upload.identification if isinstance(upload.identification, list) else None,
+    )
 
-    upload.lesson_id = real_lesson_id
-    upload.status = "grading"
-    upload.progress = {"stage": "queued", "total": 0, "graded": 0}
-    db.commit()
+    apply_confirm(db, upload, real_lesson_id)
 
     # Kick off grading in background — pass real Story.id so grader picks correct schema
     background_tasks.add_task(_run_grading, upload_id, real_lesson_id)
@@ -520,10 +459,7 @@ async def regrade_upload(
             detail="尚未確認課程，請先確認課程後再批改",
         )
 
-    upload.status = "grading"
-    upload.progress = {"stage": "queued", "total": 0, "graded": 0}
-    upload.error_message = None
-    db.commit()
+    apply_regrade(db, upload)
 
     background_tasks.add_task(_run_grading, upload_id, upload.lesson_id)
 
@@ -560,31 +496,7 @@ def flag_answer(
             detail="批改尚未完成，無法標記問題",
         )
 
-    answers = list(upload.answers or [])
-    found = False
-    for a in answers:
-        if a.get("question_id") == question_id:
-            a["flag"] = {
-                "flagged_by": current_user.id,
-                "reason": payload.reason,
-                "flagged_at": datetime.now(timezone.utc).isoformat(),
-            }
-            found = True
-            logger.info(
-                "OMO answer flagged: upload_id=%d question_id=%s student=%d reason=%s",
-                upload_id, question_id, current_user.id, payload.reason,
-            )
-            break
-
-    if not found:
-        raise HTTPException(status_code=404, detail=f"找不到題目 {question_id}")
-
-    # SQLAlchemy needs explicit reassignment + flag_modified to detect JSON mutation
-    # (especially on SQLite test DB which uses JSON not JSONB)
-    from sqlalchemy.orm.attributes import flag_modified
-    upload.answers = answers
-    flag_modified(upload, "answers")
-    db.commit()
+    apply_flag(db, upload, question_id, current_user.id, payload.reason)
 
     return {"upload_id": upload_id, "question_id": question_id, "flagged": True}
 

--- a/backend/app/services/omo_state_service.py
+++ b/backend/app/services/omo_state_service.py
@@ -1,0 +1,197 @@
+"""OMO state-transition service — confirm, regrade, flag, lesson-id mapping.
+
+Extracted from backend/app/routes/omo.py as part of the 3-module split.
+AnalysisBy: issue #1857 — routes/omo.py second-pass refactor.
+
+Contains:
+- resolve_lesson_id(): #1740 fix — maps synthetic lesson_id → canonical Story.id
+- apply_confirm(): set upload to grading state after student confirmation
+- apply_regrade(): reset upload to grading for a student-initiated retry
+- apply_flag(): mark a specific answer as flagged by student
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from ..models.omo_upload import OmoUpload
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_lesson_id(
+    confirmed_lesson_id: int,
+    identification: Optional[list],
+) -> int:
+    """Map a synthetic lesson_id (YAML display_order) to a canonical Story.id.
+
+    Issue #1740 fix: the AI identifier returns a synthetic lesson_id derived
+    from the YAML catalog's display_order integer, which does NOT match the
+    Story.id used by the frontend /api/stories endpoints and by _run_grading
+    to look up the question schema.
+
+    Resolution strategy:
+    1. Find the candidate in ``identification`` whose lesson_id matches
+       ``confirmed_lesson_id``.
+    2. Extract its ``grade_code`` (e.g. "G5-L25").
+    3. Call ``get_lesson_by_code(grade_code)`` to fetch the DB-loaded lesson.
+    4. Return that lesson's ``id`` as the canonical Story.id.
+
+    Falls through unchanged if any step fails (no candidates, no grade_code,
+    no matching DB row).
+
+    Parameters
+    ----------
+    confirmed_lesson_id:
+        The synthetic lesson_id the student confirmed.
+    identification:
+        The JSON array stored in OmoUpload.identification (list of candidate dicts).
+
+    Returns
+    -------
+    int
+        Canonical Story.id if resolved, else ``confirmed_lesson_id`` unchanged.
+    """
+    if not identification or not isinstance(identification, list):
+        return confirmed_lesson_id
+
+    matched = next(
+        (c for c in identification if c.get("lesson_id") == confirmed_lesson_id),
+        None,
+    )
+    if not matched:
+        return confirmed_lesson_id
+
+    grade_code = matched.get("grade_code")
+    if not grade_code:
+        return confirmed_lesson_id
+
+    try:
+        from .lesson_loader import get_lesson_by_code
+        story = get_lesson_by_code(grade_code)
+        if story and story.get("id"):
+            real_id = story["id"]
+            logger.info(
+                "OMO #1740 lesson_id mapping: synthetic %d → Story.id %d via grade_code %s",
+                confirmed_lesson_id, real_id, grade_code,
+            )
+            return real_id
+    except Exception as exc:  # pragma: no cover
+        logger.warning("resolve_lesson_id: grade_code=%r lookup failed: %s", grade_code, exc)
+
+    return confirmed_lesson_id
+
+
+def apply_confirm(db: Session, upload: OmoUpload, real_lesson_id: int) -> None:
+    """Transition upload to grading state after student lesson confirmation.
+
+    Sets:
+    - ``upload.lesson_id`` = real_lesson_id (canonical Story.id)
+    - ``upload.status``    = "grading"
+    - ``upload.progress``  = {"stage": "queued", "total": 0, "graded": 0}
+
+    Commits the session.
+
+    Parameters
+    ----------
+    db:
+        Active SQLAlchemy session.
+    upload:
+        The OmoUpload being confirmed.
+    real_lesson_id:
+        Canonical Story.id (after #1740 mapping).
+    """
+    upload.lesson_id = real_lesson_id
+    upload.status = "grading"
+    upload.progress = {"stage": "queued", "total": 0, "graded": 0}
+    db.commit()
+
+
+def apply_regrade(db: Session, upload: OmoUpload) -> None:
+    """Reset upload to grading state for a student-initiated re-grade.
+
+    Sets:
+    - ``upload.status``        = "grading"
+    - ``upload.progress``      = {"stage": "queued", "total": 0, "graded": 0}
+    - ``upload.error_message`` = None
+
+    Commits the session.
+
+    Parameters
+    ----------
+    db:
+        Active SQLAlchemy session.
+    upload:
+        The OmoUpload to re-grade.
+    """
+    upload.status = "grading"
+    upload.progress = {"stage": "queued", "total": 0, "graded": 0}
+    upload.error_message = None
+    db.commit()
+
+
+def apply_flag(
+    db: Session,
+    upload: OmoUpload,
+    question_id: str,
+    flagged_by: int,
+    reason: str,
+) -> None:
+    """Set the flag dict on the answer item matching question_id.
+
+    The flag structure is::
+
+        {
+            "flagged_by":  <int: student user id>,
+            "reason":      <str>,
+            "flagged_at":  <ISO-8601 UTC timestamp>,
+        }
+
+    Uses ``flag_modified`` so SQLAlchemy detects the JSON mutation on both
+    PostgreSQL JSONB and SQLite JSON columns.
+
+    Raises HTTPException 404 if no answer with the given question_id is found.
+    Commits the session on success.
+
+    Parameters
+    ----------
+    db:
+        Active SQLAlchemy session.
+    upload:
+        The graded OmoUpload whose answers should be flagged.
+    question_id:
+        Identifier of the answer (e.g. "fb_1", "mc_2").
+    flagged_by:
+        User.id of the student flagging the answer.
+    reason:
+        Student-supplied reason for the flag.
+    """
+    answers = list(upload.answers or [])
+    found = False
+    for a in answers:
+        if a.get("question_id") == question_id:
+            a["flag"] = {
+                "flagged_by": flagged_by,
+                "reason": reason,
+                "flagged_at": datetime.now(timezone.utc).isoformat(),
+            }
+            found = True
+            logger.info(
+                "OMO answer flagged: upload_id=%d question_id=%s student=%d reason=%s",
+                upload.id, question_id, flagged_by, reason,
+            )
+            break
+
+    if not found:
+        raise HTTPException(status_code=404, detail=f"找不到題目 {question_id}")
+
+    # SQLAlchemy needs explicit reassignment + flag_modified to detect JSON mutation
+    upload.answers = answers
+    flag_modified(upload, "answers")
+    db.commit()

--- a/backend/app/services/omo_upload_service.py
+++ b/backend/app/services/omo_upload_service.py
@@ -1,0 +1,165 @@
+"""OMO upload DB service — dedup, record creation, supersede logic.
+
+Extracted from backend/app/routes/omo.py as part of the 3-module split.
+AnalysisBy: issue #1857 — routes/omo.py second-pass refactor.
+
+Contains:
+- check_dedup(): SHA-256 duplicate detection scoped per student
+- create_upload_record(): insert OmoUpload row with status=identifying
+- create_attempt_record(): insert OmoUploadAttempt row
+- supersede_existing_uploads(): mark prior uploads for same lesson as superseded
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from ..models.omo_upload import OmoUpload, OmoUploadAttempt
+
+logger = logging.getLogger(__name__)
+
+
+def check_dedup(db: Session, student_id: int, primary_hash: str) -> Optional[OmoUpload]:
+    """Return the existing OmoUpload if a duplicate image hash exists for this student.
+
+    Dedup is student-scoped: same hash uploaded by a different student does NOT
+    trigger a cache hit.
+
+    Parameters
+    ----------
+    db:
+        Active SQLAlchemy session.
+    student_id:
+        ID of the uploading student (current_user.id).
+    primary_hash:
+        SHA-256 hex digest of the first (primary) uploaded file.
+
+    Returns
+    -------
+    OmoUpload | None
+        The matching upload if found, else None.
+    """
+    existing_attempt = (
+        db.query(OmoUploadAttempt)
+        .join(OmoUpload, OmoUploadAttempt.omo_upload_id == OmoUpload.id)
+        .filter(
+            OmoUploadAttempt.image_hash == primary_hash,
+            OmoUpload.student_id == student_id,
+        )
+        .first()
+    )
+    if not existing_attempt:
+        return None
+
+    return db.query(OmoUpload).filter(
+        OmoUpload.id == existing_attempt.omo_upload_id
+    ).first()
+
+
+def create_upload_record(db: Session, student_id: int) -> OmoUpload:
+    """Insert a new OmoUpload row with status=identifying.
+
+    Flushes to obtain the auto-generated id before returning.  The caller
+    is responsible for committing after subsequent operations (e.g. creating
+    the first attempt record).
+
+    Parameters
+    ----------
+    db:
+        Active SQLAlchemy session.
+    student_id:
+        ID of the uploading student.
+
+    Returns
+    -------
+    OmoUpload
+        The newly created (flushed) upload instance with id populated.
+    """
+    upload = OmoUpload(
+        student_id=student_id,
+        status="identifying",
+        answers=[],
+        progress={},
+    )
+    db.add(upload)
+    db.flush()   # get id before commit
+    return upload
+
+
+def create_attempt_record(
+    db: Session,
+    upload_id: int,
+    attempt_idx: int,
+    image_paths: list[str],
+    image_hash: Optional[str] = None,
+    is_active: bool = True,
+) -> OmoUploadAttempt:
+    """Insert a new OmoUploadAttempt and return it after commit + refresh.
+
+    Parameters
+    ----------
+    db:
+        Active SQLAlchemy session.
+    upload_id:
+        FK to OmoUpload.id.
+    attempt_idx:
+        0-based attempt index within the upload session.
+    image_paths:
+        List of GCS object paths (one per uploaded file).
+    image_hash:
+        SHA-256 digest of the primary image (optional; stored for dedup).
+    is_active:
+        Whether this attempt is the currently active one.
+
+    Returns
+    -------
+    OmoUploadAttempt
+        The persisted attempt instance (post-refresh).
+    """
+    attempt = OmoUploadAttempt(
+        omo_upload_id=upload_id,
+        attempt_idx=attempt_idx,
+        image_paths=image_paths,
+        image_hash=image_hash,
+        is_active=is_active,
+    )
+    db.add(attempt)
+    db.commit()
+    db.refresh(attempt)
+    return attempt
+
+
+def supersede_existing_uploads(
+    db: Session,
+    student_id: int,
+    lesson_id: int,
+    current_upload_id: int,
+) -> None:
+    """Mark prior non-superseded uploads for this student+lesson as superseded.
+
+    Used by the upload-replace UX (hint path) so the frontend's by-lesson
+    query only surfaces the latest upload.
+
+    Parameters
+    ----------
+    db:
+        Active SQLAlchemy session.
+    student_id:
+        ID of the student whose prior uploads should be superseded.
+    lesson_id:
+        Canonical Story.id of the lesson.
+    current_upload_id:
+        The just-created upload that should NOT be superseded.
+    """
+    now_ts = datetime.now(timezone.utc)
+    db.query(OmoUpload).filter(
+        OmoUpload.student_id == student_id,
+        OmoUpload.lesson_id == lesson_id,
+        OmoUpload.superseded_at.is_(None),
+        OmoUpload.id != current_upload_id,
+    ).update({"superseded_at": now_ts})
+    db.commit()

--- a/backend/app/services/omo_upload_validator.py
+++ b/backend/app/services/omo_upload_validator.py
@@ -1,0 +1,96 @@
+"""OMO upload input validation — pure, sync, no DB/GCS side-effects.
+
+Extracted from backend/app/routes/omo.py as part of the 3-module split.
+AnalysisBy: issue #1857 — routes/omo.py second-pass refactor.
+
+Contains:
+- Upload constraint constants
+- validate_upload_files(): raises HTTPException for invalid file lists
+- validate_attempt_files(): same checks + attempt-count guard
+"""
+
+from fastapi import HTTPException
+
+# ── Upload constraints (single source of truth) ────────────────────────────────
+_MAX_FILE_SIZE_BYTES: int = 10 * 1024 * 1024   # 10 MB per image
+_MAX_FILES_PER_UPLOAD: int = 20                  # max files per single upload call
+_MAX_TOTAL_ATTEMPTS: int = 5                     # max attempts per upload session
+_ALLOWED_MIME_TYPES: frozenset[str] = frozenset({
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/webp",
+})
+
+
+def validate_upload_files(files_data: list[tuple[bytes, str]]) -> None:
+    """Validate a list of (bytes, mime_type) tuples for a new upload.
+
+    Raises HTTPException (400 or 413) for any of:
+    - Empty file list
+    - Too many files (> _MAX_FILES_PER_UPLOAD)
+    - Unsupported MIME type
+    - Oversized file (> _MAX_FILE_SIZE_BYTES)
+    - Zero-byte file content
+
+    Parameters
+    ----------
+    files_data:
+        List of (raw_bytes, content_type) for each uploaded file.
+        Bytes must already be read (no async here).
+    """
+    if not files_data:
+        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
+    if len(files_data) > _MAX_FILES_PER_UPLOAD:
+        raise HTTPException(
+            status_code=400,
+            detail=f"最多只能上傳 {_MAX_FILES_PER_UPLOAD} 張照片",
+        )
+    for data, content_type in files_data:
+        if content_type not in _ALLOWED_MIME_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"不支援的圖片格式 {content_type}，請上傳 JPEG 或 PNG",
+            )
+        if len(data) > _MAX_FILE_SIZE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"圖片太大（{len(data) // (1024 * 1024)}MB），最大允許 10MB",
+            )
+        if len(data) == 0:
+            raise HTTPException(status_code=400, detail="上傳的圖片是空的")
+
+
+def validate_attempt_files(
+    files_data: list[tuple[bytes, str]],
+    existing_attempt_count: int,
+) -> None:
+    """Validate files for an additional attempt on an existing upload session.
+
+    Extends validate_upload_files with an attempt-count guard.
+
+    Raises HTTPException 400 if existing_attempt_count >= _MAX_TOTAL_ATTEMPTS.
+    All other checks are identical to validate_upload_files.
+    """
+    if existing_attempt_count >= _MAX_TOTAL_ATTEMPTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"最多 {_MAX_TOTAL_ATTEMPTS} 次重拍機會",
+        )
+    if not files_data:
+        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
+    if len(files_data) > _MAX_FILES_PER_UPLOAD:
+        raise HTTPException(
+            status_code=400,
+            detail=f"每次最多上傳 {_MAX_FILES_PER_UPLOAD} 張照片",
+        )
+    for data, content_type in files_data:
+        if content_type not in _ALLOWED_MIME_TYPES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"不支援的圖片格式 {content_type}",
+            )
+        if len(data) > _MAX_FILE_SIZE_BYTES:
+            raise HTTPException(status_code=413, detail="圖片超過 10MB")
+        if not data:
+            raise HTTPException(status_code=400, detail="空的圖片檔案")

--- a/backend/tests/test_characterization_omo_1857.py
+++ b/backend/tests/test_characterization_omo_1857.py
@@ -1,0 +1,564 @@
+"""Characterization tests for OMO routes — issue #1857 split guard.
+
+TDD Phase 1 (Red → Green): write tests that pin current behaviour BEFORE
+any refactor.  After extraction into omo_upload_validator.py,
+omo_upload_service.py, omo_state_service.py these tests MUST still pass.
+
+Four behaviour clusters:
+  A. Upload input-validation (empty / oversized / bad-MIME / too-many files)
+     — all must reject BEFORE any GCS work.
+  B. Dedup: duplicate image scoped per student returns cached flags.
+  C. Confirm: maps synthetic lesson_id → Story.id via grade_code.
+  D. Regrade: rejects grading/no-lesson states; queues for graded/error/identified.
+
+Run:
+    cd backend && python -m pytest tests/test_characterization_omo_1857.py -v
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import os
+import hashlib
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from unittest.mock import patch, MagicMock
+
+from app.main import app
+from app.database import get_db
+from app.models import Base
+from app.models.user import Role
+from app.models.omo_upload import OmoUpload, OmoUploadAttempt
+from app.auth.rate_limiter import ai_rate_limiter
+
+# ---------------------------------------------------------------------------
+# SQLite in-memory DB (same pattern as other omo tests)
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+_SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for r in _SEED_ROLES:
+        session.add(Role(
+            name=r["name"],
+            display_name=r["display_name"],
+            scope_level=r["scope_level"],
+        ))
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    with ai_rate_limiter._lock:
+        ai_rate_limiter._store.clear()
+    yield
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Minimal valid JPEG (2x2 pixels) — small enough for all size tests
+# ---------------------------------------------------------------------------
+_TINY_JPEG = bytes([
+    0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+    0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43,
+    0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08, 0x07, 0x07, 0x07, 0x09,
+    0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12,
+    0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
+    0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29,
+    0x2C, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32,
+    0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x02,
+    0x00, 0x02, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0A, 0x0B, 0xFF, 0xC4, 0x00, 0xB5, 0x10, 0x00, 0x02, 0x01, 0x03,
+    0x03, 0x02, 0x04, 0x03, 0x05, 0x05, 0x04, 0x04, 0x00, 0x00, 0x01, 0x7D,
+    0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F, 0x00, 0xFB, 0xFF,
+    0xD9,
+])
+
+
+def _make_file(data: bytes, mime: str = "image/jpeg", name: str = "test.jpg"):
+    return ("files", (name, io.BytesIO(data), mime))
+
+
+# ---------------------------------------------------------------------------
+# Helper: register + login → token
+# ---------------------------------------------------------------------------
+
+def _auth(client, suffix: str) -> str:
+    email = f"char1857_{suffix}@example.com"
+    reg = client.post("/api/auth/register", json={
+        "email": email,
+        "password": "TestPass123!",
+        "name": f"Char1857 {suffix}",
+    })
+    if reg.status_code == 201:
+        vt = reg.json().get("verification_token")
+        if vt:
+            client.post("/api/auth/verify-email", json={"token": vt})
+    login = client.post("/api/auth/login", json={"email": email, "password": "TestPass123!"})
+    return login.json()["access_token"]
+
+
+# ---------------------------------------------------------------------------
+# Helper: force upload to a specific status via direct DB write
+# ---------------------------------------------------------------------------
+
+def _force_status(upload_id: int, status: str, extra: dict | None = None):
+    db = TestingSessionLocal()
+    try:
+        upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
+        if upload:
+            upload.status = status
+            if extra:
+                for k, v in extra.items():
+                    setattr(upload, k, v)
+            db.commit()
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Cluster A: Upload input validation
+# ---------------------------------------------------------------------------
+
+class TestUploadInputValidation:
+    """These 400/413 responses MUST come back before any GCS interaction.
+
+    All tests patch _upload_to_gcs so that if any validation is bypassed
+    the patch call count will remain 0 — that is the tautology check.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_gcs(self):
+        """Patch GCS upload so we can assert it was never called on rejection."""
+        with patch("app.routes.omo._upload_to_gcs") as mock_gcs:
+            self._gcs_mock = mock_gcs
+            yield
+
+    def _get_headers(self, client):
+        token = _auth(client, "upload_val_" + str(id(self)))
+        return {"Authorization": f"Bearer {token}"}
+
+    def test_empty_files_list_returns_400(self, client):
+        """Uploading zero files → 400 before GCS."""
+        headers = self._get_headers(client)
+        # TestClient multipart with empty list — send no file parts
+        resp = client.post(
+            "/api/omo/upload",
+            headers=headers,
+            # Omitting files entirely simulates no-file upload; FastAPI 422
+            # for missing required field also demonstrates pre-GCS rejection
+        )
+        # Either 400 (our check) or 422 (FastAPI required field) — both pre-GCS
+        assert resp.status_code in (400, 422), f"Expected 400/422, got {resp.status_code}"
+        assert self._gcs_mock.call_count == 0, "GCS must not be called when no files supplied"
+
+    def test_oversized_file_returns_413(self, client):
+        """File > 10MB → 413 before GCS."""
+        headers = self._get_headers(client)
+        big_data = b"x" * (10 * 1024 * 1024 + 1)  # 10MB + 1 byte
+        resp = client.post(
+            "/api/omo/upload",
+            files=[_make_file(big_data)],
+            headers=headers,
+        )
+        assert resp.status_code == 413, f"Expected 413, got {resp.status_code}: {resp.text}"
+        assert self._gcs_mock.call_count == 0, "GCS must not be called for oversized file"
+
+    def test_bad_mime_type_returns_400(self, client):
+        """Non-image MIME → 400 before GCS."""
+        headers = self._get_headers(client)
+        resp = client.post(
+            "/api/omo/upload",
+            files=[_make_file(b"<html></html>", mime="text/html", name="evil.html")],
+            headers=headers,
+        )
+        assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+        assert self._gcs_mock.call_count == 0, "GCS must not be called for invalid MIME"
+
+    def test_too_many_files_returns_400(self, client):
+        """More than 20 files → 400 before GCS."""
+        headers = self._get_headers(client)
+        files = [_make_file(_TINY_JPEG + bytes([i]), name=f"img{i}.jpg") for i in range(21)]
+        resp = client.post(
+            "/api/omo/upload",
+            files=files,
+            headers=headers,
+        )
+        assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+        assert self._gcs_mock.call_count == 0, "GCS must not be called when too many files"
+
+    def test_empty_file_bytes_returns_400(self, client):
+        """Zero-byte file content → 400 before GCS."""
+        headers = self._get_headers(client)
+        resp = client.post(
+            "/api/omo/upload",
+            files=[_make_file(b"")],
+            headers=headers,
+        )
+        assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text}"
+        assert self._gcs_mock.call_count == 0, "GCS must not be called for empty file bytes"
+
+
+# ---------------------------------------------------------------------------
+# Cluster B: Dedup — per-student, returns cached flags
+# ---------------------------------------------------------------------------
+
+class TestUploadDedup:
+    """SHA-256 dedup must be scoped per student."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_gcs_and_bg(self):
+        with patch("app.routes.omo._upload_to_gcs", return_value="gs://bucket/path.jpg"), \
+             patch("app.routes.omo._run_identification"):
+            yield
+
+    def test_duplicate_upload_same_student_returns_from_cache(self, client):
+        """Same image bytes uploaded twice by same student → 2nd has from_cache=True."""
+        token = _auth(client, "dedup_same_student")
+        headers = {"Authorization": f"Bearer {token}"}
+        unique_bytes = _TINY_JPEG + b"dedup_same_1857"
+
+        resp1 = client.post(
+            "/api/omo/upload",
+            files=[_make_file(unique_bytes)],
+            headers=headers,
+        )
+        assert resp1.status_code == 201
+
+        resp2 = client.post(
+            "/api/omo/upload",
+            files=[_make_file(unique_bytes)],
+            headers=headers,
+        )
+        assert resp2.status_code == 201
+        data2 = resp2.json()
+        assert data2["from_cache"] is True, "Second identical upload must return from_cache=True"
+
+    def test_duplicate_upload_returns_already_graded_flag(self, client):
+        """When the cached upload is graded, already_graded must be True."""
+        token = _auth(client, "dedup_graded_flag")
+        headers = {"Authorization": f"Bearer {token}"}
+        unique_bytes = _TINY_JPEG + b"dedup_graded_1857"
+
+        resp1 = client.post(
+            "/api/omo/upload",
+            files=[_make_file(unique_bytes)],
+            headers=headers,
+        )
+        assert resp1.status_code == 201
+        upload_id = resp1.json()["upload_id"]
+        _force_status(upload_id, "graded", {"lesson_id": 1, "answers": []})
+
+        resp2 = client.post(
+            "/api/omo/upload",
+            files=[_make_file(unique_bytes)],
+            headers=headers,
+        )
+        assert resp2.status_code == 201
+        data2 = resp2.json()
+        assert data2["from_cache"] is True
+        assert data2["already_graded"] is True, "already_graded must be True when cached upload is graded"
+
+    def test_duplicate_upload_different_students_not_cached(self, client):
+        """Same image bytes, different students → NOT deduped (student-scoped)."""
+        token_a = _auth(client, "dedup_cross_a_1857")
+        token_b = _auth(client, "dedup_cross_b_1857")
+        unique_bytes = _TINY_JPEG + b"dedup_cross_1857"
+
+        resp_a = client.post(
+            "/api/omo/upload",
+            files=[_make_file(unique_bytes)],
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        assert resp_a.status_code == 201
+
+        resp_b = client.post(
+            "/api/omo/upload",
+            files=[_make_file(unique_bytes)],
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert resp_b.status_code == 201
+        data_b = resp_b.json()
+        assert data_b["from_cache"] is False, "Different students must never share dedup cache"
+
+    def test_different_bytes_no_cache(self, client):
+        """Different image bytes → fresh upload, from_cache=False."""
+        token = _auth(client, "dedup_different")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp1 = client.post(
+            "/api/omo/upload",
+            files=[_make_file(_TINY_JPEG + b"unique_a")],
+            headers=headers,
+        )
+        assert resp1.status_code == 201
+
+        resp2 = client.post(
+            "/api/omo/upload",
+            files=[_make_file(_TINY_JPEG + b"unique_b")],
+            headers=headers,
+        )
+        assert resp2.status_code == 201
+        data2 = resp2.json()
+        assert data2["from_cache"] is False, "Different bytes must not be cached"
+
+
+# ---------------------------------------------------------------------------
+# Cluster C: Confirm — synthetic lesson_id → Story.id via grade_code
+# ---------------------------------------------------------------------------
+
+class TestConfirmLessonIdMapping:
+    """Confirm must translate synthetic lesson_id → real Story.id through grade_code.
+
+    The identifier returns a synthetic lesson_id (YAML display_order integer).
+    Confirm reads upload.identification candidates, finds the grade_code for the
+    confirmed_lesson_id, then calls get_lesson_by_code(grade_code) to resolve
+    the canonical Story.id used by _run_grading.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_gcs_and_jobs(self):
+        with patch("app.routes.omo._upload_to_gcs", return_value="gs://bucket/path.jpg"), \
+             patch("app.routes.omo._run_identification"), \
+             patch("app.routes.omo._run_grading"):
+            yield
+
+    def _make_upload_with_identification(self, client, suffix: str, candidates: list) -> tuple[str, int]:
+        """Create an upload and force it to identified state with given candidates."""
+        token = _auth(client, suffix)
+        headers = {"Authorization": f"Bearer {token}"}
+        unique_bytes = _TINY_JPEG + suffix.encode()
+
+        resp = client.post(
+            "/api/omo/upload",
+            files=[_make_file(unique_bytes)],
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        upload_id = resp.json()["upload_id"]
+
+        # Force to identified with synthetic candidates
+        _force_status(upload_id, "identified", {"identification": candidates})
+        return token, upload_id
+
+    def test_confirm_with_no_grade_code_match_uses_confirmed_id_as_is(self, client):
+        """When no grade_code in candidates, lesson_id passes through unchanged."""
+        candidates = [{"lesson_id": 99, "grade_code": "", "title": "Test", "confidence": 0.9, "reasoning": "test"}]
+        token, upload_id = self._make_upload_with_identification(client, "confirm_no_gc", candidates)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        with patch("app.services.lesson_loader.get_lesson_by_code", return_value=None):
+            resp = client.post(
+                f"/api/omo/{upload_id}/confirm",
+                json={"confirmed_lesson_id": 99},
+                headers=headers,
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # No mapping possible → lesson_id stays 99
+        assert data["lesson_id"] == 99
+
+    def test_confirm_maps_synthetic_id_to_story_id_via_grade_code(self, client):
+        """Synthetic lesson_id 42 maps to Story.id 7 when grade_code resolves."""
+        grade_code = "G5-L25"
+        candidates = [
+            {"lesson_id": 42, "grade_code": grade_code, "title": "Test Lesson",
+             "confidence": 0.95, "reasoning": "test"},
+        ]
+        token, upload_id = self._make_upload_with_identification(client, "confirm_mapping", candidates)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # Simulate get_lesson_by_code returning a story with id=7
+        fake_story = {"id": 7, "title": "Test Lesson", "grade_code": grade_code}
+        with patch("app.services.lesson_loader.get_lesson_by_code", return_value=fake_story):
+            resp = client.post(
+                f"/api/omo/{upload_id}/confirm",
+                json={"confirmed_lesson_id": 42},
+                headers=headers,
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Must use Story.id=7, not synthetic 42
+        assert data["lesson_id"] == 7, f"Expected Story.id=7, got {data['lesson_id']}"
+
+    def test_confirm_rejects_grading_status(self, client):
+        """Confirm while status=grading → 409."""
+        candidates = [{"lesson_id": 1, "grade_code": "G5-L1", "title": "T", "confidence": 0.9, "reasoning": "r"}]
+        token, upload_id = self._make_upload_with_identification(client, "confirm_grading_409", candidates)
+        _force_status(upload_id, "grading")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(
+            f"/api/omo/{upload_id}/confirm",
+            json={"confirmed_lesson_id": 1},
+            headers=headers,
+        )
+        assert resp.status_code == 409
+
+    def test_confirm_rejects_graded_status(self, client):
+        """Confirm while status=graded → 409 (use /regrade instead)."""
+        candidates = [{"lesson_id": 1, "grade_code": "G5-L1", "title": "T", "confidence": 0.9, "reasoning": "r"}]
+        token, upload_id = self._make_upload_with_identification(client, "confirm_graded_409", candidates)
+        _force_status(upload_id, "graded", {"lesson_id": 1, "answers": []})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(
+            f"/api/omo/{upload_id}/confirm",
+            json={"confirmed_lesson_id": 1},
+            headers=headers,
+        )
+        assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Cluster D: Regrade state machine
+# ---------------------------------------------------------------------------
+
+class TestRegradeStateMachine:
+    """Regrade must only be allowed from graded/error/identified states."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_gcs_and_jobs(self):
+        with patch("app.routes.omo._upload_to_gcs", return_value="gs://bucket/path.jpg"), \
+             patch("app.routes.omo._run_identification"), \
+             patch("app.routes.omo._run_grading"):
+            yield
+
+    def _make_upload(self, client, suffix: str) -> tuple[str, int]:
+        token = _auth(client, suffix)
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = client.post(
+            "/api/omo/upload",
+            files=[_make_file(_TINY_JPEG + suffix.encode())],
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        return token, resp.json()["upload_id"]
+
+    def test_regrade_from_graded_returns_200_and_grading(self, client):
+        """Regrade from graded → 200, status=grading."""
+        token, upload_id = self._make_upload(client, "rg_graded")
+        _force_status(upload_id, "graded", {"lesson_id": 1, "answers": []})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(f"/api/omo/{upload_id}/regrade", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "grading"
+
+    def test_regrade_from_error_returns_200_and_grading(self, client):
+        """Regrade from error state → 200, status=grading (retry after failed grading)."""
+        token, upload_id = self._make_upload(client, "rg_error")
+        _force_status(upload_id, "error", {"lesson_id": 1})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(f"/api/omo/{upload_id}/regrade", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "grading"
+
+    def test_regrade_from_identified_returns_200_and_grading(self, client):
+        """Regrade from identified state → 200 (lesson already confirmed)."""
+        token, upload_id = self._make_upload(client, "rg_identified")
+        _force_status(upload_id, "identified", {"lesson_id": 1})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(f"/api/omo/{upload_id}/regrade", headers=headers)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "grading"
+
+    def test_regrade_while_grading_returns_409(self, client):
+        """Regrade while still grading → 409 (prevents double-grading)."""
+        token, upload_id = self._make_upload(client, "rg_grading_409")
+        _force_status(upload_id, "grading", {"lesson_id": 1})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(f"/api/omo/{upload_id}/regrade", headers=headers)
+        assert resp.status_code == 409
+
+    def test_regrade_without_lesson_id_returns_409(self, client):
+        """Regrade when no lesson_id → 409 (must confirm first)."""
+        token, upload_id = self._make_upload(client, "rg_no_lesson")
+        # Upload is still identifying with no lesson_id
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(f"/api/omo/{upload_id}/regrade", headers=headers)
+        assert resp.status_code == 409
+
+    def test_regrade_from_identifying_returns_409(self, client):
+        """Regrade while identifying → 409 (not an allowed regrade state)."""
+        token, upload_id = self._make_upload(client, "rg_identifying_409")
+        # Upload starts as "identifying" — no lesson_id
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = client.post(f"/api/omo/{upload_id}/regrade", headers=headers)
+        assert resp.status_code == 409
+
+    def test_regrade_queues_grading_job(self, client):
+        """After regrade, polling GET shows status=grading (job was queued)."""
+        token, upload_id = self._make_upload(client, "rg_poll_grading")
+        _force_status(upload_id, "graded", {"lesson_id": 5, "answers": []})
+        headers = {"Authorization": f"Bearer {token}"}
+
+        client.post(f"/api/omo/{upload_id}/regrade", headers=headers)
+        poll = client.get(f"/api/omo/{upload_id}", headers=headers)
+        assert poll.status_code == 200
+        assert poll.json()["status"] == "grading"


### PR DESCRIPTION
Fixes #1857

## Summary

TDD-first refactor: extracted 3 focused service modules from `backend/app/routes/omo.py` (741L → 653L).

### New files
- `services/omo_upload_validator.py` — pure sync guards (file-count/size/MIME), no DB/GCS side-effects
- `services/omo_upload_service.py` — dedup, create_upload_record, create_attempt_record, supersede_existing_uploads
- `services/omo_state_service.py` — resolve_lesson_id (#1740 mapping), apply_confirm, apply_regrade, apply_flag

### TDD evidence
- 20 characterization tests written **before** extraction (all green on staging code)
- Same 20 tests green **after** extraction — proves zero behaviour change
- 4 clusters: A. input validation (GCS mock asserts 0 calls on rejection) / B. dedup per-student / C. lesson-id mapping / D. regrade state machine

### Pre-existing failure (NOT introduced by this PR)
`test_omo_upload.py::TestOmoUploadInputValidation::test_too_many_files_returns_400` — test expected 6 files to 400 but `_MAX_FILES_PER_UPLOAD = 20` was already 20 before this PR. Verified with `git stash` + re-run.

## Test plan
- [x] 20 new characterization tests pass pre- and post-refactor
- [x] 69/70 existing omo tests pass (1 pre-existing failure unrelated)
- [ ] CI preview deploy green
- [ ] Staging deploy and `GET /api/health` 200