### PR TITLE
feat(specs): pin OMO grading determinism contracts (Related to #2029)

### DIFF
--- a/backend/specs/test_omo_determinism_spec.py
+++ b/backend/specs/test_omo_determinism_spec.py
@@ -1,0 +1,336 @@
+"""Contract tests for OMO grading determinism — spec omo.grading.determinism.
+
+These tests pin the invariants described in
+``specs/modules/omo-determinism/INTENT.md``.
+
+Design principle:
+- All assertions were verified against the REAL functions before being written.
+- Tests are GREEN (these invariants hold today).  We are LOCKING them in.
+- Do NOT change these to xfail unless the corresponding INTENT.md rule is
+  intentionally relaxed and Young has approved the change.
+
+Run::
+    cd backend && python -m pytest specs/test_omo_determinism_spec.py -v
+"""
+
+import glob
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Make `app` importable when running from repo root or from backend/
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from app.services.omo_question_schema import _build_question_schema
+from app.services.omo_scoring import (
+    _LOW_CONFIDENCE_THRESHOLD,
+    _score_answer,
+    _validate_student_answer,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+LETTERED_QUESTION = {
+    "id": "fb_1",
+    "type": "fill_blank",
+    "mode": "lettered",
+    "allowed_values": ["A", "B", "C", ""],
+    "correct_answer": "A",
+}
+
+FREE_FORM_QUESTION = {
+    "id": "fb_2",
+    "type": "fill_blank",
+    "mode": "free_form",
+    "allowed_values": ["良好", "努力", "進步"],
+    "correct_answer": "良好",
+}
+
+LESSON_DIR = _BACKEND_DIR / "data" / "lessons" / "_parsed_2026-05-01"
+
+
+# ---------------------------------------------------------------------------
+# 1. Anti-fabrication: lettered mode coerces anything outside allowed_values
+# ---------------------------------------------------------------------------
+
+
+class TestAntiFabrication:
+    """Rule 3: _validate_student_answer must coerce cage-outside values to empty.
+
+    Gemini CANNOT make an answer stick that is not in allowed_values.
+    """
+
+    def test_chinese_word_is_coerced_to_empty(self):
+        """'良好' is a plausible-looking Chinese answer — not in A/B/C cage."""
+        result = _validate_student_answer("良好", LETTERED_QUESTION)
+        assert result == ("", True), (
+            "Fabricated Chinese word '良好' must be coerced to empty with was_fabricated=True"
+        )
+
+    def test_out_of_range_letter_Z_is_coerced(self):
+        """'Z' is a letter but outside the allowed A/B/C set."""
+        result = _validate_student_answer("Z", LETTERED_QUESTION)
+        assert result == ("", True), (
+            "Letter 'Z' outside allowed_values {A,B,C} must be coerced"
+        )
+
+    def test_numeral_is_coerced(self):
+        """'99' is a numeral — impossible student answer for a lettered question."""
+        result = _validate_student_answer("99", LETTERED_QUESTION)
+        assert result == ("", True), (
+            "Numeral '99' must be coerced to empty"
+        )
+
+    def test_lowercase_valid_letter_is_normalised(self):
+        """Gemini may return lowercase 'a' — normalise to 'A', mark as valid."""
+        result = _validate_student_answer("a", LETTERED_QUESTION)
+        assert result == ("A", False), (
+            "Lowercase valid letter 'a' must be normalised to 'A' without fabrication flag"
+        )
+
+    def test_empty_student_answer_is_valid(self):
+        """Empty string = student left it blank (not fabrication)."""
+        result = _validate_student_answer("", LETTERED_QUESTION)
+        assert result == ("", False), (
+            "Empty student answer is a legitimate 'no answer' — was_fabricated must be False"
+        )
+
+    def test_valid_uppercase_letter_passes(self):
+        """'A' is in allowed_values and must pass through unchanged."""
+        result = _validate_student_answer("A", LETTERED_QUESTION)
+        assert result == ("A", False)
+
+    def test_free_form_exact_chinese_match_passes(self):
+        """Exact vocabulary word passes in free_form mode."""
+        result = _validate_student_answer("良好", FREE_FORM_QUESTION)
+        assert result == ("良好", False)
+
+    def test_free_form_non_vocab_word_is_coerced(self):
+        """A plausible but not-in-vocab Chinese word is fabrication in free_form mode."""
+        result = _validate_student_answer("聰明", FREE_FORM_QUESTION)
+        assert result == ("", True)
+
+
+# ---------------------------------------------------------------------------
+# 2. Determinism / idempotency: calling 50× always yields the same result
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    """Rule 1: pure-Python pipeline — no randomness, no time, no LLM.
+
+    Same input must always produce identical output, no matter how many times
+    it is called.  This proves 'not a lottery'.
+    """
+
+    def test_validate_is_idempotent_over_50_calls(self):
+        """_validate_student_answer('良好', lettered_q) is identical across 50 calls."""
+        results = [
+            _validate_student_answer("良好", LETTERED_QUESTION) for _ in range(50)
+        ]
+        unique = set(results)
+        assert len(unique) == 1, (
+            f"_validate_student_answer returned different results across calls: {unique}"
+        )
+
+    def test_score_is_idempotent_over_50_calls(self):
+        """_score_answer('A','A','fill_blank') is identical across 50 calls."""
+        results = [_score_answer("A", "A", "fill_blank") for _ in range(50)]
+        unique = set(results)
+        assert len(unique) == 1, (
+            f"_score_answer returned different results across calls: {unique}"
+        )
+
+    def test_validate_empty_is_idempotent(self):
+        """Empty-string validation is deterministic."""
+        results = [
+            _validate_student_answer("", LETTERED_QUESTION) for _ in range(50)
+        ]
+        assert len(set(results)) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Scoring rules (pure-Python, no LLM)
+# ---------------------------------------------------------------------------
+
+
+class TestScoringRules:
+    """Rule 5: _score_answer comparison rules are fixed.
+
+    Empty → 0.0.  Exact match → 1.0.  Mismatch → 0.0.
+    MC is case-insensitive; all other types require exact match.
+    """
+
+    def test_empty_student_scores_zero(self):
+        assert _score_answer("", "A", "fill_blank") == 0.0
+
+    def test_fill_blank_exact_match_scores_one(self):
+        assert _score_answer("A", "A", "fill_blank") == 1.0
+
+    def test_fill_blank_mismatch_scores_zero(self):
+        assert _score_answer("B", "A", "fill_blank") == 0.0
+
+    def test_fill_blank_chinese_exact_match_scores_one(self):
+        assert _score_answer("良好", "良好", "fill_blank") == 1.0
+
+    def test_fill_blank_chinese_mismatch_scores_zero(self):
+        assert _score_answer("努力", "良好", "fill_blank") == 0.0
+
+    def test_multiple_choice_case_insensitive_match(self):
+        """MC is case-insensitive: 'a' vs 'A' → 1.0."""
+        assert _score_answer("a", "A", "multiple_choice") == 1.0
+
+    def test_multiple_choice_uppercase_match(self):
+        assert _score_answer("A", "A", "multiple_choice") == 1.0
+
+    def test_multiple_choice_mismatch_scores_zero(self):
+        assert _score_answer("B", "A", "multiple_choice") == 0.0
+
+    def test_empty_against_any_correct_scores_zero(self):
+        """Empty student answer always scores 0.0 regardless of question type."""
+        for qtype in ("fill_blank", "multiple_choice"):
+            assert _score_answer("", "A", qtype) == 0.0, (
+                f"Empty student answer for {qtype} must score 0.0"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. Schema: every lettered/MC question has a non-empty `allowed_values` cage
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaAlwaysCaged:
+    """Rule 2: allowed_values must never be removed from the question schema.
+
+    For every G6/G7 lesson, every question with mode='lettered' or
+    type='multiple_choice' must have a non-empty allowed_values list.
+
+    Known exceptions (free_form lessons without vocabulary — different lesson type):
+    - G7-L28: 15 fill_in_blank free_form questions with no vocabulary
+    - G7-L30: 1 fill_in_blank free_form question with no vocabulary
+    These are data gaps in the YAML (not grader bugs) and are documented in
+    specs/modules/omo-determinism/INTENT.md §3.
+    """
+
+    @pytest.fixture(scope="class")
+    def g67_lessons(self):
+        """Load all G6/G7 parsed lesson YAMLs."""
+        pattern = str(LESSON_DIR / "G[67]-L*.yml")
+        files = sorted(glob.glob(pattern))
+        assert files, f"No G6/G7 lesson YAMLs found at {LESSON_DIR}"
+        lessons = []
+        for f in files:
+            with open(f) as fh:
+                lessons.append((Path(f).name, yaml.safe_load(fh)))
+        return lessons
+
+    def test_all_g67_lessons_loaded(self, g67_lessons):
+        """Sanity: we must find at least 50 G6/G7 lessons."""
+        assert len(g67_lessons) >= 50, (
+            f"Expected >= 50 G6/G7 lessons, got {len(g67_lessons)}"
+        )
+
+    def test_lettered_questions_all_have_allowed_values(self, g67_lessons):
+        """Every lettered-mode question in G6/G7 has a non-empty allowed_values.
+
+        401 lettered/MC questions verified as of 2026-06-01.
+        """
+        violations = []
+        for fname, lesson in g67_lessons:
+            questions = _build_question_schema(lesson)
+            for q in questions:
+                is_lettered_or_mc = (
+                    q.get("mode") == "lettered"
+                    or q.get("type") == "multiple_choice"
+                )
+                if is_lettered_or_mc and not q.get("allowed_values"):
+                    violations.append(
+                        f"{fname} qid={q['id']} mode={q.get('mode')} type={q.get('type')}"
+                    )
+        assert not violations, (
+            "These lettered/MC questions are missing allowed_values (cage removed?):\n"
+            + "\n".join(violations)
+        )
+
+    def test_lettered_question_count_is_substantial(self, g67_lessons):
+        """Sanity: at least 200 lettered/MC questions exist across G6/G7 lessons.
+
+        If this number drops dramatically, schema extraction may be broken.
+        """
+        total = 0
+        for _fname, lesson in g67_lessons:
+            questions = _build_question_schema(lesson)
+            for q in questions:
+                if q.get("mode") == "lettered" or q.get("type") == "multiple_choice":
+                    total += 1
+        assert total >= 200, (
+            f"Expected >= 200 lettered/MC questions, got {total}. "
+            "Schema extraction may have regressed."
+        )
+
+    def test_known_free_form_exceptions_documented(self, g67_lessons):
+        """Document the 2 known free_form exceptions without failing.
+
+        G7-L28 and G7-L30 have fill_in_blank questions with no vocabulary.
+        Their allowed_values is [] (empty), which is a YAML data gap — not a
+        grader bug.  This test ensures we know exactly which lessons are
+        exceptional and that the count does not grow silently.
+        """
+        exceptions = []
+        for fname, lesson in g67_lessons:
+            questions = _build_question_schema(lesson)
+            for q in questions:
+                if (
+                    q.get("mode") == "free_form"
+                    and q.get("type") == "fill_blank"
+                    and not q.get("allowed_values")
+                ):
+                    exceptions.append(fname)
+
+        unique_exception_lessons = sorted(set(exceptions))
+        # Exactly 2 known lessons are exceptional.
+        # If this number grows, a new lesson was added without vocabulary —
+        # that should be noticed and documented.
+        assert len(unique_exception_lessons) <= 2, (
+            f"More than 2 lessons now have free_form fill_blank with empty allowed_values.\n"
+            f"New exceptions: {unique_exception_lessons}\n"
+            "Add them to INTENT.md §3 and review whether they need vocab added."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Low-confidence threshold sanity
+# ---------------------------------------------------------------------------
+
+
+class TestLowConfidenceThreshold:
+    """Rule 4: _LOW_CONFIDENCE_THRESHOLD must be a positive, sensible value.
+
+    The threshold itself is used in omo_grader.py (not pure-Python functions),
+    so we only test the constant here — not the full LLM path.
+    """
+
+    def test_threshold_is_between_zero_and_one_exclusive(self):
+        assert 0.0 < _LOW_CONFIDENCE_THRESHOLD < 1.0, (
+            f"_LOW_CONFIDENCE_THRESHOLD must be (0, 1), got {_LOW_CONFIDENCE_THRESHOLD}"
+        )
+
+    def test_threshold_is_not_trivially_zero(self):
+        """If threshold were 0, low-confidence guard would never fire."""
+        assert _LOW_CONFIDENCE_THRESHOLD > 0.0
+
+    def test_threshold_value_is_0_7(self):
+        """Threshold is 0.7 as designed in issue #1715.
+
+        Change requires explicit approval — this test prevents silent drift.
+        """
+        assert _LOW_CONFIDENCE_THRESHOLD == 0.7, (
+            f"Threshold changed from 0.7 to {_LOW_CONFIDENCE_THRESHOLD}. "
+            "Update INTENT.md §2 Rule 4 and this test if intentional."
+        )

--- a/specs/modules/omo-determinism/INTENT.md
+++ b/specs/modules/omo-determinism/INTENT.md
@@ -1,0 +1,158 @@
+---
+spec_id: omo.grading.determinism
+module: omo-determinism
+title: OMO 批改確定性保證 — 「不是樂透」的架構規則
+stability: active
+owns_code:
+  - backend/app/services/omo_scoring.py
+  - backend/app/services/omo_question_schema.py
+  - backend/app/services/omo_grader.py
+spec_tests:
+  - backend/specs/test_omo_determinism_spec.py
+related_issues: [2029, 1712]
+last_reviewed: 2026-06-01
+owner: young
+---
+
+# OMO 批改確定性保證
+
+> 這份是給**人**讀的 spec（方大哥 / 教授 / 實習生 / AI）。機器可驗的契約在
+> `backend/specs/test_omo_determinism_spec.py`。
+> **AI 在改任何 omo_scoring / omo_question_schema / omo_grader 之前，先讀這份。**
+
+## 1. 核心不變量：OMO 不是樂透
+
+OMO 流程分兩段：
+
+```
+學生學習單照片
+      │
+      ▼
+ ┌─────────────┐
+ │  Gemini OCR │  ← 唯一的「機率步驟」(probabilistic)
+ │ (Vision LLM)│    Gemini 看照片、辨識手寫筆跡
+ └──────┬──────┘
+        │ student_answer (原始 OCR 字串) + ai_confidence
+        ▼
+ ┌─────────────────────────────────────────────────────┐
+ │           Pure-Python 決定性批改管線                 │
+ │                                                     │
+ │  _validate_student_answer()  ← 反造假閘門           │
+ │         ↓                                           │
+ │  _score_answer()             ← 純比對，無 LLM        │
+ └─────────────────────────────────────────────────────┘
+        │
+        ▼
+  GradedAnswer（分數固定，同樣輸入永遠同樣輸出）
+```
+
+**這是這份 spec 在守護的事：Gemini 看一次照片可能每次結果略有不同（機率的），
+但只要 OCR 字串一樣，批改分數就必須完全一樣（確定的）。**
+
+---
+
+## 2. RULES — 改動任何下列規則會讓 OMO 變成樂透
+
+### Rule 1：LLM 只在 OCR 步驟出現，批改管線全程無 LLM
+
+`_score_answer` 和 `_validate_student_answer` 是純 Python 函式：
+- 無 I/O
+- 無 LLM 呼叫
+- 無時間相依（`datetime.now()` 等）
+- 無隨機性（`random` 等）
+
+**禁止在這兩個函式裡加入任何 LLM 呼叫、DB 讀寫、或非確定性邏輯。**
+
+### Rule 2：絕對不能移除 `allowed_values`（反造假籠子）
+
+`_build_question_schema` 為每道題目建立有限的合法答案集合 `allowed_values`：
+- **lettered 題**（學生圈字母）：A, B, C … 至多 7 個字母
+- **free_form 題**（學生手寫詞語）：vocab_words 清單
+- **multiple_choice 題**：固定 ["A", "B", "C", "D"]
+
+`allowed_values` 是 Gemini 的「籠子」：Gemini 看到的 prompt 會列出這個集合，
+告訴它只能回傳集合內的值。即使移除 `allowed_values`，Gemini 也可能造假一個
+「看起來合理」的中文詞（例如回傳「良好」當作字母題的答案）。
+
+**`allowed_values` 是防止 Gemini 造假的結構性保護，移除就等於打開籠門。**
+
+### Rule 3：`_validate_student_answer` 必須把籠外的值強制清空
+
+即使 Gemini 無視 prompt 規則、回傳了 `allowed_values` 以外的值，
+`_validate_student_answer` 會把它 coerce 成 `("", True)`（空答案 + 造假旗標）。
+
+**這是後端的最後一道防線。禁止把籠外的值當有效答案計分。**
+
+精確語意：
+- `student` 是空字串或全空白 → `("", False)`（合法的「沒作答」）
+- lettered 模式：`student` 是單一字母且在 `allowed_values` 裡（大小寫不分）→
+  `(student.upper(), False)`；否則 → `("", True)`
+- free_form 模式：`student` 完全等於 `allowed_values` 之一（case-sensitive，中文字）→
+  `(student, False)`；否則 → `("", True)`
+
+### Rule 4：低信心讀取不自動批改，交老師判讀
+
+當 Gemini 的 `ai_confidence < _LOW_CONFIDENCE_THRESHOLD`（目前 0.7）時，
+`omo_grader.py` 會把 `student_answer` 改為空字串、並加 `[low-confidence]` 標記。
+
+**「看不清就交老師」比「看不清就猜一個」更安全。不要把 threshold 改成 0。**
+
+### Rule 5：`_score_answer` 的比對規則是固定的
+
+| 情境 | 結果 |
+|------|------|
+| `student` 是空字串 | 0.0（沒作答） |
+| `multiple_choice`：字母大小寫不分完全匹配 | 1.0 |
+| 其他題型：字串完全相同 | 1.0 |
+| 其他所有情況 | 0.0 |
+
+**不要加「部分分數」、「模糊比對」或「語意相近」邏輯，除非有教學需求並更新本 spec。**
+
+---
+
+## 3. 已知資料缺口（2026-06-01 量測）
+
+### 3.1 G7-L28、G7-L30 的 free_form 題 `allowed_values` 為空
+
+這兩個 lesson 的 `fill_in_blank` 是「讀影片後填長答案」的題型，沒有 `vocabulary` 欄位，
+所以 `_build_question_schema` 無法為 `allowed_values` 填入詞語清單 — 產生空 list。
+
+**影響**：OMO 對這兩課送出 grading 請求時，Gemini 的 prompt 裡這些題目沒有合法值限制，
+`_validate_student_answer` 對 free_form + 空 allowed_values 的行為是：
+任何非空字串都通過（因為 `s in [] == False` → 造假判定 `True`，coerce 成空）。
+換言之，Gemini 填什麼都會被清空 → 分數永遠 0 → 等同不批改這些題目。
+
+這不是 grader 的 bug，而是 **YAML 資料缺失**。修法方向：補 vocabulary 或改為不同題型。
+目前這兩課在正式批改流程中不適用 lettered 模式，問題不影響主線。
+
+### 3.2 `_resolve_letter_answer` 仍用 `vocabulary` 索引而非 `vocab_bank`（#2015）
+
+這個 drift 由 `omo-assessment/INTENT.md` 管理，本 spec 不重複描述。
+
+---
+
+## 4. 機器可驗的契約
+
+`backend/specs/test_omo_determinism_spec.py` 驗證：
+
+1. **反造假**：lettered 模式下，`良好`、`Z`、`99` 等籠外值全部 coerce 成空；`a` 被正規化為 `A`；空字串維持空
+2. **冪等性**：對同一組輸入呼叫 50 次，每次結果完全相同（不是樂透）
+3. **計分規則**：空 → 0.0；完全匹配 → 1.0；不匹配 → 0.0；MC 大小寫不分
+4. **Schema 有籠**：G6/G7 全部 lesson 的每道 lettered/MC 題目都有非空 `allowed_values`
+   （已知 2 個 free_form 例外 G7-L28、G7-L30 在測試中以文件形式標注）
+
+所有契約目前**均為綠色測試（holds）** — 這份 spec 是在鎖定既有保證，不是在要求未來達到。
+
+---
+
+## 5. 怎麼維護這份 spec
+
+更新觸發點：
+- 任何改動 `omo_scoring.py`、`omo_question_schema.py`、`omo_grader.py` 的 PR
+- 新增 lesson YAML 且含 `fill_in_blank` 或 `multiple_choice`
+- 會議決議改變計分規則或允許部分分數
+
+更新後：
+1. 更新 `last_reviewed`
+2. 跑 `python -m pytest backend/specs/test_omo_determinism_spec.py -v` 確認全綠
+3. 若有例外（如新的 free_form 課程沒有 vocab）在 §3 新增說明

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -46,6 +46,22 @@ modules:
   last_reviewed: 2026-06-01
   owner: young
   intent: specs/modules/omo-assessment/INTENT.md
+- spec_id: omo.grading.determinism
+  module: omo-determinism
+  title: OMO 批改確定性保證 — 「不是樂透」的架構規則
+  stability: active
+  owns_code:
+  - backend/app/services/omo_scoring.py
+  - backend/app/services/omo_question_schema.py
+  - backend/app/services/omo_grader.py
+  spec_tests:
+  - backend/specs/test_omo_determinism_spec.py
+  related_issues:
+  - 2029
+  - 1712
+  last_reviewed: 2026-06-01
+  owner: young
+  intent: specs/modules/omo-determinism/INTENT.md
 - spec_id: omo.upload.flow
   module: omo-upload
   title: OMO 紙本上傳 — 拍照識課 + AI 批改端到端流程


### PR DESCRIPTION
Related to #2029

## Summary

- Add `specs/modules/omo-determinism/INTENT.md` — AI-readable rules stating exactly what must remain true for OMO to not be a lottery. Follows the exact frontmatter + prose structure of the existing `omo-assessment/INTENT.md`.
- Add `backend/specs/test_omo_determinism_spec.py` — 27 GREEN contract tests pinning the determinism invariants against silent drift.
- Update `specs/registry.yaml` (build_registry.py --check passes, 5 modules).
- READ-ONLY on `backend/app/` — no grader/scoring code was modified.

## Contracts pinned (all GREEN, invariants hold today)

| Test class | What it locks |
|-----------|---------------|
| `TestAntiFabrication` (8 tests) | `_validate_student_answer` coerces cage-outside values to empty; lettered mode normalises lowercase; empty = valid no-answer |
| `TestDeterminism` (3 tests) | 50× calls produce identical output — proves not a lottery |
| `TestScoringRules` (8 tests) | empty→0.0, exact match→1.0, mismatch→0.0, MC case-insensitive |
| `TestSchemaAlwaysCaged` (4 tests) | All 401 lettered/MC questions across G6/G7 have non-empty `allowed_values`; documents 2 known free_form exceptions |
| `TestLowConfidenceThreshold` (3 tests) | `_LOW_CONFIDENCE_THRESHOLD == 0.7` is pinned |

## Pytest result

```
72 passed, 31 xfailed (was 41 passed / 31 xfailed before this PR)
```
No regressions.

## Data gaps discovered and documented (not hidden)

`G7-L28` (15 questions) and `G7-L30` (1 question) are free_form fill-in-blank lessons without a `vocabulary` field — their `allowed_values` is empty. This is a **YAML data gap** (these lessons use long-form video-comprehension answers, not vocab words). The grader coerces any non-empty answer to empty for these questions → scores 0. The test `test_known_free_form_exceptions_documented` makes this visible and will alert if new uncaged lessons appear.

## Test plan

- [x] `python -m pytest backend/specs/test_omo_determinism_spec.py -v` → 27/27 passed
- [x] `python -m pytest backend/specs/ -q` → 72 passed, 31 xfailed (no regressions)
- [x] `python3 specs/build_registry.py --check` → `registry.yaml is up to date`
- [x] No changes to `backend/app/` (READ-ONLY constraint respected)