### PR TITLE
fix(teacher): greeting must not duplicate 老師 suffix (Fixes #1984)

### DIFF
--- a/frontend/src/pages/teacher/TeacherHome.tsx
+++ b/frontend/src/pages/teacher/TeacherHome.tsx
@@ -194,7 +194,10 @@ const TeacherHome: React.FC = () => {
     };
   }, [token]);
 
-  const firstName = user?.name ?? '老師';
+  const rawName = user?.name ?? '老師';
+  // Issue #1984: avoid duplicating role suffix when name already ends with 老師
+  // e.g. '李老師' → '李老師！' (not '李老師 老師！')
+  const displayName = rawName.endsWith('老師') ? rawName : `${rawName} 老師`;
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -207,12 +210,12 @@ const TeacherHome: React.FC = () => {
               aria-hidden="true"
             >
               <span className="text-white text-2xl font-bold">
-                {firstName.charAt(0)}
+                {rawName.charAt(0)}
               </span>
             </div>
             <div>
               <h1 className="text-xl font-bold text-gray-900">
-                歡迎回來，{firstName} 老師！
+                歡迎回來，{displayName}！
               </h1>
               <p className="text-sm text-gray-500 mt-0.5">
                 今天也來關心一下學生的學習進度吧

--- a/frontend/src/pages/teacher/__tests__/TeacherHome.routing.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/TeacherHome.routing.test.tsx
@@ -7,6 +7,11 @@
  *
  * Regression guard: 管理班級 and 建立作業 must navigate to /teacher
  * WITHOUT the reports intent flag.
+ *
+ * Issue #1984 — greeting must not duplicate role suffix
+ * When user.name ends with 老師 (e.g. '李老師'), the greeting
+ * must NOT append another 老師 → should show "歡迎回來，李老師！"
+ * not "歡迎回來，李老師 老師！"
  */
 
 import React from 'react';
@@ -117,6 +122,46 @@ describe('TeacherHome — 查看報告 routing (issue #1545)', () => {
     fireEvent.click(screen.getByRole('button', { name: /前往 三年甲班/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/teacher/classroom/1');
+  });
+});
+
+describe('TeacherHome — greeting name+role deduplication (issue #1984)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not duplicate role suffix when user.name already ends with 老師', async () => {
+    // user.name = '李老師' (ends with 老師); greeting must NOT show '李老師 老師'
+    renderTeacherHome();
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading.textContent).not.toMatch(/老師\s*老師/);
+    expect(heading.textContent).toContain('李老師');
+  });
+
+  it('still appends 老師 when user.name does not end with 老師', async () => {
+    // Override mock for this test only — name = '王小明' (no 老師 suffix)
+    vi.doMock('../../../contexts/AuthContext', () => ({
+      useAuth: () => ({
+        user: { id: 2, name: '王小明' },
+        token: 'test-token',
+      }),
+    }));
+    // Re-import to pick up new mock
+    const { default: TeacherHomeFresh } = await import('../TeacherHome?name=fresh');
+    render(
+      <MemoryRouter initialEntries={['/teacher-home']}>
+        <TeacherHomeFresh />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading.textContent).toContain('王小明');
+    expect(heading.textContent).toContain('老師');
   });
 });
 


### PR DESCRIPTION
Fixes #1984

## Summary
- `TeacherHome.tsx` line 215 was rendering `{firstName} 老師！`, unconditionally appending the role suffix
- When `user.name = '李老師'` (already ends with 老師), the heading showed **「歡迎回來，李老師 老師！」**
- Fix: compute `displayName` once — if `rawName` ends with `老師`, use as-is; otherwise append ` 老師`

## Files changed
- `frontend/src/pages/teacher/TeacherHome.tsx` — 2-line logic change
- `frontend/src/pages/teacher/__tests__/TeacherHome.routing.test.tsx` — added 2 regression tests

## Test plan
- [x] TDD: test written first (Red), then fix applied (Green)
- [x] `does not duplicate role suffix when user.name already ends with 老師` — passes
- [x] `still appends 老師 when user.name does not end with 老師` — passes
- [x] All 8 existing TeacherHome routing tests still pass