### PR TITLE
fix(word-search): balance H/V directions, cleaner copy, remove N/M counter (Fixes #2086)

### DIFF
--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -206,11 +206,7 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
       <div className="text-center">
         <h2 className="text-lg font-bold text-on-surface">語詞複習</h2>
         <p className="text-sm text-on-surface-variant mt-0.5">
-          拖曳選取字元，水平或垂直圈出語詞 · 找出
-          <span className="font-black text-accent mx-1">{foundWords.size}</span>
-          /
-          <span className="mx-1">{placedWords.length}</span>
-          個語詞
+          水平或垂直拖曳圈出語詞
         </p>
       </div>
 

--- a/frontend/src/components/reading-steps/wordSearchGrid.ts
+++ b/frontend/src/components/reading-steps/wordSearchGrid.ts
@@ -121,12 +121,27 @@ export function generateGrid(words: string[]): GeneratedGrid {
   const placedWords: PlacedWord[] = [];
   const dirs: Direction[] = ['horizontal', 'vertical'];
 
+  // Direction balance counters: bias each word toward the under-represented
+  // direction so that |horizontal_count - vertical_count| stays ≤ 1.
+  let hCount = 0;
+  let vCount = 0;
+
   for (const word of shuffleArray(words)) {
     const wordLen = [...word].length;
     let placed = false;
 
+    // Preferred direction: whichever has fewer placements so far.
+    // If equal, pick randomly (standard 50/50).
+    const preferred: Direction =
+      hCount < vCount ? 'horizontal'
+      : vCount < hCount ? 'vertical'
+      : dirs[Math.floor(Math.random() * 2)];
+    const fallback: Direction = preferred === 'horizontal' ? 'vertical' : 'horizontal';
+
+    // First half of the attempt budget uses the preferred direction;
+    // second half falls back to the other direction so we never fail to place.
     for (let attempt = 0; attempt < 200 && !placed; attempt++) {
-      const dir = dirs[Math.floor(Math.random() * 2)];
+      const dir: Direction = attempt < 100 ? preferred : fallback;
       const maxRow = dir === 'vertical' ? size - wordLen : size - 1;
       const maxCol = dir === 'horizontal' ? size - wordLen : size - 1;
       if (maxRow < 0 || maxCol < 0) continue;
@@ -135,6 +150,7 @@ export function generateGrid(words: string[]): GeneratedGrid {
 
       if (tryPlaceWord(grid, word, size, dir, row, col)) {
         placedWords.push({ word, row, col, direction: dir });
+        if (dir === 'horizontal') hCount++; else vCount++;
         placed = true;
       }
     }


### PR DESCRIPTION
Fixes #2086

## Summary

- **Direction balance** (`wordSearchGrid.ts`): `generateGrid` now tracks `hCount`/`vCount` and biases each word toward the under-represented direction. First 100 of the 200 attempts use the preferred direction; attempts 101-200 fall back to the other direction so placement never fails. Result: `|horizontal - vertical|` stays at most 1 when the grid geometry allows, without ever skipping a word.
- **Instruction copy** (`VocabWordSearch.tsx`): Changed from `「拖曳選取字元，水平或垂直圈出語詞」` to `「水平或垂直拖曳圈出語詞」` (clearer phrasing per professor feedback).
- **Remove N/M found-count** (`VocabWordSearch.tsx`): Removed the `找出 N/M 個語詞` indicator from the header. The progress bar and word-pill strikethrough already show progress; the changing number was distracting per professor feedback.

## What was NOT changed

- No lesson YAML touched (Q-count fix already merged via #2092).
- Existing retry/fallback logic in `generateGrid` is preserved; only the direction selection is biased.
- All 19 existing unit tests in `wordSearchGrid.test.ts` pass.

## Test plan

- `npx vitest run src/components/reading-steps/__tests__/wordSearchGrid.test.ts` — 19/19 pass
- `npm run build` — clean build (no TS errors)
- `bash specs/run-ci.sh --quick` — registry OK
- Open any lesson's 語詞複習 step → confirm instruction reads 「水平或垂直拖曳圈出語詞」
- Confirm no `N/M 個語詞` counter appears in the header
- Play through several words → confirm roughly equal H/V distribution in the grid

🤖 Generated with [Claude Code](https://claude.ai/code)