### PR TITLE
refactor(full-reading): split FullReading.tsx into 3 UI sub-components (Fixes #1960)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Story, FullReadingResult } from '../../types';
 import { parseReadingBenchmark, getBenchmarkFeedback, getSecBenchmarkFeedback, type ParsedBenchmark } from '../../utils/fluencyAnalyzer';
-import DiffDisplay from '../ui/DiffDisplay';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { useKaraoke } from '../../context/KaraokeContext';
 import { useFullReadingSession, type SavedResult } from '../../hooks/useFullReadingSession';
@@ -12,24 +11,13 @@ import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStor
 import { useAuth } from '../../contexts/AuthContext';
 import { splitZhuyinChars } from '../../utils/zhuyinUtils';
 import { fontForZhuyin } from '../../constants/fonts';
-import ToolboxCompletionActions from '../tools/ToolboxCompletionActions';
 import { groupIdxForProgress } from '../../utils/ttsHighlight';
 import FluencyProgressChart, { type FullReadingAttempt } from './full-reading/FluencyProgressChart';
 import SelfAssessment, { type AssessmentRating } from './full-reading/SelfAssessment';
-
-/* ── Encouragement helper (same tier logic as ParagraphCard) ─────────────── */
-
-const FULL_READING_TIERS: Array<{ min: number; stars: number; text: string; color: string }> = [
-  { min: 0.90, stars: 5, text: '太厲害了！', color: 'text-emerald-600' },
-  { min: 0.75, stars: 4, text: '唸得很流暢！', color: 'text-green-600' },
-  { min: 0.60, stars: 3, text: '繼續練習！', color: 'text-green-600' },
-  { min: 0,    stars: 2, text: '再多練幾次就會更熟～', color: 'text-amber-600' },
-];
-
-function getFullReadingEncouragement(matchRate: number): { stars: number; text: string; color: string } {
-  const tier = FULL_READING_TIERS.find(t => matchRate >= t.min) ?? FULL_READING_TIERS[FULL_READING_TIERS.length - 1];
-  return { stars: tier.stars, text: tier.text, color: tier.color };
-}
+// Issue #1960: extracted sub-components
+import FullReadingControls, { type ControlState } from './full-reading/FullReadingControls';
+import FullReadingScoreCard from './full-reading/FullReadingScoreCard';
+import FullReadingFeedbackPanel from './full-reading/FullReadingFeedbackPanel';
 
 /* ------------------------------------------------------------------ */
 
@@ -212,6 +200,31 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     setShowComparison(false);
   }, [storageKey, setResult, setStreamingTranscript, audioRecorder]);
 
+  const handleFinish = useCallback(() => {
+    if (!result) return;
+    try { localStorage.removeItem(storageKey); } catch {}
+    onFinish({
+      matchRate: result.matchRate,
+      feedback: result.feedback,
+      diffTokens: result.diffTokens,
+      transcript: streamingTranscript,
+      cpm: result.cpm,
+      durationMs: result.durationMs,
+      errorBreakdown: result.errorBreakdown,
+    });
+  }, [result, storageKey, streamingTranscript, onFinish]);
+
+  /* ── Derive control state for FullReadingControls ─────────────────── */
+  const controlState: ControlState = result
+    ? 'result'
+    : isPreparing
+    ? 'preparing'
+    : isSessionActive
+    ? 'recording'
+    : isTtsPlaying
+    ? 'ttsPlaying'
+    : 'idle';
+
   /* ================================================================ */
   /*  JSX                                                             */
   /* ================================================================ */
@@ -292,54 +305,15 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
           {/* ── Result section ──────────────────────────────────────── */}
           {result && (
             <div ref={resultRef} className="mt-6 space-y-6">
-              {/* Encouragement — no numbers shown to student (Issues #1094, #1097) */}
-              {(() => {
-                const enc = getFullReadingEncouragement(result.matchRate);
-                return (
-                  <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 flex flex-col items-center gap-3">
-                    <div className="flex gap-1">
-                      {Array.from({ length: 5 }).map((_, i) => (
-                        <span
-                          key={i}
-                          className={`material-symbols-outlined text-3xl transition-colors ${
-                            i < enc.stars ? 'text-amber-400' : 'text-on-surface-variant/20'
-                          }`}
-                          style={{ fontVariationSettings: i < enc.stars ? "'FILL' 1" : "'FILL' 0" }}
-                        >
-                          star
-                        </span>
-                      ))}
-                    </div>
-                    <p className={`text-xl font-headline font-bold text-center ${enc.color}`}>
-                      {enc.text}
-                    </p>
-                  </div>
-                );
-              })()}
+              {/* Stars + encouragement + transcript + audio (Issue #1960 — FullReadingScoreCard) */}
+              <FullReadingScoreCard
+                result={result}
+                streamingTranscript={streamingTranscript}
+                audioUrl={audioRecorder.audioUrl ?? null}
+              />
 
-              {/* Transcript */}
-              {streamingTranscript && (
-                <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
-                  <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">你說的</p>
-                  <p className="text-base text-on-surface leading-relaxed line-clamp-6">{streamingTranscript}</p>
-                </div>
-              )}
-
-              {/* Diff display */}
-              {result.diffTokens && result.diffTokens.length > 0 && (
-                <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
-                  <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">逐字比對</p>
-                  <DiffDisplay tokens={result.diffTokens} showLegend className="text-lg" />
-                </div>
-              )}
-
-              {/* Audio playback */}
-              {audioRecorder.audioUrl && (
-                <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
-                  <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">重聽錄音</p>
-                  <audio src={audioRecorder.audioUrl} controls className="w-full h-10" aria-label="播放您的朗讀錄音" />
-                </div>
-              )}
+              {/* 逐字比對 diff (Issue #1960 — FullReadingFeedbackPanel) */}
+              <FullReadingFeedbackPanel diffTokens={result.diffTokens} />
 
               {/* 正確率 + 語速 metrics card (Issue #1505) */}
               <ReadingMetricsCard
@@ -383,108 +357,21 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
         </div>
       )}
 
-      {/* ── Fixed bottom CTA ──────────────────────────────────────────── */}
-      <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
-           style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
-        <div className="max-w-md mx-auto pointer-events-auto flex flex-col items-center gap-3">
-
-          {result ? (
-            inToolbox ? (
-              <ToolboxCompletionActions
-                onRetry={handleRetry}
-                className="w-full"
-              />
-            ) : (
-              <>
-                <button
-                  onClick={handleRetry}
-                  className="w-full h-12 rounded-full font-headline font-bold text-base text-on-surface bg-surface-container-lowest shadow-editorial hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-                >
-                  <span className="material-symbols-outlined text-lg">refresh</span>
-                  再讀一次
-                </button>
-                <button
-                  onClick={() => {
-                    try { localStorage.removeItem(storageKey); } catch {}
-                    onFinish({
-                      matchRate: result.matchRate,
-                      feedback: result.feedback,
-                      diffTokens: result.diffTokens,
-                      transcript: streamingTranscript,
-                      cpm: result.cpm,
-                      durationMs: result.durationMs,
-                      errorBreakdown: result.errorBreakdown,
-                    });
-                  }}
-                  className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-                  style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
-                >
-                  <span>下一關</span>
-                  <span className="material-symbols-outlined text-xl">arrow_forward</span>
-                </button>
-              </>
-            )
-          ) : isPreparing ? (
-            <button disabled className="w-full h-14 rounded-full font-headline font-bold text-lg bg-surface-container-high text-on-surface-variant cursor-wait flex items-center justify-center gap-2">
-              <div className="w-4 h-4 border-2 border-on-surface-variant border-t-transparent rounded-full animate-spin" />
-              準備中...
-            </button>
-          ) : isSessionActive ? (
-            <button
-              onClick={submitReading}
-              disabled={!sessionTranscript}
-              className={`w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] ${
-                sessionTranscript
-                  ? 'text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)]'
-                  : 'bg-surface-container-high text-on-surface-variant cursor-not-allowed'
-              }`}
-              style={sessionTranscript ? { background: 'linear-gradient(135deg, #006947, #34d399)' } : undefined}
-            >
-              <span className="material-symbols-outlined text-xl">check</span>
-              完成朗讀
-            </button>
-          ) : isTtsPlaying ? (
-            /* TTS playing — show pause/stop controls */
-            <div className="w-full flex gap-3">
-              <button
-                onClick={tts.isTtsPaused ? tts.resumeTts : tts.pauseTts}
-                className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-accent/10 text-accent hover:bg-accent/15 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-              >
-                <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>
-                  {tts.isTtsPaused ? 'play_arrow' : 'pause'}
-                </span>
-                {tts.isTtsPaused ? '繼續' : '暫停'}
-              </button>
-              <button
-                onClick={stopTtsAll}
-                className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-              >
-                <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>stop</span>
-                停止
-              </button>
-            </div>
-          ) : (
-            /* Idle — AI朗讀 + 開始朗讀 side by side */
-            <div className="w-full flex gap-3">
-              <button
-                onClick={speakFullStory}
-                className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
-              >
-                <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>volume_up</span>
-                AI 朗讀
-              </button>
-              <button
-                onClick={startSession}
-                className="flex-1 h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-3 animate-pulse"
-                style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
-              >
-                <span className="material-symbols-outlined text-2xl" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
-                開始朗讀
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
+      {/* ── Fixed bottom CTA (Issue #1960 — FullReadingControls) ────── */}
+      <FullReadingControls
+        state={controlState}
+        onSpeak={speakFullStory}
+        onStartSession={startSession}
+        onSubmit={submitReading}
+        onStopTts={stopTtsAll}
+        onPauseTts={tts.pauseTts}
+        onResumeTts={tts.resumeTts}
+        onRetry={handleRetry}
+        onFinish={handleFinish}
+        isTtsPaused={tts.isTtsPaused}
+        sessionTranscriptReady={!!sessionTranscript}
+        inToolbox={inToolbox}
+      />
 
       {/* Background decoration */}
       <div className="fixed top-0 right-0 -z-10 w-96 h-96 bg-accent/5 rounded-full blur-[100px] pointer-events-none" />

--- a/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
@@ -1,0 +1,151 @@
+/**
+ * FullReadingControls — Fixed bottom CTA buttons for FullReading (Issue #1960).
+ *
+ * Extracted from FullReading.tsx to own the state-machine button rendering:
+ *   idle       → AI 朗讀 + 開始朗讀
+ *   preparing  → 準備中... (disabled)
+ *   recording  → 完成朗讀 (enabled when transcript ready)
+ *   ttsPlaying → 暫停/繼續 + 停止
+ *   result     → 再讀一次 + 下一關  (or ToolboxCompletionActions)
+ */
+
+import React from 'react';
+import ToolboxCompletionActions from '../../tools/ToolboxCompletionActions';
+
+export type ControlState = 'idle' | 'preparing' | 'recording' | 'ttsPlaying' | 'result';
+
+export interface FullReadingControlsProps {
+  state: ControlState;
+  /** Called when user clicks AI 朗讀 */
+  onSpeak: () => void;
+  /** Called when user clicks 開始朗讀 */
+  onStartSession: () => void;
+  /** Called when user clicks 完成朗讀 */
+  onSubmit: () => void;
+  /** Called when user clicks 停止 (TTS) */
+  onStopTts: () => void;
+  /** Called when user clicks 暫停 (TTS playing, not paused) */
+  onPauseTts: () => void;
+  /** Called when user clicks 繼續 (TTS paused) */
+  onResumeTts: () => void;
+  /** Called when user clicks 再讀一次 */
+  onRetry: () => void;
+  /** Called when user clicks 下一關 */
+  onFinish: () => void;
+  /** Whether TTS is currently paused (toggle text 暫停 ↔ 繼續) */
+  isTtsPaused: boolean;
+  /** Whether any STT transcript exists (enables 完成朗讀 button) */
+  sessionTranscriptReady: boolean;
+  /** When true, shows ToolboxCompletionActions instead of 再讀一次 / 下一關 */
+  inToolbox: boolean;
+}
+
+const FullReadingControls: React.FC<FullReadingControlsProps> = ({
+  state,
+  onSpeak,
+  onStartSession,
+  onSubmit,
+  onStopTts,
+  onPauseTts,
+  onResumeTts,
+  onRetry,
+  onFinish,
+  isTtsPaused,
+  sessionTranscriptReady,
+  inToolbox,
+}) => {
+  return (
+    <div
+      className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+      style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}
+    >
+      <div className="max-w-md mx-auto pointer-events-auto flex flex-col items-center gap-3">
+        {state === 'result' ? (
+          inToolbox ? (
+            <ToolboxCompletionActions onRetry={onRetry} className="w-full" />
+          ) : (
+            <>
+              <button
+                onClick={onRetry}
+                className="w-full h-12 rounded-full font-headline font-bold text-base text-on-surface bg-surface-container-lowest shadow-editorial hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+              >
+                <span className="material-symbols-outlined text-lg">refresh</span>
+                再讀一次
+              </button>
+              <button
+                onClick={onFinish}
+                className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+                style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+              >
+                <span>下一關</span>
+                <span className="material-symbols-outlined text-xl">arrow_forward</span>
+              </button>
+            </>
+          )
+        ) : state === 'preparing' ? (
+          <button
+            disabled
+            className="w-full h-14 rounded-full font-headline font-bold text-lg bg-surface-container-high text-on-surface-variant cursor-wait flex items-center justify-center gap-2"
+          >
+            <div className="w-4 h-4 border-2 border-on-surface-variant border-t-transparent rounded-full animate-spin" />
+            準備中...
+          </button>
+        ) : state === 'recording' ? (
+          <button
+            onClick={onSubmit}
+            disabled={!sessionTranscriptReady}
+            className={`w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] ${
+              sessionTranscriptReady
+                ? 'text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)]'
+                : 'bg-surface-container-high text-on-surface-variant cursor-not-allowed'
+            }`}
+            style={sessionTranscriptReady ? { background: 'linear-gradient(135deg, #006947, #34d399)' } : undefined}
+          >
+            <span className="material-symbols-outlined text-xl">check</span>
+            完成朗讀
+          </button>
+        ) : state === 'ttsPlaying' ? (
+          <div className="w-full flex gap-3">
+            <button
+              onClick={isTtsPaused ? onResumeTts : onPauseTts}
+              className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-accent/10 text-accent hover:bg-accent/15 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+            >
+              <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>
+                {isTtsPaused ? 'play_arrow' : 'pause'}
+              </span>
+              {isTtsPaused ? '繼續' : '暫停'}
+            </button>
+            <button
+              onClick={onStopTts}
+              className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+            >
+              <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>stop</span>
+              停止
+            </button>
+          </div>
+        ) : (
+          /* idle */
+          <div className="w-full flex gap-3">
+            <button
+              onClick={onSpeak}
+              className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+            >
+              <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>volume_up</span>
+              AI 朗讀
+            </button>
+            <button
+              onClick={onStartSession}
+              className="flex-1 h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-3 animate-pulse"
+              style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
+            >
+              <span className="material-symbols-outlined text-2xl" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
+              開始朗讀
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FullReadingControls;

--- a/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
@@ -1,0 +1,34 @@
+/**
+ * FullReadingFeedbackPanel — Per-token diff display (Issue #1960).
+ *
+ * Extracted from FullReading.tsx result section.
+ * Renders the 逐字比對 card using DiffDisplay when diffTokens are present.
+ *
+ * Intentionally minimal: only renders when tokens exist and length > 0.
+ */
+
+import React from 'react';
+import DiffDisplay from '../../ui/DiffDisplay';
+
+export interface DiffToken {
+  type: string;
+  text: string;
+}
+
+export interface FullReadingFeedbackPanelProps {
+  /** Token array from analyzeFluency. undefined or empty → renders nothing. */
+  diffTokens: DiffToken[] | undefined;
+}
+
+const FullReadingFeedbackPanel: React.FC<FullReadingFeedbackPanelProps> = ({ diffTokens }) => {
+  if (!diffTokens || diffTokens.length === 0) return null;
+
+  return (
+    <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
+      <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">逐字比對</p>
+      <DiffDisplay tokens={diffTokens} showLegend className="text-lg" />
+    </div>
+  );
+};
+
+export default FullReadingFeedbackPanel;

--- a/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
@@ -1,0 +1,90 @@
+/**
+ * FullReadingScoreCard — Star encouragement + transcript + audio playback (Issue #1960).
+ *
+ * Extracted from FullReading.tsx result section:
+ *   - Star encouragement (5/4/3/2 stars based on matchRate)
+ *   - 你說的 streaming transcript (optional)
+ *   - 重聽錄音 audio playback (optional)
+ *
+ * Note: DiffDisplay (逐字比對) is intentionally kept in FullReadingFeedbackPanel
+ * to keep this component focused on the summary score + playback.
+ */
+
+import React from 'react';
+
+const FULL_READING_TIERS: Array<{ min: number; stars: number; text: string; color: string }> = [
+  { min: 0.90, stars: 5, text: '太厲害了！',         color: 'text-emerald-600' },
+  { min: 0.75, stars: 4, text: '唸得很流暢！',       color: 'text-green-600'   },
+  { min: 0.60, stars: 3, text: '繼續練習！',         color: 'text-green-600'   },
+  { min: 0,    stars: 2, text: '再多練幾次就會更熟～', color: 'text-amber-600'   },
+];
+
+export function getFullReadingEncouragement(matchRate: number): { stars: number; text: string; color: string } {
+  const tier = FULL_READING_TIERS.find(t => matchRate >= t.min) ?? FULL_READING_TIERS[FULL_READING_TIERS.length - 1];
+  return { stars: tier.stars, text: tier.text, color: tier.color };
+}
+
+export interface FullReadingScoreCardProps {
+  result: {
+    matchRate: number;
+    feedback: string;
+    diffTokens?: Array<{ type: string; text: string }>;
+    cpm: number;
+    durationMs: number;
+    errorBreakdown: { correct: number; wrong: number; missing: number; extra: number };
+  };
+  /** The streaming transcript text after STT. Empty string → no section shown. */
+  streamingTranscript: string;
+  /** Blob URL for the recorded audio. null → no audio section shown. */
+  audioUrl: string | null;
+}
+
+const FullReadingScoreCard: React.FC<FullReadingScoreCardProps> = ({
+  result,
+  streamingTranscript,
+  audioUrl,
+}) => {
+  const enc = getFullReadingEncouragement(result.matchRate);
+
+  return (
+    <>
+      {/* Encouragement stars (Issues #1094, #1097 — no raw numbers shown to students) */}
+      <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 flex flex-col items-center gap-3">
+        <div className="flex gap-1">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <span
+              key={i}
+              className={`material-symbols-outlined text-3xl transition-colors ${
+                i < enc.stars ? 'text-amber-400' : 'text-on-surface-variant/20'
+              }`}
+              style={{ fontVariationSettings: i < enc.stars ? "'FILL' 1" : "'FILL' 0" }}
+            >
+              star
+            </span>
+          ))}
+        </div>
+        <p className={`text-xl font-headline font-bold text-center ${enc.color}`}>
+          {enc.text}
+        </p>
+      </div>
+
+      {/* 你說的 transcript */}
+      {streamingTranscript && (
+        <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
+          <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">你說的</p>
+          <p className="text-base text-on-surface leading-relaxed line-clamp-6">{streamingTranscript}</p>
+        </div>
+      )}
+
+      {/* 重聽錄音 audio playback */}
+      {audioUrl && (
+        <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
+          <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">重聽錄音</p>
+          <audio src={audioUrl} controls className="w-full h-10" aria-label="播放您的朗讀錄音" />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default FullReadingScoreCard;

--- a/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
+++ b/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
@@ -1,0 +1,339 @@
+/**
+ * Characterization tests for FullReading UI sub-panels (Issue #1960).
+ *
+ * TDD-first: written BEFORE the components exist so they fail (RED),
+ * then pass once the components are extracted (GREEN).
+ *
+ * Panels under test:
+ *   - FullReadingControls  — play/record/restart buttons
+ *   - FullReadingScoreCard — star encouragement + transcript + diff
+ *   - FullReadingFeedbackPanel — per-paragraph feedback display
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ── 1. FullReadingControls ────────────────────────────────────────────────────
+import FullReadingControls from '../FullReadingControls';
+
+describe('FullReadingControls', () => {
+  const noop = () => {};
+
+  it('renders AI朗讀 and 開始朗讀 buttons in idle state', () => {
+    render(
+      <FullReadingControls
+        state="idle"
+        onSpeak={noop}
+        onStartSession={noop}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={noop}
+        onFinish={noop}
+        isTtsPaused={false}
+        sessionTranscriptReady={false}
+        inToolbox={false}
+      />
+    );
+    expect(screen.getByText('AI 朗讀')).toBeInTheDocument();
+    expect(screen.getByText('開始朗讀')).toBeInTheDocument();
+  });
+
+  it('calls onStartSession when 開始朗讀 is clicked', () => {
+    const onStartSession = vi.fn();
+    render(
+      <FullReadingControls
+        state="idle"
+        onSpeak={noop}
+        onStartSession={onStartSession}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={noop}
+        onFinish={noop}
+        isTtsPaused={false}
+        sessionTranscriptReady={false}
+        inToolbox={false}
+      />
+    );
+    fireEvent.click(screen.getByText('開始朗讀'));
+    expect(onStartSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders 完成朗讀 button when recording is active', () => {
+    render(
+      <FullReadingControls
+        state="recording"
+        onSpeak={noop}
+        onStartSession={noop}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={noop}
+        onFinish={noop}
+        isTtsPaused={false}
+        sessionTranscriptReady={true}
+        inToolbox={false}
+      />
+    );
+    expect(screen.getByText('完成朗讀')).toBeInTheDocument();
+  });
+
+  it('renders 準備中... button when preparing', () => {
+    render(
+      <FullReadingControls
+        state="preparing"
+        onSpeak={noop}
+        onStartSession={noop}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={noop}
+        onFinish={noop}
+        isTtsPaused={false}
+        sessionTranscriptReady={false}
+        inToolbox={false}
+      />
+    );
+    expect(screen.getByText('準備中...')).toBeInTheDocument();
+  });
+
+  it('renders TTS controls when playing', () => {
+    render(
+      <FullReadingControls
+        state="ttsPlaying"
+        onSpeak={noop}
+        onStartSession={noop}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={noop}
+        onFinish={noop}
+        isTtsPaused={false}
+        sessionTranscriptReady={false}
+        inToolbox={false}
+      />
+    );
+    expect(screen.getByText('暫停')).toBeInTheDocument();
+    expect(screen.getByText('停止')).toBeInTheDocument();
+  });
+
+  it('shows 繼續 when TTS is paused', () => {
+    render(
+      <FullReadingControls
+        state="ttsPlaying"
+        onSpeak={noop}
+        onStartSession={noop}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={noop}
+        onFinish={noop}
+        isTtsPaused={true}
+        sessionTranscriptReady={false}
+        inToolbox={false}
+      />
+    );
+    expect(screen.getByText('繼續')).toBeInTheDocument();
+  });
+
+  it('renders 再讀一次 and 下一關 when result is available', () => {
+    render(
+      <FullReadingControls
+        state="result"
+        onSpeak={noop}
+        onStartSession={noop}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={noop}
+        onFinish={noop}
+        isTtsPaused={false}
+        sessionTranscriptReady={false}
+        inToolbox={false}
+      />
+    );
+    expect(screen.getByText('再讀一次')).toBeInTheDocument();
+    expect(screen.getByText('下一關')).toBeInTheDocument();
+  });
+
+  it('calls onRetry when 再讀一次 is clicked', () => {
+    const onRetry = vi.fn();
+    render(
+      <FullReadingControls
+        state="result"
+        onSpeak={noop}
+        onStartSession={noop}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={onRetry}
+        onFinish={noop}
+        isTtsPaused={false}
+        sessionTranscriptReady={false}
+        inToolbox={false}
+      />
+    );
+    fireEvent.click(screen.getByText('再讀一次'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onFinish when 下一關 is clicked', () => {
+    const onFinish = vi.fn();
+    render(
+      <FullReadingControls
+        state="result"
+        onSpeak={noop}
+        onStartSession={noop}
+        onSubmit={noop}
+        onStopTts={noop}
+        onPauseTts={noop}
+        onResumeTts={noop}
+        onRetry={noop}
+        onFinish={onFinish}
+        isTtsPaused={false}
+        sessionTranscriptReady={false}
+        inToolbox={false}
+      />
+    );
+    fireEvent.click(screen.getByText('下一關'));
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── 2. FullReadingScoreCard ───────────────────────────────────────────────────
+import FullReadingScoreCard from '../FullReadingScoreCard';
+
+describe('FullReadingScoreCard', () => {
+  const baseResult = {
+    matchRate: 0.92,
+    feedback: '很好',
+    diffTokens: [{ type: 'correct', text: '你好' }],
+    cpm: 120,
+    durationMs: 5000,
+    errorBreakdown: { correct: 10, wrong: 0, missing: 0, extra: 0 },
+  };
+
+  it('renders 5 stars and encouragement text for high match rate', () => {
+    render(
+      <FullReadingScoreCard
+        result={baseResult}
+        streamingTranscript="你好世界"
+        audioUrl={null}
+      />
+    );
+    // 5 stars rendered (material-symbols star icons)
+    const stars = document.querySelectorAll('.material-symbols-outlined');
+    expect(stars.length).toBeGreaterThanOrEqual(5);
+    // Encouragement text for 0.92 → 5 stars
+    expect(screen.getByText('太厲害了！')).toBeInTheDocument();
+  });
+
+  it('shows 你說的 transcript section when transcript is provided', () => {
+    render(
+      <FullReadingScoreCard
+        result={baseResult}
+        streamingTranscript="你好世界"
+        audioUrl={null}
+      />
+    );
+    expect(screen.getByText('你說的')).toBeInTheDocument();
+    expect(screen.getByText('你好世界')).toBeInTheDocument();
+  });
+
+  it('does not render transcript section when transcript is empty', () => {
+    render(
+      <FullReadingScoreCard
+        result={baseResult}
+        streamingTranscript=""
+        audioUrl={null}
+      />
+    );
+    expect(screen.queryByText('你說的')).not.toBeInTheDocument();
+  });
+
+  it('renders audio element when audioUrl is provided', () => {
+    const { container } = render(
+      <FullReadingScoreCard
+        result={baseResult}
+        streamingTranscript=""
+        audioUrl="blob:test-url"
+      />
+    );
+    const audio = container.querySelector('audio');
+    expect(audio).toBeInTheDocument();
+    expect(audio?.src).toContain('test-url');
+  });
+
+  it('does not render audio element when audioUrl is null', () => {
+    const { container } = render(
+      <FullReadingScoreCard
+        result={baseResult}
+        streamingTranscript=""
+        audioUrl={null}
+      />
+    );
+    expect(container.querySelector('audio')).not.toBeInTheDocument();
+  });
+
+  it('renders correct encouragement for mid match rate (0.78 → 4 stars)', () => {
+    render(
+      <FullReadingScoreCard
+        result={{ ...baseResult, matchRate: 0.78 }}
+        streamingTranscript=""
+        audioUrl={null}
+      />
+    );
+    expect(screen.getByText('唸得很流暢！')).toBeInTheDocument();
+  });
+
+  it('renders correct encouragement for low match rate (0.3 → 2 stars)', () => {
+    render(
+      <FullReadingScoreCard
+        result={{ ...baseResult, matchRate: 0.3 }}
+        streamingTranscript=""
+        audioUrl={null}
+      />
+    );
+    expect(screen.getByText('再多練幾次就會更熟～')).toBeInTheDocument();
+  });
+});
+
+// ── 3. FullReadingFeedbackPanel ───────────────────────────────────────────────
+import FullReadingFeedbackPanel from '../FullReadingFeedbackPanel';
+
+describe('FullReadingFeedbackPanel', () => {
+  it('renders diff section when diffTokens are present', () => {
+    const diffTokens = [
+      { type: 'correct', text: '你好' },
+      { type: 'wrong', text: '世界' },
+    ];
+    render(
+      <FullReadingFeedbackPanel diffTokens={diffTokens} />
+    );
+    expect(screen.getByText('逐字比對')).toBeInTheDocument();
+  });
+
+  it('does not render diff section when diffTokens is empty', () => {
+    render(
+      <FullReadingFeedbackPanel diffTokens={[]} />
+    );
+    expect(screen.queryByText('逐字比對')).not.toBeInTheDocument();
+  });
+
+  it('does not render diff section when diffTokens is undefined', () => {
+    render(
+      <FullReadingFeedbackPanel diffTokens={undefined} />
+    );
+    expect(screen.queryByText('逐字比對')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1960

## Summary

Residual UI component refactor after #1880 extracted STT/TTS/persistence hooks.

Extracted 3 sub-components from FullReading.tsx:

- FullReadingControls: 5-state CTA button machine (idle/preparing/recording/ttsPlaying/result). Takes typed ControlState prop and all callbacks.
- FullReadingScoreCard: Star encouragement (matchRate -> 2-5 stars) + transcript + audio playback.
- FullReadingFeedbackPanel: diff display via DiffDisplay. Renders nothing when diffTokens is empty/undefined.

FullReading.tsx: 503 -> 390 LOC (-22%). Now an orchestrator composing hooks + sub-components.

## Test plan

- [x] TDD: 19 new characterization tests in __tests__/FullReadingPanels.test.tsx written RED before components, now GREEN
- [x] Existing 10 hook-contract tests (fullReading.test.ts) still pass - 29/29 total
- [x] Pre-existing test failures (ClassroomDetail, e2e, OmoIdentifyResult) are unrelated to this PR
- [x] TypeScript: ControlState union exported for parent use

## Files changed

- frontend/src/components/reading-steps/FullReading.tsx (503 -> 390 LOC)
- frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx (new)
- frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx (new)
- frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx (new)
- frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx (new, 19 tests)