### PR TITLE
fix(learning): 浮動 step CTA 抬高避開持久 footer nav (Fixes #2137)

### DIFF
--- a/frontend/src/components/reading-steps/ComprehensionChat.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionChat.tsx
@@ -351,7 +351,7 @@ const ComprehensionChat: React.FC<ComprehensionChatProps> = ({
 
       {/* ── Fixed bottom CTA — shows after MCQ (or structure) is complete ── */}
       {isWorksheetComplete && (
-        <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+        <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
              style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
           <div className="max-w-md mx-auto pointer-events-auto">
             {isToolboxMode() ? (

--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -292,7 +292,7 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
         </div>
 
         {/* Fixed bottom CTA */}
-        <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+        <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
              style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
           <div className="max-w-md mx-auto pointer-events-auto flex flex-col gap-2">
             {isToolboxMode() ? (

--- a/frontend/src/components/reading-steps/KnowledgeStation.tsx
+++ b/frontend/src/components/reading-steps/KnowledgeStation.tsx
@@ -114,7 +114,7 @@ const KnowledgeStation: React.FC<KnowledgeStationProps> = ({ story, onFinish }) 
       </div>
 
       {/* Fixed bottom CTA */}
-      <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+      <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
            style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
         <div className="max-w-md mx-auto pointer-events-auto">
           {isToolboxMode() ? (

--- a/frontend/src/components/reading-steps/ListeningPractice.tsx
+++ b/frontend/src/components/reading-steps/ListeningPractice.tsx
@@ -219,7 +219,7 @@ const ListeningPractice: React.FC<ListeningPracticeProps> = ({ story, onFinish, 
       </div>
 
       {/* ── Fixed bottom CTA ──────────────────────────────────────── */}
-      <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+      <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
            style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
         <div className="max-w-md mx-auto pointer-events-auto flex flex-col items-center gap-3">
 

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -557,7 +557,7 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
       </div>
 
       {/* ── Fixed bottom CTA — gradient fade ─────────────────────────── */}
-      <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+      <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
            style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
         <div className="max-w-md mx-auto pointer-events-auto">
           <button

--- a/frontend/src/components/reading-steps/SentencePractice.tsx
+++ b/frontend/src/components/reading-steps/SentencePractice.tsx
@@ -265,7 +265,7 @@ const SentencePractice: React.FC<SentencePracticeProps> = ({
 
       {/* Fixed bottom CTA — only when all words done */}
       {allWordsDone && (
-        <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+        <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
              style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
           <div className="max-w-md mx-auto pointer-events-auto">
             {isToolboxMode() ? (

--- a/frontend/src/components/reading-steps/VocabDefinitionMatchSummary.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatchSummary.tsx
@@ -122,7 +122,7 @@ export function SummaryScreen({
       {renderResultSection('第二關：拖拉配對', dragDropAnswers, 'drag-drop')}
 
       {/* Fixed bottom CTA */}
-      <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+      <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
            style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
         <div className="max-w-md mx-auto pointer-events-auto flex flex-col gap-2">
           {inToolbox ? (

--- a/frontend/src/components/reading-steps/VocabPractice.tsx
+++ b/frontend/src/components/reading-steps/VocabPractice.tsx
@@ -412,7 +412,7 @@ const VocabPractice: React.FC<VocabPracticeProps> = ({ story, attempt, onFinish,
 
       {/* ── Fixed bottom CTA — only show "完成練習" when all done ──── */}
       {allDone && (
-        <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+        <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
              style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
           <div className="max-w-md mx-auto pointer-events-auto">
             {isToolboxMode() ? (

--- a/frontend/src/components/reading-steps/VocabWordSearch.tsx
+++ b/frontend/src/components/reading-steps/VocabWordSearch.tsx
@@ -340,7 +340,7 @@ export default function VocabWordSearch({ story, onFinish }: VocabWordSearchProp
 
       {/* Completion — fixed bottom CTA */}
       {finished && (
-        <div className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+        <div className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
              style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}>
           <div className="max-w-md mx-auto pointer-events-auto flex flex-col gap-2">
             {isToolboxMode() ? (

--- a/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
@@ -56,7 +56,7 @@ const FullReadingControls: React.FC<FullReadingControlsProps> = ({
 }) => {
   return (
     <div
-      className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+      className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
       style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}
     >
       <div className="max-w-md mx-auto pointer-events-auto flex flex-col items-center gap-3">

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -61,7 +61,7 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
 
   return (
     <div
-      className="fixed bottom-0 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
+      className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
       style={{ background: 'linear-gradient(to top, #FBF6EE 60%, transparent)' }}
     >
       <div className="max-w-md mx-auto pointer-events-auto flex flex-col items-center gap-3">


### PR DESCRIPTION
## 問題
教授 demo：底部浮動 CTA(完成標記等)被 StepFooterNav(#2082 A9)蓋住。

## 修法
11 個 step 元件浮動 CTA `fixed bottom-0` → `bottom-16`(footer h-16=64px),浮在 footer 正上方。純 className,無邏輯變更。

Fixes #2137

🤖 Generated with [Claude Code](https://claude.com/claude-code)