### PR TITLE
fix(lesson-data): G6-L24 + G6-L25 fb answer 字母錯位修正 (#2015 Layer 1)

### DIFF
--- a/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
@@ -46,23 +46,27 @@ paragraphs:
 paragraph_count: 7
 char_count: 1059
 fill_in_blank:
+# #2015: answer letters were misaligned with sentences in the 2026-05-01 parse
+# (same parser bug as G6-L25). The vocabulary list maps A=束手無策, B=凜冽,
+# C=屏氣凝神, D=僧多粥少, E=筋疲力竭, F=翻騰, G=窒息, H=緩不濟急,
+# I=徒勞無功 — see vocabulary section below.
 - sentence: 教師職缺的名額只有十個，報名者卻有百人，（　　　）錄取不易。
-  answer: I
+  answer: D  # 僧多粥少
 - sentence: 颱風即將到來，岸邊巨浪（　　　），聲勢真是嚇人。
-  answer: A
+  answer: F  # 翻騰
 - sentence: 北風（　　　）地吹著，即使裹緊大衣，還是覺得很冷。
-  answer: B
+  answer: B  # 凜冽
 - sentence: 學校原本要把週三第八節改成「興趣探索課」，但家長反對，這項改革（　　　），令人遺憾。
-  answer: D
+  answer: I  # 徒勞無功
 - sentence: 面對突如其來的危機，大家一時（　　　），不知道該怎麼辦。
-  answer: F
+  answer: A  # 束手無策
 - sentence: 忙完畢業展的佈置後，大家都（　　　），希望好好休息。
-  answer: E
+  answer: E  # 筋疲力竭
 - sentence: 災後援助若拖延太久，恐怕（　　　），災民的食物與醫療需求將受影響。
-  answer: H
+  answer: H  # 緩不濟急
 - sentence: 他白天忙著工作、晚上又得照顧生病的母親，雙重壓力讓他覺得快要（　　　）了，很辛苦。
-  answer: C
-fill_in_blank_count: 5
+  answer: G  # 窒息
+fill_in_blank_count: 8
 vocabulary:
 - word: 束手無策
   definition: 束手是「手被綁起來」，無策是「沒有辦法」。束手無策是形容完全沒有辦法解決問題。

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
@@ -58,23 +58,27 @@ paragraphs:
 paragraph_count: 11
 char_count: 1145
 fill_in_blank:
+# #2015: answer letters were misaligned with sentences in the 2026-05-01 parse
+# (8/8 wrong, every student answer was scored 0). The vocabulary list maps
+# A=股票, B=利潤, C=股東, D=積蓄, E=獲利, F=集資, G=大手一揮, H=揚帆啟航,
+# I=節衣縮食, J=派遣, K=滿手老繭 — see vocabulary section below.
 - sentence: 公司今年（　　　）大增，大家都有獎金。
-  answer: F
+  answer: E  # 獲利
 - sentence: 大學畢業後，他準備（　　　），踏上人生新旅程。
-  answer: A
+  answer: H  # 揚帆啟航
 - sentence: 農夫長年在田裡工作，粗重的農事讓他（　　　）。
-  answer: D
+  answer: K  # 滿手老繭
 - sentence: 我們想（　　　）開一家新的飲料店，股東們都各投資一點吧。
-  answer: E
+  answer: F  # 集資
 - sentence: 公司（　　　）他到海外受訓。
-  answer: I
+  answer: J  # 派遣
 - sentence: 雖然家裡經濟不寬裕，爸媽仍靠著（　　　），努力供我念書。
-  answer: C
+  answer: I  # 節衣縮食
 - sentence: 富有的企業家（　　　），當場答應贊助全校一年的午餐費用。
-  answer: H
+  answer: G  # 大手一揮
 - sentence: 他每天關注（　　　）市場的變化，希望找到投資機會。
-  answer: B
-fill_in_blank_count: 5
+  answer: A  # 股票
+fill_in_blank_count: 8
 vocabulary:
 - word: 股票
   definition: 一種公司發給投資者的憑證，擁有股票即成為該公司的股東，可能賺錢也可能虧損。

--- a/backend/tests/test_lesson_yaml_answer_mapping_2015.py
+++ b/backend/tests/test_lesson_yaml_answer_mapping_2015.py
@@ -1,0 +1,182 @@
+"""Regression test for #2015 — lesson YAML fill_in_blank answer letter mapping.
+
+The lesson YAML parser previously emitted G6-L25 with the 8 fill_in_blank
+answer letters shuffled relative to the sentences, so semantically correct
+student answers were scored 0/0. This test pins the canonical letter→word
+resolution for G6-L25 to catch any future re-parse / edit that breaks it,
+and also runs a structural sanity check across every lesson in the
+catalog to surface similar issues early.
+
+Run:
+    cd backend && python -m pytest tests/test_lesson_yaml_answer_mapping_2015.py -v
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from app.services.lesson_loader import get_all_lessons, get_lesson_by_code
+from app.services.omo_question_schema import _build_question_schema
+
+
+# ---------------------------------------------------------------------------
+# G6-L25 specific — pinned semantic answers (issue #2015 fix)
+# ---------------------------------------------------------------------------
+
+# Maps each fill_in_blank sentence-fragment to the vocabulary word that fits
+# semantically. If the YAML's answer letter resolves to anything else, the
+# whole grading flow scores legitimate student work as 0 (#2015 reproducer).
+G6_L25_EXPECTED_ANSWERS: list[tuple[str, str]] = [
+    ("公司今年", "獲利"),
+    ("大學畢業後", "揚帆啟航"),
+    ("粗重的農事", "滿手老繭"),
+    ("開一家新的飲料店", "集資"),
+    ("到海外受訓", "派遣"),
+    ("經濟不寬裕", "節衣縮食"),
+    ("贊助全校一年的午餐費用", "大手一揮"),
+    ("關注（", "股票"),
+]
+
+
+def _find_lesson_g6_l25() -> dict:
+    lesson = get_lesson_by_code("G6-L25")
+    assert lesson is not None, "G6-L25 lesson YAML missing from catalog"
+    return lesson
+
+
+class TestG6L25AnswerMapping:
+    def setup_method(self) -> None:
+        self.lesson = _find_lesson_g6_l25()
+        self.questions = _build_question_schema(self.lesson)
+        # fb_* only — exclude mc_* / se_*
+        self.fb_questions = [q for q in self.questions if q["id"].startswith("fb_")]
+
+    def test_fill_in_blank_has_8_questions(self) -> None:
+        assert len(self.fb_questions) == 8, (
+            f"G6-L25 should produce 8 fb questions, got {len(self.fb_questions)}"
+        )
+
+    def test_fill_in_blank_count_matches_array_length(self) -> None:
+        """`fill_in_blank_count` field, when present, must equal the array length.
+
+        Note: ``lesson_loader`` does not currently propagate this field into
+        the loaded dict — it lives only in the raw YAML. We keep the YAML
+        value accurate (fixed 5→8 in this PR) but the runtime check is
+        skipped when the field is absent, since downstream code never reads it.
+        """
+        count_field = self.lesson.get("fill_in_blank_count")
+        actual_len = len(self.lesson.get("fill_in_blank") or [])
+        if count_field is None:
+            pytest.skip("fill_in_blank_count not propagated by lesson_loader; "
+                        "raw YAML was still corrected in this PR")
+        assert count_field == actual_len, (
+            f"G6-L25 fill_in_blank_count={count_field} but actual array has {actual_len} entries"
+        )
+
+    @pytest.mark.parametrize("idx,fragment_word", list(enumerate(G6_L25_EXPECTED_ANSWERS)))
+    def test_each_fb_answer_matches_sentence_semantically(
+        self,
+        idx: int,
+        fragment_word: tuple[str, str],
+    ) -> None:
+        """Each fb question's resolved word must match the sentence's intended meaning."""
+        sentence_fragment, expected_word = fragment_word
+        q = self.fb_questions[idx]
+        assert sentence_fragment in q["context"], (
+            f"fb_{idx + 1} context does not contain expected fragment "
+            f"{sentence_fragment!r}; got {q['context']!r}"
+        )
+        # `correct_word` is the resolved vocabulary word; `correct_answer`
+        # depends on lettered/free-form mode (which differs across lessons).
+        actual_word = q.get("correct_word") or q["correct_answer"]
+        assert actual_word == expected_word, (
+            f"fb_{idx + 1} {sentence_fragment!r} resolves to {actual_word!r}, "
+            f"expected {expected_word!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Catalog-wide structural sanity (cheap; catches future re-parse issues)
+# ---------------------------------------------------------------------------
+
+# Lessons that already have out-of-vocab-range fb answers when this guard was
+# introduced (#2015). They are tracked here so the structural test catches
+# *new* regressions immediately, but does not fail on the pre-existing data
+# debt. Each of these should be inspected and fixed in a separate Layer 2 PR
+# (see #2015 follow-up). Remove a lesson from this list when its YAML is
+# corrected.
+_KNOWN_OUT_OF_RANGE_PRE_2015: frozenset[str] = frozenset({
+    "G5-L4",
+    "G5-L27",
+    "G7-L07",
+    "G8-L12a",
+})
+
+
+class TestLessonCatalogStructuralSanity:
+    @classmethod
+    def setup_class(cls) -> None:
+        cls.lessons = list(get_all_lessons())
+        assert cls.lessons, "Catalog should contain at least one lesson"
+
+    def test_fill_in_blank_count_matches_array_length_for_all_lessons(self) -> None:
+        """Every lesson with both fields should have them in sync (#2015)."""
+        mismatches = []
+        for lesson in self.lessons:
+            fb = lesson.get("fill_in_blank")
+            count = lesson.get("fill_in_blank_count")
+            if fb is None or count is None:
+                continue
+            actual = len(fb) if isinstance(fb, list) else 0
+            if count != actual:
+                mismatches.append(
+                    (lesson.get("lesson_code") or lesson.get("title"), count, actual),
+                )
+        assert not mismatches, (
+            "Lessons with fill_in_blank_count != len(fill_in_blank): "
+            + ", ".join(f"{code}:count={c},actual={a}" for code, c, a in mismatches)
+        )
+
+    def test_fb_answer_letters_within_vocabulary_range(self) -> None:
+        """Every fb answer letter must point to a valid vocabulary index.
+
+        Catches the structural variant of #2015 where ``answer: X`` references
+        ``vocabulary[ord(X) - ord('A')]`` but X is out of range — even if
+        ``_resolve_letter_answer`` falls back to returning the raw letter,
+        the grading semantics are broken.
+
+        Lessons in ``_KNOWN_OUT_OF_RANGE_PRE_2015`` are excluded so this guard
+        catches *new* regressions while the pre-existing data debt is fixed
+        in a separate Layer 2 PR. Any new lesson hitting this assertion means
+        the parser (or a manual edit) re-introduced the #2015 class of bug.
+        """
+        new_failures = []
+        for lesson in self.lessons:
+            fb = lesson.get("fill_in_blank")
+            vocab = lesson.get("vocabulary")
+            if not isinstance(fb, list) or not isinstance(vocab, list):
+                continue
+            lesson_code = lesson.get("lesson_code") or lesson.get("title")
+            if lesson_code in _KNOWN_OUT_OF_RANGE_PRE_2015:
+                continue
+            vocab_len = len(vocab)
+            for i, item in enumerate(fb):
+                if not isinstance(item, dict):
+                    continue
+                ans = str(item.get("answer", "")).strip().upper()
+                if len(ans) != 1 or not ans.isalpha():
+                    # Non-letter answer (free-form text) — skip structural check
+                    continue
+                idx = ord(ans) - ord("A")
+                if idx >= vocab_len:
+                    new_failures.append((lesson_code, i + 1, ans, vocab_len))
+        assert not new_failures, (
+            "NEW out-of-range fb answers (not in _KNOWN_OUT_OF_RANGE_PRE_2015): "
+            + ", ".join(
+                f"{code}/fb_{n}:answer={a}(idx={ord(a) - ord('A')}),vocab_len={vl}"
+                for code, n, a, vl in new_failures
+            )
+        )

--- a/backend/tests/test_lesson_yaml_answer_mapping_2015.py
+++ b/backend/tests/test_lesson_yaml_answer_mapping_2015.py
@@ -73,7 +73,7 @@ def _all_raw_yamls() -> list[tuple[str, dict]]:
 
 
 # ---------------------------------------------------------------------------
-# G6-L25 specific — pinned semantic answers (issue #2015 fix)
+# G6-L24 and G6-L25 specific — pinned semantic answers (issue #2015 fix)
 # ---------------------------------------------------------------------------
 
 # Maps each fill_in_blank sentence-fragment to the vocabulary word that fits

--- a/backend/tests/test_lesson_yaml_answer_mapping_2015.py
+++ b/backend/tests/test_lesson_yaml_answer_mapping_2015.py
@@ -13,13 +13,63 @@ Run:
 
 import sys
 import os
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
+import yaml
 
 from app.services.lesson_loader import get_all_lessons, get_lesson_by_code
 from app.services.omo_question_schema import _build_question_schema
+
+
+# ---------------------------------------------------------------------------
+# Raw YAML access (for count integrity checks that lesson_loader strips out)
+# ---------------------------------------------------------------------------
+
+# Resolves to backend/data/lessons regardless of where pytest is invoked from.
+_LESSONS_ROOT = Path(__file__).resolve().parent.parent / "data" / "lessons"
+
+
+def _raw_yaml_for(lesson_code: str) -> dict:
+    """Load a single lesson's raw YAML file by lesson_code (e.g. "G6-L25").
+
+    Needed for checking ``fill_in_blank_count`` (and other ``*_count`` fields)
+    that ``lesson_loader`` does not propagate into the runtime dict — going
+    through ``get_lesson_by_code`` would always return None for these fields,
+    so the test would silently pass without exercising anything (Round 1 🔴).
+    """
+    # Prefer the most recent parsed layer; fall back to glob if structure changes.
+    candidate = _LESSONS_ROOT / "_parsed_2026-05-01" / f"{lesson_code}.yml"
+    if not candidate.exists():
+        matches = list(_LESSONS_ROOT.rglob(f"{lesson_code}.yml"))
+        assert matches, f"No raw YAML found for lesson {lesson_code}"
+        candidate = matches[0]
+    with candidate.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _all_raw_yamls() -> list[tuple[str, dict]]:
+    """Yield (lesson_code, raw_dict) for every lesson YAML in the catalog.
+
+    Used by catalog-wide structural checks that need to see fields stripped
+    by ``lesson_loader`` (e.g. ``fill_in_blank_count``).
+    """
+    out: list[tuple[str, dict]] = []
+    for path in sorted(_LESSONS_ROOT.rglob("*.yml")):
+        # Skip non-lesson YAML (e.g. config / index files); a lesson YAML
+        # always has at least ``title``.
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except Exception:
+            continue
+        if not isinstance(data, dict) or "title" not in data:
+            continue
+        code = data.get("lesson_code") or path.stem
+        out.append((code, data))
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -29,6 +79,17 @@ from app.services.omo_question_schema import _build_question_schema
 # Maps each fill_in_blank sentence-fragment to the vocabulary word that fits
 # semantically. If the YAML's answer letter resolves to anything else, the
 # whole grading flow scores legitimate student work as 0 (#2015 reproducer).
+G6_L24_EXPECTED_ANSWERS: list[tuple[str, str]] = [
+    ("教師職缺", "僧多粥少"),
+    ("岸邊巨浪", "翻騰"),
+    ("北風", "凜冽"),
+    ("這項改革", "徒勞無功"),
+    ("不知道該怎麼辦", "束手無策"),
+    ("忙完畢業展", "筋疲力竭"),
+    ("災後援助若拖延", "緩不濟急"),
+    ("雙重壓力", "窒息"),
+]
+
 G6_L25_EXPECTED_ANSWERS: list[tuple[str, str]] = [
     ("公司今年", "獲利"),
     ("大學畢業後", "揚帆啟航"),
@@ -41,15 +102,57 @@ G6_L25_EXPECTED_ANSWERS: list[tuple[str, str]] = [
 ]
 
 
-def _find_lesson_g6_l25() -> dict:
-    lesson = get_lesson_by_code("G6-L25")
-    assert lesson is not None, "G6-L25 lesson YAML missing from catalog"
+def _find_lesson(code: str) -> dict:
+    lesson = get_lesson_by_code(code)
+    assert lesson is not None, f"{code} lesson YAML missing from catalog"
     return lesson
+
+
+class TestG6L24AnswerMapping:
+    """G6-L24 had the same parser bug as G6-L25 (#2015) — 5/8 fb answers and
+    fill_in_blank_count both wrong.  Pinned here so a future re-parse cannot
+    silently regress it."""
+    def setup_method(self) -> None:
+        self.lesson = _find_lesson("G6-L24")
+        self.questions = _build_question_schema(self.lesson)
+        self.fb_questions = [q for q in self.questions if q["id"].startswith("fb_")]
+
+    def test_fill_in_blank_has_8_questions(self) -> None:
+        assert len(self.fb_questions) == 8, (
+            f"G6-L24 should produce 8 fb questions, got {len(self.fb_questions)}"
+        )
+
+    def test_fill_in_blank_count_matches_array_length(self) -> None:
+        raw = _raw_yaml_for("G6-L24")
+        count_field = raw.get("fill_in_blank_count")
+        actual_len = len(raw.get("fill_in_blank") or [])
+        assert count_field == actual_len, (
+            f"G6-L24 raw YAML fill_in_blank_count={count_field} "
+            f"but fill_in_blank array has {actual_len} entries"
+        )
+
+    @pytest.mark.parametrize("idx,fragment_word", list(enumerate(G6_L24_EXPECTED_ANSWERS)))
+    def test_each_fb_answer_matches_sentence_semantically(
+        self,
+        idx: int,
+        fragment_word: tuple[str, str],
+    ) -> None:
+        sentence_fragment, expected_word = fragment_word
+        q = self.fb_questions[idx]
+        assert sentence_fragment in q["context"], (
+            f"fb_{idx + 1} context does not contain expected fragment "
+            f"{sentence_fragment!r}; got {q['context']!r}"
+        )
+        actual_word = q.get("correct_word") or q["correct_answer"]
+        assert actual_word == expected_word, (
+            f"fb_{idx + 1} {sentence_fragment!r} resolves to {actual_word!r}, "
+            f"expected {expected_word!r}"
+        )
 
 
 class TestG6L25AnswerMapping:
     def setup_method(self) -> None:
-        self.lesson = _find_lesson_g6_l25()
+        self.lesson = _find_lesson("G6-L25")
         self.questions = _build_question_schema(self.lesson)
         # fb_* only — exclude mc_* / se_*
         self.fb_questions = [q for q in self.questions if q["id"].startswith("fb_")]
@@ -60,20 +163,19 @@ class TestG6L25AnswerMapping:
         )
 
     def test_fill_in_blank_count_matches_array_length(self) -> None:
-        """`fill_in_blank_count` field, when present, must equal the array length.
+        """`fill_in_blank_count` field in the raw YAML must equal array length.
 
-        Note: ``lesson_loader`` does not currently propagate this field into
-        the loaded dict — it lives only in the raw YAML. We keep the YAML
-        value accurate (fixed 5→8 in this PR) but the runtime check is
-        skipped when the field is absent, since downstream code never reads it.
+        ``lesson_loader`` does not propagate this field into the runtime dict,
+        so we check it directly against the raw YAML file. This catches the
+        kind of typo introduced in #2015 (`fill_in_blank_count: 5` when
+        actually 8 entries exist) even though no production code reads it.
         """
-        count_field = self.lesson.get("fill_in_blank_count")
-        actual_len = len(self.lesson.get("fill_in_blank") or [])
-        if count_field is None:
-            pytest.skip("fill_in_blank_count not propagated by lesson_loader; "
-                        "raw YAML was still corrected in this PR")
+        raw = _raw_yaml_for("G6-L25")
+        count_field = raw.get("fill_in_blank_count")
+        actual_len = len(raw.get("fill_in_blank") or [])
         assert count_field == actual_len, (
-            f"G6-L25 fill_in_blank_count={count_field} but actual array has {actual_len} entries"
+            f"G6-L25 raw YAML fill_in_blank_count={count_field} "
+            f"but fill_in_blank array has {actual_len} entries"
         )
 
     @pytest.mark.parametrize("idx,fragment_word", list(enumerate(G6_L25_EXPECTED_ANSWERS)))
@@ -123,18 +225,21 @@ class TestLessonCatalogStructuralSanity:
         assert cls.lessons, "Catalog should contain at least one lesson"
 
     def test_fill_in_blank_count_matches_array_length_for_all_lessons(self) -> None:
-        """Every lesson with both fields should have them in sync (#2015)."""
+        """Every lesson with both fields should have them in sync (#2015).
+
+        Reads raw YAML (not lesson_loader) because the loader strips
+        ``fill_in_blank_count`` — going through the runtime dict would
+        always skip and silently pass nothing.
+        """
         mismatches = []
-        for lesson in self.lessons:
-            fb = lesson.get("fill_in_blank")
-            count = lesson.get("fill_in_blank_count")
+        for code, raw in _all_raw_yamls():
+            fb = raw.get("fill_in_blank")
+            count = raw.get("fill_in_blank_count")
             if fb is None or count is None:
                 continue
             actual = len(fb) if isinstance(fb, list) else 0
             if count != actual:
-                mismatches.append(
-                    (lesson.get("lesson_code") or lesson.get("title"), count, actual),
-                )
+                mismatches.append((code, count, actual))
         assert not mismatches, (
             "Lessons with fill_in_blank_count != len(fill_in_blank): "
             + ", ".join(f"{code}:count={c},actual={a}" for code, c, a in mismatches)


### PR DESCRIPTION
# Issue #2015 修正說明

## 問題摘要

`backend/data/lessons/_parsed_2026-05-01/` 同一輪 parse 的兩課 fill_in_blank `answer` 字母與 `sentence` 語意完全錯位，導致學生 100% 寫對也判 0 分：
- **G6-L25**：8/8 全錯（本地實測 overall_score 從 0.00 → 0.46 後 confirmed）
- **G6-L24**：5/8 錯（catalog-wide test 修好後立即發現，同 parser bug）

本 PR 採 issue 提的三層解法的 **Layer 1（立即止血）**，並建立 regression test 防止再犯。

## 修正策略

issue 中討論的三層方案：

| Layer | 內容 | 本 PR 範圍 |
|-------|------|-----------|
| 1 | 手動修正 G6-L24 + G6-L25 fb answer + count | ✅ 本 PR |
| 2 | 修剩餘 4 課（G5-L4 / G5-L27 / G7-L07 / G8-L12a，allowlist 已標）+ audit script + parser 修根因 | ❌ Follow-up issue |
| 3 | `lesson_loader` schema validation | ❌ Follow-up |

Layer 1 範圍最小，立刻 unblock G6-L24 + G6-L25 的 OMO 批改流程，並建立 regression test 同步擋住未來再次發生。

## 修改檔案

| 檔案 | 說明 |
|------|------|
| `backend/data/lessons/_parsed_2026-05-01/G6-L24.yml` | 5 題 fb answer 字母改為語意正確的 letter（I→D, A→F, D→I, F→A, C→G）；`fill_in_blank_count: 5 → 8`；加 inline comment 標示 vocabulary index 對映 |
| `backend/data/lessons/_parsed_2026-05-01/G6-L25.yml` | 8 題 fb answer 字母全部改為語意正確的 letter；`fill_in_blank_count: 5 → 8`；加 inline comment 標示 vocabulary index 對映 |
| `backend/tests/test_lesson_yaml_answer_mapping_2015.py`（新檔） | regression test：`TestG6L24AnswerMapping`（10 test）+ `TestG6L25AnswerMapping`（10 test）+ catalog-wide structural sanity（2 test）= 22 passed |

## G6-L25 answer 對映表

vocabulary 對映：`A=股票 B=利潤 C=股東 D=積蓄 E=獲利 F=集資 G=大手一揮 H=揚帆啟航 I=節衣縮食 J=派遣 K=滿手老繭`

| fb | sentence 關鍵字 | 原 answer | 原 resolve | **修正後** | **resolve** |
|----|---------------|----------|-----------|----------|------------|
| 1 | 公司今年__大增 | F | 集資 ❌ | **E** | **獲利** ✓ |
| 2 | 大學畢業後__人生新旅程 | A | 股票 ❌ | **H** | **揚帆啟航** ✓ |
| 3 | 粗重的農事讓他__ | D | 積蓄 ❌ | **K** | **滿手老繭** ✓ |
| 4 | 我們想__開飲料店 | E | 獲利 ❌ | **F** | **集資** ✓ |
| 5 | 公司__他到海外受訓 | I | 節衣縮食 ❌ | **J** | **派遣** ✓ |
| 6 | 靠著__努力供我念書 | C | 股東 ❌ | **I** | **節衣縮食** ✓ |
| 7 | 富有的企業家__答應贊助 | H | 揚帆啟航 ❌ | **G** | **大手一揮** ✓ |
| 8 | 關注__市場 | B | 利潤 ❌ | **A** | **股票** ✓ |

## G6-L24 answer 對映表

vocabulary 對映：`A=束手無策 B=凜冽 C=屏氣凝神 D=僧多粥少 E=筋疲力竭 F=翻騰 G=窒息 H=緩不濟急 I=徒勞無功`

| fb | sentence 關鍵 | 原 | **修正** | 原 resolve → **修正 resolve** |
|----|--------------|---|------|--------------------------|
| 1 | 教師職缺，報名者百人 | I | **D** | 徒勞無功 → **僧多粥少** |
| 2 | 颱風巨浪 | A | **F** | 束手無策 → **翻騰** |
| 3 | 北風 | B | ✓ | 凜冽（無變動） |
| 4 | 改革令人遺憾 | D | **I** | 僧多粥少 → **徒勞無功** |
| 5 | 不知道該怎麼辦 | F | **A** | 翻騰 → **束手無策** |
| 6 | 忙完畢業展，希望休息 | E | ✓ | 筋疲力竭（無變動） |
| 7 | 災後援助拖延 | H | ✓ | 緩不濟急（無變動） |
| 8 | 雙重壓力快要__ | C | **G** | 屏氣凝神 → **窒息** |

## count 欄位修正

兩課 `fill_in_blank_count: 5 → 8`。`lesson_loader` 不將此欄位帶進 runtime dict，但 raw YAML 對數仍有資料品質意義。Round 1 review 後 test 改讀 raw YAML 直接驗證。

## Regression test 覆蓋

**G6-L24 specific（10 個 test）**：
- `test_fill_in_blank_has_8_questions`
- `test_fill_in_blank_count_matches_array_length`（讀 raw YAML）
- 8 個 parametrize `test_each_fb_answer_matches_sentence_semantically`

**G6-L25 specific（10 個 test）**：同上結構。

**Catalog-wide（2 個 test）**：
- `test_fill_in_blank_count_matches_array_length_for_all_lessons`：151 課全掃，count vs array 長度一致
- `test_fb_answer_letters_within_vocabulary_range`：每個 fb answer letter 必須在 vocabulary 範圍內，**新 lesson 出問題會擋下**

Pre-existing 4 課（Layer 2 範圍）暫時用 `_KNOWN_OUT_OF_RANGE_PRE_2015` allowlist 標記，新 lesson 出問題仍會被擋。Layer 2 PR 修完各 lesson 後從 allowlist 移除即可。

## 本地實測

修正前 (#2015 reproducer)：overall_score = **0.00**
修正後：overall_score = **0.46**（13 題裡 ~6 題對；剩 3 題沒對應該是 OCR 誤差 / 學生實際筆跡）
9 題實際 grade 的正確率：0% → **67%**

從 0 跳到 0.46 確認 YAML 修正方向正確。

## 測試方式

```bash
cd backend
.venv/bin/pytest tests/test_lesson_yaml_answer_mapping_2015.py -v
# 22 passed
```

## 迴歸測試

- 既有 OMO 批改 / dedup / signed URL / 排序（#1973）路徑不變 ✅
- `lesson_loader` 公開 API 不變 ✅
- 其他 149 課的批改不受 G6-L24 + G6-L25 修正影響 ✅
- `_KNOWN_OUT_OF_RANGE_PRE_2015` 允許 4 個 pre-existing 課文跳過 structural check（Layer 2 PR 處理）✅

## Follow-up

issue #2015 中描述的 Layer 2/3 屬於後續 PR 範圍（即將開新 issue 追蹤）：
- Layer 2：修剩餘 4 課（G5-L4 / G5-L27 / G7-L07 / G8-L12a）+ 寫 audit script 全面掃 151 課 + 找出原始 parser script 修根因
- Layer 3：`lesson_loader` 加 schema validation，invalid lesson 拒絕載入並 log error