### PR TITLE
fix(learning): 移除跟讀按鈕 (Fixes #2140)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -15,7 +15,6 @@ import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { useLearningNav } from '../../contexts/LearningNavContext';
 import { useZhuyin } from '../../context/ZhuyinContext';
-import { useKaraoke } from '../../context/KaraokeContext';
 import { getMyAssignments } from '../../services/assignmentApi';
 import { AppView } from '../../types';
 import { ACTIVE_STEPS } from '../../config/stepConfig';
@@ -167,7 +166,6 @@ const ImmersiveTopBar: React.FC = () => {
   const currentView = useAppView();
   const { selectedStory, session } = useLearningNav();
   const { zhuyinMode, zhuyinReady, setZhuyinMode } = useZhuyin();
-  const { karaokeEnabled, toggleKaraoke } = useKaraoke();
 
   // #1460 — toolbox mode: single-shot practice from /tools picker.
   // Hide multi-step navigation (dots + arrows) and route the back button
@@ -306,27 +304,8 @@ const ImmersiveTopBar: React.FC = () => {
         )}
       </div>
 
-      {/* Right: karaoke toggle + zhuyin toggle */}
+      {/* Right: zhuyin toggle */}
       <div className="shrink-0 flex items-center gap-2">
-        {selectedStory && (
-          <button
-            type="button"
-            onClick={toggleKaraoke}
-            aria-pressed={karaokeEnabled}
-            aria-label={karaokeEnabled ? '關閉跟讀' : '開啟跟讀'}
-            title={karaokeEnabled ? '關閉跟讀' : '開啟跟讀'}
-            className={`relative inline-flex items-center gap-1.5 h-10 pl-3 pr-3 rounded-full font-headline font-bold text-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 active:scale-[0.95] ${
-              karaokeEnabled
-                ? 'bg-accent text-white shadow-[0_4px_16px_rgba(86,74,191,0.3)]'
-                : 'bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest'
-            }`}
-          >
-            <span className="material-symbols-outlined text-base leading-none" style={{ fontVariationSettings: "'FILL' 1" }}>
-              {karaokeEnabled ? 'lyrics' : 'lyrics'}
-            </span>
-            <span className="whitespace-nowrap hidden md:inline">跟讀</span>
-          </button>
-        )}
         {selectedStory && (
           <ZhuyinToggle
             mode={zhuyinMode}


### PR DESCRIPTION
Fixes #2140

## 問題

教授 demo 回饋（2026-06-04）：學習流程頂部工具列的「跟讀」toggle 按鈕需移除。

## 變更內容

- `frontend/src/components/layout/AppShell.tsx` - 移除跟讀按鈕 JSX、`useKaraoke` import、及 hook destructuring

## 注意

`KaraokeContext` 本身**保留未動** — `FullReading.tsx` 仍使用 `karaokeEnabled` 控制全文朗讀的 KTV 字元高亮效果。僅移除 UI 入口按鈕。

## 受影響範圍

- 移除：`ImmersiveTopBar` 右側「跟讀」toggle 按鈕（aria-label 開啟/關閉跟讀、icon = lyrics）
- 保留：注音顯示模式按鈕群（`ZhuyinToggle`）完整不動
- 保留：`KaraokeContext`、`KaraokeProvider`、`FullReading.tsx` 的 karaokeEnabled 邏輯

## TypeScript 驗證

`npx tsc --noEmit` — 無 AppShell.tsx 相關 TS error（其他 pre-existing errors 與本 PR 無關）