### PR TITLE
feat(full-reading): accuracy-only pass/fail + encouragement feedback — Block 1 (Fixes part of #2131)

### DIFF
--- a/frontend/src/utils/fluencyAnalyzer.test.ts
+++ b/frontend/src/utils/fluencyAnalyzer.test.ts
@@ -189,3 +189,119 @@ describe('getThresholdsFromBenchmark — lesson-aware (Bug B)', () => {
     expect(thresholds!.accuracyPass).toBe(0.80);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Block 1 (Issue #2131): passed = accuracyPassed only; encouragement-first feedback
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { analyzeFluency } from './fluencyAnalyzer';
+
+describe('analyzeFluency — passed uses accuracy only (Issue #2131)', () => {
+  // Scenario: high accuracy but slow speed → should PASS after fix
+  it('passes when accuracy is high even if speed is below threshold', () => {
+    // target text of 20 chars; read in 30s → CPM = 20/30*60 = 40 (well below any threshold)
+    // accuracy: read all 20 chars correctly → matchRate ≥ 0.80
+    const target = '春風吹過田野花兒開了我愛讀書學習進步';
+    const result = analyzeFluency({
+      spoken: target, // perfect reading
+      target,
+      durationMs: 30_000, // 30s → CPM ≈ 36 (very slow)
+      thresholds: { cpmPass: 120, accuracyPass: 0.80 },
+    });
+    expect(result.accuracyPassed).toBe(true);
+    expect(result.speedPassed).toBe(false); // slow
+    expect(result.passed).toBe(true); // <-- FAILS before fix (was: accuracyPassed && speedPassed)
+  });
+
+  // Scenario: low accuracy + low speed → should NOT pass
+  it('does not pass when accuracy is below threshold', () => {
+    const target = '春風吹過田野花兒開了我愛讀書學習進步';
+    const result = analyzeFluency({
+      spoken: '123456', // garbage
+      target,
+      durationMs: 5_000,
+      thresholds: { cpmPass: 120, accuracyPass: 0.80 },
+    });
+    expect(result.accuracyPassed).toBe(false);
+    expect(result.passed).toBe(false);
+  });
+
+  // Scenario: high accuracy + high speed → should still pass
+  it('passes when both accuracy and speed are high', () => {
+    const target = '春風吹過田野花兒開了我愛讀書學習進步';
+    const result = analyzeFluency({
+      spoken: target,
+      target,
+      durationMs: 2_000, // 2s → CPM ≈ 540 (very fast)
+      thresholds: { cpmPass: 120, accuracyPass: 0.80 },
+    });
+    expect(result.accuracyPassed).toBe(true);
+    expect(result.speedPassed).toBe(true);
+    expect(result.passed).toBe(true);
+  });
+
+  // Scenario: speedPassed is still computed (for display purposes)
+  it('still computes speedPassed for display even when it does not affect passed', () => {
+    const target = '春風吹過田野花兒開了';
+    const result = analyzeFluency({
+      spoken: target,
+      target,
+      durationMs: 30_000, // slow
+      thresholds: { cpmPass: 120, accuracyPass: 0.80 },
+    });
+    expect(result.speedPassed).toBe(false); // computed
+    expect(typeof result.cpm).toBe('number');
+    expect(result.cpm).toBeGreaterThan(0);
+  });
+});
+
+describe('generateFeedback — encouragement-first, no negative speed language (Issue #2131)', () => {
+  // The feedback is embedded in FluencyResult.feedback from analyzeFluency()
+  // We verify the new message strings via result.feedback
+
+  it('accurate reader gets positive feedback without negative speed mention', () => {
+    const target = '春風吹過田野花兒開了我愛讀書學習進步';
+    const result = analyzeFluency({
+      spoken: target,
+      target,
+      durationMs: 30_000, // slow
+      thresholds: { cpmPass: 120, accuracyPass: 0.80 },
+    });
+    expect(result.accuracyPassed).toBe(true);
+    // Old feedback: "讀得很準確！速度再練快一點就完美了。" (negative speed message)
+    // New feedback: should NOT contain "速度不過" pattern and should be encouraging
+    expect(result.feedback).not.toContain('速度再練快一點就完美了');
+    expect(result.feedback).not.toContain('速度不過');
+    // Should be positive/encouraging
+    expect(result.feedback.length).toBeGreaterThan(0);
+  });
+
+  it('highly accurate reader (≥0.75) gets very positive feedback', () => {
+    const target = '春風吹過田野花兒開了我愛讀書學習進步';
+    const result = analyzeFluency({
+      spoken: target,
+      target,
+      durationMs: 30_000,
+      thresholds: { cpmPass: 120, accuracyPass: 0.80 },
+    });
+    // accuracy should be near 1.0 for perfect reading
+    expect(result.accuracy).toBeGreaterThanOrEqual(0.75);
+    // Should get the top-tier positive feedback
+    expect(result.feedback).toMatch(/流暢|棒|很好|不錯/);
+  });
+
+  it('low accuracy reader gets encouragement to keep practicing', () => {
+    const target = '春風吹過田野花兒開了我愛讀書學習進步';
+    const result = analyzeFluency({
+      spoken: '一二三四五', // very wrong
+      target,
+      durationMs: 5_000,
+      thresholds: { cpmPass: 120, accuracyPass: 0.80 },
+    });
+    expect(result.accuracyPassed).toBe(false);
+    // Should be encouraging, not punishing
+    expect(result.feedback).toMatch(/練|進步|多/);
+    // Should NOT say "速度不過" or blame speed
+    expect(result.feedback).not.toContain('速度不過');
+  });
+});

--- a/frontend/src/utils/fluencyAnalyzer.ts
+++ b/frontend/src/utils/fluencyAnalyzer.ts
@@ -60,13 +60,21 @@ export interface BenchmarkLevelSec {
 
 export type ParsedBenchmark = BenchmarkLevel | BenchmarkLevelSec;
 
-function generateFeedback(speedPassed: boolean, accuracyPassed: boolean): string {
-  if (speedPassed && accuracyPassed)
-    return '太棒了！速度和準確度都過關了！';
-  if (accuracyPassed && !speedPassed)
-    return '讀得很準確！速度再練快一點就完美了。';
-  if (speedPassed && !accuracyPassed)
-    return '速度很好！不過有些字要再練一練，讀慢一點沒關係。';
+/**
+ * Encouragement-first feedback (Issue #2131).
+ * Speed (CPM) is no longer a pass/fail criterion and never appears in feedback —
+ * it stays display-only on the score card. Feedback tiers are accuracy-based only:
+ *   - accuracy >= 0.75: top tier, very fluent
+ *   - accuracy >= 0.55: mid tier, decent
+ *   - else: encourage to keep practising
+ */
+function generateFeedback(accuracy: number): string {
+  if (accuracy >= 0.75) {
+    return '讀得很流暢！繼續保持，越來越棒！';
+  }
+  if (accuracy >= 0.55) {
+    return '讀得不錯！多練幾次，準確度會越來越高。';
+  }
   return '沒關係，多練幾次就會進步！先把每一段練熟，再挑戰全文。';
 }
 
@@ -87,7 +95,8 @@ export function analyzeFluency(input: {
 
   const accuracyPassed = diffResult.matchRate >= thresholds.accuracyPass;
   const speedPassed = cpm >= thresholds.cpmPass;
-  const passed = accuracyPassed && speedPassed;
+  // Issue #2131: passed is accuracy-only; speedPassed is kept for display reference only.
+  const passed = accuracyPassed;
 
   const errorBreakdown: ErrorBreakdown = {
     correct: diffResult.correctCount,
@@ -107,7 +116,7 @@ export function analyzeFluency(input: {
     errorBreakdown,
     diffTokens: diffResult.tokens,
     thresholds,
-    feedback: generateFeedback(speedPassed, accuracyPassed),
+    feedback: generateFeedback(diffResult.matchRate),
   };
 }
 

--- a/frontend/src/utils/personaConfig.ts
+++ b/frontend/src/utils/personaConfig.ts
@@ -21,7 +21,12 @@ export const READING_PASS = 0.60; // ≥60%: 很好，過關
 // Grade-based defaults (from lesson YAML research, Issue #1378):
 //   G4: 190 | G5: 200 | G6: 210 | G7-G9: 220
 // The floor of 120 is from 臺師大 Brain & Learning Lab (G2+ minimum).
-export const FULLREADING_CPM_PASS = 120; // global fallback — prefer lesson YAML
+// Issue #2131: CPM (speed) no longer contributes to pass/fail.
+// analyzeFluency() now uses passed = accuracyPassed only.
+// FULLREADING_CPM_PASS is retained so getThresholdsFromBenchmark() can still
+// compute speedPassed for display purposes (SelfAssessment aiRating) and
+// for the learning-unit benchmark reference shown in ReadingMetricsCard.
+export const FULLREADING_CPM_PASS = 120; // display reference — NOT a pass/fail gate (Issue #2131)
 export const FULLREADING_ACCURACY_PASS = 0.80;
 
 // Grade-based CPM pass defaults (fallback when no lesson YAML present)


### PR DESCRIPTION
## Summary

Block 1 of Issue #2131 — FullReading STT upgrade.

**Problem**: Students who read accurately but slowly were shown "not passing" (speed AND accuracy both required). Discouraging UX.

**Fix (Block 1 — low risk, frontend-only)**:
- `analyzeFluency`: `passed = accuracyPassed` only. Speed (`speedPassed`) is still computed and returned for display/reference but does not gate passing.
- `generateFeedback`: accuracy-tier encouragement messages. No negative speed language.
  - accuracy ≥ 0.75 → "讀得很流暢！繼續保持，越來越棒！"
  - accuracy ≥ 0.55 → "讀得不錯！多練幾次，準確度會越來越高。"
  - else → "沒關係，多練幾次就會進步！"
- `personaConfig`: annotate `FULLREADING_CPM_PASS` as display-reference only (not a pass/fail gate).
- Star tiers in `FullReadingScoreCard` were already accuracy-based — no change needed.
- CPM display in `ReadingMetricsCard` shows the number as reference — no "不過關" text — already correct.

## Test plan

- 7 new TDD tests in `fluencyAnalyzer.test.ts`: accuracy-only pass logic + feedback tier strings
- All 38 tests pass (`vitest run fluencyAnalyzer.test.ts fullReading.test.ts`)
- `specs/run-ci.sh --quick` registry green

## Scope

This is **Block 1 only** — no backend changes, no audio recording, no Gemini calls.
Block 3 (Gemini audio STT) + Block 2 (punctuation reinsertion) follow in a separate PR.

## Related

Part of #2131