### PR TITLE
test(specs): OMO grading ground-truth corpus + regression framework (#2028)

### DIFF
--- a/backend/specs/test_omo_grading_corpus.py
+++ b/backend/specs/test_omo_grading_corpus.py
@@ -1,0 +1,147 @@
+"""Corpus-driven grading regression — OMO 語詞應用 (issue 2028).
+
+spec_id: omo.grader.letter_mapping (corpus layer)
+human_spec: specs/modules/omo-assessment/INTENT.md
+corpus:     specs/modules/omo-assessment/fixtures/grading-corpus.yaml
+related_issues: [2015, 2028]
+
+Drives the REAL deterministic grading pipeline (no LLM, no grader edits):
+    _build_question_schema(lesson)
+      -> _validate_student_answer(raw, q)   # anti-fabrication coercion
+      -> _score_answer(student, correct, qtype)
+
+Each corpus case asserts (teacher-key lesson + simulated student fill) -> score.
+xfail cases document the issue-2015 letter-mapping drift; they flip to XPASS
+when the grader fix lands — that is the signal to make them hard expectations.
+
+Run: cd backend && python -m pytest specs/test_omo_grading_corpus.py -v
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+CORPUS = _REPO_ROOT / "specs" / "modules" / "omo-assessment" / "fixtures" / "grading-corpus.yaml"
+LESSON_DIR = _REPO_ROOT / "backend" / "data" / "lessons" / "_parsed_2026-05-01"
+
+
+def _grade(lesson: dict, student: dict) -> dict:
+    """Run one lesson + student answers through the deterministic pipeline."""
+    from app.services.omo_question_schema import _build_question_schema
+    from app.services.omo_scoring import _score_answer, _validate_student_answer
+
+    out = {}
+    for q in _build_question_schema(lesson):
+        qid = q["id"]
+        validated, _ok = _validate_student_answer(student.get(qid, ""), q)
+        out[qid] = _score_answer(validated, q["correct_answer"], q["type"])
+    return out
+
+
+def _load_cases() -> list[dict]:
+    return (yaml.safe_load(CORPUS.read_text()) or {}).get("cases", [])
+
+
+def _corpus_params():
+    params = []
+    for case in _load_cases():
+        # strict=True: when the grader bug (2015) is fixed, the case XPASSes and
+        # CI goes red — forcing whoever fixed it to delete the xfail and make it
+        # a hard expectation. A silent strict=False would let the drift marker rot.
+        marks = [pytest.mark.xfail(reason=case["xfail"], strict=True)] if case.get("xfail") else []
+        params.append(pytest.param(case, id=case["id"], marks=marks))
+    return params
+
+
+def test_corpus_file_exists():
+    assert CORPUS.is_file(), f"corpus missing: {CORPUS}"
+    assert _load_cases(), "corpus has no cases"
+
+
+@pytest.mark.parametrize("case", _corpus_params())
+def test_grading_corpus_case(case):
+    scores = _grade(case["lesson"], case["student"])
+    for qid, expected in case["expect"].items():
+        assert scores.get(qid) == expected, (
+            f"[{case['id']}] {case.get('desc', '')}: "
+            f"{qid} expected {expected}, got {scores.get(qid)}"
+        )
+
+
+def _vocab_bank_lessons() -> list[Path]:
+    out = []
+    for f in sorted(LESSON_DIR.glob("G[67]-L*.yml")):
+        try:
+            d = yaml.safe_load(f.read_text())
+        except Exception:
+            continue
+        if isinstance(d, dict) and isinstance(d.get("vocab_bank"), dict) and d.get("fill_in_blank"):
+            out.append(f)
+    return out
+
+
+def _perfect_student(lesson: dict) -> dict:
+    """The student who circles exactly the answer key for every blank."""
+    fb = lesson.get("fill_in_blank") or []
+    pairs = fb.items() if isinstance(fb, dict) else enumerate(fb)
+    student = {}
+    for key, item in pairs:
+        qid = str(key) if isinstance(fb, dict) else f"fb_{key + 1}"
+        ans = item.get("answer") if isinstance(item, dict) else str(item)
+        student[qid] = str(ans)
+    return student
+
+
+def _has_answer_beyond_AG(lesson: dict) -> bool:
+    """True if any fill_in_blank answer letter falls outside A-G.
+
+    These lessons currently break: a single H-K answer flips the whole lesson
+    out of 'lettered' mode into 'free_form', so the student's circled letter is
+    validated against vocab words, coerced to empty, and scored 0 (issue 2015).
+    """
+    fb = lesson.get("fill_in_blank") or []
+    pairs = fb.items() if isinstance(fb, dict) else enumerate(fb)
+    for _, item in pairs:
+        ans = item.get("answer") if isinstance(item, dict) else str(item)
+        if isinstance(ans, str) and len(ans.strip()) == 1 and ans.strip().upper() not in "ABCDEFG":
+            return True
+    return False
+
+
+def _lesson_sweep_params():
+    """One param per vocab_bank lesson. A-G-only lessons must hard-pass (catches
+    new regressions); lessons with H-K answers are xfail(strict) until 2015 lands."""
+    params = []
+    for f in _vocab_bank_lessons():
+        try:
+            d = yaml.safe_load(f.read_text())
+        except Exception:
+            continue
+        marks = []
+        if _has_answer_beyond_AG(d):
+            marks.append(pytest.mark.xfail(
+                reason="issue 2015 — H-K answer degrades lesson to free_form, perfect student scored 0",
+                strict=True,
+            ))
+        params.append(pytest.param(f, id=f.stem, marks=marks))
+    return params
+
+
+def test_perfect_student_sweep_has_lessons():
+    assert _vocab_bank_lessons(), "expected vocab_bank lessons in corpus dir"
+
+
+@pytest.mark.parametrize("lesson_file", _lesson_sweep_params())
+def test_perfect_student_scores_full(lesson_file):
+    """A student who circles exactly the answer key must score 100% on this lesson.
+
+    A-G-only lessons hard-pass (so a future regression there fails loudly);
+    H-K lessons are xfail until the grader fix (issue 2015) lands.
+    """
+    d = yaml.safe_load(lesson_file.read_text())
+    bad = [(qid, sc) for qid, sc in _grade(d, _perfect_student(d)).items()
+           if qid.startswith("fb_") and sc != 1.0]
+    assert not bad, f"{lesson_file.stem}: perfect-student answers scored <1.0: {bad}"

--- a/specs/build_registry.py
+++ b/specs/build_registry.py
@@ -34,6 +34,7 @@ _FIELDS = [
     "owns_code",
     "owns_data",
     "spec_tests",
+    "fixtures",
     "probes",
     "related_issues",
     "source_meetings",

--- a/specs/modules/omo-assessment/INTENT.md
+++ b/specs/modules/omo-assessment/INTENT.md
@@ -10,6 +10,9 @@ owns_data:
   - backend/data/lessons/_parsed_2026-05-01/**/*.yml
 spec_tests:
   - backend/specs/test_omo_assessment_spec.py
+  - backend/specs/test_omo_grading_corpus.py
+fixtures:
+  - specs/modules/omo-assessment/fixtures/grading-corpus.yaml
 probes:
   - specs/modules/omo-assessment/probes
 related_issues: [2015, 2027, 2028]

--- a/specs/modules/omo-assessment/fixtures/grading-corpus.yaml
+++ b/specs/modules/omo-assessment/fixtures/grading-corpus.yaml
@@ -1,0 +1,105 @@
+# AI-era grading regression corpus — OMO 語詞應用 (lettered fill-in-blank).
+#
+# Each case is a self-contained mini-lesson + a simulated student answer + the
+# grade we EXPECT. The harness in backend/specs/test_omo_grading_corpus.py drives
+# every case through the REAL deterministic pipeline, no LLM, no grader edits:
+#   _build_question_schema(lesson)   ->  per-question correct_answer + schema
+#   _validate_student_answer(raw, q) ->  anti-fabrication coercion
+#   _score_answer(student, correct, qtype) -> 0.0 / 1.0
+#
+# What actually drives SCORING here: in lettered mode the grader compares the
+# student's circled letter against the fill_in_blank `answer` letter. So a case's
+# pass/fail depends on `answer` + the validator, NOT on vocab_bank. vocab_bank is
+# included because it's the worksheet teacher-key context (and it's what triggers
+# the free_form degradation when answers go beyond A-G). The separate contract
+# "vocab_bank IS the letter->word source of truth for the displayed 正解" lives in
+# backend/specs/test_omo_assessment_spec.py, not here.
+#
+# `xfail` marks a case that SHOULD pass but currently fails because of the
+# grader letter-mapping bug (issue 2015): letters resolve via vocabulary[index]
+# and lettered mode is capped at A-G. When 2015 is fixed these flip to XPASS,
+# which is the signal to delete the xfail and make it a hard expectation.
+#
+# This file is meant to GROW. Every real-world edge case the team hits on a
+# paper worksheet (the 5/29 landing review listed many) becomes one more entry
+# here, so a future change that re-breaks it goes red in CI.
+
+cases:
+  # --- happy path -----------------------------------------------------------
+  - id: correct_letter_scores_full
+    desc: 學生圈對的字母 → 滿分
+    lesson:
+      vocab_bank: {A: 揚帆啟航, B: 股票, C: 集資}
+      vocabulary: [{word: 揚帆啟航}, {word: 股票}, {word: 集資}]
+      fill_in_blank: [{sentence: "公司今年（）大增，大家都有獎金", answer: C}]
+    student: {fb_1: C}
+    expect: {fb_1: 1.0}
+
+  - id: wrong_letter_scores_zero
+    desc: 學生圈錯字母 → 0 分
+    lesson:
+      vocab_bank: {A: 揚帆啟航, B: 股票, C: 集資}
+      vocabulary: [{word: 揚帆啟航}, {word: 股票}, {word: 集資}]
+      fill_in_blank: [{sentence: "...", answer: C}]
+    student: {fb_1: A}
+    expect: {fb_1: 0.0}
+
+  # --- edge cases from the 2026-05-29 landing review ------------------------
+  - id: blank_answer_no_crash    # 漏題
+    desc: 學生漏題（空白）→ 0 分且不可 crash
+    lesson:
+      vocab_bank: {A: 揚帆啟航, B: 股票, C: 集資}
+      vocabulary: [{word: 揚帆啟航}, {word: 股票}, {word: 集資}]
+      fill_in_blank: [{sentence: "...", answer: B}]
+    student: {fb_1: ""}
+    expect: {fb_1: 0.0}
+
+  - id: zhuyin_instead_of_letter    # 手寫注音
+    desc: 學生不會寫就寫注音 → 非法作答，coerce 空、不可當正解
+    lesson:
+      vocab_bank: {A: 揚帆啟航, B: 股票, C: 集資}
+      vocabulary: [{word: 揚帆啟航}, {word: 股票}, {word: 集資}]
+      fill_in_blank: [{sentence: "...", answer: B}]
+    student: {fb_1: "ㄍㄨˇ"}
+    expect: {fb_1: 0.0}
+
+  - id: digit_wrong_type    # 填錯型別 ABCD vs 1234
+    desc: 該圈 A-G 卻寫數字 → 非法 → 0 分
+    lesson:
+      vocab_bank: {A: 揚帆啟航, B: 股票, C: 集資}
+      vocabulary: [{word: 揚帆啟航}, {word: 股票}, {word: 集資}]
+      fill_in_blank: [{sentence: "...", answer: B}]
+    student: {fb_1: "2"}
+    expect: {fb_1: 0.0}
+
+  - id: lowercase_letter_accepted
+    desc: 學生寫小寫 b → 應視同 B（大小寫不敏感）
+    lesson:
+      vocab_bank: {A: 揚帆啟航, B: 股票, C: 集資}
+      vocabulary: [{word: 揚帆啟航}, {word: 股票}, {word: 集資}]
+      fill_in_blank: [{sentence: "...", answer: B}]
+    student: {fb_1: "b"}
+    expect: {fb_1: 1.0}
+
+  # --- the issue-2015 bug, pinned as xfail ----------------------------------
+  - id: letter_beyond_AG_should_score    # 越界字母 H-K
+    desc: >
+      學生圈正解 I → 應滿分。但只要有一題答案超過 A-G，fb_lettered 偵測就整課判 False，
+      模式退成 free_form：correct_answer 變成詞、allowed_values 變成 vocab words，
+      學生圈的 'I' 不在 vocab words 裡 → 被 validator coerce 成空 → 判 0。
+    lesson:
+      vocab_bank: {A: 揚帆啟航, B: 股票, C: 節衣縮食, D: 滿手老繭, E: 集資, F: 獲利, G: 股東, H: 大手一揮, I: 派遣}
+      vocabulary:
+        - {word: 揚帆啟航}
+        - {word: 股票}
+        - {word: 節衣縮食}
+        - {word: 滿手老繭}
+        - {word: 集資}
+        - {word: 獲利}
+        - {word: 股東}
+        - {word: 大手一揮}
+        - {word: 派遣}
+      fill_in_blank: [{sentence: "畢業後他準備（），踏上新旅程", answer: I}]
+    student: {fb_1: I}
+    expect: {fb_1: 1.0}
+    xfail: "issue 2015 — one H-K answer flips the lesson to free_form; circled 'I' is coerced empty and scored 0"

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -12,6 +12,9 @@ modules:
   - backend/data/lessons/_parsed_2026-05-01/**/*.yml
   spec_tests:
   - backend/specs/test_omo_assessment_spec.py
+  - backend/specs/test_omo_grading_corpus.py
+  fixtures:
+  - specs/modules/omo-assessment/fixtures/grading-corpus.yaml
   probes:
   - specs/modules/omo-assessment/probes
   related_issues:


### PR DESCRIPTION
Implements #2028 using the modular spec system. **Does not touch grader code** — that's issue 2015 (intern's). This is the test/regression layer only.

## What
Corpus-driven grading regression driving the **real deterministic pipeline** (no LLM): build_question_schema → validate_student_answer → score_answer.

- `specs/modules/omo-assessment/fixtures/grading-corpus.yaml` — teacher-key vs student-fill cases incl. 5/29 landing-review edge cases: blank / zhuyin / digit wrong-type / lowercase / wrong-letter / beyond-A-G. Designed to grow.
- `backend/specs/test_omo_grading_corpus.py` — corpus harness + per-lesson "perfect student" sweep. A-G lessons hard-pass (catch future regressions); H-K lessons xfail(strict) until the grader fix (issue 2015) lands.
- INTENT.md + build_registry.py — register new test + fixtures.

## Result
34 passed, 31 xfailed. The xfails precisely document the issue-2015 drift; strict=True turns them RED (XPASS) when the grader is fixed, forcing cleanup.

## Codex review (gpt-5.5)
Applied all 4 must-fixes: per-lesson sweep (was a single xfail hiding A-G regressions), strict=True xfails, clarified vocab_bank-vs-scoring comment, precise free_form-degradation description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)