### PR TITLE
fix(ux): remove copyright checkbox from assign-text modal (Fixes #1983)

### DIFF
--- a/frontend/src/pages/teacher/TextManagementTab.tsx
+++ b/frontend/src/pages/teacher/TextManagementTab.tsx
@@ -39,8 +39,6 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
   // Assign flow
   const [showAssignSelector, setShowAssignSelector] = useState(false);
   const [assigningTextId, setAssigningTextId] = useState<string | null>(null);
-  const [copyrightConfirmed, setCopyrightConfirmed] = useState(false);
-  const [showTooltip, setShowTooltip] = useState(false);
 
   // Unassign flow
   const [confirmUnassignId, setConfirmUnassignId] = useState<string | null>(null);
@@ -115,19 +113,20 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
 
   const handleOpenAssignSelector = () => {
     setShowAssignSelector(true);
-    setCopyrightConfirmed(false);
     loadStories();
   };
 
   const handleCloseAssignSelector = () => {
     setShowAssignSelector(false);
-    setCopyrightConfirmed(false);
   };
 
   const handleAssign = async (textId: string) => {
-    if (!token || !copyrightConfirmed) return;
+    if (!token) return;
     setAssigningTextId(textId);
     try {
+      // All stories in this list are platform YAML content — copyright_confirmed is
+      // always true for internal content. User confirmation is only needed for
+      // teacher-uploaded texts (managed via MyTextsTab). See issue #1983.
       const newItem = await assignText(token, classroomId, textId, true);
       setAssignedTexts((prev) => [...prev, newItem]);
     } catch (err) {
@@ -247,42 +246,6 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
             </button>
           </div>
 
-          {/* Copyright confirmation */}
-          <div className="mb-3 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-            <label className="flex items-start gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={copyrightConfirmed}
-                onChange={(e) => setCopyrightConfirmed(e.target.checked)}
-                className="mt-0.5 h-4 w-4 rounded border-gray-300 text-accent cursor-pointer shrink-0"
-              />
-              <span className="text-xs text-amber-900 leading-relaxed">
-                我確認本教材的使用符合著作權規範
-              </span>
-            </label>
-            <div className="mt-1.5 ml-6 flex items-center gap-1 relative">
-              <button
-                type="button"
-                onMouseEnter={() => setShowTooltip(true)}
-                onMouseLeave={() => setShowTooltip(false)}
-                onFocus={() => setShowTooltip(true)}
-                onBlur={() => setShowTooltip(false)}
-                className="text-xs text-amber-700 underline cursor-pointer hover:text-amber-900 flex items-center gap-0.5"
-              >
-                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                著作權說明
-              </button>
-              {showTooltip && (
-                <div className="absolute bottom-full left-0 mb-1 w-64 p-2.5 bg-gray-800 text-white text-xs rounded-lg shadow-lg z-10 leading-relaxed">
-                  依據著作權法第46條，學校教師在教學目的下得合理使用已公開發表之著作。請確認您使用的教材符合合理使用原則，或已取得著作權人授權。
-                  <div className="absolute top-full left-3 border-4 border-transparent border-t-gray-800" />
-                </div>
-              )}
-            </div>
-          </div>
-
           {isLoadingStories ? (
             <div className="flex items-center gap-2 py-4">
               <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
@@ -307,16 +270,21 @@ const TextManagementTab: React.FC<TextManagementTabProps> = ({ classroomId }) =>
                 <div key={story.id} className="px-4 py-2.5 flex items-center justify-between">
                   <div>
                     <p className="text-sm font-medium text-gray-900">{story.title}</p>
-                    <p className="text-xs text-gray-500">
-                      {story.grade ? `${story.grade} 年級` : ''}
-                      {story.genre ? ` / ${story.genre}` : ''}
-                      {story.charCount ? ` / ${story.charCount} 字` : ''}
-                    </p>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      <p className="text-xs text-gray-500">
+                        {story.grade ? `${story.grade} 年級` : ''}
+                        {story.genre ? ` / ${story.genre}` : ''}
+                        {story.charCount ? ` / ${story.charCount} 字` : ''}
+                      </p>
+                      {/* Platform badge — all stories here are internal YAML content (#1983) */}
+                      <span className="text-xs bg-blue-50 text-blue-600 border border-blue-100 px-1.5 py-0.5 rounded shrink-0">
+                        平台教材
+                      </span>
+                    </div>
                   </div>
                   <button
                     onClick={() => handleAssign(story.id)}
-                    disabled={assigningTextId === story.id || !copyrightConfirmed}
-                    title={!copyrightConfirmed ? '請先確認著作權聲明' : undefined}
+                    disabled={assigningTextId === story.id}
                     className="px-3 py-1 rounded-md bg-accent hover:bg-accent-hover text-white text-xs font-medium transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
                   >
                     {assigningTextId === story.id ? '指派中...' : '指派'}

--- a/frontend/src/pages/teacher/__tests__/TextManagementTab.copyright.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/TextManagementTab.copyright.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * TDD tests for issue #1983:
+ * Platform YAML texts (all stories in fetchStories) should NOT require
+ * copyright checkbox — the assign button must be enabled immediately.
+ *
+ * All stories returned by fetchStories are internal platform content.
+ * The copyright checkbox should be removed from the TextManagementTab flow.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import TextManagementTab from '../TextManagementTab';
+
+// Mock auth context
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ token: 'test-token' }),
+}));
+
+// Mock teacher API
+vi.mock('../../../services/teacherApi', () => ({
+  getClassroomTexts: vi.fn().mockResolvedValue([]),
+  assignText: vi.fn().mockResolvedValue({
+    id: 1,
+    text_id: 'story-1',
+    title: '贏得喝采的輸家',
+    assigned_at: '2026-05-26T00:00:00Z',
+  }),
+  unassignText: vi.fn().mockResolvedValue(undefined),
+  listStoryTags: vi.fn().mockResolvedValue([]),
+  TeacherApiError: class TeacherApiError extends Error {},
+}));
+
+// Mock fetchStories — returns platform YAML stories (all internal content)
+vi.mock('../../../services/api', () => ({
+  fetchStories: vi.fn().mockResolvedValue({
+    stories: [
+      {
+        id: 'story-1',
+        title: '贏得喝采的輸家',
+        grade: 5,
+        genre: '記敘文',
+        charCount: 800,
+        filename: 'story-1.yaml',
+      },
+      {
+        id: 'story-2',
+        title: '孔子與學問',
+        grade: 6,
+        genre: '議論文',
+        charCount: 600,
+        filename: 'story-2.yaml',
+      },
+    ],
+    total: 2,
+    grades: [5, 6],
+  }),
+}));
+
+describe('TextManagementTab — copyright checkbox behavior for platform texts (#1983)', () => {
+  const renderTab = () => render(<TextManagementTab classroomId={1} />);
+
+  it('should NOT show copyright checkbox when assign selector is open', async () => {
+    renderTab();
+
+    // Wait for initial load to finish
+    await waitFor(() => expect(screen.queryByText('載入課文列表...')).not.toBeInTheDocument());
+
+    // Open the assign selector
+    const assignBtn = screen.getByRole('button', { name: /指派課文/ });
+    fireEvent.click(assignBtn);
+
+    // Wait for stories to load
+    await waitFor(() => expect(screen.getByText('贏得喝采的輸家')).toBeInTheDocument());
+
+    // Copyright checkbox should NOT be present for platform texts
+    expect(screen.queryByText('我確認本教材的使用符合著作權規範')).not.toBeInTheDocument();
+  });
+
+  it('assign button for platform story should be enabled without any checkbox interaction', async () => {
+    renderTab();
+
+    await waitFor(() => expect(screen.queryByText('載入課文列表...')).not.toBeInTheDocument());
+
+    // Open assign selector
+    fireEvent.click(screen.getByRole('button', { name: /指派課文/ }));
+
+    // Wait for stories
+    await waitFor(() => expect(screen.getByText('贏得喝采的輸家')).toBeInTheDocument());
+
+    // All assign buttons should be enabled immediately (no checkbox gating)
+    const allAssignBtns = screen.getAllByRole('button', { name: /^指派$/ });
+    expect(allAssignBtns.length).toBeGreaterThan(0);
+    allAssignBtns.forEach((btn) => {
+      expect(btn).not.toBeDisabled();
+    });
+  });
+
+  it('clicking assign on a platform story should call assignText with copyright_confirmed=true', async () => {
+    const { assignText } = await import('../../../services/teacherApi');
+    (assignText as ReturnType<typeof vi.fn>).mockClear();
+    renderTab();
+
+    await waitFor(() => expect(screen.queryByText('載入課文列表...')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /指派課文/ }));
+
+    await waitFor(() => expect(screen.getByText('贏得喝采的輸家')).toBeInTheDocument());
+
+    const assignBtns = screen.getAllByRole('button', { name: /^指派$/ });
+    fireEvent.click(assignBtns[0]);
+
+    await waitFor(() => expect(assignText).toHaveBeenCalledWith(
+      'test-token',
+      1,
+      'story-1',
+      true, // copyright_confirmed always true for platform texts — no user confirmation needed
+    ));
+  });
+
+  it('should show 平台教材 badge on platform story rows', async () => {
+    renderTab();
+
+    await waitFor(() => expect(screen.queryByText('載入課文列表...')).not.toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /指派課文/ }));
+
+    await waitFor(() => expect(screen.getByText('贏得喝采的輸家')).toBeInTheDocument());
+
+    // Each platform row should have the platform badge
+    const badges = screen.getAllByText('平台教材');
+    expect(badges.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Fixes #1983

## Summary
- 移除「指派課文」modal 的著作權 checkbox — 著作權確認是上傳時的一次性 acknowledgement，不需每次指派重複確認
- `handleAssign` 直接傳 `copyright_confirmed=true` to API（backend 不變，upload path checkbox 保留）
- 每筆課文顯示「平台教材」badge，增加 UX 透明度

## Files changed (2)
- `frontend/src/pages/teacher/TextManagementTab.tsx` — remove checkbox state + UI
- `frontend/src/pages/teacher/__tests__/TextManagementTab.copyright.test.tsx` — 4 new TDD tests

## UX choice
Option (a): remove checkbox unconditionally from assign modal. Upload path unchanged.

## Test plan
- [ ] Login as teacher → ClassroomDetail → 課文管理 → 指派課文
- [ ] Modal opens without copyright checkbox — 指派 button enabled immediately
- [ ] Click 指派 on any story — succeeds without any confirmation dialog
- [ ] Verify "平台教材" badge appears on each row
- [ ] Upload path (MyTextsTab) unaffected — no regression