### PR TITLE
refactor(zhuyin-game): full UI split — ModeSelect/ScoreBanner/PickGame/ComposeGame (Fixes #1885)

### DIFF
--- a/frontend/src/components/reading-steps/ComposeGame.tsx
+++ b/frontend/src/components/reading-steps/ComposeGame.tsx
@@ -1,0 +1,187 @@
+/**
+ * ComposeGame.tsx
+ *
+ * 拼音合成 game screen for ZhuyinPhoneticGame.
+ * Student taps bopomofo symbols in order to spell a character's pronunciation.
+ *
+ * Extracted from ZhuyinPhoneticGame.tsx as part of refactor/issue-1885.
+ * Palette construction delegated to buildComposePalette (engine),
+ * scoring delegated to scoreOnce (engine).
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CharZhuyin,
+  AnswerState,
+  buildComposePalette,
+  scoreOnce,
+} from './zhuyinGameEngine';
+import { composeTargetSeq } from './zhuyinGameLogic';
+
+export interface ComposeGameProps {
+  questions: CharZhuyin[];
+  onFinish: (score: number, total: number) => void;
+  onBack: () => void;
+}
+
+export function ComposeGame({ questions, onFinish, onBack }: ComposeGameProps) {
+  const [qIdx, setQIdx] = useState(0);
+  const [score, setScore] = useState(0);
+  const [tapped, setTapped] = useState<string[]>([]);
+  const [answerState, setAnswerState] = useState<AnswerState>('idle');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const q = questions[qIdx];
+
+  // Target sequence: [initial, medial, finalPart, tone] — non-empty parts
+  const targetSeq = useMemo(() => composeTargetSeq(q), [q]);
+
+  // Build symbol palette via engine helper
+  const palette = useMemo(() => buildComposePalette(targetSeq), [targetSeq]);
+
+  const handleTap = useCallback((sym: string) => {
+    if (answerState !== 'idle') return;
+    const next = [...tapped, sym];
+    setTapped(next);
+
+    // Check if length matches target
+    if (next.length === targetSeq.length) {
+      const isCorrect = next.join('') === targetSeq.join('');
+      setAnswerState(isCorrect ? 'correct' : 'wrong');
+      const newScore = scoreOnce(score, isCorrect);
+      if (isCorrect) setScore(newScore);
+
+      timerRef.current = setTimeout(() => {
+        if (qIdx + 1 >= questions.length) {
+          onFinish(newScore, questions.length);
+        } else {
+          setQIdx(i => i + 1);
+          setTapped([]);
+          setAnswerState('idle');
+        }
+      }, 1000);
+    }
+  }, [answerState, tapped, targetSeq, score, qIdx, questions.length, onFinish]);
+
+  const handleClear = useCallback(() => {
+    if (answerState !== 'idle') return;
+    setTapped([]);
+  }, [answerState]);
+
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
+
+  const progress = `${qIdx + 1} / ${questions.length}`;
+
+  return (
+    <div className="flex-1 flex flex-col bg-indigo-50">
+      {/* Header */}
+      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-2 shrink-0">
+        <button
+          onClick={onBack}
+          aria-label="返回生字練習"
+          className="text-gray-400 hover:text-gray-700 transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <span className="text-xs text-gray-700 font-semibold flex-1">拼音合成練習</span>
+        <span className="text-xs text-gray-400" aria-label={`第 ${qIdx + 1} 題，共 ${questions.length} 題`}>{progress}</span>
+      </div>
+
+      {/* Progress bar */}
+      <div
+        role="progressbar"
+        aria-valuenow={qIdx + 1}
+        aria-valuemin={1}
+        aria-valuemax={questions.length}
+        aria-label={`練習進度：第 ${qIdx + 1} 題，共 ${questions.length} 題`}
+        className="w-full h-1.5 bg-gray-200"
+      >
+        <div
+          className="h-full bg-indigo-500 transition-all duration-500"
+          style={{ width: `${(qIdx / questions.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Main area */}
+      <div className="flex-1 flex flex-col items-center justify-center px-6 gap-6">
+
+        {/* Prompt */}
+        <div className="text-center space-y-3">
+          <p className="text-sm text-gray-500">
+            按順序拼出這個字的注音
+          </p>
+          <div className="w-28 h-28 mx-auto bg-white rounded-3xl shadow-md border border-indigo-100 flex items-center justify-center">
+            <span className="text-5xl font-bold text-gray-900">{q.char}</span>
+          </div>
+        </div>
+
+        {/* Answer slots */}
+        <div className="flex items-center gap-2">
+          {targetSeq.map((part, i) => {
+            const filled = tapped[i];
+            const stateClass = answerState === 'idle'
+              ? filled
+                ? 'bg-indigo-100 border-indigo-400 text-indigo-700'
+                : 'bg-white border-dashed border-indigo-300 text-transparent'
+              : answerState === 'correct'
+                ? 'bg-emerald-100 border-emerald-400 text-emerald-700'
+                : 'bg-red-100 border-red-400 text-red-700';
+            return (
+              <div
+                key={i}
+                className={`w-12 h-12 flex items-center justify-center rounded-xl border-2 text-xl font-bold transition-all duration-200 ${stateClass}`}
+              >
+                {filled || '?'}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Feedback */}
+        {answerState !== 'idle' && (
+          <div className={`flex items-center gap-2 px-5 py-2 rounded-xl text-sm font-semibold animate-slide-up-fast ${
+            answerState === 'correct'
+              ? 'bg-emerald-100 text-emerald-700 border border-emerald-200'
+              : 'bg-red-100 text-red-700 border border-red-200'
+          }`}>
+            {answerState === 'correct'
+              ? '拼對了！'
+              : `正確是「${targetSeq.join('')}」`}
+          </div>
+        )}
+
+        {/* Symbol palette */}
+        <div className="flex flex-wrap justify-center gap-2 max-w-xs">
+          {palette.map((sym, i) => (
+            <button
+              key={`${sym}-${i}`}
+              onClick={() => handleTap(sym)}
+              disabled={answerState !== 'idle' || tapped.includes(sym)}
+              className={`w-11 h-11 rounded-xl border-2 text-lg font-bold transition-all active:scale-90 ${
+                tapped.includes(sym)
+                  ? 'bg-indigo-200 border-indigo-300 text-indigo-400 opacity-50'
+                  : 'bg-white border-indigo-200 text-gray-800 hover:bg-indigo-50 hover:border-indigo-400'
+              }`}
+            >
+              {sym}
+            </button>
+          ))}
+        </div>
+
+        {/* Clear + score row */}
+        <div className="flex items-center gap-4">
+          <button
+            onClick={handleClear}
+            disabled={answerState !== 'idle' || tapped.length === 0}
+            className="px-4 py-1.5 rounded-lg text-xs font-semibold text-gray-500 hover:text-gray-800 hover:bg-gray-100 disabled:opacity-40 transition-all"
+          >
+            清除重拼
+          </button>
+          <span className="text-xs text-gray-400">加油！</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reading-steps/ModeSelect.tsx
+++ b/frontend/src/components/reading-steps/ModeSelect.tsx
@@ -1,0 +1,60 @@
+/**
+ * ModeSelect.tsx
+ *
+ * Mode intro card for ZhuyinPhoneticGame.
+ * Lets the student choose: 選聲母 / 選韻母 / 拼音合成.
+ *
+ * Extracted from ZhuyinPhoneticGame.tsx as part of refactor/issue-1885.
+ */
+
+import React from 'react';
+import { GameMode } from './zhuyinGameEngine';
+
+export interface ModeSelectProps {
+  charCount: number;
+  onSelect: (mode: GameMode) => void;
+  onBack: () => void;
+}
+
+export function ModeSelect({ charCount, onSelect, onBack }: ModeSelectProps) {
+  const modes: { id: GameMode; label: string; desc: string; icon: string }[] = [
+    { id: 'initial', label: '選聲母', desc: '看字選出正確的聲母 ㄅㄆㄇ…', icon: '🔤' },
+    { id: 'final',   label: '選韻母', desc: '看字選出正確的韻母 ㄚㄛㄜ…', icon: '🎵' },
+    { id: 'compose', label: '拼音合成', desc: '把注音符號拼出正確的字音', icon: '🧩' },
+  ];
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center bg-indigo-50 px-6 py-10">
+      <div className="max-w-sm w-full bg-white rounded-3xl shadow-lg border border-indigo-100 p-8 flex flex-col items-center gap-6">
+        <div className="w-16 h-16 rounded-full bg-indigo-100 flex items-center justify-center text-3xl select-none">
+          🎮
+        </div>
+        <div className="text-center">
+          <h2 className="text-xl font-bold text-gray-900 mb-1">注音拼讀練習</h2>
+          <p className="text-sm text-gray-500">本課有 {charCount} 個字可以練習，請選擇模式</p>
+        </div>
+        <div className="w-full flex flex-col gap-3">
+          {modes.map(m => (
+            <button
+              key={m.id}
+              onClick={() => onSelect(m.id)}
+              className="w-full flex items-center gap-4 px-5 py-4 rounded-2xl border border-indigo-100 hover:border-indigo-400 hover:bg-indigo-50 transition-all active:scale-95 text-left"
+            >
+              <span className="text-2xl select-none">{m.icon}</span>
+              <div>
+                <div className="font-bold text-gray-900 text-sm">{m.label}</div>
+                <div className="text-xs text-gray-500">{m.desc}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={onBack}
+          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+        >
+          返回生字練習
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reading-steps/PickGame.tsx
+++ b/frontend/src/components/reading-steps/PickGame.tsx
@@ -1,0 +1,167 @@
+/**
+ * PickGame.tsx
+ *
+ * 聲母配對 / 韻母配對 game screen for ZhuyinPhoneticGame.
+ * Student picks the correct initial (聲母) or final (韻母) from 4 choices.
+ *
+ * Extracted from ZhuyinPhoneticGame.tsx as part of refactor/issue-1885.
+ * Logic delegated to zhuyinGameEngine (deriveInitialAnswer, deriveFinalAnswer,
+ * buildPickChoices) instead of being inlined.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  CharZhuyin,
+  GameMode,
+  AnswerState,
+  deriveInitialAnswer,
+  deriveFinalAnswer,
+  buildPickChoices,
+} from './zhuyinGameEngine';
+
+export interface PickGameProps {
+  mode: 'initial' | 'final';
+  questions: CharZhuyin[];
+  onFinish: (score: number, total: number) => void;
+  onBack: () => void;
+}
+
+export function PickGame({ mode, questions, onFinish, onBack }: PickGameProps) {
+  const [qIdx, setQIdx] = useState(0);
+  const [score, setScore] = useState(0);
+  const [answerState, setAnswerState] = useState<AnswerState>('idle');
+  const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const q = questions[qIdx];
+
+  // Build correct answer for the current mode using engine helpers
+  const correctAnswer = useMemo(() => {
+    if (mode === 'initial') return deriveInitialAnswer(q);
+    return deriveFinalAnswer(q);
+  }, [q, mode]);
+
+  // Build choices via engine — correct answer included, no duplicates
+  const choices = useMemo(
+    () => buildPickChoices(correctAnswer, mode as GameMode),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [qIdx, mode],
+  );
+
+  const handleChoice = useCallback((choice: string) => {
+    if (answerState !== 'idle') return;
+    setSelectedChoice(choice);
+    const isCorrect = choice === correctAnswer;
+    setAnswerState(isCorrect ? 'correct' : 'wrong');
+    if (isCorrect) setScore(s => s + 1);
+
+    timerRef.current = setTimeout(() => {
+      if (qIdx + 1 >= questions.length) {
+        onFinish(isCorrect ? score + 1 : score, questions.length);
+      } else {
+        setQIdx(i => i + 1);
+        setAnswerState('idle');
+        setSelectedChoice(null);
+      }
+    }, 900);
+  }, [answerState, correctAnswer, qIdx, questions.length, score, onFinish]);
+
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
+
+  const modeLabel = mode === 'initial' ? '聲母' : '韻母';
+  const progress = `${qIdx + 1} / ${questions.length}`;
+
+  return (
+    <div className="flex-1 flex flex-col bg-indigo-50">
+      {/* Header */}
+      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-2 shrink-0">
+        <button
+          onClick={onBack}
+          aria-label="返回生字練習"
+          className="text-gray-400 hover:text-gray-700 transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <span className="text-xs text-gray-700 font-semibold flex-1">選{modeLabel}練習</span>
+        <span className="text-xs text-gray-400" aria-label={`第 ${qIdx + 1} 題，共 ${questions.length} 題`}>{progress}</span>
+      </div>
+
+      {/* Progress bar */}
+      <div
+        role="progressbar"
+        aria-valuenow={qIdx + 1}
+        aria-valuemin={1}
+        aria-valuemax={questions.length}
+        aria-label={`練習進度：第 ${qIdx + 1} 題，共 ${questions.length} 題`}
+        className="w-full h-1.5 bg-gray-200"
+      >
+        <div
+          className="h-full bg-indigo-500 transition-all duration-500"
+          style={{ width: `${((qIdx) / questions.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Main area */}
+      <div className="flex-1 flex flex-col items-center justify-center px-6 gap-8">
+
+        {/* Question prompt */}
+        <div className="text-center space-y-2">
+          <p className="text-sm text-gray-500 font-medium">
+            這個字的<span className="text-indigo-600 font-bold">{modeLabel}</span>是哪個？
+          </p>
+          {/* Character display */}
+          <div className="w-32 h-32 mx-auto bg-white rounded-3xl shadow-md border border-indigo-100 flex flex-col items-center justify-center gap-1">
+            <span className="text-6xl font-bold text-gray-900 leading-none">{q.char}</span>
+            <span className="text-xs text-gray-400 mt-1">{q.zhuyin}</span>
+          </div>
+        </div>
+
+        {/* Feedback flash */}
+        {answerState !== 'idle' && (
+          <div className={`flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold animate-slide-up-fast ${
+            answerState === 'correct'
+              ? 'bg-emerald-100 text-emerald-700 border border-emerald-200'
+              : 'bg-red-100 text-red-700 border border-red-200'
+          }`}>
+            {answerState === 'correct' ? '答對了！真棒！' : `正確答案是「${correctAnswer}」`}
+          </div>
+        )}
+
+        {/* Choice buttons */}
+        <div className="grid grid-cols-2 gap-4 w-full max-w-xs">
+          {choices.map(choice => {
+            const isSelected = selectedChoice === choice;
+            const isCorrectChoice = choice === correctAnswer;
+            let btnClass = 'flex items-center justify-center h-16 rounded-2xl text-2xl font-bold border-2 transition-all active:scale-95 ';
+            if (answerState === 'idle') {
+              btnClass += 'bg-white border-indigo-200 text-gray-800 hover:bg-indigo-50 hover:border-indigo-400';
+            } else if (isCorrectChoice) {
+              btnClass += 'bg-emerald-100 border-emerald-500 text-emerald-800';
+            } else if (isSelected) {
+              btnClass += 'bg-red-100 border-red-400 text-red-700';
+            } else {
+              btnClass += 'bg-white border-gray-200 text-gray-400';
+            }
+            return (
+              <button
+                key={choice}
+                onClick={() => handleChoice(choice)}
+                disabled={answerState !== 'idle'}
+                aria-label={`選擇 ${choice}${answerState !== 'idle' && isCorrectChoice ? '（正確答案）' : answerState !== 'idle' && isSelected && !isCorrectChoice ? '（答錯）' : ''}`}
+                aria-pressed={isSelected ? true : undefined}
+                className={btnClass}
+              >
+                {choice}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Encouragement — Issue #1094: 學生端不顯示得分數字 */}
+        <p className="text-xs text-gray-400">繼續加油！</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reading-steps/ScoreBanner.tsx
+++ b/frontend/src/components/reading-steps/ScoreBanner.tsx
@@ -1,0 +1,58 @@
+/**
+ * ScoreBanner.tsx
+ *
+ * End-of-game score screen for ZhuyinPhoneticGame.
+ * Shows percentage bar, encouragement, retry and finish buttons.
+ *
+ * Extracted from ZhuyinPhoneticGame.tsx as part of refactor/issue-1885.
+ */
+
+import React from 'react';
+
+export interface ScoreBannerProps {
+  score: number;
+  total: number;
+  onFinish: () => void;
+  onRetry: () => void;
+}
+
+export function ScoreBanner({ score, total, onFinish, onRetry }: ScoreBannerProps) {
+  const pct = total > 0 ? Math.round((score / total) * 100) : 0;
+  const isGreat = pct >= 80;
+
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center bg-indigo-50 px-6 py-10">
+      <div className="max-w-sm w-full bg-white rounded-3xl shadow-lg border border-indigo-100 p-8 flex flex-col items-center gap-5 text-center">
+        <div className="text-5xl select-none">{isGreat ? '🌟' : '💪'}</div>
+        <div>
+          <h3 className="text-2xl font-bold text-gray-900">
+            {isGreat ? '太厲害了！' : '繼續加油！'}
+          </h3>
+          <p className="text-gray-500 text-sm mt-1">
+            {isGreat ? '幾乎全對，超級棒！' : '有答對一些，再試一次會更好'}
+          </p>
+        </div>
+        <div className="w-full bg-gray-100 rounded-full h-3 overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all duration-700 ${isGreat ? 'bg-emerald-500' : 'bg-indigo-400'}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <div className="w-full flex flex-col gap-3 mt-2">
+          <button
+            onClick={onRetry}
+            className="w-full py-2.5 rounded-full font-bold text-sm bg-indigo-600 hover:bg-indigo-500 text-white shadow transition-all active:scale-95"
+          >
+            再玩一次
+          </button>
+          <button
+            onClick={onFinish}
+            className="w-full py-2.5 rounded-full font-semibold text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 transition-all active:scale-95"
+          >
+            返回生字練習
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reading-steps/ZhuyinPhoneticGame.tsx
+++ b/frontend/src/components/reading-steps/ZhuyinPhoneticGame.tsx
@@ -11,21 +11,19 @@
  * Falls back gracefully when zhuyin data is unavailable.
  *
  * Refactored (issue-1859): pure logic extracted to zhuyinGameLogic.ts.
+ * Refactored (issue-1885): UI sub-components extracted to separate files;
+ *   game engine logic moved to zhuyinGameEngine.ts.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { lookupCharactersBatch } from '../../services/learningApi';
-import { INITIALS, PRENUCLEAR, FINALS } from '../zhuyin/bopomoConstants';
 import { Story } from '../../types';
-import {
-  CharZhuyin,
-  parseZhuyin,
-  shuffle,
-  buildChoices,
-  getInitialModeAnswer,
-  getFinalModeAnswer,
-  composeTargetSeq,
-} from './zhuyinGameLogic';
+import { CharZhuyin, parseZhuyin, shuffle } from './zhuyinGameLogic';
+import { GameMode, filterQuestionsForMode } from './zhuyinGameEngine';
+import { ModeSelect } from './ModeSelect';
+import { ScoreBanner } from './ScoreBanner';
+import { PickGame } from './PickGame';
+import { ComposeGame } from './ComposeGame';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -39,11 +37,8 @@ interface ZhuyinPhoneticGameProps {
   onBack: () => void;
 }
 
-type GameMode = 'initial' | 'final' | 'compose';
-type AnswerState = 'idle' | 'correct' | 'wrong';
-
 // ─────────────────────────────────────────────────────────────────────────────
-// Loading / Error states
+// Loading state
 // ─────────────────────────────────────────────────────────────────────────────
 
 function LoadingState() {
@@ -51,464 +46,6 @@ function LoadingState() {
     <div className="flex-1 flex flex-col items-center justify-center py-12 gap-4" role="status" aria-label="載入注音資料中">
       <div className="w-10 h-10 border-4 border-indigo-200 border-t-indigo-500 rounded-full animate-spin" aria-hidden="true" />
       <p className="text-sm text-gray-500">載入注音資料中…</p>
-    </div>
-  );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Mode intro card
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface ModeSelectProps {
-  charCount: number;
-  onSelect: (mode: GameMode) => void;
-  onBack: () => void;
-}
-
-function ModeSelect({ charCount, onSelect, onBack }: ModeSelectProps) {
-  const modes: { id: GameMode; label: string; desc: string; icon: string }[] = [
-    { id: 'initial', label: '選聲母', desc: '看字選出正確的聲母 ㄅㄆㄇ…', icon: '🔤' },
-    { id: 'final',   label: '選韻母', desc: '看字選出正確的韻母 ㄚㄛㄜ…', icon: '🎵' },
-    { id: 'compose', label: '拼音合成', desc: '把注音符號拼出正確的字音', icon: '🧩' },
-  ];
-
-  return (
-    <div className="flex-1 flex flex-col items-center justify-center bg-indigo-50 px-6 py-10">
-      <div className="max-w-sm w-full bg-white rounded-3xl shadow-lg border border-indigo-100 p-8 flex flex-col items-center gap-6">
-        <div className="w-16 h-16 rounded-full bg-indigo-100 flex items-center justify-center text-3xl select-none">
-          🎮
-        </div>
-        <div className="text-center">
-          <h2 className="text-xl font-bold text-gray-900 mb-1">注音拼讀練習</h2>
-          <p className="text-sm text-gray-500">本課有 {charCount} 個字可以練習，請選擇模式</p>
-        </div>
-        <div className="w-full flex flex-col gap-3">
-          {modes.map(m => (
-            <button
-              key={m.id}
-              onClick={() => onSelect(m.id)}
-              className="w-full flex items-center gap-4 px-5 py-4 rounded-2xl border border-indigo-100 hover:border-indigo-400 hover:bg-indigo-50 transition-all active:scale-95 text-left"
-            >
-              <span className="text-2xl select-none">{m.icon}</span>
-              <div>
-                <div className="font-bold text-gray-900 text-sm">{m.label}</div>
-                <div className="text-xs text-gray-500">{m.desc}</div>
-              </div>
-            </button>
-          ))}
-        </div>
-        <button
-          onClick={onBack}
-          className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
-        >
-          返回生字練習
-        </button>
-      </div>
-    </div>
-  );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Score banner
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface ScoreBannerProps {
-  score: number;
-  total: number;
-  onFinish: () => void;
-  onRetry: () => void;
-}
-
-function ScoreBanner({ score, total, onFinish, onRetry }: ScoreBannerProps) {
-  const pct = total > 0 ? Math.round((score / total) * 100) : 0;
-  const isGreat = pct >= 80;
-
-  return (
-    <div className="flex-1 flex flex-col items-center justify-center bg-indigo-50 px-6 py-10">
-      <div className="max-w-sm w-full bg-white rounded-3xl shadow-lg border border-indigo-100 p-8 flex flex-col items-center gap-5 text-center">
-        <div className="text-5xl select-none">{isGreat ? '🌟' : '💪'}</div>
-        <div>
-          <h3 className="text-2xl font-bold text-gray-900">
-            {isGreat ? '太厲害了！' : '繼續加油！'}
-          </h3>
-          <p className="text-gray-500 text-sm mt-1">
-            {isGreat ? '幾乎全對，超級棒！' : '有答對一些，再試一次會更好'}
-          </p>
-        </div>
-        <div className="w-full bg-gray-100 rounded-full h-3 overflow-hidden">
-          <div
-            className={`h-full rounded-full transition-all duration-700 ${isGreat ? 'bg-emerald-500' : 'bg-indigo-400'}`}
-            style={{ width: `${pct}%` }}
-          />
-        </div>
-        <div className="w-full flex flex-col gap-3 mt-2">
-          <button
-            onClick={onRetry}
-            className="w-full py-2.5 rounded-full font-bold text-sm bg-indigo-600 hover:bg-indigo-500 text-white shadow transition-all active:scale-95"
-          >
-            再玩一次
-          </button>
-          <button
-            onClick={onFinish}
-            className="w-full py-2.5 rounded-full font-semibold text-sm text-gray-500 hover:text-gray-800 hover:bg-gray-100 transition-all active:scale-95"
-          >
-            返回生字練習
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// InitialGame — 聲母配對 or 韻母配對
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface PickGameProps {
-  mode: 'initial' | 'final';
-  questions: CharZhuyin[];
-  onFinish: (score: number, total: number) => void;
-  onBack: () => void;
-}
-
-function PickGame({ mode, questions, onFinish, onBack }: PickGameProps) {
-  const [qIdx, setQIdx] = useState(0);
-  const [score, setScore] = useState(0);
-  const [answerState, setAnswerState] = useState<AnswerState>('idle');
-  const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const q = questions[qIdx];
-
-  // Build correct answer and choice pool for the current mode
-  const correctAnswer = useMemo(() => {
-    if (mode === 'initial') return getInitialModeAnswer(q);
-    return getFinalModeAnswer(q);
-  }, [q, mode]);
-
-  const choicePool = useMemo(() => {
-    if (mode === 'initial') {
-      // Pool: all initials + prenuclear symbols
-      return [...INITIALS, ...PRENUCLEAR];
-    }
-    // Final pool: all finals + medials + tones combined
-    // Generate some common finals with tone variations
-    const baseFinals = [
-      ...FINALS.map(f => f),                // no tone = tone 1
-      ...FINALS.map(f => f + 'ˊ'),
-      ...FINALS.map(f => f + 'ˇ'),
-      ...FINALS.map(f => f + 'ˋ'),
-      ...PRENUCLEAR.map(p => p),
-      ...PRENUCLEAR.map(p => p + 'ˊ'),
-      ...PRENUCLEAR.map(p => p + 'ˇ'),
-      ...PRENUCLEAR.map(p => p + 'ˋ'),
-    ];
-    return baseFinals;
-  }, [mode]);
-
-  const choices = useMemo(
-    () => buildChoices(correctAnswer, choicePool),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [qIdx, mode],
-  );
-
-  const handleChoice = useCallback((choice: string) => {
-    if (answerState !== 'idle') return;
-    setSelectedChoice(choice);
-    const isCorrect = choice === correctAnswer;
-    setAnswerState(isCorrect ? 'correct' : 'wrong');
-    if (isCorrect) setScore(s => s + 1);
-
-    timerRef.current = setTimeout(() => {
-      if (qIdx + 1 >= questions.length) {
-        onFinish(isCorrect ? score + 1 : score, questions.length);
-      } else {
-        setQIdx(i => i + 1);
-        setAnswerState('idle');
-        setSelectedChoice(null);
-      }
-    }, 900);
-  }, [answerState, correctAnswer, qIdx, questions.length, score, onFinish]);
-
-  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
-
-  const modeLabel = mode === 'initial' ? '聲母' : '韻母';
-  const progress = `${qIdx + 1} / ${questions.length}`;
-
-  return (
-    <div className="flex-1 flex flex-col bg-indigo-50">
-      {/* Header */}
-      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-2 shrink-0">
-        <button
-          onClick={onBack}
-          aria-label="返回生字練習"
-          className="text-gray-400 hover:text-gray-700 transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-          </svg>
-        </button>
-        <span className="text-xs text-gray-700 font-semibold flex-1">選{modeLabel}練習</span>
-        <span className="text-xs text-gray-400" aria-label={`第 ${qIdx + 1} 題，共 ${questions.length} 題`}>{progress}</span>
-      </div>
-
-      {/* Progress bar */}
-      <div
-        role="progressbar"
-        aria-valuenow={qIdx + 1}
-        aria-valuemin={1}
-        aria-valuemax={questions.length}
-        aria-label={`練習進度：第 ${qIdx + 1} 題，共 ${questions.length} 題`}
-        className="w-full h-1.5 bg-gray-200"
-      >
-        <div
-          className="h-full bg-indigo-500 transition-all duration-500"
-          style={{ width: `${((qIdx) / questions.length) * 100}%` }}
-        />
-      </div>
-
-      {/* Main area */}
-      <div className="flex-1 flex flex-col items-center justify-center px-6 gap-8">
-
-        {/* Question prompt */}
-        <div className="text-center space-y-2">
-          <p className="text-sm text-gray-500 font-medium">
-            這個字的<span className="text-indigo-600 font-bold">{modeLabel}</span>是哪個？
-          </p>
-          {/* Character display */}
-          <div className="w-32 h-32 mx-auto bg-white rounded-3xl shadow-md border border-indigo-100 flex flex-col items-center justify-center gap-1">
-            <span className="text-6xl font-bold text-gray-900 leading-none">{q.char}</span>
-            <span className="text-xs text-gray-400 mt-1">{q.zhuyin}</span>
-          </div>
-        </div>
-
-        {/* Feedback flash */}
-        {answerState !== 'idle' && (
-          <div className={`flex items-center gap-2 px-5 py-2.5 rounded-xl text-sm font-semibold animate-slide-up-fast ${
-            answerState === 'correct'
-              ? 'bg-emerald-100 text-emerald-700 border border-emerald-200'
-              : 'bg-red-100 text-red-700 border border-red-200'
-          }`}>
-            {answerState === 'correct' ? '答對了！真棒！' : `正確答案是「${correctAnswer}」`}
-          </div>
-        )}
-
-        {/* Choice buttons */}
-        <div className="grid grid-cols-2 gap-4 w-full max-w-xs">
-          {choices.map(choice => {
-            const isSelected = selectedChoice === choice;
-            const isCorrectChoice = choice === correctAnswer;
-            let btnClass = 'flex items-center justify-center h-16 rounded-2xl text-2xl font-bold border-2 transition-all active:scale-95 ';
-            if (answerState === 'idle') {
-              btnClass += 'bg-white border-indigo-200 text-gray-800 hover:bg-indigo-50 hover:border-indigo-400';
-            } else if (isCorrectChoice) {
-              btnClass += 'bg-emerald-100 border-emerald-500 text-emerald-800';
-            } else if (isSelected) {
-              btnClass += 'bg-red-100 border-red-400 text-red-700';
-            } else {
-              btnClass += 'bg-white border-gray-200 text-gray-400';
-            }
-            return (
-              <button
-                key={choice}
-                onClick={() => handleChoice(choice)}
-                disabled={answerState !== 'idle'}
-                aria-label={`選擇 ${choice}${answerState !== 'idle' && isCorrectChoice ? '（正確答案）' : answerState !== 'idle' && isSelected && !isCorrectChoice ? '（答錯）' : ''}`}
-                aria-pressed={isSelected ? true : undefined}
-                className={btnClass}
-              >
-                {choice}
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Encouragement — Issue #1094: 學生端不顯示得分數字 */}
-        <p className="text-xs text-gray-400">繼續加油！</p>
-      </div>
-    </div>
-  );
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// ComposeGame — 拼音合成: tap bopomofo symbols in order
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface ComposeGameProps {
-  questions: CharZhuyin[];
-  onFinish: (score: number, total: number) => void;
-  onBack: () => void;
-}
-
-function ComposeGame({ questions, onFinish, onBack }: ComposeGameProps) {
-  const [qIdx, setQIdx] = useState(0);
-  const [score, setScore] = useState(0);
-  const [tapped, setTapped] = useState<string[]>([]);
-  const [answerState, setAnswerState] = useState<AnswerState>('idle');
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const q = questions[qIdx];
-
-  // Target sequence: [initial, medial, finalPart, tone] — non-empty parts
-  const targetSeq = useMemo(() => composeTargetSeq(q), [q]);
-
-  // Build a palette of symbols to tap from
-  const palette = useMemo(() => {
-    const correct = new Set(targetSeq);
-    // Add distractors: pick random symbols from pools not in correct set
-    const distractorPool = shuffle([
-      ...INITIALS.filter(x => !correct.has(x)),
-      ...PRENUCLEAR.filter(x => !correct.has(x)),
-      ...FINALS.filter(x => !correct.has(x)),
-      ...['ˊ', 'ˇ', 'ˋ'].filter(x => !correct.has(x)),
-    ]);
-    const distractors = distractorPool.slice(0, Math.max(0, 8 - targetSeq.length));
-    return shuffle([...targetSeq, ...distractors]);
-  }, [targetSeq]);
-
-  const handleTap = useCallback((sym: string) => {
-    if (answerState !== 'idle') return;
-    const next = [...tapped, sym];
-    setTapped(next);
-
-    // Check if length matches target
-    if (next.length === targetSeq.length) {
-      const isCorrect = next.join('') === targetSeq.join('');
-      setAnswerState(isCorrect ? 'correct' : 'wrong');
-      if (isCorrect) setScore(s => s + 1);
-
-      timerRef.current = setTimeout(() => {
-        const newScore = isCorrect ? score + 1 : score;
-        if (qIdx + 1 >= questions.length) {
-          onFinish(newScore, questions.length);
-        } else {
-          setQIdx(i => i + 1);
-          setTapped([]);
-          setAnswerState('idle');
-        }
-      }, 1000);
-    }
-  }, [answerState, tapped, targetSeq, score, qIdx, questions.length, onFinish]);
-
-  const handleClear = useCallback(() => {
-    if (answerState !== 'idle') return;
-    setTapped([]);
-  }, [answerState]);
-
-  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
-
-  const progress = `${qIdx + 1} / ${questions.length}`;
-
-  return (
-    <div className="flex-1 flex flex-col bg-indigo-50">
-      {/* Header */}
-      <div className="h-9 bg-white border-b border-gray-200 flex items-center px-4 gap-2 shrink-0">
-        <button
-          onClick={onBack}
-          aria-label="返回生字練習"
-          className="text-gray-400 hover:text-gray-700 transition-colors p-1 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
-        >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-          </svg>
-        </button>
-        <span className="text-xs text-gray-700 font-semibold flex-1">拼音合成練習</span>
-        <span className="text-xs text-gray-400" aria-label={`第 ${qIdx + 1} 題，共 ${questions.length} 題`}>{progress}</span>
-      </div>
-
-      {/* Progress bar */}
-      <div
-        role="progressbar"
-        aria-valuenow={qIdx + 1}
-        aria-valuemin={1}
-        aria-valuemax={questions.length}
-        aria-label={`練習進度：第 ${qIdx + 1} 題，共 ${questions.length} 題`}
-        className="w-full h-1.5 bg-gray-200"
-      >
-        <div
-          className="h-full bg-indigo-500 transition-all duration-500"
-          style={{ width: `${(qIdx / questions.length) * 100}%` }}
-        />
-      </div>
-
-      {/* Main area */}
-      <div className="flex-1 flex flex-col items-center justify-center px-6 gap-6">
-
-        {/* Prompt */}
-        <div className="text-center space-y-3">
-          <p className="text-sm text-gray-500">
-            按順序拼出這個字的注音
-          </p>
-          <div className="w-28 h-28 mx-auto bg-white rounded-3xl shadow-md border border-indigo-100 flex items-center justify-center">
-            <span className="text-5xl font-bold text-gray-900">{q.char}</span>
-          </div>
-        </div>
-
-        {/* Answer slots */}
-        <div className="flex items-center gap-2">
-          {targetSeq.map((part, i) => {
-            const filled = tapped[i];
-            const stateClass = answerState === 'idle'
-              ? filled
-                ? 'bg-indigo-100 border-indigo-400 text-indigo-700'
-                : 'bg-white border-dashed border-indigo-300 text-transparent'
-              : answerState === 'correct'
-                ? 'bg-emerald-100 border-emerald-400 text-emerald-700'
-                : 'bg-red-100 border-red-400 text-red-700';
-            return (
-              <div
-                key={i}
-                className={`w-12 h-12 flex items-center justify-center rounded-xl border-2 text-xl font-bold transition-all duration-200 ${stateClass}`}
-              >
-                {filled || '?'}
-              </div>
-            );
-          })}
-        </div>
-
-        {/* Feedback */}
-        {answerState !== 'idle' && (
-          <div className={`flex items-center gap-2 px-5 py-2 rounded-xl text-sm font-semibold animate-slide-up-fast ${
-            answerState === 'correct'
-              ? 'bg-emerald-100 text-emerald-700 border border-emerald-200'
-              : 'bg-red-100 text-red-700 border border-red-200'
-          }`}>
-            {answerState === 'correct'
-              ? '拼對了！'
-              : `正確是「${targetSeq.join('')}」`}
-          </div>
-        )}
-
-        {/* Symbol palette */}
-        <div className="flex flex-wrap justify-center gap-2 max-w-xs">
-          {palette.map((sym, i) => (
-            <button
-              key={`${sym}-${i}`}
-              onClick={() => handleTap(sym)}
-              disabled={answerState !== 'idle' || tapped.includes(sym)}
-              className={`w-11 h-11 rounded-xl border-2 text-lg font-bold transition-all active:scale-90 ${
-                tapped.includes(sym)
-                  ? 'bg-indigo-200 border-indigo-300 text-indigo-400 opacity-50'
-                  : 'bg-white border-indigo-200 text-gray-800 hover:bg-indigo-50 hover:border-indigo-400'
-              }`}
-            >
-              {sym}
-            </button>
-          ))}
-        </div>
-
-        {/* Clear + score row */}
-        <div className="flex items-center gap-4">
-          <button
-            onClick={handleClear}
-            disabled={answerState !== 'idle' || tapped.length === 0}
-            className="px-4 py-1.5 rounded-lg text-xs font-semibold text-gray-500 hover:text-gray-800 hover:bg-gray-100 disabled:opacity-40 transition-all"
-          >
-            清除重拼
-          </button>
-          <span className="text-xs text-gray-400">加油！</span>
-        </div>
-      </div>
     </div>
   );
 }
@@ -537,7 +74,7 @@ const ZhuyinPhoneticGame: React.FC<ZhuyinPhoneticGameProps> = ({
     const chars: string[] = [];
     for (const line of story.content) {
       for (const ch of line) {
-        if (/[\u4e00-\u9fa5]/.test(ch) && !seen.has(ch)) {
+        if (/[一-龥]/.test(ch) && !seen.has(ch)) {
           chars.push(ch);
           seen.add(ch);
         }
@@ -580,18 +117,9 @@ const ZhuyinPhoneticGame: React.FC<ZhuyinPhoneticGameProps> = ({
       .finally(() => setLoading(false));
   }, [targetChars]);
 
-  // Build questions for the active mode (filter chars that have the needed part)
+  // Build questions for the active mode (filter + shuffle)
   const questions = useMemo(() => {
-    let filtered = charData;
-    if (activeMode === 'initial') {
-      // Need at least initial or medial
-      filtered = charData.filter(c => c.initial || c.medial);
-    } else if (activeMode === 'final') {
-      // Need finalPart or medial
-      filtered = charData.filter(c => c.finalPart || c.medial);
-    }
-    // Shuffle for variety
-    return shuffle(filtered);
+    return shuffle(filterQuestionsForMode(charData, activeMode));
   }, [charData, activeMode]);
 
   const handleModeSelect = (mode: GameMode) => {

--- a/frontend/src/components/reading-steps/zhuyinGameEngine.test.ts
+++ b/frontend/src/components/reading-steps/zhuyinGameEngine.test.ts
@@ -1,0 +1,225 @@
+/**
+ * zhuyinGameEngine.test.ts
+ *
+ * TDD-first tests for zhuyinGameEngine.ts.
+ * Written BEFORE refactor (tautology check: tests pass on current engine).
+ *
+ * Three required test cases from issue #1885:
+ *   1. parse_zhuyin_splits_initial_medial_final_and_tone
+ *   2. build_choices_includes_correct_answer_once
+ *   3. compose_game_scores_once_when_sequence_completed
+ *
+ * Run: npx vitest run src/components/reading-steps/zhuyinGameEngine.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  deriveInitialAnswer,
+  deriveFinalAnswer,
+  buildPickChoices,
+  buildComposePalette,
+  scoreOnce,
+  filterQuestionsForMode,
+  GameMode,
+} from './zhuyinGameEngine';
+import { parseZhuyin } from './zhuyinGameLogic';
+import type { CharZhuyin } from './zhuyinGameEngine';
+
+// Helper: build a CharZhuyin from a raw zhuyin string
+function makeChar(char: string, zhuyinStr: string): CharZhuyin {
+  const parsed = parseZhuyin(zhuyinStr);
+  return { char, zhuyin: zhuyinStr, ...parsed };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 1: parse_zhuyin_splits_initial_medial_final_and_tone
+//
+// Validates parseZhuyin (via makeChar) correctly splits all four parts for
+// multiple phonological patterns, including zero-initial and tone marks.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('parse_zhuyin_splits_initial_medial_final_and_tone', () => {
+  it('full syllable ㄑㄧㄥˊ (情) → initial=ㄑ medial=ㄧ final=ㄥ tone=ˊ', () => {
+    const q = makeChar('情', 'ㄑㄧㄥˊ');
+    expect(q.initial).toBe('ㄑ');
+    expect(q.medial).toBe('ㄧ');
+    expect(q.finalPart).toBe('ㄥ');
+    expect(q.tone).toBe('ˊ');
+  });
+
+  it('zero-initial medial-only ㄧ (一) → initial="" medial=ㄧ final="" tone=""', () => {
+    const q = makeChar('一', 'ㄧ');
+    expect(q.initial).toBe('');
+    expect(q.medial).toBe('ㄧ');
+    expect(q.finalPart).toBe('');
+    expect(q.tone).toBe('');
+  });
+
+  it('zero-initial with tone ㄨˇ (五) → initial="" medial=ㄨ final="" tone=ˇ', () => {
+    const q = makeChar('五', 'ㄨˇ');
+    expect(q.initial).toBe('');
+    expect(q.medial).toBe('ㄨ');
+    expect(q.finalPart).toBe('');
+    expect(q.tone).toBe('ˇ');
+  });
+
+  it('initial + final, no medial ㄇㄢˋ (慢) → initial=ㄇ medial="" final=ㄢ tone=ˋ', () => {
+    const q = makeChar('慢', 'ㄇㄢˋ');
+    expect(q.initial).toBe('ㄇ');
+    expect(q.medial).toBe('');
+    expect(q.finalPart).toBe('ㄢ');
+    expect(q.tone).toBe('ˋ');
+  });
+
+  it('neutral tone mark ˙ is captured as tone', () => {
+    const q = makeChar('嗎', 'ㄇㄜ˙');
+    expect(q.initial).toBe('ㄇ');
+    expect(q.finalPart).toBe('ㄜ');
+    expect(q.tone).toBe('˙');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 2: build_choices_includes_correct_answer_once
+//
+// buildPickChoices must:
+//   a) include the correct answer in returned choices
+//   b) produce no duplicates
+//   c) return exactly 4 choices by default
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('build_choices_includes_correct_answer_once', () => {
+  const correct = 'ㄑ';
+
+  it('initial mode: correct answer ㄑ is present in 4 choices', () => {
+    const choices = buildPickChoices(correct, 'initial');
+    expect(choices).toContain(correct);
+    expect(choices).toHaveLength(4);
+  });
+
+  it('initial mode: no duplicates in choices', () => {
+    // Run 10 times to check across shuffle randomness
+    for (let i = 0; i < 10; i++) {
+      const choices = buildPickChoices(correct, 'initial');
+      expect(new Set(choices).size).toBe(choices.length);
+    }
+  });
+
+  it('final mode: correct answer ㄥˊ is present once', () => {
+    const finalCorrect = 'ㄥˊ';
+    const choices = buildPickChoices(finalCorrect, 'final');
+    const occurrences = choices.filter(c => c === finalCorrect).length;
+    expect(occurrences).toBe(1);
+    expect(choices).toHaveLength(4);
+  });
+
+  it('correct answer appears exactly once even if correct is in pool', () => {
+    // Correct answer 'ㄧ' (PRENUCLEAR) is part of the initial pool — must not duplicate
+    const choices = buildPickChoices('ㄧ', 'initial');
+    const occurrences = choices.filter(c => c === 'ㄧ').length;
+    expect(occurrences).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test 3: compose_game_scores_once_when_sequence_completed
+//
+// scoreOnce is a pure function:
+//   - correct tap on last symbol → increments score by 1
+//   - wrong answer → score unchanged
+//   - called multiple times doesn't double-count (caller manages state)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('compose_game_scores_once_when_sequence_completed', () => {
+  it('correct answer increments score by exactly 1', () => {
+    const newScore = scoreOnce(2, true);
+    expect(newScore).toBe(3);
+  });
+
+  it('wrong answer does not change score', () => {
+    const newScore = scoreOnce(2, false);
+    expect(newScore).toBe(2);
+  });
+
+  it('score starts at 0 and increments correctly across sequence', () => {
+    // Simulate completing a 3-question sequence: correct, wrong, correct
+    let score = 0;
+    score = scoreOnce(score, true);   // 1
+    score = scoreOnce(score, false);  // 1
+    score = scoreOnce(score, true);   // 2
+    expect(score).toBe(2);
+  });
+
+  it('calling scoreOnce twice for same question does NOT double-count', () => {
+    // Caller is responsible for calling once per question — pure fn test
+    const scoreAfterFirst = scoreOnce(0, true);  // 1
+    // Should NOT call again for the same question
+    expect(scoreAfterFirst).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Additional engine tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('deriveInitialAnswer', () => {
+  it('returns initial when present', () => {
+    const q = makeChar('情', 'ㄑㄧㄥˊ');
+    expect(deriveInitialAnswer(q)).toBe('ㄑ');
+  });
+
+  it('falls back to medial when no initial', () => {
+    const q = makeChar('一', 'ㄧ');
+    expect(deriveInitialAnswer(q)).toBe('ㄧ');
+  });
+});
+
+describe('deriveFinalAnswer', () => {
+  it('returns finalPart + tone for full syllable', () => {
+    const q = makeChar('情', 'ㄑㄧㄥˊ');
+    expect(deriveFinalAnswer(q)).toBe('ㄥˊ');
+  });
+
+  it('returns medial + tone when medial-only (no finalPart)', () => {
+    const q = makeChar('五', 'ㄨˇ');
+    expect(deriveFinalAnswer(q)).toBe('ㄨˇ');
+  });
+});
+
+describe('buildComposePalette', () => {
+  it('palette includes all target sequence symbols', () => {
+    const targetSeq = ['ㄑ', 'ㄧ', 'ㄥ', 'ˊ'];
+    const palette = buildComposePalette(targetSeq);
+    for (const sym of targetSeq) {
+      expect(palette).toContain(sym);
+    }
+  });
+
+  it('palette has at least 8 symbols', () => {
+    const targetSeq = ['ㄅ', 'ㄚ'];
+    const palette = buildComposePalette(targetSeq);
+    expect(palette.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
+describe('filterQuestionsForMode', () => {
+  const chars: CharZhuyin[] = [
+    { char: '情', zhuyin: 'ㄑㄧㄥˊ', initial: 'ㄑ', medial: 'ㄧ', finalPart: 'ㄥ', tone: 'ˊ' },
+    { char: '一', zhuyin: 'ㄧ', initial: '', medial: 'ㄧ', finalPart: '', tone: '' },
+    // contrived char with no initial, no medial — should be filtered in initial mode
+    { char: '?', zhuyin: 'ㄚ', initial: '', medial: '', finalPart: 'ㄚ', tone: '' },
+  ];
+
+  it('initial mode keeps chars with initial or medial', () => {
+    const filtered = filterQuestionsForMode(chars, 'initial');
+    // '?' has no initial and no medial → excluded
+    expect(filtered.some(c => c.char === '?')).toBe(false);
+    expect(filtered.some(c => c.char === '情')).toBe(true);
+    expect(filtered.some(c => c.char === '一')).toBe(true);
+  });
+
+  it('compose mode returns all chars', () => {
+    const filtered = filterQuestionsForMode(chars, 'compose');
+    expect(filtered).toHaveLength(chars.length);
+  });
+});

--- a/frontend/src/components/reading-steps/zhuyinGameEngine.ts
+++ b/frontend/src/components/reading-steps/zhuyinGameEngine.ts
@@ -1,0 +1,112 @@
+/**
+ * zhuyinGameEngine.ts
+ *
+ * Game-level logic for ZhuyinPhoneticGame: answer derivation, palette
+ * construction, scoring helpers. Separate from zhuyinGameLogic.ts (which
+ * holds pure parse/shuffle/buildChoices utilities).
+ *
+ * No React imports — testable in isolation.
+ * Extracted as part of refactor/issue-1885-zhuyin-game-ui-split.
+ */
+
+import { INITIALS, PRENUCLEAR, FINALS } from '../zhuyin/bopomoConstants';
+import { CharZhuyin, shuffle, buildChoices as rawBuildChoices } from './zhuyinGameLogic';
+
+// Re-export CharZhuyin so UI files can import from a single engine file
+export type { CharZhuyin };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type GameMode = 'initial' | 'final' | 'compose';
+export type AnswerState = 'idle' | 'correct' | 'wrong';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// deriveAnswer
+//
+// Returns the single correct answer string for a given mode and question.
+// For initial mode: use initial if present, else fall back to medial.
+// For final mode: finalPart+tone, falling back to medial+tone when no finalPart.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function deriveInitialAnswer(q: CharZhuyin): string {
+  return q.initial || q.medial;
+}
+
+export function deriveFinalAnswer(q: CharZhuyin): string {
+  const fin = q.medial && !q.finalPart ? q.medial : q.finalPart || q.medial;
+  return fin + q.tone;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildPickChoices
+//
+// Build the 4 answer choices for initial/final (pick) mode.
+// Correct answer is always included exactly once; no duplicates.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildInitialPool(): string[] {
+  return [...INITIALS, ...PRENUCLEAR];
+}
+
+export function buildFinalPool(): string[] {
+  return [
+    ...FINALS,
+    ...FINALS.map(f => f + 'ˊ'),
+    ...FINALS.map(f => f + 'ˇ'),
+    ...FINALS.map(f => f + 'ˋ'),
+    ...PRENUCLEAR,
+    ...PRENUCLEAR.map(p => p + 'ˊ'),
+    ...PRENUCLEAR.map(p => p + 'ˇ'),
+    ...PRENUCLEAR.map(p => p + 'ˋ'),
+  ];
+}
+
+export function buildPickChoices(correct: string, mode: GameMode, count = 4): string[] {
+  const pool = mode === 'initial' ? buildInitialPool() : buildFinalPool();
+  return rawBuildChoices(correct, pool, count);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildComposePalette
+//
+// Builds the symbol palette for compose mode: correct sequence symbols
+// plus distractors. Total size = max(targetSeq.length + 4, 8).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function buildComposePalette(targetSeq: string[]): string[] {
+  const correct = new Set(targetSeq);
+  const distractorPool = shuffle([
+    ...INITIALS.filter(x => !correct.has(x)),
+    ...PRENUCLEAR.filter(x => !correct.has(x)),
+    ...FINALS.filter(x => !correct.has(x)),
+    ...['ˊ', 'ˇ', 'ˋ'].filter(x => !correct.has(x)),
+  ]);
+  const distractors = distractorPool.slice(0, Math.max(0, 8 - targetSeq.length));
+  return shuffle([...targetSeq, ...distractors]);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scoreOnce
+//
+// Returns the new score when a question completes.
+// If correct: increment by 1. If wrong: unchanged.
+// Pure function — no side effects.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function scoreOnce(currentScore: number, isCorrect: boolean): number {
+  return isCorrect ? currentScore + 1 : currentScore;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// filterQuestionsForMode
+//
+// Filter charData for questions that have the required phonetic components.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function filterQuestionsForMode(data: CharZhuyin[], mode: GameMode): CharZhuyin[] {
+  if (mode === 'initial') return data.filter(c => c.initial || c.medial);
+  if (mode === 'final')   return data.filter(c => c.finalPart || c.medial);
+  return data; // compose uses all
+}


### PR DESCRIPTION
Fixes #1885

## Summary
- Extract `zhuyinGameEngine.ts` (112L) — game-level logic: `deriveInitialAnswer`, `deriveFinalAnswer`, `buildPickChoices`, `buildComposePalette`, `scoreOnce`, `filterQuestionsForMode`
- Extract 4 UI files: `ModeSelect.tsx` (60L), `ScoreBanner.tsx` (58L), `PickGame.tsx` (167L), `ComposeGame.tsx` (187L)
- `ZhuyinPhoneticGame.tsx` slimmed 693→221 lines (pure orchestrator: data fetch + phase routing)
- Add `zhuyinGameEngine.test.ts` (21 tests) covering the 3 required TDD cases from issue

## TDD Coverage (3 required cases)
- `parse_zhuyin_splits_initial_medial_final_and_tone` — ㄑㄧㄥˊ + zero-initial + tone marks
- `build_choices_includes_correct_answer_once` — correct in 4 choices, no duplicates
- `compose_game_scores_once_when_sequence_completed` — `scoreOnce` is pure, no double-count

## Test Results
- `zhuyinGameEngine.test.ts`: 21/21 pass
- `zhuyinGameLogic.test.ts`: 22/22 pass (untouched)
- `zhuyinGameLogic.ts`: NOT modified

## Files Touched
- `ZhuyinPhoneticGame.tsx` — slimmed
- `zhuyinGameEngine.ts` — new engine
- `zhuyinGameEngine.test.ts` — new tests
- `ModeSelect.tsx`, `ScoreBanner.tsx`, `PickGame.tsx`, `ComposeGame.tsx` — new UI files