### PR TITLE
docs(meeting): polish 5/29 agenda — remove OS/blame + add real cost data (Related to #2007)

### DIFF
--- a/docs/meetings/2026-05-29-agenda.md
+++ b/docs/meetings/2026-05-29-agenda.md
@@ -4,36 +4,34 @@
 - Young（lead dev）
 - 靖杭 @if-else-master（intern）
 - 啟翔 @stgst（intern）
-- 方大哥 @Shinjou（product owner）— TBD（先發議程讓他過目）
-
-> 📝 會議實際紀錄：[2026-05-29-record.md](./2026-05-29-record.md)（會後補）
+- 方大哥 @Shinjou（product owner）
 
 ---
 
-## ⏰ Deadline 倒數
+## ⏰ Deadline
 
-- **6/1（日）曾世杰教授 review — 倒數 3 天**
 - **7/1（二）正式 launch — 倒數 33 天**
-- 本週會議首要議題：**OMO 是否可以落地（GO / DELAY / NO-GO）**
+- 本週首要議題：**OMO 是否可以落地（GO / DELAY / NO-GO）**
 
 ---
 
 ## 一、🎯 OMO 可行性檢討（first priority，40 min）
 
-> 7/1 launch 是否把 OMO 列入 must-have，本週必須拍板。需要的不是「有跑通 demo」，而是**真實學生 / 真實老師能用得起來的訊號**。
+### 1.1 端到端 dogfood 實機測試（必跑）
 
-### 1.1 端到端 dogfood 實機測試狀態（核心訊號）
+**原則**：不管誰跑，每課**都要有人實際順過一次** — 印出 → 填寫 → 拍照/掃描 → upload → identifier → grader → result → history 回看。沒有 dogfood 數字 = 不能判斷可行。
 
-| Issue | Assignee | 任務 | 狀態 | 影響 |
-|-------|----------|------|------|------|
-| 靖杭 OMO test | 靖杭 | 印出 + 填寫 + 上傳 G6-L22~25（摘要策略 4 課）| ⚠️ 5/14 開、**13 天 0 進展** | 沒實機跑過 = 無法判斷可行 |
-| 啟翔 OMO test | 啟翔 | 印出 + 填寫 + 上傳 G7-L28~30（圖文整合 3 課）| ⚠️ 5/14 開、**13 天 0 進展** | 同上 |
-| Young 自跑 e2e | Young | 完整跑一次紙本 → upload → identifier → grader → result → history 回看 | 尚未跑 | 6/1 demo 前必跑 |
+**分工**（共 7 課，不問能不能，問誰跑哪幾課）：
+
+| 課文範圍 | 內容 | 預設跑者 |
+|---------|------|---------|
+| G6-L22~25（4 課摘要策略）| 印出 + 填寫 + 上傳 | 靖杭 |
+| G7-L28~30（3 課圖文整合）| 印出 + 填寫 + 上傳 | 啟翔 |
+| 至少 1 課完整 e2e cycle | upload → grader → result → history | Young（保證有人跑過）|
 
 **會議要決定**：
-- 兩位實習生本週能不能各完成 1 課的真實 dogfood test？
-- 如果無法 → Young 自己手動跑代替（不靠實習生）？
-- 沒有 dogfood 數字 → **OMO 不能進 7/1 launch**
+- 7 課分工拍板（誰沒空 → Young 接手該課）
+- Dogfood 完成時點：6/1 教授 review 前必須有至少 N 課跑過（N = ?）
 
 ### 1.2 Grader 真實準確率 baseline（沒有數字 = 沒有可行性）
 
@@ -47,18 +45,29 @@
 - 蒐 N=20 真實手寫樣本（含好+爛+ambiguous）跑 evaluation，誰做？什麼時候？
 - 如果準確率 < threshold → OMO 是「教師輔助工具」（必須老師複核）還是「自動批改工具」？產品定位差很大
 
-### 1.3 Cost per worksheet（單張學習單 USD）
+### 1.3 Cost per worksheet（實算）
 
-**待算**：
-- 1 張學習單 = 1 次 identifier (vision) + 1 次 grader (vision) + N 題 crop preview
-- Identifier 用 `gemini-flash-lite-latest`（global）
-- Grader 用 `gemini-2.5-flash`（us-central1，鎖定）
-- 估算：每張 USD ?
+**單張學習單成本（依 Test 3 #1730 baseline 實測 + pricing 換算）**：
+
+| 階段 | Model | 來源 | $/call |
+|------|-------|------|--------|
+| Identifier | `gemini-flash-lite-latest` @ global | A/B 推算 | ~$0.0004 |
+| Grader（5 題 fill_blank PDF）| `gemini-2.5-flash` @ us-central1 | Test 3 #1730 baseline 實測 | **$0.002313** |
+| **合計（單張）** | | | **~$0.0027** |
+
+**規模換算**：
+
+| 規模 | 計算 | USD/cycle |
+|------|------|-----------|
+| 1 班 30 學生 × 7 課 dogfood | 210 張 | $0.57 |
+| 1 校 100 學生 × 30 課 | 3000 張 | **$8.1** |
+| 全國 1000 學生 × 50 課 | 50000 張 | **$135** |
+
+**結論**：cost 不是 7/1 launch blocker — 萬張規模才到三位數 USD。但仍需設 throttle 防濫用 retry。
 
 **會議要決定**：
-- 學校導入 100 學生 × 30 課 = 3000 張，月成本可承受區間？
-- 是否需要 quota guard / 限制每生每日上傳數？
-- 老師 retry / regrade 需不需要 throttle？
+- Quota guard 設限：每生每張上限 N 次 retry？教師 regrade 上限？
+- 是否暫不設 quota guard，先看 dogfood 真實使用 pattern？
 
 ### 1.4 失敗模式 catalog（哪些已 handle、哪些會爆）
 
@@ -95,9 +104,9 @@
 ### 1.6 7/1 launch OMO GO / DELAY / NO-GO 標準
 
 提案 GO threshold（會議調整）：
-1. ✅ Young + 靖杭 + 啟翔各完成至少 1 課 dogfood test（共 3 課）
+1. ✅ 7 課 dogfood test 至少完成 N 課（N 本會決定）
 2. ✅ Grader 準確率 ≥ ?% （threshold 本會決定）
-3. ✅ Cost per worksheet 算出來 + quota guard 上線
+3. ✅ Quota guard 上線（cost 已算 ~$0.0027/張，見 § 1.3）
 4. ✅ 至少 5 個失敗模式有測試案例（pass 或 known-issue 標記）
 5. ✅ Phase 2 決策（include / defer / drop）拍板
 
@@ -105,20 +114,6 @@
 - 5 條全達 → **GO**：7/1 launch 含 OMO
 - 達 3-4 條 → **DELAY**：7/1 launch 不含 OMO，Phase 2 路線繼續
 - 達 ≤ 2 條 → **NO-GO**：OMO 砍掉 / 改 internal tool only / 重做 scope
-
-### 1.7 方大哥視角（product fit check）
-
-**問**：OMO 是不是真解「學生紙本作業跨入數位歷程」的產品需求？還是技術可行但對學校老師沒感？
-
-- 老師的痛點是「紙本批改太慢」還是「紙本歷程斷在數位之外」？
-- 學校接受「拍照上傳」這個 onboarding 摩擦嗎？vs 直接讓學生在 iPad 上做？
-- 競品（均一 / 學習吧 / 親子天下 / 翰林）有沒有類似 feature？我們的差異化在哪？
-
-### 1.8 Backup plan（6/1 教授 demo OMO fail 怎麼辦）
-
-- 切到非 OMO demo path（純數位歷程 + 7 課內容深度示範）
-- 預錄 OMO demo 影片備用
-- Feature flag 關閉 OMO entry，避免教授當場上傳出爆
 
 ---
 
@@ -142,13 +137,11 @@ Open PR：多頁上傳 UX（縮圖 / 排序 / 確認再送）5/26 待 review。
 
 **Skill 升級**：後端 Python 閱讀 lvl 1→2（pypdfium2 整合 + cross-module 修改）
 
-### 啟翔 — 🔴 連續第二週 0 PR merged（詳見 § 四）
+### 啟翔 — 工作對齊（詳見 § 四）
 
 ---
 
 ## 三、6/1 教授 review 準備（15 min）
-
-> § 一 OMO 可行性是核心；本節聚焦 demo 流程細節。
 
 ### ✅ Ready
 - Staging 7 課 demo path（G6-L22~25 + G7-L28~30）
@@ -159,7 +152,7 @@ Open PR：多頁上傳 UX（縮圖 / 排序 / 確認再送）5/26 待 review。
 
 ### ⚠️ 需確認
 - 哪 1-2 課當主示範？OMO 用哪課？
-- 教授要不要實際上傳紙本？（依 § 一 1.8 backup plan 而定）
+- 教授要不要實際上傳紙本？
 - 預想教授提問 3-5 題（pedagogy / privacy / scale / cost / 跟方大哥原版差異）
 
 ### 風險
@@ -168,26 +161,21 @@ Open PR：多頁上傳 UX（縮圖 / 排序 / 確認再送）5/26 待 review。
 
 ---
 
-## 四、啟翔卡點對話（15 min）
+## 四、啟翔工作對齊（15 min）
 
-**事實**：
-- 5/8 後 0 PR merged（連續 2 週）
-- Open PR step-progress（#1601）自 5/14 開、5/22 後 0 update、CONFLICTING
-- 7/1 deadline 的閱讀聚光燈 AI 助教（#1340）assign 4 週無進展
-- 過去 PR quality 證明技能 OK（沉浸式設計系統 +3205/-4777、selection regression 跨層 root cause）
+**會議重點**：跟啟翔對齊接下來到 7/1 怎麼一起把事情做完。
 
-**對話目標**（避免假設，直接問）：
-1. 5/8 後 2-3 週發生什麼（學校 / 健康 / 興趣 / 任務分配不對）
-2. #1601 conflict 處理需不需要支援
-3. #1340 閱讀聚光燈需不需要重新拆 issue / Young paired onboarding
-4. 到 7/1 還能投入多少時間
-5. 喜歡做什麼類型工作（UX / 後端 / AI prompt / data infra）— 重新配對
+**想討論的方向**：
+1. 最近學校跟生活節奏怎麼樣，到 7/1 大概能撥多少時間
+2. step-progress PR 有 conflict 卡住，需要一起 review 一下 unblock 路徑
+3. 閱讀聚光燈 AI 助教是不是要重新拆成幾個小 issue 比較好上手
+4. 工作類型偏好（UX 設計 / 後端 / AI prompt / data infra）— 重新配對適合的 issue
 
-**Scope reset 選項**：
-- A：close #1340 + #1601，從新小 issue 重建節奏
-- B：Young paired 開發 1-2hr 幫 unblock #1340
-- C：分擔 OMO Phase 2（靖杭已熟，啟翔加入 UI 部分）
-- D：先不接 7/1 deadline 工作，做 OMO test dogfood + 失敗模式記錄
+**可能的路線**（會議一起選）：
+- A：把現有兩個大 issue 換成幾個小 issue 重起節奏
+- B：Young 一起 paired 1-2hr 把閱讀聚光燈起頭做掉
+- C：加入 OMO Phase 2 的 UI 部分（靖杭主導後端）
+- D：先 focus OMO dogfood test + 失敗模式 catalog 蒐集，7/1 deadline 工作之後再接
 
 ---
 
@@ -218,18 +206,15 @@ Open PR：多頁上傳 UX（縮圖 / 排序 / 確認再送）5/26 待 review。
 
 ## 七、Action Items
 
-按優先序排：
-
 | # | 項目 | Owner | 截止日 |
 |---|------|-------|-------|
-| 1 | 跑一次完整 OMO 紙本 e2e（拍照 → identifier → grader → 結果頁 → 歷史頁）| Young | 2026-05-29 會前 |
-| 2 | Dogfood test — 靖杭 G6-L22 至少 1 課實機跑通 | 靖杭 | 2026-05-30 |
-| 3 | Dogfood test — 啟翔 G7-L28 至少 1 課實機跑通（依 § 四 對話決定）| 啟翔 | 2026-05-30 |
+| 1 | OMO 紙本 e2e 至少 1 課跑通（保底）| Young | 2026-05-29 會前 |
+| 2 | Dogfood — G6-L22~25 摘要策略 4 課 | 靖杭（或 Young 接手） | 2026-05-30 |
+| 3 | Dogfood — G7-L28~30 圖文整合 3 課 | 啟翔（或 Young 接手）| 2026-05-30 |
 | 4 | OMO grader 真實準確率 evaluation（N=20 樣本）| Young + 靖杭 | 2026-06-03 |
-| 5 | Cost per worksheet 算清楚 + quota guard 設計 | Young | 2026-06-03 |
+| 5 | Quota guard 設計 + 上線（cost 已算 ~$0.0027/張）| Young | 2026-06-03 |
 | 6 | 拍板 OMO GO / DELAY / NO-GO（依 § 一 1.6 標準）| 會議共識 | 2026-05-29 |
 | 7 | 7 課 demo path 逐課 staging 驗證 | Young | 2026-05-30 |
-| 8 | 啟翔卡點對話 → scope reset 4 選項拍板 | Young + 啟翔 | 2026-05-29 |
-| 9 | 教授提問 3-5 題預想 + backup plan 寫定 | Young | 2026-05-31 |
-| 10 | 收完 多頁上傳 UX PR | 靖杭 + Young review | 2026-05-30 |
-| 11 | 方大哥 OMO product fit 視角對話 | Young + 方大哥 | 會議或會後 |
+| 8 | 啟翔工作對齊 → 接下來路線拍板 | Young + 啟翔 | 2026-05-29 |
+| 9 | 教授提問 3-5 題預想 | Young | 2026-05-31 |
+| 10 | 收完多頁上傳 UX PR | 靖杭 + Young review | 2026-05-30 |


### PR DESCRIPTION
## Summary

Polish pass on 5/29 agenda per Young directives during review.

## Removed (OS / blame / fabricated)

- OS aside in 參與者
- 6/1 prof review countdown line
- Blame language in dogfood status (「13 天 0 進展」)
- § 1.7 方大哥視角 — fabricated, he never asked
- § 1.8 Backup plan — committed, no fallback needed
- 啟翔「連續第二週」/「4 週無進展」blame language
- Section preamble blockquotes

## Reframed

- § 1.1 dogfood test: **必跑** principle + 7-lesson distributed assignment (not "can interns do it?")
- § 四: 卡點對話 → 工作對齊 (conservative wording, no face-loss)

## Added real numbers (verify-first)

§ 1.3 Cost per worksheet calculated from Test 3 baseline:
- Grader call: $0.002313 (real measured)
- Identifier call: ~$0.0004
- **Per worksheet: ~$0.0027**
- Scale: 100 students × 30 lessons = $8.1
- **Conclusion: cost is not a 7/1 launch blocker**

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [x] No dangling section refs
- [ ] Young manual merge