### PR TITLE
refactor(listening): split ListeningPractice.tsx into 4 modules (Fixes #1956)

### DIFF
--- a/frontend/src/components/reading-steps/ListeningPractice.tsx
+++ b/frontend/src/components/reading-steps/ListeningPractice.tsx
@@ -1,22 +1,28 @@
 /**
- * ListeningPractice — Issue #251 / #764
+ * ListeningPractice — Issue #251 / #764 / #1956
  *
  * Three-phase listening comprehension exercise:
  *   Phase 1: Play story text via Azure TTS (zh-TW), paragraph by paragraph
  *   Phase 2: Student retells what they heard (voice or text input)
  *   Phase 3: Show AI evaluation with score and feedback
+ *
+ * Refactored (#1956): Orchestrator only.
+ *   - TTS state machine → useTTSEngine
+ *   - Phase 2 Q/A UI → ListeningQuestionPanel
+ *   - Phase 3 results → ListeningScoring
  */
 
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Story } from '../../types';
 import { evaluateListeningRetelling, ListeningEvaluateResponse } from '../../services/learningApi';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { useAuth } from '../../contexts/AuthContext';
 import { useZhuyin } from '../../context/ZhuyinContext';
-import { speakTextWithProgress, cancelTts, TtsProgressInfo } from '../../services/ttsApi';
-import { encourageAccuracy } from '../../utils/encouragement';
 import { isToolboxMode } from '../../services/learningStorageScope';
 import ToolboxCompletionActions from '../tools/ToolboxCompletionActions';
+import { useTTSEngine } from './listening/useTTSEngine';
+import ListeningQuestionPanel from './listening/ListeningQuestionPanel';
+import ListeningScoring from './listening/ListeningScoring';
 
 export interface ListeningResult {
   score: number;
@@ -32,48 +38,24 @@ interface ListeningPracticeProps {
 }
 
 type Phase = 'play' | 'retell' | 'results';
-type PlayState = 'idle' | 'playing' | 'paused' | 'done';
-type ParagraphPlayState = 'idle' | 'playing' | 'between' | 'done';
-
-function createSpeaker(text: string, _rate: number) {
-  const start = (
-    onEnd: () => void,
-    onError: (e: string) => void,
-    onProgress: (info: TtsProgressInfo) => void,
-  ) => {
-    speakTextWithProgress(text, onProgress)
-      .then(onEnd)
-      .catch((err: Error) => onError(err?.message ?? 'speech error'));
-  };
-  return { start, cancel: () => cancelTts() };
-}
-
-function scoreColour(score: number): string {
-  if (score >= 80) return 'text-emerald-700';
-  if (score >= 60) return 'text-amber-700';
-  return 'text-tertiary';
-}
 
 const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, onBack }) => {
   const { token } = useAuth();
   const { zhuyinActive, processZhuyin } = useZhuyin();
 
   const [phase, setPhase] = useState<Phase>('play');
-  const [playState, setPlayState] = useState<PlayState>('idle');
-  const [playRate, setPlayRate] = useState(0.85);
-  const [ttsError, setTtsError] = useState<string | null>(null);
-  const [ttsProgress, setTtsProgress] = useState<TtsProgressInfo | null>(null);
-  const speakerRef = useRef<ReturnType<typeof createSpeaker> | null>(null);
-
-  const paragraphs = story.content;
-  const [paragraphIdx, setParagraphIdx] = useState(0);
-  const [paragraphPlayState, setParagraphPlayState] = useState<ParagraphPlayState>('idle');
-
   const [retelling, setRetelling] = useState('');
   const [retellMode, setRetellMode] = useState<'text' | 'voice'>('text');
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isEvaluating, setIsEvaluating] = useState(false);
   const [evalResult, setEvalResult] = useState<ListeningEvaluateResponse | null>(null);
+
+  const paragraphs = story.content;
+  const fullText = story.content.join('\n');
+  const zh = (text: string) => zhuyinActive ? processZhuyin(text) : text;
+
+  // ── TTS Engine (Phase 1) ───────────────────────────────────────────
+  const tts = useTTSEngine(paragraphs, () => setPhase('retell'));
 
   const {
     status: speechStatus, isSupported: speechSupported,
@@ -81,50 +63,6 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
   } = useSpeechRecognition('zh-TW', (finalText) => {
     setRetelling((prev) => (prev ? prev + ' ' + finalText : finalText).trim());
   });
-
-  useEffect(() => { return () => { speakerRef.current?.cancel(); }; }, []);
-
-  const fullText = story.content.join('\n');
-  const zh = (text: string) => zhuyinActive ? processZhuyin(text) : text;
-  // ── Phase 1: Playback ──────────────────────────────────────────────
-  const playParagraph = useCallback((idx: number) => {
-    const text = paragraphs[idx];
-    if (!text) return;
-    setTtsError(null); setTtsProgress(null);
-    setPlayState('playing'); setParagraphPlayState('playing');
-    const speaker = createSpeaker(text, playRate);
-    speakerRef.current = speaker;
-    speaker.start(
-      () => {
-        setPlayState('done'); setTtsProgress(null);
-        if (idx >= paragraphs.length - 1) setParagraphPlayState('done');
-        else setParagraphPlayState('between');
-      },
-      (errMsg) => { setTtsError(`播放發生錯誤：${errMsg}`); setPlayState('idle'); setTtsProgress(null); setParagraphPlayState('idle'); },
-      (info) => setTtsProgress(info),
-    );
-  }, [paragraphs, playRate]);
-
-  const handlePlay = useCallback(() => playParagraph(paragraphIdx), [playParagraph, paragraphIdx]);
-  const handleContinueNext = useCallback(() => {
-    const next = paragraphIdx + 1;
-    if (next >= paragraphs.length) { setParagraphPlayState('done'); return; }
-    setParagraphIdx(next);
-    // Brief delay lets React commit the new paragraphIdx before TTS starts,
-    // ensuring highlight state stays in sync with the playing paragraph.
-    setTimeout(() => playParagraph(next), 50);
-  }, [paragraphIdx, paragraphs.length, playParagraph]);
-  const handlePause = useCallback(() => { cancelTts(); setPlayState('paused'); setTtsProgress(null); }, []);
-  const handleResume = useCallback(() => playParagraph(paragraphIdx), [playParagraph, paragraphIdx]);
-  const handleStop = useCallback(() => { speakerRef.current?.cancel(); setPlayState('idle'); setTtsProgress(null); setParagraphPlayState('idle'); setParagraphIdx(0); }, []);
-  const handleReplay = useCallback(() => { speakerRef.current?.cancel(); setParagraphIdx(0); setParagraphPlayState('idle'); setPlayState('idle'); setTtsProgress(null); setTimeout(() => playParagraph(0), 100); }, [playParagraph]);
-  const handleProceedToRetell = useCallback(() => { speakerRef.current?.cancel(); setPhase('retell'); }, []);
-
-  const isPlaying = playState === 'playing';
-  const isPaused = playState === 'paused';
-  const isIdle = playState === 'idle' && paragraphPlayState === 'idle';
-  const isAllDone = paragraphPlayState === 'done';
-  const isBetweenParagraphs = paragraphPlayState === 'between';
 
   // ── Phase 2: Retelling ─────────────────────────────────────────────
   const handleVoiceToggle = useCallback(() => {
@@ -138,16 +76,29 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
     if (!token) { setSubmitError('請先登入再提交。'); return; }
     setSubmitError(null); setIsEvaluating(true);
     try {
-      const result = await evaluateListeningRetelling(token, { storyTitle: story.title, originalText: fullText, studentRetelling: trimmed });
-      setEvalResult(result); setPhase('results');
-    } catch (err) { setSubmitError(err instanceof Error ? err.message : 'AI 評估失敗，請稍後再試。'); }
-    finally { setIsEvaluating(false); }
+      const result = await evaluateListeningRetelling(token, {
+        storyTitle: story.title,
+        originalText: fullText,
+        studentRetelling: trimmed,
+      });
+      setEvalResult(result);
+      setPhase('results');
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'AI 評估失敗，請稍後再試。');
+    } finally {
+      setIsEvaluating(false);
+    }
   }, [retelling, token, story.title, fullText]);
 
   // ── Phase 3: Results ───────────────────────────────────────────────
   const handleFinish = useCallback(() => {
     if (!evalResult) return;
-    onFinish({ score: evalResult.score, keyPointsCovered: evalResult.key_points_covered, keyPointsMissed: evalResult.key_points_missed, feedback: evalResult.feedback });
+    onFinish({
+      score: evalResult.score,
+      keyPointsCovered: evalResult.key_points_covered,
+      keyPointsMissed: evalResult.key_points_missed,
+      feedback: evalResult.feedback,
+    });
   }, [evalResult, onFinish]);
 
   // ── Render ─────────────────────────────────────────────────────────
@@ -166,12 +117,12 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
                   <div className="flex items-center gap-3">
                     <span className="material-symbols-outlined text-on-surface-variant text-xl">speed</span>
                     <span className="text-sm font-headline font-bold text-on-surface-variant">
-                      {playRate === 0.7 ? '慢速' : playRate === 0.85 ? '標準' : '快速'}
+                      {tts.playRate === 0.7 ? '慢速' : tts.playRate === 0.85 ? '標準' : '快速'}
                     </span>
                     <input
-                      type="range" min="0.7" max="1.1" step="0.2" value={playRate}
-                      onChange={(e) => { setPlayRate(parseFloat(e.target.value)); if (isPlaying || isPaused) handleStop(); }}
-                      disabled={isPlaying}
+                      type="range" min="0.7" max="1.1" step="0.2" value={tts.playRate}
+                      onChange={(e) => { tts.setPlayRate(parseFloat(e.target.value)); if (tts.isPlaying || tts.isPaused) tts.handleStop(); }}
+                      disabled={tts.isPlaying}
                       className="w-24 h-2 bg-surface-container-high rounded-lg appearance-none cursor-pointer disabled:opacity-50"
                     />
                   </div>
@@ -179,25 +130,25 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
                   {/* Paragraph progress */}
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-headline font-bold text-on-surface-variant">
-                      第 {paragraphIdx + 1} / {paragraphs.length} 段
+                      第 {tts.paragraphIdx + 1} / {paragraphs.length} 段
                     </span>
-                    {isPlaying && ttsProgress && (
+                    {tts.isPlaying && tts.ttsProgress && (
                       <div className="w-20 h-2 bg-surface-container-high rounded-full overflow-hidden">
-                        <div className="h-full bg-accent rounded-full transition-all duration-300" style={{ width: `${ttsProgress.progress * 100}%` }} />
+                        <div className="h-full bg-accent rounded-full transition-all duration-300" style={{ width: `${tts.ttsProgress.progress * 100}%` }} />
                       </div>
                     )}
                   </div>
 
                   {/* Status badge */}
-                  {isPlaying && (
+                  {tts.isPlaying && (
                     <span className="flex items-center gap-1.5 text-sm font-headline font-bold text-accent animate-pulse">
                       <span className="material-symbols-outlined text-lg" style={{ fontVariationSettings: "'FILL' 1" }}>volume_up</span>
                       播放中
                     </span>
                   )}
-                  {isPaused && <span className="text-sm font-headline font-bold text-on-surface-variant">已暫停</span>}
-                  {isBetweenParagraphs && <span className="text-sm font-headline font-bold text-emerald-600">段落完成</span>}
-                  {isAllDone && <span className="text-sm font-headline font-bold text-emerald-600">全部播完</span>}
+                  {tts.isPaused && <span className="text-sm font-headline font-bold text-on-surface-variant">已暫停</span>}
+                  {tts.isBetweenParagraphs && <span className="text-sm font-headline font-bold text-emerald-600">段落完成</span>}
+                  {tts.isAllDone && <span className="text-sm font-headline font-bold text-emerald-600">全部播完</span>}
                 </div>
 
                 {/* Progress dots */}
@@ -205,8 +156,8 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
                   <div className="flex gap-1 mt-3">
                     {paragraphs.map((_, i) => (
                       <div key={i} className={`flex-1 h-2 rounded-full transition-colors ${
-                        i < paragraphIdx ? 'bg-accent/50'
-                        : i === paragraphIdx ? (isPlaying || isPaused || isBetweenParagraphs ? 'bg-accent' : 'bg-accent/70')
+                        i < tts.paragraphIdx ? 'bg-accent/50'
+                        : i === tts.paragraphIdx ? (tts.isPlaying || tts.isPaused || tts.isBetweenParagraphs ? 'bg-accent' : 'bg-accent/70')
                         : 'bg-surface-container-high'
                       }`} />
                     ))}
@@ -219,9 +170,9 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
                 <div className="space-y-8">
                   {paragraphs.map((line, idx) => (
                     <div key={idx} className={`flex gap-4 items-start rounded-2xl px-4 py-3 -mx-4 transition-all ${
-                      idx === paragraphIdx && (isPlaying || isBetweenParagraphs || isPaused)
+                      idx === tts.paragraphIdx && (tts.isPlaying || tts.isBetweenParagraphs || tts.isPaused)
                         ? 'bg-accent/5'
-                        : idx < paragraphIdx ? 'opacity-40' : ''
+                        : idx < tts.paragraphIdx ? 'opacity-40' : ''
                     }`}>
                       <span className="text-xs font-headline font-bold text-on-surface-variant/40 pt-2 select-none shrink-0 w-6 text-right">
                         {String(idx + 1).padStart(2, '0')}
@@ -234,9 +185,9 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
                 </div>
               </div>
 
-              {ttsError && (
+              {tts.ttsError && (
                 <div className="mt-4 px-5 py-3 bg-tertiary-container/20 rounded-2xl">
-                  <span className="text-sm text-tertiary">{ttsError}</span>
+                  <span className="text-sm text-tertiary">{tts.ttsError}</span>
                 </div>
               )}
             </>
@@ -244,132 +195,25 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
 
           {/* ── Phase 2: Retell ───────────────────────────────────── */}
           {phase === 'retell' && (
-            <>
-              <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 mt-4 mb-6">
-                <div className="flex items-center gap-3 mb-4">
-                  <span className="material-symbols-outlined text-accent text-2xl">record_voice_over</span>
-                  <h2 className="font-headline font-bold text-on-surface text-lg">用自己的話覆述</h2>
-                </div>
-                <p className="text-sm text-on-surface-variant leading-relaxed">
-                  試著說出你剛才聽到的課文重點。不需要一字不差，用自己的話表達你記得的內容就可以。
-                </p>
-              </div>
-
-              {/* Input mode toggle */}
-              <div className="flex bg-surface-container-high rounded-full p-1.5 mb-6">
-                <button
-                  onClick={() => { if (speechStatus === 'listening') stopListening(); setRetellMode('text'); }}
-                  className={`flex-1 px-5 py-3 rounded-full text-sm font-headline font-bold transition-all ${
-                    retellMode === 'text' ? 'bg-surface-container-lowest text-accent shadow-sm' : 'text-on-surface-variant'
-                  }`}
-                >
-                  鍵盤輸入
-                </button>
-                <button
-                  onClick={() => setRetellMode('voice')}
-                  disabled={!speechSupported}
-                  className={`flex-1 px-5 py-3 rounded-full text-sm font-headline font-bold transition-all ${
-                    retellMode === 'voice' ? 'bg-surface-container-lowest text-accent shadow-sm' : 'text-on-surface-variant'
-                  } ${!speechSupported ? 'opacity-50 cursor-not-allowed' : ''}`}
-                >
-                  語音輸入
-                </button>
-              </div>
-
-              {retellMode === 'text' && (
-                <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
-                  <textarea
-                    value={retelling}
-                    onChange={(e) => setRetelling(e.target.value)}
-                    placeholder="在這裡輸入你記得的課文內容..."
-                    rows={6}
-                    maxLength={2000}
-                    className="w-full px-4 py-3 border-2 border-surface-container-high rounded-2xl text-on-surface text-base placeholder-on-surface-variant/40 resize-none focus:outline-none focus:border-accent bg-transparent"
-                  />
-                  <p className="text-xs text-right text-on-surface-variant mt-2">{retelling.length} / 2000</p>
-                </div>
-              )}
-
-              {retellMode === 'voice' && (
-                <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 flex flex-col items-center gap-4">
-                  <button
-                    onClick={handleVoiceToggle}
-                    className={`w-20 h-20 rounded-full flex items-center justify-center shadow-lg transition-all ${
-                      speechStatus === 'listening'
-                        ? 'bg-tertiary hover:brightness-110 animate-pulse'
-                        : 'bg-accent hover:brightness-110'
-                    }`}
-                  >
-                    <span className="material-symbols-outlined text-white text-3xl" style={{ fontVariationSettings: "'FILL' 1" }}>
-                      {speechStatus === 'listening' ? 'stop' : 'mic'}
-                    </span>
-                  </button>
-                  <p className="text-sm text-on-surface-variant">
-                    {speechStatus === 'listening' ? '正在聆聽，點擊停止...' : '點擊麥克風開始說話'}
-                  </p>
-                  {retelling && (
-                    <div className="w-full bg-surface-container-low rounded-2xl p-4 mt-2">
-                      <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-2">已記錄</p>
-                      <p className="text-base text-on-surface leading-relaxed">{retelling}</p>
-                    </div>
-                  )}
-                  {speechError && <p className="text-sm text-tertiary">{speechError}</p>}
-                </div>
-              )}
-
-              {submitError && (
-                <div className="mt-4 px-5 py-3 bg-tertiary-container/20 rounded-2xl">
-                  <span className="text-sm text-tertiary">{submitError}</span>
-                </div>
-              )}
-            </>
+            <ListeningQuestionPanel
+              retelling={retelling}
+              setRetelling={setRetelling}
+              retellMode={retellMode}
+              setRetellMode={setRetellMode}
+              speechStatus={speechStatus}
+              speechSupported={speechSupported}
+              speechError={speechError}
+              submitError={submitError}
+              isEvaluating={isEvaluating}
+              onVoiceToggle={handleVoiceToggle}
+              onSubmit={handleSubmitRetelling}
+              onStopListening={stopListening}
+            />
           )}
 
           {/* ── Phase 3: Results ──────────────────────────────────── */}
           {phase === 'results' && evalResult && (
-            <>
-              {/* Feedback card — Issue #1094: 學生端不顯示分數，只保留鼓勵文字 + AI 回饋 */}
-              <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 mt-4 flex flex-col items-center gap-4">
-                <div className={`w-20 h-20 rounded-full flex items-center justify-center ${
-                  evalResult.score >= 80 ? 'bg-emerald-100' : evalResult.score >= 60 ? 'bg-amber-100' : 'bg-tertiary-container/30'
-                }`}>
-                  <span className="material-symbols-outlined text-4xl" aria-hidden="true">
-                    {evalResult.score >= 80 ? 'celebration' : evalResult.score >= 60 ? 'thumb_up' : 'favorite'}
-                  </span>
-                </div>
-                <p className={`text-lg font-headline font-bold ${scoreColour(evalResult.score)}`}>{encourageAccuracy(evalResult.score)}</p>
-                <p className="text-sm text-on-surface-variant text-center leading-relaxed">{evalResult.feedback}</p>
-              </div>
-
-              {/* Key points */}
-              {evalResult.key_points_covered.length > 0 && (
-                <div className="bg-emerald-50 rounded-3xl p-6 mt-6">
-                  <div className="flex items-center gap-2 mb-3">
-                    <span className="material-symbols-outlined text-emerald-600">check_circle</span>
-                    <span className="font-headline font-bold text-emerald-700 text-sm">提到的重點</span>
-                  </div>
-                  <ul className="space-y-2">
-                    {evalResult.key_points_covered.map((p, i) => (
-                      <li key={i} className="text-sm text-emerald-800 leading-relaxed">• {p}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
-              {evalResult.key_points_missed.length > 0 && (
-                <div className="bg-tertiary-container/10 rounded-3xl p-6 mt-4">
-                  <div className="flex items-center gap-2 mb-3">
-                    <span className="material-symbols-outlined text-tertiary">info</span>
-                    <span className="font-headline font-bold text-tertiary text-sm">遺漏的重點</span>
-                  </div>
-                  <ul className="space-y-2">
-                    {evalResult.key_points_missed.map((p, i) => (
-                      <li key={i} className="text-sm text-on-surface leading-relaxed">• {p}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-            </>
+            <ListeningScoring evalResult={evalResult} />
           )}
         </div>
       </div>
@@ -381,14 +225,14 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
 
           {phase === 'play' && (
             <>
-              {isIdle && (
+              {tts.isIdle && (
                 <div className="w-full flex gap-3">
-                  <button onClick={handleProceedToRetell}
+                  <button onClick={tts.handleProceedToRetell}
                     className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2">
                     <span className="material-symbols-outlined text-xl">skip_next</span>
                     跳過
                   </button>
-                  <button onClick={handlePlay}
+                  <button onClick={tts.handlePlay}
                     className="flex-1 h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-3 animate-pulse"
                     style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}>
                     <span className="material-symbols-outlined text-2xl" style={{ fontVariationSettings: "'FILL' 1" }}>play_arrow</span>
@@ -396,51 +240,51 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
                   </button>
                 </div>
               )}
-              {isPlaying && (
+              {tts.isPlaying && (
                 <div className="w-full flex gap-3">
-                  <button onClick={handlePause}
+                  <button onClick={tts.handlePause}
                     className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-accent/10 text-accent hover:bg-accent/15 active:scale-[0.98] transition-all flex items-center justify-center gap-2">
                     <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>pause</span>
                     暫停
                   </button>
-                  <button onClick={handleStop}
+                  <button onClick={tts.handleStop}
                     className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2">
                     <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>stop</span>
                     停止
                   </button>
                 </div>
               )}
-              {isPaused && (
+              {tts.isPaused && (
                 <div className="w-full flex gap-3">
-                  <button onClick={handleResume}
+                  <button onClick={tts.handleResume}
                     className="flex-1 h-14 rounded-full font-headline font-bold text-lg text-white active:scale-[0.98] transition-all flex items-center justify-center gap-2"
                     style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}>
                     <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>play_arrow</span>
                     繼續
                   </button>
-                  <button onClick={handleStop}
+                  <button onClick={tts.handleStop}
                     className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2">
                     <span className="material-symbols-outlined text-xl" style={{ fontVariationSettings: "'FILL' 1" }}>stop</span>
                     停止
                   </button>
                 </div>
               )}
-              {isBetweenParagraphs && (
-                <button onClick={handleContinueNext}
+              {tts.isBetweenParagraphs && (
+                <button onClick={tts.handleContinueNext}
                   className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
                   style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}>
                   <span className="material-symbols-outlined text-xl">play_arrow</span>
                   繼續下一段
                 </button>
               )}
-              {isAllDone && (
+              {tts.isAllDone && (
                 <>
-                  <button onClick={handleReplay}
+                  <button onClick={tts.handleReplay}
                     className="w-full h-12 rounded-full font-headline font-bold text-base text-on-surface bg-surface-container-lowest shadow-editorial hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2">
                     <span className="material-symbols-outlined text-lg">refresh</span>
                     重聽
                   </button>
-                  <button onClick={handleProceedToRetell}
+                  <button onClick={tts.handleProceedToRetell}
                     className="w-full h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(86,74,191,0.3)] hover:brightness-110 active:scale-[0.98] transition-all flex items-center justify-center gap-2"
                     style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}>
                     開始覆述
@@ -472,12 +316,9 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
               <ToolboxCompletionActions
                 onRetry={() => {
                   // Toolbox retry: reset eval state + put student back at the play stage.
-                  // TODO(#1462 follow-up): if ListeningPractice ever adds
-                  // localStorage persistence, also clear the corresponding
-                  // scopedStepStorageKey here so a redo starts truly blank.
                   setEvalResult(null);
                   setRetelling('');
-                  setParagraphIdx(0);
+                  tts.handleStop();
                   setPhase('play');
                 }}
                 className="w-full"

--- a/frontend/src/components/reading-steps/__tests__/ListeningPractice.characterization.test.ts
+++ b/frontend/src/components/reading-steps/__tests__/ListeningPractice.characterization.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Characterization tests for ListeningPractice refactor — Issue #1956
+ *
+ * TDD-first: these tests encode behaviors from the 511-LOC monolith that
+ * must survive the split into:
+ *   - useTTSEngine (TTS state machine)
+ *   - ListeningQuestionPanel (Q/A UI — tested via component tests)
+ *   - ListeningScoring (correctness logic + feedback render)
+ *
+ * Run with: npx vitest run src/components/reading-steps/__tests__/ListeningPractice.characterization.test.ts
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock ttsApi — required before importing any module that imports it
+vi.mock('../../../services/ttsApi', () => ({
+  speakTextWithProgress: vi.fn(),
+  cancelTts: vi.fn(),
+}));
+
+import {
+  scoreColour,
+  buildSpeaker,
+  computePlayStateFlags,
+} from '../listening/listeningUtils';
+
+import { speakTextWithProgress, cancelTts } from '../../../services/ttsApi';
+
+// ─── scoreColour ─────────────────────────────────────────────────────────────
+
+describe('scoreColour', () => {
+  it('returns emerald class for score >= 80', () => {
+    expect(scoreColour(80)).toBe('text-emerald-700');
+    expect(scoreColour(100)).toBe('text-emerald-700');
+    expect(scoreColour(95)).toBe('text-emerald-700');
+  });
+
+  it('returns amber class for score 60-79', () => {
+    expect(scoreColour(60)).toBe('text-amber-700');
+    expect(scoreColour(79)).toBe('text-amber-700');
+    expect(scoreColour(65)).toBe('text-amber-700');
+  });
+
+  it('returns tertiary class for score < 60', () => {
+    expect(scoreColour(0)).toBe('text-tertiary');
+    expect(scoreColour(59)).toBe('text-tertiary');
+    expect(scoreColour(30)).toBe('text-tertiary');
+  });
+});
+
+// ─── buildSpeaker ─────────────────────────────────────────────────────────────
+
+describe('buildSpeaker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls speakTextWithProgress with the provided text on start()', async () => {
+    const mockSpeak = vi.mocked(speakTextWithProgress);
+    mockSpeak.mockResolvedValueOnce(undefined);
+
+    const speaker = buildSpeaker('你好世界', 0.85);
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+    const onProgress = vi.fn();
+
+    speaker.start(onEnd, onError, onProgress);
+
+    await vi.waitFor(() => {
+      expect(mockSpeak).toHaveBeenCalledWith('你好世界', onProgress);
+    });
+  });
+
+  it('calls onEnd callback when speakTextWithProgress resolves', async () => {
+    const mockSpeak = vi.mocked(speakTextWithProgress);
+    mockSpeak.mockResolvedValueOnce(undefined);
+
+    const speaker = buildSpeaker('hello', 1.0);
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+    const onProgress = vi.fn();
+
+    speaker.start(onEnd, onError, onProgress);
+
+    await vi.waitFor(() => {
+      expect(onEnd).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('calls onError callback when speakTextWithProgress rejects', async () => {
+    const mockSpeak = vi.mocked(speakTextWithProgress);
+    mockSpeak.mockRejectedValueOnce(new Error('network error'));
+
+    const speaker = buildSpeaker('hello', 1.0);
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+    const onProgress = vi.fn();
+
+    speaker.start(onEnd, onError, onProgress);
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.stringContaining('network error'));
+    });
+  });
+
+  it('cancel() calls cancelTts from ttsApi', () => {
+    const mockCancel = vi.mocked(cancelTts);
+    const speaker = buildSpeaker('hello', 1.0);
+    speaker.cancel();
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses generic error message when rejection has no message', async () => {
+    const mockSpeak = vi.mocked(speakTextWithProgress);
+    // Reject with a non-Error value
+    mockSpeak.mockRejectedValueOnce(null);
+
+    const speaker = buildSpeaker('test', 1.0);
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+    const onProgress = vi.fn();
+
+    speaker.start(onEnd, onError, onProgress);
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith('speech error');
+    });
+  });
+});
+
+// ─── computePlayStateFlags ────────────────────────────────────────────────────
+
+describe('computePlayStateFlags', () => {
+  it('isIdle=true when playState=idle and paragraphPlayState=idle', () => {
+    const flags = computePlayStateFlags('idle', 'idle');
+    expect(flags.isIdle).toBe(true);
+    expect(flags.isPlaying).toBe(false);
+    expect(flags.isPaused).toBe(false);
+    expect(flags.isAllDone).toBe(false);
+    expect(flags.isBetweenParagraphs).toBe(false);
+  });
+
+  it('isPlaying=true when playState=playing', () => {
+    const flags = computePlayStateFlags('playing', 'playing');
+    expect(flags.isPlaying).toBe(true);
+    expect(flags.isIdle).toBe(false);
+  });
+
+  it('isPaused=true when playState=paused', () => {
+    const flags = computePlayStateFlags('paused', 'idle');
+    expect(flags.isPaused).toBe(true);
+    expect(flags.isIdle).toBe(false);
+  });
+
+  it('isAllDone=true when paragraphPlayState=done', () => {
+    const flags = computePlayStateFlags('done', 'done');
+    expect(flags.isAllDone).toBe(true);
+  });
+
+  it('isBetweenParagraphs=true when paragraphPlayState=between', () => {
+    const flags = computePlayStateFlags('done', 'between');
+    expect(flags.isBetweenParagraphs).toBe(true);
+  });
+
+  it('isIdle=false when playState=idle but paragraphPlayState is not idle', () => {
+    // Mid-session pause (paragraphPlayState=between) makes isIdle false
+    const flags = computePlayStateFlags('idle', 'between');
+    expect(flags.isIdle).toBe(false);
+  });
+});

--- a/frontend/src/components/reading-steps/listening/ListeningQuestionPanel.tsx
+++ b/frontend/src/components/reading-steps/listening/ListeningQuestionPanel.tsx
@@ -1,0 +1,139 @@
+/**
+ * ListeningQuestionPanel — Phase 2 retell UI (Issue #1956)
+ *
+ * Renders the retelling input panel (text or voice mode) that was previously
+ * embedded in the ListeningPractice monolith.
+ */
+import React from 'react';
+
+interface ListeningQuestionPanelProps {
+  retelling: string;
+  setRetelling: (value: string) => void;
+  retellMode: 'text' | 'voice';
+  setRetellMode: (mode: 'text' | 'voice') => void;
+  speechStatus: string;
+  speechSupported: boolean;
+  speechError: string | undefined;
+  submitError: string | null;
+  isEvaluating: boolean;
+  onVoiceToggle: () => void;
+  onSubmit: () => void;
+  onStopListening: () => void;
+}
+
+const ListeningQuestionPanel: React.FC<ListeningQuestionPanelProps> = ({
+  retelling,
+  setRetelling,
+  retellMode,
+  setRetellMode,
+  speechStatus,
+  speechSupported,
+  speechError,
+  submitError,
+  isEvaluating,
+  onVoiceToggle,
+  onSubmit,
+  onStopListening,
+}) => {
+  return (
+    <>
+      {/* Header card */}
+      <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 mt-4 mb-6">
+        <div className="flex items-center gap-3 mb-4">
+          <span className="material-symbols-outlined text-accent text-2xl">record_voice_over</span>
+          <h2 className="font-headline font-bold text-on-surface text-lg">用自己的話覆述</h2>
+        </div>
+        <p className="text-sm text-on-surface-variant leading-relaxed">
+          試著說出你剛才聽到的課文重點。不需要一字不差，用自己的話表達你記得的內容就可以。
+        </p>
+      </div>
+
+      {/* Input mode toggle */}
+      <div className="flex bg-surface-container-high rounded-full p-1.5 mb-6">
+        <button
+          onClick={() => {
+            if (speechStatus === 'listening') onStopListening();
+            setRetellMode('text');
+          }}
+          className={`flex-1 px-5 py-3 rounded-full text-sm font-headline font-bold transition-all ${
+            retellMode === 'text'
+              ? 'bg-surface-container-lowest text-accent shadow-sm'
+              : 'text-on-surface-variant'
+          }`}
+        >
+          鍵盤輸入
+        </button>
+        <button
+          onClick={() => setRetellMode('voice')}
+          disabled={!speechSupported}
+          className={`flex-1 px-5 py-3 rounded-full text-sm font-headline font-bold transition-all ${
+            retellMode === 'voice'
+              ? 'bg-surface-container-lowest text-accent shadow-sm'
+              : 'text-on-surface-variant'
+          } ${!speechSupported ? 'opacity-50 cursor-not-allowed' : ''}`}
+        >
+          語音輸入
+        </button>
+      </div>
+
+      {/* Text input */}
+      {retellMode === 'text' && (
+        <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
+          <textarea
+            value={retelling}
+            onChange={(e) => setRetelling(e.target.value)}
+            placeholder="在這裡輸入你記得的課文內容..."
+            rows={6}
+            maxLength={2000}
+            className="w-full px-4 py-3 border-2 border-surface-container-high rounded-2xl text-on-surface text-base placeholder-on-surface-variant/40 resize-none focus:outline-none focus:border-accent bg-transparent"
+          />
+          <p className="text-xs text-right text-on-surface-variant mt-2">{retelling.length} / 2000</p>
+        </div>
+      )}
+
+      {/* Voice input */}
+      {retellMode === 'voice' && (
+        <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 flex flex-col items-center gap-4">
+          <button
+            onClick={onVoiceToggle}
+            className={`w-20 h-20 rounded-full flex items-center justify-center shadow-lg transition-all ${
+              speechStatus === 'listening'
+                ? 'bg-tertiary hover:brightness-110 animate-pulse'
+                : 'bg-accent hover:brightness-110'
+            }`}
+          >
+            <span
+              className="material-symbols-outlined text-white text-3xl"
+              style={{ fontVariationSettings: "'FILL' 1" }}
+            >
+              {speechStatus === 'listening' ? 'stop' : 'mic'}
+            </span>
+          </button>
+          <p className="text-sm text-on-surface-variant">
+            {speechStatus === 'listening' ? '正在聆聽，點擊停止...' : '點擊麥克風開始說話'}
+          </p>
+          {retelling && (
+            <div className="w-full bg-surface-container-low rounded-2xl p-4 mt-2">
+              <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-2">
+                已記錄
+              </p>
+              <p className="text-base text-on-surface leading-relaxed">{retelling}</p>
+            </div>
+          )}
+          {speechError && <p className="text-sm text-tertiary">{speechError}</p>}
+        </div>
+      )}
+
+      {/* Submit error */}
+      {submitError && (
+        <div className="mt-4 px-5 py-3 bg-tertiary-container/20 rounded-2xl">
+          <span className="text-sm text-tertiary">{submitError}</span>
+        </div>
+      )}
+
+      {/* Submit CTA — fixed bar is handled by parent orchestrator, this is the inline version */}
+    </>
+  );
+};
+
+export default ListeningQuestionPanel;

--- a/frontend/src/components/reading-steps/listening/ListeningScoring.tsx
+++ b/frontend/src/components/reading-steps/listening/ListeningScoring.tsx
@@ -1,0 +1,81 @@
+/**
+ * ListeningScoring — Phase 3 results display (Issue #1956)
+ *
+ * Renders the score card + key points covered/missed sections that were
+ * previously embedded in the ListeningPractice monolith.
+ */
+import React from 'react';
+import { ListeningEvaluateResponse } from '../../../services/learningApi';
+import { encourageAccuracy } from '../../../utils/encouragement';
+import { scoreColour } from './listeningUtils';
+
+interface ListeningScoringProps {
+  evalResult: ListeningEvaluateResponse;
+}
+
+const ListeningScoring: React.FC<ListeningScoringProps> = ({ evalResult }) => {
+  const score = evalResult.score;
+
+  return (
+    <>
+      {/* Feedback card — Issue #1094: student view hides numeric score, shows encouragement only */}
+      <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 mt-4 flex flex-col items-center gap-4">
+        <div
+          className={`w-20 h-20 rounded-full flex items-center justify-center ${
+            score >= 80
+              ? 'bg-emerald-100'
+              : score >= 60
+              ? 'bg-amber-100'
+              : 'bg-tertiary-container/30'
+          }`}
+        >
+          <span className="material-symbols-outlined text-4xl" aria-hidden="true">
+            {score >= 80 ? 'celebration' : score >= 60 ? 'thumb_up' : 'favorite'}
+          </span>
+        </div>
+        <p className={`text-lg font-headline font-bold ${scoreColour(score)}`}>
+          {encourageAccuracy(score)}
+        </p>
+        <p className="text-sm text-on-surface-variant text-center leading-relaxed">
+          {evalResult.feedback}
+        </p>
+      </div>
+
+      {/* Key points covered */}
+      {evalResult.key_points_covered.length > 0 && (
+        <div className="bg-emerald-50 rounded-3xl p-6 mt-6">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="material-symbols-outlined text-emerald-600">check_circle</span>
+            <span className="font-headline font-bold text-emerald-700 text-sm">提到的重點</span>
+          </div>
+          <ul className="space-y-2">
+            {evalResult.key_points_covered.map((point, i) => (
+              <li key={i} className="text-sm text-emerald-800 leading-relaxed">
+                • {point}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Key points missed */}
+      {evalResult.key_points_missed.length > 0 && (
+        <div className="bg-tertiary-container/10 rounded-3xl p-6 mt-4">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="material-symbols-outlined text-tertiary">info</span>
+            <span className="font-headline font-bold text-tertiary text-sm">遺漏的重點</span>
+          </div>
+          <ul className="space-y-2">
+            {evalResult.key_points_missed.map((point, i) => (
+              <li key={i} className="text-sm text-on-surface leading-relaxed">
+                • {point}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ListeningScoring;

--- a/frontend/src/components/reading-steps/listening/listeningUtils.ts
+++ b/frontend/src/components/reading-steps/listening/listeningUtils.ts
@@ -1,0 +1,72 @@
+/**
+ * listeningUtils.ts — Pure helpers extracted from ListeningPractice (Issue #1956)
+ *
+ * No React imports — fully unit-testable.
+ */
+
+import { speakTextWithProgress, cancelTts, TtsProgressInfo } from '../../../services/ttsApi';
+
+export type PlayState = 'idle' | 'playing' | 'paused' | 'done';
+export type ParagraphPlayState = 'idle' | 'playing' | 'between' | 'done';
+
+export interface PlayStateFlags {
+  isPlaying: boolean;
+  isPaused: boolean;
+  isIdle: boolean;
+  isAllDone: boolean;
+  isBetweenParagraphs: boolean;
+}
+
+export interface Speaker {
+  start: (
+    onEnd: () => void,
+    onError: (msg: string) => void,
+    onProgress: (info: TtsProgressInfo) => void,
+  ) => void;
+  cancel: () => void;
+}
+
+/**
+ * Returns the Tailwind text-color class corresponding to a listening score.
+ * Mirrors the original scoreColour() inline function in ListeningPractice.tsx.
+ */
+export function scoreColour(score: number): string {
+  if (score >= 80) return 'text-emerald-700';
+  if (score >= 60) return 'text-amber-700';
+  return 'text-tertiary';
+}
+
+/**
+ * Creates a Speaker object that wraps speakTextWithProgress + cancelTts.
+ * The `_rate` parameter is accepted for API symmetry but TTS rate is controlled
+ * server-side via the TTS service configuration.
+ */
+export function buildSpeaker(text: string, _rate: number): Speaker {
+  const start = (
+    onEnd: () => void,
+    onError: (msg: string) => void,
+    onProgress: (info: TtsProgressInfo) => void,
+  ) => {
+    speakTextWithProgress(text, onProgress)
+      .then(onEnd)
+      .catch((err: Error) => onError(err?.message ?? 'speech error'));
+  };
+  return { start, cancel: () => cancelTts() };
+}
+
+/**
+ * Derives boolean UI-state flags from the raw playState + paragraphPlayState enums.
+ * Extracted so the main component and unit tests share a single source of truth.
+ */
+export function computePlayStateFlags(
+  playState: PlayState,
+  paragraphPlayState: ParagraphPlayState,
+): PlayStateFlags {
+  return {
+    isPlaying: playState === 'playing',
+    isPaused: playState === 'paused',
+    isIdle: playState === 'idle' && paragraphPlayState === 'idle',
+    isAllDone: paragraphPlayState === 'done',
+    isBetweenParagraphs: paragraphPlayState === 'between',
+  };
+}

--- a/frontend/src/components/reading-steps/listening/useTTSEngine.ts
+++ b/frontend/src/components/reading-steps/listening/useTTSEngine.ts
@@ -1,0 +1,162 @@
+/**
+ * useTTSEngine — TTS playback state machine (Issue #1956)
+ *
+ * Encapsulates all TTS state (play/pause/stop/paragraph navigation) that
+ * previously lived inline in the ListeningPractice monolith.
+ *
+ * Returns:
+ *  - Current play/paragraph state enums
+ *  - Derived boolean flags (isPlaying, isPaused, isIdle, isAllDone, isBetweenParagraphs)
+ *  - Action handlers: handlePlay, handlePause, handleResume, handleStop,
+ *    handleContinueNext, handleReplay, handleProceedToRetell
+ *  - TTS error / progress state
+ *  - playRate + setPlayRate
+ */
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { TtsProgressInfo, cancelTts } from '../../../services/ttsApi';
+import {
+  PlayState,
+  ParagraphPlayState,
+  buildSpeaker,
+  computePlayStateFlags,
+  Speaker,
+} from './listeningUtils';
+
+export interface TTSEngineState {
+  playState: PlayState;
+  paragraphPlayState: ParagraphPlayState;
+  paragraphIdx: number;
+  playRate: number;
+  ttsError: string | null;
+  ttsProgress: TtsProgressInfo | null;
+  isPlaying: boolean;
+  isPaused: boolean;
+  isIdle: boolean;
+  isAllDone: boolean;
+  isBetweenParagraphs: boolean;
+  setPlayRate: (rate: number) => void;
+  handlePlay: () => void;
+  handlePause: () => void;
+  handleResume: () => void;
+  handleStop: () => void;
+  handleContinueNext: () => void;
+  handleReplay: () => void;
+  handleProceedToRetell: () => void;
+}
+
+export function useTTSEngine(
+  paragraphs: string[],
+  onProceedToRetell: () => void,
+): TTSEngineState {
+  const [playState, setPlayState] = useState<PlayState>('idle');
+  const [playRate, setPlayRate] = useState(0.85);
+  const [ttsError, setTtsError] = useState<string | null>(null);
+  const [ttsProgress, setTtsProgress] = useState<TtsProgressInfo | null>(null);
+  const speakerRef = useRef<Speaker | null>(null);
+
+  const [paragraphIdx, setParagraphIdx] = useState(0);
+  const [paragraphPlayState, setParagraphPlayState] = useState<ParagraphPlayState>('idle');
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      speakerRef.current?.cancel();
+    };
+  }, []);
+
+  const playParagraph = useCallback(
+    (idx: number) => {
+      const text = paragraphs[idx];
+      if (!text) return;
+      setTtsError(null);
+      setTtsProgress(null);
+      setPlayState('playing');
+      setParagraphPlayState('playing');
+      const speaker = buildSpeaker(text, playRate);
+      speakerRef.current = speaker;
+      speaker.start(
+        () => {
+          setPlayState('done');
+          setTtsProgress(null);
+          if (idx >= paragraphs.length - 1) {
+            setParagraphPlayState('done');
+          } else {
+            setParagraphPlayState('between');
+          }
+        },
+        (errMsg) => {
+          setTtsError(`播放發生錯誤：${errMsg}`);
+          setPlayState('idle');
+          setTtsProgress(null);
+          setParagraphPlayState('idle');
+        },
+        (info) => setTtsProgress(info),
+      );
+    },
+    [paragraphs, playRate],
+  );
+
+  const handlePlay = useCallback(() => playParagraph(paragraphIdx), [playParagraph, paragraphIdx]);
+
+  const handleContinueNext = useCallback(() => {
+    const next = paragraphIdx + 1;
+    if (next >= paragraphs.length) {
+      setParagraphPlayState('done');
+      return;
+    }
+    setParagraphIdx(next);
+    // Brief delay lets React commit the new paragraphIdx before TTS starts,
+    // ensuring highlight state stays in sync with the playing paragraph.
+    setTimeout(() => playParagraph(next), 50);
+  }, [paragraphIdx, paragraphs.length, playParagraph]);
+
+  const handlePause = useCallback(() => {
+    cancelTts();
+    setPlayState('paused');
+    setTtsProgress(null);
+  }, []);
+
+  const handleResume = useCallback(() => playParagraph(paragraphIdx), [playParagraph, paragraphIdx]);
+
+  const handleStop = useCallback(() => {
+    speakerRef.current?.cancel();
+    setPlayState('idle');
+    setTtsProgress(null);
+    setParagraphPlayState('idle');
+    setParagraphIdx(0);
+  }, []);
+
+  const handleReplay = useCallback(() => {
+    speakerRef.current?.cancel();
+    setParagraphIdx(0);
+    setParagraphPlayState('idle');
+    setPlayState('idle');
+    setTtsProgress(null);
+    setTimeout(() => playParagraph(0), 100);
+  }, [playParagraph]);
+
+  const handleProceedToRetell = useCallback(() => {
+    speakerRef.current?.cancel();
+    onProceedToRetell();
+  }, [onProceedToRetell]);
+
+  const flags = computePlayStateFlags(playState, paragraphPlayState);
+
+  return {
+    playState,
+    paragraphPlayState,
+    paragraphIdx,
+    playRate,
+    ttsError,
+    ttsProgress,
+    ...flags,
+    setPlayRate,
+    handlePlay,
+    handlePause,
+    handleResume,
+    handleStop,
+    handleContinueNext,
+    handleReplay,
+    handleProceedToRetell,
+  };
+}


### PR DESCRIPTION
Fixes #1956

## Summary

Split 511-LOC `ListeningPractice.tsx` monolith into 4 focused modules:

- `listening/listeningUtils.ts` (72 LOC) — pure helpers: `scoreColour`, `buildSpeaker`, `computePlayStateFlags`
- `listening/useTTSEngine.ts` (162 LOC) — TTS state machine hook encapsulating all playback state
- `listening/ListeningQuestionPanel.tsx` (139 LOC) — phase-2 retell Q/A UI
- `listening/ListeningScoring.tsx` (81 LOC) — phase-3 results display
- `ListeningPractice.tsx` reduced from 511 → 352 LOC (orchestrator only)

## Test plan

- [x] 14/14 characterization tests GREEN (scoreColour, buildSpeaker, computePlayStateFlags)
- [x] TypeScript: zero new errors introduced
- [x] Functional equivalence: all phase 1/2/3 UI preserved exactly
- [x] Toolbox retry flow preserved (`tts.handleStop()` replaces manual state reset)