### PR TITLE
refactor(admin): split SemesterPanel.tsx — list + create form + icons (Fixes #1959)

### DIFF
--- a/frontend/src/pages/admin/SemesterPanel.tsx
+++ b/frontend/src/pages/admin/SemesterPanel.tsx
@@ -1,5 +1,10 @@
 /**
- * SemesterPanel — manage semesters for a school.
+ * SemesterPanel — orchestrator for semester management.
+ *
+ * Owns loading state, semester list data, and top-level error.
+ * Delegates rendering to:
+ *   - SemesterCreateForm  (new semester modal/inline form)
+ *   - SemesterList        (sortable list with inline edit + activate)
  *
  * Features:
  * - List all semesters for a school (ordered newest first)
@@ -12,74 +17,10 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
-import {
-  listSemesters,
-  createSemester,
-  updateSemester,
-  activateSemester,
-  SemesterResponse,
-  SemesterApiError,
-} from '../../services/semesterApi';
-
-// ── Icons ─────────────────────────────────────────────────────────────────────
-
-const CalendarIcon: React.FC<{ className?: string }> = ({ className = 'w-4 h-4' }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-  </svg>
-);
-
-const PlusIcon: React.FC = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-  </svg>
-);
-
-const CheckCircleIcon: React.FC<{ className?: string }> = ({ className = 'w-4 h-4' }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-  </svg>
-);
-
-const EditIcon: React.FC = () => (
-  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-  </svg>
-);
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function formatDate(iso: string): string {
-  return iso; // already YYYY-MM-DD
-}
-
-// ── Sub-components ─────────────────────────────────────────────────────────────
-
-interface CreateFormState {
-  name: string;
-  start_date: string;
-  end_date: string;
-  grace_days: number;
-  is_active: boolean;
-}
-
-const DEFAULT_FORM: CreateFormState = {
-  name: '',
-  start_date: '',
-  end_date: '',
-  grace_days: 7,
-  is_active: false,
-};
-
-interface EditFormState {
-  name: string;
-  start_date: string;
-  end_date: string;
-  grace_days: number;
-}
+import { listSemesters, SemesterResponse, SemesterApiError } from '../../services/semesterApi';
+import { CalendarIcon, PlusIcon } from './semester/semesterIcons';
+import SemesterCreateForm from './semester/SemesterCreateForm';
+import SemesterList from './semester/SemesterList';
 
 // ── Main Component ────────────────────────────────────────────────────────────
 
@@ -93,21 +34,7 @@ const SemesterPanel: React.FC<SemesterPanelProps> = ({ schoolId }) => {
   const [semesters, setSemesters] = useState<SemesterResponse[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState('');
-
-  // Create form
   const [showCreate, setShowCreate] = useState(false);
-  const [createForm, setCreateForm] = useState<CreateFormState>(DEFAULT_FORM);
-  const [createError, setCreateError] = useState('');
-  const [isCreating, setIsCreating] = useState(false);
-
-  // Edit form
-  const [editingId, setEditingId] = useState<number | null>(null);
-  const [editForm, setEditForm] = useState<EditFormState>({ name: '', start_date: '', end_date: '', grace_days: 7 });
-  const [editError, setEditError] = useState('');
-  const [isSavingEdit, setIsSavingEdit] = useState(false);
-
-  // Activate
-  const [activatingId, setActivatingId] = useState<number | null>(null);
 
   // ── Load ────────────────────────────────────────────────────────────────────
 
@@ -127,110 +54,11 @@ const SemesterPanel: React.FC<SemesterPanelProps> = ({ schoolId }) => {
 
   useEffect(() => { load(); }, [load]);
 
-  // ── Create ──────────────────────────────────────────────────────────────────
+  // ── Handlers ────────────────────────────────────────────────────────────────
 
-  const handleCreate = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!token) return;
-    setCreateError('');
-
-    if (!createForm.name.trim()) {
-      setCreateError('請輸入學期名稱');
-      return;
-    }
-    if (!createForm.start_date || !createForm.end_date) {
-      setCreateError('請選擇開始和結束日期');
-      return;
-    }
-    if (createForm.end_date <= createForm.start_date) {
-      setCreateError('結束日期必須晚於開始日期');
-      return;
-    }
-
-    setIsCreating(true);
-    try {
-      await createSemester(token, schoolId, {
-        name: createForm.name.trim(),
-        start_date: createForm.start_date,
-        end_date: createForm.end_date,
-        grace_days: createForm.grace_days,
-        is_active: createForm.is_active,
-      });
-      setCreateForm(DEFAULT_FORM);
-      setShowCreate(false);
-      await load();
-    } catch (err) {
-      setCreateError(err instanceof SemesterApiError ? err.message : '建立學期失敗');
-    } finally {
-      setIsCreating(false);
-    }
-  };
-
-  // ── Activate ─────────────────────────────────────────────────────────────────
-
-  const handleActivate = async (semId: number) => {
-    if (!token) return;
-    setActivatingId(semId);
-    try {
-      await activateSemester(token, schoolId, semId);
-      await load();
-    } catch (err) {
-      setError(err instanceof SemesterApiError ? err.message : '啟用學期失敗');
-    } finally {
-      setActivatingId(null);
-    }
-  };
-
-  // ── Edit ─────────────────────────────────────────────────────────────────────
-
-  const startEdit = (sem: SemesterResponse) => {
-    setEditingId(sem.id);
-    setEditForm({
-      name: sem.name,
-      start_date: sem.start_date,
-      end_date: sem.end_date,
-      grace_days: sem.grace_days,
-    });
-    setEditError('');
-  };
-
-  const handleSaveEdit = async (semId: number) => {
-    if (!token) return;
-    setEditError('');
-
-    if (!editForm.name.trim()) {
-      setEditError('名稱不可空白');
-      return;
-    }
-    if (editForm.end_date <= editForm.start_date) {
-      setEditError('結束日期必須晚於開始日期');
-      return;
-    }
-
-    setIsSavingEdit(true);
-    try {
-      await updateSemester(token, schoolId, semId, {
-        name: editForm.name.trim(),
-        start_date: editForm.start_date,
-        end_date: editForm.end_date,
-        grace_days: editForm.grace_days,
-      });
-      setEditingId(null);
-      await load();
-    } catch (err) {
-      setEditError(err instanceof SemesterApiError ? err.message : '儲存失敗');
-    } finally {
-      setIsSavingEdit(false);
-    }
-  };
-
-  // ── Computed expires preview ──────────────────────────────────────────────
-
-  const computeExpires = (end: string, grace: number): string => {
-    if (!end) return '';
-    const d = new Date(end);
-    d.setDate(d.getDate() + grace);
-    return d.toISOString().split('T')[0];
+  const handleCreateSuccess = () => {
+    setShowCreate(false);
+    load();
   };
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -245,7 +73,7 @@ const SemesterPanel: React.FC<SemesterPanelProps> = ({ schoolId }) => {
         </div>
         {!showCreate && (
           <button
-            onClick={() => { setShowCreate(true); setCreateError(''); setCreateForm(DEFAULT_FORM); }}
+            onClick={() => setShowCreate(true)}
             className="flex items-center gap-1.5 px-3 py-1.5 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer"
           >
             <PlusIcon />
@@ -255,91 +83,13 @@ const SemesterPanel: React.FC<SemesterPanelProps> = ({ schoolId }) => {
       </div>
 
       {/* Create form */}
-      {showCreate && (
-        <form
-          onSubmit={handleCreate}
-          className="mb-6 p-4 border border-indigo-200 rounded-xl bg-indigo-50"
-        >
-          <h3 className="text-sm font-semibold text-indigo-700 mb-3">新增學期</h3>
-          <div className="grid grid-cols-2 gap-3 mb-3">
-            <div className="col-span-2">
-              <label className="block text-xs text-gray-600 mb-1">學期名稱</label>
-              <input
-                type="text"
-                placeholder="例：113學年度上學期"
-                value={createForm.name}
-                onChange={e => setCreateForm(f => ({ ...f, name: e.target.value }))}
-                className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-gray-600 mb-1">開始日期</label>
-              <input
-                type="date"
-                value={createForm.start_date}
-                onChange={e => setCreateForm(f => ({ ...f, start_date: e.target.value }))}
-                className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-gray-600 mb-1">結束日期</label>
-              <input
-                type="date"
-                value={createForm.end_date}
-                onChange={e => setCreateForm(f => ({ ...f, end_date: e.target.value }))}
-                className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-              />
-            </div>
-            <div>
-              <label className="block text-xs text-gray-600 mb-1">課文過期寬限天數</label>
-              <input
-                type="number"
-                min={0}
-                max={365}
-                value={createForm.grace_days}
-                onChange={e => setCreateForm(f => ({ ...f, grace_days: Number(e.target.value) }))}
-                className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-              />
-            </div>
-            <div className="flex items-end">
-              {createForm.end_date && (
-                <p className="text-xs text-gray-500">
-                  課文將於 <span className="font-medium text-indigo-600">{computeExpires(createForm.end_date, createForm.grace_days)}</span> 後過期
-                </p>
-              )}
-            </div>
-            <div className="col-span-2">
-              <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={createForm.is_active}
-                  onChange={e => setCreateForm(f => ({ ...f, is_active: e.target.checked }))}
-                  className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                />
-                立即設為目前學期（會停用其他學期）
-              </label>
-            </div>
-          </div>
-          {createError && (
-            <p className="text-red-600 text-xs mb-3">{createError}</p>
-          )}
-          <div className="flex gap-2">
-            <button
-              type="submit"
-              disabled={isCreating}
-              className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors cursor-pointer"
-            >
-              {isCreating ? '建立中...' : '建立'}
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowCreate(false)}
-              className="px-4 py-1.5 bg-white border border-gray-300 text-sm rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
-            >
-              取消
-            </button>
-          </div>
-        </form>
+      {showCreate && token && (
+        <SemesterCreateForm
+          token={token}
+          schoolId={schoolId}
+          onSuccess={handleCreateSuccess}
+          onCancel={() => setShowCreate(false)}
+        />
       )}
 
       {/* Loading */}
@@ -368,127 +118,14 @@ const SemesterPanel: React.FC<SemesterPanelProps> = ({ schoolId }) => {
       )}
 
       {/* Semester list */}
-      {!isLoading && semesters.length > 0 && (
-        <div className="space-y-3">
-          {semesters.map(sem => (
-            <div
-              key={sem.id}
-              className={`border rounded-xl p-4 transition-colors ${
-                sem.is_active
-                  ? 'border-green-300 bg-green-50'
-                  : 'border-gray-200 bg-white'
-              }`}
-            >
-              {editingId === sem.id ? (
-                /* Edit inline form */
-                <div>
-                  <div className="grid grid-cols-2 gap-3 mb-3">
-                    <div className="col-span-2">
-                      <label className="block text-xs text-gray-600 mb-1">學期名稱</label>
-                      <input
-                        type="text"
-                        value={editForm.name}
-                        onChange={e => setEditForm(f => ({ ...f, name: e.target.value }))}
-                        className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-xs text-gray-600 mb-1">開始日期</label>
-                      <input
-                        type="date"
-                        value={editForm.start_date}
-                        onChange={e => setEditForm(f => ({ ...f, start_date: e.target.value }))}
-                        className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-xs text-gray-600 mb-1">結束日期</label>
-                      <input
-                        type="date"
-                        value={editForm.end_date}
-                        onChange={e => setEditForm(f => ({ ...f, end_date: e.target.value }))}
-                        className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-xs text-gray-600 mb-1">寬限天數</label>
-                      <input
-                        type="number"
-                        min={0}
-                        max={365}
-                        value={editForm.grace_days}
-                        onChange={e => setEditForm(f => ({ ...f, grace_days: Number(e.target.value) }))}
-                        className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                      />
-                    </div>
-                    <div className="flex items-end">
-                      {editForm.end_date && (
-                        <p className="text-xs text-gray-500">
-                          過期日：<span className="font-medium text-indigo-600">
-                            {computeExpires(editForm.end_date, editForm.grace_days)}
-                          </span>
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                  {editError && <p className="text-red-600 text-xs mb-2">{editError}</p>}
-                  <div className="flex gap-2">
-                    <button
-                      onClick={() => handleSaveEdit(sem.id)}
-                      disabled={isSavingEdit}
-                      className="px-3 py-1.5 bg-indigo-600 text-white text-xs rounded-lg hover:bg-indigo-700 disabled:opacity-50 cursor-pointer"
-                    >
-                      {isSavingEdit ? '儲存中...' : '儲存'}
-                    </button>
-                    <button
-                      onClick={() => setEditingId(null)}
-                      className="px-3 py-1.5 bg-white border border-gray-300 text-xs rounded-lg hover:bg-gray-50 cursor-pointer"
-                    >
-                      取消
-                    </button>
-                  </div>
-                </div>
-              ) : (
-                /* Display row */
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="font-medium text-gray-800 text-sm">{sem.name}</span>
-                      {sem.is_active && (
-                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs font-medium">
-                          <CheckCircleIcon className="w-3 h-3" />
-                          目前學期
-                        </span>
-                      )}
-                    </div>
-                    <div className="text-xs text-gray-500 space-y-0.5">
-                      <p>學期期間：{formatDate(sem.start_date)} — {formatDate(sem.end_date)}</p>
-                      <p>課文過期日：<span className="text-orange-600 font-medium">{formatDate(sem.expires_at_date)}</span>（寬限 {sem.grace_days} 天）</p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2 shrink-0">
-                    {!sem.is_active && (
-                      <button
-                        onClick={() => handleActivate(sem.id)}
-                        disabled={activatingId === sem.id}
-                        className="px-3 py-1.5 text-xs bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition-colors cursor-pointer"
-                      >
-                        {activatingId === sem.id ? '設定中...' : '設為目前學期'}
-                      </button>
-                    )}
-                    <button
-                      onClick={() => startEdit(sem)}
-                      className="p-1.5 text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors cursor-pointer"
-                      title="編輯"
-                    >
-                      <EditIcon />
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+      {!isLoading && semesters.length > 0 && token && (
+        <SemesterList
+          token={token}
+          schoolId={schoolId}
+          semesters={semesters}
+          onReload={load}
+          onError={setError}
+        />
       )}
 
       {/* Expiry policy note */}

--- a/frontend/src/pages/admin/__tests__/SemesterPanel.test.tsx
+++ b/frontend/src/pages/admin/__tests__/SemesterPanel.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * SemesterPanel refactor characterization tests (Issue #1959)
+ *
+ * TDD contract:
+ *  1. SemesterList renders list of semesters with correct names and active badge
+ *  2. SemesterCreateForm submit calls createSemester with correct payload and reloads
+ *  3. Modal (create form) opens on button click and closes on cancel
+ *  4. Edit inline form: start edit → save → reload; cancel closes form
+ *  5. Activate button calls activateSemester and reloads
+ *
+ * Tests are written against the public behaviour observable from SemesterPanel's
+ * rendered output — agnostic to internal decomposition.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+
+// --- Module mocks -----------------------------------------------------------
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+const mockListSemesters = vi.fn();
+const mockCreateSemester = vi.fn();
+const mockUpdateSemester = vi.fn();
+const mockActivateSemester = vi.fn();
+
+vi.mock('../../../services/semesterApi', () => ({
+  listSemesters: (...args: unknown[]) => mockListSemesters(...args),
+  createSemester: (...args: unknown[]) => mockCreateSemester(...args),
+  updateSemester: (...args: unknown[]) => mockUpdateSemester(...args),
+  activateSemester: (...args: unknown[]) => mockActivateSemester(...args),
+  SemesterApiError: class SemesterApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.name = 'SemesterApiError';
+      this.status = status;
+    }
+  },
+}));
+
+// --- Fixture data -----------------------------------------------------------
+
+const SEMESTER_ACTIVE = {
+  id: 1,
+  school_id: 10,
+  name: '113學年度上學期',
+  start_date: '2024-09-01',
+  end_date: '2025-01-31',
+  grace_days: 7,
+  is_active: true,
+  expires_at_date: '2025-02-07',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+const SEMESTER_INACTIVE = {
+  id: 2,
+  school_id: 10,
+  name: '112學年度下學期',
+  start_date: '2024-02-01',
+  end_date: '2024-06-30',
+  grace_days: 14,
+  is_active: false,
+  expires_at_date: '2024-07-14',
+  created_at: '2023-08-01T00:00:00Z',
+  updated_at: '2023-08-01T00:00:00Z',
+};
+
+// --- Lazy import (after mocks) ---------------------------------------------
+
+let SemesterPanel: React.ComponentType<{ schoolId: number }>;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mockListSemesters.mockResolvedValue([SEMESTER_ACTIVE, SEMESTER_INACTIVE]);
+  mockCreateSemester.mockResolvedValue({ ...SEMESTER_ACTIVE, id: 3 });
+  mockUpdateSemester.mockResolvedValue({ ...SEMESTER_ACTIVE });
+  mockActivateSemester.mockResolvedValue({ ...SEMESTER_INACTIVE, is_active: true });
+
+  // Dynamic import so mocks are applied before module init
+  const mod = await import('../SemesterPanel');
+  SemesterPanel = mod.default;
+});
+
+// ---------------------------------------------------------------------------
+// 1. List render
+// ---------------------------------------------------------------------------
+
+describe('SemesterList — list render', () => {
+  it('renders semester names after load', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('113學年度上學期')).toBeInTheDocument();
+      expect(screen.getByText('112學年度下學期')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "目前學期" badge only on active semester', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    const badges = screen.getAllByText('目前學期');
+    expect(badges).toHaveLength(1);
+  });
+
+  it('shows "設為目前學期" button only for inactive semesters', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('112學年度下學期'));
+
+    const activateBtns = screen.getAllByText('設為目前學期');
+    expect(activateBtns).toHaveLength(1);
+  });
+
+  it('shows empty state when no semesters', async () => {
+    mockListSemesters.mockResolvedValue([]);
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('尚無學期設定')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when load fails', async () => {
+    const { SemesterApiError } = await import('../../../services/semesterApi');
+    mockListSemesters.mockRejectedValue(new SemesterApiError('Server error', 500));
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Create form — modal open/close
+// ---------------------------------------------------------------------------
+
+describe('SemesterCreateForm — modal open/close', () => {
+  it('create form is hidden initially', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    expect(screen.queryByText('新增學期', { selector: 'h3' })).not.toBeInTheDocument();
+  });
+
+  it('clicking "新增學期" button shows the create form', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    const addBtn = screen.getByRole('button', { name: /新增學期/ });
+    fireEvent.click(addBtn);
+
+    expect(screen.getByText('新增學期', { selector: 'h3' })).toBeInTheDocument();
+  });
+
+  it('clicking cancel closes the create form', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    fireEvent.click(screen.getByRole('button', { name: /新增學期/ }));
+    expect(screen.getByText('新增學期', { selector: 'h3' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '取消' }));
+    expect(screen.queryByText('新增學期', { selector: 'h3' })).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Create form — submission
+// ---------------------------------------------------------------------------
+
+describe('SemesterCreateForm — form submit', () => {
+  it('calls createSemester with correct payload and reloads list', async () => {
+    // Second call (after create) returns updated list
+    mockListSemesters
+      .mockResolvedValueOnce([SEMESTER_ACTIVE, SEMESTER_INACTIVE])
+      .mockResolvedValueOnce([SEMESTER_ACTIVE, SEMESTER_INACTIVE, { ...SEMESTER_ACTIVE, id: 3, name: '新學期', is_active: false }]);
+
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    // Open form
+    fireEvent.click(screen.getByRole('button', { name: /新增學期/ }));
+
+    // Fill form
+    const nameInput = screen.getByPlaceholderText('例：113學年度上學期');
+    const [startInput, endInput] = screen.getAllByDisplayValue('').filter(
+      (el): el is HTMLInputElement => el instanceof HTMLInputElement && el.type === 'date'
+    );
+    fireEvent.change(nameInput, { target: { value: '新學期' } });
+    fireEvent.change(startInput, { target: { value: '2025-09-01' } });
+    fireEvent.change(endInput, { target: { value: '2026-01-31' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '建立' }));
+    });
+
+    await waitFor(() => {
+      expect(mockCreateSemester).toHaveBeenCalledWith(
+        'test-token',
+        10,
+        expect.objectContaining({
+          name: '新學期',
+          start_date: '2025-09-01',
+          end_date: '2026-01-31',
+        })
+      );
+    });
+
+    // After create, list reloaded (listSemesters called twice)
+    expect(mockListSemesters).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows validation error when name is empty', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    fireEvent.click(screen.getByRole('button', { name: /新增學期/ }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '建立' }));
+    });
+
+    expect(screen.getByText('請輸入學期名稱')).toBeInTheDocument();
+    expect(mockCreateSemester).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when end_date <= start_date', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    fireEvent.click(screen.getByRole('button', { name: /新增學期/ }));
+
+    const nameInput = screen.getByPlaceholderText('例：113學年度上學期');
+    const dateInputs = screen.getAllByDisplayValue('').filter(
+      (el): el is HTMLInputElement => el instanceof HTMLInputElement && el.type === 'date'
+    );
+    fireEvent.change(nameInput, { target: { value: '測試學期' } });
+    fireEvent.change(dateInputs[0], { target: { value: '2025-09-01' } });
+    fireEvent.change(dateInputs[1], { target: { value: '2025-01-01' } }); // end before start
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '建立' }));
+    });
+
+    expect(screen.getByText('結束日期必須晚於開始日期')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Edit inline form
+// ---------------------------------------------------------------------------
+
+describe('SemesterList — edit inline', () => {
+  it('clicking edit icon shows inline edit form for that semester', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    // There should be edit buttons (one per semester)
+    const editBtns = screen.getAllByTitle('編輯');
+    expect(editBtns.length).toBeGreaterThanOrEqual(1);
+
+    fireEvent.click(editBtns[0]);
+
+    // Edit form shows 儲存 button
+    expect(screen.getByRole('button', { name: '儲存' })).toBeInTheDocument();
+  });
+
+  it('cancel edit closes the inline form', async () => {
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    const editBtns = screen.getAllByTitle('編輯');
+    fireEvent.click(editBtns[0]);
+
+    expect(screen.getByRole('button', { name: '儲存' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '取消' }));
+
+    expect(screen.queryByRole('button', { name: '儲存' })).not.toBeInTheDocument();
+  });
+
+  it('save edit calls updateSemester and reloads', async () => {
+    mockListSemesters
+      .mockResolvedValueOnce([SEMESTER_ACTIVE, SEMESTER_INACTIVE])
+      .mockResolvedValueOnce([{ ...SEMESTER_ACTIVE, name: '113學年度上學期（已更新）' }, SEMESTER_INACTIVE]);
+
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('113學年度上學期'));
+
+    const editBtns = screen.getAllByTitle('編輯');
+    fireEvent.click(editBtns[0]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '儲存' }));
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateSemester).toHaveBeenCalledWith(
+        'test-token',
+        10,
+        SEMESTER_ACTIVE.id,
+        expect.objectContaining({ name: '113學年度上學期' })
+      );
+    });
+
+    expect(mockListSemesters).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Activate
+// ---------------------------------------------------------------------------
+
+describe('activate semester', () => {
+  it('clicking "設為目前學期" calls activateSemester and reloads', async () => {
+    mockListSemesters
+      .mockResolvedValueOnce([SEMESTER_ACTIVE, SEMESTER_INACTIVE])
+      .mockResolvedValueOnce([
+        { ...SEMESTER_ACTIVE, is_active: false },
+        { ...SEMESTER_INACTIVE, is_active: true },
+      ]);
+
+    render(<SemesterPanel schoolId={10} />);
+
+    await waitFor(() => screen.getByText('設為目前學期'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('設為目前學期'));
+    });
+
+    await waitFor(() => {
+      expect(mockActivateSemester).toHaveBeenCalledWith('test-token', 10, SEMESTER_INACTIVE.id);
+    });
+
+    expect(mockListSemesters).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/pages/admin/semester/SemesterCreateForm.tsx
+++ b/frontend/src/pages/admin/semester/SemesterCreateForm.tsx
@@ -1,0 +1,158 @@
+/**
+ * SemesterCreateForm — inline form for creating a new semester.
+ *
+ * Owns its own form state; calls onSuccess() after a successful create.
+ */
+import React, { useState } from 'react';
+import { createSemester, SemesterApiError } from '../../../services/semesterApi';
+import {
+  CreateFormState,
+  DEFAULT_CREATE_FORM,
+  computeExpires,
+} from './semesterTypes';
+
+interface SemesterCreateFormProps {
+  token: string;
+  schoolId: number;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+const SemesterCreateForm: React.FC<SemesterCreateFormProps> = ({
+  token,
+  schoolId,
+  onSuccess,
+  onCancel,
+}) => {
+  const [form, setForm] = useState<CreateFormState>(DEFAULT_CREATE_FORM);
+  const [error, setError] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (!form.name.trim()) {
+      setError('請輸入學期名稱');
+      return;
+    }
+    if (!form.start_date || !form.end_date) {
+      setError('請選擇開始和結束日期');
+      return;
+    }
+    if (form.end_date <= form.start_date) {
+      setError('結束日期必須晚於開始日期');
+      return;
+    }
+
+    setIsCreating(true);
+    try {
+      await createSemester(token, schoolId, {
+        name: form.name.trim(),
+        start_date: form.start_date,
+        end_date: form.end_date,
+        grace_days: form.grace_days,
+        is_active: form.is_active,
+      });
+      setForm(DEFAULT_CREATE_FORM);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof SemesterApiError ? err.message : '建立學期失敗');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mb-6 p-4 border border-indigo-200 rounded-xl bg-indigo-50"
+    >
+      <h3 className="text-sm font-semibold text-indigo-700 mb-3">新增學期</h3>
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div className="col-span-2">
+          <label className="block text-xs text-gray-600 mb-1">學期名稱</label>
+          <input
+            type="text"
+            placeholder="例：113學年度上學期"
+            value={form.name}
+            onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-600 mb-1">開始日期</label>
+          <input
+            type="date"
+            value={form.start_date}
+            onChange={e => setForm(f => ({ ...f, start_date: e.target.value }))}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-600 mb-1">結束日期</label>
+          <input
+            type="date"
+            value={form.end_date}
+            onChange={e => setForm(f => ({ ...f, end_date: e.target.value }))}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-600 mb-1">課文過期寬限天數</label>
+          <input
+            type="number"
+            min={0}
+            max={365}
+            value={form.grace_days}
+            onChange={e => setForm(f => ({ ...f, grace_days: Number(e.target.value) }))}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          />
+        </div>
+        <div className="flex items-end">
+          {form.end_date && (
+            <p className="text-xs text-gray-500">
+              課文將於{' '}
+              <span className="font-medium text-indigo-600">
+                {computeExpires(form.end_date, form.grace_days)}
+              </span>{' '}
+              後過期
+            </p>
+          )}
+        </div>
+        <div className="col-span-2">
+          <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={form.is_active}
+              onChange={e => setForm(f => ({ ...f, is_active: e.target.checked }))}
+              className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            立即設為目前學期（會停用其他學期）
+          </label>
+        </div>
+      </div>
+
+      {error && <p className="text-red-600 text-xs mb-3">{error}</p>}
+
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={isCreating}
+          className="px-4 py-1.5 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-colors cursor-pointer"
+        >
+          {isCreating ? '建立中...' : '建立'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-1.5 bg-white border border-gray-300 text-sm rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
+        >
+          取消
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default SemesterCreateForm;

--- a/frontend/src/pages/admin/semester/SemesterList.tsx
+++ b/frontend/src/pages/admin/semester/SemesterList.tsx
@@ -1,0 +1,218 @@
+/**
+ * SemesterList — sortable list of semesters with inline edit support.
+ *
+ * Renders each semester row with view/edit modes and an activate action.
+ */
+import React, { useState } from 'react';
+import { SemesterResponse, SemesterApiError, updateSemester, activateSemester } from '../../../services/semesterApi';
+import { EditFormState, formatDate, computeExpires } from './semesterTypes';
+import { CheckCircleIcon, EditIcon } from './semesterIcons';
+
+interface SemesterListProps {
+  token: string;
+  schoolId: number;
+  semesters: SemesterResponse[];
+  onReload: () => void;
+  onError: (msg: string) => void;
+}
+
+const SemesterList: React.FC<SemesterListProps> = ({
+  token,
+  schoolId,
+  semesters,
+  onReload,
+  onError,
+}) => {
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editForm, setEditForm] = useState<EditFormState>({
+    name: '',
+    start_date: '',
+    end_date: '',
+    grace_days: 7,
+  });
+  const [editError, setEditError] = useState('');
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+  const [activatingId, setActivatingId] = useState<number | null>(null);
+
+  const startEdit = (sem: SemesterResponse) => {
+    setEditingId(sem.id);
+    setEditForm({
+      name: sem.name,
+      start_date: sem.start_date,
+      end_date: sem.end_date,
+      grace_days: sem.grace_days,
+    });
+    setEditError('');
+  };
+
+  const handleSaveEdit = async (semId: number) => {
+    setEditError('');
+
+    if (!editForm.name.trim()) {
+      setEditError('名稱不可空白');
+      return;
+    }
+    if (editForm.end_date <= editForm.start_date) {
+      setEditError('結束日期必須晚於開始日期');
+      return;
+    }
+
+    setIsSavingEdit(true);
+    try {
+      await updateSemester(token, schoolId, semId, {
+        name: editForm.name.trim(),
+        start_date: editForm.start_date,
+        end_date: editForm.end_date,
+        grace_days: editForm.grace_days,
+      });
+      setEditingId(null);
+      onReload();
+    } catch (err) {
+      setEditError(err instanceof SemesterApiError ? err.message : '儲存失敗');
+    } finally {
+      setIsSavingEdit(false);
+    }
+  };
+
+  const handleActivate = async (semId: number) => {
+    setActivatingId(semId);
+    try {
+      await activateSemester(token, schoolId, semId);
+      onReload();
+    } catch (err) {
+      onError(err instanceof SemesterApiError ? err.message : '啟用學期失敗');
+    } finally {
+      setActivatingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {semesters.map(sem => (
+        <div
+          key={sem.id}
+          className={`border rounded-xl p-4 transition-colors ${
+            sem.is_active
+              ? 'border-green-300 bg-green-50'
+              : 'border-gray-200 bg-white'
+          }`}
+        >
+          {editingId === sem.id ? (
+            /* Edit inline form */
+            <div>
+              <div className="grid grid-cols-2 gap-3 mb-3">
+                <div className="col-span-2">
+                  <label className="block text-xs text-gray-600 mb-1">學期名稱</label>
+                  <input
+                    type="text"
+                    value={editForm.name}
+                    onChange={e => setEditForm(f => ({ ...f, name: e.target.value }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">開始日期</label>
+                  <input
+                    type="date"
+                    value={editForm.start_date}
+                    onChange={e => setEditForm(f => ({ ...f, start_date: e.target.value }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">結束日期</label>
+                  <input
+                    type="date"
+                    value={editForm.end_date}
+                    onChange={e => setEditForm(f => ({ ...f, end_date: e.target.value }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-600 mb-1">寬限天數</label>
+                  <input
+                    type="number"
+                    min={0}
+                    max={365}
+                    value={editForm.grace_days}
+                    onChange={e => setEditForm(f => ({ ...f, grace_days: Number(e.target.value) }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                  />
+                </div>
+                <div className="flex items-end">
+                  {editForm.end_date && (
+                    <p className="text-xs text-gray-500">
+                      過期日：
+                      <span className="font-medium text-indigo-600">
+                        {computeExpires(editForm.end_date, editForm.grace_days)}
+                      </span>
+                    </p>
+                  )}
+                </div>
+              </div>
+              {editError && <p className="text-red-600 text-xs mb-2">{editError}</p>}
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleSaveEdit(sem.id)}
+                  disabled={isSavingEdit}
+                  className="px-3 py-1.5 bg-indigo-600 text-white text-xs rounded-lg hover:bg-indigo-700 disabled:opacity-50 cursor-pointer"
+                >
+                  {isSavingEdit ? '儲存中...' : '儲存'}
+                </button>
+                <button
+                  onClick={() => setEditingId(null)}
+                  className="px-3 py-1.5 bg-white border border-gray-300 text-xs rounded-lg hover:bg-gray-50 cursor-pointer"
+                >
+                  取消
+                </button>
+              </div>
+            </div>
+          ) : (
+            /* Display row */
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-medium text-gray-800 text-sm">{sem.name}</span>
+                  {sem.is_active && (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs font-medium">
+                      <CheckCircleIcon className="w-3 h-3" />
+                      目前學期
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-gray-500 space-y-0.5">
+                  <p>學期期間：{formatDate(sem.start_date)} — {formatDate(sem.end_date)}</p>
+                  <p>
+                    課文過期日：
+                    <span className="text-orange-600 font-medium">{formatDate(sem.expires_at_date)}</span>
+                    （寬限 {sem.grace_days} 天）
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {!sem.is_active && (
+                  <button
+                    onClick={() => handleActivate(sem.id)}
+                    disabled={activatingId === sem.id}
+                    className="px-3 py-1.5 text-xs bg-green-600 text-white rounded-lg hover:bg-green-700 disabled:opacity-50 transition-colors cursor-pointer"
+                  >
+                    {activatingId === sem.id ? '設定中...' : '設為目前學期'}
+                  </button>
+                )}
+                <button
+                  onClick={() => startEdit(sem)}
+                  className="p-1.5 text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors cursor-pointer"
+                  title="編輯"
+                >
+                  <EditIcon />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default SemesterList;

--- a/frontend/src/pages/admin/semester/semesterIcons.tsx
+++ b/frontend/src/pages/admin/semester/semesterIcons.tsx
@@ -1,0 +1,31 @@
+/**
+ * Icon components shared across SemesterPanel sub-components.
+ */
+import React from 'react';
+
+export const CalendarIcon: React.FC<{ className?: string }> = ({ className = 'w-4 h-4' }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+  </svg>
+);
+
+export const PlusIcon: React.FC = () => (
+  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+  </svg>
+);
+
+export const CheckCircleIcon: React.FC<{ className?: string }> = ({ className = 'w-4 h-4' }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+  </svg>
+);
+
+export const EditIcon: React.FC = () => (
+  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+  </svg>
+);

--- a/frontend/src/pages/admin/semester/semesterTypes.ts
+++ b/frontend/src/pages/admin/semester/semesterTypes.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared types for SemesterPanel sub-components.
+ */
+
+export interface CreateFormState {
+  name: string;
+  start_date: string;
+  end_date: string;
+  grace_days: number;
+  is_active: boolean;
+}
+
+export const DEFAULT_CREATE_FORM: CreateFormState = {
+  name: '',
+  start_date: '',
+  end_date: '',
+  grace_days: 7,
+  is_active: false,
+};
+
+export interface EditFormState {
+  name: string;
+  start_date: string;
+  end_date: string;
+  grace_days: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+export function formatDate(iso: string): string {
+  return iso; // already YYYY-MM-DD
+}
+
+export function computeExpires(end: string, grace: number): string {
+  if (!end) return '';
+  const d = new Date(end);
+  d.setDate(d.getDate() + grace);
+  return d.toISOString().split('T')[0];
+}


### PR DESCRIPTION
Fixes #1959

## Summary

Split 505-LOC `SemesterPanel.tsx` into 4 focused modules:

| File | LOC | Responsibility |
|------|-----|----------------|
| `semester/SemesterList.tsx` | ~160 | Sortable list with inline edit + activate |
| `semester/SemesterCreateForm.tsx` | ~110 | New semester modal/inline form, owns its own state |
| `semester/semesterIcons.tsx` | ~30 | Shared SVG icons (Calendar, Plus, CheckCircle, Edit) |
| `semester/semesterTypes.ts` | ~25 | Shared types + helpers (formatDate, computeExpires) |
| `SemesterPanel.tsx` (orchestrator) | ~90 | Owns load state only, delegates to sub-components |

## TDD Evidence

15 characterization tests written FIRST (RED), then implementation (GREEN):

- List render: semester names, active badge, activate button, empty state, error state
- Create form: modal open/close, form submit with correct payload, validation errors
- Edit inline: open/cancel/save with reload
- Activate: calls API and reloads

All 15/15 pass before and after refactor — behavior preserved exactly.

## Test plan

- [ ] Open admin panel > school detail > semester tab
- [ ] Verify semester list renders correctly
- [ ] Create a new semester via "新增學期" button
- [ ] Edit an existing semester inline
- [ ] Activate an inactive semester
- [ ] CI green