### PR TITLE
refactor(lesson): split lesson_loader.py into focused modules (Fixes #1889)

### DIFF
--- a/backend/app/services/lesson_code_normalization.py
+++ b/backend/app/services/lesson_code_normalization.py
@@ -1,0 +1,149 @@
+"""
+Lesson code normalization: static override maps + manifest code normalization.
+
+Extracted from lesson_loader.py (Issue #1889).
+
+Public API:
+    CATALOG_TO_PARSED_OVERRIDE   — exported dict (public name, no underscore prefix)
+    MULTI_LESSON_PRIMARY         — exported dict
+    MULTI_LESSON_MAP             — exported dict
+    normalize_manifest_code()    — public wrapper (preferred by new callers)
+    halfwidth()                  — public wrapper
+
+Internal aliases (_CATALOG_TO_PARSED_OVERRIDE etc.) are re-exported for
+backward compatibility with existing tests that import the underscore names
+directly from lesson_loader.
+"""
+
+import re
+
+
+# ---------------------------------------------------------------------------
+# Character normalization
+# ---------------------------------------------------------------------------
+
+def halfwidth(code: str) -> str:
+    """Convert fullwidth ASCII letters (Ａ-Ｚ, ａ-ｚ) to halfwidth (A-Z, a-z).
+
+    YAML fill_in_blank answers are sometimes typed as fullwidth (Ａ, Ｂ…)
+    while vocab_bank keys are always halfwidth (A, B…), causing mismatches.
+    """
+    return "".join(
+        chr(ord(c) - 0xFEE0) if 0xFF01 <= ord(c) <= 0xFF5E else c
+        for c in (code or "")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manifest code normalization
+# ---------------------------------------------------------------------------
+
+def normalize_manifest_code(code: str) -> str:
+    """Normalize curriculum manifest lesson_code to match _parsed/*.yml lesson_code format.
+
+    Examples:
+        G4-L01  -> G4-L1
+        G4-L03a -> G4-L3a
+        WW-L01  -> 文-L1
+    """
+    if code.startswith("WW-"):
+        m = re.search(r"L(\d+)", code)
+        if m:
+            return f"文-L{int(m.group(1))}"
+        return code
+    m = re.match(r"(G\d+)-L(\d+)(.*)", code)
+    if m:
+        grade_part = m.group(1)
+        num = int(m.group(2))
+        suffix = m.group(3)  # '', 'a', 'b'
+        return f"{grade_part}-L{num}{suffix}"
+    return code
+
+
+# ---------------------------------------------------------------------------
+# Multi-lesson YAML edge-case maps
+# ---------------------------------------------------------------------------
+
+# Curriculum slots that are covered by a multi-lesson YAML.
+#
+# Primary slots: curriculum code → compound lesson_code in parsed YAML
+#   (these are loaded and exposed under the primary curriculum code)
+# Secondary slots: curriculum code → compound lesson_code in parsed YAML
+#   (these are skipped — content is accessible via the primary slot)
+MULTI_LESSON_PRIMARY: dict[str, str] = {
+    "G4-L20": "G4-L20-22",
+    "G5-L24": "G5-L24-25",
+    "G9-L15": "G9-L15-16",
+    "G9-L17": "G9-L17-19",
+}
+
+MULTI_LESSON_MAP: dict[str, str] = {
+    "G4-L21": "G4-L20-22",
+    "G4-L22": "G4-L20-22",
+    "G5-L25": "G5-L24-25",
+    "G9-L16": "G9-L15-16",
+    "G9-L18": "G9-L17-19",
+    "G9-L19": "G9-L17-19",
+}
+
+
+# ---------------------------------------------------------------------------
+# Catalog→parsed override maps
+# ---------------------------------------------------------------------------
+
+# Catalog code → parsed YAML lesson_code overrides (#1669).
+#
+# Two distinct correction patterns covered here:
+#
+# 1. G8 catalog↔Layer-2 offset (5 課): catalog uses curriculum sub-letter
+#    numbering (G8-L03a/03b/04/05/...), Layer-2 uses sequential parse-order
+#    (G8-L1/L2/L3/...). The default normalize_manifest_code produces the
+#    wrong file (e.g. G8-L04 → G8-L4 = 植物肉, real story is G8-L5 = 玻璃娃娃).
+#
+# 2. G8 a/b sub-letter (8 課): each catalog a/b code maps to its own
+#    distinct Layer-2 file (a/b are SEPARATE stories, NOT shared content).
+#    This replaces the older _AB_SECONDARY_MAP design which incorrectly
+#    assumed a/b sub-letters share one parsed file.
+#
+# 3. G7-L31 (1 課): shares Layer-2 G7-L23 (multi-text 第一篇/第二篇).
+CATALOG_TO_PARSED_OVERRIDE: dict[str, str] = {
+    # Category A: G8 offset (#1669) — catalog uses curriculum sub-letter
+    # numbering, Layer-2 uses sequential parse-order. The offset grows by 1
+    # each time an a/b split occurs in the curriculum.
+    "G8-L4": "G8-L5",    # 好心沒好報玻璃娃娃 (catalog G8-L04 after normalize)
+    "G8-L5": "G8-L6",    # 戲院賭場檳榔攤 (catalog G8-L05 after normalize)
+    "G8-L7": "G8-L9",    # 讓黑猩猩被看見 (catalog G8-L07 after normalize)
+    "G8-L8": "G8-L10",   # 按讚背後的真相 (catalog G8-L08 after normalize)
+    "G8-L10": "G8-L13",  # 構樹 (catalog G8-L10 after normalize)
+    "G8-L11": "G8-L14",  # 蝴蝶蘭花期密碼 (catalog G8-L11 after normalize)
+    "G8-L13": "G8-L17",  # 我能不能選擇告別方式 (catalog G8-L13 after normalize)
+    "G8-L14": "G8-L18",  # 石虎保育 (catalog G8-L14 after normalize)
+    "G8-L15": "G8-L19",  # 核能的兩難抉擇 (catalog G8-L15 after normalize)
+    # Category B: G8 sub-letter (each a/b has own parsed file)
+    "G8-L3a": "G8-L3",   # 集中營的一門課
+    "G8-L3b": "G8-L4",   # 新奇植物肉
+    "G8-L6a": "G8-L7",   # 讓你口中的甜蜜
+    "G8-L6b": "G8-L8",   # 隱形的征服者
+    "G8-L9a": "G8-L11",  # 虎襲事件的真相
+    "G8-L9b": "G8-L12",  # 語言的足跡
+    "G8-L12a": "G8-L15", # 球場上的另類指揮家
+    "G8-L12b": "G8-L16", # 我的阿嬤
+    # Category C: G7-L31 (旅人鴿 = 第二篇 of G7-L23 multi-text docx)
+    "G7-L31": "G7-L23",
+}
+
+# Legacy: kept for backward compat; superseded by CATALOG_TO_PARSED_OVERRIDE.
+# G8-L*b entries are now correctly routed to their own Layer-2 files (not
+# shared with the a slot). Other entries here remain inert.
+AB_SECONDARY_MAP: dict[str, str] = {}
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat underscore aliases (used by lesson_loader.py internally
+# and by tests that import private names directly from lesson_loader)
+# ---------------------------------------------------------------------------
+
+_MULTI_LESSON_PRIMARY = MULTI_LESSON_PRIMARY
+_MULTI_LESSON_MAP = MULTI_LESSON_MAP
+_CATALOG_TO_PARSED_OVERRIDE = CATALOG_TO_PARSED_OVERRIDE
+_AB_SECONDARY_MAP = AB_SECONDARY_MAP

--- a/backend/app/services/lesson_indexes.py
+++ b/backend/app/services/lesson_indexes.py
@@ -1,0 +1,103 @@
+"""
+Lesson in-memory indexes: build and expose the singleton lesson collections.
+
+Extracted from lesson_loader.py (Issue #1889).
+
+Public API:
+    build_all_lessons()  — load + merge + sort all lessons from both layers
+    build_indexes()      — construct all lookup dicts from a lesson list
+
+These are called once at module load time by lesson_loader.py (and directly
+by tests that need to verify index construction in isolation).
+"""
+
+from app.services.lesson_layer_loaders import (
+    ENRICHMENT_FIELDS,
+    load_curriculum_manifest,
+    load_layer1_lessons,
+    load_layer2_lessons,
+    build_layer2_enrichment_index,
+)
+
+
+def build_all_lessons() -> list[dict]:
+    """Load all lessons from both layers and return sorted by display_order / lesson_number.
+
+    Merge strategy:
+      1. Load Layer-1 (L*.yml, 57 lessons with integer IDs 1-57)
+      2. Load Layer-2 (_parsed_2026-05-01/*.yml, deduped by title)
+      3. Enrich Layer-1 entries with truthy fields from matching Layer-2 parsed files
+      4. Sort: Layer-1 by lesson_number, Layer-2 by display_order
+    """
+    manifest_index = load_curriculum_manifest()
+
+    # Layer 1: existing production L*.yml
+    layer1 = load_layer1_lessons()
+    layer1_titles = {lesson["title"] for lesson in layer1}
+
+    # Layer 2: new parsed lessons (title-deduped against Layer-1)
+    layer2 = load_layer2_lessons(manifest_index, layer1_titles)
+
+    # Merge Layer-2 enrichment into Layer-1 entries with matching title (#1666).
+    #
+    # Problem: when a curriculum slot has BOTH a Layer-1 L*.yml (legacy, no
+    # step_sequence) AND a Layer-2 _parsed_/G*-L*.yml (new SOT with
+    # step_sequence + worksheet_* + lesson_intro + layout_mode), load_layer2_lessons()
+    # skips the Layer-2 entry on title match to avoid duplicate cards. Result:
+    # /api/stories/G6-L10 resolves to Layer-1 entry with step_sequence=null.
+    #
+    # Fix: build a title→Layer-2 lookup from _parsed_ files (regardless of
+    # whether the Layer-2 entry was kept after dedup), then copy the enrichment
+    # fields onto matching Layer-1 entries. Layer-1 keeps its id/lesson_number
+    # /title/paragraphs (preserves DB Text FK + session.story_slug back-compat).
+    layer2_by_title = build_layer2_enrichment_index()
+
+    for lesson in layer1:
+        l2_data = layer2_by_title.get(lesson["title"])
+        if not l2_data:
+            continue
+        for field in ENRICHMENT_FIELDS:
+            l2_value = l2_data.get(field)
+            # strategy_exercise: Layer-2 may use plural key (legacy G7 圖文整合)
+            if field == "strategy_exercise" and l2_value is None:
+                l2_value = l2_data.get("strategy_exercises")
+            if l2_value:  # only override when Layer-2 has a truthy value
+                lesson[field] = l2_value
+
+    all_lessons = layer1 + layer2
+
+    # Sort: Layer-1 by lesson_number, Layer-2 by display_order, then mix.
+    # Use display_order from manifest for Layer-2; for Layer-1 use lesson_number as proxy.
+    def sort_key(lesson: dict) -> tuple[int, int]:
+        if lesson["_layer"] == 1:
+            # Layer-1 lessons map to curriculum display_order via manifest.
+            # For simplicity, sort them by lesson_number (1-57) at the front.
+            return (0, lesson["lesson_number"])
+        else:
+            return (1, lesson.get("display_order", 9999))
+
+    all_lessons.sort(key=sort_key)
+    return all_lessons
+
+
+def build_indexes(all_lessons: list[dict]) -> tuple[
+    dict[int, dict],
+    dict[str, dict],
+    dict[str, dict],
+    list[int],
+]:
+    """Build all lookup indexes from the full lesson list.
+
+    Returns:
+        lessons_by_id    — {id: lesson}
+        lessons_by_code  — {lesson_code: lesson}
+        lessons_by_title — {title: lesson}
+        available_grades — sorted list of unique grade ints
+    """
+    lessons_by_id: dict[int, dict] = {l["id"]: l for l in all_lessons}
+    lessons_by_code: dict[str, dict] = {
+        l["lesson_code"]: l for l in all_lessons if l.get("lesson_code")
+    }
+    lessons_by_title: dict[str, dict] = {l["title"]: l for l in all_lessons}
+    available_grades: list[int] = sorted({l["grade"] for l in all_lessons})
+    return lessons_by_id, lessons_by_code, lessons_by_title, available_grades

--- a/backend/app/services/lesson_layer_loaders.py
+++ b/backend/app/services/lesson_layer_loaders.py
@@ -1,0 +1,424 @@
+"""
+Lesson layer loaders: I/O for Layer-1 (L*.yml) and Layer-2 (_parsed_2026-05-01/*.yml).
+
+Extracted from lesson_loader.py (Issue #1889).
+
+Public API:
+    GENRE_TO_CATEGORY    — static genre→display category map
+    ENRICHMENT_FIELDS    — tuple of field names merged from Layer-2 into Layer-1
+    build_intro()        — construct intro dict from raw lesson data
+    normalize_fill_in_blank_item()  — tag and normalize fill_in_blank items
+    load_curriculum_manifest()      — load manifest.yml → code→meta index
+    load_layer1_lessons()           — load production L*.yml lessons
+    load_layer2_lessons()           — load _parsed_2026-05-01/*.yml lessons
+    build_layer2_enrichment_index() — build title→Layer-2 data dict for enrichment
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+from app.services.lesson_code_normalization import (
+    halfwidth,
+    normalize_manifest_code,
+    MULTI_LESSON_PRIMARY,
+    MULTI_LESSON_MAP,
+    CATALOG_TO_PARSED_OVERRIDE,
+    AB_SECONDARY_MAP,
+)
+
+
+# ---------------------------------------------------------------------------
+# Paths (must match lesson_loader.py)
+# ---------------------------------------------------------------------------
+
+_LESSONS_DIR = Path(__file__).parent.parent.parent / "data" / "lessons"
+_PARSED_DIR = _LESSONS_DIR / "_parsed_2026-05-01"
+_CURRICULUM_MANIFEST = Path(__file__).parent.parent.parent / "data" / "curriculum" / "manifest.yml"
+
+# Offset added to curriculum display_order to generate synthetic integer IDs
+# for Layer-2 lessons (avoids collision with Layer-1 ids 1–57).
+LAYER2_ID_OFFSET = 1000
+
+
+# ---------------------------------------------------------------------------
+# Static maps
+# ---------------------------------------------------------------------------
+
+GENRE_TO_CATEGORY: dict[str, str] = {
+    "記敘文": "Fable",
+    "說明文": "Science",
+    "説明文": "Science",
+    "議論文": "History",
+    "文言文": "History",
+    "應用文": "Daily",
+}
+
+# Fields copied from Layer-2 parsed data onto matching Layer-1 entries (#1666).
+ENRICHMENT_FIELDS = (
+    "step_sequence",
+    "worksheet_section_order",
+    "worksheet_intro",
+    "lesson_intro",
+    "worksheet_pdf_url",
+    "layout_mode",
+    "reading_strategy_type",
+    "images",
+    "strategy_exercise",
+    "story_structure_table",
+    "story_structure_rows",
+    # 紙本表格 (#1685): some Layer-2 lessons (G7-L28, G7-L30) carry extracted
+    # tables; copy onto matching Layer-1 entries to preserve back-compat.
+    "tables",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def normalize_fill_in_blank_item(item: dict) -> dict:
+    """Normalize a fill_in_blank item, tagging new-format items for frontend detection.
+
+    Two schemas coexist in the data:
+      Legacy (Layer-1 / old parsed):
+        { sentence: "孟嘗君（　　）逃離秦國。", answer: "A" }
+        answer is a letter code that matches a vocab_bank key.
+
+      New-format (5/1 curriculum batch, Layer-2):
+        { id, answer: "模仿雞叫", context_before: "...", context_after: "...",
+          context_paragraph_idx: N }
+        answer is freetext (strategy worksheet cloze), NOT a vocab_bank letter code.
+
+    FillInBlankExercise.tsx expects legacy format: item.sentence (string) and
+    item.answer (letter code matching vocab_bank). New-format items cannot be used
+    with the current exercise component because answers are freetext, not letter codes.
+
+    This function:
+    1. Synthesizes a sentence string for new-format items (context_before + blank + context_after)
+       so the sentence text is available for future exercise types.
+    2. Adds _schema flag to distinguish schema types without fragile duck-typing in callers.
+
+    Frontend api.ts filters by _schema: items with _schema="context_fill" are dropped
+    from fillInBlank → hasData=false → NoDataFallback renders (correct for 6/1 demo).
+    When a proper cloze exercise component is built, this flag enables clean routing.
+
+    Related: #1559, #1563
+    """
+    if "context_before" in item and "sentence" not in item:
+        before = item.get("context_before") or ""
+        after = item.get("context_after") or ""
+        return {**item, "sentence": f"{before}（　　）{after}", "_schema": "context_fill"}
+    # Legacy format: no change needed, but tag it too for symmetry.
+    return {**item, "_schema": "legacy"}
+
+
+def build_intro(lesson: dict) -> dict:
+    """Replicate frontend lessonLoader.ts intro construction."""
+    genre = lesson.get("genre", "")
+    strategy = lesson.get("reading_strategy")
+
+    author = genre
+    if strategy and strategy != "無":
+        author = f"{genre} · {strategy}"
+
+    paragraphs = lesson.get("paragraphs", [])
+    background = ""
+    if paragraphs:
+        p = paragraphs[0]
+        background = p[:100] + "..." if len(p) > 100 else p
+
+    return {"author": author, "background": background}
+
+
+# ---------------------------------------------------------------------------
+# Curriculum manifest loader
+# ---------------------------------------------------------------------------
+
+def load_curriculum_manifest() -> dict[str, dict]:
+    """Load curriculum/manifest.yml and return a dict keyed by normalized lesson_code.
+
+    Returns {} if the manifest file does not exist.
+    """
+    if not _CURRICULUM_MANIFEST.exists():
+        return {}
+
+    with open(_CURRICULUM_MANIFEST, "r", encoding="utf-8") as f:
+        manifest = yaml.safe_load(f)
+
+    index: dict[str, dict] = {}
+    for entry in manifest.get("lessons", []):
+        norm_code = normalize_manifest_code(entry["lesson_code"])
+        index[norm_code] = entry
+    return index
+
+
+# ---------------------------------------------------------------------------
+# Layer-1 loader
+# ---------------------------------------------------------------------------
+
+def load_layer1_lessons() -> list[dict]:
+    """Load existing production lessons: backend/data/lessons/L*.yml
+
+    These have integer lesson_number fields and form the original 57-lesson set.
+    """
+    lessons: list[dict] = []
+
+    if not _LESSONS_DIR.exists():
+        return lessons
+
+    for yml_path in sorted(_LESSONS_DIR.glob("L*.yml")):
+        with open(yml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+
+        if not data or "lesson_number" not in data:
+            continue
+
+        genre = data.get("genre", "")
+        strategy = data.get("reading_strategy")
+        if strategy == "無":
+            strategy = None
+
+        lesson = {
+            "id": data["lesson_number"],
+            "lesson_number": data["lesson_number"],
+            "lesson_code": data.get("grade_code", ""),  # e.g. "G4-1"
+            "title": data["title"],
+            "grade": data["grade"],
+            "grade_code": data.get("grade_code", ""),
+            "genre": genre,
+            "text_type": data.get("text_type", "單"),
+            "category": GENRE_TO_CATEGORY.get(genre, "Daily"),
+            "reading_strategy": strategy,
+            "paragraphs": data.get("paragraphs", []),
+            "full_text": data.get("story_text"),
+            "char_count": data.get("char_count", 0),
+            "thumbnail_url": (
+                f"https://storage.googleapis.com/lingoleap-assets/stories/"
+                f"thumbnails/lesson-{data['lesson_number']}.webp"
+            ),
+            "vocabulary": data.get("vocabulary") or [],
+            "fill_in_blank": [
+                {**normalize_fill_in_blank_item(item), "answer": halfwidth(item.get("answer", ""))}
+                for item in (data.get("fill_in_blank") or [])
+            ] or None,
+            "multiple_choice": data.get("multiple_choice"),
+            "vocab_bank": data.get("vocab_bank"),
+            "knowledge_video_url": data.get("knowledge_video_url"),
+            # Full video list (#1683) — for Layer-1 lessons, derive single-item
+            # list from knowledge_video_url if no explicit video_links field.
+            "video_links": data.get("video_links") or (
+                [{"title": "影片", "url": data["knowledge_video_url"]}]
+                if data.get("knowledge_video_url") else None
+            ),
+            "reading_benchmark": data.get("reading_benchmark"),
+            "source_file": data.get("source_file"),
+            "strategy_exercise": data.get("strategy_exercise"),
+            # Schema-driven step composition (#1374): pass through if present in YAML.
+            # None (absent) means frontend uses DEFAULT_STEP_SEQUENCE.
+            "step_sequence": data.get("step_sequence") or None,
+            "story_structure_table": data.get("story_structure_table"),
+            "story_structure_rows": data.get("story_structure_rows"),
+            # Plugin-pattern dispatch fields (#1404):
+            "reading_strategy_type": data.get("reading_strategy_type") or "general",
+            "layout_mode": data.get("layout_mode") or "standard",
+            # Image gallery for graphic-text layout (#1341)
+            "images": data.get("images") or [],
+            "intro": build_intro(data),
+            # 學習單 section order + intro metadata (#1434) — None for Layer-1
+            "worksheet_section_order": data.get("worksheet_section_order"),
+            "worksheet_intro": data.get("worksheet_intro"),
+            # Lesson intro (#1443): docx 說明/導讀 or excel fallback
+            "lesson_intro": data.get("lesson_intro"),
+            # Public PDF URL of the original 紙本學習單 (#1444)
+            "worksheet_pdf_url": data.get("worksheet_pdf_url"),
+            # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
+            "tables": data.get("tables"),
+            "_layer": 1,
+        }
+        lessons.append(lesson)
+
+    return lessons
+
+
+# ---------------------------------------------------------------------------
+# Layer-2 loader
+# ---------------------------------------------------------------------------
+
+def load_layer2_lessons(
+    manifest_index: dict[str, dict],
+    layer1_titles: set[str],
+) -> list[dict]:
+    """Load new parsed lessons from _parsed_2026-05-01/*.yml.
+
+    Assigns synthetic integer IDs using curriculum display_order + LAYER2_ID_OFFSET.
+    Skips lessons whose title already appears in Layer-1 (dedup).
+    Skips secondary multi-lesson and a/b slots (only the primary is exposed).
+    """
+    if not _PARSED_DIR.exists():
+        return []
+
+    # Build index: parsed lesson_code -> (data, path)
+    parsed_index: dict[str, tuple[dict, Path]] = {}
+    for yml_path in _PARSED_DIR.glob("*.yml"):
+        with open(yml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if data and data.get("lesson_code"):
+            parsed_index[data["lesson_code"]] = (data, yml_path)
+
+    lessons: list[dict] = []
+
+    for norm_code, meta in manifest_index.items():
+        # Skip secondary multi-lesson slots (covered by the primary)
+        if norm_code in MULTI_LESSON_MAP:
+            continue
+        # Skip secondary a/b slots (covered by the primary a-slot)
+        if norm_code in AB_SECONDARY_MAP:
+            continue
+
+        # Resolve which parsed YAML handles this curriculum slot
+        parsed_code = norm_code
+
+        # Multi-lesson primary: curriculum code → compound parsed YAML code
+        if norm_code in MULTI_LESSON_PRIMARY:
+            parsed_code = MULTI_LESSON_PRIMARY[norm_code]
+
+        # Catalog→parsed override (#1669): G8 offset + G8 a/b + G7-L31
+        if norm_code in CATALOG_TO_PARSED_OVERRIDE:
+            parsed_code = CATALOG_TO_PARSED_OVERRIDE[norm_code]
+
+        if parsed_code not in parsed_index:
+            # For a/b primary slots (e.g. G8-L3a), the parsed file is G8-L3 (no suffix)
+            # Try stripping trailing 'a' suffix → base code (e.g. G8-L3a → G8-L3)
+            base_code = re.sub(r"a$", "", parsed_code)
+            if base_code != parsed_code and base_code in parsed_index:
+                parsed_code = base_code
+            else:
+                # No parsed YAML available
+                continue
+
+        data, _ = parsed_index[parsed_code]
+
+        # Title: prefer catalog manifest title when a catalog→parsed override
+        # is in effect (#1669). This prevents catalog G7-L31 from displaying
+        # parsed G7-L23.yml's title (which would collide with G7-L23's own
+        # entry and confuse the lesson card UI).
+        if norm_code in CATALOG_TO_PARSED_OVERRIDE:
+            title = meta.get("title") or data.get("title", "")
+        else:
+            title = data.get("title", "")
+        # Deduplicate: if title already in Layer-1, skip
+        if title in layer1_titles:
+            continue
+
+        display_order = meta.get("display_order", 0)
+        lesson_id = LAYER2_ID_OFFSET + display_order
+
+        genre = data.get("genre", "")
+        strategy = data.get("reading_strategy") or meta.get("strategy_name")
+        if strategy in ("", "無", "general"):
+            strategy = None
+
+        # Grade: use manifest grade (authoritative). Parsed grade=0 for 文言文 → map to 8
+        grade = meta.get("grade") or data.get("grade") or 0
+        if grade == 0:
+            grade = 8  # 文言文 is pitched at G8 per curriculum
+
+        # Vocabulary: parsed YAML may have empty list for 文言文/graphic-text → keep as empty list
+        vocabulary = data.get("vocabulary") or []
+
+        # Video links: prefer manifest (has cleaned URLs), fall back to parsed
+        video_links = meta.get("video_links") or data.get("video_links")
+
+        lesson = {
+            "id": lesson_id,
+            "lesson_number": lesson_id,  # kept for backward compat with schemas
+            "lesson_code": norm_code,
+            "title": title,
+            "grade": grade,
+            "grade_code": norm_code,
+            "genre": genre,
+            "text_type": data.get("text_type") or meta.get("text_type") or "單",
+            "category": GENRE_TO_CATEGORY.get(genre, "Daily"),
+            "reading_strategy": strategy,
+            "paragraphs": data.get("paragraphs", []),
+            "full_text": data.get("story_text"),
+            "char_count": data.get("char_count", 0),
+            "thumbnail_url": (
+                f"https://storage.googleapis.com/lingoleap-assets/stories/"
+                f"thumbnails/{norm_code}.webp"
+            ),
+            "vocabulary": vocabulary,
+            "fill_in_blank": [
+                {**normalize_fill_in_blank_item(item), "answer": halfwidth(item.get("answer", ""))}
+                for item in (data.get("fill_in_blank") or [])
+            ] or None,
+            "multiple_choice": data.get("multiple_choice"),
+            "vocab_bank": data.get("vocab_bank"),
+            "knowledge_video_url": (
+                video_links[0].get("url") if video_links else None
+            ),
+            # Full video list (#1683) — KnowledgeStation renders all videos.
+            "video_links": video_links,
+            "reading_benchmark": data.get("reading_benchmark"),
+            "source_file": data.get("source_file"),
+            # Accept both keys: 'strategy_exercise' (singular, guided_steps shape — Gemini
+            # structured output from #1418) OR 'strategy_exercises' (plural, legacy skeleton
+            # list shape for G7 圖文整合). Singular takes priority.
+            "strategy_exercise": (
+                data.get("strategy_exercise") or data.get("strategy_exercises")
+            ),
+            "story_structure_table": data.get("story_structure_table"),
+            "story_structure_rows": data.get("story_structure_rows"),
+            "display_order": display_order,
+            # Schema-driven step composition (#1374): pass through if present in YAML.
+            # None (absent) means frontend uses DEFAULT_STEP_SEQUENCE.
+            "step_sequence": data.get("step_sequence") or None,
+            # Plugin-pattern dispatch fields (#1404):
+            "reading_strategy_type": data.get("reading_strategy_type") or "general",
+            "layout_mode": data.get("layout_mode") or "standard",
+            # Image gallery for graphic-text layout (#1341)
+            "images": data.get("images") or [],
+            "intro": build_intro({**data, "reading_strategy": strategy}),
+            # 學習單 section order + intro metadata (#1434)
+            "worksheet_section_order": data.get("worksheet_section_order"),
+            "worksheet_intro": data.get("worksheet_intro"),
+            # Lesson intro (#1443): docx 說明/導讀 or excel fallback
+            "lesson_intro": data.get("lesson_intro"),
+            # Public PDF URL of the original 紙本學習單 (#1444)
+            "worksheet_pdf_url": data.get("worksheet_pdf_url"),
+            # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
+            "tables": data.get("tables"),
+            "_layer": 2,
+        }
+        lessons.append(lesson)
+
+    return lessons
+
+
+# ---------------------------------------------------------------------------
+# Layer-2 enrichment index builder
+# ---------------------------------------------------------------------------
+
+def build_layer2_enrichment_index() -> dict[str, dict]:
+    """Build title→Layer-2 raw data index for enriching Layer-1 lessons.
+
+    Reads all _parsed_2026-05-01/*.yml files regardless of whether they were
+    kept after dedup — this ensures Layer-1 lessons get enrichment fields even
+    when their Layer-2 counterpart was skipped during load_layer2_lessons().
+    """
+    layer2_by_title: dict[str, dict] = {}
+    if not _PARSED_DIR.exists():
+        return layer2_by_title
+
+    for yml_path in _PARSED_DIR.glob("*.yml"):
+        with open(yml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if not data:
+            continue
+        title = data.get("title", "")
+        if title:
+            layer2_by_title[title] = data
+
+    return layer2_by_title

--- a/backend/app/services/lesson_loader.py
+++ b/backend/app/services/lesson_loader.py
@@ -26,541 +26,63 @@ a/b suffix YAML edge cases (one YAML covers two curriculum a/b slots):
 
 Usage:
     from app.services.lesson_loader import get_all_lessons, get_lessons_by_grade, get_lesson_by_id
+
+Internal structure (Issue #1889 — split into focused modules):
+  lesson_code_normalization.py  — static override maps + manifest code normalization
+  lesson_layer_loaders.py       — I/O for Layer-1 and Layer-2 YAML files
+  lesson_indexes.py             — build + expose singleton lesson collections
 """
 
-import re
-from pathlib import Path
-
-import yaml
-
-
-_LESSONS_DIR = Path(__file__).parent.parent.parent / "data" / "lessons"
-_PARSED_DIR = _LESSONS_DIR / "_parsed_2026-05-01"
-_CURRICULUM_MANIFEST = Path(__file__).parent.parent.parent / "data" / "curriculum" / "manifest.yml"
-
-# Offset added to curriculum display_order to generate synthetic integer IDs
-# for Layer-2 lessons (avoids collision with Layer-1 ids 1–57).
-_LAYER2_ID_OFFSET = 1000
-
-
-def _halfwidth(code: str) -> str:
-    """Convert fullwidth ASCII letters (Ａ-Ｚ, ａ-ｚ) to halfwidth (A-Z, a-z).
-
-    YAML fill_in_blank answers are sometimes typed as fullwidth (Ａ, Ｂ…)
-    while vocab_bank keys are always halfwidth (A, B…), causing mismatches.
-    """
-    return "".join(
-        chr(ord(c) - 0xFEE0) if 0xFF01 <= ord(c) <= 0xFF5E else c
-        for c in (code or "")
-    )
-
-
-def _normalize_fill_in_blank_item(item: dict) -> dict:
-    """Normalize a fill_in_blank item, tagging new-format items for frontend detection.
-
-    Two schemas coexist in the data:
-      Legacy (Layer-1 / old parsed):
-        { sentence: "孟嘗君（　　）逃離秦國。", answer: "A" }
-        answer is a letter code that matches a vocab_bank key.
-
-      New-format (5/1 curriculum batch, Layer-2):
-        { id, answer: "模仿雞叫", context_before: "...", context_after: "...",
-          context_paragraph_idx: N }
-        answer is freetext (strategy worksheet cloze), NOT a vocab_bank letter code.
-
-    FillInBlankExercise.tsx expects legacy format: item.sentence (string) and
-    item.answer (letter code matching vocab_bank). New-format items cannot be used
-    with the current exercise component because answers are freetext, not letter codes.
-
-    This function:
-    1. Synthesizes a sentence string for new-format items (context_before + blank + context_after)
-       so the sentence text is available for future exercise types.
-    2. Adds _schema flag to distinguish schema types without fragile duck-typing in callers.
-
-    Frontend api.ts filters by _schema: items with _schema="context_fill" are dropped
-    from fillInBlank → hasData=false → NoDataFallback renders (correct for 6/1 demo).
-    When a proper cloze exercise component is built, this flag enables clean routing.
-
-    Related: #1559, #1563
-    """
-    if "context_before" in item and "sentence" not in item:
-        before = item.get("context_before") or ""
-        after = item.get("context_after") or ""
-        return {**item, "sentence": f"{before}（　　）{after}", "_schema": "context_fill"}
-    # Legacy format: no change needed, but tag it too for symmetry.
-    return {**item, "_schema": "legacy"}
-
-
-_GENRE_TO_CATEGORY = {
-    "記敘文": "Fable",
-    "說明文": "Science",
-    "説明文": "Science",
-    "議論文": "History",
-    "文言文": "History",
-    "應用文": "Daily",
-}
-
-
-def _build_intro(lesson: dict) -> dict:
-    """Replicate frontend lessonLoader.ts intro construction."""
-    genre = lesson.get("genre", "")
-    strategy = lesson.get("reading_strategy")
-
-    author = genre
-    if strategy and strategy != "無":
-        author = f"{genre} · {strategy}"
-
-    paragraphs = lesson.get("paragraphs", [])
-    background = ""
-    if paragraphs:
-        p = paragraphs[0]
-        background = p[:100] + "..." if len(p) > 100 else p
-
-    return {"author": author, "background": background}
-
-
-def _normalize_manifest_code(code: str) -> str:
-    """Normalize curriculum manifest lesson_code to match _parsed/*.yml lesson_code format.
-
-    Examples:
-        G4-L01  -> G4-L1
-        G4-L03a -> G4-L3a
-        WW-L01  -> 文-L1
-    """
-    if code.startswith("WW-"):
-        m = re.search(r"L(\d+)", code)
-        if m:
-            return f"文-L{int(m.group(1))}"
-        return code
-    m = re.match(r"(G\d+)-L(\d+)(.*)", code)
-    if m:
-        grade_part = m.group(1)
-        num = int(m.group(2))
-        suffix = m.group(3)  # '', 'a', 'b'
-        return f"{grade_part}-L{num}{suffix}"
-    return code
-
-
-# Curriculum slots that are covered by a multi-lesson YAML.
-#
-# Primary slots: curriculum code → compound lesson_code in parsed YAML
-#   (these are loaded and exposed under the primary curriculum code)
-# Secondary slots: curriculum code → compound lesson_code in parsed YAML
-#   (these are skipped — content is accessible via the primary slot)
-_MULTI_LESSON_PRIMARY: dict[str, str] = {
-    "G4-L20": "G4-L20-22",
-    "G5-L24": "G5-L24-25",
-    "G9-L15": "G9-L15-16",
-    "G9-L17": "G9-L17-19",
-}
-
-_MULTI_LESSON_MAP: dict[str, str] = {
-    "G4-L21": "G4-L20-22",
-    "G4-L22": "G4-L20-22",
-    "G5-L25": "G5-L24-25",
-    "G9-L16": "G9-L15-16",
-    "G9-L18": "G9-L17-19",
-    "G9-L19": "G9-L17-19",
-}
-
-# Catalog code → parsed YAML lesson_code overrides (#1669).
-#
-# Two distinct correction patterns covered here:
-#
-# 1. G8 catalog↔Layer-2 offset (5 課): catalog uses curriculum sub-letter
-#    numbering (G8-L03a/03b/04/05/...), Layer-2 uses sequential parse-order
-#    (G8-L1/L2/L3/...). The default _normalize_manifest_code produces the
-#    wrong file (e.g. G8-L04 → G8-L4 = 植物肉, real story is G8-L5 = 玻璃娃娃).
-#
-# 2. G8 a/b sub-letter (8 課): each catalog a/b code maps to its own
-#    distinct Layer-2 file (a/b are SEPARATE stories, NOT shared content).
-#    This replaces the older _AB_SECONDARY_MAP design which incorrectly
-#    assumed a/b sub-letters share one parsed file.
-#
-# 3. G7-L31 (1 課): shares Layer-2 G7-L23 (multi-text 第一篇/第二篇).
-_CATALOG_TO_PARSED_OVERRIDE: dict[str, str] = {
-    # Category A: G8 offset (#1669) — catalog uses curriculum sub-letter
-    # numbering, Layer-2 uses sequential parse-order. The offset grows by 1
-    # each time an a/b split occurs in the curriculum.
-    "G8-L4": "G8-L5",    # 好心沒好報玻璃娃娃 (catalog G8-L04 after normalize)
-    "G8-L5": "G8-L6",    # 戲院賭場檳榔攤 (catalog G8-L05 after normalize)
-    "G8-L7": "G8-L9",    # 讓黑猩猩被看見 (catalog G8-L07 after normalize)
-    "G8-L8": "G8-L10",   # 按讚背後的真相 (catalog G8-L08 after normalize)
-    "G8-L10": "G8-L13",  # 構樹 (catalog G8-L10 after normalize)
-    "G8-L11": "G8-L14",  # 蝴蝶蘭花期密碼 (catalog G8-L11 after normalize)
-    "G8-L13": "G8-L17",  # 我能不能選擇告別方式 (catalog G8-L13 after normalize)
-    "G8-L14": "G8-L18",  # 石虎保育 (catalog G8-L14 after normalize)
-    "G8-L15": "G8-L19",  # 核能的兩難抉擇 (catalog G8-L15 after normalize)
-    # Category B: G8 sub-letter (each a/b has own parsed file)
-    "G8-L3a": "G8-L3",   # 集中營的一門課
-    "G8-L3b": "G8-L4",   # 新奇植物肉
-    "G8-L6a": "G8-L7",   # 讓你口中的甜蜜
-    "G8-L6b": "G8-L8",   # 隱形的征服者
-    "G8-L9a": "G8-L11",  # 虎襲事件的真相
-    "G8-L9b": "G8-L12",  # 語言的足跡
-    "G8-L12a": "G8-L15", # 球場上的另類指揮家
-    "G8-L12b": "G8-L16", # 我的阿嬤
-    # Category C: G7-L31 (旅人鴿 = 第二篇 of G7-L23 multi-text docx)
-    "G7-L31": "G7-L23",
-}
-
-# Legacy: kept for backward compat; superseded by _CATALOG_TO_PARSED_OVERRIDE.
-# G8-L*b entries are now correctly routed to their own Layer-2 files (not
-# shared with the a slot). Other entries here remain inert.
-_AB_SECONDARY_MAP: dict[str, str] = {}
-
-
-def _load_curriculum_manifest() -> dict[str, dict]:
-    """Load curriculum/manifest.yml and return a dict keyed by normalized lesson_code.
-
-    Returns {} if the manifest file does not exist.
-    """
-    if not _CURRICULUM_MANIFEST.exists():
-        return {}
-
-    with open(_CURRICULUM_MANIFEST, "r", encoding="utf-8") as f:
-        manifest = yaml.safe_load(f)
-
-    index: dict[str, dict] = {}
-    for entry in manifest.get("lessons", []):
-        norm_code = _normalize_manifest_code(entry["lesson_code"])
-        index[norm_code] = entry
-    return index
-
-
-def _load_layer1_lessons() -> list[dict]:
-    """Load existing production lessons: backend/data/lessons/L*.yml
-
-    These have integer lesson_number fields and form the original 57-lesson set.
-    """
-    lessons: list[dict] = []
-
-    if not _LESSONS_DIR.exists():
-        return lessons
-
-    for yml_path in sorted(_LESSONS_DIR.glob("L*.yml")):
-        with open(yml_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-
-        if not data or "lesson_number" not in data:
-            continue
-
-        genre = data.get("genre", "")
-        strategy = data.get("reading_strategy")
-        if strategy == "無":
-            strategy = None
-
-        lesson = {
-            "id": data["lesson_number"],
-            "lesson_number": data["lesson_number"],
-            "lesson_code": data.get("grade_code", ""),  # e.g. "G4-1"
-            "title": data["title"],
-            "grade": data["grade"],
-            "grade_code": data.get("grade_code", ""),
-            "genre": genre,
-            "text_type": data.get("text_type", "單"),
-            "category": _GENRE_TO_CATEGORY.get(genre, "Daily"),
-            "reading_strategy": strategy,
-            "paragraphs": data.get("paragraphs", []),
-            "full_text": data.get("story_text"),
-            "char_count": data.get("char_count", 0),
-            "thumbnail_url": (
-                f"https://storage.googleapis.com/lingoleap-assets/stories/"
-                f"thumbnails/lesson-{data['lesson_number']}.webp"
-            ),
-            "vocabulary": data.get("vocabulary") or [],
-            "fill_in_blank": [
-                {**_normalize_fill_in_blank_item(item), "answer": _halfwidth(item.get("answer", ""))}
-                for item in (data.get("fill_in_blank") or [])
-            ] or None,
-            "multiple_choice": data.get("multiple_choice"),
-            "vocab_bank": data.get("vocab_bank"),
-            "knowledge_video_url": data.get("knowledge_video_url"),
-            # Full video list (#1683) — for Layer-1 lessons, derive single-item
-            # list from knowledge_video_url if no explicit video_links field.
-            "video_links": data.get("video_links") or (
-                [{"title": "影片", "url": data["knowledge_video_url"]}]
-                if data.get("knowledge_video_url") else None
-            ),
-            "reading_benchmark": data.get("reading_benchmark"),
-            "source_file": data.get("source_file"),
-            "strategy_exercise": data.get("strategy_exercise"),
-            # Schema-driven step composition (#1374): pass through if present in YAML.
-            # None (absent) means frontend uses DEFAULT_STEP_SEQUENCE.
-            "step_sequence": data.get("step_sequence") or None,
-            "story_structure_table": data.get("story_structure_table"),
-            "story_structure_rows": data.get("story_structure_rows"),
-            # Plugin-pattern dispatch fields (#1404):
-            "reading_strategy_type": data.get("reading_strategy_type") or "general",
-            "layout_mode": data.get("layout_mode") or "standard",
-            # Image gallery for graphic-text layout (#1341)
-            "images": data.get("images") or [],
-            "intro": _build_intro(data),
-            # 學習單 section order + intro metadata (#1434) — None for Layer-1
-            "worksheet_section_order": data.get("worksheet_section_order"),
-            "worksheet_intro": data.get("worksheet_intro"),
-            # Lesson intro (#1443): docx 說明/導讀 or excel fallback
-            "lesson_intro": data.get("lesson_intro"),
-            # Public PDF URL of the original 紙本學習單 (#1444)
-            "worksheet_pdf_url": data.get("worksheet_pdf_url"),
-            # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
-            "tables": data.get("tables"),
-            "_layer": 1,
-        }
-        lessons.append(lesson)
-
-    return lessons
-
-
-def _load_layer2_lessons(
-    manifest_index: dict[str, dict],
-    layer1_titles: set[str],
-) -> list[dict]:
-    """Load new parsed lessons from _parsed_2026-05-01/*.yml.
-
-    Assigns synthetic integer IDs using curriculum display_order + _LAYER2_ID_OFFSET.
-    Skips lessons whose title already appears in Layer-1 (dedup).
-    Skips secondary multi-lesson and a/b slots (only the primary is exposed).
-    """
-    if not _PARSED_DIR.exists():
-        return []
-
-    # Build index: parsed lesson_code -> (data, path)
-    parsed_index: dict[str, tuple[dict, Path]] = {}
-    for yml_path in _PARSED_DIR.glob("*.yml"):
-        with open(yml_path, "r", encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-        if data and data.get("lesson_code"):
-            parsed_index[data["lesson_code"]] = (data, yml_path)
-
-    lessons: list[dict] = []
-
-    for norm_code, meta in manifest_index.items():
-        # Skip secondary multi-lesson slots (covered by the primary)
-        if norm_code in _MULTI_LESSON_MAP:
-            continue
-        # Skip secondary a/b slots (covered by the primary a-slot)
-        if norm_code in _AB_SECONDARY_MAP:
-            continue
-
-        # Resolve which parsed YAML handles this curriculum slot
-        parsed_code = norm_code
-
-        # Multi-lesson primary: curriculum code → compound parsed YAML code
-        if norm_code in _MULTI_LESSON_PRIMARY:
-            parsed_code = _MULTI_LESSON_PRIMARY[norm_code]
-
-        # Catalog→parsed override (#1669): G8 offset + G8 a/b + G7-L31
-        if norm_code in _CATALOG_TO_PARSED_OVERRIDE:
-            parsed_code = _CATALOG_TO_PARSED_OVERRIDE[norm_code]
-
-        if parsed_code not in parsed_index:
-            # For a/b primary slots (e.g. G8-L3a), the parsed file is G8-L3 (no suffix)
-            # Try stripping trailing 'a' suffix → base code (e.g. G8-L3a → G8-L3)
-            base_code = re.sub(r"a$", "", parsed_code)
-            if base_code != parsed_code and base_code in parsed_index:
-                parsed_code = base_code
-            else:
-                # No parsed YAML available
-                continue
-
-        data, _ = parsed_index[parsed_code]
-
-        # Title: prefer catalog manifest title when a catalog→parsed override
-        # is in effect (#1669). This prevents catalog G7-L31 from displaying
-        # parsed G7-L23.yml's title (which would collide with G7-L23's own
-        # entry and confuse the lesson card UI).
-        if norm_code in _CATALOG_TO_PARSED_OVERRIDE:
-            title = meta.get("title") or data.get("title", "")
-        else:
-            title = data.get("title", "")
-        # Deduplicate: if title already in Layer-1, skip
-        if title in layer1_titles:
-            continue
-
-        display_order = meta.get("display_order", 0)
-        lesson_id = _LAYER2_ID_OFFSET + display_order
-
-        genre = data.get("genre", "")
-        strategy = data.get("reading_strategy") or meta.get("strategy_name")
-        if strategy in ("", "無", "general"):
-            strategy = None
-
-        # Grade: use manifest grade (authoritative). Parsed grade=0 for 文言文 → map to 8
-        grade = meta.get("grade") or data.get("grade") or 0
-        if grade == 0:
-            grade = 8  # 文言文 is pitched at G8 per curriculum
-
-        # Vocabulary: parsed YAML may have empty list for 文言文/graphic-text → keep as empty list
-        vocabulary = data.get("vocabulary") or []
-
-        # Video links: prefer manifest (has cleaned URLs), fall back to parsed
-        video_links = meta.get("video_links") or data.get("video_links")
-
-        lesson = {
-            "id": lesson_id,
-            "lesson_number": lesson_id,  # kept for backward compat with schemas
-            "lesson_code": norm_code,
-            "title": title,
-            "grade": grade,
-            "grade_code": norm_code,
-            "genre": genre,
-            "text_type": data.get("text_type") or meta.get("text_type") or "單",
-            "category": _GENRE_TO_CATEGORY.get(genre, "Daily"),
-            "reading_strategy": strategy,
-            "paragraphs": data.get("paragraphs", []),
-            "full_text": data.get("story_text"),
-            "char_count": data.get("char_count", 0),
-            "thumbnail_url": (
-                f"https://storage.googleapis.com/lingoleap-assets/stories/"
-                f"thumbnails/{norm_code}.webp"
-            ),
-            "vocabulary": vocabulary,
-            "fill_in_blank": [
-                {**_normalize_fill_in_blank_item(item), "answer": _halfwidth(item.get("answer", ""))}
-                for item in (data.get("fill_in_blank") or [])
-            ] or None,
-            "multiple_choice": data.get("multiple_choice"),
-            "vocab_bank": data.get("vocab_bank"),
-            "knowledge_video_url": (
-                video_links[0].get("url") if video_links else None
-            ),
-            # Full video list (#1683) — KnowledgeStation renders all videos.
-            "video_links": video_links,
-            "reading_benchmark": data.get("reading_benchmark"),
-            "source_file": data.get("source_file"),
-            # Accept both keys: 'strategy_exercise' (singular, guided_steps shape — Gemini
-            # structured output from #1418) OR 'strategy_exercises' (plural, legacy skeleton
-            # list shape for G7 圖文整合). Singular takes priority.
-            "strategy_exercise": (
-                data.get("strategy_exercise") or data.get("strategy_exercises")
-            ),
-            "story_structure_table": data.get("story_structure_table"),
-            "story_structure_rows": data.get("story_structure_rows"),
-            "display_order": display_order,
-            # Schema-driven step composition (#1374): pass through if present in YAML.
-            # None (absent) means frontend uses DEFAULT_STEP_SEQUENCE.
-            "step_sequence": data.get("step_sequence") or None,
-            # Plugin-pattern dispatch fields (#1404):
-            "reading_strategy_type": data.get("reading_strategy_type") or "general",
-            "layout_mode": data.get("layout_mode") or "standard",
-            # Image gallery for graphic-text layout (#1341)
-            "images": data.get("images") or [],
-            "intro": _build_intro({**data, "reading_strategy": strategy}),
-            # 學習單 section order + intro metadata (#1434)
-            "worksheet_section_order": data.get("worksheet_section_order"),
-            "worksheet_intro": data.get("worksheet_intro"),
-            # Lesson intro (#1443): docx 說明/導讀 or excel fallback
-            "lesson_intro": data.get("lesson_intro"),
-            # Public PDF URL of the original 紙本學習單 (#1444)
-            "worksheet_pdf_url": data.get("worksheet_pdf_url"),
-            # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
-            "tables": data.get("tables"),
-            "_layer": 2,
-        }
-        lessons.append(lesson)
-
-    return lessons
-
+# ---------------------------------------------------------------------------
+# Backward-compatible re-exports from sub-modules
+# (all names that callers currently import directly from lesson_loader)
+# ---------------------------------------------------------------------------
+
+from app.services.lesson_code_normalization import (
+    halfwidth as _halfwidth,
+    normalize_manifest_code as _normalize_manifest_code,
+    MULTI_LESSON_PRIMARY as _MULTI_LESSON_PRIMARY,
+    MULTI_LESSON_MAP as _MULTI_LESSON_MAP,
+    CATALOG_TO_PARSED_OVERRIDE as _CATALOG_TO_PARSED_OVERRIDE,
+    AB_SECONDARY_MAP as _AB_SECONDARY_MAP,
+)
+
+from app.services.lesson_layer_loaders import (
+    normalize_fill_in_blank_item as _normalize_fill_in_blank_item,
+    build_intro as _build_intro,
+    GENRE_TO_CATEGORY as _GENRE_TO_CATEGORY,
+    LAYER2_ID_OFFSET as _LAYER2_ID_OFFSET,
+    load_curriculum_manifest as _load_curriculum_manifest,
+    load_layer1_lessons as _load_layer1_lessons,
+    load_layer2_lessons as _load_layer2_lessons,
+)
+
+from app.services.lesson_indexes import (
+    build_all_lessons as _build_all_lessons,
+    build_indexes as _build_indexes,
+)
+
+
+# ---------------------------------------------------------------------------
+# Private alias kept for tests that call _load_lessons() from lesson_loader
+# ---------------------------------------------------------------------------
 
 def _load_lessons() -> list[dict]:
-    """Load all lessons from both layers and return sorted by display_order / lesson_number."""
-    manifest_index = _load_curriculum_manifest()
-
-    # Layer 1: existing production L*.yml
-    layer1 = _load_layer1_lessons()
-    layer1_titles = {l["title"] for l in layer1}
-
-    # Layer 2: new parsed lessons
-    layer2 = _load_layer2_lessons(manifest_index, layer1_titles)
-
-    # Merge Layer-2 enrichment into Layer-1 entries with matching title (#1666).
-    #
-    # Problem: when a curriculum slot has BOTH a Layer-1 L*.yml (legacy, no
-    # step_sequence) AND a Layer-2 _parsed_/G*-L*.yml (new SOT with
-    # step_sequence + worksheet_* + lesson_intro + layout_mode), `_load_layer2_lessons`
-    # skips the Layer-2 entry on title match to avoid duplicate cards. Result:
-    # /api/stories/G6-L10 resolves to Layer-1 entry with step_sequence=null.
-    #
-    # Fix: build a title→Layer-2 lookup from _parsed_ files (regardless of
-    # whether the Layer-2 entry was kept after dedup), then copy the enrichment
-    # fields onto matching Layer-1 entries. Layer-1 keeps its id/lesson_number
-    # /title/paragraphs (preserves DB Text FK + session.story_slug back-compat).
-    #
-    # Enrichment fields inherited from Layer-2 (when source has a non-None value):
-    #   - step_sequence (#1374)
-    #   - worksheet_section_order, worksheet_intro (#1434)
-    #   - lesson_intro (#1443)
-    #   - worksheet_pdf_url (#1444)
-    #   - layout_mode, reading_strategy_type (#1404)
-    #   - images (#1341)
-    #   - strategy_exercise (#1418, structured Gemini output — Layer-2 richer)
-    #   - story_structure_table, story_structure_rows
-    layer2_by_title: dict[str, dict] = {}
-    if _PARSED_DIR.exists():
-        for yml_path in _PARSED_DIR.glob("*.yml"):
-            with open(yml_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f)
-            if not data:
-                continue
-            title = data.get("title", "")
-            if title:
-                layer2_by_title[title] = data
-
-    _ENRICHMENT_FIELDS = (
-        "step_sequence",
-        "worksheet_section_order",
-        "worksheet_intro",
-        "lesson_intro",
-        "worksheet_pdf_url",
-        "layout_mode",
-        "reading_strategy_type",
-        "images",
-        "strategy_exercise",
-        "story_structure_table",
-        "story_structure_rows",
-        # 紙本表格 (#1685): some Layer-2 lessons (G7-L28, G7-L30) carry extracted
-        # tables; copy onto matching Layer-1 entries to preserve back-compat.
-        "tables",
-    )
-
-    for lesson in layer1:
-        l2_data = layer2_by_title.get(lesson["title"])
-        if not l2_data:
-            continue
-        for field in _ENRICHMENT_FIELDS:
-            l2_value = l2_data.get(field)
-            # strategy_exercise: Layer-2 may use plural key (legacy G7 圖文整合)
-            if field == "strategy_exercise" and l2_value is None:
-                l2_value = l2_data.get("strategy_exercises")
-            if l2_value:  # only override when Layer-2 has a truthy value
-                lesson[field] = l2_value
-
-    all_lessons = layer1 + layer2
-
-    # Sort: Layer-1 by lesson_number, Layer-2 by display_order, then mix
-    # Use display_order from manifest for Layer-2; for Layer-1 use lesson_number as proxy.
-    def sort_key(lesson: dict) -> tuple[int, int]:
-        if lesson["_layer"] == 1:
-            # Layer-1 lessons map to curriculum display_order via manifest
-            # For simplicity, sort them by lesson_number (1-57) at the front
-            return (0, lesson["lesson_number"])
-        else:
-            return (1, lesson.get("display_order", 9999))
-
-    all_lessons.sort(key=sort_key)
-    return all_lessons
+    """Load all lessons from both layers and return sorted. Delegates to lesson_indexes."""
+    return _build_all_lessons()
 
 
-# Load once at import time
-_ALL_LESSONS: list[dict] = _load_lessons()
-_LESSONS_BY_ID: dict[int, dict] = {l["id"]: l for l in _ALL_LESSONS}
-_LESSONS_BY_CODE: dict[str, dict] = {
-    l["lesson_code"]: l for l in _ALL_LESSONS if l.get("lesson_code")
-}
-_LESSONS_BY_TITLE: dict[str, dict] = {l["title"]: l for l in _ALL_LESSONS}
-_AVAILABLE_GRADES: list[int] = sorted({l["grade"] for l in _ALL_LESSONS})
+# ---------------------------------------------------------------------------
+# Singleton indexes — loaded once at import time
+# ---------------------------------------------------------------------------
 
+_ALL_LESSONS: list[dict] = _build_all_lessons()
+_LESSONS_BY_ID, _LESSONS_BY_CODE, _LESSONS_BY_TITLE, _AVAILABLE_GRADES = _build_indexes(_ALL_LESSONS)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 def get_all_lessons() -> list[dict]:
     return _ALL_LESSONS

--- a/backend/tests/test_lesson_loader_split_1889.py
+++ b/backend/tests/test_lesson_loader_split_1889.py
@@ -1,0 +1,274 @@
+"""TDD tests for lesson_loader split into focused modules (Issue #1889).
+
+Three tests pinned to specific behaviors that must survive the refactor:
+
+1. catalog_to_parsed_overrides_resolve_g8_offset_and_ab_slots
+   Verifies _CATALOG_TO_PARSED_OVERRIDE map correctness — G8 offset corrections
+   and a/b slot separate-file routing are all present.
+
+2. layer2_enrichment_merges_truthy_fields_into_layer1_by_title
+   Verifies the Layer-1 enrichment step: when a Layer-1 lesson shares a title
+   with a Layer-2 parsed file, truthy Layer-2 fields propagate onto the Layer-1
+   lesson dict while Layer-1 id/lesson_number/title are preserved.
+
+3. get_lesson_by_code_falls_back_multi_text_secondary_to_primary
+   Verifies that G4-L21 / G4-L22 (secondary multi-text slots) fall back to
+   the G4-L20 primary slot instead of returning None.
+
+These tests pass on the CURRENT lesson_loader.py and MUST continue passing
+after the split into lesson_code_normalization / lesson_layer_loaders /
+lesson_indexes sub-modules.
+
+Run:
+    cd backend && python -m pytest tests/test_lesson_loader_split_1889.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — catalog_to_parsed_overrides_resolve_g8_offset_and_ab_slots
+# ---------------------------------------------------------------------------
+
+class TestCatalogToParsedOverridesG8:
+    """_CATALOG_TO_PARSED_OVERRIDE contains the expected G8 mappings.
+
+    Imports the map from wherever it lives after the refactor:
+    - lesson_loader (original)
+    - lesson_code_normalization (post-refactor dedicated module)
+    Both paths must work (backward-compat re-export from lesson_loader).
+    """
+
+    def _get_override_map(self) -> dict:
+        """Import override map — try new module first, fall back to lesson_loader."""
+        try:
+            from app.services.lesson_code_normalization import CATALOG_TO_PARSED_OVERRIDE
+            return CATALOG_TO_PARSED_OVERRIDE
+        except ImportError:
+            from app.services.lesson_loader import _CATALOG_TO_PARSED_OVERRIDE
+            return _CATALOG_TO_PARSED_OVERRIDE
+
+    def test_g8_offset_corrections_present(self):
+        """G8 catalog↔Layer-2 offset corrections map catalog codes to correct parsed codes."""
+        override = self._get_override_map()
+        # Category A: G8 offset (5 entries)
+        expected = {
+            "G8-L4": "G8-L5",
+            "G8-L5": "G8-L6",
+            "G8-L7": "G8-L9",
+            "G8-L8": "G8-L10",
+            "G8-L10": "G8-L13",
+        }
+        for catalog_code, expected_parsed in expected.items():
+            actual = override.get(catalog_code)
+            assert actual == expected_parsed, (
+                f"_CATALOG_TO_PARSED_OVERRIDE[{catalog_code!r}] = {actual!r}, "
+                f"expected {expected_parsed!r}. G8 offset correction is missing/wrong."
+            )
+
+    def test_g8_ab_slots_each_have_own_parsed_file(self):
+        """G8 a/b curriculum slots route to distinct parsed file codes (not shared)."""
+        override = self._get_override_map()
+        # Category B: G8 a/b (8 entries — a and b are SEPARATE stories)
+        expected = {
+            "G8-L3a": "G8-L3",
+            "G8-L3b": "G8-L4",
+            "G8-L6a": "G8-L7",
+            "G8-L6b": "G8-L8",
+            "G8-L9a": "G8-L11",
+            "G8-L9b": "G8-L12",
+            "G8-L12a": "G8-L15",
+            "G8-L12b": "G8-L16",
+        }
+        for catalog_code, expected_parsed in expected.items():
+            actual = override.get(catalog_code)
+            assert actual == expected_parsed, (
+                f"_CATALOG_TO_PARSED_OVERRIDE[{catalog_code!r}] = {actual!r}, "
+                f"expected {expected_parsed!r}. G8 a/b slot routing is missing/wrong."
+            )
+
+    def test_g7_l31_multi_text_override_present(self):
+        """G7-L31 maps to G7-L23 (旅人鴿 = 第二篇 of G7-L23 multi-text)."""
+        override = self._get_override_map()
+        assert override.get("G7-L31") == "G7-L23", (
+            f"_CATALOG_TO_PARSED_OVERRIDE['G7-L31'] = {override.get('G7-L31')!r}, "
+            f"expected 'G7-L23'. G7-L31 multi-text override missing."
+        )
+
+    def test_all_ab_pairs_route_to_different_parsed_codes(self):
+        """Each a/b pair in Category B routes to distinct (non-identical) parsed codes."""
+        override = self._get_override_map()
+        ab_pairs = [
+            ("G8-L3a", "G8-L3b"),
+            ("G8-L6a", "G8-L6b"),
+            ("G8-L9a", "G8-L9b"),
+            ("G8-L12a", "G8-L12b"),
+        ]
+        for a_code, b_code in ab_pairs:
+            parsed_a = override.get(a_code)
+            parsed_b = override.get(b_code)
+            assert parsed_a is not None, f"Missing override for {a_code!r}"
+            assert parsed_b is not None, f"Missing override for {b_code!r}"
+            assert parsed_a != parsed_b, (
+                f"G8 a/b pair {a_code!r}/{b_code!r} route to same parsed code {parsed_a!r}. "
+                f"They should map to distinct files (a and b are separate stories)."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — layer2_enrichment_merges_truthy_fields_into_layer1_by_title
+# ---------------------------------------------------------------------------
+
+class TestLayer2EnrichmentMergesIntoLayer1:
+    """Layer-1 lessons get enrichment fields from matching Layer-2 parsed data.
+
+    Uses the live loaded data to verify the enrichment actually applied:
+    a Layer-1 lesson that has a matching parsed file should have non-None
+    enrichment fields (step_sequence / layout_mode / reading_strategy_type).
+    """
+
+    def test_layer1_lesson_with_l2_match_gets_enriched_fields(self):
+        """A Layer-1 lesson whose title matches a parsed YAML inherits Layer-2 fields.
+
+        G6-L10 (末日種子庫) is a Layer-1 L*.yml that has a corresponding
+        _parsed_2026-05-01 YAML. After enrichment, it should have step_sequence.
+        """
+        from app.services.lesson_loader import get_lesson_by_code
+        lesson = get_lesson_by_code("G6-L10")
+        if lesson is None:
+            pytest.skip("G6-L10 not found in lesson data")
+        assert lesson.get("_layer") == 1, (
+            f"G6-L10 should be Layer-1, got _layer={lesson.get('_layer')}"
+        )
+        # Enrichment: step_sequence must be present (from Layer-2 YAML via enrichment)
+        seq = lesson.get("step_sequence")
+        assert seq is not None, (
+            "G6-L10 (Layer-1) should have step_sequence enriched from Layer-2 YAML. "
+            "Enrichment merge in _load_lessons() may be broken."
+        )
+        assert isinstance(seq, list) and len(seq) > 0, (
+            f"step_sequence should be a non-empty list, got {seq!r}"
+        )
+
+    def test_enrichment_preserves_layer1_id_and_lesson_number(self):
+        """Enrichment must NOT overwrite Layer-1 id / lesson_number / title."""
+        from app.services.lesson_loader import get_lesson_by_code, get_all_lessons
+        # Pick any Layer-1 lesson
+        all_lessons = get_all_lessons()
+        layer1_lessons = [l for l in all_lessons if l.get("_layer") == 1]
+        assert len(layer1_lessons) >= 50, "Expected at least 50 Layer-1 lessons"
+
+        for lesson in layer1_lessons[:5]:  # spot-check first 5
+            lesson_num = lesson.get("lesson_number")
+            lesson_id = lesson.get("id")
+            assert isinstance(lesson_num, int) and 1 <= lesson_num <= 100, (
+                f"Layer-1 lesson {lesson.get('lesson_code')!r} has "
+                f"lesson_number={lesson_num!r}, expected 1-100 integer. "
+                "Enrichment may have overwritten lesson_number with Layer-2 value."
+            )
+            assert lesson_id == lesson_num, (
+                f"Layer-1 lesson id={lesson_id} should equal lesson_number={lesson_num}. "
+                "Enrichment corrupted the id field."
+            )
+
+    def test_enrichment_only_copies_truthy_values(self):
+        """Fields are only copied when Layer-2 has a truthy value (not None/empty)."""
+        from app.services.lesson_loader import get_all_lessons
+        all_lessons = get_all_lessons()
+        layer1_lessons = [l for l in all_lessons if l.get("_layer") == 1]
+
+        # None / empty string / empty list should NOT be enriched
+        for lesson in layer1_lessons:
+            # images defaults to [] in Layer-1 loader; if Layer-2 also has []
+            # the enrichment must NOT copy that empty list (falsy → skip).
+            # Verify images is either [] (original) or a non-empty list (enriched).
+            images = lesson.get("images")
+            assert images == [] or (isinstance(images, list) and len(images) > 0), (
+                f"Lesson {lesson.get('lesson_code')!r} has unexpected images={images!r}. "
+                "Should be [] (Layer-1 default) or non-empty list (enriched)."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — get_lesson_by_code_falls_back_multi_text_secondary_to_primary
+# ---------------------------------------------------------------------------
+
+class TestGetLessonByCodeMultiTextFallback:
+    """Secondary multi-text slots fall back to the primary slot's lesson dict."""
+
+    def test_g4_l21_falls_back_to_g4_l20(self):
+        """G4-L21 is a secondary slot (covered by G4-L20-22 YAML); must return G4-L20's lesson."""
+        from app.services.lesson_loader import get_lesson_by_code
+        lesson = get_lesson_by_code("G4-L21")
+        assert lesson is not None, (
+            "get_lesson_by_code('G4-L21') returned None. "
+            "Expected fallback to G4-L20 (primary slot for G4-L20-22 multi-text YAML). "
+            "Multi-text secondary fallback in get_lesson_by_code() may be broken."
+        )
+        # The returned lesson should be the primary (G4-L20)
+        assert lesson.get("lesson_code") == "G4-L20", (
+            f"G4-L21 fallback should return lesson_code='G4-L20', "
+            f"got {lesson.get('lesson_code')!r}."
+        )
+
+    def test_g4_l22_falls_back_to_g4_l20(self):
+        """G4-L22 is also secondary under G4-L20-22; must return G4-L20's lesson."""
+        from app.services.lesson_loader import get_lesson_by_code
+        lesson = get_lesson_by_code("G4-L22")
+        assert lesson is not None, (
+            "get_lesson_by_code('G4-L22') returned None. "
+            "Expected fallback to G4-L20."
+        )
+        assert lesson.get("lesson_code") == "G4-L20", (
+            f"G4-L22 fallback should return lesson_code='G4-L20', "
+            f"got {lesson.get('lesson_code')!r}."
+        )
+
+    def test_g5_l25_falls_back_to_g5_l24(self):
+        """G5-L25 secondary → G5-L24 primary (G5-L24-25 multi-text YAML)."""
+        from app.services.lesson_loader import get_lesson_by_code
+        lesson = get_lesson_by_code("G5-L25")
+        assert lesson is not None, (
+            "get_lesson_by_code('G5-L25') returned None. Expected fallback to G5-L24."
+        )
+        assert lesson.get("lesson_code") == "G5-L24", (
+            f"G5-L25 fallback should return G5-L24, got {lesson.get('lesson_code')!r}."
+        )
+
+    def test_g9_secondary_slots_fall_back(self):
+        """G9-L16 / G9-L18 / G9-L19 secondaries fall back to their primaries."""
+        from app.services.lesson_loader import get_lesson_by_code
+        cases = [
+            ("G9-L16", "G9-L15"),
+            ("G9-L18", "G9-L17"),
+            ("G9-L19", "G9-L17"),
+        ]
+        for secondary, expected_primary in cases:
+            lesson = get_lesson_by_code(secondary)
+            assert lesson is not None, (
+                f"get_lesson_by_code({secondary!r}) returned None. "
+                f"Expected fallback to {expected_primary!r}."
+            )
+            assert lesson.get("lesson_code") == expected_primary, (
+                f"{secondary} fallback should return {expected_primary!r}, "
+                f"got {lesson.get('lesson_code')!r}."
+            )
+
+    def test_primary_slots_return_directly(self):
+        """Primary multi-text slots (G4-L20, G5-L24, G9-L15, G9-L17) return their own lesson."""
+        from app.services.lesson_loader import get_lesson_by_code
+        primaries = ["G4-L20", "G5-L24", "G9-L15", "G9-L17"]
+        for code in primaries:
+            lesson = get_lesson_by_code(code)
+            # They may be None if Layer-2 parsed file doesn't exist locally,
+            # but if they exist, they should return the correct code.
+            if lesson is not None:
+                assert lesson.get("lesson_code") == code, (
+                    f"{code} primary should return itself, "
+                    f"got {lesson.get('lesson_code')!r}."
+                )


### PR DESCRIPTION
Fixes #1889

## Summary

- `lesson_loader.py` shrunk from 634L to 156L (thin facade with backward-compat re-exports)
- Three new focused modules created:
  - `lesson_code_normalization.py` (149L) — static override maps (`CATALOG_TO_PARSED_OVERRIDE`, `MULTI_LESSON_PRIMARY/MAP`) + `normalize_manifest_code()` + `halfwidth()`
  - `lesson_layer_loaders.py` (424L) — YAML I/O for Layer-1 (`L*.yml`) and Layer-2 (`_parsed_2026-05-01/*.yml`), genre→category map, enrichment field list, `build_layer2_enrichment_index()`
  - `lesson_indexes.py` (103L) — `build_all_lessons()` + `build_indexes()` singleton builders
- All underscore-prefixed names re-exported from `lesson_loader.py` for zero caller impact

## Test plan

TDD — 3 test classes / 12 assertions in `test_lesson_loader_split_1889.py`:
- [x] `TestCatalogToParsedOverridesG8` — G8 offset + a/b slot maps correct (imports from both new module and lesson_loader)
- [x] `TestLayer2EnrichmentMergesIntoLayer1` — Layer-1 enrichment preserves id/lesson_number, only copies truthy fields
- [x] `TestGetLessonByCodeMultiTextFallback` — G4-L21/22, G5-L25, G9-L16/18/19 all fall back to primary slots

Regression: 84 existing lesson-loader tests pass unchanged (`test_regression_layer2_shadow_merge_1666`, `test_fill_in_blank_normalization`, `test_regression_fill_in_blank_127_lessons_1753`, `test_slug_grade_code`, etc.)