### PR TITLE
refactor(omo): split omo_identifier.py into catalog + matching + prompt (Fixes #1886)

### DIFF
--- a/backend/app/services/omo_identifier.py
+++ b/backend/app/services/omo_identifier.py
@@ -13,19 +13,28 @@ llm-endpoint-hardening checklist:
 - Fail-closed: returns empty candidates on error, never auto-passes ✅
 - Reasoning field: each candidate has reasoning string ✅
 - Circuit breaker: 3 consecutive errors → raise RuntimeError → 503 ✅
+
+Refactored (#1886): catalog/cache → omo_lesson_catalog.py,
+title normalisation + fuzzy match → omo_title_matching.py,
+prompt builder → omo_identifier_prompt.py.
 """
 
 import base64
-import difflib
 import json
 import logging
-from dataclasses import dataclass, field
-from pathlib import Path
-
-import yaml
 
 from .ai_base import _repair_json, GeminiContentFilterError
 from .llm_models import get_model_for_task
+from .omo_lesson_catalog import (
+    LessonCandidate,
+    _LESSON_CACHE,
+    _CURRICULUM_TITLE_CACHE,
+    _resolve_story_id,
+    _load_omo_lessons,
+    _load_curriculum_titles,
+)
+from .omo_title_matching import _normalize_title, _fuzzy_match_title
+from .omo_identifier_prompt import _build_identification_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -35,312 +44,6 @@ logger = logging.getLogger(__name__)
 # Max consecutive AI errors before raising RuntimeError (circuit breaker)
 _MAX_CONSECUTIVE_ERRORS = 3
 _consecutive_errors = 0
-
-# Lesson metadata cache (loaded once at import)
-_LESSON_CACHE: list[dict] = []
-
-# Full curriculum title cache: {lesson_code -> {title, grade_code}} for all 158 lessons
-# Used by fuzzy-match fallback (stdlib difflib, no extra deps)
-_CURRICULUM_TITLE_CACHE: dict[str, dict] = {}
-
-
-@dataclass
-class LessonCandidate:
-    lesson_id: int
-    grade_code: str
-    title: str
-    confidence: float
-    reasoning: str = field(default="")
-    # #1775: canonical Story.id resolved at service boundary — None when grade_code
-    # is not in lesson_loader (e.g. fallback content-only lessons without a DB row).
-    story_id: int | None = field(default=None)
-
-
-def _resolve_story_id(grade_code: str) -> int | None:
-    """Resolve canonical Story.id from grade_code via lesson_loader.
-
-    Called once per candidate at identifier output construction so callers
-    receive story_id without needing to do a second lookup (#1775).
-    Returns None when grade_code has no matching DB-loaded lesson.
-    """
-    try:
-        from .lesson_loader import get_lesson_by_code
-        story = get_lesson_by_code(grade_code)
-        if story and story.get("id"):
-            return int(story["id"])
-    except Exception as exc:
-        logger.debug("_resolve_story_id: grade_code=%r lookup failed: %s", grade_code, exc)
-    return None
-
-
-def _load_omo_lessons() -> list[dict]:
-    """Load metadata for ALL lessons in the full curriculum catalog.
-
-    Source priority:
-    1. backend/data/curriculum/lessons/G*-L*.yml — 158 catalog entries (lesson_code, title, vocab, strategy_name)
-    2. Fallback: backend/data/lessons/L*.yml — 57 content lessons with story_text (for any lessons not in catalog)
-
-    Catalog entries provide title + vocab only (no story_text). Content lessons additionally provide story snippet.
-    """
-    global _LESSON_CACHE
-    if _LESSON_CACHE:
-        return _LESSON_CACHE
-
-    base_dir = Path(__file__).parent.parent.parent / "data"
-    catalog_dir = base_dir / "curriculum" / "lessons"
-    content_dir = base_dir / "lessons"
-
-    # Build content lookup by title (to enrich catalog entries with story_text)
-    content_by_title = {}
-    for yml_path in content_dir.glob("L*.yml"):
-        try:
-            with open(yml_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-            title = (data.get("title", "") or "").lstrip("-").strip()
-            if title:
-                content_by_title[title] = data
-        except Exception:
-            continue
-
-    result = []
-    # 1) Catalog scan (preferred — 158 lessons)
-    for yml_path in sorted(catalog_dir.glob("G*-L*.yml")):
-        try:
-            with open(yml_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-            title = (data.get("title", "") or "").strip()
-            if not title:
-                continue
-            lesson_code = data.get("lesson_code", yml_path.stem)
-            # Use lesson_code hash for lesson_id (stable int per lesson_code)
-            # Or parse from order field
-            lesson_id = data.get("display_order") or data.get("original_order") or 0
-            vocab_list = data.get("vocab") or []
-            # Enrich with story snippet if content YAML exists
-            story_snippet = ""
-            content_data = content_by_title.get(title)
-            if content_data:
-                story_snippet = (content_data.get("story_text", "") or "")[:120]
-            result.append({
-                "lesson_id": int(lesson_id) if lesson_id else 0,
-                "lesson_code": lesson_code,
-                "grade_code": lesson_code,
-                "title": title,
-                "story_snippet": story_snippet,
-                "vocabulary": [str(v) for v in vocab_list[:5]],
-            })
-        except Exception as exc:
-            logger.warning("Failed to load OMO catalog %s: %s", yml_path.name, exc)
-
-    # 2) Add any content-only lessons not in catalog (rare)
-    catalog_titles = {r["title"] for r in result}
-    for yml_path in content_dir.glob("L*.yml"):
-        try:
-            with open(yml_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-            title = (data.get("title", "") or "").lstrip("-").strip()
-            if not title or title in catalog_titles:
-                continue
-            stem = yml_path.stem
-            try:
-                lesson_id = int(stem[1:])
-            except ValueError:
-                continue
-            result.append({
-                "lesson_id": lesson_id,
-                "lesson_code": data.get("grade_code", f"L{lesson_id}"),
-                "grade_code": data.get("grade_code", f"L{lesson_id}"),
-                "title": title,
-                "story_snippet": (data.get("story_text", "") or "")[:120],
-                "vocabulary": [
-                    v.get("word", "") for v in (data.get("vocabulary") or [])[:5]
-                ],
-            })
-        except Exception as exc:
-            logger.warning("Failed to load fallback content lesson %s: %s", yml_path.name, exc)
-
-    _LESSON_CACHE = result
-    logger.info("Loaded %d OMO lesson entries (curriculum catalog + content fallback)", len(result))
-    return result
-
-
-def _load_curriculum_titles() -> dict[str, dict]:
-    """Load all curriculum lesson titles for fuzzy-match fallback.
-
-    Returns a dict of {lesson_code: {"title": str, "grade_code": str}} for all
-    lessons in backend/data/curriculum/lessons/*.yml.  Cached after first call.
-    Uses stdlib only (no extra deps).
-    """
-    global _CURRICULUM_TITLE_CACHE
-    if _CURRICULUM_TITLE_CACHE:
-        return _CURRICULUM_TITLE_CACHE
-
-    curriculum_dir = Path(__file__).parent.parent.parent / "data" / "curriculum" / "lessons"
-    if not curriculum_dir.exists():
-        logger.warning("Curriculum lessons dir not found: %s", curriculum_dir)
-        return {}
-
-    result: dict[str, dict] = {}
-    for yml_path in curriculum_dir.glob("*.yml"):
-        lesson_code = yml_path.stem  # e.g. "G5-L25"
-        try:
-            with open(yml_path, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f)
-            title = (data.get("title") or "").lstrip("-").strip()
-            grade_code = data.get("lesson_code") or lesson_code
-            if title:
-                result[lesson_code] = {"title": title, "grade_code": grade_code}
-        except Exception as exc:
-            logger.warning("Failed to load curriculum lesson %s: %s", lesson_code, exc)
-
-    _CURRICULUM_TITLE_CACHE = result
-    logger.info("Loaded %d curriculum titles for fuzzy-match fallback", len(result))
-    return result
-
-
-def _normalize_title(s: str) -> str:
-    """Normalize punctuation for fuzzy matching.
-
-    Covers two known mismatch classes:
-    1. Half-width ASCII vs full-width CJK (e.g. '?' vs '？')
-    2. Dash variants: YAML uses '──' (BOX DRAWINGS LIGHT HORIZONTAL U+2500×2)
-       while Gemini OCR returns '——' (EM DASH U+2014×2). Collapse both to '—'.
-    """
-    return (
-        s.replace("?", "？")
-         .replace("!", "！")
-         .replace(",", "，")
-         .replace("──", "—")   # BOX DRAWINGS ×2 → em-dash
-         .replace("——", "—")   # EM DASH ×2 → em-dash
-         .replace("─", "—")    # single BOX DRAWINGS → em-dash
-         .strip()
-    )
-
-
-def _fuzzy_match_title(extracted_title: str) -> list[LessonCandidate]:
-    """Match extracted_title against all known curriculum titles using difflib.
-
-    Args:
-        extracted_title: Title string extracted by Gemini OCR.
-
-    Returns:
-        Up to 1 LessonCandidate:
-        - ratio >= 0.85 → confidence 0.95
-        - ratio 0.70-0.84 → confidence 0.70
-        - ratio < 0.70 → empty list
-    """
-    if not extracted_title:
-        return []
-
-    curriculum = _load_curriculum_titles()
-    if not curriculum:
-        return []
-
-    best_code = ""
-    best_ratio = 0.0
-    normalized_extracted = _normalize_title(extracted_title)
-
-    for code, info in curriculum.items():
-        ratio = difflib.SequenceMatcher(
-            None, normalized_extracted, _normalize_title(info["title"])
-        ).ratio()
-        if ratio > best_ratio:
-            best_ratio = ratio
-            best_code = code
-
-    if best_ratio < 0.70:
-        logger.info(
-            "Fuzzy match: extracted_title=%r best_ratio=%.3f < 0.70 — no match",
-            extracted_title,
-            best_ratio,
-        )
-        return []
-
-    info = curriculum[best_code]
-    confidence = 0.95 if best_ratio >= 0.85 else 0.70
-
-    # lesson_id is the numeric part of the code (e.g. G5-L25 → 25)
-    try:
-        lesson_id = int(best_code.split("-L")[1])
-    except (IndexError, ValueError):
-        lesson_id = 0
-
-    logger.info(
-        "Fuzzy match: extracted_title=%r → %s %r ratio=%.3f conf=%.2f",
-        extracted_title,
-        best_code,
-        info["title"],
-        best_ratio,
-        confidence,
-    )
-    resolved_grade_code = info["grade_code"]
-    return [
-        LessonCandidate(
-            lesson_id=lesson_id,
-            grade_code=resolved_grade_code,
-            title=info["title"],
-            confidence=confidence,
-            reasoning=f"標題模糊匹配 ratio={best_ratio:.2f}",
-            story_id=_resolve_story_id(resolved_grade_code),
-        )
-    ]
-
-
-def _build_identification_prompt(lessons: list[dict]) -> str:
-    """Build the structured Gemini prompt for lesson identification.
-
-    With the full 158-lesson corpus, we list only grade_code + title per entry
-    (no story snippet or vocab) to keep prompt size manageable (~1300 tokens).
-    Gemini matches by reading the visible title from the worksheet image.
-    """
-    lesson_list = "\n".join(
-        f"  - {l['grade_code']}: \"{l['title']}\""
-        for l in lessons
-    )
-    n = len(lessons)
-
-    return f"""You are an AI reading assistant for a Taiwanese elementary/junior-high school platform.
-
-A student uploaded a photo of a paper worksheet. Your task is to identify which of the following {n} known lessons this worksheet belongs to, by reading visible text in the image.
-
-Known lessons:
-{lesson_list}
-
-Instructions:
-1. Read all visible text in the image, especially the large title text at the top.
-2. Extract the exact title you can read from the image. Put it in "extracted_title".
-3. Find the best matching lesson from the known list by comparing the extracted title verbatim.
-   IMPORTANT: If the extracted_title matches any known lesson title exactly or near-exactly,
-   that candidate MUST have confidence >= 0.9. Do NOT assign low confidence to an exact match.
-4. Return AT MOST 3 best-matching candidates, sorted by confidence (highest first).
-5. Use confidence 0.0–1.0 where:
-   - 0.95+ = extracted_title matches the lesson title exactly (character-for-character)
-   - 0.85–0.94 = extracted_title is nearly identical (1-2 char difference)
-   - 0.7–0.84 = partial title match
-   - 0.4–0.69 = content/theme match without title
-   - <0.4 = weak or speculative
-6. Keep each `reasoning` to ≤ 15 Chinese characters. Be terse.
-
-Respond ONLY with valid JSON in this exact format (no markdown, no explanation outside JSON):
-{{
-  "extracted_title": "<title text you could read from the image, or empty string>",
-  "candidates": [
-    {{
-      "lesson_id": <integer from grade_code suffix, e.g. G5-L25 → 25>,
-      "grade_code": "<string e.g. G5-L25>",
-      "title": "<string matching the known lesson title exactly>",
-      "confidence": <float 0.0-1.0>,
-      "reasoning": "<≤15 Chinese characters>"
-    }}
-  ]
-}}
-
-If the image is too blurry or no text is readable, return:
-{{
-  "extracted_title": "",
-  "candidates": [],
-  "error": "image_unclear"
-}}"""
 
 
 async def identify_lesson_from_image(image_bytes: bytes, mime_type: str = "image/jpeg") -> list[LessonCandidate]:
@@ -553,6 +256,10 @@ def identify_lesson_from_hint(lesson_code: str) -> list[LessonCandidate]:
     Returns:
         A single LessonCandidate with confidence=1.0, or [] if the code is not
         found in the curriculum catalog.
+
+    Note: Defined here (not delegated to omo_lesson_catalog) so that existing
+    tests can monkeypatch _load_curriculum_titles and _resolve_story_id on this
+    module (#1886 backward-compat).
     """
     curriculum = _load_curriculum_titles()
     if not curriculum:

--- a/backend/app/services/omo_identifier_prompt.py
+++ b/backend/app/services/omo_identifier_prompt.py
@@ -1,0 +1,63 @@
+"""OMO lesson identification prompt builder.
+
+Extracted from omo_identifier.py (#1886) — builds the Gemini structured prompt
+for the image-based lesson identification task.  Pure string manipulation;
+no I/O or Vertex AI dependency.
+"""
+
+
+def _build_identification_prompt(lessons: list[dict]) -> str:
+    """Build the structured Gemini prompt for lesson identification.
+
+    With the full 158-lesson corpus, we list only grade_code + title per entry
+    (no story snippet or vocab) to keep prompt size manageable (~1300 tokens).
+    Gemini matches by reading the visible title from the worksheet image.
+    """
+    lesson_list = "\n".join(
+        f"  - {l['grade_code']}: \"{l['title']}\""
+        for l in lessons
+    )
+    n = len(lessons)
+
+    return f"""You are an AI reading assistant for a Taiwanese elementary/junior-high school platform.
+
+A student uploaded a photo of a paper worksheet. Your task is to identify which of the following {n} known lessons this worksheet belongs to, by reading visible text in the image.
+
+Known lessons:
+{lesson_list}
+
+Instructions:
+1. Read all visible text in the image, especially the large title text at the top.
+2. Extract the exact title you can read from the image. Put it in "extracted_title".
+3. Find the best matching lesson from the known list by comparing the extracted title verbatim.
+   IMPORTANT: If the extracted_title matches any known lesson title exactly or near-exactly,
+   that candidate MUST have confidence >= 0.9. Do NOT assign low confidence to an exact match.
+4. Return AT MOST 3 best-matching candidates, sorted by confidence (highest first).
+5. Use confidence 0.0–1.0 where:
+   - 0.95+ = extracted_title matches the lesson title exactly (character-for-character)
+   - 0.85–0.94 = extracted_title is nearly identical (1-2 char difference)
+   - 0.7–0.84 = partial title match
+   - 0.4–0.69 = content/theme match without title
+   - <0.4 = weak or speculative
+6. Keep each `reasoning` to ≤ 15 Chinese characters. Be terse.
+
+Respond ONLY with valid JSON in this exact format (no markdown, no explanation outside JSON):
+{{
+  "extracted_title": "<title text you could read from the image, or empty string>",
+  "candidates": [
+    {{
+      "lesson_id": <integer from grade_code suffix, e.g. G5-L25 → 25>,
+      "grade_code": "<string e.g. G5-L25>",
+      "title": "<string matching the known lesson title exactly>",
+      "confidence": <float 0.0-1.0>,
+      "reasoning": "<≤15 Chinese characters>"
+    }}
+  ]
+}}
+
+If the image is too blurry or no text is readable, return:
+{{
+  "extracted_title": "",
+  "candidates": [],
+  "error": "image_unclear"
+}}"""

--- a/backend/app/services/omo_lesson_catalog.py
+++ b/backend/app/services/omo_lesson_catalog.py
@@ -1,0 +1,225 @@
+"""OMO lesson catalog: dataclass, cache loading, story-id resolution, hint path.
+
+Extracted from omo_identifier.py (#1886) — handles all catalog I/O and the
+lesson hint path that bypasses AI identification.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# Lesson metadata cache (loaded once at import)
+_LESSON_CACHE: list[dict] = []
+
+# Full curriculum title cache: {lesson_code -> {title, grade_code}} for all 158 lessons
+# Used by fuzzy-match fallback (stdlib difflib, no extra deps)
+_CURRICULUM_TITLE_CACHE: dict[str, dict] = {}
+
+
+@dataclass
+class LessonCandidate:
+    lesson_id: int
+    grade_code: str
+    title: str
+    confidence: float
+    reasoning: str = field(default="")
+    # #1775: canonical Story.id resolved at service boundary — None when grade_code
+    # is not in lesson_loader (e.g. fallback content-only lessons without a DB row).
+    story_id: int | None = field(default=None)
+
+
+def _resolve_story_id(grade_code: str) -> int | None:
+    """Resolve canonical Story.id from grade_code via lesson_loader.
+
+    Called once per candidate at identifier output construction so callers
+    receive story_id without needing to do a second lookup (#1775).
+    Returns None when grade_code has no matching DB-loaded lesson.
+    """
+    try:
+        from .lesson_loader import get_lesson_by_code
+        story = get_lesson_by_code(grade_code)
+        if story and story.get("id"):
+            return int(story["id"])
+    except Exception as exc:
+        logger.debug("_resolve_story_id: grade_code=%r lookup failed: %s", grade_code, exc)
+    return None
+
+
+def _load_omo_lessons() -> list[dict]:
+    """Load metadata for ALL lessons in the full curriculum catalog.
+
+    Source priority:
+    1. backend/data/curriculum/lessons/G*-L*.yml — 158 catalog entries (lesson_code, title, vocab, strategy_name)
+    2. Fallback: backend/data/lessons/L*.yml — 57 content lessons with story_text (for any lessons not in catalog)
+
+    Catalog entries provide title + vocab only (no story_text). Content lessons additionally provide story snippet.
+    """
+    global _LESSON_CACHE
+    if _LESSON_CACHE:
+        return _LESSON_CACHE
+
+    base_dir = Path(__file__).parent.parent.parent / "data"
+    catalog_dir = base_dir / "curriculum" / "lessons"
+    content_dir = base_dir / "lessons"
+
+    # Build content lookup by title (to enrich catalog entries with story_text)
+    content_by_title = {}
+    for yml_path in content_dir.glob("L*.yml"):
+        try:
+            with open(yml_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            title = (data.get("title", "") or "").lstrip("-").strip()
+            if title:
+                content_by_title[title] = data
+        except Exception:
+            continue
+
+    result = []
+    # 1) Catalog scan (preferred — 158 lessons)
+    for yml_path in sorted(catalog_dir.glob("G*-L*.yml")):
+        try:
+            with open(yml_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            title = (data.get("title", "") or "").strip()
+            if not title:
+                continue
+            lesson_code = data.get("lesson_code", yml_path.stem)
+            # Use lesson_code hash for lesson_id (stable int per lesson_code)
+            # Or parse from order field
+            lesson_id = data.get("display_order") or data.get("original_order") or 0
+            vocab_list = data.get("vocab") or []
+            # Enrich with story snippet if content YAML exists
+            story_snippet = ""
+            content_data = content_by_title.get(title)
+            if content_data:
+                story_snippet = (content_data.get("story_text", "") or "")[:120]
+            result.append({
+                "lesson_id": int(lesson_id) if lesson_id else 0,
+                "lesson_code": lesson_code,
+                "grade_code": lesson_code,
+                "title": title,
+                "story_snippet": story_snippet,
+                "vocabulary": [str(v) for v in vocab_list[:5]],
+            })
+        except Exception as exc:
+            logger.warning("Failed to load OMO catalog %s: %s", yml_path.name, exc)
+
+    # 2) Add any content-only lessons not in catalog (rare)
+    catalog_titles = {r["title"] for r in result}
+    for yml_path in content_dir.glob("L*.yml"):
+        try:
+            with open(yml_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+            title = (data.get("title", "") or "").lstrip("-").strip()
+            if not title or title in catalog_titles:
+                continue
+            stem = yml_path.stem
+            try:
+                lesson_id = int(stem[1:])
+            except ValueError:
+                continue
+            result.append({
+                "lesson_id": lesson_id,
+                "lesson_code": data.get("grade_code", f"L{lesson_id}"),
+                "grade_code": data.get("grade_code", f"L{lesson_id}"),
+                "title": title,
+                "story_snippet": (data.get("story_text", "") or "")[:120],
+                "vocabulary": [
+                    v.get("word", "") for v in (data.get("vocabulary") or [])[:5]
+                ],
+            })
+        except Exception as exc:
+            logger.warning("Failed to load fallback content lesson %s: %s", yml_path.name, exc)
+
+    _LESSON_CACHE = result
+    logger.info("Loaded %d OMO lesson entries (curriculum catalog + content fallback)", len(result))
+    return result
+
+
+def _load_curriculum_titles() -> dict[str, dict]:
+    """Load all curriculum lesson titles for fuzzy-match fallback.
+
+    Returns a dict of {lesson_code: {"title": str, "grade_code": str}} for all
+    lessons in backend/data/curriculum/lessons/*.yml.  Cached after first call.
+    Uses stdlib only (no extra deps).
+    """
+    global _CURRICULUM_TITLE_CACHE
+    if _CURRICULUM_TITLE_CACHE:
+        return _CURRICULUM_TITLE_CACHE
+
+    curriculum_dir = Path(__file__).parent.parent.parent / "data" / "curriculum" / "lessons"
+    if not curriculum_dir.exists():
+        logger.warning("Curriculum lessons dir not found: %s", curriculum_dir)
+        return {}
+
+    result: dict[str, dict] = {}
+    for yml_path in curriculum_dir.glob("*.yml"):
+        lesson_code = yml_path.stem  # e.g. "G5-L25"
+        try:
+            with open(yml_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            title = (data.get("title") or "").lstrip("-").strip()
+            grade_code = data.get("lesson_code") or lesson_code
+            if title:
+                result[lesson_code] = {"title": title, "grade_code": grade_code}
+        except Exception as exc:
+            logger.warning("Failed to load curriculum lesson %s: %s", lesson_code, exc)
+
+    _CURRICULUM_TITLE_CACHE = result
+    logger.info("Loaded %d curriculum titles for fuzzy-match fallback", len(result))
+    return result
+
+
+def identify_lesson_from_hint(lesson_code: str) -> list[LessonCandidate]:
+    """Resolve a lesson by its known lesson_code (hint path — skips AI fuzzy match).
+
+    Used when the student uploads from within a lesson reading page, so the
+    system already knows which lesson they're working on.  The upload route
+    uses this function when ``lesson_code_hint`` is provided in the request,
+    saving ~6-24 s of Vertex AI latency and ~$0.0003 per call.
+
+    Args:
+        lesson_code: Canonical lesson code from the YAML catalog (e.g. "G5-L25").
+
+    Returns:
+        A single LessonCandidate with confidence=1.0, or [] if the code is not
+        found in the curriculum catalog.
+    """
+    curriculum = _load_curriculum_titles()
+    if not curriculum:
+        logger.warning("identify_lesson_from_hint: curriculum cache empty")
+        return []
+
+    info = curriculum.get(lesson_code)
+    if not info:
+        logger.warning(
+            "identify_lesson_from_hint: lesson_code=%r not found in catalog", lesson_code
+        )
+        return []
+
+    try:
+        lesson_id = int(lesson_code.split("-L")[1])
+    except (IndexError, ValueError):
+        lesson_id = 0
+
+    logger.info(
+        "identify_lesson_from_hint: lesson_code=%r → id=%d title=%r (hint path, no AI call)",
+        lesson_code,
+        lesson_id,
+        info["title"],
+    )
+    resolved_grade_code = info["grade_code"]
+    return [
+        LessonCandidate(
+            lesson_id=lesson_id,
+            grade_code=resolved_grade_code,
+            title=info["title"],
+            confidence=1.0,
+            reasoning="user-provided lesson hint (課文頁面內上傳)",
+            story_id=_resolve_story_id(resolved_grade_code),
+        )
+    ]

--- a/backend/app/services/omo_title_matching.py
+++ b/backend/app/services/omo_title_matching.py
@@ -1,0 +1,114 @@
+"""OMO title normalisation and fuzzy-match fallback.
+
+Extracted from omo_identifier.py (#1886) — pure stdlib (difflib) title matching.
+No Vertex AI dependency; safe to import in tests without GCP credentials.
+"""
+
+import difflib
+import logging
+
+from .omo_lesson_catalog import LessonCandidate, _load_curriculum_titles, _resolve_story_id
+
+logger = logging.getLogger(__name__)
+
+# Keep private cache alias so monkeypatching in tests targeting _CURRICULUM_TITLE_CACHE
+# on this module also works.
+_CURRICULUM_TITLE_CACHE: dict = {}  # local alias; actual cache lives in omo_lesson_catalog
+
+
+def normalize_title(s: str) -> str:
+    """Normalize punctuation for fuzzy matching.
+
+    Covers two known mismatch classes:
+    1. Half-width ASCII vs full-width CJK (e.g. '?' vs '？')
+    2. Dash variants: YAML uses '──' (BOX DRAWINGS LIGHT HORIZONTAL U+2500×2)
+       while Gemini OCR returns '——' (EM DASH U+2014×2). Collapse both to '—'.
+    """
+    return (
+        s.replace("?", "？")
+         .replace("!", "！")
+         .replace(",", "，")
+         .replace("──", "—")   # BOX DRAWINGS ×2 → em-dash
+         .replace("——", "—")   # EM DASH ×2 → em-dash
+         .replace("─", "—")    # single BOX DRAWINGS → em-dash
+         .strip()
+    )
+
+
+# Private alias for backward-compat with existing call-sites in omo_identifier.py
+_normalize_title = normalize_title
+
+
+def fuzzy_match_title(extracted_title: str) -> list[LessonCandidate]:
+    """Match extracted_title against all known curriculum titles using difflib.
+
+    Args:
+        extracted_title: Title string extracted by Gemini OCR.
+
+    Returns:
+        Up to 1 LessonCandidate:
+        - ratio >= 0.85 → confidence 0.95
+        - ratio 0.70-0.84 → confidence 0.70
+        - ratio < 0.70 → empty list
+    """
+    if not extracted_title:
+        return []
+
+    # Honour monkeypatch on this module's _CURRICULUM_TITLE_CACHE if set in tests,
+    # otherwise fall through to the canonical loader.
+    curriculum = _CURRICULUM_TITLE_CACHE if _CURRICULUM_TITLE_CACHE else _load_curriculum_titles()
+    if not curriculum:
+        return []
+
+    best_code = ""
+    best_ratio = 0.0
+    normalized_extracted = normalize_title(extracted_title)
+
+    for code, info in curriculum.items():
+        ratio = difflib.SequenceMatcher(
+            None, normalized_extracted, normalize_title(info["title"])
+        ).ratio()
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_code = code
+
+    if best_ratio < 0.70:
+        logger.info(
+            "Fuzzy match: extracted_title=%r best_ratio=%.3f < 0.70 — no match",
+            extracted_title,
+            best_ratio,
+        )
+        return []
+
+    info = curriculum[best_code]
+    confidence = 0.95 if best_ratio >= 0.85 else 0.70
+
+    # lesson_id is the numeric part of the code (e.g. G5-L25 → 25)
+    try:
+        lesson_id = int(best_code.split("-L")[1])
+    except (IndexError, ValueError):
+        lesson_id = 0
+
+    logger.info(
+        "Fuzzy match: extracted_title=%r → %s %r ratio=%.3f conf=%.2f",
+        extracted_title,
+        best_code,
+        info["title"],
+        best_ratio,
+        confidence,
+    )
+    resolved_grade_code = info["grade_code"]
+    return [
+        LessonCandidate(
+            lesson_id=lesson_id,
+            grade_code=resolved_grade_code,
+            title=info["title"],
+            confidence=confidence,
+            reasoning=f"標題模糊匹配 ratio={best_ratio:.2f}",
+            story_id=_resolve_story_id(resolved_grade_code),
+        )
+    ]
+
+
+# Private alias for backward-compat
+_fuzzy_match_title = fuzzy_match_title

--- a/backend/tests/test_omo_identifier_split_1886.py
+++ b/backend/tests/test_omo_identifier_split_1886.py
@@ -1,0 +1,257 @@
+"""TDD tests for #1886 — omo_identifier.py split.
+
+Phase 1 (Red → Green):
+  Three tests pinning behaviours in the monolithic omo_identifier.py.
+  ALL THREE must pass on the CURRENT code before refactoring begins.
+
+Phase 2 (Refactor):
+  Extract omo_lesson_catalog.py / omo_title_matching.py / omo_identifier_prompt.py.
+  Same three tests (imported from new modules) must still pass.
+
+Tautology check: each test has a negative assertion or strictly-constrained
+expected value so a trivially-passing stub would fail.
+
+Run:
+    cd backend && python -m pytest tests/test_omo_identifier_split_1886.py -v
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1: normalize_title_collapses_punctuation_and_dash_variants
+# ---------------------------------------------------------------------------
+class TestNormalizeTitle:
+    """_normalize_title must fold OCR punctuation variants into a stable form."""
+
+    def _norm(self, s: str) -> str:
+        """Import from wherever it lives (monolith or extracted module)."""
+        try:
+            from app.services.omo_title_matching import normalize_title
+            return normalize_title(s)
+        except ImportError:
+            from app.services.omo_identifier import _normalize_title
+            return _normalize_title(s)
+
+    def test_half_width_question_mark_becomes_full_width(self):
+        result = self._norm("你好嗎?")
+        assert result == "你好嗎？", f"expected full-width ？, got {result!r}"
+
+    def test_half_width_exclamation_becomes_full_width(self):
+        result = self._norm("太棒了!")
+        assert result == "太棒了！", f"expected full-width ！, got {result!r}"
+
+    def test_box_drawing_double_collapses_to_em_dash(self):
+        # U+2500 U+2500 — the YAML file uses BOX DRAWINGS LIGHT HORIZONTAL ×2
+        result = self._norm("蔡英文──歷史")
+        assert result == "蔡英文—歷史", f"got {result!r}"
+        # Negative: original must differ from normalized
+        assert result != "蔡英文──歷史"
+
+    def test_em_dash_double_collapses_to_em_dash(self):
+        # U+2014 U+2014 — Gemini OCR returns double EM DASH
+        result = self._norm("題目——副標")
+        assert result == "題目—副標", f"got {result!r}"
+
+    def test_single_box_drawing_collapses_to_em_dash(self):
+        # U+2500 single — also seen in some YAML titles
+        result = self._norm("前─後")
+        assert result == "前—後", f"got {result!r}"
+
+    def test_leading_trailing_whitespace_stripped(self):
+        result = self._norm("  標題  ")
+        assert result == "標題", f"expected stripped result, got {result!r}"
+
+    def test_ascii_comma_becomes_full_width(self):
+        result = self._norm("一,二,三")
+        assert result == "一，二，三", f"got {result!r}"
+
+    def test_already_normalized_unchanged(self):
+        original = "一本好書"
+        result = self._norm(original)
+        assert result == original
+
+
+# ---------------------------------------------------------------------------
+# Test 2: fuzzy_match_title_thresholds_confidence_correctly
+# ---------------------------------------------------------------------------
+class TestFuzzyMatchThresholds:
+    """_fuzzy_match_title must map ratio bands to the correct confidence values."""
+
+    def _fuzzy(self, extracted_title: str):
+        """Call fuzzy match from wherever it lives."""
+        try:
+            from app.services.omo_title_matching import fuzzy_match_title
+            return fuzzy_match_title(extracted_title)
+        except ImportError:
+            from app.services.omo_identifier import _fuzzy_match_title
+            return _fuzzy_match_title(extracted_title)
+
+    def _inject_curriculum(self, monkeypatch, titles: dict[str, dict]):
+        """Patch the curriculum cache used by the fuzzy matcher."""
+        import app.services.omo_identifier as omo_id
+        try:
+            import app.services.omo_title_matching as omo_tm
+            monkeypatch.setattr(omo_tm, "_CURRICULUM_TITLE_CACHE", titles)
+            # Also patch loader so cache isn't re-initialised
+            monkeypatch.setattr(omo_tm, "_load_curriculum_titles", lambda: titles)
+        except (ImportError, AttributeError):
+            pass
+        monkeypatch.setattr(omo_id, "_CURRICULUM_TITLE_CACHE", titles)
+        monkeypatch.setattr(omo_id, "_load_curriculum_titles", lambda: titles)
+
+    def test_exact_match_returns_confidence_095(self, monkeypatch):
+        """ratio >= 0.85 → confidence exactly 0.95."""
+        catalog = {
+            "G5-L25": {"title": "阿里山的故事", "grade_code": "G5-L25"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        results = self._fuzzy("阿里山的故事")
+        assert len(results) == 1, f"expected 1 result, got {results}"
+        assert results[0].confidence == 0.95, f"expected 0.95, got {results[0].confidence}"
+
+    def test_near_match_returns_confidence_070(self, monkeypatch):
+        """ratio 0.70–0.84 → confidence exactly 0.70."""
+        catalog = {
+            "G5-L25": {"title": "阿里山的故事很長很長", "grade_code": "G5-L25"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        # "阿里山的故事" vs "阿里山的故事很長很長" — ratio ~0.75
+        results = self._fuzzy("阿里山的故事")
+        if results:
+            # If matched, confidence must be 0.70 (not 0.95)
+            assert results[0].confidence == 0.70, (
+                f"expected 0.70 for near match, got {results[0].confidence}"
+            )
+        # Negative: must NOT return confidence=0.95 for a partial match
+        for r in results:
+            assert r.confidence != 0.95, "partial match must not get high confidence"
+
+    def test_below_threshold_returns_empty(self, monkeypatch):
+        """ratio < 0.70 → empty list (no match)."""
+        catalog = {
+            "G7-L30": {"title": "完全不相關的課文標題", "grade_code": "G7-L30"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        results = self._fuzzy("xyz english title")
+        assert results == [], f"expected [] for low ratio, got {results}"
+
+    def test_empty_string_returns_empty(self, monkeypatch):
+        """Empty extracted_title → empty list (no match attempted)."""
+        catalog = {
+            "G5-L25": {"title": "阿里山的故事", "grade_code": "G5-L25"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        results = self._fuzzy("")
+        assert results == [], f"expected [] for empty input, got {results}"
+
+    def test_returned_candidate_has_grade_code(self, monkeypatch):
+        """Returned candidate grade_code must match catalog grade_code."""
+        catalog = {
+            "G6-L22": {"title": "生命的奇蹟", "grade_code": "G6-L22"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        results = self._fuzzy("生命的奇蹟")
+        assert results, "expected a match"
+        assert results[0].grade_code == "G6-L22", (
+            f"expected G6-L22, got {results[0].grade_code!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: hint_path_returns_confidence_one_and_resolved_story_id
+# ---------------------------------------------------------------------------
+class TestHintPath:
+    """identify_lesson_from_hint must bypass AI and return confidence=1.0."""
+
+    def _hint(self, lesson_code: str):
+        """Call hint function from wherever it lives."""
+        try:
+            from app.services.omo_lesson_catalog import identify_lesson_from_hint
+        except ImportError:
+            from app.services.omo_identifier import identify_lesson_from_hint
+        return identify_lesson_from_hint(lesson_code)
+
+    def _inject_curriculum(self, monkeypatch, catalog: dict):
+        """Patch curriculum cache on all possible module locations."""
+        import app.services.omo_identifier as omo_id
+        try:
+            import app.services.omo_lesson_catalog as omo_cat
+            monkeypatch.setattr(omo_cat, "_CURRICULUM_TITLE_CACHE", catalog)
+            monkeypatch.setattr(omo_cat, "_load_curriculum_titles", lambda: catalog)
+        except (ImportError, AttributeError):
+            pass
+        monkeypatch.setattr(omo_id, "_CURRICULUM_TITLE_CACHE", catalog)
+        monkeypatch.setattr(omo_id, "_load_curriculum_titles", lambda: catalog)
+
+    def test_known_code_returns_confidence_one(self, monkeypatch):
+        catalog = {
+            "G5-L25": {"title": "阿里山的故事", "grade_code": "G5-L25"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        monkeypatch.setattr(
+            "app.services.omo_identifier._resolve_story_id", lambda gc: 42
+        )
+        results = self._hint("G5-L25")
+        assert len(results) == 1, f"expected 1 result, got {results}"
+        assert results[0].confidence == 1.0, (
+            f"hint path must return confidence 1.0, got {results[0].confidence}"
+        )
+        # Negative: must not be 0.0 or fractional
+        assert results[0].confidence != 0.0
+
+    def test_known_code_returns_correct_title(self, monkeypatch):
+        catalog = {
+            "G6-L22": {"title": "生命的奇蹟", "grade_code": "G6-L22"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        monkeypatch.setattr(
+            "app.services.omo_identifier._resolve_story_id", lambda gc: None
+        )
+        results = self._hint("G6-L22")
+        assert results[0].title == "生命的奇蹟", (
+            f"expected '生命的奇蹟', got {results[0].title!r}"
+        )
+
+    def test_unknown_code_returns_empty(self, monkeypatch):
+        catalog = {
+            "G5-L25": {"title": "阿里山的故事", "grade_code": "G5-L25"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        results = self._hint("G9-L99")
+        assert results == [], f"unknown code must return [], got {results}"
+
+    def test_story_id_resolved_at_hint_boundary(self, monkeypatch):
+        """story_id is attached to the candidate at hint-path resolution."""
+        catalog = {
+            "G7-L28": {"title": "課文標題", "grade_code": "G7-L28"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        # Patch _resolve_story_id on both the monolith and the extracted module
+        monkeypatch.setattr(
+            "app.services.omo_identifier._resolve_story_id", lambda gc: 99
+        )
+        try:
+            monkeypatch.setattr(
+                "app.services.omo_lesson_catalog._resolve_story_id", lambda gc: 99
+            )
+        except (ImportError, AttributeError):
+            pass
+        results = self._hint("G7-L28")
+        assert results[0].story_id == 99, (
+            f"story_id must be resolved at hint boundary, got {results[0].story_id}"
+        )
+        # Negative: story_id must not be absent
+        assert results[0].story_id is not None
+
+    def test_grade_code_from_catalog_used(self, monkeypatch):
+        """grade_code in result must come from catalog, not raw input."""
+        catalog = {
+            "G5-L25": {"title": "阿里山的故事", "grade_code": "G5-L25"},
+        }
+        self._inject_curriculum(monkeypatch, catalog)
+        monkeypatch.setattr(
+            "app.services.omo_identifier._resolve_story_id", lambda gc: None
+        )
+        results = self._hint("G5-L25")
+        assert results[0].grade_code == "G5-L25"


### PR DESCRIPTION
Fixes #1886

## Summary
- Extracted `omo_lesson_catalog.py` — LessonCandidate dataclass, lesson cache, `_load_omo_lessons`, `_load_curriculum_titles`, `_resolve_story_id`
- Extracted `omo_title_matching.py` — `_normalize_title`, `_fuzzy_match_title` with confidence thresholds
- Extracted `omo_identifier_prompt.py` — `_build_identification_prompt` (Gemini prompt template)
- `omo_identifier.py` is now a thin entrypoint (~297 lines → orchestration only), re-exporting public API unchanged
- `identify_lesson_from_hint` stays in `omo_identifier.py` for backward-compat (callers monkeypatch this module)

## Model config preserved
`get_model_for_task("omo_identifier")` call site unchanged — line 70 of `omo_identifier.py`

## Callers unchanged
`omo_jobs.py` and `omo.py` route still import from `omo_identifier` — zero breaking changes

## TDD evidence
18/18 tests pass: `TestNormalizeTitle` (8), `TestFuzzyMatchThresholds` (5), `TestHintPath` (5)

## Test plan
- [x] `python -m pytest tests/test_omo_identifier_split_1886.py -v` → 18 passed in 5.65s
- [x] Model config `get_model_for_task("omo_identifier")` preserved
- [x] Public imports (`identify_lesson_from_image`, `identify_lesson_from_hint`, `LessonCandidate`) unchanged
- [ ] CI green on preview deploy