### PR TITLE
feat(specs): local CI runner — bash specs/run-ci.sh (Related to #2029)

### DIFF
--- a/.cursor/rules/specs.mdc
+++ b/.cursor/rules/specs.mdc
@@ -13,7 +13,7 @@ Before editing backend code or lesson data, check whether it is owned by a spec 
 
 1. Read `specs/registry.yaml` — the index listing each module's `owns_code` / `owns_data`.
 2. If the file you're changing belongs to a module → read that module's `specs/modules/<feature>/INTENT.md` (human-readable spec: what may/may not change) and, when relevant, `backend/specs/test_<feature>_spec.py` (the machine contract).
-3. After changes run `cd backend && python -m pytest specs/` — a failing contract means code/data drifted from intent (fix the code, or update the spec — pick one).
+3. After changes run `bash specs/run-ci.sh` (local CI = registry freshness + all 27 module contracts) — a failing contract means code/data drifted from intent (fix the code, or update the spec — pick one). GitHub Actions auto-run is blocked on token scope (issue 2041); run this locally before pushing.
 4. For a new feature with no module → write `specs/modules/<feature>/INTENT.md` first, then the code.
 
 Purpose: load only the spec the current feature needs, instead of the whole PRD / all meeting notes — so the AI doesn't get confused by irrelevant context. Full overview: `specs/README.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,8 +146,10 @@ Before editing backend code or lesson YAML data, check ownership:
    `specs/modules/<feature>/INTENT.md` (the human-readable contract) and the
    corresponding `backend/specs/test_<feature>_spec.py` (machine-checkable
    invariants).
-3. After your change: `cd backend && python -m pytest specs/` — failures signal
-   a drift between code/data and the documented intent.
+3. After your change: `bash specs/run-ci.sh` (local CI = registry freshness +
+   all 27 module contracts) — failures signal a drift between code/data and the
+   documented intent. GitHub Actions auto-run is blocked on token scope (issue
+   2041), so run this locally before pushing.
 4. Adding a new feature with no existing module → create
    `specs/modules/<feature>/INTENT.md` first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,13 +110,21 @@ owned by a spec module:
 2. If the file you are editing appears under a module → read
    `specs/modules/<feature>/INTENT.md` (human-readable SOT) and the
    corresponding `backend/specs/test_<feature>_spec.py` (machine contracts).
-3. After changes: `cd backend && python -m pytest specs/` — a failing contract
-   means code or data drifted from the documented intent; fix the code OR
-   update the spec (but document why).
+3. After changes: run **`bash specs/run-ci.sh`** (local CI = registry-freshness
+   gate + all spec contracts). A failing contract means code or data drifted
+   from the documented intent; fix the code OR update the spec (but document
+   why). Fast registry-only check: `bash specs/run-ci.sh --quick`.
 4. No matching module for a genuinely new feature → create
-   `specs/modules/<feature>/INTENT.md` before writing code.
+   `specs/modules/<feature>/INTENT.md` before writing code, then rebuild the
+   index with `python specs/build_registry.py`.
 
-Full guide: `specs/README.md`.
+There are currently **27 modules**. Full index: `specs/registry.yaml`. Full
+guide: `specs/README.md`.
+
+**Local CI**: the GitHub Actions auto-run is blocked on a `workflow`-scoped
+token (issue 2041). Until that lands, run `bash specs/run-ci.sh` before pushing
+any change under `specs/` or `backend/app/services/`. (Last local run: 457
+passed / 31 xfailed.)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,10 +153,11 @@ cd backend && pip install -r requirements.txt && uvicorn app.main:app --reload  
 
 1. 讀 `specs/registry.yaml`（小，所有 module 的 `owns_code` / `owns_data` 索引）
 2. 要動的檔案落在某 module → 讀該 `specs/modules/<feature>/INTENT.md`（人讀 SOT）+ 需要時 `backend/specs/test_<feature>_spec.py`（機器契約）
-3. 改完跑 `cd backend && python -m pytest specs/` — 契約 fail = code/data 偏離意圖（修 code 或更新 spec，二擇一）
-4. 沒對應 module 又是新 feature → 先建 `specs/modules/<feature>/INTENT.md` 再寫 code
+3. 改完跑 **`bash specs/run-ci.sh`**（= local CI：registry 新鮮度 + 全部契約）。契約 fail = code/data 偏離意圖（修 code 或更新 spec，二擇一）。快檢只跑 registry：`bash specs/run-ci.sh --quick`
+4. 沒對應 module 又是新 feature → 先建 `specs/modules/<feature>/INTENT.md` 再寫 code，並跑 `python specs/build_registry.py` 重建索引
 
-目前 module：`omo.grader.letter_mapping`（OMO 語詞應用字母作答 = `vocab_bank` 為 SOT）。完整說明 `specs/README.md`。Phase A 純檔案約定，無 MCP。
+目前 **27 個 module**（OMO / 朗讀理解 / 計分 / 教材 / auth / 學習功能 / AI infra…）。完整索引 `specs/registry.yaml`，說明 `specs/README.md`。
+**Local CI**：GH Actions 自動跑卡在 workflow token（issue 2041），在那之前 push 前一律手動 `bash specs/run-ci.sh`（最近一次本機全綠：457 passed / 31 xfailed）。
 
 ## LLM Model 比較與更換流程
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ AI 閱讀教學平台。前端 React 19 + Vite + Tailwind，後端 FastAPI + Pos
 
 1. 讀 `specs/registry.yaml` — 索引，列出每個 module 的 `owns_code` / `owns_data`
 2. 要動的檔案落在某 module → 讀該 `specs/modules/<feature>/INTENT.md`（人讀規格，寫明什麼能改/不能改）+ 需要時 `backend/specs/test_<feature>_spec.py`（機器契約）
-3. 改完跑 `cd backend && python -m pytest specs/` — 契約 fail = code/data 偏離意圖（修 code 或更新規格，二擇一）
+3. 改完跑 `bash specs/run-ci.sh`（local CI = registry 新鮮度 + 27 模組全部契約）— 契約 fail = code/data 偏離意圖（修 code 或更新規格，二擇一）。GH Actions 自動跑卡 token（issue 2041），push 前一律本機跑這個
 4. 新功能沒對應 module → 先建 `specs/modules/<feature>/INTENT.md` 再寫 code
 
 目的：只載入當下功能需要的規格，不吞整份 PRD / 全會議記錄，避免吃太多無關 context 而誤判。完整說明 `specs/README.md`。

--- a/specs/run-ci.sh
+++ b/specs/run-ci.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Local CI for the modular spec system (specs/).
+#
+# Runs the exact same two gates as specs/ci/spec-check.yml, but locally — so the
+# 27 spec-module contracts are enforceable WITHOUT the GitHub Actions workflow
+# (which is blocked on a token with `workflow` scope, tracked in issue 2041).
+#
+# Usage:
+#   bash specs/run-ci.sh          # run both gates, exit non-zero on any failure
+#   bash specs/run-ci.sh --quick  # gate 1 only (registry freshness, instant)
+#
+# Run this before pushing changes that touch specs/ or backend/app/services/.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Prefer the backend venv (has google.genai etc.); fall back to python3.
+PYBIN="backend/.venv/bin/python"
+[ -x "$PYBIN" ] || PYBIN="$(command -v python3)"
+
+echo "== Local Spec CI =="
+echo "   python: $PYBIN"
+echo "   modules: $(ls -d specs/modules/*/ 2>/dev/null | wc -l | tr -d ' ')"
+echo ""
+
+echo "-- Gate 1/2: registry freshness (build_registry.py --check) --"
+"$PYBIN" specs/build_registry.py --check
+echo "   OK"
+echo ""
+
+if [ "${1:-}" = "--quick" ]; then
+  echo "(--quick: skipping gate 2 pytest)"
+  exit 0
+fi
+
+echo "-- Gate 2/2: spec contracts (pytest specs/) --"
+( cd backend && "$PYBIN" -m pytest specs/ -q )
+echo ""
+echo "== Local Spec CI: PASS =="


### PR DESCRIPTION
## What

Adds `specs/run-ci.sh` — a one-command **local CI** for the modular spec system, plus wires it into all 5 AI guidance files.

The GitHub Actions auto-run (`specs/ci/spec-check.yml`) is blocked on a `workflow`-scoped token (tracked in issue 2041). Until that lands, this script is how the 27-module spec contracts stay enforceable.

## The two gates (identical to the blocked workflow)

| Gate | Command | Last local run |
|------|---------|----------------|
| ① registry freshness | `python specs/build_registry.py --check` | ✅ up to date |
| ② 27 module contracts | `cd backend && python -m pytest specs/` | ✅ 457 passed / 31 xfailed |

## Usage

- `bash specs/run-ci.sh` — full local CI, run before pushing changes under `specs/` or `backend/app/services/`
- `bash specs/run-ci.sh --quick` — registry gate only (instant)

## Wiring

`run-ci.sh` is now the documented post-change step in **CLAUDE.md / AGENTS.md / .github/copilot-instructions.md / GEMINI.md / .cursor/rules/specs.mdc** (also refreshed the stale "1 module" note → "27 modules").

🤖 Generated with [Claude Code](https://claude.com/claude-code)