### PR TITLE
fix(ux): difficulty pill selected state — solid fill + aria-pressed (Fixes #1990)

### DIFF
--- a/frontend/src/components/teacher/ReadingGoalsForm.tsx
+++ b/frontend/src/components/teacher/ReadingGoalsForm.tsx
@@ -71,25 +71,30 @@ const ReadingGoalsForm: React.FC<ReadingGoalsFormProps> = ({ value, onChange, gr
       <div>
         <label className="block text-xs text-gray-500 mb-1">難度標籤</label>
         <div className="flex gap-2">
-          {DIFFICULTY_OPTIONS.map((opt) => (
-            <button
-              key={opt}
-              type="button"
-              onClick={() =>
-                onChange({
-                  ...value,
-                  difficulty_label: value.difficulty_label === opt ? null : opt,
-                })
-              }
-              className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors ${
-                value.difficulty_label === opt
-                  ? 'border-blue-500 bg-blue-100 text-blue-700'
-                  : 'border-gray-200 bg-white text-gray-600 hover:border-blue-300'
-              }`}
-            >
-              {opt}
-            </button>
-          ))}
+          {DIFFICULTY_OPTIONS.map((opt) => {
+            const isSelected = value.difficulty_label === opt;
+            return (
+              <button
+                key={opt}
+                type="button"
+                aria-pressed={isSelected}
+                data-selected={isSelected ? 'true' : 'false'}
+                onClick={() =>
+                  onChange({
+                    ...value,
+                    difficulty_label: isSelected ? null : opt,
+                  })
+                }
+                className={`px-3 py-1 rounded-full text-sm border transition-all ${
+                  isSelected
+                    ? 'border-blue-700 bg-blue-700 text-white font-bold shadow-sm scale-105'
+                    : 'border-gray-300 bg-white text-gray-600 font-medium hover:border-blue-400 hover:scale-102'
+                }`}
+              >
+                {opt}
+              </button>
+            );
+          })}
           {value.difficulty_label && (
             <button
               type="button"

--- a/frontend/src/components/teacher/__tests__/ReadingGoalsForm.difficulty-pill.test.tsx
+++ b/frontend/src/components/teacher/__tests__/ReadingGoalsForm.difficulty-pill.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * TDD test for issue #1990:
+ * Difficulty pill (初/中/高級) must have clearly distinct selected vs unselected visual state.
+ * Asserts aria-pressed + data-selected attribute so CSS can target reliably.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import ReadingGoalsForm, { GoalsFormState } from '../ReadingGoalsForm';
+
+const defaultValue: GoalsFormState = {
+  target_cpm: null,
+  target_accuracy: null,
+  difficulty_label: null,
+};
+
+describe('ReadingGoalsForm — difficulty pill selected state (#1990)', () => {
+  it('renders all 3 difficulty pills', () => {
+    render(<ReadingGoalsForm value={defaultValue} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '初級' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '中級' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '高級' })).toBeInTheDocument();
+  });
+
+  it('unselected pills have aria-pressed=false', () => {
+    render(<ReadingGoalsForm value={defaultValue} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '初級' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: '中級' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: '高級' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('selected pill has aria-pressed=true, others remain false', () => {
+    const value: GoalsFormState = { ...defaultValue, difficulty_label: '中級' };
+    render(<ReadingGoalsForm value={value} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '初級' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: '中級' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '高級' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('selected pill has data-selected=true for CSS targeting', () => {
+    const value: GoalsFormState = { ...defaultValue, difficulty_label: '高級' };
+    render(<ReadingGoalsForm value={value} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: '高級' })).toHaveAttribute('data-selected', 'true');
+    expect(screen.getByRole('button', { name: '初級' })).toHaveAttribute('data-selected', 'false');
+  });
+
+  it('clicking a pill calls onChange with correct difficulty_label', () => {
+    const onChange = vi.fn();
+    render(<ReadingGoalsForm value={defaultValue} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '初級' }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ difficulty_label: '初級' })
+    );
+  });
+
+  it('clicking the already-selected pill deselects (calls onChange with null)', () => {
+    const value: GoalsFormState = { ...defaultValue, difficulty_label: '初級' };
+    const onChange = vi.fn();
+    render(<ReadingGoalsForm value={value} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '初級' }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ difficulty_label: null })
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1990

## Summary
- Selected pill: `bg-blue-700 text-white font-bold scale-105` — clearly visible dark solid fill
- Unselected pill: `border-gray-300 bg-white text-gray-600` — outline-only, no fill ambiguity
- Added `aria-pressed` (true/false) for accessibility
- Added `data-selected` attribute for CSS targeting

## Files changed
- `frontend/src/components/teacher/ReadingGoalsForm.tsx` — pill button visual + a11y attributes
- `frontend/src/components/teacher/__tests__/ReadingGoalsForm.difficulty-pill.test.tsx` — 6 TDD tests (new)

## Test plan
- [x] 6 unit tests pass: aria-pressed, data-selected, onChange, deselect
- [ ] Open staging preview → 建作業 form → click 初/中/高級 pills → verify clear selected state