### PR TITLE
refactor(teacher): split AssignmentDetailPanel.tsx 681→250L (Fixes #1936)

### DIFF
--- a/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
+++ b/frontend/src/pages/teacher/AssignmentDetailPanel.tsx
@@ -1,10 +1,17 @@
 /**
- * AssignmentDetailPanel — expanded submission view with grading actions and bulk comment.
- * Used inside AssignmentTab when a row is expanded.
+ * AssignmentDetailPanel — orchestrator (Issue #1936 refactor).
  *
- * Issue #424: per-student teacher feedback textarea added to the grading UI.
- * Issue #1853: refactored — logic extracted to assignmentDetailLogic.ts,
- *   UI primitives to components/ReadingMetricsPanel, BulkCommentPanel, AttemptHistoryPanel.
+ * Previously a 681-line monolith. Now composes three extracted pieces:
+ *   - useGradeForm (hooks/useGradeForm.ts) — per-submission grading state
+ *   - AssignmentSubmissionTable (components/AssignmentSubmissionTable.tsx) — table/cards
+ *   - BulkCommentPanel (components/BulkCommentPanel.tsx) — bulk grading
+ *
+ * This file handles only: stats bar, bulk-comment toggle, grade-error banner,
+ * and wiring the extracted pieces together.
+ *
+ * Issue #424: per-student teacher feedback
+ * Issue #1764: grouped submissions_by_student view
+ * Issue #1853: prior logic extraction to assignmentDetailLogic.ts
  */
 import React, { useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
@@ -12,63 +19,22 @@ import {
   gradeSubmission,
   AssignmentDetailResponse,
   SubmissionResponse,
-  AssignmentApiError,
   StudentAttemptGroup,
 } from '../../services/assignmentApi';
 import { useToast } from '../../components/ui/Toast';
 import {
   countGroupedStats,
-  validateScore,
-  buildGradeClickState,
   filterSubmittedForBulk,
 } from './assignmentDetailLogic';
-import ReadingMetricsPanel from './components/ReadingMetricsPanel';
 import BulkCommentPanel from './components/BulkCommentPanel';
-import AttemptHistoryPanel from './components/AttemptHistoryPanel';
+import AssignmentSubmissionTable from './components/AssignmentSubmissionTable';
+import { useGradeForm } from './hooks/useGradeForm';
 
 interface Props {
   assignmentId: number;
   detail: AssignmentDetailResponse;
   isLoading: boolean;
   onGraded: (updated: SubmissionResponse) => void;
-}
-
-function statusBadge(status: string) {
-  switch (status) {
-    case 'in_progress':
-      return (
-        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">
-          進行中
-        </span>
-      );
-    case 'submitted':
-      return (
-        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
-          已提交
-        </span>
-      );
-    case 'graded':
-      return (
-        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-700">
-          已批改
-        </span>
-      );
-    default:
-      return (
-        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-500">
-          待完成
-        </span>
-      );
-  }
-}
-
-function formatDate(dateStr: string | null): string {
-  if (!dateStr) return '-';
-  return new Date(dateStr).toLocaleDateString('zh-TW', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
 }
 
 const AssignmentDetailPanel: React.FC<Props> = ({
@@ -79,25 +45,19 @@ const AssignmentDetailPanel: React.FC<Props> = ({
 }) => {
   const { token } = useAuth();
   const { toast, showToast } = useToast();
-  const [gradingId, setGradingId] = useState<number | null>(null);
-  const [gradeInput, setGradeInput] = useState<Record<number, string>>({});
-  // Issue #424: per-student feedback text while grading
-  const [feedbackInput, setFeedbackInput] = useState<Record<number, string>>({});
-  const [savingId, setSavingId] = useState<number | null>(null);
-  const [gradeError, setGradeError] = useState('');
-  // Track which submission row has reading metrics expanded (Issue #423)
-  const [expandedMetricsId, setExpandedMetricsId] = useState<number | null>(null);
-  // Issue #1764 Fix 4: expand attempt history per student
-  const [expandedStudentId, setExpandedStudentId] = useState<number | null>(null);
 
-  // Bulk comment state
+  // ── Grade form state (extracted hook) ──────────────────────────────────────
+  const gradeForm = useGradeForm();
+  const { gradeError, clearGradeError, handleSaveGrade } = gradeForm;
+
+  // ── Bulk comment state ─────────────────────────────────────────────────────
   const [showBulkComment, setShowBulkComment] = useState(false);
   const [bulkComment, setBulkComment] = useState('');
   const [isBulkSubmitting, setIsBulkSubmitting] = useState(false);
   const [bulkCommentError, setBulkCommentError] = useState('');
   const [bulkCommentDone, setBulkCommentDone] = useState(false);
 
-  // Stats — use grouped view when available (Fix 3 #1764)
+  // ── Derived stats ──────────────────────────────────────────────────────────
   const groups: StudentAttemptGroup[] = detail.submissions_by_student ?? [];
   const useGrouped = groups.length > 0;
 
@@ -108,44 +68,7 @@ const AssignmentDetailPanel: React.FC<Props> = ({
         submitted: detail.submissions.filter((s) => s.status === 'submitted').length,
       };
 
-  const handleGradeClick = (sub: SubmissionResponse) => {
-    setGradingId(sub.id);
-    const { gradeInput: gi, feedbackInput: fi } = buildGradeClickState(sub);
-    setGradeInput((prev) => ({ ...prev, [sub.id]: gi }));
-    setFeedbackInput((prev) => ({ ...prev, [sub.id]: fi }));
-    setGradeError('');
-  };
-
-  const handleSaveGrade = async (sub: SubmissionResponse) => {
-    if (!token) return;
-    const raw = gradeInput[sub.id] ?? '';
-    const validationError = validateScore(raw);
-    if (validationError) {
-      setGradeError(validationError);
-      return;
-    }
-
-    const score = raw.trim() === '' ? null : parseFloat(raw);
-    const feedback = feedbackInput[sub.id]?.trim() || null;
-
-    setSavingId(sub.id);
-    setGradeError('');
-    try {
-      const updated = await gradeSubmission(token, assignmentId, sub.id, score, feedback);
-      setGradingId(null);
-      onGraded(updated);
-    } catch (err) {
-      if (err instanceof AssignmentApiError) {
-        setGradeError(err.message);
-      } else {
-        setGradeError('批改失敗，請重試');
-      }
-    } finally {
-      setSavingId(null);
-    }
-  };
-
-  // Bulk grade: mark all submitted (ungraded) submissions as graded.
+  // ── Bulk comment handler ───────────────────────────────────────────────────
   const handleBulkCommentSubmit = async () => {
     if (!token) return;
     const ungraded = filterSubmittedForBulk(detail.submissions);
@@ -180,6 +103,7 @@ const AssignmentDetailPanel: React.FC<Props> = ({
     }
   };
 
+  // ── Loading state ──────────────────────────────────────────────────────────
   if (isLoading) {
     return (
       <div className="space-y-2">
@@ -203,6 +127,7 @@ const AssignmentDetailPanel: React.FC<Props> = ({
   return (
     <div>
       {toast}
+
       {/* Stats bar + actions */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex gap-4 text-xs text-gray-500">
@@ -295,387 +220,31 @@ const AssignmentDetailPanel: React.FC<Props> = ({
       {gradeError && (
         <div className="mb-2 text-xs text-red-600 bg-red-50 border border-red-200 rounded px-3 py-1.5">
           {gradeError}
-          <button
-            onClick={() => setGradeError('')}
-            className="ml-2 underline cursor-pointer"
-          >
+          <button onClick={clearGradeError} className="ml-2 underline cursor-pointer">
             關閉
           </button>
         </div>
       )}
 
-      {/* Mobile card view */}
-      <div className="md:hidden space-y-3">
-        {detail.submissions.map((sub) => (
-          <div key={sub.id} className="bg-white rounded-lg border border-gray-200 p-4 space-y-3">
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-medium text-gray-900 text-sm">{sub.student_name}</span>
-              <div className="flex items-center gap-2">
-                {statusBadge(sub.status)}
-                {gradingId === sub.id ? (
-                  <div className="flex items-center gap-1">
-                    <button
-                      onClick={() => handleSaveGrade(sub)}
-                      disabled={savingId === sub.id}
-                      className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
-                    >
-                      {savingId === sub.id ? '...' : '儲存'}
-                    </button>
-                    <button
-                      onClick={() => { setGradingId(null); setGradeError(''); }}
-                      className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                    >
-                      取消
-                    </button>
-                  </div>
-                ) : (sub.status === 'submitted' || sub.status === 'graded') ? (
-                  <button
-                    onClick={() => handleGradeClick(sub)}
-                    className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                  >
-                    {sub.status === 'graded' ? '重新批改' : '批改'}
-                  </button>
-                ) : null}
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-              <div>
-                <span className="text-xs text-gray-400">提交時間</span>
-                <p className="text-gray-700">{formatDate(sub.submitted_at)}</p>
-              </div>
-              <div>
-                <span className="text-xs text-gray-400">分數</span>
-                {gradingId === sub.id ? (
-                  <input
-                    type="number"
-                    min="0"
-                    max="100"
-                    value={gradeInput[sub.id] ?? ''}
-                    onChange={(e) =>
-                      setGradeInput((prev) => ({ ...prev, [sub.id]: e.target.value }))
-                    }
-                    className="w-20 h-7 px-2 rounded border border-gray-300 text-center text-sm text-gray-900 bg-white focus:outline-none focus:border-accent"
-                    placeholder="0-100"
-                  />
-                ) : (
-                  <p className="text-gray-700 font-medium">
-                    {sub.score != null ? `${Math.round(sub.score)}%` : '-'}
-                  </p>
-                )}
-              </div>
-            </div>
-
-            {(sub.reading_accuracy != null || sub.reading_cpm != null || sub.reading_error_chars.length > 0) && (
-              <div>
-                <button
-                  onClick={() => setExpandedMetricsId((prev) => (prev === sub.id ? null : sub.id))}
-                  className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-blue-200 text-blue-600 text-xs hover:bg-blue-50 cursor-pointer transition-colors"
-                >
-                  {expandedMetricsId === sub.id ? '收合朗讀數據' : '查看朗讀數據'}
-                </button>
-                {expandedMetricsId === sub.id && (
-                  <div className="mt-2">
-                    <ReadingMetricsPanel
-                      studentName={sub.student_name}
-                      readingAccuracy={sub.reading_accuracy}
-                      readingCpm={sub.reading_cpm}
-                      readingErrorChars={sub.reading_error_chars}
-                    />
-                  </div>
-                )}
-              </div>
-            )}
-
-            {gradingId === sub.id ? (
-              <div>
-                <span className="text-xs text-gray-400">評語</span>
-                <textarea
-                  value={feedbackInput[sub.id] ?? ''}
-                  onChange={(e) =>
-                    setFeedbackInput((prev) => ({ ...prev, [sub.id]: e.target.value }))
-                  }
-                  placeholder="輸入個別評語（選填）"
-                  rows={2}
-                  className="w-full mt-1 px-2 py-1.5 rounded border border-gray-300 text-xs text-gray-900 bg-white placeholder-gray-400 focus:outline-none focus:border-accent resize-none"
-                />
-              </div>
-            ) : sub.teacher_feedback ? (
-              <div>
-                <span className="text-xs text-gray-400">評語</span>
-                <p className="text-gray-600 text-sm mt-0.5 line-clamp-2" title={sub.teacher_feedback}>
-                  {sub.teacher_feedback}
-                </p>
-              </div>
-            ) : null}
-          </div>
-        ))}
-      </div>
-
-      {/* Desktop table view — Issue #1764 Fix 4: grouped by student when available */}
-      <div className="hidden md:block overflow-x-auto">
-      <table className="w-full text-xs">
-        <thead>
-          <tr className="text-left text-gray-400">
-            <th className="pb-1.5 font-medium">學生姓名</th>
-            <th className="pb-1.5 font-medium text-center">最新狀態</th>
-            <th className="pb-1.5 font-medium text-center">作答次數</th>
-            <th className="pb-1.5 font-medium text-center">最新分數</th>
-            <th className="pb-1.5 font-medium text-center">朗讀數據</th>
-            <th className="pb-1.5 font-medium">評語</th>
-            <th className="pb-1.5 font-medium text-center">批改</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-100">
-          {useGrouped ? groups.map((group) => {
-            const latest = group.attempts[0]; // already sorted desc by attempt_number
-            const isExpanded = expandedStudentId === group.student_id;
-            return (
-              <React.Fragment key={group.student_id}>
-                <tr>
-                  <td className="py-1.5 text-gray-700">
-                    <div className="flex items-center gap-1">
-                      {group.attempts.length > 1 && (
-                        <button
-                          onClick={() =>
-                            setExpandedStudentId((prev) =>
-                              prev === group.student_id ? null : group.student_id
-                            )
-                          }
-                          className="inline-flex items-center justify-center w-4 h-4 rounded border border-gray-300 text-gray-500 hover:bg-gray-50 cursor-pointer transition-colors"
-                          title={isExpanded ? '收合歷史作答' : '展開歷史作答'}
-                        >
-                          {isExpanded ? '−' : '+'}
-                        </button>
-                      )}
-                      {group.student_name}
-                    </div>
-                  </td>
-                  <td className="py-1.5 text-center">{statusBadge(group.latest_status)}</td>
-                  <td className="py-1.5 text-center text-gray-500">{group.attempts.length}</td>
-                  <td className="py-1.5 text-gray-700 text-center font-medium">
-                    {gradingId === latest.id ? (
-                      <input
-                        type="number"
-                        min="0"
-                        max="100"
-                        value={gradeInput[latest.id] ?? ''}
-                        onChange={(e) =>
-                          setGradeInput((prev) => ({ ...prev, [latest.id]: e.target.value }))
-                        }
-                        className="w-16 h-6 px-1.5 rounded border border-gray-300 text-center text-xs focus:outline-none focus:border-accent"
-                        placeholder="0-100"
-                      />
-                    ) : latest.score != null ? (
-                      `${Math.round(latest.score)}%`
-                    ) : (
-                      '-'
-                    )}
-                  </td>
-                  <td className="py-1.5 text-center">
-                    {latest.reading_accuracy != null || latest.reading_cpm != null || latest.reading_error_chars.length > 0 ? (
-                      <button
-                        onClick={() =>
-                          setExpandedMetricsId((prev) => (prev === latest.id ? null : latest.id))
-                        }
-                        className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-blue-200 text-blue-600 text-xs hover:bg-blue-50 cursor-pointer transition-colors"
-                        title="展開朗讀數據"
-                      >
-                        {expandedMetricsId === latest.id ? '收合' : '查看'}
-                      </button>
-                    ) : (
-                      <span className="text-gray-300">—</span>
-                    )}
-                  </td>
-                  <td className="py-1.5 max-w-[200px]">
-                    {gradingId === latest.id ? (
-                      <textarea
-                        value={feedbackInput[latest.id] ?? ''}
-                        onChange={(e) =>
-                          setFeedbackInput((prev) => ({ ...prev, [latest.id]: e.target.value }))
-                        }
-                        placeholder="輸入個別評語（選填）"
-                        rows={2}
-                        className="w-full px-1.5 py-1 rounded border border-gray-300 text-xs text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none"
-                      />
-                    ) : latest.teacher_feedback ? (
-                      <span className="text-gray-600 line-clamp-2" title={latest.teacher_feedback}>
-                        {latest.teacher_feedback}
-                      </span>
-                    ) : (
-                      <span className="text-gray-300">—</span>
-                    )}
-                  </td>
-                  <td className="py-1.5 text-center">
-                    {gradingId === latest.id ? (
-                      <div className="flex items-center justify-center gap-1">
-                        <button
-                          onClick={() => handleSaveGrade(latest as unknown as SubmissionResponse)}
-                          disabled={savingId === latest.id}
-                          className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
-                        >
-                          {savingId === latest.id ? '...' : '儲存'}
-                        </button>
-                        <button
-                          onClick={() => { setGradingId(null); setGradeError(''); }}
-                          className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                        >
-                          取消
-                        </button>
-                      </div>
-                    ) : latest.status === 'submitted' || latest.status === 'graded' ? (
-                      <button
-                        onClick={() => handleGradeClick(latest as unknown as SubmissionResponse)}
-                        className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                      >
-                        {latest.status === 'graded' ? '重新批改' : '批改'}
-                      </button>
-                    ) : (
-                      <span className="text-gray-300">—</span>
-                    )}
-                  </td>
-                </tr>
-                {expandedMetricsId === latest.id && (
-                  <tr>
-                    <td colSpan={7} className="pb-2 pt-0">
-                      <ReadingMetricsPanel
-                        studentName={group.student_name}
-                        readingAccuracy={latest.reading_accuracy}
-                        readingCpm={latest.reading_cpm}
-                        readingErrorChars={latest.reading_error_chars}
-                      />
-                    </td>
-                  </tr>
-                )}
-                {/* Expanded history rows for prior attempts */}
-                {isExpanded && (
-                  <AttemptHistoryPanel attempts={group.attempts.slice(1)} />
-                )}
-              </React.Fragment>
-            );
-          }) : detail.submissions.map((sub) => (
-            <React.Fragment key={sub.id}>
-              <tr>
-                <td className="py-1.5 text-gray-700">{sub.student_name}</td>
-                <td className="py-1.5 text-center">{statusBadge(sub.status)}</td>
-                <td className="py-1.5 text-gray-500">{formatDate(sub.submitted_at)}</td>
-                <td className="py-1.5 text-gray-700 text-center font-medium">
-                  {gradingId === sub.id ? (
-                    <input
-                      type="number"
-                      min="0"
-                      max="100"
-                      value={gradeInput[sub.id] ?? ''}
-                      onChange={(e) =>
-                        setGradeInput((prev) => ({
-                          ...prev,
-                          [sub.id]: e.target.value,
-                        }))
-                      }
-                      className="w-16 h-6 px-1.5 rounded border border-gray-300 text-center text-xs focus:outline-none focus:border-accent"
-                      placeholder="0-100"
-                    />
-                  ) : sub.score != null ? (
-                    `${Math.round(sub.score)}%`
-                  ) : (
-                    '-'
-                  )}
-                </td>
-                <td className="py-1.5 text-center">
-                  {/* Show expand button only when any reading data exists */}
-                  {sub.reading_accuracy != null || sub.reading_cpm != null || sub.reading_error_chars.length > 0 ? (
-                    <button
-                      onClick={() =>
-                        setExpandedMetricsId((prev) => (prev === sub.id ? null : sub.id))
-                      }
-                      className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-blue-200 text-blue-600 text-xs hover:bg-blue-50 cursor-pointer transition-colors"
-                      title="展開朗讀數據"
-                    >
-                      {expandedMetricsId === sub.id ? '收合' : '查看'}
-                    </button>
-                  ) : (
-                    <span className="text-gray-300">—</span>
-                  )}
-                </td>
-                {/* Per-student feedback cell (Issue #424) */}
-                <td className="py-1.5 max-w-[200px]">
-                  {gradingId === sub.id ? (
-                    <textarea
-                      value={feedbackInput[sub.id] ?? ''}
-                      onChange={(e) =>
-                        setFeedbackInput((prev) => ({
-                          ...prev,
-                          [sub.id]: e.target.value,
-                        }))
-                      }
-                      placeholder="輸入個別評語（選填）"
-                      rows={2}
-                      className="w-full px-1.5 py-1 rounded border border-gray-300 text-xs text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none"
-                    />
-                  ) : sub.teacher_feedback ? (
-                    <span
-                      className="text-gray-600 line-clamp-2"
-                      title={sub.teacher_feedback}
-                    >
-                      {sub.teacher_feedback}
-                    </span>
-                  ) : (
-                    <span className="text-gray-300">—</span>
-                  )}
-                </td>
-                <td className="py-1.5 text-center">
-                  {gradingId === sub.id ? (
-                    <div className="flex items-center justify-center gap-1">
-                      <button
-                        onClick={() => handleSaveGrade(sub)}
-                        disabled={savingId === sub.id}
-                        className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
-                      >
-                        {savingId === sub.id ? '...' : '儲存'}
-                      </button>
-                      <button
-                        onClick={() => {
-                          setGradingId(null);
-                          setGradeError('');
-                        }}
-                        className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                      >
-                        取消
-                      </button>
-                    </div>
-                  ) : sub.status === 'submitted' || sub.status === 'graded' ? (
-                    <button
-                      onClick={() => handleGradeClick(sub)}
-                      className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
-                    >
-                      {sub.status === 'graded' ? '重新批改' : '批改'}
-                    </button>
-                  ) : (
-                    <span className="text-gray-300">—</span>
-                  )}
-                </td>
-              </tr>
-              {/* Reading metrics expanded row (Issue #423) */}
-              {expandedMetricsId === sub.id && (
-                <tr>
-                  <td colSpan={7} className="pb-2 pt-0">
-                    <ReadingMetricsPanel
-                      studentName={sub.student_name}
-                      readingAccuracy={sub.reading_accuracy}
-                      readingCpm={sub.reading_cpm}
-                      readingErrorChars={sub.reading_error_chars}
-                    />
-                  </td>
-                </tr>
-              )}
-            </React.Fragment>
-          ))}
-        </tbody>
-      </table>
-      </div>
+      {/* Submission table (mobile cards + desktop table) */}
+      <AssignmentSubmissionTable
+        submissions={detail.submissions}
+        groups={groups}
+        useGrouped={useGrouped}
+        gradeForm={{
+          gradingId: gradeForm.gradingId,
+          gradeInput: gradeForm.gradeInput,
+          feedbackInput: gradeForm.feedbackInput,
+          savingId: gradeForm.savingId,
+          setGradeInput: gradeForm.setGradeInput,
+          setFeedbackInput: gradeForm.setFeedbackInput,
+          onGradeClick: gradeForm.handleGradeClick,
+          onSaveGrade: (sub) => handleSaveGrade(sub, assignmentId, onGraded),
+          onCancelGrade: gradeForm.cancelGrade,
+        }}
+      />
     </div>
   );
 };
-
 
 export default AssignmentDetailPanel;

--- a/frontend/src/pages/teacher/__tests__/AssignmentDetailPanel.refactor.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/AssignmentDetailPanel.refactor.test.tsx
@@ -1,0 +1,428 @@
+/**
+ * Characterization tests for AssignmentDetailPanel refactor (Issue #1936).
+ *
+ * TDD-FIRST: written BEFORE extraction.
+ * These tests characterize the observable behaviour of the three new units:
+ *   1. AssignmentSubmissionTable — renders student rows + grading actions
+ *   2. useGradeForm — state hook for grade/feedback per submission
+ *   3. AssignmentDetailPanel (orchestrator) — wires table + bulk comment + stats bar
+ *
+ * RED PHASE: all tests should fail until the components are extracted.
+ * GREEN PHASE: identical test file should pass after extraction without changes.
+ *
+ * Constraints:
+ *  - No mocking of gradeSubmission (unit scope; API tested in integration)
+ *  - jsdom environment (configured in vite.config.ts)
+ *  - Fixtures reused from assignmentDetailLogic.test.ts pattern
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ─── Pre-refactor: import from the monolithic panel. After refactor, these will
+// point at the extracted files. The test itself does NOT change.
+
+// We test the top-level panel — it exposes all behaviour.
+import AssignmentDetailPanel from '../AssignmentDetailPanel';
+
+import type {
+  AssignmentDetailResponse,
+  SubmissionResponse,
+  StudentAttemptGroup,
+  AttemptResponse,
+  AssignmentResponse,
+} from '../../../services/assignmentApi';
+
+// ─── Auth mock ────────────────────────────────────────────────────────────────
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+vi.mock('../../../components/ui/Toast', () => ({
+  useToast: () => ({
+    toast: null,
+    showToast: vi.fn(),
+  }),
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeSubmission(overrides: Partial<SubmissionResponse> = {}): SubmissionResponse {
+  return {
+    id: 1,
+    assignment_id: 10,
+    student_id: 1,
+    student_name: '王小明',
+    status: 'submitted',
+    submitted_at: '2026-05-01T10:00:00Z',
+    score: null,
+    reading_accuracy: null,
+    reading_cpm: null,
+    reading_error_chars: [],
+    teacher_feedback: null,
+    ...overrides,
+  };
+}
+
+function makeAttempt(overrides: Partial<AttemptResponse> = {}): AttemptResponse {
+  return {
+    id: 1,
+    attempt_number: 1,
+    status: 'submitted',
+    submitted_at: '2026-05-01T10:00:00Z',
+    score: null,
+    reading_accuracy: null,
+    reading_cpm: null,
+    reading_error_chars: [],
+    teacher_feedback: null,
+    ...overrides,
+  };
+}
+
+function makeGroup(overrides: Partial<StudentAttemptGroup> = {}): StudentAttemptGroup {
+  return {
+    student_id: 1,
+    student_name: '王小明',
+    latest_status: 'submitted',
+    latest_score: null,
+    latest_attempt_number: 1,
+    attempts: [makeAttempt()],
+    ...overrides,
+  };
+}
+
+const BASE_ASSIGNMENT: Omit<AssignmentResponse, 'id'> = {
+  classroom_id: 1,
+  story_id: 'L1',
+  text_id: null,
+  story_title: '測試課文',
+  title: '作業一',
+  description: null,
+  assignment_type: 'reading',
+  due_date: null,
+  is_active: true,
+  created_at: '2026-05-01T00:00:00Z',
+  assigned_student_count: 2,
+  submitted_student_count: 1,
+  total_attempts: 1,
+  submission_count: 1,
+  completed_count: 1,
+  skip_completed_steps: false,
+  target_cpm: null,
+  target_accuracy: null,
+  difficulty_label: null,
+  effective_cpm: 150,
+  effective_accuracy: 90,
+};
+
+function makeDetail(overrides: Partial<AssignmentDetailResponse> = {}): AssignmentDetailResponse {
+  return {
+    id: 10,
+    ...BASE_ASSIGNMENT,
+    submissions: [makeSubmission()],
+    submissions_by_student: [],
+    ...overrides,
+  };
+}
+
+// ─── 1. AssignmentDetailPanel renders student list ─────────────────────────────
+
+describe('AssignmentDetailPanel — student list rendering', () => {
+  it('renders loading skeleton when isLoading is true', () => {
+    const { container } = render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail()}
+        isLoading={true}
+        onGraded={vi.fn()}
+      />,
+    );
+    // Loading skeleton uses animate-pulse divs
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  it('renders empty state when no submissions', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({ submissions: [] })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('尚無學生提交記錄')).toBeTruthy();
+  });
+
+  it('renders student name in submission list', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ student_name: '李大明' })],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    // Student name appears in at least one rendered element
+    expect(screen.getAllByText('李大明').length).toBeGreaterThan(0);
+  });
+
+  it('renders multiple students', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [
+            makeSubmission({ id: 1, student_id: 1, student_name: '王小明' }),
+            makeSubmission({ id: 2, student_id: 2, student_name: '陳小花' }),
+          ],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText('王小明').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('陳小花').length).toBeGreaterThan(0);
+  });
+});
+
+// ─── 2. Status badge rendering ────────────────────────────────────────────────
+
+describe('AssignmentDetailPanel — status badges', () => {
+  it('shows 已提交 badge for submitted status', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ status: 'submitted' })],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText('已提交').length).toBeGreaterThan(0);
+  });
+
+  it('shows 已批改 badge for graded status', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ status: 'graded', score: 85 })],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText('已批改').length).toBeGreaterThan(0);
+  });
+});
+
+// ─── 3. Stats bar ─────────────────────────────────────────────────────────────
+
+describe('AssignmentDetailPanel — stats bar', () => {
+  it('shows submitted_student_count in stats bar', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({ submitted_student_count: 3, assigned_student_count: 5 })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    // "已完成: 3" and "總學生: 5" should appear
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+
+  it('shows bulk comment button when submitted students exist', () => {
+    // Need a submission with status submitted so submitted count > 0
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ status: 'submitted' })],
+          submissions_by_student: [],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    // "批次評語" button should appear
+    expect(screen.getByText(/批次評語/)).toBeTruthy();
+  });
+});
+
+// ─── 4. Grading interaction ───────────────────────────────────────────────────
+
+describe('AssignmentDetailPanel — grading interaction', () => {
+  it('shows 批改 button for submitted submission', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ status: 'submitted' })],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    // At least one 批改 button should be visible
+    expect(screen.getAllByText('批改').length).toBeGreaterThan(0);
+  });
+
+  it('clicking 批改 button reveals score input and cancel button', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ id: 5, status: 'submitted' })],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+
+    // Click the first 批改 button (mobile or desktop view)
+    const gradeButtons = screen.getAllByText('批改');
+    fireEvent.click(gradeButtons[0]);
+
+    // After click, should see 儲存 and 取消 buttons
+    expect(screen.getAllByText('儲存').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('取消').length).toBeGreaterThan(0);
+  });
+
+  it('clicking 取消 after 批改 hides the score input', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ id: 5, status: 'submitted' })],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+
+    const gradeButtons = screen.getAllByText('批改');
+    fireEvent.click(gradeButtons[0]);
+
+    // Cancel
+    const cancelButtons = screen.getAllByText('取消');
+    fireEvent.click(cancelButtons[0]);
+
+    // 批改 buttons should be back
+    expect(screen.getAllByText('批改').length).toBeGreaterThan(0);
+  });
+
+  it('shows 重新批改 button for already graded submission', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ status: 'graded', score: 90 })],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText('重新批改').length).toBeGreaterThan(0);
+  });
+});
+
+// ─── 5. Grouped (submissions_by_student) rendering ────────────────────────────
+
+describe('AssignmentDetailPanel — grouped submissions_by_student', () => {
+  it('renders grouped view when submissions_by_student is non-empty', () => {
+    const group = makeGroup({
+      student_id: 42,
+      student_name: '張三',
+      latest_status: 'submitted',
+    });
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ student_id: 42, student_name: '張三' })],
+          submissions_by_student: [group],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByText('張三').length).toBeGreaterThan(0);
+  });
+
+  it('shows expand button (+) when student has multiple attempts', () => {
+    const group = makeGroup({
+      student_id: 1,
+      student_name: '王小明',
+      attempts: [
+        makeAttempt({ id: 2, attempt_number: 2 }),
+        makeAttempt({ id: 1, attempt_number: 1 }),
+      ],
+    });
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission()],
+          submissions_by_student: [group],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+    // The expand button shows "+" text for the desktop grouped view
+    expect(screen.getByTitle('展開歷史作答')).toBeTruthy();
+  });
+});
+
+// ─── 6. Bulk comment panel toggle ─────────────────────────────────────────────
+
+describe('AssignmentDetailPanel — bulk comment panel', () => {
+  it('clicking bulk comment button opens the BulkCommentPanel', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ status: 'submitted' })],
+          submissions_by_student: [],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+
+    const bulkBtn = screen.getByText(/批次評語/);
+    fireEvent.click(bulkBtn);
+
+    // BulkCommentPanel renders a cancel button and textarea when open
+    expect(screen.getByText('取消')).toBeTruthy();
+  });
+
+  it('bulk comment panel closes when cancel is clicked', () => {
+    render(
+      <AssignmentDetailPanel
+        assignmentId={10}
+        detail={makeDetail({
+          submissions: [makeSubmission({ status: 'submitted' })],
+          submissions_by_student: [],
+        })}
+        isLoading={false}
+        onGraded={vi.fn()}
+      />,
+    );
+
+    // Open
+    fireEvent.click(screen.getByText(/批次評語/));
+    // Close
+    fireEvent.click(screen.getByText('取消'));
+
+    // Bulk comment panel should be gone — textarea disappears
+    expect(screen.queryByPlaceholderText('輸入統一評語（選填）')).toBeNull();
+  });
+});

--- a/frontend/src/pages/teacher/assignmentDetailUtils.tsx
+++ b/frontend/src/pages/teacher/assignmentDetailUtils.tsx
@@ -1,0 +1,47 @@
+/**
+ * UI utility helpers for AssignmentDetailPanel and sub-components (Issue #1936).
+ * Extracted from AssignmentDetailPanel.tsx to be shared across the split pieces.
+ */
+
+/** Render a status badge element for a given submission status string. */
+export function statusBadge(status: string): React.ReactElement {
+  switch (status) {
+    case 'in_progress':
+      return (
+        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">
+          進行中
+        </span>
+      );
+    case 'submitted':
+      return (
+        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+          已提交
+        </span>
+      );
+    case 'graded':
+      return (
+        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-700">
+          已批改
+        </span>
+      );
+    default:
+      return (
+        <span className="inline-block px-1.5 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-500">
+          待完成
+        </span>
+      );
+  }
+}
+
+/** Format an ISO date string to zh-TW locale short date, or '-' for null. */
+export function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '-';
+  return new Date(dateStr).toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+// React is used by statusBadge JSX — must be imported.
+import React from 'react';

--- a/frontend/src/pages/teacher/components/AssignmentSubmissionTable.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentSubmissionTable.tsx
@@ -1,0 +1,443 @@
+/**
+ * AssignmentSubmissionTable — renders the student submission list (Issue #1936).
+ *
+ * Extracted from AssignmentDetailPanel.tsx.
+ * Handles:
+ *   - Mobile card view (each student as a card)
+ *   - Desktop table view (grouped by student or flat)
+ *   - Inline grading inputs (score + feedback textarea)
+ *   - Expand/collapse reading metrics per row
+ *   - Expand/collapse attempt history for multi-attempt students
+ */
+import React, { useState } from 'react';
+import type {
+  SubmissionResponse,
+  StudentAttemptGroup,
+} from '../../../services/assignmentApi';
+import ReadingMetricsPanel from './ReadingMetricsPanel';
+import AttemptHistoryPanel from './AttemptHistoryPanel';
+import { statusBadge, formatDate } from '../assignmentDetailUtils.tsx';
+
+export interface GradeFormProps {
+  gradingId: number | null;
+  gradeInput: Record<number, string>;
+  feedbackInput: Record<number, string>;
+  savingId: number | null;
+  setGradeInput: React.Dispatch<React.SetStateAction<Record<number, string>>>;
+  setFeedbackInput: React.Dispatch<React.SetStateAction<Record<number, string>>>;
+  onGradeClick: (sub: SubmissionResponse) => void;
+  onSaveGrade: (sub: SubmissionResponse) => void;
+  onCancelGrade: () => void;
+}
+
+interface Props {
+  submissions: SubmissionResponse[];
+  groups: StudentAttemptGroup[];
+  useGrouped: boolean;
+  gradeForm: GradeFormProps;
+}
+
+const AssignmentSubmissionTable: React.FC<Props> = ({
+  submissions,
+  groups,
+  useGrouped,
+  gradeForm,
+}) => {
+  const {
+    gradingId,
+    gradeInput,
+    feedbackInput,
+    savingId,
+    setGradeInput,
+    setFeedbackInput,
+    onGradeClick,
+    onSaveGrade,
+    onCancelGrade,
+  } = gradeForm;
+
+  const [expandedMetricsId, setExpandedMetricsId] = useState<number | null>(null);
+  const [expandedStudentId, setExpandedStudentId] = useState<number | null>(null);
+
+  // ── Mobile card view ──────────────────────────────────────────────────────
+
+  const renderMobileCard = (sub: SubmissionResponse) => (
+    <div key={sub.id} className="bg-white rounded-lg border border-gray-200 p-4 space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium text-gray-900 text-sm">{sub.student_name}</span>
+        <div className="flex items-center gap-2">
+          {statusBadge(sub.status)}
+          {gradingId === sub.id ? (
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => onSaveGrade(sub)}
+                disabled={savingId === sub.id}
+                className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
+              >
+                {savingId === sub.id ? '...' : '儲存'}
+              </button>
+              <button
+                onClick={onCancelGrade}
+                className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+              >
+                取消
+              </button>
+            </div>
+          ) : (sub.status === 'submitted' || sub.status === 'graded') ? (
+            <button
+              onClick={() => onGradeClick(sub)}
+              className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+            >
+              {sub.status === 'graded' ? '重新批改' : '批改'}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+        <div>
+          <span className="text-xs text-gray-400">提交時間</span>
+          <p className="text-gray-700">{formatDate(sub.submitted_at)}</p>
+        </div>
+        <div>
+          <span className="text-xs text-gray-400">分數</span>
+          {gradingId === sub.id ? (
+            <input
+              type="number"
+              min="0"
+              max="100"
+              value={gradeInput[sub.id] ?? ''}
+              onChange={(e) =>
+                setGradeInput((prev) => ({ ...prev, [sub.id]: e.target.value }))
+              }
+              className="w-20 h-7 px-2 rounded border border-gray-300 text-center text-sm text-gray-900 bg-white focus:outline-none focus:border-accent"
+              placeholder="0-100"
+            />
+          ) : (
+            <p className="text-gray-700 font-medium">
+              {sub.score != null ? `${Math.round(sub.score)}%` : '-'}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {(sub.reading_accuracy != null || sub.reading_cpm != null || sub.reading_error_chars.length > 0) && (
+        <div>
+          <button
+            onClick={() => setExpandedMetricsId((prev) => (prev === sub.id ? null : sub.id))}
+            className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-blue-200 text-blue-600 text-xs hover:bg-blue-50 cursor-pointer transition-colors"
+          >
+            {expandedMetricsId === sub.id ? '收合朗讀數據' : '查看朗讀數據'}
+          </button>
+          {expandedMetricsId === sub.id && (
+            <div className="mt-2">
+              <ReadingMetricsPanel
+                studentName={sub.student_name}
+                readingAccuracy={sub.reading_accuracy}
+                readingCpm={sub.reading_cpm}
+                readingErrorChars={sub.reading_error_chars}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {gradingId === sub.id ? (
+        <div>
+          <span className="text-xs text-gray-400">評語</span>
+          <textarea
+            value={feedbackInput[sub.id] ?? ''}
+            onChange={(e) =>
+              setFeedbackInput((prev) => ({ ...prev, [sub.id]: e.target.value }))
+            }
+            placeholder="輸入個別評語（選填）"
+            rows={2}
+            className="w-full mt-1 px-2 py-1.5 rounded border border-gray-300 text-xs text-gray-900 bg-white placeholder-gray-400 focus:outline-none focus:border-accent resize-none"
+          />
+        </div>
+      ) : sub.teacher_feedback ? (
+        <div>
+          <span className="text-xs text-gray-400">評語</span>
+          <p className="text-gray-600 text-sm mt-0.5 line-clamp-2" title={sub.teacher_feedback}>
+            {sub.teacher_feedback}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  // ── Desktop table — grouped view ──────────────────────────────────────────
+
+  const renderGroupedRows = () =>
+    groups.map((group) => {
+      const latest = group.attempts[0]; // sorted desc by attempt_number
+      const isExpanded = expandedStudentId === group.student_id;
+      // Cast: AttemptResponse is structurally compatible with SubmissionResponse for grading
+      const latestAsSub = latest as unknown as SubmissionResponse;
+
+      return (
+        <React.Fragment key={group.student_id}>
+          <tr>
+            <td className="py-1.5 text-gray-700">
+              <div className="flex items-center gap-1">
+                {group.attempts.length > 1 && (
+                  <button
+                    onClick={() =>
+                      setExpandedStudentId((prev) =>
+                        prev === group.student_id ? null : group.student_id
+                      )
+                    }
+                    className="inline-flex items-center justify-center w-4 h-4 rounded border border-gray-300 text-gray-500 hover:bg-gray-50 cursor-pointer transition-colors"
+                    title={isExpanded ? '收合歷史作答' : '展開歷史作答'}
+                  >
+                    {isExpanded ? '−' : '+'}
+                  </button>
+                )}
+                {group.student_name}
+              </div>
+            </td>
+            <td className="py-1.5 text-center">{statusBadge(group.latest_status)}</td>
+            <td className="py-1.5 text-center text-gray-500">{group.attempts.length}</td>
+            <td className="py-1.5 text-gray-700 text-center font-medium">
+              {gradingId === latest.id ? (
+                <input
+                  type="number"
+                  min="0"
+                  max="100"
+                  value={gradeInput[latest.id] ?? ''}
+                  onChange={(e) =>
+                    setGradeInput((prev) => ({ ...prev, [latest.id]: e.target.value }))
+                  }
+                  className="w-16 h-6 px-1.5 rounded border border-gray-300 text-center text-xs focus:outline-none focus:border-accent"
+                  placeholder="0-100"
+                />
+              ) : latest.score != null ? (
+                `${Math.round(latest.score)}%`
+              ) : (
+                '-'
+              )}
+            </td>
+            <td className="py-1.5 text-center">
+              {latest.reading_accuracy != null || latest.reading_cpm != null || latest.reading_error_chars.length > 0 ? (
+                <button
+                  onClick={() =>
+                    setExpandedMetricsId((prev) => (prev === latest.id ? null : latest.id))
+                  }
+                  className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-blue-200 text-blue-600 text-xs hover:bg-blue-50 cursor-pointer transition-colors"
+                  title="展開朗讀數據"
+                >
+                  {expandedMetricsId === latest.id ? '收合' : '查看'}
+                </button>
+              ) : (
+                <span className="text-gray-300">—</span>
+              )}
+            </td>
+            <td className="py-1.5 max-w-[200px]">
+              {gradingId === latest.id ? (
+                <textarea
+                  value={feedbackInput[latest.id] ?? ''}
+                  onChange={(e) =>
+                    setFeedbackInput((prev) => ({ ...prev, [latest.id]: e.target.value }))
+                  }
+                  placeholder="輸入個別評語（選填）"
+                  rows={2}
+                  className="w-full px-1.5 py-1 rounded border border-gray-300 text-xs text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none"
+                />
+              ) : latest.teacher_feedback ? (
+                <span className="text-gray-600 line-clamp-2" title={latest.teacher_feedback}>
+                  {latest.teacher_feedback}
+                </span>
+              ) : (
+                <span className="text-gray-300">—</span>
+              )}
+            </td>
+            <td className="py-1.5 text-center">
+              {gradingId === latest.id ? (
+                <div className="flex items-center justify-center gap-1">
+                  <button
+                    onClick={() => onSaveGrade(latestAsSub)}
+                    disabled={savingId === latest.id}
+                    className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
+                  >
+                    {savingId === latest.id ? '...' : '儲存'}
+                  </button>
+                  <button
+                    onClick={onCancelGrade}
+                    className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+                  >
+                    取消
+                  </button>
+                </div>
+              ) : latest.status === 'submitted' || latest.status === 'graded' ? (
+                <button
+                  onClick={() => onGradeClick(latestAsSub)}
+                  className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+                >
+                  {latest.status === 'graded' ? '重新批改' : '批改'}
+                </button>
+              ) : (
+                <span className="text-gray-300">—</span>
+              )}
+            </td>
+          </tr>
+          {expandedMetricsId === latest.id && (
+            <tr>
+              <td colSpan={7} className="pb-2 pt-0">
+                <ReadingMetricsPanel
+                  studentName={group.student_name}
+                  readingAccuracy={latest.reading_accuracy}
+                  readingCpm={latest.reading_cpm}
+                  readingErrorChars={latest.reading_error_chars}
+                />
+              </td>
+            </tr>
+          )}
+          {isExpanded && (
+            <AttemptHistoryPanel attempts={group.attempts.slice(1)} />
+          )}
+        </React.Fragment>
+      );
+    });
+
+  // ── Desktop table — flat view ─────────────────────────────────────────────
+
+  const renderFlatRows = () =>
+    submissions.map((sub) => (
+      <React.Fragment key={sub.id}>
+        <tr>
+          <td className="py-1.5 text-gray-700">{sub.student_name}</td>
+          <td className="py-1.5 text-center">{statusBadge(sub.status)}</td>
+          <td className="py-1.5 text-gray-500">{formatDate(sub.submitted_at)}</td>
+          <td className="py-1.5 text-gray-700 text-center font-medium">
+            {gradingId === sub.id ? (
+              <input
+                type="number"
+                min="0"
+                max="100"
+                value={gradeInput[sub.id] ?? ''}
+                onChange={(e) =>
+                  setGradeInput((prev) => ({
+                    ...prev,
+                    [sub.id]: e.target.value,
+                  }))
+                }
+                className="w-16 h-6 px-1.5 rounded border border-gray-300 text-center text-xs focus:outline-none focus:border-accent"
+                placeholder="0-100"
+              />
+            ) : sub.score != null ? (
+              `${Math.round(sub.score)}%`
+            ) : (
+              '-'
+            )}
+          </td>
+          <td className="py-1.5 text-center">
+            {sub.reading_accuracy != null || sub.reading_cpm != null || sub.reading_error_chars.length > 0 ? (
+              <button
+                onClick={() =>
+                  setExpandedMetricsId((prev) => (prev === sub.id ? null : sub.id))
+                }
+                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded border border-blue-200 text-blue-600 text-xs hover:bg-blue-50 cursor-pointer transition-colors"
+                title="展開朗讀數據"
+              >
+                {expandedMetricsId === sub.id ? '收合' : '查看'}
+              </button>
+            ) : (
+              <span className="text-gray-300">—</span>
+            )}
+          </td>
+          <td className="py-1.5 max-w-[200px]">
+            {gradingId === sub.id ? (
+              <textarea
+                value={feedbackInput[sub.id] ?? ''}
+                onChange={(e) =>
+                  setFeedbackInput((prev) => ({
+                    ...prev,
+                    [sub.id]: e.target.value,
+                  }))
+                }
+                placeholder="輸入個別評語（選填）"
+                rows={2}
+                className="w-full px-1.5 py-1 rounded border border-gray-300 text-xs text-gray-900 placeholder-gray-400 focus:outline-none focus:border-accent resize-none"
+              />
+            ) : sub.teacher_feedback ? (
+              <span className="text-gray-600 line-clamp-2" title={sub.teacher_feedback}>
+                {sub.teacher_feedback}
+              </span>
+            ) : (
+              <span className="text-gray-300">—</span>
+            )}
+          </td>
+          <td className="py-1.5 text-center">
+            {gradingId === sub.id ? (
+              <div className="flex items-center justify-center gap-1">
+                <button
+                  onClick={() => onSaveGrade(sub)}
+                  disabled={savingId === sub.id}
+                  className="px-2 py-0.5 rounded bg-accent text-white text-xs font-medium hover:bg-accent-hover disabled:opacity-50 cursor-pointer transition-colors"
+                >
+                  {savingId === sub.id ? '...' : '儲存'}
+                </button>
+                <button
+                  onClick={onCancelGrade}
+                  className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+                >
+                  取消
+                </button>
+              </div>
+            ) : sub.status === 'submitted' || sub.status === 'graded' ? (
+              <button
+                onClick={() => onGradeClick(sub)}
+                className="px-2 py-0.5 rounded border border-gray-300 text-gray-600 text-xs hover:bg-gray-50 cursor-pointer transition-colors"
+              >
+                {sub.status === 'graded' ? '重新批改' : '批改'}
+              </button>
+            ) : (
+              <span className="text-gray-300">—</span>
+            )}
+          </td>
+        </tr>
+        {expandedMetricsId === sub.id && (
+          <tr>
+            <td colSpan={7} className="pb-2 pt-0">
+              <ReadingMetricsPanel
+                studentName={sub.student_name}
+                readingAccuracy={sub.reading_accuracy}
+                readingCpm={sub.reading_cpm}
+                readingErrorChars={sub.reading_error_chars}
+              />
+            </td>
+          </tr>
+        )}
+      </React.Fragment>
+    ));
+
+  return (
+    <>
+      {/* Mobile card view */}
+      <div className="md:hidden space-y-3">
+        {submissions.map(renderMobileCard)}
+      </div>
+
+      {/* Desktop table view */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-left text-gray-400">
+              <th className="pb-1.5 font-medium">學生姓名</th>
+              <th className="pb-1.5 font-medium text-center">最新狀態</th>
+              <th className="pb-1.5 font-medium text-center">作答次數</th>
+              <th className="pb-1.5 font-medium text-center">最新分數</th>
+              <th className="pb-1.5 font-medium text-center">朗讀數據</th>
+              <th className="pb-1.5 font-medium">評語</th>
+              <th className="pb-1.5 font-medium text-center">批改</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {useGrouped ? renderGroupedRows() : renderFlatRows()}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+};
+
+export default AssignmentSubmissionTable;

--- a/frontend/src/pages/teacher/hooks/useGradeForm.ts
+++ b/frontend/src/pages/teacher/hooks/useGradeForm.ts
@@ -1,0 +1,104 @@
+/**
+ * useGradeForm — state hook for per-submission grading (Issue #1936).
+ *
+ * Extracted from AssignmentDetailPanel.tsx.
+ * Manages: which submission is being graded, score/feedback inputs, saving state, error message.
+ */
+import { useState, useCallback } from 'react';
+import { useAuth } from '../../../contexts/AuthContext';
+import {
+  gradeSubmission,
+  AssignmentApiError,
+} from '../../../services/assignmentApi';
+import type { SubmissionResponse } from '../../../services/assignmentApi';
+import { validateScore, buildGradeClickState } from '../assignmentDetailLogic';
+
+export interface UseGradeFormReturn {
+  gradingId: number | null;
+  gradeInput: Record<number, string>;
+  feedbackInput: Record<number, string>;
+  savingId: number | null;
+  gradeError: string;
+  handleGradeClick: (sub: SubmissionResponse) => void;
+  handleSaveGrade: (sub: SubmissionResponse, assignmentId: number, onGraded: (updated: SubmissionResponse) => void) => Promise<void>;
+  cancelGrade: () => void;
+  setGradeInput: React.Dispatch<React.SetStateAction<Record<number, string>>>;
+  setFeedbackInput: React.Dispatch<React.SetStateAction<Record<number, string>>>;
+  clearGradeError: () => void;
+}
+
+import type React from 'react';
+
+export function useGradeForm(): UseGradeFormReturn {
+  const { token } = useAuth();
+  const [gradingId, setGradingId] = useState<number | null>(null);
+  const [gradeInput, setGradeInput] = useState<Record<number, string>>({});
+  const [feedbackInput, setFeedbackInput] = useState<Record<number, string>>({});
+  const [savingId, setSavingId] = useState<number | null>(null);
+  const [gradeError, setGradeError] = useState('');
+
+  const handleGradeClick = useCallback((sub: SubmissionResponse) => {
+    setGradingId(sub.id);
+    const { gradeInput: gi, feedbackInput: fi } = buildGradeClickState(sub);
+    setGradeInput((prev) => ({ ...prev, [sub.id]: gi }));
+    setFeedbackInput((prev) => ({ ...prev, [sub.id]: fi }));
+    setGradeError('');
+  }, []);
+
+  const cancelGrade = useCallback(() => {
+    setGradingId(null);
+    setGradeError('');
+  }, []);
+
+  const clearGradeError = useCallback(() => setGradeError(''), []);
+
+  const handleSaveGrade = useCallback(
+    async (
+      sub: SubmissionResponse,
+      assignmentId: number,
+      onGraded: (updated: SubmissionResponse) => void,
+    ) => {
+      if (!token) return;
+      const raw = gradeInput[sub.id] ?? '';
+      const validationError = validateScore(raw);
+      if (validationError) {
+        setGradeError(validationError);
+        return;
+      }
+
+      const score = raw.trim() === '' ? null : parseFloat(raw);
+      const feedback = feedbackInput[sub.id]?.trim() || null;
+
+      setSavingId(sub.id);
+      setGradeError('');
+      try {
+        const updated = await gradeSubmission(token, assignmentId, sub.id, score, feedback);
+        setGradingId(null);
+        onGraded(updated);
+      } catch (err) {
+        if (err instanceof AssignmentApiError) {
+          setGradeError(err.message);
+        } else {
+          setGradeError('批改失敗，請重試');
+        }
+      } finally {
+        setSavingId(null);
+      }
+    },
+    [token, gradeInput, feedbackInput],
+  );
+
+  return {
+    gradingId,
+    gradeInput,
+    feedbackInput,
+    savingId,
+    gradeError,
+    handleGradeClick,
+    handleSaveGrade,
+    cancelGrade,
+    setGradeInput,
+    setFeedbackInput,
+    clearGradeError,
+  };
+}


### PR DESCRIPTION
Fixes #1936

## Summary
- Split monolithic `AssignmentDetailPanel.tsx` (681 LOC) into 4 focused files
- Main panel is now an orchestrator-only (250 LOC)
- `AssignmentSubmissionTable` — mobile cards + desktop table with grading actions (443 LOC)
- `useGradeForm` hook — per-submission grade/feedback state management (104 LOC)
- `assignmentDetailUtils.tsx` — `statusBadge` + `formatDate` UI helpers (47 LOC)

## TDD evidence
- 16 new characterization tests in `AssignmentDetailPanel.refactor.test.tsx`
- All 33 tests pass (16 new + 17 pre-existing logic tests)
- Identical behaviour pre/post refactor — tests unchanged between RED and GREEN phases

## Test plan
- [ ] All 33 tests pass: `npx vitest run src/pages/teacher/__tests__/`
- [ ] No TS errors: `npx tsc --noEmit` in frontend/
- [ ] CI preview deploy green
- [ ] Teacher assignment detail view renders correctly (student list, grading, bulk comment)