### PR TITLE
fix(comprehension): 閱讀理解 quiz 預設展開 + 入口字放大 (Fixes #2133)

### DIFF
--- a/frontend/src/components/reading-steps/CollapsibleRefPanel.tsx
+++ b/frontend/src/components/reading-steps/CollapsibleRefPanel.tsx
@@ -43,12 +43,13 @@ const CollapsibleRefPanel: React.FC<CollapsibleRefPanelProps> = ({
         aria-expanded={open}
         className="w-full flex items-center gap-2 px-4 py-3 hover:bg-surface-container-low transition-colors text-left"
       >
-        <span className="material-symbols-outlined text-accent text-lg">{icon}</span>
-        <span className="font-headline font-bold text-on-surface text-xs uppercase tracking-wider">
+        <span className="material-symbols-outlined text-accent text-xl">{icon}</span>
+        {/* #2133: 教授回饋「右上字體太小」— text-xs→text-base，移除對中文無意義的 uppercase */}
+        <span className="font-headline font-bold text-on-surface text-base tracking-wide">
           {label}
         </span>
         {count !== undefined && (
-          <span className="text-xs text-on-surface-variant ml-1">{count}</span>
+          <span className="text-sm text-on-surface-variant ml-1">{count}</span>
         )}
         <span
           className={`material-symbols-outlined text-on-surface-variant text-lg ml-auto transition-transform ${

--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -387,10 +387,11 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
 
             {/* Exercise — full width, BELOW the paired reading */}
             <div className="mt-4">
+              {/* #2133: 閱讀理解 quiz 預設展開（教授「應一開始就直接呈現、不必點上方小字」）*/}
               <CollapsibleRefPanel
                 icon={exerciseIcon}
                 label={exerciseLabel}
-                defaultOpen={false}
+                defaultOpen={true}
               >
                 {children}
               </CollapsibleRefPanel>
@@ -427,10 +428,11 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
                 </CollapsibleRefPanel>
               )}
 
+              {/* #2133: 閱讀理解 quiz 預設展開（教授「應一開始就直接呈現」）*/}
               <CollapsibleRefPanel
                 icon={exerciseIcon}
                 label={exerciseLabel}
-                defaultOpen={false}
+                defaultOpen={true}
               >
                 {children}
               </CollapsibleRefPanel>


### PR DESCRIPTION
## 問題（教授 demo #12）
- 閱讀理解應一開始就直接呈現、不必點上方小字（quiz panel 預設收合，桌面也是）
- 右上字體太小（CollapsibleRefPanel 入口 label `text-xs uppercase`）

## 改動
- Exercise（閱讀理解 quiz）`CollapsibleRefPanel defaultOpen` false→**true**（圖文 + 標準兩種 layout）
- 入口字 `text-xs uppercase tracking-wider`→`text-base tracking-wide`（去掉對中文無意義的 uppercase）
- icon `text-lg`→`text-xl`、count `text-xs`→`text-sm`

## 驗證
- `tsc --noEmit` 改動檔零 error
- 紙本表格 panel 維持預設收合（僅 quiz 改預設展開），避免頁面過長

🤖 Generated with [Claude Code](https://claude.com/claude-code)