### PR TITLE
fix(vocab+annotation): A5-A8 UX — onboarding coach, verbal feedback, labels, device-aware instruction (Fixes #2082 partial)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -42,6 +42,9 @@ export type { AnnotationSummary } from './annotationReducer';
 
 const STORAGE_KEY = (storyId: string) => scopedStepStorageKey('annotations_', storyId);
 
+// A5: localStorage key for first-use onboarding gate
+const ANNOTATION_ONBOARDED_KEY = 'annotation_onboarded';
+
 // ── ID generator ───────────────────────────────────────────────────────────
 
 let _idCounter = 0;
@@ -55,6 +58,57 @@ interface ReadingAnnotationProps {
   story: Story;
   onFinish: (summary: ReturnType<typeof computeSummary>) => void;
   fontSizePx?: number;
+}
+
+// ── A5: First-use onboarding coach component ───────────────────────────────
+
+// A5: Detect touch vs mouse for device-appropriate wording
+const IS_TOUCH = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+
+interface OnboardingCoachProps {
+  onDismiss: () => void;
+}
+
+function OnboardingCoach({ onDismiss }: OnboardingCoachProps) {
+  const gestureWord = IS_TOUCH ? '用手指在文字上滑過' : '用滑鼠在文字上拖曳選取';
+  return (
+    <div className="mx-auto max-w-4xl px-6 md:px-16 pt-4 pb-2">
+      <div className="rounded-2xl border-2 border-accent/30 bg-accent/5 px-5 py-4 flex flex-col gap-3">
+        <div className="flex items-start gap-3">
+          <span className="material-symbols-outlined text-accent text-2xl flex-shrink-0 mt-0.5">
+            {IS_TOUCH ? 'swipe' : 'select_all'}
+          </span>
+          <div className="flex-1">
+            <p className="font-bold text-on-surface text-base mb-1">如何標記詞語？</p>
+            <p className="text-sm text-on-surface-variant leading-relaxed">
+              {gestureWord}，就能標記不懂的詞語。
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="self-end px-5 py-2 rounded-full text-sm font-bold text-white bg-accent hover:brightness-110 active:scale-[0.98] transition-all"
+        >
+          我知道了
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── A5: Persistent mini hint bar (shown after onboarding is dismissed) ──────
+
+function HintBar() {
+  const hint = IS_TOUCH ? '滑過文字即可標記' : '選取文字即可標記';
+  return (
+    <div className="flex items-center justify-center gap-1.5 py-1 px-3 text-xs text-on-surface-variant/60">
+      <span className="material-symbols-outlined text-xs align-middle">
+        {IS_TOUCH ? 'touch_app' : 'select_all'}
+      </span>
+      <span>{hint}</span>
+    </div>
+  );
 }
 
 // ── Main Component ─────────────────────────────────────────────────────────
@@ -98,6 +152,24 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
   const toolbarRef = useRef<HTMLDivElement>(null);
   const annotationElementRefs = useRef(new Map<string, HTMLSpanElement>());
   const [focusedAnnotationId, setFocusedAnnotationId] = useState<string | null>(null);
+
+  // A5: First-use onboarding — gated by localStorage flag
+  const [showCoach, setShowCoach] = useState<boolean>(() => {
+    try {
+      return !localStorage.getItem(ANNOTATION_ONBOARDED_KEY);
+    } catch {
+      return true;
+    }
+  });
+
+  const handleDismissCoach = useCallback(() => {
+    setShowCoach(false);
+    try {
+      localStorage.setItem(ANNOTATION_ONBOARDED_KEY, '1');
+    } catch {
+      // Storage unavailable — silently ignore
+    }
+  }, []);
 
   // ── Zhuyin ─────────────────────────────────────────────────────────────
 
@@ -324,8 +396,16 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
           onTouchEnd={handleTouchEnd}
           style={{ WebkitUserSelect: 'text', userSelect: 'text' } as React.CSSProperties}
         >
+          {/* A5: First-use onboarding coach (dismissable, gated by localStorage) */}
+          {showCoach ? (
+            <OnboardingCoach onDismiss={handleDismissCoach} />
+          ) : (
+            /* A5: Persistent mini hint bar shown after onboarding is dismissed */
+            <HintBar />
+          )}
+
           {/* Instruction banner */}
-          <div className="mx-auto max-w-4xl px-6 md:px-16 pt-6 pb-4">
+          <div className="mx-auto max-w-4xl px-6 md:px-16 pt-2 pb-4">
             <div className="rounded-2xl bg-surface-container-low px-5 py-4 text-sm text-on-surface-variant space-y-1">
               <p><span className="font-bold text-on-surface">第一次閱讀</span>：找出不懂的詞語，用 ❓ 標記</p>
               <p><span className="font-bold text-on-surface">第二次閱讀</span>：找出重要的詞語，用 💛 標記</p>

--- a/frontend/src/components/reading-steps/VocabDefinitionMatchDragDrop.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatchDragDrop.tsx
@@ -6,10 +6,17 @@
  *
  * Fix #1101 (炮灰選項): confirmed words shown as locked/dimmed in word bank so the
  * last drag-drop question always has multiple options — no forced-correct final question.
+ *
+ * Fix #2082 (A6/A7/A8): verbal feedback, larger definition text, device-aware instruction.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { VocabItem } from '../../types';
 import { AnswerRecord } from './vocabDefinitionMatchLogic';
+
+// A8: Detect touch (coarse pointer) vs mouse at mount time.
+// Using a module-level constant so it is evaluated once and shared across renders.
+const IS_TOUCH_DEVICE =
+  typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 
 export interface DragDropProps {
   vocab: VocabItem[];
@@ -28,6 +35,10 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
   // vocabIdx values currently playing the fly-away exit animation
   const [flyingAway, setFlyingAway] = useState<Set<number>>(new Set());
 
+  // A6: verbal feedback state — show praise on correct, "再試試看！" on wrong
+  const [wrongFeedbackSlot, setWrongFeedbackSlot] = useState<number | null>(null);
+  const [correctFeedbackSlot, setCorrectFeedbackSlot] = useState<number | null>(null);
+
   // Track last answer per slot for summary (correct ones only, since wrong bounce back)
   const answersRef = useRef<AnswerRecord[]>(
     activeDefIndices.map((defIdx) => ({ defIndex: defIdx, answeredWordIdx: null, correct: null })),
@@ -44,6 +55,8 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
     setHoverTarget(null);
     setTouchSelected(null);
     setFlyingAway(new Set());
+    setWrongFeedbackSlot(null);
+    setCorrectFeedbackSlot(null);
     answersRef.current = activeDefIndices.map((defIdx) => ({
       defIndex: defIdx,
       answeredWordIdx: null,
@@ -80,6 +93,10 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
         );
         confirmedRef.current = new Set([...confirmedRef.current, defIdx]);
 
+        // A6: Show explicit praise briefly
+        setCorrectFeedbackSlot(defIdx);
+        setTimeout(() => setCorrectFeedbackSlot(null), 1200);
+
         // Start fly-away animation on the chip
         setFlyingAway((prev) => new Set([...prev, vocabIdx]));
         // After animation completes, mark the slot as confirmed (chip is now hidden)
@@ -111,6 +128,8 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
           } : a,
         );
         setWrongFlash((prev) => new Set([...prev, defIdx]));
+        // A6: Show "再試試看！" verbal feedback (amber, not silent bounce)
+        setWrongFeedbackSlot(defIdx);
         setTimeout(() => {
           setPlacements((prev) => {
             const next = new Map(prev);
@@ -122,6 +141,7 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
             next.delete(defIdx);
             return next;
           });
+          setWrongFeedbackSlot(null);
         }, 650);
       }
     },
@@ -169,7 +189,8 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
     <>
       <div className="flex items-center gap-2 mb-3">
         <span className="material-symbols-outlined text-on-surface-variant text-lg">dictionary</span>
-        <span className="text-sm font-headline font-bold text-on-surface-variant uppercase tracking-wider">語詞庫</span>
+        {/* A7: Renamed from 語詞庫 to 本課語詞 */}
+        <span className="text-sm font-headline font-bold text-on-surface-variant uppercase tracking-wider">本課語詞</span>
       </div>
       <div className="flex flex-wrap gap-2 min-h-[56px]">
         {activeShuffledWords.map((vocabIdx) => {
@@ -247,12 +268,17 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
     [activeDefIndices, confirmed.size],
   );
 
+  // A8: Device-appropriate drop-zone hint text
+  const dropHintText = IS_TOUCH_DEVICE ? '點選空格放入' : '拖拉語詞到這裡';
+
   const definitionSlots = sortedDefIndices.map((defIdx) => {
     const item = vocab[defIdx];
     const placedVocabIdx = placements.get(defIdx) ?? null;
     const isCorrect = confirmed.has(defIdx);
     const isWrong = wrongFlash.has(defIdx);
     const isOver = hoverTarget === defIdx && !isCorrect;
+    const showWrongVerbal = wrongFeedbackSlot === defIdx;
+    const showCorrectVerbal = correctFeedbackSlot === defIdx;
 
     let cls =
       'rounded-3xl border-2 px-5 py-5 min-h-[80px] flex flex-col gap-2 transition-all duration-200 cursor-pointer ';
@@ -283,7 +309,8 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
         }}
         onClick={() => handleSlotTap(defIdx)}
       >
-        <p className="text-base text-on-surface leading-relaxed">{item?.definition}</p>
+        {/* A7: text-base → text-lg md:text-xl leading-relaxed */}
+        <p className="text-lg md:text-xl leading-relaxed text-on-surface">{item?.definition}</p>
         <div className="flex items-center justify-center h-8">
           {isCorrect ? (
             <span className="font-bold text-base text-emerald-700 flex items-center gap-1">
@@ -291,6 +318,17 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
                 ✓
               </span>
               {placedVocabIdx !== null ? vocab[placedVocabIdx]?.word : ''}
+              {/* A6: explicit correct praise */}
+              {showCorrectVerbal && (
+                <span className="ml-2 text-sm font-bold text-emerald-600 animate-pulse">
+                  答對了！
+                </span>
+              )}
+            </span>
+          ) : showWrongVerbal ? (
+            /* A6: wrong verbal feedback — amber text, not silent bounce */
+            <span className="font-bold text-sm text-amber-600 animate-pulse">
+              再試試看！
             </span>
           ) : placedVocabIdx !== null ? (
             <span className="font-bold text-base text-amber-800">
@@ -298,7 +336,7 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
             </span>
           ) : (
             <span className="text-xs text-on-surface-variant/40 select-none">
-              拖拉語詞到這裡
+              {dropHintText}
             </span>
           )}
         </div>
@@ -306,8 +344,21 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
     );
   });
 
+  // A8: Device-appropriate top-level instruction
+  const instructionText = IS_TOUCH_DEVICE
+    ? '點選語詞，再點空格放入'
+    : '把語詞拖到正確的解釋上';
+
   return (
     <div className="px-4 md:px-6 max-w-5xl mx-auto">
+      {/* A8: Device-aware instruction banner */}
+      <p className="text-sm text-center text-on-surface-variant mb-4">
+        <span className="material-symbols-outlined align-middle text-base mr-1">
+          {IS_TOUCH_DEVICE ? 'touch_app' : 'drag_indicator'}
+        </span>
+        {instructionText}
+      </p>
+
       {/* Progress bar */}
       <div className="flex items-center gap-3 mb-6">
         <div className="flex-1 h-2.5 bg-surface-container-high rounded-full overflow-hidden">
@@ -328,8 +379,9 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
       <div className="md:flex md:gap-6 md:items-start md:max-h-[calc(100vh-16rem)]">
         {/* Left column — definition slots, independently scrollable on desktop */}
         <div className="flex-1 min-w-0 md:overflow-y-auto md:max-h-[calc(100vh-16rem)]">
+          {/* A7: Renamed from 定義欄位 to 語詞解釋 */}
           <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2 text-center md:text-left">
-            定義欄位
+            語詞解釋
           </p>
           <div className="flex flex-col gap-3">
             {definitionSlots}


### PR DESCRIPTION
## Summary

Sub-set of #2082 professor demo feedback: 語詞理解配對 (A6/A7/A8) + 標記 (A5).
Scope: `VocabDefinitionMatchDragDrop.tsx` + `ReadingAnnotation.tsx` only.

- **A5** (ReadingAnnotation): First-use onboarding coach gated by `localStorage['annotation_onboarded']`. Shows a dismissable callout with gesture wording matched to device (swipe on touch, drag-select on mouse). After dismissal a persistent mini hint bar stays visible.
- **A6** (VocabDefinitionMatchDragDrop): Verbal feedback added. Correct → '答對了！' in emerald. Wrong → '再試試看！' in amber (was silent bounce-back with no words).
- **A7** (VocabDefinitionMatchDragDrop): Definition text enlarged `text-base` → `text-lg md:text-xl leading-relaxed`. Panel labels renamed: '定義欄位' → '語詞解釋', '語詞庫' → '本課語詞'.
- **A8** (VocabDefinitionMatchDragDrop): Detects `window.matchMedia('(pointer: coarse)')` at module load. Touch devices see '點選語詞，再點空格放入'; mouse devices see '把語詞拖到正確的解釋上'. Drop-zone placeholder text also device-aware.

## Test plan

- [ ] `cd frontend && npm run build` — passes (verified locally, 16s, 0 errors)
- [ ] `bash specs/run-ci.sh --quick` — registry OK, no pointer-rot (verified locally)
- [ ] Open PR preview → `/login` → click 學生 小明 → navigate to a lesson → ReadingAnnotation step: confirm onboarding coach appears on first visit, dismisses and shows hint bar, does not reappear after localStorage key is set
- [ ] Navigate to VocabDefinitionMatch step (drag-drop mode): verify definition text is larger, labels read '語詞解釋' / '本課語詞', wrong answer shows amber '再試試看！', correct answer shows '答對了！'
- [ ] On a touch device (or devtools coarse-pointer emulation): verify instruction reads '點選語詞，再點空格放入' and drop-zone hint reads '點選空格放入'
- [ ] On mouse device: verify instruction reads '把語詞拖到正確的解釋上'

🤖 Generated with [Claude Code](https://claude.com/claude-code)