### PR TITLE
fix(omo): grader resolves lettered answers from vocab_bank (systemic fix for issue 2015)

### DIFF
--- a/backend/app/services/omo_question_schema.py
+++ b/backend/app/services/omo_question_schema.py
@@ -15,21 +15,46 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def _resolve_letter_answer(letter: str, vocabulary: list) -> str:
-    """Resolve A/B/C/... letter to vocabulary word.
+def _vocab_bank_lookup(vocab_bank, key: str) -> str | None:
+    """Return the word a worksheet letter maps to in vocab_bank, else None.
 
-    L22-L30 YAML uses ordered letter (A=0, B=1, ...) as placeholder for the
-    vocabulary list index. So `answer: A` for fill_in_blank means the student
-    should fill in vocabulary[0].word (e.g. '奠定').
-
-    Returns the actual word if letter matches a vocab index, else returns
-    the letter as-is (for backward compatibility with non-vocab grading).
+    vocab_bank is the paper worksheet's printed legend (letter→word). Keys are
+    halfwidth single letters; match case-insensitively.
     """
-    if not isinstance(letter, str) or len(letter) != 1 or not letter.isalpha():
+    if not isinstance(vocab_bank, dict) or not vocab_bank:
+        return None
+    for k, v in vocab_bank.items():
+        if str(k).strip().upper() == key:
+            if isinstance(v, dict):
+                return str(v.get("word") or v.get("term") or "") or None
+            return str(v)
+    return None
+
+
+def _resolve_letter_answer(letter: str, vocabulary: list, vocab_bank=None) -> str:
+    """Resolve A/B/C/... letter to the vocabulary word it stands for.
+
+    Source of truth is the paper worksheet's printed legend (``vocab_bank``: a
+    letter→word dict). Its keys can be NON-CONTIGUOUS (e.g. {A, D, E, G, H}) and
+    need not match the lesson ``vocabulary`` list order, so resolve from
+    vocab_bank first when it contains the letter (#2015 — index mapping marked
+    correct answers wrong because it assumed A=vocabulary[0], B=vocabulary[1]…).
+
+    Fallback (no vocab_bank, or the letter is absent from it): legacy index
+    mapping where A=vocabulary[0], B=vocabulary[1], … (L22-L30 style).
+
+    Returns the actual word, else the letter as-is.
+    """
+    if not isinstance(letter, str) or len(letter.strip()) != 1 or not letter.strip().isalpha():
         return str(letter)
+    key = letter.strip().upper()
+    # Worksheet legend wins when present (#2015).
+    bank_word = _vocab_bank_lookup(vocab_bank, key)
+    if bank_word is not None:
+        return bank_word
     if not isinstance(vocabulary, list) or not vocabulary:
         return letter
-    idx = ord(letter.upper()) - ord("A")
+    idx = ord(key) - ord("A")
     if not (0 <= idx < len(vocabulary)):
         return letter
     v = vocabulary[idx]
@@ -48,25 +73,46 @@ def _build_question_schema(lesson: dict) -> list[dict]:
     questions = []
     vocabulary = lesson.get("vocabulary") or []
     vocab_words = [v.get("word", "") for v in vocabulary if v.get("word")]
+    # Paper worksheet legend (letter→word). When present it is the source of
+    # truth for lettered answers (#2015); its keys may be non-contiguous.
+    vocab_bank = lesson.get("vocab_bank") if isinstance(lesson.get("vocab_bank"), dict) else None
 
-    # Detect fill_in_blank mode: 'lettered' (student circles A-G) vs 'free_form'
-    # (student handwrites a word). Mode is determined by whether ALL fb answers
-    # in the lesson are single A-G letters — that pattern is used by L22-L30
-    # 「四 語詞應用」style where vocabulary letters are the choice set.
+    # Detect fill_in_blank mode: 'lettered' (student circles a letter) vs
+    # 'free_form' (student handwrites a word). Mode is determined by whether ALL
+    # fb answers are single letters within the worksheet's choice set.
     fb = lesson.get("fill_in_blank") or []
     fb_raw_items = list(fb.items()) if isinstance(fb, dict) else list(enumerate(fb))
     fb_answers = []
     for _, item in fb_raw_items:
         ans = item.get("answer", "") if isinstance(item, dict) else str(item)
         fb_answers.append(ans)
+
+    # The worksheet's legal letter set. When a vocab_bank legend is present, its
+    # keys define the letters — and they can run PAST G (H, I, J, K …) when the
+    # worksheet offers 8+ choices. Hardcoding A-G degraded those lessons to
+    # free_form and scored a perfect student 0 (#2015). Fall back to A-G only for
+    # legacy lessons (L22-L30 style) that have no vocab_bank.
+    if vocab_bank:
+        bank_letters = sorted(
+            str(k).strip().upper()
+            for k in vocab_bank.keys()
+            if len(str(k).strip()) == 1 and str(k).strip().isalpha()
+        )
+    else:
+        bank_letters = list("ABCDEFG")
+    bank_letter_set = set(bank_letters)
+
     fb_lettered = bool(fb_answers) and all(
-        isinstance(a, str) and len(a.strip()) == 1 and a.strip().upper() in "ABCDEFG"
+        isinstance(a, str) and len(a.strip()) == 1 and a.strip().upper() in bank_letter_set
         for a in fb_answers if a
     )
-    # Lettered choices use the vocabulary as the A-G mapping; allowed letters
-    # equal min(len(vocab), 7) so we don't claim more letters than choices.
-    n_letters = min(len(vocab_words), 7) if fb_lettered else 0
-    fb_allowed_letters = [chr(ord("A") + i) for i in range(n_letters)]
+    if not fb_lettered:
+        fb_allowed_letters = []
+    elif vocab_bank:
+        fb_allowed_letters = bank_letters
+    else:
+        n_letters = min(len(vocab_words), 7)
+        fb_allowed_letters = [chr(ord("A") + i) for i in range(n_letters)]
 
     for key, item in fb_raw_items:
         qid = str(key) if isinstance(fb, dict) else f"fb_{key+1}"
@@ -76,7 +122,7 @@ def _build_question_schema(lesson: dict) -> list[dict]:
         else:
             raw_answer = str(item)
             context = ""
-        correct_word = _resolve_letter_answer(raw_answer, vocabulary)
+        correct_word = _resolve_letter_answer(raw_answer, vocabulary, vocab_bank)
         # #1712: lettered fb compares letter-vs-letter (student circles a letter).
         # `correct_answer` is what we score against in _score_answer.
         # `correct_word` is kept for display ("正解：規律").

--- a/backend/specs/test_omo_grading_corpus.py
+++ b/backend/specs/test_omo_grading_corpus.py
@@ -95,25 +95,42 @@ def _perfect_student(lesson: dict) -> dict:
     return student
 
 
-def _has_answer_beyond_AG(lesson: dict) -> bool:
-    """True if any fill_in_blank answer letter falls outside A-G.
+def _answers_reference_unknown_letters(lesson: dict) -> bool:
+    """True if any single-letter fill_in_blank answer is NOT a key in vocab_bank.
 
-    These lessons currently break: a single H-K answer flips the whole lesson
-    out of 'lettered' mode into 'free_form', so the student's circled letter is
-    validated against vocab words, coerced to empty, and scored 0 (issue 2015).
+    This is a LESSON-DATA inconsistency (the answer key cites a letter the
+    worksheet legend never defines, e.g. G6-L25 answers J/K but vocab_bank only
+    runs A-I), distinct from the grader-code bug fixed in #2015. The grader is
+    correct; the data needs fixing. Tracked as xfail(strict) so a data fix
+    XPASSes and forces this marker's removal.
     """
+    vb = lesson.get("vocab_bank")
+    if not isinstance(vb, dict):
+        return False
+    keys = {str(k).strip().upper() for k in vb.keys()
+            if len(str(k).strip()) == 1 and str(k).strip().isalpha()}
+    if not keys:
+        return False
     fb = lesson.get("fill_in_blank") or []
     pairs = fb.items() if isinstance(fb, dict) else enumerate(fb)
     for _, item in pairs:
         ans = item.get("answer") if isinstance(item, dict) else str(item)
-        if isinstance(ans, str) and len(ans.strip()) == 1 and ans.strip().upper() not in "ABCDEFG":
-            return True
+        if isinstance(ans, str) and len(ans.strip()) == 1 and ans.strip().isalpha():
+            if ans.strip().upper() not in keys:
+                return True
     return False
 
 
 def _lesson_sweep_params():
-    """One param per vocab_bank lesson. A-G-only lessons must hard-pass (catches
-    new regressions); lessons with H-K answers are xfail(strict) until 2015 lands."""
+    """One param per vocab_bank lesson. EVERY well-formed lesson must hard-pass:
+    a perfect student (circles exactly the answer key) scores 100%. Includes
+    lessons whose worksheet uses letters past G (H, I, J, K …) — fixed in #2015
+    by deriving the legal letter set from vocab_bank keys instead of hardcoding
+    A-G, so an 8+-choice worksheet no longer degrades to free_form.
+
+    Lessons whose answer key cites letters absent from their own vocab_bank are
+    a separate LESSON-DATA bug (not a grader bug) and are xfail(strict) until the
+    data is corrected."""
     params = []
     for f in _vocab_bank_lessons():
         try:
@@ -121,9 +138,10 @@ def _lesson_sweep_params():
         except Exception:
             continue
         marks = []
-        if _has_answer_beyond_AG(d):
+        if _answers_reference_unknown_letters(d):
             marks.append(pytest.mark.xfail(
-                reason="issue 2015 — H-K answer degrades lesson to free_form, perfect student scored 0",
+                reason="lesson-data: answer key cites a letter absent from this "
+                "lesson's vocab_bank legend (data fix, not grader — #2015 follow-up)",
                 strict=True,
             ))
         params.append(pytest.param(f, id=f.stem, marks=marks))

--- a/specs/modules/omo-assessment/fixtures/grading-corpus.yaml
+++ b/specs/modules/omo-assessment/fixtures/grading-corpus.yaml
@@ -81,12 +81,13 @@ cases:
     student: {fb_1: "b"}
     expect: {fb_1: 1.0}
 
-  # --- the issue-2015 bug, pinned as xfail ----------------------------------
+  # --- issue-2015 regression (FIXED): letters past G must score -------------
   - id: letter_beyond_AG_should_score    # 越界字母 H-K
     desc: >
-      學生圈正解 I → 應滿分。但只要有一題答案超過 A-G，fb_lettered 偵測就整課判 False，
-      模式退成 free_form：correct_answer 變成詞、allowed_values 變成 vocab words，
-      學生圈的 'I' 不在 vocab words 裡 → 被 validator coerce 成空 → 判 0。
+      學生圈正解 I → 應滿分。修正前：只要有一題答案超過 A-G，fb_lettered 偵測整課判 False，
+      模式退成 free_form，學生圈的 'I' 被 validator coerce 成空 → 判 0。
+      修正後（#2015）：合法字母集改由 vocab_bank keys 決定（可超過 G），課程留在 lettered
+      模式，圈 'I' 正常滿分。
     lesson:
       vocab_bank: {A: 揚帆啟航, B: 股票, C: 節衣縮食, D: 滿手老繭, E: 集資, F: 獲利, G: 股東, H: 大手一揮, I: 派遣}
       vocabulary:
@@ -102,4 +103,3 @@ cases:
       fill_in_blank: [{sentence: "畢業後他準備（），踏上新旅程", answer: I}]
     student: {fb_1: I}
     expect: {fb_1: 1.0}
-    xfail: "issue 2015 — one H-K answer flips the lesson to free_form; circled 'I' is coerced empty and scored 0"


### PR DESCRIPTION
## What

Systemic root-cause fix for the OMO grader bug where **students who answered correctly were scored 0** on 語詞應用 fill-in-blank. Complements @if-else-master's per-lesson data fix already merged (PR 2023, G6-L24/L25) — this fixes the **grader code** so the bug can't recur across other lessons.

## Root cause

The grader assumed a worksheet letter = the vocabulary-list index (A=`vocabulary[0]`, B=`vocabulary[1]`…). But the paper worksheet's printed legend (`vocab_bank`: a letter→word dict) is the real source of truth, and its keys are **non-contiguous** (e.g. `{A,D,E,G,H}`) and can run **past G** (H,I,J,K) on 8+-choice worksheets.

- **free_form path**: `correct_word` resolved to the wrong vocabulary index (L55 `D` → `稀薄` instead of the worksheet's `因人而異`).
- **lettered path**: any answer past G failed the A-G-only mode detection → the whole lesson degraded to free_form → a perfect student scored 0.

## Fix (additive — lessons without vocab_bank unchanged)

- `_resolve_letter_answer`: resolve from `vocab_bank[letter]` when present.
- `_build_question_schema`: derive the legal letter set from `vocab_bank` keys (may exceed G) instead of a contiguous `A..min(vocab,7)` range.

## Verification (the spec system caught my first incomplete attempt)

- **28 corpus lessons** that previously scored a perfect student 0 now hard-pass — their `issue-2015` `xfail(strict)` markers flipped to XPASS and were removed (`grading-corpus.yaml` + `test_omo_grading_corpus.py`).
- Local CI: **527 passed, 4 xfailed**; legacy_tests union **205 passed**.
- **Zero new failures** in `tests/` (precise before/after diff: identical 12 pre-existing stale-test failures, unrelated to this change).

## Remaining (NOT this PR — lesson-data owner)

`G6-L25` still fails the perfect-student sweep because its answer key cites letters **J/K absent from its own vocab_bank (A-I)** — a **lesson-data** bug, not a grader bug. Pinned as `xfail(strict)` so the data fix XPASSes and forces the marker's removal. That's @if-else-master's lesson-data lane.

Tracking issue 2015 (assigned to @if-else-master — not closing it here; leaving for owner review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)