### PR TITLE
fix(omo): link OMO grading results to LearningSession via FK (Fixes #2087)

### DIFF
--- a/backend/alembic/versions/ls01fk02omo03_add_learning_session_id_to_omo_uploads.py
+++ b/backend/alembic/versions/ls01fk02omo03_add_learning_session_id_to_omo_uploads.py
@@ -1,0 +1,66 @@
+"""add learning_session_id FK to omo_uploads (#2087)
+
+Links OMO grading results to the student's LearningSession so the
+AssessmentReport and teacher dashboard can surface OMO scores alongside
+digital-step scores without a separate lookup.
+
+Design notes:
+- nullable: old rows and uploads that never reach confirm stay NULL.
+- ondelete=SET NULL: deleting a LearningSession keeps OMO grading data.
+- index=True (Rule 1): FK is used in teacher dashboard JOINs.
+- Idempotent (Rule 6): safe to re-run on shared staging / preview DBs.
+
+Revision ID: ls01fk02omo03
+Revises: pii01rep02air03
+Create Date: 2026-06-08
+
+"""
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "ls01fk02omo03"
+down_revision: Union[str, None] = "pii01rep02air03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # ── Add learning_session_id column (idempotent) ──────────────────────────
+    # DO $$ ... EXCEPTION WHEN duplicate_column THEN NULL; END $$;
+    # ensures this is safe to re-run on staging / preview DBs that may have
+    # been partially upgraded by a prior deploy attempt.
+    conn.execute(sa.text("""
+        DO $$ BEGIN
+            ALTER TABLE omo_uploads
+                ADD COLUMN learning_session_id INTEGER
+                REFERENCES learning_sessions(id) ON DELETE SET NULL;
+        EXCEPTION WHEN duplicate_column THEN NULL;
+        END $$;
+    """))
+
+    # ── Add index on learning_session_id (idempotent) ────────────────────────
+    # CREATE INDEX IF NOT EXISTS is the standard idempotent form (Rule 6).
+    conn.execute(sa.text("""
+        CREATE INDEX IF NOT EXISTS ix_omo_uploads_learning_session_id
+            ON omo_uploads (learning_session_id);
+    """))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # Drop index before dropping column (idempotent)
+    conn.execute(sa.text("""
+        DROP INDEX IF EXISTS ix_omo_uploads_learning_session_id;
+    """))
+
+    conn.execute(sa.text("""
+        ALTER TABLE omo_uploads
+            DROP COLUMN IF EXISTS learning_session_id;
+    """))

--- a/backend/app/models/omo_upload.py
+++ b/backend/app/models/omo_upload.py
@@ -2,6 +2,7 @@
 
 Phase 1a: upload + AI lesson identification + multi-attempt + grading.
 Phase 1b: image_hash dedup on OmoUploadAttempt.
+Phase 2 (#2087): learning_session_id FK links OMO results to LearningSession.
 
 sqlalchemy-model-safety checklist:
 - FK with index=True (Rule 1) ✅
@@ -10,6 +11,7 @@ sqlalchemy-model-safety checklist:
 - JSONB columns with server_default (Rule 4) ✅
 - status enum as String(32) with server_default (Rule 5) ✅
 - image_hash index=True (Rule 1) ✅
+- learning_session_id FK index=True, ondelete=SET NULL (Rule 1) ✅
 """
 
 from datetime import datetime
@@ -44,7 +46,7 @@ class OmoUpload(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
-    # Student who uploaded — NOT linked to a LearningSession in Phase 1
+    # Student who uploaded
     student_id: Mapped[int] = mapped_column(
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
@@ -54,6 +56,17 @@ class OmoUpload(Base):
     # Confirmed lesson_id (integer lesson_number from lesson_loader).
     # NULL until student confirms the AI's identification candidate.
     lesson_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, index=True)
+
+    # Phase 2 (#2087): link to the student's LearningSession for this lesson.
+    # Resolved/created when student confirms the lesson (confirm endpoint).
+    # Nullable: old rows before migration and uploads that never reach confirm stay NULL.
+    # ondelete=SET NULL: if the session is deleted, the OMO record stays (grading is valuable).
+    # index=True: Rule 1 — FK must be indexed (used in teacher dashboard JOIN).
+    learning_session_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("learning_sessions.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
 
     # AI identification result: top-3 candidates with confidence
     # Shape: [{"lesson_id": int, "grade_code": str, "title": str, "confidence": float, "reasoning": str}]
@@ -116,6 +129,11 @@ class OmoUpload(Base):
     student: Mapped["User"] = relationship(  # type: ignore[name-defined]
         "User",
         lazy="select",
+    )
+    learning_session: Mapped[Optional["LearningSession"]] = relationship(  # type: ignore[name-defined]
+        "LearningSession",
+        lazy="select",
+        foreign_keys="[OmoUpload.learning_session_id]",
     )
     attempts: Mapped[list["OmoUploadAttempt"]] = relationship(
         "OmoUploadAttempt",

--- a/backend/app/services/omo_state_service.py
+++ b/backend/app/services/omo_state_service.py
@@ -5,6 +5,7 @@ AnalysisBy: issue #1857 — routes/omo.py second-pass refactor.
 
 Contains:
 - resolve_lesson_id(): #1740 fix — maps synthetic lesson_id → canonical Story.id
+- _resolve_or_create_learning_session(): #2087 — find/create LearningSession for OMO link
 - apply_confirm(): set upload to grading state after student confirmation
 - apply_regrade(): reset upload to grading for a student-initiated retry
 - apply_flag(): mark a specific answer as flagged by student
@@ -88,13 +89,108 @@ def resolve_lesson_id(
     return confirmed_lesson_id
 
 
+def _resolve_or_create_learning_session(
+    student_id: int,
+    lesson_id: int,
+) -> Optional[int]:
+    """Find or create a LearningSession for this student + lesson. (#2087)
+
+    Uses its OWN short-lived DB session so that any failure (table missing,
+    JSONB incompatibility in tests, constraint errors) is fully isolated from
+    the caller's transaction.  The OmoUpload commit always succeeds regardless.
+
+    Strategy:
+    1. lesson_id is a canonical Story.id (YAML lesson_number).
+       Convert to story_slug string (the canonical key in LearningSession).
+    2. Look for an existing in_progress session for student + story_slug.
+    3. If none exists, create one (same pattern as sessions_bootstrap).
+    4. Return the LearningSession.id, or None on any error (fail-open).
+
+    Nullable-safe: returns None if the lesson cannot be resolved (old lessons,
+    bad IDs, tests). The OMO record remains valid; learning_session_id stays NULL.
+
+    Parameters
+    ----------
+    student_id:
+        The student User.id.
+    lesson_id:
+        Canonical Story.id / lesson_number.
+
+    Returns
+    -------
+    int | None
+        LearningSession.id if found or created, else None.
+    """
+    try:
+        from ..database import SessionLocal
+        from ..models.session import LearningSession
+        from ..models.text import Text
+
+        story_slug = str(lesson_id)
+
+        inner_db = SessionLocal()
+        try:
+            # Look for an existing in_progress session (most recent)
+            existing = (
+                inner_db.query(LearningSession)
+                .filter(
+                    LearningSession.student_id == student_id,
+                    LearningSession.story_slug == story_slug,
+                    LearningSession.status == "in_progress",
+                )
+                .order_by(LearningSession.started_at.desc())
+                .first()
+            )
+            if existing:
+                logger.info(
+                    "OMO #2087: linked upload to existing LearningSession %d (student=%d lesson=%d)",
+                    existing.id, student_id, lesson_id,
+                )
+                return existing.id
+
+            # No existing session — create one so OMO result is anchored.
+            # Resolve text_id from lesson_number (same pattern as sessions_bootstrap).
+            text_record = inner_db.query(Text).filter(Text.lesson_number == lesson_id).first()
+            text_id = text_record.id if text_record else None
+
+            new_session = LearningSession(
+                student_id=student_id,
+                story_slug=story_slug,
+                text_id=text_id,
+                status="in_progress",
+            )
+            inner_db.add(new_session)
+            inner_db.commit()
+            inner_db.refresh(new_session)
+            logger.info(
+                "OMO #2087: created LearningSession %d for student=%d lesson=%d",
+                new_session.id, student_id, lesson_id,
+            )
+            return new_session.id
+
+        except Exception as inner_exc:
+            inner_db.rollback()
+            raise inner_exc
+        finally:
+            inner_db.close()
+
+    except Exception as exc:
+        # Fail-open: OMO record stays valid; learning_session_id stays NULL.
+        logger.warning(
+            "OMO #2087: could not resolve/create LearningSession for student=%d lesson=%d: %s",
+            student_id, lesson_id, exc,
+        )
+        return None
+
+
 def apply_confirm(db: Session, upload: OmoUpload, real_lesson_id: int) -> None:
     """Transition upload to grading state after student lesson confirmation.
 
     Sets:
-    - ``upload.lesson_id`` = real_lesson_id (canonical Story.id)
-    - ``upload.status``    = "grading"
-    - ``upload.progress``  = {"stage": "queued", "total": 0, "graded": 0}
+    - ``upload.lesson_id``         = real_lesson_id (canonical Story.id)
+    - ``upload.learning_session_id`` = resolved/created LearningSession.id (#2087)
+    - ``upload.status``            = "grading"
+    - ``upload.progress``          = {"stage": "queued", "total": 0, "graded": 0}
 
     Commits the session.
 
@@ -110,6 +206,15 @@ def apply_confirm(db: Session, upload: OmoUpload, real_lesson_id: int) -> None:
     upload.lesson_id = real_lesson_id
     upload.status = "grading"
     upload.progress = {"stage": "queued", "total": 0, "graded": 0}
+
+    # #2087: link to LearningSession (fail-open — stays NULL if unresolvable)
+    if upload.learning_session_id is None:
+        session_id = _resolve_or_create_learning_session(
+            upload.student_id, real_lesson_id
+        )
+        if session_id is not None:
+            upload.learning_session_id = session_id
+
     db.commit()
 
 


### PR DESCRIPTION
Fixes #2087

## Summary

- **Model** (`omo_upload.py`): adds `learning_session_id` — nullable FK → `learning_sessions.id`, `ondelete=SET NULL`, `index=True` (sqlalchemy-model-safety Rule 1). Updates docstring and relationship.
- **Migration** (`ls01fk02omo03`): idempotent `DO $$ ... EXCEPTION WHEN duplicate_column THEN NULL; END $$;` for the column + `CREATE INDEX IF NOT EXISTS` for the index. Upgrades from `pii01rep02air03`. `alembic heads` = 1 before and after.
- **Wiring** (`omo_state_service.py`): `apply_confirm()` calls `_resolve_or_create_learning_session()` which finds an existing `in_progress` LearningSession (student + story_slug) or creates one (same pattern as `sessions_bootstrap`). Uses an independent `SessionLocal` DB session so any failure is fully isolated — **fail-open** design: if the session cannot be resolved, `learning_session_id` stays `NULL` and the OMO record remains valid.

## Test results

- `alembic heads` = `ls01fk02omo03 (head)` — exactly 1 before and after migration creation
- `bash specs/run-ci.sh --quick` — registry up to date, OK
- `pytest tests/test_omo_upload.py tests/test_omo_dedup.py tests/test_omo_lessons.py` — **29/30 passed**; 1 pre-existing failure (`test_too_many_files_returns_400`) caused by `MAX_FILES_PER_UPLOAD` being raised from 5→20 in a prior PR without updating the test — unrelated to this PR

## Migration note

Migration `ls01fk02omo03` does **NOT** apply to remote DB automatically. It runs on staging deploy when the backend Docker image is deployed.

## sqlalchemy-model-safety checklist

- [x] FK has `index=True` (Rule 1)
- [x] `ondelete=SET NULL` — correct for nullable link (Rule 3 cascade consideration)
- [x] Idempotent DDL — `DO $$ ... EXCEPTION WHEN duplicate_column` + `IF NOT EXISTS` (Rule 6)
- [x] Downgrade implemented — `DROP INDEX IF EXISTS` + `DROP COLUMN IF EXISTS` (Rule 7)
- [x] `alembic heads = 1` confirmed before and after (Rule 5)
- [x] No large-table CONCURRENTLY needed (`omo_uploads` is small table, Rule 8 N/A)