### PR TITLE
fix(seed): remove PII gmail accounts, fix admin roles and student enrollment (Fixes #1920)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,7 +37,7 @@ from .routes.admin_seed import router as admin_seed_router
 from .routes.omo import router as omo_router
 from .utils.logging_config import setup_logging
 from .auth.rate_limiter import general_rate_limiter
-from .services.seed import seed_default_data
+from .services.seed import seed_default_data, repair_pii_accounts
 
 # Initialise structured logging before anything else
 setup_logging()
@@ -295,6 +295,17 @@ async def lifespan(app: FastAPI):
     # on prod (ENABLE_TEST_SEED=false) it only runs non-seeding startup tasks
     # (YAML → texts sync, migration patches) without creating demo accounts.
     seed_default_data()
+    # Idempotent: deactivate PII gmail accounts that leaked into staging DB (#1920).
+    # Safe on prod — does nothing if accounts don't exist.
+    try:
+        from .database import SessionLocal as _SessionLocal
+        _db = _SessionLocal()
+        try:
+            repair_pii_accounts(_db)
+        finally:
+            _db.close()
+    except Exception as _e:
+        logger.warning("repair_pii_accounts failed (non-fatal): %s", _e)
     yield
 
 

--- a/backend/app/services/seed.py
+++ b/backend/app/services/seed.py
@@ -4,6 +4,7 @@ Seed data for demo / staging environments.
 Extracted from main.py to keep the app entry point thin.
 Functions:
   - seed_default_data()          — full demo data (org, schools, users, sessions, etc.)
+  - repair_pii_accounts(db)      — one-time repair: deactivate real gmail PII accounts (#1920)
   - _patch_seed_assignments(db)  — idempotent patch for assignment seed data (#528)
   - _sync_yaml_lessons_to_texts(db) — sync YAML lessons → texts table
 """
@@ -23,6 +24,38 @@ from ..models.assignment import Assignment, AssignmentSubmission
 from ..auth.password import hash_password
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# PII repair (#1920)
+# ---------------------------------------------------------------------------
+
+# Real gmail addresses that were manually inserted into the staging DB during
+# early dogfood sessions.  These must never appear in code or seed data; this
+# function deactivates them idempotently so they disappear from the admin UI.
+_PII_GMAIL_ACCOUNTS = [
+    "jay.tzeng@gmail.com",
+    "kuanweilu@gmail.com",
+]
+
+
+def repair_pii_accounts(db) -> None:
+    """Idempotent: deactivate real gmail PII accounts from the staging DB.
+
+    Safe to call on every startup — does nothing if accounts don't exist or
+    are already inactive.  Introduced in #1920 to remove PII that was
+    accidentally inserted during early dogfood sessions.
+    """
+    affected = 0
+    for email in _PII_GMAIL_ACCOUNTS:
+        user = db.query(User).filter(User.email == email).first()
+        if user and user.is_active:
+            user.is_active = False
+            affected += 1
+            logger.info("repair_pii_accounts: deactivated PII account %s (#1920)", email)
+    if affected:
+        db.commit()
+    else:
+        logger.debug("repair_pii_accounts: no active PII accounts found")
 
 
 def _patch_seed_assignments(db) -> None:
@@ -257,8 +290,6 @@ def seed_default_data():
             if role_org_admin:
                 role_assignments.append(UserRole(user_id=admin.id, role_id=role_org_admin.id, scope_type="organization", scope_id=str(org.id)))
             if role_teacher:
-                # admin also manages classrooms in school1
-                role_assignments.append(UserRole(user_id=admin.id, role_id=role_teacher.id, scope_type="school", scope_id=str(school1.id)))
                 role_assignments.append(UserRole(user_id=teacher1.id, role_id=role_teacher.id, scope_type="school", scope_id=str(school1.id)))
                 role_assignments.append(UserRole(user_id=teacher2.id, role_id=role_teacher.id, scope_type="school", scope_id=str(school2.id)))
             if role_student:
@@ -280,7 +311,6 @@ def seed_default_data():
                 ClassroomStudent(classroom_id=class_3a.id, student_id=student1.id),
                 ClassroomStudent(classroom_id=class_3a.id, student_id=student2.id),
                 ClassroomStudent(classroom_id=class_5b.id, student_id=student3.id),
-                ClassroomStudent(classroom_id=class_7a.id, student_id=student1.id),
             ])
 
             # -- 7. Learning sessions for students (relative dates so dashboard always shows data) --

--- a/backend/tests/test_seed_data_pii_1920.py
+++ b/backend/tests/test_seed_data_pii_1920.py
@@ -1,0 +1,149 @@
+"""Tests for Issue #1920: Seed data PII cleanup.
+
+Bug A: Real gmail PII addresses (jay.tzeng@gmail.com, kuanweilu@gmail.com) in staging DB
+Bug B: 王管理員 (admin@test.com) incorrectly assigned teacher role (should have 2 roles only)
+Bug C: 小明 (student@test.com, grade-3 persona) enrolled in 七年甲班 (grade-7 class)
+
+Strategy: static source analysis avoids SQLite JSON RETURNING issues with JSONB columns.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SEED_PY = Path(__file__).parent.parent / "app" / "services" / "seed.py"
+
+
+@pytest.fixture(scope="module")
+def seed_source() -> str:
+    return SEED_PY.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Bug A: No real gmail addresses in seed source
+# ---------------------------------------------------------------------------
+
+class TestBugA_NoGmailInSeedSource:
+    """Bug A: seed.py must not *seed* real PII gmail addresses into the DB.
+
+    jay.tzeng@gmail.com and kuanweilu@gmail.com exist only in the live staging
+    DB from early dogfood sessions.  seed.py is allowed to reference them in a
+    repair constant (_PII_GMAIL_ACCOUNTS) to deactivate them, but must NEVER
+    use them in email= keyword arguments that would re-create those accounts.
+    """
+
+    def test_no_gmail_seeded_via_user_email_kwarg(self, seed_source: str) -> None:
+        """gmail addresses must not appear in User(email=...) or email= assignments."""
+        # Match patterns like:  email="jay.tzeng@gmail.com"
+        # or:                   User(email="jay.tzeng@gmail.com", ...)
+        seeding_pattern = re.compile(r'email\s*=\s*"[^"]*@gmail\.com"')
+        matches = seeding_pattern.findall(seed_source)
+        assert matches == [], (
+            f"Found gmail address in email= assignment (would re-create PII account): {matches}"
+        )
+
+    def test_seed_user_emails_are_test_domain_only(self, seed_source: str) -> None:
+        """email= keyword arguments in seed.py use @test.com or @testdata.lingoleap.dev."""
+        # Only look at email="..." keyword argument patterns (not list/constant definitions)
+        email_kwargs = re.findall(r'email\s*=\s*"([^"]+@[^"]+)"', seed_source)
+        allowed_domains = {"test.com", "testdata.lingoleap.dev"}
+        bad = [e for e in email_kwargs if e.split("@")[-1] not in allowed_domains]
+        assert bad == [], (
+            f"Non-test email in email= kwarg: {bad}. "
+            "Only @test.com and @testdata.lingoleap.dev are allowed as seeded accounts."
+        )
+
+    def test_repair_function_exists_in_seed_source(self, seed_source: str) -> None:
+        """Bug A repair: an idempotent cleanup function for live-DB gmail rows must exist."""
+        assert "repair_pii_accounts" in seed_source or "cleanup_pii" in seed_source or "deactivate_pii" in seed_source, (
+            "No PII repair function found in seed.py. "
+            "Expected a function like repair_pii_accounts() that deactivates/anonymizes "
+            "jay.tzeng@gmail.com and kuanweilu@gmail.com in the live staging DB."
+        )
+
+    def test_pii_gmail_list_defined_for_repair_only(self, seed_source: str) -> None:
+        """The _PII_GMAIL_ACCOUNTS constant must exist and list both gmail addresses."""
+        assert "_PII_GMAIL_ACCOUNTS" in seed_source, (
+            "_PII_GMAIL_ACCOUNTS constant not found in seed.py — needed for repair function"
+        )
+        assert "jay.tzeng@gmail.com" in seed_source, (
+            "jay.tzeng@gmail.com not in _PII_GMAIL_ACCOUNTS — repair function can't target it"
+        )
+        assert "kuanweilu@gmail.com" in seed_source, (
+            "kuanweilu@gmail.com not in _PII_GMAIL_ACCOUNTS — repair function can't target it"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug B: admin must NOT have teacher role in seed source
+# ---------------------------------------------------------------------------
+
+class TestBugB_AdminRoles:
+    """Bug B: 王管理員 should only have system_admin + org_admin (2 roles).
+    Teacher role was wrongly appended to admin.
+    """
+
+    def test_admin_teacher_role_not_assigned_in_seed(self, seed_source: str) -> None:
+        """RED: the faulty admin-teacher assignment must be removed from seed.py."""
+        assert "user_id=admin.id, role_id=role_teacher.id" not in seed_source, (
+            "admin.id is being assigned role_teacher — this is Bug B. "
+            "Remove the line that gives admin the teacher role."
+        )
+
+    def test_admin_only_gets_system_admin_and_org_admin(self, seed_source: str) -> None:
+        """After fix: admin only appears in system_admin and org_admin assignments."""
+        # Count how many role_assignments use admin.id
+        assignments_with_admin = re.findall(
+            r"UserRole\([^)]*user_id=admin\.id[^)]*\)", seed_source
+        )
+        assert len(assignments_with_admin) == 2, (
+            f"Expected exactly 2 role assignments for admin (system_admin + org_admin), "
+            f"found {len(assignments_with_admin)}: {assignments_with_admin}"
+        )
+
+    def test_teacher1_still_gets_teacher_role(self, seed_source: str) -> None:
+        """teacher1 must still receive the teacher role (collateral check)."""
+        assert "user_id=teacher1.id, role_id=role_teacher.id" in seed_source, (
+            "teacher1 should still be assigned the teacher role"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug C: student1 (小明) must not be in grade-7 class
+# ---------------------------------------------------------------------------
+
+class TestBugC_StudentEnrollment:
+    """Bug C: student1 (小明, grade-3 student) must not be enrolled in class_7a (七年甲班)."""
+
+    def test_xiaoming_not_enrolled_in_class_7a(self, seed_source: str) -> None:
+        """RED: the faulty student1→class_7a enrollment must be removed."""
+        assert "classroom_id=class_7a.id, student_id=student1.id" not in seed_source, (
+            "student1 (小明) is enrolled in class_7a (七年甲班) — this is Bug C. "
+            "Remove ClassroomStudent(classroom_id=class_7a.id, student_id=student1.id)."
+        )
+
+    def test_xiaoming_still_enrolled_in_class_3a(self, seed_source: str) -> None:
+        """After fix: student1 must still be enrolled in class_3a (三年甲班)."""
+        assert "classroom_id=class_3a.id, student_id=student1.id" in seed_source, (
+            "student1 (小明) should be enrolled in class_3a (三年甲班)"
+        )
+
+    def test_student3_enrolled_in_class_5b(self, seed_source: str) -> None:
+        """Collateral: student3 enrollment in class_5b must be preserved."""
+        assert "classroom_id=class_5b.id, student_id=student3.id" in seed_source, (
+            "student3 (小美) should still be enrolled in class_5b (五年乙班)"
+        )
+
+    def test_student1_total_enrollments_is_one(self, seed_source: str) -> None:
+        """student1 should appear in exactly one ClassroomStudent entry."""
+        enrollments = re.findall(
+            r"ClassroomStudent\([^)]*student_id=student1\.id[^)]*\)", seed_source
+        )
+        assert len(enrollments) == 1, (
+            f"Expected student1 in exactly 1 classroom, found {len(enrollments)}: {enrollments}"
+        )


### PR DESCRIPTION
Fixes #1920

## Summary

Three seed data bugs cleaned up:

- **Bug A**: Added `repair_pii_accounts()` startup function that idempotently deactivates `jay.tzeng@gmail.com` and `kuanweilu@gmail.com` from the staging DB. These PII accounts are stored in `_PII_GMAIL_ACCOUNTS` constant for targeting — they are never seeded, only cleaned up. Function is called in `lifespan()` at every startup (no-op if accounts don't exist or are already inactive).
- **Bug B**: Removed erroneous teacher role assignment from admin (`王管理員`). Admin now holds only `system_admin` + `org_admin` (2 roles, not 3).
- **Bug C**: Removed `小明` (grade-3 student) from `七年甲班` (grade-7 class). 小明 now enrolls only in `三年甲班` as expected.

## Test plan

- [x] TDD: 11 static source-analysis tests in `test_seed_data_pii_1920.py` — all GREEN locally
- [x] Tests verify: no gmail in `email=` kwargs, repair function exists, admin has 2 roles, student1 in 1 classroom only
- [ ] Staging: after merge, verify in admin → 使用者管理 — no gmail accounts, admin shows 2 roles, 小明 not in 七年甲班
- [ ] `repair_pii_accounts()` will run on first deploy restart and deactivate the staging gmail rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)