### PR TITLE
fix(ux): group assignment form into 3 sections (Fixes #1989)

### DIFF
--- a/frontend/src/pages/teacher/components/AssignmentCreateForm.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentCreateForm.tsx
@@ -66,108 +66,123 @@ export const AssignmentCreateForm: React.FC<AssignmentCreateFormProps> = ({
       </div>
     )}
 
-    <form onSubmit={onSubmit} className="space-y-3">
-      <div>
-        <label htmlFor="assign-story" className="block text-sm font-medium text-gray-700 mb-1">
-          課文 <span className="text-red-500">*</span>
-        </label>
-        {isLoadingStories ? (
-          <div className="flex items-center gap-2 py-2">
-            <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
-            <span className="text-xs text-gray-400">載入課文列表...</span>
+    <form onSubmit={onSubmit} className="space-y-4">
+
+      {/* Group A: 基本資訊 */}
+      <fieldset>
+        <legend className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">基本資訊</legend>
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="assign-story" className="block text-sm font-medium text-gray-700 mb-1">
+              課文 <span className="text-red-500">*</span>
+            </label>
+            {isLoadingStories ? (
+              <div className="flex items-center gap-2 py-2">
+                <div className="w-3 h-3 border-2 border-gray-300 border-t-transparent rounded-full animate-spin" />
+                <span className="text-xs text-gray-400">載入課文列表...</span>
+              </div>
+            ) : storiesError ? (
+              <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
+                <span>載入課文失敗：{storiesError}</span>
+                <button
+                  type="button"
+                  onClick={onRetryStories}
+                  className="ml-auto text-xs underline hover:no-underline"
+                >
+                  重試
+                </button>
+              </div>
+            ) : (
+              <select
+                id="assign-story"
+                value={selectedStoryId}
+                onChange={(event) => setSelectedStoryId(event.target.value)}
+                required
+                className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+              >
+                <option value="">選擇課文</option>
+                {stories.map((story) => (
+                  <option key={story.id} value={story.id}>
+                    {story.title}
+                    {story.grade ? ` (${story.grade}年級)` : ''}
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
-        ) : storiesError ? (
-          <div className="flex items-center gap-2 py-2 px-3 rounded-lg bg-red-50 border border-red-200 text-sm text-red-700">
-            <span>載入課文失敗：{storiesError}</span>
-            <button
-              type="button"
-              onClick={onRetryStories}
-              className="ml-auto text-xs underline hover:no-underline"
-            >
-              重試
-            </button>
+
+          <div>
+            <label htmlFor="assign-title" className="block text-sm font-medium text-gray-700 mb-1">
+              作業標題（選填）
+            </label>
+            <input
+              id="assign-title"
+              type="text"
+              value={formTitle}
+              onChange={(event) => setFormTitle(event.target.value)}
+              placeholder="留空則使用課文標題"
+              className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+            />
           </div>
-        ) : (
-          <select
-            id="assign-story"
-            value={selectedStoryId}
-            onChange={(event) => setSelectedStoryId(event.target.value)}
-            required
-            className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-          >
-            <option value="">選擇課文</option>
-            {stories.map((story) => (
-              <option key={story.id} value={story.id}>
-                {story.title}
-                {story.grade ? ` (${story.grade}年級)` : ''}
-              </option>
-            ))}
-          </select>
-        )}
-      </div>
 
-      <div>
-        <label htmlFor="assign-title" className="block text-sm font-medium text-gray-700 mb-1">
-          作業標題（選填）
-        </label>
-        <input
-          id="assign-title"
-          type="text"
-          value={formTitle}
-          onChange={(event) => setFormTitle(event.target.value)}
-          placeholder="留空則使用課文標題"
-          className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-        />
-      </div>
+          <div>
+            <label htmlFor="assign-desc" className="block text-sm font-medium text-gray-700 mb-1">
+              說明（選填）
+            </label>
+            <textarea
+              id="assign-desc"
+              value={formDescription}
+              onChange={(event) => setFormDescription(event.target.value)}
+              placeholder="作業說明或提示"
+              rows={2}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors resize-none"
+            />
+          </div>
+        </div>
+      </fieldset>
 
-      <div>
-        <label htmlFor="assign-desc" className="block text-sm font-medium text-gray-700 mb-1">
-          說明（選填）
-        </label>
-        <textarea
-          id="assign-desc"
-          value={formDescription}
-          onChange={(event) => setFormDescription(event.target.value)}
-          placeholder="作業說明或提示"
-          rows={2}
-          className="w-full px-3 py-2 rounded-lg border border-gray-300 text-gray-900 bg-white placeholder-gray-400 text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors resize-none"
-        />
-      </div>
+      {/* Group B: 設定選項 */}
+      <fieldset className="border-t border-gray-100 pt-3">
+        <legend className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">設定選項</legend>
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="assign-due" className="block text-sm font-medium text-gray-700 mb-1">
+              截止日期（選填）
+            </label>
+            <input
+              id="assign-due"
+              type="date"
+              lang="zh-TW"
+              value={formDueDate}
+              onChange={(event) => setFormDueDate(event.target.value)}
+              className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+            />
+          </div>
 
-      <div>
-        <label htmlFor="assign-due" className="block text-sm font-medium text-gray-700 mb-1">
-          截止日期（選填）
-        </label>
-        <input
-          id="assign-due"
-          type="date"
-          lang="zh-TW"
-          value={formDueDate}
-          onChange={(event) => setFormDueDate(event.target.value)}
-          className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
-        />
-      </div>
+          <div className="flex items-center gap-2">
+            <input
+              id="assign-skip-completed"
+              type="checkbox"
+              checked={formSkipCompleted}
+              onChange={(event) => setFormSkipCompleted(event.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-accent focus:ring-accent"
+            />
+            <label htmlFor="assign-skip-completed" className="text-sm text-gray-700 cursor-pointer select-none">
+              跳過已完成步驟（學生重做作業時自動略過上次完成的環節）
+            </label>
+          </div>
+        </div>
+      </fieldset>
 
-      <div className="flex items-center gap-2">
-        <input
-          id="assign-skip-completed"
-          type="checkbox"
-          checked={formSkipCompleted}
-          onChange={(event) => setFormSkipCompleted(event.target.checked)}
-          className="h-4 w-4 rounded border-gray-300 text-accent focus:ring-accent"
-        />
-        <label htmlFor="assign-skip-completed" className="text-sm text-gray-700 cursor-pointer select-none">
-          跳過已完成步驟（學生重做作業時自動略過上次完成的環節）
-        </label>
-      </div>
-
-      <div className="border-t border-gray-100 pt-3">
+      {/* Group C: 朗讀目標 */}
+      <fieldset className="border-t border-gray-100 pt-3">
+        <legend className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">朗讀目標</legend>
         <ReadingGoalsForm
           value={formGoals}
           onChange={setFormGoals}
           grade={selectedStoryId ? storyGrade : null}
         />
-      </div>
+      </fieldset>
 
       <div className="flex gap-3 justify-end pt-1">
         <button

--- a/frontend/src/pages/teacher/components/__tests__/AssignmentCreateForm.grouping.test.tsx
+++ b/frontend/src/pages/teacher/components/__tests__/AssignmentCreateForm.grouping.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AssignmentCreateForm } from '../AssignmentCreateForm';
+
+// Minimal mock for ReadingGoalsForm
+vi.mock('../../../../components/teacher/ReadingGoalsForm', () => ({
+  default: () => <div data-testid="reading-goals-form" />,
+}));
+
+const baseProps = {
+  stories: [{ id: 's1', title: '測試課文', grade: 5 }],
+  storyGrade: 5,
+  isLoadingStories: false,
+  storiesError: null,
+  selectedStoryId: 's1',
+  setSelectedStoryId: vi.fn(),
+  formTitle: '',
+  setFormTitle: vi.fn(),
+  formDescription: '',
+  setFormDescription: vi.fn(),
+  formDueDate: '',
+  setFormDueDate: vi.fn(),
+  formSkipCompleted: false,
+  setFormSkipCompleted: vi.fn(),
+  formGoals: { targetDifficulty: '', targetSpeed: '', targetAccuracy: '' } as any,
+  setFormGoals: vi.fn(),
+  isCreating: false,
+  createError: '',
+  onSubmit: vi.fn(),
+  onClose: vi.fn(),
+  onRetryStories: vi.fn(),
+};
+
+describe('AssignmentCreateForm — 3-group layout (#1989)', () => {
+  it('renders "基本資訊" section header', () => {
+    render(<AssignmentCreateForm {...baseProps} />);
+    expect(screen.getByText('基本資訊')).toBeInTheDocument();
+  });
+
+  it('renders "設定選項" section header', () => {
+    render(<AssignmentCreateForm {...baseProps} />);
+    expect(screen.getByText('設定選項')).toBeInTheDocument();
+  });
+
+  it('renders "朗讀目標" section header', () => {
+    render(<AssignmentCreateForm {...baseProps} />);
+    expect(screen.getByText('朗讀目標')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1989

## Summary
- Wrap 8 flat fields in 3 `<fieldset>` groups with `<legend>` headers: **基本資訊** / **設定選項** / **朗讀目標**
- Section dividers via `border-t border-gray-100 pt-3` (existing design token, no new styles)
- Zero props/API changes — purely structural

## Test plan
- `AssignmentCreateForm.grouping.test.tsx` — 3 tests verify each legend text renders (TDD red→green)
- `npx vitest run` → 3/3 passed