### PR TITLE
feat(omo): 批改記錄頁，OmoUpload 加入口 (#1975)

### DIFF
--- a/backend/app/routes/omo/lifecycle.py
+++ b/backend/app/routes/omo/lifecycle.py
@@ -12,6 +12,7 @@ Note: /omo/by-lesson/{lesson_id} and /omo/history are static-prefix paths
 registered first in __init__.py to prevent shadowing by /omo/{upload_id}.
 """
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -238,7 +239,10 @@ def get_upload_by_lesson(
 _HISTORY_STATUSES = ("identified", "grading", "graded")
 
 
-def _resolve_lesson_meta(upload: OmoUpload, lesson_map: dict[int, dict]) -> tuple[Optional[int], Optional[str], Optional[str]]:
+def _resolve_lesson_meta(
+    upload: OmoUpload,
+    lesson_map: dict[int, dict],
+) -> tuple[Optional[int], Optional[str], Optional[str]]:
     """Pick (lesson_id, lesson_title, grade_code) for one upload.
 
     Prefers the user-confirmed ``lesson_id`` when set; otherwise falls back to
@@ -276,7 +280,7 @@ def _pick_thumbnail_path(upload: OmoUpload) -> Optional[str]:
 
 
 @router.get("/omo/history", response_model=OmoHistoryResponse)
-def list_omo_history(
+async def list_omo_history(
     limit: int = Query(20, ge=1, le=50, description="Max items returned per page"),
     offset: int = Query(0, ge=0, description="0-based offset for pagination"),
     current_user: User = Depends(get_current_user),
@@ -292,6 +296,11 @@ def list_omo_history(
 
     Filtering: only ``identified`` / ``grading`` / ``graded`` rows that
     have not been superseded by a newer upload for the same lesson.
+
+    Signed-URL strategy (#1975 review-1): IAM signing is one HTTP call per
+    URL, so N items would otherwise wall-clock as N × ~100ms. We fan the
+    signing out to a thread pool via ``asyncio.gather`` so a page of 20 only
+    takes the cost of the slowest single signing call.
     """
     # Lazy import to keep the module import-time light (lesson_loader reads YAML).
     from ...services.lesson_loader import get_all_lessons
@@ -315,20 +324,39 @@ def list_omo_history(
     # Build lesson_id → meta dict once (avoid N+1 yaml loads).
     lesson_map: dict[int, dict] = {}
     for lesson in get_all_lessons():
-        lid = lesson.get("id") or lesson.get("lesson_number")
-        if lid is None:
+        # Explicit `is not None` (not `or`) so a legitimate `id == 0` would
+        # not silently fall through to `lesson_number` — defensive even
+        # though current YAML IDs start at 1.
+        raw_lid = lesson.get("id")
+        if raw_lid is None:
+            raw_lid = lesson.get("lesson_number")
+        if raw_lid is None:
             continue
-        lesson_map[int(lid)] = {
+        lesson_map[int(raw_lid)] = {
             "title": lesson.get("title"),
             "grade_code": lesson.get("lesson_code") or lesson.get("grade_code"),
         }
 
-    items: list[OmoHistoryItem] = []
+    # Resolve lesson meta + thumbnail path (sync, in-memory) first.
+    resolved: list[tuple[OmoUpload, Optional[int], Optional[str], Optional[str], Optional[str]]] = []
     for upload in rows:
         lid, title, grade_code = _resolve_lesson_meta(upload, lesson_map)
         thumb_path = _pick_thumbnail_path(upload)
-        thumb_url = _get_signed_url(thumb_path) if thumb_path else None
+        resolved.append((upload, lid, title, grade_code, thumb_path))
 
+    # Sign all thumbnail URLs in parallel via a worker pool. Each signing
+    # call is a sync HTTP request (IAM SignBlob); we wrap with
+    # asyncio.to_thread so they overlap instead of running serially.
+    thumb_paths = [r[4] for r in resolved]
+    signed_results: list[Optional[str]] = await asyncio.gather(
+        *[
+            asyncio.to_thread(_get_signed_url, path) if path else asyncio.sleep(0, result=None)
+            for path in thumb_paths
+        ]
+    )
+
+    items: list[OmoHistoryItem] = []
+    for (upload, lid, title, grade_code, _thumb_path), thumb_url in zip(resolved, signed_results):
         items.append(OmoHistoryItem(
             upload_id=upload.id,
             lesson_id=lid,

--- a/backend/app/routes/omo/lifecycle.py
+++ b/backend/app/routes/omo/lifecycle.py
@@ -1,4 +1,4 @@
-"""OMO lifecycle sub-module — flag, signed-url, delete, crops, by-lesson endpoints.
+"""OMO lifecycle sub-module — flag, signed-url, delete, crops, by-lesson, history endpoints.
 
 Endpoints:
     PATCH  /omo/{upload_id}/answers/{question_id}/flag — student flags a question
@@ -6,14 +6,16 @@ Endpoints:
     DELETE /omo/{upload_id}                            — privacy delete
     GET    /omo/{upload_id}/crops/{question_id}        — signed crop image URL
     GET    /omo/by-lesson/{lesson_id}                  — check prior upload for lesson
+    GET    /omo/history                                — paginated list of user's uploads (#1975)
 
-Note: /omo/by-lesson/{lesson_id} is a static-prefix path registered first in __init__.py
-to prevent shadowing by /omo/{upload_id} parameterized routes.
+Note: /omo/by-lesson/{lesson_id} and /omo/history are static-prefix paths
+registered first in __init__.py to prevent shadowing by /omo/{upload_id}.
 """
 
 import logging
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.orm import Session
 
 from ...auth.dependencies import get_current_user
@@ -24,6 +26,8 @@ from ...services.omo_responses import (
     CropSignedUrlResponse,
     FlagRequest,
     OmoByLessonResponse,
+    OmoHistoryItem,
+    OmoHistoryResponse,
     OmoSignedImageInfo,
     SignedUrlResponse,
 )
@@ -225,4 +229,121 @@ def get_upload_by_lesson(
         status=upload.status,
         has_prior_upload=True,
         images=images,
+    )
+
+
+# #1975 — Statuses considered "user-visible history". Pending / identifying
+# are still in-flight; error uploads have no useful result. Same filter as
+# the by-lesson lookup above, kept in sync intentionally.
+_HISTORY_STATUSES = ("identified", "grading", "graded")
+
+
+def _resolve_lesson_meta(upload: OmoUpload, lesson_map: dict[int, dict]) -> tuple[Optional[int], Optional[str], Optional[str]]:
+    """Pick (lesson_id, lesson_title, grade_code) for one upload.
+
+    Prefers the user-confirmed ``lesson_id`` when set; otherwise falls back to
+    the top AI identification candidate (which is the state for
+    ``status == 'identified'`` rows the student hasn't confirmed yet).
+    """
+    lid = upload.lesson_id
+    if lid is not None:
+        meta = lesson_map.get(int(lid))
+        if meta:
+            return int(lid), meta.get("title"), meta.get("grade_code")
+        return int(lid), None, None
+    # Fallback: top AI candidate
+    if upload.identification and isinstance(upload.identification, list) and upload.identification:
+        top = upload.identification[0]
+        return top.get("lesson_id"), top.get("title"), top.get("grade_code")
+    return None, None, None
+
+
+def _pick_thumbnail_path(upload: OmoUpload) -> Optional[str]:
+    """Return the GCS path of the first image of the first active attempt."""
+    # Prefer active attempts; fall back to any attempt with images.
+    candidates = [
+        a for a in (upload.attempts or [])
+        if a.is_active and a.image_paths
+    ] or [
+        a for a in (upload.attempts or []) if a.image_paths
+    ]
+    if not candidates:
+        return None
+    first = candidates[0]
+    if not first.image_paths:
+        return None
+    return first.image_paths[0]
+
+
+@router.get("/omo/history", response_model=OmoHistoryResponse)
+def list_omo_history(
+    limit: int = Query(20, ge=1, le=50, description="Max items returned per page"),
+    offset: int = Query(0, ge=0, description="0-based offset for pagination"),
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """#1975 — List the current user's OMO uploads, newest first.
+
+    Returns a compact view suitable for a history list page: lesson title,
+    score, status, created timestamp, and a signed thumbnail URL. Heavy
+    fields (per-question ``answers``, ``identification`` list) are NOT
+    included — clients should call ``GET /omo/{upload_id}`` for the full
+    result page.
+
+    Filtering: only ``identified`` / ``grading`` / ``graded`` rows that
+    have not been superseded by a newer upload for the same lesson.
+    """
+    # Lazy import to keep the module import-time light (lesson_loader reads YAML).
+    from ...services.lesson_loader import get_all_lessons
+
+    base_q = (
+        db.query(OmoUpload)
+        .filter(
+            OmoUpload.student_id == current_user.id,
+            OmoUpload.superseded_at.is_(None),
+            OmoUpload.status.in_(_HISTORY_STATUSES),
+        )
+    )
+    total = base_q.count()
+    rows: list[OmoUpload] = (
+        base_q.order_by(OmoUpload.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+    # Build lesson_id → meta dict once (avoid N+1 yaml loads).
+    lesson_map: dict[int, dict] = {}
+    for lesson in get_all_lessons():
+        lid = lesson.get("id") or lesson.get("lesson_number")
+        if lid is None:
+            continue
+        lesson_map[int(lid)] = {
+            "title": lesson.get("title"),
+            "grade_code": lesson.get("lesson_code") or lesson.get("grade_code"),
+        }
+
+    items: list[OmoHistoryItem] = []
+    for upload in rows:
+        lid, title, grade_code = _resolve_lesson_meta(upload, lesson_map)
+        thumb_path = _pick_thumbnail_path(upload)
+        thumb_url = _get_signed_url(thumb_path) if thumb_path else None
+
+        items.append(OmoHistoryItem(
+            upload_id=upload.id,
+            lesson_id=lid,
+            lesson_title=title,
+            grade_code=grade_code,
+            status=upload.status,
+            overall_score=upload.overall_score,
+            answers_count=len(upload.answers or []),
+            created_at=upload.created_at.isoformat(),
+            thumbnail_url=thumb_url,
+        ))
+
+    return OmoHistoryResponse(
+        total=total,
+        limit=limit,
+        offset=offset,
+        items=items,
     )

--- a/backend/app/services/omo_responses.py
+++ b/backend/app/services/omo_responses.py
@@ -123,6 +123,27 @@ class OmoByLessonResponse(BaseModel):
     images: list[OmoSignedImageInfo] = Field(default_factory=list)
 
 
+class OmoHistoryItem(BaseModel):
+    """Compact representation of one OMO upload for the history list (#1975)."""
+    upload_id: int
+    lesson_id: Optional[int] = None
+    lesson_title: Optional[str] = None
+    grade_code: Optional[str] = None
+    status: str
+    overall_score: Optional[float] = None
+    answers_count: int = 0
+    created_at: str   # ISO-8601
+    thumbnail_url: Optional[str] = None
+
+
+class OmoHistoryResponse(BaseModel):
+    """Paginated list of the current user's OMO uploads, newest first."""
+    total: int
+    limit: int
+    offset: int
+    items: list[OmoHistoryItem] = Field(default_factory=list)
+
+
 # ── Response builder helpers ───────────────────────────────────────────────────
 
 def _build_upload_response(upload: OmoUpload) -> OmoUploadResponse:

--- a/backend/tests/test_omo_history_1975.py
+++ b/backend/tests/test_omo_history_1975.py
@@ -1,0 +1,359 @@
+"""Tests for #1975 — GET /api/omo/history endpoint.
+
+Covers:
+- Empty result for a fresh user
+- Returns user's own uploads, newest first
+- Excludes superseded uploads
+- Excludes pending / identifying / error statuses
+- Pagination (limit + offset, total stays stable)
+- User isolation (student A doesn't see student B's history)
+- Auth required (401 without token)
+- Lesson title resolution: confirmed lesson_id → lesson_loader meta
+- Lesson title fallback: identification[0] when lesson_id is NULL (identified state)
+
+Uses the same SQLite in-memory infrastructure as test_omo_upload.py.
+"""
+
+import sys
+import os
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.auth.rate_limiter import ai_rate_limiter
+from app.database import get_db
+from app.main import app
+from app.models import Base
+from app.models.omo_upload import OmoUpload, OmoUploadAttempt
+from app.models.user import Role
+
+
+# ---------------------------------------------------------------------------
+# Test DB setup (SQLite in-memory) — mirrors test_omo_upload.py
+# ---------------------------------------------------------------------------
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+
+@event.listens_for(engine, "connect")
+def _set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+_SEED_ROLES = [
+    {"name": "system_admin", "display_name": "System Admin", "scope_level": "platform"},
+    {"name": "org_admin", "display_name": "Organization Admin", "scope_level": "organization"},
+    {"name": "principal", "display_name": "Principal", "scope_level": "school"},
+    {"name": "director", "display_name": "Director", "scope_level": "school"},
+    {"name": "teacher", "display_name": "Teacher", "scope_level": "school"},
+    {"name": "homeroom_teacher", "display_name": "Homeroom Teacher", "scope_level": "school"},
+    {"name": "student", "display_name": "Student", "scope_level": "school"},
+    {"name": "parent", "display_name": "Parent", "scope_level": "school"},
+]
+
+
+def _seed_roles(session):
+    for r in _SEED_ROLES:
+        session.add(Role(name=r["name"], display_name=r["display_name"], scope_level=r["scope_level"]))
+    session.commit()
+
+
+def _override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    _seed_roles(session)
+    session.close()
+    app.dependency_overrides[get_db] = _override_get_db
+    yield
+    app.dependency_overrides.pop(get_db, None)
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limiter():
+    with ai_rate_limiter._lock:
+        ai_rate_limiter._store.clear()
+    yield
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Auth helper
+# ---------------------------------------------------------------------------
+
+def _register_user(client, suffix: str) -> tuple[int, str]:
+    """Register + login a fresh student. Returns (user_id, bearer_token)."""
+    email = f"history_{suffix}@example.com"
+    reg = client.post("/api/auth/register", json={
+        "email": email,
+        "password": "TestPass123!",
+        "name": f"History Test {suffix}",
+    })
+    assert reg.status_code == 201, reg.text
+    verification_token = reg.json().get("verification_token")
+    if verification_token:
+        client.get(f"/api/auth/verify-email?token={verification_token}")
+
+    login = client.post("/api/auth/login", json={
+        "email": email,
+        "password": "TestPass123!",
+    })
+    assert login.status_code == 200, login.text
+    # Need user_id for direct DB seeding
+    from app.models.user import User
+    db = TestingSessionLocal()
+    try:
+        user = db.query(User).filter(User.email == email).first()
+        assert user is not None
+        return user.id, login.json()["access_token"]
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Direct DB seed helper — bypass file upload + background tasks
+# ---------------------------------------------------------------------------
+
+def _seed_upload(
+    student_id: int,
+    *,
+    status: str = "graded",
+    lesson_id: int | None = 1,
+    identification: list | None = None,
+    answers: list | None = None,
+    overall_score: float | None = 0.85,
+    superseded_at: datetime | None = None,
+    created_at: datetime | None = None,
+    image_paths: list[str] | None = None,
+) -> int:
+    """Insert one OmoUpload directly into the DB. Returns the new upload_id."""
+    db = TestingSessionLocal()
+    try:
+        upload = OmoUpload(
+            student_id=student_id,
+            lesson_id=lesson_id,
+            identification=identification,
+            answers=answers or [],
+            progress={},  # required (NOT NULL) — match create_upload_record
+            overall_score=overall_score,
+            status=status,
+            superseded_at=superseded_at,
+        )
+        db.add(upload)
+        db.flush()  # get the id
+
+        if created_at is not None:
+            upload.created_at = created_at
+
+        if image_paths:
+            attempt = OmoUploadAttempt(
+                omo_upload_id=upload.id,
+                attempt_idx=0,
+                image_paths=image_paths,
+                is_active=True,
+            )
+            db.add(attempt)
+
+        db.commit()
+        return upload.id
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOmoHistoryEndpoint:
+    def test_empty_history_returns_zero_total(self, client):
+        _user_id, token = _register_user(client, "empty")
+        resp = client.get("/api/omo/history", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["items"] == []
+        assert data["limit"] == 20
+        assert data["offset"] == 0
+
+    def test_unauthorized_returns_401(self, client):
+        resp = client.get("/api/omo/history")
+        assert resp.status_code == 401, resp.text
+
+    def test_returns_user_own_uploads_newest_first(self, client):
+        user_id, token = _register_user(client, "newest")
+        now = datetime.now(timezone.utc)
+        old_id = _seed_upload(user_id, created_at=now - timedelta(days=2))
+        mid_id = _seed_upload(user_id, created_at=now - timedelta(days=1))
+        new_id = _seed_upload(user_id, created_at=now)
+
+        resp = client.get("/api/omo/history", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        ids = [it["upload_id"] for it in resp.json()["items"]]
+        assert ids == [new_id, mid_id, old_id], f"Expected newest first, got {ids}"
+
+    def test_excludes_superseded_uploads(self, client):
+        user_id, token = _register_user(client, "superseded")
+        kept_id = _seed_upload(user_id)
+        _seed_upload(
+            user_id,
+            superseded_at=datetime.now(timezone.utc),
+        )
+        resp = client.get("/api/omo/history", headers={"Authorization": f"Bearer {token}"})
+        ids = [it["upload_id"] for it in resp.json()["items"]]
+        assert ids == [kept_id], f"Superseded upload must not appear: {ids}"
+
+    @pytest.mark.parametrize("excluded_status", ["pending", "identifying", "error"])
+    def test_excludes_non_visible_statuses(self, client, excluded_status):
+        user_id, token = _register_user(client, f"excl_{excluded_status}")
+        included_id = _seed_upload(user_id, status="graded")
+        _seed_upload(user_id, status=excluded_status)
+
+        resp = client.get("/api/omo/history", headers={"Authorization": f"Bearer {token}"})
+        ids = [it["upload_id"] for it in resp.json()["items"]]
+        assert ids == [included_id], (
+            f"Status {excluded_status!r} should be filtered out; got {ids}"
+        )
+
+    @pytest.mark.parametrize("included_status", ["identified", "grading", "graded"])
+    def test_includes_visible_statuses(self, client, included_status):
+        user_id, token = _register_user(client, f"incl_{included_status}")
+        included_id = _seed_upload(user_id, status=included_status)
+
+        resp = client.get("/api/omo/history", headers={"Authorization": f"Bearer {token}"})
+        ids = [it["upload_id"] for it in resp.json()["items"]]
+        assert ids == [included_id]
+
+    def test_pagination_limit_and_offset(self, client):
+        user_id, token = _register_user(client, "page")
+        now = datetime.now(timezone.utc)
+        # Seed 5 uploads with deterministic timestamps
+        ids = [
+            _seed_upload(user_id, created_at=now - timedelta(hours=i))
+            for i in range(5)
+        ]
+        # IDs above are oldest-last in time; newest-first should be ids[0], ids[1], ...
+
+        # First page: 2 items
+        resp1 = client.get(
+            "/api/omo/history?limit=2&offset=0",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        data1 = resp1.json()
+        assert data1["total"] == 5
+        assert data1["limit"] == 2
+        assert data1["offset"] == 0
+        assert [it["upload_id"] for it in data1["items"]] == ids[:2]
+
+        # Second page
+        resp2 = client.get(
+            "/api/omo/history?limit=2&offset=2",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        data2 = resp2.json()
+        assert data2["total"] == 5
+        assert data2["offset"] == 2
+        assert [it["upload_id"] for it in data2["items"]] == ids[2:4]
+
+        # Last page (single item)
+        resp3 = client.get(
+            "/api/omo/history?limit=2&offset=4",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert [it["upload_id"] for it in resp3.json()["items"]] == [ids[4]]
+
+    def test_pagination_rejects_invalid_params(self, client):
+        _user_id, token = _register_user(client, "badpage")
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # limit > 50 → 422
+        resp = client.get("/api/omo/history?limit=999", headers=headers)
+        assert resp.status_code == 422
+
+        # offset < 0 → 422
+        resp = client.get("/api/omo/history?offset=-1", headers=headers)
+        assert resp.status_code == 422
+
+    def test_user_isolation(self, client):
+        a_id, a_token = _register_user(client, "isolation_a")
+        b_id, b_token = _register_user(client, "isolation_b")
+        a_upload = _seed_upload(a_id)
+        b_upload = _seed_upload(b_id)
+
+        resp_a = client.get("/api/omo/history", headers={"Authorization": f"Bearer {a_token}"})
+        ids_a = [it["upload_id"] for it in resp_a.json()["items"]]
+        assert ids_a == [a_upload], "Student A must see only their uploads"
+        assert b_upload not in ids_a
+
+        resp_b = client.get("/api/omo/history", headers={"Authorization": f"Bearer {b_token}"})
+        ids_b = [it["upload_id"] for it in resp_b.json()["items"]]
+        assert ids_b == [b_upload]
+        assert a_upload not in ids_b
+
+    def test_answers_count_reflects_answers_array_length(self, client):
+        user_id, token = _register_user(client, "count")
+        # 3-answer upload
+        _seed_upload(
+            user_id,
+            answers=[
+                {"question_id": "fb_1", "student_answer": "A", "score": 1.0},
+                {"question_id": "fb_2", "student_answer": "B", "score": 0.0},
+                {"question_id": "mc_1", "student_answer": "C", "score": 1.0},
+            ],
+        )
+        resp = client.get("/api/omo/history", headers={"Authorization": f"Bearer {token}"})
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert items[0]["answers_count"] == 3
+
+    def test_lesson_title_falls_back_to_identification_when_lesson_id_null(self, client):
+        """For status='identified' rows the student hasn't confirmed yet,
+        lesson_id may be NULL; we should fall back to the top AI candidate."""
+        user_id, token = _register_user(client, "fallback")
+        _seed_upload(
+            user_id,
+            status="identified",
+            lesson_id=None,
+            identification=[
+                {
+                    "lesson_id": 42,
+                    "title": "G5-L25 候選課文",
+                    "grade_code": "G5-L25",
+                    "confidence": 0.92,
+                    "reasoning": "...",
+                }
+            ],
+        )
+        resp = client.get("/api/omo/history", headers={"Authorization": f"Bearer {token}"})
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert items[0]["lesson_title"] == "G5-L25 候選課文"
+        assert items[0]["grade_code"] == "G5-L25"
+        assert items[0]["lesson_id"] == 42

--- a/frontend/src/components/omo/OmoHistoryList.tsx
+++ b/frontend/src/components/omo/OmoHistoryList.tsx
@@ -1,0 +1,135 @@
+/**
+ * OmoHistoryList — presentational card list for OMO upload history (#1975).
+ *
+ * Stateless: receives the items + click handler from a parent that owns
+ * fetching, pagination, and routing. Keeps this component testable in
+ * isolation and reusable in dashboards later.
+ */
+import React from 'react';
+import type { OmoHistoryItem } from '../../services/omoApi';
+
+interface OmoHistoryListProps {
+  items: OmoHistoryItem[];
+  onSelect: (uploadId: number) => void;
+}
+
+function formatScore(score: number | null | undefined): string {
+  if (score === null || score === undefined) return '—';
+  return `${Math.round(score * 100)} 分`;
+}
+
+function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (!Number.isFinite(then)) return iso;
+  const diffMs = Date.now() - then;
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return '剛剛';
+  if (diffMin < 60) return `${diffMin} 分鐘前`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH} 小時前`;
+  const diffD = Math.floor(diffH / 24);
+  if (diffD < 7) return `${diffD} 天前`;
+  // > 1 week: show absolute date
+  return new Date(iso).toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+}
+
+function statusBadge(status: string): { label: string; cls: string } {
+  switch (status) {
+    case 'graded':
+      return { label: '已批改', cls: 'bg-emerald-50 text-emerald-700 border-emerald-200' };
+    case 'grading':
+      return { label: '批改中', cls: 'bg-blue-50 text-blue-700 border-blue-200' };
+    case 'identified':
+      return { label: '待確認', cls: 'bg-amber-50 text-amber-700 border-amber-200' };
+    default:
+      return { label: status, cls: 'bg-gray-50 text-gray-600 border-gray-200' };
+  }
+}
+
+const HistoryCard: React.FC<{
+  item: OmoHistoryItem;
+  onClick: () => void;
+}> = ({ item, onClick }) => {
+  const badge = statusBadge(item.status);
+  const title = item.lesson_title || '（尚未辨識課程名稱）';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-stretch gap-3 p-3 bg-white rounded-2xl border border-gray-200 shadow-sm
+        hover:bg-gray-50 active:bg-gray-100
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+        transition-colors text-left"
+    >
+      {/* Thumbnail (or 📄 placeholder) */}
+      <div className="shrink-0 w-16 h-16 rounded-xl overflow-hidden bg-gray-100 border border-gray-200 flex items-center justify-center">
+        {item.thumbnail_url ? (
+          <img
+            src={item.thumbnail_url}
+            alt={`${title} 縮圖`}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <span className="text-3xl" aria-hidden="true">📄</span>
+        )}
+      </div>
+
+      {/* Right: title + meta */}
+      <div className="flex-1 min-w-0 flex flex-col gap-1">
+        <div className="flex items-center gap-2 min-w-0">
+          {item.grade_code && (
+            <span className="shrink-0 text-[11px] font-semibold text-blue-700 bg-blue-50 px-1.5 py-0.5 rounded">
+              {item.grade_code}
+            </span>
+          )}
+          <p className="text-sm font-semibold text-gray-900 truncate">{title}</p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className={`text-[11px] font-medium px-1.5 py-0.5 rounded border ${badge.cls}`}
+          >
+            {badge.label}
+          </span>
+          <span className="text-xs text-gray-500">{formatScore(item.overall_score)}</span>
+          <span className="text-xs text-gray-400">·</span>
+          <span className="text-xs text-gray-500">共 {item.answers_count} 題</span>
+        </div>
+        <p className="text-xs text-gray-400" title={item.created_at}>
+          {formatRelativeTime(item.created_at)}
+        </p>
+      </div>
+    </button>
+  );
+};
+
+const OmoHistoryList: React.FC<OmoHistoryListProps> = ({ items, onSelect }) => {
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 px-4 py-12 text-center">
+        <div className="text-5xl" aria-hidden="true">🗂️</div>
+        <p className="text-sm text-gray-600">還沒有任何批改記錄</p>
+        <p className="text-xs text-gray-400">上傳學習單後，批改完成的紀錄會出現在這裡</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {items.map((item) => (
+        <HistoryCard
+          key={item.upload_id}
+          item={item}
+          onClick={() => onSelect(item.upload_id)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default OmoHistoryList;

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -44,6 +44,13 @@ interface OmoUploadProps {
    * backend so it can skip Gemini fuzzy-match (faster + cheaper).
    */
   lessonCodeHint?: string;
+  /**
+   * Issue #1975: optional callback to view OMO batch grading history. When
+   * provided, an extra「📋 查看批改記錄」button is rendered alongside the
+   * camera + gallery CTAs. Parent owns the navigation target so this
+   * component stays framework-agnostic.
+   */
+  onShowHistory?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -132,7 +139,12 @@ function useLoadingMessage(active: boolean): string {
 // OmoUpload component
 // ---------------------------------------------------------------------------
 
-const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint }) => {
+const OmoUpload: React.FC<OmoUploadProps> = ({
+  token,
+  onUploaded,
+  lessonCodeHint,
+  onShowHistory,
+}) => {
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
@@ -286,6 +298,22 @@ const OmoUpload: React.FC<OmoUploadProps> = ({ token, onUploaded, lessonCodeHint
             className="hidden"
             onChange={(e) => handleFiles(e.target.files)}
           />
+
+          {/* #1975 — entry point to view previous OMO grading results */}
+          {onShowHistory && (
+            <button
+              type="button"
+              onClick={onShowHistory}
+              className="w-full flex items-center justify-center gap-2 py-2.5 px-6
+                text-gray-600 hover:text-gray-900 hover:bg-gray-100 active:bg-gray-200
+                text-sm font-medium rounded-xl
+                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+                transition-colors"
+            >
+              <span aria-hidden="true">📋</span>
+              查看批改記錄
+            </button>
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/omo/OmoHistoryPage.tsx
+++ b/frontend/src/pages/omo/OmoHistoryPage.tsx
@@ -1,0 +1,150 @@
+/**
+ * OmoHistoryPage — standalone page wrapper for the OMO upload history (#1975).
+ *
+ * Owns auth check, fetch, pagination state, error handling, and navigation
+ * to individual upload results. Renders OmoHistoryList for the actual UI.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import OmoHistoryList from '../../components/omo/OmoHistoryList';
+import { useAuth } from '../../contexts/AuthContext';
+import { getOmoHistory } from '../../services/omoApi';
+import type { OmoHistoryItem } from '../../services/omoApi';
+
+const PAGE_SIZE = 20;
+
+type LoadState = 'loading' | 'ready' | 'error';
+
+const OmoHistoryPage: React.FC = () => {
+  const { token } = useAuth();
+  const navigate = useNavigate();
+
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [items, setItems] = useState<OmoHistoryItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  // Fetch the first page (also re-used by retry).
+  const fetchFirstPage = useCallback(async () => {
+    if (!token) return;
+    setLoadState('loading');
+    try {
+      const data = await getOmoHistory(token, PAGE_SIZE, 0);
+      setItems(data.items);
+      setTotal(data.total);
+      setOffset(data.items.length);
+      setLoadState('ready');
+    } catch {
+      setLoadState('error');
+    }
+  }, [token]);
+
+  useEffect(() => {
+    fetchFirstPage();
+  }, [fetchFirstPage]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (!token || loadingMore || items.length >= total) return;
+    setLoadingMore(true);
+    try {
+      const data = await getOmoHistory(token, PAGE_SIZE, offset);
+      setItems((prev) => [...prev, ...data.items]);
+      setOffset(offset + data.items.length);
+    } catch {
+      // Surface a small error inline rather than wiping the existing list.
+      setLoadState('error');
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [token, loadingMore, items.length, total, offset]);
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const hasMore = items.length < total;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Sticky header — matches OmoResultStandalonePage style */}
+      <div className="sticky top-0 z-10 bg-white border-b border-gray-200 px-4 py-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => navigate('/omo')}
+          aria-label="返回上傳頁"
+          className="p-1 rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100
+            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            className="w-5 h-5"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M17 10a.75.75 0 01-.75.75H5.612l4.158 3.96a.75.75 0 11-1.04 1.08l-5.5-5.25a.75.75 0 010-1.08l5.5-5.25a.75.75 0 111.04 1.08L5.612 9.25H16.25A.75.75 0 0117 10z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+        <h2 className="font-semibold text-gray-900">批改記錄</h2>
+        {loadState === 'ready' && total > 0 && (
+          <span className="ml-auto text-xs text-gray-400">共 {total} 筆</span>
+        )}
+      </div>
+
+      <div className="px-4 py-5 max-w-md mx-auto pb-20">
+        {loadState === 'loading' && (
+          <div className="flex flex-col items-center gap-3 py-12">
+            <div
+              className="w-12 h-12 rounded-full border-4 border-blue-200 border-t-blue-600 animate-spin"
+              role="status"
+              aria-label="載入批改記錄中"
+            />
+            <p className="text-sm text-gray-500">載入批改記錄中…</p>
+          </div>
+        )}
+
+        {loadState === 'error' && items.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-12 text-center">
+            <p className="text-sm text-red-600 font-medium">載入批改記錄失敗</p>
+            <button
+              type="button"
+              onClick={fetchFirstPage}
+              className="py-2 px-5 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold rounded-xl"
+            >
+              重試
+            </button>
+          </div>
+        )}
+
+        {loadState !== 'loading' && (
+          <OmoHistoryList
+            items={items}
+            onSelect={(uploadId) => navigate(`/omo/result/${uploadId}`)}
+          />
+        )}
+
+        {hasMore && (
+          <div className="mt-5 flex justify-center">
+            <button
+              type="button"
+              onClick={handleLoadMore}
+              disabled={loadingMore}
+              className="px-5 py-2 text-sm font-medium rounded-xl border border-gray-300 bg-white
+                hover:bg-gray-50 active:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed
+                transition-colors"
+            >
+              {loadingMore ? '載入中…' : '載入更多'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default OmoHistoryPage;

--- a/frontend/src/pages/omo/OmoHistoryPage.tsx
+++ b/frontend/src/pages/omo/OmoHistoryPage.tsx
@@ -5,7 +5,7 @@
  * to individual upload results. Renders OmoHistoryList for the actual UI.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import OmoHistoryList from '../../components/omo/OmoHistoryList';
 import { useAuth } from '../../contexts/AuthContext';
 import { getOmoHistory } from '../../services/omoApi';
@@ -15,6 +15,8 @@ const PAGE_SIZE = 20;
 
 type LoadState = 'loading' | 'ready' | 'error';
 
+// Route is wrapped in <ProtectedRoute> in AppRoutes, so the token guard is
+// not needed here — context will always have a token by the time we render.
 const OmoHistoryPage: React.FC = () => {
   const { token } = useAuth();
   const navigate = useNavigate();
@@ -24,11 +26,16 @@ const OmoHistoryPage: React.FC = () => {
   const [total, setTotal] = useState(0);
   const [offset, setOffset] = useState(0);
   const [loadingMore, setLoadingMore] = useState(false);
+  // #1975 review-1: separate inline error for failed "load more" so the
+  // existing list stays visible — wiping it on a partial-page failure is
+  // worse UX than telling the user the next page didn't load.
+  const [loadMoreError, setLoadMoreError] = useState(false);
 
   // Fetch the first page (also re-used by retry).
   const fetchFirstPage = useCallback(async () => {
     if (!token) return;
     setLoadState('loading');
+    setLoadMoreError(false);
     try {
       const data = await getOmoHistory(token, PAGE_SIZE, 0);
       setItems(data.items);
@@ -47,21 +54,17 @@ const OmoHistoryPage: React.FC = () => {
   const handleLoadMore = useCallback(async () => {
     if (!token || loadingMore || items.length >= total) return;
     setLoadingMore(true);
+    setLoadMoreError(false);
     try {
       const data = await getOmoHistory(token, PAGE_SIZE, offset);
       setItems((prev) => [...prev, ...data.items]);
       setOffset(offset + data.items.length);
     } catch {
-      // Surface a small error inline rather than wiping the existing list.
-      setLoadState('error');
+      setLoadMoreError(true);
     } finally {
       setLoadingMore(false);
     }
   }, [token, loadingMore, items.length, total, offset]);
-
-  if (!token) {
-    return <Navigate to="/login" replace />;
-  }
 
   const hasMore = items.length < total;
 
@@ -129,7 +132,7 @@ const OmoHistoryPage: React.FC = () => {
         )}
 
         {hasMore && (
-          <div className="mt-5 flex justify-center">
+          <div className="mt-5 flex flex-col items-center gap-2">
             <button
               type="button"
               onClick={handleLoadMore}
@@ -138,8 +141,13 @@ const OmoHistoryPage: React.FC = () => {
                 hover:bg-gray-50 active:bg-gray-100 disabled:opacity-60 disabled:cursor-not-allowed
                 transition-colors"
             >
-              {loadingMore ? '載入中…' : '載入更多'}
+              {loadingMore ? '載入中…' : loadMoreError ? '再試一次' : '載入更多'}
             </button>
+            {loadMoreError && (
+              <p className="text-xs text-red-500" role="alert">
+                載入下一頁失敗，請再試一次
+              </p>
+            )}
           </div>
         )}
       </div>

--- a/frontend/src/pages/omo/OmoPage.tsx
+++ b/frontend/src/pages/omo/OmoPage.tsx
@@ -104,6 +104,7 @@ const OmoPage: React.FC = () => {
             token={token}
             onUploaded={handleUploaded}
             lessonCodeHint={lessonCodeHint}
+            onShowHistory={() => navigate('/omo/history')}
           />
         )}
 

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -72,6 +72,7 @@ const ProjectHubPage = lazy(() => import('../pages/ProjectHubPage'));
 // OMO (Online-Merge-Offline) paper worksheet upload (Issue #1343)
 const OmoPage = lazy(() => import('../pages/omo/OmoPage'));
 const OmoResultStandalonePage = lazy(() => import('../pages/omo/OmoResultStandalonePage'));
+const OmoHistoryPage = lazy(() => import('../pages/omo/OmoHistoryPage'));
 
 // Utility pages — rarely visited after first load
 const PrivacyPolicy = lazy(() => import('../pages/PrivacyPolicy'));
@@ -402,6 +403,15 @@ const AppRoutes: React.FC = () => (
         element={
           <ProtectedRoute>
             <OmoResultStandalonePage />
+          </ProtectedRoute>
+        }
+      />
+      {/* #1975 — history of past OMO uploads for the current student */}
+      <Route
+        path="/omo/history"
+        element={
+          <ProtectedRoute>
+            <OmoHistoryPage />
           </ProtectedRoute>
         }
       />

--- a/frontend/src/services/omoApi.ts
+++ b/frontend/src/services/omoApi.ts
@@ -116,6 +116,26 @@ export interface OmoSignedUrlResponse {
   expires_in_seconds: number;
 }
 
+/** Issue #1975 — compact item shown in the OMO history list page. */
+export interface OmoHistoryItem {
+  upload_id: number;
+  lesson_id?: number | null;
+  lesson_title?: string | null;
+  grade_code?: string | null;
+  status: OmoStatus;
+  overall_score?: number | null;
+  answers_count: number;
+  created_at: string;          // ISO-8601
+  thumbnail_url?: string | null;
+}
+
+export interface OmoHistoryResponse {
+  total: number;
+  limit: number;
+  offset: number;
+  items: OmoHistoryItem[];
+}
+
 // ---------------------------------------------------------------------------
 // API calls
 // ---------------------------------------------------------------------------
@@ -254,6 +274,26 @@ export async function getOmoLessons(token: string): Promise<OmoLessonSummary[]> 
     throw new Error(`Lessons fetch failed (${res.status}): ${text}`);
   }
   return res.json() as Promise<OmoLessonSummary[]>;
+}
+
+/**
+ * Issue #1975 — paginated list of the current user's OMO uploads, newest first.
+ * Excludes superseded uploads and in-flight statuses (pending/identifying/error).
+ */
+export async function getOmoHistory(
+  token: string,
+  limit = 20,
+  offset = 0,
+): Promise<OmoHistoryResponse> {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  const res = await fetch(`${API_BASE}/api/omo/history?${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`History fetch failed (${res.status}): ${text}`);
+  }
+  return res.json() as Promise<OmoHistoryResponse>;
 }
 
 export async function getPriorOmoUploadByLesson(


### PR DESCRIPTION
# Issue #1975 修正說明

## 問題摘要

學生 / 老師 OMO 批改完成、離開頁面後，原本就再也找不到批改記錄 —— 資料其實有存在 `omo_uploads` DB table（`status='graded'`、`superseded_at IS NULL`），但前端沒任何入口。每次想看舊批改只能重新上傳同一張學習單，浪費 Gemini quota 也很挫折。

## 修正策略

新增 backend 列表 endpoint + frontend 歷史頁 + 上傳頁加入口，三段拼起來變成可用的「批改記錄」功能。

設計重點：
- **endpoint 回精簡欄位**：歷史列表不需要整包 `answers`（5-20 題的 JSONB），只回 8 個顯示用欄位 + thumbnail URL；想看詳情仍走 `GET /omo/{upload_id}`，跟既有 result page 共用同一條資料路徑
- **lesson title 解析雙路**：`lesson_id` 已確認 → 走 `lesson_loader`；未確認（status='identified'）→ 退而求其次用 `identification[0]` 的 AI 候選 title。讓「待確認」狀態的記錄也能列出有意義的內容
- **靜態路徑註冊順序**：`/omo/history` 加在 `lifecycle.py`（已含 `/omo/by-lesson/{lesson_id}` 靜態前綴），register 在 `grade.py`（有 `/omo/{upload_id}`）之前，避免被 parameterized 路徑 shadow
- **元件邊界**：`OmoHistoryList` 純展示無 router 依賴；fetch / pagination / navigation 都在 `OmoHistoryPage` wrapper；`OmoUpload` 用 prop callback 而非自帶 `useNavigate`，保留框架無關

## 修改檔案

### Backend

| 檔案 | 說明 |
|------|------|
| `backend/app/services/omo_responses.py` | 新增 `OmoHistoryItem` + `OmoHistoryResponse` Pydantic schema |
| `backend/app/routes/omo/lifecycle.py` | 新增 `GET /omo/history` endpoint + `_resolve_lesson_meta` + `_pick_thumbnail_path` helpers |
| `backend/tests/test_omo_history_1975.py`（新檔）| 15 個 unit test：空 / 自己的記錄 / 排序 / superseded / status filter (parametrize) / pagination / 422 / 跨 user 隔離 / answers_count / fallback |

### Frontend

| 檔案 | 說明 |
|------|------|
| `frontend/src/services/omoApi.ts` | `OmoHistoryItem` / `OmoHistoryResponse` type + `getOmoHistory(token, limit, offset)` |
| `frontend/src/components/omo/OmoHistoryList.tsx`（新檔）| stateless 卡片列表（縮圖 + 課程名 + 分數 + status badge + 相對時間 + 空狀態）|
| `frontend/src/pages/omo/OmoHistoryPage.tsx`（新檔）| standalone 頁，sticky header + 分頁 + retry |
| `frontend/src/components/omo/OmoUpload.tsx` | 加 prop `onShowHistory?: () => void` + 第三顆「📋 查看批改記錄」按鈕 |
| `frontend/src/pages/omo/OmoPage.tsx` | 傳 `onShowHistory={() => navigate('/omo/history')}` |
| `frontend/src/routes/AppRoutes.tsx` | lazy `OmoHistoryPage` + `<Route path="/omo/history">` |

## API 設計

```http
GET /api/omo/history?limit=20&offset=0
Authorization: Bearer <token>
```

```jsonc
{
  "total": 42,
  "limit": 20,
  "offset": 0,
  "items": [
    {
      "upload_id": 17,
      "lesson_id": 25,
      "lesson_title": "黃花山下的客家村",
      "grade_code": "G5-L25",
      "status": "graded",
      "overall_score": 0.85,
      "answers_count": 12,
      "created_at": "2026-05-23T08:42:11+00:00",
      "thumbnail_url": "https://storage.googleapis.com/...signed-url..."
    }
  ]
}
```

**過濾**：`student_id == current_user.id` 且 `superseded_at IS NULL` 且 `status IN ('identified', 'grading', 'graded')`。`pending` / `identifying` / `error` 排除（無法看結果）。

**排序**：`created_at DESC`，最新批改在上。

**Pagination**：`limit` 1-50（FastAPI Query 驗證），`offset` >= 0。`total` 在過濾後計算，前端用「載入更多」逐頁拼。

## Backend 詳述

```python
# routes/omo/lifecycle.py — registration order in __init__.py 確保不被 shadow
@router.get("/omo/history", response_model=OmoHistoryResponse)
def list_omo_history(
    limit: int = Query(20, ge=1, le=50),
    offset: int = Query(0, ge=0),
    current_user: User = Depends(get_current_user),
    db: Session = Depends(get_db),
):
    base_q = db.query(OmoUpload).filter(
        OmoUpload.student_id == current_user.id,
        OmoUpload.superseded_at.is_(None),
        OmoUpload.status.in_(_HISTORY_STATUSES),
    )
    total = base_q.count()
    rows = base_q.order_by(OmoUpload.created_at.desc()).offset(offset).limit(limit).all()

    # Build lesson_id → meta dict once (no N+1 yaml loads)
    lesson_map = {...}

    items = [
        OmoHistoryItem(
            upload_id=u.id,
            lesson_id=..., lesson_title=..., grade_code=...,  # via _resolve_lesson_meta
            status=u.status,
            overall_score=u.overall_score,
            answers_count=len(u.answers or []),
            created_at=u.created_at.isoformat(),
            thumbnail_url=_get_signed_url(_pick_thumbnail_path(u)) if ... else None,
        )
        for u in rows
    ]
    return OmoHistoryResponse(total=total, limit=limit, offset=offset, items=items)
```

## Frontend 詳述

### `OmoHistoryList`（presentational, stateless）

```tsx
// 不依賴 router，純 props in / events out
interface Props {
  items: OmoHistoryItem[];
  onSelect: (uploadId: number) => void;
}
```

- 每張卡片：左邊 64×64 thumbnail（或 `📄` placeholder）+ 右邊 grade_code badge / lesson title / status badge / score / answers_count / 相對時間
- 空狀態：`🗂️` icon + 「還沒有任何批改記錄」+ 引導文
- 點卡片 → 呼叫 `onSelect(upload_id)`

### `OmoHistoryPage`（page-level state + navigation）

- 首次 mount 抓第一頁 20 筆
- `loadState = loading | ready | error`
- 「載入更多」按鈕：條件 `items.length < total`、disable 期間顯示「載入中…」
- 點任一卡片 → `navigate(`/omo/result/${upload_id}`)`（route 既存）
- 錯誤時：空狀態顯示「重試」CTA；已有資料時靜默 fallback（不洗掉列表）

### `OmoUpload` 入口按鈕

```tsx
{onShowHistory && (
  <button onClick={onShowHistory}>📋 查看批改記錄</button>
)}
```

只有當 parent 傳 `onShowHistory` 才 render，避免污染其他用途的呼叫者。

## 測試

### Backend pytest（15 passed）

```
TestOmoHistoryEndpoint:
  ✓ test_empty_history_returns_zero_total
  ✓ test_unauthorized_returns_401
  ✓ test_returns_user_own_uploads_newest_first
  ✓ test_excludes_superseded_uploads
  ✓ test_excludes_non_visible_statuses[pending]
  ✓ test_excludes_non_visible_statuses[identifying]
  ✓ test_excludes_non_visible_statuses[error]
  ✓ test_includes_visible_statuses[identified]
  ✓ test_includes_visible_statuses[grading]
  ✓ test_includes_visible_statuses[graded]
  ✓ test_pagination_limit_and_offset
  ✓ test_pagination_rejects_invalid_params
  ✓ test_user_isolation
  ✓ test_answers_count_reflects_answers_array_length
  ✓ test_lesson_title_falls_back_to_identification_when_lesson_id_null
```

Tests 直接 seed DB（不走 upload endpoint）以隔離 history 邏輯本身；用 `freeze`-able timestamp 驗證排序確定性。

### Frontend

- `npx tsc --noEmit`: 9 個改動檔案零 type error
- `npm run build`: ✓ 4.77s

### 既有測試迴歸

- `test_omo_crop_provenance.py` 4 個 fail 為 staging baseline pre-existing（`_upload_to_gcs` attribute），與本 PR 無關，與 #1973 review 相同結論
- `test_omo_upload.py::test_too_many_files_returns_400` 也是 staging baseline issue

## 與其他 PR 的關係

- **PR #1977 (#1973 grader 排序)**：完全獨立，不同檔
- **PR #1978 (#1974 多頁 UX)**：都改 `OmoUpload.tsx`，merge 時 conflict 但易解 — 兩邊都改 props/JSX 結構，#1974 用 staged queue、#1975 加新按鈕
- **PR #1979 (#1976 PDF)**：都改 `OmoUpload.tsx`，merge 時 conflict 但易解 — PDF 加 MIME，本 PR 加按鈕

合入 staging 後，「批改記錄」按鈕會自然搭配多頁 UX + PDF 上傳，三者體驗連貫。

## 驗證方式（待 staging deploy 後）

1. 上傳一份學習單批改完
2. 重新進 `/omo` → 看到第三顆「📋 查看批改記錄」按鈕
3. 點進去 → 看到剛剛的批改卡片
4. 點卡片 → 跳到 `/omo/result/{upload_id}`，顯示完整批改結果
5. 用另一個帳號登入 → `/omo/history` 看不到 user A 的記錄