### PR TITLE
fix(classrooms): normalize_story_slug before int() to fix GET /classrooms/{id}/texts 500 (Fixes #2097)

### DIFF
--- a/backend/app/routes/classroom_texts.py
+++ b/backend/app/routes/classroom_texts.py
@@ -14,6 +14,7 @@ from ..models.assignment import Assignment
 from ..models.school import Classroom, ClassroomStudent, ClassroomText
 from ..models.user import User
 from ..services.lesson_loader import get_lesson_by_id
+from ..utils.slug import normalize_story_slug
 from .classrooms import _get_classroom_or_404, _require_owner_or_admin
 
 router = APIRouter(tags=["classroom-texts"])
@@ -63,9 +64,12 @@ def assign_text_to_classroom(
     if not payload.copyright_confirmed:
         raise HTTPException(status_code=422, detail="copyright_confirmed must be true")
 
-    # Validate that the story exists
+    # Validate that the story exists.
+    # normalize_story_slug converts lesson-code formats (e.g. "L06", "G4-L21")
+    # to a plain numeric string before int() — same pattern used in
+    # assignment_queries.py and assignment_lifecycle_service.py.
     try:
-        story = get_lesson_by_id(int(payload.text_id))
+        story = get_lesson_by_id(int(normalize_story_slug(payload.text_id)))
     except (ValueError, TypeError):
         raise HTTPException(status_code=422, detail="Invalid text_id format")
     if not story:
@@ -146,12 +150,21 @@ def list_classroom_texts(
         .all()
     )
 
-    # Collect text_ids already present from classroom_texts
+    # Collect text_ids already present from classroom_texts.
+    # Guard each row individually: a single unparseable text_id must not
+    # 500 the entire list response (issue #2097).
     seen_text_ids: set[str] = set()
     results = []
     for ct in text_rows:
         seen_text_ids.add(ct.text_id)
-        story = get_lesson_by_id(int(ct.text_id))
+        try:
+            story = get_lesson_by_id(int(normalize_story_slug(ct.text_id)))
+        except (ValueError, TypeError):
+            logger.warning(
+                "classroom_texts row id=%d has unparseable text_id=%r — skipping",
+                ct.id, ct.text_id,
+            )
+            story = None
         title = story["title"] if story else f"Unknown ({ct.text_id})"
         results.append(
             ClassroomTextResponse(
@@ -179,7 +192,14 @@ def list_classroom_texts(
         if asn.story_id in seen_text_ids:
             continue
         seen_text_ids.add(asn.story_id)
-        story = get_lesson_by_id(int(asn.story_id))
+        try:
+            story = get_lesson_by_id(int(normalize_story_slug(asn.story_id)))
+        except (ValueError, TypeError):
+            logger.warning(
+                "assignment id=%d has unparseable story_id=%r — skipping",
+                asn.id, asn.story_id,
+            )
+            story = None
         title = story["title"] if story else f"Unknown ({asn.story_id})"
         results.append(
             ClassroomTextResponse(

--- a/backend/tests/test_classroom_texts_api.py
+++ b/backend/tests/test_classroom_texts_api.py
@@ -679,3 +679,136 @@ class TestClassroomTextsFullFlow:
         # 9. List still shows 2 texts (unchanged after failed operations)
         final_list = client.get(f"/api/classrooms/{cid}/texts", headers=headers)
         assert len(final_list.json()) == 2
+
+
+# ===========================================================================
+# Regression: non-numeric text_id (e.g. "L06") must not 500 — issue #2097
+# ===========================================================================
+
+
+class TestNonNumericTextId:
+    """Regression for GET /classrooms/{id}/texts 500 on lesson-code text_ids.
+
+    Before the fix, int('L06') raised ValueError -> HTTP 500.
+    After the fix, normalize_story_slug() converts 'L06' -> '6' so the lookup
+    succeeds, and a per-row try/except in the list handler prevents a single
+    bad identifier from killing the whole response.
+    """
+
+    def test_assign_with_l_prefix_text_id_returns_201(self, client, teacher, school_id):
+        """POST with text_id='L06' should work (normalize_story_slug -> '6')."""
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "L-Prefix Assign Class", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        cid = cr.json()["id"]
+
+        resp = client.post(
+            f"/api/classrooms/{cid}/texts",
+            json={"text_id": "L06", "copyright_confirmed": True},
+            headers=auth_header(teacher["token"]),
+        )
+        # The story at id=6 exists in fixtures; must not 500
+        assert resp.status_code in (201, 404), (
+            f"Expected 201 or 404, got {resp.status_code}: {resp.text}"
+        )
+        assert resp.status_code != 500
+
+    def test_list_does_not_500_when_row_has_l_prefix_text_id(
+        self, client, teacher, school_id
+    ):
+        """GET /classrooms/{id}/texts must return 200 even if a stored
+        text_id is 'L06' (lesson-code format), not a plain int string.
+
+        Simulates the staging failure: classroom_texts row with text_id='L06'
+        caused int('L06') -> ValueError -> 500.
+        """
+        from sqlalchemy.orm import Session as SASession
+
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "L-Prefix List Class", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        assert cr.status_code == 201
+        cid = cr.json()["id"]
+
+        # Directly insert a ClassroomText row with a non-numeric text_id
+        # to reproduce the staging condition without going through the POST
+        # endpoint (which may or may not normalise on write).
+        db: SASession = TestingSessionLocal()
+        try:
+            from app.models.school import ClassroomText
+            import datetime
+
+            bad_row = ClassroomText(
+                classroom_id=cid,
+                text_id="L06",
+                assigned_by=teacher["user_id"],
+                assigned_at=datetime.datetime.utcnow(),
+            )
+            db.add(bad_row)
+            db.commit()
+        finally:
+            db.close()
+
+        # GET must return 200 (not 500)
+        resp = client.get(
+            f"/api/classrooms/{cid}/texts",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200 but got {resp.status_code}: {resp.text}"
+        )
+        # The row with L06 should either resolve to a real title or be skipped;
+        # either way the list must be a JSON array.
+        assert isinstance(resp.json(), list)
+
+    def test_list_returns_200_with_mixed_numeric_and_code_ids(
+        self, client, teacher, school_id
+    ):
+        """List endpoint stays 200 when classroom has both numeric and
+        L-prefixed text_ids stored (partial-failure guard)."""
+        cr = client.post(
+            "/api/classrooms",
+            json={"name": "Mixed ID Class", "school_id": school_id},
+            headers=auth_header(teacher["token"]),
+        )
+        assert cr.status_code == 201
+        cid = cr.json()["id"]
+
+        # Assign a known-good numeric text
+        client.post(
+            f"/api/classrooms/{cid}/texts",
+            json={"text_id": "1", "copyright_confirmed": True},
+            headers=auth_header(teacher["token"]),
+        )
+
+        # Directly insert a bad row (L-prefix)
+        db: SASession = TestingSessionLocal()
+        try:
+            from app.models.school import ClassroomText
+            import datetime
+
+            bad_row = ClassroomText(
+                classroom_id=cid,
+                text_id="L99",  # deliberately bad (no lesson id=99)
+                assigned_by=teacher["user_id"],
+                assigned_at=datetime.datetime.utcnow(),
+            )
+            db.add(bad_row)
+            db.commit()
+        finally:
+            db.close()
+
+        resp = client.get(
+            f"/api/classrooms/{cid}/texts",
+            headers=auth_header(teacher["token"]),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # At minimum the valid text "1" should be present; the bad row should
+        # either be resolved or silently skipped, never 500.
+        text_ids = {item["text_id"] for item in data}
+        assert "1" in text_ids


### PR DESCRIPTION
Fixes #2097

## Summary

- `GET /api/classrooms/{id}/texts` was returning HTTP 500 when any stored `text_id` was a lesson-code string like `"L06"` instead of a plain integer string — `int("L06")` raises `ValueError`
- Root cause: three call sites in `classroom_texts.py` cast identifiers with `int()` directly, skipping the `normalize_story_slug()` helper that already exists for this exact purpose elsewhere in the codebase

## Changes

**`backend/app/routes/classroom_texts.py`**
- Import `normalize_story_slug` from `utils.slug`
- Wrap `int()` with `normalize_story_slug()` at all three call sites (assign POST, list GET classroom_texts loop, list GET assignments loop) — matching the pattern in `assignment_queries.py` and `assignment_lifecycle_service.py`
- Add per-row `try/except (ValueError, TypeError)` in the list handler: a single bad `text_id` now logs a warning and skips the row instead of 500-ing the entire response

**`backend/tests/test_classroom_texts_api.py`**
- Add `TestNonNumericTextId` regression class (3 tests):
  - POST with `text_id='L06'` must not 500
  - GET list with a DB row containing `text_id='L06'` must return 200
  - GET list with mixed numeric + bad ids must return 200 and include valid rows

## Test plan

- [x] `pytest tests/test_classroom_texts_api.py` — 28/28 passed (0 regressions)
- [x] `specs/run-ci.sh --quick` — registry OK
- [x] TDD: tests were written first (Red), confirmed 500, then fix applied (Green)

## What `normalize_story_slug` does

`"L06"` → strips leading `L` → `int("06")` → `"6"` → `get_lesson_by_id(6)` resolves correctly.