### PR TITLE
refactor(report): split AssessmentReport.tsx into section components (Fixes #1945)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -1,11 +1,9 @@
 
-import React, { useRef, useState, useEffect } from 'react';
-import { speakText as azureSpeakText } from '../../services/ttsApi';
+import React, { useState, useEffect } from 'react';
 import { LearningSession } from '../../types';
 import type { Story } from '../../types';
 import type { ComprehensionScoreResult } from '../../services/learningApi';
 import { getReadingHistory, type ReadingHistoryPoint } from '../../services/learningApi';
-import DiffDisplay from '../ui/DiffDisplay';
 import CelebrationOverlay from '../ui/CelebrationOverlay';
 import ExitTicket from './ExitTicket';
 import { trackLearningEvent } from '../../utils/analytics';
@@ -26,6 +24,12 @@ import {
 } from './AssessmentComprehensionSection';
 import { useRepeatedErrorAlerts } from './useRepeatedErrorAlerts';
 
+// Extracted section components (#1945)
+import AssessmentSectionWrapper from './AssessmentSectionWrapper';
+import IntelligentAnalysisSection from './IntelligentAnalysisSection';
+import ErrorWordListSection from './ErrorWordListSection';
+import PracticeRecommendationSection from './PracticeRecommendationSection';
+
 interface AssessmentReportProps {
   session: LearningSession | null;
   story?: Story | null;
@@ -42,11 +46,6 @@ interface AssessmentReportProps {
   /** When true, suppresses celebration overlays and interactive elements (teacher view) */
   readOnly?: boolean;
 }
-
-/** Speak a Chinese character/word using Azure TTS */
-const speakText = (text: string) => {
-  azureSpeakText(text).catch(() => {});
-};
 
 /** Generate practice suggestions based on performance */
 const generateSuggestions = (
@@ -70,47 +69,6 @@ const generateSuggestions = (
   suggestions.push({ icon: '📈', title: '追蹤改進', desc: '重新朗讀一次，看看這次能不能比上次進步！' });
 
   return suggestions.slice(0, 4);
-};
-
-/** Section wrapper component for consistent styling, with optional collapse support */
-const Section: React.FC<{
-  number: number;
-  title: string;
-  children: React.ReactNode;
-  disabled?: boolean;
-  defaultOpen?: boolean;
-}> = ({ number, title, children, disabled, defaultOpen = true }) => {
-  const [open, setOpen] = useState(defaultOpen);
-  const canToggle = !disabled;
-
-  return (
-    <div className={`rounded-3xl border overflow-hidden ${disabled ? 'bg-gray-50 border-dashed border-gray-300' : 'bg-white border-slate-200 shadow-sm'}`}>
-      <div
-        className={`px-6 py-4 flex items-center gap-3 ${disabled ? 'border-gray-200' : 'border-slate-100'} ${open ? 'border-b' : ''} ${canToggle ? 'cursor-pointer select-none hover:bg-slate-50 transition-colors' : ''}`}
-        onClick={canToggle ? () => setOpen(o => !o) : undefined}
-        role={canToggle ? 'button' : undefined}
-        aria-expanded={canToggle ? open : undefined}
-      >
-        <span className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold shrink-0 ${disabled ? 'bg-gray-200 text-gray-400' : 'bg-accent text-white'}`}>
-          {number}
-        </span>
-        <h3 className={`text-lg font-bold flex-1 ${disabled ? 'text-gray-400' : 'text-gray-900'}`}>{title}</h3>
-        {canToggle && (
-          <svg
-            className={`w-5 h-5 text-gray-400 transition-transform shrink-0 ${open ? 'rotate-180' : ''}`}
-            fill="none" stroke="currentColor" viewBox="0 0 24 24"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
-          </svg>
-        )}
-      </div>
-      {open && (
-        <div className="p-6">
-          {children}
-        </div>
-      )}
-    </div>
-  );
 };
 
 const AssessmentReport: React.FC<AssessmentReportProps> = ({
@@ -192,6 +150,11 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
   const cpm = readingAttempt?.cpm ?? 0;
   const accuracy = readingAttempt?.accuracy ?? 0;
   const suggestions = readingAttempt ? generateSuggestions(wrongTokens, accuracy, cpm) : [];
+
+  // Transcription from readingAttempt or fullReadingResult
+  const transcription =
+    (readingAttempt?.transcription ?? '').trim() ||
+    (fullReadingResult?.transcript ?? '').trim();
 
   const starCount = calcStarRating({
     readingAccuracy: bestReadingAccuracy,
@@ -298,7 +261,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
       </div>
 
       {/* ============ 環節一：朗讀結果總覽 ============ */}
-      <Section number={1} title="朗讀結果總覽" defaultOpen={true} disabled={!readingAttempt && !fullReadingResult}>
+      <AssessmentSectionWrapper number={1} title="朗讀結果總覽" defaultOpen={true} disabled={!readingAttempt && !fullReadingResult}>
         <AssessmentReadingSummary
           readingAttempt={readingAttempt}
           fullReadingResult={fullReadingResult}
@@ -306,169 +269,54 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
           story={story}
           readingGoals={readingGoals}
         />
-      </Section>
+      </AssessmentSectionWrapper>
 
       {/* ============ 環節二：錄音內容與智能分析 ============ */}
-      <Section number={2} title="錄音內容與智能分析" defaultOpen={false} disabled={!readingAttempt && !fullReadingResult}>
-        {(readingAttempt || fullReadingResult) ? (
-          <div className="space-y-4">
-            {/* Transcription text */}
-            {((readingAttempt?.transcription ?? '').trim() || (fullReadingResult?.transcript ?? '').trim()) && (
-              <div>
-                <p className="text-xs text-gray-500 font-bold mb-2">語音轉文字</p>
-                <div className="bg-slate-50 rounded-2xl p-4 text-sm text-gray-700 leading-relaxed">
-                  {(readingAttempt?.transcription ?? '').trim() || (fullReadingResult?.transcript ?? '').trim()}
-                </div>
-              </div>
-            )}
-
-            {/* 4 category cards — hidden for students (Issue #1094) */}
-            {lineBreakdown.length > 0 && !hideScores && (
-              <div>
-                <p className="text-xs text-gray-500 font-bold mb-2">朗讀分析</p>
-                <div className="grid grid-cols-4 gap-3">
-                  <div className="bg-emerald-50 rounded-xl p-3 text-center">
-                    <span className="text-2xl font-black text-emerald-600">{segmentStats.correct}</span>
-                    <p className="text-xs text-emerald-600 font-bold mt-0.5">正確</p>
-                  </div>
-                  <div className="bg-red-50 rounded-xl p-3 text-center">
-                    <span className="text-2xl font-black text-red-500">{segmentStats.wrong}</span>
-                    <p className="text-xs text-red-500 font-bold mt-0.5">讀錯</p>
-                  </div>
-                  <div className="bg-amber-50 rounded-xl p-3 text-center">
-                    <span className="text-2xl font-black text-amber-600">{segmentStats.missing}</span>
-                    <p className="text-xs text-amber-600 font-bold mt-0.5">遺漏</p>
-                  </div>
-                  <div className="bg-blue-50 rounded-xl p-3 text-center">
-                    <span className="text-2xl font-black text-blue-600">{segmentStats.total}</span>
-                    <p className="text-xs text-blue-600 font-bold mt-0.5">總計</p>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {/* Fallback */}
-            {!(readingAttempt?.transcription ?? '').trim() && !(fullReadingResult?.transcript ?? '').trim() && lineBreakdown.length === 0 && (
-              <p className="text-sm text-gray-400 text-center py-4">語音辨識資料不足，準確度過低時建議重新朗讀</p>
-            )}
-          </div>
-        ) : (
-          <p className="text-sm text-gray-400 text-center py-4">尚未完成朗讀練習</p>
-        )}
-      </Section>
+      <AssessmentSectionWrapper number={2} title="錄音內容與智能分析" defaultOpen={false} disabled={!readingAttempt && !fullReadingResult}>
+        <IntelligentAnalysisSection
+          transcription={transcription}
+          lineBreakdown={lineBreakdown}
+          segmentStats={segmentStats}
+          hideScores={hideScores}
+          hasReadingData={hasReadingData}
+        />
+      </AssessmentSectionWrapper>
 
       {/* ============ 環節三：逐句分析對比 ============ */}
-      <Section number={3} title="逐句分析對比" defaultOpen={false} disabled={lineBreakdown.length === 0}>
+      <AssessmentSectionWrapper number={3} title="逐句分析對比" defaultOpen={false} disabled={lineBreakdown.length === 0}>
         <AssessmentDiffSection
           lineBreakdown={lineBreakdown}
           fullReadingResult={fullReadingResult}
           hideScores={hideScores}
         />
-      </Section>
+      </AssessmentSectionWrapper>
 
       {/* ============ 環節四：錯字詞練習清單 ============ */}
-      <Section number={4} title="錯字詞練習清單" defaultOpen={true} disabled={wrongTokens.length === 0 && missingChars.length === 0}>
-        {wrongTokens.length > 0 || missingChars.length > 0 ? (
-          <div className="space-y-4">
-            {wrongTokens.length > 0 && (
-              <div>
-                <p className="text-xs text-gray-500 font-bold mb-2">讀錯的字（共 {wrongTokens.length} 個）</p>
-                <div>
-                  {wrongTokens.map((t, idx) => (
-                    <div key={idx} className="flex items-center gap-4 py-3 border-b border-slate-100 last:border-0">
-                      <div className="flex items-center gap-2 flex-1">
-                        <span className="text-red-500 line-through text-lg">{t.char}</span>
-                        <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 7l5 5m0 0l-5 5m5-5H6" />
-                        </svg>
-                        <span className="text-emerald-600 font-bold text-lg">{t.expected}</span>
-                      </div>
-                      <button
-                        onClick={() => speakText(t.expected)}
-                        className="w-8 h-8 rounded-full bg-accent/10 text-accent flex items-center justify-center hover:bg-accent/20 transition-colors shrink-0"
-                        title="聽發音"
-                      >
-                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-                          <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z"/>
-                        </svg>
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {missingChars.length > 0 && (
-              <div>
-                <p className="text-xs text-gray-500 font-bold mb-2">漏讀的字（共 {missingChars.length} 個）</p>
-                <div className="flex flex-wrap gap-2">
-                  {missingChars.slice(0, 20).map((ch, idx) => (
-                    <button
-                      key={idx}
-                      onClick={() => speakText(ch)}
-                      className="bg-amber-50 border border-amber-200 text-amber-800 text-sm font-bold px-3 py-1.5 rounded-lg hover:bg-amber-100 transition-colors flex items-center gap-1"
-                    >
-                      {ch}
-                      <svg className="w-3 h-3 text-amber-500" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z" />
-                      </svg>
-                    </button>
-                  ))}
-                  {missingChars.length > 20 && (
-                    <span className="text-xs text-gray-400 self-center">...還有 {missingChars.length - 20} 個</span>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {onGoToVocab && (
-              <button
-                onClick={onGoToVocab}
-                className="w-full mt-2 flex items-center justify-center gap-2 py-2.5 bg-accent/10 hover:bg-accent/20 text-accent font-bold text-sm rounded-full transition-colors"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                </svg>
-                去生字練習
-              </button>
-            )}
-          </div>
-        ) : (
-          <div className="bg-green-50 rounded-2xl p-6 text-center">
-            <p className="text-emerald-700 font-bold">
-              {readingAttempt ? '恭喜！沒有讀錯的字詞！' : '尚無朗讀資料'}
-            </p>
-          </div>
-        )}
-      </Section>
+      <AssessmentSectionWrapper number={4} title="錯字詞練習清單" defaultOpen={true} disabled={wrongTokens.length === 0 && missingChars.length === 0}>
+        <ErrorWordListSection
+          wrongTokens={wrongTokens}
+          missingChars={missingChars}
+          onGoToVocab={onGoToVocab}
+          hasReadingAttempt={!!readingAttempt}
+        />
+      </AssessmentSectionWrapper>
 
       {/* ============ 環節五：練習建議 ============ */}
-      <Section number={5} title="練習建議" defaultOpen={false} disabled={!readingAttempt}>
-        {suggestions.length > 0 ? (
-          <div className="space-y-3">
-            {suggestions.map((s, idx) => (
-              <div key={idx} className="flex items-start gap-3 p-3 bg-gray-50 rounded-xl">
-                <span className="text-2xl shrink-0">{s.icon}</span>
-                <div>
-                  <p className="font-bold text-sm text-gray-900">{s.title}</p>
-                  <p className="text-sm text-gray-500">{s.desc}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-sm text-gray-400 text-center py-4">完成朗讀練習後會產生建議</p>
-        )}
-      </Section>
+      <AssessmentSectionWrapper number={5} title="練習建議" defaultOpen={false} disabled={!readingAttempt}>
+        <PracticeRecommendationSection
+          suggestions={suggestions}
+          hasReadingAttempt={!!readingAttempt}
+        />
+      </AssessmentSectionWrapper>
 
       {/* ============ 環節六：課文理解力評估 (Issue #243) ============ */}
-      <Section number={6} title="課文理解力評估" defaultOpen={true} disabled={!comprehensionScores && !comprehensionScoresLoading}>
+      <AssessmentSectionWrapper number={6} title="課文理解力評估" defaultOpen={true} disabled={!comprehensionScores && !comprehensionScoresLoading}>
         <AssessmentComprehensionSection
           comprehensionScores={comprehensionScores}
           comprehensionScoresLoading={comprehensionScoresLoading}
           hideScores={hideScores}
         />
-      </Section>
+      </AssessmentSectionWrapper>
 
       {/* ============ 補充資訊：聽寫練習 + 課文理解 ============ */}
       {/* vocab (#1333): removed from report — now a standalone practice tool in 練習工具箱. */}
@@ -491,7 +339,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
 
       {/* ============ 朗讀進步曲線 (#909) — 學生端隱藏（Issue #1094，數據曲線屬教師觀察用） ============ */}
       {!hideScores && readingHistory.length >= 2 && (
-        <Section number={8} title="朗讀進步曲線" defaultOpen={true}>
+        <AssessmentSectionWrapper number={8} title="朗讀進步曲線" defaultOpen={true}>
           <div className="space-y-4">
             <p className="text-sm text-gray-500">
               本篇課文已練習 {readingHistory.length} 次，持續練習可以看到明顯進步
@@ -543,7 +391,7 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
               </p>
             )}
           </div>
-        </Section>
+        </AssessmentSectionWrapper>
       )}
 
       {/* CTA */}

--- a/frontend/src/components/reading-steps/AssessmentSectionWrapper.tsx
+++ b/frontend/src/components/reading-steps/AssessmentSectionWrapper.tsx
@@ -1,0 +1,87 @@
+/**
+ * AssessmentSectionWrapper — Collapsible section shell for AssessmentReport (#1945).
+ *
+ * Extracted from the inline `Section` component in AssessmentReport.tsx.
+ * Provides numbered header with collapse toggle and disabled (greyed-out) state.
+ */
+
+import React, { useState } from 'react';
+
+interface AssessmentSectionWrapperProps {
+  number: number;
+  title: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+  defaultOpen?: boolean;
+}
+
+/**
+ * Section wrapper with numbered badge, collapsible body, and disabled styling.
+ * When disabled=true the section is non-interactive (cannot collapse).
+ */
+const AssessmentSectionWrapper: React.FC<AssessmentSectionWrapperProps> = ({
+  number,
+  title,
+  children,
+  disabled,
+  defaultOpen = true,
+}) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const canToggle = !disabled;
+
+  return (
+    <div
+      className={`rounded-3xl border overflow-hidden ${
+        disabled
+          ? 'bg-gray-50 border-dashed border-gray-300'
+          : 'bg-white border-slate-200 shadow-sm'
+      }`}
+    >
+      <div
+        className={`px-6 py-4 flex items-center gap-3 ${
+          disabled ? 'border-gray-200' : 'border-slate-100'
+        } ${open ? 'border-b' : ''} ${
+          canToggle ? 'cursor-pointer select-none hover:bg-slate-50 transition-colors' : ''
+        }`}
+        onClick={canToggle ? () => setOpen((o) => !o) : undefined}
+        role={canToggle ? 'button' : undefined}
+        aria-expanded={canToggle ? open : undefined}
+      >
+        <span
+          className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold shrink-0 ${
+            disabled ? 'bg-gray-200 text-gray-400' : 'bg-accent text-white'
+          }`}
+        >
+          {number}
+        </span>
+        <h3
+          className={`text-lg font-bold flex-1 ${
+            disabled ? 'text-gray-400' : 'text-gray-900'
+          }`}
+        >
+          {title}
+        </h3>
+        {canToggle && (
+          <svg
+            className={`w-5 h-5 text-gray-400 transition-transform shrink-0 ${
+              open ? 'rotate-180' : ''
+            }`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        )}
+      </div>
+      {open && <div className="p-6">{children}</div>}
+    </div>
+  );
+};
+
+export default AssessmentSectionWrapper;

--- a/frontend/src/components/reading-steps/ErrorWordListSection.tsx
+++ b/frontend/src/components/reading-steps/ErrorWordListSection.tsx
@@ -1,0 +1,153 @@
+/**
+ * ErrorWordListSection — Section 4 of AssessmentReport (#1945).
+ * 環節四：錯字詞練習清單
+ *
+ * Extracted from the inline Section 4 block in AssessmentReport.tsx.
+ * Displays wrong tokens (with TTS) and missing characters (as clickable chips).
+ */
+
+import React from 'react';
+import { speakText as azureSpeakText } from '../../services/ttsApi';
+
+interface WrongToken {
+  char: string;
+  expected: string;
+}
+
+interface ErrorWordListSectionProps {
+  wrongTokens: WrongToken[];
+  missingChars: string[];
+  onGoToVocab?: (() => void) | undefined;
+  /** Whether readingAttempt exists (used for success-vs-no-data message) */
+  hasReadingAttempt: boolean;
+}
+
+/** Speak a Chinese character/word using Azure TTS */
+const speakText = (text: string) => {
+  azureSpeakText(text).catch(() => {});
+};
+
+/**
+ * Section 4: 錯字詞練習清單
+ *
+ * Renders:
+ * - List of wrong tokens with TTS button (char → expected mapping)
+ * - Missing characters as clickable TTS chips (capped at 20, shows overflow)
+ * - Optional "去生字練習" CTA button
+ * - Success message when reading attempt done but no errors found
+ * - No-data message when no reading attempt exists
+ */
+const ErrorWordListSection: React.FC<ErrorWordListSectionProps> = ({
+  wrongTokens,
+  missingChars,
+  onGoToVocab,
+  hasReadingAttempt,
+}) => {
+  const hasErrors = wrongTokens.length > 0 || missingChars.length > 0;
+
+  if (!hasErrors) {
+    return (
+      <div className="bg-green-50 rounded-2xl p-6 text-center">
+        <p className="text-emerald-700 font-bold">
+          {hasReadingAttempt ? '恭喜！沒有讀錯的字詞！' : '尚無朗讀資料'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Wrong tokens */}
+      {wrongTokens.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 font-bold mb-2">
+            讀錯的字（共 {wrongTokens.length} 個）
+          </p>
+          <div>
+            {wrongTokens.map((t, idx) => (
+              <div
+                key={idx}
+                className="flex items-center gap-4 py-3 border-b border-slate-100 last:border-0"
+              >
+                <div className="flex items-center gap-2 flex-1">
+                  <span className="text-red-500 line-through text-lg">{t.char}</span>
+                  <svg
+                    className="w-4 h-4 text-gray-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M13 7l5 5m0 0l-5 5m5-5H6"
+                    />
+                  </svg>
+                  <span className="text-emerald-600 font-bold text-lg">{t.expected}</span>
+                </div>
+                <button
+                  onClick={() => speakText(t.expected)}
+                  className="w-8 h-8 rounded-full bg-accent/10 text-accent flex items-center justify-center hover:bg-accent/20 transition-colors shrink-0"
+                  title="聽發音"
+                >
+                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z" />
+                  </svg>
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Missing characters */}
+      {missingChars.length > 0 && (
+        <div>
+          <p className="text-xs text-gray-500 font-bold mb-2">
+            漏讀的字（共 {missingChars.length} 個）
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {missingChars.slice(0, 20).map((ch, idx) => (
+              <button
+                key={idx}
+                onClick={() => speakText(ch)}
+                className="bg-amber-50 border border-amber-200 text-amber-800 text-sm font-bold px-3 py-1.5 rounded-lg hover:bg-amber-100 transition-colors flex items-center gap-1"
+              >
+                {ch}
+                <svg className="w-3 h-3 text-amber-500" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02z" />
+                </svg>
+              </button>
+            ))}
+            {missingChars.length > 20 && (
+              <span className="text-xs text-gray-400 self-center">
+                ...還有 {missingChars.length - 20} 個
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Go to vocab CTA */}
+      {onGoToVocab && (
+        <button
+          onClick={onGoToVocab}
+          className="w-full mt-2 flex items-center justify-center gap-2 py-2.5 bg-accent/10 hover:bg-accent/20 text-accent font-bold text-sm rounded-full transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+            />
+          </svg>
+          去生字練習
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ErrorWordListSection;

--- a/frontend/src/components/reading-steps/IntelligentAnalysisSection.tsx
+++ b/frontend/src/components/reading-steps/IntelligentAnalysisSection.tsx
@@ -1,0 +1,103 @@
+/**
+ * IntelligentAnalysisSection — Section 2 of AssessmentReport (#1945).
+ * 環節二：錄音內容與智能分析
+ *
+ * Extracted from the inline Section 2 block in AssessmentReport.tsx.
+ * Shows transcription text and segment breakdown stat cards (teacher-only).
+ */
+
+import React from 'react';
+import type { SegmentStats } from './assessmentReportMetrics';
+
+interface LineBreakdownItem {
+  lineIndex: number;
+  matchRate: number;
+  cpm: number;
+  transcript: string;
+  diffTokens: Array<{ char: string; type: string; expected?: string }>;
+}
+
+interface IntelligentAnalysisSectionProps {
+  /** Transcription text from readingAttempt or fullReadingResult */
+  transcription: string;
+  /** Line-by-line breakdown from readingAttempt (may be empty array) */
+  lineBreakdown: LineBreakdownItem[];
+  /** Aggregated correct/wrong/missing/total counts */
+  segmentStats: SegmentStats;
+  /** True for student view — hides numeric analysis cards (Issue #1094) */
+  hideScores: boolean;
+  /** Whether any reading data exists (readingAttempt or fullReadingResult) */
+  hasReadingData: boolean;
+}
+
+/**
+ * Section 2: 錄音內容與智能分析
+ *
+ * Renders:
+ * - Transcription text block (if non-empty)
+ * - 4-column stat cards: 正確 / 讀錯 / 遺漏 / 總計 (teacher-only, hidden for students)
+ * - Fallback message when no usable data
+ * - Empty state when no reading data at all
+ */
+const IntelligentAnalysisSection: React.FC<IntelligentAnalysisSectionProps> = ({
+  transcription,
+  lineBreakdown,
+  segmentStats,
+  hideScores,
+  hasReadingData,
+}) => {
+  if (!hasReadingData) {
+    return <p className="text-sm text-gray-400 text-center py-4">尚未完成朗讀練習</p>;
+  }
+
+  const hasTranscription = transcription.trim().length > 0;
+  const hasBreakdown = lineBreakdown.length > 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Transcription text */}
+      {hasTranscription && (
+        <div>
+          <p className="text-xs text-gray-500 font-bold mb-2">語音轉文字</p>
+          <div className="bg-slate-50 rounded-2xl p-4 text-sm text-gray-700 leading-relaxed">
+            {transcription.trim()}
+          </div>
+        </div>
+      )}
+
+      {/* 4 category cards — hidden for students (Issue #1094) */}
+      {hasBreakdown && !hideScores && (
+        <div>
+          <p className="text-xs text-gray-500 font-bold mb-2">朗讀分析</p>
+          <div className="grid grid-cols-4 gap-3">
+            <div className="bg-emerald-50 rounded-xl p-3 text-center">
+              <span className="text-2xl font-black text-emerald-600">{segmentStats.correct}</span>
+              <p className="text-xs text-emerald-600 font-bold mt-0.5">正確</p>
+            </div>
+            <div className="bg-red-50 rounded-xl p-3 text-center">
+              <span className="text-2xl font-black text-red-500">{segmentStats.wrong}</span>
+              <p className="text-xs text-red-500 font-bold mt-0.5">讀錯</p>
+            </div>
+            <div className="bg-amber-50 rounded-xl p-3 text-center">
+              <span className="text-2xl font-black text-amber-600">{segmentStats.missing}</span>
+              <p className="text-xs text-amber-600 font-bold mt-0.5">遺漏</p>
+            </div>
+            <div className="bg-blue-50 rounded-xl p-3 text-center">
+              <span className="text-2xl font-black text-blue-600">{segmentStats.total}</span>
+              <p className="text-xs text-blue-600 font-bold mt-0.5">總計</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Fallback: neither transcription nor breakdown available */}
+      {!hasTranscription && !hasBreakdown && (
+        <p className="text-sm text-gray-400 text-center py-4">
+          語音辨識資料不足，準確度過低時建議重新朗讀
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default IntelligentAnalysisSection;

--- a/frontend/src/components/reading-steps/PracticeRecommendationSection.tsx
+++ b/frontend/src/components/reading-steps/PracticeRecommendationSection.tsx
@@ -1,0 +1,54 @@
+/**
+ * PracticeRecommendationSection — Section 5 of AssessmentReport (#1945).
+ * 環節五：練習建議
+ *
+ * Extracted from the inline Section 5 block in AssessmentReport.tsx.
+ * Renders AI-generated practice suggestion cards based on reading performance.
+ */
+
+import React from 'react';
+
+interface Suggestion {
+  icon: string;
+  title: string;
+  desc: string;
+}
+
+interface PracticeRecommendationSectionProps {
+  suggestions: Suggestion[];
+  /** Whether a reading attempt exists — used to decide which empty-state to show */
+  hasReadingAttempt: boolean;
+}
+
+/**
+ * Section 5: 練習建議
+ *
+ * Renders:
+ * - List of icon + title + description suggestion cards
+ * - Empty state with prompt to complete reading practice
+ */
+const PracticeRecommendationSection: React.FC<PracticeRecommendationSectionProps> = ({
+  suggestions,
+}) => {
+  if (suggestions.length === 0) {
+    return (
+      <p className="text-sm text-gray-400 text-center py-4">完成朗讀練習後會產生建議</p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {suggestions.map((s, idx) => (
+        <div key={idx} className="flex items-start gap-3 p-3 bg-gray-50 rounded-xl">
+          <span className="text-2xl shrink-0">{s.icon}</span>
+          <div>
+            <p className="font-bold text-sm text-gray-900">{s.title}</p>
+            <p className="text-sm text-gray-500">{s.desc}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PracticeRecommendationSection;

--- a/frontend/src/components/reading-steps/__tests__/AssessmentReportSections.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/AssessmentReportSections.test.tsx
@@ -1,0 +1,379 @@
+/**
+ * Characterization tests for AssessmentReport section components (#1945).
+ *
+ * TDD-first: these tests MUST fail until the section components are extracted.
+ *
+ * Covers:
+ *   1. Section wrapper — render, collapse toggle, disabled state
+ *   2. IntelligentAnalysisSection (環節二) — transcription, stats cards, empty state
+ *   3. ErrorWordListSection (環節四) — wrongTokens, missingChars, TTS button, empty state
+ *   4. PracticeRecommendationSection (環節五) — suggestions list, empty state
+ *
+ * Note: Sections 1 (AssessmentReadingSummary), 3 (AssessmentDiffSection),
+ * and 6 (AssessmentComprehensionSection) are already extracted in #1845.
+ * This test file covers the three sections remaining inline after #1845.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import AssessmentSectionWrapper from '../AssessmentSectionWrapper';
+import IntelligentAnalysisSection from '../IntelligentAnalysisSection';
+import ErrorWordListSection from '../ErrorWordListSection';
+import PracticeRecommendationSection from '../PracticeRecommendationSection';
+
+/* ------------------------------------------------------------------ */
+/*  Mocks                                                               */
+/* ------------------------------------------------------------------ */
+
+// Mock TTS so speakText calls don't throw
+vi.mock('../../../services/ttsApi', () => ({
+  speakText: vi.fn().mockResolvedValue(undefined),
+}));
+
+/* ------------------------------------------------------------------ */
+/*  Fixtures                                                            */
+/* ------------------------------------------------------------------ */
+
+const WRONG_TOKENS = [
+  { char: '好', expected: '壞' },
+  { char: '天', expected: '地' },
+];
+
+const MISSING_CHARS = ['風', '雨', '雷'];
+
+const SEGMENT_STATS = {
+  correct: 5,
+  wrong: 2,
+  missing: 1,
+  total: 8,
+};
+
+const SUGGESTIONS = [
+  { icon: '🔊', title: '聽正確發音', desc: '點擊上方錯字詞旁的喇叭按鈕，反覆聆聽正確讀法。' },
+  { icon: '🔄', title: '反覆練習錯誤詞語', desc: '把讀錯的字詞抄寫三遍，邊寫邊唸出聲音。' },
+];
+
+/* ------------------------------------------------------------------ */
+/*  1. AssessmentSectionWrapper                                         */
+/* ------------------------------------------------------------------ */
+
+describe('AssessmentSectionWrapper', () => {
+  it('renders the section number and title', () => {
+    render(
+      <AssessmentSectionWrapper number={2} title="錄音內容與智能分析">
+        <div>content</div>
+      </AssessmentSectionWrapper>,
+    );
+    expect(screen.getByText('2')).toBeTruthy();
+    expect(screen.getByText('錄音內容與智能分析')).toBeTruthy();
+  });
+
+  it('renders children when defaultOpen=true', () => {
+    render(
+      <AssessmentSectionWrapper number={1} title="Test" defaultOpen={true}>
+        <div data-testid="child-content">Hello</div>
+      </AssessmentSectionWrapper>,
+    );
+    expect(screen.getByTestId('child-content')).toBeTruthy();
+  });
+
+  it('hides children when defaultOpen=false', () => {
+    render(
+      <AssessmentSectionWrapper number={1} title="Test" defaultOpen={false}>
+        <div data-testid="child-content">Hello</div>
+      </AssessmentSectionWrapper>,
+    );
+    expect(screen.queryByTestId('child-content')).toBeNull();
+  });
+
+  it('toggles open/closed when header is clicked', () => {
+    render(
+      <AssessmentSectionWrapper number={1} title="Toggleable" defaultOpen={true}>
+        <div data-testid="child-content">Hello</div>
+      </AssessmentSectionWrapper>,
+    );
+    // Initially open
+    expect(screen.getByTestId('child-content')).toBeTruthy();
+    // Click header to close
+    fireEvent.click(screen.getByText('Toggleable'));
+    expect(screen.queryByTestId('child-content')).toBeNull();
+    // Click header to open again
+    fireEvent.click(screen.getByText('Toggleable'));
+    expect(screen.getByTestId('child-content')).toBeTruthy();
+  });
+
+  it('does NOT toggle when disabled=true', () => {
+    render(
+      <AssessmentSectionWrapper number={1} title="Disabled" disabled={true} defaultOpen={true}>
+        <div data-testid="child-content">Hello</div>
+      </AssessmentSectionWrapper>,
+    );
+    // Clicking should not toggle
+    fireEvent.click(screen.getByText('Disabled'));
+    // Still open (disabled cannot collapse)
+    expect(screen.getByTestId('child-content')).toBeTruthy();
+  });
+
+  it('applies disabled styling when disabled=true', () => {
+    const { container } = render(
+      <AssessmentSectionWrapper number={1} title="Disabled" disabled={true}>
+        <div>x</div>
+      </AssessmentSectionWrapper>,
+    );
+    // The outer div should have dashed border class
+    expect(container.innerHTML).toContain('border-dashed');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  2. IntelligentAnalysisSection (環節二)                              */
+/* ------------------------------------------------------------------ */
+
+describe('IntelligentAnalysisSection', () => {
+  it('renders transcription text when provided', () => {
+    render(
+      <IntelligentAnalysisSection
+        transcription="今天天氣很好"
+        lineBreakdown={[]}
+        segmentStats={SEGMENT_STATS}
+        hideScores={false}
+        hasReadingData={true}
+      />,
+    );
+    expect(screen.getByText('今天天氣很好')).toBeTruthy();
+  });
+
+  it('does not render transcription block when empty', () => {
+    render(
+      <IntelligentAnalysisSection
+        transcription="  "
+        lineBreakdown={[]}
+        segmentStats={SEGMENT_STATS}
+        hideScores={false}
+        hasReadingData={true}
+      />,
+    );
+    expect(screen.queryByText('語音轉文字')).toBeNull();
+  });
+
+  it('renders 4 stat cards (correct/wrong/missing/total) when hideScores=false and lineBreakdown present', () => {
+    render(
+      <IntelligentAnalysisSection
+        transcription=""
+        lineBreakdown={[{ lineIndex: 0, matchRate: 1, cpm: 100, transcript: 'a', diffTokens: [] }]}
+        segmentStats={SEGMENT_STATS}
+        hideScores={false}
+        hasReadingData={true}
+      />,
+    );
+    expect(screen.getByText('正確')).toBeTruthy();
+    expect(screen.getByText('讀錯')).toBeTruthy();
+    expect(screen.getByText('遺漏')).toBeTruthy();
+    expect(screen.getByText('總計')).toBeTruthy();
+    expect(screen.getByText('5')).toBeTruthy(); // correct count
+    expect(screen.getByText('2')).toBeTruthy(); // wrong count
+  });
+
+  it('hides stat cards when hideScores=true (student view)', () => {
+    render(
+      <IntelligentAnalysisSection
+        transcription=""
+        lineBreakdown={[{ lineIndex: 0, matchRate: 1, cpm: 100, transcript: 'a', diffTokens: [] }]}
+        segmentStats={SEGMENT_STATS}
+        hideScores={true}
+        hasReadingData={true}
+      />,
+    );
+    expect(screen.queryByText('正確')).toBeNull();
+    expect(screen.queryByText('讀錯')).toBeNull();
+  });
+
+  it('shows empty state when no reading data', () => {
+    render(
+      <IntelligentAnalysisSection
+        transcription=""
+        lineBreakdown={[]}
+        segmentStats={{ correct: 0, wrong: 0, missing: 0, total: 0 }}
+        hideScores={false}
+        hasReadingData={false}
+      />,
+    );
+    expect(screen.getByText('尚未完成朗讀練習')).toBeTruthy();
+  });
+
+  it('shows fallback message when no transcription and no lineBreakdown', () => {
+    render(
+      <IntelligentAnalysisSection
+        transcription=""
+        lineBreakdown={[]}
+        segmentStats={{ correct: 0, wrong: 0, missing: 0, total: 0 }}
+        hideScores={false}
+        hasReadingData={true}
+      />,
+    );
+    expect(screen.getByText(/語音辨識資料不足/)).toBeTruthy();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  3. ErrorWordListSection (環節四)                                    */
+/* ------------------------------------------------------------------ */
+
+describe('ErrorWordListSection', () => {
+  it('renders wrong tokens list', () => {
+    render(
+      <ErrorWordListSection
+        wrongTokens={WRONG_TOKENS}
+        missingChars={[]}
+        onGoToVocab={undefined}
+        hasReadingAttempt={true}
+      />,
+    );
+    expect(screen.getByText('好')).toBeTruthy();
+    expect(screen.getByText('壞')).toBeTruthy();
+    expect(screen.getByText('天')).toBeTruthy();
+    expect(screen.getByText('地')).toBeTruthy();
+  });
+
+  it('renders missing chars as buttons', () => {
+    render(
+      <ErrorWordListSection
+        wrongTokens={[]}
+        missingChars={MISSING_CHARS}
+        onGoToVocab={undefined}
+        hasReadingAttempt={true}
+      />,
+    );
+    expect(screen.getByText('風')).toBeTruthy();
+    expect(screen.getByText('雨')).toBeTruthy();
+    expect(screen.getByText('雷')).toBeTruthy();
+  });
+
+  it('shows count label for wrong tokens', () => {
+    render(
+      <ErrorWordListSection
+        wrongTokens={WRONG_TOKENS}
+        missingChars={[]}
+        onGoToVocab={undefined}
+        hasReadingAttempt={true}
+      />,
+    );
+    expect(screen.getByText(/共 2 個/)).toBeTruthy();
+  });
+
+  it('shows TTS speak button for each wrong token', () => {
+    render(
+      <ErrorWordListSection
+        wrongTokens={WRONG_TOKENS}
+        missingChars={[]}
+        onGoToVocab={undefined}
+        hasReadingAttempt={true}
+      />,
+    );
+    // Each token has a "聽發音" button
+    const speakBtns = screen.getAllByTitle('聽發音');
+    expect(speakBtns).toHaveLength(2);
+  });
+
+  it('shows "去生字練習" button when onGoToVocab is provided', () => {
+    const mockGo = vi.fn();
+    render(
+      <ErrorWordListSection
+        wrongTokens={WRONG_TOKENS}
+        missingChars={[]}
+        onGoToVocab={mockGo}
+        hasReadingAttempt={true}
+      />,
+    );
+    const btn = screen.getByText('去生字練習');
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    expect(mockGo).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT show "去生字練習" when onGoToVocab is undefined', () => {
+    render(
+      <ErrorWordListSection
+        wrongTokens={WRONG_TOKENS}
+        missingChars={[]}
+        onGoToVocab={undefined}
+        hasReadingAttempt={true}
+      />,
+    );
+    expect(screen.queryByText('去生字練習')).toBeNull();
+  });
+
+  it('shows success message when no errors and hasReadingAttempt=true', () => {
+    render(
+      <ErrorWordListSection
+        wrongTokens={[]}
+        missingChars={[]}
+        onGoToVocab={undefined}
+        hasReadingAttempt={true}
+      />,
+    );
+    expect(screen.getByText(/恭喜！沒有讀錯的字詞/)).toBeTruthy();
+  });
+
+  it('shows "尚無朗讀資料" when no reading attempt', () => {
+    render(
+      <ErrorWordListSection
+        wrongTokens={[]}
+        missingChars={[]}
+        onGoToVocab={undefined}
+        hasReadingAttempt={false}
+      />,
+    );
+    expect(screen.getByText(/尚無朗讀資料/)).toBeTruthy();
+  });
+
+  it('truncates missing chars to 20 and shows overflow count', () => {
+    const manyChars = Array.from({ length: 25 }, (_, i) => `字${i}`);
+    render(
+      <ErrorWordListSection
+        wrongTokens={[]}
+        missingChars={manyChars}
+        onGoToVocab={undefined}
+        hasReadingAttempt={true}
+      />,
+    );
+    expect(screen.getByText(/還有 5 個/)).toBeTruthy();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  4. PracticeRecommendationSection (環節五)                           */
+/* ------------------------------------------------------------------ */
+
+describe('PracticeRecommendationSection', () => {
+  it('renders all suggestion cards', () => {
+    render(<PracticeRecommendationSection suggestions={SUGGESTIONS} hasReadingAttempt={true} />);
+    expect(screen.getByText('聽正確發音')).toBeTruthy();
+    expect(screen.getByText('反覆練習錯誤詞語')).toBeTruthy();
+    expect(screen.getByText('點擊上方錯字詞旁的喇叭按鈕，反覆聆聽正確讀法。')).toBeTruthy();
+  });
+
+  it('renders suggestion icons', () => {
+    render(<PracticeRecommendationSection suggestions={SUGGESTIONS} hasReadingAttempt={true} />);
+    expect(screen.getByText('🔊')).toBeTruthy();
+    expect(screen.getByText('🔄')).toBeTruthy();
+  });
+
+  it('shows empty state message when no suggestions and no reading attempt', () => {
+    render(<PracticeRecommendationSection suggestions={[]} hasReadingAttempt={false} />);
+    expect(screen.getByText('完成朗讀練習後會產生建議')).toBeTruthy();
+  });
+
+  it('shows empty state message when suggestions is empty but hasReadingAttempt=true', () => {
+    render(<PracticeRecommendationSection suggestions={[]} hasReadingAttempt={true} />);
+    expect(screen.getByText('完成朗讀練習後會產生建議')).toBeTruthy();
+  });
+
+  it('renders an empty list gracefully (no crash)', () => {
+    const { container } = render(
+      <PracticeRecommendationSection suggestions={[]} hasReadingAttempt={false} />,
+    );
+    expect(container).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #1945

## Summary

- Extract `AssessmentSectionWrapper` from inline `Section` component — collapsible numbered shell used by all 6 sections
- Extract `IntelligentAnalysisSection` — Section 2 (錄音內容與智能分析): transcription display + 4 stat cards
- Extract `ErrorWordListSection` — Section 4 (錯字詞練習清單): wrong tokens with TTS + missing chars + CTA
- Extract `PracticeRecommendationSection` — Section 5 (練習建議): practice suggestion cards
- `AssessmentReport.tsx`: 563 → 411 LOC (-27%), now a pure orchestrator

Sections 1/3/6 were already extracted in #1845. All 6 sections are now independent components.

## TDD Evidence

RED → GREEN → REFACTOR strictly followed:

1. Wrote 26 characterization tests (`AssessmentReportSections.test.tsx`) — confirmed failing (import errors)
2. Implemented 3 section components + wrapper — all 26 tests pass
3. Refactored `AssessmentReport.tsx` to use new components — 60/60 tests pass (26 new + 34 existing metrics tests)

```
Test Files  2 passed (2)
Tests       60 passed (60)
```

## Test plan

- [ ] CI green (vitest + build)
- [ ] Preview URL loads AssessmentReport correctly for student view (hideScores=true)
- [ ] Teacher view (readOnly=true) shows numeric scores and stat cards
- [ ] Section collapse/expand works for all 6 sections
- [ ] TTS button fires on wrong token click (ErrorWordListSection)
- [ ] No visual regression vs pre-refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)