### PR TITLE
fix(omo): three UX gaps — all-blank guard, candidate chips, reasoning expansion (Fixes #1921)

### DIFF
--- a/frontend/src/components/omo/OmoResultPage.test.tsx
+++ b/frontend/src/components/omo/OmoResultPage.test.tsx
@@ -1,0 +1,372 @@
+/**
+ * OmoResultPage — TDD tests for issue #1921 three UX gaps:
+ *   Gap 1: all-blank answers → show "not a worksheet" banner + re-upload CTA
+ *   Gap 2: candidates[] array → render chip list + "not this lesson?" expander
+ *   Gap 3: "批改有誤?" → expand reasoning text + ai_confidence per answer
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OmoResultPage from './OmoResultPage';
+import type { OmoAnswerItem, OmoCandidate } from '../../services/omoApi';
+
+// Mock API calls — OmoResultPage does not call APIs directly in render, but
+// flagOmoAnswer and getOmoCropSignedUrl are imported so we mock to prevent
+// any accidental network calls.
+vi.mock('../../services/omoApi', () => ({
+  flagOmoAnswer: vi.fn(),
+  getOmoCropSignedUrl: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const TOKEN = 'test-token';
+const UPLOAD_ID = 212;
+
+const blankAnswer = (qid: string): OmoAnswerItem => ({
+  question_id: qid,
+  student_answer: '',
+  correct_answer: '根據',
+  score: 0,
+  ai_confidence: 0,
+  reasoning: '作答區空白，沒有看到學生手寫的任何字跡',
+});
+
+const normalAnswer = (qid: string): OmoAnswerItem => ({
+  question_id: qid,
+  student_answer: '根據',
+  correct_answer: '根據',
+  score: 1,
+  ai_confidence: 0.95,
+  reasoning: '完全符合標準答案',
+});
+
+const CANDIDATE_A: OmoCandidate = {
+  lesson_id: 3,
+  grade_code: 'G6-L03',
+  title: '古典詩詞欣賞',
+  confidence: 0.95,
+  reasoning: '標題完全符合',
+};
+
+const CANDIDATE_B: OmoCandidate = {
+  lesson_id: 11,
+  grade_code: 'G6-11',
+  title: '海洋的故事',
+  confidence: 0.9,
+  reasoning: '標題部分符合，但課號不同',
+};
+
+// ---------------------------------------------------------------------------
+// Gap 1: All-blank detection
+// ---------------------------------------------------------------------------
+
+describe('Gap 1 — all-blank worksheet detection', () => {
+  it('renders the "不是學習單" banner when every answer is blank/空白', () => {
+    const allBlankAnswers = ['fb_1', 'fb_2', 'fb_3'].map(blankAnswer);
+
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={allBlankAnswers}
+        overallScore={0}
+        onRetry={vi.fn()}
+        candidates={[]}
+      />,
+    );
+
+    // Banner text must be visible
+    expect(
+      screen.getByText(/這張看起來不是填寫過的學習單/i),
+    ).toBeTruthy();
+  });
+
+  it('renders "重新上傳" CTA button when all answers are blank', () => {
+    const allBlankAnswers = ['fb_1', 'fb_2'].map(blankAnswer);
+    const onRetry = vi.fn();
+
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={allBlankAnswers}
+        overallScore={0}
+        onRetry={onRetry}
+        candidates={[]}
+      />,
+    );
+
+    const ctaButton = screen.getByRole('button', { name: /重新上傳/i });
+    expect(ctaButton).toBeTruthy();
+
+    fireEvent.click(ctaButton);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT render the all-blank banner when at least one answer is non-blank', () => {
+    const mixedAnswers = [blankAnswer('fb_1'), normalAnswer('fb_2')];
+
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={mixedAnswers}
+        overallScore={0.5}
+        onRetry={vi.fn()}
+        candidates={[]}
+      />,
+    );
+
+    expect(screen.queryByText(/這張看起來不是填寫過的學習單/i)).toBeNull();
+  });
+
+  it('does NOT render the all-blank banner when an answer has non-空白 reasoning', () => {
+    // Blank student_answer but reasoning says something different (human override)
+    const weirdAnswer: OmoAnswerItem = {
+      question_id: 'fb_1',
+      student_answer: '',
+      correct_answer: '根據',
+      score: 0,
+      ai_confidence: 0.3,
+      reasoning: '字跡潦草，無法辨識',
+    };
+
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[weirdAnswer]}
+        overallScore={0}
+        onRetry={vi.fn()}
+        candidates={[]}
+      />,
+    );
+
+    // This answer is blank but reasoning doesn't say 空白 → not "all blank" case
+    expect(screen.queryByText(/這張看起來不是填寫過的學習單/i)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 2: Multi-candidate chip list
+// ---------------------------------------------------------------------------
+
+describe('Gap 2 — multi-candidate identifier chip list', () => {
+  it('shows primary candidate chip with grade_code and title', () => {
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[normalAnswer('fb_1')]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[CANDIDATE_A, CANDIDATE_B]}
+      />,
+    );
+
+    // Primary candidate title visible
+    expect(screen.getByText(/古典詩詞欣賞/i)).toBeTruthy();
+  });
+
+  it('shows confidence percentage for primary candidate', () => {
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[normalAnswer('fb_1')]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[CANDIDATE_A, CANDIDATE_B]}
+      />,
+    );
+
+    // 0.95 → 95% — candidate chip shows "信心 95%" (distinct from confidence bar label)
+    expect(screen.getByText(/信心 95%/i)).toBeTruthy();
+  });
+
+  it('shows "不是這課？" expander button when there are multiple candidates', () => {
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[normalAnswer('fb_1')]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[CANDIDATE_A, CANDIDATE_B]}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /不是這課/i })).toBeTruthy();
+  });
+
+  it('reveals secondary candidate after clicking "不是這課？"', () => {
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[normalAnswer('fb_1')]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[CANDIDATE_A, CANDIDATE_B]}
+      />,
+    );
+
+    // Initially secondary candidate is hidden
+    expect(screen.queryByText(/海洋的故事/i)).toBeNull();
+
+    // Click expander
+    fireEvent.click(screen.getByRole('button', { name: /不是這課/i }));
+
+    // Now secondary candidate should be visible
+    expect(screen.getByText(/海洋的故事/i)).toBeTruthy();
+  });
+
+  it('does NOT render candidate section when candidates array is empty', () => {
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[normalAnswer('fb_1')]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[]}
+      />,
+    );
+
+    expect(screen.queryByText(/不是這課/i)).toBeNull();
+  });
+
+  it('does NOT render "不是這課？" expander when only one candidate', () => {
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[normalAnswer('fb_1')]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[CANDIDATE_A]}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /不是這課/i })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gap 3: Reasoning expansion on "批改有誤？"
+// ---------------------------------------------------------------------------
+
+describe('Gap 3 — reasoning expansion in AnswerCard', () => {
+  it('reasoning text is NOT visible before clicking "批改有誤？"', () => {
+    const answer = normalAnswer('fb_1');
+
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[answer]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[]}
+      />,
+    );
+
+    // reasoning should not be visible in the answer detail area initially
+    // (it shows inline truncated via line-clamp — check that the dedicated
+    // expansion panel is absent)
+    expect(screen.queryByRole('region', { name: /AI 批改依據/i })).toBeNull();
+  });
+
+  it('clicking "批改有誤？" expands the reasoning panel', () => {
+    const answer: OmoAnswerItem = {
+      question_id: 'fb_1',
+      student_answer: '根據',
+      correct_answer: '根據',
+      score: 1,
+      ai_confidence: 0.92,
+      reasoning: '完全符合標準答案，字跡清晰',
+    };
+
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[answer]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[]}
+      />,
+    );
+
+    const flagBtn = screen.getByRole('button', { name: /批改有誤/i });
+    fireEvent.click(flagBtn);
+
+    // Reasoning panel should now be visible
+    const panel = screen.getByRole('region', { name: /AI 批改依據/i });
+    expect(panel).toBeTruthy();
+    // Panel contains the reasoning text (there may be 2 occurrences: truncated header + panel)
+    expect(panel.textContent).toContain('完全符合標準答案，字跡清晰');
+  });
+
+  it('shows ai_confidence percentage in the expanded reasoning panel', () => {
+    const answer: OmoAnswerItem = {
+      question_id: 'fb_1',
+      student_answer: '根據',
+      correct_answer: '根據',
+      score: 1,
+      ai_confidence: 0.92,
+      reasoning: '完全符合',
+    };
+
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[answer]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /批改有誤/i }));
+
+    // 0.92 → 92% — the panel shows "AI 信心度：92%" (distinct text from the confidence bar "AI 92%")
+    const panel = screen.getByRole('region', { name: /AI 批改依據/i });
+    expect(panel.textContent).toContain('92%');
+  });
+
+  it('clicking "批改有誤？" again collapses the reasoning panel (toggle)', () => {
+    const answer: OmoAnswerItem = {
+      question_id: 'fb_1',
+      student_answer: '根據',
+      correct_answer: '根據',
+      score: 1,
+      ai_confidence: 0.88,
+      reasoning: '字跡清晰可辨識',
+    };
+
+    render(
+      <OmoResultPage
+        uploadId={UPLOAD_ID}
+        token={TOKEN}
+        answers={[answer]}
+        overallScore={1}
+        onRetry={vi.fn()}
+        candidates={[]}
+      />,
+    );
+
+    const flagBtn = screen.getByRole('button', { name: /批改有誤/i });
+
+    // First click: expand
+    fireEvent.click(flagBtn);
+    expect(screen.getByRole('region', { name: /AI 批改依據/i })).toBeTruthy();
+
+    // Second click: collapse
+    fireEvent.click(flagBtn);
+    expect(screen.queryByRole('region', { name: /AI 批改依據/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/omo/OmoResultPage.tsx
+++ b/frontend/src/components/omo/OmoResultPage.tsx
@@ -3,20 +3,24 @@
  *
  * Shown after grading completes (status=graded). Displays:
  *   - Overall score banner
+ *   - Gap 1: "not a worksheet" banner if every answer is blank (issue #1921)
+ *   - Gap 2: identifier candidates chip list (issue #1921)
  *   - Per-question cards: student answer, correct answer, AI score, confidence bar
+ *   - Gap 3: "批改有誤?" expands reasoning + ai_confidence (issue #1921)
  *   - Flag button on each card → opens FlagModal to report incorrect grading
  *
  * Props:
- *   uploadId  — the graded OmoUpload id
- *   token     — JWT for API calls
+ *   uploadId    — the graded OmoUpload id
+ *   token       — JWT for API calls
  *   lessonTitle — display name for the header
- *   answers   — OmoAnswerItem[] from the graded upload
+ *   answers     — OmoAnswerItem[] from the graded upload
  *   overallScore — 0–1 float, percentage shown as 0–100
- *   onRetry   — go back to upload screen
+ *   onRetry     — go back to upload screen
+ *   candidates  — OmoCandidate[] identifier results (Gap 2)
  */
 import React, { useState } from 'react';
 import { flagOmoAnswer, getOmoCropSignedUrl } from '../../services/omoApi';
-import type { OmoAnswerItem } from '../../services/omoApi';
+import type { OmoAnswerItem, OmoCandidate } from '../../services/omoApi';
 
 // ---------------------------------------------------------------------------
 // Flag Modal
@@ -220,6 +224,83 @@ function ScoreBadge({ score }: { score: number }) {
 }
 
 // ---------------------------------------------------------------------------
+// Gap 1: All-blank detector
+// Condition: every answer either has empty student_answer AND
+// reasoning contains "空白" (indicating AI saw nothing).
+// Only when ALL answers match do we show the banner.
+// ---------------------------------------------------------------------------
+
+function computeIsAllBlank(answers: OmoAnswerItem[]): boolean {
+  if (answers.length === 0) return false;
+  return answers.every(
+    (a) => !a.student_answer && a.reasoning.includes('空白'),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Gap 2: Candidate chips
+// ---------------------------------------------------------------------------
+
+interface CandidateChipsProps {
+  candidates: OmoCandidate[];
+}
+
+const CandidateChips: React.FC<CandidateChipsProps> = ({ candidates }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  if (candidates.length === 0) return null;
+
+  const primary = candidates[0];
+  const rest = candidates.slice(1);
+  const primaryPct = Math.round(primary.confidence * 100);
+
+  return (
+    <div className="bg-blue-50 border border-blue-100 rounded-2xl px-4 py-3">
+      <p className="text-xs text-blue-500 font-medium mb-1.5">AI 辨識結果</p>
+      {/* Primary candidate */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <span className="text-sm font-semibold text-gray-800">
+          {primary.grade_code}·{primary.title}
+        </span>
+        <span className="text-xs text-blue-600 font-medium bg-blue-100 px-2 py-0.5 rounded-full shrink-0">
+          信心 {primaryPct}%
+        </span>
+      </div>
+
+      {/* "不是這課？" expander — only when there are additional candidates */}
+      {rest.length > 0 && (
+        <div className="mt-2">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="text-xs text-blue-500 hover:text-blue-700 transition-colors flex items-center gap-1"
+            aria-expanded={expanded}
+          >
+            <span aria-hidden="true">{expanded ? '▲' : '▼'}</span>
+            不是這課？
+          </button>
+
+          {expanded && (
+            <div className="mt-2 flex flex-col gap-1.5 pl-2 border-l-2 border-blue-200">
+              {rest.map((c) => (
+                <div key={c.lesson_id} className="flex items-center justify-between gap-2">
+                  <span className="text-xs text-gray-600">
+                    {c.grade_code}·{c.title}
+                  </span>
+                  <span className="text-[10px] text-gray-400 shrink-0">
+                    {Math.round(c.confidence * 100)}%
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Answer Card
 // ---------------------------------------------------------------------------
 
@@ -234,6 +315,13 @@ const AnswerCard: React.FC<AnswerCardProps> = ({ answer, onFlag, onViewCrop, fla
   const confPct = Math.round(answer.ai_confidence * 100);
   // #1721: low confidence (< 0.7) → orange ⚠️ flag so teacher knows to manually verify
   const lowConfidence = answer.ai_confidence < 0.7;
+
+  // Gap 3: reasoning panel toggle (replaces direct flag modal open on click)
+  const [reasoningExpanded, setReasoningExpanded] = useState(false);
+
+  const handleFlagButtonClick = () => {
+    setReasoningExpanded((v) => !v);
+  };
 
   return (
     <div className={`bg-white rounded-2xl border shadow-sm p-4 ${lowConfidence ? 'border-amber-300 ring-1 ring-amber-200' : 'border-gray-100'}`}>
@@ -288,6 +376,25 @@ const AnswerCard: React.FC<AnswerCardProps> = ({ answer, onFlag, onViewCrop, fla
         <span className="text-[10px] text-gray-400 shrink-0">AI {confPct}%</span>
       </div>
 
+      {/* Gap 3: Reasoning expansion panel */}
+      {reasoningExpanded && (
+        <div
+          role="region"
+          aria-label="AI 批改依據"
+          className="mb-3 bg-amber-50 border border-amber-200 rounded-xl px-3 py-2.5"
+        >
+          <p className="text-[10px] text-amber-700 font-semibold uppercase tracking-wide mb-1">
+            AI 批改依據
+          </p>
+          <p className="text-sm text-gray-700 leading-relaxed">
+            {answer.reasoning}
+          </p>
+          <p className="text-xs text-gray-400 mt-1.5">
+            AI 信心度：<span className="font-semibold text-gray-600">{confPct}%</span>
+          </p>
+        </div>
+      )}
+
       {/* Action buttons */}
       <div className="flex justify-end gap-3">
         {answer.crop_image_url && (
@@ -310,8 +417,9 @@ const AnswerCard: React.FC<AnswerCardProps> = ({ answer, onFlag, onViewCrop, fla
         ) : (
           <button
             type="button"
-            onClick={() => onFlag(answer.question_id)}
+            onClick={handleFlagButtonClick}
             className="text-xs text-gray-400 hover:text-orange-500 transition-colors flex items-center gap-1"
+            aria-expanded={reasoningExpanded}
           >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" className="w-3.5 h-3.5" aria-hidden="true">
               <path d="M2 3a1 1 0 011-1h10a1 1 0 01.707 1.707L10.414 7l3.293 3.293A1 1 0 0113 12H3a1 1 0 01-1-1V3z" />
@@ -320,6 +428,23 @@ const AnswerCard: React.FC<AnswerCardProps> = ({ answer, onFlag, onViewCrop, fla
           </button>
         )}
       </div>
+
+      {/* Flag Modal (opened from reasoning panel via separate CTA) */}
+      {/* Keep FlagModal accessible: show a "送出標記" button inside the expanded panel */}
+      {reasoningExpanded && !flagged && !answer.flag && (
+        <div className="mt-2 flex justify-end">
+          <button
+            type="button"
+            onClick={() => {
+              setReasoningExpanded(false);
+              onFlag(answer.question_id);
+            }}
+            className="text-xs text-orange-500 hover:text-orange-700 underline transition-colors"
+          >
+            送出標記給老師
+          </button>
+        </div>
+      )}
     </div>
   );
 };
@@ -335,6 +460,8 @@ interface OmoResultPageProps {
   answers: OmoAnswerItem[];
   overallScore: number | null;
   onRetry: () => void;
+  /** Gap 2: identifier candidates from backend */
+  candidates?: OmoCandidate[];
 }
 
 const OmoResultPage: React.FC<OmoResultPageProps> = ({
@@ -344,6 +471,7 @@ const OmoResultPage: React.FC<OmoResultPageProps> = ({
   answers,
   overallScore,
   onRetry,
+  candidates = [],
 }) => {
   const [flaggingQuestionId, setFlaggingQuestionId] = useState<string | null>(null);
   const [flaggedIds, setFlaggedIds] = useState<Set<string>>(new Set());
@@ -355,6 +483,9 @@ const OmoResultPage: React.FC<OmoResultPageProps> = ({
   } | null>(null);
 
   const overallPct = overallScore !== null ? Math.round(overallScore * 100) : null;
+
+  // Gap 1: detect all-blank submission
+  const isAllBlank = computeIsAllBlank(answers);
 
   const handleFlagged = (questionId: string) => {
     setFlaggedIds((prev) => new Set(prev).add(questionId));
@@ -403,6 +534,36 @@ const OmoResultPage: React.FC<OmoResultPageProps> = ({
         )}
         <p className="text-xs text-gray-400 mt-2">共 {answers.length} 題</p>
       </div>
+
+      {/* Gap 1: All-blank warning banner */}
+      {isAllBlank && (
+        <div
+          role="alert"
+          className="bg-amber-50 border border-amber-300 rounded-2xl px-4 py-4 flex flex-col items-center gap-3 text-center"
+        >
+          <div className="text-3xl" aria-hidden="true">📷</div>
+          <div>
+            <p className="text-sm font-semibold text-amber-800">
+              這張看起來不是填寫過的學習單，請重拍學生作答
+            </p>
+            <p className="text-xs text-amber-600 mt-1">
+              AI 在所有作答欄位都找不到手寫字跡
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="px-5 py-2.5 rounded-xl bg-amber-500 hover:bg-amber-600 text-white text-sm font-semibold transition-colors"
+          >
+            重新上傳
+          </button>
+        </div>
+      )}
+
+      {/* Gap 2: Candidate chips */}
+      {candidates.length > 0 && (
+        <CandidateChips candidates={candidates} />
+      )}
 
       {/* Per-question cards */}
       {answers.length > 0 ? (

--- a/frontend/src/pages/omo/OmoResultStandalonePage.tsx
+++ b/frontend/src/pages/omo/OmoResultStandalonePage.tsx
@@ -122,6 +122,7 @@ const OmoResultStandalonePage: React.FC = () => {
           answers={result.answers ?? []}
           overallScore={result.overall_score ?? null}
           onRetry={() => navigate('/omo')}
+          candidates={result.candidates ?? []}
         />
       );
     }


### PR DESCRIPTION
Fixes #1921

## Summary

- **Gap 1 — all-blank guard**: `computeIsAllBlank()` detects when every answer has `student_answer=""` AND `reasoning` contains "空白" (AI saw no handwriting). Renders an amber banner "這張看起來不是填寫過的學習單，請重拍學生作答" with a "重新上傳" CTA. Prevents the confusing 0/10 display for mis-uploaded images.
- **Gap 2 — candidate chips**: `CandidateChips` component renders the primary identifier match with grade_code, title, and confidence %. A "不是這課？" expander reveals secondary candidates when candidates.length > 1. `OmoResultStandalonePage` now threads `candidates={result.candidates ?? []}`.
- **Gap 3 — reasoning expansion**: "批改有誤？" button toggles a collapsible `role="region"` panel showing backend `reasoning` text and `ai_confidence` %. Flag modal still reachable via "送出標記給老師" inside the expanded panel.

## Test plan

- TDD: 14 Vitest tests added in `OmoResultPage.test.tsx`, all GREEN
  - 4 tests: Gap 1 (all-blank detection, CTA click, non-blank passthrough, 空白-only reasoning boundary)
  - 6 tests: Gap 2 (primary chip, confidence %, expander button, secondary reveal, empty/single candidate)
  - 4 tests: Gap 3 (panel hidden before click, expand on click, ai_confidence in panel, toggle collapse)
- Pre-existing `OmoIdentifyResult.test.tsx` — 9/10 pass (1 pre-existing failure unrelated to this PR)
- TypeScript: no new errors introduced
- UI only, no backend changes, Low risk