### PR TITLE
feat(ui): 圖文並陳 side-by-side layout + in-pane zoom (Fixes #2085)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -16,7 +16,7 @@
  *   - Outer wrapper: flex flex-col flex-1 min-h-0 — NO scrollIntoView, NO min-h-full on children
  *   - Body: flex-1 min-h-0 overflow-hidden — establishes height boundary
  *   - Grid: grid-rows-[1fr] — CRITICAL: locks row height to 1fr so children cannot push it out
- *   - Right col: min-h-0 overflow-y-auto, children shrink-0 → natural flow stack
+ *   - Right col: min-h-0 overflow-y-auto, children shrink-0 -> natural flow stack
  *
  * History:
  *   - #1341 introduced a 3-pane layout (text / image strip / exercise)
@@ -28,9 +28,13 @@
  *     (defaultOpen=true) so all 3 right-col panels share the same accordion style,
  *     and removes the inner flex-1/min-h-0 nesting that caused the panels to
  *     visually overlap the exercise questions on scroll.
- *   - #1701 reorders right-col panels: 圖文對照 → 紙本表格 → 練習 (exercise last),
+ *   - #1701 reorders right-col panels: 圖文對照 -> 紙本表格 -> 練習 (exercise last),
  *     and sets all 3 panels to defaultOpen=true so students see reference material
  *     immediately without manually expanding.
+ *   - #2085 (B1 圖文並陳) graphic-text lessons get a dedicated split layout:
+ *     Desktop (>=1024px): left image pane (50%) | right text+exercise pane (50%).
+ *     Portrait/tablet (<1024px): top image pane (~40vh) / bottom text+exercise stack.
+ *     ZoomableImage modal removed — GraphicTextImageStrip now uses in-pane +/- zoom.
  */
 import React, { useMemo } from 'react';
 import { Story } from '../../types';
@@ -45,7 +49,7 @@ interface ComprehensionLayoutProps {
   dbSessionId?: number;
   /** The exercise component rendered in the right panel */
   children: React.ReactNode;
-  /** Progress 0–100 to show in the bottom bar of the left card. -1 = hide bar. */
+  /** Progress 0-100 to show in the bottom bar of the left card. -1 = hide bar. */
   progressPercent?: number;
   /** Label shown next to the progress percent. Defaults to empty. */
   progressLabel?: string;
@@ -54,6 +58,60 @@ interface ComprehensionLayoutProps {
   /** Header label for the exercise collapsible. */
   exerciseLabel?: string;
 }
+
+/** Scrollable lesson text card — shared between standard and graphic-text layouts. */
+const StoryTextCard: React.FC<{
+  story: Story;
+  zhuyinLines: React.ReactNode[] | null;
+  zhuyinActive: boolean;
+  progressPercent: number;
+  progressLabel: string;
+  className?: string;
+}> = ({ story, zhuyinLines, zhuyinActive, progressPercent, progressLabel, className = '' }) => (
+  <div className={`bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full flex-1 min-h-0 ${className}`}>
+    <div className="flex items-center gap-2 mb-4 shrink-0">
+      <span className="material-symbols-outlined text-accent text-xl">menu_book</span>
+      <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">
+        參考課文
+      </span>
+    </div>
+    <div className="flex-1 min-h-0 overflow-y-auto pr-2 custom-scrollbar space-y-6">
+      {story.content.map((line, idx) => (
+        <div key={idx} className="flex gap-3 items-start">
+          <span className="text-xs font-headline font-bold text-on-surface-variant/30 pt-1 select-none shrink-0 w-5 text-right">
+            {String(idx + 1).padStart(2, '0')}
+          </span>
+          <p
+            className={`text-lg md:text-xl text-on-surface leading-[2rem] md:leading-[2.2rem] ${
+              zhuyinActive ? 'tracking-[0.15em]' : ''
+            }`}
+          >
+            {zhuyinLines ? zhuyinLines[idx] : line}
+          </p>
+        </div>
+      ))}
+    </div>
+
+    {progressPercent >= 0 && (
+      <div className="mt-4 pt-4 border-t border-surface-container-high shrink-0">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-xs font-headline font-bold text-on-surface-variant">
+            {progressLabel || '完成進度'}
+          </span>
+          <span className="text-xs font-headline font-bold text-accent">
+            {progressPercent === 100 ? '完成！' : `${progressPercent}%`}
+          </span>
+        </div>
+        <div className="h-2 bg-surface-container-high rounded-full overflow-hidden">
+          <div
+            className="h-full bg-accent rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      </div>
+    )}
+  </div>
+);
 
 const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
   story,
@@ -78,126 +136,128 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
   const tables = story.tables ?? [];
   const hasImages = isGraphicText && images.length > 0;
   const hasTables = tables.length > 0;
-  // Lessons without any reference material (e.g. G6 摘要策略 課文) still render
-  // the exercise inside its own CollapsibleRefPanel for consistent visual
-  // styling — there's just nothing below it.
 
   return (
     <div className="flex flex-col flex-1 min-h-0 overflow-hidden bg-surface relative">
-      {/* ── Main content area ─────────────────────────────────────────────────── */}
       <div className="flex-1 min-h-0 px-4 md:px-6 py-6 md:py-8 overflow-hidden">
-        {/*
-          CRITICAL: grid-rows-[1fr] pins row height so child content changes
-          (checkbox toggle, MCQ answer reveal) cannot re-expand the row.
-          This is the fix for the height-collapse bug in #1332.
-        */}
-        <div className="w-full h-full grid grid-cols-1 md:grid-cols-12 grid-rows-[1fr] gap-6">
 
-          {/* ── Left: Text-only card ───────────────────────────────────────────
-              #1697: images + tables moved to right column. Left always col-span-7
-              now (wider when there are no images/tables; previously col-span-8 for
-              graphic-text so the bottom image strip had room). */}
-          <div className="md:col-span-7 min-h-0 flex flex-col">
-            <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8 flex flex-col w-full flex-1 min-h-0">
-              <div className="flex items-center gap-2 mb-4 shrink-0">
-                <span className="material-symbols-outlined text-accent text-xl">menu_book</span>
+        {hasImages ? (
+          /* ══════════════════════════════════════════════════════════════════
+           * 圖文並陳 layout (B1, #2085) — for graphic-text lessons with images
+           *
+           * Desktop/landscape (>=1024px):
+           *   Left pane  (50%): image gallery, full pane width, independently scrollable
+           *   Right pane (50%): text card (scrollable) + exercise + tables
+           *
+           * Portrait/tablet (<1024px):
+           *   Top:    image strip (~40vh, capped so text stays visible)
+           *   Bottom: text card + exercise stack, scrollable
+           *
+           * Both panes are independently scrollable. Images are never modal-covered.
+           * ══════════════════════════════════════════════════════════════════ */
+          <div className="w-full h-full flex flex-col lg:flex-row gap-4 lg:gap-6">
+
+            {/* Image pane — full width on mobile (top), 50% on desktop (left) */}
+            <div
+              className="
+                w-full lg:w-1/2
+                h-[40vh] lg:h-full
+                min-h-0
+                flex-shrink-0 lg:flex-shrink
+                bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5
+                flex flex-col
+              "
+            >
+              <div className="flex items-center gap-2 mb-3 shrink-0">
+                <span className="material-symbols-outlined text-accent text-xl">photo_library</span>
                 <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">
-                  參考課文
+                  課文圖表
                 </span>
+                <span className="text-xs text-on-surface-variant ml-1">{images.length} 張</span>
               </div>
-              {/* Scrollable story content — overflow-y-auto on the inner div only.
-                  #1697 removes inline image/table placement (was #1692) — students
-                  now consult them from the right column collapsibles instead. */}
-              <div className="flex-1 min-h-0 overflow-y-auto pr-2 custom-scrollbar space-y-6">
-                {story.content.map((line, idx) => (
-                  <div key={idx} className="flex gap-3 items-start">
-                    <span className="text-xs font-headline font-bold text-on-surface-variant/30 pt-1 select-none shrink-0 w-5 text-right">
-                      {String(idx + 1).padStart(2, '0')}
-                    </span>
-                    <p
-                      className={`text-lg md:text-xl text-on-surface leading-[2rem] md:leading-[2.2rem] ${
-                        zhuyinActive ? 'tracking-[0.15em]' : ''
-                      }`}
-                    >
-                      {zhuyinLines ? zhuyinLines[idx] : line}
-                    </p>
-                  </div>
-                ))}
+              {/* GraphicTextImageStrip fills the remaining height of this pane */}
+              <div className="flex-1 min-h-0">
+                <GraphicTextImageStrip
+                  images={images}
+                  lessonCode={story.lesson_code}
+                />
               </div>
+            </div>
 
-              {/* Progress bar — only shown when progressPercent >= 0 */}
-              {progressPercent >= 0 && (
-                <div className="mt-4 pt-4 border-t border-surface-container-high shrink-0">
-                  <div className="flex items-center justify-between mb-2">
-                    <span className="text-xs font-headline font-bold text-on-surface-variant">
-                      {progressLabel || '完成進度'}
-                    </span>
-                    <span className="text-xs font-headline font-bold text-accent">
-                      {progressPercent === 100 ? '完成！' : `${progressPercent}%`}
-                    </span>
-                  </div>
-                  <div className="h-2 bg-surface-container-high rounded-full overflow-hidden">
-                    <div
-                      className="h-full bg-accent rounded-full transition-all duration-500 ease-out"
-                      style={{ width: `${progressPercent}%` }}
-                    />
-                  </div>
-                </div>
+            {/* Text + exercise pane — full width on mobile (bottom), 50% on desktop (right) */}
+            <div className="w-full lg:w-1/2 min-h-0 flex flex-col gap-3 overflow-y-auto custom-scrollbar pr-1">
+              {/* Text card */}
+              <StoryTextCard
+                story={story}
+                zhuyinLines={zhuyinLines}
+                zhuyinActive={zhuyinActive}
+                progressPercent={progressPercent}
+                progressLabel={progressLabel}
+              />
+
+              {/* Tables (if any) */}
+              {hasTables && (
+                <CollapsibleRefPanel
+                  icon="table_chart"
+                  label="紙本表格"
+                  count={`${tables.length} 張`}
+                  defaultOpen={false}
+                >
+                  <TableDisplay tables={tables} layout="stacked" />
+                </CollapsibleRefPanel>
               )}
+
+              {/* Exercise */}
+              <CollapsibleRefPanel
+                icon={exerciseIcon}
+                label={exerciseLabel}
+                defaultOpen={false}
+              >
+                {children}
+              </CollapsibleRefPanel>
             </div>
           </div>
+        ) : (
+          /* ══════════════════════════════════════════════════════════════════
+           * Standard 2-column layout — lessons without graphic-text images.
+           * Unchanged from #1701 / #1703.
+           * ══════════════════════════════════════════════════════════════════ */
+          <div className="w-full h-full grid grid-cols-1 md:grid-cols-12 grid-rows-[1fr] gap-6">
 
-          {/* ── Right: 3 sibling accordion panels (ref material + exercise) ──
-              #1701: reorder so reference panels (圖文/紙本) come first, then
-              exercise. All 3 default to open so students see everything
-              immediately without needing to manually expand panels.
-              #1699: all 3 panels are CollapsibleRefPanel siblings in a vertical
-              flow stack. Outer div is the single scroll container; each panel
-              is shrink-0 so they take only the height they need. No flex-1,
-              no nested overflow, no z-index — purely natural document flow. */}
-          <div className="md:col-span-5 min-h-0 flex flex-col gap-3 overflow-y-auto custom-scrollbar pr-1">
-            {/* Reference panels first — students consult images/tables before filling exercise. */}
-            {hasImages && (
+            {/* Left: text card (col-span-7) */}
+            <div className="md:col-span-7 min-h-0 flex flex-col">
+              <StoryTextCard
+                story={story}
+                zhuyinLines={zhuyinLines}
+                zhuyinActive={zhuyinActive}
+                progressPercent={progressPercent}
+                progressLabel={progressLabel}
+              />
+            </div>
+
+            {/* Right: reference panels + exercise (col-span-5) */}
+            <div className="md:col-span-5 min-h-0 flex flex-col gap-3 overflow-y-auto custom-scrollbar pr-1">
+              {hasTables && (
+                <CollapsibleRefPanel
+                  icon="table_chart"
+                  label="紙本表格"
+                  count={`${tables.length} 張`}
+                  defaultOpen={false}
+                >
+                  <TableDisplay tables={tables} layout="stacked" />
+                </CollapsibleRefPanel>
+              )}
+
               <CollapsibleRefPanel
-                icon="photo_library"
-                label="圖文對照"
-                count={`${images.length} 張`}
+                icon={exerciseIcon}
+                label={exerciseLabel}
                 defaultOpen={false}
               >
-                {/* Constrain image strip height when expanded so it doesn't push
-                    the exercise off-screen. ZoomableImage modal still works for
-                    full-screen viewing. */}
-                <div className="h-64 flex">
-                  <GraphicTextImageStrip
-                    images={images}
-                    lessonCode={story.lesson_code}
-                  />
-                </div>
+                {children}
               </CollapsibleRefPanel>
-            )}
-
-            {hasTables && (
-              <CollapsibleRefPanel
-                icon="table_chart"
-                label="紙本表格"
-                count={`${tables.length} 張`}
-                defaultOpen={false}
-              >
-                <TableDisplay tables={tables} layout="stacked" />
-              </CollapsibleRefPanel>
-            )}
-
-            {/* Exercise — after reference material. #1703: default collapsed
-                so right column starts compact; students expand panels they need. */}
-            <CollapsibleRefPanel
-              icon={exerciseIcon}
-              label={exerciseLabel}
-              defaultOpen={false}
-            >
-              {children}
-            </CollapsibleRefPanel>
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       {/* Floating AI helper */}

--- a/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
+++ b/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
@@ -1,12 +1,33 @@
-import React from 'react';
-import ZoomableImage from '../ui/ZoomableImage';
+/**
+ * GraphicTextImageStrip — 圖文並陳圖片欄 (B1 redesign, issue #2085)
+ *
+ * Before (#1697): horizontal scroll strip, clamp(180px,22vw,260px) tiles,
+ *   click opens fullscreen modal that covers the lesson text.
+ *
+ * After (B1):
+ * - Vertical image gallery: each figure fills pane width (not a tiny tile).
+ * - 中文序號 badges (圖一/圖二/…) positioned top-left of each figure.
+ * - Enlarged captions (text-sm, no line-clamp).
+ * - In-pane zoom: +/– controls scale the image within its container.
+ *   NO fullscreen modal — text pane is never occluded.
+ *
+ * Layout context (ComprehensionLayout):
+ *   Desktop (>=1024px): rendered in the left split pane (50% width) — image
+ *   fills that pane width naturally, both text and images visible simultaneously.
+ *   Portrait/tablet (<1024px): rendered above the text/exercise in a stacked
+ *   layout, height capped ~40vh.
+ *
+ * The component is scroll-container-agnostic: its parent sets the height/
+ * overflow-y; this component fills 100% of that space.
+ */
+import React, { useState } from 'react';
 
 interface GraphicTextImageStripProps {
   images: { filename: string; caption?: string }[];
   /**
    * Lesson code (e.g. 'G7-L28') used to build GCS image URL.
    * Optional — falls back to the first path segment of `images[0].filename`
-   * (e.g. 'images/G7-L28/G7-L28-08.jpg' → 'G7-L28') when not supplied.
+   * (e.g. 'images/G7-L28/G7-L28-08.jpg' -> 'G7-L28') when not supplied.
    * Many lessons have `story.lesson_code === undefined` but `images[i].filename`
    * always carries the lesson directory, so the fallback is reliable (#1681).
    */
@@ -14,6 +35,12 @@ interface GraphicTextImageStripProps {
 }
 
 const GCS_IMAGE_BASE = 'https://storage.googleapis.com/lingoleap-assets/lessons-images';
+
+/** Chinese numeral labels (1-based) for figure badges */
+const CHINESE_NUMERALS = ['一', '二', '三', '四', '五', '六', '七', '八', '九', '十'];
+function chineseNumeral(n: number): string {
+  return n <= CHINESE_NUMERALS.length ? CHINESE_NUMERALS[n - 1] : String(n);
+}
 
 /** Derive lesson code from an image filename like `images/G7-L28/G7-L28-08.jpg`. */
 function deriveLessonCodeFromFilename(filename: string): string {
@@ -24,45 +51,154 @@ function deriveLessonCodeFromFilename(filename: string): string {
   return '';
 }
 
+/** Per-figure in-pane zoom controls (no fullscreen modal). */
+const ZOOM_MIN = 1;
+const ZOOM_MAX = 3;
+const ZOOM_STEP = 0.5;
+
+interface FigureCardProps {
+  src: string;
+  alt: string;
+  caption?: string;
+  index: number; // 0-based
+}
+
+const FigureCard: React.FC<FigureCardProps> = ({ src, alt, caption, index }) => {
+  const [scale, setScale] = useState(1);
+  const [imgError, setImgError] = useState(false);
+
+  const zoomIn = () => setScale((s) => Math.min(s + ZOOM_STEP, ZOOM_MAX));
+  const zoomOut = () => setScale((s) => Math.max(s - ZOOM_STEP, ZOOM_MIN));
+  const resetZoom = () => setScale(1);
+
+  const figureLabel = `圖${chineseNumeral(index + 1)}`;
+
+  return (
+    <figure className="flex flex-col w-full mb-5 last:mb-0">
+      {/* Image container — overflow:auto so zoomed content is scrollable within pane */}
+      <div className="relative w-full overflow-hidden rounded-xl border border-outline-variant bg-surface-container-low">
+        {/* 圖一/圖二/… badge — top-left, always visible */}
+        <span className="absolute top-2 left-2 z-10 inline-flex items-center px-2 py-0.5 rounded-md bg-on-surface/70 text-white text-xs font-bold tracking-wide select-none pointer-events-none">
+          {figureLabel}
+        </span>
+
+        {/* In-pane zoom controls — top-right; hidden when image failed */}
+        {!imgError && (
+          <div className="absolute top-2 right-2 z-10 flex items-center gap-1">
+            <button
+              type="button"
+              onClick={zoomOut}
+              disabled={scale <= ZOOM_MIN}
+              aria-label="縮小"
+              className="w-7 h-7 rounded-full bg-on-surface/60 hover:bg-on-surface/80 text-white flex items-center justify-center transition-colors disabled:opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              <span className="material-symbols-outlined text-base leading-none">remove</span>
+            </button>
+            {scale !== 1 && (
+              <button
+                type="button"
+                onClick={resetZoom}
+                aria-label="還原縮放"
+                className="px-1.5 h-7 rounded-full bg-on-surface/60 hover:bg-on-surface/80 text-white text-[11px] font-bold flex items-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                {Math.round(scale * 100)}%
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={zoomIn}
+              disabled={scale >= ZOOM_MAX}
+              aria-label="放大"
+              className="w-7 h-7 rounded-full bg-on-surface/60 hover:bg-on-surface/80 text-white flex items-center justify-center transition-colors disabled:opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              <span className="material-symbols-outlined text-base leading-none">add</span>
+            </button>
+          </div>
+        )}
+
+        {imgError ? (
+          <div className="w-full h-40 flex flex-col items-center justify-center gap-1 text-on-surface-variant/50">
+            <span className="material-symbols-outlined text-3xl">broken_image</span>
+            <span className="text-xs">圖片載入失敗</span>
+          </div>
+        ) : (
+          /**
+           * Scrollable inner div: when scale > 1 the image overflows the container
+           * and this div allows the user to pan by scrolling/touch-drag.
+           * transform-origin: top left ensures the badge stays anchored.
+           */
+          <div
+            className="w-full overflow-auto"
+            style={{ cursor: scale > 1 ? 'grab' : 'default' }}
+          >
+            <img
+              src={src}
+              alt={alt}
+              loading="lazy"
+              onError={() => setImgError(true)}
+              style={{
+                display: 'block',
+                width: '100%',
+                transform: `scale(${scale})`,
+                transformOrigin: 'top left',
+                /**
+                 * When scaled, we shrink the CSS width so the scaled
+                 * rendered size equals the container width at scale 1.
+                 * This avoids the image overflowing to the right before
+                 * the overflow-auto div can scroll.
+                 */
+                ...(scale > 1 ? { width: `${(100 / scale).toFixed(1)}%` } : {}),
+                transition: 'transform 0.15s ease',
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Caption — enlarged to text-sm, no line-clamp */}
+      {caption ? (
+        <figcaption className="mt-2 text-sm text-on-surface-variant leading-relaxed px-1">
+          <span className="font-semibold text-on-surface">{figureLabel}：</span>
+          {caption}
+        </figcaption>
+      ) : (
+        <figcaption className="mt-1.5 text-sm text-on-surface-variant/60 px-1">
+          {figureLabel}
+        </figcaption>
+      )}
+    </figure>
+  );
+};
+
 const GraphicTextImageStrip: React.FC<GraphicTextImageStripProps> = ({ images, lessonCode }) => {
   const resolvedLessonCode =
     lessonCode || (images[0] ? deriveLessonCodeFromFilename(images[0].filename) : '');
+
   return (
     <div
       data-testid="graphic-text-image-pane"
-      className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 md:p-5 flex flex-col w-full min-h-0 flex-[2]"
+      className="w-full h-full flex flex-col min-h-0"
     >
-      {/* #1706: header removed — collapsible parent shows icon/title/count. */}
-      <div className="text-[11px] text-on-surface-variant text-right mb-2 shrink-0 hidden md:block">點圖可放大</div>
       {images.length === 0 ? (
-        <div className="flex-1 min-h-0 flex items-center justify-center text-on-surface-variant text-sm">
+        <div className="flex-1 flex items-center justify-center text-on-surface-variant text-sm">
           暫無圖片
         </div>
       ) : (
-        <div className="flex-1 min-h-0 overflow-x-auto custom-scrollbar">
-          <div className="flex gap-3 h-full pr-2">
-            {images.map((img, idx) => (
-              <figure
+        /* Scrollable vertical gallery — parent controls the height boundary */
+        <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar pr-1">
+          {images.map((img, idx) => {
+            const basename = img.filename.split('/').pop() ?? img.filename;
+            const src = `${GCS_IMAGE_BASE}/${resolvedLessonCode}/${basename}`;
+            return (
+              <FigureCard
                 key={idx}
-                className="flex flex-col items-stretch shrink-0 h-full"
-                style={{ width: 'clamp(180px, 22vw, 260px)' }}
-              >
-                <div className="flex-1 min-h-0">
-                  <ZoomableImage
-                    src={`${GCS_IMAGE_BASE}/${resolvedLessonCode}/${img.filename.split('/').pop()}`}
-                    alt={img.caption ?? `圖 ${idx + 1}`}
-                    caption={img.caption}
-                    className="h-full"
-                  />
-                </div>
-                {img.caption && (
-                  <figcaption className="text-[11px] text-on-surface-variant mt-1.5 line-clamp-2 shrink-0">
-                    {img.caption}
-                  </figcaption>
-                )}
-              </figure>
-            ))}
-          </div>
+                src={src}
+                alt={img.caption ?? `圖 ${idx + 1}`}
+                caption={img.caption}
+                index={idx}
+              />
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
Fixes #2085

## Summary

B1 — data-independent layout redesign for 圖文整合 lessons (G7-L28~30, story ids 1108/1109/1110).

### GraphicTextImageStrip.tsx (rewritten)
- **Full-pane vertical gallery**: each figure fills the pane width (was clamp 180–260px tiles)
- **圖一/圖二/… badges**: Chinese numeral label top-left of every figure
- **In-pane zoom (+/−)**: scale 1×–3×, zoomed image pans within its container — no fullscreen modal, text pane is never occluded
- **Readable captions**: `text-sm` with no `line-clamp` (was `text-[11px] line-clamp-2`)
- Removed dependency on `ZoomableImage` (fullscreen overlay gone)

### ComprehensionLayout.tsx (graphic-text path updated)
- Graphic-text lessons with images now get a dedicated **50/50 split layout**:
  - Desktop/landscape (≥1024px): left image pane | right text + exercise (`flex-row`)
  - Portrait/tablet (<1024px): top image pane (~40vh capped) → bottom text + exercise (stacked)
- Both panes are independently scrollable
- Header "課文圖表 N 張" on the image pane for orientation
- Non-graphic-text lessons: **unchanged** standard 12-col grid layout
- Extracted `StoryTextCard` as a local sub-component (DRY, no API change)

## What is NOT in this PR

**B2** (per-question paragraph+image pairing — each exercise question shows its corresponding paragraph + figure) requires new YAML schema fields and is intentionally out of scope for this PR.

## Test plan

- [ ] Login as 學生 小明 via `/login` 1-click demo button
- [ ] Navigate to a G7 圖文整合 lesson (e.g. `/learn/1109/reading-strategy`)
- [ ] Verify: image pane and text pane are visible side-by-side (desktop) or stacked (mobile)
- [ ] Verify: each figure has a visible 圖一/圖二/… badge top-left
- [ ] Verify: zoom +/− buttons expand the image within pane — text is never covered
- [ ] Verify: captions are legible (≥14px, no truncation)
- [ ] Non-graphic-text lesson (e.g. G6 摘要策略): layout unchanged, no regression
- [ ] `npm run build` passes (verified locally ✓)
- [ ] `bash specs/run-ci.sh --quick` passes (verified locally ✓)