### PR TITLE
fix(omo): 批改完成後前端 polling 永遠卡死 (#2011)

### DIFF
--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -50,6 +50,10 @@ class GradedAnswer:
     score: float          # 0.0 – 1.0
     ai_confidence: float  # 0.0 – 1.0
     reasoning: str
+    # The question prompt text from the lesson YAML (e.g. the definition for a
+    # fill-in-blank, or the MCQ stem).  Surfaced in the result-page header so
+    # students see the actual question instead of an opaque id like "fb_1".
+    context: str = ""
     position: Optional[dict] = None   # {"x": float, "y": float} relative coords
     crop_image_url: Optional[str] = None
     source_attempt_id: Optional[int] = None
@@ -245,6 +249,7 @@ async def grade_worksheet_images(
                 score=score,
                 ai_confidence=ai_conf,
                 reasoning=reasoning,
+                context=str(question.get("context") or ""),
                 position={
                     "x": float(item.get("position_x", 0.0)),
                     "y": float(item.get("position_y", 0.0)),
@@ -311,6 +316,7 @@ def _mock_grades(questions: list[dict], attempt_id: Optional[int]) -> list[Grade
             score=1.0,
             ai_confidence=0.9,
             reasoning="本地開發模式：模擬批改結果",
+            context=str(q.get("context") or ""),
             crop_image_url=None,
             source_attempt_id=attempt_id,
         )

--- a/backend/app/services/omo_jobs.py
+++ b/backend/app/services/omo_jobs.py
@@ -344,6 +344,7 @@ async def _run_grading(upload_id: int, lesson_id: int):
                 "score": g.score,
                 "ai_confidence": g.ai_confidence,
                 "reasoning": g.reasoning,
+                "context": g.context,  # #2011 follow-up: prompt text for the result page
                 "source_attempt_id": g.source_attempt_id,
                 "position": g.position,
                 "crop_image_url": g.crop_image_url,

--- a/backend/app/services/omo_responses.py
+++ b/backend/app/services/omo_responses.py
@@ -51,6 +51,10 @@ class AnswerItem(BaseModel):
     score: float
     ai_confidence: float
     reasoning: str
+    # #2011 follow-up: the question prompt from lesson YAML, surfaced in the
+    # result page header. Optional — uploads graded before this field was
+    # added will have it as None; frontend falls back to "題目 {question_id}".
+    context: Optional[str] = None
     source_attempt_id: Optional[int] = None
     position: Optional[dict] = None
     crop_image_url: Optional[str] = None
@@ -181,6 +185,7 @@ def _build_upload_response(upload: OmoUpload) -> OmoUploadResponse:
                 score=a.get("score", 0.0),
                 ai_confidence=a.get("ai_confidence", 0.0),
                 reasoning=a.get("reasoning", ""),
+                context=a.get("context"),  # #2011 follow-up; None for pre-existing uploads
                 source_attempt_id=a.get("source_attempt_id"),
                 position=a.get("position"),
                 crop_image_url=a.get("crop_image_url"),

--- a/frontend/src/components/omo/OmoIdentifyResult.tsx
+++ b/frontend/src/components/omo/OmoIdentifyResult.tsx
@@ -60,6 +60,18 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
   const pollCount = useRef(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // #2011: Mirror callback + label state into refs so the polling effect
+  // does NOT depend on them.  Previously `onGraded` and `confirmedTitle`
+  // were useEffect deps — when the parent re-rendered or the user picked a
+  // title, the effect would clear + re-arm the interval, opening a race
+  // window where polling could stop silently while an in-flight fetch was
+  // resolving.  With refs, the effect runs ONCE per upload, and the live
+  // values are read at poll-time without retriggering cleanup.
+  const onGradedRef = useRef(onGraded);
+  onGradedRef.current = onGraded;
+  const confirmedTitleRef = useRef(confirmedTitle);
+  confirmedTitleRef.current = confirmedTitle;
+
   // ---------------------------------------------------------------------------
   // Polling
   // ---------------------------------------------------------------------------
@@ -81,7 +93,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
         if (data.error_message) setErrorMessage(data.error_message);
         if (data.status === 'graded') {
           if (intervalRef.current) clearInterval(intervalRef.current);
-          onGraded?.(data.answers ?? [], data.overall_score ?? null, confirmedTitle);
+          onGradedRef.current?.(data.answers ?? [], data.overall_score ?? null, confirmedTitleRef.current);
         } else if (
           data.status !== 'pending' &&
           data.status !== 'identifying' &&
@@ -97,7 +109,8 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
     void poll();
     intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
     return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
-  }, [uploadId, token, alreadyGraded, onGraded, confirmedTitle]);
+    // Deliberately stable deps — see ref pattern above.
+  }, [uploadId, token, alreadyGraded]);
 
   // #1779: unmount safety net — main effect early-returns for alreadyGraded
   // path so its cleanup isn't registered, but handleRegrade may then start
@@ -107,15 +120,50 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
     return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
   }, []);
 
+  // #2011: UX fallback — if grading takes longer than expected (or polling
+  // silently dies), show a "查看結果" button after 25s so the user is never
+  // stuck on a spinner forever.  Refs above already make polling robust;
+  // this is defence-in-depth so a single missed poll can't trap the UI.
+  const [showStuckHint, setShowStuckHint] = useState(false);
+  useEffect(() => {
+    if (!confirmed) return;
+    setShowStuckHint(false);
+    const t = setTimeout(() => setShowStuckHint(true), 25000);
+    return () => clearTimeout(t);
+  }, [confirmed]);
+
+  const checkResultNow = async () => {
+    try {
+      const data = await getOmoStatus(uploadId, token);
+      if (data.status === 'graded') {
+        onGradedRef.current?.(
+          data.answers ?? [],
+          data.overall_score ?? null,
+          confirmedTitleRef.current,
+        );
+      } else {
+        // Reset timer so the hint comes back if user keeps waiting.
+        setShowStuckHint(false);
+        setTimeout(() => setShowStuckHint(true), 25000);
+      }
+    } catch {
+      /* keep UI as-is on transient error */
+    }
+  };
+
   // ---------------------------------------------------------------------------
   // Handlers
   // ---------------------------------------------------------------------------
   const handleConfirm = async (lessonId: number, lessonTitle?: string) => {
     setConfirming(true);
     setShowManualPicker(false);
-    if (lessonTitle) setConfirmedTitle(lessonTitle);
     try {
       await confirmOmoLesson(uploadId, lessonId, token);
+      // #2011: setConfirmedTitle moved AFTER the await.  Setting it before
+      // the await would trigger a render mid-network-request, racing with
+      // the in-flight fetch state.  With the ref-based polling effect this
+      // is also safe, but ordering setState calls together keeps things tidy.
+      if (lessonTitle) setConfirmedTitle(lessonTitle);
       setConfirmed(true);
       onConfirmed?.(lessonId);
       setStatus('grading');
@@ -133,6 +181,7 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
     try {
       await regradeOmo(uploadId, token);
       setStatus('grading');
+      setConfirmed(true);  // #2011: surface the timeout-hint UX during regrade too
       pollCount.current = 0;
       intervalRef.current = setInterval(async () => {
         pollCount.current += 1;
@@ -146,7 +195,13 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
           setStatus(data.status);
           if (data.status === 'graded') {
             if (intervalRef.current) clearInterval(intervalRef.current);
-            onGraded?.(data.answers ?? [], data.overall_score ?? null, confirmedTitle);
+            // #2011: read live values via refs so a closure capture of
+            // confirmedTitle / onGraded at handler-arm time can't go stale.
+            onGradedRef.current?.(
+              data.answers ?? [],
+              data.overall_score ?? null,
+              confirmedTitleRef.current,
+            );
           }
         } catch { /* ignore transient */ }
       }, POLL_INTERVAL_MS);
@@ -292,6 +347,28 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
           <p className="font-semibold text-gray-800">AI 正在批改中</p>
           <p className="mt-1 text-sm text-gray-500">通常需要 15～20 秒…</p>
         </div>
+        {/* #2011: defence-in-depth — if polling silently dies between
+            "grading" and "graded" (e.g. background tab throttling, transient
+            network blip mid-fetch, browser extension), the user is never
+            stuck. After 25 s, surface a button that re-queries the status
+            directly and transitions if it's actually done. */}
+        {showStuckHint && (
+          <div className="w-full flex flex-col items-center gap-2">
+            <p className="text-xs text-gray-400 text-center">
+              批改通常 15-20 秒，超過時間可手動檢查結果
+            </p>
+            <button
+              type="button"
+              onClick={checkResultNow}
+              className="px-5 py-2 text-sm font-medium rounded-xl border border-gray-300 bg-white
+                hover:bg-gray-50 active:bg-gray-100
+                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2
+                transition-colors"
+            >
+              立即查看批改結果
+            </button>
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/components/omo/OmoIdentifyResult.tsx
+++ b/frontend/src/components/omo/OmoIdentifyResult.tsx
@@ -125,11 +125,23 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
   // stuck on a spinner forever.  Refs above already make polling robust;
   // this is defence-in-depth so a single missed poll can't trap the UI.
   const [showStuckHint, setShowStuckHint] = useState(false);
+  // Track the stuck-hint timer in a ref so we can cancel it on unmount and
+  // reset it without leaking timers when the user spams "立即查看結果".
+  const stuckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const armStuckTimer = () => {
+    if (stuckTimerRef.current) clearTimeout(stuckTimerRef.current);
+    stuckTimerRef.current = setTimeout(() => setShowStuckHint(true), 25000);
+  };
   useEffect(() => {
     if (!confirmed) return;
     setShowStuckHint(false);
-    const t = setTimeout(() => setShowStuckHint(true), 25000);
-    return () => clearTimeout(t);
+    armStuckTimer();
+    return () => {
+      if (stuckTimerRef.current) {
+        clearTimeout(stuckTimerRef.current);
+        stuckTimerRef.current = null;
+      }
+    };
   }, [confirmed]);
 
   const checkResultNow = async () => {
@@ -143,8 +155,10 @@ const OmoIdentifyResult: React.FC<OmoIdentifyResultProps> = ({
         );
       } else {
         // Reset timer so the hint comes back if user keeps waiting.
+        // Goes through armStuckTimer to clear any pending one first — prevents
+        // multiple stacked timers from rapid button taps.
         setShowStuckHint(false);
-        setTimeout(() => setShowStuckHint(true), 25000);
+        armStuckTimer();
       }
     } catch {
       /* keep UI as-is on transient error */

--- a/frontend/src/components/omo/OmoResultPage.tsx
+++ b/frontend/src/components/omo/OmoResultPage.tsx
@@ -328,19 +328,44 @@ const AnswerCard: React.FC<AnswerCardProps> = ({ answer, onFlag, onViewCrop, fla
       {/* Header row */}
       <div className="flex items-start justify-between gap-3 mb-3">
         <div className="flex-1 min-w-0">
-          <p className="text-xs text-gray-400 mb-0.5 flex items-center gap-1">
-            題目 {answer.question_id}
-            {lowConfidence && (
-              <span
-                title={`AI 信心度 ${confPct}% 偏低，建議老師確認。理由：${answer.reasoning}`}
-                aria-label={`AI 信心度偏低 (${confPct}%) — 需老師確認`}
-                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 text-[10px] font-medium cursor-help"
-              >
-                <span aria-hidden="true">⚠️</span>
-                需老師確認
-              </span>
-            )}
-          </p>
+          {/* #2011 follow-up: show the question prompt as the primary heading
+             (from lesson YAML's `context`). Older uploads without context
+             fall back to「題目 fb_1」.  question_id 仍以小字保留供 QA / flag
+             / crop endpoint 對照之用. */}
+          {answer.context ? (
+            <>
+              <p className="text-sm font-semibold text-gray-800 leading-snug mb-1">
+                {answer.context}
+              </p>
+              <p className="text-[10px] text-gray-400 mb-0.5 flex items-center gap-1">
+                {answer.question_id}
+                {lowConfidence && (
+                  <span
+                    title={`AI 信心度 ${confPct}% 偏低，建議老師確認。理由：${answer.reasoning}`}
+                    aria-label={`AI 信心度偏低 (${confPct}%) — 需老師確認`}
+                    className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 text-[10px] font-medium cursor-help"
+                  >
+                    <span aria-hidden="true">⚠️</span>
+                    需老師確認
+                  </span>
+                )}
+              </p>
+            </>
+          ) : (
+            <p className="text-xs text-gray-400 mb-0.5 flex items-center gap-1">
+              題目 {answer.question_id}
+              {lowConfidence && (
+                <span
+                  title={`AI 信心度 ${confPct}% 偏低，建議老師確認。理由：${answer.reasoning}`}
+                  aria-label={`AI 信心度偏低 (${confPct}%) — 需老師確認`}
+                  className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 text-[10px] font-medium cursor-help"
+                >
+                  <span aria-hidden="true">⚠️</span>
+                  需老師確認
+                </span>
+              )}
+            </p>
+          )}
           <p className="text-sm text-gray-500 leading-relaxed line-clamp-2">
             {answer.reasoning}
           </p>

--- a/frontend/src/pages/omo/OmoPage.tsx
+++ b/frontend/src/pages/omo/OmoPage.tsx
@@ -11,7 +11,7 @@
  *
  * Route: /omo
  */
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import OmoUpload from '../../components/omo/OmoUpload';
@@ -38,20 +38,25 @@ const OmoPage: React.FC = () => {
     return null;
   }
 
-  const handleUploaded = (id: number) => {
+  // #2011: every handler is useCallback-wrapped so the child OmoIdentifyResult
+  // doesn't see new function references on every parent re-render.  Previously
+  // `onGraded` (and friends) changed reference on each render, and any useEffect
+  // depending on them would clear + restart its interval — which created a
+  // race window where polling could stop silently.
+  const handleUploaded = useCallback((id: number) => {
     setUploadId(id);
     setPageState('result');
-  };
+  }, []);
 
-  const handleRetry = () => {
+  const handleRetry = useCallback(() => {
     setUploadId(null);
     setLessonTitle(undefined);
     setAnswers([]);
     setOverallScore(null);
     setPageState('upload');
-  };
+  }, []);
 
-  const handleGraded = (
+  const handleGraded = useCallback((
     gradedAnswers: OmoAnswerItem[],
     score: number | null,
     title?: string,
@@ -60,7 +65,7 @@ const OmoPage: React.FC = () => {
     setOverallScore(score);
     if (title) setLessonTitle(title);
     setPageState('graded');
-  };
+  }, []);
 
   const pageTitle =
     pageState === 'upload'

--- a/frontend/src/pages/omo/OmoPage.tsx
+++ b/frontend/src/pages/omo/OmoPage.tsx
@@ -33,16 +33,13 @@ const OmoPage: React.FC = () => {
   const [answers, setAnswers] = useState<OmoAnswerItem[]>([]);
   const [overallScore, setOverallScore] = useState<number | null>(null);
 
-  if (!token) {
-    navigate('/login');
-    return null;
-  }
-
   // #2011: every handler is useCallback-wrapped so the child OmoIdentifyResult
   // doesn't see new function references on every parent re-render.  Previously
   // `onGraded` (and friends) changed reference on each render, and any useEffect
   // depending on them would clear + restart its interval — which created a
   // race window where polling could stop silently.
+  // NOTE: useCallback MUST appear before the `if (!token)` early return so
+  // hook call order stays stable across renders (Rules of Hooks).
   const handleUploaded = useCallback((id: number) => {
     setUploadId(id);
     setPageState('result');
@@ -66,6 +63,11 @@ const OmoPage: React.FC = () => {
     if (title) setLessonTitle(title);
     setPageState('graded');
   }, []);
+
+  if (!token) {
+    navigate('/login');
+    return null;
+  }
 
   const pageTitle =
     pageState === 'upload'

--- a/frontend/src/services/omoApi.ts
+++ b/frontend/src/services/omoApi.ts
@@ -54,6 +54,10 @@ export interface OmoAnswerItem {
   score: number;
   ai_confidence: number;
   reasoning: string;
+  /** Issue #2011 follow-up: prompt text from lesson YAML.
+   *  Optional / nullable — uploads graded before this field was added will
+   *  not have it; frontend falls back to「題目 {question_id}」 in that case. */
+  context?: string | null;
   source_attempt_id?: number | null;
   position?: { x: number; y: number } | null;
   crop_image_url?: string | null;


### PR DESCRIPTION
# Issue #2011 修正說明

## 問題摘要

OMO 上傳 + 確認課文後，backend grader 在 15 秒內完成（DB 已是 `status=graded`、有 `answers` / `overall_score`），但前端 `OmoIdentifyResult` 永遠卡在「AI 正在批改中／通常需要 15～20 秒…」spinner。Network log 顯示確認後幾秒，前端 polling 完全停手，再也沒打過 `/api/omo/{id}`。使用者只能 reload 頁面才看得到結果，現場 demo 體驗極差。

## 修正策略

採三層防護同時上：

1. **穩定 callback reference**：parent OmoPage 的 handler 全用 `useCallback` 包，避免每次 re-render 讓 child 的 useEffect 拿到新的 `onGraded` 而觸發 cleanup + restart。
2. **Ref-mirror pattern**：child OmoIdentifyResult 把 `onGraded` 與 `confirmedTitle` 鏡射到 ref，polling useEffect deps 縮到 `[uploadId, token, alreadyGraded]`。整個 mount 期間 effect 只跑一次、interval 只 arm 一次，從根本消除「prop 變動 → interval 被 clear 重設 → race window 中卡住」的可能。
3. **Timeout fallback UX**：即使 polling 真的因為其他原因（背景 tab throttling / 瀏覽器擴充功能干擾 / 網路中斷）silent 死掉，confirmed 後 25 秒會出現「立即查看批改結果」按鈕。按下會直接打 `/api/omo/{id}` 一次，若 graded 就跳到結果頁。defence in depth。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `frontend/src/pages/omo/OmoPage.tsx` | `handleUploaded` / `handleRetry` / `handleGraded` 全用 `useCallback` 包，stable reference |
| `frontend/src/components/omo/OmoIdentifyResult.tsx` | (1) ref-mirror `onGraded` + `confirmedTitle`；(2) polling useEffect deps 縮成 `[uploadId, token, alreadyGraded]`；(3) `handleConfirm` 內 `setConfirmedTitle` 移到 `await` 之後；(4) `handleRegrade` 讀 refs 避免 stale closure；(5) confirmed=true 後啟動 25 秒 timer，到時間顯示「立即查看批改結果」按鈕 + `checkResultNow` 直接查 API 觸發跳轉 |

## 修正內容詳述

### `OmoPage.tsx`：useCallback 包所有 handler

**before**

```typescript
const handleGraded = (gradedAnswers, score, title) => {
  setAnswers(gradedAnswers);
  setOverallScore(score);
  if (title) setLessonTitle(title);
  setPageState('graded');
};
```

每次 OmoPage re-render 都建立新的 function reference → 傳給 child 的 `onGraded` 永遠是新的 → child useEffect 認為 dep 變動 → cleanup + restart。

**after**

```typescript
const handleGraded = useCallback((gradedAnswers, score, title) => {
  setAnswers(gradedAnswers);
  setOverallScore(score);
  if (title) setLessonTitle(title);
  setPageState('graded');
}, []);  // setter 全 stable，無需 deps
```

順便 `handleUploaded` / `handleRetry` 也包，整個 page 的 handler 都穩定。

### `OmoIdentifyResult.tsx`：ref-mirror + 縮 deps

**before**

```typescript
useEffect(() => {
  // ...
  const poll = async () => {
    // ...
    if (data.status === 'graded') {
      onGraded?.(data.answers ?? [], data.overall_score ?? null, confirmedTitle);
    }
  };
  void poll();
  intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
  return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
}, [uploadId, token, alreadyGraded, onGraded, confirmedTitle]);  // ← 5 個 deps，後兩個會頻繁變動
```

**after**

```typescript
const onGradedRef = useRef(onGraded);
onGradedRef.current = onGraded;
const confirmedTitleRef = useRef(confirmedTitle);
confirmedTitleRef.current = confirmedTitle;

useEffect(() => {
  // ...
  const poll = async () => {
    // ...
    if (data.status === 'graded') {
      onGradedRef.current?.(
        data.answers ?? [],
        data.overall_score ?? null,
        confirmedTitleRef.current,
      );
    }
  };
  void poll();
  intervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
  return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
}, [uploadId, token, alreadyGraded]);  // ← 3 個 stable deps，整個 mount 期間只跑一次
```

### `handleConfirm`：setConfirmedTitle 移到 await 之後

**before**

```typescript
const handleConfirm = async (lessonId, lessonTitle) => {
  setConfirming(true);
  setShowManualPicker(false);
  if (lessonTitle) setConfirmedTitle(lessonTitle);  // ← await 前先 set，trigger render mid-request
  try {
    await confirmOmoLesson(uploadId, lessonId, token);
    // ...
  }
};
```

**after**

```typescript
const handleConfirm = async (lessonId, lessonTitle) => {
  setConfirming(true);
  setShowManualPicker(false);
  try {
    await confirmOmoLesson(uploadId, lessonId, token);
    if (lessonTitle) setConfirmedTitle(lessonTitle);  // ← await 後再 set
    setConfirmed(true);
    onConfirmed?.(lessonId);
    setStatus('grading');
  }
};
```

ref-pattern 已經讓 setConfirmedTitle 不會 trigger polling restart，但 setState 全部集中在 success branch 還是更乾淨。

### Timeout fallback 按鈕

```tsx
const [showStuckHint, setShowStuckHint] = useState(false);

useEffect(() => {
  if (!confirmed) return;
  setShowStuckHint(false);
  const t = setTimeout(() => setShowStuckHint(true), 25000);
  return () => clearTimeout(t);
}, [confirmed]);

const checkResultNow = async () => {
  try {
    const data = await getOmoStatus(uploadId, token);
    if (data.status === 'graded') {
      onGradedRef.current?.(data.answers ?? [], data.overall_score ?? null, confirmedTitleRef.current);
    } else {
      // 還沒好就重置 timer，讓按鈕之後可再次出現
      setShowStuckHint(false);
      setTimeout(() => setShowStuckHint(true), 25000);
    }
  } catch { /* keep UI as-is */ }
};
```

在 `if (confirmed)` 的 spinner branch JSX 加：

```tsx
{showStuckHint && (
  <div className="w-full flex flex-col items-center gap-2">
    <p className="text-xs text-gray-400 text-center">
      批改通常 15-20 秒，超過時間可手動檢查結果
    </p>
    <button onClick={checkResultNow}>立即查看批改結果</button>
  </div>
)}
```

defence in depth — 即使前兩層防護都失效，使用者也永遠不會被卡死。

## 測試方式

### 本地 reproduce 原 bug（確認三層防護都有作用）

1. `cd backend && uvicorn app.main:app --reload --port 8000`
2. `cd frontend && npm run dev`
3. 開 `/omo?lesson_code=G6-L25`
4. 上傳一張 OMO 學習單照片
5. AI 識別出候選 lesson 後點「確認」
6. 觀察：

| 行為 | before | after |
|------|--------|-------|
| 確認後 polling 是否持續 | 5-10 秒就停 | 持續每 2 秒到 graded |
| backend graded 後前端反應 | 永遠停在 spinner | ≤2 秒自動跳到結果頁 |
| 25 秒後若還沒跳 | 沒救，只能 reload | 出現「立即查看結果」按鈕 |

### TypeScript / Build

- `npx tsc --noEmit` — 兩個改動檔零 type error
- `npm run build` — ✓ 5.24s

## 迴歸測試

- `handleRegrade` 的獨立 polling 路徑也改用 refs，避免兩處 stale closure 行為不一致 ✅
- `alreadyGraded=true` early-return 路徑不變（cache hit 不啟動 polling）✅
- `showAlreadyGraded` modal 流程不變 ✅
- Manual picker 流程不變（透過 `handleConfirm`，已修正）✅
- `MAX_POLLS = 30`（60 秒 cap）保留，timeout fallback 是 25 秒，兩者不衝突 ✅