### PR TITLE
docs(meeting): professional rewrite — drop OS/decision-tree/debate questions (Related to #2007)

### DIFF
--- a/docs/meetings/2026-05-29-agenda.md
+++ b/docs/meetings/2026-05-29-agenda.md
@@ -15,131 +15,83 @@
 ## ⏰ Deadline
 
 - **7/1（二）正式 launch — 倒數 33 天**
-- 本週首要議題：**OMO 是否可以落地（GO / DELAY / NO-GO）**
+- 本週首要：OMO 是否可以落地
 
 ---
 
-## 一、🎯 OMO 可行性檢討（first priority，40 min）
+## 一、OMO 可行性檢討（40 min）
 
-### 1.1 端到端 dogfood 實機測試（必跑）
+### 1.1 端到端 dogfood
 
-**原則**：不管誰跑，每課**都要有人實際順過一次** — 印出 → 填寫 → 拍照/掃描 → upload → identifier → grader → result → history 回看。沒有 dogfood 數字 = 不能判斷可行。
+6/1 前 7 課全部跑過。流程：印出 → 填寫 → 拍照/掃描 → upload → identifier → grader → result → history。
 
-**分工**（共 7 課，不問能不能，問誰跑哪幾課）：
+| 課文 | 跑者 |
+|------|------|
+| G6-L22~25（4 課摘要策略）| 靖杭 |
+| G7-L28~30（3 課圖文整合）| 啟翔 |
+| 保底 1 課完整 e2e | Young |
 
-| 課文範圍 | 內容 | 預設跑者 |
-|---------|------|---------|
-| G6-L22~25（4 課摘要策略）| 印出 + 填寫 + 上傳 | 靖杭 |
-| G7-L28~30（3 課圖文整合）| 印出 + 填寫 + 上傳 | 啟翔 |
-| 至少 1 課完整 e2e cycle | upload → grader → result → history | Young（保證有人跑過）|
+### 1.2 Grader 準確率 baseline
 
-**會議要決定**：
-- 7 課分工拍板（誰沒空 → Young 接手該課）
-- Dogfood 完成時點：6/1 教授 review 前必須有至少 N 課跑過（N = ?）
+| 證據 | 狀態 |
+|------|------|
+| Vision A/B #1730 lettered circle | 5/5 ✅ |
+| Identifier swap #1729 conf | 0.973 ✅ |
+| 真實手寫對答率 | 缺數字 — N=20 evaluation，Young + 靖杭 6/3 |
 
-### 1.2 Grader 真實準確率 baseline（沒有數字 = 沒有可行性）
+**拍板**：grader 對答率 GO threshold（80% / 90%？）。
 
-**現有證據**：
-- ✅ Vision A/B（#1730）：lettered circle OMO grader 鎖 `gemini-2.5-flash` 5/5 vs lite 1/5
-- ✅ Identifier swap（#1729）：lite latest conf 0.973 vs 0.934
-- ❌ **沒有「N 份真實學生手寫 → 對答案準確率 %」的數字**
+### 1.3 Cost per worksheet
 
-**會議要決定**：
-- 我們對 OMO 可行性的 quality threshold 是什麼？grader 對答率要 ≥ 80%？≥ 90%？
-- 蒐 N=20 真實手寫樣本（含好+爛+ambiguous）跑 evaluation，誰做？什麼時候？
-- 如果準確率 < threshold → OMO 是「教師輔助工具」（必須老師複核）還是「自動批改工具」？產品定位差很大
+| 階段 | Model | $/call |
+|------|-------|--------|
+| Identifier | `gemini-flash-lite-latest` | ~$0.0004 |
+| Grader（5 題 fill_blank PDF）| `gemini-2.5-flash` | $0.002313（#1730 實測）|
+| **合計** | | **~$0.0027/張** |
 
-### 1.3 Cost per worksheet（實算）
+規模：100 學生 × 30 課 = $8.1 / 50000 張 = $135。**Cost 不是 blocker**。
 
-**單張學習單成本（依 Test 3 #1730 baseline 實測 + pricing 換算）**：
+**Quota guard 提案**：每生每張 5 retry / 教師每天 100 regrade。Young 6/3 上線。
 
-| 階段 | Model | 來源 | $/call |
-|------|-------|------|--------|
-| Identifier | `gemini-flash-lite-latest` @ global | A/B 推算 | ~$0.0004 |
-| Grader（5 題 fill_blank PDF）| `gemini-2.5-flash` @ us-central1 | Test 3 #1730 baseline 實測 | **$0.002313** |
-| **合計（單張）** | | | **~$0.0027** |
+### 1.4 失敗模式 catalog
 
-**規模換算**：
+**已 handle**：#1921、#1712、#1614、#1610、#1788、#1740、PDF 多頁。
 
-| 規模 | 計算 | USD/cycle |
-|------|------|-----------|
-| 1 班 30 學生 × 7 課 dogfood | 210 張 | $0.57 |
-| 1 校 100 學生 × 30 課 | 3000 張 | **$8.1** |
-| 全國 1000 學生 × 50 課 | 50000 張 | **$135** |
+**dogfood 過程記錄到 catalog**：拍照角度、多人筆跡、漏題、寫錯課文、低光源、淡鉛筆、注音手寫、塗鴉干擾。
 
-**結論**：cost 不是 7/1 launch blocker — 萬張規模才到三位數 USD。但仍需設 throttle 防濫用 retry。
+### 1.5 Phase 2 — grader 結果寫入 LearningSession
 
-**會議要決定**：
-- Quota guard 設限：每生每張上限 N 次 retry？教師 regrade 上限？
-- 是否暫不設 quota guard，先看 dogfood 真實使用 pattern？
+紙本批改 → `LearningSession.assessment_outcomes`，數位/紙本歷程合一。Owner Young，6/3 起 2-3 天工程（grade hook + 寫入 + teacher dashboard read）。
 
-### 1.4 失敗模式 catalog（哪些已 handle、哪些會爆）
+### 1.6 7/1 launch OMO 拍板
 
-**已有 guard**：
-- ✅ #1921 OMO three UX gaps — all-blank guard、candidate chips、reasoning expansion
-- ✅ #1712 grader fabricates student_answer — fixed
-- ✅ #1614 grader 抄答案（reference answers leak in prompt）— fixed
-- ✅ #1610 JSON truncation 25% false-negative — fixed
-- ✅ #1788 confidence threshold + ambiguity 規則
-- ✅ #1740 synthetic lesson_id ≠ DB Story.id — fixed
-- ✅ PDF 多頁上傳（5/25 pypdfium2）
+GO threshold（會議調整數字）：
+1. 7 課 dogfood 全跑過
+2. Grader 對答率 ≥ ?%（依 § 1.2 拍板）
+3. Quota guard 上線
+4. Phase 2 寫入 LearningSession 上線
 
-**待測 / 未知**：
-- ❓ 拍照角度歪斜（手機拍 vs 掃描）
-- ❓ 多人筆跡混雜（哥哥幫弟弟寫一半）
-- ❓ 漏題（學生跳過 fb_3 沒寫）
-- ❓ 寫錯課文（identifier 抓到 L22 但學生其實寫 L23）
-- ❓ 低光源 / 反光 / 摺痕
-- ❓ 鉛筆超淡 / 橡皮擦痕 / 寫錯塗黑
-- ❓ 注音手寫（學生寫注音不寫國字）
-- ❓ 老師蓋章 / 學生塗鴉干擾
-
-**會議要決定**：dogfood test 至少要 cover 哪幾個失敗模式？
-
-### 1.5 Phase 2 — grader 結果寫入 LearningSession（auto-merge）
-
-**現況**：紙本批改完留在 `omo_uploads` table，學生數位歷程（`LearningSession`）看不到。學生上完數位課 + 紙本作業 = 兩套不互通的歷程。
-
-**會議要決定**：
-- 7/1 launch 必須有 Phase 2 嗎？還是只到「教師可在歷史頁看」就夠？
-- 如果必要 — owner（Young / 靖杭 / 共同），多大工程量？schema 影響？
-- 如果不必要 — 7/1 之後 Phase 2 的優先序？
-
-### 1.6 7/1 launch OMO GO / DELAY / NO-GO 標準
-
-提案 GO threshold（會議調整）：
-1. ✅ 7 課 dogfood test 至少完成 N 課（N 本會決定）
-2. ✅ Grader 準確率 ≥ ?% （threshold 本會決定）
-3. ✅ Quota guard 上線（cost 已算 ~$0.0027/張，見 § 1.3）
-4. ✅ 至少 5 個失敗模式有測試案例（pass 或 known-issue 標記）
-5. ✅ Phase 2 決策（include / defer / drop）拍板
-
-**Decision tree**：
-- 5 條全達 → **GO**：7/1 launch 含 OMO
-- 達 3-4 條 → **DELAY**：7/1 launch 不含 OMO，Phase 2 路線繼續
-- 達 ≤ 2 條 → **NO-GO**：OMO 砍掉 / 改 internal tool only / 重做 scope
+**拍板**：7/1 launch 是否含 OMO。
 
 ---
 
 ## 二、本週進度快照（10 min）
 
-### Young — 60+ refactor split + UX polish batch
+### Young
 
-5/22-5/23 集中拆 monoliths（backend service / route / admin UI / teacher UI / learning UI / infra），5/26 收 12+ 個 UX / data-isolation / assignment 修補。為 6/1 review 做 codebase deep-clean，目前 staging 健康。
+- 5/22-5/23：60+ refactor PR 拆 monoliths（backend service / route / admin / teacher / learning UI / infra）
+- 5/26：12+ UX / data-isolation / assignment 修補
+- 代表 PR：#1907 LearningLayout 1209→349 LOC、#1972 learning-sessions、#1970 omo upload/grade/lifecycle、#1893 omo_grader、#1862 admin shared primitives、#1934 staging PII 修復、#1988+#2005 zh-TW date picker
 
-代表 PR：#1907 LearningLayout 1209→349 LOC、#1972 learning-sessions、#1970 omo upload/grade/lifecycle、#1893 omo_grader、#1862 admin shared primitives、#1934 staging PII rows 修復、#1988+#2005 zh-TW custom date picker。
-
-### 靖杭 — 🟢 OMO 3 連 PR 5/25 同日
+### 靖杭 — OMO 3 PR 5/25 merged
 
 | PR | 內容 |
 |----|------|
-| grader 結果依 YAML 題號排序 | 在 service 層做，重用既有 schema 當 SOT |
-| OMO 支援 PDF 上傳 | 首次引入 backend 新 dep（pypdfium2），lib 選型有 rationale |
-| OMO 批改記錄頁 + 上傳頁入口 | list vs detail endpoint 有意識拆分 |
+| grader 結果依 YAML 題號排序 | service 層排序，重用既有 schema |
+| OMO 支援 PDF 上傳 | 引入 pypdfium2，server-side 拆頁，下游 pipeline 不改 |
+| OMO 批改記錄頁 + 上傳頁入口 | list vs detail endpoint 拆分 |
 
-Open PR：多頁上傳 UX（縮圖 / 排序 / 確認再送）5/26 待 review。
-
-**Skill 升級**：後端 Python 閱讀 lvl 1→2（pypdfium2 整合 + cross-module 修改）
+Open PR：多頁上傳 UX（縮圖 / 排序 / 確認再送）待 review。
 
 ### 啟翔 — 工作對齊（詳見 § 四）
 
@@ -167,57 +119,46 @@ Open PR：多頁上傳 UX（縮圖 / 排序 / 確認再送）5/26 待 review。
 
 ## 四、啟翔工作對齊（15 min）
 
-**會議重點**：跟啟翔對齊接下來到 7/1 怎麼一起把事情做完。
+**對齊方向**：
+1. 到 7/1 可投入時間
+2. step-progress PR conflict unblock 路徑
+3. 閱讀聚光燈 AI 助教是否重新拆小 issue
+4. 工作類型偏好（UX / 後端 / AI prompt / data infra）
 
-**想討論的方向**：
-1. 最近學校跟生活節奏怎麼樣，到 7/1 大概能撥多少時間
-2. step-progress PR 有 conflict 卡住，需要一起 review 一下 unblock 路徑
-3. 閱讀聚光燈 AI 助教是不是要重新拆成幾個小 issue 比較好上手
-4. 工作類型偏好（UX 設計 / 後端 / AI prompt / data infra）— 重新配對適合的 issue
-
-**可能的路線**（會議一起選）：
-- A：把現有兩個大 issue 換成幾個小 issue 重起節奏
-- B：Young 一起 paired 1-2hr 把閱讀聚光燈起頭做掉
-- C：加入 OMO Phase 2 的 UI 部分（靖杭主導後端）
-- D：先 focus OMO dogfood test + 失敗模式 catalog 蒐集，7/1 deadline 工作之後再接
+**接下來路線**（拍板一個）：
+- A：close 現有兩個大 issue，從小 issue 重起節奏
+- B：Young paired 1-2hr 把閱讀聚光燈起頭做掉
+- C：加入 OMO Phase 2 的 UI 部分
+- D：focus OMO dogfood test + 失敗模式 catalog，7/1 deadline 工作之後接
 
 ---
 
 ## 五、現場推廣 + 邀請老師試用（10 min）
 
-**背景**：Young 本週會跟 @Kuanwei_Lu 對齊資源面、請益邀請老師作法。
+Young 本週跟 @Kuanwei_Lu 對齊資源 + 邀請老師作法。
 
-**會議要對齊**：
-- 7/1 launch 前需要幾位老師、哪種類型（國小高年級 / 國中 / 公私校）試用？
-- 邀請老師的管道（均一網絡 / 方大哥人脈 / 冷啟動）？
-- 試用 onboarding：帳號建立 / 培訓 / 第一堂課帶不帶？
-- 試用回饋收集機制（每課填表 / 每週訪談 / Slack 群組）？
-- 跟 OMO GO/DELAY/NO-GO（§ 一 1.6）的相依性 — OMO 進不進 launch 影響邀請說法
+**對齊**：
+- 7/1 launch 需要幾位老師、哪種類型（國小高年級 / 國中 / 公私校）
+- 邀請管道（均一網絡 / 方大哥人脈 / 冷啟動）
+- 試用 onboarding：帳號建立 / 培訓 / 第一堂課帶不帶
+- 回饋收集機制（每課填表 / 每週訪談 / Slack 群組）
 
 ---
 
 ## 六、7/1 launch scope（10 min）
 
-依 § 一 1.6 OMO GO/DELAY/NO-GO 結果，scope 分支：
+**7/1 必上**：
+- 閱讀聚光燈 AI 助教（依 § 四 啟翔路線決定 owner）
+- 真實學生流量導入（依 § 五 老師試用排程）
 
-| 情境 | 7/1 必要工作 |
-|------|------------|
-| OMO GO | Phase 2 grader→LearningSession 寫入 + 真實流量導入 + 學校 onboarding flow |
-| OMO DELAY | OMO 留 staging 做內部試驗 + 7/1 launch 純數位歷程 + #1340 必上 |
-| OMO NO-GO | OMO 砍 + #1340 + 朗讀指導語 fail-safe（4/17 遺留）|
-
-**所有情境共同**：
-- #1340 閱讀聚光燈 AI 助教 — 7/1 必上（依 § 四 啟翔對話決定路線）
-- 真實學生流量導入策略 — 跟方大哥確認學校排程（呼應 § 五 邀請老師作法）
+**OMO 含不含**：依 § 一 1.6 拍板結果決定。
 
 ---
 
 ## 七、其他
 
-- 5/22-5/23 60+ refactor PR 規模罕見，codebase 健康度大幅提升
-- 5/26 一天 12+ 修補完成，teacher dashboard MVP 接近 review-ready
-- Staging 環境隔離（從 prod 拆 Cloud SQL + GCS + JWT）已穩定
-- 方大哥 TTS 校正後台稽核頁進度（建造中）
+- Staging 環境隔離（Cloud SQL + GCS + JWT 從 prod 拆）已穩定
+- 方大哥 TTS 校正後台稽核頁進度同步
 
 ---
 
@@ -230,7 +171,7 @@ Open PR：多頁上傳 UX（縮圖 / 排序 / 確認再送）5/26 待 review。
 | 3 | Dogfood — G7-L28~30 圖文整合 3 課 | 啟翔（或 Young 接手）| 2026-05-30 |
 | 4 | OMO grader 真實準確率 evaluation（N=20 樣本）| Young + 靖杭 | 2026-06-03 |
 | 5 | Quota guard 設計 + 上線（cost 已算 ~$0.0027/張）| Young | 2026-06-03 |
-| 6 | 拍板 OMO GO / DELAY / NO-GO（依 § 一 1.6 標準）| 會議共識 | 2026-05-29 |
+| 6 | 拍板 7/1 launch 是否含 OMO（依 § 一 1.6 threshold）| 會議共識 | 2026-05-29 |
 | 7 | 7 課 demo path 逐課 staging 驗證 | Young | 2026-05-30 |
 | 8 | 啟翔工作對齊 → 接下來路線拍板 | Young + 啟翔 | 2026-05-29 |
 | 9 | 教授提問 3-5 題預想 | Young | 2026-05-31 |

--- a/docs/meetings/2026-05-29-agenda.md
+++ b/docs/meetings/2026-05-29-agenda.md
@@ -15,63 +15,58 @@
 ## ⏰ Deadline
 
 - **7/1（二）正式 launch — 倒數 33 天**
-- 本週首要：OMO 是否可以落地
+- 本週首要：OMO 落地前檢查
 
 ---
 
-## 一、OMO 可行性檢討（40 min）
+## 一、OMO 落地前檢查（40 min）
 
-### 1.1 端到端 dogfood
-
-6/1 前 7 課全部跑過。流程：印出 → 填寫 → 拍照/掃描 → upload → identifier → grader → result → history。
+### 1.1 Dogfood — 6/1 前 7 課全跑過
 
 | 課文 | 跑者 |
 |------|------|
-| G6-L22~25（4 課摘要策略）| 靖杭 |
-| G7-L28~30（3 課圖文整合）| 啟翔 |
-| 保底 1 課完整 e2e | Young |
+| G6-L22~25 摘要策略 4 課 | 靖杭 |
+| G7-L28~30 圖文整合 3 課 | 啟翔 |
+| 保底 1 課 e2e | Young |
 
-### 1.2 Grader 準確率 baseline
+### 1.2 Grader 準確率
 
-| 證據 | 狀態 |
-|------|------|
-| Vision A/B #1730 lettered circle | 5/5 ✅ |
-| Identifier swap #1729 conf | 0.973 ✅ |
-| 真實手寫對答率 | 缺數字 — N=20 evaluation，Young + 靖杭 6/3 |
+- Vision A/B #1730 lettered circle：5/5 ✅
+- Identifier #1729 conf：0.973 ✅
+- 真實手寫對答率：缺數字，N=20 evaluation（Young + 靖杭，6/3）
 
-**拍板**：grader 對答率 GO threshold（80% / 90%？）。
+**拍板**：對答率 GO threshold（80% / 90%？）
 
-### 1.3 Cost per worksheet
+### 1.3 Cost
 
-| 階段 | Model | $/call |
-|------|-------|--------|
-| Identifier | `gemini-flash-lite-latest` | ~$0.0004 |
-| Grader（5 題 fill_blank PDF）| `gemini-2.5-flash` | $0.002313（#1730 實測）|
-| **合計** | | **~$0.0027/張** |
+| 階段 | $/call |
+|------|--------|
+| Identifier `gemini-flash-lite-latest` | ~$0.0004 |
+| Grader `gemini-2.5-flash`（#1730 實測）| $0.002313 |
+| **合計** | **~$0.0027/張** |
 
-規模：100 學生 × 30 課 = $8.1 / 50000 張 = $135。**Cost 不是 blocker**。
+100 學生 × 30 課 = $8.1 / 50000 張 = $135。**不是 blocker**。
 
-**Quota guard 提案**：每生每張 5 retry / 教師每天 100 regrade。Young 6/3 上線。
+**Quota guard**：5 retry / 生 / 張、100 regrade / 教師 / 天。Young 6/3 上線。
 
-### 1.4 失敗模式 catalog
+### 1.4 失敗模式
 
-**已 handle**：#1921、#1712、#1614、#1610、#1788、#1740、PDF 多頁。
+- 已 handle：#1921、#1712、#1614、#1610、#1788、#1740、PDF 多頁
+- Dogfood 記錄：拍照角度、多人筆跡、漏題、寫錯課文、低光源、淡鉛筆、注音手寫、塗鴉干擾
 
-**dogfood 過程記錄到 catalog**：拍照角度、多人筆跡、漏題、寫錯課文、低光源、淡鉛筆、注音手寫、塗鴉干擾。
+### 1.5 Phase 2 — 寫入 LearningSession
 
-### 1.5 Phase 2 — grader 結果寫入 LearningSession
+紙本批改 → `LearningSession.assessment_outcomes`。Owner Young，6/3 起 2-3 天。
 
-紙本批改 → `LearningSession.assessment_outcomes`，數位/紙本歷程合一。Owner Young，6/3 起 2-3 天工程（grade hook + 寫入 + teacher dashboard read）。
+### 1.6 7/1 拍板
 
-### 1.6 7/1 launch OMO 拍板
-
-GO threshold（會議調整數字）：
+GO threshold：
 1. 7 課 dogfood 全跑過
-2. Grader 對答率 ≥ ?%（依 § 1.2 拍板）
+2. 對答率 ≥ ?%
 3. Quota guard 上線
 4. Phase 2 寫入 LearningSession 上線
 
-**拍板**：7/1 launch 是否含 OMO。
+**拍板**：7/1 是否含 OMO。
 
 ---
 


### PR DESCRIPTION
Per Young 直接指示：

- 全局拿掉 OS narrator / 旁白
- 砍 decision tree（5 條全達 → GO 等山盤）
- 砍「會議要決定」debate 包裝，能做掉的直接 Action Items
- § 一 各小節壓到純要點 bullet
- L18 改「OMO 落地前檢查」

Diff: -160 / +96 lines。Final = 175 行。