### PR TITLE
feat(omo): 批改記錄按課文分組檢視 (#2089 item 1)

### DIFF
--- a/frontend/src/components/omo/OmoHistoryList.test.tsx
+++ b/frontend/src/components/omo/OmoHistoryList.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for OmoHistoryList per-lesson grouping (#2089 item 1).
+ *
+ * The history endpoint returns a flat, newest-first list mixing every
+ * lesson. The list must regroup it so each lesson's records sit under one
+ * section header, in first-appearance (newest-active) order, with cards
+ * still newest-first inside each group.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within, fireEvent } from '@testing-library/react';
+import OmoHistoryList from './OmoHistoryList';
+import type { OmoHistoryItem } from '../../services/omoApi';
+
+function makeItem(over: Partial<OmoHistoryItem>): OmoHistoryItem {
+  return {
+    upload_id: 1,
+    lesson_id: 30,
+    lesson_title: '都是八哥',
+    grade_code: 'G7-L30',
+    status: 'graded',
+    overall_score: 0.8,
+    answers_count: 5,
+    created_at: new Date().toISOString(),
+    thumbnail_url: null,
+    ...over,
+  };
+}
+
+describe('OmoHistoryList grouping', () => {
+  it('shows the empty state when there are no items', () => {
+    render(<OmoHistoryList items={[]} onSelect={vi.fn()} />);
+    expect(screen.getByText('還沒有任何批改記錄')).toBeInTheDocument();
+  });
+
+  it('groups records by lesson under one section header each', () => {
+    const items: OmoHistoryItem[] = [
+      makeItem({ upload_id: 1, lesson_id: 30, lesson_title: '都是八哥', grade_code: 'G7-L30' }),
+      makeItem({ upload_id: 2, lesson_id: 30, lesson_title: '都是八哥', grade_code: 'G7-L30' }),
+      makeItem({ upload_id: 3, lesson_id: 24, lesson_title: '碧沉西瓜', grade_code: 'G6-L24' }),
+    ];
+    render(<OmoHistoryList items={items} onSelect={vi.fn()} />);
+
+    // Two section headers, one per lesson.
+    const sections = screen.getAllByRole('region');
+    expect(sections).toHaveLength(2);
+
+    // The G7-L30 section header shows the lesson title + a count of 2.
+    expect(screen.getByRole('heading', { name: '都是八哥' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '碧沉西瓜' })).toBeInTheDocument();
+
+    const g730 = screen.getByRole('region', { name: '都是八哥' });
+    expect(within(g730).getByText('2 筆')).toBeInTheDocument();
+    // Two upload cards live under that lesson.
+    expect(within(g730).getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('keeps groups in first-appearance order (newest-active lesson first)', () => {
+    const items: OmoHistoryItem[] = [
+      makeItem({ upload_id: 1, lesson_id: 24, lesson_title: '碧沉西瓜', grade_code: 'G6-L24' }),
+      makeItem({ upload_id: 2, lesson_id: 30, lesson_title: '都是八哥', grade_code: 'G7-L30' }),
+    ];
+    render(<OmoHistoryList items={items} onSelect={vi.fn()} />);
+    const headings = screen.getAllByRole('heading');
+    expect(headings.map((h) => h.textContent)).toEqual(['碧沉西瓜', '都是八哥']);
+  });
+
+  it('puts items with no lesson_id into a dedicated unidentified group', () => {
+    const items: OmoHistoryItem[] = [
+      makeItem({ upload_id: 1, lesson_id: null, lesson_title: null, grade_code: null, status: 'identified' }),
+    ];
+    render(<OmoHistoryList items={items} onSelect={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: '（尚未辨識課程名稱）' })).toBeInTheDocument();
+  });
+
+  it('backfills a missing title from a later item in the same lesson group', () => {
+    const items: OmoHistoryItem[] = [
+      makeItem({ upload_id: 1, lesson_id: 30, lesson_title: null, grade_code: null }),
+      makeItem({ upload_id: 2, lesson_id: 30, lesson_title: '都是八哥', grade_code: 'G7-L30' }),
+    ];
+    render(<OmoHistoryList items={items} onSelect={vi.fn()} />);
+    // Only one group, titled from the item that had the name.
+    expect(screen.getAllByRole('region')).toHaveLength(1);
+    expect(screen.getByRole('heading', { name: '都是八哥' })).toBeInTheDocument();
+  });
+
+  it('invokes onSelect with the upload id when a card is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <OmoHistoryList items={[makeItem({ upload_id: 42 })]} onSelect={onSelect} />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onSelect).toHaveBeenCalledWith(42);
+  });
+});

--- a/frontend/src/components/omo/OmoHistoryList.tsx
+++ b/frontend/src/components/omo/OmoHistoryList.tsx
@@ -95,7 +95,11 @@ function groupByLesson(items: OmoHistoryItem[]): LessonGroup[] {
       order.push(key);
     }
     // Backfill a missing title/grade_code from a later item in the same group.
-    if (group.title === '（尚未辨識課程名稱）' && item.lesson_title) {
+    // Never rename the unidentified group, even if a null-lesson_id item
+    // happens to carry a lesson_title (backend data inconsistency) — that
+    // item belongs in the unidentified bucket by lesson_id, so its title
+    // must not leak into the section header.
+    if (key !== UNIDENTIFIED_KEY && group.title === '（尚未辨識課程名稱）' && item.lesson_title) {
       group.title = item.lesson_title;
     }
     if (!group.gradeCode && item.grade_code) {
@@ -172,8 +176,12 @@ const OmoHistoryList: React.FC<OmoHistoryListProps> = ({ items, onSelect }) => {
 
   return (
     <div className="flex flex-col gap-6">
-      {groups.map((group) => (
-        <section key={group.key} aria-label={group.title} className="flex flex-col gap-2">
+      {groups.map((group) => {
+        // Label the region via the heading's id (not aria-label with the same
+        // text) so screen readers don't announce the lesson name twice.
+        const headingId = `omo-history-lesson-${group.key}`;
+        return (
+        <section key={group.key} aria-labelledby={headingId} className="flex flex-col gap-2">
           {/* Per-lesson section header (#2089) */}
           <div className="flex items-center gap-2 px-1">
             {group.gradeCode && (
@@ -181,7 +189,7 @@ const OmoHistoryList: React.FC<OmoHistoryListProps> = ({ items, onSelect }) => {
                 {group.gradeCode}
               </span>
             )}
-            <h3 className="text-sm font-bold text-gray-900 truncate">{group.title}</h3>
+            <h3 id={headingId} className="text-sm font-bold text-gray-900 truncate">{group.title}</h3>
             <span className="ml-auto shrink-0 text-xs text-gray-400">{group.items.length} 筆</span>
           </div>
           <div className="flex flex-col gap-3">
@@ -194,7 +202,8 @@ const OmoHistoryList: React.FC<OmoHistoryListProps> = ({ items, onSelect }) => {
             ))}
           </div>
         </section>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/components/omo/OmoHistoryList.tsx
+++ b/frontend/src/components/omo/OmoHistoryList.tsx
@@ -1,6 +1,13 @@
 /**
  * OmoHistoryList — presentational card list for OMO upload history (#1975).
  *
+ * #2089 item 1: records are now grouped per-lesson instead of one flat list.
+ * Each lesson gets a section header (grade_code + title + count) and its
+ * upload cards underneath, so a student's paper-grading history for one
+ * lesson no longer mixes in with every other lesson's records. The DB was
+ * already per-lesson (OmoUpload.lesson_id); this is purely a presentation
+ * regrouping done client-side from the fields the history endpoint returns.
+ *
  * Stateless: receives the items + click handler from a parent that owns
  * fetching, pagination, and routing. Keeps this component testable in
  * isolation and reusable in dashboards later.
@@ -50,12 +57,61 @@ function statusBadge(status: string): { label: string; cls: string } {
   }
 }
 
+const UNIDENTIFIED_KEY = '__unidentified__';
+
+interface LessonGroup {
+  /** Stable React key — lesson_id as string, or a sentinel for unidentified. */
+  key: string;
+  /** Display title for the section header. */
+  title: string;
+  /** Grade code badge for the header, when known. */
+  gradeCode: string | null;
+  items: OmoHistoryItem[];
+}
+
+/**
+ * Group history items by lesson, preserving first-appearance order. Because
+ * the endpoint returns items newest-first, the most recently active lesson
+ * surfaces at the top, and cards stay in newest-first order within a group.
+ */
+function groupByLesson(items: OmoHistoryItem[]): LessonGroup[] {
+  const order: string[] = [];
+  const byKey = new Map<string, LessonGroup>();
+
+  for (const item of items) {
+    const key = item.lesson_id != null ? String(item.lesson_id) : UNIDENTIFIED_KEY;
+    let group = byKey.get(key);
+    if (!group) {
+      group = {
+        key,
+        title:
+          key === UNIDENTIFIED_KEY
+            ? '（尚未辨識課程名稱）'
+            : item.lesson_title || '（尚未辨識課程名稱）',
+        gradeCode: item.grade_code ?? null,
+        items: [],
+      };
+      byKey.set(key, group);
+      order.push(key);
+    }
+    // Backfill a missing title/grade_code from a later item in the same group.
+    if (group.title === '（尚未辨識課程名稱）' && item.lesson_title) {
+      group.title = item.lesson_title;
+    }
+    if (!group.gradeCode && item.grade_code) {
+      group.gradeCode = item.grade_code;
+    }
+    group.items.push(item);
+  }
+
+  return order.map((key) => byKey.get(key)!);
+}
+
 const HistoryCard: React.FC<{
   item: OmoHistoryItem;
   onClick: () => void;
 }> = ({ item, onClick }) => {
   const badge = statusBadge(item.status);
-  const title = item.lesson_title || '（尚未辨識課程名稱）';
 
   return (
     <button
@@ -71,7 +127,7 @@ const HistoryCard: React.FC<{
         {item.thumbnail_url ? (
           <img
             src={item.thumbnail_url}
-            alt={`${title} 縮圖`}
+            alt={`${item.lesson_title || '學習單'} 縮圖`}
             className="w-full h-full object-cover"
             loading="lazy"
           />
@@ -80,16 +136,9 @@ const HistoryCard: React.FC<{
         )}
       </div>
 
-      {/* Right: title + meta */}
-      <div className="flex-1 min-w-0 flex flex-col gap-1">
-        <div className="flex items-center gap-2 min-w-0">
-          {item.grade_code && (
-            <span className="shrink-0 text-[11px] font-semibold text-blue-700 bg-blue-50 px-1.5 py-0.5 rounded">
-              {item.grade_code}
-            </span>
-          )}
-          <p className="text-sm font-semibold text-gray-900 truncate">{title}</p>
-        </div>
+      {/* Right: status + meta. Lesson title lives in the group header now,
+          so cards focus on the per-upload status / score / time. */}
+      <div className="flex-1 min-w-0 flex flex-col gap-1 justify-center">
         <div className="flex items-center gap-2 flex-wrap">
           <span
             className={`text-[11px] font-medium px-1.5 py-0.5 rounded border ${badge.cls}`}
@@ -119,14 +168,32 @@ const OmoHistoryList: React.FC<OmoHistoryListProps> = ({ items, onSelect }) => {
     );
   }
 
+  const groups = groupByLesson(items);
+
   return (
-    <div className="flex flex-col gap-3">
-      {items.map((item) => (
-        <HistoryCard
-          key={item.upload_id}
-          item={item}
-          onClick={() => onSelect(item.upload_id)}
-        />
+    <div className="flex flex-col gap-6">
+      {groups.map((group) => (
+        <section key={group.key} aria-label={group.title} className="flex flex-col gap-2">
+          {/* Per-lesson section header (#2089) */}
+          <div className="flex items-center gap-2 px-1">
+            {group.gradeCode && (
+              <span className="shrink-0 text-[11px] font-semibold text-blue-700 bg-blue-50 px-1.5 py-0.5 rounded">
+                {group.gradeCode}
+              </span>
+            )}
+            <h3 className="text-sm font-bold text-gray-900 truncate">{group.title}</h3>
+            <span className="ml-auto shrink-0 text-xs text-gray-400">{group.items.length} 筆</span>
+          </div>
+          <div className="flex flex-col gap-3">
+            {group.items.map((item) => (
+              <HistoryCard
+                key={item.upload_id}
+                item={item}
+                onClick={() => onSelect(item.upload_id)}
+              />
+            ))}
+          </div>
+        </section>
       ))}
     </div>
   );


### PR DESCRIPTION
## 背景
#2089 OMO 系統全面更新 **項目 1：每篇課文的批改記錄分開**。

原本 `/omo` 批改記錄頁把所有課文的記錄混在同一個 flat list。本 PR 改成**依課文分組**。

## 關鍵發現
DB 其實**早就分課** —— `OmoUpload.lesson_id` 每筆上傳都綁課文。「混在一起」純粹是 history 頁 UI 沒分組。所以這是 **純前端 presentation 分組**，用 history endpoint 既有欄位（`lesson_id` / `lesson_title` / `grade_code`）client-side group-by，**無 schema / endpoint 變更**，零後端風險。

## 變更
- `OmoHistoryList.tsx`：
  - 新增 `groupByLesson()` —— 依 `lesson_id` 分組，保留 first-appearance 順序（newest-active 課文在最上、組內維持 newest-first）
  - 每組一個 section header：`grade_code` badge + 課名 + 「N 筆」
  - 卡片移除重複的課名/grade（已在 header），聚焦狀態 badge / 分數 / 題數 / 時間
  - 無 `lesson_id` 的上傳 → 「尚未辨識課程名稱」群組
  - 同組缺 title/grade_code 時從同組其他筆 backfill
- `OmoHistoryList.test.tsx`（新）：6 tests

## 測試
- ✅ `OmoHistoryList.test.tsx` 6/6 passed（空狀態 / 分組 / 順序 / 未辨識群組 / backfill / onSelect）
- ✅ `tsc --noEmit`：無新增 error（既有 unrelated 檔的 error 與本 PR 無關，已 stash 驗證）
- ℹ️ `OmoIdentifyResult.test.tsx` 1 個既有失敗 —— stash 本 PR 後仍 fail，**非本 PR 造成**

## QA（staging preview）
- [ ] `/omo` 批改記錄頁：多課文記錄按課分組顯示、各組 header 課名+筆數正確
- [ ] 點卡片正確導向該筆結果頁
- [ ] 「載入更多」分頁後分組仍正確
- [ ] 無記錄時空狀態正常

關聯 #2089