### PR TITLE
fix(student): 學生端年級標示改為第 N 級（教授回饋 A13 補完）(Fixes #2120)

### DIFF
--- a/frontend/src/components/student/RecommendedStories.tsx
+++ b/frontend/src/components/student/RecommendedStories.tsx
@@ -21,15 +21,7 @@ import { useAuth } from '../../contexts/AuthContext';
 // ── Grade display helper ─────────────────────────────────────────────────────
 
 function gradeLabel(grade: number): string {
-  const labels: Record<number, string> = {
-    4: '四年級',
-    5: '五年級',
-    6: '六年級',
-    7: '七年級',
-    8: '八年級',
-    9: '九年級',
-  };
-  return labels[grade] ?? `${grade} 年級`;
+  return `第 ${grade} 級`;
 }
 
 // ── Tooltip component ────────────────────────────────────────────────────────

--- a/frontend/src/components/student/StoryCard.tsx
+++ b/frontend/src/components/student/StoryCard.tsx
@@ -73,7 +73,7 @@ const StoryCard: React.FC<StoryCardProps> = ({ story, isLoading, isCompleted, on
         <div className="absolute top-2 right-2 flex flex-col items-end gap-1">
           {story.grade && (
             <div className="bg-accent text-white text-xs font-bold px-2 py-0.5 rounded">
-              {story.grade}年級
+              第 {story.grade} 級
             </div>
           )}
           <div className={`text-xs font-medium px-2 py-0.5 rounded ${diffConfig.className}`}>

--- a/frontend/src/components/tools/LessonPicker.tsx
+++ b/frontend/src/components/tools/LessonPicker.tsx
@@ -14,13 +14,9 @@ interface LessonPickerProps {
   onChange: (story: Story | null) => void;
 }
 
-const GRADE_LABELS: Record<number, string> = {
-  3: '三年級',
-  4: '四年級',
-  5: '五年級',
-  6: '六年級',
-  7: '七年級',
-};
+function gradeToLevelLabel(grade: number): string {
+  return `第 ${grade} 級`;
+}
 
 const LessonPicker: React.FC<LessonPickerProps> = ({ selectedId, onChange }) => {
   const { token } = useAuth();
@@ -89,7 +85,7 @@ const LessonPicker: React.FC<LessonPickerProps> = ({ selectedId, onChange }) => 
                 : 'bg-white text-gray-600 border border-gray-200 hover:border-accent'
             }`}
           >
-            {GRADE_LABELS[g] ?? `${g}年級`}
+            {gradeToLevelLabel(g)}
           </button>
         ))}
       </div>
@@ -181,7 +177,7 @@ const LessonPicker: React.FC<LessonPickerProps> = ({ selectedId, onChange }) => 
                   <span className="block text-sm font-medium truncate">{story.title}</span>
                   {story.grade && (
                     <span className="text-xs text-gray-400">
-                      {GRADE_LABELS[story.grade] ?? `${story.grade}年級`}
+                      {gradeToLevelLabel(story.grade)}
                       {story.genre ? ` · ${story.genre}` : ''}
                     </span>
                   )}

--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -267,7 +267,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
             selectedGrade === null ? 'bg-accent text-white' : 'bg-white text-gray-600 border border-gray-200 hover:border-accent'
           }`}
         >
-          全部年級
+          全部級別
         </button>
         {availableGrades.map((grade) => (
           <button
@@ -277,7 +277,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
               selectedGrade === grade ? 'bg-accent text-white' : 'bg-white text-gray-600 border border-gray-200 hover:border-accent'
             }`}
           >
-            {grade}年級
+            第 {grade} 級
           </button>
         ))}
 

--- a/frontend/src/pages/student/StudentProfile.tsx
+++ b/frontend/src/pages/student/StudentProfile.tsx
@@ -205,7 +205,7 @@ const StudentProfile: React.FC = () => {
                     <p className="text-xs text-gray-500 mt-0.5">老師：{c.teacher_name}</p>
                   </div>
                   {c.grade != null && (
-                    <span className="shrink-0 text-xs text-gray-400">{c.grade} 年級</span>
+                    <span className="shrink-0 text-xs text-gray-400">第 {c.grade} 級</span>
                   )}
                 </li>
               ))}


### PR DESCRIPTION
Fixes #2120

## Summary

教授 6/5 demo 回饋 (A13)：學生端一律改為「第 N 級」，避免年長學生閱讀低年段教材時尷尬。Intro 頁在 #2096 已改，此 PR 補完其餘學生端位置。

變更為純 **display string**，未異動任何資料欄位、API 或 grade_code。

## 修改檔案

| 檔案 | 舊字串 | 新字串 |
|------|-------|-------|
| `StoryCard.tsx` | `{N}年級` (badge) | `第 {N} 級` |
| `StoryLibrary.tsx` | `全部年級` / `{N}年級` (filter tabs) | `全部級別` / `第 {N} 級` |
| `RecommendedStories.tsx` | `gradeLabel()` 回傳 四/五/六年級… | `第 N 級` (簡化 helper) |
| `StudentProfile.tsx` | `{N} 年級` (班級列) | `第 {N} 級` |
| `LessonPicker.tsx` | `GRADE_LABELS` map + fallback `${g}年級` | `gradeToLevelLabel()` helper |

## 未修改（教師/管理員端）

`StoryTagEditor.tsx`, `ReadingGoalsForm.tsx`, `admin/*.tsx`, `HelpPage.tsx` — 保持「年級」原字。

## Test plan

- [ ] PR Preview 部署完成後，以「學生 小明」登入 `/login`
- [ ] `/library` 篩選列顯示「全部級別」、「第 4 級」、「第 5 級」…
- [ ] 課文卡右上角 badge 顯示「第 N 級」
- [ ] `/profile` 班級列顯示「第 N 級」
- [ ] `/tools` 課文選取器 tab 顯示「第 N 級」
- [ ] 教師端 `/teacher` 和 admin 端仍顯示「年級」字樣（未被動到）
- [ ] `npm run build` 通過（已本機驗證）
- [ ] `bash specs/run-ci.sh --quick` 通過（已本機驗證）