### PR TITLE
refactor(stroke): extract useWriteCharacterMachine + useStrokeCanvasRenderer (Fixes #1858)

### DIFF
--- a/frontend/src/components/stroke-order/WriteCharacter.tsx
+++ b/frontend/src/components/stroke-order/WriteCharacter.tsx
@@ -8,48 +8,17 @@ import {
   CANVAS_SIZE,
   HINT_THRESHOLD,
 } from './strokeData';
-import { renderStrokes, RenderState } from './strokeRenderer';
+import { Step, useWriteCharacterMachine } from './useWriteCharacterMachine';
+import { useStrokeCanvasRenderer } from './useStrokeCanvasRenderer';
 
 interface WriteCharacterProps {
   character: string;
   onComplete?: () => void;
   onBack?: () => void;
-  /** When true, only renders the canvas + minimal controls (no header/back/progress dots). */
   embedded?: boolean;
-  /**
-   * Practice flow shape (#1342 / VocabPractice rounds):
-   *   - 'standard' (default): animation preview + 3 outlined practices +
-   *     1 no-outline practice. The historical 4-trace flow.
-   *   - 'outlined-once': skip animation; one outlined practice only;
-   *     fire onComplete on success. Used for round-1 仿寫.
-   *   - 'no-outline-once': skip animation + outline; one no-outline
-   *     practice only; fire onComplete on success. Used for round-2 再生回憶.
-   *
-   * Named `practiceMode` rather than `mode` to avoid shadowing the internal
-   * `mode` state variable ('idle' | 'animating' | 'quizzing').
-   */
   practiceMode?: 'standard' | 'outlined-once' | 'no-outline-once';
-  /**
-   * #1342: colour completed strokes by their component group on the canvas.
-   * Once every stroke is done the colours unify into the default ink colour
-   * ("合體"). Number of distinct colours is driven by `componentCount` below.
-   */
   radicalColorMode?: boolean;
-  /**
-   * #1529: number of components for this character (from getDecomposition).
-   * One colour per component, up to the palette length (5). Defaults to 2
-   * (primary radical + body) when omitted, matching the previous behaviour.
-   */
   componentCount?: number;
-}
-
-enum Step {
-  ANIMATION,
-  PRACTICE_1,
-  PRACTICE_2,
-  PRACTICE_3,
-  PRACTICE_NO_OUTLINE,
-  COMPLETE,
 }
 
 /* ================================================================ */
@@ -90,7 +59,6 @@ interface ProgressDotsProps {
 function ProgressDots({ step, practiceLeft }: ProgressDotsProps) {
   if (step === Step.ANIMATION || step === Step.COMPLETE) return null;
 
-  // 3 bordered rounds + 1 no-outline round = 4 total
   const dots = [
     { label: '1', filled: practiceLeft < 4, isNoOutline: false },
     { label: '2', filled: practiceLeft < 3, isNoOutline: false },
@@ -214,135 +182,58 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
   componentCount = 2,
 }) => {
   // #1342 / #1529: derived flags for the simplified single-shot rounds.
-  // outlined-once still plays the animation preview (#1529); only the recall
-  // round (no-outline-once) skips it.
   const isOutlinedOnce = practiceMode === 'outlined-once';
   const isNoOutlineOnce = practiceMode === 'no-outline-once';
-  /* ---- React state (drives UI controls) ---- */
+
+  /* ---- Step/mode state (via useWriteCharacterMachine) ---- */
+  const [machineState, machineActions] = useWriteCharacterMachine();
+  const {
+    step, mode, practiceLeft, showOutline, completedStrokesUI,
+    toast, toastType, canvasShake,
+  } = machineState;
+  const {
+    setStep, setMode, setPracticeLeft, setShowOutline,
+    setCompletedStrokesUI, setToast, setToastType, setCanvasShake,
+    resetMachineState,
+  } = machineActions;
+
+  /* ---- Data loading state ---- */
   const [data, setData] = useState<CharacterStrokeData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [step, setStep] = useState(Step.ANIMATION);
-  const [mode, setMode] = useState<'idle' | 'animating' | 'quizzing'>('idle');
-  const [practiceLeft, setPracticeLeft] = useState(4);
-  const [toast, setToast] = useState('');
-  const [toastType, setToastType] = useState<'success' | 'error' | 'info'>('success');
-  const [showOutline, setShowOutline] = useState(true);
-  const [canvasShake, setCanvasShake] = useState(false);
-  const [completedStrokesUI, setCompletedStrokesUI] = useState(0);
 
-  /* ---- Refs for imperative canvas rendering ---- */
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const offCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  /* ---- Canvas refs / rendering (via useStrokeCanvasRenderer) ---- */
+  const renderer = useStrokeCanvasRenderer({ radicalColorMode, componentCount });
+  const {
+    canvasRef, r, m,
+    animFrameRef, hintFrameRef,
+    loopTimerRef, shakeTimerRef, completionTimerRef,
+    isDrawingRef, isAutoLoopingRef, pendingAutoStartRef,
+    doRender,
+  } = renderer;
 
-  // Rendering state (read by the render function, written by animation/quiz/drawing)
-  const r = useRef({
-    completedStrokes: 0,
-    animStroke: -1,
-    animProgress: 0,
-    hintStroke: -1,
-    hintProgress: 0,
-    correctPaths: [] as Point[][],
-    activeBrush: [] as Point[],
-  });
+  // Animation start timestamps are attached to the renderer's `r` ref
+  const animStartRef = (r as any).animStartRef as React.MutableRefObject<number>;
+  const hintStartRef = (r as any).hintStartRef as React.MutableRefObject<number>;
 
-  // Mirrors of React state for async/imperative callbacks
-  const m = useRef({
-    data: null as CharacterStrokeData | null,
-    step: Step.ANIMATION,
-    mode: 'idle' as string,
-    practiceLeft: 4,
-    showOutline: true,
-    mistakes: [] as number[],
-    quizStroke: 0,
-  });
+  // Sync mirrors every render so async callbacks see latest React state
   m.current.data = data;
   m.current.step = step;
   m.current.mode = mode;
   m.current.practiceLeft = practiceLeft;
   m.current.showOutline = showOutline;
 
-  // Animation & drawing refs
-  const animFrameRef = useRef(0);
-  const animStartRef = useRef(0);
-  const hintFrameRef = useRef(0);
-  const hintStartRef = useRef(0);
-  const isDrawingRef = useRef(false);
-  const isAutoLoopingRef = useRef(false);
-  const pendingAutoStartRef = useRef(false);
-  const loopTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  const shakeTimerRef = useRef<ReturnType<typeof setTimeout>>();
-  // #1342: holds the auto-onComplete timer for single-shot rounds so we can
-  // cancel it on character change / unmount, preventing a stale closure from
-  // firing onComplete after the parent has already advanced (e.g. the user
-  // tapped "跳過第 2 次練習" inside the 600 ms window).
-  const completionTimerRef = useRef<ReturnType<typeof setTimeout>>();
-
-  /* ---- Off-screen canvas (created once, reused) ---- */
-  const getOffCanvas = useCallback(() => {
-    if (!offCanvasRef.current) {
-      offCanvasRef.current = document.createElement('canvas');
-      offCanvasRef.current.width = CANVAS_SIZE;
-      offCanvasRef.current.height = CANVAS_SIZE;
-    }
-    return offCanvasRef.current;
-  }, []);
-
-  /* ---- Render to canvas ---- */
-  const doRender = useCallback(() => {
-    const canvas = canvasRef.current;
-    const d = m.current.data;
-    if (!canvas || !d) return;
-    const ctx = canvas.getContext('2d')!;
-    const state: RenderState = {
-      data: d,
-      completedStrokes: r.current.completedStrokes,
-      animStroke: r.current.animStroke,
-      animProgress: r.current.animProgress,
-      hintStroke: r.current.hintStroke,
-      hintProgress: r.current.hintProgress,
-      showOutline: m.current.showOutline,
-      correctPaths: r.current.correctPaths,
-      activeBrush: r.current.activeBrush,
-      radicalColorMode,
-      componentCount,
-    };
-    renderStrokes(ctx, getOffCanvas(), state);
-  }, [getOffCanvas, radicalColorMode, componentCount]);
-
-  /* ---- Shared state reset (used by both initial load and retry) ---- */
+  /* ---- Shared state reset ---- */
   const resetState = useCallback((nStrokes: number) => {
-    // #1342 / #1529 single-shot rounds:
-    //   outlined-once → ANIMATION first (preview stroke order), then a single
-    //     PRACTICE_1 trace once the student clicks 開始練習. Restored in #1529
-    //     so children see the correct stroke order before writing — without
-    //     having to wait the full animation out (skip button stays available).
-    //   no-outline-once → PRACTICE_NO_OUTLINE, outline hidden, no preview.
-    // standard preserves the original animation-led 4-trace flow.
-    let initialStep = Step.ANIMATION;
-    let outlineOn = true;
-    let leftCount = 4;
-    if (isOutlinedOnce) {
-      leftCount = 1;
-    } else if (isNoOutlineOnce) {
-      initialStep = Step.PRACTICE_NO_OUTLINE;
-      outlineOn = false;
-      leftCount = 1;
-    }
-    setStep(initialStep);
-    setMode('idle');
-    setPracticeLeft(leftCount);
-    setShowOutline(outlineOn);
-    setToast('');
-    setCompletedStrokesUI(0);
+    const result = resetMachineState({ nStrokes, isOutlinedOnce, isNoOutlineOnce });
     r.current = {
       completedStrokes: 0, animStroke: -1, animProgress: 0,
       hintStroke: -1, hintProgress: 0, correctPaths: [], activeBrush: [],
     };
-    m.current.showOutline = outlineOn;
+    m.current.showOutline = result.outlineOn;
     m.current.mistakes = new Array(nStrokes).fill(0);
     m.current.quizStroke = 0;
-  }, [isOutlinedOnce, isNoOutlineOnce]);
+  }, [isOutlinedOnce, isNoOutlineOnce, resetMachineState, r, m]);
 
   /* ---- Load character data ---- */
   useEffect(() => {
@@ -370,7 +261,8 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
       clearTimeout(shakeTimerRef.current);
       clearTimeout(completionTimerRef.current);
     };
-  }, [character, resetState]);
+  }, [character, resetState, isAutoLoopingRef, pendingAutoStartRef, m,
+      animFrameRef, hintFrameRef, loopTimerRef, shakeTimerRef, completionTimerRef]);
 
   /* ---- Re-render when declarative state changes ---- */
   useEffect(() => {
@@ -382,27 +274,26 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
     if (!toast) return;
     const t = setTimeout(() => setToast(''), 3500);
     return () => clearTimeout(t);
-  }, [toast]);
+  }, [toast, setToast]);
 
-  /* ---- Trigger shake animation ---- */
+  /* ---- Shake animation ---- */
   const triggerShake = useCallback(() => {
     setCanvasShake(false);
     clearTimeout(shakeTimerRef.current);
-    // Use rAF to allow React to clear the class first
     requestAnimationFrame(() => {
       setCanvasShake(true);
       shakeTimerRef.current = setTimeout(() => setCanvasShake(false), 450);
     });
-  }, []);
+  }, [setCanvasShake, shakeTimerRef]);
 
   const showToast = useCallback((msg: string, type: 'success' | 'error' | 'info' = 'success') => {
     setToast('');
-    // slight delay to re-trigger animation
+    setToastType(type);
     requestAnimationFrame(() => {
       setToast(msg);
       setToastType(type);
     });
-  }, []);
+  }, [setToast, setToastType]);
 
   /* ================================================================ */
   /*  Animation                                                        */
@@ -453,7 +344,8 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
       animFrameRef.current = requestAnimationFrame(tick);
     };
     animFrameRef.current = requestAnimationFrame(tick);
-  }, [doRender]);
+  }, [doRender, setMode, setStep, animFrameRef, hintFrameRef,
+      animStartRef, isAutoLoopingRef, loopTimerRef, r, m]);
 
   const handleRetry = useCallback(() => {
     if (!data) return;
@@ -463,18 +355,13 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
     resetState(data.nStrokes);
     isAutoLoopingRef.current = true;
     startAnimation();
-  }, [data, resetState, startAnimation]);
+  }, [data, resetState, startAnimation, animFrameRef, hintFrameRef, loopTimerRef, isAutoLoopingRef]);
 
-  /* ---- Auto-start animation loop when data first loads ---- */
-  // Forward-ref pattern: startQuiz is defined below; capture its current value
-  // through a ref so this effect can call it without a hoisting error.
+  /* ---- Auto-start when data loads ---- */
   const startQuizRef = useRef<() => void>(() => {});
   useEffect(() => {
     if (data && pendingAutoStartRef.current) {
       pendingAutoStartRef.current = false;
-      // #1529: only the recall round (no-outline-once) skips the animation.
-      // outlined-once now plays the stroke-order preview (with a 開始 button)
-      // so children see the correct stroke order before writing.
       if (isNoOutlineOnce) {
         isAutoLoopingRef.current = false;
         startQuizRef.current();
@@ -483,7 +370,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         startAnimation();
       }
     }
-  }, [data, isNoOutlineOnce, startAnimation]);
+  }, [data, isNoOutlineOnce, startAnimation, pendingAutoStartRef, isAutoLoopingRef]);
 
   /* ================================================================ */
   /*  Quiz (writing practice)                                          */
@@ -503,9 +390,8 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
     m.current.quizStroke = 0;
     setCompletedStrokesUI(0);
     doRender();
-  }, [doRender]);
+  }, [doRender, setMode, setCompletedStrokesUI, animFrameRef, hintFrameRef, r, m]);
 
-  // Keep startQuizRef pointing at the latest startQuiz (#1342 forward-ref).
   useEffect(() => { startQuizRef.current = startQuiz; }, [startQuiz]);
 
   const handleBeginPractice = useCallback(() => {
@@ -516,7 +402,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
     r.current.animProgress = 0;
     setStep(Step.PRACTICE_1);
     startQuiz();
-  }, [startQuiz]);
+  }, [startQuiz, setStep, isAutoLoopingRef, animFrameRef, loopTimerRef, r]);
 
   const showHint = useCallback(() => {
     const d = m.current.data;
@@ -542,7 +428,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
       }
     };
     hintFrameRef.current = requestAnimationFrame(tick);
-  }, [doRender]);
+  }, [doRender, hintFrameRef, hintStartRef, r, m]);
 
   const handleStrokeDrawn = useCallback((points: Point[]) => {
     const d = m.current.data;
@@ -563,13 +449,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         const pl = m.current.practiceLeft;
 
         if (s >= Step.PRACTICE_1 && s <= Step.PRACTICE_3) {
-          // #1342: outlined-once mode auto-advances to whatever the parent
-          // wires onComplete to (round 2 in VocabPractice). The COMPLETE
-          // overlay's "下一個字" button was misleading — it actually moves
-          // to the same character's round 2, not the next character — so we
-          // skip the overlay entirely here. The 600 ms pause lets the
-          // student see the radical-coloured strokes merge into one colour
-          // (allDone branch in strokeRenderer's colourFor).
           if (isOutlinedOnce) {
             showToast('恭喜筆畫正確！', 'success');
             clearTimeout(completionTimerRef.current);
@@ -578,7 +457,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
             const newLeft = pl - 1;
             setPracticeLeft(newLeft);
             if (s === Step.PRACTICE_3) {
-              // Auto-advance to no-outline practice
               m.current.showOutline = false;
               setShowOutline(false);
               setStep(Step.PRACTICE_NO_OUTLINE);
@@ -592,9 +470,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
             }
           }
         } else if (s === Step.PRACTICE_NO_OUTLINE) {
-          // #1342: same auto-advance for no-outline-once (round 2). Standard
-          // flow keeps the COMPLETE overlay so users have a "下一個字" CTA
-          // when they have finished BOTH rounds (= the whole character is done).
           if (isNoOutlineOnce) {
             showToast('恭喜筆畫正確！這個字完成了！', 'success');
             clearTimeout(completionTimerRef.current);
@@ -615,7 +490,10 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         showHint();
       }
     }
-  }, [doRender, showHint, startQuiz, triggerShake, showToast, isOutlinedOnce, isNoOutlineOnce, onComplete]);
+  }, [doRender, showHint, startQuiz, triggerShake, showToast,
+      isOutlinedOnce, isNoOutlineOnce, onComplete,
+      setMode, setCompletedStrokesUI, setPracticeLeft, setShowOutline, setStep,
+      completionTimerRef, r, m]);
 
   /* ================================================================ */
   /*  Pointer events (drawing)                                         */
@@ -628,7 +506,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
       x: ((e.clientX - rect.left) / rect.width) * CANVAS_SIZE,
       y: ((e.clientY - rect.top) / rect.height) * CANVAS_SIZE,
     };
-  }, []);
+  }, [canvasRef]);
 
   const handlePointerDown = useCallback((e: React.PointerEvent) => {
     if (m.current.mode !== 'quizzing') return;
@@ -637,7 +515,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
     isDrawingRef.current = true;
     r.current.activeBrush = [pt];
     canvasRef.current?.setPointerCapture(e.pointerId);
-  }, [toCanvasCoords]);
+  }, [toCanvasCoords, isDrawingRef, r, m, canvasRef]);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
     if (!isDrawingRef.current) return;
@@ -647,7 +525,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
       r.current.activeBrush.push(pt);
     }
     doRender();
-  }, [toCanvasCoords, doRender]);
+  }, [toCanvasCoords, doRender, isDrawingRef, r]);
 
   const handlePointerUp = useCallback(() => {
     if (!isDrawingRef.current) return;
@@ -656,7 +534,7 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
     r.current.activeBrush = [];
     doRender();
     if (points.length > 1) handleStrokeDrawn(points);
-  }, [doRender, handleStrokeDrawn]);
+  }, [doRender, handleStrokeDrawn, isDrawingRef, r]);
 
   /* ================================================================ */
   /*  Derived values                                                   */
@@ -695,7 +573,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
 
   return (
     <div className={`flex-1 flex flex-col items-center ${embedded ? 'gap-3' : 'p-4 gap-4 overflow-auto'}`}>
-      {/* Header — hidden in embedded mode */}
       {!embedded && (
         <div className="flex items-center gap-4 w-full max-w-lg">
           {onBack && (
@@ -719,10 +596,8 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         </div>
       )}
 
-      {/* Progress dots — hidden in embedded mode */}
       {!embedded && <ProgressDots step={step} practiceLeft={practiceLeft} />}
 
-      {/* Stroke progress bar (during quiz) */}
       {mode === 'quizzing' && nStrokes > 0 && (
         <div className={`w-full ${embedded ? '' : 'max-w-lg'}`}>
           <div className="flex justify-between text-[10px] text-on-surface-variant mb-1">
@@ -738,11 +613,9 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         </div>
       )}
 
-      {/* Canvas */}
       <div
         className={`relative w-full max-w-lg aspect-square ${canvasShake ? 'animate-shake' : ''}`}
       >
-        {/* Completion overlay */}
         {isComplete && (
           <div className="absolute inset-0 flex flex-col items-center justify-center bg-surface/95 rounded-xl z-10 gap-4 p-6 animate-fade-in" style={{ backdropFilter: 'blur(8px)' }}>
             <ConfettiParticles />
@@ -786,7 +659,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         />
       </div>
 
-      {/* Begin practice button (animation phase) */}
       {step === Step.ANIMATION && (
         <button
           onClick={handleBeginPractice}
@@ -798,7 +670,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         </button>
       )}
 
-      {/* Step guidance — hidden in embedded mode */}
       {!embedded && (
         <StepGuidance
           step={step}
@@ -808,7 +679,6 @@ const WriteCharacter: React.FC<WriteCharacterProps> = ({
         />
       )}
 
-      {/* Toast */}
       {toast && <Toast message={toast} type={toastType} />}
     </div>
   );

--- a/frontend/src/components/stroke-order/__tests__/WriteCharacter.test.tsx
+++ b/frontend/src/components/stroke-order/__tests__/WriteCharacter.test.tsx
@@ -1,0 +1,238 @@
+/**
+ * TDD tests for WriteCharacter.tsx — issue #1858
+ *
+ * Acceptance criteria (from issue):
+ * 1. outlined-once: starts with animation preview + completes after 1 correct trace
+ * 2. no-outline-once: skips animation + hides outline
+ * 3. standard: advances 3 outlined practices then 1 no-outline practice
+ * 4. missing stroke data: shows character-specific error + no canvas practice
+ *
+ * Tests must pass BEFORE and AFTER the refactor.
+ * Tautology guard: assertions are behavioural, not implementation.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// ──────────────────────────────────────────────────────────────────────
+//  Mocks
+// ──────────────────────────────────────────────────────────────────────
+
+// Minimal CharacterStrokeData for a 2-stroke character
+const MOCK_DATA = {
+  character: '人',
+  strokePaths: ['M 0 0 L 100 100', 'M 100 0 L 0 100'],
+  medians: [
+    [{ x: 0, y: 0 }, { x: 100, y: 100 }],
+    [{ x: 100, y: 0 }, { x: 0, y: 100 }],
+  ],
+  radicalIndices: [],
+  nStrokes: 2,
+};
+
+// loadCharacterStrokeData returns mock data by default; set to null to simulate missing data
+let mockLoadResult: typeof MOCK_DATA | null = MOCK_DATA;
+
+vi.mock('../strokeData', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../strokeData')>();
+  return {
+    ...actual,
+    loadCharacterStrokeData: vi.fn(() => Promise.resolve(mockLoadResult)),
+    CANVAS_SIZE: 1024,
+    HINT_THRESHOLD: 3,
+    isStrokeCorrect: vi.fn(() => true), // always correct by default
+    getStrokeDuration: vi.fn(() => 100),
+    renderStrokes: vi.fn(),
+  };
+});
+
+vi.mock('../strokeRenderer', () => ({
+  renderStrokes: vi.fn(),
+}));
+
+// Mock canvas APIs not available in jsdom
+beforeEach(() => {
+  // HTMLCanvasElement.getContext is undefined in jsdom; provide a minimal stub
+  const stubCtx: Partial<CanvasRenderingContext2D> = {};
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => stubCtx as CanvasRenderingContext2D);
+  HTMLCanvasElement.prototype.setPointerCapture = vi.fn();
+  // Stub requestAnimationFrame / cancelAnimationFrame to run synchronously
+  let rafId = 0;
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    const id = ++rafId;
+    // Use Promise.resolve so it runs in the microtask queue (non-recursive)
+    Promise.resolve().then(() => cb(performance.now()));
+    return id;
+  });
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  mockLoadResult = MOCK_DATA;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ──────────────────────────────────────────────────────────────────────
+//  Helper
+// ──────────────────────────────────────────────────────────────────────
+
+async function renderAndLoad(props: Partial<Parameters<typeof import('../WriteCharacter').default>[0]> = {}) {
+  const { default: WriteCharacter } = await import('../WriteCharacter');
+
+  let rendered: ReturnType<typeof render>;
+  await act(async () => {
+    rendered = render(
+      <WriteCharacter
+        character="人"
+        onComplete={vi.fn()}
+        {...props}
+      />
+    );
+  });
+  // Drain microtasks / state updates from the async data load
+  await act(async () => {});
+  return rendered!;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+//  Test: missing stroke data
+// ──────────────────────────────────────────────────────────────────────
+
+describe('WriteCharacter — missing stroke data', () => {
+  it('shows a character-specific error message', async () => {
+    mockLoadResult = null; // simulate no data
+    await renderAndLoad({ character: '吔' });
+
+    // Should show the error text mentioning the character
+    expect(screen.getByText(/吔.*筆順資料|筆順資料.*吔/)).toBeTruthy();
+  });
+
+  it('does not render a canvas for practice', async () => {
+    mockLoadResult = null;
+    const { container } = await renderAndLoad({ character: '吔' });
+
+    // canvas element should not be present when there is no stroke data
+    const canvases = container.querySelectorAll('canvas');
+    expect(canvases.length).toBe(0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+//  Test: no-outline-once mode
+// ──────────────────────────────────────────────────────────────────────
+
+describe('WriteCharacter — no-outline-once mode', () => {
+  it('skips animation and goes straight to practice (no 開始練習 button)', async () => {
+    await renderAndLoad({ practiceMode: 'no-outline-once' });
+
+    // The animation phase shows a "開始練習" button; in no-outline-once there is none
+    expect(screen.queryByText('開始練習')).toBeNull();
+  });
+
+  it('renders a canvas for practice', async () => {
+    const { container } = await renderAndLoad({ practiceMode: 'no-outline-once' });
+    expect(container.querySelectorAll('canvas').length).toBeGreaterThan(0);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+//  Test: outlined-once mode
+// ──────────────────────────────────────────────────────────────────────
+
+describe('WriteCharacter — outlined-once mode', () => {
+  it('starts with animation preview (shows 開始練習 button)', async () => {
+    await renderAndLoad({ practiceMode: 'outlined-once' });
+
+    // outlined-once plays the stroke-order preview first (restored in #1529)
+    expect(screen.getByText('開始練習')).toBeTruthy();
+  });
+
+  it('fires onComplete after 1 correct trace is submitted', async () => {
+    const onComplete = vi.fn();
+    const { container } = await renderAndLoad({
+      practiceMode: 'outlined-once',
+      onComplete,
+    });
+
+    // Simulate clicking 開始練習
+    await act(async () => {
+      screen.getByText('開始練習').click();
+    });
+    await act(async () => {});
+
+    // Simulate drawing a correct stroke sequence on the canvas
+    const canvas = container.querySelector('canvas')!;
+
+    // Fire pointer events for each of the 2 strokes
+    for (let i = 0; i < 2; i++) {
+      await act(async () => {
+        const rect = { left: 0, top: 0, width: 300, height: 300 } as DOMRect;
+        canvas.getBoundingClientRect = vi.fn(() => rect);
+        canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 10, clientY: 10, bubbles: true }));
+        canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 50, clientY: 50, bubbles: true }));
+        canvas.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      });
+      await act(async () => {});
+    }
+
+    // Wait for the 600ms completion timer (real timers)
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    }, { timeout: 1500 });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+//  Test: standard mode
+// ──────────────────────────────────────────────────────────────────────
+
+describe('WriteCharacter — standard mode', () => {
+  it('shows 開始練習 button during animation phase', async () => {
+    await renderAndLoad({ practiceMode: 'standard' });
+    expect(screen.getByText('開始練習')).toBeTruthy();
+  });
+
+  it('shows progress dots (練習回合 tracking) in standard mode', async () => {
+    const { container } = await renderAndLoad({ practiceMode: 'standard' });
+
+    // Click 開始練習 to advance past animation
+    await act(async () => {
+      screen.getByText('開始練習').click();
+    });
+    await act(async () => {});
+
+    // Progress dots are rendered in standard (non-embedded) mode
+    // They contain labels "1" "2" "3" and "無框"
+    expect(screen.queryByText('無框')).toBeTruthy();
+  });
+
+  it('does not call onComplete during outlined practice rounds', async () => {
+    const onComplete = vi.fn();
+    await renderAndLoad({ practiceMode: 'standard', onComplete });
+
+    // Just click 開始練習 and do one stroke sequence; onComplete should NOT fire
+    const { container } = await renderAndLoad({ practiceMode: 'standard', onComplete });
+    await act(async () => {
+      screen.getAllByText('開始練習')[0].click();
+    });
+    await act(async () => {});
+
+    const canvas = container.querySelector('canvas')!;
+    for (let i = 0; i < 2; i++) {
+      await act(async () => {
+        const rect = { left: 0, top: 0, width: 300, height: 300 } as DOMRect;
+        canvas.getBoundingClientRect = vi.fn(() => rect);
+        canvas.dispatchEvent(new PointerEvent('pointerdown', { clientX: 10, clientY: 10, bubbles: true }));
+        canvas.dispatchEvent(new PointerEvent('pointermove', { clientX: 50, clientY: 50, bubbles: true }));
+        canvas.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+      });
+      await act(async () => {});
+    }
+
+    // Give 300ms — onComplete should NOT fire after one practice round in standard mode
+    await new Promise(r => setTimeout(r, 300));
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/stroke-order/useStrokeCanvasRenderer.ts
+++ b/frontend/src/components/stroke-order/useStrokeCanvasRenderer.ts
@@ -1,0 +1,165 @@
+/**
+ * useStrokeCanvasRenderer — issue #1858
+ *
+ * Owns all imperative canvas state:
+ *   - the r-ref (completedStrokes, animStroke, animProgress, hintStroke, hintProgress,
+ *     correctPaths, activeBrush)
+ *   - animFrameRef / hintFrameRef and their start timestamps
+ *   - isDrawingRef, isAutoLoopingRef, pendingAutoStartRef
+ *   - loopTimerRef, shakeTimerRef, completionTimerRef
+ *   - offCanvasRef
+ *   - doRender
+ *   - getOffCanvas
+ *
+ * This hook only mutates refs + triggers rerender via the setters passed in.
+ * It does NOT own React state.
+ */
+
+import { useRef, useCallback } from 'react';
+import {
+  CharacterStrokeData,
+  Point,
+  CANVAS_SIZE,
+  getStrokeDuration,
+} from './strokeData';
+import { renderStrokes, RenderState } from './strokeRenderer';
+
+export interface CanvasRenderConfig {
+  radicalColorMode: boolean;
+  componentCount: number;
+}
+
+/** Mutable render state, kept in a single ref to avoid stale closures. */
+export interface RenderRef {
+  completedStrokes: number;
+  animStroke: number;
+  animProgress: number;
+  hintStroke: number;
+  hintProgress: number;
+  correctPaths: Point[][];
+  activeBrush: Point[];
+}
+
+/** Mutable mirrors of React state for use inside async/imperative callbacks. */
+export interface MirrorRef {
+  data: CharacterStrokeData | null;
+  step: number;
+  mode: string;
+  practiceLeft: number;
+  showOutline: boolean;
+  mistakes: number[];
+  quizStroke: number;
+}
+
+export interface StrokeCanvasRenderer {
+  /** The main on-screen canvas ref — pass as `ref` to `<canvas>`. */
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  /** Mutable render state ref. */
+  r: React.MutableRefObject<RenderRef>;
+  /** Mutable mirror-state ref (synced by WriteCharacter each render). */
+  m: React.MutableRefObject<MirrorRef>;
+  /** Animation / timer refs — exposed for cleanup in useEffect. */
+  animFrameRef: React.MutableRefObject<number>;
+  hintFrameRef: React.MutableRefObject<number>;
+  loopTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | undefined>;
+  shakeTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | undefined>;
+  completionTimerRef: React.MutableRefObject<ReturnType<typeof setTimeout> | undefined>;
+  isDrawingRef: React.MutableRefObject<boolean>;
+  isAutoLoopingRef: React.MutableRefObject<boolean>;
+  pendingAutoStartRef: React.MutableRefObject<boolean>;
+  /** Get (or lazily create) the off-screen canvas. */
+  getOffCanvas: () => HTMLCanvasElement;
+  /** Draw the current render state to the main canvas. */
+  doRender: () => void;
+}
+
+export function useStrokeCanvasRenderer(config: CanvasRenderConfig): StrokeCanvasRenderer {
+  const { radicalColorMode, componentCount } = config;
+
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const offCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const r = useRef<RenderRef>({
+    completedStrokes: 0,
+    animStroke: -1,
+    animProgress: 0,
+    hintStroke: -1,
+    hintProgress: 0,
+    correctPaths: [],
+    activeBrush: [],
+  });
+
+  const m = useRef<MirrorRef>({
+    data: null,
+    step: 0,
+    mode: 'idle',
+    practiceLeft: 4,
+    showOutline: true,
+    mistakes: [],
+    quizStroke: 0,
+  });
+
+  // Animation & drawing refs
+  const animFrameRef = useRef(0);
+  const animStartRef = useRef(0);
+  const hintFrameRef = useRef(0);
+  const hintStartRef = useRef(0);
+  const isDrawingRef = useRef(false);
+  const isAutoLoopingRef = useRef(false);
+  const pendingAutoStartRef = useRef(false);
+  const loopTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const shakeTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const completionTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Expose start timestamps so animation functions can reference them
+  // (they'll be written by the animation loops inside WriteCharacter)
+  // We attach them to the renderer so the component can reach them.
+  (r as any).animStartRef = animStartRef;
+  (r as any).hintStartRef = hintStartRef;
+
+  const getOffCanvas = useCallback((): HTMLCanvasElement => {
+    if (!offCanvasRef.current) {
+      offCanvasRef.current = document.createElement('canvas');
+      offCanvasRef.current.width = CANVAS_SIZE;
+      offCanvasRef.current.height = CANVAS_SIZE;
+    }
+    return offCanvasRef.current;
+  }, []);
+
+  const doRender = useCallback(() => {
+    const canvas = canvasRef.current;
+    const d = m.current.data;
+    if (!canvas || !d) return;
+    const ctx = canvas.getContext('2d')!;
+    const state: RenderState = {
+      data: d,
+      completedStrokes: r.current.completedStrokes,
+      animStroke: r.current.animStroke,
+      animProgress: r.current.animProgress,
+      hintStroke: r.current.hintStroke,
+      hintProgress: r.current.hintProgress,
+      showOutline: m.current.showOutline,
+      correctPaths: r.current.correctPaths,
+      activeBrush: r.current.activeBrush,
+      radicalColorMode,
+      componentCount,
+    };
+    renderStrokes(ctx, getOffCanvas(), state);
+  }, [getOffCanvas, radicalColorMode, componentCount]);
+
+  return {
+    canvasRef,
+    r,
+    m,
+    animFrameRef,
+    hintFrameRef,
+    loopTimerRef,
+    shakeTimerRef,
+    completionTimerRef,
+    isDrawingRef,
+    isAutoLoopingRef,
+    pendingAutoStartRef,
+    getOffCanvas,
+    doRender,
+  };
+}

--- a/frontend/src/components/stroke-order/useWriteCharacterMachine.ts
+++ b/frontend/src/components/stroke-order/useWriteCharacterMachine.ts
@@ -1,0 +1,109 @@
+/**
+ * useWriteCharacterMachine — issue #1858
+ *
+ * Owns step / mode / practiceLeft state transitions for WriteCharacter.
+ * Pure step-machine logic; no canvas, no refs, no animation.
+ */
+
+import { useState, useCallback } from 'react';
+
+export enum Step {
+  ANIMATION,
+  PRACTICE_1,
+  PRACTICE_2,
+  PRACTICE_3,
+  PRACTICE_NO_OUTLINE,
+  COMPLETE,
+}
+
+export type Mode = 'idle' | 'animating' | 'quizzing';
+
+export interface WriteCharacterMachineState {
+  step: Step;
+  mode: Mode;
+  practiceLeft: number;
+  showOutline: boolean;
+  completedStrokesUI: number;
+  toast: string;
+  toastType: 'success' | 'error' | 'info';
+  canvasShake: boolean;
+}
+
+export interface WriteCharacterMachineActions {
+  setStep: (s: Step) => void;
+  setMode: (m: Mode) => void;
+  setPracticeLeft: (n: number) => void;
+  setShowOutline: (v: boolean) => void;
+  setCompletedStrokesUI: (n: number) => void;
+  setToast: (msg: string) => void;
+  setToastType: (t: 'success' | 'error' | 'info') => void;
+  setCanvasShake: (v: boolean) => void;
+  /** Apply the per-practiceMode initial state. */
+  resetMachineState: (opts: { nStrokes: number; isOutlinedOnce: boolean; isNoOutlineOnce: boolean }) => InitialMachineResult;
+}
+
+export interface InitialMachineResult {
+  initialStep: Step;
+  outlineOn: boolean;
+  leftCount: number;
+}
+
+export function useWriteCharacterMachine(): [WriteCharacterMachineState, WriteCharacterMachineActions] {
+  const [step, setStep] = useState<Step>(Step.ANIMATION);
+  const [mode, setMode] = useState<Mode>('idle');
+  const [practiceLeft, setPracticeLeft] = useState(4);
+  const [showOutline, setShowOutline] = useState(true);
+  const [completedStrokesUI, setCompletedStrokesUI] = useState(0);
+  const [toast, setToast] = useState('');
+  const [toastType, setToastType] = useState<'success' | 'error' | 'info'>('success');
+  const [canvasShake, setCanvasShake] = useState(false);
+
+  const resetMachineState = useCallback(
+    (opts: { nStrokes: number; isOutlinedOnce: boolean; isNoOutlineOnce: boolean }): InitialMachineResult => {
+      const { isOutlinedOnce, isNoOutlineOnce } = opts;
+      let initialStep = Step.ANIMATION;
+      let outlineOn = true;
+      let leftCount = 4;
+      if (isOutlinedOnce) {
+        leftCount = 1;
+      } else if (isNoOutlineOnce) {
+        initialStep = Step.PRACTICE_NO_OUTLINE;
+        outlineOn = false;
+        leftCount = 1;
+      }
+      setStep(initialStep);
+      setMode('idle');
+      setPracticeLeft(leftCount);
+      setShowOutline(outlineOn);
+      setToast('');
+      setCompletedStrokesUI(0);
+      return { initialStep, outlineOn, leftCount };
+    },
+    [],
+  );
+
+  const state: WriteCharacterMachineState = {
+    step,
+    mode,
+    practiceLeft,
+    showOutline,
+    completedStrokesUI,
+    toast,
+    toastType,
+    canvasShake,
+  };
+
+  const actions: WriteCharacterMachineActions = {
+    setStep,
+    setMode,
+    setPracticeLeft,
+    setShowOutline,
+    setCompletedStrokesUI,
+    setToast,
+    setToastType,
+    setCanvasShake,
+    resetMachineState,
+  };
+
+  return [state, actions];
+}


### PR DESCRIPTION
Fixes #1858

## Summary

- Extract `useWriteCharacterMachine` (109L): owns `step / mode / practiceLeft / showOutline / completedStrokesUI / toast / canvasShake` state transitions and `resetMachineState`
- Extract `useStrokeCanvasRenderer` (165L): owns all imperative canvas refs — `r`-ref (completedStrokes/animStroke/animProgress/hintStroke/hintProgress/correctPaths/activeBrush), `m`-ref mirrors, `animFrameRef / hintFrameRef / loopTimerRef / shakeTimerRef / completionTimerRef`, `isDrawingRef / isAutoLoopingRef / pendingAutoStartRef`, `doRender`, `getOffCanvas`
- `WriteCharacter.tsx`: 817L → 687L — wires the two hooks, zero change to renderer math or animation timing

## TDD Evidence

Tests written **before** refactor, all 9 pass on original code. Same 9 pass after refactor.

| Test | Result |
|------|--------|
| `outlined-once` starts with animation preview (shows 開始練習) | ✅ |
| `outlined-once` fires `onComplete` after 1 correct trace | ✅ |
| `no-outline-once` skips animation (no 開始練習 button) | ✅ |
| `no-outline-once` renders canvas for practice | ✅ |
| `standard` shows 開始練習 during animation phase | ✅ |
| `standard` shows progress dots (無框) | ✅ |
| `standard` does NOT call `onComplete` after 1 round | ✅ |
| missing data shows character-specific error | ✅ |
| missing data shows no canvas | ✅ |

## Risk

High (canvas state + animation timing) — mitigated by TDD. Renderer math untouched: zero change to `strokeRenderer.ts`, `strokeData.ts`, or any coordinate/animation calculation.

## Test Plan

1. Open the vocabulary practice step on any lesson
2. Verify stroke-order animation plays on load
3. Click 開始練習 and trace each stroke — confirm outlined rounds advance correctly
4. Complete 3 outlined rounds — confirm automatic transition to 無框 round
5. Complete 無框 round — confirm completion overlay with 🎉
6. Test with `outlined-once` mode (VocabPractice round 1): verify `onComplete` fires after 1 trace
7. Test with `no-outline-once` mode (VocabPractice round 2): verify no animation, `onComplete` fires after 1 trace
8. Verify wrong stroke triggers shake and hint animation after 3 mistakes