### PR TITLE
feat(specs): wire Gemini + Cursor to spec system

### DIFF
--- a/.cursor/rules/specs.mdc
+++ b/.cursor/rules/specs.mdc
@@ -1,0 +1,19 @@
+---
+description: Modular spec system — check specs/registry before editing owned backend code or lesson data
+globs:
+  - "backend/**"
+  - "specs/**"
+  - "frontend/src/config/**"
+alwaysApply: true
+---
+
+# Modular Spec System (`specs/`)
+
+Before editing backend code or lesson data, check whether it is owned by a spec module:
+
+1. Read `specs/registry.yaml` — the index listing each module's `owns_code` / `owns_data`.
+2. If the file you're changing belongs to a module → read that module's `specs/modules/<feature>/INTENT.md` (human-readable spec: what may/may not change) and, when relevant, `backend/specs/test_<feature>_spec.py` (the machine contract).
+3. After changes run `cd backend && python -m pytest specs/` — a failing contract means code/data drifted from intent (fix the code, or update the spec — pick one).
+4. For a new feature with no module → write `specs/modules/<feature>/INTENT.md` first, then the code.
+
+Purpose: load only the spec the current feature needs, instead of the whole PRD / all meeting notes — so the AI doesn't get confused by irrelevant context. Full overview: `specs/README.md`.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,20 @@
+# GEMINI.md — LingoLeap (國語文閱讀學習平台)
+
+AI 閱讀教學平台。前端 React 19 + Vite + Tailwind，後端 FastAPI + PostgreSQL + SQLAlchemy，部署於 GCP Cloud Run。完整慣例見 `CLAUDE.md` 與 `AGENTS.md`（本檔只列 Gemini 必讀的關鍵規則）。
+
+## Modular Spec System (`specs/`)
+
+改 backend code 或 lesson 資料前，**先查該段是否被某個 spec module 擁有**：
+
+1. 讀 `specs/registry.yaml` — 索引，列出每個 module 的 `owns_code` / `owns_data`
+2. 要動的檔案落在某 module → 讀該 `specs/modules/<feature>/INTENT.md`（人讀規格，寫明什麼能改/不能改）+ 需要時 `backend/specs/test_<feature>_spec.py`（機器契約）
+3. 改完跑 `cd backend && python -m pytest specs/` — 契約 fail = code/data 偏離意圖（修 code 或更新規格，二擇一）
+4. 新功能沒對應 module → 先建 `specs/modules/<feature>/INTENT.md` 再寫 code
+
+目的：只載入當下功能需要的規格，不吞整份 PRD / 全會議記錄，避免吃太多無關 context 而誤判。完整說明 `specs/README.md`。
+
+## 其他關鍵規則（同 CLAUDE.md）
+
+- 改 SQLAlchemy model / Alembic migration → 先看 `sqlalchemy-model-safety` 原則（FK index、cascade、idempotent DDL、single head）
+- 新增呼叫 LLM 的 FastAPI route → 先看 `llm-endpoint-hardening`（rate-limit、auth、input cap、fail-closed、reasoning field）
+- Git flow：`feature/* → staging → main`，PR review 過才 merge


### PR DESCRIPTION
Completes cross-AI coverage for the modular spec system. Now all 5 AI guidance files route to `specs/registry` before editing owned code:

| AI | guidance file | status |
|----|------|------|
| Claude | CLAUDE.md | ✅ (#2032) |
| Codex | AGENTS.md | ✅ (#2044) |
| Copilot | .github/copilot-instructions.md | ✅ (#2044) |
| Gemini | GEMINI.md | ✅ this PR |
| Cursor | .cursor/rules/specs.mdc | ✅ this PR |

Follow-up to issue 2029. 🤖 Generated with [Claude Code](https://claude.com/claude-code)