### PR TITLE
refactor(admin): adopt shared primitives in StoryManagementPanel (Fixes #1851)

### DIFF
--- a/frontend/src/pages/admin/StoryManagementPanel.tsx
+++ b/frontend/src/pages/admin/StoryManagementPanel.tsx
@@ -12,80 +12,27 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { PlusIcon } from '../../components/icons';
+import AdminPageShell from '../../components/admin/AdminPageShell';
+import AdminTable, { ColumnDef } from '../../components/admin/AdminTable';
+import ConfirmDialog from '../../components/admin/ConfirmDialog';
 import {
   listAdminStories,
   createStory,
   updateStory,
   deleteStory,
   StoryAdminListItem,
-  StoryCreateRequest,
   StoryUpdateRequest,
   AdminStoryApiError,
 } from '../../services/adminStoryApi';
-
-// ── Types ────────────────────────────────────────────────────────────────────
-
-type ModalMode = 'create' | 'edit';
-
-interface StoryFormState {
-  lesson_number: string;
-  title: string;
-  grade: string;
-  grade_code: string;
-  genre: string;
-  text_type: string;
-  reading_strategy: string;
-  paragraphs: string; // newline-separated
-  source_file: string;
-}
-
-const EMPTY_FORM: StoryFormState = {
-  lesson_number: '',
-  title: '',
-  grade: '4',
-  grade_code: '',
-  genre: '記敘文',
-  text_type: '單',
-  reading_strategy: '',
-  paragraphs: '',
-  source_file: '',
-};
-
-const GENRE_OPTIONS = ['記敘文', '說明文', '議論文', '文言文', '應用文'];
-const TEXT_TYPE_OPTIONS = ['單', '多*2', '多*3'];
-
-// ── Helper ───────────────────────────────────────────────────────────────────
-
-function formToCreateRequest(form: StoryFormState): StoryCreateRequest {
-  return {
-    lesson_number: parseInt(form.lesson_number, 10),
-    title: form.title.trim(),
-    grade: parseInt(form.grade, 10),
-    grade_code: form.grade_code.trim(),
-    genre: form.genre,
-    text_type: form.text_type,
-    reading_strategy: form.reading_strategy.trim() || undefined,
-    paragraphs: form.paragraphs
-      .split('\n')
-      .map((p) => p.trim())
-      .filter(Boolean),
-    source_file: form.source_file.trim() || undefined,
-  };
-}
-
-function storyToFormState(story: StoryAdminListItem): StoryFormState {
-  return {
-    lesson_number: String(story.lesson_number),
-    title: story.title,
-    grade: String(story.grade),
-    grade_code: story.grade_code,
-    genre: story.genre,
-    text_type: story.text_type,
-    reading_strategy: story.reading_strategy ?? '',
-    paragraphs: '',
-    source_file: story.source_file ?? '',
-  };
-}
+import {
+  EMPTY_FORM,
+  GENRE_OPTIONS,
+  ModalMode,
+  StoryFormState,
+  TEXT_TYPE_OPTIONS,
+  formToCreateRequest,
+  storyToFormState,
+} from './storyFormMapper';
 
 // ── Main Component ────────────────────────────────────────────────────────────
 
@@ -257,20 +204,79 @@ const StoryManagementPanel: React.FC = () => {
     }
   };
 
+  const storyColumns: ColumnDef<StoryAdminListItem>[] = [
+    {
+      key: 'lesson_number',
+      header: '編號',
+      render: (story) => (
+        <span className="font-mono text-gray-500">{story.lesson_number}</span>
+      ),
+      className: 'w-16',
+    },
+    {
+      key: 'title',
+      header: '標題',
+      render: (story) => (
+        <span className="font-medium text-gray-900">{story.title}</span>
+      ),
+    },
+    {
+      key: 'grade_code',
+      header: '年級',
+      className: 'w-20',
+    },
+    {
+      key: 'genre',
+      header: '文體',
+      className: 'w-24',
+    },
+    {
+      key: 'paragraph_count',
+      header: '段落數',
+      className: 'w-20',
+    },
+    {
+      key: 'char_count',
+      header: '字數',
+      className: 'w-20',
+    },
+    {
+      key: 'actions',
+      header: '操作',
+      className: 'w-28 text-right',
+      render: (story) => (
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => openEditModal(story)}
+            className="text-accent hover:underline text-xs font-medium cursor-pointer"
+          >
+            編輯
+          </button>
+          <button
+            type="button"
+            onClick={() => openDeleteConfirm(story)}
+            className="text-red-500 hover:underline text-xs font-medium cursor-pointer"
+          >
+            刪除
+          </button>
+        </div>
+      ),
+    },
+  ];
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div className="p-6 sm:p-8">
-      <div className="max-w-5xl mx-auto space-y-6">
-
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-xl font-bold text-gray-900">課文管理</h2>
-            <p className="text-sm text-gray-500 mt-1">
-              {isLoading ? '載入中...' : `共 ${total} 篇課文`}
-            </p>
-          </div>
+    <>
+      <AdminPageShell
+        title="課文管理"
+        subtitle={isLoading ? '載入中...' : `共 ${total} 篇課文`}
+        isLoading={false}
+        error=""
+        isEmpty={false}
+        emptyMessage="尚無課文"
+        headerActions={(
           <button
             onClick={openCreateModal}
             className="flex items-center gap-2 px-4 py-2 bg-accent text-white text-sm font-medium rounded-lg hover:bg-accent/90 transition-colors cursor-pointer"
@@ -278,9 +284,8 @@ const StoryManagementPanel: React.FC = () => {
             <PlusIcon className="w-4 h-4" />
             新增課文
           </button>
-        </div>
-
-        {/* Filters */}
+        )}
+      >
         <div className="flex items-center gap-3 flex-wrap">
           <input
             type="text"
@@ -303,7 +308,6 @@ const StoryManagementPanel: React.FC = () => {
           </select>
         </div>
 
-        {/* Error */}
         {loadError && (
           <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-sm text-red-700">
             {loadError}
@@ -316,7 +320,6 @@ const StoryManagementPanel: React.FC = () => {
           </div>
         )}
 
-        {/* Loading skeleton */}
         {isLoading && (
           <div className="space-y-2">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -325,134 +328,21 @@ const StoryManagementPanel: React.FC = () => {
           </div>
         )}
 
-        {/* Table */}
-        {!isLoading && !loadError && (
-          <>
-            {stories.length === 0 ? (
-              <div className="rounded-2xl shadow-card px-4 py-12 text-center text-gray-400 text-sm bg-white">
-                {searchQuery || gradeFilter ? '找不到符合條件的課文' : '尚無課文'}
-              </div>
-            ) : (
-              <>
-                {/* Mobile card view */}
-                <div className="md:hidden space-y-3">
-                  {stories.map((story) => (
-                    <div key={story.lesson_number} className="bg-white rounded-2xl shadow-card p-4 space-y-2.5">
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0">
-                          <p className="font-medium text-gray-900 text-sm">{story.title}</p>
-                          <p className="text-xs text-gray-400 font-mono mt-0.5">L{story.lesson_number}</p>
-                        </div>
-                        <div className="flex items-center gap-2 shrink-0">
-                          <button
-                            onClick={() => openEditModal(story)}
-                            className="text-accent hover:underline text-xs font-medium cursor-pointer"
-                          >
-                            編輯
-                          </button>
-                          <button
-                            onClick={() => openDeleteConfirm(story)}
-                            className="text-red-500 hover:underline text-xs font-medium cursor-pointer"
-                          >
-                            刪除
-                          </button>
-                        </div>
-                      </div>
-                      <div className="grid grid-cols-4 gap-2 text-xs">
-                        <div>
-                          <span className="text-gray-400">年級</span>
-                          <p className="text-gray-700">{story.grade_code}</p>
-                        </div>
-                        <div>
-                          <span className="text-gray-400">文體</span>
-                          <p className="text-gray-700">{story.genre}</p>
-                        </div>
-                        <div>
-                          <span className="text-gray-400">段落</span>
-                          <p className="text-gray-700">{story.paragraph_count}</p>
-                        </div>
-                        <div>
-                          <span className="text-gray-400">字數</span>
-                          <p className="text-gray-700">{story.char_count}</p>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-
-                {/* Desktop table view */}
-                <div className="hidden md:block overflow-x-auto rounded-2xl shadow-card">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="bg-gray-50 border-b border-gray-200">
-                        <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide w-16">
-                          編號
-                        </th>
-                        <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                          標題
-                        </th>
-                        <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide w-20">
-                          年級
-                        </th>
-                        <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide w-24">
-                          文體
-                        </th>
-                        <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide w-20">
-                          段落數
-                        </th>
-                        <th className="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide w-20">
-                          字數
-                        </th>
-                        <th className="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide w-28">
-                          操作
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100">
-                      {stories.map((story) => (
-                        <tr key={story.lesson_number} className="hover:bg-gray-50 transition-colors">
-                          <td className="px-4 py-3 font-mono text-gray-500">
-                            {story.lesson_number}
-                          </td>
-                          <td className="px-4 py-3 font-medium text-gray-900">
-                            {story.title}
-                          </td>
-                          <td className="px-4 py-3 text-gray-600">
-                            {story.grade_code}
-                          </td>
-                          <td className="px-4 py-3 text-gray-600">
-                            {story.genre}
-                          </td>
-                          <td className="px-4 py-3 text-gray-500">
-                            {story.paragraph_count}
-                          </td>
-                          <td className="px-4 py-3 text-gray-500">
-                            {story.char_count}
-                          </td>
-                          <td className="px-4 py-3 text-right">
-                            <button
-                              onClick={() => openEditModal(story)}
-                              className="text-accent hover:underline text-xs font-medium cursor-pointer mr-3"
-                            >
-                              編輯
-                            </button>
-                            <button
-                              onClick={() => openDeleteConfirm(story)}
-                              className="text-red-500 hover:underline text-xs font-medium cursor-pointer"
-                            >
-                              刪除
-                            </button>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </>
-            )}
-          </>
+        {!isLoading && !loadError && stories.length === 0 && (
+          <div className="rounded-2xl shadow-card px-4 py-12 text-center text-gray-400 text-sm bg-white">
+            {searchQuery || gradeFilter ? '找不到符合條件的課文' : '尚無課文'}
+          </div>
         )}
-      </div>
+
+        {!isLoading && !loadError && stories.length > 0 && (
+          <AdminTable
+            columns={storyColumns}
+            rows={stories}
+            rowKey={(story) => story.lesson_number}
+            cardTitle={(story) => story.title}
+          />
+        )}
+      </AdminPageShell>
 
       {/* Create / Edit Modal */}
       {showModal && (
@@ -468,16 +358,28 @@ const StoryManagementPanel: React.FC = () => {
       )}
 
       {/* Delete Confirmation Dialog */}
-      {deleteTarget && (
-        <DeleteConfirmDialog
-          story={deleteTarget}
-          isDeleting={isDeleting}
-          deleteError={deleteError}
-          onConfirm={confirmDelete}
-          onCancel={cancelDelete}
-        />
-      )}
-    </div>
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title="確認刪除"
+        variant="destructive"
+        message={deleteTarget && (
+          <>
+            確定要刪除課文「<strong>{deleteTarget.title}</strong>」（L{deleteTarget.lesson_number}）嗎？
+            <br />
+            <span className="text-gray-400 text-xs mt-1 block">課文將移至歸檔目錄，不會永久刪除。</span>
+            {deleteError && (
+              <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2 mt-3">
+                {deleteError}
+              </p>
+            )}
+          </>
+        )}
+        confirmLabel={isDeleting ? '刪除中...' : '確認刪除'}
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
+        isLoading={isDeleting}
+      />
+    </>
   );
 };
 
@@ -661,58 +563,6 @@ const StoryFormModal: React.FC<StoryFormModalProps> = ({
     </div>
   );
 };
-
-// ── Delete Confirm Dialog ─────────────────────────────────────────────────────
-
-interface DeleteConfirmDialogProps {
-  story: StoryAdminListItem;
-  isDeleting: boolean;
-  deleteError: string;
-  onConfirm: () => void;
-  onCancel: () => void;
-}
-
-const DeleteConfirmDialog: React.FC<DeleteConfirmDialogProps> = ({
-  story,
-  isDeleting,
-  deleteError,
-  onConfirm,
-  onCancel,
-}) => (
-  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-    <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6 space-y-4">
-      <h3 className="text-lg font-bold text-gray-900">確認刪除</h3>
-      <p className="text-sm text-gray-600">
-        確定要刪除課文「<strong>{story.title}</strong>」（L{story.lesson_number}）嗎？
-        <br />
-        <span className="text-gray-400 text-xs mt-1 block">課文將移至歸檔目錄，不會永久刪除。</span>
-      </p>
-      {deleteError && (
-        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
-          {deleteError}
-        </p>
-      )}
-      <div className="flex justify-end gap-3">
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={isDeleting}
-          className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg cursor-pointer"
-        >
-          取消
-        </button>
-        <button
-          type="button"
-          onClick={onConfirm}
-          disabled={isDeleting}
-          className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg cursor-pointer disabled:opacity-60"
-        >
-          {isDeleting ? '刪除中...' : '確認刪除'}
-        </button>
-      </div>
-    </div>
-  </div>
-);
 
 // ── Field helper ──────────────────────────────────────────────────────────────
 

--- a/frontend/src/pages/admin/__tests__/StoryManagementPanel.test.tsx
+++ b/frontend/src/pages/admin/__tests__/StoryManagementPanel.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * TDD tests for StoryManagementPanel refactor (Issue #1851)
+ *
+ * These tests document the BEHAVIOUR before refactoring so the same tests
+ * must pass after extraction of storyFormMapper.ts + sub-components.
+ *
+ * Test scope (from issue acceptance criteria):
+ *   1. formToCreateRequest trims fields + splits non-empty paragraphs
+ *   2. Edit modal preserves lesson_number + only sends paragraphs when provided
+ *   3. 409 create error renders duplicate lesson message
+ *   4. Filters call list API with search + grade params
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import StoryManagementPanel from '../StoryManagementPanel';
+
+// ── Auth mock ──────────────────────────────────────────────────────────────
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+// ── API mocks ──────────────────────────────────────────────────────────────
+const mockListAdminStories = vi.fn();
+const mockCreateStory = vi.fn();
+const mockUpdateStory = vi.fn();
+const mockDeleteStory = vi.fn();
+
+vi.mock('../../../services/adminStoryApi', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/adminStoryApi')>(
+    '../../../services/adminStoryApi',
+  );
+  return {
+    ...actual,
+    listAdminStories: (...args: unknown[]) => mockListAdminStories(...args),
+    createStory: (...args: unknown[]) => mockCreateStory(...args),
+    updateStory: (...args: unknown[]) => mockUpdateStory(...args),
+    deleteStory: (...args: unknown[]) => mockDeleteStory(...args),
+  };
+});
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+const BASE_STORY = {
+  lesson_number: 58,
+  title: '第一百碗麵',
+  grade: 5,
+  grade_code: 'G5-10',
+  genre: '記敘文',
+  text_type: '單',
+  paragraph_count: 4,
+  char_count: 320,
+  reading_strategy: '掌握段落大意',
+  source_file: 'G5-10-L58.docx',
+};
+
+const EMPTY_LIST = { stories: [], total: 0 };
+const ONE_STORY_LIST = { stories: [BASE_STORY], total: 1 };
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function renderPanel() {
+  return render(<StoryManagementPanel />);
+}
+
+/** Open the create modal and wait for form to appear */
+async function openCreateModal() {
+  // Wait for initial load to complete (loading state gone)
+  await waitFor(() => {
+    const btn = screen.getByText('新增課文');
+    expect(btn).toBeTruthy();
+  });
+  fireEvent.click(screen.getByText('新增課文'));
+  // Wait for modal heading to be present
+  await waitFor(() => screen.getByText('新增課文', { selector: 'h3' }));
+}
+
+/** Get the paragraphs textarea (the only <textarea> in the form) */
+function getParagraphsTextarea(): HTMLTextAreaElement {
+  return document.querySelector('textarea')!;
+}
+
+// ══════════════════════════════════════════════════════════════════════════
+// 1. formToCreateRequest — trims fields + splits non-empty paragraphs
+// ══════════════════════════════════════════════════════════════════════════
+describe('formToCreateRequest logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAdminStories.mockResolvedValue(EMPTY_LIST);
+    mockCreateStory.mockResolvedValue(BASE_STORY);
+  });
+
+  it('trims title and splits paragraphs on newline, filtering blank lines', async () => {
+    renderPanel();
+    await openCreateModal();
+
+    // Fill lesson_number
+    const numInput = screen.getByPlaceholderText('例：58');
+    fireEvent.change(numInput, { target: { value: '99' } });
+
+    // Fill title with surrounding whitespace
+    const titleInput = screen.getByPlaceholderText('例：第一百碗麵');
+    fireEvent.change(titleInput, { target: { value: '  測試標題  ' } });
+
+    // Fill paragraphs: two real paragraphs with surrounding whitespace + blank line
+    const textarea = getParagraphsTextarea();
+    fireEvent.change(textarea, { target: { value: '  第一段  \n\n  第二段  ' } });
+
+    // Submit the form
+    fireEvent.submit(textarea.closest('form')!);
+
+    await waitFor(() => {
+      expect(mockCreateStory).toHaveBeenCalledWith(
+        'test-token',
+        expect.objectContaining({
+          title: '測試標題',               // trimmed
+          lesson_number: 99,
+          paragraphs: ['第一段', '第二段'], // trimmed + empty filtered
+        }),
+      );
+    });
+  });
+
+  it('sends only the single non-blank paragraph when surrounded by empty lines', async () => {
+    renderPanel();
+    await openCreateModal();
+
+    const numInput = screen.getByPlaceholderText('例：58');
+    fireEvent.change(numInput, { target: { value: '10' } });
+
+    const titleInput = screen.getByPlaceholderText('例：第一百碗麵');
+    fireEvent.change(titleInput, { target: { value: '任意標題' } });
+
+    const textarea = getParagraphsTextarea();
+    // Three surrounding newlines, only one real paragraph
+    fireEvent.change(textarea, { target: { value: '\n\n唯一一段\n\n' } });
+
+    fireEvent.submit(textarea.closest('form')!);
+
+    await waitFor(() => {
+      expect(mockCreateStory).toHaveBeenCalledWith(
+        'test-token',
+        expect.objectContaining({ paragraphs: ['唯一一段'] }),
+      );
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// 2. Edit modal — preserves lesson_number, only sends paragraphs if provided
+// ══════════════════════════════════════════════════════════════════════════
+describe('edit modal behaviour', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAdminStories.mockResolvedValue(ONE_STORY_LIST);
+    mockUpdateStory.mockResolvedValue(BASE_STORY);
+  });
+
+  it('preserves lesson_number (read-only) when edit modal opens', async () => {
+    renderPanel();
+    // Wait for edit buttons to appear
+    await waitFor(() => expect(screen.getAllByText('編輯').length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getAllByText('編輯')[0]);
+
+    // The lesson_number field should be disabled and contain the story's number
+    const numInput = screen.getByPlaceholderText('例：58') as HTMLInputElement;
+    expect(numInput.value).toBe('58');
+    expect(numInput.disabled).toBe(true);
+  });
+
+  it('does NOT include paragraphs in update request when textarea is left empty', async () => {
+    // When paragraphs textarea is empty in edit mode, the update request
+    // should omit the paragraphs field (treated as "no change").
+    // Note: the component allows edit submission only when paragraphs is
+    // populated. Providing one paragraph then clearing to test omission.
+    renderPanel();
+    await waitFor(() => expect(screen.getAllByText('編輯').length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getAllByText('編輯')[0]);
+
+    // Change the title
+    const titleInput = screen.getByDisplayValue('第一百碗麵');
+    fireEvent.change(titleInput, { target: { value: '新標題' } });
+
+    // Leave textarea empty — in edit mode, empty paragraphs means "no update"
+    const textarea = getParagraphsTextarea();
+    expect(textarea.value).toBe('');
+
+    // The form should submit without paragraphs key in update payload.
+    // We check by triggering with a minimal paragraph, then verify
+    // the update path with empty textarea shows validation message.
+    // (Current code: empty paragraphs in edit shows error "至少需要一個段落"
+    // but does NOT call updateStory with paragraphs: [])
+    fireEvent.submit(textarea.closest('form')!);
+
+    // With empty paragraphs in edit mode, the current code blocks submission
+    // and shows validation error — updateStory is NOT called
+    await waitFor(() => {
+      expect(screen.getByText('至少需要一個段落')).toBeTruthy();
+    });
+    expect(mockUpdateStory).not.toHaveBeenCalled();
+  });
+
+  it('includes paragraphs in update request when textarea is filled', async () => {
+    renderPanel();
+    await waitFor(() => expect(screen.getAllByText('編輯').length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getAllByText('編輯')[0]);
+
+    const textarea = getParagraphsTextarea();
+    fireEvent.change(textarea, { target: { value: '更新段落一\n更新段落二' } });
+
+    fireEvent.submit(textarea.closest('form')!);
+
+    await waitFor(() => {
+      const callArg = mockUpdateStory.mock.calls[0][2];
+      expect(callArg.paragraphs).toEqual(['更新段落一', '更新段落二']);
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// 3. 409 error on create → renders duplicate lesson message
+// ══════════════════════════════════════════════════════════════════════════
+describe('409 create error', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAdminStories.mockResolvedValue(EMPTY_LIST);
+  });
+
+  it('shows duplicate lesson error message when API returns 409', async () => {
+    const { AdminStoryApiError } = await import('../../../services/adminStoryApi');
+    mockCreateStory.mockRejectedValue(new AdminStoryApiError(409, 'already exists'));
+
+    renderPanel();
+    await openCreateModal();
+
+    const numInput = screen.getByPlaceholderText('例：58');
+    fireEvent.change(numInput, { target: { value: '58' } });
+
+    const titleInput = screen.getByPlaceholderText('例：第一百碗麵');
+    fireEvent.change(titleInput, { target: { value: '任意課文' } });
+
+    const textarea = getParagraphsTextarea();
+    fireEvent.change(textarea, { target: { value: '段落' } });
+
+    fireEvent.submit(textarea.closest('form')!);
+
+    await waitFor(() => {
+      // Error message should contain lesson number "58" and "已存在"
+      expect(screen.getByText(/58.*已存在/)).toBeTruthy();
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// 4. Filters — call list API with search + grade params
+// ══════════════════════════════════════════════════════════════════════════
+describe('filter behaviour', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListAdminStories.mockResolvedValue(EMPTY_LIST);
+  });
+
+  it('calls listAdminStories with search param when user types in search box', async () => {
+    renderPanel();
+    // Wait for initial load
+    await waitFor(() => expect(mockListAdminStories).toHaveBeenCalled());
+    vi.clearAllMocks();
+    mockListAdminStories.mockResolvedValue(EMPTY_LIST);
+
+    const searchInput = screen.getByPlaceholderText('搜尋課文標題...');
+    fireEvent.change(searchInput, { target: { value: '麵' } });
+
+    await waitFor(() => {
+      expect(mockListAdminStories).toHaveBeenCalledWith(
+        'test-token',
+        expect.objectContaining({ search: '麵' }),
+      );
+    });
+  });
+
+  it('calls listAdminStories with grade param when user selects a grade', async () => {
+    renderPanel();
+    await waitFor(() => expect(mockListAdminStories).toHaveBeenCalled());
+    vi.clearAllMocks();
+    mockListAdminStories.mockResolvedValue(EMPTY_LIST);
+
+    const gradeSelect = screen.getByDisplayValue('所有年級');
+    fireEvent.change(gradeSelect, { target: { value: '5' } });
+
+    await waitFor(() => {
+      expect(mockListAdminStories).toHaveBeenCalledWith(
+        'test-token',
+        expect.objectContaining({ grade: 5 }),
+      );
+    });
+  });
+
+  it('calls listAdminStories with both search and grade when both are set', async () => {
+    renderPanel();
+    await waitFor(() => expect(mockListAdminStories).toHaveBeenCalled());
+    vi.clearAllMocks();
+    mockListAdminStories.mockResolvedValue(EMPTY_LIST);
+
+    fireEvent.change(screen.getByPlaceholderText('搜尋課文標題...'), {
+      target: { value: '麵' },
+    });
+    fireEvent.change(screen.getByDisplayValue('所有年級'), {
+      target: { value: '6' },
+    });
+
+    await waitFor(() => {
+      const calls = mockListAdminStories.mock.calls;
+      const lastCall = calls.at(-1)!;
+      expect(lastCall[1]).toMatchObject({ search: '麵', grade: 6 });
+    });
+  });
+});

--- a/frontend/src/pages/admin/storyFormMapper.ts
+++ b/frontend/src/pages/admin/storyFormMapper.ts
@@ -1,0 +1,64 @@
+import {
+  StoryAdminListItem,
+  StoryCreateRequest,
+} from '../../services/adminStoryApi';
+
+export type ModalMode = 'create' | 'edit';
+
+export interface StoryFormState {
+  lesson_number: string;
+  title: string;
+  grade: string;
+  grade_code: string;
+  genre: string;
+  text_type: string;
+  reading_strategy: string;
+  paragraphs: string;
+  source_file: string;
+}
+
+export const EMPTY_FORM: StoryFormState = {
+  lesson_number: '',
+  title: '',
+  grade: '4',
+  grade_code: '',
+  genre: '記敘文',
+  text_type: '單',
+  reading_strategy: '',
+  paragraphs: '',
+  source_file: '',
+};
+
+export const GENRE_OPTIONS = ['記敘文', '說明文', '議論文', '文言文', '應用文'];
+export const TEXT_TYPE_OPTIONS = ['單', '多*2', '多*3'];
+
+export function formToCreateRequest(form: StoryFormState): StoryCreateRequest {
+  return {
+    lesson_number: parseInt(form.lesson_number, 10),
+    title: form.title.trim(),
+    grade: parseInt(form.grade, 10),
+    grade_code: form.grade_code.trim(),
+    genre: form.genre,
+    text_type: form.text_type,
+    reading_strategy: form.reading_strategy.trim() || undefined,
+    paragraphs: form.paragraphs
+      .split('\n')
+      .map((p) => p.trim())
+      .filter(Boolean),
+    source_file: form.source_file.trim() || undefined,
+  };
+}
+
+export function storyToFormState(story: StoryAdminListItem): StoryFormState {
+  return {
+    lesson_number: String(story.lesson_number),
+    title: story.title,
+    grade: String(story.grade),
+    grade_code: story.grade_code,
+    genre: story.genre,
+    text_type: story.text_type,
+    reading_strategy: story.reading_strategy ?? '',
+    paragraphs: '',
+    source_file: story.source_file ?? '',
+  };
+}


### PR DESCRIPTION
Fixes #1851

## Summary
- Extract `storyFormMapper.ts` with pure `formToCreateRequest()` + `storyToFormState()` functions (64L)
- Replace inline `DeleteConfirmDialog` with shared `ConfirmDialog` primitive
- Replace hand-rolled dual mobile-card/desktop-table layout with `AdminTable`
- Replace hand-rolled title/subtitle/header-actions with `AdminPageShell`
- Net: `StoryManagementPanel.tsx` 726L → 576L (-150L)

## TDD Evidence
9 tests written BEFORE refactor, all 9 pass AFTER (tautology check complete):
- `formToCreateRequest` trims title, splits/filters paragraphs on newline
- Edit modal preserves lesson_number (read-only), validates empty paragraphs
- Edit modal includes paragraphs in update request when filled
- 409 create error renders duplicate lesson message
- Filter calls list API with search + grade params (3 combinations)

## Test Plan
- All 9 new TDD tests pass
- All 69 admin panel tests pass (no regression)
- Pre-existing 31 failures in VocabWordSearch/FillInBlank/StoryStructure are unrelated to this PR