### PR TITLE
refactor(student): split StudentHome.tsx 527L → 4 focused components (Fixes #1952)

### DIFF
--- a/frontend/src/components/student/home/AssignmentWidget.tsx
+++ b/frontend/src/components/student/home/AssignmentWidget.tsx
@@ -1,0 +1,73 @@
+/**
+ * AssignmentWidget — 班級作業 + 圖書館 2-column secondary tile grid.
+ *
+ * Extracted from StudentHome.tsx (Issue #1952)
+ */
+
+import React from 'react';
+
+export interface AssignmentWidgetProps {
+  pendingCount: number;
+  onGoAssignments: () => void;
+  onGoLibrary: () => void;
+}
+
+const AssignmentWidget: React.FC<AssignmentWidgetProps> = ({
+  pendingCount,
+  onGoAssignments,
+  onGoLibrary,
+}) => (
+  <div className="grid grid-cols-2 gap-3">
+    <button
+      type="button"
+      onClick={onGoAssignments}
+      className="
+        relative text-left
+        bg-surface-container-lowest border border-[#E5E0D5] rounded-xl
+        p-4 flex items-center gap-3
+        transition-all duration-150
+        hover:shadow-md hover:border-accent/40 active:scale-[0.99]
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+      "
+      aria-label="查看班級作業"
+    >
+      <span className="text-xl sm:text-2xl" aria-hidden="true">📋</span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-bold text-on-surface leading-tight">班級作業</p>
+        <p className="text-xs text-on-surface-variant mt-0.5">
+          {pendingCount > 0 ? `${pendingCount} 個待完成` : '查看紀錄'}
+        </p>
+      </div>
+      {pendingCount > 0 && (
+        <span
+          className="px-2 py-0.5 rounded-full bg-error/10 text-error text-[11px] font-bold tabular-nums"
+          aria-hidden="true"
+        >
+          {pendingCount}
+        </span>
+      )}
+    </button>
+
+    <button
+      type="button"
+      onClick={onGoLibrary}
+      className="
+        text-left
+        bg-surface-container-lowest border border-[#E5E0D5] rounded-xl
+        p-4 flex items-center gap-3
+        transition-all duration-150
+        hover:shadow-md hover:border-accent/40 active:scale-[0.99]
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+      "
+      aria-label="前往圖書館"
+    >
+      <span className="text-xl sm:text-2xl" aria-hidden="true">📚</span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-bold text-on-surface leading-tight">圖書館</p>
+        <p className="text-xs text-on-surface-variant mt-0.5">探索更多課文</p>
+      </div>
+    </button>
+  </div>
+);
+
+export default AssignmentWidget;

--- a/frontend/src/components/student/home/HomeStats.tsx
+++ b/frontend/src/components/student/home/HomeStats.tsx
@@ -1,0 +1,48 @@
+/**
+ * HomeStats — compact inline XP/streak/level pill for StudentHome.
+ *
+ * Extracted from StudentHome.tsx (Issue #1952)
+ */
+
+import React from 'react';
+import type { GamificationSummary } from '../../../services/gamificationApi';
+
+// ---------------------------------------------------------------------------
+// InlineXPPill — compact XP + streak + level pill, not a hero block.
+// Replaces the old purple-gradient GamificationHero on this page.
+// ---------------------------------------------------------------------------
+
+export interface InlineXPPillProps {
+  summary: GamificationSummary;
+  onClick: () => void;
+}
+
+export const InlineXPPill: React.FC<InlineXPPillProps> = ({ summary, onClick }) => {
+  const { level_info: li, streak } = summary;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="
+        flex items-center gap-2.5 px-3.5 py-1.5 rounded-full
+        bg-surface-container-lowest border border-[#E5E0D5]
+        hover:border-accent/40 hover:shadow-sm
+        transition-all duration-150
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
+      "
+      aria-label={`目前 Lv.${li.level}，連續 ${streak.current} 天，點我看成就`}
+    >
+      <span className="flex items-center gap-1 text-sm font-bold text-tertiary-fixed-dim">
+        <span aria-hidden="true">{streak.current > 0 ? '🔥' : '💤'}</span>
+        <span className="tabular-nums">{streak.current}</span>
+        <span className="text-xs font-medium">天</span>
+      </span>
+      <span className="px-2 py-0.5 rounded-full bg-accent/10 text-accent text-[11px] font-black tabular-nums">
+        Lv.{li.level}
+      </span>
+      <span className="hidden sm:inline text-xs text-on-surface-variant tabular-nums">
+        {li.current_level_xp} / {li.next_level_xp ?? '—'} XP
+      </span>
+    </button>
+  );
+};

--- a/frontend/src/components/student/home/TodayLessonCard.tsx
+++ b/frontend/src/components/student/home/TodayLessonCard.tsx
@@ -1,0 +1,247 @@
+/**
+ * TodayLessonCard — today's lesson hero area sub-components.
+ *
+ * Exports:
+ * - BookJacketCover     (internal thumbnail)
+ * - BookJacketHero      (full lesson hero with CTA)
+ * - ClassroomFallbackHero (shown when no active assignment)
+ * - NoClassroomWaitingScreen (shown when student not in any classroom)
+ *
+ * Extracted from StudentHome.tsx (Issue #1952)
+ */
+
+import React, { useEffect, useState } from 'react';
+import type { StudentAssignmentResponse } from '../../../services/assignmentApi';
+import type { StudentEnrolledClassroom } from '../../../services/learningApi';
+
+// ---------------------------------------------------------------------------
+// NoClassroomWaitingScreen — shown to students not yet added to any classroom
+// Issue #457
+// ---------------------------------------------------------------------------
+
+interface NoClassroomWaitingScreenProps {
+  firstName: string;
+}
+
+export const NoClassroomWaitingScreen: React.FC<NoClassroomWaitingScreenProps> = ({ firstName }) => (
+  <div className="flex-1 flex items-center justify-center min-h-[60vh]">
+    <div className="max-w-sm w-full mx-auto px-6 py-10 text-center space-y-6">
+      <div
+        className="w-20 h-20 rounded-full bg-accent/10 flex items-center justify-center mx-auto"
+        aria-hidden="true"
+      >
+        <span className="text-4xl">🏫</span>
+      </div>
+      <div>
+        <h1 className="text-2xl font-bold font-headline text-on-surface">
+          你好，{firstName}！
+        </h1>
+        <p className="text-base text-on-surface-variant mt-2">你的老師還沒有把你加入班級</p>
+      </div>
+      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-5 text-left space-y-3">
+        <p className="text-sm font-semibold text-amber-900">下一步怎麼做？</p>
+        <ol className="space-y-2 text-sm text-amber-800 list-decimal list-inside">
+          <li>請聯繫你的老師</li>
+          <li>請老師把你加入班級</li>
+          <li>加入後重新登入，即可開始學習</li>
+        </ol>
+      </div>
+      <p className="text-xs text-on-surface-variant/60">加入班級後重新整理頁面即可繼續</p>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// BookJacketCover — 200x270 book cover with real lesson thumbnail.
+// Renders amber gradient + title fallback if the image fails to load.
+// ---------------------------------------------------------------------------
+
+interface BookJacketCoverProps {
+  storyId: string | null;
+  title: string;
+}
+
+const THUMBNAIL_BASE = 'https://storage.googleapis.com/lingoleap-assets/stories/thumbnails';
+
+export const BookJacketCover: React.FC<BookJacketCoverProps> = ({ storyId, title }) => {
+  const [imgOk, setImgOk] = useState(true);
+  const imgSrc = storyId ? `${THUMBNAIL_BASE}/lesson-${storyId}.webp` : null;
+
+  // Reset error state when the story changes, so a previous 404 doesn't
+  // block a new valid thumbnail if the component is reused.
+  useEffect(() => {
+    setImgOk(true);
+  }, [storyId]);
+
+  return (
+    <div
+      className="
+        relative w-[160px] sm:w-[200px] aspect-[200/270] shrink-0
+        rounded-l-sm rounded-r-md overflow-hidden
+        bg-gradient-to-br from-[#F7B76B] via-[#F59E42] to-[#E8841C]
+        shadow-[4px_6px_16px_rgba(245,158,66,0.3),-2px_0_0_rgba(0,0,0,0.05)]
+      "
+      aria-hidden="true"
+    >
+      {/* Spine shadow line */}
+      <div
+        className="absolute inset-y-0 left-0 w-2 bg-gradient-to-r from-black/15 to-transparent"
+        aria-hidden="true"
+      />
+
+      {/* Real cover image (hidden on error) */}
+      {imgSrc && imgOk && (
+        <img
+          src={imgSrc}
+          alt=""
+          onError={() => setImgOk(false)}
+          className="absolute inset-0 w-full h-full object-cover"
+          loading="eager"
+        />
+      )}
+
+      {/* Text fallback (shown only if image absent or failed) */}
+      {(!imgSrc || !imgOk) && (
+        <div className="absolute inset-0 p-4 sm:p-5 flex flex-col justify-between text-white">
+          <div className="text-xl sm:text-2xl font-bold leading-tight tracking-tight line-clamp-4">
+            {title}
+          </div>
+          <div className="text-[10px] sm:text-xs opacity-90 tracking-widest">今 日 課 文</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// BookJacketHero — large "today's lesson" anchor card.
+// ---------------------------------------------------------------------------
+
+export interface BookJacketHeroProps {
+  assignment: StudentAssignmentResponse;
+  onContinue: () => void;
+}
+
+export const BookJacketHero: React.FC<BookJacketHeroProps> = ({ assignment, onContinue }) => {
+  const isInProgress = assignment.status === 'in_progress';
+  const ctaLabel = isInProgress ? '繼續閱讀' : '開始閱讀';
+
+  return (
+    <section
+      aria-labelledby="today-lesson-title"
+      className="
+        bg-surface-container-lowest border border-[#E5E0D5] rounded-2xl
+        p-5 sm:p-7
+        grid grid-cols-[160px_1fr] sm:grid-cols-[200px_1fr] gap-5 sm:gap-7
+        items-center
+        shadow-editorial
+      "
+    >
+      <BookJacketCover storyId={assignment.story_id} title={assignment.story_title} />
+
+      <div className="min-w-0">
+        <div className="text-[11px] font-bold tracking-widest text-tertiary-fixed-dim uppercase mb-1.5">
+          今 日 課 文
+        </div>
+        <h1
+          id="today-lesson-title"
+          className="text-xl sm:text-[26px] font-bold font-headline text-on-surface leading-tight mb-1.5 line-clamp-2"
+        >
+          {assignment.story_title}
+        </h1>
+        <p className="text-sm text-on-surface-variant mb-4">
+          {assignment.classroom_name}
+        </p>
+
+        {isInProgress && assignment.current_step && (
+          <div className="flex items-center gap-2 mb-4">
+            <span
+              className="inline-flex items-center px-2.5 py-0.5 rounded-full
+                         bg-tertiary-fixed/20 text-tertiary-dim
+                         text-xs font-bold"
+            >
+              上次讀到
+            </span>
+            <span className="text-xs text-on-surface-variant">可以接著讀下去</span>
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={onContinue}
+          className="
+            inline-flex items-center gap-2
+            px-5 sm:px-6 py-3
+            bg-accent hover:bg-accent-hover
+            text-white font-bold text-sm sm:text-base
+            rounded-xl
+            shadow-sm hover:shadow-md
+            transition-all duration-150
+            active:scale-[0.98]
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
+          "
+          aria-label={`${ctaLabel}「${assignment.story_title}」`}
+        >
+          <span aria-hidden="true">▶</span>
+          <span>{ctaLabel}</span>
+        </button>
+      </div>
+    </section>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ClassroomFallbackHero — shown when student has no active assignment.
+// ---------------------------------------------------------------------------
+
+export interface ClassroomFallbackHeroProps {
+  classroom: StudentEnrolledClassroom;
+  onClick: () => void;
+}
+
+export const ClassroomFallbackHero: React.FC<ClassroomFallbackHeroProps> = ({ classroom, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="
+      w-full text-left
+      bg-surface-container-lowest border border-[#E5E0D5] rounded-2xl
+      p-5 sm:p-6
+      flex items-center gap-4
+      shadow-editorial
+      hover:shadow-md hover:border-accent/40 transition-all duration-150
+      focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
+    "
+    aria-label={`前往${classroom.name}`}
+  >
+    <div
+      className="
+        w-16 h-20 shrink-0
+        rounded-sm
+        bg-gradient-to-br from-[#F7B76B] via-[#F59E42] to-[#E8841C]
+        flex items-center justify-center
+        shadow-md
+      "
+      aria-hidden="true"
+    >
+      <span className="text-2xl">📖</span>
+    </div>
+    <div className="flex-1 min-w-0">
+      <div className="text-[11px] font-bold tracking-widest text-tertiary-fixed-dim uppercase mb-1">
+        繼 續 學 習
+      </div>
+      <h1 className="text-xl sm:text-2xl font-bold font-headline text-on-surface leading-tight truncate">
+        {classroom.name}
+      </h1>
+      <p className="text-sm text-on-surface-variant mt-0.5">
+        老師：{classroom.teacher_name}
+      </p>
+    </div>
+    <div
+      className="w-9 h-9 rounded-xl bg-accent/10 flex items-center justify-center shrink-0 text-accent font-bold"
+      aria-hidden="true"
+    >
+      →
+    </div>
+  </button>
+);

--- a/frontend/src/components/student/home/__tests__/AssignmentWidget.test.tsx
+++ b/frontend/src/components/student/home/__tests__/AssignmentWidget.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * TDD tests for AssignmentWidget (Issue #1952)
+ * Covers the 班級作業 + 圖書館 2-col tile grid.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+// RED: will fail until AssignmentWidget is created
+import AssignmentWidget from '../AssignmentWidget';
+
+describe('AssignmentWidget', () => {
+  it('renders 班級作業 tile', () => {
+    render(
+      <BrowserRouter>
+        <AssignmentWidget pendingCount={0} onGoAssignments={vi.fn()} onGoLibrary={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('班級作業')).toBeTruthy();
+  });
+
+  it('renders 圖書館 tile', () => {
+    render(
+      <BrowserRouter>
+        <AssignmentWidget pendingCount={0} onGoAssignments={vi.fn()} onGoLibrary={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('圖書館')).toBeTruthy();
+  });
+
+  it('shows pending count badge when pendingCount > 0', () => {
+    render(
+      <BrowserRouter>
+        <AssignmentWidget pendingCount={3} onGoAssignments={vi.fn()} onGoLibrary={vi.fn()} />
+      </BrowserRouter>,
+    );
+    // badge text
+    const badges = screen.getAllByText('3');
+    expect(badges.length).toBeGreaterThan(0);
+    // subtitle
+    expect(screen.getByText('3 個待完成')).toBeTruthy();
+  });
+
+  it('shows "查看紀錄" when pendingCount is 0', () => {
+    render(
+      <BrowserRouter>
+        <AssignmentWidget pendingCount={0} onGoAssignments={vi.fn()} onGoLibrary={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('查看紀錄')).toBeTruthy();
+  });
+
+  it('calls onGoAssignments when 班級作業 tile is clicked', () => {
+    const onGoAssignments = vi.fn();
+    render(
+      <BrowserRouter>
+        <AssignmentWidget pendingCount={0} onGoAssignments={onGoAssignments} onGoLibrary={vi.fn()} />
+      </BrowserRouter>,
+    );
+    fireEvent.click(screen.getByLabelText('查看班級作業'));
+    expect(onGoAssignments).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onGoLibrary when 圖書館 tile is clicked', () => {
+    const onGoLibrary = vi.fn();
+    render(
+      <BrowserRouter>
+        <AssignmentWidget pendingCount={0} onGoAssignments={vi.fn()} onGoLibrary={onGoLibrary} />
+      </BrowserRouter>,
+    );
+    fireEvent.click(screen.getByLabelText('前往圖書館'));
+    expect(onGoLibrary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/student/home/__tests__/HomeStats.test.tsx
+++ b/frontend/src/components/student/home/__tests__/HomeStats.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * TDD tests for HomeStats / InlineXPPill (Issue #1952)
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+// RED: will fail until HomeStats is created
+import { InlineXPPill } from '../HomeStats';
+import type { GamificationSummary } from '../../../../services/gamificationApi';
+
+const mockSummary: GamificationSummary = {
+  student_id: 1,
+  total_xp: 250,
+  stories_completed: 5,
+  level_info: {
+    level: 3,
+    title: 'Reader',
+    current_level_xp: 50,
+    next_level_xp: 100,
+    total_xp: 250,
+    progress_percent: 50,
+  },
+  streak: {
+    current: 7,
+    longest: 10,
+    last_activity_date: '2026-05-22',
+  },
+  badges: [],
+  all_badges: [],
+};
+
+const mockSummaryNoStreak: GamificationSummary = {
+  ...mockSummary,
+  streak: { current: 0, longest: 0, last_activity_date: '' },
+};
+
+describe('InlineXPPill', () => {
+  it('renders level number', () => {
+    render(<InlineXPPill summary={mockSummary} onClick={vi.fn()} />);
+    expect(screen.getByText('Lv.3')).toBeTruthy();
+  });
+
+  it('renders streak count', () => {
+    render(<InlineXPPill summary={mockSummary} onClick={vi.fn()} />);
+    expect(screen.getByText('7')).toBeTruthy();
+  });
+
+  it('shows fire emoji when streak > 0', () => {
+    render(<InlineXPPill summary={mockSummary} onClick={vi.fn()} />);
+    expect(screen.getByText('🔥')).toBeTruthy();
+  });
+
+  it('shows sleep emoji when streak is 0', () => {
+    render(<InlineXPPill summary={mockSummaryNoStreak} onClick={vi.fn()} />);
+    expect(screen.getByText('💤')).toBeTruthy();
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<InlineXPPill summary={mockSummary} onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/student/home/__tests__/StudentHome.integration.test.tsx
+++ b/frontend/src/components/student/home/__tests__/StudentHome.integration.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Integration test for the refactored StudentHome orchestrator (Issue #1952)
+ *
+ * Mocks API calls and verifies the full page renders the correct sub-components.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+
+// Mock API modules
+vi.mock('../../../../services/learningApi', () => ({
+  fetchMyEnrolledClassrooms: vi.fn(),
+}));
+vi.mock('../../../../services/gamificationApi', () => ({
+  fetchGamificationSummary: vi.fn(),
+}));
+vi.mock('../../../../services/assignmentApi', () => ({
+  getMyAssignments: vi.fn(),
+}));
+vi.mock('../../../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 1, name: '小明', role: 'student' },
+    token: 'mock-token',
+  }),
+}));
+
+// Stub heavy sub-components that are not under test here
+vi.mock('../../../../components/student/StudentProgressDashboard', () => ({
+  default: () => <div data-testid="progress-dashboard" />,
+}));
+vi.mock('../../../../components/student/RecommendedStories', () => ({
+  default: () => <div data-testid="recommended-stories" />,
+}));
+vi.mock('../../../../components/SessionResumePrompt', () => ({
+  default: () => null,
+}));
+vi.mock('../../../../components/gamification/RecentBadgesStrip', () => ({
+  default: () => null,
+}));
+vi.mock('../../../../components/student/QuickPracticeStrip', () => ({
+  default: () => <div data-testid="quick-practice-strip" />,
+}));
+
+import { fetchMyEnrolledClassrooms } from '../../../../services/learningApi';
+import { fetchGamificationSummary } from '../../../../services/gamificationApi';
+import { getMyAssignments } from '../../../../services/assignmentApi';
+import StudentHome from '../../../../pages/student/StudentHome';
+
+const mockClassroom = {
+  id: 10,
+  name: '五年甲班',
+  teacher_name: '陳老師',
+  is_active: false, // not active — won't trigger auto-redirect
+  code: 'CLS01',
+};
+
+const mockAssignment = {
+  assignment_id: 1,
+  story_id: 'L1',
+  text_id: null,
+  story_slug: 'l1',
+  story_title: '春天來了',
+  title: null,
+  description: null,
+  assignment_type: 'reading',
+  due_date: null,
+  classroom_name: '五年甲班',
+  status: 'pending',
+  session_id: null,
+  current_step: null,
+  steps_completed: [],
+  submitted_at: null,
+  score: null,
+  teacher_feedback: null,
+  attempt_number: 1,
+  session_mode: 'normal',
+  skip_completed_steps: false,
+  skipped_steps: [],
+  target_cpm: null,
+  target_accuracy: null,
+  difficulty_label: null,
+  effective_cpm: 150,
+  effective_accuracy: 90,
+};
+
+const mockGamification = {
+  student_id: 1,
+  total_xp: 100,
+  stories_completed: 2,
+  level_info: {
+    level: 2,
+    title: 'Reader',
+    current_level_xp: 0,
+    next_level_xp: 100,
+    total_xp: 100,
+    progress_percent: 0,
+  },
+  streak: { current: 3, longest: 5, last_activity_date: '2026-05-22' },
+  badges: [],
+  all_badges: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('StudentHome integration', () => {
+  it('renders greeting with student name', async () => {
+    vi.mocked(fetchMyEnrolledClassrooms).mockResolvedValue({ classrooms: [mockClassroom] });
+    vi.mocked(fetchGamificationSummary).mockResolvedValue(mockGamification);
+    vi.mocked(getMyAssignments).mockResolvedValue([mockAssignment]);
+
+    render(
+      <MemoryRouter>
+        <StudentHome />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('你好，小明！')).toBeTruthy();
+    });
+  });
+
+  it('renders today assignment title when assignment exists', async () => {
+    vi.mocked(fetchMyEnrolledClassrooms).mockResolvedValue({ classrooms: [mockClassroom] });
+    vi.mocked(fetchGamificationSummary).mockResolvedValue(mockGamification);
+    vi.mocked(getMyAssignments).mockResolvedValue([mockAssignment]);
+
+    render(
+      <MemoryRouter>
+        <StudentHome />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('春天來了')).toBeTruthy();
+    });
+  });
+
+  it('renders QuickPracticeStrip', async () => {
+    vi.mocked(fetchMyEnrolledClassrooms).mockResolvedValue({ classrooms: [mockClassroom] });
+    vi.mocked(fetchGamificationSummary).mockResolvedValue(mockGamification);
+    vi.mocked(getMyAssignments).mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <StudentHome />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('quick-practice-strip')).toBeTruthy();
+    });
+  });
+
+  it('shows NoClassroomWaitingScreen when no classrooms', async () => {
+    vi.mocked(fetchMyEnrolledClassrooms).mockResolvedValue({ classrooms: [] });
+    vi.mocked(fetchGamificationSummary).mockResolvedValue(mockGamification);
+    vi.mocked(getMyAssignments).mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <StudentHome />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/你的老師還沒有把你加入班級/)).toBeTruthy();
+    });
+  });
+
+  it('renders 班級作業 tile', async () => {
+    vi.mocked(fetchMyEnrolledClassrooms).mockResolvedValue({ classrooms: [mockClassroom] });
+    vi.mocked(fetchGamificationSummary).mockResolvedValue(mockGamification);
+    vi.mocked(getMyAssignments).mockResolvedValue([mockAssignment]);
+
+    render(
+      <MemoryRouter>
+        <StudentHome />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('班級作業')).toBeTruthy();
+    });
+  });
+
+  it('renders XP pill when gamification is loaded', async () => {
+    vi.mocked(fetchMyEnrolledClassrooms).mockResolvedValue({ classrooms: [mockClassroom] });
+    vi.mocked(fetchGamificationSummary).mockResolvedValue(mockGamification);
+    vi.mocked(getMyAssignments).mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <StudentHome />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lv.2')).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/components/student/home/__tests__/TodayLessonCard.test.tsx
+++ b/frontend/src/components/student/home/__tests__/TodayLessonCard.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * TDD tests for TodayLessonCard (Issue #1952)
+ *
+ * Covers:
+ * - BookJacketHero: renders assignment title, classroom, CTA button label
+ * - ClassroomFallbackHero: renders classroom name + teacher when no assignment
+ * - NoClassroomWaitingScreen: shown when student not in any classroom
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+// These imports will FAIL initially (RED phase) — components don't exist yet
+import {
+  BookJacketHero,
+  ClassroomFallbackHero,
+  NoClassroomWaitingScreen,
+} from '../TodayLessonCard';
+import type { StudentAssignmentResponse } from '../../../../services/assignmentApi';
+import type { StudentEnrolledClassroom } from '../../../../services/learningApi';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockAssignmentPending: StudentAssignmentResponse = {
+  assignment_id: 1,
+  story_id: 'L1',
+  text_id: null,
+  story_slug: 'l1',
+  story_title: '春天來了',
+  title: null,
+  description: null,
+  assignment_type: 'reading',
+  due_date: null,
+  classroom_name: '五年甲班',
+  status: 'pending',
+  session_id: null,
+  current_step: null,
+  steps_completed: [],
+  submitted_at: null,
+  score: null,
+  teacher_feedback: null,
+  attempt_number: 1,
+  session_mode: 'normal',
+  skip_completed_steps: false,
+  skipped_steps: [],
+  target_cpm: null,
+  target_accuracy: null,
+  difficulty_label: null,
+  effective_cpm: 150,
+  effective_accuracy: 90,
+};
+
+const mockAssignmentInProgress: StudentAssignmentResponse = {
+  ...mockAssignmentPending,
+  status: 'in_progress',
+  current_step: 'tutor',
+};
+
+const mockClassroom: StudentEnrolledClassroom = {
+  id: 10,
+  name: '六年乙班',
+  teacher_name: '林老師',
+  is_active: true,
+  code: 'CLS01',
+};
+
+// ---------------------------------------------------------------------------
+// BookJacketHero
+// ---------------------------------------------------------------------------
+
+describe('BookJacketHero', () => {
+  it('renders story title', () => {
+    render(
+      <BrowserRouter>
+        <BookJacketHero assignment={mockAssignmentPending} onContinue={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('春天來了')).toBeTruthy();
+  });
+
+  it('renders classroom name', () => {
+    render(
+      <BrowserRouter>
+        <BookJacketHero assignment={mockAssignmentPending} onContinue={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('五年甲班')).toBeTruthy();
+  });
+
+  it('shows "開始閱讀" CTA when status is pending', () => {
+    render(
+      <BrowserRouter>
+        <BookJacketHero assignment={mockAssignmentPending} onContinue={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('開始閱讀')).toBeTruthy();
+  });
+
+  it('shows "繼續閱讀" CTA when status is in_progress', () => {
+    render(
+      <BrowserRouter>
+        <BookJacketHero assignment={mockAssignmentInProgress} onContinue={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('繼續閱讀')).toBeTruthy();
+  });
+
+  it('calls onContinue when CTA is clicked', () => {
+    const onContinue = vi.fn();
+    render(
+      <BrowserRouter>
+        <BookJacketHero assignment={mockAssignmentPending} onContinue={onContinue} />
+      </BrowserRouter>,
+    );
+    fireEvent.click(screen.getByText('開始閱讀'));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "上次讀到" badge when in_progress with current_step', () => {
+    render(
+      <BrowserRouter>
+        <BookJacketHero assignment={mockAssignmentInProgress} onContinue={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('上次讀到')).toBeTruthy();
+  });
+
+  it('does not show "上次讀到" badge when pending', () => {
+    render(
+      <BrowserRouter>
+        <BookJacketHero assignment={mockAssignmentPending} onContinue={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.queryByText('上次讀到')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClassroomFallbackHero
+// ---------------------------------------------------------------------------
+
+describe('ClassroomFallbackHero', () => {
+  it('renders classroom name', () => {
+    render(
+      <BrowserRouter>
+        <ClassroomFallbackHero classroom={mockClassroom} onClick={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText('六年乙班')).toBeTruthy();
+  });
+
+  it('renders teacher name', () => {
+    render(
+      <BrowserRouter>
+        <ClassroomFallbackHero classroom={mockClassroom} onClick={vi.fn()} />
+      </BrowserRouter>,
+    );
+    expect(screen.getByText(/林老師/)).toBeTruthy();
+  });
+
+  it('calls onClick when button is clicked', () => {
+    const onClick = vi.fn();
+    render(
+      <BrowserRouter>
+        <ClassroomFallbackHero classroom={mockClassroom} onClick={onClick} />
+      </BrowserRouter>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NoClassroomWaitingScreen
+// ---------------------------------------------------------------------------
+
+describe('NoClassroomWaitingScreen', () => {
+  it('renders greeting with firstName', () => {
+    render(<NoClassroomWaitingScreen firstName="小明" />);
+    expect(screen.getByText('你好，小明！')).toBeTruthy();
+  });
+
+  it('shows the waiting message', () => {
+    render(<NoClassroomWaitingScreen firstName="小明" />);
+    expect(screen.getByText(/你的老師還沒有把你加入班級/)).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/student/StudentHome.tsx
+++ b/frontend/src/pages/student/StudentHome.tsx
@@ -1,7 +1,8 @@
 /**
- * StudentHome — student landing page / dashboard.
+ * StudentHome — student landing page / dashboard (orchestrator).
  *
  * Issue #1215: Variant B "Book Jacket" — today's lesson is the visual anchor.
+ * Issue #1952: Split 527 LOC into focused sub-components.
  *
  * Layout (top to bottom):
  * 1. Compact greeting row — avatar + name + inline XP pill (no purple gradient)
@@ -25,6 +26,13 @@ import SessionResumePrompt from '../../components/SessionResumePrompt';
 import RecentBadgesStrip from '../../components/gamification/RecentBadgesStrip';
 import QuickPracticeStrip from '../../components/student/QuickPracticeStrip';
 import {
+  BookJacketHero,
+  ClassroomFallbackHero,
+  NoClassroomWaitingScreen,
+} from '../../components/student/home/TodayLessonCard';
+import { InlineXPPill } from '../../components/student/home/HomeStats';
+import AssignmentWidget from '../../components/student/home/AssignmentWidget';
+import {
   fetchMyEnrolledClassrooms,
   type StudentEnrolledClassroom,
 } from '../../services/learningApi';
@@ -38,279 +46,7 @@ import {
 } from '../../services/assignmentApi';
 
 // ---------------------------------------------------------------------------
-// NoClassroomWaitingScreen — shown to students not yet added to any classroom
-// Issue #457
-// ---------------------------------------------------------------------------
-
-interface NoClassroomWaitingScreenProps {
-  firstName: string;
-}
-
-const NoClassroomWaitingScreen: React.FC<NoClassroomWaitingScreenProps> = ({ firstName }) => (
-  <div className="flex-1 flex items-center justify-center min-h-[60vh]">
-    <div className="max-w-sm w-full mx-auto px-6 py-10 text-center space-y-6">
-      <div
-        className="w-20 h-20 rounded-full bg-accent/10 flex items-center justify-center mx-auto"
-        aria-hidden="true"
-      >
-        <span className="text-4xl">🏫</span>
-      </div>
-      <div>
-        <h1 className="text-2xl font-bold font-headline text-on-surface">
-          你好，{firstName}！
-        </h1>
-        <p className="text-base text-on-surface-variant mt-2">你的老師還沒有把你加入班級</p>
-      </div>
-      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-5 text-left space-y-3">
-        <p className="text-sm font-semibold text-amber-900">下一步怎麼做？</p>
-        <ol className="space-y-2 text-sm text-amber-800 list-decimal list-inside">
-          <li>請聯繫你的老師</li>
-          <li>請老師把你加入班級</li>
-          <li>加入後重新登入，即可開始學習</li>
-        </ol>
-      </div>
-      <p className="text-xs text-on-surface-variant/60">加入班級後重新整理頁面即可繼續</p>
-    </div>
-  </div>
-);
-
-// ---------------------------------------------------------------------------
-// InlineXPPill — compact XP + streak + level pill, not a hero block.
-// Replaces the old purple-gradient GamificationHero on this page.
-// ---------------------------------------------------------------------------
-
-interface InlineXPPillProps {
-  summary: GamificationSummary;
-  onClick: () => void;
-}
-
-const InlineXPPill: React.FC<InlineXPPillProps> = ({ summary, onClick }) => {
-  const { level_info: li, streak } = summary;
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="
-        flex items-center gap-2.5 px-3.5 py-1.5 rounded-full
-        bg-surface-container-lowest border border-[#E5E0D5]
-        hover:border-accent/40 hover:shadow-sm
-        transition-all duration-150
-        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
-      "
-      aria-label={`目前 Lv.${li.level}，連續 ${streak.current} 天，點我看成就`}
-    >
-      <span className="flex items-center gap-1 text-sm font-bold text-tertiary-fixed-dim">
-        <span aria-hidden="true">{streak.current > 0 ? '🔥' : '💤'}</span>
-        <span className="tabular-nums">{streak.current}</span>
-        <span className="text-xs font-medium">天</span>
-      </span>
-      <span className="px-2 py-0.5 rounded-full bg-accent/10 text-accent text-[11px] font-black tabular-nums">
-        Lv.{li.level}
-      </span>
-      <span className="hidden sm:inline text-xs text-on-surface-variant tabular-nums">
-        {li.current_level_xp} / {li.next_level_xp ?? '—'} XP
-      </span>
-    </button>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// BookJacketCover — 200x270 book cover with real lesson thumbnail.
-// Renders amber gradient + title fallback if the image fails to load.
-// ---------------------------------------------------------------------------
-
-interface BookJacketCoverProps {
-  storyId: string | null;
-  title: string;
-}
-
-const THUMBNAIL_BASE = 'https://storage.googleapis.com/lingoleap-assets/stories/thumbnails';
-
-const BookJacketCover: React.FC<BookJacketCoverProps> = ({ storyId, title }) => {
-  const [imgOk, setImgOk] = useState(true);
-  const imgSrc = storyId ? `${THUMBNAIL_BASE}/lesson-${storyId}.webp` : null;
-
-  // Reset error state when the story changes, so a previous 404 doesn't
-  // block a new valid thumbnail if the component is reused.
-  useEffect(() => {
-    setImgOk(true);
-  }, [storyId]);
-
-  return (
-    <div
-      className="
-        relative w-[160px] sm:w-[200px] aspect-[200/270] shrink-0
-        rounded-l-sm rounded-r-md overflow-hidden
-        bg-gradient-to-br from-[#F7B76B] via-[#F59E42] to-[#E8841C]
-        shadow-[4px_6px_16px_rgba(245,158,66,0.3),-2px_0_0_rgba(0,0,0,0.05)]
-      "
-      aria-hidden="true"
-    >
-      {/* Spine shadow line */}
-      <div
-        className="absolute inset-y-0 left-0 w-2 bg-gradient-to-r from-black/15 to-transparent"
-        aria-hidden="true"
-      />
-
-      {/* Real cover image (hidden on error) */}
-      {imgSrc && imgOk && (
-        <img
-          src={imgSrc}
-          alt=""
-          onError={() => setImgOk(false)}
-          className="absolute inset-0 w-full h-full object-cover"
-          loading="eager"
-        />
-      )}
-
-      {/* Text fallback (shown only if image absent or failed) */}
-      {(!imgSrc || !imgOk) && (
-        <div className="absolute inset-0 p-4 sm:p-5 flex flex-col justify-between text-white">
-          <div className="text-xl sm:text-2xl font-bold leading-tight tracking-tight line-clamp-4">
-            {title}
-          </div>
-          <div className="text-[10px] sm:text-xs opacity-90 tracking-widest">今 日 課 文</div>
-        </div>
-      )}
-    </div>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// BookJacketHero — large "today's lesson" anchor card.
-// ---------------------------------------------------------------------------
-
-interface BookJacketHeroProps {
-  assignment: StudentAssignmentResponse;
-  onContinue: () => void;
-}
-
-const BookJacketHero: React.FC<BookJacketHeroProps> = ({ assignment, onContinue }) => {
-  const isInProgress = assignment.status === 'in_progress';
-  const ctaLabel = isInProgress ? '繼續閱讀' : '開始閱讀';
-
-  return (
-    <section
-      aria-labelledby="today-lesson-title"
-      className="
-        bg-surface-container-lowest border border-[#E5E0D5] rounded-2xl
-        p-5 sm:p-7
-        grid grid-cols-[160px_1fr] sm:grid-cols-[200px_1fr] gap-5 sm:gap-7
-        items-center
-        shadow-editorial
-      "
-    >
-      <BookJacketCover storyId={assignment.story_id} title={assignment.story_title} />
-
-      <div className="min-w-0">
-        <div className="text-[11px] font-bold tracking-widest text-tertiary-fixed-dim uppercase mb-1.5">
-          今 日 課 文
-        </div>
-        <h1
-          id="today-lesson-title"
-          className="text-xl sm:text-[26px] font-bold font-headline text-on-surface leading-tight mb-1.5 line-clamp-2"
-        >
-          {assignment.story_title}
-        </h1>
-        <p className="text-sm text-on-surface-variant mb-4">
-          {assignment.classroom_name}
-        </p>
-
-        {isInProgress && assignment.current_step && (
-          <div className="flex items-center gap-2 mb-4">
-            <span
-              className="inline-flex items-center px-2.5 py-0.5 rounded-full
-                         bg-tertiary-fixed/20 text-tertiary-dim
-                         text-xs font-bold"
-            >
-              上次讀到
-            </span>
-            <span className="text-xs text-on-surface-variant">可以接著讀下去</span>
-          </div>
-        )}
-
-        <button
-          type="button"
-          onClick={onContinue}
-          className="
-            inline-flex items-center gap-2
-            px-5 sm:px-6 py-3
-            bg-accent hover:bg-accent-hover
-            text-white font-bold text-sm sm:text-base
-            rounded-xl
-            shadow-sm hover:shadow-md
-            transition-all duration-150
-            active:scale-[0.98]
-            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
-          "
-          aria-label={`${ctaLabel}「${assignment.story_title}」`}
-        >
-          <span aria-hidden="true">▶</span>
-          <span>{ctaLabel}</span>
-        </button>
-      </div>
-    </section>
-  );
-};
-
-// ---------------------------------------------------------------------------
-// ClassroomFallbackHero — shown when student has no active assignment.
-// ---------------------------------------------------------------------------
-
-interface ClassroomFallbackHeroProps {
-  classroom: StudentEnrolledClassroom;
-  onClick: () => void;
-}
-
-const ClassroomFallbackHero: React.FC<ClassroomFallbackHeroProps> = ({ classroom, onClick }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className="
-      w-full text-left
-      bg-surface-container-lowest border border-[#E5E0D5] rounded-2xl
-      p-5 sm:p-6
-      flex items-center gap-4
-      shadow-editorial
-      hover:shadow-md hover:border-accent/40 transition-all duration-150
-      focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2
-    "
-    aria-label={`前往${classroom.name}`}
-  >
-    <div
-      className="
-        w-16 h-20 shrink-0
-        rounded-sm
-        bg-gradient-to-br from-[#F7B76B] via-[#F59E42] to-[#E8841C]
-        flex items-center justify-center
-        shadow-md
-      "
-      aria-hidden="true"
-    >
-      <span className="text-2xl">📖</span>
-    </div>
-    <div className="flex-1 min-w-0">
-      <div className="text-[11px] font-bold tracking-widest text-tertiary-fixed-dim uppercase mb-1">
-        繼 續 學 習
-      </div>
-      <h1 className="text-xl sm:text-2xl font-bold font-headline text-on-surface leading-tight truncate">
-        {classroom.name}
-      </h1>
-      <p className="text-sm text-on-surface-variant mt-0.5">
-        老師：{classroom.teacher_name}
-      </p>
-    </div>
-    <div
-      className="w-9 h-9 rounded-xl bg-accent/10 flex items-center justify-center shrink-0 text-accent font-bold"
-      aria-hidden="true"
-    >
-      →
-    </div>
-  </button>
-);
-
-// ---------------------------------------------------------------------------
-// Main component
+// Main component — orchestrator only
 // ---------------------------------------------------------------------------
 
 const StudentHome: React.FC = () => {
@@ -445,57 +181,11 @@ const StudentHome: React.FC = () => {
         <QuickPracticeStrip />
 
         {/* ── Secondary tiles: assignments + library ─────────────────────── */}
-        <div className="grid grid-cols-2 gap-3">
-          <button
-            type="button"
-            onClick={() => navigate('/assignments')}
-            className="
-              relative text-left
-              bg-surface-container-lowest border border-[#E5E0D5] rounded-xl
-              p-4 flex items-center gap-3
-              transition-all duration-150
-              hover:shadow-md hover:border-accent/40 active:scale-[0.99]
-              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
-            "
-            aria-label="查看班級作業"
-          >
-            <span className="text-xl sm:text-2xl" aria-hidden="true">📋</span>
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-bold text-on-surface leading-tight">班級作業</p>
-              <p className="text-xs text-on-surface-variant mt-0.5">
-                {pendingAssignmentCount > 0 ? `${pendingAssignmentCount} 個待完成` : '查看紀錄'}
-              </p>
-            </div>
-            {pendingAssignmentCount > 0 && (
-              <span
-                className="px-2 py-0.5 rounded-full bg-error/10 text-error text-[11px] font-bold tabular-nums"
-                aria-hidden="true"
-              >
-                {pendingAssignmentCount}
-              </span>
-            )}
-          </button>
-
-          <button
-            type="button"
-            onClick={() => navigate('/library')}
-            className="
-              text-left
-              bg-surface-container-lowest border border-[#E5E0D5] rounded-xl
-              p-4 flex items-center gap-3
-              transition-all duration-150
-              hover:shadow-md hover:border-accent/40 active:scale-[0.99]
-              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1
-            "
-            aria-label="前往圖書館"
-          >
-            <span className="text-xl sm:text-2xl" aria-hidden="true">📚</span>
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-bold text-on-surface leading-tight">圖書館</p>
-              <p className="text-xs text-on-surface-variant mt-0.5">探索更多課文</p>
-            </div>
-          </button>
-        </div>
+        <AssignmentWidget
+          pendingCount={pendingAssignmentCount}
+          onGoAssignments={() => navigate('/assignments')}
+          onGoLibrary={() => navigate('/library')}
+        />
 
         {/* ── Learning progress ──────────────────────────────────────────── */}
         <section aria-labelledby="progress-title">


### PR DESCRIPTION
Fixes #1952

## Summary

Split `frontend/src/pages/student/StudentHome.tsx` (527 LOC) into focused sub-components, keeping exact same behavior.

### New files in `frontend/src/components/student/home/`

| File | Exports | LOC |
|------|---------|-----|
| `TodayLessonCard.tsx` | `BookJacketHero`, `ClassroomFallbackHero`, `NoClassroomWaitingScreen`, `BookJacketCover` | 247 |
| `HomeStats.tsx` | `InlineXPPill` | 48 |
| `AssignmentWidget.tsx` | `AssignmentWidget` (default) | 73 |

### Orchestrator

`StudentHome.tsx`: 527L → 217L (orchestrator only — data fetching + composition)

## TDD

RED → GREEN cycle:

- `TodayLessonCard.test.tsx` — 12 tests (BookJacketHero, ClassroomFallbackHero, NoClassroomWaitingScreen)
- `HomeStats.test.tsx` — 5 tests (InlineXPPill: level, streak, fire/sleep emoji, click)
- `AssignmentWidget.test.tsx` — 6 tests (tiles render, pending count, callbacks)
- `StudentHome.integration.test.tsx` — 6 integration tests (greeting, assignment title, QuickPracticeStrip, waiting screen, tiles, XP pill)

Total: 29 tests, all passing. Pre-existing 31 failures in other test files unchanged.

## Test plan

- [ ] Open PR Preview URL and navigate to student home
- [ ] Verify: greeting, XP pill, today's lesson card all render
- [ ] Verify: 班級作業 and 圖書館 tiles navigate correctly
- [ ] Verify: student with no classroom sees waiting screen
- [ ] Verify: CI all green