### PR TITLE
fix(ux): collapse join code block into accordion by default (Fixes #1987)

### DIFF
--- a/frontend/src/pages/teacher/ClassroomHeaderCard.tsx
+++ b/frontend/src/pages/teacher/ClassroomHeaderCard.tsx
@@ -1,12 +1,12 @@
 /**
- * ClassroomHeaderCard — Issue #1943
+ * ClassroomHeaderCard — Issue #1943 / #1987
  *
  * Renders:
  *  - Classroom name, grade badge, student count, active status (view + edit form)
  *  - Action buttons: 編輯 / 停用啟用 / 匯出CSV
- *  - Join code panel with 複製 and 重生代碼 + confirm dialog
+ *  - Join code panel — accordion (collapsed when ≥1 student, expanded for new class)
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { ClassroomDetailResponse } from '../../services/classroomApi';
 
 interface ClassroomHeaderCardProps {
@@ -69,8 +69,12 @@ const ClassroomHeaderCard: React.FC<ClassroomHeaderCardProps> = ({
   onHideRegenConfirm,
   onRegenerateCode,
   formatDate,
-}) => (
-  <>
+}) => {
+  // Default: collapsed for established classrooms (≥1 student), expanded for new (0 student)
+  const [joinCodeOpen, setJoinCodeOpen] = useState(classroom.student_count === 0);
+
+  return (
+    <>
     {/* Classroom info card */}
     <div className="bg-white rounded-2xl shadow-card p-6">
       {isEditing ? (
@@ -187,60 +191,93 @@ const ClassroomHeaderCard: React.FC<ClassroomHeaderCardProps> = ({
       )}
     </div>
 
-    {/* Join Code card */}
-    <div className="bg-white rounded-2xl shadow-card p-6">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div className="flex-1">
-          <h3 className="text-sm font-semibold text-gray-700 mb-1">加入代碼</h3>
-          {classroom.join_code ? (
-            <p className="font-mono text-2xl font-bold tracking-widest text-accent select-all">
+    {/* Join Code card — accordion */}
+    <div className="bg-white rounded-2xl shadow-card overflow-hidden">
+      {/* Accordion header / toggle */}
+      <button
+        type="button"
+        onClick={() => setJoinCodeOpen((prev) => !prev)}
+        aria-expanded={joinCodeOpen}
+        aria-controls="join-code-panel"
+        className="w-full flex items-center justify-between px-6 py-3 text-left hover:bg-gray-50 transition-colors"
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold text-gray-700">
+          加入代碼
+          {classroom.join_code && !joinCodeOpen && (
+            <span className="font-mono text-xs font-medium text-accent bg-accent-bg px-2 py-0.5 rounded tracking-wider">
               {classroom.join_code}
-            </p>
-          ) : (
-            <p className="font-mono text-2xl font-bold tracking-widest text-gray-300">—</p>
+            </span>
           )}
-          <p className="text-xs text-gray-400 mt-1.5">
-            把此代碼給學生，他們從首頁「加入班級」輸入即可加入
-          </p>
-        </div>
-        <div className="flex gap-2 shrink-0">
-          <button
-            onClick={onCopyJoinCode}
-            disabled={!classroom.join_code}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            {isCopied ? (
-              <>
-                <svg className="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-                <span className="text-emerald-600">已複製</span>
-              </>
+        </span>
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform duration-200 ${joinCodeOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* Accordion body */}
+      <div
+        id="join-code-panel"
+        aria-hidden={!joinCodeOpen}
+        className={`transition-all duration-200 ${joinCodeOpen ? 'block' : 'hidden'}`}
+      >
+        <div className="px-6 pb-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex-1">
+            {classroom.join_code ? (
+              <p className="font-mono text-2xl font-bold tracking-widest text-accent select-all">
+                {classroom.join_code}
+              </p>
             ) : (
-              <>
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-                複製代碼
-              </>
+              <p className="font-mono text-2xl font-bold tracking-widest text-gray-300">—</p>
             )}
-          </button>
-          <button
-            onClick={onShowRegenConfirm}
-            disabled={isRegenerating}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            {isRegenerating ? (
-              '產生中...'
-            ) : (
-              <>
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                </svg>
-                重生代碼
-              </>
-            )}
-          </button>
+            <p className="text-xs text-gray-400 mt-1.5">
+              把此代碼給學生，他們從首頁「加入班級」輸入即可加入
+            </p>
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <button
+              onClick={onCopyJoinCode}
+              disabled={!classroom.join_code}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 text-sm hover:bg-gray-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {isCopied ? (
+                <>
+                  <svg className="w-4 h-4 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                  <span className="text-emerald-600">已複製</span>
+                </>
+              ) : (
+                <>
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                  </svg>
+                  複製代碼
+                </>
+              )}
+            </button>
+            <button
+              onClick={onShowRegenConfirm}
+              disabled={isRegenerating}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-amber-300 text-amber-700 text-sm hover:bg-amber-50 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {isRegenerating ? (
+                '產生中...'
+              ) : (
+                <>
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                  </svg>
+                  重生代碼
+                </>
+              )}
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -276,6 +313,7 @@ const ClassroomHeaderCard: React.FC<ClassroomHeaderCardProps> = ({
       </div>
     )}
   </>
-);
+  );
+};
 
 export default ClassroomHeaderCard;

--- a/frontend/src/pages/teacher/__tests__/ClassroomDetail.joincode.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/ClassroomDetail.joincode.test.tsx
@@ -55,7 +55,8 @@ const MOCK_CLASSROOM = {
   grade: 3,
   is_active: true,
   created_at: '2026-01-01T00:00:00Z',
-  student_count: 5,
+  // student_count: 0 → accordion starts expanded so join code panel is visible for these tests
+  student_count: 0,
   students: [],
   join_code: 'ABC123',
   school_name: '測試國小',

--- a/frontend/src/pages/teacher/__tests__/ClassroomHeaderCard.accordion.test.tsx
+++ b/frontend/src/pages/teacher/__tests__/ClassroomHeaderCard.accordion.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests for ClassroomHeaderCard join code accordion — Issue #1987
+ * Verifies:
+ *  1. Join code panel is collapsed by default when classroom has ≥1 student
+ *  2. Join code panel is expanded by default when classroom has 0 students
+ *  3. Clicking the toggle header expands the collapsed panel
+ *  4. Clicking the toggle header collapses the expanded panel
+ *  5. Join code content is not visible when collapsed (aria-hidden or hidden)
+ *  6. Copy and regen buttons are accessible when expanded
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ClassroomHeaderCard from '../ClassroomHeaderCard';
+
+const baseProps = {
+  isEditing: false,
+  editName: '',
+  editGrade: '',
+  isSaving: false,
+  editError: '',
+  onStartEditing: vi.fn(),
+  onCancelEditing: vi.fn(),
+  onEditNameChange: vi.fn(),
+  onEditGradeChange: vi.fn(),
+  onSaveEdit: vi.fn(),
+  isTogglingActive: false,
+  onToggleActive: vi.fn(),
+  isExporting: false,
+  onExportCsv: vi.fn(),
+  isCopied: false,
+  showRegenConfirm: false,
+  isRegenerating: false,
+  onCopyJoinCode: vi.fn(),
+  onShowRegenConfirm: vi.fn(),
+  onHideRegenConfirm: vi.fn(),
+  onRegenerateCode: vi.fn(),
+  formatDate: (s: string) => s,
+};
+
+const classroomWithStudents = {
+  id: 1,
+  name: '三年甲班',
+  school_id: 1,
+  teacher_id: 1,
+  grade: 3,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  student_count: 5,
+  students: [],
+  join_code: 'LMC2PA',
+  school_name: '測試國小',
+};
+
+const classroomNoStudents = {
+  ...classroomWithStudents,
+  student_count: 0,
+};
+
+describe('ClassroomHeaderCard — join code accordion (#1987)', () => {
+  it('1. collapsed by default when classroom has ≥1 student', () => {
+    render(<ClassroomHeaderCard {...baseProps} classroom={classroomWithStudents} />);
+    // Panel should be hidden (aria-hidden="true")
+    const panel = document.getElementById('join-code-panel');
+    expect(panel).not.toBeNull();
+    expect(panel?.getAttribute('aria-hidden')).toBe('true');
+    // Toggle button should be aria-expanded=false
+    const toggleBtn = screen.getByRole('button', { name: /加入代碼/i });
+    expect(toggleBtn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('2. expanded by default when classroom has 0 students', () => {
+    render(<ClassroomHeaderCard {...baseProps} classroom={classroomNoStudents} />);
+    // Join code should be visible
+    expect(screen.getByText('LMC2PA')).toBeInTheDocument();
+    const codeText = screen.getByText('LMC2PA');
+    // Should NOT be hidden
+    const hiddenPanel = codeText.closest('[aria-hidden="true"], [hidden]');
+    expect(hiddenPanel).toBeNull();
+  });
+
+  it('3. clicking the toggle button expands the collapsed panel', () => {
+    render(<ClassroomHeaderCard {...baseProps} classroom={classroomWithStudents} />);
+    // Find the accordion toggle button for join code
+    const toggleBtn = screen.getByRole('button', { name: /加入代碼/i });
+    fireEvent.click(toggleBtn);
+    // After click, code should be visible
+    expect(screen.getByText('LMC2PA')).toBeInTheDocument();
+    const codeText = screen.getByText('LMC2PA');
+    const hiddenPanel = codeText.closest('[aria-hidden="true"], [hidden]');
+    expect(hiddenPanel).toBeNull();
+  });
+
+  it('4. clicking toggle again collapses the expanded panel', () => {
+    render(<ClassroomHeaderCard {...baseProps} classroom={classroomNoStudents} />);
+    // Initially expanded (0 students) → aria-hidden="false"
+    const panel = document.getElementById('join-code-panel');
+    expect(panel?.getAttribute('aria-hidden')).toBe('false');
+    const toggleBtn = screen.getByRole('button', { name: /加入代碼/i });
+    fireEvent.click(toggleBtn);
+    // After collapse → aria-hidden="true"
+    expect(panel?.getAttribute('aria-hidden')).toBe('true');
+    expect(toggleBtn).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('5. toggle button has correct aria-expanded state', () => {
+    render(<ClassroomHeaderCard {...baseProps} classroom={classroomWithStudents} />);
+    const toggleBtn = screen.getByRole('button', { name: /加入代碼/i });
+    // Initially collapsed → aria-expanded="false"
+    expect(toggleBtn).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(toggleBtn);
+    // After expand → aria-expanded="true"
+    expect(toggleBtn).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('6. copy and regen buttons are accessible when expanded', () => {
+    render(<ClassroomHeaderCard {...baseProps} classroom={classroomWithStudents} />);
+    const toggleBtn = screen.getByRole('button', { name: /加入代碼/i });
+    fireEvent.click(toggleBtn);
+    expect(screen.getByRole('button', { name: /複製代碼/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /重生代碼/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1987

## Summary
- Join code panel converted from always-visible card to collapsible accordion
- **Collapsed by default** when classroom has ≥1 student (the common daily view)
- **Expanded by default** for new classrooms with 0 students (setup flow)
- Code chip preview visible in header even when collapsed (no info loss)
- Full `aria-expanded` / `aria-hidden` accessibility support

## Test plan
- 6 new accordion tests (collapse/expand toggle, aria states, button accessibility)
- 7 existing join code tests updated and passing (regression: panel starts expanded for 0-student mock)
- All 13 tests pass

## Before / After
Before: Join code block always occupied ~25% screen height regardless of context
After: Single-row accordion header with code chip; expands on demand