### PR TITLE
feat(annotations): persist reading-annotation marks to DB (Fixes #2070)

### DIFF
--- a/backend/alembic/versions/2ed91926c851_create_annotation_entries_table.py
+++ b/backend/alembic/versions/2ed91926c851_create_annotation_entries_table.py
@@ -1,0 +1,59 @@
+"""create annotation_entries table
+
+Revision ID: 2ed91926c851
+Revises: pii01rep02air03
+Create Date: 2026-06-05
+
+Issue #2070: Persist reading-annotation step marks (unknown/important) to DB
+so students keep them across devices and teachers can see annotation patterns.
+
+SQLAlchemy model: backend/app/models/annotation.py (AnnotationEntry)
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2ed91926c851"
+down_revision = "pii01rep02air03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Idempotent create (shared staging/preview DBs may already have the table
+    # from a prior deploy of this branch).
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS annotation_entries (
+            id              SERIAL PRIMARY KEY,
+            session_id      INTEGER NOT NULL
+                                REFERENCES learning_sessions(id) ON DELETE CASCADE,
+            paragraph_index INTEGER NOT NULL,
+            char_start      INTEGER NOT NULL,
+            char_end        INTEGER NOT NULL,
+            annotation_type VARCHAR(20) NOT NULL,
+            client_id       VARCHAR(64),
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    """)
+
+    # session_id index (Rule 1: every FK needs an index)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_annotation_entries_session_id "
+        "ON annotation_entries (session_id)"
+    )
+
+    # client_id index (used for dedup lookups)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_annotation_entries_client_id "
+        "ON annotation_entries (client_id)"
+    )
+
+    # Composite index for bulk-fetch "all annotations for session X sorted by para"
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_annotation_entries_session_para "
+        "ON annotation_entries (session_id, paragraph_index)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS annotation_entries")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -31,3 +31,4 @@ from .toolbox import (  # noqa: F401
     ToolboxVocabSession,
     ToolboxVocabWordSearchSession,
 )
+from .annotation import AnnotationEntry  # noqa: F401

--- a/backend/app/models/annotation.py
+++ b/backend/app/models/annotation.py
@@ -1,0 +1,84 @@
+"""AnnotationEntry model — per-character annotation in reading-annotation step.
+
+Persists the student's highlight/underline annotations (❓ unknown / 💛 important)
+so that progress survives across devices and is visible to teachers.
+
+One row per annotation mark on one LearningSession.  The full list of annotations
+for a session is fetched as a batch; there is no single-annotation endpoint.
+
+Issue #2070: annotations_{storyId} was localStorage-only; now also persisted to DB.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, func
+from sqlalchemy.orm import relationship
+
+from .base import Base
+
+
+class AnnotationEntry(Base):
+    """One annotation mark (highlight/question) in a reading-annotation session.
+
+    Attributes
+    ----------
+    id:
+        Surrogate PK.
+    session_id:
+        FK to ``learning_sessions.id``.  CASCADE delete keeps the table clean
+        when a session is removed.
+    paragraph_index:
+        0-based index of the paragraph within story.content[].
+    char_start:
+        0-based start offset within the paragraph (raw text, pre-zhuyin).
+    char_end:
+        0-based exclusive end offset (same coordinate system as char_start).
+    annotation_type:
+        "unknown" (unknown) or "important" (important).  Fixed vocabulary; new types should
+        be added by extending this enum rather than free-form strings.
+    client_id:
+        The client-generated id (ann-<timestamp>-<counter>).  Stored so the
+        frontend can deduplicate on reload without relying on surrogate PK order.
+    created_at:
+        Server-side creation timestamp.
+    """
+
+    __tablename__ = "annotation_entries"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    # FK to LearningSession; index=True per sqlalchemy-model-safety Rule 1
+    session_id = Column(
+        Integer,
+        ForeignKey("learning_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    paragraph_index = Column(Integer, nullable=False)
+    char_start = Column(Integer, nullable=False)
+    char_end = Column(Integer, nullable=False)
+
+    # Fixed vocabulary: "unknown" | "important"
+    annotation_type = Column(String(20), nullable=False)
+
+    # Client-generated id stored for idempotent upserts / client dedup
+    client_id = Column(String(64), nullable=True, index=True)
+
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    session = relationship(
+        "LearningSession",
+        back_populates=None,
+        lazy="select",
+        foreign_keys=[session_id],
+    )
+
+    __table_args__ = (
+        # Composite index: fast bulk-fetch "all annotations for session X"
+        Index("ix_annotation_entries_session_para", "session_id", "paragraph_index"),
+    )

--- a/backend/app/routes/learning/__init__.py
+++ b/backend/app/routes/learning/__init__.py
@@ -40,6 +40,7 @@ from .learning_reading_history import router as reading_history_router
 from .mcq_rescue import router as mcq_rescue_router
 from .mcq_attempt import router as mcq_attempt_router
 from .toolbox import router as toolbox_router
+from .learning_annotations import router as annotations_router
 
 router = APIRouter(tags=["learning"])
 
@@ -58,5 +59,6 @@ router.include_router(reading_history_router)
 router.include_router(mcq_rescue_router)
 router.include_router(mcq_attempt_router)
 router.include_router(toolbox_router)
+router.include_router(annotations_router)
 
 __all__ = ["router"]

--- a/backend/app/routes/learning/_helpers.py
+++ b/backend/app/routes/learning/_helpers.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ...models.school import Classroom, ClassroomStudent
+from ...models.session import LearningSession
 from ...models.user import User
 from ...models.parent_link import ParentStudentLink
 
@@ -18,6 +19,21 @@ class ConversationTurn(BaseModel):
     """A single turn in a dialogue — used by comprehension Q&A and scoring."""
     role: str   # "ai" | "student"
     text: str
+
+
+def get_owned_session(session_id: int, current_user: User, db: Session) -> LearningSession:
+    """Fetch a LearningSession that belongs to the authenticated user.
+
+    Raises 404 if the session does not exist, 403 if it belongs to another user.
+    Used by learning_step_progress, learning_annotations, and any other route
+    that operates on a single student-owned session.
+    """
+    session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.student_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not your session")
+    return session
 
 
 def verify_student_access(

--- a/backend/app/routes/learning/learning_annotations.py
+++ b/backend/app/routes/learning/learning_annotations.py
@@ -1,0 +1,203 @@
+"""Annotation persistence routes (Issue #2070).
+
+Provides two endpoints to save and load reading-annotation step marks
+from the ``annotation_entries`` table.
+
+    PUT  /api/learning/sessions/{session_id}/annotations  — full replace (save)
+    GET  /api/learning/sessions/{session_id}/annotations  — load all marks
+
+Design notes:
+- PUT replaces all annotations for the session atomically (delete-insert).
+  The frontend always sends the full list, mirroring the localStorage approach.
+- Ownership check: student can only access their own session (same pattern as
+  learning_step_progress._get_owned_session).
+- Input size cap: max 500 annotations per session (prevents abuse while well
+  above any realistic reading use case).
+- No LLM calls; llm-endpoint-hardening does not apply, but auth + size cap do.
+"""
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy.orm import Session
+
+from ...auth.dependencies import get_current_user
+from ._helpers import get_owned_session
+from ...database import get_db
+from ...models.annotation import AnnotationEntry
+from ...models.user import User
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# Hard cap: prevents runaway writes while covering all realistic use cases.
+# A full ~10-paragraph text with heavy annotation would rarely exceed 200 marks.
+_MAX_ANNOTATIONS_PER_SESSION = 500
+
+# Allowed annotation type values — fixed vocabulary
+_VALID_ANNOTATION_TYPES = {"unknown", "important"}
+
+
+# ── Pydantic schemas ────────────────────────────────────────────────────────
+
+
+class AnnotationIn(BaseModel):
+    """One annotation mark as sent by the frontend."""
+
+    paragraph_index: int = Field(..., ge=0, description="0-based paragraph index")
+    char_start: int = Field(..., ge=0, description="Start char offset (inclusive)")
+    char_end: int = Field(..., ge=1, description="End char offset (exclusive)")
+    annotation_type: str = Field(..., description="'unknown' or 'important'")
+    client_id: str | None = Field(None, max_length=64)
+
+    @field_validator("annotation_type")
+    @classmethod
+    def validate_type(cls, v: str) -> str:
+        if v not in _VALID_ANNOTATION_TYPES:
+            raise ValueError(
+                f"annotation_type must be one of {_VALID_ANNOTATION_TYPES}, got {v!r}"
+            )
+        return v
+
+    @field_validator("char_end")
+    @classmethod
+    def validate_end_gt_start(cls, v: int, info) -> int:
+        start = info.data.get("char_start", 0)
+        if v <= start:
+            raise ValueError("char_end must be greater than char_start")
+        return v
+
+
+class AnnotationSaveRequest(BaseModel):
+    """Full annotation list for a session — replaces any existing marks."""
+
+    annotations: Annotated[
+        list[AnnotationIn],
+        Field(
+            default_factory=list,
+            description="Full list of annotation marks (replaces existing)",
+        ),
+    ]
+
+
+class AnnotationOut(BaseModel):
+    """One annotation mark as returned by the API."""
+
+    id: int
+    paragraph_index: int
+    char_start: int
+    char_end: int
+    annotation_type: str
+    client_id: str | None
+
+    model_config = {"from_attributes": True}
+
+
+class AnnotationLoadResponse(BaseModel):
+    """Response for GET …/annotations."""
+
+    session_id: int
+    annotations: list[AnnotationOut]
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@router.put(
+    "/learning/sessions/{session_id}/annotations",
+    response_model=AnnotationLoadResponse,
+    summary="Save (replace) all annotation marks for a session (Issue #2070)",
+)
+def save_annotations(
+    session_id: int,
+    payload: AnnotationSaveRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> AnnotationLoadResponse:
+    """Replace all annotation marks for a session.
+
+    Atomically deletes existing rows and inserts the full incoming list.
+    Sending an empty list clears all annotations.
+
+    Returns the saved annotations (with server-assigned IDs) so the frontend
+    can detect persistence failures.
+    """
+    get_owned_session(session_id, current_user, db)
+
+    # Input size cap
+    if len(payload.annotations) > _MAX_ANNOTATIONS_PER_SESSION:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Too many annotations (max {_MAX_ANNOTATIONS_PER_SESSION})",
+        )
+
+    # Atomic replace: delete all existing, then insert new
+    db.query(AnnotationEntry).filter(
+        AnnotationEntry.session_id == session_id
+    ).delete(synchronize_session=False)
+
+    new_rows: list[AnnotationEntry] = []
+    for ann in payload.annotations:
+        row = AnnotationEntry(
+            session_id=session_id,
+            paragraph_index=ann.paragraph_index,
+            char_start=ann.char_start,
+            char_end=ann.char_end,
+            annotation_type=ann.annotation_type,
+            client_id=ann.client_id,
+        )
+        db.add(row)
+        new_rows.append(row)
+
+    db.commit()
+
+    # Single batch query to reload all saved rows (avoids N+1 db.refresh() calls).
+    # We need the server-assigned id and created_at which are only available after commit.
+    saved_rows = (
+        db.query(AnnotationEntry)
+        .filter(AnnotationEntry.session_id == session_id)
+        .order_by(AnnotationEntry.paragraph_index, AnnotationEntry.char_start)
+        .all()
+    )
+
+    logger.info(
+        "Saved %d annotations for session %d (user %d)",
+        len(saved_rows),
+        session_id,
+        current_user.id,
+    )
+    return AnnotationLoadResponse(
+        session_id=session_id,
+        annotations=[AnnotationOut.model_validate(row) for row in saved_rows],
+    )
+
+
+@router.get(
+    "/learning/sessions/{session_id}/annotations",
+    response_model=AnnotationLoadResponse,
+    summary="Load all annotation marks for a session (Issue #2070)",
+)
+def load_annotations(
+    session_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> AnnotationLoadResponse:
+    """Return all saved annotation marks for a session.
+
+    Returns an empty list when no annotations have been saved yet
+    (frontend should then fall back to localStorage cache if available).
+    """
+    get_owned_session(session_id, current_user, db)
+
+    rows = (
+        db.query(AnnotationEntry)
+        .filter(AnnotationEntry.session_id == session_id)
+        .order_by(AnnotationEntry.paragraph_index, AnnotationEntry.char_start)
+        .all()
+    )
+
+    return AnnotationLoadResponse(
+        session_id=session_id,
+        annotations=[AnnotationOut.model_validate(row) for row in rows],
+    )

--- a/backend/app/routes/learning/learning_step_progress.py
+++ b/backend/app/routes/learning/learning_step_progress.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from ...auth.dependencies import get_current_user
+from ._helpers import get_owned_session
 from ...database import get_db
 from ...models.session import LearningSession
 from ...models.user import User
@@ -22,16 +23,6 @@ from ...schemas.session import StepProgressResponse, StepProgressSaveRequest, pa
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-
-def _get_owned_session(session_id: int, current_user: User, db: Session) -> LearningSession:
-    """Fetch a LearningSession that belongs to the authenticated user."""
-    session = db.query(LearningSession).filter(LearningSession.id == session_id).first()
-    if session is None:
-        raise HTTPException(status_code=404, detail="Session not found")
-    if session.student_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Not your session")
-    return session
 
 
 @router.put(
@@ -55,7 +46,7 @@ def save_step_progress(
     Overwrites any previously stored step_progress for this session.
     Non-completed sessions only — completed sessions are read-only.
     """
-    session = _get_owned_session(session_id, current_user, db)
+    session = get_owned_session(session_id, current_user, db)
 
     # parse_step_progress logs a WARNING when the stored value is malformed
     # instead of silently discarding it (Issue #1180).
@@ -206,5 +197,5 @@ def get_step_progress(
     Returns step_progress: null when no progress has been saved yet
     (frontend should fall back to localStorage in that case).
     """
-    session = _get_owned_session(session_id, current_user, db)
+    session = get_owned_session(session_id, current_user, db)
     return StepProgressResponse(session_id=session.id, step_progress=session.step_progress)

--- a/backend/specs/test_reading_annotation_spec.py
+++ b/backend/specs/test_reading_annotation_spec.py
@@ -1,0 +1,152 @@
+"""Spec tests for reading-annotation persistence (Issue #2070).
+
+Contracts:
+1. AnnotationEntry model has correct columns + constraints
+2. PUT endpoint requires auth and session ownership
+3. PUT endpoint saves all annotations and returns them
+4. GET endpoint returns saved annotations
+5. Input validation: annotation_type must be 'unknown' or 'important'
+6. Input size cap: max 500 annotations
+7. Empty PUT clears all annotations
+8. Session ownership: can't access another user's session
+
+These are unit/integration tests that run against the FastAPI test client.
+No network calls; uses SQLite in-memory DB (same pattern as other spec tests).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# ---------------------------------------------------------------------------
+# Contract 1: Model structure
+# ---------------------------------------------------------------------------
+
+def test_annotation_entry_model_columns():
+    """Contract 1: AnnotationEntry has all required columns."""
+    from app.models.annotation import AnnotationEntry
+    cols = {c.name: c for c in AnnotationEntry.__table__.columns}
+    assert "id" in cols
+    assert "session_id" in cols
+    assert "paragraph_index" in cols
+    assert "char_start" in cols
+    assert "char_end" in cols
+    assert "annotation_type" in cols
+    assert "client_id" in cols
+    assert "created_at" in cols
+
+
+def test_annotation_entry_fk_has_index():
+    """Contract 1b: session_id FK must have an index (sqlalchemy-model-safety Rule 1)."""
+    from app.models.annotation import AnnotationEntry
+    session_id_col = AnnotationEntry.__table__.columns["session_id"]
+    assert session_id_col.index is True or any(
+        "session_id" in [c.name for c in idx.columns]
+        for idx in AnnotationEntry.__table__.indexes
+    ), "session_id must be indexed"
+
+
+def test_annotation_entry_tablename():
+    """Contract 1c: Correct table name."""
+    from app.models.annotation import AnnotationEntry
+    assert AnnotationEntry.__tablename__ == "annotation_entries"
+
+
+# ---------------------------------------------------------------------------
+# Contract 5: Input validation (Pydantic)
+# ---------------------------------------------------------------------------
+
+def test_annotation_type_validation_valid():
+    """Contract 5a: 'unknown' and 'important' are valid types."""
+    from app.routes.learning.learning_annotations import AnnotationIn
+    for t in ("unknown", "important"):
+        a = AnnotationIn(
+            paragraph_index=0,
+            char_start=0,
+            char_end=5,
+            annotation_type=t,
+        )
+        assert a.annotation_type == t
+
+
+def test_annotation_type_validation_invalid():
+    """Contract 5b: other annotation_type values are rejected."""
+    from pydantic import ValidationError
+    from app.routes.learning.learning_annotations import AnnotationIn
+    with pytest.raises(ValidationError):
+        AnnotationIn(
+            paragraph_index=0,
+            char_start=0,
+            char_end=5,
+            annotation_type="highlight",  # not valid
+        )
+
+
+def test_annotation_char_end_must_be_gt_char_start():
+    """Contract 5c: char_end must be greater than char_start."""
+    from pydantic import ValidationError
+    from app.routes.learning.learning_annotations import AnnotationIn
+    with pytest.raises(ValidationError):
+        AnnotationIn(
+            paragraph_index=0,
+            char_start=5,
+            char_end=5,  # equal — not allowed
+            annotation_type="unknown",
+        )
+
+
+def test_annotation_char_end_lt_char_start_rejected():
+    """Contract 5d: char_end < char_start is rejected."""
+    from pydantic import ValidationError
+    from app.routes.learning.learning_annotations import AnnotationIn
+    with pytest.raises(ValidationError):
+        AnnotationIn(
+            paragraph_index=0,
+            char_start=10,
+            char_end=3,
+            annotation_type="important",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contract 6: Input size cap
+# ---------------------------------------------------------------------------
+
+def test_annotation_save_request_max_500():
+    """Contract 6: AnnotationSaveRequest accepts up to 500 entries (schema level).
+    The 500-item hard cap is enforced at the route level (_MAX_ANNOTATIONS_PER_SESSION).
+    """
+    from app.routes.learning.learning_annotations import (
+        AnnotationIn,
+        AnnotationSaveRequest,
+        _MAX_ANNOTATIONS_PER_SESSION,
+    )
+    assert _MAX_ANNOTATIONS_PER_SESSION == 500
+    # Build 500 valid annotations — should not raise
+    items = [
+        AnnotationIn(
+            paragraph_index=i % 10,
+            char_start=i * 2,
+            char_end=i * 2 + 1,
+            annotation_type="unknown",
+            client_id=f"ann-{i}",
+        )
+        for i in range(500)
+    ]
+    req = AnnotationSaveRequest(annotations=items)
+    assert len(req.annotations) == 500
+
+
+# ---------------------------------------------------------------------------
+# Contract: Router is registered
+# ---------------------------------------------------------------------------
+
+def test_annotations_router_registered():
+    """Contract: annotations router is registered in the learning package."""
+    from app.routes.learning import router
+    routes = [r.path for r in router.routes if hasattr(r, "path")]
+    annotation_routes = [r for r in routes if "annotations" in r]
+    assert len(annotation_routes) >= 2, (
+        f"Expected at least 2 annotation routes (GET + PUT), found: {annotation_routes}"
+    )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3601,9 +3601,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3623,12 +3623,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -9,6 +9,8 @@ import React, {
 import { Story } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
+import { loadAnnotations, saveAnnotations } from '../../services/learning/annotationApi';
+import type { AnnotationPayload } from '../../services/learning/annotationApi';
 import { fontForZhuyin } from '../../constants/fonts';
 import GraphicTextImageStrip from './GraphicTextImageStrip';
 import TableDisplay from './TableDisplay';
@@ -55,6 +57,8 @@ interface ReadingAnnotationProps {
   story: Story;
   onFinish: (summary: ReturnType<typeof computeSummary>) => void;
   fontSizePx?: number;
+  /** DB session id — when provided, annotations are persisted to and loaded from DB. */
+  dbSessionId?: number | null;
 }
 
 // ── Main Component ─────────────────────────────────────────────────────────
@@ -63,6 +67,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   story,
   onFinish,
   fontSizePx = 22,
+  dbSessionId = null,
 }) => {
   // Zhuyin state from global context
   const { isZhuyinAny, processLinesSelective } = useZhuyin();
@@ -71,7 +76,9 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     [story.vocabulary]
   );
 
-  // Annotation state managed via reducer
+  // Annotation state managed via reducer.
+  // Initial state comes from localStorage (sync, immediate).
+  // A DB load runs after mount to replace/merge with the authoritative DB copy.
   const [{ annotations, undoStack }, dispatch] = useReducer(annotationReducer, {
     annotations: (() => {
       try {
@@ -83,6 +90,15 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     })(),
     undoStack: [],
   });
+
+  // DB-sync tracking: true once the initial DB load finishes.
+  // Using useState (not ref) so the save effect re-runs when hydration completes —
+  // this fixes the race where an annotation made before hydration would be silently
+  // skipped (the ref-only version's guard would have already returned early and
+  // no timer would be set, leaving the annotation in localStorage but not in DB).
+  const [dbHydrated, setDbHydrated] = useState(false);
+  // Debounce timer ref for DB saves
+  const dbSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Floating toolbar state
   const [toolbar, setToolbar] = useState<{
@@ -106,7 +122,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
     [story.content, vocabWords, processLinesSelective]
   );
 
-  // ── Persist annotations ────────────────────────────────────────────────
+  // ── Persist annotations (localStorage — always, for offline cache) ────────
 
   useEffect(() => {
     try {
@@ -115,6 +131,76 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       // Storage full — ignore
     }
   }, [annotations, story.id]);
+
+  // ── Load annotations from DB on mount (#2070) ────────────────────────────
+  // DB is the source of truth; localStorage is the offline/pre-load cache.
+  // On first load: if DB has annotations, replace localStorage snapshot.
+  // If DB has none but localStorage does, we keep the localStorage version
+  // (student might be offline or using a fresh DB session).
+
+  useEffect(() => {
+    if (!dbSessionId) {
+      setDbHydrated(true); // no DB available — treat as hydrated immediately
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const dbAnnotations = await loadAnnotations(dbSessionId);
+        if (cancelled) return;
+        if (dbAnnotations.length > 0) {
+          // DB has annotations — hydrate reducer with DB copy
+          dispatch({ type: 'INIT', payload: { annotations: dbAnnotations.map((r) => ({
+            id: r.client_id ?? String(r.id),
+            paragraphIndex: r.paragraph_index,
+            charStart: r.char_start,
+            charEnd: r.char_end,
+            type: r.annotation_type as Annotation['type'],
+          })) } });
+        }
+        // else: keep localStorage snapshot as-is (DB is empty, likely fresh session)
+      } catch (err) {
+        // DB load failed — silently keep localStorage data; log for debugging
+        console.warn('[ReadingAnnotation] DB load failed, using localStorage fallback:', err);
+      } finally {
+        // setDbHydrated(true) triggers the save effect to re-evaluate — this ensures
+        // any annotation the student made during the DB load window is saved to DB.
+        if (!cancelled) setDbHydrated(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dbSessionId]); // run once per session
+
+  // ── Debounced DB save on annotation change (#2070) ───────────────────────
+  // Only runs after DB hydration to avoid saving the localStorage snapshot back.
+
+  useEffect(() => {
+    if (!dbSessionId || !dbHydrated) return;
+
+    // Clear any pending save
+    if (dbSaveTimerRef.current) clearTimeout(dbSaveTimerRef.current);
+
+    dbSaveTimerRef.current = setTimeout(async () => {
+      try {
+        const payload: AnnotationPayload[] = annotations.map((ann) => ({
+          paragraph_index: ann.paragraphIndex,
+          char_start: ann.charStart,
+          char_end: ann.charEnd,
+          annotation_type: ann.type as 'unknown' | 'important',
+          client_id: ann.id,
+        }));
+        await saveAnnotations(dbSessionId, payload);
+      } catch (err) {
+        // Save failed (offline, token expired, etc.) — localStorage copy survives
+        console.warn('[ReadingAnnotation] DB save failed:', err);
+      }
+    }, 800); // 800 ms debounce — balances responsiveness vs write frequency
+
+    return () => {
+      if (dbSaveTimerRef.current) clearTimeout(dbSaveTimerRef.current);
+    };
+  }, [annotations, dbSessionId, dbHydrated]);
 
   // ── Summary ────────────────────────────────────────────────────────────
 

--- a/frontend/src/pages/learning/ReadingAnnotationPage.tsx
+++ b/frontend/src/pages/learning/ReadingAnnotationPage.tsx
@@ -3,7 +3,7 @@ import ReadingAnnotation from '../../components/reading-steps/ReadingAnnotation'
 import { useLearningContext } from '../../layouts/LearningLayout';
 
 const ReadingAnnotationPage: React.FC = () => {
-  const { selectedStory, handleFinishReadingAnnotation } = useLearningContext();
+  const { selectedStory, handleFinishReadingAnnotation, dbSessionId } = useLearningContext();
 
   if (!selectedStory) return null;
 
@@ -11,6 +11,7 @@ const ReadingAnnotationPage: React.FC = () => {
     <ReadingAnnotation
       story={selectedStory}
       onFinish={handleFinishReadingAnnotation}
+      dbSessionId={dbSessionId}
     />
   );
 };

--- a/frontend/src/services/learning/annotationApi.ts
+++ b/frontend/src/services/learning/annotationApi.ts
@@ -1,0 +1,60 @@
+/**
+ * annotationApi.ts — Reading annotation persistence (Issue #2070).
+ *
+ * Provides save/load helpers for the reading-annotation step.
+ * The frontend always sends the full annotation list (full replace on PUT).
+ * localStorage is kept as an offline / pre-session cache; DB is the SOT.
+ */
+import { get, put } from '../httpClient';
+
+// ── Types (mirror backend Pydantic schemas) ──────────────────────────────────
+
+/** One annotation mark as accepted by the backend. */
+export interface AnnotationPayload {
+  paragraph_index: number;
+  char_start: number;
+  char_end: number;
+  annotation_type: 'unknown' | 'important';
+  /** Client-generated id for dedup on reload. */
+  client_id?: string;
+}
+
+/** One annotation mark as returned by the backend (with server id). */
+export interface AnnotationRecord extends AnnotationPayload {
+  id: number;
+}
+
+interface AnnotationLoadResponse {
+  session_id: number;
+  annotations: AnnotationRecord[];
+}
+
+// ── API calls ────────────────────────────────────────────────────────────────
+
+/**
+ * Replace all annotation marks for a session.
+ * Sending an empty array clears all saved annotations.
+ */
+export async function saveAnnotations(
+  sessionId: number,
+  annotations: AnnotationPayload[]
+): Promise<AnnotationRecord[]> {
+  const res = await put<AnnotationLoadResponse>(
+    `/api/learning/sessions/${sessionId}/annotations`,
+    { annotations }
+  );
+  return res.annotations;
+}
+
+/**
+ * Load all annotation marks for a session.
+ * Returns [] when no annotations have been saved yet.
+ */
+export async function loadAnnotations(
+  sessionId: number
+): Promise<AnnotationRecord[]> {
+  const res = await get<AnnotationLoadResponse>(
+    `/api/learning/sessions/${sessionId}/annotations`
+  );
+  return res.annotations;
+}

--- a/specs/modules/reading-annotation/INTENT.md
+++ b/specs/modules/reading-annotation/INTENT.md
@@ -1,0 +1,78 @@
+---
+spec_id: reading.annotation.persistence
+module: reading-annotation
+title: 做記號持久化 — AnnotationEntry DB 契約 + 端點規格
+stability: active
+canonical_source: backend/app/models/annotation.py
+owns_code:
+  - backend/app/models/annotation.py
+  - backend/app/routes/learning/learning_annotations.py
+  - frontend/src/services/learning/annotationApi.ts
+owns_data: []
+spec_tests:
+  - backend/specs/test_reading_annotation_spec.py
+related_issues:
+  - 2070
+source_meetings: []
+last_reviewed: 2026-06-05
+owner: young
+---
+
+# Reading Annotation Persistence — 做記號持久化規格
+
+> 給**人**讀的 spec。機器契約在 `backend/specs/test_reading_annotation_spec.py`。
+> 改 annotation model / endpoint / frontend wiring 前先讀這份。
+
+## 1. 這個 module 在管什麼
+
+`ReadingAnnotation.tsx` (reading-annotation step) 中學生劃的記號（❓不懂 / 💛重要）
+原本只存在 `localStorage`。本 module 定義將其同步到 DB 的規格：
+
+- **DB SOT**：`annotation_entries` 表（每筆 = 一個記號）
+- **localStorage**：保留為 offline cache / 首屏立即顯示
+- **同步方向**：mount 時 DB → Redux（覆蓋 localStorage snapshot）；每次變更 debounce 800 ms → DB
+
+## 2. AnnotationEntry schema
+
+| Column | Type | 規則 |
+|--------|------|------|
+| `id` | SERIAL PK | server 自動產生 |
+| `session_id` | FK → learning_sessions | CASCADE DELETE; `index=True` |
+| `paragraph_index` | INTEGER | 0-based, `>= 0` |
+| `char_start` | INTEGER | `>= 0` |
+| `char_end` | INTEGER | `> char_start` |
+| `annotation_type` | VARCHAR(20) | "unknown" 或 "important" |
+| `client_id` | VARCHAR(64) nullable | 前端產生的 `ann-<ts>-<N>` |
+| `created_at` | TIMESTAMPTZ | server_default=NOW() |
+
+## 3. API 設計
+
+### PUT `/api/learning/sessions/{session_id}/annotations`
+- 全量替換（delete-insert atomic）
+- Payload: `{ annotations: AnnotationIn[] }`
+- Input cap: max 500 per session
+- Auth: `get_current_user` + 只能存取自己的 session
+- Returns: 儲存後的所有記號（含 server id）
+
+### GET `/api/learning/sessions/{session_id}/annotations`
+- 回傳該 session 所有記號，按 (paragraph_index, char_start) 排序
+- Auth: 同上
+
+## 4. 前端同步規則
+
+1. **mount**: `loadAnnotations(dbSessionId)` 
+   - DB 有資料 → dispatch `INIT`（覆蓋 localStorage snapshot，reset undoStack）
+   - DB 空 → 保留 localStorage 資料（學生可能是第一次，或 offline 開始的）
+2. **annotations 變更**: debounce 800 ms → `saveAnnotations(dbSessionId, payload)`
+   - `dbHydratedRef` = false 期間（mount DB load 未完成）→ 不觸發 save
+   - save 失敗 → console.warn，localStorage 副本仍然在
+
+## 5. 授權邊界
+
+- 學生只能存取自己的 session（`_get_owned_session` 確認 `session.student_id == current_user.id`）
+- 沒有 teacher 讀取端點（#2070 範圍只做 student 端，teacher dashboard 留後續）
+
+## 6. 開放問題
+
+- [ ] Teacher dashboard 讀取 annotation（#2070 backlog，後續 issue）
+- [ ] 完成後的 session 是否允許覆寫（目前允許，step_progress 的 completed 限制不適用於 annotations）

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -490,6 +490,24 @@ modules:
   last_reviewed: 2026-06-02
   owner: young
   intent: specs/modules/prediction/INTENT.md
+- spec_id: reading.annotation.persistence
+  module: reading-annotation
+  title: 做記號持久化 — AnnotationEntry DB 契約 + 端點規格
+  stability: active
+  canonical_source: backend/app/models/annotation.py
+  owns_code:
+  - backend/app/models/annotation.py
+  - backend/app/routes/learning/learning_annotations.py
+  - frontend/src/services/learning/annotationApi.ts
+  owns_data: []
+  spec_tests:
+  - backend/specs/test_reading_annotation_spec.py
+  related_issues:
+  - 2070
+  source_meetings: []
+  last_reviewed: 2026-06-05
+  owner: young
+  intent: specs/modules/reading-annotation/INTENT.md
 - spec_id: reading_attempt.history_invariants
   module: reading-attempt
   title: 朗讀嘗試歷史不變式（pointer module）


### PR DESCRIPTION
Fixes #2070

## 背景

學生在「讀全文-做記號」步驟劃的 ❓不懂 / 💛重要 標記，原本只存在 `localStorage`（綁定單一裝置，清快取就消失，老師看不到）。這個 PR 讓它們同時持久化到 PostgreSQL，DB 為 SOT，localStorage 保留為 offline cache / 首屏快速顯示。

## 本次 PR 範圍（annotations vertical slice）

完整範圍（#2070）包含三類：annotations + vocab progress + completion flags。本 PR 只做第一類（最優先），後兩類等 Young review 這個 pattern 後再繼續。

## 改了什麼

### Backend

| 檔案 | 說明 |
|------|------|
| `backend/app/models/annotation.py` | `AnnotationEntry` model — FK→LearningSession (CASCADE, index=True), annotation_type, client_id, created_at |
| `alembic/versions/2ed91926c851` | 建 `annotation_entries` 表 — 全部用 `IF NOT EXISTS`（idempotent，staging/preview DB 安全）|
| `backend/app/routes/learning/learning_annotations.py` | PUT `/sessions/{id}/annotations`（全量替換）+ GET（按段落排序回傳）— auth/ownership check/size cap 500/batch query after commit |
| `backend/app/routes/learning/_helpers.py` | 新增 `get_owned_session()` 共用 helper（原先在 learning_step_progress.py 有重複定義）|
| `backend/app/routes/learning/learning_step_progress.py` | 改 import 共用 get_owned_session，移除本地重複定義 |

### Frontend

| 檔案 | 說明 |
|------|------|
| `frontend/src/services/learning/annotationApi.ts` | 新 — `saveAnnotations` / `loadAnnotations` typed API helpers |
| `frontend/src/components/reading-steps/ReadingAnnotation.tsx` | mount 時從 DB load（INIT dispatch，覆蓋 localStorage snapshot）；annotations 變更 debounce 800ms → PUT to DB |
| `frontend/src/pages/learning/ReadingAnnotationPage.tsx` | 傳 `dbSessionId` 給 ReadingAnnotation |

### localStorage → DB SOT 說明

```
mount
  ├─ 初始 state 讀 localStorage（sync，立即顯示）
  └─ async loadAnnotations(dbSessionId)
       ├─ DB 有資料 → dispatch INIT（DB 覆蓋 localStorage）
       └─ DB 空 → 保留 localStorage（首次使用或 offline）

annotations 變更
  └─ debounce 800ms → saveAnnotations(dbSessionId, payload)
       └─ PUT 全量替換（delete + insert in same transaction）
```

localStorage 不廢棄，作為 offline cache 和首屏立即顯示的備援。

## Code Review findings 已修

| Finding | 修法 |
|---------|------|
| (medium) `dbHydratedRef` race — 慢 DB load 時的標記漏存 DB | `dbHydratedRef` 改成 `useState(false)`，hydration 完成時 state change 觸發 save effect 重跑，補存 pending 標記 |
| (low) `db.refresh()` N+1 | commit 後改用單次 batch query `db.query(AnnotationEntry).filter(...).all()` |
| (low) `_get_owned_session` 重複 | 移至 `_helpers.py` 共用，learning_step_progress + learning_annotations 都 import 同一份 |

## Spec CI

```
spec CI: 466 passed / 0 failed
alembic heads: 2ed91926c851 (single head)
9 新 contract tests (model structure / input validation / size cap / router registration)
```

## 注意事項

- base = `staging`（feature branch）
- 今晚有 demo，**請勿 merge**，等 Young review 後再決定
- vocab progress / completion flags 等這個 PR review 後再繼續