### PR TITLE
feat(omo): 紙本批改同步到 LearningSession — 關卡綠點 + 各關卡顯示作答對錯 (#2027, #2089 item 3)

### DIFF
--- a/backend/app/services/omo_grader.py
+++ b/backend/app/services/omo_grader.py
@@ -50,6 +50,10 @@ class GradedAnswer:
     score: float          # 0.0 – 1.0
     ai_confidence: float  # 0.0 – 1.0
     reasoning: str
+    # The UI step (step_sequence id) this question belongs to, e.g.
+    # "vocab-application" / "comprehension" / "reading-strategy". Used to order
+    # results by the lesson's on-screen 關卡 sequence (#2038 / #2089 item 2).
+    step: str = ""
     # The question prompt text from the lesson YAML (e.g. the definition for a
     # fill-in-blank, or the MCQ stem).  Surfaced in the result-page header so
     # students see the actual question instead of an opaque id like "fb_1".
@@ -249,6 +253,7 @@ async def grade_worksheet_images(
                 score=score,
                 ai_confidence=ai_conf,
                 reasoning=reasoning,
+                step=str(question.get("step") or ""),
                 context=str(question.get("context") or ""),
                 position={
                     "x": float(item.get("position_x", 0.0)),
@@ -291,11 +296,8 @@ async def grade_worksheet_images(
             )
             result.crop_image_url = gs_uri
 
-    # #1973: sort by YAML question order (fb_1, fb_2, …, mc_1, mc_2, …) so the
-    # client renders in a stable, student-readable order rather than Gemini's
-    # visual-scan order (which can jump around — esp. after _split_spread).
-    qid_order = {q["id"]: idx for idx, q in enumerate(questions)}
-    results.sort(key=lambda g: qid_order.get(g.question_id, len(qid_order)))
+    # #2038 / #2089 item 2: order results by the lesson's on-screen 關卡 sequence.
+    results = _order_by_step_sequence(results, lesson, questions)
 
     logger.info(
         "OMO grader: graded %d/%d questions for lesson '%s'",
@@ -304,6 +306,35 @@ async def grade_worksheet_images(
         lesson.get("title", "unknown"),
     )
     return results
+
+
+def _order_by_step_sequence(
+    results: list[GradedAnswer],
+    lesson: dict,
+    questions: list[dict],
+) -> list[GradedAnswer]:
+    """Order graded results by the lesson's on-screen 關卡 (step_sequence) order.
+
+    #2038 / #2089 item 2: the student sees the worksheet steps in the lesson's
+    step_sequence order (e.g. vocab-application → reading-strategy →
+    comprehension). Grading results must follow that same order rather than
+    question type (fb→mc→se) — under the old type sort, comprehension (mc) came
+    before reading-strategy (se), the reverse of the on-screen order.
+
+    Tie-break within a step keeps the stable YAML question order (#1973:
+    fb_1, fb_2, …). A question whose step is absent from this lesson's
+    step_sequence sorts last, still stably. Pure + deterministic (no LLM) so it
+    stays within the omo-determinism contract.
+    """
+    step_sequence = lesson.get("step_sequence") or []
+    step_order = {sid: idx for idx, sid in enumerate(step_sequence)}
+    qid_order = {q["id"]: idx for idx, q in enumerate(questions)}
+
+    def _sort_key(g: GradedAnswer) -> tuple:
+        step_idx = step_order.get(g.step, len(step_order))  # unknown/missing → last
+        return (step_idx, qid_order.get(g.question_id, len(qid_order)))
+
+    return sorted(results, key=_sort_key)
 
 
 def _mock_grades(questions: list[dict], attempt_id: Optional[int]) -> list[GradedAnswer]:
@@ -316,6 +347,7 @@ def _mock_grades(questions: list[dict], attempt_id: Optional[int]) -> list[Grade
             score=1.0,
             ai_confidence=0.9,
             reasoning="本地開發模式：模擬批改結果",
+            step=str(q.get("step") or ""),
             context=str(q.get("context") or ""),
             crop_image_url=None,
             source_attempt_id=attempt_id,

--- a/backend/app/services/omo_jobs.py
+++ b/backend/app/services/omo_jobs.py
@@ -256,10 +256,12 @@ async def _run_grading(upload_id: int, lesson_id: int):
         db = SessionLocal()
         active_attempt = None
         image_paths = []
+        student_id = None  # #2027: needed to sync grading into the LearningSession
         try:
             upload = db.query(OmoUpload).filter(OmoUpload.id == upload_id).first()
             if not upload:
                 return
+            student_id = upload.student_id
 
             # Find the latest active attempt
             for attempt in reversed(upload.attempts or []):
@@ -368,6 +370,20 @@ async def _run_grading(upload_id: int, lesson_id: int):
             len(graded),
             overall_score or 0.0,
         )
+
+        # #2027 / #2089 item 3: sync the paper grading into the student's
+        # LearningSession step_progress — lights up the 關卡 dots and stores the
+        # paper作答對錯 where the learning UI reads it. Best-effort: the grade is
+        # already saved above, so a sync failure never loses the result.
+        if student_id is not None and graded:
+            try:
+                from ..services.omo_session_sync import sync_omo_grading_to_session
+                sync_omo_grading_to_session(student_id, lesson_id, graded)
+            except Exception as exc:
+                logger.error(
+                    "OMO upload %d: session sync failed (non-fatal): %s",
+                    upload_id, exc, exc_info=True,
+                )
 
     # ── Task-level timeout wrapper ────────────────────────────────────────────
     try:

--- a/backend/app/services/omo_jobs.py
+++ b/backend/app/services/omo_jobs.py
@@ -345,6 +345,7 @@ async def _run_grading(upload_id: int, lesson_id: int):
                 "ai_confidence": g.ai_confidence,
                 "reasoning": g.reasoning,
                 "context": g.context,  # #2011 follow-up: prompt text for the result page
+                "step": g.step,        # #2038: UI 關卡 id — drives 依關卡順序 + (item 3) 綠點同步
                 "source_attempt_id": g.source_attempt_id,
                 "position": g.position,
                 "crop_image_url": g.crop_image_url,

--- a/backend/app/services/omo_question_schema.py
+++ b/backend/app/services/omo_question_schema.py
@@ -15,9 +15,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-# Which UI step (step_sequence id, see frontend stepConfig.ts) each grader
-# question type belongs to. Used to order graded results by the lesson's
-# on-screen 關卡 sequence (#2038 / #2089 item 2) instead of by question type.
+# Which UI step (step_sequence id, see frontend stepConfig.ts) each worksheet
+# section maps to. Used to order graded results by the lesson's on-screen 關卡
+# sequence (#2038 / #2089 item 2) instead of by question type.
+#
+# NOTE: keys are YAML SECTION names (fill_in_blank / multiple_choice /
+# strategy_exercise), NOT the schema's question `type` field — strategy_exercise
+# questions are emitted with type "fill_blank" but belong to "reading-strategy".
+# Do not look this up via q["type"]; assign step at the section it is built in.
 QUESTION_TYPE_TO_STEP = {
     "fill_blank": "vocab-application",       # 語詞應用
     "multiple_choice": "comprehension",      # 閱讀理解
@@ -118,8 +123,13 @@ def _build_question_schema(lesson: dict) -> list[dict]:
     # fb answers are single letters within the worksheet's choice set.
     fb = lesson.get("fill_in_blank") or []
     fb_raw_items = list(fb.items()) if isinstance(fb, dict) else list(enumerate(fb))
+    # Skip media artifacts here too (#2038 review): an artifact's non-letter
+    # answer (e.g. '外來種') would otherwise drag fb_lettered to False and turn
+    # a genuinely lettered lesson into free_form mode — scoring every fb wrong.
     fb_answers = []
     for _, item in fb_raw_items:
+        if _is_media_artifact(item):
+            continue
         ans = item.get("answer", "") if isinstance(item, dict) else str(item)
         fb_answers.append(ans)
 

--- a/backend/app/services/omo_question_schema.py
+++ b/backend/app/services/omo_question_schema.py
@@ -15,6 +15,42 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+# Which UI step (step_sequence id, see frontend stepConfig.ts) each grader
+# question type belongs to. Used to order graded results by the lesson's
+# on-screen 關卡 sequence (#2038 / #2089 item 2) instead of by question type.
+QUESTION_TYPE_TO_STEP = {
+    "fill_blank": "vocab-application",       # 語詞應用
+    "multiple_choice": "comprehension",      # 閱讀理解
+    "strategy_exercise": "reading-strategy", # 閱讀聚光燈
+}
+
+# Video-link metadata markers. These are extremely specific to the YouTube-link
+# region of a worksheet (片長 = clip length, 建議觀看 = recommended viewing). A
+# real cloze sentence essentially never contains them — validated across all 57
+# lessons (#2038): only G7-L28 id=1 and G7-L30 id=1 match, both genuine parse
+# artifacts where the video caption region was mis-parsed as a fill-in blank.
+_VIDEO_METADATA_MARKERS = ("片長", "建議觀看")
+
+
+def _is_media_artifact(item) -> bool:
+    """True when a fill_in_blank entry is a video-caption parse artifact, not a
+    real question (#2038 — meeting §2「占位空格 / 示意 sample 被誤判為題目」).
+
+    Signal: the blank's surrounding context carries video-link metadata
+    (片長 / 建議觀看) AND it has no real cloze sentence. Such entries come from
+    the worksheet's video-links region, not a gradeable blank — including them
+    makes the grader hunt for handwriting that does not exist and can derange
+    alignment of the real questions.
+    """
+    if not isinstance(item, dict):
+        return False
+    sentence = (item.get("sentence") or item.get("context") or "").strip()
+    if sentence:
+        return False  # a real cloze sentence is present → it is a question
+    context_blob = (item.get("context_before") or "") + (item.get("context_after") or "")
+    return any(marker in context_blob for marker in _VIDEO_METADATA_MARKERS)
+
+
 def _vocab_bank_lookup(vocab_bank, key: str) -> str | None:
     """Return the word a worksheet letter maps to in vocab_bank, else None.
 
@@ -116,6 +152,14 @@ def _build_question_schema(lesson: dict) -> list[dict]:
 
     for key, item in fb_raw_items:
         qid = str(key) if isinstance(fb, dict) else f"fb_{key+1}"
+        # #2038 Task A: skip video-caption parse artifacts so they never enter
+        # the reference schema (root cause of meeting §2「占位空格誤判為填空題」).
+        if _is_media_artifact(item):
+            logger.info(
+                "omo_question_schema: skipping media-artifact fill_in_blank %s "
+                "(video-caption region, not a real question)", qid,
+            )
+            continue
         if isinstance(item, dict):
             raw_answer = item.get("answer", "")
             context = item.get("context", item.get("sentence", ""))
@@ -133,6 +177,7 @@ def _build_question_schema(lesson: dict) -> list[dict]:
         questions.append({
             "id": qid,
             "type": "fill_blank",
+            "step": QUESTION_TYPE_TO_STEP["fill_blank"],
             "context": context,
             "correct_answer": correct_for_scoring,
             "correct_word": correct_word,
@@ -154,6 +199,7 @@ def _build_question_schema(lesson: dict) -> list[dict]:
         questions.append({
             "id": qid,
             "type": "multiple_choice",
+            "step": QUESTION_TYPE_TO_STEP["multiple_choice"],
             "context": context,
             "correct_answer": correct,
             "mode": "lettered",
@@ -171,6 +217,7 @@ def _build_question_schema(lesson: dict) -> list[dict]:
                     questions.append({
                         "id": qid,
                         "type": "fill_blank",
+                        "step": QUESTION_TYPE_TO_STEP["strategy_exercise"],
                         "context": item.get("stem", item.get("question", "")),
                         "correct_answer": item.get("answer", ""),
                     })

--- a/backend/app/services/omo_session_sync.py
+++ b/backend/app/services/omo_session_sync.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 
 
 # Fallback step inference from question_id prefix, used only when a GradedAnswer
-# carries no `step` (older grader output). Mirrors QUESTION_TYPE_TO_STEP.
+# carries no `step` (older grader output). Keys are qid prefixes (fb_/mc_/se_),
+# not section names — values match QUESTION_TYPE_TO_STEP in omo_question_schema.
 _QID_PREFIX_TO_STEP = {
     "fb_": "vocab-application",
     "mc_": "comprehension",
@@ -47,25 +48,53 @@ def _step_for(graded) -> str:
     return ""
 
 
-def _get_or_create_session(db, student_id: int, story_slug: str) -> LearningSession:
-    """Find the student's in_progress self-study session for this lesson, or
-    create one. Mirrors the get-or-create in sessions_bootstrap.py (same unique
-    index uq_session_student_story_inprogress guards against races)."""
-    def _find():
+def _get_or_create_session(
+    db, student_id: int, story_slug: str
+) -> Optional[LearningSession]:
+    """Find the student's in_progress SELF-STUDY session for this lesson, or
+    create one. Returns None (skip sync) when the single in_progress slot for
+    this (student, story) is held by a non-self_study (assignment) session.
+
+    Why self_study only: the unique index uq_session_student_story_inprogress
+    allows just one in_progress session per (student, story), regardless of
+    session_mode. Writing paper-grading into an active assignment session would
+    silently pollute that assignment's progress / submission, so we never do —
+    paper uploads are self-study. Mirrors sessions_bootstrap.py's get-or-create.
+    """
+    def _find_self_study():
         return (
             db.query(LearningSession)
             .filter(
                 LearningSession.student_id == student_id,
                 LearningSession.story_slug == story_slug,
                 LearningSession.status == "in_progress",
+                LearningSession.session_mode == "self_study",
             )
             .order_by(LearningSession.started_at.desc())
             .first()
         )
 
-    existing = _find()
+    existing = _find_self_study()
     if existing:
         return existing
+
+    # Slot occupied by an assignment session → skip rather than pollute it.
+    occupant = (
+        db.query(LearningSession)
+        .filter(
+            LearningSession.student_id == student_id,
+            LearningSession.story_slug == story_slug,
+            LearningSession.status == "in_progress",
+        )
+        .first()
+    )
+    if occupant is not None:
+        logger.info(
+            "OMO→session sync skipped: student %d lesson %s has an in_progress "
+            "%s session — not writing paper data into it.",
+            student_id, story_slug, occupant.session_mode,
+        )
+        return None
 
     text_id = None
     try:
@@ -89,12 +118,10 @@ def _get_or_create_session(db, student_id: int, story_slug: str) -> LearningSess
         db.refresh(session)
         return session
     except IntegrityError:
-        # Concurrent create (unique index) — fall back to the row that won.
+        # Lost a create race for the single in_progress slot. If a self_study
+        # session won, use it; if an assignment session took the slot, skip.
         db.rollback()
-        won = _find()
-        if won is None:
-            raise
-        return won
+        return _find_self_study()
 
 
 def build_step_progress_update(existing: Optional[dict], graded: list) -> Optional[dict]:
@@ -167,6 +194,8 @@ def sync_omo_grading_to_session(
     db = SessionLocal()
     try:
         session = _get_or_create_session(db, student_id, story_slug)
+        if session is None:
+            return None  # slot held by an assignment session — skip (see helper)
         new_sp = build_step_progress_update(session.step_progress, graded)
         if new_sp is None:
             return None

--- a/backend/app/services/omo_session_sync.py
+++ b/backend/app/services/omo_session_sync.py
@@ -1,0 +1,188 @@
+"""Sync OMO paper-grading results into the student's LearningSession.
+
+#2027 Phase 2 / #2089 item 3. Goal: 把紙本作答平移到線上，邏輯跟線上作答完全一樣。
+
+When a paper worksheet finishes grading we merge the result into the SAME
+`step_progress` JSONB store that online answers use, so:
+  - the 關卡 (step) dots the worksheet covered light up green (steps_completed)
+  - each step can show the paper作答 + 對錯 (step_data[step]["omo"])
+
+Writing into step_progress (not a new assessment_outcomes column) means no
+migration and the data lands exactly where the learning UI already reads it.
+
+The sync is best-effort: the grading result is already persisted on OmoUpload
+before this runs, so a failure here never loses the grade — it only means the
+dots don't light up, which a re-grade can fix.
+"""
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+
+from ..models.session import LearningSession
+from ..models.text import Text
+
+logger = logging.getLogger(__name__)
+
+
+# Fallback step inference from question_id prefix, used only when a GradedAnswer
+# carries no `step` (older grader output). Mirrors QUESTION_TYPE_TO_STEP.
+_QID_PREFIX_TO_STEP = {
+    "fb_": "vocab-application",
+    "mc_": "comprehension",
+    "se_": "reading-strategy",
+}
+
+
+def _step_for(graded) -> str:
+    """Resolve the UI step for a graded answer, falling back to qid prefix."""
+    step = (getattr(graded, "step", "") or "").strip()
+    if step:
+        return step
+    qid = str(getattr(graded, "question_id", ""))
+    for prefix, sid in _QID_PREFIX_TO_STEP.items():
+        if qid.startswith(prefix):
+            return sid
+    return ""
+
+
+def _get_or_create_session(db, student_id: int, story_slug: str) -> LearningSession:
+    """Find the student's in_progress self-study session for this lesson, or
+    create one. Mirrors the get-or-create in sessions_bootstrap.py (same unique
+    index uq_session_student_story_inprogress guards against races)."""
+    def _find():
+        return (
+            db.query(LearningSession)
+            .filter(
+                LearningSession.student_id == student_id,
+                LearningSession.story_slug == story_slug,
+                LearningSession.status == "in_progress",
+            )
+            .order_by(LearningSession.started_at.desc())
+            .first()
+        )
+
+    existing = _find()
+    if existing:
+        return existing
+
+    text_id = None
+    try:
+        text = db.query(Text).filter(Text.lesson_number == int(story_slug)).first()
+        if text:
+            text_id = text.id
+    except (ValueError, TypeError):
+        pass
+
+    session = LearningSession(
+        student_id=student_id,
+        story_slug=story_slug,
+        text_id=text_id,
+        status="in_progress",
+        classroom_id=None,
+        session_mode="self_study",
+    )
+    db.add(session)
+    try:
+        db.commit()
+        db.refresh(session)
+        return session
+    except IntegrityError:
+        # Concurrent create (unique index) — fall back to the row that won.
+        db.rollback()
+        won = _find()
+        if won is None:
+            raise
+        return won
+
+
+def build_step_progress_update(existing: Optional[dict], graded: list) -> Optional[dict]:
+    """Pure: merge graded answers into an existing step_progress dict.
+
+    Returns the new step_progress dict, or None when there is nothing to write.
+    - steps_completed: union of existing + steps the worksheet covered (green dots)
+    - step_data[step]["omo"]: paper assessment record (preserves any online data)
+    - version: bumped so the frontend's optimistic-concurrency check accepts it
+    Online progress already in step_data / steps_completed is preserved.
+    """
+    sp = existing if isinstance(existing, dict) else {}
+    steps_completed = list(sp.get("steps_completed") or [])
+    step_data = dict(sp.get("step_data") or {})
+
+    by_step: dict[str, list] = {}
+    for g in graded:
+        step = _step_for(g)
+        if step:
+            by_step.setdefault(step, []).append(g)
+    if not by_step:
+        return None
+
+    graded_at = datetime.now(tz=timezone.utc).isoformat()
+    for step, items in by_step.items():
+        omo_record = {
+            "graded_at": graded_at,
+            "source": "omo",
+            "answers": [
+                {
+                    "question_id": g.question_id,
+                    "student_answer": g.student_answer,
+                    "correct_answer": g.correct_answer,
+                    "score": g.score,
+                    "ai_confidence": g.ai_confidence,
+                    "context": g.context,
+                }
+                for g in items
+            ],
+        }
+        merged_step = dict(step_data.get(step) or {})
+        merged_step["omo"] = omo_record
+        step_data[step] = merged_step
+        if step not in steps_completed:
+            steps_completed.append(step)
+
+    meta = dict(sp.get("__meta") or {})
+    meta["last_synced_at"] = graded_at
+    meta["omo_synced_at"] = graded_at
+
+    return {
+        "current_step": sp.get("current_step"),  # leave navigation as-is
+        "steps_completed": steps_completed,
+        "step_data": step_data,
+        "version": int(sp.get("version") or 0) + 1,
+        "__meta": meta,
+    }
+
+
+def sync_omo_grading_to_session(
+    student_id: int, lesson_number: int, graded: list
+) -> Optional[int]:
+    """Find-or-create the student's session for this lesson and merge the OMO
+    grading into its step_progress. Returns the session id, or None if nothing
+    was written (no gradeable steps) or on failure (best-effort)."""
+    if not graded:
+        return None
+    story_slug = str(lesson_number)
+    from ..database import SessionLocal
+    db = SessionLocal()
+    try:
+        session = _get_or_create_session(db, student_id, story_slug)
+        new_sp = build_step_progress_update(session.step_progress, graded)
+        if new_sp is None:
+            return None
+        session.step_progress = new_sp
+        db.commit()
+        logger.info(
+            "OMO→session sync: session %d student %d lesson %s, steps=%s",
+            session.id, student_id, story_slug, new_sp["steps_completed"],
+        )
+        return session.id
+    except Exception as exc:
+        logger.error(
+            "OMO→session sync failed (student %d lesson %s): %s",
+            student_id, lesson_number, exc, exc_info=True,
+        )
+        db.rollback()
+        return None
+    finally:
+        db.close()

--- a/backend/tests/test_omo_reference_alignment_2038.py
+++ b/backend/tests/test_omo_reference_alignment_2038.py
@@ -1,0 +1,182 @@
+"""Tests for #2038 OMO reference-led alignment (also #2089 item 2).
+
+Two behaviours:
+
+  Task A — media-artifact filter:
+    video-caption parse artifacts (片長 / 建議觀看 regions mis-parsed as
+    fill-in blanks) must NOT enter the reference question schema. Validated
+    against meeting §2「占位空格被誤判為填空題」. Across the 57 lessons exactly
+    two such entries exist (G7-L28 id=1, G7-L30 id=1) — real blanks (933 of
+    them) must be untouched.
+
+  依關卡順序 — step ordering:
+    each question carries the UI step (step_sequence id) it belongs to, and
+    graded results are ordered by the lesson's step_sequence rather than by
+    question type (fb→mc→se).
+"""
+import glob
+import os
+
+import pytest
+import yaml
+
+from app.services.omo_question_schema import (
+    _build_question_schema,
+    _is_media_artifact,
+    QUESTION_TYPE_TO_STEP,
+)
+from app.services.omo_grader import GradedAnswer, _order_by_step_sequence
+
+LESSON_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "data", "lessons", "_parsed_2026-05-01"
+)
+
+
+def _load(code: str) -> dict:
+    with open(os.path.join(LESSON_DIR, f"{code}.yml"), encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+# ---------------------------------------------------------------------------
+# Task A — media-artifact filter
+# ---------------------------------------------------------------------------
+
+class TestMediaArtifactFilter:
+    def test_detects_video_caption_artifact(self):
+        artifact = {
+            "answer": "外來種",
+            "context_before": "",
+            "context_after": "你知道八哥有分本土和外來種嗎？｜ ・片長：(22:48) 建議觀看",
+        }
+        assert _is_media_artifact(artifact) is True
+
+    def test_real_cloze_with_sentence_is_not_artifact(self):
+        # Even if the surrounding text mentions a video, a real cloze sentence
+        # means it is a genuine question.
+        real = {
+            "answer": "微生物",
+            "sentence": "肉湯腐敗和空氣中的【微生物】有關。",
+            "context_after": "・片長：(12:59)",
+        }
+        assert _is_media_artifact(real) is False
+
+    def test_plain_blank_without_video_markers_is_not_artifact(self):
+        assert _is_media_artifact(
+            {"answer": "煮沸", "context_before": "只要把肉湯", "context_after": "並阻止微生物"}
+        ) is False
+
+    def test_g7l30_noise_blank_removed_from_schema(self):
+        # G7-L30 has a single fill_in_blank that is a video-caption artifact.
+        questions = _build_question_schema(_load("G7-L30"))
+        assert not any(q.get("step") == "vocab-application" for q in questions), (
+            "G7-L30's video-caption blank must not become a graded question"
+        )
+
+    def test_g7l28_drops_only_the_artifact_keeps_real_blanks(self):
+        # G7-L28 id=1 ('LIS科學史' video region) is an artifact; id=2..15 are
+        # real Pasteur-experiment cloze questions and must survive.
+        questions = _build_question_schema(_load("G7-L28"))
+        fb_ids = [q["id"] for q in questions if q.get("step") == "vocab-application"]
+        assert "fb_1" not in fb_ids
+        assert "fb_2" in fb_ids and "fb_15" in fb_ids
+        assert len(fb_ids) == 14
+
+    def test_filter_does_not_drop_real_blanks_across_all_lessons(self):
+        # Guardrail: only the two known artifacts may be filtered. Compare the
+        # raw fill_in_blank count to the schema fill_blank count per lesson.
+        total_dropped = 0
+        for path in glob.glob(os.path.join(LESSON_DIR, "*.yml")):
+            d = yaml.safe_load(open(path, encoding="utf-8")) or {}
+            fb = d.get("fill_in_blank") or []
+            raw_fb = len(fb) if isinstance(fb, (list, dict)) else 0
+            if raw_fb == 0:
+                continue
+            schema_fb = sum(
+                1 for q in _build_question_schema(d)
+                if q.get("step") == "vocab-application"
+            )
+            total_dropped += raw_fb - schema_fb
+        assert total_dropped == 2, (
+            f"expected exactly 2 artifacts filtered across all lessons, got {total_dropped}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 依關卡順序 — step assignment + ordering
+# ---------------------------------------------------------------------------
+
+class TestStepAssignment:
+    def test_each_type_maps_to_its_ui_step(self):
+        assert QUESTION_TYPE_TO_STEP["fill_blank"] == "vocab-application"
+        assert QUESTION_TYPE_TO_STEP["multiple_choice"] == "comprehension"
+        assert QUESTION_TYPE_TO_STEP["strategy_exercise"] == "reading-strategy"
+
+    def test_schema_questions_carry_a_step(self):
+        questions = _build_question_schema(_load("G6-L24"))
+        assert questions, "G6-L24 should produce questions"
+        assert all(q.get("step") for q in questions)
+        steps = {q["step"] for q in questions}
+        assert steps <= {"vocab-application", "comprehension", "reading-strategy"}
+
+
+class TestStepOrdering:
+    def _ans(self, qid: str, step: str) -> GradedAnswer:
+        return GradedAnswer(
+            question_id=qid, student_answer="", correct_answer="",
+            score=0.0, ai_confidence=0.0, reasoning="", step=step,
+        )
+
+    def test_orders_by_step_sequence_not_question_type(self):
+        # Lesson runs vocab-application → reading-strategy → comprehension, so
+        # se (reading-strategy) must come BEFORE mc (comprehension) — the
+        # reverse of the old fb→mc→se type order.
+        lesson = {
+            "step_sequence": [
+                "intro", "vocab-application", "reading-strategy",
+                "comprehension", "report",
+            ]
+        }
+        questions = [
+            {"id": "fb_1"}, {"id": "mc_1"}, {"id": "se_1"},
+        ]
+        # Results arrive in arbitrary (Gemini visual-scan) order.
+        results = [
+            self._ans("mc_1", "comprehension"),
+            self._ans("se_1", "reading-strategy"),
+            self._ans("fb_1", "vocab-application"),
+        ]
+        ordered = _order_by_step_sequence(results, lesson, questions)
+        assert [g.question_id for g in ordered] == ["fb_1", "se_1", "mc_1"]
+
+    def test_within_step_keeps_stable_yaml_order(self):
+        lesson = {"step_sequence": ["vocab-application"]}
+        questions = [{"id": "fb_1"}, {"id": "fb_2"}, {"id": "fb_3"}]
+        results = [
+            self._ans("fb_3", "vocab-application"),
+            self._ans("fb_1", "vocab-application"),
+            self._ans("fb_2", "vocab-application"),
+        ]
+        ordered = _order_by_step_sequence(results, lesson, questions)
+        assert [g.question_id for g in ordered] == ["fb_1", "fb_2", "fb_3"]
+
+    def test_unknown_step_sorts_last(self):
+        # A question whose step is not in step_sequence goes to the end.
+        lesson = {"step_sequence": ["comprehension"]}
+        questions = [{"id": "mc_1"}, {"id": "fb_1"}]
+        results = [
+            self._ans("fb_1", "vocab-application"),  # step absent from sequence
+            self._ans("mc_1", "comprehension"),
+        ]
+        ordered = _order_by_step_sequence(results, lesson, questions)
+        assert [g.question_id for g in ordered] == ["mc_1", "fb_1"]
+
+    def test_empty_step_sequence_falls_back_to_question_order(self):
+        lesson = {}  # no step_sequence
+        questions = [{"id": "fb_1"}, {"id": "mc_1"}]
+        results = [
+            self._ans("mc_1", "comprehension"),
+            self._ans("fb_1", "vocab-application"),
+        ]
+        ordered = _order_by_step_sequence(results, lesson, questions)
+        # All steps unknown → sort by qid_order (YAML order) → fb_1, mc_1.
+        assert [g.question_id for g in ordered] == ["fb_1", "mc_1"]

--- a/backend/tests/test_omo_reference_alignment_2038.py
+++ b/backend/tests/test_omo_reference_alignment_2038.py
@@ -81,6 +81,29 @@ class TestMediaArtifactFilter:
         assert "fb_2" in fb_ids and "fb_15" in fb_ids
         assert len(fb_ids) == 14
 
+    def test_artifact_does_not_corrupt_lettered_mode_detection(self):
+        # #2038 review: a lettered lesson whose first fb entry is a video
+        # artifact with a NON-letter answer ('外來種') must still be detected as
+        # lettered — the artifact must be skipped before fb_lettered is computed,
+        # otherwise every real fb gets scored as free_form.
+        lesson = {
+            "fill_in_blank": {
+                "1": {"answer": "外來種", "context_before": "",
+                      "context_after": "・片長：(3:00) 建議觀看"},
+                "2": {"answer": "A", "sentence": "學生需填入【   】"},
+                "3": {"answer": "B", "sentence": "另一格【   】"},
+            },
+            "vocabulary": [{"word": "規律"}, {"word": "秩序"}],
+        }
+        questions = _build_question_schema(lesson)
+        real = [q for q in questions if q["id"] == "2"]
+        assert real, "the real lettered blank must survive"
+        assert real[0]["mode"] == "lettered", (
+            "artifact's non-letter answer must not flip the lesson to free_form"
+        )
+        # The artifact itself must not appear as a question.
+        assert not any(q["id"] == "1" for q in questions)
+
     def test_filter_does_not_drop_real_blanks_across_all_lessons(self):
         # Guardrail: only the two known artifacts may be filtered. Compare the
         # raw fill_in_blank count to the schema fill_blank count per lesson.

--- a/backend/tests/test_omo_session_sync_2027.py
+++ b/backend/tests/test_omo_session_sync_2027.py
@@ -1,0 +1,122 @@
+"""Tests for OMO → LearningSession step_progress sync (#2027 / #2089 item 3).
+
+Covers the pure merge logic that writes paper-grading results into the same
+step_progress store online answers use: lighting up the 關卡 dots
+(steps_completed) and storing the paper作答對錯 (step_data[step]["omo"]),
+without clobbering any online progress.
+"""
+from types import SimpleNamespace
+
+from app.services.omo_session_sync import (
+    build_step_progress_update,
+    _step_for,
+    _QID_PREFIX_TO_STEP,
+)
+
+
+def _g(qid, step="", student="", correct="", score=0.0, conf=0.9, context=""):
+    return SimpleNamespace(
+        question_id=qid, step=step, student_answer=student,
+        correct_answer=correct, score=score, ai_confidence=conf, context=context,
+    )
+
+
+class TestStepResolution:
+    def test_uses_explicit_step_when_present(self):
+        assert _step_for(_g("fb_1", step="reading-strategy")) == "reading-strategy"
+
+    def test_falls_back_to_qid_prefix(self):
+        assert _step_for(_g("fb_1")) == "vocab-application"
+        assert _step_for(_g("mc_2")) == "comprehension"
+        assert _step_for(_g("se_3")) == "reading-strategy"
+
+    def test_unknown_qid_with_no_step_returns_empty(self):
+        assert _step_for(_g("weird_1")) == ""
+
+    def test_prefix_map_matches_question_type_mapping(self):
+        assert set(_QID_PREFIX_TO_STEP.values()) == {
+            "vocab-application", "comprehension", "reading-strategy",
+        }
+
+
+class TestBuildStepProgressUpdate:
+    def test_lights_up_covered_steps(self):
+        graded = [
+            _g("fb_1", "vocab-application", student="A", correct="A", score=1.0),
+            _g("mc_1", "comprehension", student="B", correct="C", score=0.0),
+        ]
+        sp = build_step_progress_update(None, graded)
+        assert set(sp["steps_completed"]) == {"vocab-application", "comprehension"}
+
+    def test_stores_paper_answers_under_omo_key(self):
+        graded = [_g("fb_1", "vocab-application", student="冬", correct="冬", score=1.0)]
+        sp = build_step_progress_update(None, graded)
+        omo = sp["step_data"]["vocab-application"]["omo"]
+        assert omo["source"] == "omo"
+        assert omo["answers"][0] == {
+            "question_id": "fb_1", "student_answer": "冬", "correct_answer": "冬",
+            "score": 1.0, "ai_confidence": 0.9, "context": "",
+        }
+        assert "graded_at" in omo
+
+    def test_preserves_existing_online_step_data(self):
+        existing = {
+            "current_step": "comprehension",
+            "steps_completed": ["intro", "comprehension"],
+            "step_data": {
+                "comprehension": {"online_answers": [1, 2, 3]},
+                "intro": {"seen": True},
+            },
+            "version": 5,
+        }
+        graded = [_g("fb_1", "vocab-application", student="A", correct="A", score=1.0)]
+        sp = build_step_progress_update(existing, graded)
+        # online comprehension data untouched, omo added alongside
+        assert sp["step_data"]["comprehension"]["online_answers"] == [1, 2, 3]
+        assert sp["step_data"]["intro"] == {"seen": True}
+        assert "omo" in sp["step_data"]["vocab-application"]
+        # union of completed steps (no duplicates)
+        assert sp["steps_completed"] == ["intro", "comprehension", "vocab-application"]
+        # current_step navigation preserved
+        assert sp["current_step"] == "comprehension"
+
+    def test_does_not_duplicate_already_completed_step(self):
+        existing = {"steps_completed": ["vocab-application"], "step_data": {}, "version": 1}
+        graded = [_g("fb_1", "vocab-application", student="A", correct="A", score=1.0)]
+        sp = build_step_progress_update(existing, graded)
+        assert sp["steps_completed"] == ["vocab-application"]
+
+    def test_bumps_version_for_optimistic_concurrency(self):
+        existing = {"steps_completed": [], "step_data": {}, "version": 7}
+        sp = build_step_progress_update(existing, [_g("fb_1", "vocab-application")])
+        assert sp["version"] == 8
+
+    def test_version_starts_at_one_for_fresh_session(self):
+        sp = build_step_progress_update(None, [_g("fb_1", "vocab-application")])
+        assert sp["version"] == 1
+
+    def test_re_upload_overwrites_previous_omo_record(self):
+        first = build_step_progress_update(
+            None, [_g("fb_1", "vocab-application", student="wrong", correct="A", score=0.0)]
+        )
+        second = build_step_progress_update(
+            first, [_g("fb_1", "vocab-application", student="A", correct="A", score=1.0)]
+        )
+        answers = second["step_data"]["vocab-application"]["omo"]["answers"]
+        assert len(answers) == 1
+        assert answers[0]["student_answer"] == "A"
+        assert answers[0]["score"] == 1.0
+
+    def test_returns_none_when_no_gradeable_steps(self):
+        # answers with no resolvable step (no .step, unknown qid prefix)
+        assert build_step_progress_update(None, [_g("weird_1")]) is None
+
+    def test_groups_multiple_answers_per_step(self):
+        graded = [
+            _g("fb_1", "vocab-application", student="A", correct="A", score=1.0),
+            _g("fb_2", "vocab-application", student="B", correct="C", score=0.0),
+            _g("mc_1", "comprehension", student="D", correct="D", score=1.0),
+        ]
+        sp = build_step_progress_update(None, graded)
+        assert len(sp["step_data"]["vocab-application"]["omo"]["answers"]) == 2
+        assert len(sp["step_data"]["comprehension"]["omo"]["answers"]) == 1

--- a/frontend/src/components/reading-steps/OmoPaperResultBanner.test.tsx
+++ b/frontend/src/components/reading-steps/OmoPaperResultBanner.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Tests for OmoPaperResultBanner (#2027 / #2089 item 3).
+ * The banner reads step_data[stepId].omo from the learning context and renders
+ * the paper作答 + 對錯, or nothing when this step has no paper record.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import OmoPaperResultBanner from './OmoPaperResultBanner';
+
+const mockContext = vi.fn();
+vi.mock('../../layouts/LearningLayout', () => ({
+  useLearningContext: () => mockContext(),
+}));
+
+function withStepData(stepData: Record<string, unknown>) {
+  mockContext.mockReturnValue({ stepProgressData: { step_data: stepData } });
+}
+
+const omoRecord = (answers: unknown[]) => ({
+  graded_at: '2026-06-07T10:00:00Z',
+  source: 'omo',
+  answers,
+});
+
+describe('OmoPaperResultBanner', () => {
+  it('renders nothing when the step has no omo record', () => {
+    withStepData({ 'vocab-application': { online_answers: [1] } });
+    const { container } = render(<OmoPaperResultBanner stepId="vocab-application" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when step_data is empty', () => {
+    withStepData({});
+    const { container } = render(<OmoPaperResultBanner stepId="comprehension" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the paper answers and correct/total summary', () => {
+    withStepData({
+      'vocab-application': {
+        omo: omoRecord([
+          { question_id: 'fb_1', student_answer: '冬天', correct_answer: '冬天', score: 1, ai_confidence: 0.9, context: '第一格' },
+          { question_id: 'fb_2', student_answer: '夏', correct_answer: '秋', score: 0, ai_confidence: 0.9, context: '第二格' },
+        ]),
+      },
+    });
+    render(<OmoPaperResultBanner stepId="vocab-application" />);
+    expect(screen.getByRole('region', { name: '紙本批改結果' })).toBeInTheDocument();
+    expect(screen.getByText('答對 1/2')).toBeInTheDocument();
+    expect(screen.getByText('冬天')).toBeInTheDocument();
+    // wrong answer shows the correct one
+    expect(screen.getByText('正解：秋')).toBeInTheDocument();
+  });
+
+  it('marks an unanswered question as 未作答 without showing 正解', () => {
+    withStepData({
+      comprehension: {
+        omo: omoRecord([
+          { question_id: 'mc_1', student_answer: '', correct_answer: 'B', score: 0, ai_confidence: 0, context: '第一題' },
+        ]),
+      },
+    });
+    render(<OmoPaperResultBanner stepId="comprehension" />);
+    expect(screen.getByText('未作答')).toBeInTheDocument();
+    expect(screen.queryByText(/正解/)).toBeNull();
+  });
+
+  it('reads the record for the requested step only', () => {
+    withStepData({
+      'vocab-application': { omo: omoRecord([{ question_id: 'fb_1', student_answer: 'A', correct_answer: 'A', score: 1, ai_confidence: 1, context: '' }]) },
+      comprehension: { omo: omoRecord([{ question_id: 'mc_1', student_answer: 'B', correct_answer: 'B', score: 1, ai_confidence: 1, context: '' }]) },
+    });
+    render(<OmoPaperResultBanner stepId="comprehension" />);
+    // only the comprehension record (1 answer) → 答對 1/1
+    expect(screen.getByText('答對 1/1')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/reading-steps/OmoPaperResultBanner.tsx
+++ b/frontend/src/components/reading-steps/OmoPaperResultBanner.tsx
@@ -1,0 +1,126 @@
+/**
+ * OmoPaperResultBanner — shows this step's paper (OMO) grading inside the
+ * matching online 關卡 (#2027 / #2089 item 3).
+ *
+ * When a student uploads a paper worksheet and it finishes grading, the backend
+ * merges the result into LearningSession.step_progress.step_data[step].omo (the
+ * same store online answers use). This banner surfaces that record at the top of
+ * the corresponding step page so the paper作答 + 對錯 appears in-flow — the goal
+ * being「把紙本作答平移到線上，邏輯跟線上作答完全一樣」.
+ *
+ * Renders nothing when this step has no paper record, so it is safe to drop into
+ * any step page unconditionally.
+ */
+import React from 'react';
+import { useLearningContext } from '../../layouts/LearningLayout';
+
+interface OmoStepAnswer {
+  question_id: string;
+  student_answer: string;
+  correct_answer: string;
+  score: number;
+  ai_confidence: number;
+  context: string;
+}
+
+interface OmoStepRecord {
+  graded_at: string;
+  source: string;
+  answers: OmoStepAnswer[];
+}
+
+function extractOmoRecord(
+  stepData: Record<string, unknown> | undefined,
+  stepId: string,
+): OmoStepRecord | null {
+  const step = stepData?.[stepId];
+  if (!step || typeof step !== 'object') return null;
+  const omo = (step as Record<string, unknown>).omo;
+  if (!omo || typeof omo !== 'object') return null;
+  const answers = (omo as Record<string, unknown>).answers;
+  if (!Array.isArray(answers)) return null;
+  return omo as unknown as OmoStepRecord;
+}
+
+function formatGradedAt(iso: string): string {
+  const t = new Date(iso).getTime();
+  if (!Number.isFinite(t)) return '';
+  return new Date(iso).toLocaleString('zh-TW', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+const AnswerRow: React.FC<{ ans: OmoStepAnswer }> = ({ ans }) => {
+  const answered = (ans.student_answer || '').trim().length > 0;
+  const correct = ans.score >= 1;
+  const partial = ans.score > 0 && ans.score < 1;
+  const mark = !answered ? '—' : correct ? '✓' : partial ? '◐' : '✗';
+  const markCls = !answered
+    ? 'text-gray-400'
+    : correct
+    ? 'text-emerald-600'
+    : partial
+    ? 'text-amber-500'
+    : 'text-red-500';
+
+  return (
+    <li className="flex items-start gap-2 py-1.5 border-b border-amber-100 last:border-0">
+      <span className={`shrink-0 w-5 text-center font-bold ${markCls}`} aria-hidden="true">
+        {mark}
+      </span>
+      <div className="flex-1 min-w-0">
+        {ans.context && (
+          <p className="text-xs text-gray-500 truncate" title={ans.context}>
+            {ans.context}
+          </p>
+        )}
+        <p className="text-sm text-gray-800">
+          你的作答：
+          <span className={answered ? 'font-semibold' : 'text-gray-400'}>
+            {answered ? ans.student_answer : '未作答'}
+          </span>
+          {answered && !correct && ans.correct_answer && (
+            <span className="ml-2 text-emerald-700">正解：{ans.correct_answer}</span>
+          )}
+        </p>
+      </div>
+    </li>
+  );
+};
+
+const OmoPaperResultBanner: React.FC<{ stepId: string }> = ({ stepId }) => {
+  const { stepProgressData } = useLearningContext();
+  const record = extractOmoRecord(stepProgressData?.step_data, stepId);
+  if (!record || record.answers.length === 0) return null;
+
+  const correctCount = record.answers.filter((a) => a.score >= 1).length;
+  const gradedAt = formatGradedAt(record.graded_at);
+
+  return (
+    <section
+      aria-label="紙本批改結果"
+      className="mb-4 rounded-2xl border border-amber-200 bg-amber-50/70 p-4 shadow-sm"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-lg" aria-hidden="true">📄</span>
+        <h3 className="text-sm font-bold text-amber-900">紙本批改結果</h3>
+        <span className="ml-auto text-xs font-medium text-amber-700">
+          答對 {correctCount}/{record.answers.length}
+        </span>
+      </div>
+      <ul className="rounded-xl bg-white/70 px-3">
+        {record.answers.map((ans) => (
+          <AnswerRow key={ans.question_id} ans={ans} />
+        ))}
+      </ul>
+      {gradedAt && (
+        <p className="mt-2 text-[11px] text-amber-600">紙本批改於 {gradedAt}</p>
+      )}
+    </section>
+  );
+};
+
+export default OmoPaperResultBanner;

--- a/frontend/src/components/reading-steps/OmoPaperResultBanner.tsx
+++ b/frontend/src/components/reading-steps/OmoPaperResultBanner.tsx
@@ -43,9 +43,9 @@ function extractOmoRecord(
 }
 
 function formatGradedAt(iso: string): string {
-  const t = new Date(iso).getTime();
-  if (!Number.isFinite(t)) return '';
-  return new Date(iso).toLocaleString('zh-TW', {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return '';
+  return d.toLocaleString('zh-TW', {
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',

--- a/frontend/src/pages/learning/ComprehensionMcqPage.tsx
+++ b/frontend/src/pages/learning/ComprehensionMcqPage.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import ComprehensionLayout from '../../components/reading-steps/ComprehensionLayout';
 import MultipleChoiceExercise from '../../components/reading-steps/MultipleChoiceExercise';
+import OmoPaperResultBanner from '../../components/reading-steps/OmoPaperResultBanner';
 import { useLearningContext } from '../../layouts/LearningLayout';
 import { ComprehensionResult } from '../../types';
 
@@ -83,6 +84,7 @@ const ComprehensionMcqPage: React.FC = () => {
       exerciseIcon="quiz"
       exerciseLabel="閱讀理解"
     >
+      <OmoPaperResultBanner stepId="comprehension" />
       {hasMcq ? (
         mcqDone ? (
           /* Done state */

--- a/frontend/src/pages/learning/StrategyExercisePage.tsx
+++ b/frontend/src/pages/learning/StrategyExercisePage.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom';
 import ComprehensionLayout from '../../components/reading-steps/ComprehensionLayout';
 import StrategyExercise from '../../components/reading-steps/StrategyExercise';
 import GraphicTextIntegrationExercise from '../../components/reading-steps/GraphicTextIntegrationExercise';
+import OmoPaperResultBanner from '../../components/reading-steps/OmoPaperResultBanner';
 import { useLearningContext } from '../../layouts/LearningLayout';
 import type { StrategyExercise as StrategyExerciseType, StrategyExerciseItem } from '../../types';
 
@@ -80,6 +81,7 @@ const StrategyExercisePage: React.FC = () => {
       exerciseIcon="lightbulb"
       exerciseLabel="閱讀聚光燈"
     >
+      <OmoPaperResultBanner stepId="reading-strategy" />
       {hasStrategy ? (
         <>
           {isGraphicTextList ? (

--- a/frontend/src/pages/learning/VocabApplicationPage.tsx
+++ b/frontend/src/pages/learning/VocabApplicationPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import VocabApplication from '../../components/reading-steps/VocabApplication';
+import OmoPaperResultBanner from '../../components/reading-steps/OmoPaperResultBanner';
 import { useLearningContext } from '../../layouts/LearningLayout';
 
 const VocabApplicationPage: React.FC = () => {
@@ -8,11 +9,14 @@ const VocabApplicationPage: React.FC = () => {
   if (!selectedStory) return null;
 
   return (
-    <VocabApplication
-      story={selectedStory}
-      onFinish={handleFinishVocabApplication}
-      saveStepProgressPatch={saveStepProgressPatch}
-    />
+    <>
+      <OmoPaperResultBanner stepId="vocab-application" />
+      <VocabApplication
+        story={selectedStory}
+        onFinish={handleFinishVocabApplication}
+        saveStepProgressPatch={saveStepProgressPatch}
+      />
+    </>
   );
 };
 


### PR DESCRIPTION
## 背景
#2089 OMO 全面更新 **項目 3**，落地 #2027 Phase 2（持久化）。

**主目標：把紙本作答平移到線上，邏輯跟線上作答完全一樣。**

## 設計決策
- **寫進 `step_progress`（線上作答用的同一個 store），不開 `assessment_outcomes` 新 column** → 不需 migration、不卡 Young、資料落在學習 UI 既有讀取處。
- 5/29 audit 確認：grader 原本完全沒寫 LearningSession。本 PR 補上這個 hook。

## 後端
- **`omo_session_sync.py`**（新）：grade 完成 → find-or-create 該生自學 session（沿用 sessions_bootstrap 的 get-or-create + unique index 防 race）→ merge 進 `step_progress`：
  - `steps_completed` 加入紙本涵蓋的關卡 → **StepperNav 綠點自動亮**
  - `step_data[step].omo` 存紙本作答對錯（**保留既有線上 step_data，不覆蓋**）
  - `version` bump（相容前端樂觀鎖）
  - **best-effort**：sync 失敗不影響已存的批改結果（grade 在 sync 前已 commit）
  - step 解析優先用 `GradedAnswer.step`（#2091），fallback by qid prefix
- **`omo_jobs.py`**：`_run_grading` 批改完成後呼叫 sync（包 try/except，非阻斷）

## 前端
- **`OmoPaperResultBanner`**（新）：讀 `step_data[step].omo`，在對應關卡頁頂顯示紙本作答 + ✓/◐/✗/未作答 + 答對數；無紀錄則不渲染（可安全放任何 step 頁）
- 接進 `VocabApplicationPage` / `StrategyExercisePage` / `ComprehensionMcqPage`
- **綠點零前端改動** —— StepperNav 既有讀 `session.completedSteps`，後端寫 steps_completed 就會亮

## 測試
- ✅ 後端 13 tests（`build_step_progress_update`：綠點 union / 保留線上 step_data / 版本 bump / 重傳覆蓋 / 分組 / step fallback）
- ✅ 前端 5 tests（顯示作答對錯 / 未作答 / 單步讀取 / 空狀態不渲染）
- ✅ OMO 契約（assessment/determinism/grading-corpus）全綠無 regression；tsc 無新增 error

## ⚠️ 依賴 & 合併順序
- **Stacked PR**：依賴 #2091（`GradedAnswer.step`），base 設為 `feat/issue-2038-omo-reference-alignment` 讓 diff 乾淨。
- **#2091 merge 到 staging 後**，這個 PR 的 base 需 retarget 到 staging（或直接接著 merge）。

## QA（staging preview，需 #2091 一起）
- [ ] 上傳紙本批改完 → 回課文頁，對應關卡的點點變綠
- [ ] 語詞應用 / 閱讀理解 / 閱讀聚光燈 關卡頁頂顯示紙本作答 + 對錯
- [ ] 答錯顯示正解、未作答顯示「未作答」
- [ ] 已有線上作答的 session 上傳紙本 → 線上進度不被覆蓋
- [ ] reload 後紙本記錄保留

關聯 #2027 #2089