### PR TITLE
feat(omo): reference 對齊 — 過濾影片雜訊題 + 依 UI 關卡順序批改 (#2038, #2089 item 2)

### DIFF
--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -50,6 +50,10 @@ class GradedAnswer:
     score: float          # 0.0 – 1.0
     ai_confidence: float  # 0.0 – 1.0
     reasoning: str
+    # The UI step (step_sequence id) this question belongs to, e.g.
+    # "vocab-application" / "comprehension" / "reading-strategy". Used to order
+    # results by the lesson's on-screen 關卡 sequence (#2038 / #2089 item 2).
+    step: str = ""
     # The question prompt text from the lesson YAML (e.g. the definition for a
     # fill-in-blank, or the MCQ stem).  Surfaced in the result-page header so
     # students see the actual question instead of an opaque id like "fb_1".
@@ -249,6 +253,7 @@ async def grade_worksheet_images(
                 score=score,
                 ai_confidence=ai_conf,
                 reasoning=reasoning,
+                step=str(question.get("step") or ""),
                 context=str(question.get("context") or ""),
                 position={
                     "x": float(item.get("position_x", 0.0)),
@@ -291,11 +296,8 @@ async def grade_worksheet_images(
             )
             result.crop_image_url = gs_uri
 
-    # #1973: sort by YAML question order (fb_1, fb_2, …, mc_1, mc_2, …) so the
-    # client renders in a stable, student-readable order rather than Gemini's
-    # visual-scan order (which can jump around — esp. after _split_spread).
-    qid_order = {q["id"]: idx for idx, q in enumerate(questions)}
-    results.sort(key=lambda g: qid_order.get(g.question_id, len(qid_order)))
+    # #2038 / #2089 item 2: order results by the lesson's on-screen 關卡 sequence.
+    results = _order_by_step_sequence(results, lesson, questions)
 
     logger.info(
         "OMO grader: graded %d/%d questions for lesson '%s'",
@@ -304,6 +306,35 @@ async def grade_worksheet_images(
         lesson.get("title", "unknown"),
     )
     return results
+
+
+def _order_by_step_sequence(
+    results: list[GradedAnswer],
+    lesson: dict,
+    questions: list[dict],
+) -> list[GradedAnswer]:
+    """Order graded results by the lesson's on-screen 關卡 (step_sequence) order.
+
+    #2038 / #2089 item 2: the student sees the worksheet steps in the lesson's
+    step_sequence order (e.g. vocab-application → reading-strategy →
+    comprehension). Grading results must follow that same order rather than
+    question type (fb→mc→se) — under the old type sort, comprehension (mc) came
+    before reading-strategy (se), the reverse of the on-screen order.
+
+    Tie-break within a step keeps the stable YAML question order (#1973:
+    fb_1, fb_2, …). A question whose step is absent from this lesson's
+    step_sequence sorts last, still stably. Pure + deterministic (no LLM) so it
+    stays within the omo-determinism contract.
+    """
+    step_sequence = lesson.get("step_sequence") or []
+    step_order = {sid: idx for idx, sid in enumerate(step_sequence)}
+    qid_order = {q["id"]: idx for idx, q in enumerate(questions)}
+
+    def _sort_key(g: GradedAnswer) -> tuple:
+        step_idx = step_order.get(g.step, len(step_order))  # unknown/missing → last
+        return (step_idx, qid_order.get(g.question_id, len(qid_order)))
+
+    return sorted(results, key=_sort_key)
 
 
 def _mock_grades(questions: list[dict], attempt_id: Optional[int]) -> list[GradedAnswer]:
@@ -316,6 +347,7 @@ def _mock_grades(questions: list[dict], attempt_id: Optional[int]) -> list[Grade
             score=1.0,
             ai_confidence=0.9,
             reasoning="本地開發模式：模擬批改結果",
+            step=str(q.get("step") or ""),
             context=str(q.get("context") or ""),
             crop_image_url=None,
             source_attempt_id=attempt_id,

--- a/backend/app/services/omo_jobs.py
+++ b/backend/app/services/omo_jobs.py
@@ -345,6 +345,7 @@ async def _run_grading(upload_id: int, lesson_id: int):
                 "ai_confidence": g.ai_confidence,
                 "reasoning": g.reasoning,
                 "context": g.context,  # #2011 follow-up: prompt text for the result page
+                "step": g.step,        # #2038: UI 關卡 id — drives 依關卡順序 + (item 3) 綠點同步
                 "source_attempt_id": g.source_attempt_id,
                 "position": g.position,
                 "crop_image_url": g.crop_image_url,

--- a/backend/app/services/omo_question_schema.py
+++ b/backend/app/services/omo_question_schema.py
@@ -15,9 +15,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-# Which UI step (step_sequence id, see frontend stepConfig.ts) each grader
-# question type belongs to. Used to order graded results by the lesson's
-# on-screen 關卡 sequence (#2038 / #2089 item 2) instead of by question type.
+# Which UI step (step_sequence id, see frontend stepConfig.ts) each worksheet
+# section maps to. Used to order graded results by the lesson's on-screen 關卡
+# sequence (#2038 / #2089 item 2) instead of by question type.
+#
+# NOTE: keys are YAML SECTION names (fill_in_blank / multiple_choice /
+# strategy_exercise), NOT the schema's question `type` field — strategy_exercise
+# questions are emitted with type "fill_blank" but belong to "reading-strategy".
+# Do not look this up via q["type"]; assign step at the section it is built in.
 QUESTION_TYPE_TO_STEP = {
     "fill_blank": "vocab-application",       # 語詞應用
     "multiple_choice": "comprehension",      # 閱讀理解
@@ -118,8 +123,13 @@ def _build_question_schema(lesson: dict) -> list[dict]:
     # fb answers are single letters within the worksheet's choice set.
     fb = lesson.get("fill_in_blank") or []
     fb_raw_items = list(fb.items()) if isinstance(fb, dict) else list(enumerate(fb))
+    # Skip media artifacts here too (#2038 review): an artifact's non-letter
+    # answer (e.g. '外來種') would otherwise drag fb_lettered to False and turn
+    # a genuinely lettered lesson into free_form mode — scoring every fb wrong.
     fb_answers = []
     for _, item in fb_raw_items:
+        if _is_media_artifact(item):
+            continue
         ans = item.get("answer", "") if isinstance(item, dict) else str(item)
         fb_answers.append(ans)
 

--- a/backend/app/services/omo_question_schema.py
+++ b/backend/app/services/omo_question_schema.py
@@ -15,6 +15,42 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+# Which UI step (step_sequence id, see frontend stepConfig.ts) each grader
+# question type belongs to. Used to order graded results by the lesson's
+# on-screen 關卡 sequence (#2038 / #2089 item 2) instead of by question type.
+QUESTION_TYPE_TO_STEP = {
+    "fill_blank": "vocab-application",       # 語詞應用
+    "multiple_choice": "comprehension",      # 閱讀理解
+    "strategy_exercise": "reading-strategy", # 閱讀聚光燈
+}
+
+# Video-link metadata markers. These are extremely specific to the YouTube-link
+# region of a worksheet (片長 = clip length, 建議觀看 = recommended viewing). A
+# real cloze sentence essentially never contains them — validated across all 57
+# lessons (#2038): only G7-L28 id=1 and G7-L30 id=1 match, both genuine parse
+# artifacts where the video caption region was mis-parsed as a fill-in blank.
+_VIDEO_METADATA_MARKERS = ("片長", "建議觀看")
+
+
+def _is_media_artifact(item) -> bool:
+    """True when a fill_in_blank entry is a video-caption parse artifact, not a
+    real question (#2038 — meeting §2「占位空格 / 示意 sample 被誤判為題目」).
+
+    Signal: the blank's surrounding context carries video-link metadata
+    (片長 / 建議觀看) AND it has no real cloze sentence. Such entries come from
+    the worksheet's video-links region, not a gradeable blank — including them
+    makes the grader hunt for handwriting that does not exist and can derange
+    alignment of the real questions.
+    """
+    if not isinstance(item, dict):
+        return False
+    sentence = (item.get("sentence") or item.get("context") or "").strip()
+    if sentence:
+        return False  # a real cloze sentence is present → it is a question
+    context_blob = (item.get("context_before") or "") + (item.get("context_after") or "")
+    return any(marker in context_blob for marker in _VIDEO_METADATA_MARKERS)
+
+
 def _vocab_bank_lookup(vocab_bank, key: str) -> str | None:
     """Return the word a worksheet letter maps to in vocab_bank, else None.
 
@@ -116,6 +152,14 @@ def _build_question_schema(lesson: dict) -> list[dict]:
 
     for key, item in fb_raw_items:
         qid = str(key) if isinstance(fb, dict) else f"fb_{key+1}"
+        # #2038 Task A: skip video-caption parse artifacts so they never enter
+        # the reference schema (root cause of meeting §2「占位空格誤判為填空題」).
+        if _is_media_artifact(item):
+            logger.info(
+                "omo_question_schema: skipping media-artifact fill_in_blank %s "
+                "(video-caption region, not a real question)", qid,
+            )
+            continue
         if isinstance(item, dict):
             raw_answer = item.get("answer", "")
             context = item.get("context", item.get("sentence", ""))
@@ -133,6 +177,7 @@ def _build_question_schema(lesson: dict) -> list[dict]:
         questions.append({
             "id": qid,
             "type": "fill_blank",
+            "step": QUESTION_TYPE_TO_STEP["fill_blank"],
             "context": context,
             "correct_answer": correct_for_scoring,
             "correct_word": correct_word,
@@ -154,6 +199,7 @@ def _build_question_schema(lesson: dict) -> list[dict]:
         questions.append({
             "id": qid,
             "type": "multiple_choice",
+            "step": QUESTION_TYPE_TO_STEP["multiple_choice"],
             "context": context,
             "correct_answer": correct,
             "mode": "lettered",
@@ -171,6 +217,7 @@ def _build_question_schema(lesson: dict) -> list[dict]:
                     questions.append({
                         "id": qid,
                         "type": "fill_blank",
+                        "step": QUESTION_TYPE_TO_STEP["strategy_exercise"],
                         "context": item.get("stem", item.get("question", "")),
                         "correct_answer": item.get("answer", ""),
                     })

--- a/backend/tests/test_omo_reference_alignment_2038.py
+++ b/backend/tests/test_omo_reference_alignment_2038.py
@@ -1,0 +1,182 @@
+"""Tests for #2038 OMO reference-led alignment (also #2089 item 2).
+
+Two behaviours:
+
+  Task A — media-artifact filter:
+    video-caption parse artifacts (片長 / 建議觀看 regions mis-parsed as
+    fill-in blanks) must NOT enter the reference question schema. Validated
+    against meeting §2「占位空格被誤判為填空題」. Across the 57 lessons exactly
+    two such entries exist (G7-L28 id=1, G7-L30 id=1) — real blanks (933 of
+    them) must be untouched.
+
+  依關卡順序 — step ordering:
+    each question carries the UI step (step_sequence id) it belongs to, and
+    graded results are ordered by the lesson's step_sequence rather than by
+    question type (fb→mc→se).
+"""
+import glob
+import os
+
+import pytest
+import yaml
+
+from app.services.omo_question_schema import (
+    _build_question_schema,
+    _is_media_artifact,
+    QUESTION_TYPE_TO_STEP,
+)
+from app.services.omo_grader import GradedAnswer, _order_by_step_sequence
+
+LESSON_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "data", "lessons", "_parsed_2026-05-01"
+)
+
+
+def _load(code: str) -> dict:
+    with open(os.path.join(LESSON_DIR, f"{code}.yml"), encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+# ---------------------------------------------------------------------------
+# Task A — media-artifact filter
+# ---------------------------------------------------------------------------
+
+class TestMediaArtifactFilter:
+    def test_detects_video_caption_artifact(self):
+        artifact = {
+            "answer": "外來種",
+            "context_before": "",
+            "context_after": "你知道八哥有分本土和外來種嗎？｜ ・片長：(22:48) 建議觀看",
+        }
+        assert _is_media_artifact(artifact) is True
+
+    def test_real_cloze_with_sentence_is_not_artifact(self):
+        # Even if the surrounding text mentions a video, a real cloze sentence
+        # means it is a genuine question.
+        real = {
+            "answer": "微生物",
+            "sentence": "肉湯腐敗和空氣中的【微生物】有關。",
+            "context_after": "・片長：(12:59)",
+        }
+        assert _is_media_artifact(real) is False
+
+    def test_plain_blank_without_video_markers_is_not_artifact(self):
+        assert _is_media_artifact(
+            {"answer": "煮沸", "context_before": "只要把肉湯", "context_after": "並阻止微生物"}
+        ) is False
+
+    def test_g7l30_noise_blank_removed_from_schema(self):
+        # G7-L30 has a single fill_in_blank that is a video-caption artifact.
+        questions = _build_question_schema(_load("G7-L30"))
+        assert not any(q.get("step") == "vocab-application" for q in questions), (
+            "G7-L30's video-caption blank must not become a graded question"
+        )
+
+    def test_g7l28_drops_only_the_artifact_keeps_real_blanks(self):
+        # G7-L28 id=1 ('LIS科學史' video region) is an artifact; id=2..15 are
+        # real Pasteur-experiment cloze questions and must survive.
+        questions = _build_question_schema(_load("G7-L28"))
+        fb_ids = [q["id"] for q in questions if q.get("step") == "vocab-application"]
+        assert "fb_1" not in fb_ids
+        assert "fb_2" in fb_ids and "fb_15" in fb_ids
+        assert len(fb_ids) == 14
+
+    def test_filter_does_not_drop_real_blanks_across_all_lessons(self):
+        # Guardrail: only the two known artifacts may be filtered. Compare the
+        # raw fill_in_blank count to the schema fill_blank count per lesson.
+        total_dropped = 0
+        for path in glob.glob(os.path.join(LESSON_DIR, "*.yml")):
+            d = yaml.safe_load(open(path, encoding="utf-8")) or {}
+            fb = d.get("fill_in_blank") or []
+            raw_fb = len(fb) if isinstance(fb, (list, dict)) else 0
+            if raw_fb == 0:
+                continue
+            schema_fb = sum(
+                1 for q in _build_question_schema(d)
+                if q.get("step") == "vocab-application"
+            )
+            total_dropped += raw_fb - schema_fb
+        assert total_dropped == 2, (
+            f"expected exactly 2 artifacts filtered across all lessons, got {total_dropped}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 依關卡順序 — step assignment + ordering
+# ---------------------------------------------------------------------------
+
+class TestStepAssignment:
+    def test_each_type_maps_to_its_ui_step(self):
+        assert QUESTION_TYPE_TO_STEP["fill_blank"] == "vocab-application"
+        assert QUESTION_TYPE_TO_STEP["multiple_choice"] == "comprehension"
+        assert QUESTION_TYPE_TO_STEP["strategy_exercise"] == "reading-strategy"
+
+    def test_schema_questions_carry_a_step(self):
+        questions = _build_question_schema(_load("G6-L24"))
+        assert questions, "G6-L24 should produce questions"
+        assert all(q.get("step") for q in questions)
+        steps = {q["step"] for q in questions}
+        assert steps <= {"vocab-application", "comprehension", "reading-strategy"}
+
+
+class TestStepOrdering:
+    def _ans(self, qid: str, step: str) -> GradedAnswer:
+        return GradedAnswer(
+            question_id=qid, student_answer="", correct_answer="",
+            score=0.0, ai_confidence=0.0, reasoning="", step=step,
+        )
+
+    def test_orders_by_step_sequence_not_question_type(self):
+        # Lesson runs vocab-application → reading-strategy → comprehension, so
+        # se (reading-strategy) must come BEFORE mc (comprehension) — the
+        # reverse of the old fb→mc→se type order.
+        lesson = {
+            "step_sequence": [
+                "intro", "vocab-application", "reading-strategy",
+                "comprehension", "report",
+            ]
+        }
+        questions = [
+            {"id": "fb_1"}, {"id": "mc_1"}, {"id": "se_1"},
+        ]
+        # Results arrive in arbitrary (Gemini visual-scan) order.
+        results = [
+            self._ans("mc_1", "comprehension"),
+            self._ans("se_1", "reading-strategy"),
+            self._ans("fb_1", "vocab-application"),
+        ]
+        ordered = _order_by_step_sequence(results, lesson, questions)
+        assert [g.question_id for g in ordered] == ["fb_1", "se_1", "mc_1"]
+
+    def test_within_step_keeps_stable_yaml_order(self):
+        lesson = {"step_sequence": ["vocab-application"]}
+        questions = [{"id": "fb_1"}, {"id": "fb_2"}, {"id": "fb_3"}]
+        results = [
+            self._ans("fb_3", "vocab-application"),
+            self._ans("fb_1", "vocab-application"),
+            self._ans("fb_2", "vocab-application"),
+        ]
+        ordered = _order_by_step_sequence(results, lesson, questions)
+        assert [g.question_id for g in ordered] == ["fb_1", "fb_2", "fb_3"]
+
+    def test_unknown_step_sorts_last(self):
+        # A question whose step is not in step_sequence goes to the end.
+        lesson = {"step_sequence": ["comprehension"]}
+        questions = [{"id": "mc_1"}, {"id": "fb_1"}]
+        results = [
+            self._ans("fb_1", "vocab-application"),  # step absent from sequence
+            self._ans("mc_1", "comprehension"),
+        ]
+        ordered = _order_by_step_sequence(results, lesson, questions)
+        assert [g.question_id for g in ordered] == ["mc_1", "fb_1"]
+
+    def test_empty_step_sequence_falls_back_to_question_order(self):
+        lesson = {}  # no step_sequence
+        questions = [{"id": "fb_1"}, {"id": "mc_1"}]
+        results = [
+            self._ans("mc_1", "comprehension"),
+            self._ans("fb_1", "vocab-application"),
+        ]
+        ordered = _order_by_step_sequence(results, lesson, questions)
+        # All steps unknown → sort by qid_order (YAML order) → fb_1, mc_1.
+        assert [g.question_id for g in ordered] == ["fb_1", "mc_1"]

--- a/backend/tests/test_omo_reference_alignment_2038.py
+++ b/backend/tests/test_omo_reference_alignment_2038.py
@@ -81,6 +81,29 @@ class TestMediaArtifactFilter:
         assert "fb_2" in fb_ids and "fb_15" in fb_ids
         assert len(fb_ids) == 14
 
+    def test_artifact_does_not_corrupt_lettered_mode_detection(self):
+        # #2038 review: a lettered lesson whose first fb entry is a video
+        # artifact with a NON-letter answer ('外來種') must still be detected as
+        # lettered — the artifact must be skipped before fb_lettered is computed,
+        # otherwise every real fb gets scored as free_form.
+        lesson = {
+            "fill_in_blank": {
+                "1": {"answer": "外來種", "context_before": "",
+                      "context_after": "・片長：(3:00) 建議觀看"},
+                "2": {"answer": "A", "sentence": "學生需填入【   】"},
+                "3": {"answer": "B", "sentence": "另一格【   】"},
+            },
+            "vocabulary": [{"word": "規律"}, {"word": "秩序"}],
+        }
+        questions = _build_question_schema(lesson)
+        real = [q for q in questions if q["id"] == "2"]
+        assert real, "the real lettered blank must survive"
+        assert real[0]["mode"] == "lettered", (
+            "artifact's non-letter answer must not flip the lesson to free_form"
+        )
+        # The artifact itself must not appear as a question.
+        assert not any(q["id"] == "1" for q in questions)
+
     def test_filter_does_not_drop_real_blanks_across_all_lessons(self):
         # Guardrail: only the two known artifacts may be filtered. Compare the
         # raw fill_in_blank count to the schema fill_blank count per lesson.


### PR DESCRIPTION
## 背景
#2089 OMO 全面更新 **項目 2**，落地 #2038「以 reference 主導對齊」+ 5/29 會議 §1/§2。

**關鍵發現：#2038 的 Task B（re-sort #1973）/ C（對齊）/ D（正規化 #1712/#2061）大半已實作。** 本 PR 補上真正剩下的兩塊（純 backend）：

---

## Task A — 過濾影片雜訊題（修 §2 根因）

§2:「某課僅圖文、無詞語應用，但占位空格被 OCR 當填空題 → 全局錯亂」。

根因不是 lesson 層級，而是**影片連結區被誤解析成填空 entry**。`_build_question_schema` 現在跳過：context 含影片 metadata（`片長`/`建議觀看`）且**無真 cloze sentence** 的 fb entry。

**全 57 課 935 個 fill_in_blank 實測驗證**：規則只命中 **2 筆**雜訊（`G7-L28 id=1` 'LIS科學史'、`G7-L30 id=1` '外來種'），**933 個真題零誤傷**。G7-L28 的 14 個真填空（巴斯德實驗 cloze）完整保留。

> ⚠️ 原本一度想用「lesson 層級 vocab_empty → 全丟」，實測發現會**誤丟 G7-L28 的 15 個真題** → 改成 per-entry 精準過濾。

## 依 UI 關卡順序批改（#2089 item 2）

- schema 每題標 `step`（對應 `frontend/src/config/stepConfig.ts`）：
  - `fill_blank` → `vocab-application`（語詞應用）
  - `multiple_choice` → `comprehension`（閱讀理解）
  - `strategy_exercise` → `reading-strategy`（閱讀聚光燈）
- grader 改依該課 `step_sequence` 順序排，**取代舊的 fb→mc→se 題型順序**
- 多數課關卡序是 `vocab-application(fb) → reading-strategy(se) → comprehension(mc)`，舊排序把 mc/se 顛倒 → 本 PR 修正
- 抽出純函式 `_order_by_step_sequence`（deterministic，守住 omo-determinism 契約）
- `step` 一併寫入 answers payload，供 **item 3（#2027 關卡綠點同步）** 使用
- 前端 result page 自動拿到新順序（零前端 churn）

---

## 變更
| 檔案 | 變更 |
|------|------|
| `omo_question_schema.py` | `_is_media_artifact()` 過濾 + 每題標 `step` + `QUESTION_TYPE_TO_STEP` |
| `omo_grader.py` | `GradedAnswer.step` 欄位 + `_order_by_step_sequence()` 依關卡排序 |
| `omo_jobs.py` | answers payload 加 `step` |
| `tests/test_omo_reference_alignment_2038.py` | 新 12 tests |

## 測試
- ✅ 新 `test_omo_reference_alignment_2038.py` 12/12 passed
- ✅ 既有契約全綠：`omo-assessment` / `omo-determinism` / `grading-corpus` **無 regression**
- ✅ 本機 `specs/ + tests/`：**533 passed / 4 xfailed**（image_preprocess / pdf_split 2 檔本地缺 Pillow 跳過，CI 環境有 `Pillow>=10.0`）
- ✅ registry freshness OK

## QA（staging preview）
- [ ] 上傳 G7-L30 → 不再出現「外來種」幻影填空題
- [ ] 上傳含 fb+mc+se 的課 → 批改結果順序符合 UI 關卡序（語詞應用 → 聚光燈 → 閱讀理解）
- [ ] 一般課批改對答率不退步

關聯 #2038 #2089