### PR TITLE
feat(rescue): wire voice input into AI tutor modal

### DIFF
--- a/frontend/src/components/reading-spotlight/McqRescueDialog.tsx
+++ b/frontend/src/components/reading-spotlight/McqRescueDialog.tsx
@@ -21,6 +21,7 @@ import {
   McqRescueRespondResponse,
   SessionExpiredError,
 } from '../../services/learningApi';
+import VoiceInputButton from '../ui/VoiceInputButton';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -112,6 +113,7 @@ const McqRescueDialog: React.FC<Props> = ({
   const dialogRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const voiceStopRef = useRef<(() => void) | null>(null);
 
   useFocusTrap(dialogRef, isOpen);
 
@@ -250,6 +252,7 @@ const McqRescueDialog: React.FC<Props> = ({
   );
 
   const handleSend = useCallback(() => {
+    voiceStopRef.current?.();
     const text = inputText;
     setInputText('');
     sendMessage(text);
@@ -459,6 +462,13 @@ const McqRescueDialog: React.FC<Props> = ({
                     className="flex-1 text-sm rounded-xl border border-gray-200 px-4 py-2.5 focus:outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-200 disabled:bg-gray-50 disabled:text-gray-400 transition-colors"
                     maxLength={500}
                     aria-label="回答輸入框"
+                  />
+                  <VoiceInputButton
+                    onTranscript={(text) => setInputText(text.slice(0, 500))}
+                    lang="zh-TW"
+                    disabled={isLoading || !sessionId}
+                    size="sm"
+                    stopRef={voiceStopRef}
                   />
                   <button
                     onClick={handleSend}


### PR DESCRIPTION
Closes #1636

## 改了什麼

`McqRescueDialog` input 框旁邊加 mic 按鈕，沿用既有 `VoiceInputButton` + `useSpeechRecognition`（Web Speech API，純前端）。

- import `VoiceInputButton`
- `voiceStopRef` 在 `handleSend` 開頭呼叫，避免送出當下還在錄
- `onTranscript` 直接覆寫整個輸入框（≤500 字）

## Scope

- MVP（issue 列出的最低要求）：✅
- TTS 念題、雙向語音流：不在本 PR scope（issue 標為 nice-to-have）
- 跨組件互動：不在 scope

## 不動

- backend / migration / prompt 都沒碰
- audio 不經 backend，直接由瀏覽器（Chrome→Google STT / Safari→Apple STT）

## Test plan

- [ ] staging 用 Chrome 桌機答錯 MCQ → 點 🦉 → mic 按鈕可見、可點
- [ ] mic 點下去 → 跳麥克風授權 → 變紅 pulse
- [ ] 講話 → 文字填入 input → 點送出 → AI 回覆正常
- [ ] iOS Safari / Android Chrome 各測一次
- [ ] Brave 不支援（Web Speech 被 Brave Shields 擋）— known browser limitation