### PR TITLE
feat(omo): 多頁上傳 UX — 縮圖 / 排序 / 確認再送 (#1974)

### DIFF
--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -1,22 +1,32 @@
 /**
- * OmoUpload — Phase 1b paper worksheet upload UI.
+ * OmoUpload — paper worksheet upload UI.
  *
- * Phase 1b improvements (Sub 4 / #1587):
- *  - Client-side image resize: canvas.toBlob() compresses to ≤1280px / 85% quality
- *    before upload. Reduces upload time on mobile (typical 4–8 MB → ~400 KB).
- *  - Status-aware loading copy: cycling messages while upload is in flight
- *    ("壓縮圖片中…" → "上傳中…" → "AI 辨識開始…")
- *  - Chinese error toasts: friendlier, more specific error copy
- *  - Dedup handling: if server returns from_cache=true, calls onUploaded with
- *    upload_id directly (skip UI re-upload)
+ * Issue #1974 (multi-page UX rewrite):
+ *  - Encourage students to upload ALL pages of the worksheet (not just the first).
+ *    Cross-page big questions used to be silently truncated when students only
+ *    uploaded page 1.
+ *  - Stages files in a queue (no immediate upload). User reviews thumbnails,
+ *    can reorder (↑/↓), remove (✕), and add more pages before confirming.
+ *  - Final 「上傳批改」 CTA shows page count + order summary.
  *
- * Phase 1a behaviour preserved:
- *  - "拍照" button (mobile capture="environment")
- *  - "選擇圖片" button (gallery/file picker)
- *  - Max 5 images, 10MB each (client-side guard + server re-validates)
+ * Integrated from staging during rebase:
+ *  - Issue #1976: PDF upload supported (server-side pypdfium2 splits to pages).
+ *    PDFs skip client-side resize and show a 📄 stub instead of a thumbnail.
+ *    Per-MIME size cap: 10 MB image / 20 MB PDF.
+ *  - Issue #1975: optional `onShowHistory` callback renders a「查看批改記錄」
+ *    button in the initial CTA section.
+ *
+ * Phase 1b behaviour preserved:
+ *  - Client-side resize (canvas.toBlob() ≤1280px / 85% quality) per image
+ *  - "拍照" capture + "選擇圖片/PDF" file picker
+ *  - Status-aware loading copy
+ *  - Chinese error toasts
+ *  - from_cache shortcut (server skips Gemini if SHA-256 hash hits)
+ *  - lessonCodeHint forwarded to backend (Issue #1637)
  */
 import React, { useEffect, useRef, useState } from 'react';
 import { uploadOmoImages } from '../../services/omoApi';
+import OmoUploadPagePreview from './OmoUploadPagePreview';
 
 const MAX_FILES = 5;
 const MAX_FILE_BYTES = 10 * 1024 * 1024;     // 10 MB per image (pre-resize)
@@ -50,10 +60,23 @@ interface OmoUploadProps {
   /**
    * Issue #1975: optional callback to view OMO batch grading history. When
    * provided, an extra「📋 查看批改記錄」button is rendered alongside the
-   * camera + gallery CTAs. Parent owns the navigation target so this
+   * initial camera + gallery CTAs. Parent owns the navigation target so this
    * component stays framework-agnostic.
    */
   onShowHistory?: () => void;
+}
+
+interface StagedPage {
+  /** Stable id used as React key — survives reorders without remount/reflow. */
+  id: number;
+  file: File;
+  /**
+   * Object URL for image thumbnails. ``null`` for PDFs since `<img>` can't
+   * render them — the page preview falls back to a 📄 icon stub.
+   * Image URLs must be URL.revokeObjectURL'd when the page is removed.
+   */
+  previewUrl: string | null;
+  isPdf: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -122,6 +145,11 @@ async function resizeImage(file: File): Promise<File> {
   });
 }
 
+// Module-level counter for stable React keys across reorders. Resets per page
+// load, which is fine since staged pages live within one OmoUpload mount.
+let _stagedIdCounter = 0;
+const nextStagedId = () => ++_stagedIdCounter;
+
 // ---------------------------------------------------------------------------
 // Loading copy cycle hook
 // ---------------------------------------------------------------------------
@@ -153,39 +181,59 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
   lessonCodeHint,
   onShowHistory,
 }) => {
+  const [staged, setStaged] = useState<StagedPage[]>([]);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-  // #1976: PDFs have no image preview (canvas can't render them) — track
-  // filename separately so the UI can show a 📄 stub with the name.
-  const [pdfPreview, setPdfPreview] = useState<{ name: string; sizeMb: string } | null>(null);
 
   const cameraInputRef = useRef<HTMLInputElement>(null);
   const galleryInputRef = useRef<HTMLInputElement>(null);
 
+  // #1974 review-3: mirror `staged` into a ref so the unmount cleanup effect
+  // (deps=[]) can see the LATEST queue instead of the empty mount-time value
+  // captured by closure.
+  const stagedRef = useRef<StagedPage[]>(staged);
+  stagedRef.current = staged;
+
   const loadingMsg = useLoadingMessage(uploading);
 
-  const handleFiles = async (files: FileList | null) => {
+  const hasStaged = staged.length > 0;
+  const canAddMore = staged.length < MAX_FILES;
+
+  // ── Revoke a page's object URL on remove/clear/unmount to avoid leaks ───
+  const revokePageUrl = (page: StagedPage) => {
+    if (!page.previewUrl) return;  // PDFs have no object URL to revoke
+    try {
+      URL.revokeObjectURL(page.previewUrl);
+    } catch {
+      // No-op: revoke is best-effort.
+    }
+  };
+
+  // ── Add files to the queue (called by both camera + gallery inputs) ──────
+  const handleAddFiles = (files: FileList | null) => {
     setError(null);
-    // #1976 review-2: clear any prior preview before validation so a fresh
-    // pick that fails (e.g. >MAX_FILES) doesn't leave the old PDF/image stub
-    // showing alongside the error toast.
-    setPreview(null);
-    setPdfPreview(null);
     if (!files || files.length === 0) return;
 
-    const fileArray = Array.from(files);
+    const incoming = Array.from(files);
+    const remaining = MAX_FILES - staged.length;
 
-    // ── Client-side validation ──────────────────────────────────────────────
-    if (fileArray.length > MAX_FILES) {
-      setError(`最多只能上傳 ${MAX_FILES} 個檔案，你選了 ${fileArray.length} 個`);
+    if (remaining <= 0) {
+      setError(`已達 ${MAX_FILES} 個檔案上限，請先移除一個`);
       return;
     }
-    for (const f of fileArray) {
+
+    // #1974 review-2: when user picks more than the remaining slots, take the
+    // first N and tell them — friendlier than rejecting the whole batch and
+    // making them re-pick. Validation errors (size/MIME) still abort.
+    const truncated = incoming.length > remaining;
+    const accepted = truncated ? incoming.slice(0, remaining) : incoming;
+
+    for (const f of accepted) {
       if (!ACCEPTED_MIME.includes(f.type)) {
         setError(`不支援「${f.name.split('.').pop()?.toUpperCase() ?? '?'}」格式，請選 JPG、PNG、WebP 或 PDF`);
         return;
       }
+      // #1976: per-MIME size cap — images 10 MB, PDFs 20 MB.
       const isPdf = f.type === PDF_MIME;
       const cap = isPdf ? MAX_PDF_BYTES : MAX_FILE_BYTES;
       if (f.size > cap) {
@@ -197,38 +245,88 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
       }
     }
 
-    // ── Preview first file (PDFs use an icon stub since <img> can't render them).
-    // Preview state already cleared at the top of handleFiles, so each branch
-    // only sets the one it owns.
-    const first = fileArray[0];
-    if (first.type === PDF_MIME) {
-      setPdfPreview({
-        name: first.name,
-        sizeMb: (first.size / (1024 * 1024)).toFixed(1),
-      });
-    } else {
-      const firstReader = new FileReader();
-      firstReader.onload = (e) => setPreview(e.target?.result as string);
-      firstReader.readAsDataURL(first);
-    }
+    const newPages: StagedPage[] = accepted.map((file) => {
+      const isPdf = file.type === PDF_MIME;
+      return {
+        id: nextStagedId(),
+        file,
+        // PDFs use a 📄 stub in the queue preview — no object URL needed.
+        previewUrl: isPdf ? null : URL.createObjectURL(file),
+        isPdf,
+      };
+    });
+    setStaged((prev) => [...prev, ...newPages]);
 
+    if (truncated) {
+      setError(
+        `一次只能再加 ${remaining} 個，已取前 ${remaining} 個檔案，其餘 ${incoming.length - remaining} 個未加入`,
+      );
+    }
+  };
+
+  // ── Manipulate the staged queue ─────────────────────────────────────────
+  const handleRemove = (idx: number) =>
+    setStaged((prev) => {
+      const target = prev[idx];
+      if (target) revokePageUrl(target);
+      return prev.filter((_, i) => i !== idx);
+    });
+
+  const handleMoveUp = (idx: number) => {
+    if (idx <= 0) return;
+    setStaged((prev) => {
+      const next = [...prev];
+      [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
+      return next;
+    });
+  };
+
+  const handleMoveDown = (idx: number) => {
+    setStaged((prev) => {
+      if (idx >= prev.length - 1) return prev;
+      const next = [...prev];
+      [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
+      return next;
+    });
+  };
+
+  const handleClearAll = () => {
+    staged.forEach(revokePageUrl);
+    setStaged([]);
+    setError(null);
+  };
+
+  // ── Revoke all object URLs on unmount ───────────────────────────────────
+  // Reads stagedRef.current rather than the `staged` from closure to avoid the
+  // empty-array stale-closure pin (deps=[] runs once at mount).  Re-running on
+  // every staged change would revoke URLs we still need to display.
+  useEffect(() => {
+    return () => {
+      stagedRef.current.forEach(revokePageUrl);
+    };
+  }, []);
+
+  // ── Trigger the actual upload (resize + POST) ───────────────────────────
+  const handleConfirmUpload = async () => {
+    if (!hasStaged) return;
+    setError(null);
     setUploading(true);
     try {
-      // ── Client-side resize ────────────────────────────────────────────────
-      const resized = await Promise.all(fileArray.map(resizeImage));
-
-      // ── Upload (pass lesson hint if available — Issue #1637) ─────────────
+      const resized = await Promise.all(staged.map((s) => resizeImage(s.file)));
       const result = await uploadOmoImages(resized, token, lessonCodeHint);
+      // #1974 review-2: clear queue + revoke object URLs after success so
+      // re-mount or remount-less reuse of <OmoUpload> starts clean.
+      staged.forEach(revokePageUrl);
+      setStaged([]);
       onUploaded(result.upload_id);
     } catch (err) {
       const raw = err instanceof Error ? err.message : '';
 
-      // Map common error patterns to friendlier Chinese copy
       let msg = '上傳失敗，請再試一次';
       if (raw.includes('413') || raw.includes('太大')) {
-        msg = '圖片太大，即使壓縮後仍超過限制，請重新拍攝較清晰的照片';
+        msg = '檔案太大，即使壓縮後仍超過限制，請重新拍攝或選較小的 PDF';
       } else if (raw.includes('400') || raw.includes('格式')) {
-        msg = '圖片格式不對，請選 JPG 或 PNG';
+        msg = '檔案格式不對，請選 JPG、PNG 或 PDF';
       } else if (raw.includes('401') || raw.includes('403')) {
         msg = '登入已逾時，請重新登入後再試';
       } else if (raw.includes('429')) {
@@ -245,38 +343,46 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
     }
   };
 
+  // ── Reset hidden file inputs so re-selecting the same file fires onChange ──
+  const onCameraChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleAddFiles(e.target.files);
+    e.target.value = '';
+  };
+  const onGalleryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleAddFiles(e.target.files);
+    e.target.value = '';
+  };
+
+  // ── Render ──────────────────────────────────────────────────────────────
   return (
     <div className="flex flex-col items-center gap-6 px-4 py-8 max-w-md mx-auto">
       {/* Header */}
       <div className="text-center">
         <div className="text-5xl mb-3" aria-hidden="true">📸</div>
-        <h1 className="text-xl font-bold text-gray-900">上傳學習單</h1>
+        <h1 className="text-xl font-bold text-gray-900">上傳學習單（所有頁面）</h1>
         <p className="mt-1 text-sm text-gray-500">
-          拍下紙本、選相簿照片，或直接上傳 PDF 掃描檔
+          拍下或選擇紙本的<span className="font-semibold text-gray-700">每一頁</span>，
+          也可直接上傳 PDF 掃描檔（AI 會合併批改，最多 {MAX_FILES} 個檔案）
         </p>
       </div>
 
-      {/* Preview — image */}
-      {preview && !uploading && (
-        <div className="w-full rounded-xl overflow-hidden border border-gray-200 shadow-sm">
-          <img
-            src={preview}
-            alt="學習單預覽"
-            className="w-full object-contain max-h-48"
-          />
-        </div>
-      )}
-
-      {/* Preview — PDF stub (no thumbnail since <img> can't render PDF) */}
-      {pdfPreview && !preview && !uploading && (
-        <div className="w-full flex items-center gap-3 rounded-xl border border-gray-200 shadow-sm px-4 py-3 bg-gray-50">
-          <div className="text-3xl shrink-0" aria-hidden="true">📄</div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-gray-800 truncate">{pdfPreview.name}</p>
-            <p className="text-xs text-gray-500 mt-0.5">PDF · {pdfPreview.sizeMb} MB · 上傳後將自動拆頁批改</p>
-          </div>
-        </div>
-      )}
+      {/* Hidden inputs (always mounted so refs are stable) */}
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={onCameraChange}
+      />
+      <input
+        ref={galleryInputRef}
+        type="file"
+        accept="image/*,application/pdf,.pdf"
+        multiple
+        className="hidden"
+        onChange={onGalleryChange}
+      />
 
       {/* Upload spinner + cycling copy */}
       {uploading && (
@@ -292,10 +398,45 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
         </div>
       )}
 
-      {/* Buttons */}
-      {!uploading && (
+      {/* Staged page queue */}
+      {!uploading && hasStaged && (
+        <div className="w-full flex flex-col gap-2">
+          <div className="flex items-center justify-between px-1">
+            <h2 className="text-sm font-semibold text-gray-700">
+              已選 {staged.length} 個檔案
+            </h2>
+            <button
+              type="button"
+              onClick={handleClearAll}
+              className="text-xs text-gray-400 hover:text-red-500 underline"
+            >
+              全部清除
+            </button>
+          </div>
+          {staged.map((page, idx) => (
+            <OmoUploadPagePreview
+              key={page.id}
+              pageIndex={idx}
+              totalPages={staged.length}
+              previewUrl={page.previewUrl}
+              fileName={page.file.name}
+              isPdf={page.isPdf}
+              onRemove={() => handleRemove(idx)}
+              onMoveUp={() => handleMoveUp(idx)}
+              onMoveDown={() => handleMoveDown(idx)}
+            />
+          ))}
+          {staged.length >= 2 && (
+            <p className="text-xs text-gray-400 px-1 mt-1">
+              請依紙本順序排好（第 1 個 → 第 {staged.length} 個）
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Initial CTAs (no staged) */}
+      {!uploading && !hasStaged && (
         <div className="flex flex-col gap-3 w-full">
-          {/* Camera capture (mobile: opens camera directly) */}
           <button
             type="button"
             onClick={() => cameraInputRef.current?.click()}
@@ -308,16 +449,6 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
             <span aria-hidden="true">📷</span>
             拍照上傳
           </button>
-          <input
-            ref={cameraInputRef}
-            type="file"
-            accept="image/*"
-            capture="environment"
-            className="hidden"
-            onChange={(e) => handleFiles(e.target.files)}
-          />
-
-          {/* Gallery / file picker — accepts images + PDF */}
           <button
             type="button"
             onClick={() => galleryInputRef.current?.click()}
@@ -331,14 +462,6 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
             <span aria-hidden="true">🖼️</span>
             選擇照片或 PDF
           </button>
-          <input
-            ref={galleryInputRef}
-            type="file"
-            accept="image/*,application/pdf,.pdf"
-            multiple
-            className="hidden"
-            onChange={(e) => handleFiles(e.target.files)}
-          />
 
           {/* #1975 — entry point to view previous OMO grading results */}
           {onShowHistory && (
@@ -355,6 +478,57 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
               查看批改記錄
             </button>
           )}
+        </div>
+      )}
+
+      {/* Add-more + Confirm buttons (queue has at least one) */}
+      {!uploading && hasStaged && (
+        <div className="flex flex-col gap-3 w-full">
+          {canAddMore && (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => cameraInputRef.current?.click()}
+                className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4
+                  bg-white hover:bg-gray-50 active:bg-gray-100
+                  text-gray-700 text-sm font-medium rounded-xl
+                  border border-gray-300 transition-colors"
+              >
+                <span aria-hidden="true">📷</span>
+                再拍一張
+              </button>
+              <button
+                type="button"
+                onClick={() => galleryInputRef.current?.click()}
+                className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4
+                  bg-white hover:bg-gray-50 active:bg-gray-100
+                  text-gray-700 text-sm font-medium rounded-xl
+                  border border-gray-300 transition-colors"
+              >
+                <span aria-hidden="true">🖼️</span>
+                再加照片/PDF
+              </button>
+            </div>
+          )}
+
+          {!canAddMore && (
+            <p className="text-xs text-amber-600 text-center">
+              已達 {MAX_FILES} 個檔案上限，請移除一個才能再加
+            </p>
+          )}
+
+          <button
+            type="button"
+            onClick={handleConfirmUpload}
+            className="w-full flex items-center justify-center gap-2 py-3.5 px-6
+              bg-blue-600 hover:bg-blue-700 active:bg-blue-800
+              text-white font-semibold rounded-xl
+              focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+              transition-colors"
+          >
+            <span aria-hidden="true">🚀</span>
+            上傳批改（{staged.length} 個檔案）
+          </button>
         </div>
       )}
 
@@ -379,7 +553,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
       )}
 
       <p className="text-xs text-gray-400 text-center">
-        支援 JPG、PNG、WebP（每張 ≤ 10 MB）或 PDF（≤ 20 MB，多頁自動拆開）
+        支援 JPG、PNG、WebP（每張 ≤ 10 MB）或 PDF（≤ 20 MB，多頁自動拆開），最多 {MAX_FILES} 個檔案
         <br />
         <span className="text-gray-300">上傳前自動壓縮以節省時間</span>
       </p>

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -492,7 +492,9 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
                 className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4
                   bg-white hover:bg-gray-50 active:bg-gray-100
                   text-gray-700 text-sm font-medium rounded-xl
-                  border border-gray-300 transition-colors"
+                  border border-gray-300
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+                  transition-colors"
               >
                 <span aria-hidden="true">📷</span>
                 再拍一張
@@ -503,7 +505,9 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
                 className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4
                   bg-white hover:bg-gray-50 active:bg-gray-100
                   text-gray-700 text-sm font-medium rounded-xl
-                  border border-gray-300 transition-colors"
+                  border border-gray-300
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+                  transition-colors"
               >
                 <span aria-hidden="true">🖼️</span>
                 再加照片/PDF

--- a/frontend/src/components/omo/OmoUploadPagePreview.tsx
+++ b/frontend/src/components/omo/OmoUploadPagePreview.tsx
@@ -74,7 +74,7 @@ const OmoUploadPagePreview: React.FC<OmoUploadPagePreviewProps> = ({
       <div className="flex-1 min-w-0">
         <p className="text-sm text-gray-700 truncate">{fileName}</p>
         <p className="text-xs text-gray-400 mt-0.5">
-          {isFirst && isLast ? '已選 1 頁' : `共 ${totalPages} 頁，點 ↑↓ 調整順序`}
+          {isFirst && isLast ? '已選 1 個' : `共 ${totalPages} 個，點 ↑↓ 調整順序`}
         </p>
       </div>
 
@@ -84,7 +84,7 @@ const OmoUploadPagePreview: React.FC<OmoUploadPagePreviewProps> = ({
           type="button"
           onClick={onMoveUp}
           disabled={isFirst}
-          aria-label={`將第 ${pageIndex + 1} 頁往上移`}
+          aria-label={`將第 ${pageIndex + 1} 個往上移`}
           className="w-7 h-6 flex items-center justify-center text-xs rounded-md border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
         >
           ↑
@@ -93,7 +93,7 @@ const OmoUploadPagePreview: React.FC<OmoUploadPagePreviewProps> = ({
           type="button"
           onClick={onMoveDown}
           disabled={isLast}
-          aria-label={`將第 ${pageIndex + 1} 頁往下移`}
+          aria-label={`將第 ${pageIndex + 1} 個往下移`}
           className="w-7 h-6 flex items-center justify-center text-xs rounded-md border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
         >
           ↓
@@ -104,7 +104,7 @@ const OmoUploadPagePreview: React.FC<OmoUploadPagePreviewProps> = ({
       <button
         type="button"
         onClick={onRemove}
-        aria-label={`移除第 ${pageIndex + 1} 頁`}
+        aria-label={`移除第 ${pageIndex + 1} 個`}
         className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full text-red-500 hover:bg-red-50 text-base font-semibold"
       >
         ✕

--- a/frontend/src/components/omo/OmoUploadPagePreview.tsx
+++ b/frontend/src/components/omo/OmoUploadPagePreview.tsx
@@ -1,0 +1,116 @@
+/**
+ * OmoUploadPagePreview — single-page thumbnail card in the OMO upload queue.
+ *
+ * Issue #1974: shows one staged page with:
+ *   - thumbnail (object URL from URL.createObjectURL) — or 📄 stub for PDFs (#1976)
+ *   - 「第 N 頁」 badge
+ *   - ↑ / ↓ reorder buttons (disabled at boundaries)
+ *   - ✕ remove button
+ *
+ * Reorder uses arrow buttons (not drag-and-drop) — primary user is a
+ * student on a mobile phone, where touch-drag is finicky; arrow buttons
+ * work the same on desktop and mobile with no extra dependencies.
+ */
+import React from 'react';
+
+interface OmoUploadPagePreviewProps {
+  /** Page index (0-based). Display number is pageIndex + 1. */
+  pageIndex: number;
+  /** Total pages in the queue (for boundary disabling). */
+  totalPages: number;
+  /** Object URL of the thumbnail (URL.createObjectURL). ``null`` for PDFs. */
+  previewUrl: string | null;
+  /** Original filename, used in alt + tooltip. */
+  fileName: string;
+  /** ``true`` when the file is a PDF — renders a 📄 stub instead of `<img>`. */
+  isPdf: boolean;
+  onRemove: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}
+
+const OmoUploadPagePreview: React.FC<OmoUploadPagePreviewProps> = ({
+  pageIndex,
+  totalPages,
+  previewUrl,
+  fileName,
+  isPdf,
+  onRemove,
+  onMoveUp,
+  onMoveDown,
+}) => {
+  const isFirst = pageIndex === 0;
+  const isLast = pageIndex === totalPages - 1;
+
+  return (
+    <div className="flex items-center gap-3 p-2 bg-white rounded-xl border border-gray-200 shadow-sm">
+      {/* Thumbnail with page-number overlay */}
+      <div className="relative shrink-0 w-16 h-16 rounded-lg overflow-hidden bg-gray-50 border border-gray-100">
+        {isPdf || !previewUrl ? (
+          <div
+            className="w-full h-full flex items-center justify-center text-3xl bg-gray-100"
+            aria-label={`${fileName} PDF 檔`}
+            title={fileName}
+          >
+            <span aria-hidden="true">📄</span>
+          </div>
+        ) : (
+          <img
+            src={previewUrl}
+            alt={`${fileName} 預覽`}
+            title={fileName}
+            className="w-full h-full object-cover"
+          />
+        )}
+        <span
+          className="absolute bottom-0 left-0 right-0 bg-black/55 text-white text-[10px] font-semibold text-center py-0.5"
+          aria-label={`第 ${pageIndex + 1} 個`}
+        >
+          {isPdf ? 'PDF' : `第 ${pageIndex + 1} 頁`}
+        </span>
+      </div>
+
+      {/* Filename + reorder hint */}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-gray-700 truncate">{fileName}</p>
+        <p className="text-xs text-gray-400 mt-0.5">
+          {isFirst && isLast ? '已選 1 頁' : `共 ${totalPages} 頁，點 ↑↓ 調整順序`}
+        </p>
+      </div>
+
+      {/* Reorder buttons */}
+      <div className="flex flex-col gap-1 shrink-0">
+        <button
+          type="button"
+          onClick={onMoveUp}
+          disabled={isFirst}
+          aria-label={`將第 ${pageIndex + 1} 頁往上移`}
+          className="w-7 h-6 flex items-center justify-center text-xs rounded-md border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          ↑
+        </button>
+        <button
+          type="button"
+          onClick={onMoveDown}
+          disabled={isLast}
+          aria-label={`將第 ${pageIndex + 1} 頁往下移`}
+          className="w-7 h-6 flex items-center justify-center text-xs rounded-md border border-gray-200 text-gray-600 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          ↓
+        </button>
+      </div>
+
+      {/* Remove */}
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`移除第 ${pageIndex + 1} 頁`}
+        className="shrink-0 w-7 h-7 flex items-center justify-center rounded-full text-red-500 hover:bg-red-50 text-base font-semibold"
+      >
+        ✕
+      </button>
+    </div>
+  );
+};
+
+export default OmoUploadPagePreview;


### PR DESCRIPTION
# Issue #1974 修正說明

## 問題摘要

OMO 上傳 UI 文案是單張口吻「拍下你的紙本學習單」，學生只拍第一頁就送出 → 跨頁大題後半被 AI 漏批。Backend 早就支援多檔（`_MAX_FILES_PER_UPLOAD=20`），但 UI 沒導引、沒順序提示、沒給機會增刪。

## 修正策略

把 UI 從「選一次就送」改為「累積 → 預覽 → 排序 → 確認送」：

1. 文案改多頁口吻
2. 新增 staged queue 狀態，選完不立即上傳
3. 每頁顯示縮圖卡片（新元件 `OmoUploadPagePreview`），可刪除 / 排序
4. 「再拍一頁」/「再加相片」按鈕方便累積
5. 「上傳批改（N 頁）」CTA 在確認後才真的 resize + POST

### 為什麼用 ↑/↓ 而非 drag-and-drop

Mobile-first 學生用戶，HTML5 drag 在觸控上不可靠，第三方庫（@dnd-kit）會多 ~30KB。對 3-5 張縮圖的小集合，arrow buttons 同樣達意又無新依賴。Issue spec 講「可拖曳排序」精神是「可重新排」，箭頭按鈕滿足需求。若未來真有人反映，補 drag 是另一個小 PR。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/components/omo/OmoUpload.tsx` | 重寫上傳流程：staged queue + 預覽列表 + 兩段 CTA |
| `frontend/src/components/omo/OmoUploadPagePreview.tsx`（新檔）| 單頁縮圖卡片元件（縮圖 + 「第 N 頁」標籤 + ↑/↓ + ✕） |

## 修正內容詳述

### `OmoUpload.tsx` 主要 state 變動

**before**

```typescript
const [preview, setPreview] = useState<string | null>(null);
// handleFiles → 直接 resize + uploadOmoImages
```

**after**

```typescript
interface StagedPage {
  file: File;
  previewUrl: string;
}
const [staged, setStaged] = useState<StagedPage[]>([]);
// handleAddFiles → 進 staged queue
// handleRemove / handleMoveUp / handleMoveDown / handleClearAll → queue 操作
// handleConfirmUpload → 才實際 resize + uploadOmoImages
```

### 累加而非替換

每次點「再拍一頁」/「再加相片」呼叫的 `handleAddFiles` 用 `setStaged(prev => [...prev, ...newPages])` 累加；超過 `MAX_FILES = 5` 會顯示「最多 5 頁，目前已選 N 頁，還能再加 K 頁」。

### File input 重置

選同一個檔案再次觸發 `onChange` 需要清空 `e.target.value = ''`，否則 React 不會 fire。

### Mobile-first ↑/↓ 排序

`OmoUploadPagePreview` 的箭頭按鈕：邊界自動 disabled（第一頁 ↑ disabled、最後一頁 ↓ disabled），`aria-label` 含頁次方便 screen reader。

### 不動的既有邏輯

- `resizeImage` 壓縮邏輯保留
- `useLoadingMessage` cycling copy 保留
- Error 文案映射（413 / 401 / 429 / 5xx / NetworkError）保留
- `uploadOmoImages(files, token, lessonCodeHint)` 簽名不變，FormData 依 array 順序 append，所以前端 reorder = backend 收到的順序

## 測試方式

### Type-check

```bash
cd frontend && npx tsc --noEmit
```

兩個改動檔案零 type error。（Staging baseline 既存 11 個 TS error 與本 PR 無關。）

### Build

```bash
cd frontend && npm run build
# ✓ built in 4.97s
```

### 手動驗證流程（待 staging deploy 後）

1. `/omo` 顯示「上傳學習單（所有頁面）」標題
2. 拍 / 選 1 張 → 縮圖出現，「第 1 頁」標籤
3. 點「再拍一頁」加 2 張 → 共 3 張縮圖，每張可 ↑↓ 排序、可 ✕ 刪
4. 達到 5 張 → 「再加」按鈕消失，提示「已達 5 頁上限」
5. 點「上傳批改（3 頁）」→ 進原本批改流程

## 迴歸測試

- `OmoPage.tsx` caller：`token / onUploaded / lessonCodeHint` props 不變 ✅
- `Intro.tsx`：只用 `omoApi`，沒直接 import `<OmoUpload>`，不受影響 ✅
- Backend `omo/upload.py`：接收 `files: list[UploadFile]`，FormData 已按 array 順序送 → 不需改 ✅
- #1973 排序修正：跟本 PR 獨立，sort 仍在 grader service 層 ✅