### PR TITLE
feat(omo): 網頁內相機掃描器 — 連續拍多頁直接上傳 (#2089 item 4)

### DIFF
--- a/frontend/src/components/omo/OmoCameraScanner.test.tsx
+++ b/frontend/src/components/omo/OmoCameraScanner.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for OmoCameraScanner (#2089 item 4) — in-browser camera scanner.
+ * Focuses on the states jsdom can exercise: unsupported browser, permission
+ * denied, and the live-state shutter/done controls. Frame capture (canvas
+ * toBlob from a live <video>) is not exercisable in jsdom and is covered by
+ * manual / staging QA.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import OmoCameraScanner from './OmoCameraScanner';
+
+function setMediaDevices(getUserMedia: unknown) {
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: getUserMedia ? { getUserMedia } : undefined,
+  });
+}
+
+describe('OmoCameraScanner', () => {
+  beforeEach(() => {
+    // jsdom has no real media playback; stub play().
+    (HTMLMediaElement.prototype as unknown as { play: () => Promise<void> }).play = vi
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    setMediaDevices(null);
+  });
+
+  it('shows an unsupported message when getUserMedia is unavailable', async () => {
+    setMediaDevices(undefined);
+    render(
+      <OmoCameraScanner onCapture={vi.fn()} onClose={vi.fn()} pageCount={0} canCapture />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/不支援網頁內相機/)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows a permission message when the user denies the camera', async () => {
+    const denied = vi.fn().mockRejectedValue(
+      Object.assign(new DOMException('denied', 'NotAllowedError')),
+    );
+    setMediaDevices(denied);
+    render(
+      <OmoCameraScanner onCapture={vi.fn()} onClose={vi.fn()} pageCount={0} canCapture />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/沒有相機權限/)).toBeInTheDocument(),
+    );
+  });
+
+  it('stops tracks and closes when 返回上傳 is clicked after an error', async () => {
+    setMediaDevices(vi.fn().mockRejectedValue(new DOMException('x', 'NotFoundError')));
+    const onClose = vi.fn();
+    render(
+      <OmoCameraScanner onCapture={vi.fn()} onClose={onClose} pageCount={0} canCapture />,
+    );
+    await waitFor(() => expect(screen.getByText(/找不到可用的相機/)).toBeInTheDocument());
+    fireEvent.click(screen.getByText('返回上傳'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('goes live and shows the running page count + enabled 完成', async () => {
+    const stop = vi.fn();
+    const stream = { getTracks: () => [{ stop }] };
+    setMediaDevices(vi.fn().mockResolvedValue(stream));
+    render(
+      <OmoCameraScanner onCapture={vi.fn()} onClose={vi.fn()} pageCount={2} canCapture />,
+    );
+    await waitFor(() => expect(screen.getByText('已掃描 2 頁')).toBeInTheDocument());
+    // shutter is present and enabled
+    expect(screen.getByLabelText('拍攝這一頁')).not.toBeDisabled();
+    // 完成 enabled because pageCount > 0
+    expect(screen.getByText('完成')).not.toBeDisabled();
+  });
+
+  it('disables the shutter when the file cap is reached', async () => {
+    const stream = { getTracks: () => [{ stop: vi.fn() }] };
+    setMediaDevices(vi.fn().mockResolvedValue(stream));
+    render(
+      <OmoCameraScanner onCapture={vi.fn()} onClose={vi.fn()} pageCount={5} canCapture={false} />,
+    );
+    await waitFor(() => expect(screen.getByLabelText('拍攝這一頁')).toBeDisabled());
+    expect(screen.getByText(/已達檔案數上限/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/omo/OmoCameraScanner.tsx
+++ b/frontend/src/components/omo/OmoCameraScanner.tsx
@@ -1,0 +1,218 @@
+/**
+ * OmoCameraScanner — in-browser document scanner (#2089 item 4, approach A).
+ *
+ * Opens the camera as a LIVE preview INSIDE the web page via getUserMedia — it
+ * does NOT launch the phone's native camera app (the old `<input capture>`
+ * flow). The student points at each worksheet page, taps the in-page shutter,
+ * and the frame is captured to a JPEG File without ever leaving the page; they
+ * keep shooting page after page, then tap 完成 to hand the whole batch back to
+ * the upload queue. No native app round-trip, no separate save-to-PNG step.
+ *
+ * Lightweight by design: native getUserMedia + canvas only, no third-party
+ * image library (no edge-detection / perspective-correction). The grader
+ * tolerates skew / rotation / page-order via reference re-sort (#2091), so the
+ * marginal value of auto-correction is low for now.
+ *
+ * Requires a secure context (HTTPS) — staging/prod qualify. On unsupported
+ * browsers or denied permission it shows a clear message and the caller's
+ * file-upload path stays available as the fallback.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+interface OmoCameraScannerProps {
+  /** Called with a captured JPEG File for each shutter press. */
+  onCapture: (file: File) => void;
+  /** Close the scanner (done / cancel / fatal error). */
+  onClose: () => void;
+  /** Pages already in the upload queue — shown as the running count. */
+  pageCount: number;
+  /** False when the queue is at its file cap — shutter is disabled. */
+  canCapture: boolean;
+}
+
+type CamState = 'starting' | 'live' | 'error';
+
+const CAPTURE_QUALITY = 0.9;
+
+const OmoCameraScanner: React.FC<OmoCameraScannerProps> = ({
+  onCapture,
+  onClose,
+  pageCount,
+  canCapture,
+}) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const [state, setState] = useState<CamState>('starting');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+  // Brief shutter flash for capture feedback.
+  const [flash, setFlash] = useState(false);
+
+  const stopStream = useCallback(() => {
+    const stream = streamRef.current;
+    if (stream) {
+      stream.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+  }, []);
+
+  // Start the camera on mount; stop all tracks on unmount.
+  useEffect(() => {
+    let cancelled = false;
+
+    async function start() {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setErrorMsg('這個瀏覽器不支援網頁內相機，請改用「選擇照片或 PDF」上傳。');
+        setState('error');
+        return;
+      }
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            facingMode: { ideal: 'environment' }, // rear camera for documents
+            width: { ideal: 1920 },
+            height: { ideal: 1080 },
+          },
+          audio: false,
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play().catch(() => {/* autoplay guard */});
+        }
+        setState('live');
+      } catch (err) {
+        const name = err instanceof DOMException ? err.name : '';
+        if (name === 'NotAllowedError' || name === 'SecurityError') {
+          setErrorMsg('沒有相機權限。請允許使用相機，或改用「選擇照片或 PDF」上傳。');
+        } else if (name === 'NotFoundError' || name === 'OverconstrainedError') {
+          setErrorMsg('找不到可用的相機，請改用「選擇照片或 PDF」上傳。');
+        } else {
+          setErrorMsg('無法開啟相機，請改用「選擇照片或 PDF」上傳。');
+        }
+        setState('error');
+      }
+    }
+
+    start();
+    return () => {
+      cancelled = true;
+      stopStream();
+    };
+  }, [stopStream]);
+
+  const handleClose = useCallback(() => {
+    stopStream();
+    onClose();
+  }, [stopStream, onClose]);
+
+  const handleShutter = useCallback(() => {
+    const video = videoRef.current;
+    if (!video || state !== 'live' || !canCapture) return;
+    const w = video.videoWidth;
+    const h = video.videoHeight;
+    if (!w || !h) return;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0, w, h);
+
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) return;
+        const file = new File([blob], `scan-${Date.now()}.jpg`, {
+          type: 'image/jpeg',
+          lastModified: Date.now(),
+        });
+        onCapture(file);
+        setFlash(true);
+        window.setTimeout(() => setFlash(false), 150);
+      },
+      'image/jpeg',
+      CAPTURE_QUALITY,
+    );
+  }, [state, canCapture, onCapture]);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black flex flex-col" role="dialog" aria-label="掃描學習單">
+      {/* Top bar */}
+      <div className="flex items-center justify-between px-4 py-3 text-white">
+        <button
+          type="button"
+          onClick={handleClose}
+          className="text-sm font-medium px-3 py-1.5 rounded-lg hover:bg-white/10"
+        >
+          取消
+        </button>
+        <span className="text-sm font-semibold">
+          {pageCount > 0 ? `已掃描 ${pageCount} 頁` : '對準學習單後按下快門'}
+        </span>
+        <button
+          type="button"
+          onClick={handleClose}
+          disabled={pageCount === 0}
+          className="text-sm font-bold px-3 py-1.5 rounded-lg text-emerald-300 hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          完成
+        </button>
+      </div>
+
+      {/* Live preview / states */}
+      <div className="relative flex-1 flex items-center justify-center overflow-hidden">
+        <video
+          ref={videoRef}
+          playsInline
+          muted
+          className={`max-h-full max-w-full ${state === 'live' ? 'block' : 'hidden'}`}
+        />
+        {flash && <div className="absolute inset-0 bg-white animate-pulse" aria-hidden="true" />}
+
+        {state === 'starting' && (
+          <div className="flex flex-col items-center gap-3 text-white/80">
+            <div className="w-10 h-10 rounded-full border-4 border-white/30 border-t-white animate-spin" />
+            <p className="text-sm">正在開啟相機…</p>
+          </div>
+        )}
+
+        {state === 'error' && (
+          <div className="flex flex-col items-center gap-4 px-8 text-center text-white/90">
+            <span className="text-4xl" aria-hidden="true">📷</span>
+            <p className="text-sm">{errorMsg}</p>
+            <button
+              type="button"
+              onClick={handleClose}
+              className="mt-2 px-5 py-2 rounded-xl bg-white text-gray-900 text-sm font-semibold"
+            >
+              返回上傳
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Shutter bar */}
+      {state === 'live' && (
+        <div className="flex flex-col items-center gap-2 pb-8 pt-4">
+          {!canCapture && (
+            <p className="text-xs text-amber-300">已達檔案數上限，請先完成或移除一些頁面</p>
+          )}
+          <button
+            type="button"
+            onClick={handleShutter}
+            disabled={!canCapture}
+            aria-label="拍攝這一頁"
+            className="w-16 h-16 rounded-full bg-white ring-4 ring-white/40 active:scale-95 transition-transform disabled:opacity-40 disabled:cursor-not-allowed"
+          />
+          <p className="text-xs text-white/60">拍完一頁可直接翻頁繼續拍，完成後按右上角「完成」</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default OmoCameraScanner;

--- a/frontend/src/components/omo/OmoCameraScanner.tsx
+++ b/frontend/src/components/omo/OmoCameraScanner.tsx
@@ -69,8 +69,11 @@ const OmoCameraScanner: React.FC<OmoCameraScannerProps> = ({
         const stream = await navigator.mediaDevices.getUserMedia({
           video: {
             facingMode: { ideal: 'environment' }, // rear camera for documents
-            width: { ideal: 1920 },
-            height: { ideal: 1080 },
+            // Match the upload resize target (1280px longest side) so the
+            // captured frame usually needs no second compression pass in
+            // resizeImage — avoids stacking JPEG artifacts (#2094 review).
+            width: { ideal: 1280 },
+            height: { ideal: 1280 },
           },
           audio: false,
         });
@@ -126,13 +129,14 @@ const OmoCameraScanner: React.FC<OmoCameraScannerProps> = ({
     canvas.toBlob(
       (blob) => {
         if (!blob) return;
-        const file = new File([blob], `scan-${Date.now()}.jpg`, {
+        const now = Date.now();
+        const file = new File([blob], `scan-${now}.jpg`, {
           type: 'image/jpeg',
-          lastModified: Date.now(),
+          lastModified: now,
         });
         onCapture(file);
         setFlash(true);
-        window.setTimeout(() => setFlash(false), 150);
+        setTimeout(() => setFlash(false), 150);
       },
       'image/jpeg',
       CAPTURE_QUALITY,
@@ -171,7 +175,7 @@ const OmoCameraScanner: React.FC<OmoCameraScannerProps> = ({
           muted
           className={`max-h-full max-w-full ${state === 'live' ? 'block' : 'hidden'}`}
         />
-        {flash && <div className="absolute inset-0 bg-white animate-pulse" aria-hidden="true" />}
+        {flash && <div className="absolute inset-0 bg-white opacity-80" aria-hidden="true" />}
 
         {state === 'starting' && (
           <div className="flex flex-col items-center gap-3 text-white/80">

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -27,6 +27,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { uploadOmoImages } from '../../services/omoApi';
 import OmoUploadPagePreview from './OmoUploadPagePreview';
+import OmoCameraScanner from './OmoCameraScanner';
 
 const MAX_FILES = 5;
 const MAX_FILE_BYTES = 10 * 1024 * 1024;     // 10 MB per image (pre-resize)
@@ -184,8 +185,9 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
   const [staged, setStaged] = useState<StagedPage[]>([]);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // #2089 item 4: in-browser scanner overlay (live camera inside the page).
+  const [scannerOpen, setScannerOpen] = useState(false);
 
-  const cameraInputRef = useRef<HTMLInputElement>(null);
   const galleryInputRef = useRef<HTMLInputElement>(null);
 
   // #1974 review-3: mirror `staged` into a ref so the unmount cleanup effect
@@ -209,12 +211,13 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
     }
   };
 
-  // ── Add files to the queue (called by both camera + gallery inputs) ──────
-  const handleAddFiles = (files: FileList | null) => {
+  // ── Add files to the queue ───────────────────────────────────────────────
+  // Core accepts a File[] so both the file inputs (gallery/PDF) and the
+  // in-browser scanner (#2089 item 4) feed the same validation + queue path.
+  const addFiles = (incoming: File[]) => {
     setError(null);
-    if (!files || files.length === 0) return;
+    if (incoming.length === 0) return;
 
-    const incoming = Array.from(files);
     const remaining = MAX_FILES - staged.length;
 
     if (remaining <= 0) {
@@ -262,6 +265,11 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
         `一次只能再加 ${remaining} 個，已取前 ${remaining} 個檔案，其餘 ${incoming.length - remaining} 個未加入`,
       );
     }
+  };
+
+  const handleAddFiles = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    addFiles(Array.from(files));
   };
 
   // ── Manipulate the staged queue ─────────────────────────────────────────
@@ -343,11 +351,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
     }
   };
 
-  // ── Reset hidden file inputs so re-selecting the same file fires onChange ──
-  const onCameraChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleAddFiles(e.target.files);
-    e.target.value = '';
-  };
+  // ── Reset hidden file input so re-selecting the same file fires onChange ──
   const onGalleryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     handleAddFiles(e.target.files);
     e.target.value = '';
@@ -361,20 +365,22 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
         <div className="text-5xl mb-3" aria-hidden="true">📸</div>
         <h1 className="text-xl font-bold text-gray-900">上傳學習單（所有頁面）</h1>
         <p className="mt-1 text-sm text-gray-500">
-          拍下或選擇紙本的<span className="font-semibold text-gray-700">每一頁</span>，
-          也可直接上傳 PDF 掃描檔（AI 會合併批改，最多 {MAX_FILES} 個檔案）
+          用<span className="font-semibold text-gray-700">掃描</span>連續拍下紙本的每一頁，
+          或選擇照片 / PDF 上傳（AI 會合併批改，最多 {MAX_FILES} 個檔案）
         </p>
       </div>
 
-      {/* Hidden inputs (always mounted so refs are stable) */}
-      <input
-        ref={cameraInputRef}
-        type="file"
-        accept="image/*"
-        capture="environment"
-        className="hidden"
-        onChange={onCameraChange}
-      />
+      {/* In-browser scanner overlay (live camera inside the page, #2089 item 4) */}
+      {scannerOpen && (
+        <OmoCameraScanner
+          pageCount={staged.length}
+          canCapture={canAddMore}
+          onCapture={(file) => addFiles([file])}
+          onClose={() => setScannerOpen(false)}
+        />
+      )}
+
+      {/* Hidden file input (always mounted so the ref is stable) */}
       <input
         ref={galleryInputRef}
         type="file"
@@ -439,7 +445,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
         <div className="flex flex-col gap-3 w-full">
           <button
             type="button"
-            onClick={() => cameraInputRef.current?.click()}
+            onClick={() => setScannerOpen(true)}
             className="w-full flex items-center justify-center gap-2 py-3.5 px-6
               bg-blue-600 hover:bg-blue-700 active:bg-blue-800
               text-white font-semibold rounded-xl
@@ -447,7 +453,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
               transition-colors"
           >
             <span aria-hidden="true">📷</span>
-            拍照上傳
+            掃描上傳（連續拍多頁）
           </button>
           <button
             type="button"
@@ -488,7 +494,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
             <div className="flex gap-2">
               <button
                 type="button"
-                onClick={() => cameraInputRef.current?.click()}
+                onClick={() => setScannerOpen(true)}
                 className="flex-1 flex items-center justify-center gap-2 py-2.5 px-4
                   bg-white hover:bg-gray-50 active:bg-gray-100
                   text-gray-700 text-sm font-medium rounded-xl
@@ -497,7 +503,7 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
                   transition-colors"
               >
                 <span aria-hidden="true">📷</span>
-                再拍一張
+                繼續掃描
               </button>
               <button
                 type="button"

--- a/frontend/src/components/omo/OmoUpload.tsx
+++ b/frontend/src/components/omo/OmoUpload.tsx
@@ -258,7 +258,22 @@ const OmoUpload: React.FC<OmoUploadProps> = ({
         isPdf,
       };
     });
-    setStaged((prev) => [...prev, ...newPages]);
+    // Cap guard inside the functional update (#2094 review): scanner captures
+    // go through canvas.toBlob (async), so two rapid shutter taps can both read
+    // the same `staged` snapshot and each append — overflowing MAX_FILES. Re-cap
+    // against the freshest `prev` here and revoke any dropped page's object URL.
+    setStaged((prev) => {
+      const room = MAX_FILES - prev.length;
+      if (room <= 0) {
+        newPages.forEach(revokePageUrl);
+        return prev;
+      }
+      if (newPages.length > room) {
+        newPages.slice(room).forEach(revokePageUrl);
+        return [...prev, ...newPages.slice(0, room)];
+      }
+      return [...prev, ...newPages];
+    });
 
     if (truncated) {
       setError(


### PR DESCRIPTION
## 背景
#2089 OMO 全面更新 **項目 4：內建掃描功能**（approach A — 輕量連拍）。

需求：學生直接在**網頁內開相機**掃描多頁上傳，**不要跳出手機系統相機 App**；保留檔案上傳。

## 做法（approach A）
用 `getUserMedia` 在網頁內開 **live 相機預覽**（不是 `<input capture>` 跳系統相機）。對準學習單按網頁快門 → 連續拍多頁 → 直接進上傳佇列 → 一鍵送批改，**不需另存 PNG/PDF**。

**輕量設計**：原生 `getUserMedia` + canvas，**無第三方庫**（不做邊框偵測/透視校正）。因批改端 #2091 已容忍拍歪/拍反/順序錯置（reference re-sort），自動校正邊際效益低 —— 對應會議 §5「勿過早 over-engineer」。

## 變更
- **`OmoCameraScanner.tsx`**（新）：全螢幕 overlay
  - `getUserMedia({facingMode: environment})` live 預覽 + 網頁快門擷取 canvas → JPEG File
  - 連拍計數「已掃描 N 頁」+ 完成/取消
  - 不支援 / 拒絕權限 / 無相機 → 清楚中文訊息 + 引導改用檔案上傳
  - unmount/關閉時 `stop()` 所有 track（無相機燈殘留/洩漏）
  - 佇列達上限時快門 disabled
- **`OmoUpload.tsx`**：
  - 抽出 `addFiles(File[])` 核心 → 掃描擷取與檔案選取**共用同一套驗證/佇列/cap**
  - 主 CTA → 「掃描上傳（連續拍多頁）」開 in-page scanner；**移除舊的 native 拍照 `<input capture>`**
  - **保留「選擇照片或 PDF」**檔案上傳（fallback）

## 前提（已滿足）
- `getUserMedia` 需 **HTTPS** → staging/prod 都是 HTTPS ✅
- 首次跳相機權限（瀏覽器標準行為）；拒絕/不支援自動引導回檔案上傳

## 測試
- ✅ `OmoCameraScanner.test.tsx` 5 tests（不支援瀏覽器 / 拒絕權限 / 無相機 / live 計數+完成啟用 / 上限 disable）
- ✅ tsc 無新增 error
- ℹ️ `OmoIdentifyResult.test.tsx` 1 個失敗為 **staging 既有**（未碰該檔；本 session 已 stash 驗證）
- ⚠️ 相機 frame 擷取（canvas toBlob from live video）jsdom 無法測 → 列 staging 手動 QA

## QA（staging preview，手機）
- [ ] 點「掃描上傳」→ 網頁內出現相機畫面（**不跳系統相機 App**）
- [ ] 按快門連續拍多頁 → 縮圖進佇列、計數正確
- [ ] 完成 → 佇列含所有掃描頁 → 上傳批改成功
- [ ] 拒絕相機權限 → 顯示訊息 + 可改用檔案上傳
- [ ] 「選擇照片或 PDF」檔案上傳仍正常

關聯 #2089