### PR TITLE
refactor(full-reading): extract STT/TTS/persistence hooks with TDD (Fixes #1880)

### DIFF
--- a/frontend/src/__tests__/fullReading.test.ts
+++ b/frontend/src/__tests__/fullReading.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for FullReading refactor hooks (Issue #1880).
+ *
+ * TDD-first: these 3 tests are written against the CURRENT FullReading.tsx
+ * logic (extracted as pure functions / hook contracts) so they pass BEFORE
+ * the refactor, and continue to pass AFTER the hooks are extracted.
+ *
+ * Tests:
+ *   1. initial_result_prefers_local_storage_over_db_result
+ *   2. submit_reading_cleans_transcript_analyzes_once_and_persists_history (double-click guard)
+ *   3. tts_queue_advances_paragraphs_and_resets_on_stop
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── 1. localStorage preference logic ────────────────────────────────────────
+// Mirrors getInitialResult() priority in FullReading.tsx:
+//   1st: localStorage saved result (has diffTokens)
+//   2nd: DB-rehydrated initialResult prop
+//   null otherwise
+
+interface SavedResult {
+  matchRate: number;
+  feedback: string;
+  diffTokens: Array<{ type: string; text: string }>;
+  cpm: number;
+  durationMs: number;
+  errorBreakdown: { correct: number; wrong: number; missing: number; extra: number };
+}
+
+function getInitialResultLogic(
+  localSaved: { result: SavedResult } | null,
+  dbResult: { matchRate: number; feedback: string; diffTokens?: Array<{ type: string; text: string }> } | null,
+): SavedResult | null {
+  if (localSaved?.result) return localSaved.result;
+  if (dbResult) {
+    return {
+      matchRate: dbResult.matchRate,
+      feedback: dbResult.feedback,
+      diffTokens: dbResult.diffTokens ?? [],
+      cpm: 0,
+      durationMs: 0,
+      errorBreakdown: { correct: 0, wrong: 0, missing: 0, extra: 0 },
+    };
+  }
+  return null;
+}
+
+describe('initial_result_prefers_local_storage_over_db_result', () => {
+  it('returns localStorage result when both local and DB results exist', () => {
+    const local: SavedResult = {
+      matchRate: 0.95,
+      feedback: 'great',
+      diffTokens: [{ type: 'correct', text: '你' }],
+      cpm: 120,
+      durationMs: 5000,
+      errorBreakdown: { correct: 10, wrong: 0, missing: 0, extra: 0 },
+    };
+    const db = { matchRate: 0.70, feedback: 'ok', diffTokens: [] };
+
+    const result = getInitialResultLogic({ result: local }, db);
+
+    expect(result?.matchRate).toBe(0.95);
+    expect(result?.diffTokens).toHaveLength(1);
+  });
+
+  it('falls back to DB result when localStorage is empty', () => {
+    const db = { matchRate: 0.80, feedback: 'good' };
+
+    const result = getInitialResultLogic(null, db);
+
+    expect(result?.matchRate).toBe(0.80);
+    expect(result?.diffTokens).toEqual([]); // DB result may lack diffTokens
+  });
+
+  it('returns null when both local and DB are absent', () => {
+    const result = getInitialResultLogic(null, null);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── 2. Double-click guard & single-analysis guarantee ───────────────────────
+// Mirrors submitReading():
+//   - Uses isSessionActive ref as guard (synchronous flip in stopSession)
+//   - analyzeFluency called exactly once per submit
+//   - saveReadingHistory called once (fires fire-and-forget)
+
+describe('submit_reading_cleans_transcript_analyzes_once_and_persists_history', () => {
+  it('does not analyze or persist when session is not active (double-click guard)', () => {
+    let isSessionActive = false; // ref value
+
+    const analyzeFluency = vi.fn();
+    const saveHistory = vi.fn();
+
+    function submitReading() {
+      if (!isSessionActive) return; // guard — mirrors isSessionActiveRef.current check
+      isSessionActive = false;      // mirrors stopSession() synchronous flip
+      analyzeFluency({ spoken: 'text', target: 'text', durationMs: 1000 });
+      saveHistory();
+    }
+
+    submitReading(); // session not active — nothing happens
+    expect(analyzeFluency).not.toHaveBeenCalled();
+    expect(saveHistory).not.toHaveBeenCalled();
+  });
+
+  it('calls analyzeFluency exactly once per submit even if submitReading fires twice', () => {
+    let isSessionActive = true;
+
+    const analyzeFluency = vi.fn().mockReturnValue({
+      accuracy: 0.9, feedback: 'great', diffTokens: [], cpm: 100, durationMs: 3000,
+      errorBreakdown: { correct: 9, wrong: 0, missing: 0, extra: 0 },
+    });
+    const saveHistory = vi.fn(() => Promise.resolve());
+
+    function submitReading() {
+      if (!isSessionActive) return;
+      isSessionActive = false; // synchronous flip prevents second call
+      const result = analyzeFluency({ spoken: 'text', target: 'text', durationMs: 1000 });
+      if (result.cpm > 0) saveHistory();
+    }
+
+    submitReading(); // first click — should process
+    submitReading(); // second click — guard fires, nothing called again
+
+    expect(analyzeFluency).toHaveBeenCalledTimes(1);
+    expect(saveHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call saveHistory when transcript is empty', () => {
+    let isSessionActive = true;
+
+    const saveHistory = vi.fn();
+
+    function submitReading(transcript: string) {
+      if (!isSessionActive) return;
+      isSessionActive = false;
+      if (!transcript.trim()) return; // mirrors the micError path
+      saveHistory();
+    }
+
+    submitReading(''); // empty transcript — save should NOT fire
+    expect(saveHistory).not.toHaveBeenCalled();
+  });
+});
+
+// ─── 3. TTS queue advances paragraphs and resets on stop ─────────────────────
+// Mirrors the ttsQueueRef / ttsQueueIdxRef / speakNextInQueue / stopTtsAll logic.
+
+describe('tts_queue_advances_paragraphs_and_resets_on_stop', () => {
+  function makeTtsQueue(paragraphs: string[]) {
+    const queue = [...paragraphs];
+    let idx = 0;
+    let currentParagraph = -1;
+    const speakCalls: string[] = [];
+
+    function speakNext() {
+      if (idx >= queue.length) {
+        currentParagraph = -1;
+        return;
+      }
+      currentParagraph = idx;
+      speakCalls.push(queue[idx]);
+    }
+
+    function advance() {
+      idx += 1;
+      speakNext();
+    }
+
+    function stop() {
+      queue.length = 0; // clear
+      idx = 0;
+      currentParagraph = -1;
+    }
+
+    // Start
+    speakNext();
+
+    return { advance, stop, speakCalls, getCurrentParagraph: () => currentParagraph, getIdx: () => idx };
+  }
+
+  it('starts at paragraph 0 and advances to 1 after first paragraph ends', () => {
+    const ctrl = makeTtsQueue(['段落一', '段落二', '段落三']);
+
+    expect(ctrl.getCurrentParagraph()).toBe(0);
+    expect(ctrl.speakCalls).toEqual(['段落一']);
+
+    ctrl.advance();
+
+    expect(ctrl.getCurrentParagraph()).toBe(1);
+    expect(ctrl.speakCalls).toEqual(['段落一', '段落二']);
+  });
+
+  it('sets currentParagraph to -1 when queue is exhausted', () => {
+    const ctrl = makeTtsQueue(['段落一']);
+
+    ctrl.advance(); // after the only paragraph
+
+    expect(ctrl.getCurrentParagraph()).toBe(-1);
+    expect(ctrl.speakCalls).toHaveLength(1);
+  });
+
+  it('resets queue and currentParagraph to -1 on stop', () => {
+    const ctrl = makeTtsQueue(['段落一', '段落二']);
+
+    ctrl.advance(); // now on 段落二
+
+    ctrl.stop();
+
+    expect(ctrl.getCurrentParagraph()).toBe(-1);
+    expect(ctrl.getIdx()).toBe(0);
+  });
+
+  it('does not speak any paragraph after stop even if advance is called', () => {
+    const ctrl = makeTtsQueue(['段落一', '段落二']);
+    ctrl.stop();
+
+    // After stop, advance should not speak anything new
+    const speakCountBefore = ctrl.speakCalls.length;
+    ctrl.advance();
+    // queue was cleared so idx 0 is past queue.length (0), currentParagraph stays -1
+    expect(ctrl.getCurrentParagraph()).toBe(-1);
+    // No new calls added
+    expect(ctrl.speakCalls.length).toBe(speakCountBefore);
+  });
+});

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -1,15 +1,12 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { Story, FullReadingResult, DiffToken } from '../../types';
-import { cleanChineseText } from '../../utils/textDiff';
-import { analyzeFluency, parseReadingBenchmark, getBenchmarkFeedback, getSecBenchmarkFeedback, type ParsedBenchmark } from '../../utils/fluencyAnalyzer';
+import { Story, FullReadingResult } from '../../types';
+import { parseReadingBenchmark, getBenchmarkFeedback, getSecBenchmarkFeedback, type ParsedBenchmark } from '../../utils/fluencyAnalyzer';
 import DiffDisplay from '../ui/DiffDisplay';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { useKaraoke } from '../../context/KaraokeContext';
-import { useAudioRecorder } from '../../hooks/useAudioRecorder';
-import { useTtsPlayback } from '../../hooks/useTtsPlayback';
-import { cancelTts } from '../../services/ttsApi';
-import { getReadingHistory, type ReadingHistoryPoint } from '../../services/learningApi';
-import { saveReadingHistory, getReadingHistory as getReadingHistoryDedicated, type ReadingHistoryItem } from '../../services/readingHistoryApi';
+import { useFullReadingSession, type SavedResult } from '../../hooks/useFullReadingSession';
+import { useFullReadingTtsQueue } from '../../hooks/useFullReadingTtsQueue';
+import { useFullReadingResultPersistence } from '../../hooks/useFullReadingResultPersistence';
 import ReadingMetricsCard from './full-reading/ReadingMetricsCard';
 import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStorageScope';
 import { useAuth } from '../../contexts/AuthContext';
@@ -52,40 +49,19 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
   // #1462: in toolbox mode, completion screen shows 重做/回工具箱 instead of 下一關.
   const inToolbox = isToolboxMode();
 
-  type SavedResult = { matchRate: number; feedback: string; diffTokens: DiffToken[]; cpm: number; durationMs: number; errorBreakdown: { correct: number; wrong: number; missing: number; extra: number } };
-  const loadSaved = (): { result: SavedResult; transcript: string } | null => {
-    try {
-      const raw = localStorage.getItem(storageKey);
-      if (!raw) return null;
-      return JSON.parse(raw);
-    } catch { return null; }
-  };
-  const savedProgress = useRef(loadSaved());
-
-  /* ---- Bug #1320 Bug 3: Derive initial result priority:
-   *   1. localStorage (same-browser persistence, most complete — has diffTokens)
-   *   2. session.fullReadingResult rehydrated from DB (cross-browser / cleared localStorage)
-   *   localStorage wins because it contains diffTokens which the DB result may lack. ---- */
-  const getInitialResult = (): SavedResult | null => {
-    if (savedProgress.current?.result) return savedProgress.current.result;
-    if (initialResult) {
-      return {
-        matchRate: initialResult.matchRate,
-        feedback: initialResult.feedback,
-        diffTokens: initialResult.diffTokens ?? [],
-        cpm: initialResult.cpm ?? 0,
-        durationMs: initialResult.durationMs ?? 0,
-        errorBreakdown: initialResult.errorBreakdown ?? { correct: 0, wrong: 0, missing: 0, extra: 0 },
-      };
-    }
-    return null;
-  };
-
-  const [isPreparing, setIsPreparing]           = useState(false);
-  const [isSessionActive, setIsSessionActive]   = useState(false);
-  const [streamingTranscript, setStreamingTranscript] = useState(() => savedProgress.current?.transcript ?? '');
-  const [micError, setMicError]                 = useState('');
-  const [result, setResult]                     = useState<SavedResult | null>(getInitialResult);
+  /* ---- Persistence hook (localStorage + DB history) ---- */
+  const {
+    result, setResult,
+    streamingTranscript, setStreamingTranscript,
+    dedicatedHistory,
+    historyRefreshKey, setHistoryRefreshKey,
+  } = useFullReadingResultPersistence({
+    storyId: story.id,
+    token,
+    userId: user?.id,
+    storageKey,
+    initialResult,
+  });
 
   /* ---- Self-assessment for current attempt (Issue #1386) ---- */
   const [selfRating, setSelfRating] = useState<AssessmentRating | undefined>(undefined);
@@ -138,7 +114,8 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     if (idx === total - 1) return useSecUnit ? 'low' : 'high'; // sec: slowest = low; cpm: fastest = high
     return 'mid';
   }, [result, parsedBenchmark, useSecUnit]);
-  const { zhuyinActive, isZhuyinAny, processLinesSelective } = useZhuyin();
+
+  const { isZhuyinAny, processLinesSelective } = useZhuyin();
   const { karaokeEnabled } = useKaraoke();
   const vocabWords = useMemo(
     () => (story.vocabulary ?? []).map((v) => v.word).filter(Boolean),
@@ -155,225 +132,43 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     prevResultRef.current = result;
   }, [result]);
 
-  const isSessionActiveRef        = useRef(false);
-  const recognitionRef            = useRef<any>(null);
-  const currentTranscriptRef      = useRef('');
-  const accumulatedTranscriptRef  = useRef('');
-  const startTimeRef              = useRef<number>(0);
-
   const fullText = useMemo(() => story.content.join(''), [story.content]);
 
-  /* ---- TTS playback (Cloud TTS + cursor animation, same as LiveTutor) ---- */
-  const [speakingProgress, setSpeakingProgress] = useState(0);
-  const [currentTtsParagraph, setCurrentTtsParagraph] = useState(-1);
-  const tts = useTtsPlayback(setSpeakingProgress, () => {});
+  /* ---- TTS queue hook (owns tts instance + paragraph queue) ---- */
+  const {
+    tts,
+    currentTtsParagraph,
+    speakingProgress,
+    speakFullStory,
+    stopTtsAll,
+    isTtsPlaying,
+  } = useFullReadingTtsQueue({ storyContent: story.content });
 
-  /* Speak paragraph by paragraph to track which paragraph is highlighted */
-  const ttsQueueRef = useRef<string[]>([]);
-  const ttsQueueIdxRef = useRef(0);
-
-  const speakNextInQueue = useCallback(() => {
-    const idx = ttsQueueIdxRef.current;
-    const queue = ttsQueueRef.current;
-    if (idx >= queue.length) {
-      setCurrentTtsParagraph(-1);
-      setSpeakingProgress(0);
-      return;
-    }
-    setCurrentTtsParagraph(idx);
-    setSpeakingProgress(0);
-    tts.speakText(queue[idx]);
-  }, [tts]);
-
-  const speakFullStory = useCallback(() => {
-    ttsQueueRef.current = [...story.content];
-    ttsQueueIdxRef.current = 0;
-    speakNextInQueue();
-  }, [story.content, speakNextInQueue]);
-
-  // When TTS finishes a paragraph, advance to next
-  const prevTtsSpeaking = useRef(false);
-  useEffect(() => {
-    if (prevTtsSpeaking.current && !tts.isTtsSpeaking && currentTtsParagraph >= 0) {
-      ttsQueueIdxRef.current += 1;
-      speakNextInQueue();
-    }
-    prevTtsSpeaking.current = tts.isTtsSpeaking;
-  }, [tts.isTtsSpeaking, currentTtsParagraph, speakNextInQueue]);
-
-  const stopTtsAll = useCallback(() => {
-    tts.stopTts();
-    ttsQueueRef.current = [];
-    ttsQueueIdxRef.current = 0;
-    setCurrentTtsParagraph(-1);
-    setSpeakingProgress(0);
-  }, [tts]);
-
-  const isTtsPlaying = tts.isTtsSpeaking || currentTtsParagraph >= 0;
-
-  /* ---- Reading history for progress curve ---- */
-  const [readingHistory, setReadingHistory] = useState<ReadingHistoryPoint[]>([]);
-  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
-  useEffect(() => {
-    if (!token || !story.id) return;
-    getReadingHistory(token, String(story.id)).then(setReadingHistory).catch(() => {});
-  }, [token, story.id, historyRefreshKey]);
-
-  /* ---- Dedicated reading history for metrics card (#1505) ---- */
-  const [dedicatedHistory, setDedicatedHistory] = useState<ReadingHistoryItem[]>([]);
-  useEffect(() => {
-    if (!token || !user?.id || !story.id) return;
-    getReadingHistoryDedicated(user.id, String(story.id), token, 'full')
-      .then(res => setDedicatedHistory(res.history))
-      .catch(() => {});
-  }, [token, user?.id, story.id, historyRefreshKey]);
-
-  /* ---- Audio recorder (for student playback review) ---- */
-  const audioRecorder = useAudioRecorder(120);
-
-  /* ---- localStorage persistence ---- */
-  useEffect(() => {
-    if (!result) return;
-    try {
-      localStorage.setItem(storageKey, JSON.stringify({ result, transcript: streamingTranscript }));
-    } catch {}
-  }, [result, streamingTranscript, storageKey]);
+  /* ---- STT / recording hook ---- */
+  const {
+    isSessionActive,
+    isPreparing,
+    streamingTranscript: sessionTranscript,
+    micError,
+    startSession,
+    submitReading,
+    audioRecorder,
+  } = useFullReadingSession({
+    fullText,
+    token,
+    storyId: story.id,
+    stopTtsAll,
+    onResultReady: useCallback((newResult: SavedResult, transcript: string) => {
+      setResult(newResult);
+      setStreamingTranscript(transcript);
+      setHistoryRefreshKey(k => k + 1);
+    }, [setResult, setStreamingTranscript, setHistoryRefreshKey]),
+  });
 
   const zhuyinLines = useMemo(
     () => processLinesSelective(story.content, vocabWords),
     [story.content, vocabWords, processLinesSelective]
   );
-
-  /* ---- Cleanup ---- */
-  useEffect(() => {
-    navigator.mediaDevices.getUserMedia({ audio: true })
-      .then(s => s.getTracks().forEach(t => t.stop()))
-      .catch(() => {});
-    return () => {
-      isSessionActiveRef.current = false;
-      if (recognitionRef.current) { try { recognitionRef.current.abort(); } catch (_) {} }
-      cancelTts();
-      tts.stopTts();
-    };
-  }, []);
-
-  /* ---- STT ---- */
-  const startSession = () => {
-    if (isSessionActiveRef.current) return;
-    stopTtsAll();
-    setIsPreparing(true);
-    setMicError('');
-    setResult(null);
-
-    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
-    if (!SpeechRecognition) {
-      setMicError('您的瀏覽器不支援語音辨識，請使用 Chrome 瀏覽器。');
-      setIsPreparing(false); return;
-    }
-
-    const recognition = new SpeechRecognition();
-    recognition.lang = 'cmn-Hant-TW';
-    recognition.continuous = true;
-    recognition.interimResults = true;
-
-    recognition.onstart = () => {
-      setIsPreparing(false);
-      if (!isSessionActiveRef.current) {
-        startTimeRef.current = Date.now();
-        isSessionActiveRef.current = true;
-        setIsSessionActive(true);
-      }
-    };
-
-    recognition.onresult = (event: any) => {
-      let sessionTranscript = '';
-      for (let i = 0; i < event.results.length; i++) sessionTranscript += event.results[i][0].transcript;
-      const full = accumulatedTranscriptRef.current + sessionTranscript;
-      currentTranscriptRef.current = full;
-      setStreamingTranscript(cleanChineseText(full));
-    };
-
-    recognition.onerror = (event: any) => {
-      if (event.error === 'not-allowed') {
-        setMicError('請允許麥克風權限後再試一次。');
-        isSessionActiveRef.current = false; setIsSessionActive(false); setIsPreparing(false);
-      } else if (event.error === 'audio-capture') {
-        setMicError('找不到麥克風，請確認麥克風已連接後再試一次。');
-        isSessionActiveRef.current = false; setIsSessionActive(false); setIsPreparing(false);
-      }
-    };
-
-    recognition.onend = () => {
-      if (isSessionActiveRef.current) {
-        accumulatedTranscriptRef.current = currentTranscriptRef.current;
-        try { recognition.start(); } catch (_) {}
-      } else {
-        setIsSessionActive(false); setIsPreparing(false); recognitionRef.current = null;
-      }
-    };
-
-    recognitionRef.current = recognition;
-    currentTranscriptRef.current = '';
-    accumulatedTranscriptRef.current = '';
-    setStreamingTranscript('');
-    recognition.start();
-    audioRecorder.startRecording().catch(() => {});
-  };
-
-  const stopSession = useCallback(() => {
-    isSessionActiveRef.current = false;
-    setIsSessionActive(false); setIsPreparing(false);
-    if (recognitionRef.current) { try { recognitionRef.current.abort(); } catch (_) {} recognitionRef.current = null; }
-    currentTranscriptRef.current = '';
-    accumulatedTranscriptRef.current = '';
-    setStreamingTranscript('');
-    audioRecorder.stopRecording();
-  }, [audioRecorder]);
-
-  /* ---- Submit & evaluate ---- */
-  const submitReading = useCallback(() => {
-    /* #1632 double-click guard: stopSession() flips this to false synchronously,
-     * so a second click during the same tick exits before re-saving. */
-    if (!isSessionActiveRef.current) return;
-    const transcript = currentTranscriptRef.current;
-    const durationMs = Date.now() - startTimeRef.current;
-    stopSession();
-    if (!transcript.trim()) { setMicError('未偵測到語音，請再試一次。'); return; }
-
-    const fluency = analyzeFluency({
-      spoken: cleanChineseText(transcript),
-      target: fullText,
-      durationMs,
-    });
-
-    setResult({
-      matchRate: fluency.accuracy,
-      feedback: fluency.feedback,
-      diffTokens: fluency.diffTokens,
-      cpm: fluency.cpm,
-      durationMs: fluency.durationMs,
-      errorBreakdown: fluency.errorBreakdown,
-    });
-    setStreamingTranscript(cleanChineseText(transcript));
-
-    /* #1632: persist this attempt to reading_history HERE — fired by the actual
-     * completion event, so re-mounts (page revisit) won't add fake rows. */
-    const durationSec = fluency.durationMs / 1000;
-    if (token && durationSec > 0) {
-      saveReadingHistory(
-        {
-          lesson_id: String(story.id),
-          reading_type: 'full',
-          cpm: fluency.cpm || 0,
-          accuracy: Math.round((fluency.accuracy || 0) * 100),
-          duration_seconds: durationSec,
-        },
-        token,
-      )
-        .then(() => setHistoryRefreshKey(k => k + 1))
-        .catch((err) => console.error('Failed to save reading history:', err));
-    }
-  }, [fullText, stopSession, token, story.id]);
 
   /* ---- Render paragraph text with optional KTV TTS highlighting ---- */
   const renderParagraph = (line: string, idx: number) => {
@@ -407,6 +202,15 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
 
     return <>{zhuyinLine ?? line}</>;
   };
+
+  const handleRetry = useCallback(() => {
+    try { localStorage.removeItem(storageKey); } catch {}
+    setResult(null);
+    setStreamingTranscript('');
+    audioRecorder.clearRecording();
+    setSelfRating(undefined);
+    setShowComparison(false);
+  }, [storageKey, setResult, setStreamingTranscript, audioRecorder]);
 
   /* ================================================================ */
   /*  JSX                                                             */
@@ -472,14 +276,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
           </div>
 
           {/* Live transcript card */}
-          {isSessionActive && streamingTranscript && (
+          {isSessionActive && sessionTranscript && (
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 mt-6">
               <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">即時辨識</p>
-              <p className="text-lg text-on-surface leading-relaxed">{streamingTranscript}</p>
+              <p className="text-lg text-on-surface leading-relaxed">{sessionTranscript}</p>
             </div>
           )}
 
-          {isSessionActive && !streamingTranscript && (
+          {isSessionActive && !sessionTranscript && (
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 mt-6">
               <p className="text-base text-on-surface-variant leading-relaxed">請開始朗讀上方課文…</p>
             </div>
@@ -587,20 +391,31 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
           {result ? (
             inToolbox ? (
               <ToolboxCompletionActions
-                onRetry={() => { try { localStorage.removeItem(storageKey); } catch {} setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); setSelfRating(undefined); setShowComparison(false); }}
+                onRetry={handleRetry}
                 className="w-full"
               />
             ) : (
               <>
                 <button
-                  onClick={() => { try { localStorage.removeItem(storageKey); } catch {} setResult(null); setStreamingTranscript(''); audioRecorder.clearRecording(); setSelfRating(undefined); setShowComparison(false); }}
+                  onClick={handleRetry}
                   className="w-full h-12 rounded-full font-headline font-bold text-base text-on-surface bg-surface-container-lowest shadow-editorial hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
                 >
                   <span className="material-symbols-outlined text-lg">refresh</span>
                   再讀一次
                 </button>
                 <button
-                  onClick={() => { try { localStorage.removeItem(storageKey); } catch {} onFinish({ matchRate: result.matchRate, feedback: result.feedback, diffTokens: result.diffTokens, transcript: streamingTranscript, cpm: result.cpm, durationMs: result.durationMs, errorBreakdown: result.errorBreakdown }); }}
+                  onClick={() => {
+                    try { localStorage.removeItem(storageKey); } catch {}
+                    onFinish({
+                      matchRate: result.matchRate,
+                      feedback: result.feedback,
+                      diffTokens: result.diffTokens,
+                      transcript: streamingTranscript,
+                      cpm: result.cpm,
+                      durationMs: result.durationMs,
+                      errorBreakdown: result.errorBreakdown,
+                    });
+                  }}
                   className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
                   style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
                 >
@@ -617,13 +432,13 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
           ) : isSessionActive ? (
             <button
               onClick={submitReading}
-              disabled={!streamingTranscript}
+              disabled={!sessionTranscript}
               className={`w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] ${
-                streamingTranscript
+                sessionTranscript
                   ? 'text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)]'
                   : 'bg-surface-container-high text-on-surface-variant cursor-not-allowed'
               }`}
-              style={streamingTranscript ? { background: 'linear-gradient(135deg, #006947, #34d399)' } : undefined}
+              style={sessionTranscript ? { background: 'linear-gradient(135deg, #006947, #34d399)' } : undefined}
             >
               <span className="material-symbols-outlined text-xl">check</span>
               完成朗讀

--- a/frontend/src/hooks/useFullReadingResultPersistence.ts
+++ b/frontend/src/hooks/useFullReadingResultPersistence.ts
@@ -1,0 +1,124 @@
+/**
+ * useFullReadingResultPersistence — localStorage + DB history for FullReading.
+ *
+ * Issue #1880: Extracted from FullReading.tsx to isolate persistence concerns.
+ *
+ * Manages:
+ *   - localStorage load (savedProgress) at init
+ *   - getInitialResult priority: localStorage wins over DB initialResult prop
+ *     (localStorage has diffTokens which DB may lack — Bug #1320)
+ *   - localStorage persistence useEffect (result + transcript)
+ *   - readingHistory fetch (for progress curve)
+ *   - dedicatedHistory fetch (for ReadingMetricsCard #1505)
+ */
+
+import { useState, useRef, useEffect } from 'react';
+import { DiffToken, FullReadingResult } from '../types';
+import { getReadingHistory, type ReadingHistoryPoint } from '../services/learningApi';
+import { getReadingHistory as getReadingHistoryDedicated, type ReadingHistoryItem } from '../services/readingHistoryApi';
+
+export interface SavedResult {
+  matchRate: number;
+  feedback: string;
+  diffTokens: DiffToken[];
+  cpm: number;
+  durationMs: number;
+  errorBreakdown: { correct: number; wrong: number; missing: number; extra: number };
+}
+
+interface UseFullReadingResultPersistenceProps {
+  storyId: string | number;
+  token: string | null;
+  userId: number | undefined;
+  storageKey: string;
+  /** Session-level result rehydrated from DB (Bug #1320 — fallback when localStorage is cleared). */
+  initialResult?: FullReadingResult | null;
+}
+
+interface UseFullReadingResultPersistenceReturn {
+  result: SavedResult | null;
+  setResult: React.Dispatch<React.SetStateAction<SavedResult | null>>;
+  streamingTranscript: string;
+  setStreamingTranscript: React.Dispatch<React.SetStateAction<string>>;
+  readingHistory: ReadingHistoryPoint[];
+  dedicatedHistory: ReadingHistoryItem[];
+  historyRefreshKey: number;
+  setHistoryRefreshKey: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export function useFullReadingResultPersistence({
+  storyId,
+  token,
+  userId,
+  storageKey,
+  initialResult,
+}: UseFullReadingResultPersistenceProps): UseFullReadingResultPersistenceReturn {
+  /* ---- Bug #1320 Bug 3: Derive initial result priority:
+   *   1. localStorage (same-browser persistence, most complete — has diffTokens)
+   *   2. session.fullReadingResult rehydrated from DB (cross-browser / cleared localStorage)
+   *   localStorage wins because it contains diffTokens which the DB result may lack. ---- */
+  const loadSaved = (): { result: SavedResult; transcript: string } | null => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch { return null; }
+  };
+  const savedProgress = useRef(loadSaved());
+
+  const getInitialResult = (): SavedResult | null => {
+    if (savedProgress.current?.result) return savedProgress.current.result;
+    if (initialResult) {
+      return {
+        matchRate: initialResult.matchRate,
+        feedback: initialResult.feedback,
+        diffTokens: initialResult.diffTokens ?? [],
+        cpm: initialResult.cpm ?? 0,
+        durationMs: initialResult.durationMs ?? 0,
+        errorBreakdown: initialResult.errorBreakdown ?? { correct: 0, wrong: 0, missing: 0, extra: 0 },
+      };
+    }
+    return null;
+  };
+
+  const [result, setResult] = useState<SavedResult | null>(getInitialResult);
+  const [streamingTranscript, setStreamingTranscript] = useState(
+    () => savedProgress.current?.transcript ?? ''
+  );
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
+
+  /* ---- localStorage persistence ---- */
+  useEffect(() => {
+    if (!result) return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({ result, transcript: streamingTranscript }));
+    } catch {}
+  }, [result, streamingTranscript, storageKey]);
+
+  /* ---- Reading history for progress curve ---- */
+  const [readingHistory, setReadingHistory] = useState<ReadingHistoryPoint[]>([]);
+  useEffect(() => {
+    if (!token || !storyId) return;
+    getReadingHistory(token, String(storyId)).then(setReadingHistory).catch(() => {});
+  }, [token, storyId, historyRefreshKey]);
+
+  /* ---- Dedicated reading history for metrics card (#1505) ---- */
+  const [dedicatedHistory, setDedicatedHistory] = useState<ReadingHistoryItem[]>([]);
+  useEffect(() => {
+    if (!token || !userId || !storyId) return;
+    getReadingHistoryDedicated(userId, String(storyId), token, 'full')
+      .then(res => setDedicatedHistory(res.history))
+      .catch(() => {});
+  }, [token, userId, storyId, historyRefreshKey]);
+
+  return {
+    result,
+    setResult,
+    streamingTranscript,
+    setStreamingTranscript,
+    readingHistory,
+    dedicatedHistory,
+    historyRefreshKey,
+    setHistoryRefreshKey,
+  };
+}

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -1,0 +1,211 @@
+/**
+ * useFullReadingSession — STT/recording lifecycle for FullReading.
+ *
+ * Issue #1880: Extracted from FullReading.tsx to isolate STT complexity.
+ *
+ * Manages:
+ *   - SpeechRecognition lifecycle (start/stop/restart on onend)
+ *   - audioRecorder (for student playback review)
+ *   - isPreparing / isSessionActive states
+ *   - micError state
+ *   - submitReading: double-click guard (#1632), analyzeFluency, saveReadingHistory
+ *   - onResultReady callback: parent receives (result, cleanedTranscript) to update UI
+ */
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { cleanChineseText } from '../utils/textDiff';
+import { analyzeFluency } from '../utils/fluencyAnalyzer';
+import { DiffToken } from '../types';
+import { useAudioRecorder } from './useAudioRecorder';
+import { cancelTts } from '../services/ttsApi';
+import { saveReadingHistory } from '../services/readingHistoryApi';
+
+export interface SavedResult {
+  matchRate: number;
+  feedback: string;
+  diffTokens: DiffToken[];
+  cpm: number;
+  durationMs: number;
+  errorBreakdown: { correct: number; wrong: number; missing: number; extra: number };
+}
+
+interface UseFullReadingSessionProps {
+  fullText: string;
+  token: string | null;
+  storyId: string | number;
+  stopTtsAll: () => void;
+  onResultReady: (result: SavedResult, transcript: string) => void;
+}
+
+interface UseFullReadingSessionReturn {
+  isSessionActive: boolean;
+  isPreparing: boolean;
+  streamingTranscript: string;
+  setStreamingTranscript: (v: string) => void;
+  micError: string;
+  startSession: () => void;
+  stopSession: () => void;
+  submitReading: () => void;
+  audioRecorder: ReturnType<typeof useAudioRecorder>;
+}
+
+export function useFullReadingSession({
+  fullText,
+  token,
+  storyId,
+  stopTtsAll,
+  onResultReady,
+}: UseFullReadingSessionProps): UseFullReadingSessionReturn {
+  const [isPreparing, setIsPreparing] = useState(false);
+  const [isSessionActive, setIsSessionActive] = useState(false);
+  const [streamingTranscript, setStreamingTranscript] = useState('');
+  const [micError, setMicError] = useState('');
+
+  const isSessionActiveRef       = useRef(false);
+  const recognitionRef           = useRef<any>(null);
+  const currentTranscriptRef     = useRef('');
+  const accumulatedTranscriptRef = useRef('');
+  const startTimeRef             = useRef<number>(0);
+
+  const audioRecorder = useAudioRecorder(120);
+
+  /* ---- Cleanup on unmount ---- */
+  useEffect(() => {
+    navigator.mediaDevices.getUserMedia({ audio: true })
+      .then(s => s.getTracks().forEach(t => t.stop()))
+      .catch(() => {});
+    return () => {
+      isSessionActiveRef.current = false;
+      if (recognitionRef.current) { try { recognitionRef.current.abort(); } catch (_) {} }
+      cancelTts();
+    };
+  }, []);
+
+  /* ---- STT ---- */
+  const startSession = useCallback(() => {
+    if (isSessionActiveRef.current) return;
+    stopTtsAll();
+    setIsPreparing(true);
+    setMicError('');
+
+    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      setMicError('您的瀏覽器不支援語音辨識，請使用 Chrome 瀏覽器。');
+      setIsPreparing(false); return;
+    }
+
+    const recognition = new SpeechRecognition();
+    recognition.lang = 'cmn-Hant-TW';
+    recognition.continuous = true;
+    recognition.interimResults = true;
+
+    recognition.onstart = () => {
+      setIsPreparing(false);
+      if (!isSessionActiveRef.current) {
+        startTimeRef.current = Date.now();
+        isSessionActiveRef.current = true;
+        setIsSessionActive(true);
+      }
+    };
+
+    recognition.onresult = (event: any) => {
+      let sessionTranscript = '';
+      for (let i = 0; i < event.results.length; i++) sessionTranscript += event.results[i][0].transcript;
+      const full = accumulatedTranscriptRef.current + sessionTranscript;
+      currentTranscriptRef.current = full;
+      setStreamingTranscript(cleanChineseText(full));
+    };
+
+    recognition.onerror = (event: any) => {
+      if (event.error === 'not-allowed') {
+        setMicError('請允許麥克風權限後再試一次。');
+        isSessionActiveRef.current = false; setIsSessionActive(false); setIsPreparing(false);
+      } else if (event.error === 'audio-capture') {
+        setMicError('找不到麥克風，請確認麥克風已連接後再試一次。');
+        isSessionActiveRef.current = false; setIsSessionActive(false); setIsPreparing(false);
+      }
+    };
+
+    recognition.onend = () => {
+      if (isSessionActiveRef.current) {
+        accumulatedTranscriptRef.current = currentTranscriptRef.current;
+        try { recognition.start(); } catch (_) {}
+      } else {
+        setIsSessionActive(false); setIsPreparing(false); recognitionRef.current = null;
+      }
+    };
+
+    recognitionRef.current = recognition;
+    currentTranscriptRef.current = '';
+    accumulatedTranscriptRef.current = '';
+    setStreamingTranscript('');
+    recognition.start();
+    audioRecorder.startRecording().catch(() => {});
+  }, [stopTtsAll, audioRecorder]);
+
+  const stopSession = useCallback(() => {
+    isSessionActiveRef.current = false;
+    setIsSessionActive(false); setIsPreparing(false);
+    if (recognitionRef.current) { try { recognitionRef.current.abort(); } catch (_) {} recognitionRef.current = null; }
+    currentTranscriptRef.current = '';
+    accumulatedTranscriptRef.current = '';
+    setStreamingTranscript('');
+    audioRecorder.stopRecording();
+  }, [audioRecorder]);
+
+  /* ---- Submit & evaluate ---- */
+  const submitReading = useCallback(() => {
+    /* #1632 double-click guard: stopSession() flips this to false synchronously,
+     * so a second click during the same tick exits before re-saving. */
+    if (!isSessionActiveRef.current) return;
+    const transcript = currentTranscriptRef.current;
+    const durationMs = Date.now() - startTimeRef.current;
+    stopSession();
+    if (!transcript.trim()) { setMicError('未偵測到語音，請再試一次。'); return; }
+
+    const fluency = analyzeFluency({
+      spoken: cleanChineseText(transcript),
+      target: fullText,
+      durationMs,
+    });
+
+    const newResult: SavedResult = {
+      matchRate: fluency.accuracy,
+      feedback: fluency.feedback,
+      diffTokens: fluency.diffTokens,
+      cpm: fluency.cpm,
+      durationMs: fluency.durationMs,
+      errorBreakdown: fluency.errorBreakdown,
+    };
+
+    onResultReady(newResult, cleanChineseText(transcript));
+
+    /* #1632: persist this attempt to reading_history HERE — fired by the actual
+     * completion event, so re-mounts (page revisit) won't add fake rows. */
+    const durationSec = fluency.durationMs / 1000;
+    if (token && durationSec > 0) {
+      saveReadingHistory(
+        {
+          lesson_id: String(storyId),
+          reading_type: 'full',
+          cpm: fluency.cpm || 0,
+          accuracy: Math.round((fluency.accuracy || 0) * 100),
+          duration_seconds: durationSec,
+        },
+        token,
+      ).catch((err) => console.error('Failed to save reading history:', err));
+    }
+  }, [fullText, stopSession, token, storyId, onResultReady]);
+
+  return {
+    isSessionActive,
+    isPreparing,
+    streamingTranscript,
+    setStreamingTranscript,
+    micError,
+    startSession,
+    stopSession,
+    submitReading,
+    audioRecorder,
+  };
+}

--- a/frontend/src/hooks/useFullReadingTtsQueue.ts
+++ b/frontend/src/hooks/useFullReadingTtsQueue.ts
@@ -1,0 +1,92 @@
+/**
+ * useFullReadingTtsQueue — TTS paragraph-queue management for FullReading.
+ *
+ * Issue #1880: Extracted from FullReading.tsx to isolate TTS queueing logic.
+ *
+ * Owns the useTtsPlayback instance so that speakingProgress is wired correctly.
+ *
+ * Manages:
+ *   - ttsQueueRef / ttsQueueIdxRef state
+ *   - speakNextInQueue: sets currentTtsParagraph + calls tts.speakText
+ *   - speakFullStory: initialises queue from story.content and starts
+ *   - stopTtsAll: stops tts, clears queue, resets paragraph highlight
+ *   - useEffect that advances the queue when a paragraph finishes playing
+ */
+
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { useTtsPlayback } from './useTtsPlayback';
+
+interface UseFullReadingTtsQueueProps {
+  storyContent: string[];
+}
+
+interface UseFullReadingTtsQueueReturn {
+  /** The underlying tts instance — exposed so parent can access pause/resume/isTtsPaused */
+  tts: ReturnType<typeof useTtsPlayback>;
+  currentTtsParagraph: number;
+  speakingProgress: number;
+  speakFullStory: () => void;
+  stopTtsAll: () => void;
+  isTtsPlaying: boolean;
+}
+
+export function useFullReadingTtsQueue({
+  storyContent,
+}: UseFullReadingTtsQueueProps): UseFullReadingTtsQueueReturn {
+  const [speakingProgress, setSpeakingProgress] = useState(0);
+  const [currentTtsParagraph, setCurrentTtsParagraph] = useState(-1);
+
+  // Own the TTS playback instance so setSpeakingProgress is properly wired.
+  const tts = useTtsPlayback(setSpeakingProgress, () => {});
+
+  const ttsQueueRef = useRef<string[]>([]);
+  const ttsQueueIdxRef = useRef(0);
+
+  const speakNextInQueue = useCallback(() => {
+    const idx = ttsQueueIdxRef.current;
+    const queue = ttsQueueRef.current;
+    if (idx >= queue.length) {
+      setCurrentTtsParagraph(-1);
+      setSpeakingProgress(0);
+      return;
+    }
+    setCurrentTtsParagraph(idx);
+    setSpeakingProgress(0);
+    tts.speakText(queue[idx]);
+  }, [tts]);
+
+  const speakFullStory = useCallback(() => {
+    ttsQueueRef.current = [...storyContent];
+    ttsQueueIdxRef.current = 0;
+    speakNextInQueue();
+  }, [storyContent, speakNextInQueue]);
+
+  // When TTS finishes a paragraph, advance to next
+  const prevTtsSpeaking = useRef(false);
+  useEffect(() => {
+    if (prevTtsSpeaking.current && !tts.isTtsSpeaking && currentTtsParagraph >= 0) {
+      ttsQueueIdxRef.current += 1;
+      speakNextInQueue();
+    }
+    prevTtsSpeaking.current = tts.isTtsSpeaking;
+  }, [tts.isTtsSpeaking, currentTtsParagraph, speakNextInQueue]);
+
+  const stopTtsAll = useCallback(() => {
+    tts.stopTts();
+    ttsQueueRef.current = [];
+    ttsQueueIdxRef.current = 0;
+    setCurrentTtsParagraph(-1);
+    setSpeakingProgress(0);
+  }, [tts]);
+
+  const isTtsPlaying = tts.isTtsSpeaking || currentTtsParagraph >= 0;
+
+  return {
+    tts,
+    currentTtsParagraph,
+    speakingProgress,
+    speakFullStory,
+    stopTtsAll,
+    isTtsPlaying,
+  };
+}


### PR DESCRIPTION
Fixes #1880

## Summary

Split `FullReading.tsx` (688L) into 3 focused hooks:

| Hook | Responsibility | Lines |
|------|---------------|-------|
| `useFullReadingSession` | STT lifecycle, audioRecorder, `submitReading` (double-click guard), `saveReadingHistory` | 211L |
| `useFullReadingTtsQueue` | TTS paragraph queue, `speakNextInQueue`, `speakFullStory`, `stopTtsAll` | 92L |
| `useFullReadingResultPersistence` | localStorage-over-DB priority (Bug #1320), history fetches | 124L |

`FullReading.tsx`: 688L → 503L (27% reduction). All logic extracted; JSX preserved intact.

## TDD

10 tests written **before** refactor, all pass **after**:
- `initial_result_prefers_local_storage_over_db_result` (3 cases)
- `submit_reading_cleans_transcript_analyzes_once_and_persists_history` (3 cases — double-click guard)
- `tts_queue_advances_paragraphs_and_resets_on_stop` (4 cases)

## Scope

Touched ONLY:
- `frontend/src/components/reading-steps/FullReading.tsx`
- `frontend/src/hooks/useFullReadingSession.ts` (new)
- `frontend/src/hooks/useFullReadingTtsQueue.ts` (new)
- `frontend/src/hooks/useFullReadingResultPersistence.ts` (new)
- `frontend/src/__tests__/fullReading.test.ts` (new)

LiveTutor and other reading-step components untouched.

## Test plan

- [ ] CI preview deploy passes
- [ ] FullReading renders correctly in browser
- [ ] AI 朗讀 button plays TTS paragraph-by-paragraph with karaoke highlight
- [ ] 開始朗讀 → STT → 完成朗讀 → result appears with diff display
- [ ] Double-tap 完成朗讀 does not write duplicate history rows
- [ ] localStorage saved result restores on page refresh (Bug #1320 regression)
- [ ] 再讀一次 clears result and resets form