### PR TITLE
refactor(ai-gen): split ai_generation.py into ai_generation/ subpackage (Fixes #1888)

### DIFF
--- a/backend/app/services/ai_generation/__init__.py
+++ b/backend/app/services/ai_generation/__init__.py
@@ -1,0 +1,50 @@
+"""
+ai_generation subpackage — AI content generation split by task.
+
+Public API is identical to the former monolithic ai_generation.py.
+All names are re-exported here so existing imports continue to work:
+
+    from app.services.ai_generation import generate_exit_ticket  # still works
+    from app.services.ai_generation import EXIT_TICKET_SCHEMA    # still works
+"""
+
+from .exit_ticket import (  # noqa: F401
+    EXIT_TICKET_SCHEMA,
+    generate_exit_ticket,
+    grade_exit_ticket,
+)
+from .sentence_practice import (  # noqa: F401
+    EXAMPLE_SENTENCES_SCHEMA,
+    SENTENCE_VALIDATION_SCHEMA,
+    generate_example_sentences,
+    validate_student_sentence,
+)
+from .story_structure import (  # noqa: F401
+    STORY_STRUCTURE_SCHEMA,
+    generate_story_structure,
+    grade_story_structure,
+)
+from .teacher_comment import (  # noqa: F401
+    TEACHER_COMMENT_SCHEMA,
+    generate_teacher_comment,
+)
+
+__all__ = [
+    # Schemas
+    "EXIT_TICKET_SCHEMA",
+    "EXAMPLE_SENTENCES_SCHEMA",
+    "SENTENCE_VALIDATION_SCHEMA",
+    "STORY_STRUCTURE_SCHEMA",
+    "TEACHER_COMMENT_SCHEMA",
+    # Exit Ticket
+    "generate_exit_ticket",
+    "grade_exit_ticket",
+    # Sentence Practice
+    "generate_example_sentences",
+    "validate_student_sentence",
+    # Story Structure
+    "generate_story_structure",
+    "grade_story_structure",
+    # Teacher Comment
+    "generate_teacher_comment",
+]

--- a/backend/app/services/ai_generation/exit_ticket.py
+++ b/backend/app/services/ai_generation/exit_ticket.py
@@ -1,0 +1,139 @@
+"""
+Exit Ticket AI generation and grading (Issue #463).
+
+Schema, system prompt, and two public functions:
+  generate_exit_ticket — MCQ generation
+  grade_exit_ticket    — stub (MCQ graded deterministically in route layer)
+"""
+
+import logging
+
+from google.genai import types as genai_types
+
+from ..ai_base import (
+    generate_structured_response,
+    sanitize_ai_input,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EXIT_TICKET_SCHEMA",
+    "generate_exit_ticket",
+    "grade_exit_ticket",
+]
+
+EXIT_TICKET_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "questions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "question": {"type": "string"},
+                    "options": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 4,
+                        "maxItems": 4,
+                    },
+                    "correct_index": {"type": "integer"},
+                    "explanation": {"type": "string"},
+                },
+                "required": ["id", "question", "options", "correct_index", "explanation"],
+            },
+            "minItems": 3,
+            "maxItems": 5,
+        }
+    },
+    "required": ["questions"],
+}
+
+_EXIT_TICKET_SYSTEM_PROMPT = """你是一位專業的國語文教師，負責出「出場卷」測驗。
+
+根據課文內容，設計 3~5 題選擇題，測驗學生對課文的理解程度。
+題目類型應包含：
+1. 字面理解題（直接從課文找答案）
+2. 推論理解題（需要推理或推斷）
+3. 評價理解題（整體評價、主旨、道理）
+
+規則：
+- 每題有 4 個選項，只有一個正確答案
+- correct_index 從 0 開始（0=第一個選項, 1=第二個, 2=第三個, 3=第四個）
+- explanation 用中文說明正確答案的依據（1~2 句）
+- 題目難易度適合國小高年級～國中生
+- 嚴禁出現與課文無關的問題
+- 如果有提供學生讀錯的字，至少出一題考形近字辨識
+"""
+
+
+async def generate_exit_ticket(
+    text: str,
+    wrong_chars: list[str] | None = None,
+) -> dict:
+    """
+    Generate exit-ticket multiple choice questions for a story text (Issue #463).
+
+    Uses Gemini 2.5 Flash to produce 3-5 multiple choice questions covering
+    literal comprehension, inferential comprehension, and evaluative comprehension
+    (三層次理解). If wrong_chars are provided, includes at least one character
+    recognition question based on the student's errors.
+
+    Args:
+        text: Story/lesson content (joined paragraphs)
+        wrong_chars: Optional list of characters the student mispronounced
+
+    Returns:
+        {"questions": [{"id", "question", "options", "correct_index", "explanation"}, ...]}
+        On AI failure: {"questions": [], "fallback": True}
+        NEVER returns auto-pass data on failure.
+    """
+    sanitized_text, _ = sanitize_ai_input(text[:3000])
+    wrong_chars_info = ""
+    if wrong_chars:
+        wrong_chars_info = f"\n\n【學生朗讀時讀錯的字】：{', '.join(wrong_chars[:10])}\n請至少出一題考這些字的辨識（形近字選擇）。"
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[
+                genai_types.Part(
+                    text=f"以下是課文內容：\n\n{sanitized_text}{wrong_chars_info}\n\n請根據課文出 3~5 題選擇題。",
+                ),
+            ],
+        )
+    ]
+
+    try:
+        result = await generate_structured_response(
+            system_prompt=_EXIT_TICKET_SYSTEM_PROMPT,
+            contents=contents,
+            response_schema=EXIT_TICKET_SCHEMA,
+            max_tokens=2048,
+            temperature=0.5,
+            task="exit_ticket_generate",
+        )
+        questions = result.get("questions", [])
+        if not questions:
+            logger.warning("generate_exit_ticket: AI returned empty questions list")
+            return {"questions": [], "fallback": True}
+        # Clamp correct_index to valid range 0-3
+        for q in questions:
+            q["correct_index"] = max(0, min(3, int(q.get("correct_index", 0))))
+        return {"questions": questions}
+    except Exception as e:
+        logger.error("generate_exit_ticket AI call failed: %s", e)
+        return {"questions": [], "fallback": True}
+
+
+async def grade_exit_ticket(question: str, student_answer: str, reference_text: str) -> dict:
+    """
+    Grade a student's exit-ticket answer.
+
+    For multiple-choice exit tickets, grading is done deterministically
+    by comparing selected_index to correct_index (handled in the route/service).
+    This function is preserved for potential future open-ended answer grading.
+    """
+    return {"score": 0, "feedback": "此函式保留給未來開放式題型批改使用"}

--- a/backend/app/services/ai_generation/sentence_practice.py
+++ b/backend/app/services/ai_generation/sentence_practice.py
@@ -1,0 +1,165 @@
+"""
+Sentence Practice AI generation and validation (Issue #109).
+
+Schema, prompts, and two public functions:
+  generate_example_sentences  — two example sentences for a vocabulary word
+  validate_student_sentence   — AI evaluation of student's sentence
+"""
+
+import logging
+
+from google.genai import types as genai_types
+
+from ..ai_base import (
+    generate_structured_response,
+    sanitize_ai_input,
+    TUTOR_PERSONA,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "EXAMPLE_SENTENCES_SCHEMA",
+    "SENTENCE_VALIDATION_SCHEMA",
+    "generate_example_sentences",
+    "validate_student_sentence",
+]
+
+EXAMPLE_SENTENCES_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "sentences": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "sentence": {"type": "string"},
+                    "explanation": {"type": "string"},
+                },
+                "required": ["sentence", "explanation"],
+            },
+            "minItems": 2,
+            "maxItems": 2,
+        }
+    },
+    "required": ["sentences"],
+}
+
+SENTENCE_VALIDATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "is_correct": {"type": "boolean"},
+        "feedback": {"type": "string"},
+        "suggestion": {"type": "string"},
+    },
+    "required": ["is_correct", "feedback", "suggestion"],
+}
+
+
+async def generate_example_sentences(word: str, story_title: str) -> dict:
+    """Generate 2 example sentences for a Chinese vocabulary word.
+
+    Returns {"sentences": [{"sentence": str, "explanation": str}, ...]}
+    Each sentence uses the target word in a contextually appropriate way
+    suited for elementary/middle school students.
+    """
+    safe_word, _ = sanitize_ai_input(word)
+    safe_title, _ = sanitize_ai_input(story_title)
+
+    system_prompt = f"""{TUTOR_PERSONA}
+
+你是一位專業的國語文教師，請為學生示範如何使用詞語造句。
+
+目標詞語：「{safe_word}」
+課文名稱：《{safe_title}》
+
+請造 2 個包含目標詞語的例句，要求：
+1. 符合國小高年級～國中的語文程度
+2. 句子自然流暢，生動有趣
+3. 幫助學生理解這個詞語的用法
+4. 用繁體中文（zh-TW）
+
+請以 JSON 格式輸出，包含 sentences 陣列，每個元素有：
+- sentence（例句）
+- explanation（簡短說明這個詞語在句中的意思）"""
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[genai_types.Part(text=f"請為詞語「{safe_word}」造兩個例句。")],
+        )
+    ]
+
+    result = await generate_structured_response(
+        system_prompt=system_prompt,
+        contents=contents,
+        response_schema=EXAMPLE_SENTENCES_SCHEMA,
+        max_tokens=2048,
+        temperature=0.8,
+        task="example_sentences",
+    )
+    return result
+
+
+async def validate_student_sentence(
+    word: str,
+    student_sentence: str,
+    story_title: str,
+    passage_sentences: list[str] | None = None,
+) -> dict:
+    """Validate a student's sentence for a given vocabulary word.
+
+    Returns {"is_correct": bool, "feedback": str, "suggestion": str}
+    - is_correct: True if grammatically correct and uses the word appropriately
+    - feedback: encouraging feedback message (in Chinese)
+    - suggestion: improvement hint if not correct (empty string if correct)
+    """
+    safe_word, _ = sanitize_ai_input(word)
+    safe_sentence, _ = sanitize_ai_input(student_sentence)
+    safe_title, _ = sanitize_ai_input(story_title)
+
+    system_prompt = f"""{TUTOR_PERSONA}
+
+正在陪學生練習用「{safe_word}」造句（課文：《{safe_title}》）。
+
+判斷規則：
+- 句子有用到「{safe_word}」、語法基本通順、是學生自己寫的（沒抄課文或例句）→ is_correct=true
+- 否則 → is_correct=false
+
+回覆規則（非常重要）：
+- feedback **只能一句話**，不要用「錯」「不對」「不行」「不正確」等否定字眼
+- is_correct=true：feedback 是一句純鼓勵（不要加提醒）；suggestion 留空字串
+- is_correct=false：feedback 是一句溫柔提醒（先肯定再提示，例如「再想想看…」「換個說法可能更順喔」）；suggestion 是一句改寫提示
+- 一律使用臺灣繁體中文（zh-TW）"""
+
+    if passage_sentences:
+        passage_ref = "\n".join(f"- {s}" for s in passage_sentences[:5])
+        system_prompt += f"""
+
+以下是課文或例句中含「{safe_word}」的片段（供比對是否抄寫）：
+{passage_ref}
+
+若學生的句子與上述片段意思和結構幾乎一樣，判 is_correct=false，
+feedback 統一說「和課文或例句有點像，試試看用自己的話說說看」，不要點名是哪一句。"""
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[genai_types.Part(text=f"學生的造句：「{safe_sentence}」\n請評估這個造句是否正確。")],
+        )
+    ]
+
+    result = await generate_structured_response(
+        system_prompt=system_prompt,
+        contents=contents,
+        response_schema=SENTENCE_VALIDATION_SCHEMA,
+        max_tokens=1024,
+        task="sentence_validate",
+        temperature=0.3,
+    )
+
+    # Ensure suggestion is empty string if correct (defensive, in case model violates prompt)
+    if result.get("is_correct"):
+        result["suggestion"] = ""
+
+    return result

--- a/backend/app/services/ai_generation/story_structure.py
+++ b/backend/app/services/ai_generation/story_structure.py
@@ -1,297 +1,27 @@
 """
-AI content generation — MCQ, story structure, fill-in-blank, vocabulary, sentences.
+Story Structure AI generation and grading (#615, #1082).
+
+Schema, prompts, and three public functions:
+  generate_story_structure — AI-generated interactive story structure table
+  grade_story_structure    — deterministic grading (fill_blank fuzzy + checkbox exact)
+  _fuzzy_match_chinese     — internal helper (exported for tests that patch around it)
 """
 
 import logging
 
 from google.genai import types as genai_types
 
-from .ai_base import (
-    CONTENT_FILTER_FRIENDLY_MSG,
-    GeminiContentFilterError,
+from ..ai_base import (
     generate_structured_response,
-    sanitize_ai_input,
-    TUTOR_PERSONA,
 )
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
-    "generate_exit_ticket",
-    "grade_exit_ticket",
-    "generate_example_sentences",
-    "validate_student_sentence",
+    "STORY_STRUCTURE_SCHEMA",
     "generate_story_structure",
     "grade_story_structure",
-    "generate_teacher_comment",
-    "EXIT_TICKET_SCHEMA",
-    "EXAMPLE_SENTENCES_SCHEMA",
-    "SENTENCE_VALIDATION_SCHEMA",
-    "STORY_STRUCTURE_SCHEMA",
 ]
-
-
-# ── Exit Ticket (Issue #463) ─────────────────────────────────────────────────
-
-EXIT_TICKET_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "questions": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "id": {"type": "integer"},
-                    "question": {"type": "string"},
-                    "options": {
-                        "type": "array",
-                        "items": {"type": "string"},
-                        "minItems": 4,
-                        "maxItems": 4,
-                    },
-                    "correct_index": {"type": "integer"},
-                    "explanation": {"type": "string"},
-                },
-                "required": ["id", "question", "options", "correct_index", "explanation"],
-            },
-            "minItems": 3,
-            "maxItems": 5,
-        }
-    },
-    "required": ["questions"],
-}
-
-_EXIT_TICKET_SYSTEM_PROMPT = """你是一位專業的國語文教師，負責出「出場卷」測驗。
-
-根據課文內容，設計 3~5 題選擇題，測驗學生對課文的理解程度。
-題目類型應包含：
-1. 字面理解題（直接從課文找答案）
-2. 推論理解題（需要推理或推斷）
-3. 評價理解題（整體評價、主旨、道理）
-
-規則：
-- 每題有 4 個選項，只有一個正確答案
-- correct_index 從 0 開始（0=第一個選項, 1=第二個, 2=第三個, 3=第四個）
-- explanation 用中文說明正確答案的依據（1~2 句）
-- 題目難易度適合國小高年級～國中生
-- 嚴禁出現與課文無關的問題
-- 如果有提供學生讀錯的字，至少出一題考形近字辨識
-"""
-
-
-async def generate_exit_ticket(
-    text: str,
-    wrong_chars: list[str] | None = None,
-) -> dict:
-    """
-    Generate exit-ticket multiple choice questions for a story text (Issue #463).
-
-    Uses Gemini 2.5 Flash to produce 3-5 multiple choice questions covering
-    literal comprehension, inferential comprehension, and evaluative comprehension
-    (三層次理解). If wrong_chars are provided, includes at least one character
-    recognition question based on the student's errors.
-
-    Args:
-        text: Story/lesson content (joined paragraphs)
-        wrong_chars: Optional list of characters the student mispronounced
-
-    Returns:
-        {"questions": [{"id", "question", "options", "correct_index", "explanation"}, ...]}
-        On AI failure: {"questions": [], "fallback": True}
-        NEVER returns auto-pass data on failure.
-    """
-    sanitized_text, _ = sanitize_ai_input(text[:3000])
-    wrong_chars_info = ""
-    if wrong_chars:
-        wrong_chars_info = f"\n\n【學生朗讀時讀錯的字】：{', '.join(wrong_chars[:10])}\n請至少出一題考這些字的辨識（形近字選擇）。"
-
-    contents = [
-        genai_types.Content(
-            role="user",
-            parts=[
-                genai_types.Part(
-                    text=f"以下是課文內容：\n\n{sanitized_text}{wrong_chars_info}\n\n請根據課文出 3~5 題選擇題。",
-                ),
-            ],
-        )
-    ]
-
-    try:
-        result = await generate_structured_response(
-            system_prompt=_EXIT_TICKET_SYSTEM_PROMPT,
-            contents=contents,
-            response_schema=EXIT_TICKET_SCHEMA,
-            max_tokens=2048,
-            temperature=0.5,
-            task="exit_ticket_generate",
-        )
-        questions = result.get("questions", [])
-        if not questions:
-            logger.warning("generate_exit_ticket: AI returned empty questions list")
-            return {"questions": [], "fallback": True}
-        # Clamp correct_index to valid range 0-3
-        for q in questions:
-            q["correct_index"] = max(0, min(3, int(q.get("correct_index", 0))))
-        return {"questions": questions}
-    except Exception as e:
-        logger.error("generate_exit_ticket AI call failed: %s", e)
-        return {"questions": [], "fallback": True}
-
-
-async def grade_exit_ticket(question: str, student_answer: str, reference_text: str) -> dict:
-    """
-    Grade a student's exit-ticket answer.
-
-    For multiple-choice exit tickets, grading is done deterministically
-    by comparing selected_index to correct_index (handled in the route/service).
-    This function is preserved for potential future open-ended answer grading.
-    """
-    return {"score": 0, "feedback": "此函式保留給未來開放式題型批改使用"}
-
-
-# ── Sentence Practice (Issue #109) ──────────────────────────────────────────
-
-EXAMPLE_SENTENCES_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "sentences": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "sentence": {"type": "string"},
-                    "explanation": {"type": "string"},
-                },
-                "required": ["sentence", "explanation"],
-            },
-            "minItems": 2,
-            "maxItems": 2,
-        }
-    },
-    "required": ["sentences"],
-}
-
-SENTENCE_VALIDATION_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "is_correct": {"type": "boolean"},
-        "feedback": {"type": "string"},
-        "suggestion": {"type": "string"},
-    },
-    "required": ["is_correct", "feedback", "suggestion"],
-}
-
-
-async def generate_example_sentences(word: str, story_title: str) -> dict:
-    """Generate 2 example sentences for a Chinese vocabulary word.
-
-    Returns {"sentences": [{"sentence": str, "explanation": str}, ...]}
-    Each sentence uses the target word in a contextually appropriate way
-    suited for elementary/middle school students.
-    """
-    safe_word, _ = sanitize_ai_input(word)
-    safe_title, _ = sanitize_ai_input(story_title)
-
-    system_prompt = f"""{TUTOR_PERSONA}
-
-你是一位專業的國語文教師，請為學生示範如何使用詞語造句。
-
-目標詞語：「{safe_word}」
-課文名稱：《{safe_title}》
-
-請造 2 個包含目標詞語的例句，要求：
-1. 符合國小高年級～國中的語文程度
-2. 句子自然流暢，生動有趣
-3. 幫助學生理解這個詞語的用法
-4. 用繁體中文（zh-TW）
-
-請以 JSON 格式輸出，包含 sentences 陣列，每個元素有：
-- sentence（例句）
-- explanation（簡短說明這個詞語在句中的意思）"""
-
-    contents = [
-        genai_types.Content(
-            role="user",
-            parts=[genai_types.Part(text=f"請為詞語「{safe_word}」造兩個例句。")],
-        )
-    ]
-
-    result = await generate_structured_response(
-        system_prompt=system_prompt,
-        contents=contents,
-        response_schema=EXAMPLE_SENTENCES_SCHEMA,
-        max_tokens=2048,
-        temperature=0.8,
-        task="example_sentences",
-    )
-    return result
-
-
-async def validate_student_sentence(
-    word: str,
-    student_sentence: str,
-    story_title: str,
-    passage_sentences: list[str] | None = None,
-) -> dict:
-    """Validate a student's sentence for a given vocabulary word.
-
-    Returns {"is_correct": bool, "feedback": str, "suggestion": str}
-    - is_correct: True if grammatically correct and uses the word appropriately
-    - feedback: encouraging feedback message (in Chinese)
-    - suggestion: improvement hint if not correct (empty string if correct)
-    """
-    safe_word, _ = sanitize_ai_input(word)
-    safe_sentence, _ = sanitize_ai_input(student_sentence)
-    safe_title, _ = sanitize_ai_input(story_title)
-
-    system_prompt = f"""{TUTOR_PERSONA}
-
-正在陪學生練習用「{safe_word}」造句（課文：《{safe_title}》）。
-
-判斷規則：
-- 句子有用到「{safe_word}」、語法基本通順、是學生自己寫的（沒抄課文或例句）→ is_correct=true
-- 否則 → is_correct=false
-
-回覆規則（非常重要）：
-- feedback **只能一句話**，不要用「錯」「不對」「不行」「不正確」等否定字眼
-- is_correct=true：feedback 是一句純鼓勵（不要加提醒）；suggestion 留空字串
-- is_correct=false：feedback 是一句溫柔提醒（先肯定再提示，例如「再想想看…」「換個說法可能更順喔」）；suggestion 是一句改寫提示
-- 一律使用臺灣繁體中文（zh-TW）"""
-
-    if passage_sentences:
-        passage_ref = "\n".join(f"- {s}" for s in passage_sentences[:5])
-        system_prompt += f"""
-
-以下是課文或例句中含「{safe_word}」的片段（供比對是否抄寫）：
-{passage_ref}
-
-若學生的句子與上述片段意思和結構幾乎一樣，判 is_correct=false，
-feedback 統一說「和課文或例句有點像，試試看用自己的話說說看」，不要點名是哪一句。"""
-
-    contents = [
-        genai_types.Content(
-            role="user",
-            parts=[genai_types.Part(text=f"學生的造句：「{safe_sentence}」\n請評估這個造句是否正確。")],
-        )
-    ]
-
-    result = await generate_structured_response(
-        system_prompt=system_prompt,
-        contents=contents,
-        response_schema=SENTENCE_VALIDATION_SCHEMA,
-        max_tokens=1024,
-        task="sentence_validate",
-        temperature=0.3,
-    )
-
-    # Ensure suggestion is empty string if correct (defensive, in case model violates prompt)
-    if result.get("is_correct"):
-        result["suggestion"] = ""
-
-    return result
-
-
-# ── ⑤ 文章重點表 — AI-generated story structure (#615, #1082) ─────────────────
 
 # interactive_type values:
 #   "fill_blank" — student types in the answer (open-ended)
@@ -513,8 +243,8 @@ def _fuzzy_match_chinese(student: str, reference: str, story_text: str = "") -> 
         return True
 
     _PARTICLES = set("的了在是有和與也都就把被讓給從到著過嗎呢吧啊、，。！？")
-    ref_chars = [c for c in reference if c not in _PARTICLES and '\u4e00' <= c <= '\u9fff']
-    stu_chars = [c for c in student if c not in _PARTICLES and '\u4e00' <= c <= '\u9fff']
+    ref_chars = [c for c in reference if c not in _PARTICLES and '一' <= c <= '鿿']
+    stu_chars = [c for c in student if c not in _PARTICLES and '一' <= c <= '鿿']
 
     if not ref_chars:
         return len(student) > 0
@@ -617,72 +347,3 @@ async def grade_story_structure(
 
     score = round((correct_count / total) * 100) if total > 0 else 0
     return {"results": results, "score": score}
-
-
-# ── Teacher Comment Generation (Issue #993) ──────────────────────────────────
-
-TEACHER_COMMENT_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "comment": {"type": "string"},
-    },
-    "required": ["comment"],
-}
-
-_TEACHER_COMMENT_SYSTEM_PROMPT = """你是一位專業的國語文教師助理。
-根據學生的朗讀表現數據，撰寫一段簡短的個人化評語（100-200字），供教師參考。
-
-規則：
-- 語氣溫暖、正面鼓勵，同時具體指出可改進之處
-- 先肯定優點，再建議改進方向
-- 用「你」稱呼學生
-- 適合國小高年級～國中生閱讀
-- 不要使用表情符號
-- 如果有錯字資料，具體提到哪些字需要多練習
-"""
-
-
-async def generate_teacher_comment(
-    story_title: str,
-    accuracy: float | None,
-    cpm: float | None,
-    error_chars: list[str] | None = None,
-    comprehension_score: float | None = None,
-) -> str:
-    """Generate an AI comment for a learning session to assist teacher review (Issue #993)."""
-    # Don't generate if there's no meaningful data
-    if accuracy is None and cpm is None and comprehension_score is None:
-        return ""
-
-    parts = [f"課文：{sanitize_ai_input(story_title[:100])[0]}"]
-    if accuracy is not None:
-        parts.append(f"朗讀正確率：{accuracy:.0f}%")
-    if cpm is not None:
-        parts.append(f"朗讀速度：每分鐘 {cpm:.0f} 字")
-    if comprehension_score is not None:
-        parts.append(f"課文理解分數：{comprehension_score:.0f}/100")
-    if error_chars:
-        chars_str = "、".join(error_chars[:15])
-        parts.append(f"讀錯的字：{chars_str}")
-
-    user_msg = "\n".join(parts) + "\n\n請撰寫教師評語。"
-
-    try:
-        contents = [
-            genai_types.Content(
-                role="user",
-                parts=[genai_types.Part(text=user_msg)],
-            )
-        ]
-        result = await generate_structured_response(
-            system_prompt=_TEACHER_COMMENT_SYSTEM_PROMPT,
-            contents=contents,
-            response_schema=TEACHER_COMMENT_SCHEMA,
-            max_tokens=512,
-            temperature=0.7,
-            task="teacher_comment",
-        )
-        return result.get("comment", "")
-    except Exception as e:
-        logger.warning("generate_teacher_comment failed: %s", e)
-        return ""

--- a/backend/app/services/ai_generation/teacher_comment.py
+++ b/backend/app/services/ai_generation/teacher_comment.py
@@ -1,0 +1,88 @@
+"""
+Teacher Comment AI generation (Issue #993).
+
+Schema, system prompt, and one public function:
+  generate_teacher_comment — personalized teacher comment for a learning session
+"""
+
+import logging
+
+from google.genai import types as genai_types
+
+from ..ai_base import (
+    generate_structured_response,
+    sanitize_ai_input,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "TEACHER_COMMENT_SCHEMA",
+    "generate_teacher_comment",
+]
+
+TEACHER_COMMENT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "comment": {"type": "string"},
+    },
+    "required": ["comment"],
+}
+
+_TEACHER_COMMENT_SYSTEM_PROMPT = """你是一位專業的國語文教師助理。
+根據學生的朗讀表現數據，撰寫一段簡短的個人化評語（100-200字），供教師參考。
+
+規則：
+- 語氣溫暖、正面鼓勵，同時具體指出可改進之處
+- 先肯定優點，再建議改進方向
+- 用「你」稱呼學生
+- 適合國小高年級～國中生閱讀
+- 不要使用表情符號
+- 如果有錯字資料，具體提到哪些字需要多練習
+"""
+
+
+async def generate_teacher_comment(
+    story_title: str,
+    accuracy: float | None,
+    cpm: float | None,
+    error_chars: list[str] | None = None,
+    comprehension_score: float | None = None,
+) -> str:
+    """Generate an AI comment for a learning session to assist teacher review (Issue #993)."""
+    # Don't generate if there's no meaningful data
+    if accuracy is None and cpm is None and comprehension_score is None:
+        return ""
+
+    parts = [f"課文：{sanitize_ai_input(story_title[:100])[0]}"]
+    if accuracy is not None:
+        parts.append(f"朗讀正確率：{accuracy:.0f}%")
+    if cpm is not None:
+        parts.append(f"朗讀速度：每分鐘 {cpm:.0f} 字")
+    if comprehension_score is not None:
+        parts.append(f"課文理解分數：{comprehension_score:.0f}/100")
+    if error_chars:
+        chars_str = "、".join(error_chars[:15])
+        parts.append(f"讀錯的字：{chars_str}")
+
+    user_msg = "\n".join(parts) + "\n\n請撰寫教師評語。"
+
+    try:
+        contents = [
+            genai_types.Content(
+                role="user",
+                parts=[genai_types.Part(text=user_msg)],
+            )
+        ]
+        result = await generate_structured_response(
+            system_prompt=_TEACHER_COMMENT_SYSTEM_PROMPT,
+            contents=contents,
+            response_schema=TEACHER_COMMENT_SCHEMA,
+            max_tokens=512,
+            temperature=0.7,
+            task="teacher_comment",
+        )
+        return result.get("comment", "")
+    except Exception as e:
+        logger.warning("generate_teacher_comment failed: %s", e)
+        return ""

--- a/backend/tests/test_ai_generation_split_1888.py
+++ b/backend/tests/test_ai_generation_split_1888.py
@@ -1,0 +1,332 @@
+"""
+TDD tests for ai_generation.py split (Issue #1888).
+
+Three characterization tests that must:
+1. PASS on current monolithic ai_generation.py (green before refactor)
+2. PASS after split into ai_generation/ submodule (regression guard)
+
+Tests cover the three specific post-processing / fallback rules called out in the issue.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+# ── Test 1: exit_ticket_clamps_correct_index_and_fails_closed_on_empty_questions ────────
+
+@pytest.mark.asyncio
+class TestExitTicketClampAndFallback:
+    """correct_index clamping + fail-closed on empty questions — no auto-pass."""
+
+    async def test_clamps_correct_index_out_of_range_to_3(self):
+        """correct_index=99 must clamp to max=3 (0-indexed 4-option MCQ)."""
+        mock_response = {
+            "questions": [
+                {
+                    "id": 1,
+                    "question": "測試題？",
+                    "options": ["A", "B", "C", "D"],
+                    "correct_index": 99,
+                    "explanation": "說明",
+                }
+            ]
+        }
+        with patch(
+            "app.services.ai_generation.exit_ticket.generate_structured_response",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            from app.services.ai_generation import generate_exit_ticket
+            result = await generate_exit_ticket(text="課文內容")
+        assert result["questions"][0]["correct_index"] == 3
+
+    async def test_clamps_negative_correct_index_to_0(self):
+        """correct_index=-5 must clamp to 0."""
+        mock_response = {
+            "questions": [
+                {
+                    "id": 1,
+                    "question": "測試題？",
+                    "options": ["A", "B", "C", "D"],
+                    "correct_index": -5,
+                    "explanation": "說明",
+                }
+            ]
+        }
+        with patch(
+            "app.services.ai_generation.exit_ticket.generate_structured_response",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            from app.services.ai_generation import generate_exit_ticket
+            result = await generate_exit_ticket(text="課文內容")
+        assert result["questions"][0]["correct_index"] == 0
+
+    async def test_fails_closed_on_empty_questions_list(self):
+        """AI returns empty questions → fallback=True, NEVER auto-pass."""
+        with patch(
+            "app.services.ai_generation.exit_ticket.generate_structured_response",
+            new=AsyncMock(return_value={"questions": []}),
+        ):
+            from app.services.ai_generation import generate_exit_ticket
+            result = await generate_exit_ticket(text="課文內容")
+        assert result.get("fallback") is True
+        assert result["questions"] == []
+
+    async def test_fails_closed_on_ai_exception(self):
+        """AI throws → fallback=True, questions=[], NEVER raise to caller."""
+        with patch(
+            "app.services.ai_generation.exit_ticket.generate_structured_response",
+            new=AsyncMock(side_effect=RuntimeError("AI down")),
+        ):
+            from app.services.ai_generation import generate_exit_ticket
+            result = await generate_exit_ticket(text="課文內容")
+        assert result.get("fallback") is True
+        assert result["questions"] == []
+
+    async def test_no_auto_pass_on_missing_questions_key(self):
+        """AI returns dict without 'questions' key → fallback, not auto-pass."""
+        with patch(
+            "app.services.ai_generation.exit_ticket.generate_structured_response",
+            new=AsyncMock(return_value={}),
+        ):
+            from app.services.ai_generation import generate_exit_ticket
+            result = await generate_exit_ticket(text="課文內容")
+        assert result["questions"] == []
+        assert result.get("fallback") is True
+
+
+# ── Test 2: validate_student_sentence_clears_suggestion_when_correct ─────────
+
+@pytest.mark.asyncio
+class TestValidateStudentSentenceClearsSuggestion:
+    """When AI returns is_correct=True, suggestion must be cleared to '' defensively."""
+
+    async def test_clears_suggestion_when_model_says_correct_but_includes_suggestion(self):
+        """Model should not include suggestion when correct, but if it does we clear it."""
+        mock_response = {
+            "is_correct": True,
+            "feedback": "造句非常棒！",
+            "suggestion": "可以試試用更豐富的詞彙",  # model violated the prompt
+        }
+        with patch(
+            "app.services.ai_generation.sentence_practice.generate_structured_response",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            from app.services.ai_generation import validate_student_sentence
+            result = await validate_student_sentence(
+                word="來源",
+                student_sentence="這個故事的來源很有趣。",
+                story_title="課文",
+            )
+        assert result["is_correct"] is True
+        assert result["suggestion"] == ""
+
+    async def test_preserves_suggestion_when_incorrect(self):
+        """When is_correct=False, suggestion must be preserved unchanged."""
+        mock_response = {
+            "is_correct": False,
+            "feedback": "再試試看！",
+            "suggestion": "試試：這條河的來源是高山上的冰雪。",
+        }
+        with patch(
+            "app.services.ai_generation.sentence_practice.generate_structured_response",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            from app.services.ai_generation import validate_student_sentence
+            result = await validate_student_sentence(
+                word="來源",
+                student_sentence="來源好",
+                story_title="課文",
+            )
+        assert result["is_correct"] is False
+        assert result["suggestion"] == "試試：這條河的來源是高山上的冰雪。"
+
+    async def test_suggestion_empty_string_when_model_omits_it_and_correct(self):
+        """Model returns is_correct=True with empty suggestion → stays empty."""
+        mock_response = {
+            "is_correct": True,
+            "feedback": "很好！",
+            "suggestion": "",
+        }
+        with patch(
+            "app.services.ai_generation.sentence_practice.generate_structured_response",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            from app.services.ai_generation import validate_student_sentence
+            result = await validate_student_sentence(
+                word="來源",
+                student_sentence="這本書的來源是圖書館。",
+                story_title="課文",
+            )
+        assert result["is_correct"] is True
+        assert result["suggestion"] == ""
+
+
+# ── Test 3: grade_story_structure_handles_fill_blank_checkbox_and_display_rows ─
+
+class TestGradeStoryStructureScoringRules:
+    """Scoring rules: fill_blank fuzzy match, checkbox exact set, display skipped."""
+
+    def _make_structure(self):
+        return {
+            "rows": [
+                {
+                    "label": "主角",
+                    "value": "戴資穎",
+                    "interactive_type": "fill_blank",
+                    "hint": "課文主角是誰？",
+                },
+                {
+                    "label": "事例",
+                    "value": "",
+                    "interactive_type": "display",  # not graded
+                    "sub_rows": [
+                        {
+                            "label": "背景",
+                            "value": "台灣羽球選手",
+                            "interactive_type": "checkbox",
+                            "options": ["台灣羽球選手", "中國排球選手", "日本網球選手"],
+                            "correct_options": [0],
+                        }
+                    ],
+                },
+                {
+                    "label": "主題",
+                    "value": "堅持不懈的精神",
+                    "interactive_type": "fill_blank",
+                    "hint": "課文想告訴我們什麼？",
+                },
+            ]
+        }
+
+    @pytest.mark.asyncio
+    async def test_fill_blank_exact_match_scores_correct(self):
+        """fill_blank row with exact match → correct=True."""
+        from app.services.ai_generation import grade_story_structure
+        structure = self._make_structure()
+        answers = [{"row_index": 0, "value": "戴資穎"}]
+        result = await grade_story_structure(structure, answers)
+        assert result["results"][0]["correct"] is True
+        assert result["score"] == 100
+
+    @pytest.mark.asyncio
+    async def test_fill_blank_nickname_match_scores_correct(self):
+        """fill_blank row with nickname (小戴 for 戴資穎) → correct via fuzzy match."""
+        from app.services.ai_generation import grade_story_structure
+        structure = self._make_structure()
+        story_text = "小戴是台灣最有名的羽球選手，她的全名是戴資穎。"
+        answers = [{"row_index": 0, "value": "小戴"}]
+        result = await grade_story_structure(structure, answers, story_text=story_text)
+        assert result["results"][0]["correct"] is True
+
+    @pytest.mark.asyncio
+    async def test_display_rows_are_skipped_not_graded(self):
+        """display interactive_type rows must not appear in results."""
+        from app.services.ai_generation import grade_story_structure
+        structure = self._make_structure()
+        # Answer the display row directly — it should be silently skipped
+        answers = [{"row_index": 1, "value": "任意答案"}]
+        result = await grade_story_structure(structure, answers)
+        assert result["results"] == []
+        # score is 0/0 = 0 when no gradable rows
+        assert result["score"] == 0
+
+    @pytest.mark.asyncio
+    async def test_checkbox_sub_row_correct_set_match(self):
+        """checkbox sub_row with exact selected_options match → correct=True."""
+        from app.services.ai_generation import grade_story_structure
+        structure = self._make_structure()
+        answers = [{"row_index": 1, "sub_row_index": 0, "selected_options": [0]}]
+        result = await grade_story_structure(structure, answers)
+        assert result["results"][0]["correct"] is True
+        assert result["score"] == 100
+
+    @pytest.mark.asyncio
+    async def test_checkbox_sub_row_wrong_set_returns_correct_answer_text(self):
+        """checkbox sub_row with wrong selected_options → correct=False + feedback with correct text."""
+        from app.services.ai_generation import grade_story_structure
+        structure = self._make_structure()
+        answers = [{"row_index": 1, "sub_row_index": 0, "selected_options": [1]}]
+        result = await grade_story_structure(structure, answers)
+        r = result["results"][0]
+        assert r["correct"] is False
+        assert "台灣羽球選手" in r["feedback"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_answers_score_proportional(self):
+        """Two gradable rows: 1 correct fill_blank + 1 correct checkbox → score=100."""
+        from app.services.ai_generation import grade_story_structure
+        structure = self._make_structure()
+        answers = [
+            {"row_index": 0, "value": "戴資穎"},           # fill_blank correct
+            {"row_index": 1, "sub_row_index": 0, "selected_options": [0]},  # checkbox correct
+        ]
+        result = await grade_story_structure(structure, answers)
+        assert result["score"] == 100
+        assert len(result["results"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_fill_blank_wrong_answer_scores_zero(self):
+        """fill_blank with wrong answer → correct=False, feedback shows reference answer."""
+        from app.services.ai_generation import grade_story_structure
+        structure = self._make_structure()
+        answers = [{"row_index": 0, "value": "錯誤答案"}]
+        result = await grade_story_structure(structure, answers)
+        assert result["results"][0]["correct"] is False
+        assert result["score"] == 0
+        assert "戴資穎" in result["results"][0]["feedback"]
+
+
+# ── Backward-compat: verify re-exports still work after split ─────────────────
+
+class TestBackwardCompatImports:
+    """After split, ai_generation.py must still export all public names."""
+
+    def test_exit_ticket_functions_importable_from_ai_generation(self):
+        from app.services.ai_generation import generate_exit_ticket, grade_exit_ticket
+        assert callable(generate_exit_ticket)
+        assert callable(grade_exit_ticket)
+
+    def test_sentence_practice_functions_importable_from_ai_generation(self):
+        from app.services.ai_generation import (
+            generate_example_sentences,
+            validate_student_sentence,
+        )
+        assert callable(generate_example_sentences)
+        assert callable(validate_student_sentence)
+
+    def test_story_structure_functions_importable_from_ai_generation(self):
+        from app.services.ai_generation import (
+            generate_story_structure,
+            grade_story_structure,
+        )
+        assert callable(generate_story_structure)
+        assert callable(grade_story_structure)
+
+    def test_teacher_comment_importable_from_ai_generation(self):
+        from app.services.ai_generation import generate_teacher_comment
+        assert callable(generate_teacher_comment)
+
+    def test_schemas_importable_from_ai_generation(self):
+        from app.services.ai_generation import (
+            EXIT_TICKET_SCHEMA,
+            EXAMPLE_SENTENCES_SCHEMA,
+            SENTENCE_VALIDATION_SCHEMA,
+            STORY_STRUCTURE_SCHEMA,
+        )
+        assert isinstance(EXIT_TICKET_SCHEMA, dict)
+        assert isinstance(EXAMPLE_SENTENCES_SCHEMA, dict)
+        assert isinstance(SENTENCE_VALIDATION_SCHEMA, dict)
+        assert isinstance(STORY_STRUCTURE_SCHEMA, dict)
+
+    def test_ai_service_still_exports_generation_functions(self):
+        """ai_service.py wildcard re-export must still work."""
+        from app.services.ai_service import (
+            generate_exit_ticket,
+            validate_student_sentence,
+            generate_story_structure,
+            generate_teacher_comment,
+        )
+        assert callable(generate_exit_ticket)
+        assert callable(validate_student_sentence)
+        assert callable(generate_story_structure)
+        assert callable(generate_teacher_comment)


### PR DESCRIPTION
Fixes #1888

## Summary

- Split monolithic `backend/app/services/ai_generation.py` (688L) into `ai_generation/` subpackage with 4 focused modules
- Each module owns its schema, system prompt, and task functions
- `ai_generation/__init__.py` re-exports all public names — zero change to existing imports
- 21 TDD characterization tests added covering the three critical post-processing rules

## Modules Created

| File | Responsibility |
|------|---------------|
| `ai_generation/exit_ticket.py` | EXIT_TICKET_SCHEMA, generate_exit_ticket (clamping + fail-closed), grade_exit_ticket stub |
| `ai_generation/sentence_practice.py` | EXAMPLE_SENTENCES_SCHEMA, SENTENCE_VALIDATION_SCHEMA, generate_example_sentences, validate_student_sentence (suggestion clearing) |
| `ai_generation/story_structure.py` | STORY_STRUCTURE_SCHEMA, generate_story_structure, grade_story_structure (fill_blank fuzzy + checkbox exact + display skip), _fuzzy_match_chinese |
| `ai_generation/teacher_comment.py` | TEACHER_COMMENT_SCHEMA, generate_teacher_comment |

## Test Coverage (21 tests — all green)

- `test_exit_ticket_clamps_correct_index_and_fails_closed_on_empty_questions` — 5 cases: clamping 99→3, -5→0, empty questions fallback, AI exception fallback, missing key fallback
- `test_validate_student_sentence_clears_suggestion_when_correct` — 3 cases: model-violated suggestion cleared, incorrect preserves suggestion, empty stays empty
- `test_grade_story_structure_handles_fill_blank_checkbox_and_display_rows` — 7 cases: exact match, nickname fuzzy match, display skip, checkbox correct/wrong, mixed score, wrong fill_blank
- `test_backward_compat_imports` — 6 cases: all public names still importable from `ai_generation` and `ai_service`

## Risk

Low — pure structural refactor. All business logic is bit-for-bit identical. Backward-compat import layer verified by `test_ai_service_refactor.py` (existing suite) + new tests.