### PR TITLE
fix(worksheet): digit-boundary docx match in rebuild script (#2018 follow-up)

### DIFF
--- a/scripts/rebuild_worksheets_fonts.py
+++ b/scripts/rebuild_worksheets_fonts.py
@@ -6,6 +6,7 @@ Issue #2018: https://github.com/Youngger9765/chinese-literacy-platform/issues/20
 """
 
 import os
+import re
 import subprocess
 import json
 import time
@@ -101,7 +102,11 @@ def find_docx(gcs_name):
             if not fname.endswith(".docx"):
                 continue
             for pat in search_patterns:
-                if pat in fname:
+                # Digit-boundary match: "G7-L1" must NOT match "G7-L10"/"G7-L11".
+                # Plain substring matching corrupted single-digit codes by pulling
+                # the wrong source docx (e.g. G7-L1 → G7-L10塑膠), so the rebuilt
+                # PDF carried a different lesson's content (#2018 follow-up).
+                if re.search(re.escape(pat) + r'(?![0-9])', fname):
                     full_path = os.path.join(root, fname)
                     is_student = ("學生版" in root or "-SL" in fname)
                     if is_student:


### PR DESCRIPTION
## Summary
- `rebuild_worksheets_fonts.py` 的 `find_docx` 用 plain substring match，單位數課號（`G7-L1`）會撈到 `G7-L10塑膠` docx → 重建的 PDF 帶**錯誤課文內容**
- 已造成 4 個 worksheet GCS 上內容污染（G6-L1 / G7-L1 / G9-L01 / G9-L1）— **已用正確 lesson-1 docx 重建+上傳修復**（課號=1、正確主題、字型 clean，GCS 重驗過）
- 本 PR 修 latent bug：加 `import re` + 要求配到的 code 後面不接數字（`(?![0-9])`），`G7-L1` 不再配 `G7-L10`/`G7-L11`

## Why it matters
腳本已 merge 到 staging。誰再跑一次 rebuild 會再次污染同樣 4 個檔。

## Verification
- 修後 `find_docx` 對 4 個 code 全配到正確 lesson-1 docx（運動傷害 / 夏夜 / 盡信書）
- regex 單元測試通過（`G7-L1` ✗ `G7-L10`，✓ `G7-L1夏夜`）
- py 語法檢查 OK

## Test plan
- [ ] 全 233 worksheet 內容掃描：232 課號相符（24 個 code≠章節號是正常編號慣例，已用 manifest 標題確認內容正確）
- [ ] WW-L10 仍待內容團隊挖空版 source（#2021）