### PR TITLE
fix: replace native date input with zh-TW custom picker (Fixes #2005)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,10 @@
       "name": "ai-reading-tutor-frontend",
       "version": "0.2.6",
       "dependencies": {
+        "date-fns": "^4.3.0",
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
+        "react-datepicker": "^9.1.0",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1",
         "recharts": "^3.7.0"
@@ -1018,6 +1020,59 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -2421,6 +2476,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
+      "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3460,6 +3525,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-9.1.0.tgz",
+      "integrity": "sha512-lOp+m5bc+ttgtB5MHEjwiVu4nlp4CvJLS/PG1OiOe5pmg9kV73pEqO8H0Geqvg2E8gjqTaL9eRhSe+ZpeKP3nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.15",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "date-fns-tz": "^3.0.0",
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "date-fns-tz": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
@@ -3869,6 +3955,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
     "node_modules/tailwindcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,10 @@
     "e2e": "playwright test"
   },
   "dependencies": {
+    "date-fns": "^4.3.0",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
+    "react-datepicker": "^9.1.0",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.7.0"

--- a/frontend/src/components/ui/ZhTWDatePicker.tsx
+++ b/frontend/src/components/ui/ZhTWDatePicker.tsx
@@ -1,0 +1,78 @@
+/**
+ * ZhTWDatePicker — zh-TW localized date picker component.
+ *
+ * Replaces native <input type="date"> whose Chrome placeholder always shows
+ * "mm/dd/yyyy" regardless of lang attribute (issue #2005 / #1988).
+ *
+ * Uses react-datepicker with zh-TW locale from date-fns.
+ * Displays 年/月/日 placeholder and yyyy/MM/dd value format.
+ */
+import React from 'react';
+import DatePicker from 'react-datepicker';
+import { zhTW } from 'date-fns/locale';
+import { format, parse, isValid } from 'date-fns';
+import 'react-datepicker/dist/react-datepicker.css';
+
+interface ZhTWDatePickerProps {
+  /** ISO date string: "yyyy-MM-dd" or empty string */
+  value: string;
+  onChange: (value: string) => void;
+  id?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Parse "yyyy-MM-dd" string to Date, return null if invalid/empty.
+ */
+function parseISODate(value: string): Date | null {
+  if (!value) return null;
+  const parsed = parse(value, 'yyyy-MM-dd', new Date());
+  return isValid(parsed) ? parsed : null;
+}
+
+export const ZhTWDatePicker: React.FC<ZhTWDatePickerProps> = ({
+  value,
+  onChange,
+  id,
+  className,
+  disabled,
+}) => {
+  const selectedDate = parseISODate(value);
+
+  const handleChange = (date: Date | null) => {
+    if (date && isValid(date)) {
+      onChange(format(date, 'yyyy-MM-dd'));
+    } else {
+      onChange('');
+    }
+  };
+
+  const displayValue = selectedDate ? format(selectedDate, 'yyyy/MM/dd') : '';
+
+  return (
+    <DatePicker
+      id={id}
+      selected={selectedDate}
+      onChange={handleChange}
+      locale={zhTW}
+      dateFormat="yyyy/MM/dd"
+      placeholderText="年/月/日"
+      disabled={disabled}
+      customInput={
+        <input
+          type="text"
+          readOnly
+          value={displayValue}
+          placeholder="年/月/日"
+          className={
+            className ??
+            'w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors cursor-pointer'
+          }
+        />
+      }
+    />
+  );
+};
+
+export default ZhTWDatePicker;

--- a/frontend/src/components/ui/__tests__/ZhTWDatePicker.test.tsx
+++ b/frontend/src/components/ui/__tests__/ZhTWDatePicker.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * TDD test for ZhTWDatePicker — issue #2005
+ * Asserts the component does NOT show mm/dd/yyyy Chrome-native placeholder,
+ * and instead renders a zh-TW localized date picker.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ZhTWDatePicker } from '../ZhTWDatePicker';
+
+describe('ZhTWDatePicker', () => {
+  it('renders without a native date input (no mm/dd/yyyy placeholder)', () => {
+    render(<ZhTWDatePicker value="" onChange={() => {}} />);
+    // Native <input type="date"> would have a shadow-DOM placeholder of "mm/dd/yyyy".
+    // Our custom picker must NOT render a raw <input type="date">.
+    const nativeDateInputs = document.querySelectorAll('input[type="date"]');
+    expect(nativeDateInputs.length).toBe(0);
+  });
+
+  it('renders a text input (custom picker trigger)', () => {
+    render(<ZhTWDatePicker value="" onChange={() => {}} />);
+    // Should have at least one text/button input or trigger button
+    const textInput = screen.getByRole('textbox');
+    expect(textInput).toBeInTheDocument();
+  });
+
+  it('shows yyyy/MM/dd placeholder text (zh-TW format)', () => {
+    render(<ZhTWDatePicker value="" onChange={() => {}} />);
+    const input = screen.getByPlaceholderText('年/月/日');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('displays existing value in yyyy/MM/dd format', () => {
+    render(<ZhTWDatePicker value="2026-06-15" onChange={() => {}} />);
+    const input = screen.getByDisplayValue('2026/06/15');
+    expect(input).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/teacher/components/AssignmentCreateForm.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentCreateForm.tsx
@@ -1,5 +1,6 @@
 import React, { FormEvent } from 'react';
 import ReadingGoalsForm, { GoalsFormState } from '../../../components/teacher/ReadingGoalsForm';
+import { ZhTWDatePicker } from '../../../components/ui/ZhTWDatePicker';
 import { Story } from '../../../types';
 
 export interface AssignmentCreateFormProps {
@@ -149,13 +150,10 @@ export const AssignmentCreateForm: React.FC<AssignmentCreateFormProps> = ({
             <label htmlFor="assign-due" className="block text-sm font-medium text-gray-700 mb-1">
               截止日期（選填）
             </label>
-            <input
+            <ZhTWDatePicker
               id="assign-due"
-              type="date"
-              lang="zh-TW"
               value={formDueDate}
-              onChange={(event) => setFormDueDate(event.target.value)}
-              className="w-full h-10 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+              onChange={setFormDueDate}
             />
           </div>
 

--- a/frontend/src/pages/teacher/components/AssignmentInlineEdit.tsx
+++ b/frontend/src/pages/teacher/components/AssignmentInlineEdit.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ZhTWDatePicker } from '../../../components/ui/ZhTWDatePicker';
 
 export interface AssignmentInlineEditProps {
   editTitle: string;
@@ -51,12 +52,9 @@ export const AssignmentInlineEdit: React.FC<AssignmentInlineEditProps> = ({
       </div>
       <div>
         <label className="block text-xs font-medium text-gray-600 mb-1">截止日期</label>
-        <input
-          type="date"
-          lang="zh-TW"
+        <ZhTWDatePicker
           value={editDueDate}
-          onChange={(event) => setEditDueDate(event.target.value)}
-          className="w-full h-9 px-3 rounded-lg border border-gray-300 text-gray-900 bg-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/40 focus:border-accent transition-colors"
+          onChange={setEditDueDate}
         />
       </div>
     </div>


### PR DESCRIPTION
Fixes #2005

## Problem
Chrome ignores `lang="zh-TW"` on `<input type="date">`, always showing `mm/dd/yyyy` placeholder regardless of locale.

## Solution
Replace native date input with `react-datepicker` + `date-fns/locale/zhTW`:
- New `ZhTWDatePicker` component with `年/月/日` placeholder and `yyyy/MM/dd` display format
- Applied to `AssignmentCreateForm` and `AssignmentInlineEdit`

## Lib chosen
**react-datepicker** (option a) — battle-tested, `date-fns` zhTW locale included, fits existing Tailwind theme

## Files changed
- `frontend/src/components/ui/ZhTWDatePicker.tsx` (new)
- `frontend/src/components/ui/__tests__/ZhTWDatePicker.test.tsx` (new, 4 TDD tests)
- `frontend/src/pages/teacher/components/AssignmentCreateForm.tsx`
- `frontend/src/pages/teacher/components/AssignmentInlineEdit.tsx`
- `frontend/package.json` + `frontend/package-lock.json`

## Test plan
- [ ] 4 unit tests pass: no native date input, textbox role, `年/月/日` placeholder, `yyyy/MM/dd` value display
- [ ] Open PR preview URL → teacher view → 建作業 form → date picker shows `年/月/日` (not `mm/dd/yyyy`)
- [ ] Select a date → form submits correct ISO `yyyy-MM-dd` value to API