### PR TITLE
fix(csp): add blob: to img-src for OMO cropped image previews (Fixes #1917)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,7 +86,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         "script-src 'self' 'unsafe-inline' https://apis.google.com; "
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
         "font-src 'self' https://fonts.gstatic.com; "
-        "img-src 'self' data: https:; "
+        "img-src 'self' data: blob: https:; "  # blob: needed for OMO cropped image previews (#1917)
         "media-src 'self' blob:; "
         "connect-src 'self' "
         "https://*.run.app "

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -143,3 +143,24 @@ class TestCspDirectives:
         response = client.get("/")
         csp = response.headers.get("content-security-policy", "")
         assert "default-src 'self'" in csp
+
+    def test_csp_img_src_includes_blob(self):
+        """Regression test for #1917 — OMO cropped image previews use blob: URLs.
+
+        Without blob: in img-src, the browser silently blocks the preview image,
+        giving no feedback to the teacher uploading the OMO worksheet.
+        """
+        response = client.get("/")
+        csp = response.headers.get("content-security-policy", "")
+        # Extract the img-src directive value
+        img_src_directive = ""
+        for part in csp.split(";"):
+            stripped = part.strip()
+            if stripped.startswith("img-src"):
+                img_src_directive = stripped
+                break
+        assert img_src_directive, "CSP is missing img-src directive entirely"
+        assert "blob:" in img_src_directive, (
+            f"CSP img-src must include 'blob:' for OMO cropped image previews (#1917). "
+            f"Got: {img_src_directive!r}"
+        )


### PR DESCRIPTION
Fixes #1917

## Summary

- Adds `blob:` to the `img-src` CSP directive in `SecurityHeadersMiddleware` (`backend/app/main.py`)
- Browser was silently blocking `blob:` object URLs generated by the OMO crop UI, making the preview image invisible after a teacher crops a worksheet photo
- `blob:` was already present in `media-src` — this is a one-token additive fix to `img-src`

## Root cause

`SecurityHeadersMiddleware.CSP` line 89 had:
```
img-src 'self' data: https:
```
but the OMO crop-and-preview flow creates `blob:` object URLs via `URL.createObjectURL()` for the cropped canvas. Without `blob:` in `img-src`, Chrome/Firefox silently block the `<img src="blob:...">` render.

## TDD

- RED: added `test_csp_img_src_includes_blob` to `test_security_headers.py` — confirmed FAIL before fix
- Tautology check: verified test logic fails when `blob:` absent, passes when present
- GREEN: all 15 security header tests pass after fix

## Test plan

- [ ] CI pytest passes
- [ ] PR preview deploys and frontend loads (HTTP 200)
- [ ] `curl -sI https://lingoleap-frontend-issue-1917-958347263320.asia-east1.run.app/ | grep -i content-security-policy` shows `blob:` in `img-src`