### PR TITLE
feat(ux): group ClassroomDetail 8 tabs into 2 rows (Fixes #1986)

### DIFF
--- a/frontend/src/pages/teacher/ClassroomTabs.tsx
+++ b/frontend/src/pages/teacher/ClassroomTabs.tsx
@@ -1,8 +1,11 @@
 /**
- * ClassroomTabs — Issue #1943
+ * ClassroomTabs — Issue #1943 + Issue #1986
  *
- * Renders the tab bar + delegates to the appropriate tab component.
- * All tab components remain unchanged — this is purely a delegation container.
+ * Renders a 2-row grouped tab bar:
+ *   Row 1 (日常管理): 學生進度 / 學生名單 / 課文管理 / 協同教師
+ *   Row 2 (進階分析): 學習分析 / 跨課文分析 / 早期介入 / 錯字熱力圖
+ *
+ * All tab components remain unchanged — this is purely a presentation change.
  */
 import React from 'react';
 import { ClassroomDetailResponse } from '../../services/classroomApi';
@@ -17,6 +20,26 @@ import CoTeachingTab from './CoTeachingTab';
 
 type TabKey = 'progress' | 'texts' | 'students' | 'analytics' | 'cross-text' | 'at-risk' | 'error-heatmap' | 'teachers';
 
+interface TabDef {
+  key: TabKey;
+  label: string;
+}
+
+const CORE_TABS: TabDef[] = [
+  { key: 'progress', label: '學生進度' },
+  { key: 'students', label: '學生名單' },
+  { key: 'texts', label: '課文管理' },
+  { key: 'teachers', label: '協同教師' },
+];
+
+const ANALYSIS_TABS: TabDef[] = [
+  { key: 'analytics', label: '學習分析' },
+  { key: 'cross-text', label: '跨課文分析' },
+  { key: 'at-risk', label: '早期介入' },
+  { key: 'error-heatmap', label: '錯字熱力圖' },
+];
+
+// Backwards-compat export (kept for any external consumers)
 export const TABS: { key: TabKey; label: string; group?: 'core' | 'analysis' | 'other' }[] = [
   { key: 'progress', label: '學生進度', group: 'core' },
   { key: 'students', label: '學生名單', group: 'core' },
@@ -52,6 +75,42 @@ interface ClassroomTabsProps {
   studentListProps: StudentListTabPassthroughProps;
 }
 
+interface TabRowProps {
+  groupLabel: string;
+  tabs: TabDef[];
+  activeTab: TabKey;
+  onTabChange: (tab: TabKey) => void;
+  hasBorderBottom?: boolean;
+}
+
+const TabRow: React.FC<TabRowProps> = ({ groupLabel, tabs, activeTab, onTabChange, hasBorderBottom = true }) => (
+  <div
+    role="group"
+    aria-label={groupLabel}
+    className={`flex items-center gap-1 px-4 ${hasBorderBottom ? 'border-b border-gray-200' : 'border-b border-gray-100'}`}
+  >
+    <span className="text-xs font-medium text-gray-400 pr-2 shrink-0 py-2 select-none">
+      {groupLabel}
+    </span>
+    <span className="w-px h-4 bg-gray-200 shrink-0" aria-hidden="true" />
+    <nav className="flex -mb-px" aria-label={groupLabel}>
+      {tabs.map((tab) => (
+        <button
+          key={tab.key}
+          onClick={() => onTabChange(tab.key)}
+          className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors cursor-pointer shrink-0 ${
+            activeTab === tab.key
+              ? 'border-accent text-accent'
+              : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+          }`}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </nav>
+  </div>
+);
+
 const ClassroomTabs: React.FC<ClassroomTabsProps> = ({
   activeTab,
   onTabChange,
@@ -60,34 +119,22 @@ const ClassroomTabs: React.FC<ClassroomTabsProps> = ({
   studentListProps,
 }) => (
   <div className="bg-white rounded-2xl shadow-card">
-    {/* Tab bar */}
-    <div className="border-b border-gray-200 overflow-x-auto">
-      <nav className="flex -mb-px whitespace-nowrap items-center" aria-label="Tabs">
-        {TABS.map((tab, i) => {
-          const prevGroup = TABS[i - 1]?.group;
-          const showDivider = prevGroup && prevGroup !== tab.group;
-          return (
-            <React.Fragment key={tab.key}>
-              {showDivider && (
-                <span
-                  className="shrink-0 w-px h-5 bg-gray-200 mx-1"
-                  aria-hidden="true"
-                />
-              )}
-              <button
-                onClick={() => onTabChange(tab.key)}
-                className={`px-5 py-3 text-sm font-medium border-b-2 transition-colors cursor-pointer shrink-0 ${
-                  activeTab === tab.key
-                    ? 'border-accent text-accent'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                }`}
-              >
-                {tab.label}
-              </button>
-            </React.Fragment>
-          );
-        })}
-      </nav>
+    {/* 2-row grouped tab bar */}
+    <div className="overflow-x-auto">
+      <TabRow
+        groupLabel="日常管理"
+        tabs={CORE_TABS}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        hasBorderBottom={false}
+      />
+      <TabRow
+        groupLabel="進階分析"
+        tabs={ANALYSIS_TABS}
+        activeTab={activeTab}
+        onTabChange={onTabChange}
+        hasBorderBottom
+      />
     </div>
 
     {/* Tab content */}

--- a/frontend/src/pages/teacher/__tests__/ClassroomTabs.grouping.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/ClassroomTabs.grouping.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * TDD tests for ClassroomTabs 2-group layout — Issue #1986
+ *
+ * Asserts:
+ * 1. Two visual group rows exist (日常管理 / 進階分析)
+ * 2. Tabs are assigned to correct groups
+ * 3. Active tab persists when switching between group rows
+ * 4. All 8 tabs are reachable
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ClassroomTabs from '../ClassroomTabs';
+import type { ClassroomDetailResponse } from '../../../services/classroomApi';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../StudentProgressTab', () => ({ default: () => <div>StudentProgress</div> }));
+vi.mock('../TextManagementTab', () => ({ default: () => <div>TextManagement</div> }));
+vi.mock('../StudentListTab', () => ({ default: () => <div>StudentList</div> }));
+vi.mock('../ClassroomAnalytics', () => ({ default: () => <div>Analytics</div> }));
+vi.mock('../CrossTextAnalytics', () => ({ default: () => <div>CrossText</div> }));
+vi.mock('../../../components/teacher/AtRiskStudents', () => ({ default: () => <div>AtRisk</div> }));
+vi.mock('../ErrorHeatmapTab', () => ({ default: () => <div>ErrorHeatmap</div> }));
+vi.mock('../CoTeachingTab', () => ({ default: () => <div>CoTeaching</div> }));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const mockClassroom: ClassroomDetailResponse = {
+  id: 1,
+  name: '五年一班',
+  grade: 5,
+  teacher_id: 1,
+  is_active: true,
+  join_code: 'ABC123',
+  created_at: '2026-01-01T00:00:00Z',
+  students: [],
+};
+
+const defaultProps = {
+  activeTab: 'progress' as const,
+  onTabChange: vi.fn(),
+  classroomId: 1,
+  classroom: mockClassroom,
+  studentListProps: {
+    token: 'test-token',
+    studentIdInput: '',
+    setStudentIdInput: vi.fn(),
+    isAddingStudent: false,
+    addStudentError: '',
+    setAddStudentError: vi.fn(),
+    onAddStudent: vi.fn(),
+    removingStudentId: null,
+    onRemoveStudent: vi.fn(),
+    setRemovingStudentId: vi.fn(),
+    formatDate: (s: string) => s,
+    onStudentsImported: vi.fn(),
+  },
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('ClassroomTabs — 2-group layout (#1986)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders two group label rows: 日常管理 and 進階分析', () => {
+    render(<ClassroomTabs {...defaultProps} />);
+    expect(screen.getByText('日常管理')).toBeInTheDocument();
+    expect(screen.getByText('進階分析')).toBeInTheDocument();
+  });
+
+  it('places 日常管理 tabs (學生進度, 學生名單, 課文管理, 協同教師) in the first row', () => {
+    render(<ClassroomTabs {...defaultProps} />);
+    const coreGroup = screen.getByRole('group', { name: '日常管理' });
+    expect(within(coreGroup).getByText('學生進度')).toBeInTheDocument();
+    expect(within(coreGroup).getByText('學生名單')).toBeInTheDocument();
+    expect(within(coreGroup).getByText('課文管理')).toBeInTheDocument();
+    expect(within(coreGroup).getByText('協同教師')).toBeInTheDocument();
+  });
+
+  it('places 進階分析 tabs (學習分析, 跨課文分析, 早期介入, 錯字熱力圖) in the second row', () => {
+    render(<ClassroomTabs {...defaultProps} />);
+    const analysisGroup = screen.getByRole('group', { name: '進階分析' });
+    expect(within(analysisGroup).getByText('學習分析')).toBeInTheDocument();
+    expect(within(analysisGroup).getByText('跨課文分析')).toBeInTheDocument();
+    expect(within(analysisGroup).getByText('早期介入')).toBeInTheDocument();
+    expect(within(analysisGroup).getByText('錯字熱力圖')).toBeInTheDocument();
+  });
+
+  it('calls onTabChange when clicking a tab in the 日常管理 group', async () => {
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+    render(<ClassroomTabs {...defaultProps} onTabChange={onTabChange} />);
+    await user.click(screen.getByText('學生名單'));
+    expect(onTabChange).toHaveBeenCalledWith('students');
+  });
+
+  it('calls onTabChange when clicking a tab in the 進階分析 group', async () => {
+    const user = userEvent.setup();
+    const onTabChange = vi.fn();
+    render(<ClassroomTabs {...defaultProps} onTabChange={onTabChange} />);
+    await user.click(screen.getByText('跨課文分析'));
+    expect(onTabChange).toHaveBeenCalledWith('cross-text');
+  });
+
+  it('active tab within 日常管理 group shows accent styling', () => {
+    render(<ClassroomTabs {...defaultProps} activeTab="progress" />);
+    const activeBtn = screen.getByRole('button', { name: '學生進度' });
+    expect(activeBtn.className).toMatch(/border-accent/);
+  });
+
+  it('active tab within 進階分析 group shows accent styling', () => {
+    render(<ClassroomTabs {...defaultProps} activeTab="analytics" />);
+    const activeBtn = screen.getByRole('button', { name: '學習分析' });
+    expect(activeBtn.className).toMatch(/border-accent/);
+  });
+
+  it('renders correct content panel for active tab', () => {
+    render(<ClassroomTabs {...defaultProps} activeTab="cross-text" />);
+    expect(screen.getByText('CrossText')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1986

## Summary
- Replace the single flat 8-tab row with a 2-row grouped layout in `ClassroomTabs.tsx`
- Row 1 「日常管理」: 學生進度 / 學生名單 / 課文管理 / 協同教師
- Row 2 「進階分析」: 學習分析 / 跨課文分析 / 早期介入 / 錯字熱力圖
- Group labels use `role="group"` + `aria-label` for accessibility
- `TABS` export kept for backwards-compat; no tab content components changed

## Test plan
- [x] TDD: 8 new tests in `ClassroomTabs.grouping.test.tsx` (Red → Green)
- [x] Both group rows visible with correct labels
- [x] Each tab routes to correct group via `within(group)` assertions
- [x] Accent styling on active tab in both rows
- [x] `onTabChange` fires correct `TabKey` from both rows
- [x] Content panel renders correctly for cross-group active tab
- [x] No regression in existing 111 teacher tests (CrossTextAnalytics failure is pre-existing on staging, unrelated to this PR)