### PR TITLE
release: staging → production (CI cleanup honesty + worksheet student-version)

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -44,17 +44,23 @@ jobs:
               TOTAL=$(echo "$DIGESTS" | wc -l | tr -d ' ')
               echo "Found $TOTAL images, keeping latest $KEEP"
 
-              DELETED=0
-              echo "$DIGESTS" | tail -n +$((KEEP + 1)) | while read -r DIGEST; do
+              # Real counting (no 2>/dev/null swallow, no subshell via <<<) so the
+              # report is the actual delete count, not TOTAL-KEEP arithmetic (#2064).
+              DELETED=0; FAILED=0
+              while read -r DIGEST; do
                 [ -z "$DIGEST" ] && continue
                 echo "DELETE: ${PACKAGE}@${DIGEST:0:20}..."
-                gcloud artifacts docker images delete \
-                  "${{ env.REGISTRY }}/${PACKAGE}@${DIGEST}" \
-                  --delete-tags --quiet 2>/dev/null || true
-                DELETED=$((DELETED + 1))
-              done
+                if gcloud artifacts docker images delete \
+                    "${{ env.REGISTRY }}/${PACKAGE}@${DIGEST}" \
+                    --delete-tags --quiet; then
+                  DELETED=$((DELETED + 1))
+                else
+                  FAILED=$((FAILED + 1))
+                  echo "::warning::failed to delete ${PACKAGE}@${DIGEST:0:25} (#2064)"
+                fi
+              done <<< "$(echo "$DIGESTS" | tail -n +$((KEEP + 1)))"
 
-              echo "Done: ${PACKAGE}/${PREFIX} — deleted $((TOTAL - KEEP > 0 ? TOTAL - KEEP : 0)) of $TOTAL"
+              echo "Done: ${PACKAGE}/${PREFIX} — deleted ${DELETED}, failed ${FAILED} (of $TOTAL total)"
               echo ""
             done
           done
@@ -78,13 +84,20 @@ jobs:
             TOTAL=$(echo "$DIGESTS" | wc -l | tr -d ' ')
             echo "Found $TOTAL untagged images"
 
-            echo "$DIGESTS" | while read -r DIGEST; do
+            DELETED=0; FAILED=0
+            while read -r DIGEST; do
               [ -z "$DIGEST" ] && continue
               echo "DELETE: ${PACKAGE}@${DIGEST:0:20}..."
-              gcloud artifacts docker images delete \
-                "${{ env.REGISTRY }}/${PACKAGE}@${DIGEST}" \
-                --delete-tags --quiet 2>/dev/null || true
-            done
+              if gcloud artifacts docker images delete \
+                  "${{ env.REGISTRY }}/${PACKAGE}@${DIGEST}" \
+                  --delete-tags --quiet; then
+                DELETED=$((DELETED + 1))
+              else
+                FAILED=$((FAILED + 1))
+                echo "::warning::failed to delete untagged ${PACKAGE}@${DIGEST:0:25} (#2064)"
+              fi
+            done <<< "$DIGESTS"
+            echo "Done: ${PACKAGE} untagged — deleted ${DELETED}, failed ${FAILED} (of $TOTAL)"
           done
 
   cleanup-revisions:
@@ -125,18 +138,23 @@ jobs:
             TOTAL=$(echo "$REVISIONS" | wc -l | tr -d ' ')
             echo "Found $TOTAL revisions, keeping latest $KEEP"
 
-            DELETED=0
-            echo "$REVISIONS" | tail -n +$((KEEP + 1)) | while read -r REV; do
+            DELETED=0; FAILED=0
+            while read -r REV; do
               [ -z "$REV" ] && continue
               echo "DELETE: ${REV}"
-              gcloud run revisions delete "${REV}" \
-                --region="${{ env.REGION }}" \
-                --project="${{ env.PROJECT_ID }}" \
-                --quiet 2>/dev/null || true
-              DELETED=$((DELETED + 1))
-            done
+              if gcloud run revisions delete "${REV}" \
+                  --region="${{ env.REGION }}" \
+                  --project="${{ env.PROJECT_ID }}" \
+                  --quiet; then
+                DELETED=$((DELETED + 1))
+              else
+                # An active/serving revision can't be deleted — expected, not alarming.
+                FAILED=$((FAILED + 1))
+                echo "  (skip: ${REV} not deletable — likely still serving traffic)"
+              fi
+            done <<< "$(echo "$REVISIONS" | tail -n +$((KEEP + 1)))"
 
-            echo "Done: ${SERVICE} — cleaned $((TOTAL - KEEP > 0 ? TOTAL - KEEP : 0)) of $TOTAL revisions"
+            echo "Done: ${SERVICE} — deleted ${DELETED}, skipped ${FAILED} (of $TOTAL revisions)"
             echo ""
           done
 

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -88,6 +88,7 @@ jobs:
             // === Part 2: AR Preview Tags + Images ===
             console.log('\n=== AR Preview Tags ===');
             let tagDeleted = 0;
+            let tagFailed = 0;
 
             for (const sub of ['backend', 'frontend']) {
               let tags;
@@ -106,17 +107,30 @@ jobs:
                 }
                 console.log(`UNTAG: ${sub}:${tag} (issue #${match[1]} closed)`);
                 try {
+                  // Removing a tagged preview image ALWAYS needs
+                  // artifactregistry.tags.delete — whether via `tags delete` or
+                  // `images delete --delete-tags` (verified both fail identically).
+                  // The CI SA currently LACKS that perm (#2064: PERMISSION_DENIED).
+                  // There is no code workaround; the fix is the IAM grant in #2064.
+                  // No 2>/dev/null here (unlike cleanup.yml) so it fails LOUD, not
+                  // silent — and tagFailed + the ::warning:: below make it visible.
                   execSync(
-                    `gcloud artifacts docker tags delete "${registry}/${sub}:${tag}" --quiet 2>/dev/null`
+                    `gcloud artifacts docker tags delete "${registry}/${sub}:${tag}" --quiet`,
+                    { stdio: 'pipe' }
                   );
                   tagDeleted++;
                 } catch(e) {
-                  console.log(`  Failed: ${e.message}`);
+                  const detail = ((e.stderr || e.message || '') + '').trim().slice(0, 200);
+                  console.log(`  Failed: ${detail}`);
+                  tagFailed++;
                 }
               }
             }
 
             console.log(`\n=== Summary ===`);
             console.log(`Services: ${svcDeleted} deleted`);
-            console.log(`AR Tags: ${tagDeleted} untagged`);
+            console.log(`AR Tags: ${tagDeleted} untagged, ${tagFailed} failed`);
             console.log('L1 AR Policy will auto-clean untagged images within 7 days');
+            if (tagFailed > 0) {
+              console.log(`::warning::${tagFailed} AR tag deletes failed — see 'Failed:' lines above for the real gcloud error (#2064)`);
+            }

--- a/scripts/convert_docx_to_pdf.py
+++ b/scripts/convert_docx_to_pdf.py
@@ -5,9 +5,12 @@ convert_docx_to_pdf.py — Convert 158 lesson docx worksheets to PDF.
 Usage:
     python3 scripts/convert_docx_to_pdf.py [--dry-run] [--force]
 
-Source directories (教師版 L1~122 + 第三階段 L123~157 學生版):
-    private/curriculum-source/2026-05-01/1.L1-158新版完成學習單1150415/1-1教師版(L1~122)/
-    private/curriculum-source/2026-05-01/1.L1-158新版完成學習單1150415/第三階段(L123開始~L157)差學生版/
+Source directories — STUDENT versions preferred (#2043: student-facing PDFs must
+never embed teacher answers); teacher dir is a last-resort fallback only:
+    .../2-1學生版(L1~122)/
+    .../2-1學生版補L123-L157/
+    .../第三階段(L123開始~L157)差學生版/
+    .../1-1教師版(L1~122)/   (fallback — only for codes with no student source)
 
 Output: /tmp/lingoleap-worksheets/{lesson_code}.pdf
     e.g. G6-L22.pdf
@@ -46,9 +49,14 @@ def _find_private_dir() -> Path:
 
 PRIVATE_DIR = _find_private_dir()
 
+# Student versions FIRST so student-facing PDFs never embed teacher answers
+# (#2043). The teacher dir is a last-resort fallback for lesson codes that have
+# no student source. Mirrors rebuild_worksheets_fonts.py's student-preferred order.
 SOURCE_DIRS = [
-    PRIVATE_DIR / "1-1教師版(L1~122)",
+    PRIVATE_DIR / "2-1學生版(L1~122)",
+    PRIVATE_DIR / "2-1學生版補L123-L157",
     PRIVATE_DIR / "第三階段(L123開始~L157)差學生版",
+    PRIVATE_DIR / "1-1教師版(L1~122)",
 ]
 
 OUTPUT_DIR = Path("/tmp/lingoleap-worksheets")
@@ -86,13 +94,23 @@ def extract_lesson_code(filename: str) -> str | None:
 
     Examples:
         'G6-L22小兵立大功.docx' → 'G6-L22'
+        'G6-SL25...docx'        → 'G6-L25'   (student 'SL' → canonical 'L', #2043)
         'G4-L20-22物以稀為貴.docx' → 'G4-L20-22'
-        'G9-L15-16.docx' → 'G9-L15-16'
+        'G9-SL15~16.docx'       → 'G9-L15-16'
         '文-L1假新聞.docx' → '文-L1'
+
+    Student-version files are named with an 'SL' marker (學生版); normalize it to
+    the canonical 'L' so the student and teacher versions of a lesson resolve to
+    the SAME code (#2043). Without this, 'G6-SL25' failed to parse, every student
+    file was skipped, and the teacher version (with answers) won by default.
     """
+    # Normalize: fullwidth Ｇ → G, range tildes → '-', and the student 'SL' marker
+    # ('G6-SL25' / '文-SL1') → canonical 'L' before matching.
+    name = filename.replace("Ｇ", "G").replace("～", "-").replace("~", "-")
+    name = re.sub(r"-S(L\d)", r"-\1", name)
     # Match G{grade}-L{num} optionally followed by -L{num} or -{num} for ranges,
     # or 文-L{num} for 文言文 lessons.
-    m = re.match(r"^(G\d+-L\d+(?:-L?\d+)?|文-L\d+)", filename)
+    m = re.match(r"^(G\d+-L\d+(?:-L?\d+)?|文-L\d+)", name)
     if m:
         return m.group(1)
     return None
@@ -101,7 +119,8 @@ def extract_lesson_code(filename: str) -> str | None:
 def find_all_docx_files() -> list[tuple[str, Path]]:
     """
     Return list of (lesson_code, docx_path) tuples.
-    When both source dirs have the same lesson code, prefer 教師版 (first dir).
+    When multiple source dirs have the same lesson code, the FIRST dir wins, and
+    student dirs are ordered first — so the student version is preferred (#2043).
     """
     seen: dict[str, Path] = {}
 
@@ -117,7 +136,7 @@ def find_all_docx_files() -> list[tuple[str, Path]]:
                 continue
             if code not in seen:
                 seen[code] = docx
-            # else: already have this code from 教師版, skip duplicate
+            # else: already have this code from an earlier (student-preferred) dir
 
     return sorted(seen.items())
 


### PR DESCRIPTION
Low-risk release (3 commits, CI + build-script only, no app runtime change): #2063 convert student-version, #2065 preview-cleanup loud, #2066 cleanup.yml honest counting. Grader fix #2061 already in prod. Rollback: git revert on main. 🤖