### PR TITLE
refactor(teacher): split ClassroomDetail.tsx into 3 components (Fixes #1943)

### DIFF
--- a/frontend/src/pages/teacher/ClassroomDetail.tsx
+++ b/frontend/src/pages/teacher/ClassroomDetail.tsx
@@ -1,3 +1,11 @@
+/**
+ * ClassroomDetail — Issue #1943
+ *
+ * Orchestrator: owns all state + data-fetching.
+ * Renders via:
+ *   - ClassroomHeaderCard  (班級資訊 + 加入代碼 panel)
+ *   - ClassroomTabs        (tab bar + tab content delegation)
+ */
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import {
@@ -11,27 +19,8 @@ import {
   StudentInClassroomResponse,
   ClassroomApiError,
 } from '../../services/classroomApi';
-import StudentProgressTab from './StudentProgressTab';
-import TextManagementTab from './TextManagementTab';
-import StudentListTab from './StudentListTab';
-import ClassroomAnalytics from './ClassroomAnalytics';
-import CrossTextAnalytics from './CrossTextAnalytics';
-import AtRiskStudents from '../../components/teacher/AtRiskStudents';
-import ErrorHeatmapTab from './ErrorHeatmapTab';
-import CoTeachingTab from './CoTeachingTab';
-
-type TabKey = 'progress' | 'texts' | 'students' | 'analytics' | 'cross-text' | 'at-risk' | 'error-heatmap' | 'teachers';
-
-const TABS: { key: TabKey; label: string; group?: 'core' | 'analysis' | 'other' }[] = [
-  { key: 'progress', label: '學生進度', group: 'core' },
-  { key: 'students', label: '學生名單', group: 'core' },
-  { key: 'texts', label: '課文管理', group: 'core' },
-  { key: 'analytics', label: '學習分析', group: 'analysis' },
-  { key: 'cross-text', label: '跨課文分析', group: 'analysis' },
-  { key: 'at-risk', label: '早期介入', group: 'analysis' },
-  { key: 'error-heatmap', label: '錯字熱力圖', group: 'analysis' },
-  { key: 'teachers', label: '協同教師', group: 'other' },
-];
+import ClassroomHeaderCard from './ClassroomHeaderCard';
+import ClassroomTabs, { TabKey } from './ClassroomTabs';
 
 interface ClassroomDetailProps {
   classroomId: number;
@@ -292,293 +281,52 @@ const ClassroomDetail: React.FC<ClassroomDetailProps> = ({ classroomId, onBack }
           </div>
         )}
 
-        {/* Classroom info card */}
-        <div className="bg-white rounded-2xl shadow-card p-6">
-          {isEditing ? (
-            <form onSubmit={handleSaveEdit} className="space-y-4">
-              <h2 className="text-base font-bold text-gray-900">編輯班級</h2>
-              {editError && (
-                <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
-                  {editError}
-                </div>
-              )}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div>
-                  <label htmlFor="edit-name" className="block text-sm font-medium text-gray-700 mb-1">
-                    班級名稱 <span className="text-red-500">*</span>
-                  </label>
-                  <input
-                    id="edit-name"
-                    type="text"
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                    required
-                    className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                  />
-                </div>
-                <div>
-                  <label htmlFor="edit-grade" className="block text-sm font-medium text-gray-700 mb-1">
-                    年級
-                  </label>
-                  <select
-                    id="edit-grade"
-                    value={editGrade}
-                    onChange={(e) => setEditGrade(e.target.value)}
-                    className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-                  >
-                    <option value="">未指定</option>
-                    <optgroup label="國小">
-                      {[1,2,3,4,5,6].map((g) => (
-                        <option key={g} value={g}>{g} 年級</option>
-                      ))}
-                    </optgroup>
-                    <optgroup label="國中">
-                      {[7,8,9].map((g) => (
-                        <option key={g} value={g}>{g} 年級</option>
-                      ))}
-                    </optgroup>
-                  </select>
-                </div>
-              </div>
-              <div className="flex gap-3 justify-end">
-                <button
-                  type="button"
-                  onClick={() => setIsEditing(false)}
-                  className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors"
-                >
-                  取消
-                </button>
-                <button
-                  type="submit"
-                  disabled={isSaving || !editName.trim()}
-                  className="bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white px-5 py-2 rounded-lg font-medium text-sm transition-colors"
-                >
-                  {isSaving ? '儲存中...' : '儲存'}
-                </button>
-              </div>
-            </form>
-          ) : (
-            <div className="flex items-start justify-between">
-              <div>
-                <h2 className="text-xl font-bold text-gray-900">{classroom.name}</h2>
-                <div className="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500">
-                  {classroom.grade != null && (
-                    <span className="bg-accent-bg text-accent text-xs font-medium px-2.5 py-0.5 rounded">
-                      {classroom.grade} 年級
-                    </span>
-                  )}
-                  <span>{classroom.student_count} 位學生</span>
-                  <span>{formatDate(classroom.created_at)}</span>
-                  <span className={classroom.is_active ? 'text-emerald-600' : 'text-gray-400'}>
-                    {classroom.is_active ? '使用中' : '已停用'}
-                  </span>
-                </div>
-              </div>
-              <div className="flex gap-2 shrink-0">
-                <button
-                  onClick={startEditing}
-                  className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm hover:bg-gray-50 transition-colors cursor-pointer"
-                >
-                  編輯
-                </button>
-                <button
-                  onClick={handleToggleActive}
-                  disabled={isTogglingActive}
-                  className={`px-3 py-1.5 rounded-lg border text-sm transition-colors cursor-pointer ${
-                    isTogglingActive ? 'opacity-50 cursor-not-allowed' : ''
-                  } ${
-                    classroom.is_active
-                      ? 'border-gray-300 text-gray-700 hover:bg-gray-50'
-                      : 'border-emerald-300 text-emerald-700 hover:bg-emerald-50'
-                  }`}
-                >
-                  {isTogglingActive ? '更新中...' : classroom.is_active ? '停用' : '啟用'}
-                </button>
-                <button
-                  onClick={handleExportCsv}
-                  disabled={isExporting}
-                  className={`px-3 py-1.5 rounded-lg border border-blue-300 text-blue-700 text-sm hover:bg-blue-50 transition-colors cursor-pointer ${
-                    isExporting ? 'opacity-50 cursor-not-allowed' : ''
-                  }`}
-                >
-                  {isExporting ? '匯出中...' : '匯出 CSV'}
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
+        <ClassroomHeaderCard
+          classroom={classroom}
+          isEditing={isEditing}
+          editName={editName}
+          editGrade={editGrade}
+          isSaving={isSaving}
+          editError={editError}
+          onStartEditing={startEditing}
+          onCancelEditing={() => setIsEditing(false)}
+          onEditNameChange={setEditName}
+          onEditGradeChange={setEditGrade}
+          onSaveEdit={handleSaveEdit}
+          isTogglingActive={isTogglingActive}
+          onToggleActive={handleToggleActive}
+          isExporting={isExporting}
+          onExportCsv={handleExportCsv}
+          isCopied={isCopied}
+          showRegenConfirm={showRegenConfirm}
+          isRegenerating={isRegenerating}
+          onCopyJoinCode={handleCopyJoinCode}
+          onShowRegenConfirm={() => setShowRegenConfirm(true)}
+          onHideRegenConfirm={() => setShowRegenConfirm(false)}
+          onRegenerateCode={handleRegenerateCode}
+          formatDate={formatDate}
+        />
 
-        {/* Join Code card */}
-        <div className="bg-white rounded-2xl shadow-card p-6">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div className="flex-1">
-              <h3 className="text-sm font-semibold text-gray-700 mb-1">加入代碼</h3>
-              {classroom.join_code ? (
-                <p className="font-mono text-2xl font-bold tracking-widest text-accent select-all">
-                  {classroom.join_code}
-                </p>
-              ) : (
-                <p className="font-mono text-2xl font-bold tracking-widest text-gray-300">—</p>
-              )}
-              <p className="text-xs text-gray-400 mt-1.5">
-                把此代碼給學生，他們從首頁「加入班級」輸入即可加入
-              </p>
-            </div>
-            <div className="flex gap-2 shrink-0">
-              <button
-                onClick={handleCopyJoinCode}
-                disabled={!classroom.join_code}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                {isCopied ? (
-                  <>
-                    <svg className="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    <span className="text-emerald-600">已複製</span>
-                  </>
-                ) : (
-                  <>
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                    </svg>
-                    複製代碼
-                  </>
-                )}
-              </button>
-              <button
-                onClick={() => setShowRegenConfirm(true)}
-                disabled={isRegenerating}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                {isRegenerating ? (
-                  '產生中...'
-                ) : (
-                  <>
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                    </svg>
-                    重生代碼
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {/* Confirm regenerate dialog */}
-        {showRegenConfirm && (
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="regen-dialog-title"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-          >
-            <div className="bg-white rounded-2xl shadow-xl p-6 max-w-sm w-full mx-4">
-              <h3 id="regen-dialog-title" className="text-base font-bold text-gray-900 mb-2">確認重新產生代碼？</h3>
-              <p className="text-sm text-gray-600 mb-6">
-                舊代碼將立即失效，學生需重新輸入新代碼才能加入此班級。
-              </p>
-              <div className="flex justify-end gap-3">
-                <button
-                  onClick={() => setShowRegenConfirm(false)}
-                  className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
-                >
-                  取消
-                </button>
-                <button
-                  onClick={handleRegenerateCode}
-                  className="px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium transition-colors cursor-pointer"
-                >
-                  確定
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Tabbed content card */}
-        <div className="bg-white rounded-2xl shadow-card">
-          {/* Tab bar */}
-          <div className="border-b border-gray-200 overflow-x-auto">
-            <nav className="flex -mb-px whitespace-nowrap items-center" aria-label="Tabs">
-              {TABS.map((tab, i) => {
-                const prevGroup = TABS[i - 1]?.group;
-                const showDivider = prevGroup && prevGroup !== tab.group;
-                return (
-                  <React.Fragment key={tab.key}>
-                    {showDivider && (
-                      <span
-                        className="shrink-0 w-px h-5 bg-gray-200 mx-1"
-                        aria-hidden="true"
-                      />
-                    )}
-                    <button
-                      onClick={() => setActiveTab(tab.key)}
-                      className={`px-5 py-3 text-sm font-medium border-b-2 transition-colors cursor-pointer shrink-0 ${
-                        activeTab === tab.key
-                          ? 'border-accent text-accent'
-                          : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                      }`}
-                    >
-                      {tab.label}
-                    </button>
-                  </React.Fragment>
-                );
-              })}
-            </nav>
-          </div>
-
-          {/* Tab content */}
-          {activeTab === 'progress' && (
-            <StudentProgressTab classroomId={classroomId} />
-          )}
-
-          {activeTab === 'analytics' && (
-            <ClassroomAnalytics classroomId={classroomId} />
-          )}
-
-          {activeTab === 'cross-text' && (
-            <CrossTextAnalytics classroomId={classroomId} />
-          )}
-
-          {activeTab === 'at-risk' && (
-            <AtRiskStudents classroomId={classroomId} />
-          )}
-
-          {activeTab === 'error-heatmap' && (
-            <ErrorHeatmapTab classroomId={classroomId} />
-          )}
-
-          {activeTab === 'texts' && (
-            <TextManagementTab classroomId={classroomId} />
-          )}
-
-          {activeTab === 'students' && (
-            <StudentListTab
-              classroom={classroom}
-              token={token}
-              studentIdInput={studentIdInput}
-              setStudentIdInput={setStudentIdInput}
-              isAddingStudent={isAddingStudent}
-              addStudentError={addStudentError}
-              setAddStudentError={setAddStudentError}
-              onAddStudent={handleAddStudent}
-              removingStudentId={removingStudentId}
-              onRemoveStudent={handleRemoveStudent}
-              setRemovingStudentId={setRemovingStudentId}
-              formatDate={formatDate}
-              onStudentsImported={loadClassroom}
-            />
-          )}
-
-          {activeTab === 'teachers' && (
-            <CoTeachingTab
-              classroomId={classroomId}
-              ownerId={classroom.teacher_id}
-            />
-          )}
-        </div>
+        <ClassroomTabs
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+          classroomId={classroomId}
+          classroom={classroom}
+          studentListProps={{
+            token,
+            studentIdInput,
+            setStudentIdInput,
+            isAddingStudent,
+            addStudentError,
+            setAddStudentError,
+            onAddStudent: handleAddStudent,
+            removingStudentId,
+            onRemoveStudent: handleRemoveStudent,
+            setRemovingStudentId,
+            formatDate,
+            onStudentsImported: loadClassroom,
+          }}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/teacher/ClassroomHeaderCard.tsx
+++ b/frontend/src/pages/teacher/ClassroomHeaderCard.tsx
@@ -1,0 +1,281 @@
+/**
+ * ClassroomHeaderCard — Issue #1943
+ *
+ * Renders:
+ *  - Classroom name, grade badge, student count, active status (view + edit form)
+ *  - Action buttons: 編輯 / 停用啟用 / 匯出CSV
+ *  - Join code panel with 複製 and 重生代碼 + confirm dialog
+ */
+import React from 'react';
+import { ClassroomDetailResponse } from '../../services/classroomApi';
+
+interface ClassroomHeaderCardProps {
+  classroom: ClassroomDetailResponse;
+
+  // Edit mode
+  isEditing: boolean;
+  editName: string;
+  editGrade: string;
+  isSaving: boolean;
+  editError: string;
+  onStartEditing: () => void;
+  onCancelEditing: () => void;
+  onEditNameChange: (value: string) => void;
+  onEditGradeChange: (value: string) => void;
+  onSaveEdit: (e: React.FormEvent) => void;
+
+  // Toggle active
+  isTogglingActive: boolean;
+  onToggleActive: () => void;
+
+  // Export CSV
+  isExporting: boolean;
+  onExportCsv: () => void;
+
+  // Join code
+  isCopied: boolean;
+  showRegenConfirm: boolean;
+  isRegenerating: boolean;
+  onCopyJoinCode: () => void;
+  onShowRegenConfirm: () => void;
+  onHideRegenConfirm: () => void;
+  onRegenerateCode: () => void;
+
+  // Util
+  formatDate: (dateStr: string) => string;
+}
+
+const ClassroomHeaderCard: React.FC<ClassroomHeaderCardProps> = ({
+  classroom,
+  isEditing,
+  editName,
+  editGrade,
+  isSaving,
+  editError,
+  onStartEditing,
+  onCancelEditing,
+  onEditNameChange,
+  onEditGradeChange,
+  onSaveEdit,
+  isTogglingActive,
+  onToggleActive,
+  isExporting,
+  onExportCsv,
+  isCopied,
+  showRegenConfirm,
+  isRegenerating,
+  onCopyJoinCode,
+  onShowRegenConfirm,
+  onHideRegenConfirm,
+  onRegenerateCode,
+  formatDate,
+}) => (
+  <>
+    {/* Classroom info card */}
+    <div className="bg-white rounded-2xl shadow-card p-6">
+      {isEditing ? (
+        <form onSubmit={onSaveEdit} className="space-y-4">
+          <h2 className="text-base font-bold text-gray-900">編輯班級</h2>
+          {editError && (
+            <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg px-4 py-3">
+              {editError}
+            </div>
+          )}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="edit-name" className="block text-sm font-medium text-gray-700 mb-1">
+                班級名稱 <span className="text-red-500">*</span>
+              </label>
+              <input
+                id="edit-name"
+                type="text"
+                value={editName}
+                onChange={(e) => onEditNameChange(e.target.value)}
+                required
+                className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+              />
+            </div>
+            <div>
+              <label htmlFor="edit-grade" className="block text-sm font-medium text-gray-700 mb-1">
+                年級
+              </label>
+              <select
+                id="edit-grade"
+                value={editGrade}
+                onChange={(e) => onEditGradeChange(e.target.value)}
+                className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+              >
+                <option value="">未指定</option>
+                <optgroup label="國小">
+                  {[1,2,3,4,5,6].map((g) => (
+                    <option key={g} value={g}>{g} 年級</option>
+                  ))}
+                </optgroup>
+                <optgroup label="國中">
+                  {[7,8,9].map((g) => (
+                    <option key={g} value={g}>{g} 年級</option>
+                  ))}
+                </optgroup>
+              </select>
+            </div>
+          </div>
+          <div className="flex gap-3 justify-end">
+            <button
+              type="button"
+              onClick={onCancelEditing}
+              className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors"
+            >
+              取消
+            </button>
+            <button
+              type="submit"
+              disabled={isSaving || !editName.trim()}
+              className="bg-accent hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed text-white px-5 py-2 rounded-lg font-medium text-sm transition-colors"
+            >
+              {isSaving ? '儲存中...' : '儲存'}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-gray-900">{classroom.name}</h2>
+            <div className="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500">
+              {classroom.grade != null && (
+                <span className="bg-accent-bg text-accent text-xs font-medium px-2.5 py-0.5 rounded">
+                  {classroom.grade} 年級
+                </span>
+              )}
+              <span>{classroom.student_count} 位學生</span>
+              <span>{formatDate(classroom.created_at)}</span>
+              <span className={classroom.is_active ? 'text-emerald-600' : 'text-gray-400'}>
+                {classroom.is_active ? '使用中' : '已停用'}
+              </span>
+            </div>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <button
+              onClick={onStartEditing}
+              className="px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm hover:bg-gray-50 transition-colors cursor-pointer"
+            >
+              編輯
+            </button>
+            <button
+              onClick={onToggleActive}
+              disabled={isTogglingActive}
+              className={`px-3 py-1.5 rounded-lg border text-sm transition-colors cursor-pointer ${
+                isTogglingActive ? 'opacity-50 cursor-not-allowed' : ''
+              } ${
+                classroom.is_active
+                  ? 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                  : 'border-emerald-300 text-emerald-700 hover:bg-emerald-50'
+              }`}
+            >
+              {isTogglingActive ? '更新中...' : classroom.is_active ? '停用' : '啟用'}
+            </button>
+            <button
+              onClick={onExportCsv}
+              disabled={isExporting}
+              className={`px-3 py-1.5 rounded-lg border border-blue-300 text-blue-700 text-sm hover:bg-blue-50 transition-colors cursor-pointer ${
+                isExporting ? 'opacity-50 cursor-not-allowed' : ''
+              }`}
+            >
+              {isExporting ? '匯出中...' : '匯出 CSV'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+
+    {/* Join Code card */}
+    <div className="bg-white rounded-2xl shadow-card p-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-gray-700 mb-1">加入代碼</h3>
+          {classroom.join_code ? (
+            <p className="font-mono text-2xl font-bold tracking-widest text-accent select-all">
+              {classroom.join_code}
+            </p>
+          ) : (
+            <p className="font-mono text-2xl font-bold tracking-widest text-gray-300">—</p>
+          )}
+          <p className="text-xs text-gray-400 mt-1.5">
+            把此代碼給學生，他們從首頁「加入班級」輸入即可加入
+          </p>
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <button
+            onClick={onCopyJoinCode}
+            disabled={!classroom.join_code}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {isCopied ? (
+              <>
+                <svg className="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                <span className="text-emerald-600">已複製</span>
+              </>
+            ) : (
+              <>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                複製代碼
+              </>
+            )}
+          </button>
+          <button
+            onClick={onShowRegenConfirm}
+            disabled={isRegenerating}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {isRegenerating ? (
+              '產生中...'
+            ) : (
+              <>
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                重生代碼
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    {/* Confirm regenerate dialog */}
+    {showRegenConfirm && (
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="regen-dialog-title"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      >
+        <div className="bg-white rounded-2xl shadow-xl p-6 max-w-sm w-full mx-4">
+          <h3 id="regen-dialog-title" className="text-base font-bold text-gray-900 mb-2">確認重新產生代碼？</h3>
+          <p className="text-sm text-gray-600 mb-6">
+            舊代碼將立即失效，學生需重新輸入新代碼才能加入此班級。
+          </p>
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={onHideRegenConfirm}
+              className="px-4 py-2 rounded-lg border border-gray-300 text-gray-700 text-sm font-medium hover:bg-gray-50 transition-colors cursor-pointer"
+            >
+              取消
+            </button>
+            <button
+              onClick={onRegenerateCode}
+              className="px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium transition-colors cursor-pointer"
+            >
+              確定
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
+  </>
+);
+
+export default ClassroomHeaderCard;

--- a/frontend/src/pages/teacher/ClassroomTabs.tsx
+++ b/frontend/src/pages/teacher/ClassroomTabs.tsx
@@ -1,0 +1,146 @@
+/**
+ * ClassroomTabs — Issue #1943
+ *
+ * Renders the tab bar + delegates to the appropriate tab component.
+ * All tab components remain unchanged — this is purely a delegation container.
+ */
+import React from 'react';
+import { ClassroomDetailResponse } from '../../services/classroomApi';
+import StudentProgressTab from './StudentProgressTab';
+import TextManagementTab from './TextManagementTab';
+import StudentListTab from './StudentListTab';
+import ClassroomAnalytics from './ClassroomAnalytics';
+import CrossTextAnalytics from './CrossTextAnalytics';
+import AtRiskStudents from '../../components/teacher/AtRiskStudents';
+import ErrorHeatmapTab from './ErrorHeatmapTab';
+import CoTeachingTab from './CoTeachingTab';
+
+type TabKey = 'progress' | 'texts' | 'students' | 'analytics' | 'cross-text' | 'at-risk' | 'error-heatmap' | 'teachers';
+
+export const TABS: { key: TabKey; label: string; group?: 'core' | 'analysis' | 'other' }[] = [
+  { key: 'progress', label: '學生進度', group: 'core' },
+  { key: 'students', label: '學生名單', group: 'core' },
+  { key: 'texts', label: '課文管理', group: 'core' },
+  { key: 'analytics', label: '學習分析', group: 'analysis' },
+  { key: 'cross-text', label: '跨課文分析', group: 'analysis' },
+  { key: 'at-risk', label: '早期介入', group: 'analysis' },
+  { key: 'error-heatmap', label: '錯字熱力圖', group: 'analysis' },
+  { key: 'teachers', label: '協同教師', group: 'other' },
+];
+
+// Props passed through to StudentListTab
+interface StudentListTabPassthroughProps {
+  token: string | null;
+  studentIdInput: string;
+  setStudentIdInput: (v: string) => void;
+  isAddingStudent: boolean;
+  addStudentError: string;
+  setAddStudentError: (v: string) => void;
+  onAddStudent: (e: React.FormEvent) => void;
+  removingStudentId: number | null;
+  onRemoveStudent: (student: { id: number; username: string; full_name?: string }) => void;
+  setRemovingStudentId: (id: number | null) => void;
+  formatDate: (dateStr: string) => string;
+  onStudentsImported: () => void;
+}
+
+interface ClassroomTabsProps {
+  activeTab: TabKey;
+  onTabChange: (tab: TabKey) => void;
+  classroomId: number;
+  classroom: ClassroomDetailResponse;
+  studentListProps: StudentListTabPassthroughProps;
+}
+
+const ClassroomTabs: React.FC<ClassroomTabsProps> = ({
+  activeTab,
+  onTabChange,
+  classroomId,
+  classroom,
+  studentListProps,
+}) => (
+  <div className="bg-white rounded-2xl shadow-card">
+    {/* Tab bar */}
+    <div className="border-b border-gray-200 overflow-x-auto">
+      <nav className="flex -mb-px whitespace-nowrap items-center" aria-label="Tabs">
+        {TABS.map((tab, i) => {
+          const prevGroup = TABS[i - 1]?.group;
+          const showDivider = prevGroup && prevGroup !== tab.group;
+          return (
+            <React.Fragment key={tab.key}>
+              {showDivider && (
+                <span
+                  className="shrink-0 w-px h-5 bg-gray-200 mx-1"
+                  aria-hidden="true"
+                />
+              )}
+              <button
+                onClick={() => onTabChange(tab.key)}
+                className={`px-5 py-3 text-sm font-medium border-b-2 transition-colors cursor-pointer shrink-0 ${
+                  activeTab === tab.key
+                    ? 'border-accent text-accent'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {tab.label}
+              </button>
+            </React.Fragment>
+          );
+        })}
+      </nav>
+    </div>
+
+    {/* Tab content */}
+    {activeTab === 'progress' && (
+      <StudentProgressTab classroomId={classroomId} />
+    )}
+
+    {activeTab === 'analytics' && (
+      <ClassroomAnalytics classroomId={classroomId} />
+    )}
+
+    {activeTab === 'cross-text' && (
+      <CrossTextAnalytics classroomId={classroomId} />
+    )}
+
+    {activeTab === 'at-risk' && (
+      <AtRiskStudents classroomId={classroomId} />
+    )}
+
+    {activeTab === 'error-heatmap' && (
+      <ErrorHeatmapTab classroomId={classroomId} />
+    )}
+
+    {activeTab === 'texts' && (
+      <TextManagementTab classroomId={classroomId} />
+    )}
+
+    {activeTab === 'students' && (
+      <StudentListTab
+        classroom={classroom}
+        token={studentListProps.token}
+        studentIdInput={studentListProps.studentIdInput}
+        setStudentIdInput={studentListProps.setStudentIdInput}
+        isAddingStudent={studentListProps.isAddingStudent}
+        addStudentError={studentListProps.addStudentError}
+        setAddStudentError={studentListProps.setAddStudentError}
+        onAddStudent={studentListProps.onAddStudent}
+        removingStudentId={studentListProps.removingStudentId}
+        onRemoveStudent={studentListProps.onRemoveStudent}
+        setRemovingStudentId={studentListProps.setRemovingStudentId}
+        formatDate={studentListProps.formatDate}
+        onStudentsImported={studentListProps.onStudentsImported}
+      />
+    )}
+
+    {activeTab === 'teachers' && (
+      <CoTeachingTab
+        classroomId={classroomId}
+        ownerId={classroom.teacher_id}
+      />
+    )}
+  </div>
+);
+
+export type { TabKey };
+export default ClassroomTabs;

--- a/frontend/src/pages/teacher/__tests__/ClassroomDetail.refactor.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/ClassroomDetail.refactor.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Characterization tests for ClassroomDetail refactor — Issue #1943
+ *
+ * These tests document existing behaviour before the split into:
+ *   - ClassroomHeaderCard
+ *   - ClassroomTabs
+ *   - ClassroomStudentRoster (wired via StudentListTab)
+ *   - ClassroomDetail (orchestrator)
+ *
+ * All tests must pass both before and after the refactor (same observable behaviour).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ClassroomDetail from '../ClassroomDetail';
+import * as classroomApi from '../../../services/classroomApi';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token', user: { id: 1, role: 'teacher' } }),
+}));
+
+vi.mock('../../../services/classroomApi', () => ({
+  getClassroomDetail: vi.fn(),
+  updateClassroom: vi.fn(),
+  addStudent: vi.fn(),
+  removeStudent: vi.fn(),
+  exportClassroomReport: vi.fn(),
+  regenerateClassroomCode: vi.fn(),
+  ClassroomApiError: class ClassroomApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'ClassroomApiError';
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock('../StudentProgressTab', () => ({ default: () => <div data-testid="student-progress-tab" /> }));
+vi.mock('../TextManagementTab', () => ({ default: () => <div data-testid="text-management-tab" /> }));
+vi.mock('../StudentListTab', () => ({ default: (props: { classroom: { name: string } }) => <div data-testid="student-list-tab" data-classroom={props.classroom?.name} /> }));
+vi.mock('../ClassroomAnalytics', () => ({ default: () => <div data-testid="classroom-analytics" /> }));
+vi.mock('../CrossTextAnalytics', () => ({ default: () => <div data-testid="cross-text-analytics" /> }));
+vi.mock('../../components/teacher/AtRiskStudents', () => ({ default: () => <div data-testid="at-risk-students" /> }));
+vi.mock('../ErrorHeatmapTab', () => ({ default: () => <div data-testid="error-heatmap-tab" /> }));
+vi.mock('../CoTeachingTab', () => ({ default: () => <div data-testid="co-teaching-tab" /> }));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_CLASSROOM = {
+  id: 42,
+  name: '三年甲班',
+  school_id: 1,
+  teacher_id: 1,
+  grade: 3,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  student_count: 5,
+  students: [],
+  join_code: 'ABC123',
+  school_name: '測試國小',
+};
+
+function renderDetail(classroomId = 42) {
+  return render(<ClassroomDetail classroomId={classroomId} onBack={vi.fn()} />);
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(classroomApi.getClassroomDetail).mockResolvedValue(MOCK_CLASSROOM);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ClassroomDetail (refactor characterization) — render with mock data', () => {
+  it('renders classroom name after loading', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('三年甲班')).toBeInTheDocument();
+    });
+  });
+
+  it('renders grade badge', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('3 年級')).toBeInTheDocument();
+    });
+  });
+
+  it('renders student count', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText(/5 位學生/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders 返回班級列表 back button', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText(/返回班級列表/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders join code prominently', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('ABC123')).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading skeleton while fetching', () => {
+    vi.mocked(classroomApi.getClassroomDetail).mockReturnValue(new Promise(() => {})); // never resolves
+    renderDetail();
+    // Should show animated pulse skeleton, not classroom name
+    expect(screen.queryByText('三年甲班')).toBeNull();
+  });
+
+  it('shows error state when fetch fails with no classroom loaded', async () => {
+    vi.mocked(classroomApi.getClassroomDetail).mockRejectedValue(new Error('Network error'));
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText(/無法載入班級資料/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ClassroomDetail (refactor characterization) — tab switching', () => {
+  it('renders progress tab by default', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByTestId('student-progress-tab')).toBeInTheDocument();
+    });
+  });
+
+  it('switches to 課文管理 tab on click', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('課文管理'));
+
+    await user.click(screen.getByRole('button', { name: '課文管理' }));
+    expect(screen.getByTestId('text-management-tab')).toBeInTheDocument();
+    expect(screen.queryByTestId('student-progress-tab')).toBeNull();
+  });
+
+  it('switches to 學生名單 tab on click', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('學生名單'));
+
+    await user.click(screen.getByRole('button', { name: '學生名單' }));
+    expect(screen.getByTestId('student-list-tab')).toBeInTheDocument();
+  });
+
+  it('switches to 學習分析 tab on click', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('學習分析'));
+
+    await user.click(screen.getByRole('button', { name: '學習分析' }));
+    expect(screen.getByTestId('classroom-analytics')).toBeInTheDocument();
+  });
+
+  it('switches to 協同教師 tab on click', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('協同教師'));
+
+    await user.click(screen.getByRole('button', { name: '協同教師' }));
+    expect(screen.getByTestId('co-teaching-tab')).toBeInTheDocument();
+  });
+
+  it('renders all 8 tab labels', async () => {
+    renderDetail();
+    await waitFor(() => screen.getByText('學生進度'));
+
+    const tabLabels = ['學生進度', '學生名單', '課文管理', '學習分析', '跨課文分析', '早期介入', '錯字熱力圖', '協同教師'];
+    for (const label of tabLabels) {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    }
+  });
+});
+
+describe('ClassroomDetail (refactor characterization) — join code copy', () => {
+  it('clicking 複製代碼 copies join code to clipboard', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('ABC123'));
+
+    await user.click(screen.getByRole('button', { name: /複製代碼/i }));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('ABC123');
+  });
+
+  it('shows "已複製" feedback after copy', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('ABC123'));
+
+    await user.click(screen.getByRole('button', { name: /複製代碼/i }));
+    await waitFor(() => {
+      expect(screen.getByText('已複製')).toBeInTheDocument();
+    });
+  });
+
+  it('shows confirm dialog before regenerating code', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('ABC123'));
+
+    await user.click(screen.getByRole('button', { name: /重生代碼/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(classroomApi.regenerateClassroomCode).not.toHaveBeenCalled();
+  });
+
+  it('confirming dialog calls regenerateClassroomCode', async () => {
+    vi.mocked(classroomApi.regenerateClassroomCode).mockResolvedValue({ join_code: 'XYZ789' });
+    vi.mocked(classroomApi.getClassroomDetail)
+      .mockResolvedValueOnce(MOCK_CLASSROOM)
+      .mockResolvedValueOnce({ ...MOCK_CLASSROOM, join_code: 'XYZ789' });
+
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('ABC123'));
+
+    await user.click(screen.getByRole('button', { name: /重生代碼/i }));
+    await user.click(screen.getByRole('button', { name: /確定/i }));
+
+    await waitFor(() => {
+      expect(classroomApi.regenerateClassroomCode).toHaveBeenCalledWith('test-token', 42);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('XYZ789')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ClassroomDetail (refactor characterization) — student roster via StudentListTab', () => {
+  it('passes classroom prop to StudentListTab', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await waitFor(() => screen.getByText('學生名單'));
+
+    await user.click(screen.getByRole('button', { name: '學生名單' }));
+    const listTab = screen.getByTestId('student-list-tab');
+    expect(listTab).toBeInTheDocument();
+    // ClassroomHeaderCard passes classroom name down
+    expect(listTab.getAttribute('data-classroom')).toBe('三年甲班');
+  });
+});


### PR DESCRIPTION
Fixes #1943

## Summary

Split `ClassroomDetail.tsx` (587 LOC) into focused components:

- **`ClassroomHeaderCard`** — 班級資訊卡 + 加入代碼 panel + 重生代碼 confirm dialog. Pure presentational — receives all handlers as props from parent.
- **`ClassroomTabs`** — Tab bar + tab content delegation to existing tab components. Owns `TABS` constant and `TabKey` type (exported). Zero new logic.
- **`ClassroomDetail`** — Reduced to orchestrator: owns all state and data-fetching, composes the two above.

No logic moved — handlers, state, and API calls stay in the orchestrator.

## Test plan

- TDD characterization tests (`ClassroomDetail.refactor.test.tsx`): **17 tests GREEN** covering render-with-mock-data, tab switching (8 tabs), join code copy feedback, confirm dialog, student roster prop passthrough
- Pre-existing `ClassroomDetail.joincode.test.tsx` (#1643): **7 tests still GREEN** post-refactor
- Total: **24/24 tests pass**