### PR TITLE
refactor(omo): split omo_grader.py into schema/scoring/preprocess/upload (Fixes #1879)

### DIFF
--- a/backend/app/services/omo_crop_upload.py
+++ b/backend/app/services/omo_crop_upload.py
@@ -1,0 +1,97 @@
+"""OMO crop and GCS upload — extracts per-question answer strips from images.
+
+Extracted from omo_grader.py (issue #1879).
+
+Responsibilities:
+  - _crop_and_upload: crops a generous strip around the question position
+    (relative y-coord) and uploads to GCS as JPEG q85.
+    Fail-open: returns None on any error so crop failure never blocks grading.
+  - _crop_and_upload_answer_image: alias for backward compatibility.
+"""
+
+import io
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _crop_and_upload(
+    image_bytes_list: list[bytes],
+    question: dict,
+    upload_id: int,
+    question_id: str,
+    gcs_bucket: Optional[str] = None,
+) -> Optional[str]:
+    """Crop a generous strip around the question position and upload to GCS.
+
+    Position comes from the grader's position_x / position_y fields (relative 0-1 coords).
+    For fill_blank (fb_*): full-width strip (0, y-200, W, y+200), clipped to bounds.
+    For multiple_choice (mc_*): full-width strip (0, y-300, W, y+400), clipped to bounds.
+
+    Falls back to page 0 if no position or position_y=0.
+    Uploads as JPEG q85 to gs://{gcs_bucket}/crops/{upload_id}/{question_id}.jpg
+    Returns gs:// URI on success, None on any failure (fail-open: crop failure must not block grading).
+    """
+    try:
+        from PIL import Image
+    except ImportError:
+        return None
+
+    position = question.get('position') or {}
+    pos_y = float(position.get('y', 0.0))
+
+    # Use first image as source (page 0 fallback)
+    source_bytes = image_bytes_list[0] if image_bytes_list else None
+    if not source_bytes or source_bytes == b'placeholder':
+        return None
+
+    try:
+        img = Image.open(io.BytesIO(source_bytes))
+        if img.mode != 'RGB':
+            img = img.convert('RGB')
+        W, H = img.size
+
+        # Convert relative y to pixel coordinate
+        py = int(pos_y * H)
+
+        qtype = question.get('type', 'fill_blank')
+        if qtype == 'multiple_choice':
+            top = max(0, py - 300)
+            bottom = min(H, py + 400)
+        else:
+            top = max(0, py - 200)
+            bottom = min(H, py + 200)
+
+        # Full-width strip
+        cropped = img.crop((0, top, W, bottom))
+        buf = io.BytesIO()
+        cropped.save(buf, format='JPEG', quality=85)
+        crop_bytes = buf.getvalue()
+    except Exception as exc:
+        logger.warning('omo_grader crop failed for %s q=%s: %s', upload_id, question_id, exc)
+        return None
+
+    # Upload to GCS
+    bucket_name = gcs_bucket or os.environ.get("GCS_OMO_BUCKET", "lingoleap-omo-uploads")
+    object_path = f'crops/{upload_id}/{question_id}.jpg'
+    try:
+        from google.cloud import storage  # type: ignore[import]
+        client = storage.Client()
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(object_path)
+        blob.upload_from_string(crop_bytes, content_type='image/jpeg')
+        gs_uri = f'gs://{bucket_name}/{object_path}'
+        logger.info('omo_grader: uploaded crop %s', gs_uri)
+        return gs_uri
+    except ImportError:
+        logger.debug('google-cloud-storage not available — skipping crop upload (local dev)')
+        return None
+    except Exception as exc:
+        logger.warning('omo_grader: GCS crop upload failed for %s: %s', object_path, exc)
+        return None
+
+
+# Backward-compatibility alias
+_crop_and_upload_answer_image = _crop_and_upload

--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -1,4 +1,4 @@
-"""OMO grading service — extracts per-question student answers from worksheet images.
+"""OMO grading service — orchestration facade for worksheet image grading.
 
 Uses Vertex AI Gemini (gemini-2.5-flash) with structured output to:
   1. Analyse worksheet image(s) against the lesson YAML schema
@@ -15,26 +15,30 @@ llm-endpoint-hardening checklist (applied in calling route, not here):
 - Reasoning field: every answer item has a reasoning string ✅
 
 Circuit breaker: 3 consecutive errors → RuntimeError (same pattern as omo_identifier)
+
+Extracted helpers (issue #1879):
+  omo_question_schema  — schema extraction + OCR prompt building
+  omo_scoring          — pure-Python answer scoring + anti-fabrication
+  omo_image_preprocess — landscape spread splitting
+  omo_crop_upload      — GCS crop upload
 """
 
 import asyncio
-import io
 import logging
-import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 from .llm_models import get_model_for_task
+from .omo_question_schema import _build_question_schema, _build_grading_prompt
+from .omo_scoring import _score_answer, _validate_student_answer, _LOW_CONFIDENCE_THRESHOLD
+from .omo_image_preprocess import _split_spread
+from .omo_crop_upload import _crop_and_upload, _crop_and_upload_answer_image  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
 # Circuit breaker state (module-level singleton, per-process)
 _consecutive_errors = 0
 _CIRCUIT_BREAKER_THRESHOLD = 3
-# #1715: answers with self-reported confidence below this threshold are coerced
-# to empty + flagged for teacher review. Chosen generic (not tuned to specific
-# PDFs/handwriting/devices) so it generalizes across student worksheets.
-_LOW_CONFIDENCE_THRESHOLD = 0.7
 
 
 @dataclass
@@ -49,344 +53,6 @@ class GradedAnswer:
     position: Optional[dict] = None   # {"x": float, "y": float} relative coords
     crop_image_url: Optional[str] = None
     source_attempt_id: Optional[int] = None
-
-
-def _split_spread(image_bytes: bytes, mime: str) -> list[tuple[bytes, str]]:
-    """Split a 2-page worksheet spread into single-page halves (#1717).
-
-    Many scanners output a single image containing two facing worksheet pages
-    (e.g. Sharp MX-M4050 default). Sending the spread as one image forces the
-    OCR model to attend across the spine, which hurts letter-position accuracy.
-    Splitting into left/right halves gives each page focused attention.
-
-    Generic policy: only split when aspect ratio suggests a landscape spread
-    (width > 1.3 × height). Portrait single pages pass through untouched.
-    Falls back to the original image on any error — no PDF-specific tuning.
-
-    Returns:
-        List of (bytes, mime) tuples — 1 element if single-page, 2 if spread.
-    """
-    try:
-        from PIL import Image
-    except ImportError:
-        return [(image_bytes, mime)]
-
-    try:
-        img = Image.open(io.BytesIO(image_bytes))
-        w, h = img.size
-        if w <= h * 1.3:
-            return [(image_bytes, mime)]
-        mid = w // 2
-        out_mime = "image/jpeg"
-        halves = []
-        for box in [(0, 0, mid, h), (mid, 0, w, h)]:
-            half = img.crop(box)
-            if half.mode != "RGB":
-                half = half.convert("RGB")
-            buf = io.BytesIO()
-            half.save(buf, format="JPEG", quality=92)
-            halves.append((buf.getvalue(), out_mime))
-        return halves
-    except Exception:
-        return [(image_bytes, mime)]
-
-
-def _resolve_letter_answer(letter: str, vocabulary: list) -> str:
-    """Resolve A/B/C/... letter to vocabulary word.
-
-    L22-L30 YAML uses ordered letter (A=0, B=1, ...) as placeholder for the
-    vocabulary list index. So `answer: A` for fill_in_blank means the student
-    should fill in vocabulary[0].word (e.g. '奠定').
-
-    Returns the actual word if letter matches a vocab index, else returns
-    the letter as-is (for backward compatibility with non-vocab grading).
-    """
-    if not isinstance(letter, str) or len(letter) != 1 or not letter.isalpha():
-        return str(letter)
-    if not isinstance(vocabulary, list) or not vocabulary:
-        return letter
-    idx = ord(letter.upper()) - ord("A")
-    if not (0 <= idx < len(vocabulary)):
-        return letter
-    v = vocabulary[idx]
-    if isinstance(v, dict):
-        return str(v.get("word") or v.get("term") or letter)
-    return str(v)
-
-
-def _build_question_schema(lesson: dict) -> list[dict]:
-    """Extract expected-answer schema from lesson YAML for the grading prompt.
-
-    Each question dict includes `allowed_values` — the only legal student_answer
-    values for that question (#1712 fix: prevents Gemini fabrication by giving
-    it a finite value space to choose from).
-    """
-    questions = []
-    vocabulary = lesson.get("vocabulary") or []
-    vocab_words = [v.get("word", "") for v in vocabulary if v.get("word")]
-
-    # Detect fill_in_blank mode: 'lettered' (student circles A-G) vs 'free_form'
-    # (student handwrites a word). Mode is determined by whether ALL fb answers
-    # in the lesson are single A-G letters — that pattern is used by L22-L30
-    # 「四 語詞應用」style where vocabulary letters are the choice set.
-    fb = lesson.get("fill_in_blank") or []
-    fb_raw_items = list(fb.items()) if isinstance(fb, dict) else list(enumerate(fb))
-    fb_answers = []
-    for _, item in fb_raw_items:
-        ans = item.get("answer", "") if isinstance(item, dict) else str(item)
-        fb_answers.append(ans)
-    fb_lettered = bool(fb_answers) and all(
-        isinstance(a, str) and len(a.strip()) == 1 and a.strip().upper() in "ABCDEFG"
-        for a in fb_answers if a
-    )
-    # Lettered choices use the vocabulary as the A-G mapping; allowed letters
-    # equal min(len(vocab), 7) so we don't claim more letters than choices.
-    n_letters = min(len(vocab_words), 7) if fb_lettered else 0
-    fb_allowed_letters = [chr(ord("A") + i) for i in range(n_letters)]
-
-    for key, item in fb_raw_items:
-        qid = str(key) if isinstance(fb, dict) else f"fb_{key+1}"
-        if isinstance(item, dict):
-            raw_answer = item.get("answer", "")
-            context = item.get("context", item.get("sentence", ""))
-        else:
-            raw_answer = str(item)
-            context = ""
-        correct_word = _resolve_letter_answer(raw_answer, vocabulary)
-        # #1712: lettered fb compares letter-vs-letter (student circles a letter).
-        # `correct_answer` is what we score against in _score_answer.
-        # `correct_word` is kept for display ("正解：規律").
-        if fb_lettered:
-            correct_for_scoring = str(raw_answer).strip().upper()
-        else:
-            correct_for_scoring = correct_word
-        questions.append({
-            "id": qid,
-            "type": "fill_blank",
-            "context": context,
-            "correct_answer": correct_for_scoring,
-            "correct_word": correct_word,
-            "mode": "lettered" if fb_lettered else "free_form",
-            "allowed_values": fb_allowed_letters if fb_lettered else vocab_words,
-        })
-
-    # multiple_choice section — accepts list[dict] or dict[str, dict]
-    mc = lesson.get("multiple_choice") or []
-    mc_items = mc.items() if isinstance(mc, dict) else enumerate(mc)
-    for key, item in mc_items:
-        qid = str(key) if isinstance(mc, dict) else f"mc_{key+1}"
-        if isinstance(item, dict):
-            correct = item.get("answer", "")
-            context = item.get("question", item.get("sentence", ""))
-        else:
-            correct = str(item)
-            context = ""
-        questions.append({
-            "id": qid,
-            "type": "multiple_choice",
-            "context": context,
-            "correct_answer": correct,
-            "mode": "lettered",
-            "allowed_values": ["A", "B", "C", "D"],
-        })
-
-    # strategy_exercise section (structured exercises in 7-lesson set)
-    se = lesson.get("strategy_exercise") or {}
-    if isinstance(se, dict):
-        items = se.get("items") or se.get("questions") or []
-        if isinstance(items, list):
-            for i, item in enumerate(items):
-                if isinstance(item, dict) and "answer" in item:
-                    qid = item.get("id", f"se_{i+1}")
-                    questions.append({
-                        "id": qid,
-                        "type": "fill_blank",
-                        "context": item.get("stem", item.get("question", "")),
-                        "correct_answer": item.get("answer", ""),
-                    })
-
-    return questions
-
-
-def _build_grading_prompt(questions: list[dict]) -> str:
-    """Build OCR-only prompt with per-question allowed-value constraints.
-
-    Design (fixes #1712 — round 3 of #1614/#1616):
-    - Each question explicitly lists the legal student_answer values so Gemini
-      cannot return a plausible-but-fabricated answer like 「良好」 when the
-      choice set is A-G letters.
-    - Reference (correct) answers stay HIDDEN per #1616 — Gemini sees the value
-      SPACE but not which value is correct.
-    - Empty answer is always legal — if Gemini can't see handwriting, it should
-      say so instead of inventing.
-    """
-    def _format(q: dict) -> str:
-        mode = q.get("mode", "free_form")
-        allowed = q.get("allowed_values") or []
-        if mode == "lettered":
-            value_hint = "{" + ", ".join(allowed) + ', ""}'
-            instr = "學生在題號旁圈一個字母。逐筆檢查圈圈/勾選/箭頭標記。"
-        else:
-            sample = "、".join(allowed[:6]) + ("…" if len(allowed) > 6 else "")
-            value_hint = f'{{{sample}, ""}}'
-            instr = "學生用鉛筆/原子筆在空格內手寫一個詞。逐字 OCR。"
-        return (
-            f"  - {q['id']} ({q['type']}): {q['context']}\n"
-            f"      合法答案 = {value_hint}\n"
-            f"      做法：{instr}"
-        )
-
-    questions_text = "\n".join(_format(q) for q in questions)
-    return f"""你是 OCR 識字員。讀學生在學習單照片上的**手寫筆跡**。
-
-== 絕對規則 ==
-1. 只報告學生**實際用鉛筆/原子筆寫**的字 — 從照片像素讀出來的。
-2. **禁止編造**：student_answer 必須是該題「合法答案」清單裡的值，或空字串 ""。
-3. 看不到手寫、看不清、學生跳過 → student_answer=""，ai_confidence=0.0。
-4. 不要把印刷的題目文字、題目選項、或正確答案當作學生作答。
-5. 紅筆批改痕跡（✗ / 紅線 / 紅筆覆寫）= 老師批改 — student_answer 填學生**原本**寫的字（紅筆修改前），不是老師訂正的字。
-6. 對 lettered 題（A/B/C/D…），只能回字母本身（單一大寫字母）— 不能回詞語。
-
-== 模糊情況的處理（#1715 disambiguation） ==
-7. **多個圈/猶豫筆跡**：學生圈了又劃掉、或同時圈兩個字母 → 取**最終確定**的那個（最濃、最完整、沒被劃掉的）；無法判斷哪個是最終 → student_answer=""，ai_confidence 標低。
-8. **圈圈跨越兩個字母邊界**：圈圈中心離哪個字母最近就選哪個；若無法決定 → 回空。
-9. **筆跡淡 / 模糊 / 被擦過**：勉強看到也不要硬猜 → 不確定就回空 + ai_confidence ≤ 0.5。
-10. **ai_confidence 校準**：清楚看到 → 0.85-1.0；尚可辨識但有疑慮 → 0.5-0.85；勉強猜 → 0.0-0.5（後端會把 < 0.7 的視為無作答，請誠實標註不要灌水）。
-
-== 題目清單（含合法答案清單） ==
-{questions_text}
-
-回傳 JSON 陣列，每題一筆：
-[{{"question_id":"fb_1","student_answer":"<合法值或空字串>","ai_confidence":0.0~1.0,"reasoning":"50字內描述照片裡看到的筆跡"}}]"""
-
-
-def _score_answer(student: str, correct: str, qtype: str) -> float:
-    """Compare student OCR output against YAML correct_answer. Pure Python — no LLM.
-
-    Rules:
-    - Empty student → 0.0 (could not OCR / blank)
-    - Exact match (after strip + lowercase for letters) → 1.0
-    - MC: letter comparison case-insensitive
-    - Fill-blank: exact string match required (educational rigor)
-    - Otherwise → 0.0
-    """
-    s = (student or "").strip()
-    c = (correct or "").strip()
-    if not s:
-        return 0.0
-    if qtype == "multiple_choice":
-        return 1.0 if s.upper() == c.upper() else 0.0
-    return 1.0 if s == c else 0.0
-
-
-def _validate_student_answer(student: str, question: dict) -> tuple[str, bool]:
-    """Coerce fabricated student_answer to empty (#1712 fix).
-
-    A valid answer is either:
-    - Empty string (Gemini saw nothing / wasn't sure)
-    - A value in `question['allowed_values']` (case-insensitive for letters,
-      exact match for words; also accepts a letter that resolves to a vocab
-      word in the lettered list — Gemini sometimes returns the word instead).
-
-    Anything else (e.g. 「良好」when allowed = {A,B,C,D,E,F,G,""}) is treated
-    as fabrication: coerce to "" and signal coercion happened.
-
-    Returns:
-        (sanitized_answer, was_fabricated)
-    """
-    s = (student or "").strip()
-    if not s:
-        return "", False
-    allowed = question.get("allowed_values") or []
-    mode = question.get("mode", "free_form")
-    if mode == "lettered":
-        # Accept the letter itself
-        if len(s) == 1 and s.upper() in [a.upper() for a in allowed]:
-            return s.upper(), False
-        return "", True
-    # free_form: exact word match (case-sensitive — Chinese characters)
-    if s in allowed:
-        return s, False
-    return "", True
-
-
-def _crop_and_upload(
-    image_bytes_list: list[bytes],
-    question: dict,
-    upload_id: int,
-    question_id: str,
-    gcs_bucket: Optional[str] = None,
-) -> Optional[str]:
-    """Crop a generous strip around the question position and upload to GCS.
-
-    Position comes from the grader's position_x / position_y fields (relative 0-1 coords).
-    For fill_blank (fb_*): full-width strip (0, y-200, W, y+200), clipped to bounds.
-    For multiple_choice (mc_*): full-width strip (0, y-300, W, y+400), clipped to bounds.
-
-    Falls back to page 0 if no position or position_y=0.
-    Uploads as JPEG q85 to gs://{gcs_bucket}/crops/{upload_id}/{question_id}.jpg
-    Returns gs:// URI on success, None on any failure (fail-open: crop failure must not block grading).
-    """
-    try:
-        from PIL import Image
-    except ImportError:
-        return None
-
-    position = question.get('position') or {}
-    pos_y = float(position.get('y', 0.0))
-
-    # Use first image as source (page 0 fallback)
-    source_bytes = image_bytes_list[0] if image_bytes_list else None
-    if not source_bytes or source_bytes == b'placeholder':
-        return None
-
-    try:
-        img = Image.open(io.BytesIO(source_bytes))
-        if img.mode != 'RGB':
-            img = img.convert('RGB')
-        W, H = img.size
-
-        # Convert relative y to pixel coordinate
-        py = int(pos_y * H)
-
-        qtype = question.get('type', 'fill_blank')
-        if qtype == 'multiple_choice':
-            top = max(0, py - 300)
-            bottom = min(H, py + 400)
-        else:
-            top = max(0, py - 200)
-            bottom = min(H, py + 200)
-
-        # Full-width strip
-        cropped = img.crop((0, top, W, bottom))
-        buf = io.BytesIO()
-        cropped.save(buf, format='JPEG', quality=85)
-        crop_bytes = buf.getvalue()
-    except Exception as exc:
-        logger.warning('omo_grader crop failed for %s q=%s: %s', upload_id, question_id, exc)
-        return None
-
-    # Upload to GCS
-    bucket_name = gcs_bucket or os.environ.get("GCS_OMO_BUCKET", "lingoleap-omo-uploads")
-    object_path = f'crops/{upload_id}/{question_id}.jpg'
-    try:
-        from google.cloud import storage  # type: ignore[import]
-        client = storage.Client()
-        bucket = client.bucket(bucket_name)
-        blob = bucket.blob(object_path)
-        blob.upload_from_string(crop_bytes, content_type='image/jpeg')
-        gs_uri = f'gs://{bucket_name}/{object_path}'
-        logger.info('omo_grader: uploaded crop %s', gs_uri)
-        return gs_uri
-    except ImportError:
-        logger.debug('google-cloud-storage not available — skipping crop upload (local dev)')
-        return None
-    except Exception as exc:
-        logger.warning('omo_grader: GCS crop upload failed for %s: %s', object_path, exc)
-        return None
-
-
-_crop_and_upload_answer_image = _crop_and_upload
 
 
 async def grade_worksheet_images(

--- a/backend/app/services/omo_image_preprocess.py
+++ b/backend/app/services/omo_image_preprocess.py
@@ -1,0 +1,54 @@
+"""OMO image preprocessing — splits 2-page worksheet spreads into single pages.
+
+Extracted from omo_grader.py (issue #1879).
+
+Responsibilities:
+  - _split_spread: detects landscape scanner output (2 facing pages joined) and
+    splits into left/right halves so the OCR model can attend to each page
+    independently. Falls back to original on any error (fail-open). (#1717)
+"""
+
+import io
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _split_spread(image_bytes: bytes, mime: str) -> list[tuple[bytes, str]]:
+    """Split a 2-page worksheet spread into single-page halves (#1717).
+
+    Many scanners output a single image containing two facing worksheet pages
+    (e.g. Sharp MX-M4050 default). Sending the spread as one image forces the
+    OCR model to attend across the spine, which hurts letter-position accuracy.
+    Splitting into left/right halves gives each page focused attention.
+
+    Generic policy: only split when aspect ratio suggests a landscape spread
+    (width > 1.3 × height). Portrait single pages pass through untouched.
+    Falls back to the original image on any error — no PDF-specific tuning.
+
+    Returns:
+        List of (bytes, mime) tuples — 1 element if single-page, 2 if spread.
+    """
+    try:
+        from PIL import Image
+    except ImportError:
+        return [(image_bytes, mime)]
+
+    try:
+        img = Image.open(io.BytesIO(image_bytes))
+        w, h = img.size
+        if w <= h * 1.3:
+            return [(image_bytes, mime)]
+        mid = w // 2
+        out_mime = "image/jpeg"
+        halves = []
+        for box in [(0, 0, mid, h), (mid, 0, w, h)]:
+            half = img.crop(box)
+            if half.mode != "RGB":
+                half = half.convert("RGB")
+            buf = io.BytesIO()
+            half.save(buf, format="JPEG", quality=92)
+            halves.append((buf.getvalue(), out_mime))
+        return halves
+    except Exception:
+        return [(image_bytes, mime)]

--- a/backend/app/services/omo_question_schema.py
+++ b/backend/app/services/omo_question_schema.py
@@ -1,0 +1,184 @@
+"""OMO question schema extraction — builds per-question schema + grading prompt.
+
+Extracted from omo_grader.py (issue #1879).
+
+Responsibilities:
+  - _resolve_letter_answer: maps A-G letter to vocabulary word by index
+  - _build_question_schema: parses lesson YAML into a list of question dicts
+    with allowed_values, mode (lettered/free_form), and correct_answer
+  - _build_grading_prompt: builds the OCR system prompt with per-question
+    allowed-value constraints (anti-fabrication, #1712)
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_letter_answer(letter: str, vocabulary: list) -> str:
+    """Resolve A/B/C/... letter to vocabulary word.
+
+    L22-L30 YAML uses ordered letter (A=0, B=1, ...) as placeholder for the
+    vocabulary list index. So `answer: A` for fill_in_blank means the student
+    should fill in vocabulary[0].word (e.g. '奠定').
+
+    Returns the actual word if letter matches a vocab index, else returns
+    the letter as-is (for backward compatibility with non-vocab grading).
+    """
+    if not isinstance(letter, str) or len(letter) != 1 or not letter.isalpha():
+        return str(letter)
+    if not isinstance(vocabulary, list) or not vocabulary:
+        return letter
+    idx = ord(letter.upper()) - ord("A")
+    if not (0 <= idx < len(vocabulary)):
+        return letter
+    v = vocabulary[idx]
+    if isinstance(v, dict):
+        return str(v.get("word") or v.get("term") or letter)
+    return str(v)
+
+
+def _build_question_schema(lesson: dict) -> list[dict]:
+    """Extract expected-answer schema from lesson YAML for the grading prompt.
+
+    Each question dict includes `allowed_values` — the only legal student_answer
+    values for that question (#1712 fix: prevents Gemini fabrication by giving
+    it a finite value space to choose from).
+    """
+    questions = []
+    vocabulary = lesson.get("vocabulary") or []
+    vocab_words = [v.get("word", "") for v in vocabulary if v.get("word")]
+
+    # Detect fill_in_blank mode: 'lettered' (student circles A-G) vs 'free_form'
+    # (student handwrites a word). Mode is determined by whether ALL fb answers
+    # in the lesson are single A-G letters — that pattern is used by L22-L30
+    # 「四 語詞應用」style where vocabulary letters are the choice set.
+    fb = lesson.get("fill_in_blank") or []
+    fb_raw_items = list(fb.items()) if isinstance(fb, dict) else list(enumerate(fb))
+    fb_answers = []
+    for _, item in fb_raw_items:
+        ans = item.get("answer", "") if isinstance(item, dict) else str(item)
+        fb_answers.append(ans)
+    fb_lettered = bool(fb_answers) and all(
+        isinstance(a, str) and len(a.strip()) == 1 and a.strip().upper() in "ABCDEFG"
+        for a in fb_answers if a
+    )
+    # Lettered choices use the vocabulary as the A-G mapping; allowed letters
+    # equal min(len(vocab), 7) so we don't claim more letters than choices.
+    n_letters = min(len(vocab_words), 7) if fb_lettered else 0
+    fb_allowed_letters = [chr(ord("A") + i) for i in range(n_letters)]
+
+    for key, item in fb_raw_items:
+        qid = str(key) if isinstance(fb, dict) else f"fb_{key+1}"
+        if isinstance(item, dict):
+            raw_answer = item.get("answer", "")
+            context = item.get("context", item.get("sentence", ""))
+        else:
+            raw_answer = str(item)
+            context = ""
+        correct_word = _resolve_letter_answer(raw_answer, vocabulary)
+        # #1712: lettered fb compares letter-vs-letter (student circles a letter).
+        # `correct_answer` is what we score against in _score_answer.
+        # `correct_word` is kept for display ("正解：規律").
+        if fb_lettered:
+            correct_for_scoring = str(raw_answer).strip().upper()
+        else:
+            correct_for_scoring = correct_word
+        questions.append({
+            "id": qid,
+            "type": "fill_blank",
+            "context": context,
+            "correct_answer": correct_for_scoring,
+            "correct_word": correct_word,
+            "mode": "lettered" if fb_lettered else "free_form",
+            "allowed_values": fb_allowed_letters if fb_lettered else vocab_words,
+        })
+
+    # multiple_choice section — accepts list[dict] or dict[str, dict]
+    mc = lesson.get("multiple_choice") or []
+    mc_items = mc.items() if isinstance(mc, dict) else enumerate(mc)
+    for key, item in mc_items:
+        qid = str(key) if isinstance(mc, dict) else f"mc_{key+1}"
+        if isinstance(item, dict):
+            correct = item.get("answer", "")
+            context = item.get("question", item.get("sentence", ""))
+        else:
+            correct = str(item)
+            context = ""
+        questions.append({
+            "id": qid,
+            "type": "multiple_choice",
+            "context": context,
+            "correct_answer": correct,
+            "mode": "lettered",
+            "allowed_values": ["A", "B", "C", "D"],
+        })
+
+    # strategy_exercise section (structured exercises in 7-lesson set)
+    se = lesson.get("strategy_exercise") or {}
+    if isinstance(se, dict):
+        items = se.get("items") or se.get("questions") or []
+        if isinstance(items, list):
+            for i, item in enumerate(items):
+                if isinstance(item, dict) and "answer" in item:
+                    qid = item.get("id", f"se_{i+1}")
+                    questions.append({
+                        "id": qid,
+                        "type": "fill_blank",
+                        "context": item.get("stem", item.get("question", "")),
+                        "correct_answer": item.get("answer", ""),
+                    })
+
+    return questions
+
+
+def _build_grading_prompt(questions: list[dict]) -> str:
+    """Build OCR-only prompt with per-question allowed-value constraints.
+
+    Design (fixes #1712 — round 3 of #1614/#1616):
+    - Each question explicitly lists the legal student_answer values so Gemini
+      cannot return a plausible-but-fabricated answer like 「良好」 when the
+      choice set is A-G letters.
+    - Reference (correct) answers stay HIDDEN per #1616 — Gemini sees the value
+      SPACE but not which value is correct.
+    - Empty answer is always legal — if Gemini can't see handwriting, it should
+      say so instead of inventing.
+    """
+    def _format(q: dict) -> str:
+        mode = q.get("mode", "free_form")
+        allowed = q.get("allowed_values") or []
+        if mode == "lettered":
+            value_hint = "{" + ", ".join(allowed) + ', ""}'
+            instr = "學生在題號旁圈一個字母。逐筆檢查圈圈/勾選/箭頭標記。"
+        else:
+            sample = "、".join(allowed[:6]) + ("…" if len(allowed) > 6 else "")
+            value_hint = f'{{{sample}, ""}}'
+            instr = "學生用鉛筆/原子筆在空格內手寫一個詞。逐字 OCR。"
+        return (
+            f"  - {q['id']} ({q['type']}): {q['context']}\n"
+            f"      合法答案 = {value_hint}\n"
+            f"      做法：{instr}"
+        )
+
+    questions_text = "\n".join(_format(q) for q in questions)
+    return f"""你是 OCR 識字員。讀學生在學習單照片上的**手寫筆跡**。
+
+== 絕對規則 ==
+1. 只報告學生**實際用鉛筆/原子筆寫**的字 — 從照片像素讀出來的。
+2. **禁止編造**：student_answer 必須是該題「合法答案」清單裡的值，或空字串 ""。
+3. 看不到手寫、看不清、學生跳過 → student_answer=""，ai_confidence=0.0。
+4. 不要把印刷的題目文字、題目選項、或正確答案當作學生作答。
+5. 紅筆批改痕跡（✗ / 紅線 / 紅筆覆寫）= 老師批改 — student_answer 填學生**原本**寫的字（紅筆修改前），不是老師訂正的字。
+6. 對 lettered 題（A/B/C/D…），只能回字母本身（單一大寫字母）— 不能回詞語。
+
+== 模糊情況的處理（#1715 disambiguation） ==
+7. **多個圈/猶豫筆跡**：學生圈了又劃掉、或同時圈兩個字母 → 取**最終確定**的那個（最濃、最完整、沒被劃掉的）；無法判斷哪個是最終 → student_answer=""，ai_confidence 標低。
+8. **圈圈跨越兩個字母邊界**：圈圈中心離哪個字母最近就選哪個；若無法決定 → 回空。
+9. **筆跡淡 / 模糊 / 被擦過**：勉強看到也不要硬猜 → 不確定就回空 + ai_confidence ≤ 0.5。
+10. **ai_confidence 校準**：清楚看到 → 0.85-1.0；尚可辨識但有疑慮 → 0.5-0.85；勉強猜 → 0.0-0.5（後端會把 < 0.7 的視為無作答，請誠實標註不要灌水）。
+
+== 題目清單（含合法答案清單） ==
+{questions_text}
+
+回傳 JSON 陣列，每題一筆：
+[{{"question_id":"fb_1","student_answer":"<合法值或空字串>","ai_confidence":0.0~1.0,"reasoning":"50字內描述照片裡看到的筆跡"}}]"""

--- a/backend/app/services/omo_scoring.py
+++ b/backend/app/services/omo_scoring.py
@@ -1,0 +1,68 @@
+"""OMO scoring utilities — pure-Python answer comparison and anti-fabrication.
+
+Extracted from omo_grader.py (issue #1879).
+
+Responsibilities:
+  - _LOW_CONFIDENCE_THRESHOLD: module-level constant (0.7); answers below this
+    are coerced to empty and flagged for teacher review (#1715)
+  - _score_answer: pure-Python comparison of student OCR output vs correct answer
+  - _validate_student_answer: anti-fabrication guard — coerces answers not in
+    allowed_values to empty string (#1712)
+
+No I/O, no LLM calls — safe to unit-test without mocking.
+"""
+
+# #1715: answers with self-reported confidence below this threshold are coerced
+# to empty + flagged for teacher review. Chosen generic (not tuned to specific
+# PDFs/handwriting/devices) so it generalizes across student worksheets.
+_LOW_CONFIDENCE_THRESHOLD = 0.7
+
+
+def _score_answer(student: str, correct: str, qtype: str) -> float:
+    """Compare student OCR output against YAML correct_answer. Pure Python — no LLM.
+
+    Rules:
+    - Empty student → 0.0 (could not OCR / blank)
+    - Exact match (after strip + lowercase for letters) → 1.0
+    - MC: letter comparison case-insensitive
+    - Fill-blank: exact string match required (educational rigor)
+    - Otherwise → 0.0
+    """
+    s = (student or "").strip()
+    c = (correct or "").strip()
+    if not s:
+        return 0.0
+    if qtype == "multiple_choice":
+        return 1.0 if s.upper() == c.upper() else 0.0
+    return 1.0 if s == c else 0.0
+
+
+def _validate_student_answer(student: str, question: dict) -> tuple[str, bool]:
+    """Coerce fabricated student_answer to empty (#1712 fix).
+
+    A valid answer is either:
+    - Empty string (Gemini saw nothing / wasn't sure)
+    - A value in `question['allowed_values']` (case-insensitive for letters,
+      exact match for words; also accepts a letter that resolves to a vocab
+      word in the lettered list — Gemini sometimes returns the word instead).
+
+    Anything else (e.g. 「良好」when allowed = {A,B,C,D,E,F,G,""}) is treated
+    as fabrication: coerce to "" and signal coercion happened.
+
+    Returns:
+        (sanitized_answer, was_fabricated)
+    """
+    s = (student or "").strip()
+    if not s:
+        return "", False
+    allowed = question.get("allowed_values") or []
+    mode = question.get("mode", "free_form")
+    if mode == "lettered":
+        # Accept the letter itself
+        if len(s) == 1 and s.upper() in [a.upper() for a in allowed]:
+            return s.upper(), False
+        return "", True
+    # free_form: exact word match (case-sensitive — Chinese characters)
+    if s in allowed:
+        return s, False
+    return "", True

--- a/backend/tests/test_omo_grader_split_1879.py
+++ b/backend/tests/test_omo_grader_split_1879.py
@@ -1,0 +1,449 @@
+"""TDD tests for #1879 — omo_grader.py split.
+
+Phase 1 (Red → Green):
+  Write tests that pin the THREE specific behaviours listed in the issue.
+  They MUST pass on the CURRENT monolithic omo_grader.py.
+
+Phase 2 (Refactor):
+  Extract omo_question_schema.py / omo_scoring.py / omo_image_preprocess.py /
+  omo_crop_upload.py.  The same three tests (plus any extras) must still pass.
+
+Tautology check: each test has a negative assertion or uses a strictly-
+constrained expected value, so a trivially-passing stub would fail.
+
+Run:
+    cd backend && python -m pytest tests/test_omo_grader_split_1879.py -v
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: lesson data reflecting the L22-L30 lettered fill_in_blank pattern
+# ---------------------------------------------------------------------------
+
+LETTERED_LESSON = {
+    "title": "L22-測試課",
+    "vocabulary": [
+        {"word": "奠定"},   # A → idx 0
+        {"word": "覓食"},   # B → idx 1
+        {"word": "迅雷不及掩耳"},  # C → idx 2
+        {"word": "臨機應變"},      # D → idx 3
+        {"word": "注目"},   # E → idx 4
+        {"word": "規律"},   # F → idx 5
+        {"word": "勇氣"},   # G → idx 6
+    ],
+    "fill_in_blank": [
+        {"answer": "A", "sentence": "打下基礎"},   # fb_1 → lettered A
+        {"answer": "C", "sentence": "行動迅速"},   # fb_2 → lettered C
+        {"answer": "F", "sentence": "有規律"},      # fb_3 → lettered F
+        {"answer": "G", "sentence": "需要勇氣"},   # fb_4 → lettered G
+        {"answer": "B", "sentence": "找尋食物"},   # fb_5 → lettered B
+    ],
+}
+
+FREE_FORM_LESSON = {
+    "title": "free-form-test",
+    "vocabulary": [
+        {"word": "觀察"},
+        {"word": "記錄"},
+        {"word": "歸納"},
+    ],
+    "fill_in_blank": [
+        {"answer": "觀察", "sentence": "仔細觀察"},
+        {"answer": "記錄", "sentence": "詳細記錄"},
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Test 1: question_schema_lettered_fill_blank_uses_vocab_letters_and_word_display
+#
+# The issue spec: L22-L30 YAML uses letter (A=0, B=1, ...) as placeholder for
+# vocabulary list index.  _build_question_schema must:
+#   (a) produce mode="lettered" when all fb answers are single A-G letters
+#   (b) set correct_answer = the LETTER (not the word) for scoring
+#   (c) set correct_word = the resolved vocabulary word for display
+#   (d) set allowed_values = the full set of letters up to min(len(vocab), 7)
+# ---------------------------------------------------------------------------
+
+class TestQuestionSchemaLetteredFillBlank:
+    def setup_method(self):
+        from app.services.omo_grader import _build_question_schema
+        self.questions = _build_question_schema(LETTERED_LESSON)
+        self.fb_qs = [q for q in self.questions if q["type"] == "fill_blank"]
+
+    def test_lettered_mode_detected(self):
+        """All fill_in_blank answers are A-G → mode must be 'lettered'."""
+        for q in self.fb_qs:
+            assert q["mode"] == "lettered", (
+                f"Expected mode='lettered', got {q['mode']!r} for question {q['id']}"
+            )
+
+    def test_correct_answer_is_letter_not_word(self):
+        """correct_answer for scoring must be the LETTER, not the resolved word.
+
+        Tautology: if this were a no-op returning the word, 'A' != '奠定' would fail.
+        """
+        # fb_1 answer='A' → correct_answer must be 'A' (for letter-vs-letter scoring)
+        fb1 = next(q for q in self.fb_qs if q["id"] in ("fb_1", "0"))
+        assert fb1["correct_answer"] == "A", (
+            f"Lettered fb correct_answer must be the letter 'A', got {fb1['correct_answer']!r}"
+        )
+
+    def test_correct_word_resolves_vocabulary(self):
+        """correct_word must resolve A→vocabulary[0].word='奠定'.
+
+        Tautology: if resolution were skipped, 'A' != '奠定' fails.
+        """
+        fb1 = next(q for q in self.fb_qs if q["id"] in ("fb_1", "0"))
+        assert fb1["correct_word"] == "奠定", (
+            f"Lettered fb correct_word must resolve A→'奠定', got {fb1['correct_word']!r}"
+        )
+
+    def test_allowed_values_contains_letters_up_to_vocab_count(self):
+        """allowed_values must be ['A','B','C','D','E','F','G'] (7 vocab words, capped at 7).
+
+        Tautology: empty list or word list would both fail.
+        """
+        fb1 = next(q for q in self.fb_qs if q["id"] in ("fb_1", "0"))
+        expected = ["A", "B", "C", "D", "E", "F", "G"]
+        assert fb1["allowed_values"] == expected, (
+            f"allowed_values must be {expected}, got {fb1['allowed_values']!r}"
+        )
+
+    def test_word_display_mapping_for_all_letters(self):
+        """Every letter maps to the correct vocabulary word by index."""
+        expected_mapping = {
+            "A": "奠定",
+            "B": "覓食",
+            "C": "迅雷不及掩耳",
+            "D": "臨機應變",
+            "E": "注目",
+            "F": "規律",
+            "G": "勇氣",
+        }
+        for q in self.fb_qs:
+            letter = q["correct_answer"]   # should be A-G
+            assert letter in expected_mapping, f"Unexpected letter {letter!r}"
+            assert q["correct_word"] == expected_mapping[letter], (
+                f"Letter {letter}: expected word {expected_mapping[letter]!r}, "
+                f"got {q['correct_word']!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: validate_student_answer_coerces_fabricated_values_to_empty
+#
+# The issue spec: illegal AI answers (not in allowed_values) must fail-closed
+# → student_answer coerced to "", was_fabricated=True.
+# Tautology: accepts "" trivially passing is prevented by checking was_fabricated.
+# ---------------------------------------------------------------------------
+
+class TestValidateStudentAnswerCoercesFabricated:
+    def setup_method(self):
+        from app.services.omo_grader import _validate_student_answer
+        self.validate = _validate_student_answer
+
+    def _lettered_question(self, allowed=None):
+        return {
+            "mode": "lettered",
+            "allowed_values": allowed or ["A", "B", "C", "D", "E", "F", "G"],
+        }
+
+    def _free_form_question(self, allowed=None):
+        return {
+            "mode": "free_form",
+            "allowed_values": allowed or ["觀察", "記錄", "歸納"],
+        }
+
+    def test_fabricated_word_for_lettered_question_coerced(self):
+        """AI returns a word ('良好') for a lettered question → must coerce to ''.
+
+        Tautology: was_fabricated must be True — a stub that always returns ('', False)
+        would fail this assertion.
+        """
+        answer, was_fabricated = self.validate("良好", self._lettered_question())
+        assert answer == "", f"Fabricated answer should be coerced to '', got {answer!r}"
+        assert was_fabricated is True, "was_fabricated must be True for fabricated answer"
+
+    def test_fabricated_chinese_word_for_lettered_question_coerced(self):
+        """AI returns '奠定' (the resolved word) instead of the letter → coerce."""
+        answer, was_fabricated = self.validate("奠定", self._lettered_question())
+        assert answer == ""
+        assert was_fabricated is True
+
+    def test_valid_letter_accepted(self):
+        """Valid letter 'C' in allowed list → accepted, not fabricated."""
+        answer, was_fabricated = self.validate("C", self._lettered_question())
+        assert answer == "C"
+        assert was_fabricated is False
+
+    def test_lowercase_letter_normalised_to_uppercase(self):
+        """Letter 'c' (lowercase) → accepted and normalised to 'C'."""
+        answer, was_fabricated = self.validate("c", self._lettered_question())
+        assert answer == "C"
+        assert was_fabricated is False
+
+    def test_fabricated_word_not_in_free_form_allowed_values_coerced(self):
+        """Free-form: word not in allowed list → coerced to '', was_fabricated=True."""
+        answer, was_fabricated = self.validate("發現", self._free_form_question())
+        assert answer == ""
+        assert was_fabricated is True
+
+    def test_valid_free_form_word_accepted(self):
+        """Free-form: word in allowed list → accepted as-is."""
+        answer, was_fabricated = self.validate("觀察", self._free_form_question())
+        assert answer == "觀察"
+        assert was_fabricated is False
+
+    def test_empty_string_is_valid_not_fabricated(self):
+        """Empty student answer (student left blank) → ('', False) — not fabricated."""
+        answer, was_fabricated = self.validate("", self._lettered_question())
+        assert answer == ""
+        assert was_fabricated is False
+
+    def test_multi_character_lettered_fabrication(self):
+        """Lettered mode: multi-char string 'AB' is not a valid single letter → coerce."""
+        answer, was_fabricated = self.validate("AB", self._lettered_question())
+        assert answer == ""
+        assert was_fabricated is True
+
+
+# ---------------------------------------------------------------------------
+# Test 3: low_confidence_non_empty_answer_is_blank_for_teacher_review
+#
+# The issue spec: when Gemini self-reports confidence < 0.7 AND student_answer
+# is non-empty, the grader must:
+#   (a) coerce student_answer to ""
+#   (b) prepend "[low-confidence]" to reasoning
+#   (c) preserve the original score=0.0 (empty → score never inflated)
+#
+# This is tested by injecting a mock Gemini response with low ai_confidence.
+# ---------------------------------------------------------------------------
+
+import asyncio
+import json
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+
+def _make_mock_response(items: list[dict]) -> MagicMock:
+    mock = MagicMock()
+    mock.text = json.dumps(items)
+    return mock
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _patch_and_grade(lesson: dict, mock_items: list[dict]) -> list:
+    """Patch Gemini client and run grade_worksheet_images."""
+    import app.services.omo_grader as grader_mod
+    grader_mod._consecutive_errors = 0
+
+    mock_response = _make_mock_response(mock_items)
+
+    fake_genai = types.ModuleType("google.genai")
+    fake_types = types.ModuleType("google.genai.types")
+
+    class FakeContent:
+        def __init__(self, **kwargs): pass
+
+    class FakePart:
+        @staticmethod
+        def from_bytes(**kwargs): return FakePart()
+
+    class FakeThinkingConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeAutoFuncCallingConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeGenerateContentConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeModels:
+        @staticmethod
+        def generate_content(**kwargs):
+            return mock_response
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.models = FakeModels()
+
+    fake_types.Content = FakeContent
+    fake_types.Part = FakePart
+    fake_types.ThinkingConfig = FakeThinkingConfig
+    fake_types.AutomaticFunctionCallingConfig = FakeAutoFuncCallingConfig
+    fake_types.GenerateContentConfig = FakeGenerateContentConfig
+    fake_genai.Client = FakeClient
+
+    fake_google = types.ModuleType("google")
+    fake_google.genai = fake_genai
+
+    with patch.dict(sys.modules, {
+        "google": fake_google,
+        "google.genai": fake_genai,
+        "google.genai.types": fake_types,
+    }):
+        return _run(grader_mod.grade_worksheet_images(
+            image_bytes_list=[b"fake_image_bytes"],
+            mime_types=["image/jpeg"],
+            lesson=lesson,
+            attempt_id=None,
+        ))
+
+
+class TestLowConfidenceAnswerIsBlankForTeacherReview:
+    """Confidence threshold: < 0.7 non-empty answer → coerced to blank."""
+
+    THRESHOLD = 0.7
+
+    def test_low_confidence_non_empty_coerced_to_blank(self):
+        """ai_confidence=0.5 with a valid answer → student_answer coerced to ''.
+
+        Tautology: if grader did NOT apply threshold, student_answer would remain
+        non-empty and this assertion would fail.
+        """
+        lesson = {
+            "title": "confidence-test",
+            "fill_in_blank": [
+                {"answer": "觀察", "sentence": "仔細觀察"},
+            ],
+        }
+        mock_items = [{
+            "question_id": "fb_1",
+            "student_answer": "觀察",    # valid free-form answer
+            "ai_confidence": 0.5,         # below threshold
+            "reasoning": "字跡模糊",
+        }]
+        results = _patch_and_grade(lesson, mock_items)
+        fb1 = next((r for r in results if r.question_id == "fb_1"), None)
+        assert fb1 is not None, "Should produce a result for fb_1"
+        assert fb1.student_answer == "", (
+            f"Low-confidence answer must be coerced to '', got {fb1.student_answer!r}"
+        )
+        assert fb1.score == 0.0, (
+            f"Coerced answer must score 0.0, got {fb1.score}"
+        )
+
+    def test_low_confidence_reasoning_prepends_marker(self):
+        """[low-confidence] marker must appear in reasoning for teacher review.
+
+        Uses free-form lesson so anti-fabrication validation passes first
+        (answer '記錄' is in vocabulary → allowed_values), then low-confidence
+        check fires.
+        """
+        lesson = {
+            "title": "confidence-reasoning-test",
+            "vocabulary": [
+                {"word": "觀察"},
+                {"word": "記錄"},
+                {"word": "歸納"},
+            ],
+            "fill_in_blank": [
+                {"answer": "記錄", "sentence": "詳細記錄"},
+            ],
+        }
+        mock_items = [{
+            "question_id": "fb_1",
+            "student_answer": "記錄",
+            "ai_confidence": 0.4,
+            "reasoning": "勉強看到",
+        }]
+        results = _patch_and_grade(lesson, mock_items)
+        fb1 = next((r for r in results if r.question_id == "fb_1"), None)
+        assert fb1 is not None
+        assert "[low-confidence]" in fb1.reasoning, (
+            f"reasoning must contain '[low-confidence]' marker, got: {fb1.reasoning!r}"
+        )
+
+    def test_high_confidence_answer_not_coerced(self):
+        """ai_confidence=0.9 (above threshold) → student_answer preserved.
+
+        Tautology: a stub that always coerces would fail this.
+        Uses vocabulary list so anti-fabrication passes and the answer reaches
+        the confidence check cleanly.
+        """
+        lesson = {
+            "title": "high-confidence-test",
+            "vocabulary": [
+                {"word": "觀察"},
+                {"word": "記錄"},
+                {"word": "歸納"},
+            ],
+            "fill_in_blank": [
+                {"answer": "歸納", "sentence": "加以歸納"},
+            ],
+        }
+        mock_items = [{
+            "question_id": "fb_1",
+            "student_answer": "歸納",
+            "ai_confidence": 0.9,
+            "reasoning": "清楚可見",
+        }]
+        results = _patch_and_grade(lesson, mock_items)
+        fb1 = next((r for r in results if r.question_id == "fb_1"), None)
+        assert fb1 is not None
+        assert fb1.student_answer == "歸納", (
+            f"High-confidence answer must NOT be coerced, got {fb1.student_answer!r}"
+        )
+        assert fb1.score == 1.0, "Correct high-confidence answer must score 1.0"
+
+    def test_exact_threshold_boundary_is_coerced(self):
+        """ai_confidence == threshold (0.7) is NOT coerced (threshold is exclusive: < 0.7).
+
+        Spec says 'ai_conf < _LOW_CONFIDENCE_THRESHOLD' — boundary value is accepted.
+        Tautology: threshold-on-boundary would flip if implementation used <=.
+        Uses vocabulary list so anti-fabrication passes and threshold logic is tested.
+        """
+        lesson = {
+            "title": "boundary-threshold-test",
+            "vocabulary": [
+                {"word": "觀察"},
+                {"word": "記錄"},
+                {"word": "歸納"},
+            ],
+            "fill_in_blank": [
+                {"answer": "觀察", "sentence": "仔細觀察"},
+            ],
+        }
+        mock_items = [{
+            "question_id": "fb_1",
+            "student_answer": "觀察",
+            "ai_confidence": 0.7,          # exactly at threshold — should NOT be coerced
+            "reasoning": "剛好邊界",
+        }]
+        results = _patch_and_grade(lesson, mock_items)
+        fb1 = next((r for r in results if r.question_id == "fb_1"), None)
+        assert fb1 is not None
+        # At exact threshold 0.7, the condition is `ai_conf < 0.7` → False → NOT coerced
+        assert fb1.student_answer == "觀察", (
+            f"Boundary ai_confidence=0.7 must NOT be coerced, got {fb1.student_answer!r}"
+        )
+
+    def test_low_confidence_empty_answer_stays_empty_no_marker(self):
+        """ai_confidence=0.3 but student_answer='' → already blank, no [low-confidence] marker."""
+        lesson = {
+            "title": "empty-low-conf-test",
+            "fill_in_blank": [
+                {"answer": "記錄", "sentence": "詳細記錄"},
+            ],
+        }
+        mock_items = [{
+            "question_id": "fb_1",
+            "student_answer": "",     # already blank — low-confidence coercion only
+            "ai_confidence": 0.3,     # applies when student_answer is non-empty
+            "reasoning": "看不見",
+        }]
+        results = _patch_and_grade(lesson, mock_items)
+        fb1 = next((r for r in results if r.question_id == "fb_1"), None)
+        assert fb1 is not None
+        assert fb1.student_answer == "", "Already-empty answer stays empty"
+        # No [low-confidence] marker for already-empty answers
+        assert "[low-confidence]" not in fb1.reasoning, (
+            "No [low-confidence] marker when answer was already blank"
+        )


### PR DESCRIPTION
Fixes #1879

## Summary

Splits the 646-line `omo_grader.py` monolith into 4 focused modules, keeping `grade_worksheet_images()` as a slim orchestration facade (~210 lines):

| New module | Responsibility |
|---|---|
| `omo_question_schema.py` | Schema extraction + OCR prompt building |
| `omo_scoring.py` | Pure-Python answer scoring + anti-fabrication |
| `omo_image_preprocess.py` | Landscape spread splitting (#1717) |
| `omo_crop_upload.py` | GCS crop upload + backward-compat alias |

## TDD Coverage (18 new tests)

- `question_schema_lettered_fill_blank_uses_vocab_letters_and_word_display` — letter→vocab mapping for L22-L30 lettered fill-blank
- `validate_student_answer_coerces_fabricated_values_to_empty` — anti-fabrication guard (#1712)
- `low_confidence_non_empty_answer_is_blank_for_teacher_review` — confidence threshold blanking (#1715)

All 3 test classes include negative assertions (tautology check passed).

## Test Results

- 18/18 new TDD tests: PASSED
- 74/74 existing passing tests: unchanged
- 7 pre-existing failures in `test_omo_grader_real.py`: confirmed pre-existing on staging (not regressions)
- 1 skipped: unchanged

## No Behavior Changes

This is a pure structural refactor — zero logic moved, zero imports changed from external callers. `omo_identifier.py` untouched (separate issue #1886).