### PR TITLE
fix(ui): 閱讀聚光燈 empty-state warm copy + library CTA (Fixes #1923)

### DIFF
--- a/frontend/src/pages/learning/StrategyExercisePage.tsx
+++ b/frontend/src/pages/learning/StrategyExercisePage.tsx
@@ -9,6 +9,7 @@
  * Calls handleFinishReadingStrategy from LearningContext when done.
  */
 import React, { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import ComprehensionLayout from '../../components/reading-steps/ComprehensionLayout';
 import StrategyExercise from '../../components/reading-steps/StrategyExercise';
 import GraphicTextIntegrationExercise from '../../components/reading-steps/GraphicTextIntegrationExercise';
@@ -16,6 +17,7 @@ import { useLearningContext } from '../../layouts/LearningLayout';
 import type { StrategyExercise as StrategyExerciseType, StrategyExerciseItem } from '../../types';
 
 const StrategyExercisePage: React.FC = () => {
+  const navigate = useNavigate();
   const {
     selectedStory,
     handleFinishReadingStrategy,
@@ -120,14 +122,26 @@ const StrategyExercisePage: React.FC = () => {
           </div>
         </>
       ) : (
-        /* Lesson has no strategy exercise — show placeholder + skip */
+        /* Lesson has no strategy exercise — warm reassuring empty-state + CTA */
         <div className="flex flex-col items-center justify-center py-12 gap-5 text-on-surface-variant">
           <span className="material-symbols-outlined text-5xl opacity-30">lightbulb</span>
-          <p className="text-sm font-medium">此課文尚未有閱讀聚光燈練習</p>
+          <div className="text-center">
+            <p className="text-sm font-medium text-on-surface">本課暫無閱讀聚光燈練習 — 老師團隊正在整理中</p>
+            <p className="text-xs mt-1 opacity-60">你可以先去其他課文練習，或直接跳到下一個步驟</p>
+          </div>
+          {/* Primary CTA: navigate to library */}
           <button
-            onClick={handleNext}
+            onClick={() => navigate('/library')}
             className="px-8 h-11 rounded-full font-headline font-bold text-sm text-white shadow-[0_8px_32px_rgba(86,74,191,0.25)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center gap-2"
             style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+          >
+            <span className="material-symbols-outlined text-sm">library_books</span>
+            <span>找其他課文練習</span>
+          </button>
+          {/* Secondary: skip to next step */}
+          <button
+            onClick={handleNext}
+            className="px-6 h-9 rounded-full font-headline text-sm text-on-surface-variant border border-outline-variant hover:bg-surface-variant active:scale-[0.98] transition-all flex items-center gap-1"
           >
             <span>跳過，下一關</span>
             <span className="material-symbols-outlined text-sm">arrow_forward</span>

--- a/frontend/src/pages/learning/__tests__/StrategyExercisePage.test.tsx
+++ b/frontend/src/pages/learning/__tests__/StrategyExercisePage.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * TDD tests for StrategyExercisePage empty-state (#1923)
+ *
+ * Bug A: When a lesson has no strategyExercise, the empty-state message
+ * used to say「此課文尚未有閱讀聚光燈練習」which reads as apology/absence.
+ * Fix: warm, reassuring copy + a "找其他課文" CTA that navigates to library.
+ *
+ * RED phase assertions:
+ *   1. Old text "尚未有" must NOT appear.
+ *   2. New text "本課暫無閱讀聚光燈練習" MUST appear.
+ *   3. "找其他課文" CTA must be rendered and call the library navigation handler.
+ *   4. Skip/next button still present (secondary style).
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock dependencies ─────────────────────────────────────────────────────────
+
+// StrategyExercisePage uses useLearningContext from LearningLayout
+vi.mock('../../../layouts/LearningLayout', () => ({
+  useLearningContext: vi.fn(),
+}));
+
+// ComprehensionLayout wraps the page — render children directly
+vi.mock('../../../components/reading-steps/ComprehensionLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="comprehension-layout">{children}</div>
+  ),
+}));
+
+// StrategyExercise and GraphicTextIntegrationExercise are not needed for empty-state tests
+vi.mock('../../../components/reading-steps/StrategyExercise', () => ({
+  default: () => <div data-testid="strategy-exercise" />,
+}));
+
+vi.mock('../../../components/reading-steps/GraphicTextIntegrationExercise', () => ({
+  default: () => <div data-testid="graphic-text-exercise" />,
+}));
+
+// react-router-dom useNavigate for the "找其他課文" CTA
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+import { useLearningContext } from '../../../layouts/LearningLayout';
+import StrategyExercisePage from '../StrategyExercisePage';
+import type { Story } from '../../../types';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const baseStory: Story = {
+  id: 'L-test',
+  title: '贏得喝采的輸家',
+  level: 5,
+  content: ['段落一', '段落二'],
+  thumbnail: '/thumb.jpg',
+  category: 'Fable',
+  filename: 'L-test.yml',
+  vocabulary: [],
+  // No strategyExercise — this is the empty-state scenario
+};
+
+const mockHandleFinishReadingStrategy = vi.fn();
+const mockSaveStepProgressPatch = vi.fn();
+
+const makeContext = (story: Story | null = baseStory) => ({
+  selectedStory: story,
+  handleFinishReadingStrategy: mockHandleFinishReadingStrategy,
+  dbSessionId: 'sess-123',
+  saveStepProgressPatch: mockSaveStepProgressPatch,
+  stepProgressData: { step_data: {} },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(makeContext());
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('StrategyExercisePage — empty state (no strategyExercise)', () => {
+  it('does NOT show the old apology text「尚未有」', () => {
+    render(<StrategyExercisePage />);
+    expect(screen.queryByText(/尚未有/)).toBeNull();
+  });
+
+  it('shows the new warm copy「本課暫無閱讀聚光燈練習」', () => {
+    render(<StrategyExercisePage />);
+    expect(screen.getByText(/本課暫無閱讀聚光燈練習/)).toBeTruthy();
+  });
+
+  it('renders a「找其他課文練習」CTA button', () => {
+    render(<StrategyExercisePage />);
+    expect(screen.getByRole('button', { name: /找其他課文練習/ })).toBeTruthy();
+  });
+
+  it('「找其他課文練習」CTA navigates to library when clicked', () => {
+    render(<StrategyExercisePage />);
+    fireEvent.click(screen.getByRole('button', { name: /找其他課文練習/ }));
+    expect(mockNavigate).toHaveBeenCalledWith('/library');
+  });
+
+  it('still renders a skip/next button', () => {
+    render(<StrategyExercisePage />);
+    // The secondary skip button should still be present
+    expect(screen.getByRole('button', { name: /跳過|下一關/ })).toBeTruthy();
+  });
+});
+
+describe('StrategyExercisePage — with strategyExercise present', () => {
+  it('renders the strategy exercise component, not the empty state', () => {
+    const storyWithStrategy: Story = {
+      ...baseStory,
+      strategyExercise: {
+        type: 'guided_steps',
+        strategy_name: '自我提問',
+        instruction: '練習。',
+        steps: [],
+      },
+    };
+    (useLearningContext as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeContext(storyWithStrategy),
+    );
+
+    render(<StrategyExercisePage />);
+    expect(screen.queryByText(/本課暫無/)).toBeNull();
+    expect(screen.getByTestId('strategy-exercise')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #1923

## Summary

- **Bug A**: Replace apologetic empty-state copy「此課文尚未有閱讀聚光燈練習」with warm reassuring text「本課暫無閱讀聚光燈練習 — 老師團隊正在整理中」
- **Bug B**: Code-splitting chunk 404 / MIME errors — **already resolved by recent deploys**. Verified: `assets/index-CQFbXNpn.js → 200 [application/javascript]` and `assets/index-Bt38dKf_.css → 200 [text/css]`. No code change needed.

## Changes

- `frontend/src/pages/learning/StrategyExercisePage.tsx` — improved empty-state:
  - New warm copy with reassuring subtitle
  - Primary CTA「找其他課文練習」→ navigates to `/library`
  - Skip button de-emphasized as secondary style (border, no gradient fill)
- `frontend/src/pages/learning/__tests__/StrategyExercisePage.test.tsx` — 6 Vitest tests (TDD RED→GREEN)

## Test plan

- TDD: 6/6 tests pass — old text absent, new copy present, CTA renders + navigates to `/library`, skip button still present, exercise renders normally when data exists
- Bug B curl verification (pre-merge): all chunk assets return HTTP 200 + correct MIME