### PR TITLE
fix(omo): grader 結果依 YAML 題號排序 (#1973)

### DIFF
--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -286,6 +286,12 @@ async def grade_worksheet_images(
             )
             result.crop_image_url = gs_uri
 
+    # #1973: sort by YAML question order (fb_1, fb_2, …, mc_1, mc_2, …) so the
+    # client renders in a stable, student-readable order rather than Gemini's
+    # visual-scan order (which can jump around — esp. after _split_spread).
+    qid_order = {q["id"]: idx for idx, q in enumerate(questions)}
+    results.sort(key=lambda g: qid_order.get(g.question_id, len(qid_order)))
+
     logger.info(
         "OMO grader: graded %d/%d questions for lesson '%s'",
         len(results),

--- a/backend/tests/test_regression_omo_grader_question_order_1973.py
+++ b/backend/tests/test_regression_omo_grader_question_order_1973.py
@@ -1,0 +1,170 @@
+"""Regression test for #1973 — OMO grader must return answers sorted by YAML
+question order (fb_1, fb_2, …, mc_1, mc_2, …), not by Gemini's visual-scan order.
+
+Before the fix, ``grade_worksheet_images`` returned ``results`` in the order
+Gemini emitted them — which after ``_split_spread`` could jump arbitrarily
+(right-half scanned first, etc.) and confused students cross-checking against
+their paper worksheet.
+
+The fix sorts ``results`` by each question's position in the ``questions``
+list built by ``_build_question_schema`` (YAML order).
+"""
+
+import asyncio
+import json
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Lesson with 5 fb_* and 3 mc_* — enough to make a wrong order obvious.
+LESSON = {
+    "title": "L25-測試課",
+    "vocabulary": [
+        {"word": "奠定"},   # A
+        {"word": "覓食"},   # B
+        {"word": "迅雷不及掩耳"},  # C
+        {"word": "臨機應變"},      # D
+        {"word": "注目"},   # E
+        {"word": "規律"},   # F
+        {"word": "勇氣"},   # G
+    ],
+    "fill_in_blank": [
+        {"answer": "A", "sentence": "打下基礎"},   # fb_1
+        {"answer": "B", "sentence": "找尋食物"},   # fb_2
+        {"answer": "C", "sentence": "行動迅速"},   # fb_3
+        {"answer": "F", "sentence": "有規律"},      # fb_4
+        {"answer": "G", "sentence": "需要勇氣"},   # fb_5
+    ],
+    "multiple_choice": [
+        {"answer": "A", "question": "q1"},   # mc_1
+        {"answer": "B", "question": "q2"},   # mc_2
+        {"answer": "C", "question": "q3"},   # mc_3
+    ],
+}
+
+
+def _make_mock_response(items: list[dict]) -> MagicMock:
+    mock_resp = MagicMock()
+    mock_resp.text = json.dumps(items)
+    return mock_resp
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _patch_and_grade(mock_items: list[dict]) -> list:
+    """Patch the google.genai module and run grade_worksheet_images."""
+    import app.services.omo_grader as grader_mod
+
+    grader_mod._consecutive_errors = 0
+    mock_response = _make_mock_response(mock_items)
+
+    fake_genai = types.ModuleType("google.genai")
+    fake_types = types.ModuleType("google.genai.types")
+
+    class FakeContent:
+        def __init__(self, **kwargs): pass
+
+    class FakePart:
+        @staticmethod
+        def from_bytes(**kwargs): return FakePart()
+
+    class FakeThinkingConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeAutoFuncCallingConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeGenerateContentConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeClient:
+        def __init__(self, **kwargs): pass
+        class models:
+            @staticmethod
+            def generate_content(**kwargs):
+                return mock_response
+
+    fake_types.Content = FakeContent
+    fake_types.Part = FakePart
+    fake_types.ThinkingConfig = FakeThinkingConfig
+    fake_types.AutomaticFunctionCallingConfig = FakeAutoFuncCallingConfig
+    fake_types.GenerateContentConfig = FakeGenerateContentConfig
+    fake_genai.Client = FakeClient
+
+    fake_google = types.ModuleType("google")
+    fake_google.genai = fake_genai
+
+    with patch.dict(sys.modules, {
+        "google": fake_google,
+        "google.genai": fake_genai,
+        "google.genai.types": fake_types,
+    }):
+        return _run(grader_mod.grade_worksheet_images(
+            image_bytes_list=[b"fake_image_bytes"],
+            mime_types=["image/jpeg"],
+            lesson=LESSON,
+            attempt_id=None,
+        ))
+
+
+def test_results_sorted_by_yaml_order_when_gemini_returns_scrambled():
+    """Gemini returns answers in arbitrary visual-scan order — grader must
+    sort them back to YAML order (fb_1..fb_5, mc_1..mc_3)."""
+    # Deliberately scrambled — mc before fb, fb not in numeric order.
+    scrambled = [
+        {"question_id": "mc_2", "student_answer": "B", "ai_confidence": 0.9, "reasoning": "圈B"},
+        {"question_id": "fb_3", "student_answer": "C", "ai_confidence": 0.9, "reasoning": "圈C"},
+        {"question_id": "fb_1", "student_answer": "A", "ai_confidence": 0.9, "reasoning": "圈A"},
+        {"question_id": "mc_1", "student_answer": "A", "ai_confidence": 0.9, "reasoning": "圈A"},
+        {"question_id": "fb_5", "student_answer": "G", "ai_confidence": 0.9, "reasoning": "圈G"},
+        {"question_id": "fb_2", "student_answer": "B", "ai_confidence": 0.9, "reasoning": "圈B"},
+        {"question_id": "mc_3", "student_answer": "C", "ai_confidence": 0.9, "reasoning": "圈C"},
+        {"question_id": "fb_4", "student_answer": "F", "ai_confidence": 0.9, "reasoning": "圈F"},
+    ]
+    results = _patch_and_grade(scrambled)
+    actual_order = [r.question_id for r in results]
+    expected_order = ["fb_1", "fb_2", "fb_3", "fb_4", "fb_5", "mc_1", "mc_2", "mc_3"]
+    assert actual_order == expected_order, (
+        f"Expected YAML order {expected_order}, got {actual_order}"
+    )
+
+
+def test_results_already_sorted_remain_sorted():
+    """Idempotency: when Gemini already returns YAML order, the sort doesn't
+    disturb it."""
+    in_order = [
+        {"question_id": "fb_1", "student_answer": "A", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "fb_2", "student_answer": "B", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "fb_3", "student_answer": "C", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "fb_4", "student_answer": "F", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "fb_5", "student_answer": "G", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "mc_1", "student_answer": "A", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "mc_2", "student_answer": "B", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "mc_3", "student_answer": "C", "ai_confidence": 0.9, "reasoning": ""},
+    ]
+    results = _patch_and_grade(in_order)
+    actual_order = [r.question_id for r in results]
+    expected_order = ["fb_1", "fb_2", "fb_3", "fb_4", "fb_5", "mc_1", "mc_2", "mc_3"]
+    assert actual_order == expected_order
+
+
+def test_results_with_missing_questions_keep_yaml_order_for_present():
+    """When Gemini only returns some questions (e.g. couldn't read fb_3, fb_5),
+    the remaining present ones still come out in YAML order."""
+    partial = [
+        {"question_id": "mc_3", "student_answer": "C", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "fb_2", "student_answer": "B", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "fb_1", "student_answer": "A", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "mc_1", "student_answer": "A", "ai_confidence": 0.9, "reasoning": ""},
+    ]
+    results = _patch_and_grade(partial)
+    actual_order = [r.question_id for r in results]
+    expected_order = ["fb_1", "fb_2", "mc_1", "mc_3"]
+    assert actual_order == expected_order, (
+        f"Expected YAML order {expected_order} for present questions, got {actual_order}"
+    )

--- a/backend/tests/test_regression_omo_grader_question_order_1973.py
+++ b/backend/tests/test_regression_omo_grader_question_order_1973.py
@@ -57,9 +57,16 @@ def _run(coro):
     return asyncio.run(coro)
 
 
-def _patch_and_grade(mock_items: list[dict]) -> list:
-    """Patch the google.genai module and run grade_worksheet_images."""
+def _patch_and_grade(mock_items: list[dict], lesson: dict | None = None) -> list:
+    """Patch the google.genai module and run grade_worksheet_images.
+
+    Default lesson is the 5-fb + 3-mc fixture; pass ``lesson=`` to use a
+    different one (e.g. LESSON_WITH_SE for the strategy_exercise case).
+    """
     import app.services.omo_grader as grader_mod
+
+    if lesson is None:
+        lesson = LESSON
 
     grader_mod._consecutive_errors = 0
     mock_response = _make_mock_response(mock_items)
@@ -108,7 +115,7 @@ def _patch_and_grade(mock_items: list[dict]) -> list:
         return _run(grader_mod.grade_worksheet_images(
             image_bytes_list=[b"fake_image_bytes"],
             mime_types=["image/jpeg"],
-            lesson=LESSON,
+            lesson=lesson,
             attempt_id=None,
         ))
 
@@ -196,62 +203,6 @@ LESSON_WITH_SE = {
 }
 
 
-def _patch_and_grade_lesson(mock_items: list[dict], lesson: dict) -> list:
-    """Same as _patch_and_grade but with a custom lesson fixture."""
-    import app.services.omo_grader as grader_mod
-
-    grader_mod._consecutive_errors = 0
-    mock_response = _make_mock_response(mock_items)
-
-    fake_genai = types.ModuleType("google.genai")
-    fake_types = types.ModuleType("google.genai.types")
-
-    class FakeContent:
-        def __init__(self, **kwargs): pass
-
-    class FakePart:
-        @staticmethod
-        def from_bytes(**kwargs): return FakePart()
-
-    class FakeThinkingConfig:
-        def __init__(self, **kwargs): pass
-
-    class FakeAutoFuncCallingConfig:
-        def __init__(self, **kwargs): pass
-
-    class FakeGenerateContentConfig:
-        def __init__(self, **kwargs): pass
-
-    class FakeClient:
-        def __init__(self, **kwargs): pass
-        class models:
-            @staticmethod
-            def generate_content(**kwargs):
-                return mock_response
-
-    fake_types.Content = FakeContent
-    fake_types.Part = FakePart
-    fake_types.ThinkingConfig = FakeThinkingConfig
-    fake_types.AutomaticFunctionCallingConfig = FakeAutoFuncCallingConfig
-    fake_types.GenerateContentConfig = FakeGenerateContentConfig
-    fake_genai.Client = FakeClient
-
-    fake_google = types.ModuleType("google")
-    fake_google.genai = fake_genai
-
-    with patch.dict(sys.modules, {
-        "google": fake_google,
-        "google.genai": fake_genai,
-        "google.genai.types": fake_types,
-    }):
-        return _run(grader_mod.grade_worksheet_images(
-            image_bytes_list=[b"fake_image_bytes"],
-            mime_types=["image/jpeg"],
-            lesson=lesson,
-            attempt_id=None,
-        ))
-
-
 def test_results_sorted_across_fb_mc_se_question_types():
     """Sort must handle the full schema (fb_* → mc_* → se_*) — strategy_exercise
     is appended after MC in _build_question_schema, so sort key must respect
@@ -269,7 +220,7 @@ def test_results_sorted_across_fb_mc_se_question_types():
         {"question_id": "fb_1", "student_answer": "觀察", "ai_confidence": 0.9, "reasoning": ""},
         {"question_id": "mc_2", "student_answer": "B", "ai_confidence": 0.9, "reasoning": ""},
     ]
-    results = _patch_and_grade_lesson(scrambled, LESSON_WITH_SE)
+    results = _patch_and_grade(scrambled, lesson=LESSON_WITH_SE)
     actual_order = [r.question_id for r in results]
     expected_order = ["fb_1", "fb_2", "mc_1", "mc_2", "se_1", "se_2"]
     assert actual_order == expected_order, (

--- a/backend/tests/test_regression_omo_grader_question_order_1973.py
+++ b/backend/tests/test_regression_omo_grader_question_order_1973.py
@@ -53,7 +53,8 @@ def _make_mock_response(items: list[dict]) -> MagicMock:
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    # Python 3.10+: get_event_loop() is deprecated when no running loop exists.
+    return asyncio.run(coro)
 
 
 def _patch_and_grade(mock_items: list[dict]) -> list:
@@ -167,4 +168,110 @@ def test_results_with_missing_questions_keep_yaml_order_for_present():
     expected_order = ["fb_1", "fb_2", "mc_1", "mc_3"]
     assert actual_order == expected_order, (
         f"Expected YAML order {expected_order} for present questions, got {actual_order}"
+    )
+
+
+# Lesson with all three question types — fb_*, mc_*, se_* — to verify the
+# sort handles the full schema produced by _build_question_schema (#1879).
+LESSON_WITH_SE = {
+    "title": "L24-含策略練習",
+    "vocabulary": [
+        {"word": "觀察"},
+        {"word": "記錄"},
+    ],
+    "fill_in_blank": [
+        {"answer": "觀察", "sentence": "仔細觀察"},   # fb_1 (free_form)
+        {"answer": "記錄", "sentence": "詳細記錄"},   # fb_2 (free_form)
+    ],
+    "multiple_choice": [
+        {"answer": "A", "question": "q1"},   # mc_1
+        {"answer": "B", "question": "q2"},   # mc_2
+    ],
+    "strategy_exercise": {
+        "items": [
+            {"id": "se_1", "stem": "第一題策略", "answer": "策略A"},
+            {"id": "se_2", "stem": "第二題策略", "answer": "策略B"},
+        ],
+    },
+}
+
+
+def _patch_and_grade_lesson(mock_items: list[dict], lesson: dict) -> list:
+    """Same as _patch_and_grade but with a custom lesson fixture."""
+    import app.services.omo_grader as grader_mod
+
+    grader_mod._consecutive_errors = 0
+    mock_response = _make_mock_response(mock_items)
+
+    fake_genai = types.ModuleType("google.genai")
+    fake_types = types.ModuleType("google.genai.types")
+
+    class FakeContent:
+        def __init__(self, **kwargs): pass
+
+    class FakePart:
+        @staticmethod
+        def from_bytes(**kwargs): return FakePart()
+
+    class FakeThinkingConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeAutoFuncCallingConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeGenerateContentConfig:
+        def __init__(self, **kwargs): pass
+
+    class FakeClient:
+        def __init__(self, **kwargs): pass
+        class models:
+            @staticmethod
+            def generate_content(**kwargs):
+                return mock_response
+
+    fake_types.Content = FakeContent
+    fake_types.Part = FakePart
+    fake_types.ThinkingConfig = FakeThinkingConfig
+    fake_types.AutomaticFunctionCallingConfig = FakeAutoFuncCallingConfig
+    fake_types.GenerateContentConfig = FakeGenerateContentConfig
+    fake_genai.Client = FakeClient
+
+    fake_google = types.ModuleType("google")
+    fake_google.genai = fake_genai
+
+    with patch.dict(sys.modules, {
+        "google": fake_google,
+        "google.genai": fake_genai,
+        "google.genai.types": fake_types,
+    }):
+        return _run(grader_mod.grade_worksheet_images(
+            image_bytes_list=[b"fake_image_bytes"],
+            mime_types=["image/jpeg"],
+            lesson=lesson,
+            attempt_id=None,
+        ))
+
+
+def test_results_sorted_across_fb_mc_se_question_types():
+    """Sort must handle the full schema (fb_* → mc_* → se_*) — strategy_exercise
+    is appended after MC in _build_question_schema, so sort key must respect
+    that even though the IDs aren't lexicographically ordered.
+
+    Note: se_* answers use empty student_answer to avoid the anti-fabrication
+    coercion (se_* doesn't expose allowed_values), but the result is still
+    appended to `results` so the ordering is still observable.
+    """
+    scrambled = [
+        {"question_id": "se_2", "student_answer": "", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "mc_1", "student_answer": "A", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "fb_2", "student_answer": "記錄", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "se_1", "student_answer": "", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "fb_1", "student_answer": "觀察", "ai_confidence": 0.9, "reasoning": ""},
+        {"question_id": "mc_2", "student_answer": "B", "ai_confidence": 0.9, "reasoning": ""},
+    ]
+    results = _patch_and_grade_lesson(scrambled, LESSON_WITH_SE)
+    actual_order = [r.question_id for r in results]
+    expected_order = ["fb_1", "fb_2", "mc_1", "mc_2", "se_1", "se_2"]
+    assert actual_order == expected_order, (
+        f"Expected YAML order across fb/mc/se {expected_order}, got {actual_order}"
     )


### PR DESCRIPTION
# Issue #1973 修正說明

## 問題摘要

OMO 紙本批改完成後，結果卡片是依 Gemini 視覺掃描回傳的順序顯示，不是依 lesson YAML 的題號順序（`fb_1 → fb_2 → … → mc_1 → mc_2`）。學生對著紙本核對答案時題號跳來跳去，體驗很差，特別是 `_split_spread` 把雙頁拆成左右兩半後，Gemini 從右半開始 scan 順序更亂。

## 修正策略

在 `backend/app/services/omo_grader.py` 的 `grade_worksheet_images` 回傳前，依 `_build_question_schema(lesson)` 產出的 `questions` 順序（YAML 順序：先 fb_*、再 mc_*、再 se_*）排序 `results`。

選擇在 grader service 層做的好處：
1. 所有 caller（背景批改 job / regrade / 未來的歷史頁）一律拿到穩定排序，不必各自重複 sort
2. 不影響既有 anti-fabrication / low-confidence / crop 上傳邏輯
3. 修改最小（5 行 + 一個 dict comprehension）

`_mock_grades` 已是按 `questions` 順序產生（line 304-318），不需動。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `backend/app/services/omo_grader.py` | `grade_worksheet_images` return 前依 questions 順序 sort `results`（+6 行） |
| `backend/tests/test_regression_omo_grader_question_order_1973.py` | 新增 regression test（3 個 case：scrambled / already-sorted / partial）|

## 修正內容詳述

### `omo_grader.py` (line 286-291 附近)

**before**

```python
            result.crop_image_url = gs_uri

    logger.info(
        "OMO grader: graded %d/%d questions for lesson '%s'",
        len(results),
        len(questions),
        lesson.get("title", "unknown"),
    )
    return results
```

**after**

```python
            result.crop_image_url = gs_uri

    # #1973: sort by YAML question order (fb_1, fb_2, …, mc_1, mc_2, …) so the
    # client renders in a stable, student-readable order rather than Gemini's
    # visual-scan order (which can jump around — esp. after _split_spread).
    qid_order = {q["id"]: idx for idx, q in enumerate(questions)}
    results.sort(key=lambda g: qid_order.get(g.question_id, len(qid_order)))

    logger.info(
        "OMO grader: graded %d/%d questions for lesson '%s'",
        len(results),
        len(questions),
        lesson.get("title", "unknown"),
    )
    return results
```

排序 key：每個 result 找它 `question_id` 在 `questions` list 中的 index；找不到（理論上不該發生，因為上面 line 211 已 skip unknown question_id）就排最後。

### `test_regression_omo_grader_question_order_1973.py`（新檔）

mock 一個 8 題的 lesson（fb_1~fb_5、mc_1~mc_3），測 3 種狀況：

1. **`test_results_sorted_by_yaml_order_when_gemini_returns_scrambled`** — Gemini 故意亂序回傳（mc 在 fb 中間、fb 不照數字）→ 驗證 results 順序為 `[fb_1, fb_2, fb_3, fb_4, fb_5, mc_1, mc_2, mc_3]`
2. **`test_results_already_sorted_remain_sorted`** — Gemini 本來就照 YAML 順序 → idempotent，順序維持
3. **`test_results_with_missing_questions_keep_yaml_order_for_present`** — Gemini 只回傳部分題目（缺 fb_3, fb_5, mc_2）→ 驗證有的題目仍照 YAML 順序

每個 test 都用嚴格的 expected list 比對，沒有 tautology。

## 測試方式

### 本地 unit test

```bash
cd backend
.venv/bin/pytest tests/test_regression_omo_grader_question_order_1973.py -v
```

結果：3 passed。

### 確認不影響既有測試

執行 `pytest tests/test_omo_grader_real.py tests/test_omo_grader_split_1879.py tests/test_regression_omo_grader_locked_1730.py tests/test_omo_crop_provenance.py tests/test_regression_llm_models_per_task_1734.py`

有 11 個 fail，但**與本 PR 無關**：經過 stash 我的改動後在 staging baseline 重跑，這 11 個一樣失敗（內容如 `_upload_to_gcs` attribute 不存在、prompt 文字格式不符等），是既存 broken tests。

### Staging 驗證（merge 後）

1. 上傳 G5-L25 學習單 → 等批改完成
2. 觀察結果卡片：題號應為 `fb_1, fb_2, fb_3, fb_4, fb_5, mc_1, mc_2`，不再亂跳
3. 雙頁掃描（landscape spread）特別容易觸發舊問題 — 拿來壓測排序

## 迴歸測試

- 批改分數計算：`overall_score = sum(g.score) / len(graded)`（`omo_jobs.py:333`）— 與順序無關 ✅
- 信心度計算：`overall_confidence = sum(g.ai_confidence) / len(graded)`（`omo_jobs.py:334`）— 與順序無關 ✅
- Crop 上傳：line 271-287 的 `for result in results` 迴圈在 sort **之前**，逐題上傳邏輯不變 ✅
- Anti-fabrication / low-confidence：line 215-235 在 sort 之前處理，邏輯不變 ✅
- Frontend `OmoResultPage.tsx` 直接 `answers.map`，現在會自動拿到正確順序 ✅