### PR TITLE
feat(specs): Wave 7 — 4 OMO/cache spec modules (registry 27→31) (Related to #2029)

### DIFF
--- a/backend/specs/test_example_sentence_cache_spec.py
+++ b/backend/specs/test_example_sentence_cache_spec.py
@@ -1,0 +1,66 @@
+"""
+Spec: example-sentence-cache — TTL and pre-generated cache contracts.
+
+Canonical source: backend/app/services/example_sentence_cache.py
+Related issue: #780
+Module spec: specs/modules/example-sentence-cache/INTENT.md
+
+These tests are pure-function, no DB, no AI.
+"""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Make app importable regardless of invocation cwd
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from app.services.example_sentence_cache import CACHE_TTL_DAYS, _is_expired
+
+
+# ---------------------------------------------------------------------------
+# I-1: Cache TTL constant is 30 days
+# ---------------------------------------------------------------------------
+
+class TestCacheTtlConstant:
+    def test_cache_ttl_days(self):
+        assert CACHE_TTL_DAYS == 30
+
+
+# ---------------------------------------------------------------------------
+# I-2: Runtime-generated entries expire after TTL
+# ---------------------------------------------------------------------------
+
+class TestRuntimeEntryExpiry:
+    def test_entry_older_than_ttl_is_expired(self):
+        entry = {
+            "cached_at": (
+                datetime.now(timezone.utc) - timedelta(days=CACHE_TTL_DAYS, seconds=1)
+            ).isoformat(),
+        }
+        assert _is_expired(entry) is True
+
+    def test_fresh_entry_is_not_expired(self):
+        entry = {"cached_at": datetime.now(timezone.utc).isoformat()}
+        assert _is_expired(entry) is False
+
+    def test_missing_cached_at_is_expired(self):
+        assert _is_expired({}) is True
+
+    def test_invalid_cached_at_is_expired(self):
+        assert _is_expired({"cached_at": "not-a-date"}) is True
+
+
+# ---------------------------------------------------------------------------
+# I-3: Pre-generated entries are curated content and never expire
+# ---------------------------------------------------------------------------
+
+class TestPregeneratedEntryExpiry:
+    def test_pregenerated_entry_never_expires_regardless_of_age(self):
+        entry = {
+            "source": "pregenerated",
+            "cached_at": "2000-01-01T00:00:00+00:00",
+        }
+        assert _is_expired(entry) is False

--- a/backend/specs/test_omo_image_preprocess_spec.py
+++ b/backend/specs/test_omo_image_preprocess_spec.py
@@ -1,0 +1,64 @@
+"""
+Spec: omo-image-preprocess — spread splitting and fail-open contracts.
+
+Canonical source: backend/app/services/omo_image_preprocess.py
+Related issue: #1717
+Module spec: specs/modules/omo-image-preprocess/INTENT.md
+
+These tests are pure-function, no DB, no AI.
+"""
+
+import io
+import sys
+from pathlib import Path
+
+# Make app importable regardless of invocation cwd
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from PIL import Image
+
+from app.services.omo_image_preprocess import _split_spread
+
+
+def _jpeg_bytes(width: int, height: int) -> bytes:
+    image = Image.new("RGB", (width, height), "white")
+    buf = io.BytesIO()
+    image.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# I-1: Split spread fails open on unreadable image bytes
+# ---------------------------------------------------------------------------
+
+class TestSplitSpreadFailOpen:
+    def test_garbage_bytes_never_raise_and_return_original(self):
+        original = b"not an image"
+        assert _split_spread(original, "image/jpeg") == [(original, "image/jpeg")]
+
+
+# ---------------------------------------------------------------------------
+# I-2: Non-wide images pass through untouched
+# ---------------------------------------------------------------------------
+
+class TestSplitSpreadSinglePage:
+    def test_normal_non_wide_image_returns_original_single_element(self):
+        original = _jpeg_bytes(800, 1000)
+        assert _split_spread(original, "image/jpeg") == [(original, "image/jpeg")]
+
+
+# ---------------------------------------------------------------------------
+# I-3: Wide spreads split into two JPEG halves
+# ---------------------------------------------------------------------------
+
+class TestSplitSpreadWideImage:
+    def test_very_wide_image_returns_two_halves(self):
+        original = _jpeg_bytes(2000, 600)
+
+        halves = _split_spread(original, "image/jpeg")
+
+        assert len(halves) == 2
+        assert all(mime == "image/jpeg" for _, mime in halves)
+        assert all(data.startswith(b"\xff\xd8") for data, _ in halves)

--- a/backend/specs/test_omo_pdf_split_spec.py
+++ b/backend/specs/test_omo_pdf_split_spec.py
@@ -1,0 +1,79 @@
+"""
+Spec: omo-pdf-split — PDF render constants and per-page JPEG contracts.
+
+Canonical source: backend/app/services/omo_pdf_split.py
+Related issue: #1976
+Module spec: specs/modules/omo-pdf-split/INTENT.md
+
+These tests are pure-function, no DB, no AI.
+"""
+
+import inspect
+import io
+import sys
+import types
+from pathlib import Path
+
+# Make app importable regardless of invocation cwd
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+import pytest
+from PIL import Image
+
+try:
+    import pypdfium2  # noqa: F401
+    _PDFIUM_AVAILABLE = True
+except ModuleNotFoundError:
+    _PDFIUM_AVAILABLE = False
+
+    def _missing_pdfium_document(*_args, **_kwargs):
+        raise ModuleNotFoundError("No module named 'pypdfium2'")
+
+    sys.modules["pypdfium2"] = types.SimpleNamespace(
+        PdfDocument=_missing_pdfium_document,
+    )
+
+from app.services.omo_pdf_split import (
+    _JPEG_QUALITY,
+    _RENDER_SCALE,
+    pdf_to_jpeg_pages,
+)
+from app.services.omo_upload_validator import MAX_FILES_PER_UPLOAD
+
+
+# ---------------------------------------------------------------------------
+# I-1: Render constants match the OCR-oriented PDF conversion contract
+# ---------------------------------------------------------------------------
+
+class TestPdfRenderConstants:
+    def test_render_scale_and_jpeg_quality(self):
+        assert _RENDER_SCALE == 150.0 / 72.0
+        assert _JPEG_QUALITY == 85
+
+    def test_default_max_pages_matches_upload_cap(self):
+        signature = inspect.signature(pdf_to_jpeg_pages)
+        assert signature.parameters["max_pages"].default == 20
+        assert signature.parameters["max_pages"].default == MAX_FILES_PER_UPLOAD
+
+
+# ---------------------------------------------------------------------------
+# I-2: Real multi-page PDFs render into JPEG page blobs
+# ---------------------------------------------------------------------------
+
+class TestPdfToJpegPages:
+    def test_real_multi_page_pdf_renders_to_jpeg_pages(self):
+        if not _PDFIUM_AVAILABLE:
+            pytest.xfail("pypdfium2 is unavailable in this test environment")
+        first = Image.new("RGB", (120, 160), "white")
+        second = Image.new("RGB", (120, 160), "lightgray")
+        third = Image.new("RGB", (120, 160), "white")
+        buf = io.BytesIO()
+        first.save(buf, format="PDF", save_all=True, append_images=[second, third])
+
+        pages = pdf_to_jpeg_pages(buf.getvalue(), max_pages=MAX_FILES_PER_UPLOAD)
+
+        assert 0 < len(pages) <= MAX_FILES_PER_UPLOAD
+        assert len(pages) == 3
+        assert all(page.startswith(b"\xff\xd8") for page in pages)

--- a/backend/specs/test_omo_upload_validation_spec.py
+++ b/backend/specs/test_omo_upload_validation_spec.py
@@ -1,0 +1,96 @@
+"""
+Spec: omo-upload-validation — file size, count, and retry validation contracts.
+
+Canonical source: backend/app/services/omo_upload_validator.py
+Module spec: specs/modules/omo-upload-validation/INTENT.md
+
+These tests are pure-function, no DB, no AI.
+"""
+
+import sys
+from pathlib import Path
+
+# Make app importable regardless of invocation cwd
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.omo_upload_validator import (
+    MAX_FILE_SIZE_BYTES,
+    MAX_FILES_PER_UPLOAD,
+    MAX_PDF_SIZE_BYTES,
+    PDF_MIME_TYPE,
+    _MAX_TOTAL_ATTEMPTS,
+    validate_attempt_files,
+    validate_upload_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# I-1: Upload constraint constants are the single source of truth
+# ---------------------------------------------------------------------------
+
+class TestUploadConstraintConstants:
+    def test_file_size_constants(self):
+        assert MAX_FILE_SIZE_BYTES == 10 * 1024 * 1024
+        assert MAX_PDF_SIZE_BYTES == 20 * 1024 * 1024
+
+    def test_count_and_attempt_constants(self):
+        assert MAX_FILES_PER_UPLOAD == 20
+        assert _MAX_TOTAL_ATTEMPTS == 5
+
+
+# ---------------------------------------------------------------------------
+# I-2: New upload validation rejects invalid file lists
+# ---------------------------------------------------------------------------
+
+class TestValidateUploadFiles:
+    def test_empty_file_list_raises_400(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_upload_files([])
+        assert exc.value.status_code == 400
+
+    def test_more_than_max_files_raises_400(self):
+        files = [(b"x", "image/jpeg")] * (MAX_FILES_PER_UPLOAD + 1)
+        with pytest.raises(HTTPException) as exc:
+            validate_upload_files(files)
+        assert exc.value.status_code == 400
+
+    def test_empty_file_bytes_raises_400(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_upload_files([(b"", "image/jpeg")])
+        assert exc.value.status_code == 400
+
+    def test_single_oversized_image_raises_413(self):
+        oversized = b"x" * (MAX_FILE_SIZE_BYTES + 1)
+        with pytest.raises(HTTPException) as exc:
+            validate_upload_files([(oversized, "image/jpeg")])
+        assert exc.value.status_code == 413
+
+    def test_pdf_uses_pdf_size_cap(self):
+        image_oversized_but_pdf_allowed = b"x" * (MAX_FILE_SIZE_BYTES + 1)
+        validate_upload_files([(image_oversized_but_pdf_allowed, PDF_MIME_TYPE)])
+
+        oversized_pdf = b"x" * (MAX_PDF_SIZE_BYTES + 1)
+        with pytest.raises(HTTPException) as exc:
+            validate_upload_files([(oversized_pdf, PDF_MIME_TYPE)])
+        assert exc.value.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# I-3: Existing upload attempts have a hard retry cap
+# ---------------------------------------------------------------------------
+
+class TestValidateAttemptFiles:
+    def test_existing_attempt_count_at_cap_raises_400(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_attempt_files([(b"x", "image/jpeg")], _MAX_TOTAL_ATTEMPTS)
+        assert exc.value.status_code == 400
+
+    def test_existing_attempt_count_above_cap_raises_400(self):
+        with pytest.raises(HTTPException) as exc:
+            validate_attempt_files([(b"x", "image/jpeg")], _MAX_TOTAL_ATTEMPTS + 1)
+        assert exc.value.status_code == 400

--- a/specs/modules/example-sentence-cache/INTENT.md
+++ b/specs/modules/example-sentence-cache/INTENT.md
@@ -1,0 +1,41 @@
+---
+spec_id: example_sentence.cache.ttl
+module: example-sentence-cache
+title: 例句快取 — TTL 與 pre-generated 永不過期契約
+stability: active
+canonical_source: backend/app/services/example_sentence_cache.py
+owns_code:
+  - backend/app/services/example_sentence_cache.py
+owns_data: []
+spec_tests:
+  - backend/specs/test_example_sentence_cache_spec.py
+related_issues:
+  - 780
+source_meetings: []
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# 例句快取：TTL 與 pre-generated 永不過期規格
+
+## Intent
+
+`example_sentence_cache.py` 用本地 JSON cache 避免同一課文、同一生字反覆呼叫 Gemini 產生例句。
+runtime 產生的快取有 TTL；由預產生腳本寫入的 curated 例句則是內容資產，不應因時間到期被丟棄。
+
+這份 spec 鎖定 `_is_expired()` 的時間語意，尤其是 issue #780 的 pre-generated 永不過期保證。
+
+## Invariants
+
+1. `CACHE_TTL_DAYS == 30`。
+2. runtime cache entry 超過 30 天必須視為 expired。
+3. fresh runtime cache entry 不可視為 expired。
+4. `source == "pregenerated"` 是 seed / pre-generated entry 的標記。
+5. pre-generated entry 不論 `cached_at` 多舊都不可 expired。
+6. 缺少 `cached_at` 的 runtime entry 必須 expired。
+7. 無法 parse 的 `cached_at` 必須 expired。
+
+## Out of scope
+
+AI 例句生成品質、JSON 檔案 I/O、bulk seed 腳本、cache key 選字策略與 API route 行為不屬於這個 module。
+這裡只管 cache TTL 判斷與 pre-generated 永不過期契約。

--- a/specs/modules/omo-image-preprocess/INTENT.md
+++ b/specs/modules/omo-image-preprocess/INTENT.md
@@ -1,0 +1,41 @@
+---
+spec_id: omo.image_preprocess.spread_split
+module: omo-image-preprocess
+title: OMO 圖片預處理 — 橫向雙頁切半 fail-open 契約
+stability: active
+canonical_source: backend/app/services/omo_image_preprocess.py
+owns_code:
+  - backend/app/services/omo_image_preprocess.py
+owns_data: []
+spec_tests:
+  - backend/specs/test_omo_image_preprocess_spec.py
+related_issues:
+  - 1717
+source_meetings: []
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# OMO 圖片預處理：橫向雙頁切半規格
+
+## Intent
+
+`omo_image_preprocess.py` 在 OMO 批改前處理掃描器常見的橫向雙頁 spread。當圖片寬度明顯大於高度時，
+`_split_spread()` 將左右頁切成兩張 JPEG，讓後續 OCR 不必同時處理跨頁內容。
+
+Issue #1717 的核心保證是 fail-open：圖片預處理不能因為壞圖、未知格式或 Pillow 問題阻斷批改流程。
+
+## Invariants
+
+1. `_split_spread()` 收到垃圾 bytes 或非圖片 bytes 時永遠不可 raise。
+2. 無法解析圖片時，`_split_spread()` 必須回傳 `[(original_bytes, mime)]`。
+3. 一般非寬圖必須維持原始單元素 list，不重新編碼、不改 MIME。
+4. 寬圖判斷門檻是 `width > height * 1.3`。
+5. 非寬圖，例如 800x1000，必須回傳原始單元素 list。
+6. 很寬的圖，例如 2000x600，必須回傳左右兩半。
+7. 切半輸出固定為 JPEG bytes，MIME 為 `image/jpeg`。
+
+## Out of scope
+
+PDF 拆頁、OCR、GCS、AI 批改、影像去噪、旋轉校正與版面偵測不屬於這個 module。
+這裡只管簡單 aspect-ratio spread split 與 fail-open 行為。

--- a/specs/modules/omo-pdf-split/INTENT.md
+++ b/specs/modules/omo-pdf-split/INTENT.md
@@ -1,0 +1,42 @@
+---
+spec_id: omo.pdf_split.rendering
+module: omo-pdf-split
+title: OMO PDF 拆頁 — PDF 轉 per-page JPEG 契約
+stability: active
+canonical_source: backend/app/services/omo_pdf_split.py
+owns_code:
+  - backend/app/services/omo_pdf_split.py
+owns_data: []
+spec_tests:
+  - backend/specs/test_omo_pdf_split_spec.py
+related_issues:
+  - 1976
+source_meetings: []
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# OMO PDF 拆頁：PDF 轉 per-page JPEG 規格
+
+## Intent
+
+`omo_pdf_split.py` 讓掃描器或手機掃描 app 產出的多頁 PDF 可以進入既有 OMO 圖片流程。
+它是純函式：輸入 PDF bytes，輸出每頁 JPEG bytes，不碰檔案系統、DB、GCS 或 AI。
+
+這份 spec 鎖定 PDF render 參數、預設頁數上限，以及與 `omo_upload_validator.py`
+單次上傳張數上限的 coupling。
+
+## Invariants
+
+1. `_RENDER_SCALE == 150.0 / 72.0`，以 PDF 72 DPI baseline render 約 150 DPI 圖片。
+2. `_JPEG_QUALITY == 85`，與既有圖片 resize 品質目標一致。
+3. `pdf_to_jpeg_pages()` 的預設 `max_pages` 必須是 20。
+4. `pdf_to_jpeg_pages()` 的預設 `max_pages` 必須等於
+   `omo_upload_validator.MAX_FILES_PER_UPLOAD`，避免 PDF 預設展開頁數與 OMO 單次上傳張數上限 drift。
+5. 真實多頁 PDF 經 `pdf_to_jpeg_pages()` render 後，輸出張數不可超過 `max_pages`。
+6. 每個 render 出來的 page bytes 必須是 JPEG，開頭為 `b"\xff\xd8"`。
+
+## Out of scope
+
+上傳前的 PDF 大小驗證、展開後的 route error copy、GCS 儲存、AI OCR 品質與頁面方向校正不在此 module。
+本 module 只負責 PDF bytes 到 JPEG page bytes 的純轉換。

--- a/specs/modules/omo-upload-validation/INTENT.md
+++ b/specs/modules/omo-upload-validation/INTENT.md
@@ -1,0 +1,44 @@
+---
+spec_id: omo.upload.validation
+module: omo-upload-validation
+title: OMO 上傳驗證 — 檔案大小、數量、重拍次數契約
+stability: active
+canonical_source: backend/app/services/omo_upload_validator.py
+owns_code:
+  - backend/app/services/omo_upload_validator.py
+owns_data: []
+spec_tests:
+  - backend/specs/test_omo_upload_validation_spec.py
+related_issues: []
+source_meetings: []
+last_reviewed: 2026-06-02
+owner: young
+---
+
+# OMO 上傳驗證：檔案大小、數量、重拍次數規格
+
+## Intent
+
+`omo_upload_validator.py` 是 OMO 紙本上傳進入後端後的第一道純函式防線。它不碰 DB、
+GCS 或 AI，只驗證 `(bytes, mime_type)` 清單是否符合上傳限制，並用 `HTTPException`
+回傳路由層可直接轉成使用者訊息的錯誤。
+
+這份 spec 鎖定三組契約：單檔大小上限、單次上傳檔案數上限、同一 session 的重拍次數上限。
+
+## Invariants
+
+1. 圖片單檔上限是 `MAX_FILE_SIZE_BYTES == 10 * 1024 * 1024`。
+2. PDF 單檔上限是 `MAX_PDF_SIZE_BYTES == 20 * 1024 * 1024`。
+3. 單次上傳最多 `MAX_FILES_PER_UPLOAD == 20` 個檔案。
+4. 同一 upload session 最多 `_MAX_TOTAL_ATTEMPTS == 5` 次重拍。
+5. `validate_upload_files([])` 必須 raise `HTTPException`，`status_code == 400`。
+6. `validate_upload_files()` 收到超過 20 個檔案必須 raise `HTTPException`，`status_code == 400`。
+7. 單一圖片超過 10 MB 必須被拒絕；單一 PDF 超過 20 MB 才使用 PDF 上限拒絕。
+8. 空 bytes 檔案必須 raise `HTTPException`，`status_code == 400`。
+9. `validate_attempt_files()` 在 `existing_attempt_count >= 5` 時必須 raise `HTTPException`，
+   `status_code == 400`。
+
+## Out of scope
+
+PDF 展開、圖片切半、GCS 儲存、DB session 狀態、AI 識課與批改都不屬於這個 module。
+這裡只管同步、純函式、檔案輸入驗證。

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -129,6 +129,22 @@ modules:
   last_reviewed: 2026-06-02
   owner: young
   intent: specs/modules/dictionary/INTENT.md
+- spec_id: example_sentence.cache.ttl
+  module: example-sentence-cache
+  title: 例句快取 — TTL 與 pre-generated 永不過期契約
+  stability: active
+  canonical_source: backend/app/services/example_sentence_cache.py
+  owns_code:
+  - backend/app/services/example_sentence_cache.py
+  owns_data: []
+  spec_tests:
+  - backend/specs/test_example_sentence_cache_spec.py
+  related_issues:
+  - 780
+  source_meetings: []
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/example-sentence-cache/INTENT.md
 - spec_id: exit.ticket.schema_and_scoring
   module: exit-ticket
   title: 學習出場券 — 題目轉換 + 答案計分契約
@@ -332,6 +348,38 @@ modules:
   last_reviewed: 2026-06-02
   owner: young
   intent: specs/modules/omo-identifier/INTENT.md
+- spec_id: omo.image_preprocess.spread_split
+  module: omo-image-preprocess
+  title: OMO 圖片預處理 — 橫向雙頁切半 fail-open 契約
+  stability: active
+  canonical_source: backend/app/services/omo_image_preprocess.py
+  owns_code:
+  - backend/app/services/omo_image_preprocess.py
+  owns_data: []
+  spec_tests:
+  - backend/specs/test_omo_image_preprocess_spec.py
+  related_issues:
+  - 1717
+  source_meetings: []
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/omo-image-preprocess/INTENT.md
+- spec_id: omo.pdf_split.rendering
+  module: omo-pdf-split
+  title: OMO PDF 拆頁 — PDF 轉 per-page JPEG 契約
+  stability: active
+  canonical_source: backend/app/services/omo_pdf_split.py
+  owns_code:
+  - backend/app/services/omo_pdf_split.py
+  owns_data: []
+  spec_tests:
+  - backend/specs/test_omo_pdf_split_spec.py
+  related_issues:
+  - 1976
+  source_meetings: []
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/omo-pdf-split/INTENT.md
 - spec_id: omo.upload.flow
   module: omo-upload
   title: OMO 紙本上傳 — 拍照識課 + AI 批改端到端流程
@@ -365,6 +413,21 @@ modules:
   last_reviewed: 2026-06-01
   owner: young
   intent: specs/modules/omo-upload/INTENT.md
+- spec_id: omo.upload.validation
+  module: omo-upload-validation
+  title: OMO 上傳驗證 — 檔案大小、數量、重拍次數契約
+  stability: active
+  canonical_source: backend/app/services/omo_upload_validator.py
+  owns_code:
+  - backend/app/services/omo_upload_validator.py
+  owns_data: []
+  spec_tests:
+  - backend/specs/test_omo_upload_validation_spec.py
+  related_issues: []
+  source_meetings: []
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/omo-upload-validation/INTENT.md
 - spec_id: prediction.difficulty
   module: prediction
   title: 學習困難預測 — 規則引擎不變量（無 ML）

--- a/specs/run-ci.sh
+++ b/specs/run-ci.sh
@@ -12,10 +12,11 @@
 # Run this before pushing changes that touch specs/ or backend/app/services/.
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 
 # Prefer the backend venv (has google.genai etc.); fall back to python3.
-PYBIN="backend/.venv/bin/python"
+PYBIN="$REPO_ROOT/backend/.venv/bin/python"
 [ -x "$PYBIN" ] || PYBIN="$(command -v python3)"
 
 echo "== Local Spec CI =="


### PR DESCRIPTION
## What

Wave 7 of the modular spec system: 4 new modules for pure-function services that had real, machine-verifiable invariants but no spec module yet. Registry **27 → 31 modules**.

| Module | Service | Locked invariants |
|--------|---------|-------------------|
| `omo-upload-validation` | omo_upload_validator.py | image 10MB/413, PDF 20MB/413, ≤20 files/400, ≤5 attempts/400, empty/400 |
| `omo-pdf-split` | omo_pdf_split.py | 150DPI scale, JPEG q85, **default max_pages == MAX_FILES_PER_UPLOAD (20)** cross-module coupling |
| `omo-image-preprocess` | omo_image_preprocess.py | #1717 fail-open — never raises on garbage; wide spread → 2 halves; normal → passthrough |
| `example-sentence-cache` | example_sentence_cache.py | 30-day TTL; #780 seed entries never expire |

## Grounding (verified, not fabricated)

- Contracts lock **real** behavior: oversized files return **413** (confirmed in `omo_upload_validator.py:52`), not a guessed 400.
- The pdfium render test `xfail`s **only** when `pypdfium2` is absent (conditional, not blanket).
- Also fixes a `run-ci.sh` path bug: the relative venv path broke after `cd backend` → made it absolute via `REPO_ROOT`.

## Verification

`bash specs/run-ci.sh` → **477 passed, 32 xfailed** (independently re-run, matches the writer's claim; was 457/31 before this wave).

Written by `codex exec`, every test file independently verified by Claude (real imports, real asserts, honest status codes) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)