### PR TITLE
fix: worksheet PDF→docx for 7 demo lessons — G7-L29/L30 破圖修復 (Fixes #2073)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -261,6 +261,8 @@ def get_story(story_id: str):
         lesson_intro=story.get("lesson_intro"),
         # 紙本學習單 PDF (#1444) — public GCS URL or None
         worksheet_pdf_url=story.get("worksheet_pdf_url"),
+        # Direct docx URL when soffice PDF conversion is broken (#2073)
+        worksheet_docx_url=story.get("worksheet_docx_url"),
         # 紙本表格 (#1685) — extracted tables for 圖文表整合 lessons; None for others
         tables=story.get("tables"),
         # Story structure scaffold (#1683 item 4): YAML data for StoryStructure step.

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -77,6 +77,10 @@ class StoryDetail(StoryListItem):
     # Public PDF URL of the original 紙本學習單 docx (#1444)
     # Hosted at gs://lingoleap-assets/worksheets/{lesson_code}.pdf
     worksheet_pdf_url: Optional[str] = None
+    # Public docx URL for lessons where soffice PDF conversion produces broken output (#2073)
+    # When present, frontend shows a download link instead of the broken PDF iframe.
+    # Hosted at gs://lingoleap-assets/worksheets/{lesson_code}.docx
+    worksheet_docx_url: Optional[str] = None
     # Tables extracted from 紙本學習單 PDF (#1685).
     # Each item: {id, title, headers: list[str], rows: list[{cells: list[str], section?: str}],
     #             section_label_col?: str, notes?: list[str]}

--- a/backend/app/services/lesson_layer_loaders.py
+++ b/backend/app/services/lesson_layer_loaders.py
@@ -62,6 +62,8 @@ ENRICHMENT_FIELDS = (
     "worksheet_intro",
     "lesson_intro",
     "worksheet_pdf_url",
+    # Direct docx URL when soffice PDF conversion is broken (#2073)
+    "worksheet_docx_url",
     "layout_mode",
     "reading_strategy_type",
     "images",
@@ -233,6 +235,8 @@ def load_layer1_lessons() -> list[dict]:
             "lesson_intro": data.get("lesson_intro"),
             # Public PDF URL of the original 紙本學習單 (#1444)
             "worksheet_pdf_url": data.get("worksheet_pdf_url"),
+            # Direct docx URL when soffice PDF conversion is broken (#2073)
+            "worksheet_docx_url": data.get("worksheet_docx_url"),
             # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
             "tables": data.get("tables"),
             "_layer": 1,
@@ -388,6 +392,8 @@ def load_layer2_lessons(
             "lesson_intro": data.get("lesson_intro"),
             # Public PDF URL of the original 紙本學習單 (#1444)
             "worksheet_pdf_url": data.get("worksheet_pdf_url"),
+            # Direct docx URL when soffice PDF conversion is broken (#2073)
+            "worksheet_docx_url": data.get("worksheet_docx_url"),
             # 紙本表格 HTML render (#1685) — None when lesson has no extracted tables
             "tables": data.get("tables"),
             "_layer": 2,

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L22.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L22.yml
@@ -351,6 +351,7 @@ lesson_intro:
   course_intro: 這篇文章講述了戰國時期齊國孟嘗君的故事。孟嘗君以養士聞名，門下食客眾多。當他被秦昭王軟禁並面臨生命危險時，兩位看似擁有微不足道技能的食客，如何運用他們的「雞鳴狗盜」之術，幫助孟嘗君化險為夷，成功脫離秦國。故事展現了在關鍵時刻，小人物的特殊才能也能發揮意想不到的巨大作用。
   course_intro_source: ai-generated-2026-05-14
 worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L22.pdf
+worksheet_docx_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L22.docx
 spotlight_answers:
 - id: 1
   answer: 模仿雞叫

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L23.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L23.yml
@@ -275,6 +275,7 @@ lesson_intro:
   course_intro: 這篇文章從老鷹中毒事件談起，帶我們認識了農民在種植紅豆時，為了減少鳥害和方便採收，可能使用毒餌或落葉劑，進而對生態環境造成傷害。文中也介紹了各方人士如何共同努力，推動友善耕作方式，讓紅豆生產與生態保育得以並存，並探討了消費者在其中扮演的角色。
   course_intro_source: ai-generated-2026-05-14
 worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L23.pdf
+worksheet_docx_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L23.docx
 spotlight_answers:
 - id: 1
   answer: 中毒

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L24.yml
@@ -242,6 +242,7 @@ lesson_intro:
   course_intro: 這篇文章記錄了一場發生在北極海的白鯨救援行動。故事描述了數千頭白鯨因氣候驟變受困於冰層中，面臨生命威脅的緊急情況。從當地居民的初步嘗試，到政府出動破冰船，救援過程一波三折，充滿了意想不到的挑戰。文章將帶領讀者了解人類如何運用智慧與創意，與大自然中的生命進行溝通與互動，最終共同譜寫出一段特別的經歷。
   course_intro_source: ai-generated-2026-05-14
 worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L24.pdf
+worksheet_docx_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L24.docx
 spotlight_answers:
 - id: 1
   answer: 困在冰原裡，冰洞愈來愈小，因為無法換氣快要窒息了

--- a/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G6-L25.yml
@@ -265,6 +265,7 @@ lesson_intro:
   course_intro: 這篇文章將帶我們回到十七世紀，認識當時荷蘭人如何運用智慧，解決遠洋貿易所需龐大資金的問題。文中會介紹「股票」這種金融工具的誕生背景，以及它如何讓一般民眾也能參與投資，共同成就大型商業計畫。透過荷蘭東印度公司的例子，我們將了解股票如何運作，以及它對當時社會和經濟發展帶來的影響。
   course_intro_source: ai-generated-2026-05-14
 worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L25.pdf
+worksheet_docx_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L25.docx
 spotlight_answers:
 - id: 1
   answer: 想要航行到亞洲買香料回來賣，但遠洋探險不容易，費用高，任何人都無法單獨承擔

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L28.yml
@@ -382,6 +382,7 @@ lesson_intro:
   course_intro: 這篇文章將帶你回到十九世紀，探討一個關於食物腐敗的科學謎團。當時人們普遍認為肉湯變質是自然發生的現象，但一位科學家對此提出了不同的看法。文章會介紹這位科學家如何設計巧妙的實驗，一步步驗證自己的假設，最終推翻了舊有的觀念。透過閱讀，你將了解這項實驗的過程、結果，以及它如何影響了後世對生物、醫學和公共衛生的理解。
   course_intro_source: ai-generated-2026-05-14
 worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L28.pdf
+worksheet_docx_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L28.docx
 # Tables extracted from 紙本學習單 PDF (#1685).
 # Source: /tmp/worksheets-7priority/G7-L28.pdf page 6 (manual extract from 紙本).
 tables:

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L29.yml
@@ -301,3 +301,4 @@ lesson_intro:
   course_intro: 這篇文章以圖表數據為基礎，探討了近年來地球氣溫上升的現象。文章首先點出人們對氣候變化的感受，接著引用數據說明地球平均氣溫的長期變化趨勢。隨後，文章介紹了目前主流的「溫室效應假說」，解釋人類活動如何影響大氣中的二氧化碳濃度，並透過圖表呈現二氧化碳排放量與全球氣溫的關聯。然而，文章也提出不同的觀點，藉由更長遠的地球歷史氣溫變化圖，引導讀者思考近期暖化現象是否完全歸因於人類活動，並提醒我們在推論時應保持謹慎。
   course_intro_source: ai-generated-2026-05-14
 worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L29.pdf
+worksheet_docx_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L29.docx

--- a/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
+++ b/backend/data/lessons/_parsed_2026-05-01/G7-L30.yml
@@ -229,6 +229,7 @@ lesson_intro:
   course_intro: 這篇文章將帶你認識兩種在臺灣常見的八哥鳥——白尾八哥和臺灣冠八哥。雖然牠們外形相似，但其實有著不同的身世和習性。文章會介紹如何分辨這兩種八哥，並透過數據和圖表，探討為什麼外來種白尾八哥的數量，近年來會大幅超越臺灣原生種的臺灣冠八哥。讀完這篇文章，你將對這兩種鳥類有更深入的了解，並思考牠們在臺灣生態環境中的處境。
   course_intro_source: ai-generated-2026-05-14
 worksheet_pdf_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L30.pdf
+worksheet_docx_url: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L30.docx
 # Tables extracted from 紙本學習單 PDF (#1685) — yml `paragraphs` only kept
 # table titles, full row data was lost during docx → yml parse.
 # Source: /tmp/worksheets-7priority/G7-L30.pdf pages 2-3 (manual extract from 紙本).

--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -225,10 +225,23 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
           {/* 知識補給站 YouTube embed was removed — intro page shows course intro only */}
 
           {/* 紙本學習單 PDF button (#1444) + 上傳學習單 button (#1637) */}
-          {(story.worksheetPdfUrl || story.lesson_code) && (
+          {(story.worksheetPdfUrl || story.worksheetDocxUrl || story.lesson_code) && (
             <div className="flex flex-wrap items-center gap-2">
-              {/* PDF view button — only when a PDF is available */}
-              {story.worksheetPdfUrl && (
+              {/* Docx download link (#2073) — preferred when docx is available (avoids broken soffice PDF) */}
+              {story.worksheetDocxUrl ? (
+                <a
+                  href={story.worksheetDocxUrl}
+                  download
+                  className="flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-bold border border-blue-300 bg-blue-50 hover:bg-blue-100 text-blue-700 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-1"
+                  aria-label="下載紙本學習單"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                  </svg>
+                  下載紙本學習單
+                </a>
+              ) : story.worksheetPdfUrl ? (
+                /* PDF view button — fallback when no docx available */
                 <button
                   type="button"
                   onClick={() => setShowWorksheetModal(true)}
@@ -240,7 +253,7 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
                   </svg>
                   查看紙本學習單
                 </button>
-              )}
+              ) : null}
 
               {/* Upload button — #1637: available for any lesson with a lesson_code */}
               {story.lesson_code && (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -93,6 +93,8 @@ interface ApiStoryDetail extends ApiStoryListItem {
   } | null;
   // 紙本學習單 PDF URL (#1444) — null when no matching PDF exists
   worksheet_pdf_url?: string | null;
+  // Direct docx URL when soffice PDF conversion is broken (#2073)
+  worksheet_docx_url?: string | null;
   // 紙本表格 HTML render (#1685) — null when lesson has no extracted tables
   tables?: Array<{
     id: string;
@@ -172,6 +174,7 @@ function apiDetailToStory(detail: ApiStoryDetail): Story {
     worksheetIntro: detail.worksheet_intro ?? undefined,
     lessonIntro: detail.lesson_intro ?? undefined,
     worksheetPdfUrl: detail.worksheet_pdf_url ?? undefined,
+    worksheetDocxUrl: detail.worksheet_docx_url ?? undefined,
     tables: detail.tables ?? undefined,
     // Plugin-pattern dispatch fields (#1404 / #1341):
     layout_mode: (detail.layout_mode as Story['layout_mode']) ?? 'standard',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -180,6 +180,11 @@ export interface Story {
    *  Optional — lessons without a matching PDF (e.g. G8-L3a, 文-L*) leave this null,
    *  which hides the "查看紙本學習單" button on the Intro page. */
   worksheetPdfUrl?: string;
+  /** Direct docx URL for lessons where soffice PDF conversion produces broken output (#2073).
+   *  When present, the "查看紙本學習單" button becomes a download link for the docx instead
+   *  of opening the broken PDF in an iframe.
+   *  Hosted on GCS at gs://lingoleap-assets/worksheets/{lesson_code}.docx. */
+  worksheetDocxUrl?: string;
   /** Tables extracted from 紙本學習單 PDF (#1685).
    *  Used by 圖文表整合 lessons (G7-L28, G7-L30) where docx → yml parser dropped
    *  table row data. Frontend renders via TableDisplay with click-to-zoom.


### PR DESCRIPTION
Fixes #2073

## Summary
- G7-L29/L30 的 worksheet PDF 由 soffice 轉檔時浮動圖片疊圖，改為直接服務學用版 docx
- 影響範圍：G6-L22/L23/L24/L25（摘要策略）+ G7-L28/L29/L30（圖文整合），共 7 課
- 不影響其他 233 課（PDF 路徑不變，只有有 worksheet_docx_url 的課才走 docx）

## Changes
- `backend/app/schemas/story.py` — 新增 `worksheet_docx_url: Optional[str]`
- `backend/app/services/lesson_layer_loaders.py` — Layer-1/Layer-2 loader + ENRICHMENT_FIELDS 加 worksheet_docx_url
- `backend/app/routes/stories.py` — StoryDetail 序列化加 worksheet_docx_url
- `backend/data/lessons/_parsed_2026-05-01/G6-L22~25.yml` + `G7-L28~30.yml` — 加 worksheet_docx_url
- `frontend/src/types.ts` — 加 worksheetDocxUrl 型別
- `frontend/src/services/api.ts` — 映射 worksheet_docx_url → worksheetDocxUrl
- `frontend/src/components/reading-steps/Intro.tsx` — 有 docxUrl 時顯示下載連結取代 PDF iframe
- GCS: 上傳 7 個學用版 docx 到 `gs://lingoleap-assets/worksheets/{grade_code}.docx`（已完成，不在 git diff）

## Test plan
- [ ] 開 G7-L29 課，Intro 頁「查看紙本學習單」變成「下載紙本學習單」，點按下載到正確 docx
- [ ] G7-L30 同上
- [ ] G7-L28、G6-L22/23/24/25 同上
- [ ] 其他課（如 G6-L10）仍顯示 PDF 查看按鈕（不受影響）
- [ ] Spec CI: 526 passed / 5 xfailed（本機已跑）

## GCS Upload Evidence
```
G6-L22.docx HTTP 200: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L22.docx
G6-L23.docx HTTP 200: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L23.docx
G6-L24.docx HTTP 200: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L24.docx
G6-L25.docx HTTP 200: https://storage.googleapis.com/lingoleap-assets/worksheets/G6-L25.docx
G7-L28.docx HTTP 200: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L28.docx
G7-L29.docx HTTP 200: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L29.docx
G7-L30.docx HTTP 200: https://storage.googleapis.com/lingoleap-assets/worksheets/G7-L30.docx
```