### PR TITLE
feat(specs): Wave 9 — DB-tier foundation + stuck-detection (registry 32→33) (Related to #2029)

### DIFF
--- a/backend/specs/conftest.py
+++ b/backend/specs/conftest.py
@@ -1,7 +1,16 @@
-"""Make `app` importable for spec files regardless of pytest invocation cwd.
+"""Shared spec-test configuration.
 
-CI runs `cd backend && python -m pytest specs/` (backend on sys.path), but this
-keeps `pytest backend/specs/` working from the repo root too.
+Two jobs:
+
+1. Make ``app`` importable regardless of pytest invocation cwd. CI runs
+   ``cd backend && python -m pytest specs/`` (backend on sys.path), but this
+   keeps ``pytest backend/specs/`` working from the repo root too.
+
+2. Patch PostgreSQL-specific column types/defaults so spec tests that need a
+   real (DB-coupled) contract can use an in-memory SQLite database. Mirrors
+   ``backend/tests/conftest.py`` — JSONB → JSON, and strips ``::jsonb`` casts
+   from server_default that SQLite cannot parse. Pure-function spec modules are
+   unaffected; only the DB-tier modules rely on this.
 """
 import sys
 from pathlib import Path
@@ -9,3 +18,44 @@ from pathlib import Path
 _BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(_BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(_BACKEND_DIR))
+
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.models import Base
+
+
+def _patch_jsonb_columns() -> None:
+    """Replace JSONB column types with JSON for SQLite compatibility."""
+    for table in Base.metadata.sorted_tables:
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+def _patch_pg_server_defaults() -> None:
+    """Strip PostgreSQL-specific server_default values (e.g. ``'{}'::jsonb``).
+
+    SQLite cannot parse ``'{}'::jsonb``; remove any server_default whose text
+    contains ``::``, leaving Python-side defaults intact.
+    """
+    for table in Base.metadata.sorted_tables:
+        for column in table.columns:
+            sd = column.server_default
+            if sd is None:
+                continue
+            arg = getattr(sd, "arg", None)
+            if arg is None:
+                continue
+            # server_default arg may be a TextClause (.text) OR a plain string
+            # (e.g. mapped_column(JSONB, server_default="'[]'::jsonb")).
+            arg_text = getattr(arg, "text", None)
+            if arg_text is None and isinstance(arg, str):
+                arg_text = arg
+            if isinstance(arg_text, str) and "::" in arg_text:
+                column.server_default = None
+
+
+# Run once at import time, before any spec test creates tables.
+_patch_jsonb_columns()
+_patch_pg_server_defaults()

--- a/backend/specs/test_stuck_detection_spec.py
+++ b/backend/specs/test_stuck_detection_spec.py
@@ -1,0 +1,197 @@
+"""
+Spec: stuck-detection — struggling-student detection thresholds + recommendation rules.
+
+Canonical source: backend/app/services/stuck_detection_service.py
+Related issue: #91
+Module spec: specs/modules/stuck-detection/INTENT.md
+
+Two tiers in one file:
+- build_recommendations(): pure rule-based, no DB — runs in < 1 ms.
+- detect_stuck_points(): DB-coupled — uses an in-memory SQLite DB. FK enforcement
+  is intentionally OFF (phantom student_id) so we test detection logic, not
+  referential integrity. JSONB→JSON patching comes from specs/conftest.py.
+"""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+_BACKEND_DIR = Path(__file__).resolve().parents[1]
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from app.models import Base
+from app.models.session import CharacterError, LearningSession
+from app.services.stuck_detection_service import (
+    ACCURACY_DECLINE_SESSIONS,
+    CHARACTER_ERROR_THRESHOLD,
+    LOOKBACK_DAYS,
+    STUCK_ATTEMPT_THRESHOLD,
+    build_recommendations,
+    detect_stuck_points,
+)
+
+_STUDENT_ID = 999  # phantom; FK not enforced in SQLite here
+
+
+# ===========================================================================
+# Tier 1 — pure: build_recommendations rule mapping
+# ===========================================================================
+
+def _empty_stuck():
+    return {"story_stuck": [], "character_stuck": [], "is_declining": False, "accuracy_trend": []}
+
+
+class TestRecommendationRules:
+    def test_no_stuck_points_returns_single_encouragement(self):
+        recs = build_recommendations(_empty_stuck())
+        assert len(recs) == 1
+        assert recs[0]["type"] == "encouragement"
+
+    def test_declining_produces_declining_rec(self):
+        data = _empty_stuck()
+        data["is_declining"] = True
+        types = [r["type"] for r in build_recommendations(data)]
+        assert "declining" in types
+
+    def test_story_stuck_recs_capped_at_three(self):
+        data = _empty_stuck()
+        data["story_stuck"] = [
+            {"story_slug": f"s{i}", "attempt_count": 3, "best_accuracy": 50.0} for i in range(5)
+        ]
+        story_recs = [r for r in build_recommendations(data) if r["type"] == "story_stuck"]
+        assert len(story_recs) == 3
+
+    def test_character_stuck_recs_capped_at_five(self):
+        data = _empty_stuck()
+        data["character_stuck"] = [
+            {"character": chr(0x4E00 + i), "error_count": 3} for i in range(8)
+        ]
+        char_recs = [r for r in build_recommendations(data) if r["type"] == "character_stuck"]
+        assert len(char_recs) == 5
+
+    def test_every_rec_has_action(self):
+        data = _empty_stuck()
+        data["is_declining"] = True
+        data["story_stuck"] = [{"story_slug": "s", "attempt_count": 3, "best_accuracy": 40.0}]
+        data["character_stuck"] = [{"character": "難", "error_count": 4}]
+        for rec in build_recommendations(data):
+            assert rec.get("action")
+
+
+# ===========================================================================
+# Tier 2 — DB-coupled: detect_stuck_points thresholds
+# ===========================================================================
+
+_engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_Session = sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+
+
+@pytest.fixture()
+def db():
+    Base.metadata.create_all(bind=_engine)
+    session = _Session()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=_engine)
+
+
+def _add_session(db, *, story_slug=None, accuracy=None, days_ago=1):
+    started = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    row = LearningSession(
+        student_id=_STUDENT_ID,
+        story_slug=story_slug,
+        accuracy=accuracy,
+        status="completed",
+        current_step=1,
+        started_at=started,
+        full_reading_attempts=[],  # NOT NULL JSONB; default stripped for SQLite
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+class TestStorySlugDrift:
+    """detect_stuck_points groups multiple LearningSession rows by story_slug to
+    find a story "attempted 3+ times". But the current schema enforces
+    UNIQUE(student_id, story_slug) — a student can have at most ONE session per
+    story_slug — so the story_stuck branch is unreachable via repeated sessions.
+    This is real drift: the #91 logic predates the uniqueness constraint.
+    """
+
+    def test_unique_story_slug_per_student_is_enforced(self, db):
+        from sqlalchemy.exc import IntegrityError
+        _add_session(db, story_slug="dup", accuracy=50.0)
+        with pytest.raises(IntegrityError):
+            _add_session(db, story_slug="dup", accuracy=60.0)
+
+    @pytest.mark.xfail(
+        reason="story_stuck needs >=3 sessions sharing story_slug, but schema "
+        "enforces UNIQUE(student_id, story_slug); detection logic (#91) is stale",
+        strict=True,
+    )
+    def test_story_stuck_triggers_on_repeated_attempts(self, db):
+        for acc in (50.0, 51.0, 52.0):
+            _add_session(db, story_slug="stuck", accuracy=acc)
+        result = detect_stuck_points(_STUDENT_ID, db)
+        assert any(s["story_slug"] == "stuck" for s in result["story_stuck"])
+
+
+class TestCharacterStuck:
+    def test_character_with_threshold_errors_is_flagged(self, db):
+        sess = _add_session(db, story_slug="cs", accuracy=60.0)
+        for _ in range(CHARACTER_ERROR_THRESHOLD):
+            db.add(CharacterError(session_id=sess.id, character="難", error_type="pronunciation"))
+        db.commit()
+        result = detect_stuck_points(_STUDENT_ID, db)
+        chars = [c["character"] for c in result["character_stuck"]]
+        assert "難" in chars
+
+    def test_character_below_threshold_not_flagged(self, db):
+        sess = _add_session(db, story_slug="cs2", accuracy=60.0)
+        for _ in range(CHARACTER_ERROR_THRESHOLD - 1):
+            db.add(CharacterError(session_id=sess.id, character="易", error_type="pronunciation"))
+        db.commit()
+        result = detect_stuck_points(_STUDENT_ID, db)
+        assert all(c["character"] != "易" for c in result["character_stuck"])
+
+
+class TestDecliningTrend:
+    def test_strictly_declining_accuracy_flags_declining(self, db):
+        # story_slug=None avoids UNIQUE(student_id, story_slug); trend uses all sessions.
+        # most-recent-last; strictly declining over the last ACCURACY_DECLINE_SESSIONS
+        accs = [90.0, 80.0, 70.0]
+        for i, acc in enumerate(accs):
+            _add_session(db, story_slug=None, accuracy=acc, days_ago=len(accs) - i)
+        result = detect_stuck_points(_STUDENT_ID, db)
+        assert result["is_declining"] is True
+
+    def test_improving_accuracy_not_declining(self, db):
+        accs = [70.0, 80.0, 90.0]
+        for i, acc in enumerate(accs):
+            _add_session(db, story_slug=None, accuracy=acc, days_ago=len(accs) - i)
+        result = detect_stuck_points(_STUDENT_ID, db)
+        assert result["is_declining"] is False
+
+
+class TestLookbackWindow:
+    def test_sessions_older_than_lookback_excluded(self, db):
+        # sessions older than the 30-day window must not appear in the trend
+        for acc in (50.0, 51.0, 52.0):
+            _add_session(db, story_slug=None, accuracy=acc, days_ago=LOOKBACK_DAYS + 5)
+        result = detect_stuck_points(_STUDENT_ID, db)
+        assert result["accuracy_trend"] == []
+        assert result["story_stuck"] == []

--- a/specs/modules/stuck-detection/INTENT.md
+++ b/specs/modules/stuck-detection/INTENT.md
@@ -1,0 +1,52 @@
+---
+spec_id: learning.stuck_detection
+module: stuck-detection
+title: 卡點偵測 — 掙扎學生偵測閾值 + 規則式建議
+stability: active
+canonical_source: backend/app/services/stuck_detection_service.py
+owns_code:
+  - backend/app/services/stuck_detection_service.py
+owns_data: []
+spec_tests:
+  - backend/specs/test_stuck_detection_spec.py
+related_issues:
+  - 91
+source_meetings: []
+last_reviewed: 2026-06-02
+owner: young
+---
+
+## Intent
+
+`stuck_detection_service` 分析 `LearningSession` + `CharacterError` 找出掙扎中的學生，
+並用規則（非 AI、即時、永遠可用）產生行動建議。這是教師端「誰需要幫忙」的判斷依據，
+閾值直接綁 PRD（同一字錯 ≥3 次、同篇練 ≥3 次、連續 3 次正確率下滑）。
+
+本 module 是 DB-tier 的第一個範本：純函式部分（`build_recommendations`）秒測，
+DB 部分（`detect_stuck_points`）用 in-memory SQLite + phantom student_id（不驗 FK，
+只驗偵測邏輯），JSONB→JSON patch 來自 `specs/conftest.py`。
+
+## Invariants
+
+1. 閾值常數固定：`STUCK_ATTEMPT_THRESHOLD == 3`、`CHARACTER_ERROR_THRESHOLD == 3`、
+   `ACCURACY_DECLINE_SESSIONS == 3`、`LOOKBACK_DAYS == 30`。
+2. `build_recommendations`：無卡點 → 回 1 筆 `encouragement`；`is_declining` → 含
+   `declining`；`story_stuck` 建議上限 3 筆；`character_stuck` 建議上限 5 筆；每筆建議
+   都有 `action`。
+3. `detect_stuck_points` character_stuck：同字錯誤 ≥3 次才標記，< 3 不標記。
+4. `detect_stuck_points` 趨勢：最近 `ACCURACY_DECLINE_SESSIONS` 次嚴格遞減 → `is_declining`
+   True；遞增 → False。
+5. Lookback：`started_at` 早於 30 天的 session 不計入 `accuracy_trend`。
+
+## Known drift（契約標記，待 #91 處理）
+
+`detect_stuck_points` 的 **story_stuck** 分支假設「同一 `story_slug` 有 ≥3 筆 session」，
+但現行 schema 對 `learning_sessions` 有 `UNIQUE(student_id, story_slug)` 約束 —
+一個學生每篇課文最多一筆 session，story_stuck 因此**永遠觸發不了**。
+契約用一個 `xfail(strict=True)` 鎖定此事實：當有人修掉 drift（改用 `reading_attempt_history`
+的 attempt_no，或移除約束），該測試會 XPASS，強制回來更新規格。
+
+## Out of scope
+
+- `detect_stuck_points` 對真實 User/Classroom 階層的 FK 完整性（測試刻意關閉 FK）。
+- 路由層（teacher 端如何呈現建議）、AI 強化建議（本 module 只管規則式 baseline）。

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -530,6 +530,22 @@ modules:
   last_reviewed: 2026-06-02
   owner: young
   intent: specs/modules/step-sequence/INTENT.md
+- spec_id: learning.stuck_detection
+  module: stuck-detection
+  title: 卡點偵測 — 掙扎學生偵測閾值 + 規則式建議
+  stability: active
+  canonical_source: backend/app/services/stuck_detection_service.py
+  owns_code:
+  - backend/app/services/stuck_detection_service.py
+  owns_data: []
+  spec_tests:
+  - backend/specs/test_stuck_detection_spec.py
+  related_issues:
+  - 91
+  source_meetings: []
+  last_reviewed: 2026-06-02
+  owner: young
+  intent: specs/modules/stuck-detection/INTENT.md
 - spec_id: tts.synthesis.provider_chain
   module: tts
   title: TTS 合成服務 — 提供者鏈（Chirp3-HD → Azure fallback）+ synthesize_speech 入口


### PR DESCRIPTION
## What

Opens the **DB-coupled spec tier** and adds the first DB module.

**1. DB-tier foundation (`specs/conftest.py`)**
Now mirrors `tests/conftest.py` (JSONB→JSON + strips `::jsonb` server_defaults) so spec contracts can run against an in-memory SQLite DB. **Also fixes a latent bug both conftests shared:** a `server_default` passed as a plain string (`server_default="'[]'::jsonb"`) was never stripped — the code only checked `TextClause.text`. Now handles the plain-string case, so `full_reading_attempts` and similar columns no longer break SQLite inserts.

**2. `stuck-detection` module** (`stuck_detection_service.py`, #91)
- pure `build_recommendations` rules: encouragement fallback, declining rec, 3/5 caps, every rec has an action
- DB-coupled `detect_stuck_points`: character ≥3 errors flagged, strict accuracy decline → `is_declining`, 30-day lookback window — all tested against in-memory SQLite

## Drift found + locked

`detect_stuck_points`' **story_stuck** branch groups multiple `LearningSession` rows by `story_slug` to find a story "attempted 3+ times" — but the schema enforces `UNIQUE(student_id, story_slug)`, so a student can only have **one** session per story. story_stuck is therefore **unreachable**. Captured as `xfail(strict=True)`: the day someone fixes #91 (e.g. count via `reading_attempt_history.attempt_no`), it XPASSes and forces a spec update.

## Verification

`bash specs/run-ci.sh` → **498 passed, 33 xfailed** (was 487/32). Conftest change verified not to break any existing spec module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)