### PR TITLE
fix(ci): preview-cleanup fails loud on AR untag + diagnose root cause (Related to #2064)

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -105,12 +105,17 @@ jobs:
                   console.log(`KEEP: ${sub}:${tag} (issue #${match[1]} open)`);
                   continue;
                 }
-                console.log(`UNTAG: ${sub}:${tag} (issue #${match[1]} closed)`);
+                console.log(`DELETE-IMAGE: ${sub}:${tag} (issue #${match[1]} closed)`);
                 try {
-                  // No 2>/dev/null: capture the real gcloud stderr so a failing
-                  // delete surfaces PERMISSION_DENIED / NOT_FOUND / syntax (#2064).
+                  // The CI service account has artifactregistry.versions.delete
+                  // (images delete) but NOT artifactregistry.tags.delete (#2064:
+                  // `tags delete` failed PERMISSION_DENIED on all 376). Delete the
+                  // image VERSION the tag points to with --delete-tags — works with
+                  // the existing perm AND frees storage immediately instead of
+                  // waiting for the L1 untagged policy. No 2>/dev/null so a real
+                  // failure (NOT_FOUND for an already-gone digest, etc.) surfaces.
                   execSync(
-                    `gcloud artifacts docker tags delete "${registry}/${sub}:${tag}" --quiet`,
+                    `gcloud artifacts docker images delete "${registry}/${sub}:${tag}" --delete-tags --quiet`,
                     { stdio: 'pipe' }
                   );
                   tagDeleted++;

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -88,6 +88,7 @@ jobs:
             // === Part 2: AR Preview Tags + Images ===
             console.log('\n=== AR Preview Tags ===');
             let tagDeleted = 0;
+            let tagFailed = 0;
 
             for (const sub of ['backend', 'frontend']) {
               let tags;
@@ -106,17 +107,25 @@ jobs:
                 }
                 console.log(`UNTAG: ${sub}:${tag} (issue #${match[1]} closed)`);
                 try {
+                  // No 2>/dev/null: capture the real gcloud stderr so a failing
+                  // delete surfaces PERMISSION_DENIED / NOT_FOUND / syntax (#2064).
                   execSync(
-                    `gcloud artifacts docker tags delete "${registry}/${sub}:${tag}" --quiet 2>/dev/null`
+                    `gcloud artifacts docker tags delete "${registry}/${sub}:${tag}" --quiet`,
+                    { stdio: 'pipe' }
                   );
                   tagDeleted++;
                 } catch(e) {
-                  console.log(`  Failed: ${e.message}`);
+                  const detail = ((e.stderr || e.message || '') + '').trim().slice(0, 300);
+                  console.log(`  Failed: ${detail}`);
+                  tagFailed++;
                 }
               }
             }
 
             console.log(`\n=== Summary ===`);
             console.log(`Services: ${svcDeleted} deleted`);
-            console.log(`AR Tags: ${tagDeleted} untagged`);
+            console.log(`AR Tags: ${tagDeleted} untagged, ${tagFailed} failed`);
             console.log('L1 AR Policy will auto-clean untagged images within 7 days');
+            if (tagFailed > 0) {
+              console.log(`::warning::${tagFailed} AR tag deletes failed — see 'Failed:' lines above for the real gcloud error (#2064)`);
+            }

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -105,26 +105,22 @@ jobs:
                   console.log(`KEEP: ${sub}:${tag} (issue #${match[1]} open)`);
                   continue;
                 }
-                console.log(`DELETE-IMAGE: ${sub}:${tag} (issue #${match[1]} closed)`);
+                console.log(`UNTAG: ${sub}:${tag} (issue #${match[1]} closed)`);
                 try {
-                  // Delete by @DIGEST, not :tag (#2064). The CI SA has
-                  // artifactregistry.versions.delete but NOT tags.delete; deleting a
-                  // :tag reference takes the tags.delete path (PERMISSION_DENIED),
-                  // whereas `images delete <pkg>@<digest> --delete-tags` uses
-                  // versions.delete — exactly what cleanup.yml does (600+/wk OK).
-                  // So resolve the tag → its digest first, then delete the version.
-                  const digest = execSync(
-                    `gcloud artifacts docker images list "${registry}/${sub}" --include-tags --filter="tags:${tag}" --format="value(version)" --limit=1`,
-                    { stdio: 'pipe' }
-                  ).toString().trim();
-                  if (!digest) { console.log('  (no digest for tag — already gone, skip)'); continue; }
+                  // Removing a tagged preview image ALWAYS needs
+                  // artifactregistry.tags.delete — whether via `tags delete` or
+                  // `images delete --delete-tags` (verified both fail identically).
+                  // The CI SA currently LACKS that perm (#2064: PERMISSION_DENIED).
+                  // There is no code workaround; the fix is the IAM grant in #2064.
+                  // No 2>/dev/null here (unlike cleanup.yml) so it fails LOUD, not
+                  // silent — and tagFailed + the ::warning:: below make it visible.
                   execSync(
-                    `gcloud artifacts docker images delete "${registry}/${sub}@${digest}" --delete-tags --quiet`,
+                    `gcloud artifacts docker tags delete "${registry}/${sub}:${tag}" --quiet`,
                     { stdio: 'pipe' }
                   );
                   tagDeleted++;
                 } catch(e) {
-                  const detail = ((e.stderr || e.message || '') + '').trim().slice(0, 300);
+                  const detail = ((e.stderr || e.message || '') + '').trim().slice(0, 200);
                   console.log(`  Failed: ${detail}`);
                   tagFailed++;
                 }

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -107,15 +107,19 @@ jobs:
                 }
                 console.log(`DELETE-IMAGE: ${sub}:${tag} (issue #${match[1]} closed)`);
                 try {
-                  // The CI service account has artifactregistry.versions.delete
-                  // (images delete) but NOT artifactregistry.tags.delete (#2064:
-                  // `tags delete` failed PERMISSION_DENIED on all 376). Delete the
-                  // image VERSION the tag points to with --delete-tags — works with
-                  // the existing perm AND frees storage immediately instead of
-                  // waiting for the L1 untagged policy. No 2>/dev/null so a real
-                  // failure (NOT_FOUND for an already-gone digest, etc.) surfaces.
+                  // Delete by @DIGEST, not :tag (#2064). The CI SA has
+                  // artifactregistry.versions.delete but NOT tags.delete; deleting a
+                  // :tag reference takes the tags.delete path (PERMISSION_DENIED),
+                  // whereas `images delete <pkg>@<digest> --delete-tags` uses
+                  // versions.delete — exactly what cleanup.yml does (600+/wk OK).
+                  // So resolve the tag → its digest first, then delete the version.
+                  const digest = execSync(
+                    `gcloud artifacts docker images list "${registry}/${sub}" --include-tags --filter="tags:${tag}" --format="value(version)" --limit=1`,
+                    { stdio: 'pipe' }
+                  ).toString().trim();
+                  if (!digest) { console.log('  (no digest for tag — already gone, skip)'); continue; }
                   execSync(
-                    `gcloud artifacts docker images delete "${registry}/${sub}:${tag}" --delete-tags --quiet`,
+                    `gcloud artifacts docker images delete "${registry}/${sub}@${digest}" --delete-tags --quiet`,
                     { stdio: 'pipe' }
                   );
                   tagDeleted++;


### PR DESCRIPTION
Makes the silently-failing AR tag cleanup LOUD (removes 2>/dev/null, adds tagFailed + ::warning::). Root cause diagnosed: CI SA lacks `artifactregistry.tags.delete` (PERMISSION_DENIED on all 376). No code workaround — real fix is the IAM grant tracked in #2064. cleanup.yml has the same latent fake-success issue. 🤖