### PR TITLE
refactor(socratic): split mcq_rescue_agent.py into store/state-machine/prompt (Fixes #1887)

### DIFF
--- a/backend/app/services/mcq_rescue_agent.py
+++ b/backend/app/services/mcq_rescue_agent.py
@@ -12,22 +12,40 @@ Architecture mirrors socratic_agent.py:
   - Error fallback: should_advance=False (NEVER True on error — auto-passing students on error is catastrophic)
 
 Session key: mcq_rescue_{user_id}_{question_id}
+
+Refactored (Issue #1887): session store, state machine, and prompt builder
+are extracted into focused modules:
+  - rescue_session_store.py   — RescueSessionState + RescueSessionStore
+  - rescue_state_machine.py   — give-up / step-advance / termination logic
+  - rescue_prompt_builder.py  — Gemini system prompt construction
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from google.genai import errors as genai_errors
 from google.genai import types as genai_types
 
 from .ai_service import generate_structured_response
 from .input_sanitizer import sanitize_ai_input
-from .persona import TUTOR_PERSONA
+from .rescue_prompt_builder import build_system_prompt
+from .rescue_session_store import RescueSessionState, RescueSessionStore
+from .rescue_state_machine import _fallback_prompt, apply_state_transitions
 from .strategy_prompts import StrategyPromptError, load_strategy_prompt
+
+# Re-export for backward compatibility — existing tests and routes import these names.
+__all__ = [
+    "McqRescueAgent",
+    "RescueResponse",
+    "RescueSessionState",
+    "RescueSessionStore",
+    "_store",
+    "mcq_rescue_agent",
+    "RESCUE_RESPONSE_SCHEMA",
+]
 
 # AI-layer exceptions we expect and handle gracefully.
 # Any other exception (KeyError, TypeError, AttributeError, JSONDecodeError, …)
@@ -40,87 +58,7 @@ _AI_ERRORS = (
 
 logger = logging.getLogger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Session State
-# ---------------------------------------------------------------------------
-
-@dataclass
-class RescueSessionState:
-    session_id: str
-    user_id: int
-    question_id: str
-    lesson_id: str
-    wrong_choice: str
-    question_text: str
-    correct_answer: str
-    strategy_type: str | None
-    # SOP state
-    current_step: int = 1          # 1-5
-    conversation: list[dict] = field(default_factory=list)   # {role, text}
-    consecutive_errors: int = 0
-    give_up_count: int = 0         # consecutive "不知道" / "我不會"
-    created_at: float = field(default_factory=time.time)
-    is_terminated: bool = False
-
-
-# ---------------------------------------------------------------------------
-# Session Store
-# ---------------------------------------------------------------------------
-
-class RescueSessionStore:
-    """In-memory session store for MCQ rescue dialogues.
-
-    Mirrors SessionStore from socratic_agent.py.
-    Key: mcq_rescue_{user_id}_{question_id}
-    TTL: 30 minutes (same as Socratic agent)
-    Rate limit: 30 requests / 60 seconds per session
-    """
-
-    TTL_SECONDS = 30 * 60
-    RATE_LIMIT = 30
-    RATE_WINDOW = 60
-
-    def __init__(self) -> None:
-        self._sessions: dict[str, RescueSessionState] = {}
-        self._rate_counts: dict[str, list[float]] = {}
-
-    @staticmethod
-    def make_key(user_id: int, question_id: str) -> str:
-        return f"mcq_rescue_{user_id}_{question_id}"
-
-    def get(self, session_id: str) -> RescueSessionState | None:
-        self._cleanup()
-        return self._sessions.get(session_id)
-
-    def save(self, state: RescueSessionState) -> None:
-        self._sessions[state.session_id] = state
-
-    def delete(self, session_id: str) -> None:
-        self._sessions.pop(session_id, None)
-
-    def check_rate_limit(self, session_id: str) -> bool:
-        """Return True if rate limit exceeded."""
-        now = time.time()
-        timestamps = self._rate_counts.get(session_id, [])
-        timestamps = [t for t in timestamps if now - t < self.RATE_WINDOW]
-        if len(timestamps) >= self.RATE_LIMIT:
-            return True
-        timestamps.append(now)
-        self._rate_counts[session_id] = timestamps
-        return False
-
-    def _cleanup(self) -> None:
-        now = time.time()
-        expired = [
-            sid for sid, s in self._sessions.items()
-            if now - s.created_at > self.TTL_SECONDS
-        ]
-        for sid in expired:
-            del self._sessions[sid]
-
-
-# Module-level singleton
+# Module-level singleton store (backward-compat — tests import `_store` directly)
 _store = RescueSessionStore()
 
 
@@ -196,72 +134,6 @@ class McqRescueAgent:
     MAX_HISTORY_TURNS = 10
     MAX_CONSECUTIVE_ERRORS = 3
     GIVE_UP_THRESHOLD = 3       # 3 consecutive give-up responses → skip to step 5
-
-    def _build_system_prompt(
-        self,
-        state: RescueSessionState,
-        prompt_data: dict,
-    ) -> str:
-        step_index = state.current_step - 1
-        steps = prompt_data.get("steps", [])
-        current_step_data = steps[step_index] if 0 <= step_index < len(steps) else {}
-
-        step_descriptions = "\n".join(
-            f"  步驟 {s['step']} [{s.get('name','')}] — {s.get('label','')}：{s.get('intent','')}"
-            for s in steps
-        )
-
-        tone_lines = "\n".join(f"  - {t}" for t in prompt_data.get("tone", []))
-
-        terminate_conds = prompt_data.get("terminate_conditions", [])
-        if isinstance(terminate_conds, list):
-            terminate_str = "\n".join(f"  - {c}" for c in terminate_conds)
-        else:
-            terminate_str = str(terminate_conds)
-
-        return f"""{TUTOR_PERSONA}
-
-你是「MCQ 解題助教」。學生在閱讀理解選擇題答錯了，你的任務是用 5 步驟 SOP 引導他找到正確答案。
-
-【策略類型】{prompt_data.get("display_name", "通用")}
-{prompt_data.get("description", "")}
-
-【學生答錯的題目】
-題目：{state.question_text}
-學生選了：{state.wrong_choice}
-
-【5 步驟 SOP 總覽】
-{step_descriptions}
-
-【目前步驟】步驟 {state.current_step} — {current_step_data.get("label", "")}
-目標：{current_step_data.get("intent", "")}
-advance 條件：{current_step_data.get("advance_when", "")}
-fail 條件：{current_step_data.get("fail_when", "")}
-
-引導原則（此步驟）：
-{current_step_data.get("sample_prompt", "")}
-
-【結束條件】
-{terminate_str}
-
-【語氣規範】
-{tone_lines}
-
-評分規則：
-- should_advance = true：學生回答達到此步驟的 advance_when 條件
-- should_advance = false：學生還沒達到，繼續同一步驟引導
-- should_terminate = true：
-  (a) 步驟 4 學生選對了（rescue 成功），或
-  (b) 步驟 5 完成（已直接教學），或
-  (c) 連續 {self.GIVE_UP_THRESHOLD} 次 give_up_detected=true
-- give_up_detected = true：學生說「不知道」「隨便」「我不會」「放棄」等敷衍或放棄詞
-- reasoning 欄位：必填。說明為什麼你設定了 should_advance / should_terminate 這樣的值
-
-絕對禁止：
-- 不可直接給答案，除非到了步驟 5
-- 不可說「答案是 X」直到 step 5
-- 不可讓學生答錯也 should_advance=true（即使他很接近）
-- 不可在 AI 出錯時讓 should_advance=true（錯誤降級必須 should_advance=false）"""
 
     async def start_session(
         self,
@@ -398,7 +270,7 @@ fail 條件：{current_step_data.get("fail_when", "")}
             )
 
         prompt_data = load_strategy_prompt(state.strategy_type)
-        system_prompt = self._build_system_prompt(state, prompt_data)
+        system_prompt = build_system_prompt(state, prompt_data, self.GIVE_UP_THRESHOLD)
 
         # Build Gemini contents
         contents: list[genai_types.Content] = [
@@ -501,30 +373,16 @@ fail 條件：{current_step_data.get("fail_when", "")}
             returned_step = state.current_step
             reasoning = f"AI error fallback (attempt {state.consecutive_errors})"
 
-        # Update give_up_count
-        if give_up_detected:
-            state.give_up_count += 1
-        else:
-            state.give_up_count = 0  # Reset on real answer
-
-        # Auto-skip to step 5 if too many give-ups
-        if state.give_up_count >= self.GIVE_UP_THRESHOLD:
-            returned_step = 5
-            should_advance = False
-            should_terminate = False  # Let step 5 run first, then terminate
-            reasoning += " [Give-up threshold reached — advancing to step 5 direct teach]"
-
-        # Advance step if criteria met
-        if should_advance and returned_step == state.current_step and state.current_step < 5:
-            state.current_step += 1
-            returned_step = state.current_step
-
-        # If step 5 is active and should_advance, terminate
-        if state.current_step == 5 and should_advance:
-            should_terminate = True
-
-        # Clamp step
-        state.current_step = max(1, min(5, returned_step))
+        # Apply state machine transitions (give-up, step advance, termination)
+        should_advance, should_terminate, final_step, reasoning = apply_state_transitions(
+            state=state,
+            give_up_detected=give_up_detected,
+            should_advance=should_advance,
+            should_terminate=should_terminate,
+            returned_step=returned_step,
+            reasoning=reasoning,
+            give_up_threshold=self.GIVE_UP_THRESHOLD,
+        )
 
         # Persist AI response
         full_ai_text = ai_feedback
@@ -538,7 +396,7 @@ fail 條件：{current_step_data.get("fail_when", "")}
         _store.save(state)
 
         return RescueResponse(
-            current_step=state.current_step,
+            current_step=final_step,
             should_advance=should_advance,
             should_terminate=should_terminate,
             give_up_detected=give_up_detected,
@@ -546,17 +404,6 @@ fail 條件：{current_step_data.get("fail_when", "")}
             next_question=next_question,
             reasoning=reasoning,
         )
-
-
-def _fallback_prompt(step: int) -> str:
-    fallbacks = {
-        1: "你能說說看，這題在問什麼嗎？",
-        2: "課文裡哪一段和這個問題有關？",
-        3: "你能用自己的話說說那段在講什麼嗎？",
-        4: "那 A/B/C/D 哪個選項符合你剛才說的？",
-        5: "我們一起來看一下答案好了。",
-    }
-    return fallbacks.get(step, fallbacks[1])
 
 
 # Module-level agent singleton

--- a/backend/app/services/rescue_prompt_builder.py
+++ b/backend/app/services/rescue_prompt_builder.py
@@ -1,0 +1,88 @@
+"""
+rescue_prompt_builder.py — System prompt construction for MCQ Rescue sessions.
+
+Extracted from mcq_rescue_agent.py (Issue #1887).
+Builds the Gemini system prompt from strategy YAML data and session state.
+"""
+
+from __future__ import annotations
+
+from .persona import TUTOR_PERSONA
+from .rescue_session_store import RescueSessionState
+
+
+def build_system_prompt(
+    state: RescueSessionState,
+    prompt_data: dict,
+    give_up_threshold: int = 3,
+) -> str:
+    """Build the Gemini system prompt for a rescue session turn.
+
+    Args:
+        state: Current rescue session state.
+        prompt_data: Loaded strategy YAML data (from load_strategy_prompt).
+        give_up_threshold: Number of consecutive give-ups before step 5 skip.
+
+    Returns:
+        System prompt string for Gemini.
+    """
+    step_index = state.current_step - 1
+    steps = prompt_data.get("steps", [])
+    current_step_data = steps[step_index] if 0 <= step_index < len(steps) else {}
+
+    step_descriptions = "\n".join(
+        f"  步驟 {s['step']} [{s.get('name','')}] — {s.get('label','')}：{s.get('intent','')}"
+        for s in steps
+    )
+
+    tone_lines = "\n".join(f"  - {t}" for t in prompt_data.get("tone", []))
+
+    terminate_conds = prompt_data.get("terminate_conditions", [])
+    if isinstance(terminate_conds, list):
+        terminate_str = "\n".join(f"  - {c}" for c in terminate_conds)
+    else:
+        terminate_str = str(terminate_conds)
+
+    return f"""{TUTOR_PERSONA}
+
+你是「MCQ 解題助教」。學生在閱讀理解選擇題答錯了，你的任務是用 5 步驟 SOP 引導他找到正確答案。
+
+【策略類型】{prompt_data.get("display_name", "通用")}
+{prompt_data.get("description", "")}
+
+【學生答錯的題目】
+題目：{state.question_text}
+學生選了：{state.wrong_choice}
+
+【5 步驟 SOP 總覽】
+{step_descriptions}
+
+【目前步驟】步驟 {state.current_step} — {current_step_data.get("label", "")}
+目標：{current_step_data.get("intent", "")}
+advance 條件：{current_step_data.get("advance_when", "")}
+fail 條件：{current_step_data.get("fail_when", "")}
+
+引導原則（此步驟）：
+{current_step_data.get("sample_prompt", "")}
+
+【結束條件】
+{terminate_str}
+
+【語氣規範】
+{tone_lines}
+
+評分規則：
+- should_advance = true：學生回答達到此步驟的 advance_when 條件
+- should_advance = false：學生還沒達到，繼續同一步驟引導
+- should_terminate = true：
+  (a) 步驟 4 學生選對了（rescue 成功），或
+  (b) 步驟 5 完成（已直接教學），或
+  (c) 連續 {give_up_threshold} 次 give_up_detected=true
+- give_up_detected = true：學生說「不知道」「隨便」「我不會」「放棄」等敷衍或放棄詞
+- reasoning 欄位：必填。說明為什麼你設定了 should_advance / should_terminate 這樣的值
+
+絕對禁止：
+- 不可直接給答案，除非到了步驟 5
+- 不可說「答案是 X」直到 step 5
+- 不可讓學生答錯也 should_advance=true（即使他很接近）
+- 不可在 AI 出錯時讓 should_advance=true（錯誤降級必須 should_advance=false）"""

--- a/backend/app/services/rescue_session_store.py
+++ b/backend/app/services/rescue_session_store.py
@@ -1,0 +1,94 @@
+"""
+rescue_session_store.py — In-memory session store for MCQ Rescue dialogues.
+
+Extracted from mcq_rescue_agent.py (Issue #1887).
+Mirrors SessionStore from socratic_agent.py.
+
+Key: mcq_rescue_{user_id}_{question_id}
+TTL: 30 minutes
+Rate limit: 30 requests / 60 seconds per session
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+
+
+# ---------------------------------------------------------------------------
+# Session State dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RescueSessionState:
+    session_id: str
+    user_id: int
+    question_id: str
+    lesson_id: str
+    wrong_choice: str
+    question_text: str
+    correct_answer: str
+    strategy_type: str | None
+    # SOP state
+    current_step: int = 1          # 1-5
+    conversation: list[dict] = field(default_factory=list)   # {role, text}
+    consecutive_errors: int = 0
+    give_up_count: int = 0         # consecutive "不知道" / "我不會"
+    created_at: float = field(default_factory=time.time)
+    is_terminated: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Session Store
+# ---------------------------------------------------------------------------
+
+class RescueSessionStore:
+    """In-memory session store for MCQ rescue dialogues.
+
+    Mirrors SessionStore from socratic_agent.py.
+    Key: mcq_rescue_{user_id}_{question_id}
+    TTL: 30 minutes (same as Socratic agent)
+    Rate limit: 30 requests / 60 seconds per session
+    """
+
+    TTL_SECONDS = 30 * 60
+    RATE_LIMIT = 30
+    RATE_WINDOW = 60
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, RescueSessionState] = {}
+        self._rate_counts: dict[str, list[float]] = {}
+
+    @staticmethod
+    def make_key(user_id: int, question_id: str) -> str:
+        return f"mcq_rescue_{user_id}_{question_id}"
+
+    def get(self, session_id: str) -> RescueSessionState | None:
+        self._cleanup()
+        return self._sessions.get(session_id)
+
+    def save(self, state: RescueSessionState) -> None:
+        self._sessions[state.session_id] = state
+
+    def delete(self, session_id: str) -> None:
+        self._sessions.pop(session_id, None)
+
+    def check_rate_limit(self, session_id: str) -> bool:
+        """Return True if rate limit exceeded."""
+        now = time.time()
+        timestamps = self._rate_counts.get(session_id, [])
+        timestamps = [t for t in timestamps if now - t < self.RATE_WINDOW]
+        if len(timestamps) >= self.RATE_LIMIT:
+            return True
+        timestamps.append(now)
+        self._rate_counts[session_id] = timestamps
+        return False
+
+    def _cleanup(self) -> None:
+        now = time.time()
+        expired = [
+            sid for sid, s in self._sessions.items()
+            if now - s.created_at > self.TTL_SECONDS
+        ]
+        for sid in expired:
+            del self._sessions[sid]

--- a/backend/app/services/rescue_state_machine.py
+++ b/backend/app/services/rescue_state_machine.py
@@ -1,0 +1,79 @@
+"""
+rescue_state_machine.py — State transition logic for MCQ Rescue sessions.
+
+Extracted from mcq_rescue_agent.py (Issue #1887).
+Handles give-up counting, step advancement, and termination decisions.
+"""
+
+from __future__ import annotations
+
+from .rescue_session_store import RescueSessionState
+
+
+def _fallback_prompt(step: int) -> str:
+    """Return a step-appropriate fallback prompt for AI error scenarios."""
+    fallbacks = {
+        1: "你能說說看，這題在問什麼嗎？",
+        2: "課文裡哪一段和這個問題有關？",
+        3: "你能用自己的話說說那段在講什麼嗎？",
+        4: "那 A/B/C/D 哪個選項符合你剛才說的？",
+        5: "我們一起來看一下答案好了。",
+    }
+    return fallbacks.get(step, fallbacks[1])
+
+
+def apply_state_transitions(
+    state: RescueSessionState,
+    give_up_detected: bool,
+    should_advance: bool,
+    should_terminate: bool,
+    returned_step: int,
+    reasoning: str,
+    give_up_threshold: int = 3,
+) -> tuple[bool, bool, int, str]:
+    """Apply all state machine transitions for a rescue session turn.
+
+    Handles:
+      1. give_up_count increment / reset
+      2. Auto-skip to step 5 on give_up_threshold reached
+      3. Step advancement when criteria met
+      4. Termination when step 5 + should_advance
+
+    Args:
+        state: Current session state (mutated in place).
+        give_up_detected: Whether the AI detected a give-up response.
+        should_advance: Whether the AI says the student met advance criteria.
+        should_terminate: Whether the AI says to terminate.
+        returned_step: The step number returned by the AI.
+        reasoning: Audit reasoning string (may be appended to).
+        give_up_threshold: Consecutive give-up count that triggers step 5.
+
+    Returns:
+        (should_advance, should_terminate, final_step, reasoning) after transitions.
+    """
+    # 1. Update give_up_count
+    if give_up_detected:
+        state.give_up_count += 1
+    else:
+        state.give_up_count = 0  # Reset on real answer
+
+    # 2. Auto-skip to step 5 if give-up threshold reached
+    if state.give_up_count >= give_up_threshold:
+        returned_step = 5
+        should_advance = False
+        should_terminate = False  # Let step 5 run first, then terminate
+        reasoning = reasoning + " [Give-up threshold reached — advancing to step 5 direct teach]"
+
+    # 3. Advance step if criteria met
+    if should_advance and returned_step == state.current_step and state.current_step < 5:
+        state.current_step += 1
+        returned_step = state.current_step
+
+    # 4. If step 5 is active and should_advance, terminate
+    if state.current_step == 5 and should_advance:
+        should_terminate = True
+
+    # 5. Clamp step to valid range
+    state.current_step = max(1, min(5, returned_step))
+
+    return should_advance, should_terminate, state.current_step, reasoning

--- a/backend/tests/test_mcq_rescue_split_1887.py
+++ b/backend/tests/test_mcq_rescue_split_1887.py
@@ -1,0 +1,359 @@
+"""
+TDD unit tests for mcq_rescue_agent.py split (Issue #1887).
+
+Tests target the behaviour that must be preserved after splitting into:
+  - rescue_session_store.py
+  - rescue_state_machine.py
+  - rescue_prompt_builder.py
+
+Three required tests (per issue spec):
+  1. start_session_is_idempotent_and_returns_last_ai_message
+  2. ai_error_fallback_never_advances_or_terminates
+  3. three_give_ups_moves_to_step_five_without_terminating_immediately
+
+Run with:
+    cd backend && python -m pytest tests/test_mcq_rescue_split_1887.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import os
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from google.genai import errors as genai_errors
+
+from app.services.mcq_rescue_agent import (
+    McqRescueAgent,
+    RescueSessionState,
+    RescueSessionStore,
+    _store,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+FAKE_USER_ID = 77
+BASE_KWARGS = dict(
+    lesson_id="G6-L23",
+    wrong_choice="B",
+    question_text="本文主要在說什麼？",
+    correct_answer="D",
+    strategy_type="summary_psr",
+)
+
+
+def _fresh_agent() -> McqRescueAgent:
+    """Return an agent instance. (module singleton is also fine — tests clean up store.)"""
+    return McqRescueAgent()
+
+
+def _make_api_error(msg: str = "Simulated error") -> genai_errors.APIError:
+    return genai_errors.APIError(429, {"error": {"message": msg}})
+
+
+def _good_ai_result(step: int = 1, advance: bool = False) -> dict:
+    return {
+        "ai_feedback": "好，讓我們繼續。",
+        "next_question": "你能說說嗎？",
+        "should_advance": advance,
+        "should_terminate": False,
+        "give_up_detected": False,
+        "current_step": step,
+        "reasoning": "Student engaged normally.",
+    }
+
+
+def _give_up_ai_result(step: int = 1) -> dict:
+    return {
+        "ai_feedback": "沒關係，換個方式。",
+        "next_question": "試試看嗎？",
+        "should_advance": False,
+        "should_terminate": False,
+        "give_up_detected": True,
+        "current_step": step,
+        "reasoning": "Student signalled give-up.",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clean_store():
+    """Reset module-level session store before every test."""
+    _store._sessions.clear()
+    _store._rate_counts.clear()
+    yield
+    _store._sessions.clear()
+    _store._rate_counts.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: start_session is idempotent and returns the last AI message
+# ---------------------------------------------------------------------------
+
+class TestStartSessionIdempotent:
+    """start_session called twice for the same user+question must:
+       - NOT overwrite the existing session
+       - return the last AI message from conversation history (not blank)
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_session_is_idempotent_and_returns_last_ai_message(self):
+        """Reload never shows a blank bubble — returns last AI turn text."""
+        agent = _fresh_agent()
+        question_id = "Q-idem-1887"
+
+        # First call — creates a new session
+        session_id, first_response = await agent.start_session(
+            user_id=FAKE_USER_ID,
+            question_id=question_id,
+            **BASE_KWARGS,
+        )
+        assert first_response.ai_feedback, "First response must have non-empty ai_feedback"
+
+        # Manually advance conversation to simulate a real dialogue
+        state = _store.get(session_id)
+        assert state is not None
+        last_ai_text = "你說得不錯！那課文哪一段提到這個？"
+        state.conversation.append({"role": "student", "text": "文章講的是主題"})
+        state.conversation.append({"role": "ai", "text": last_ai_text})
+        state.current_step = 2
+        _store.save(state)
+
+        # Second call (idempotent resume)
+        session_id2, resume_response = await agent.start_session(
+            user_id=FAKE_USER_ID,
+            question_id=question_id,
+            **BASE_KWARGS,
+        )
+
+        assert session_id2 == session_id, "Idempotent: must return same session_id"
+        assert resume_response.ai_feedback == last_ai_text, (
+            f"Must return last AI message {last_ai_text!r}, got {resume_response.ai_feedback!r}"
+        )
+        assert resume_response.current_step == 2, "Must preserve current_step from existing state"
+        assert resume_response.should_advance is False, "Resume must not set should_advance=True"
+        assert resume_response.should_terminate is False, "Resume must not terminate"
+
+        # Session state must be unchanged (not reset)
+        final_state = _store.get(session_id)
+        assert final_state is not None
+        assert final_state.current_step == 2, "Store state must not be reset by idempotent call"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: AI error fallback never advances or terminates (fail-closed)
+# ---------------------------------------------------------------------------
+
+class TestAiErrorFallbackFailClosed:
+    """On AI error, process_response must return:
+       - should_advance = False  (NEVER auto-pass a student)
+       - should_terminate = False (keep session alive for retry)
+
+    This is the fail-closed guarantee from the architecture docstring.
+    """
+
+    def _seed_state(self, question_id: str) -> str:
+        session_id = RescueSessionStore.make_key(FAKE_USER_ID, question_id)
+        state = RescueSessionState(
+            session_id=session_id,
+            user_id=FAKE_USER_ID,
+            question_id=question_id,
+            lesson_id="G6-L23",
+            wrong_choice="B",
+            question_text="本文主要在說什麼？",
+            correct_answer="D",
+            strategy_type="summary_psr",
+        )
+        state.conversation.append({"role": "ai", "text": "Opening."})
+        _store.save(state)
+        return session_id
+
+    @pytest.mark.asyncio
+    async def test_ai_error_fallback_never_advances_or_terminates(self):
+        """Fail-closed: APIError → should_advance=False, should_terminate=False."""
+        agent = _fresh_agent()
+        session_id = self._seed_state("Q-fail-closed-1887")
+
+        with patch(
+            "app.services.mcq_rescue_agent.generate_structured_response",
+            new_callable=AsyncMock,
+            side_effect=_make_api_error("Quota exceeded"),
+        ):
+            response = await agent.process_response(
+                session_id=session_id,
+                student_text="我不確定",
+            )
+
+        assert response.should_advance is False, (
+            "CRITICAL: should_advance must be False on AI error — "
+            "auto-passing students on error is catastrophic"
+        )
+        assert response.should_terminate is False, (
+            "should_terminate must be False on AI error — "
+            "session must stay alive for the student to retry"
+        )
+        assert response.ai_feedback, "Fallback must provide a non-empty ai_feedback"
+        assert response.reasoning, "Fallback must provide a non-empty reasoning for audit"
+
+    @pytest.mark.asyncio
+    async def test_ai_error_fallback_on_asyncio_timeout(self):
+        """asyncio.TimeoutError is also an AI-layer error — same fail-closed behaviour."""
+        agent = _fresh_agent()
+        session_id = self._seed_state("Q-timeout-1887")
+
+        with patch(
+            "app.services.mcq_rescue_agent.generate_structured_response",
+            new_callable=AsyncMock,
+            side_effect=asyncio.TimeoutError(),
+        ):
+            response = await agent.process_response(
+                session_id=session_id,
+                student_text="嗯",
+            )
+
+        assert response.should_advance is False
+        assert response.should_terminate is False
+
+    @pytest.mark.asyncio
+    async def test_ai_error_does_not_reset_step(self):
+        """AI error must not change current_step — student stays at same step."""
+        agent = _fresh_agent()
+        question_id = "Q-step-lock-1887"
+        session_id = RescueSessionStore.make_key(FAKE_USER_ID, question_id)
+        state = RescueSessionState(
+            session_id=session_id,
+            user_id=FAKE_USER_ID,
+            question_id=question_id,
+            lesson_id="G6-L23",
+            wrong_choice="B",
+            question_text="本文主要在說什麼？",
+            correct_answer="D",
+            strategy_type="summary_psr",
+            current_step=3,   # Already at step 3
+        )
+        state.conversation.append({"role": "ai", "text": "Step 3 prompt."})
+        _store.save(state)
+
+        with patch(
+            "app.services.mcq_rescue_agent.generate_structured_response",
+            new_callable=AsyncMock,
+            side_effect=_make_api_error(),
+        ):
+            response = await agent.process_response(
+                session_id=session_id,
+                student_text="不知道",
+            )
+
+        assert response.current_step == 3, (
+            f"AI error must not change current_step; expected 3, got {response.current_step}"
+        )
+        assert response.should_advance is False
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Three give-ups moves to step 5 without terminating immediately
+# ---------------------------------------------------------------------------
+
+class TestThreeGiveUpsDirectTeach:
+    """After 3 consecutive give-up responses, the agent must:
+       - Advance current_step to 5 (direct-teach path)
+       - NOT terminate immediately (step 5 must run first)
+
+    This matches the give_up_count >= GIVE_UP_THRESHOLD logic in process_response.
+    """
+
+    def _seed_state(self, question_id: str, current_step: int = 1) -> str:
+        session_id = RescueSessionStore.make_key(FAKE_USER_ID, question_id)
+        state = RescueSessionState(
+            session_id=session_id,
+            user_id=FAKE_USER_ID,
+            question_id=question_id,
+            lesson_id="G6-L23",
+            wrong_choice="B",
+            question_text="本文主要在說什麼？",
+            correct_answer="D",
+            strategy_type="summary_psr",
+            current_step=current_step,
+        )
+        state.conversation.append({"role": "ai", "text": "Opening."})
+        _store.save(state)
+        return session_id
+
+    @pytest.mark.asyncio
+    async def test_three_give_ups_moves_to_step_five_without_terminating_immediately(self):
+        """3 consecutive give-ups → current_step jumps to 5, should_terminate stays False."""
+        agent = _fresh_agent()
+        session_id = self._seed_state("Q-giveup-1887")
+
+        give_up_result = _give_up_ai_result(step=1)
+
+        with patch(
+            "app.services.mcq_rescue_agent.generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=give_up_result,
+        ):
+            # Give-up 1
+            r1 = await agent.process_response(session_id=session_id, student_text="不知道")
+            assert r1.give_up_detected is True
+            # Should NOT be at step 5 yet (only 1 give-up)
+            state_after_1 = _store.get(session_id)
+            assert state_after_1.give_up_count == 1
+
+            # Give-up 2
+            r2 = await agent.process_response(session_id=session_id, student_text="我不會")
+            assert r2.give_up_detected is True
+            state_after_2 = _store.get(session_id)
+            assert state_after_2.give_up_count == 2
+
+            # Give-up 3 — threshold reached
+            r3 = await agent.process_response(session_id=session_id, student_text="隨便")
+
+        assert r3.give_up_detected is True, "Third give-up must still set give_up_detected=True"
+        assert r3.current_step == 5, (
+            f"After 3 give-ups, current_step must jump to 5 (direct-teach). Got {r3.current_step}"
+        )
+        assert r3.should_terminate is False, (
+            "Must NOT terminate immediately on 3rd give-up — step 5 direct-teach must run first"
+        )
+        # Verify state was persisted correctly
+        final_state = _store.get(session_id)
+        assert final_state is not None
+        assert final_state.current_step == 5
+
+    @pytest.mark.asyncio
+    async def test_give_up_count_resets_on_real_answer(self):
+        """give_up_count resets to 0 when a student gives a real (non-give-up) answer."""
+        agent = _fresh_agent()
+        session_id = self._seed_state("Q-giveup-reset-1887")
+
+        # Two give-ups
+        with patch(
+            "app.services.mcq_rescue_agent.generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=_give_up_ai_result(step=1),
+        ):
+            await agent.process_response(session_id=session_id, student_text="不知道")
+            await agent.process_response(session_id=session_id, student_text="我不會")
+
+        state = _store.get(session_id)
+        assert state.give_up_count == 2
+
+        # Real answer — count resets
+        with patch(
+            "app.services.mcq_rescue_agent.generate_structured_response",
+            new_callable=AsyncMock,
+            return_value=_good_ai_result(step=1),
+        ):
+            await agent.process_response(session_id=session_id, student_text="文章在講摘要策略")
+
+        state = _store.get(session_id)
+        assert state.give_up_count == 0, (
+            f"give_up_count must reset to 0 after real answer; got {state.give_up_count}"
+        )
+        assert state.current_step < 5, "Step must not jump to 5 after real answer"


### PR DESCRIPTION
Fixes #1887

## Summary

- Extract `RescueSessionState` + `RescueSessionStore` (TTL, rate-limit) → `rescue_session_store.py` (94L)
- Extract give-up counting, step advancement, termination logic → `rescue_state_machine.py` (79L)
- Extract Gemini system prompt construction → `rescue_prompt_builder.py` (88L)
- `McqRescueAgent` in `mcq_rescue_agent.py` now orchestrates LLM calls only (563L → 410L)
- All existing imports from `mcq_rescue_agent` remain valid (re-exported via `__all__`)

## TDD evidence (6 new unit tests — all pass on current code first)

```
tests/test_mcq_rescue_split_1887.py::TestStartSessionIdempotent::test_start_session_is_idempotent_and_returns_last_ai_message PASSED
tests/test_mcq_rescue_split_1887.py::TestAiErrorFallbackFailClosed::test_ai_error_fallback_never_advances_or_terminates PASSED
tests/test_mcq_rescue_split_1887.py::TestAiErrorFallbackFailClosed::test_ai_error_fallback_on_asyncio_timeout PASSED
tests/test_mcq_rescue_split_1887.py::TestAiErrorFallbackFailClosed::test_ai_error_does_not_reset_step PASSED
tests/test_mcq_rescue_split_1887.py::TestThreeGiveUpsDirectTeach::test_three_give_ups_moves_to_step_five_without_terminating_immediately PASSED
tests/test_mcq_rescue_split_1887.py::TestThreeGiveUpsDirectTeach::test_give_up_count_resets_on_real_answer PASSED
```

Total: **38 passed** (32 existing + 6 new)

## Test plan

- [x] Existing `test_mcq_rescue_endpoints.py` 32 tests all green
- [x] New `test_mcq_rescue_split_1887.py` 6 unit tests green
- [x] No changes to routes, API contract, or DB schema