### PR TITLE
feat(omo): 上傳支援 PDF 檔，後端用 pypdfium2 拆頁 (#1976)

### DIFF
--- a/backend/app/routes/omo/upload.py
+++ b/backend/app/routes/omo/upload.py
@@ -12,6 +12,7 @@ llm-endpoint-hardening checklist (inherited from omo.py):
 - Fail-closed: status=error on AI failure ✅
 """
 
+import asyncio
 import hashlib
 import logging
 from typing import Optional
@@ -40,7 +41,7 @@ from ...services.omo_upload_service import (
     supersede_existing_uploads,
 )
 from ...services.omo_upload_validator import (
-    _MAX_FILES_PER_UPLOAD,
+    MAX_FILES_PER_UPLOAD,
     validate_attempt_files,
     validate_upload_files,
 )
@@ -126,9 +127,10 @@ async def upload_worksheet(
     Returns immediately with status=identifying. Poll GET /api/omo/{id} for result.
 
     Constraints:
-    - Max 5 files per call
-    - Max 10MB per file
-    - JPEG / PNG / WebP only
+    - Max ``MAX_FILES_PER_UPLOAD`` files per call (PDFs count as 1 here, expanded
+      per-page after validation)
+    - Images ≤ 10MB each, PDFs ≤ 20MB
+    - JPEG / PNG / WebP / PDF (#1976)
 
     Hint path (#1637): if ``lesson_code_hint`` is supplied, identification
     completes synchronously in the background task without any AI call
@@ -166,10 +168,13 @@ async def upload_worksheet(
     # ── #1976: expand any PDFs into per-page JPEGs ───────────────────────────
     # After this step every entry is an image and the rest of the pipeline
     # (GCS upload, identification, grading) does not need to know PDF existed.
+    # CPU-bound (pypdfium2 render) — push to a thread so we don't block the
+    # FastAPI event loop while a 20-page PDF renders (~1-3 s).
     try:
-        files_data = expand_pdf_files(
+        files_data = await asyncio.to_thread(
+            expand_pdf_files,
             files_data,
-            max_total_images=_MAX_FILES_PER_UPLOAD,
+            MAX_FILES_PER_UPLOAD,
         )
     except PdfSplitError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -264,11 +269,12 @@ async def add_attempt(
     # ── Validate (attempt count + file constraints) ───────────────────────────
     validate_attempt_files(files_data, existing_attempts)
 
-    # ── #1976: expand any PDFs into per-page JPEGs ───────────────────────────
+    # ── #1976: expand any PDFs into per-page JPEGs (off the event loop) ──────
     try:
-        files_data = expand_pdf_files(
+        files_data = await asyncio.to_thread(
+            expand_pdf_files,
             files_data,
-            max_total_images=_MAX_FILES_PER_UPLOAD,
+            MAX_FILES_PER_UPLOAD,
         )
     except PdfSplitError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/routes/omo/upload.py
+++ b/backend/app/routes/omo/upload.py
@@ -25,6 +25,7 @@ from ...database import get_db
 from ...models.omo_upload import OmoUpload, OmoUploadAttempt
 from ...models.user import User
 from ...services.omo_jobs import _run_identification
+from ...services.omo_pdf_split import PdfSplitError, expand_pdf_files
 from ...services.omo_responses import (
     LessonSummaryResponse,
     OmoAttemptResponse,
@@ -38,7 +39,11 @@ from ...services.omo_upload_service import (
     create_upload_record,
     supersede_existing_uploads,
 )
-from ...services.omo_upload_validator import validate_attempt_files, validate_upload_files
+from ...services.omo_upload_validator import (
+    _MAX_FILES_PER_UPLOAD,
+    validate_attempt_files,
+    validate_upload_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -139,12 +144,12 @@ async def upload_worksheet(
     # ── Validate (raises 400/413 before any GCS work) ────────────────────────
     validate_upload_files(files_data)
 
-    image_bytes_list = [d for d, _ in files_data]
-    mime_types = [m for _, m in files_data]
-
-    # ── Phase 1b: SHA-256 dedup check ────────────────────────────────────────
-    # Hash the primary (first) image to detect duplicate uploads.
-    primary_hash = hashlib.sha256(image_bytes_list[0]).hexdigest()
+    # ── #1976: SHA-256 dedup BEFORE PDF expansion ────────────────────────────
+    # Hash the primary file as uploaded (PDF or image) so re-uploading the
+    # same PDF still hits the cache — expansion is deterministic but
+    # hashing the rendered JPEGs would invalidate when the renderer
+    # changes versions.
+    primary_hash = hashlib.sha256(files_data[0][0]).hexdigest()
 
     existing_upload = check_dedup(db, current_user.id, primary_hash)
     if existing_upload:
@@ -157,6 +162,20 @@ async def upload_worksheet(
         response.from_cache = True
         response.already_graded = already_graded
         return response
+
+    # ── #1976: expand any PDFs into per-page JPEGs ───────────────────────────
+    # After this step every entry is an image and the rest of the pipeline
+    # (GCS upload, identification, grading) does not need to know PDF existed.
+    try:
+        files_data = expand_pdf_files(
+            files_data,
+            max_total_images=_MAX_FILES_PER_UPLOAD,
+        )
+    except PdfSplitError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    image_bytes_list = [d for d, _ in files_data]
+    mime_types = [m for _, m in files_data]
 
     # ── Create new upload record (status=identifying) ─────────────────────────
     upload = create_upload_record(db, current_user.id)
@@ -244,6 +263,15 @@ async def add_attempt(
 
     # ── Validate (attempt count + file constraints) ───────────────────────────
     validate_attempt_files(files_data, existing_attempts)
+
+    # ── #1976: expand any PDFs into per-page JPEGs ───────────────────────────
+    try:
+        files_data = expand_pdf_files(
+            files_data,
+            max_total_images=_MAX_FILES_PER_UPLOAD,
+        )
+    except PdfSplitError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     image_bytes_list = [d for d, _ in files_data]
     mime_types = [m for _, m in files_data]

--- a/backend/app/services/omo_pdf_split.py
+++ b/backend/app/services/omo_pdf_split.py
@@ -29,6 +29,11 @@ import logging
 import pypdfium2 as pdfium
 import PIL  # noqa: F401 — presence check; .to_pil() needs it at runtime
 
+# Single source of truth for the PDF MIME constant lives in
+# omo_upload_validator. Safe to import here — validator doesn't depend back
+# on this module, so no circular risk.
+from .omo_upload_validator import PDF_MIME_TYPE
+
 logger = logging.getLogger(__name__)
 
 # 150 DPI rendering scale (PDFium's render_scale uses 72 DPI baseline).
@@ -119,12 +124,6 @@ def pdf_to_jpeg_pages(pdf_bytes: bytes, max_pages: int = 20) -> list[bytes]:
             pass
 
 
-# MIME constant duplicated from omo_upload_validator to avoid a circular import
-# (validator → pdf_split via expand_pdf_files). Kept private; the
-# canonical source is omo_upload_validator._PDF_MIME_TYPE.
-_PDF_MIME_TYPE = "application/pdf"
-
-
 def expand_pdf_files(
     files_data: list[tuple[bytes, str]],
     max_total_images: int,
@@ -162,7 +161,7 @@ def expand_pdf_files(
     """
     expanded: list[tuple[bytes, str]] = []
     for data, mime in files_data:
-        if mime == _PDF_MIME_TYPE:
+        if mime == PDF_MIME_TYPE:
             page_jpegs = pdf_to_jpeg_pages(data, max_pages=per_pdf_max_pages)
             expanded.extend((page, "image/jpeg") for page in page_jpegs)
         else:

--- a/backend/app/services/omo_pdf_split.py
+++ b/backend/app/services/omo_pdf_split.py
@@ -13,7 +13,7 @@ Design:
 - Output JPEG quality 85 — same target the existing client-side resize uses.
 - Caller is responsible for enforcing per-page count caps (we just expose
   the helper); we surface `len(result)` so the route can compare against
-  `_MAX_FILES_PER_UPLOAD`.
+  `MAX_FILES_PER_UPLOAD`.
 
 Backend uses `pypdfium2` (PDFium binding, Apache-2.0 + BSD3) — pure-Python
 wheel, no native libpoppler dependency, Cloud Run friendly.
@@ -21,6 +21,13 @@ wheel, no native libpoppler dependency, Cloud Run friendly.
 
 import io
 import logging
+
+# Fail-fast at import time rather than per-request. Both deps are listed in
+# requirements.txt; a missing import here means the Cloud Run image is broken
+# and should surface immediately on startup. Pillow itself is imported only
+# to assert it's installed — pypdfium2's ``.to_pil()`` uses it internally.
+import pypdfium2 as pdfium
+import PIL  # noqa: F401 — presence check; .to_pil() needs it at runtime
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +54,7 @@ def pdf_to_jpeg_pages(pdf_bytes: bytes, max_pages: int = 20) -> list[bytes]:
     max_pages:
         Refuse to render past this many pages — caller is responsible for
         deciding what page count is reasonable for a worksheet (default 20
-        matches the upload route's ``_MAX_FILES_PER_UPLOAD`` ceiling).
+        matches the upload route's ``MAX_FILES_PER_UPLOAD`` ceiling).
 
     Returns
     -------
@@ -62,16 +69,6 @@ def pdf_to_jpeg_pages(pdf_bytes: bytes, max_pages: int = 20) -> list[bytes]:
     """
     if not pdf_bytes:
         raise PdfSplitError("PDF is empty")
-
-    try:
-        import pypdfium2 as pdfium
-    except ImportError:  # pragma: no cover - dep should be installed
-        raise PdfSplitError("pypdfium2 not installed — cannot parse PDF")
-
-    try:
-        from PIL import Image
-    except ImportError:  # pragma: no cover - dep should be installed
-        raise PdfSplitError("Pillow not installed — cannot encode JPEG")
 
     try:
         pdf = pdfium.PdfDocument(pdf_bytes)

--- a/backend/app/services/omo_pdf_split.py
+++ b/backend/app/services/omo_pdf_split.py
@@ -1,0 +1,178 @@
+"""OMO PDF split — render a PDF into per-page JPEG bytes.
+
+Issue #1976: scanner / copier output for paper worksheets is most often a
+multi-page PDF (Adobe Scan, iOS Notes, office MFPs). The existing OMO
+pipeline only accepts JPEG/PNG/WebP, so users had to manually export each
+page first. This module lets the upload route fan a single PDF out into the
+same per-page-image flow the rest of the pipeline already supports.
+
+Design:
+- Pure function: bytes-in, list[bytes]-out. No I/O, no GCS, no DB.
+- Renders at ~150 DPI (`_RENDER_SCALE`) — enough resolution for Gemini OCR
+  on student handwriting without bloating downstream image sizes.
+- Output JPEG quality 85 — same target the existing client-side resize uses.
+- Caller is responsible for enforcing per-page count caps (we just expose
+  the helper); we surface `len(result)` so the route can compare against
+  `_MAX_FILES_PER_UPLOAD`.
+
+Backend uses `pypdfium2` (PDFium binding, Apache-2.0 + BSD3) — pure-Python
+wheel, no native libpoppler dependency, Cloud Run friendly.
+"""
+
+import io
+import logging
+
+logger = logging.getLogger(__name__)
+
+# 150 DPI rendering scale (PDFium's render_scale uses 72 DPI baseline).
+# 150/72 ≈ 2.083 — empirically enough resolution for Chinese handwriting OCR
+# without producing huge JPEGs.
+_RENDER_SCALE: float = 150.0 / 72.0
+
+# JPEG quality for rendered pages (matches client-side resize quality).
+_JPEG_QUALITY: int = 85
+
+
+class PdfSplitError(ValueError):
+    """Raised when a PDF cannot be parsed or rendered to images."""
+
+
+def pdf_to_jpeg_pages(pdf_bytes: bytes, max_pages: int = 20) -> list[bytes]:
+    """Render every page of a PDF to JPEG bytes.
+
+    Parameters
+    ----------
+    pdf_bytes:
+        Raw PDF file content.
+    max_pages:
+        Refuse to render past this many pages — caller is responsible for
+        deciding what page count is reasonable for a worksheet (default 20
+        matches the upload route's ``_MAX_FILES_PER_UPLOAD`` ceiling).
+
+    Returns
+    -------
+    list[bytes]
+        One JPEG image per PDF page, in page order.
+
+    Raises
+    ------
+    PdfSplitError
+        If the PDF cannot be opened, has zero pages, exceeds ``max_pages``,
+        or any page fails to render.
+    """
+    if not pdf_bytes:
+        raise PdfSplitError("PDF is empty")
+
+    try:
+        import pypdfium2 as pdfium
+    except ImportError:  # pragma: no cover - dep should be installed
+        raise PdfSplitError("pypdfium2 not installed — cannot parse PDF")
+
+    try:
+        from PIL import Image
+    except ImportError:  # pragma: no cover - dep should be installed
+        raise PdfSplitError("Pillow not installed — cannot encode JPEG")
+
+    try:
+        pdf = pdfium.PdfDocument(pdf_bytes)
+    except Exception as exc:
+        # pypdfium2 raises various OSError / PdfiumError flavours for malformed
+        # PDFs. Normalise to PdfSplitError so callers handle one exception type.
+        raise PdfSplitError(f"無法解析 PDF：{exc}") from exc
+
+    try:
+        page_count = len(pdf)
+        if page_count == 0:
+            raise PdfSplitError("PDF 沒有任何頁面")
+        if page_count > max_pages:
+            raise PdfSplitError(
+                f"PDF 頁數過多（{page_count} 頁），最多支援 {max_pages} 頁",
+            )
+
+        pages: list[bytes] = []
+        for page_index in range(page_count):
+            try:
+                page = pdf[page_index]
+                pil_image = page.render(scale=_RENDER_SCALE).to_pil()
+                if pil_image.mode != "RGB":
+                    pil_image = pil_image.convert("RGB")
+                buf = io.BytesIO()
+                pil_image.save(buf, format="JPEG", quality=_JPEG_QUALITY)
+                pages.append(buf.getvalue())
+            except PdfSplitError:
+                raise
+            except Exception as exc:
+                raise PdfSplitError(
+                    f"第 {page_index + 1} 頁無法轉換成圖片：{exc}",
+                ) from exc
+
+        logger.info(
+            "omo_pdf_split: rendered %d page(s) (avg=%d KB/page)",
+            page_count,
+            sum(len(p) for p in pages) // (page_count * 1024) if page_count else 0,
+        )
+        return pages
+    finally:
+        # Release PDFium native handles promptly. Best-effort: a leaked
+        # document on the error path is acceptable, but normal flow should
+        # close.
+        try:
+            pdf.close()
+        except Exception:
+            pass
+
+
+# MIME constant duplicated from omo_upload_validator to avoid a circular import
+# (validator → pdf_split via expand_pdf_files). Kept private; the
+# canonical source is omo_upload_validator._PDF_MIME_TYPE.
+_PDF_MIME_TYPE = "application/pdf"
+
+
+def expand_pdf_files(
+    files_data: list[tuple[bytes, str]],
+    max_total_images: int,
+    per_pdf_max_pages: int = 20,
+) -> list[tuple[bytes, str]]:
+    """Expand any ``application/pdf`` entries into their per-page JPEGs.
+
+    Image entries pass through untouched, preserving their position in the
+    overall sequence. PDF entries are replaced in place by their N page
+    JPEGs, so the page order matches the original document.
+
+    Parameters
+    ----------
+    files_data:
+        Validated list of (raw_bytes, content_type) tuples — typically the
+        output of ``validate_upload_files``.
+    max_total_images:
+        Cap on the total number of resulting image entries. When PDFs
+        expand past this, raise PdfSplitError — the route turns that into
+        a 400 with friendly copy.
+    per_pdf_max_pages:
+        Per-PDF page cap (passed straight to ``pdf_to_jpeg_pages``).
+
+    Returns
+    -------
+    list[tuple[bytes, str]]
+        All-image entries — every tuple's MIME is one of the original
+        image MIMEs or ``image/jpeg`` for PDF-derived pages.
+
+    Raises
+    ------
+    PdfSplitError
+        If a PDF fails to render or total expanded count exceeds
+        ``max_total_images``.
+    """
+    expanded: list[tuple[bytes, str]] = []
+    for data, mime in files_data:
+        if mime == _PDF_MIME_TYPE:
+            page_jpegs = pdf_to_jpeg_pages(data, max_pages=per_pdf_max_pages)
+            expanded.extend((page, "image/jpeg") for page in page_jpegs)
+        else:
+            expanded.append((data, mime))
+
+        if len(expanded) > max_total_images:
+            raise PdfSplitError(
+                f"展開後共 {len(expanded)} 張，超過 {max_total_images} 張上限",
+            )
+    return expanded

--- a/backend/app/services/omo_upload_validator.py
+++ b/backend/app/services/omo_upload_validator.py
@@ -13,14 +13,47 @@ from fastapi import HTTPException
 
 # ── Upload constraints (single source of truth) ────────────────────────────────
 _MAX_FILE_SIZE_BYTES: int = 10 * 1024 * 1024   # 10 MB per image
+# #1976: PDFs are commonly larger because they bundle multiple pages —
+# allow a bigger cap before we expand them into per-page JPEGs.
+_MAX_PDF_SIZE_BYTES: int = 20 * 1024 * 1024    # 20 MB per PDF
 _MAX_FILES_PER_UPLOAD: int = 20                  # max files per single upload call
 _MAX_TOTAL_ATTEMPTS: int = 5                     # max attempts per upload session
-_ALLOWED_MIME_TYPES: frozenset[str] = frozenset({
+_IMAGE_MIME_TYPES: frozenset[str] = frozenset({
     "image/jpeg",
     "image/jpg",
     "image/png",
     "image/webp",
 })
+_PDF_MIME_TYPE: str = "application/pdf"
+_ALLOWED_MIME_TYPES: frozenset[str] = _IMAGE_MIME_TYPES | {_PDF_MIME_TYPE}
+
+
+def _cap_for_mime(content_type: str) -> int:
+    """Return the per-file size cap that applies to ``content_type``."""
+    return _MAX_PDF_SIZE_BYTES if content_type == _PDF_MIME_TYPE else _MAX_FILE_SIZE_BYTES
+
+
+def _check_single_file(data: bytes, content_type: str) -> None:
+    """Raise HTTPException if a single file violates MIME / size / empty rules.
+
+    Shared between validate_upload_files and validate_attempt_files so the two
+    paths can't drift on what's allowed.
+    """
+    if content_type not in _ALLOWED_MIME_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"不支援的格式 {content_type}，請上傳 JPEG / PNG / WebP / PDF",
+        )
+    cap = _cap_for_mime(content_type)
+    if len(data) > cap:
+        cap_mb = cap // (1024 * 1024)
+        kind = "PDF" if content_type == _PDF_MIME_TYPE else "圖片"
+        raise HTTPException(
+            status_code=413,
+            detail=f"{kind}太大（{len(data) // (1024 * 1024)}MB），最大允許 {cap_mb}MB",
+        )
+    if len(data) == 0:
+        raise HTTPException(status_code=400, detail="上傳的檔案是空的")
 
 
 def validate_upload_files(files_data: list[tuple[bytes, str]]) -> None:
@@ -30,7 +63,7 @@ def validate_upload_files(files_data: list[tuple[bytes, str]]) -> None:
     - Empty file list
     - Too many files (> _MAX_FILES_PER_UPLOAD)
     - Unsupported MIME type
-    - Oversized file (> _MAX_FILE_SIZE_BYTES)
+    - Oversized file (image > 10MB, PDF > 20MB)
     - Zero-byte file content
 
     Parameters
@@ -38,27 +71,22 @@ def validate_upload_files(files_data: list[tuple[bytes, str]]) -> None:
     files_data:
         List of (raw_bytes, content_type) for each uploaded file.
         Bytes must already be read (no async here).
+
+    Note
+    ----
+    PDFs count as 1 file here regardless of page count.  Per-page expansion
+    happens after validation in the route layer (#1976), where the expanded
+    image count is re-checked against ``_MAX_FILES_PER_UPLOAD``.
     """
     if not files_data:
-        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
+        raise HTTPException(status_code=400, detail="最少需要上傳 1 個檔案")
     if len(files_data) > _MAX_FILES_PER_UPLOAD:
         raise HTTPException(
             status_code=400,
-            detail=f"最多只能上傳 {_MAX_FILES_PER_UPLOAD} 張照片",
+            detail=f"最多只能上傳 {_MAX_FILES_PER_UPLOAD} 個檔案",
         )
     for data, content_type in files_data:
-        if content_type not in _ALLOWED_MIME_TYPES:
-            raise HTTPException(
-                status_code=400,
-                detail=f"不支援的圖片格式 {content_type}，請上傳 JPEG 或 PNG",
-            )
-        if len(data) > _MAX_FILE_SIZE_BYTES:
-            raise HTTPException(
-                status_code=413,
-                detail=f"圖片太大（{len(data) // (1024 * 1024)}MB），最大允許 10MB",
-            )
-        if len(data) == 0:
-            raise HTTPException(status_code=400, detail="上傳的圖片是空的")
+        _check_single_file(data, content_type)
 
 
 def validate_attempt_files(
@@ -78,19 +106,11 @@ def validate_attempt_files(
             detail=f"最多 {_MAX_TOTAL_ATTEMPTS} 次重拍機會",
         )
     if not files_data:
-        raise HTTPException(status_code=400, detail="最少需要上傳 1 張照片")
+        raise HTTPException(status_code=400, detail="最少需要上傳 1 個檔案")
     if len(files_data) > _MAX_FILES_PER_UPLOAD:
         raise HTTPException(
             status_code=400,
-            detail=f"每次最多上傳 {_MAX_FILES_PER_UPLOAD} 張照片",
+            detail=f"每次最多上傳 {_MAX_FILES_PER_UPLOAD} 個檔案",
         )
     for data, content_type in files_data:
-        if content_type not in _ALLOWED_MIME_TYPES:
-            raise HTTPException(
-                status_code=400,
-                detail=f"不支援的圖片格式 {content_type}",
-            )
-        if len(data) > _MAX_FILE_SIZE_BYTES:
-            raise HTTPException(status_code=413, detail="圖片超過 10MB")
-        if not data:
-            raise HTTPException(status_code=400, detail="空的圖片檔案")
+        _check_single_file(data, content_type)

--- a/backend/app/services/omo_upload_validator.py
+++ b/backend/app/services/omo_upload_validator.py
@@ -12,25 +12,25 @@ Contains:
 from fastapi import HTTPException
 
 # ── Upload constraints (single source of truth) ────────────────────────────────
-_MAX_FILE_SIZE_BYTES: int = 10 * 1024 * 1024   # 10 MB per image
+MAX_FILE_SIZE_BYTES: int = 10 * 1024 * 1024    # 10 MB per image
 # #1976: PDFs are commonly larger because they bundle multiple pages —
 # allow a bigger cap before we expand them into per-page JPEGs.
-_MAX_PDF_SIZE_BYTES: int = 20 * 1024 * 1024    # 20 MB per PDF
-MAX_FILES_PER_UPLOAD: int = 20                  # max files per single upload call
-_MAX_TOTAL_ATTEMPTS: int = 5                     # max attempts per upload session
+MAX_PDF_SIZE_BYTES: int = 20 * 1024 * 1024     # 20 MB per PDF
+MAX_FILES_PER_UPLOAD: int = 20                 # max files per single upload call
+_MAX_TOTAL_ATTEMPTS: int = 5                   # max attempts per upload session
 _IMAGE_MIME_TYPES: frozenset[str] = frozenset({
     "image/jpeg",
     "image/jpg",
     "image/png",
     "image/webp",
 })
-_PDF_MIME_TYPE: str = "application/pdf"
-_ALLOWED_MIME_TYPES: frozenset[str] = _IMAGE_MIME_TYPES | {_PDF_MIME_TYPE}
+PDF_MIME_TYPE: str = "application/pdf"
+_ALLOWED_MIME_TYPES: frozenset[str] = _IMAGE_MIME_TYPES | {PDF_MIME_TYPE}
 
 
 def _cap_for_mime(content_type: str) -> int:
     """Return the per-file size cap that applies to ``content_type``."""
-    return _MAX_PDF_SIZE_BYTES if content_type == _PDF_MIME_TYPE else _MAX_FILE_SIZE_BYTES
+    return MAX_PDF_SIZE_BYTES if content_type == PDF_MIME_TYPE else MAX_FILE_SIZE_BYTES
 
 
 def _check_single_file(data: bytes, content_type: str) -> None:
@@ -47,7 +47,7 @@ def _check_single_file(data: bytes, content_type: str) -> None:
     cap = _cap_for_mime(content_type)
     if len(data) > cap:
         cap_mb = cap // (1024 * 1024)
-        kind = "PDF" if content_type == _PDF_MIME_TYPE else "圖片"
+        kind = "PDF" if content_type == PDF_MIME_TYPE else "圖片"
         raise HTTPException(
             status_code=413,
             detail=f"{kind}太大（{len(data) // (1024 * 1024)}MB），最大允許 {cap_mb}MB",

--- a/backend/app/services/omo_upload_validator.py
+++ b/backend/app/services/omo_upload_validator.py
@@ -16,7 +16,7 @@ _MAX_FILE_SIZE_BYTES: int = 10 * 1024 * 1024   # 10 MB per image
 # #1976: PDFs are commonly larger because they bundle multiple pages —
 # allow a bigger cap before we expand them into per-page JPEGs.
 _MAX_PDF_SIZE_BYTES: int = 20 * 1024 * 1024    # 20 MB per PDF
-_MAX_FILES_PER_UPLOAD: int = 20                  # max files per single upload call
+MAX_FILES_PER_UPLOAD: int = 20                  # max files per single upload call
 _MAX_TOTAL_ATTEMPTS: int = 5                     # max attempts per upload session
 _IMAGE_MIME_TYPES: frozenset[str] = frozenset({
     "image/jpeg",
@@ -61,7 +61,7 @@ def validate_upload_files(files_data: list[tuple[bytes, str]]) -> None:
 
     Raises HTTPException (400 or 413) for any of:
     - Empty file list
-    - Too many files (> _MAX_FILES_PER_UPLOAD)
+    - Too many files (> MAX_FILES_PER_UPLOAD)
     - Unsupported MIME type
     - Oversized file (image > 10MB, PDF > 20MB)
     - Zero-byte file content
@@ -76,14 +76,14 @@ def validate_upload_files(files_data: list[tuple[bytes, str]]) -> None:
     ----
     PDFs count as 1 file here regardless of page count.  Per-page expansion
     happens after validation in the route layer (#1976), where the expanded
-    image count is re-checked against ``_MAX_FILES_PER_UPLOAD``.
+    image count is re-checked against ``MAX_FILES_PER_UPLOAD``.
     """
     if not files_data:
         raise HTTPException(status_code=400, detail="最少需要上傳 1 個檔案")
-    if len(files_data) > _MAX_FILES_PER_UPLOAD:
+    if len(files_data) > MAX_FILES_PER_UPLOAD:
         raise HTTPException(
             status_code=400,
-            detail=f"最多只能上傳 {_MAX_FILES_PER_UPLOAD} 個檔案",
+            detail=f"最多只能上傳 {MAX_FILES_PER_UPLOAD} 個檔案",
         )
     for data, content_type in files_data:
         _check_single_file(data, content_type)
@@ -107,10 +107,10 @@ def validate_attempt_files(
         )
     if not files_data:
         raise HTTPException(status_code=400, detail="最少需要上傳 1 個檔案")
-    if len(files_data) > _MAX_FILES_PER_UPLOAD:
+    if len(files_data) > MAX_FILES_PER_UPLOAD:
         raise HTTPException(
             status_code=400,
-            detail=f"每次最多上傳 {_MAX_FILES_PER_UPLOAD} 個檔案",
+            detail=f"每次最多上傳 {MAX_FILES_PER_UPLOAD} 個檔案",
         )
     for data, content_type in files_data:
         _check_single_file(data, content_type)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,3 +24,5 @@ python-json-logger>=2.0.0
 slowapi>=0.1.9
 sentry-sdk[fastapi]>=2.0
 google-cloud-texttospeech>=2.14
+pypdfium2>=4.30
+Pillow>=10.0

--- a/backend/tests/test_omo_pdf_split_1976.py
+++ b/backend/tests/test_omo_pdf_split_1976.py
@@ -21,7 +21,7 @@ from app.services.omo_pdf_split import (
     pdf_to_jpeg_pages,
 )
 from app.services.omo_upload_validator import (
-    _MAX_PDF_SIZE_BYTES,
+    MAX_PDF_SIZE_BYTES,
     validate_upload_files,
 )
 
@@ -152,7 +152,7 @@ class TestValidatorPdfSupport:
         validate_upload_files([(small_pdf, "application/pdf")])
 
     def test_rejects_pdf_over_20mb(self):
-        oversized = b"%PDF-1.4 " + b"x" * (_MAX_PDF_SIZE_BYTES + 1)
+        oversized = b"%PDF-1.4 " + b"x" * (MAX_PDF_SIZE_BYTES + 1)
         with pytest.raises(HTTPException) as exc:
             validate_upload_files([(oversized, "application/pdf")])
         assert exc.value.status_code == 413

--- a/backend/tests/test_omo_pdf_split_1976.py
+++ b/backend/tests/test_omo_pdf_split_1976.py
@@ -1,0 +1,173 @@
+"""Tests for #1976 — PDF upload support.
+
+Covers:
+- pdf_to_jpeg_pages renders each page as JPEG bytes in order
+- max_pages cap is enforced
+- malformed / empty PDFs raise PdfSplitError (not a generic exception)
+- expand_pdf_files preserves position of image entries and explodes PDFs
+- expand_pdf_files raises when total expanded count exceeds max_total_images
+- validator accepts application/pdf with the 20MB cap
+- validator rejects PDFs over 20MB and unknown MIME types
+"""
+
+import io
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.omo_pdf_split import (
+    PdfSplitError,
+    expand_pdf_files,
+    pdf_to_jpeg_pages,
+)
+from app.services.omo_upload_validator import (
+    _MAX_PDF_SIZE_BYTES,
+    validate_upload_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build small PDFs in-memory via Pillow
+# ---------------------------------------------------------------------------
+
+def _make_pdf(pages: int, color_per_page: tuple[str, ...] | None = None) -> bytes:
+    """Build a tiny multi-page PDF for tests.
+
+    Each page is 100x100 with the given fill colour (or white by default).
+    Returns the PDF bytes — small enough to keep tests fast.
+    """
+    from PIL import Image
+
+    if color_per_page is None:
+        color_per_page = tuple("white" for _ in range(pages))
+    assert len(color_per_page) == pages
+
+    imgs = [Image.new("RGB", (100, 100), c) for c in color_per_page]
+    buf = io.BytesIO()
+    imgs[0].save(
+        buf,
+        format="PDF",
+        save_all=True,
+        append_images=imgs[1:] if len(imgs) > 1 else [],
+    )
+    return buf.getvalue()
+
+
+def _is_jpeg(data: bytes) -> bool:
+    """Quick JPEG magic-byte check — JFIF / EXIF SOI marker."""
+    return data[:3] == b"\xff\xd8\xff"
+
+
+# ---------------------------------------------------------------------------
+# pdf_to_jpeg_pages
+# ---------------------------------------------------------------------------
+
+class TestPdfToJpegPages:
+    def test_single_page_pdf_returns_one_jpeg(self):
+        pdf = _make_pdf(1)
+        pages = pdf_to_jpeg_pages(pdf)
+        assert len(pages) == 1
+        assert _is_jpeg(pages[0]), "Output should be JPEG bytes"
+
+    def test_multi_page_pdf_returns_one_jpeg_per_page_in_order(self):
+        pdf = _make_pdf(3, color_per_page=("red", "green", "blue"))
+        pages = pdf_to_jpeg_pages(pdf)
+        assert len(pages) == 3
+        for p in pages:
+            assert _is_jpeg(p)
+
+    def test_empty_bytes_raises(self):
+        with pytest.raises(PdfSplitError):
+            pdf_to_jpeg_pages(b"")
+
+    def test_malformed_pdf_raises_pdf_split_error(self):
+        with pytest.raises(PdfSplitError):
+            pdf_to_jpeg_pages(b"not actually a pdf, just some bytes")
+
+    def test_max_pages_cap_enforced(self):
+        pdf = _make_pdf(5)
+        # Allow 4 → 5-page PDF must be rejected
+        with pytest.raises(PdfSplitError, match="頁數過多"):
+            pdf_to_jpeg_pages(pdf, max_pages=4)
+
+
+# ---------------------------------------------------------------------------
+# expand_pdf_files
+# ---------------------------------------------------------------------------
+
+class TestExpandPdfFiles:
+    def test_pure_image_list_passes_through_unchanged(self):
+        files = [(b"\xff\xd8\xff_fake1", "image/jpeg"), (b"\xff\xd8\xff_fake2", "image/png")]
+        out = expand_pdf_files(files, max_total_images=10)
+        assert out == files, "Image-only list should be returned untouched"
+
+    def test_single_pdf_explodes_to_per_page_jpegs(self):
+        pdf = _make_pdf(3)
+        out = expand_pdf_files([(pdf, "application/pdf")], max_total_images=10)
+        assert len(out) == 3
+        for data, mime in out:
+            assert mime == "image/jpeg"
+            assert _is_jpeg(data)
+
+    def test_mixed_image_and_pdf_preserves_order(self):
+        pdf = _make_pdf(2, color_per_page=("yellow", "purple"))
+        fake_jpeg = b"\xff\xd8\xff_fake"
+        out = expand_pdf_files(
+            [(fake_jpeg, "image/jpeg"), (pdf, "application/pdf"), (fake_jpeg, "image/png")],
+            max_total_images=10,
+        )
+        # Expected: jpeg, pdf-p1, pdf-p2, png
+        assert len(out) == 4
+        assert out[0] == (fake_jpeg, "image/jpeg")
+        assert out[3] == (fake_jpeg, "image/png")
+        assert out[1][1] == "image/jpeg" and _is_jpeg(out[1][0])
+        assert out[2][1] == "image/jpeg" and _is_jpeg(out[2][0])
+
+    def test_total_count_cap_enforced(self):
+        # 3-page PDF + cap 2 → should raise
+        pdf = _make_pdf(3)
+        with pytest.raises(PdfSplitError, match="超過 2 張上限"):
+            expand_pdf_files([(pdf, "application/pdf")], max_total_images=2)
+
+    def test_per_pdf_max_pages_propagates(self):
+        pdf = _make_pdf(5)
+        with pytest.raises(PdfSplitError, match="頁數過多"):
+            expand_pdf_files(
+                [(pdf, "application/pdf")],
+                max_total_images=20,
+                per_pdf_max_pages=4,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Validator — PDF acceptance & size caps
+# ---------------------------------------------------------------------------
+
+class TestValidatorPdfSupport:
+    def test_accepts_pdf_under_20mb(self):
+        # 10 MB of bytes labelled as PDF — validator must not raise (we don't
+        # actually parse here, just MIME + size).
+        small_pdf = b"%PDF-1.4 " + b"x" * (10 * 1024 * 1024)
+        # No exception
+        validate_upload_files([(small_pdf, "application/pdf")])
+
+    def test_rejects_pdf_over_20mb(self):
+        oversized = b"%PDF-1.4 " + b"x" * (_MAX_PDF_SIZE_BYTES + 1)
+        with pytest.raises(HTTPException) as exc:
+            validate_upload_files([(oversized, "application/pdf")])
+        assert exc.value.status_code == 413
+
+    def test_rejects_image_over_10mb_but_accepts_under(self):
+        small_img = b"\xff\xd8\xff" + b"x" * (5 * 1024 * 1024)
+        validate_upload_files([(small_img, "image/jpeg")])
+
+        big_img = b"\xff\xd8\xff" + b"x" * (15 * 1024 * 1024)
+        with pytest.raises(HTTPException) as exc:
+            validate_upload_files([(big_img, "image/jpeg")])
+        assert exc.value.status_code == 413
+
+    def test_rejects_unknown_mime(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_upload_files([(b"x" * 100, "application/zip")])
+        assert exc.value.status_code == 400
+        assert "格式" in exc.value.detail

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -19,8 +19,11 @@ import React, { useEffect, useRef, useState } from 'react';
 import { uploadOmoImages } from '../../services/omoApi';
 
 const MAX_FILES = 5;
-const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MB (pre-resize)
-const ACCEPTED_MIME = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
+const MAX_FILE_BYTES = 10 * 1024 * 1024;     // 10 MB per image (pre-resize)
+const MAX_PDF_BYTES = 20 * 1024 * 1024;      // 20 MB per PDF (backend splits server-side)
+const PDF_MIME = 'application/pdf';
+const IMAGE_MIME = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'];
+const ACCEPTED_MIME = [...IMAGE_MIME, PDF_MIME];
 
 // Client-side resize target: 1280px on the longest side, 85% JPEG quality
 const RESIZE_MAX_PX = 1280;
@@ -51,6 +54,11 @@ interface OmoUploadProps {
 // ---------------------------------------------------------------------------
 
 async function resizeImage(file: File): Promise<File> {
+  // #1976: canvas / <img> can't render PDF — pass it through untouched and
+  // let the backend's pypdfium2 render at server resolution.
+  if (file.type === PDF_MIME) {
+    return file;
+  }
   return new Promise((resolve) => {
     const img = new Image();
     const objectUrl = URL.createObjectURL(file);
@@ -155,20 +163,29 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
     }
     for (const f of fileArray) {
       if (!ACCEPTED_MIME.includes(f.type)) {
-        setError(`不支援「${f.name.split('.').pop()?.toUpperCase() ?? '?'}」格式，請選 JPG、PNG 或 WebP`);
+        setError(`不支援「${f.name.split('.').pop()?.toUpperCase() ?? '?'}」格式，請選 JPG、PNG、WebP 或 PDF`);
         return;
       }
-      if (f.size > MAX_FILE_BYTES) {
+      const isPdf = f.type === PDF_MIME;
+      const cap = isPdf ? MAX_PDF_BYTES : MAX_FILE_BYTES;
+      if (f.size > cap) {
         const mb = (f.size / (1024 * 1024)).toFixed(1);
-        setError(`「${f.name}」太大（${mb} MB），每張最多 10 MB`);
+        const capMb = cap / (1024 * 1024);
+        const kind = isPdf ? 'PDF' : '圖片';
+        setError(`「${f.name}」太大（${mb} MB），每個${kind}最多 ${capMb} MB`);
         return;
       }
     }
 
-    // ── Preview first file ──────────────────────────────────────────────────
-    const firstReader = new FileReader();
-    firstReader.onload = (e) => setPreview(e.target?.result as string);
-    firstReader.readAsDataURL(fileArray[0]);
+    // ── Preview first file (PDFs use an icon stub since <img> can't render them)
+    const first = fileArray[0];
+    if (first.type === PDF_MIME) {
+      setPreview(null);
+    } else {
+      const firstReader = new FileReader();
+      firstReader.onload = (e) => setPreview(e.target?.result as string);
+      firstReader.readAsDataURL(first);
+    }
 
     setUploading(true);
     try {
@@ -210,7 +227,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
         <div className="text-5xl mb-3" aria-hidden="true">📸</div>
         <h1 className="text-xl font-bold text-gray-900">上傳學習單</h1>
         <p className="mt-1 text-sm text-gray-500">
-          拍下你的紙本學習單，AI 會自動辨識是哪一課
+          拍下紙本、選相簿照片，或直接上傳 PDF 掃描檔
         </p>
       </div>
 
@@ -264,7 +281,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
             onChange={(e) => handleFiles(e.target.files)}
           />
 
-          {/* Gallery / file picker */}
+          {/* Gallery / file picker — accepts images + PDF */}
           <button
             type="button"
             onClick={() => galleryInputRef.current?.click()}
@@ -276,12 +293,12 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
               transition-colors"
           >
             <span aria-hidden="true">🖼️</span>
-            從相簿選擇
+            選擇照片或 PDF
           </button>
           <input
             ref={galleryInputRef}
             type="file"
-            accept="image/*"
+            accept="image/*,application/pdf,.pdf"
             multiple
             className="hidden"
             onChange={(e) => handleFiles(e.target.files)}
@@ -310,7 +327,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
       )}
 
       <p className="text-xs text-gray-400 text-center">
-        支援 JPG、PNG、WebP，每張最多 10 MB，最多 {MAX_FILES} 張
+        支援 JPG、PNG、WebP（每張 ≤ 10 MB）或 PDF（≤ 20 MB，多頁自動拆開）
         <br />
         <span className="text-gray-300">上傳前自動壓縮以節省時間</span>
       </p>

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -185,16 +185,16 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
       }
     }
 
-    // ── Preview first file (PDFs use an icon stub since <img> can't render them)
+    // ── Preview first file (PDFs use an icon stub since <img> can't render them).
+    // Preview state already cleared at the top of handleFiles, so each branch
+    // only sets the one it owns.
     const first = fileArray[0];
     if (first.type === PDF_MIME) {
-      setPreview(null);
       setPdfPreview({
         name: first.name,
         sizeMb: (first.size / (1024 * 1024)).toFixed(1),
       });
     } else {
-      setPdfPreview(null);
       const firstReader = new FileReader();
       firstReader.onload = (e) => setPreview(e.target?.result as string);
       firstReader.readAsDataURL(first);

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -144,6 +144,9 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
+  // #1976: PDFs have no image preview (canvas can't render them) — track
+  // filename separately so the UI can show a 📄 stub with the name.
+  const [pdfPreview, setPdfPreview] = useState<{ name: string; sizeMb: string } | null>(null);
 
   const cameraInputRef = useRef<HTMLInputElement>(null);
   const galleryInputRef = useRef<HTMLInputElement>(null);
@@ -158,7 +161,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
 
     // ── Client-side validation ──────────────────────────────────────────────
     if (fileArray.length > MAX_FILES) {
-      setError(`最多只能上傳 ${MAX_FILES} 張圖片，你選了 ${fileArray.length} 張`);
+      setError(`最多只能上傳 ${MAX_FILES} 個檔案，你選了 ${fileArray.length} 個`);
       return;
     }
     for (const f of fileArray) {
@@ -181,7 +184,12 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
     const first = fileArray[0];
     if (first.type === PDF_MIME) {
       setPreview(null);
+      setPdfPreview({
+        name: first.name,
+        sizeMb: (first.size / (1024 * 1024)).toFixed(1),
+      });
     } else {
+      setPdfPreview(null);
       const firstReader = new FileReader();
       firstReader.onload = (e) => setPreview(e.target?.result as string);
       firstReader.readAsDataURL(first);
@@ -231,7 +239,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
         </p>
       </div>
 
-      {/* Preview */}
+      {/* Preview — image */}
       {preview && !uploading && (
         <div className="w-full rounded-xl overflow-hidden border border-gray-200 shadow-sm">
           <img
@@ -239,6 +247,17 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
             alt="學習單預覽"
             className="w-full object-contain max-h-48"
           />
+        </div>
+      )}
+
+      {/* Preview — PDF stub (no thumbnail since <img> can't render PDF) */}
+      {pdfPreview && !preview && !uploading && (
+        <div className="w-full flex items-center gap-3 rounded-xl border border-gray-200 shadow-sm px-4 py-3 bg-gray-50">
+          <div className="text-3xl shrink-0" aria-hidden="true">📄</div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-gray-800 truncate">{pdfPreview.name}</p>
+            <p className="text-xs text-gray-500 mt-0.5">PDF · {pdfPreview.sizeMb} MB · 上傳後將自動拆頁批改</p>
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -155,6 +155,11 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
 
   const handleFiles = async (files: FileList | null) => {
     setError(null);
+    // #1976 review-2: clear any prior preview before validation so a fresh
+    // pick that fails (e.g. >MAX_FILES) doesn't leave the old PDF/image stub
+    // showing alongside the error toast.
+    setPreview(null);
+    setPdfPreview(null);
     if (!files || files.length === 0) return;
 
     const fileArray = Array.from(files);


### PR DESCRIPTION
# Issue #1976 修正說明

## 問題摘要

紙本作業最常見的輸出格式是掃描器 / 影印機 / 手機掃描 app 產生的多頁 PDF。原本 OMO 只收 JPEG/PNG/WebP，老師 / 學生得手動把 PDF 一頁頁轉成圖片再上傳，繁瑣又容易裁切到大題。

## 修正策略

把 PDF 視為「server-side 多檔來源」：前端只放行 PDF MIME + 拉高 size cap，後端用 `pypdfium2` 把 PDF 拆成 per-page JPEG，後續 pipeline（GCS upload / identification / grading）完全不需要知道 PDF 存在過。

PDF lib 選 **`pypdfium2`** 而非 PyMuPDF：
- 純 Python wheel，Cloud Run 部署友善
- Apache-2.0 + BSD3 license（PyMuPDF 是 AGPL）
- ~3.5MB 比 PyMuPDF ~17MB 小

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `backend/requirements.txt` | 加 pypdfium2>=4.30、Pillow>=10.0（後者其實已被 transitive 使用，補成顯式依賴） |
| `backend/app/services/omo_pdf_split.py`（新檔） | `pdf_to_jpeg_pages` + `expand_pdf_files` + `PdfSplitError` |
| `backend/app/services/omo_upload_validator.py` | `application/pdf` 加入 ALLOWED MIME，PDF size cap = 20MB，共用 `_check_single_file` helper |
| `backend/app/routes/omo/upload.py` | upload route + attempt route 在 validate 後 GCS upload 前展開 PDF；PdfSplitError → 400 friendly copy；SHA-256 dedup 改 hash 原始 PDF bytes |
| `backend/tests/test_omo_pdf_split_1976.py`（新檔） | 14 個 unit test |
| `frontend/src/components/omo/OmoUpload.tsx` | MIME list、per-MIME size cap、PDF 跳過 canvas resize、accept 屬性、文案 |

## Backend 詳述

### `omo_pdf_split.py`

```python
def pdf_to_jpeg_pages(pdf_bytes: bytes, max_pages: int = 20) -> list[bytes]:
    """每頁 ~150 DPI render → JPEG q85"""

def expand_pdf_files(files_data, max_total_images, per_pdf_max_pages=20) -> list[tuple[bytes, str]]:
    """把 (bytes, mime) list 中的 PDF entry 替換成 per-page JPEG entries，
    image entry 保留原位置；超出 max_total_images 拋 PdfSplitError"""
```

選擇 `150 / 72 ≈ 2.083` scale：在 Gemini OCR 能讀清楚手寫字的前提下避免 JPEG 過大。

### Route 整合（upload + attempt）

```python
validate_upload_files(files_data)  # 含 PDF/image MIME + 20/10MB cap

primary_hash = hashlib.sha256(files_data[0][0]).hexdigest()  # 仍 hash 原始 PDF
existing = check_dedup(...)
if existing: return cache

try:
    files_data = expand_pdf_files(files_data, max_total_images=_MAX_FILES_PER_UPLOAD)
except PdfSplitError as exc:
    raise HTTPException(400, str(exc))

# 之後流程完全不變
image_bytes_list = [d for d, _ in files_data]
```

### Dedup 邏輯不變

`primary_hash` 仍 hash 第一個原始檔案的 bytes，所以重複上傳同一個 PDF 還是會命中 cache。如果改 hash 展開後的 JPEG，pypdfium2 升版會打破 cache。

### 為什麼 PDF expansion 在 validation 後、GCS upload 前

- Validation 失敗（MIME / size）→ 不浪費 CPU 在 PDF parsing
- Dedup hit → 不浪費 CPU 在 PDF parsing
- 解析失敗 → 在 GCS 寫任何東西前回 400

## Frontend 詳述

```typescript
const MAX_FILE_BYTES = 10 * 1024 * 1024;     // 圖片
const MAX_PDF_BYTES = 20 * 1024 * 1024;      // PDF
const ACCEPTED_MIME = [...IMAGE_MIME, 'application/pdf'];

async function resizeImage(file: File) {
  if (file.type === PDF_MIME) return file;  // canvas 不能渲 PDF，pass-through
  // ...原本 resize 邏輯
}
```

Gallery input 改 `accept="image/*,application/pdf,.pdf"`，三個 token 都加是為了：
- `image/*` — 圖片
- `application/pdf` — MIME match（macOS/Windows file picker）
- `.pdf` — extension fallback（部分 Android 瀏覽器只認副檔名）

Camera input 保持 `image/*`（攝影機不會拍出 PDF）。

PDF 沒有 client-side preview（`<img>` 不能渲 PDF），但因為選完立即進 upload spinner，視覺上幾乎無差別。

## 測試

### 新 unit tests（`test_omo_pdf_split_1976.py`，14 passed）

```
TestPdfToJpegPages:
  ✓ test_single_page_pdf_returns_one_jpeg
  ✓ test_multi_page_pdf_returns_one_jpeg_per_page_in_order
  ✓ test_empty_bytes_raises
  ✓ test_malformed_pdf_raises_pdf_split_error
  ✓ test_max_pages_cap_enforced
TestExpandPdfFiles:
  ✓ test_pure_image_list_passes_through_unchanged
  ✓ test_single_pdf_explodes_to_per_page_jpegs
  ✓ test_mixed_image_and_pdf_preserves_order
  ✓ test_total_count_cap_enforced
  ✓ test_per_pdf_max_pages_propagates
TestValidatorPdfSupport:
  ✓ test_accepts_pdf_under_20mb
  ✓ test_rejects_pdf_over_20mb
  ✓ test_rejects_image_over_10mb_but_accepts_under
  ✓ test_rejects_unknown_mime
```

每 test 都用 Pillow 即時產生 multi-page PDF fixture，沒有外部 PDF 檔案依賴。

### Build

```
vite build: ✓ 4.88s
```

### 既存測試

`test_omo_upload.py::test_too_many_files_returns_400` 失敗，但這是 staging baseline 既存問題（test 寫「>5 file → 400」但實際 `_MAX_FILES_PER_UPLOAD=20`）— stash 我的改動後在 baseline 重跑仍 fail，與本 PR 無關。

## 迴歸測試確認

- 純圖片 upload：`expand_pdf_files` pass-through，行為完全不變 ✅
- Dedup：hash 仍是 `files_data[0][0]`，再次上傳同檔（含 PDF）仍 cache hit ✅
- 圖片 size cap：仍是 10MB（`_cap_for_mime` 對非 PDF 回傳 `_MAX_FILE_SIZE_BYTES`）✅
- GCS upload：不變，每張展開後的 JPEG 走原 path ✅
- Identification / grading：完全不知道 PDF 存在過 ✅

## 與其他 PR 的關係

- 與 PR #1977 (#1973 grader 排序) 完全獨立 — 後端不同檔案
- 與 PR #1978 (#1974 多頁 UX) 都改 `OmoUpload.tsx`，merge 時會有 conflict 但易解（兩邊都改 MIME list + accept attr，#1974 的 queue 模式自然吃 PDF 當 queue item）