### PR TITLE
ci(specs): wire spec-check workflow — path-filtered, delegates to run-ci.sh (Fixes #2041)

### DIFF
--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -1,0 +1,50 @@
+name: Spec Check
+
+# Modular spec system (issues #2029 + #2058 + #2041): verify the registry is
+# fresh (+ legacy_tests pointer-rot), run the executable spec contracts, and run
+# the legacy_tests union. Path-filtered so unrelated PRs (frontend/docs) skip it.
+#
+# This delegates to `bash specs/run-ci.sh` — the SAME runner used locally — so
+# the CI gates and the local gates can never drift. run-ci.sh computes the
+# legacy_tests union dynamically from specs/registry.yaml.
+on:
+  pull_request:
+    paths:
+      - 'specs/**'
+      - 'backend/specs/**'
+      - 'backend/app/services/**'
+      - 'backend/app/routes/auth.py'
+      - 'backend/app/routes/semesters.py'
+      - 'backend/data/lessons/**'
+      - 'backend/tests/test_semesters.py'
+      - 'backend/tests/test_points_system.py'
+      - 'backend/tests/test_full_reading_attempts.py'
+      - 'backend/tests/test_auth_api.py'
+      - 'backend/tests/test_auth_route_split_1844.py'
+
+jobs:
+  spec-check:
+    name: Spec registry + contracts + legacy_tests
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: sqlite://
+      JWT_SECRET_KEY: "ci-test-secret-key-not-for-production"
+      TTS_PROVIDER: google
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          cd backend
+          pip install -r requirements.txt
+
+      - name: Spec CI (registry + pointer-rot + contracts + legacy_tests union)
+        run: bash specs/run-ci.sh

--- a/specs/README.md
+++ b/specs/README.md
@@ -77,12 +77,11 @@ Spec 真正的失效不是 code 改壞，是**會議講了沒人寫回 INTENT.md
 - 全 stack 鋪開（先 OMO pilot 驗證價值）
 - LLM-judge probe 接 per-PR gate（先定 latency/budget 政策，見 `modules/omo-assessment/probes/README.md`）
 
-## CI workflow 安裝（需 workflow-scoped token）
+## CI workflow（已部署 — #2041）
 
-`specs/ci/spec-check.yml` 是 CI workflow 模板。本機 PAT 沒有 GitHub `workflow`
-scope，無法自動寫入 `.github/workflows/`。請用有 `workflow` scope 的 token / 從
-GitHub 網頁，把它複製到 `.github/workflows/spec-check.yml` 啟用：
+Live workflow：**`.github/workflows/spec-check.yml`**（2026-06 接上，workflow-scoped
+token）。它 **path-filtered**（只在 `specs/**`、`backend/specs/**`、
+`backend/app/services/**`、lesson 資料、legacy_tests 目標檔變動時跑），且直接
+`bash specs/run-ci.sh` —— 跟本機完全同一個 runner，CI 與本機 gate 永不 drift。
 
-```
-cp specs/ci/spec-check.yml .github/workflows/spec-check.yml
-```
+`specs/ci/spec-check.yml` 留作 doc anchor，內容指回 live 版（不要在那邊改邏輯）。

--- a/specs/ci/spec-check.yml
+++ b/specs/ci/spec-check.yml
@@ -1,90 +1,10 @@
-name: Spec Check
-
-# Modular spec system (issue #2029 + #2058): verify the registry is fresh and
-# run the executable spec contracts + legacy_tests union.
+# ───────────────────────────────────────────────────────────────────────────
+# DEPLOYED — the live Spec Check workflow now runs from:
+#       .github/workflows/spec-check.yml   (wired 2026-06, issue #2041)
 #
-# ⚠️  DEPLOYMENT BLOCKED: copying this file to .github/workflows/ requires a
-#     token with `workflow` scope.  Tracked in issue #2041.
-#     Until then, run locally: bash specs/run-ci.sh
+# Do NOT edit gate logic here. The live workflow path-filters relevant PRs and
+# delegates to `bash specs/run-ci.sh` (same runner used locally → no drift).
 #
-# Path filter covers:
-#   - specs/**                              — module INTENT.md + registry + scripts
-#   - backend/specs/**                      — executable spec contracts
-#   - backend/app/services/**               — service code owned by spec modules
-#   - backend/app/routes/auth.py            — auth-flows module owned code
-#   - backend/app/routes/semesters.py       — semester module owned code
-#   - backend/data/lessons/**               — lesson YAML owned by content-schema
-#   - backend/tests/test_semesters.py       — legacy_tests pointer targets
-#   - backend/tests/test_points_system.py
-#   - backend/tests/test_reading_attempt_history.py
-#   - backend/tests/test_full_reading_attempts.py
-#   - backend/tests/test_auth_api.py
-#   - backend/tests/test_auth_route_split_1844.py
-on:
-  pull_request:
-    paths:
-      - 'specs/**'
-      - 'backend/specs/**'
-      - 'backend/app/services/**'
-      - 'backend/app/routes/auth.py'
-      - 'backend/app/routes/semesters.py'
-      - 'backend/data/lessons/**'
-      - 'backend/tests/test_semesters.py'
-      - 'backend/tests/test_points_system.py'
-      - 'backend/tests/test_reading_attempt_history.py'
-      - 'backend/tests/test_full_reading_attempts.py'
-      - 'backend/tests/test_auth_api.py'
-      - 'backend/tests/test_auth_route_split_1844.py'
-
-jobs:
-  spec-check:
-    name: Spec registry + contracts + legacy_tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: backend/requirements.txt
-
-      - name: Install dependencies
-        run: |
-          cd backend
-          pip install -r requirements.txt
-
-      - name: Gate 1 — Registry freshness + pointer-rot check (build_registry.py --check)
-        run: python specs/build_registry.py --check
-
-      - name: Gate 2 — Run spec contracts (pytest specs/)
-        run: |
-          cd backend
-          python -m pytest specs/ -v --tb=short
-        env:
-          DATABASE_URL: sqlite://
-          JWT_SECRET_KEY: "ci-test-secret-key-not-for-production"
-          TTS_PROVIDER: google
-
-      - name: Gate 3 — Run legacy_tests union
-        # Note: legacy_tests require a real DB.  In GHA, use SQLite where possible;
-        # tests that need PostgreSQL will be skipped via conftest skip markers.
-        # The primary value of this gate is catching import errors and pure-logic
-        # regressions; full DB-coupled tests run in the main test matrix.
-        run: |
-          cd backend
-          python -m pytest \
-            tests/test_semesters.py \
-            tests/test_points_system.py \
-            tests/test_reading_attempt_history.py \
-            tests/test_full_reading_attempts.py \
-            tests/test_auth_api.py \
-            tests/test_auth_route_split_1844.py \
-            -v --tb=short -q
-        env:
-          DATABASE_URL: sqlite://
-          JWT_SECRET_KEY: "ci-test-secret-key-not-for-production"
-          TTS_PROVIDER: google
+# This file is kept only as a doc anchor for references in specs/README.md and
+# specs/run-ci.sh. Source of truth: .github/workflows/spec-check.yml + run-ci.sh.
+# ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Wires the modular spec system into CI — `.github/workflows/spec-check.yml`. Until now the 37-module contract suite was only runnable via local `bash specs/run-ci.sh`; this makes it an **automatic per-PR check**. Closes the last piece of the spec-coverage consensus (#2058) and unblocks #2041 (workflow-scoped token now in place).

## Design (per the 4-reviewer debate + devil's advocate)
- **Path-filtered**: runs only when `specs/**`, `backend/specs/**`, `backend/app/services/**`, lesson data, or the legacy_tests target files change → frontend/docs PRs are not slowed (addresses the "per-PR overkill / false-confidence" critique).
- **Delegates to `bash specs/run-ci.sh`** — the exact runner used locally → CI gates and local gates can never drift. run-ci computes the legacy_tests union from `registry.yaml` dynamically.
- **Fixed a real drift** in the prior template: it hardcoded `test_reading_attempt_history.py` into a gate, which run-ci deliberately excludes (complementary_tests, known SQLite/JSON edge) — that would have failed CI. Delegating removes the duplicate list.

## Self-test
This PR touches `specs/**`, so the new workflow runs **on its own PR** — watch the `Spec Check` check below go green.

Fixes #2041

🤖 Generated with [Claude Code](https://claude.com/claude-code)