### PR TITLE
feat(specs): Wave 8 — ai-usage-cost spec module (registry 31→32) (Related to #2029)

### DIFF
--- a/backend/specs/test_ai_usage_cost_spec.py
+++ b/backend/specs/test_ai_usage_cost_spec.py
@@ -1,0 +1,99 @@
+"""
+Spec: ai-usage-cost — estimate_cost formula + PRICING rate lock.
+
+Canonical source: backend/app/services/ai_usage_tracker.py
+Related issues: #1730 (OMO grader pricing), #1744 (default model), #1729 (identifier)
+Module spec: specs/modules/ai-usage-cost/INTENT.md
+
+Pure-function contracts — no DB, no AI, no network. Run in < 1 ms.
+"""
+
+import sys
+from pathlib import Path
+
+# Make app importable regardless of invocation cwd
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from app.services.ai_usage_tracker import PRICING, estimate_cost
+
+_DEFAULT_MODEL = "gemini-2.5-flash-lite"
+
+
+# ---------------------------------------------------------------------------
+# I-1: estimate_cost formula
+# ---------------------------------------------------------------------------
+
+class TestCostFormula:
+    def test_formula_matches_per_million_pricing(self):
+        # 1M input + 1M output on 2.5-flash = 0.30 + 2.50 = 2.80 USD
+        cost = estimate_cost("gemini-2.5-flash", 1_000_000, 1_000_000)
+        assert cost == 0.30 + 2.50
+
+    def test_partial_million_scales_linearly(self):
+        # 500k input + 200k output on 2.5-flash-lite
+        cost = estimate_cost(_DEFAULT_MODEL, 500_000, 200_000)
+        expected = (500_000 * 0.075 + 200_000 * 0.30) / 1_000_000
+        assert cost == expected
+
+    def test_zero_tokens_is_zero_cost(self):
+        assert estimate_cost("gemini-2.5-flash", 0, 0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# I-2: PRICING rates are the documented, decision-locked values
+# ---------------------------------------------------------------------------
+
+class TestPricingRatesLocked:
+    def test_omo_grader_model_rate(self):
+        # #1730 — OMO grader locked to gemini-2.5-flash
+        assert PRICING["gemini-2.5-flash"] == {"input": 0.30, "output": 2.50}
+
+    def test_default_model_rate(self):
+        # #1744 — non-OMO default
+        assert PRICING[_DEFAULT_MODEL] == {"input": 0.075, "output": 0.30}
+
+
+# ---------------------------------------------------------------------------
+# I-3: unknown model fails soft to the default pricing (never crash / 0 / None)
+# ---------------------------------------------------------------------------
+
+class TestUnknownModelFallback:
+    def test_unknown_model_uses_default_pricing(self):
+        unknown = estimate_cost("gpt-9-ultra-imaginary", 1_000_000, 1_000_000)
+        default = estimate_cost(_DEFAULT_MODEL, 1_000_000, 1_000_000)
+        assert unknown == default
+
+    def test_unknown_model_does_not_return_zero_or_none(self):
+        cost = estimate_cost("does-not-exist", 1_000_000, 0)
+        assert cost is not None
+        assert cost > 0
+
+
+# ---------------------------------------------------------------------------
+# I-4: monotonic + non-negative
+# ---------------------------------------------------------------------------
+
+class TestMonotonicNonNegative:
+    def test_more_tokens_never_cheaper(self):
+        small = estimate_cost("gemini-2.5-flash", 1_000, 1_000)
+        big = estimate_cost("gemini-2.5-flash", 100_000, 100_000)
+        assert big >= small
+
+    def test_cost_never_negative(self):
+        for model in PRICING:
+            assert estimate_cost(model, 0, 0) >= 0
+            assert estimate_cost(model, 1_000_000, 1_000_000) >= 0
+
+
+# ---------------------------------------------------------------------------
+# I-5: default model is the cheapest (guards "expensive = default" regression, #1744)
+# ---------------------------------------------------------------------------
+
+class TestDefaultIsCheapest:
+    def test_default_model_cheapest_on_equal_workload(self):
+        workload = (1_000_000, 1_000_000)
+        default_cost = estimate_cost(_DEFAULT_MODEL, *workload)
+        for model in PRICING:
+            assert default_cost <= estimate_cost(model, *workload)

--- a/specs/modules/ai-usage-cost/INTENT.md
+++ b/specs/modules/ai-usage-cost/INTENT.md
@@ -1,0 +1,51 @@
+---
+spec_id: ai.usage.cost
+module: ai-usage-cost
+title: LLM 用量成本估算 — estimate_cost 公式 + PRICING 費率鎖定
+stability: active
+canonical_source: backend/app/services/ai_usage_tracker.py
+owns_code:
+  - backend/app/services/ai_usage_tracker.py
+owns_data: []
+spec_tests:
+  - backend/specs/test_ai_usage_cost_spec.py
+related_issues:
+  - 1730
+  - 1744
+  - 1729
+source_meetings: []
+last_reviewed: 2026-06-02
+owner: young
+---
+
+## Intent
+
+`ai_usage_tracker.estimate_cost()` 把 Gemini 回傳的 token 數換算成美金成本，是
+平台所有「換 model 比 cost」決策的計價基礎（見 `docs/ai/llm-model-ab-2026-05.md`）。
+`PRICING` 字典裡的每一行費率都綁著一個真實的 model 選型決策：
+
+- `gemini-2.5-flash` (0.30 / 2.50) — OMO grader 鎖定 (#1730)
+- `gemini-2.5-flash-lite` (0.075 / 0.30) — 非 OMO 預設 (#1744)
+- `gemini-flash-lite-latest` (0.25 / 1.50) — identifier (#1729)
+
+如果有人手滑改了費率或公式，成本比較會整個失真、卻不會有任何報錯 — 這正是
+需要契約鎖定的地方。本 module 是純函式契約：無 DB、無 AI、無 network，跑在 < 1ms。
+
+## Invariants
+
+1. `estimate_cost` 公式 = `(input_tokens * price_in + output_tokens * price_out) / 1_000_000`，
+   單位為美金。
+2. 已知 model 的費率必須等於文件值（2.5-flash = 0.30/2.50，2.5-flash-lite =
+   0.075/0.30）。改費率 = 改契約，必須是有意識的決策。
+3. 未知 model 必須 **fail-soft fallback** 到 `gemini-2.5-flash-lite` 費率 —
+   不可 crash、不可回 0、不可回 None。
+4. 0 token → 成本 0.0。
+5. 成本對 input/output token 數單調遞增（多 token 不會更便宜），且永遠 >= 0。
+6. 預設定價 model（2.5-flash-lite）必須是三者中最便宜的（防止「貴 = 預設」回歸，
+   呼應 #1744 省 78% 的決策）。
+
+## Out of scope
+
+- `_resolve_context` / DB 維度補值、`capture_usage` 寫入 usage 表、`_extract_usage`
+  從 response 物件抽 token（這些是 DB / response-shape 耦合，屬另一測試 tier）。
+- 實際 Gemini 計費對帳（以 Google 帳單為準，本 module 只鎖內部估算公式一致性）。

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -36,6 +36,24 @@ modules:
   last_reviewed: 2026-06-02
   owner: young
   intent: specs/modules/ai-service-circuit-breaker/INTENT.md
+- spec_id: ai.usage.cost
+  module: ai-usage-cost
+  title: LLM 用量成本估算 — estimate_cost 公式 + PRICING 費率鎖定
+  stability: active
+  canonical_source: backend/app/services/ai_usage_tracker.py
+  owns_code:
+  - backend/app/services/ai_usage_tracker.py
+  owns_data: []
+  spec_tests:
+  - backend/specs/test_ai_usage_cost_spec.py
+  related_issues:
+  - 1730
+  - 1744
+  - 1729
+  source_meetings: []
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/ai-usage-cost/INTENT.md
 - spec_id: assignment.lifecycle.status
   module: assignment-lifecycle
   title: 作業生命週期 — submission status 值域 + 輸入淨化契約


### PR DESCRIPTION
## What

Wave 8 (final pure-function wave): the `ai-usage-cost` module locks LLM cost estimation — the calculation base for every model A/B cost comparison.

**Invariants:**
- `estimate_cost` formula = `(in*price_in + out*price_out) / 1M`
- PRICING pinned to model decisions: 2.5-flash `0.30/2.50` (#1730 OMO grader), 2.5-flash-lite `0.075/0.30` (#1744 default)
- unknown model fails soft to default pricing (never crash / 0 / None)
- default model must remain the cheapest (guards "expensive = default" regression, #1744)

10 pure tests, no DB/AI/network. **Local CI: 487 passed, 32 xfailed** (was 477/32).

## Coverage status

Registry now **32 modules**. This is the last clean pure-function service with a machine-verifiable invariant. Remaining uncovered services are **DB-coupled** (semester / points / reading-attempt / auth flows) — they need an in-memory-DB fixture tier, which is a separate architectural decision (slower tests, different category), not more pure-contract modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)