### PR TITLE
feat(specs): Wave 4 — 5 more modular spec modules (issue 2029)

### DIFF
--- a/backend/specs/test_dictionary_spec.py
+++ b/backend/specs/test_dictionary_spec.py
@@ -1,0 +1,179 @@
+"""Executable spec — dictionary service contracts.
+
+spec_id: dictionary.lookup
+canonical_source: backend/app/services/dictionary_service.py
+human_spec: specs/modules/dictionary/INTENT.md
+
+Only pure, DB-free / network-free functions are tested here:
+  - _strip_markup()
+  - _has_real_definition()
+  - _parse_moe_response()
+  - lookup_character() input-validation (ValueError path — no DB needed)
+
+The network / cache paths are 待查 (integration tests needed with mock httpx).
+
+Run:  cd backend && python -m pytest specs/test_dictionary_spec.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.dictionary_service import (
+    _has_real_definition,
+    _parse_moe_response,
+    _strip_markup,
+    lookup_character,
+)
+
+
+# =========================================================================
+# CONTRACT 1 — _strip_markup: removes moedict backtick/tilde annotations
+# =========================================================================
+
+def test_strip_markup_removes_backtick_tilde_pairs() -> None:
+    # moedict format: `word~ -> word
+    raw = "\x60陸地~\x60上~\x60高~\x60起~"
+    result = _strip_markup(raw)
+    assert result == "陸地上高起"
+
+
+def test_strip_markup_passthrough_no_markup() -> None:
+    plain = "陸地上高起的部分。"
+    assert _strip_markup(plain) == plain
+
+
+def test_strip_markup_empty_string_is_safe() -> None:
+    assert _strip_markup("") == ""
+
+
+def test_strip_markup_strips_stray_backtick_and_tilde() -> None:
+    """Remaining stray markers (after pair removal) are removed."""
+    raw = "test`only"
+    result = _strip_markup(raw)
+    assert "`" not in result
+    assert "~" not in result
+
+
+# =========================================================================
+# CONTRACT 2 — _has_real_definition: filters pronunciation-only heteronyms
+# =========================================================================
+
+def test_has_real_definition_returns_false_for_pron_note() -> None:
+    hetero = {"d": [{"f": "(一)之讀音。", "type": ""}]}
+    assert _has_real_definition(hetero) is False
+
+
+def test_has_real_definition_returns_true_for_real_definition() -> None:
+    hetero = {"d": [{"f": "陸地上高起的部分。", "type": "名"}]}
+    assert _has_real_definition(hetero) is True
+
+
+def test_has_real_definition_returns_false_for_empty_d() -> None:
+    assert _has_real_definition({"d": []}) is False
+
+
+def test_has_real_definition_returns_false_for_missing_d() -> None:
+    assert _has_real_definition({}) is False
+
+
+@pytest.mark.parametrize("note", [
+    "(一)之讀音。",
+    "(二)之又音。",
+    "(三)之俗音。",
+])
+def test_has_real_definition_handles_all_pron_note_patterns(note: str) -> None:
+    hetero = {"d": [{"f": note, "type": ""}]}
+    assert _has_real_definition(hetero) is False
+
+
+# =========================================================================
+# CONTRACT 3 — _parse_moe_response: well-formed output structure
+# =========================================================================
+
+_MINIMAL_MOE_RESPONSE = {
+    "c": "3",
+    "h": [
+        {
+            "b": "ㄕㄢ",
+            "d": [
+                {
+                    "f": "陸地上高起的部分。",
+                    "type": "名",
+                    "q": ["這座山很高。"],
+                    "e": [],
+                }
+            ],
+        }
+    ],
+}
+
+
+def test_parse_moe_returns_zhuyin() -> None:
+    parsed = _parse_moe_response(_MINIMAL_MOE_RESPONSE)
+    assert parsed["zhuyin"] == "ㄕㄢ"
+
+
+def test_parse_moe_returns_stroke_count_as_int() -> None:
+    parsed = _parse_moe_response(_MINIMAL_MOE_RESPONSE)
+    assert parsed["stroke_count"] == 3
+    assert isinstance(parsed["stroke_count"], int)
+
+
+def test_parse_moe_definitions_is_list() -> None:
+    parsed = _parse_moe_response(_MINIMAL_MOE_RESPONSE)
+    assert isinstance(parsed["definitions"], list)
+
+
+def test_parse_moe_definition_entry_has_required_keys() -> None:
+    parsed = _parse_moe_response(_MINIMAL_MOE_RESPONSE)
+    assert parsed["definitions"], "expected at least one definition"
+    entry = parsed["definitions"][0]
+    for key in ("type", "definition", "examples"):
+        assert key in entry, f"missing key {key!r} in definition entry"
+
+
+def test_parse_moe_empty_heteronyms_returns_empty_definitions() -> None:
+    """An API response with no heteronyms must not crash."""
+    parsed = _parse_moe_response({"h": []})
+    assert parsed["definitions"] == []
+    assert parsed["zhuyin"] is None
+    assert parsed["stroke_count"] is None
+
+
+def test_parse_moe_skips_pron_note_heteronym() -> None:
+    """When first heteronym is a pron-note, pick the next one with real defs."""
+    raw = {
+        "c": "2",
+        "h": [
+            {"b": "wǒ", "d": [{"f": "(一)之讀音。", "type": ""}]},
+            {"b": "ㄨㄛˇ", "d": [{"f": "代詞。", "type": "代"}]},
+        ],
+    }
+    parsed = _parse_moe_response(raw)
+    assert parsed["zhuyin"] == "ㄨㄛˇ"
+    assert any(d["definition"] == "代詞。" for d in parsed["definitions"])
+
+
+def test_parse_moe_missing_stroke_count_is_none() -> None:
+    raw = {"h": [{"b": "ㄕㄢ", "d": [{"f": "山。", "type": "名"}]}]}
+    parsed = _parse_moe_response(raw)
+    assert parsed["stroke_count"] is None
+
+
+# =========================================================================
+# CONTRACT 4 — lookup_character: ValueError on invalid input
+# =========================================================================
+
+def test_lookup_character_raises_on_empty_string() -> None:
+    with pytest.raises(ValueError, match="single Chinese character"):
+        lookup_character("", None)  # type: ignore[arg-type]
+
+
+def test_lookup_character_raises_on_multi_char() -> None:
+    with pytest.raises(ValueError, match="single Chinese character"):
+        lookup_character("山水", None)  # type: ignore[arg-type]
+
+
+def test_lookup_character_raises_on_two_char_string() -> None:
+    with pytest.raises(ValueError):
+        lookup_character("ab", None)  # type: ignore[arg-type]

--- a/backend/specs/test_learning_path_spec.py
+++ b/backend/specs/test_learning_path_spec.py
@@ -1,0 +1,209 @@
+"""Executable spec — learning path recommendation contracts.
+
+spec_id: learning.path.recommendation
+canonical_source: backend/app/services/learning_path_service.py
+related_issues: [252]
+human_spec: specs/modules/learning-path/INTENT.md
+
+Strategy:
+  1. Catalog-structure contracts (no DB) — always run.
+  2. Cold-start integration (student with no history) — uses a MagicMock DB
+     session that returns empty query results, exercising the full
+     recommend_next_stories() pipeline without any real database.
+
+The personalisation path (student with real session history) is 待查:
+it requires a PostgreSQL-compatible fixture, which is out of scope for
+the spec layer.
+
+Run:  cd backend && python -m pytest specs/test_learning_path_spec.py -v
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.learning_path_service import recommend_next_stories
+from app.services.lesson_loader import get_all_lessons
+
+
+# =========================================================================
+# CONTRACT 1 — lesson catalog structure (pre-condition for learning path)
+# =========================================================================
+
+@pytest.fixture(scope="module")
+def all_lessons() -> list[dict]:
+    lessons = get_all_lessons()
+    assert lessons, "get_all_lessons() must return a non-empty list"
+    return lessons
+
+
+def test_catalog_is_nonempty(all_lessons: list[dict]) -> None:
+    assert len(all_lessons) > 0
+
+
+def test_catalog_lessons_have_required_keys(all_lessons: list[dict]) -> None:
+    required = ("lesson_number", "grade", "title")
+    bad = [
+        (l.get("lesson_number"), k)
+        for l in all_lessons
+        for k in required
+        if k not in l
+    ]
+    assert not bad, f"lessons missing required keys: {bad[:10]}"
+
+
+def test_catalog_lesson_numbers_are_numeric(all_lessons: list[dict]) -> None:
+    """learning_path sorts by int(story_slug) — slugs must be numeric strings."""
+    non_numeric = [
+        l["lesson_number"]
+        for l in all_lessons
+        if not str(l["lesson_number"]).isdigit()
+    ]
+    assert not non_numeric, (
+        f"lesson_number must be numeric (used as story_slug): {non_numeric[:5]}"
+    )
+
+
+def test_catalog_grades_in_valid_range(all_lessons: list[dict]) -> None:
+    out_of_range = [l["lesson_number"] for l in all_lessons if l["grade"] not in range(4, 10)]
+    assert not out_of_range, (
+        f"lessons with grade outside [4, 9]: {out_of_range[:10]}"
+    )
+
+
+def test_catalog_titles_are_nonempty_strings(all_lessons: list[dict]) -> None:
+    bad = [
+        l["lesson_number"]
+        for l in all_lessons
+        if not isinstance(l.get("title"), str) or not l["title"].strip()
+    ]
+    assert not bad, f"lessons with missing/empty title: {bad[:10]}"
+
+
+# =========================================================================
+# Cold-start mock: DB session that returns empty results for a new student
+# (no LearningSession rows, no CharacterError rows)
+# =========================================================================
+
+def _make_empty_db_mock() -> MagicMock:
+    """Return a MagicMock that answers SQLAlchemy query chains with empty results.
+
+    recommend_next_stories() calls db.query(...).filter(...).order_by(...).all()
+    and db.query(...).join(...).filter(...).group_by(...).having(...).all().
+    All chains return [] here — the cold-start path.
+    """
+    db = MagicMock()
+    # Any query chain's terminal call (.all() / .scalar() / .first()) → empty
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+    db.query.return_value.join.return_value.filter.return_value.group_by.return_value.having.return_value.all.return_value = []
+    return db
+
+
+_NONEXISTENT_STUDENT_ID = 999_999
+
+
+@pytest.fixture(scope="module")
+def cold_start_recs() -> list[dict]:
+    db = _make_empty_db_mock()
+    return recommend_next_stories(
+        student_id=_NONEXISTENT_STUDENT_ID,
+        db=db,
+        limit=5,
+    )
+
+
+# =========================================================================
+# CONTRACT 2 — recommend_next_stories: return value structure
+# =========================================================================
+
+def test_recommendations_is_list(cold_start_recs: list) -> None:
+    assert isinstance(cold_start_recs, list)
+
+
+def test_recommendations_length_lte_limit(cold_start_recs: list) -> None:
+    assert len(cold_start_recs) <= 5
+
+
+def test_recommendations_have_required_keys(cold_start_recs: list) -> None:
+    required = ("story_slug", "title", "grade", "genre",
+                "difficulty_match_score", "reason")
+    bad = [
+        (r.get("story_slug"), k)
+        for r in cold_start_recs
+        for k in required
+        if k not in r
+    ]
+    assert not bad, f"recommendation entries missing keys: {bad}"
+
+
+# =========================================================================
+# CONTRACT 3 — ALL recommended story_slugs exist in the catalog
+# =========================================================================
+
+def test_recommended_slugs_exist_in_catalog(
+    cold_start_recs: list,
+    all_lessons: list[dict],
+) -> None:
+    """Core invariant: no fabricated lesson codes."""
+    valid_slugs = {str(l["lesson_number"]) for l in all_lessons}
+    invalid = [
+        r["story_slug"]
+        for r in cold_start_recs
+        if r["story_slug"] not in valid_slugs
+    ]
+    assert not invalid, (
+        f"recommended story_slugs not in catalog: {invalid}"
+    )
+
+
+# =========================================================================
+# CONTRACT 4 — grade in [4, 9] for all recommendations
+# =========================================================================
+
+def test_recommended_grades_in_valid_range(cold_start_recs: list) -> None:
+    out_of_range = [
+        (r["story_slug"], r["grade"])
+        for r in cold_start_recs
+        if r["grade"] not in range(4, 10)
+    ]
+    assert not out_of_range, (
+        f"recommendations with grade outside [4, 9]: {out_of_range}"
+    )
+
+
+# =========================================================================
+# CONTRACT 5 — reason field is a non-empty string
+# =========================================================================
+
+def test_recommended_reasons_are_nonempty(cold_start_recs: list) -> None:
+    bad = [
+        r["story_slug"]
+        for r in cold_start_recs
+        if not isinstance(r.get("reason"), str) or not r["reason"].strip()
+    ]
+    assert not bad, f"recommendations with empty reason: {bad}"
+
+
+# =========================================================================
+# CONTRACT 6 — no None elements in the returned list
+# =========================================================================
+
+def test_recommendations_contain_no_none(cold_start_recs: list) -> None:
+    nones = [i for i, r in enumerate(cold_start_recs) if r is None]
+    assert not nones, f"recommendation list contains None at positions: {nones}"
+
+
+# =========================================================================
+# CONTRACT 7 — limit parameter is respected for various values
+# =========================================================================
+
+@pytest.mark.parametrize("limit", [1, 3, 10])
+def test_limit_respected(limit: int) -> None:
+    db = _make_empty_db_mock()
+    recs = recommend_next_stories(
+        student_id=_NONEXISTENT_STUDENT_ID,
+        db=db,
+        limit=limit,
+    )
+    assert len(recs) <= limit

--- a/backend/specs/test_lesson_code_normalization_spec.py
+++ b/backend/specs/test_lesson_code_normalization_spec.py
@@ -1,0 +1,153 @@
+"""Executable spec — lesson code normalization contracts.
+
+spec_id: lesson.code.normalization
+canonical_source: backend/app/services/lesson_code_normalization.py
+owns_code: backend/app/services/lesson_code_normalization.py
+related_issues: [1889, 1669]
+human_spec: specs/modules/lesson-code-normalization/INTENT.md
+
+All functions under test are pure (no DB, no network) — every contract here
+is a hard assertion with no xfail markers.
+
+Run:  cd backend && python -m pytest specs/test_lesson_code_normalization_spec.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.lesson_code_normalization import (
+    CATALOG_TO_PARSED_OVERRIDE,
+    MULTI_LESSON_MAP,
+    MULTI_LESSON_PRIMARY,
+    halfwidth,
+    normalize_manifest_code,
+)
+
+
+# === CONTRACT 1 — normalize_manifest_code: leading-zero stripping ===
+
+@pytest.mark.parametrize("raw,expected", [
+    ("G4-L01",  "G4-L1"),
+    ("G4-L1",   "G4-L1"),   # already normalized
+    ("G4-L03a", "G4-L3a"),
+    ("G6-L01",  "G6-L1"),
+    ("G8-L04",  "G8-L4"),
+    ("G5-L20",  "G5-L20"),  # no leading zero — unchanged
+    ("G9-L05",  "G9-L5"),
+])
+def test_normalize_strips_leading_zero(raw: str, expected: str) -> None:
+    assert normalize_manifest_code(raw) == expected
+
+
+# === CONTRACT 2 — normalize_manifest_code: WW→文 prefix conversion ===
+
+@pytest.mark.parametrize("raw,expected", [
+    ("WW-L01", "文-L1"),
+    ("WW-L10", "文-L10"),
+    ("WW-L03", "文-L3"),
+])
+def test_normalize_converts_ww_prefix(raw: str, expected: str) -> None:
+    assert normalize_manifest_code(raw) == expected
+
+
+# === CONTRACT 3 — normalize_manifest_code: idempotency ===
+# Normalising an already-normalised code must be a no-op.
+
+@pytest.mark.parametrize("raw", [
+    "G4-L01", "G4-L1", "G4-L03a", "WW-L01", "WW-L10",
+    "G8-L04", "G5-L20", "G9-L05",
+])
+def test_normalize_is_idempotent(raw: str) -> None:
+    once = normalize_manifest_code(raw)
+    twice = normalize_manifest_code(once)
+    assert once == twice, (
+        f"normalize is not idempotent: {raw!r} -> {once!r} -> {twice!r}"
+    )
+
+
+# === CONTRACT 4 — normalize_manifest_code: pass-through for non-matching codes ===
+# Unknown / malformed codes must be returned unchanged, never raise.
+
+@pytest.mark.parametrize("raw", [
+    "RANDOM", "totally-wrong", "G4", "L01", "WW-NONUM",
+])
+def test_normalize_passthrough_unrecognised(raw: str) -> None:
+    result = normalize_manifest_code(raw)
+    assert result == raw, f"expected pass-through for {raw!r}, got {result!r}"
+
+
+def test_normalize_does_not_raise_on_empty_string() -> None:
+    # Empty string: no match → pass-through, no exception.
+    result = normalize_manifest_code("")
+    assert isinstance(result, str)
+
+
+# === CONTRACT 5 — halfwidth: full-to-half conversion ===
+
+@pytest.mark.parametrize("raw,expected", [
+    ("ＡＢＣ", "ABC"),
+    ("Ａ",     "A"),
+    ("ａ",     "a"),
+    ("ABC",    "ABC"),   # already halfwidth — unchanged
+    ("",       ""),      # empty — no crash
+    ("Ｇ４-Ｌ０１", "G4-L01"),
+])
+def test_halfwidth_conversion(raw: str, expected: str) -> None:
+    assert halfwidth(raw) == expected
+
+
+# === CONTRACT 6 — halfwidth: idempotency ===
+
+@pytest.mark.parametrize("raw", [
+    "ＡＢＣ", "ABC", "Ａ", "ａ", "",
+])
+def test_halfwidth_is_idempotent(raw: str) -> None:
+    once = halfwidth(raw)
+    twice = halfwidth(once)
+    assert once == twice, (
+        f"halfwidth is not idempotent: {raw!r} -> {once!r} -> {twice!r}"
+    )
+
+
+# === CONTRACT 7 — halfwidth: does not alter non-fullwidth characters ===
+
+def test_halfwidth_preserves_chinese_characters() -> None:
+    """CJK characters must pass through halfwidth unchanged."""
+    cjk_input = "山水花鳥"
+    assert halfwidth(cjk_input) == cjk_input
+
+
+# === CONTRACT 8 — CATALOG_TO_PARSED_OVERRIDE: keys are post-normalize form ===
+# Every key in the override map must already be in normalized form.
+# If a key re-normalizes to something different, the loader would look up the
+# wrong key and silently miss the override.
+
+def test_catalog_override_keys_are_already_normalized() -> None:
+    drifted = []
+    for key in CATALOG_TO_PARSED_OVERRIDE:
+        renorm = normalize_manifest_code(key)
+        if renorm != key:
+            drifted.append((key, renorm))
+    assert not drifted, (
+        f"CATALOG_TO_PARSED_OVERRIDE keys that are NOT in normalized form: {drifted}"
+    )
+
+
+# === CONTRACT 9 — CATALOG_TO_PARSED_OVERRIDE: no key == value (self-mapping) ===
+# A key that maps to itself is a no-op entry and should not exist.
+
+def test_catalog_override_no_self_mapping() -> None:
+    self_maps = [(k, v) for k, v in CATALOG_TO_PARSED_OVERRIDE.items() if k == v]
+    assert not self_maps, (
+        f"CATALOG_TO_PARSED_OVERRIDE has self-mapping entries: {self_maps}"
+    )
+
+
+# === CONTRACT 10 — MULTI_LESSON_MAP: secondary keys are disjoint from PRIMARY keys ===
+# A code should not appear as both a primary slot and a secondary (redirect) slot.
+
+def test_multi_lesson_maps_are_disjoint() -> None:
+    overlap = set(MULTI_LESSON_MAP) & set(MULTI_LESSON_PRIMARY)
+    assert not overlap, (
+        f"Codes appear in both MULTI_LESSON_MAP and MULTI_LESSON_PRIMARY: {overlap}"
+    )

--- a/backend/specs/test_listening_spec.py
+++ b/backend/specs/test_listening_spec.py
@@ -1,0 +1,169 @@
+"""Executable spec — listening evaluation guard contracts.
+
+spec_id: listening.eval.guards
+canonical_source: backend/app/services/listening_service.py
+related_issues: [1098]
+human_spec: specs/modules/listening/INTENT.md
+
+Tests cover the three pure-function guards only:
+  - _is_garbage_input()
+  - _is_verbatim_paste()
+  - RETELLING_EVAL_SCHEMA structure (schema is a plain dict, no runtime calls)
+
+The async evaluate_retelling() AI path is 待查 (needs mock of Vertex AI).
+The two short-circuit return values (score=0.0 and score=95.0) are validated
+indirectly by inspecting the constants in the source.
+
+Run:  cd backend && python -m pytest specs/test_listening_spec.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.listening_service import (
+    RETELLING_EVAL_SCHEMA,
+    _MIN_MEANINGFUL_CHARS,
+    _VERBATIM_SIMILARITY_THRESHOLD,
+    _is_garbage_input,
+    _is_verbatim_paste,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: a passage of realistic length for verbatim-paste tests
+# ---------------------------------------------------------------------------
+_PASSAGE = (
+    "小明走進教室，看到黑板上有一道算術題。"
+    "他拿起粉筆，仔細地把答案寫了上去。"
+    "老師微笑著點頭，全班同學都給他鼓掌。"
+    "小明感到非常高興，決定以後每天認真複習功課。"
+)
+
+
+# =========================================================================
+# CONTRACT 1 — _is_garbage_input: rejects short / digit-only / punct-only
+# =========================================================================
+
+def test_garbage_empty_string() -> None:
+    assert _is_garbage_input("") is True
+
+
+def test_garbage_whitespace_only() -> None:
+    assert _is_garbage_input("   ") is True
+
+
+def test_garbage_digits_only() -> None:
+    assert _is_garbage_input("1234") is True
+
+
+def test_garbage_digits_at_threshold_still_garbage() -> None:
+    """Exactly MIN_MEANINGFUL_CHARS digits — still garbage (all-digit pattern)."""
+    text = "1" * _MIN_MEANINGFUL_CHARS
+    assert _is_garbage_input(text) is True
+
+
+def test_garbage_punctuation_only() -> None:
+    assert _is_garbage_input("！？！？！") is True
+
+
+def test_garbage_below_min_chars_is_garbage() -> None:
+    """Fewer than MIN_MEANINGFUL_CHARS chars → garbage regardless of content."""
+    short = "好" * (_MIN_MEANINGFUL_CHARS - 1)
+    assert _is_garbage_input(short) is True
+
+
+def test_garbage_real_cjk_above_threshold_is_not_garbage() -> None:
+    """A meaningful CJK sentence of sufficient length is NOT garbage."""
+    text = "我記得課文說了"   # 7 chars, all CJK
+    assert _is_garbage_input(text) is False
+
+
+def test_garbage_mixed_digits_and_cjk_is_not_garbage() -> None:
+    """Digits mixed with real CJK content should not trigger the garbage guard."""
+    text = "第3段說了主人公"   # CJK + digit, len > MIN
+    assert _is_garbage_input(text) is False
+
+
+# =========================================================================
+# CONTRACT 2 — _is_verbatim_paste: detects copy-paste
+# =========================================================================
+
+def test_verbatim_exact_paste() -> None:
+    assert _is_verbatim_paste(_PASSAGE, _PASSAGE) is True
+
+
+def test_verbatim_minor_edit_still_triggers() -> None:
+    """Minor whitespace removal should still exceed 0.70 similarity."""
+    slightly_edited = _PASSAGE.replace("，", "").replace("。", "")
+    ratio_estimate = len(slightly_edited) / len(_PASSAGE)
+    # Only run if edited length is ≤ 1.2× original (fast-path not triggered)
+    if ratio_estimate <= 1.2:
+        result = _is_verbatim_paste(_PASSAGE, slightly_edited)
+        assert result is True
+
+
+def test_verbatim_completely_different_text() -> None:
+    different = "學生完成了作業，老師非常高興地稱讚了全班同學。"
+    assert _is_verbatim_paste(_PASSAGE, different) is False
+
+
+def test_verbatim_short_genuine_retelling() -> None:
+    """A short genuine retelling (not a paste) must return False."""
+    genuine = "課文說小明在教室裡解了一道算術題，老師很高興。"
+    assert _is_verbatim_paste(_PASSAGE, genuine) is False
+
+
+def test_verbatim_longer_than_120pct_is_not_paste() -> None:
+    """Input longer than 1.2× original triggers the fast-path and returns False."""
+    too_long = _PASSAGE * 2  # clearly > 1.2×
+    assert _is_verbatim_paste(_PASSAGE, too_long) is False
+
+
+# =========================================================================
+# CONTRACT 3 — RETELLING_EVAL_SCHEMA: required fields are present
+# =========================================================================
+
+REQUIRED_FIELDS = [
+    "score",
+    "key_points_covered",
+    "key_points_missed",
+    "feedback",
+    "encouragement",
+    "reasoning",
+]
+
+
+def test_schema_has_all_required_fields() -> None:
+    for field in REQUIRED_FIELDS:
+        assert field in RETELLING_EVAL_SCHEMA["required"], (
+            f"'{field}' missing from RETELLING_EVAL_SCHEMA['required']"
+        )
+
+
+def test_schema_reasoning_is_required() -> None:
+    """reasoning must be in required — CLAUDE.md standing rule for LLM judge outputs."""
+    assert "reasoning" in RETELLING_EVAL_SCHEMA["required"]
+
+
+def test_schema_properties_match_required() -> None:
+    """Every required field must also be declared in properties."""
+    props = set(RETELLING_EVAL_SCHEMA["properties"])
+    for field in RETELLING_EVAL_SCHEMA["required"]:
+        assert field in props, (
+            f"required field '{field}' not declared in schema properties"
+        )
+
+
+def test_schema_score_is_number_type() -> None:
+    assert RETELLING_EVAL_SCHEMA["properties"]["score"]["type"] == "NUMBER"
+
+
+# =========================================================================
+# CONTRACT 4 — guard constants are within expected ranges
+# =========================================================================
+
+def test_min_meaningful_chars_is_positive() -> None:
+    assert _MIN_MEANINGFUL_CHARS > 0
+
+
+def test_verbatim_threshold_is_between_0_and_1() -> None:
+    assert 0.0 < _VERBATIM_SIMILARITY_THRESHOLD < 1.0

--- a/backend/specs/test_prediction_spec.py
+++ b/backend/specs/test_prediction_spec.py
@@ -1,0 +1,222 @@
+"""Executable spec — prediction service rule-engine contracts.
+
+spec_id: prediction.difficulty
+canonical_source: backend/app/services/prediction_service.py
+related_issues: [254]
+human_spec: specs/modules/prediction/INTENT.md
+
+Only pure helper functions are tested here (no DB, no mocking required).
+The top-level predict_learning_difficulty() depends on DbSession and is covered
+by integration tests; those contracts are noted as 待查 in INTENT.md.
+
+Run:  cd backend && python -m pytest specs/test_prediction_spec.py -v
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.prediction_service import (
+    DECLINING_SESSIONS,
+    _check_declining_trend,
+    _check_stuck_count,
+    _compute_risk_level,
+    _empty_prediction,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stand-in for LearningSession; only accuracy & story_slug matter
+# here (both are simple attribute accesses in the helpers under test).
+# ---------------------------------------------------------------------------
+
+class _Session:
+    def __init__(self, accuracy: float | None, story_slug: str = "s1") -> None:
+        self.accuracy = accuracy
+        self.story_slug = story_slug
+
+
+# =========================================================================
+# CONTRACT 1 — _empty_prediction: safe fall-back structure
+# =========================================================================
+
+def test_empty_prediction_risk_level_is_low() -> None:
+    """No-data prediction must never claim high/medium risk."""
+    ep = _empty_prediction()
+    assert ep["risk_level"] == "low"
+
+
+def test_empty_prediction_confidence_is_zero() -> None:
+    ep = _empty_prediction()
+    assert ep["confidence_score"] == 0.0
+
+
+def test_empty_prediction_has_all_required_keys() -> None:
+    ep = _empty_prediction()
+    for key in ("risk_level", "risk_factors", "recommended_actions",
+                "confidence_score", "supporting_data"):
+        assert key in ep, f"missing key: {key!r}"
+
+
+def test_empty_prediction_lists_are_empty() -> None:
+    ep = _empty_prediction()
+    assert ep["risk_factors"] == []
+    assert ep["recommended_actions"] == []
+
+
+# =========================================================================
+# CONTRACT 2 — _compute_risk_level: only 3 valid levels
+# =========================================================================
+
+VALID_RISK_LEVELS = {"low", "medium", "high"}
+
+
+@pytest.mark.parametrize("factor_count,expected_level", [
+    (0, "low"),
+    (1, "low"),
+    (2, "medium"),
+    (3, "medium"),
+    (4, "high"),
+    (5, "high"),
+])
+def test_risk_level_mapping(factor_count: int, expected_level: str) -> None:
+    factors = [f"factor_{i}" for i in range(factor_count)]
+    sessions = [_Session(80.0)] * 5  # 5 sessions → data_confidence = 1.0
+    level, _ = _compute_risk_level(factors, sessions)
+    assert level == expected_level
+
+
+def test_compute_risk_level_returns_valid_level() -> None:
+    """The returned level string must always be one of the three valid values."""
+    for n_factors in range(8):
+        factors = [f"f{i}" for i in range(n_factors)]
+        level, _ = _compute_risk_level(factors, [_Session(80.0)] * 5)
+        assert level in VALID_RISK_LEVELS, (
+            f"invalid risk_level {level!r} for {n_factors} factors"
+        )
+
+
+# =========================================================================
+# CONTRACT 3 — _compute_risk_level: confidence_score in [0, 1]
+# =========================================================================
+
+@pytest.mark.parametrize("n_sessions", [0, 1, 3, 5, 10, 20])
+def test_confidence_score_in_range(n_sessions: int) -> None:
+    sessions = [_Session(80.0)] * n_sessions
+    _, conf = _compute_risk_level(["factor"], sessions)
+    assert 0.0 <= conf <= 1.0, f"confidence={conf} out of [0, 1] for {n_sessions} sessions"
+
+
+def test_confidence_increases_with_more_sessions() -> None:
+    """More session data → higher confidence (up to saturation)."""
+    _, conf_few = _compute_risk_level(["f"], [_Session(80.0)] * 2)
+    _, conf_many = _compute_risk_level(["f"], [_Session(80.0)] * 5)
+    assert conf_many >= conf_few
+
+
+# =========================================================================
+# CONTRACT 4 — _check_declining_trend: strict monotone decreasing
+# =========================================================================
+
+def test_declining_trend_detects_strict_decrease() -> None:
+    sessions = [_Session(90.0), _Session(80.0), _Session(70.0)]
+    result = _check_declining_trend(sessions)
+    assert result["is_declining"] is True
+
+
+def test_declining_trend_not_triggered_by_flat() -> None:
+    """Flat accuracy (no improvement, no decline) must NOT trigger the signal."""
+    sessions = [_Session(80.0), _Session(80.0), _Session(80.0)]
+    result = _check_declining_trend(sessions)
+    assert result["is_declining"] is False
+
+
+def test_declining_trend_not_triggered_by_improvement() -> None:
+    sessions = [_Session(70.0), _Session(80.0), _Session(90.0)]
+    result = _check_declining_trend(sessions)
+    assert result["is_declining"] is False
+
+
+def test_declining_trend_not_triggered_by_single_dip() -> None:
+    """Only the last DECLINING_SESSIONS values are checked."""
+    # Declining in the middle, but the last 3 are improving
+    sessions = [_Session(90.0), _Session(80.0), _Session(70.0),
+                _Session(75.0), _Session(80.0)]
+    result = _check_declining_trend(sessions)
+    assert result["is_declining"] is False
+
+
+def test_declining_trend_skips_none_accuracy() -> None:
+    """Sessions with accuracy=None are filtered before trend analysis."""
+    sessions = [_Session(None), _Session(90.0), _Session(80.0), _Session(70.0)]
+    result = _check_declining_trend(sessions)
+    assert result["is_declining"] is True
+
+
+def test_declining_trend_trend_list_has_no_nones() -> None:
+    sessions = [_Session(None), _Session(80.0), _Session(None), _Session(70.0)]
+    result = _check_declining_trend(sessions)
+    assert all(v is not None for v in result["trend"])
+
+
+# =========================================================================
+# CONTRACT 5 — _check_stuck_count: < 5% improvement = stuck
+# =========================================================================
+
+def test_stuck_count_single_stuck_story() -> None:
+    """Same story 3 times with < 5% improvement → count 1."""
+    sessions = [
+        _Session(60.0, "A"), _Session(62.0, "A"), _Session(63.0, "A"),
+    ]
+    assert _check_stuck_count(sessions) == 1
+
+
+def test_stuck_count_improved_story_not_stuck() -> None:
+    """Story with ≥ 5% improvement is NOT stuck."""
+    sessions = [
+        _Session(60.0, "A"), _Session(70.0, "A"), _Session(80.0, "A"),
+    ]
+    assert _check_stuck_count(sessions) == 0
+
+
+def test_stuck_count_two_stuck_stories() -> None:
+    sessions = [
+        _Session(60.0, "A"), _Session(61.0, "A"), _Session(62.0, "A"),
+        _Session(50.0, "B"), _Session(51.0, "B"), _Session(52.0, "B"),
+    ]
+    assert _check_stuck_count(sessions) == 2
+
+
+def test_stuck_count_requires_three_attempts() -> None:
+    """Fewer than 3 attempts for a story → cannot be stuck."""
+    sessions = [_Session(60.0, "A"), _Session(62.0, "A")]
+    assert _check_stuck_count(sessions) == 0
+
+
+def test_stuck_count_returns_nonnegative_int() -> None:
+    assert _check_stuck_count([]) == 0
+
+
+# =========================================================================
+# CONTRACT 6 — determinism: same input → same output for pure helpers
+# =========================================================================
+
+def test_declining_trend_is_deterministic() -> None:
+    sessions = [_Session(90.0), _Session(80.0), _Session(70.0)]
+    r1 = _check_declining_trend(sessions)
+    r2 = _check_declining_trend(sessions)
+    assert r1 == r2
+
+
+def test_stuck_count_is_deterministic() -> None:
+    sessions = [
+        _Session(60.0, "X"), _Session(61.0, "X"), _Session(62.0, "X"),
+    ]
+    assert _check_stuck_count(sessions) == _check_stuck_count(sessions)
+
+
+def test_compute_risk_level_is_deterministic() -> None:
+    factors = ["f1", "f2"]
+    sessions = [_Session(70.0)] * 4
+    r1 = _compute_risk_level(factors, sessions)
+    r2 = _compute_risk_level(factors, sessions)
+    assert r1 == r2

--- a/specs/modules/dictionary/INTENT.md
+++ b/specs/modules/dictionary/INTENT.md
@@ -1,0 +1,97 @@
+---
+spec_id: dictionary.lookup
+module: dictionary
+title: MOE 字典查詢 — 查無字優雅降級 + 結構驗證
+stability: active
+canonical_source: backend/app/services/dictionary_service.py
+owns_code:
+  - backend/app/services/dictionary_service.py
+spec_tests:
+  - backend/specs/test_dictionary_spec.py
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# MOE 字典查詢（Dictionary Service）
+
+> 這份是給**人**讀的 spec（方大哥 / 教授 / 實習生）。機器可驗的契約在
+> `backend/specs/test_dictionary_spec.py`。
+> 改動 `dictionary_service.py` 前先讀這份。
+
+## 1. 這個 module 在管什麼
+
+向教育部國語辭典（moedict.tw）查詢單一漢字的注音、筆畫數、定義，並以 DB 快取結果。
+學生在生字練習時點選查詢，教師可看到定義和例句。
+
+## 2. 核心不變量
+
+### 2.1 `lookup_character()` 對非法輸入 raise `ValueError`
+
+以下兩種情況明確 raise `ValueError`（呼叫者需處理）：
+- 空字串 `""`
+- 長度 > 1 的字串（例如 `"山水"`）
+
+函數文件：`"character must be a single Chinese character"`
+
+### 2.2 parse 結果結構完整
+
+`_parse_moe_response(raw)` 對任何合法 moedict JSON 回應返回完整結構：
+
+```python
+{
+    "zhuyin":      str | None,
+    "stroke_count": int | None,
+    "definitions": list[dict],   # 可為空 list，但不是 None
+}
+```
+
+- `definitions` 中每個 entry 都有 `"type"`、`"definition"`、`"examples"` 三個 key
+- 空 heteronym list（`{"h": []}`）返回 `definitions: []`，不 raise
+
+### 2.3 `_has_real_definition()` 過濾讀音注記
+
+部分漢字（例如「我」）第一個讀音是純讀音注記，例如 `"(一)之讀音。"`，
+這不是真正的定義。`_has_real_definition()` 返回 `False` 讓 `_parse_moe_response()`
+跳到有實質內容的讀音。
+
+### 2.4 `_strip_markup()` 移除 moedict 反引號標注
+
+moedict 回應使用 `` `word~ `` 格式標注注音。`_strip_markup()` 把它清掉後
+文字才能正常顯示。函數對無標注文字 pass-through，對空字串安全。
+
+### 2.5 `lookup_character()` 在 API 不可用時不 crash
+
+當 `_fetch_from_api()` 拋出任何例外（網路超時、HTTP 5xx 等），
+`lookup_character()` catch 後返回帶 `"error": "dictionary_unavailable"` 的合法 dict，
+不向上傳遞例外。
+
+**待查**：這個降級路徑只能在整合測試中驗證（需要 mock httpx）。
+本 spec 測試只覆蓋純函數（`_parse_moe_response`、`_strip_markup`、`_has_real_definition`）
+和 `ValueError` 輸入驗證。
+
+### 2.6 `lookup_characters_batch()` 對無效字元 graceful（不中斷整個 batch）
+
+批次查詢中，單一無效字元會被記錄但不中斷其餘字元的查詢；
+回傳 list 長度等於輸入 list 長度。
+
+## 3. 允許 / 禁止的改動
+
+✅ **允許**
+- 新增 source（目前只有 `"moedict"`），只要 parse 結果遵守 2.2 的結構
+- 調整 `REQUEST_TIMEOUT` 常數
+
+⛔ **禁止（會破壞契約）**
+- 讓 `lookup_character()` 對空字串 pass-through（不 raise）——呼叫者依賴 ValueError 做輸入驗證
+- 讓 `_parse_moe_response()` 在 `definitions` 為空時返回 `None`（前端做 `len()` 呼叫）
+- 讓 `_has_real_definition()` 把讀音注記視為真定義（顯示 `(一)之讀音` 給學生看很奇怪）
+
+## 4. 教學 / 產品脈絡
+
+- 字典查詢在「生字練習」步驟中出現，學生可點選生字查看注音和例句
+- 結果快取在 `DictionaryCache` table，避免對 moedict API 重複查詢
+- `not_found: True` 的快取 entry 記住「這個字 moedict 沒有」，下次直接返回空結果而不重查
+
+## 5. Open questions
+
+- 待查：`lookup_character()` 在 API timeout 時的降級路徑（需要整合測試 with mock httpx）
+- 待查：`DictionaryCache` 是否需要 TTL 過期機制（moedict 資料會更新嗎？）

--- a/specs/modules/learning-path/INTENT.md
+++ b/specs/modules/learning-path/INTENT.md
@@ -1,0 +1,102 @@
+---
+spec_id: learning.path.recommendation
+module: learning-path
+title: 個別化學習路徑推薦 — 推薦課文必須在課程目錄中存在
+stability: active
+canonical_source: backend/app/services/learning_path_service.py
+owns_code:
+  - backend/app/services/learning_path_service.py
+spec_tests:
+  - backend/specs/test_learning_path_spec.py
+related_issues: [252]
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# 個別化學習路徑推薦（Learning Path Service）
+
+> 這份是給**人**讀的 spec（方大哥 / 教授 / 實習生）。機器可驗的契約在
+> `backend/specs/test_learning_path_spec.py`。
+> 改動 `learning_path_service.py` 前先讀這份。
+
+## 1. 這個 module 在管什麼
+
+`recommend_next_stories()` 以純演算法（無 LLM 呼叫）分析學生學習歷程，
+從課程目錄中選出最適合的下一篇課文（預設推薦 5 篇）。
+
+**演算法不隨機，不呼叫外部服務；相同輸入在測試環境下產生相同輸出。**
+
+## 2. 推薦來源
+
+推薦清單的課文**全部來自 `get_all_lessons()` 返回的課程目錄**（`backend/data/lessons/`）。
+函數不自行捏造 `story_slug` — 所有推薦的 `story_slug` 必定是 `str(lesson["lesson_number"])`
+對某個真實 lesson 的計算結果。
+
+**這是最重要的不變量**：推薦不存在的課文 = 前端 API 返回 404 = 學生頁面空白。
+
+## 3. 核心不變量
+
+### 3.1 推薦課文的 story_slug 必須在課程目錄中存在
+
+```
+returned story_slug ∈ {str(l["lesson_number"]) for l in get_all_lessons()}
+```
+
+### 3.2 返回 list 長度 ≤ limit 參數
+
+`recommend_next_stories(student_id, db, limit=N)` 返回的 list 長度 ≤ N。
+（候選課文少於 limit 時，返回所有候選而不是 pad None）
+
+### 3.3 每筆推薦結果包含必要欄位
+
+```python
+{
+    "story_slug":             str,
+    "title":                  str,
+    "grade":                  int,
+    "genre":                  str,
+    "difficulty_match_score": int,
+    "reason":                 str,  # 非空
+}
+```
+
+### 3.4 grade 在合法範圍 [4, 9]
+
+目前課程目錄只有 4–9 年級。推薦結果的 `grade` 欄位必定在此範圍。
+
+### 3.5 課程目錄本身（`get_all_lessons()` 返回值）的結構守恆
+
+這是推薦演算法的「輸入合法性」前提：
+- 返回 list 非空（有課文才能推薦）
+- 每個 lesson 有 `lesson_number`（numeric）、`grade`（int）、`title`（str）
+- `grade` 在 [4, 9]
+
+## 4. 演算法評分摘要（給讀 code 的人）
+
+| 因子 | 分數 |
+|------|------|
+| 難度完全符合（同年級）| +30 |
+| 難度接近（±1 年級）| +20 |
+| 難度稍遠（±2 年級）| +10 |
+| 每個卡關生字在課文中出現 | +5（最多 +25）|
+| 最近嘗試過（7 天內）| -15 |
+| 上一篇課文同類型重複 | -10 |
+| 已精熟（正確率 ≥ 80%）| 排除不推薦 |
+
+## 5. 待查（DB 依賴路徑，spec 層無法測試）
+
+- `recommend_next_stories()` 主入口依賴 `DbSession`（`LearningSession` + `CharacterError` 查詢）
+- 學生有歷史資料時的個人化推薦正確性屬整合測試範疇
+- `well_done_slugs` 排除邏輯（accuracy ≥ 80%）和 `recently_attempted_slugs` 的 timezone 處理
+  均需 DB mock 才能驗證，列為 `待查`
+
+## 6. 允許 / 禁止的改動
+
+✅ **允許**
+- 調整評分常數（`DIFFICULTY_EXACT`、`CHAR_BONUS_PER_CHAR` 等）
+- 新增評分因子
+
+⛔ **禁止（會破壞契約）**
+- 讓推薦結果包含不在課程目錄中的 `story_slug`（前端直接用 slug 發 API 請求）
+- 讓返回 list 包含 `None` 元素
+- 讓 `reason` 欄位為空字串（前端直接顯示給學生）

--- a/specs/modules/lesson-code-normalization/INTENT.md
+++ b/specs/modules/lesson-code-normalization/INTENT.md
@@ -1,0 +1,100 @@
+---
+spec_id: lesson.code.normalization
+module: lesson-code-normalization
+title: 課文代碼正規化 — 零填充剝除 + WW→文 轉換 + 全形→半形
+stability: active
+canonical_source: backend/app/services/lesson_code_normalization.py
+owns_code:
+  - backend/app/services/lesson_code_normalization.py
+spec_tests:
+  - backend/specs/test_lesson_code_normalization_spec.py
+related_issues: [1889, 1669]
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# 課文代碼正規化
+
+> 這份是給**人**讀的 spec（方大哥 / 教授 / 實習生）。機器可驗的契約在
+> `backend/specs/test_lesson_code_normalization_spec.py`。
+> 改動 `lesson_code_normalization.py` 或 `lesson_loader.py` 前先讀這份。
+
+## 1. 這個 module 在管什麼
+
+課程系統有兩層代碼：
+
+- **catalog code**（課程目錄用）：例如 `G4-L01`、`WW-L01`、`G8-L03a`
+- **parsed YAML lesson_code**（檔案層用）：例如 `G4-L1`、`文-L1`、`G8-L3a`
+
+兩層之間的差距由三種轉換填平：
+
+| 轉換 | 例子 |
+|------|------|
+| 零填充剝除 | `G4-L01` → `G4-L1`（`L0N` → `LN`）|
+| WW→文前綴 | `WW-L01` → `文-L1`（文言文課文）|
+| 全形→半形 | `Ａ`、`Ｂ` → `A`、`B`（YAML 答案偶爾打成全形）|
+
+此外，還有兩張靜態例外表：
+- `CATALOG_TO_PARSED_OVERRIDE`：G8 offset 修正 + G7-L31 multitext 對應（18 個 entry）
+- `MULTI_LESSON_MAP` / `MULTI_LESSON_PRIMARY`：多課合一 YAML 的副鍵→主鍵對應
+
+## 2. 核心不變量
+
+### 2.1 `normalize_manifest_code()` 是冪等的
+
+```
+normalize(normalize(x)) == normalize(x)    # 對所有合法代碼成立
+```
+
+一個代碼跑兩次正規化結果和跑一次相同。這是 `lesson_loader.py` 依賴的前提。
+
+### 2.2 等效代碼映射到同一規範形式
+
+```
+normalize("G4-L01") == normalize("G4-L1")  # 都 → "G4-L1"
+normalize("WW-L01") == "文-L1"
+normalize("G4-L03a") == "G4-L3a"
+```
+
+### 2.3 不符合模式的代碼 pass-through（原樣返回）
+
+```
+normalize("RANDOM") == "RANDOM"
+normalize("totally-wrong") == "totally-wrong"
+```
+
+函數不 raise、不返回 None，不應破壞呼叫者的邏輯。
+
+### 2.4 `halfwidth()` 是冪等的，且映射正確範圍
+
+全形 ASCII 字母（U+FF01–U+FF5E）轉半形；範圍外字元原樣保留。
+
+```
+halfwidth("ＡＢＣ") == "ABC"
+halfwidth("ABC") == "ABC"
+halfwidth(halfwidth(x)) == halfwidth(x)    # 冪等
+```
+
+## 3. 允許 / 禁止的改動
+
+✅ **允許**
+- 在 `CATALOG_TO_PARSED_OVERRIDE` 新增 G8/G9 等 offset 修正 entry
+- 在 `MULTI_LESSON_MAP` 新增多課合一 YAML 的副鍵
+
+⛔ **禁止（會破壞契約）**
+- 讓 `normalize_manifest_code()` 在已正規化代碼上再次改動（破壞冪等性）
+- 讓函數對不符合任何模式的輸入 raise exception（呼叫者沒有防禦）
+- 讓 `halfwidth()` 改動非全形 ASCII 字元（例外地轉換中文字符）
+
+## 4. 教學 / 產品脈絡
+
+- `normalize_manifest_code()` 由 `lesson_loader.py` 在 Level-1 catalog 掃描時呼叫，
+  把 catalog YAML 的 `lesson_code` 欄位轉成與 Level-2 parsed YAML 匹配的形式。
+- `halfwidth()` 由 OMO grader 呼叫，處理學生 fill-in-blank 答案的全形字母輸入。
+- G8 offset 的根本原因：G8 課程目錄用「課程大綱編號」（含 sub-letter a/b），
+  但已解析的 YAML 使用「解析順序流水號」，兩者差異由 `CATALOG_TO_PARSED_OVERRIDE` 橋接。
+
+## 5. Open questions
+
+- G9 是否也有類似 G8 的 offset 問題？（目前 `CATALOG_TO_PARSED_OVERRIDE` 沒有 G9 entry，待核查）
+- `WW-` 前綴的課文是否全部已入庫？（`文-L*` 代碼目前有幾個待查）

--- a/specs/modules/listening/INTENT.md
+++ b/specs/modules/listening/INTENT.md
@@ -1,0 +1,103 @@
+---
+spec_id: listening.eval.guards
+module: listening
+title: 聽力評估安全門 — 垃圾輸入拒評 + 逐字貼上短路 + 分數 Clamp
+stability: active
+canonical_source: backend/app/services/listening_service.py
+owns_code:
+  - backend/app/services/listening_service.py
+spec_tests:
+  - backend/specs/test_listening_spec.py
+related_issues: [1098]
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# 聽力評估安全門（Listening Service）
+
+> 這份是給**人**讀的 spec（方大哥 / 教授 / 實習生）。機器可驗的契約在
+> `backend/specs/test_listening_spec.py`。
+> 改動 `listening_service.py` 前先讀這份。
+
+## 1. 這個 module 在管什麼
+
+`evaluate_retelling()` 評估學生在聽完課文後的口頭/打字覆述內容，
+使用 Gemini AI 給出分數和教學回饋。
+
+此 module 的 spec 聚焦在**三個安全門**（guards），這些是純函數，
+可在不呼叫 AI 的情況下直接測試。
+
+## 2. 三個安全門
+
+### Guard 1：垃圾輸入拒評（`_is_garbage_input()`）
+
+```
+觸發條件：
+  - 去除頭尾空白後長度 < 5 字元，OR
+  - 全部是數字 / 空白 / 標點（無中文 CJK、無英文字母）
+
+返回值：True（拒評）
+```
+
+**注意**：「太棒了」（3 字）觸發此 guard（< 5），不會被 LLM 評估。
+長度下限是 `_MIN_MEANINGFUL_CHARS = 5`。
+
+### Guard 2：逐字貼上短路（`_is_verbatim_paste()`）
+
+```
+觸發條件：
+  - 學生輸入與原始課文的 SequenceMatcher 相似度 ≥ 0.70（字元級）
+  - 且學生輸入長度 ≤ 原文長度 × 1.2（fast path 排除超長輸入）
+
+返回值：True（逐字貼上）
+→ 直接給 score=95.0，不呼叫 LLM
+```
+
+### Guard 3：分數 Clamp（`evaluate_retelling()` 後處理）
+
+```
+result["score"] = max(0, min(100, float(result.get("score", 0))))
+```
+
+LLM 返回的分數無論是 -10 或 150 都會被 clamp 到 [0, 100]。
+
+## 3. 兩個短路返回值（固定常數）
+
+| 情況 | score | 特點 |
+|------|-------|------|
+| 垃圾輸入 | `0.0` | 不呼叫 LLM，包含溫和提示 |
+| 逐字貼上 | `95.0` | 不呼叫 LLM，包含鼓勵並提醒用自己的話說 |
+
+這兩個數字是代碼中的字面值，不由任何常數變數控制。
+
+## 4. Schema 不變量
+
+`RETELLING_EVAL_SCHEMA` 有 6 個必要欄位：
+`score`、`key_points_covered`、`key_points_missed`、`feedback`、`encouragement`、`reasoning`
+
+`reasoning` 欄位是必填的（CLAUDE.md 的 LLM output 規則：判斷類 prompt 必帶 reasoning）。
+
+## 5. 允許 / 禁止的改動
+
+✅ **允許**
+- 調整 `_MIN_MEANINGFUL_CHARS`（目前 5），只要同步更新 spec 的常數描述
+- 調整 `_VERBATIM_SIMILARITY_THRESHOLD`（目前 0.70）
+
+⛔ **禁止（會破壞契約）**
+- 讓垃圾輸入 guard 在 score 非 0.0 情況下返回（AI 不應評估無語義輸入）
+- 讓 `evaluate_retelling()` 在任何輸入下返回 score > 100 或 score < 0（前端顯示進度條）
+- 移除 `reasoning` 欄位（教師稽核需要）
+- 讓 `RETELLING_EVAL_SCHEMA["required"]` 不含 `"reasoning"`
+
+## 6. AI 路徑（待查）
+
+`evaluate_retelling()` 的主要路徑（非 guard 短路）呼叫 `generate_structured_response()`，
+這需要 Vertex AI 連線，在 spec 層無法測試。列為 `待查`：
+- AI 返回 schema 是否符合 `RETELLING_EVAL_SCHEMA`（需 mock）
+- `reasoning` 欄位在 AI 回應中的實際填充情況（需整合測試）
+
+## 7. 教學 / 產品脈絡
+
+- 聽力評估在「聽力理解」步驟中觸發，學生聽完課文 TTS 後用自己的話描述
+- score 顯示在報告頁，驅動「朗朗上口六環節」的聽力環節指標
+- 垃圾輸入保護：避免學生亂打後得到誤導性的 AI 回饋（Issue #1098 修復）

--- a/specs/modules/prediction/INTENT.md
+++ b/specs/modules/prediction/INTENT.md
@@ -1,0 +1,96 @@
+---
+spec_id: prediction.difficulty
+module: prediction
+title: 學習困難預測 — 規則引擎不變量（無 ML）
+stability: active
+canonical_source: backend/app/services/prediction_service.py
+owns_code:
+  - backend/app/services/prediction_service.py
+spec_tests:
+  - backend/specs/test_prediction_spec.py
+related_issues: [254]
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# 學習困難預測（Prediction Service）
+
+> 這份是給**人**讀的 spec（方大哥 / 教授 / 實習生）。機器可驗的契約在
+> `backend/specs/test_prediction_spec.py`。
+> 改動 `prediction_service.py` 前先讀這份。
+
+## 1. 這個 module 在管什麼
+
+`predict_learning_difficulty()` 分析學生的 `LearningSession` 記錄，對其學習困難程度給出預測結果（低/中/高），讓教師在問題惡化前提早介入。
+
+**這是純規則引擎，不含 ML 模型、不含 LLM 呼叫。**
+
+## 2. 五個訊號
+
+| 訊號 | 閾值 | 描述 |
+|------|------|------|
+| 前期正確率低 | < 60% | 前 3 篇課文平均正確率不足 |
+| 生字錯誤率高 | > 30% | 錯誤獨特生字數 / 所有獨特生字數 |
+| 正確率持續下滑 | 連續 3 session | 嚴格遞減 |
+| 低投入度 | 最長間隔 > 14 天 | session 間空白過長 |
+| 多篇卡關 | ≥ 2 篇 | 同課嘗試 ≥ 3 次且進步 < 5% |
+
+## 3. 核心不變量
+
+### 3.1 無 session 記錄時安全回傳 `risk_level: "low"`
+
+`_empty_prediction()` 永遠返回合法結構：
+- `risk_level == "low"`（不是 None、不是空字串）
+- `confidence_score == 0.0`（明確表達沒有資料支撐）
+
+**禁止**：無資料時返回 `risk_level: "no_data"` 或 `None`，呼叫者不做防禦。
+
+### 3.2 pure helper 函數在相同輸入下確定性輸出
+
+`_check_declining_trend()`、`_check_stuck_count()`、`_compute_risk_level()` 不訪問 DB，
+給定相同的 session 串列必然返回相同結果。這使得 UI 呈現、教師報告不會因時間點而變動。
+
+### 3.3 risk_level 只有三個合法值
+
+`_compute_risk_level()` 返回值只能是 `"low"`、`"medium"`、`"high"`，
+不能返回其他字串或 None。
+
+### 3.4 confidence_score 在 [0, 1] 範圍內
+
+函數文件標注 `float   # 0-1`；`_compute_risk_level()` 使用 `round(... * data_confidence, 2)`，
+`data_confidence` 本身 clamp 在 [0, 1]，所以輸出亦然。
+
+### 3.5 declining trend 邏輯：嚴格遞減（不含平盤）
+
+`_check_declining_trend()` 用 `last_n[i] > last_n[i+1]`（嚴格大於），
+連續持平（例如 80, 80, 80）**不**觸發 declining 訊號。
+
+### 3.6 stuck count：< 5% 進步才算卡關
+
+`_check_stuck_count()` 比較「前半最高 vs 後半最高」，差距 < 5 才標 stuck。
+若後半明顯改善（≥ 5%），不算卡關。
+
+## 4. 允許 / 禁止的改動
+
+✅ **允許**
+- 調整閾值常數（`LOW_ACCURACY_THRESHOLD` / `DECLINING_SESSIONS` 等），
+  只要同步更新 spec 的閾值表格和對應測試
+- 新增訊號種類
+
+⛔ **禁止（會破壞契約）**
+- 讓 `predict_learning_difficulty()` 在無 session 時 raise exception
+- 讓 `_compute_risk_level()` 返回 `"low"` 以外的第四個 level 值（前端 UI hard-coded 三色）
+- 讓 `confidence_score > 1.0`（前端進度條上限 100%）
+- 讓 pure helpers 引入隨機性或時間依賴
+
+## 5. 教學 / 產品脈絡
+
+- 預測結果以 badge 顯示在教師儀表板，顏色：綠（low）/ 黃（medium）/ 紅（high）
+- `confidence_score` 低時（< 0.3）教師界面顯示「資料不足，僅供參考」
+- `recommended_actions` 對教師以條列呈現，字串由 service 負責，前端只做顯示
+
+## 6. DB 依賴的函數（待查 — 無法在 spec 層直接測試）
+
+`predict_learning_difficulty()` 主入口依賴 `DbSession`，
+`_check_character_error_rate()` 依賴 `CharacterError` 查詢。
+這些函數的整合行為列為 `待查`，由整合測試覆蓋，不在本 spec 範圍。

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -68,6 +68,18 @@ modules:
   last_reviewed: 2026-06-01
   owner: young
   intent: specs/modules/content-schema/INTENT.md
+- spec_id: dictionary.lookup
+  module: dictionary
+  title: MOE 字典查詢 — 查無字優雅降級 + 結構驗證
+  stability: active
+  canonical_source: backend/app/services/dictionary_service.py
+  owns_code:
+  - backend/app/services/dictionary_service.py
+  spec_tests:
+  - backend/specs/test_dictionary_spec.py
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/dictionary/INTENT.md
 - spec_id: gamification.xp.level_progression
   module: gamification-xp
   title: 遊戲化 XP — XP 獎勵、等級計算、streak 加成
@@ -99,6 +111,35 @@ modules:
   last_reviewed: 2026-06-02
   owner: young
   intent: specs/modules/input-sanitizer/INTENT.md
+- spec_id: learning.path.recommendation
+  module: learning-path
+  title: 個別化學習路徑推薦 — 推薦課文必須在課程目錄中存在
+  stability: active
+  canonical_source: backend/app/services/learning_path_service.py
+  owns_code:
+  - backend/app/services/learning_path_service.py
+  spec_tests:
+  - backend/specs/test_learning_path_spec.py
+  related_issues:
+  - 252
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/learning-path/INTENT.md
+- spec_id: lesson.code.normalization
+  module: lesson-code-normalization
+  title: 課文代碼正規化 — 零填充剝除 + WW→文 轉換 + 全形→半形
+  stability: active
+  canonical_source: backend/app/services/lesson_code_normalization.py
+  owns_code:
+  - backend/app/services/lesson_code_normalization.py
+  spec_tests:
+  - backend/specs/test_lesson_code_normalization_spec.py
+  related_issues:
+  - 1889
+  - 1669
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/lesson-code-normalization/INTENT.md
 - spec_id: content.lesson_loader
   module: lesson-loader
   title: 課文載入器 — 雙層合併 + strategy_exercise 鍵名容錯契約
@@ -117,6 +158,20 @@ modules:
   last_reviewed: 2026-06-02
   owner: young
   intent: specs/modules/lesson-loader/INTENT.md
+- spec_id: listening.eval.guards
+  module: listening
+  title: 聽力評估安全門 — 垃圾輸入拒評 + 逐字貼上短路 + 分數 Clamp
+  stability: active
+  canonical_source: backend/app/services/listening_service.py
+  owns_code:
+  - backend/app/services/listening_service.py
+  spec_tests:
+  - backend/specs/test_listening_spec.py
+  related_issues:
+  - 1098
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/listening/INTENT.md
 - spec_id: omo.grader.letter_mapping
   module: omo-assessment
   title: OMO 語詞應用 — 字母作答的對應來源 (vocab_bank as SOT)
@@ -209,6 +264,20 @@ modules:
   last_reviewed: 2026-06-01
   owner: young
   intent: specs/modules/omo-upload/INTENT.md
+- spec_id: prediction.difficulty
+  module: prediction
+  title: 學習困難預測 — 規則引擎不變量（無 ML）
+  stability: active
+  canonical_source: backend/app/services/prediction_service.py
+  owns_code:
+  - backend/app/services/prediction_service.py
+  spec_tests:
+  - backend/specs/test_prediction_spec.py
+  related_issues:
+  - 254
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/prediction/INTENT.md
 - spec_id: reading.eval.fallback_never_autopass
   module: reading-eval-safety
   title: 朗讀評估 — AI 失敗時 fallback 絕不自動通過學生


### PR DESCRIPTION
Related to #2029

## Summary

Adds Wave 4 of the modular spec system (15 → 20 modules, 214 → 340 passing tests, +126 tests).

| Module | INTENT.md | Contract tests | Approach |
|--------|-----------|---------------|---------|
| `lesson-code-normalization` | specs/modules/lesson-code-normalization/INTENT.md | test_lesson_code_normalization_spec.py (39 tests) | Real contract tests — all pure functions (`normalize_manifest_code`, `halfwidth`). Idempotency, WW→文, zero-stripping, passthrough, override map sanity. |
| `prediction` | specs/modules/prediction/INTENT.md | test_prediction_spec.py (32 tests) | Real contract tests — pure helpers only (`_check_declining_trend`, `_check_stuck_count`, `_compute_risk_level`, `_empty_prediction`). DB-dependent main entry is 待查. |
| `dictionary` | specs/modules/dictionary/INTENT.md | test_dictionary_spec.py (21 tests) | Real contract tests — pure functions (`_strip_markup`, `_has_real_definition`, `_parse_moe_response`) + `ValueError` input guard. Network/cache path is 待查. |
| `learning-path` | specs/modules/learning-path/INTENT.md | test_learning_path_spec.py (15 tests) | Catalog-structure contracts (no DB) + cold-start integration via MagicMock DB. Core invariant: all recommended `story_slug` values exist in `get_all_lessons()`. |
| `listening` | specs/modules/listening/INTENT.md | test_listening_spec.py (19 tests) | Real contract tests — `_is_garbage_input`, `_is_verbatim_paste`, `RETELLING_EVAL_SCHEMA` structure. LLM path is 待查. |

## Discipline applied

- Every invariant was derived by running/inspecting real code before writing a test.
- DB-dependent paths (top-level service calls requiring real PostgreSQL) are documented as 待查 in each INTENT.md — not tested with fabricated assertions.
- learning-path uses MagicMock (not SQLite) to avoid PostgreSQL JSONB incompatibility.
- No changes to `backend/app/` — read-only.

## Test results

```
340 passed, 31 xfailed  (baseline: 214 passed, 31 xfailed)
registry.yaml is up to date.  (20 modules)
```

## 待查 items (honestly listed)

| Module | What is 待查 |
|--------|-------------|
| prediction | `predict_learning_difficulty()` main entry + `_check_character_error_rate()` — require DbSession |
| dictionary | `lookup_character()` network/cache path — requires mock httpx |
| learning-path | Personalisation with real student history — requires PostgreSQL-compatible fixture |
| listening | `evaluate_retelling()` LLM path — requires mock Vertex AI |