### PR TITLE
refactor(admin): extract UsersPanel primitives — RoleBadge/UserRow/UserExpandedPanel/AssignRoleForm (Fixes #1852)

### DIFF
--- a/frontend/src/pages/admin/AssignRoleForm.tsx
+++ b/frontend/src/pages/admin/AssignRoleForm.tsx
@@ -1,0 +1,228 @@
+/**
+ * AssignRoleForm — form for assigning a role to a user.
+ *
+ * Loads available roles + organizations + schools on mount.
+ * Shows a scope picker (org or school) when the selected role requires it.
+ * Calls assignRole on submit.
+ *
+ * Security: scope_type is derived server-side from role.scope_level.
+ * We send the correct scope_type based on SCOPE_LEVEL_FOR_ASSIGN mapping.
+ */
+import React, { useState, useEffect } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import {
+  listRoles,
+  assignRole,
+  RoleResponse,
+  RoleApiError,
+} from '../../services/roleApi';
+import {
+  listOrganizations,
+  OrganizationResponse,
+} from '../../services/organizationApi';
+import { listSchools, SchoolResponse } from '../../services/schoolApi';
+
+// scope_level from role → scope_type sent to API
+const SCOPE_LEVEL_FOR_ASSIGN: Record<string, string> = {
+  global: 'platform',
+  organization: 'organization',
+  school: 'school',
+  classroom: 'classroom',
+};
+
+export interface AssignRoleFormProps {
+  userId: number;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+const AssignRoleForm: React.FC<AssignRoleFormProps> = ({ userId, onSuccess, onCancel }) => {
+  const { token } = useAuth();
+
+  const [availableRoles, setAvailableRoles] = useState<RoleResponse[]>([]);
+  const [organizations, setOrganizations] = useState<OrganizationResponse[]>([]);
+  const [schools, setSchools] = useState<SchoolResponse[]>([]);
+  const [isLoadingRoles, setIsLoadingRoles] = useState(true);
+
+  const [selectedRoleName, setSelectedRoleName] = useState('');
+  const [scopeId, setScopeId] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formError, setFormError] = useState('');
+
+  const selectedRole = availableRoles.find((r) => r.name === selectedRoleName);
+  const scopeLevel = selectedRole?.scope_level ?? '';
+  const scopeType = SCOPE_LEVEL_FOR_ASSIGN[scopeLevel] ?? 'platform';
+  const needsScope = scopeLevel === 'organization' || scopeLevel === 'school';
+
+  // Load roles + scope options on mount
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+
+    async function load() {
+      setIsLoadingRoles(true);
+      try {
+        const [rolesData, orgsData, schoolsData] = await Promise.all([
+          listRoles(token!),
+          listOrganizations(token!).then((r) => r.items),
+          listSchools(token!).then((r) => r.items),
+        ]);
+        if (!cancelled) {
+          setAvailableRoles(rolesData);
+          setOrganizations(orgsData);
+          setSchools(schoolsData);
+        }
+      } catch {
+        if (!cancelled) setFormError('無法載入角色列表');
+      } finally {
+        if (!cancelled) setIsLoadingRoles(false);
+      }
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [token]);
+
+  // Reset scope when role changes
+  useEffect(() => {
+    setScopeId('');
+  }, [selectedRoleName]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token || !selectedRoleName) return;
+
+    if (needsScope && !scopeId) {
+      setFormError('請選擇範圍');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setFormError('');
+
+    try {
+      await assignRole(token, {
+        user_id: userId,
+        role_name: selectedRoleName,
+        scope_type: scopeType,
+        scope_id: needsScope ? scopeId : undefined,
+      });
+      onSuccess();
+    } catch (err) {
+      const msg = err instanceof RoleApiError ? err.message : '指派角色失敗';
+      setFormError(msg);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoadingRoles) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+          <span className="text-xs text-gray-400">載入角色選項...</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="bg-white rounded-lg border border-gray-200 p-4 space-y-3">
+      <h5 className="text-sm font-semibold text-gray-700">指派新角色</h5>
+
+      {formError && (
+        <p className="text-xs text-red-600">{formError}</p>
+      )}
+
+      {/* Role selector */}
+      <div>
+        <label htmlFor="assign-role-select" className="block text-xs text-gray-500 mb-1">
+          角色
+        </label>
+        <select
+          id="assign-role-select"
+          value={selectedRoleName}
+          onChange={(e) => setSelectedRoleName(e.target.value)}
+          className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+        >
+          <option value="">請選擇角色</option>
+          {availableRoles.map((role) => (
+            <option key={role.id} value={role.name}>
+              {role.display_name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Scope selector (organization) */}
+      {selectedRole && scopeLevel === 'organization' && (
+        <div>
+          <label htmlFor="assign-scope-org" className="block text-xs text-gray-500 mb-1">
+            機構
+          </label>
+          <select
+            id="assign-scope-org"
+            value={scopeId}
+            onChange={(e) => setScopeId(e.target.value)}
+            className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+          >
+            <option value="">請選擇機構</option>
+            {organizations.map((org) => (
+              <option key={org.id} value={org.id}>
+                {org.display_name || org.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Scope selector (school) */}
+      {selectedRole && scopeLevel === 'school' && (
+        <div>
+          <label htmlFor="assign-scope-school" className="block text-xs text-gray-500 mb-1">
+            學校
+          </label>
+          <select
+            id="assign-scope-school"
+            value={scopeId}
+            onChange={(e) => setScopeId(e.target.value)}
+            className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
+          >
+            <option value="">請選擇學校</option>
+            {schools.map((school) => (
+              <option key={school.id} value={String(school.id)}>
+                {school.display_name || school.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {selectedRole && scopeLevel === 'global' && (
+        <p className="text-xs text-gray-400">此角色為全域角色，不需要選擇範圍</p>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 pt-1">
+        <button
+          type="submit"
+          disabled={!selectedRoleName || isSubmitting}
+          className="px-4 py-1.5 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isSubmitting ? '指派中...' : '指派'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          className="px-4 py-1.5 text-sm text-gray-500 hover:text-gray-700 cursor-pointer disabled:opacity-50"
+        >
+          取消
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default AssignRoleForm;

--- a/frontend/src/pages/admin/RoleBadge.tsx
+++ b/frontend/src/pages/admin/RoleBadge.tsx
@@ -1,0 +1,65 @@
+/**
+ * RoleBadge — colored pill for a role name.
+ *
+ * Displays a human-readable role label in a color-coded pill badge.
+ * Colors follow the admin UI convention (red=system, blue=org, green=staff, etc.).
+ */
+import React from 'react';
+
+// ── Color mapping ────────────────────────────────────────────────────────────
+
+export const ROLE_BADGE_STYLES: Record<string, string> = {
+  system_admin: 'bg-red-100 text-red-700',
+  org_admin: 'bg-blue-100 text-blue-700',
+  org_owner: 'bg-blue-100 text-blue-700',
+  teacher: 'bg-green-100 text-green-700',
+  principal: 'bg-green-100 text-green-700',
+  director: 'bg-green-100 text-green-700',
+  student: 'bg-yellow-100 text-yellow-700',
+  parent: 'bg-purple-100 text-purple-700',
+};
+
+export const ROLE_DISPLAY_NAMES: Record<string, string> = {
+  system_admin: '系統管理員',
+  org_admin: '機構管理員',
+  org_owner: '機構擁有者',
+  teacher: '教師',
+  principal: '校長',
+  director: '主任',
+  student: '學生',
+  parent: '家長',
+};
+
+export function getRoleBadgeStyle(roleName: string): string {
+  return ROLE_BADGE_STYLES[roleName] ?? 'bg-gray-100 text-gray-700';
+}
+
+export function getRoleDisplayName(roleName: string): string {
+  return ROLE_DISPLAY_NAMES[roleName] ?? roleName;
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export interface RoleBadgeProps {
+  /** Internal role name key (e.g. 'teacher', 'org_admin'). */
+  roleName: string;
+  /** Override display label. Falls back to ROLE_DISPLAY_NAMES map. */
+  label?: string;
+  /** Extra className applied to the pill. */
+  className?: string;
+}
+
+const RoleBadge: React.FC<RoleBadgeProps> = ({ roleName, label, className = '' }) => {
+  const displayLabel = label ?? getRoleDisplayName(roleName);
+  const colorClass = getRoleBadgeStyle(roleName);
+
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 text-xs font-medium ${colorClass} ${className}`.trim()}
+    >
+      {displayLabel}
+    </span>
+  );
+};
+
+export default RoleBadge;

--- a/frontend/src/pages/admin/UserExpandedPanel.tsx
+++ b/frontend/src/pages/admin/UserExpandedPanel.tsx
@@ -1,0 +1,188 @@
+/**
+ * UserExpandedPanel — role details + assign form for an expanded user row.
+ *
+ * Shows the user's current role assignments (loaded on mount via getUserRoles),
+ * with inline revoke confirm pattern and an optional AssignRoleForm.
+ * Uses ConfirmDialog primitive for the revoke confirmation gate.
+ */
+import React, { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { UserListItem } from '../../services/userApi';
+import {
+  getUserRoles,
+  revokeRole,
+  UserRoleDetailResponse,
+  RoleApiError,
+} from '../../services/roleApi';
+import { PlusIcon } from '../../components/icons';
+import RoleBadge from './RoleBadge';
+import AssignRoleForm from './AssignRoleForm';
+
+export interface UserExpandedPanelProps {
+  user: UserListItem;
+  onRolesChanged: () => void;
+}
+
+const UserExpandedPanel: React.FC<UserExpandedPanelProps> = ({ user, onRolesChanged }) => {
+  const { token } = useAuth();
+
+  const [roleDetails, setRoleDetails] = useState<UserRoleDetailResponse[]>([]);
+  const [isLoadingRoles, setIsLoadingRoles] = useState(true);
+  const [rolesError, setRolesError] = useState('');
+
+  const [showAssignForm, setShowAssignForm] = useState(false);
+
+  // Inline revoke confirm
+  const [revokeConfirmId, setRevokeConfirmId] = useState<number | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const loadRoleDetails = useCallback(async () => {
+    if (!token) return;
+    setIsLoadingRoles(true);
+    setRolesError('');
+    try {
+      const data = await getUserRoles(token, user.id);
+      setRoleDetails(data);
+    } catch (err) {
+      if (err instanceof RoleApiError) {
+        setRolesError(err.message);
+      } else {
+        setRolesError('無法載入角色資訊');
+      }
+    } finally {
+      setIsLoadingRoles(false);
+    }
+  }, [token, user.id]);
+
+  useEffect(() => {
+    loadRoleDetails();
+  }, [loadRoleDetails]);
+
+  const handleRevoke = async (assignmentId: number) => {
+    if (!token) return;
+    setIsRevoking(true);
+    try {
+      await revokeRole(token, assignmentId);
+      setRevokeConfirmId(null);
+      await loadRoleDetails();
+      onRolesChanged();
+    } catch (err) {
+      const msg = err instanceof RoleApiError ? err.message : '撤銷角色失敗';
+      setRolesError(msg);
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  const handleAssignSuccess = async () => {
+    setShowAssignForm(false);
+    await loadRoleDetails();
+    onRolesChanged();
+  };
+
+  return (
+    <div className="px-6 pb-5 bg-gray-50 border-t border-gray-100">
+      <div className="max-w-2xl space-y-4 pt-4">
+        {/* Current roles section */}
+        <div>
+          <h4 className="text-sm font-semibold text-gray-700 mb-2">目前角色</h4>
+
+          {isLoadingRoles && (
+            <div className="flex items-center gap-2 py-2">
+              <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+              <span className="text-xs text-gray-400">載入中...</span>
+            </div>
+          )}
+
+          {rolesError && (
+            <p className="text-xs text-red-600 py-1">{rolesError}</p>
+          )}
+
+          {!isLoadingRoles && !rolesError && roleDetails.length === 0 && (
+            <p className="text-xs text-gray-400 py-1">此使用者尚無任何角色</p>
+          )}
+
+          {!isLoadingRoles && !rolesError && roleDetails.length > 0 && (
+            <div className="space-y-2">
+              {roleDetails.map((rd) => (
+                <div
+                  key={rd.id}
+                  className="flex items-center justify-between bg-white rounded-lg border border-gray-200 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <RoleBadge
+                      roleName={rd.role_name}
+                      label={rd.role_display_name}
+                      className="shrink-0"
+                    />
+                    <span className="text-xs text-gray-400 truncate">
+                      {rd.scope_type}
+                      {rd.scope_id ? ` / ${rd.scope_id}` : ''}
+                    </span>
+                    {!rd.is_active && (
+                      <span className="rounded-full px-1.5 py-0.5 text-[10px] bg-gray-100 text-gray-500">
+                        停用
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Inline revoke confirm */}
+                  <div className="shrink-0 ml-2">
+                    {revokeConfirmId === rd.id ? (
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => handleRevoke(rd.id)}
+                          disabled={isRevoking}
+                          className="text-xs text-red-600 hover:text-red-800 font-medium cursor-pointer disabled:opacity-50"
+                        >
+                          {isRevoking ? '處理中...' : '確認撤銷'}
+                        </button>
+                        <button
+                          onClick={() => setRevokeConfirmId(null)}
+                          disabled={isRevoking}
+                          className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer disabled:opacity-50"
+                        >
+                          取消
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => setRevokeConfirmId(rd.id)}
+                        className="text-gray-300 hover:text-red-500 transition-colors cursor-pointer"
+                        title="撤銷此角色"
+                        aria-label={`撤銷 ${rd.role_display_name}`}
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Assign role section */}
+        {!showAssignForm ? (
+          <button
+            onClick={() => setShowAssignForm(true)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors cursor-pointer"
+          >
+            <PlusIcon />
+            指派角色
+          </button>
+        ) : (
+          <AssignRoleForm
+            userId={user.id}
+            onSuccess={handleAssignSuccess}
+            onCancel={() => setShowAssignForm(false)}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default UserExpandedPanel;

--- a/frontend/src/pages/admin/UserRow.tsx
+++ b/frontend/src/pages/admin/UserRow.tsx
@@ -1,0 +1,86 @@
+/**
+ * UserRow — a single row in the users table.
+ *
+ * Renders user name, email, role badges, active status, and a toggle button.
+ * When isExpanded is true, renders the UserExpandedPanel inline below.
+ */
+import React from 'react';
+import { UserListItem } from '../../services/userApi';
+import RoleBadge, { getRoleDisplayName } from './RoleBadge';
+import UserExpandedPanel from './UserExpandedPanel';
+
+export interface UserRowProps {
+  user: UserListItem;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onRolesChanged: () => void;
+}
+
+const UserRow: React.FC<UserRowProps> = ({ user, isExpanded, onToggleExpand, onRolesChanged }) => {
+  return (
+    <div className="border-b border-gray-100 last:border-b-0">
+      {/* Main row */}
+      <div
+        onClick={onToggleExpand}
+        className="grid grid-cols-1 sm:grid-cols-[1fr_1.5fr_1fr_80px_100px] gap-2 sm:gap-4 px-6 py-4 hover:bg-gray-50 cursor-pointer transition-colors items-center"
+      >
+        {/* Name */}
+        <div className="font-medium text-gray-900 text-sm truncate">
+          {user.name}
+        </div>
+
+        {/* Email */}
+        <div className="text-sm text-gray-500 truncate">
+          {user.email}
+        </div>
+
+        {/* Role badges */}
+        <div className="flex flex-wrap gap-1">
+          {user.roles.length === 0 && (
+            <span className="text-xs text-gray-400">無角色</span>
+          )}
+          {user.roles.map((role, i) => (
+            <RoleBadge
+              key={`${role.role_name}-${role.scope_type}-${role.scope_id ?? 'null'}-${i}`}
+              roleName={role.role_name}
+              label={getRoleDisplayName(role.role_name)}
+            />
+          ))}
+        </div>
+
+        {/* Active status */}
+        <div>
+          <span
+            className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+              user.is_active
+                ? 'bg-green-100 text-green-700'
+                : 'bg-gray-100 text-gray-500'
+            }`}
+          >
+            {user.is_active ? '啟用' : '停用'}
+          </span>
+        </div>
+
+        {/* Expand/collapse toggle */}
+        <div className="text-right">
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleExpand();
+            }}
+            className="text-xs text-accent hover:text-accent-hover font-medium cursor-pointer"
+          >
+            {isExpanded ? '收合' : '管理角色'}
+          </button>
+        </div>
+      </div>
+
+      {/* Expanded panel */}
+      {isExpanded && (
+        <UserExpandedPanel user={user} onRolesChanged={onRolesChanged} />
+      )}
+    </div>
+  );
+};
+
+export default UserRow;

--- a/frontend/src/pages/admin/UsersPanel.tsx
+++ b/frontend/src/pages/admin/UsersPanel.tsx
@@ -1,66 +1,19 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+/**
+ * UsersPanel — admin page for managing users and their role assignments.
+ *
+ * Refactored (Issue #1852) to use shared primitives:
+ *   - useDebouncedSearch hook for debounced search + page reset
+ *   - RoleBadge for role pill display
+ *   - UserRow for the clickable table row
+ *   - UserExpandedPanel for role detail + assignment form
+ *   - AssignRoleForm for the role assignment form
+ */
+import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
-import { PlusIcon, UsersIcon } from '../../components/icons';
+import { UsersIcon } from '../../components/icons';
 import { listUsers, UserListItem, UserApiError } from '../../services/userApi';
-import {
-  listRoles,
-  assignRole,
-  revokeRole,
-  getUserRoles,
-  RoleResponse,
-  UserRoleDetailResponse,
-  RoleApiError,
-} from '../../services/roleApi';
-import {
-  listOrganizations,
-  OrganizationResponse,
-} from '../../services/organizationApi';
-import { listSchools, SchoolResponse } from '../../services/schoolApi';
-
-// ── Role badge color mapping ────────────────────────────────────────────────
-
-const ROLE_BADGE_STYLES: Record<string, string> = {
-  system_admin: 'bg-red-100 text-red-700',
-  org_admin: 'bg-blue-100 text-blue-700',
-  org_owner: 'bg-blue-100 text-blue-700',
-  teacher: 'bg-green-100 text-green-700',
-  principal: 'bg-green-100 text-green-700',
-  director: 'bg-green-100 text-green-700',
-  student: 'bg-yellow-100 text-yellow-700',
-  parent: 'bg-purple-100 text-purple-700',
-};
-
-function getRoleBadgeStyle(roleName: string): string {
-  return ROLE_BADGE_STYLES[roleName] ?? 'bg-gray-100 text-gray-700';
-}
-
-// ── Role display name mapping ───────────────────────────────────────────────
-
-const ROLE_DISPLAY_NAMES: Record<string, string> = {
-  system_admin: '系統管理員',
-  org_admin: '機構管理員',
-  org_owner: '機構擁有者',
-  teacher: '教師',
-  principal: '校長',
-  director: '主任',
-  student: '學生',
-  parent: '家長',
-};
-
-function getRoleDisplayName(roleName: string): string {
-  return ROLE_DISPLAY_NAMES[roleName] ?? roleName;
-}
-
-// ── Scope type labels ───────────────────────────────────────────────────────
-
-const SCOPE_LEVEL_FOR_ASSIGN: Record<string, string> = {
-  global: 'platform',
-  organization: 'organization',
-  school: 'school',
-  classroom: 'classroom',
-};
-
-// ── Main UsersPanel ─────────────────────────────────────────────────────────
+import { useDebouncedSearch } from '../../hooks/useDebouncedSearch';
+import UserRow from './UserRow';
 
 const UsersPanel: React.FC = () => {
   const { token } = useAuth();
@@ -70,18 +23,17 @@ const UsersPanel: React.FC = () => {
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [page, setPage] = useState(0);
+
+  // Debounced search + pagination via shared hook
+  const { query: searchQuery, setQuery, debouncedQuery: debouncedSearch, page, setPage } =
+    useDebouncedSearch({ delay: 300 });
+
   const pageSize = 20;
 
   // Expanded user (show role details + assignment form)
   const [expandedUserId, setExpandedUserId] = useState<number | null>(null);
 
-  // Debounce timer ref
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [debouncedSearch, setDebouncedSearch] = useState('');
-
-  // ── Load users ──────────────────────────────────────────────────────────
+  // ── Load users ─────────────────────────────────────────────────────────────
 
   const loadUsers = useCallback(async (search: string, offset: number) => {
     if (!token) return;
@@ -110,20 +62,9 @@ const UsersPanel: React.FC = () => {
     loadUsers(debouncedSearch, page * pageSize);
   }, [loadUsers, debouncedSearch, page]);
 
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
-
-  // Debounced search
+  // Handle search input — delegates debounce logic to hook
   const handleSearchChange = (value: string) => {
-    setSearchQuery(value);
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      setPage(0);
-      setDebouncedSearch(value);
-    }, 300);
+    setQuery(value);
   };
 
   // Toggle expanded user
@@ -131,9 +72,8 @@ const UsersPanel: React.FC = () => {
     setExpandedUserId((prev) => (prev === userId ? null : userId));
   };
 
-  // Refresh a single user's roles after assign/revoke
+  // Refresh user list after role change
   const refreshUserInList = useCallback(async () => {
-    // Reload the whole list (simpler than patching a single item)
     await loadUsers(debouncedSearch, page * pageSize);
   }, [loadUsers, debouncedSearch, page]);
 
@@ -200,7 +140,6 @@ const UsersPanel: React.FC = () => {
               <span className="text-right">操作</span>
             </div>
 
-            {/* Table rows */}
             {users.map((user) => (
               <UserRow
                 key={user.id}
@@ -257,460 +196,6 @@ const UsersPanel: React.FC = () => {
         )}
       </div>
     </div>
-  );
-};
-
-// ── User Row ────────────────────────────────────────────────────────────────
-
-interface UserRowProps {
-  user: UserListItem;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-  onRolesChanged: () => void;
-}
-
-const UserRow: React.FC<UserRowProps> = ({ user, isExpanded, onToggleExpand, onRolesChanged }) => {
-  return (
-    <div className="border-b border-gray-100 last:border-b-0">
-      {/* Main row */}
-      <div
-        onClick={onToggleExpand}
-        className="grid grid-cols-1 sm:grid-cols-[1fr_1.5fr_1fr_80px_100px] gap-2 sm:gap-4 px-6 py-4 hover:bg-gray-50 cursor-pointer transition-colors items-center"
-      >
-        {/* Name */}
-        <div className="font-medium text-gray-900 text-sm truncate">
-          {user.name}
-        </div>
-
-        {/* Email */}
-        <div className="text-sm text-gray-500 truncate">
-          {user.email}
-        </div>
-
-        {/* Roles */}
-        <div className="flex flex-wrap gap-1">
-          {user.roles.length === 0 && (
-            <span className="text-xs text-gray-400">無角色</span>
-          )}
-          {user.roles.map((role, i) => (
-            <span
-              key={`${role.role_name}-${role.scope_type}-${role.scope_id ?? 'null'}-${i}`}
-              className={`rounded-full px-2 py-0.5 text-xs font-medium ${getRoleBadgeStyle(role.role_name)}`}
-            >
-              {getRoleDisplayName(role.role_name)}
-            </span>
-          ))}
-        </div>
-
-        {/* Status */}
-        <div>
-          <span
-            className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-              user.is_active
-                ? 'bg-green-100 text-green-700'
-                : 'bg-gray-100 text-gray-500'
-            }`}
-          >
-            {user.is_active ? '啟用' : '停用'}
-          </span>
-        </div>
-
-        {/* Actions */}
-        <div className="text-right">
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleExpand();
-            }}
-            className="text-xs text-accent hover:text-accent-hover font-medium cursor-pointer"
-          >
-            {isExpanded ? '收合' : '管理角色'}
-          </button>
-        </div>
-      </div>
-
-      {/* Expanded panel */}
-      {isExpanded && (
-        <UserExpandedPanel user={user} onRolesChanged={onRolesChanged} />
-      )}
-    </div>
-  );
-};
-
-// ── Expanded Panel (role details + assignment form) ─────────────────────────
-
-interface UserExpandedPanelProps {
-  user: UserListItem;
-  onRolesChanged: () => void;
-}
-
-const UserExpandedPanel: React.FC<UserExpandedPanelProps> = ({ user, onRolesChanged }) => {
-  const { token } = useAuth();
-
-  // User role details (full detail from getUserRoles)
-  const [roleDetails, setRoleDetails] = useState<UserRoleDetailResponse[]>([]);
-  const [isLoadingRoles, setIsLoadingRoles] = useState(true);
-  const [rolesError, setRolesError] = useState('');
-
-  // Assignment form state
-  const [showAssignForm, setShowAssignForm] = useState(false);
-
-  // Revoke confirm
-  const [revokeConfirmId, setRevokeConfirmId] = useState<number | null>(null);
-  const [isRevoking, setIsRevoking] = useState(false);
-
-  // Load user roles
-  const loadRoleDetails = useCallback(async () => {
-    if (!token) return;
-    setIsLoadingRoles(true);
-    setRolesError('');
-    try {
-      const data = await getUserRoles(token, user.id);
-      setRoleDetails(data);
-    } catch (err) {
-      if (err instanceof RoleApiError) {
-        setRolesError(err.message);
-      } else {
-        setRolesError('無法載入角色資訊');
-      }
-    } finally {
-      setIsLoadingRoles(false);
-    }
-  }, [token, user.id]);
-
-  useEffect(() => {
-    loadRoleDetails();
-  }, [loadRoleDetails]);
-
-  // Revoke a role
-  const handleRevoke = async (assignmentId: number) => {
-    if (!token) return;
-    setIsRevoking(true);
-    try {
-      await revokeRole(token, assignmentId);
-      setRevokeConfirmId(null);
-      await loadRoleDetails();
-      onRolesChanged();
-    } catch (err) {
-      const msg = err instanceof RoleApiError ? err.message : '撤銷角色失敗';
-      setRolesError(msg);
-    } finally {
-      setIsRevoking(false);
-    }
-  };
-
-  // After successful assignment
-  const handleAssignSuccess = async () => {
-    setShowAssignForm(false);
-    await loadRoleDetails();
-    onRolesChanged();
-  };
-
-  return (
-    <div className="px-6 pb-5 bg-gray-50 border-t border-gray-100">
-      <div className="max-w-2xl space-y-4 pt-4">
-        {/* Current roles section */}
-        <div>
-          <h4 className="text-sm font-semibold text-gray-700 mb-2">目前角色</h4>
-
-          {isLoadingRoles && (
-            <div className="flex items-center gap-2 py-2">
-              <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
-              <span className="text-xs text-gray-400">載入中...</span>
-            </div>
-          )}
-
-          {rolesError && (
-            <p className="text-xs text-red-600 py-1">{rolesError}</p>
-          )}
-
-          {!isLoadingRoles && !rolesError && roleDetails.length === 0 && (
-            <p className="text-xs text-gray-400 py-1">此使用者尚無任何角色</p>
-          )}
-
-          {!isLoadingRoles && !rolesError && roleDetails.length > 0 && (
-            <div className="space-y-2">
-              {roleDetails.map((rd) => (
-                <div
-                  key={rd.id}
-                  className="flex items-center justify-between bg-white rounded-lg border border-gray-200 px-3 py-2"
-                >
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span
-                      className={`rounded-full px-2 py-0.5 text-xs font-medium shrink-0 ${getRoleBadgeStyle(rd.role_name)}`}
-                    >
-                      {rd.role_display_name}
-                    </span>
-                    <span className="text-xs text-gray-400 truncate">
-                      {rd.scope_type}
-                      {rd.scope_id ? ` / ${rd.scope_id}` : ''}
-                    </span>
-                    {!rd.is_active && (
-                      <span className="rounded-full px-1.5 py-0.5 text-[10px] bg-gray-100 text-gray-500">
-                        停用
-                      </span>
-                    )}
-                  </div>
-
-                  {/* Revoke button / confirm */}
-                  <div className="shrink-0 ml-2">
-                    {revokeConfirmId === rd.id ? (
-                      <div className="flex items-center gap-1">
-                        <button
-                          onClick={() => handleRevoke(rd.id)}
-                          disabled={isRevoking}
-                          className="text-xs text-red-600 hover:text-red-800 font-medium cursor-pointer disabled:opacity-50"
-                        >
-                          {isRevoking ? '處理中...' : '確認撤銷'}
-                        </button>
-                        <button
-                          onClick={() => setRevokeConfirmId(null)}
-                          disabled={isRevoking}
-                          className="text-xs text-gray-400 hover:text-gray-600 cursor-pointer disabled:opacity-50"
-                        >
-                          取消
-                        </button>
-                      </div>
-                    ) : (
-                      <button
-                        onClick={() => setRevokeConfirmId(rd.id)}
-                        className="text-gray-300 hover:text-red-500 transition-colors cursor-pointer"
-                        title="撤銷此角色"
-                        aria-label={`撤銷 ${rd.role_display_name}`}
-                      >
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                        </svg>
-                      </button>
-                    )}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Assign role section */}
-        {!showAssignForm ? (
-          <button
-            onClick={() => setShowAssignForm(true)}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors cursor-pointer"
-          >
-            <PlusIcon />
-            指派角色
-          </button>
-        ) : (
-          <AssignRoleForm
-            userId={user.id}
-            onSuccess={handleAssignSuccess}
-            onCancel={() => setShowAssignForm(false)}
-          />
-        )}
-      </div>
-    </div>
-  );
-};
-
-// ── Assign Role Form ────────────────────────────────────────────────────────
-
-interface AssignRoleFormProps {
-  userId: number;
-  onSuccess: () => void;
-  onCancel: () => void;
-}
-
-const AssignRoleForm: React.FC<AssignRoleFormProps> = ({ userId, onSuccess, onCancel }) => {
-  const { token } = useAuth();
-
-  // Available roles
-  const [availableRoles, setAvailableRoles] = useState<RoleResponse[]>([]);
-  const [isLoadingRoles, setIsLoadingRoles] = useState(true);
-
-  // Scope options
-  const [organizations, setOrganizations] = useState<OrganizationResponse[]>([]);
-  const [schools, setSchools] = useState<SchoolResponse[]>([]);
-
-  // Form values
-  const [selectedRoleName, setSelectedRoleName] = useState('');
-  const [scopeId, setScopeId] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [formError, setFormError] = useState('');
-
-  // Selected role object
-  const selectedRole = availableRoles.find((r) => r.name === selectedRoleName);
-  const scopeLevel = selectedRole?.scope_level ?? '';
-  const scopeType = SCOPE_LEVEL_FOR_ASSIGN[scopeLevel] ?? 'platform';
-  const needsScope = scopeLevel === 'organization' || scopeLevel === 'school';
-
-  // Load available roles on mount
-  useEffect(() => {
-    if (!token) return;
-    let cancelled = false;
-
-    async function load() {
-      setIsLoadingRoles(true);
-      try {
-        const [rolesData, orgsData, schoolsData] = await Promise.all([
-          listRoles(token!),
-          listOrganizations(token!).then((r) => r.items),
-          listSchools(token!).then((r) => r.items),
-        ]);
-        if (!cancelled) {
-          setAvailableRoles(rolesData);
-          setOrganizations(orgsData);
-          setSchools(schoolsData);
-        }
-      } catch {
-        // Roles are critical, others optional
-        if (!cancelled) setFormError('無法載入角色列表');
-      } finally {
-        if (!cancelled) setIsLoadingRoles(false);
-      }
-    }
-
-    load();
-    return () => { cancelled = true; };
-  }, [token]);
-
-  // Reset scope when role changes
-  useEffect(() => {
-    setScopeId('');
-  }, [selectedRoleName]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!token || !selectedRoleName) return;
-
-    // Validate scope
-    if (needsScope && !scopeId) {
-      setFormError('請選擇範圍');
-      return;
-    }
-
-    setIsSubmitting(true);
-    setFormError('');
-
-    try {
-      await assignRole(token, {
-        user_id: userId,
-        role_name: selectedRoleName,
-        scope_type: scopeType,
-        scope_id: needsScope ? scopeId : undefined,
-      });
-      onSuccess();
-    } catch (err) {
-      const msg = err instanceof RoleApiError ? err.message : '指派角色失敗';
-      setFormError(msg);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  if (isLoadingRoles) {
-    return (
-      <div className="bg-white rounded-lg border border-gray-200 p-4">
-        <div className="flex items-center gap-2">
-          <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
-          <span className="text-xs text-gray-400">載入角色選項...</span>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="bg-white rounded-lg border border-gray-200 p-4 space-y-3">
-      <h5 className="text-sm font-semibold text-gray-700">指派新角色</h5>
-
-      {formError && (
-        <p className="text-xs text-red-600">{formError}</p>
-      )}
-
-      {/* Role selector */}
-      <div>
-        <label htmlFor="assign-role-select" className="block text-xs text-gray-500 mb-1">
-          角色
-        </label>
-        <select
-          id="assign-role-select"
-          value={selectedRoleName}
-          onChange={(e) => setSelectedRoleName(e.target.value)}
-          className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
-        >
-          <option value="">請選擇角色</option>
-          {availableRoles.map((role) => (
-            <option key={role.id} value={role.name}>
-              {role.display_name}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      {/* Scope selector (conditional) */}
-      {selectedRole && scopeLevel === 'organization' && (
-        <div>
-          <label htmlFor="assign-scope-org" className="block text-xs text-gray-500 mb-1">
-            機構
-          </label>
-          <select
-            id="assign-scope-org"
-            value={scopeId}
-            onChange={(e) => setScopeId(e.target.value)}
-            className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
-          >
-            <option value="">請選擇機構</option>
-            {organizations.map((org) => (
-              <option key={org.id} value={org.id}>
-                {org.display_name || org.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-
-      {selectedRole && scopeLevel === 'school' && (
-        <div>
-          <label htmlFor="assign-scope-school" className="block text-xs text-gray-500 mb-1">
-            學校
-          </label>
-          <select
-            id="assign-scope-school"
-            value={scopeId}
-            onChange={(e) => setScopeId(e.target.value)}
-            className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent focus:border-transparent"
-          >
-            <option value="">請選擇學校</option>
-            {schools.map((school) => (
-              <option key={school.id} value={String(school.id)}>
-                {school.display_name || school.name}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-
-      {selectedRole && scopeLevel === 'global' && (
-        <p className="text-xs text-gray-400">此角色為全域角色，不需要選擇範圍</p>
-      )}
-
-      {/* Actions */}
-      <div className="flex items-center gap-2 pt-1">
-        <button
-          type="submit"
-          disabled={!selectedRoleName || isSubmitting}
-          className="px-4 py-1.5 bg-accent hover:bg-accent-hover text-white text-sm font-medium rounded-lg transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {isSubmitting ? '指派中...' : '指派'}
-        </button>
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={isSubmitting}
-          className="px-4 py-1.5 text-sm text-gray-500 hover:text-gray-700 cursor-pointer disabled:opacity-50"
-        >
-          取消
-        </button>
-      </div>
-    </form>
   );
 };
 

--- a/frontend/src/pages/admin/__tests__/UsersPanel.test.tsx
+++ b/frontend/src/pages/admin/__tests__/UsersPanel.test.tsx
@@ -1,0 +1,404 @@
+/**
+ * UsersPanel tests (Issue #1852)
+ * TDD-first: tests written against current code, verified to pass, then survive refactor.
+ *
+ * Acceptance criteria:
+ * 1. debounced search resets page to 0 + calls listUsers with offset 0
+ * 2. expanding user loads role details once (not on every re-render)
+ * 3. revoke role confirms then reloads role details + parent list
+ * 4. assign role maps scope level → correct scope type/id requirement
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import React from 'react';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+vi.mock('../../../services/userApi', () => ({
+  listUsers: vi.fn(),
+  UserApiError: class UserApiError extends Error {
+    status: number;
+    constructor(msg: string, status: number) { super(msg); this.status = status; }
+  },
+}));
+
+vi.mock('../../../services/roleApi', () => ({
+  listRoles: vi.fn(),
+  assignRole: vi.fn(),
+  revokeRole: vi.fn(),
+  getUserRoles: vi.fn(),
+  RoleApiError: class RoleApiError extends Error {
+    status: number;
+    constructor(msg: string, status: number) { super(msg); this.status = status; }
+  },
+}));
+
+vi.mock('../../../services/organizationApi', () => ({
+  listOrganizations: vi.fn(),
+}));
+
+vi.mock('../../../services/schoolApi', () => ({
+  listSchools: vi.fn(),
+}));
+
+vi.mock('../../../components/icons', () => ({
+  PlusIcon: () => <span data-testid="plus-icon">+</span>,
+  UsersIcon: () => <span data-testid="users-icon">users</span>,
+}));
+
+import UsersPanel from '../UsersPanel';
+import { listUsers } from '../../../services/userApi';
+import { getUserRoles, revokeRole, assignRole, listRoles } from '../../../services/roleApi';
+import { listOrganizations } from '../../../services/organizationApi';
+import { listSchools } from '../../../services/schoolApi';
+
+const mockListUsers = vi.mocked(listUsers);
+const mockGetUserRoles = vi.mocked(getUserRoles);
+const mockRevokeRole = vi.mocked(revokeRole);
+const mockAssignRole = vi.mocked(assignRole);
+const mockListRoles = vi.mocked(listRoles);
+const mockListOrganizations = vi.mocked(listOrganizations);
+const mockListSchools = vi.mocked(listSchools);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const MOCK_USER = {
+  id: 42,
+  name: '王小明',
+  email: 'test-user@example.com',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  roles: [{ role_name: 'teacher', scope_type: 'school', scope_id: '1' }],
+};
+
+const MOCK_USERS_RESPONSE = { items: [MOCK_USER], total: 1 };
+
+const MOCK_ROLE_DETAIL = {
+  id: 100,
+  user_id: 42,
+  role_id: 3,
+  role_name: 'teacher',
+  role_display_name: '教師',
+  scope_type: 'school',
+  scope_id: '1',
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const MOCK_ROLES = [
+  { id: 1, name: 'system_admin', display_name: '系統管理員', scope_level: 'global' },
+  { id: 2, name: 'org_admin', display_name: '機構管理員', scope_level: 'organization' },
+  { id: 3, name: 'teacher', display_name: '教師', scope_level: 'school' },
+];
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockListUsers.mockResolvedValue(MOCK_USERS_RESPONSE);
+  mockGetUserRoles.mockResolvedValue([MOCK_ROLE_DETAIL]);
+  mockRevokeRole.mockResolvedValue(undefined as never);
+  mockAssignRole.mockResolvedValue(MOCK_ROLE_DETAIL);
+  mockListRoles.mockResolvedValue(MOCK_ROLES);
+  mockListOrganizations.mockResolvedValue({ items: [{ id: 10, name: 'test-org', display_name: '測試機構' }], total: 1 } as never);
+  mockListSchools.mockResolvedValue({ items: [{ id: 20, name: 'test-school', display_name: '測試學校' }], total: 1 } as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Helper: render and wait for user list ─────────────────────────────────────
+
+async function renderAndWaitForUsers() {
+  render(<UsersPanel />);
+  await waitFor(() => expect(screen.getByText('王小明')).toBeInTheDocument());
+}
+
+// ── Test 1: Debounced search ──────────────────────────────────────────────────
+
+describe('debounced search', () => {
+  it('does not call listUsers immediately on keystroke (debounce in effect)', async () => {
+    // Use fake timers for this test to control debounce
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      render(<UsersPanel />);
+
+      // Wait for initial load (timers still run because shouldAdvanceTime:true)
+      await waitFor(() => expect(mockListUsers).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByText('王小明')).toBeInTheDocument());
+
+      const callsBefore = mockListUsers.mock.calls.length;
+      const searchInput = screen.getByPlaceholderText('搜尋使用者姓名或 Email...');
+
+      // Type — debounce timer starts
+      act(() => {
+        fireEvent.change(searchInput, { target: { value: '王' } });
+      });
+
+      // Should NOT have fired another call yet (within debounce window)
+      expect(mockListUsers).toHaveBeenCalledTimes(callsBefore);
+
+      // Advance past debounce
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+      });
+
+      // Now it should have fired
+      await waitFor(() => expect(mockListUsers).toHaveBeenCalledTimes(callsBefore + 1));
+
+      expect(mockListUsers).toHaveBeenLastCalledWith('test-token', {
+        limit: 20,
+        offset: 0,
+        search: '王',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('calls listUsers with offset=0 regardless of current page (page reset)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      // Give enough users to show pagination (total > 20)
+      mockListUsers.mockResolvedValue({
+        items: [MOCK_USER],
+        total: 25, // triggers pagination
+      });
+
+      render(<UsersPanel />);
+      await waitFor(() => expect(mockListUsers).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByText('王小明')).toBeInTheDocument());
+
+      // Go to page 2
+      const nextBtn = screen.getByRole('button', { name: '下一頁' });
+      await act(async () => { fireEvent.click(nextBtn); });
+      await waitFor(() => expect(mockListUsers).toHaveBeenCalledTimes(2));
+
+      // Page 2 uses offset=20
+      expect(mockListUsers).toHaveBeenLastCalledWith('test-token', {
+        limit: 20, offset: 20, search: undefined,
+      });
+
+      // Now type search → should reset page to 0
+      const searchInput = screen.getByPlaceholderText('搜尋使用者姓名或 Email...');
+      act(() => { fireEvent.change(searchInput, { target: { value: '王' } }); });
+
+      await act(async () => { vi.advanceTimersByTime(400); });
+
+      await waitFor(() => expect(mockListUsers).toHaveBeenCalledTimes(3));
+
+      // Must use offset=0 (page reset)
+      expect(mockListUsers).toHaveBeenLastCalledWith('test-token', {
+        limit: 20,
+        offset: 0,
+        search: '王',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ── Test 2: Expanding user loads role details once ────────────────────────────
+
+describe('expanding user row', () => {
+  it('calls getUserRoles exactly once when expanded — not before and not again on idle', async () => {
+    await renderAndWaitForUsers();
+
+    // Not called before expand
+    expect(mockGetUserRoles).not.toHaveBeenCalled();
+
+    // Expand the user row
+    const manageBtn = screen.getByRole('button', { name: '管理角色' });
+    await act(async () => { fireEvent.click(manageBtn); });
+
+    await waitFor(() => {
+      expect(mockGetUserRoles).toHaveBeenCalledTimes(1);
+      expect(mockGetUserRoles).toHaveBeenCalledWith('test-token', 42);
+    });
+
+    // Panel shows the "目前角色" section heading
+    await waitFor(() => expect(screen.getByText('目前角色')).toBeInTheDocument());
+
+    // No extra calls from mere presence in DOM
+    expect(mockGetUserRoles).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call getUserRoles when user row is collapsed', async () => {
+    await renderAndWaitForUsers();
+
+    const manageBtn = screen.getByRole('button', { name: '管理角色' });
+
+    // Expand
+    await act(async () => { fireEvent.click(manageBtn); });
+    await waitFor(() => expect(mockGetUserRoles).toHaveBeenCalledTimes(1));
+
+    // Collapse — click again
+    const collapseBtn = screen.getByRole('button', { name: '收合' });
+    await act(async () => { fireEvent.click(collapseBtn); });
+
+    // Still exactly 1 call
+    expect(mockGetUserRoles).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Test 3: Revoke confirms then reloads both lists ───────────────────────────
+
+describe('revoke role', () => {
+  it('shows confirm step before calling revokeRole', async () => {
+    await renderAndWaitForUsers();
+
+    // Expand
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '管理角色' })); });
+    await waitFor(() => expect(screen.getByText('目前角色')).toBeInTheDocument());
+    // Wait for role details to load in expanded panel
+    await waitFor(() => expect(screen.getByRole('button', { name: '撤銷 教師' })).toBeInTheDocument());
+
+    // Click revoke icon
+    const revokeBtn = screen.getByRole('button', { name: '撤銷 教師' });
+    await act(async () => { fireEvent.click(revokeBtn); });
+
+    // Confirm button appears
+    expect(screen.getByText('確認撤銷')).toBeInTheDocument();
+
+    // revokeRole NOT yet called
+    expect(mockRevokeRole).not.toHaveBeenCalled();
+  });
+
+  it('reloads role details AND parent user list after confirmed revoke', async () => {
+    await renderAndWaitForUsers();
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '管理角色' })); });
+    await waitFor(() => expect(screen.getByText('目前角色')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: '撤銷 教師' })).toBeInTheDocument());
+
+    const listCallsBefore = mockListUsers.mock.calls.length;
+    const roleCallsBefore = mockGetUserRoles.mock.calls.length;
+
+    // Open confirm
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '撤銷 教師' }));
+    });
+
+    // Confirm revoke
+    const confirmBtn = await screen.findByText('確認撤銷');
+    await act(async () => { fireEvent.click(confirmBtn); });
+
+    // revokeRole called with the assignment id
+    await waitFor(() => {
+      expect(mockRevokeRole).toHaveBeenCalledWith('test-token', 100);
+    });
+
+    // getUserRoles reloaded after revoke
+    await waitFor(() => {
+      expect(mockGetUserRoles.mock.calls.length).toBeGreaterThan(roleCallsBefore);
+    });
+
+    // listUsers reloaded (parent list refresh)
+    await waitFor(() => {
+      expect(mockListUsers.mock.calls.length).toBeGreaterThan(listCallsBefore);
+    });
+  });
+});
+
+// ── Test 4: Assign role scope type/id mapping ─────────────────────────────────
+
+describe('assign role scope mapping', () => {
+  async function openAssignForm() {
+    await renderAndWaitForUsers();
+
+    // Expand user
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '管理角色' })); });
+    await waitFor(() => expect(screen.getByText('目前角色')).toBeInTheDocument());
+
+    // Open assign form
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /指派角色/ })); });
+    await waitFor(() => expect(screen.getByLabelText('角色')).toBeInTheDocument());
+  }
+
+  it('global scope_level → scope_type=platform, no scope picker, no scope_id in call', async () => {
+    await openAssignForm();
+
+    act(() => { fireEvent.change(screen.getByLabelText('角色'), { target: { value: 'system_admin' } }); });
+
+    // No scope pickers
+    await waitFor(() => expect(screen.getByText(/全域角色/)).toBeInTheDocument());
+    expect(screen.queryByLabelText('機構')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('學校')).not.toBeInTheDocument();
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '指派' })); });
+
+    await waitFor(() => {
+      expect(mockAssignRole).toHaveBeenCalledWith('test-token', {
+        user_id: 42,
+        role_name: 'system_admin',
+        scope_type: 'platform',
+        scope_id: undefined,
+      });
+    });
+  });
+
+  it('organization scope_level → shows org picker, passes scope_type=organization + selected org id', async () => {
+    await openAssignForm();
+
+    act(() => { fireEvent.change(screen.getByLabelText('角色'), { target: { value: 'org_admin' } }); });
+
+    await waitFor(() => expect(screen.getByLabelText('機構')).toBeInTheDocument());
+    expect(screen.queryByLabelText('學校')).not.toBeInTheDocument();
+
+    act(() => { fireEvent.change(screen.getByLabelText('機構'), { target: { value: '10' } }); });
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '指派' })); });
+
+    await waitFor(() => {
+      expect(mockAssignRole).toHaveBeenCalledWith('test-token', {
+        user_id: 42,
+        role_name: 'org_admin',
+        scope_type: 'organization',
+        scope_id: '10',
+      });
+    });
+  });
+
+  it('school scope_level → shows school picker, passes scope_type=school + selected school id', async () => {
+    await openAssignForm();
+
+    act(() => { fireEvent.change(screen.getByLabelText('角色'), { target: { value: 'teacher' } }); });
+
+    await waitFor(() => expect(screen.getByLabelText('學校')).toBeInTheDocument());
+    expect(screen.queryByLabelText('機構')).not.toBeInTheDocument();
+
+    act(() => { fireEvent.change(screen.getByLabelText('學校'), { target: { value: '20' } }); });
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '指派' })); });
+
+    await waitFor(() => {
+      expect(mockAssignRole).toHaveBeenCalledWith('test-token', {
+        user_id: 42,
+        role_name: 'teacher',
+        scope_type: 'school',
+        scope_id: '20',
+      });
+    });
+  });
+
+  it('organization scope requires scope_id — blocks submit and shows error if org not selected', async () => {
+    await openAssignForm();
+
+    act(() => { fireEvent.change(screen.getByLabelText('角色'), { target: { value: 'org_admin' } }); });
+    await waitFor(() => expect(screen.getByLabelText('機構')).toBeInTheDocument());
+
+    // Submit without selecting org
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: '指派' })); });
+
+    expect(mockAssignRole).not.toHaveBeenCalled();
+    expect(screen.getByText('請選擇範圍')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1852

## Summary

Refactors `frontend/src/pages/admin/UsersPanel.tsx` (717 lines → 203 lines) by extracting focused primitives and adopting the `useDebouncedSearch` hook.

### New files
- `RoleBadge.tsx` — colour-mapped role pill (system_admin=red, org=blue, teacher=green, student=yellow, parent=purple)
- `UserRow.tsx` — clickable table row + expand toggle, renders `UserExpandedPanel` when expanded
- `UserExpandedPanel.tsx` — role detail list, inline revoke-confirm pattern, mounts `AssignRoleForm`
- `AssignRoleForm.tsx` — role assignment form with scope-aware org/school picker and validation

### Changed files
- `UsersPanel.tsx` — now only owns user list state + pagination; delegates debounce/page-reset to `useDebouncedSearch({ delay: 300 })`

### Test file
- `UsersPanel.test.tsx` — 10 TDD tests (10/10 passing on old code AND refactored code):
  - debounced search: no immediate API call on keystroke; page resets to 0 on new search
  - expanding user row: `getUserRoles` called exactly once on expand; not called when collapsed
  - revoke role: confirm step shown before `revokeRole` call; reloads role details + parent list after confirmed revoke
  - assign role scope mapping: global→platform (no picker); organization→org picker; school→school picker; org scope blocks submit if no org selected

## Test plan

- [x] `vitest run` 10/10 passing against refactored code
- [ ] PR Preview deploy — verify admin users panel loads and functions correctly
- [ ] Expand a user row — roles appear
- [ ] Revoke a role — confirm step, then reload
- [ ] Assign a role with school scope — school picker appears, validation works