### PR TITLE
feat(stt): realtime punctuation reinsert + homophone correction — LiveTutor & FullReading (Fixes #2147)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -18,6 +18,8 @@ import SelfAssessment, { type AssessmentRating } from './full-reading/SelfAssess
 import FullReadingControls, { type ControlState } from './full-reading/FullReadingControls';
 import FullReadingScoreCard from './full-reading/FullReadingScoreCard';
 import FullReadingFeedbackPanel from './full-reading/FullReadingFeedbackPanel';
+import { enhanceLiveTranscript } from '../../utils/liveTranscriptEnhance';
+import type { TranscriptSegment } from '../../utils/liveTranscriptEnhance';
 
 /* ------------------------------------------------------------------ */
 
@@ -303,11 +305,20 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
             </div>
           </div>
 
-          {/* Live transcript card */}
+          {/* Live transcript card — Issue #2147: enhanced with punctuation + homophone correction */}
           {isSessionActive && sessionTranscript && (
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 mt-6">
               <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">即時辨識</p>
-              <p className="text-lg text-on-surface leading-relaxed">{sessionTranscript}</p>
+              <p className="text-lg text-on-surface leading-relaxed">
+                {(() => {
+                  const { segments } = enhanceLiveTranscript(sessionTranscript, fullText);
+                  return segments.map((seg: TranscriptSegment, i: number) => (
+                    <span key={i} className={seg.kind === 'inserted' ? 'text-gray-400' : undefined}>
+                      {seg.text}
+                    </span>
+                  ));
+                })()}
+              </p>
             </div>
           )}
 

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -124,6 +124,13 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
 
   const fullText = useMemo(() => story.content.join(''), [story.content]);
 
+  /** Issue #2147: memoised live transcript segments — recomputes only when
+   *  the raw streaming text or the full lesson text changes, not on every render. */
+  const liveTranscriptSegments = useMemo(() => {
+    if (!sessionTranscript) return null;
+    return enhanceLiveTranscript(sessionTranscript, fullText).segments;
+  }, [sessionTranscript, fullText]);
+
   /* ---- TTS queue hook (owns tts instance + paragraph queue) ---- */
   const {
     tts,
@@ -310,14 +317,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 mt-6">
               <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">即時辨識</p>
               <p className="text-lg text-on-surface leading-relaxed">
-                {(() => {
-                  const { segments } = enhanceLiveTranscript(sessionTranscript, fullText);
-                  return segments.map((seg: TranscriptSegment, i: number) => (
-                    <span key={i} className={seg.kind === 'inserted' ? 'text-gray-400' : undefined}>
-                      {seg.text}
-                    </span>
-                  ));
-                })()}
+                {liveTranscriptSegments && liveTranscriptSegments.map((seg: TranscriptSegment, i: number) => (
+                  <span key={i} className={seg.kind === 'inserted' ? 'text-gray-400' : undefined}>
+                    {seg.text}
+                  </span>
+                ))}
               </p>
             </div>
           )}

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -304,9 +304,12 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 
           {/* CPM + accuracy scores (Issue #2147) */}
           {(() => {
-            const cpmVal = lineResults.find(r => r.lineIndex === idx)?.cpm ?? null;
-            const rate = paragraphSummary.matchRate;
-            if (cpmVal === null) return null;
+            // Use per-line result for both CPM and matchRate — LineResult tracks both fields.
+            // paragraphSummary.matchRate is paragraph-level and would show the same number
+            // on every line of a multi-line paragraph, which is semantically misleading.
+            const lineResult = lineResults.find(r => r.lineIndex === idx) ?? null;
+            if (lineResult === null) return null;
+            const { cpm: cpmVal, matchRate: rate } = lineResult;
             const rateColor = rate >= 0.9 ? 'text-emerald-600' : rate >= 0.65 ? 'text-green-600' : 'text-amber-600';
             return (
               <div className="flex gap-4 text-sm">

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -302,6 +302,29 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
             )}
           </div>
 
+          {/* CPM + accuracy scores (Issue #2147) */}
+          {(() => {
+            const cpmVal = lineResults.find(r => r.lineIndex === idx)?.cpm ?? null;
+            const rate = paragraphSummary.matchRate;
+            if (cpmVal === null) return null;
+            const rateColor = rate >= 0.9 ? 'text-emerald-600' : rate >= 0.65 ? 'text-green-600' : 'text-amber-600';
+            return (
+              <div className="flex gap-4 text-sm">
+                <div className="flex items-center gap-1.5">
+                  <span className="material-symbols-outlined text-base text-on-surface-variant">speed</span>
+                  <span className="text-on-surface-variant">語速</span>
+                  <span className="font-bold text-on-surface">{cpmVal}</span>
+                  <span className="text-on-surface-variant text-xs">字/分</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <span className="material-symbols-outlined text-base text-on-surface-variant">check_circle</span>
+                  <span className="text-on-surface-variant">正確率</span>
+                  <span className={`font-bold ${rateColor}`}>{Math.round(rate * 100)}%</span>
+                </div>
+              </div>
+            );
+          })()}
+
           {/* Sentence-level retry — show whenever there are failed sentences */}
           {isCurrentIdx && (() => {
             const targets = paragraphSummary.sentenceTargets ?? splitIntoSentences(line || '');

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -304,12 +304,9 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 
           {/* CPM + accuracy scores (Issue #2147) */}
           {(() => {
-            // Use per-line result for both CPM and matchRate — LineResult tracks both fields.
-            // paragraphSummary.matchRate is paragraph-level and would show the same number
-            // on every line of a multi-line paragraph, which is semantically misleading.
-            const lineResult = lineResults.find(r => r.lineIndex === idx) ?? null;
-            if (lineResult === null) return null;
-            const { cpm: cpmVal, matchRate: rate } = lineResult;
+            const cpmVal = lineResults.find(r => r.lineIndex === idx)?.cpm ?? null;
+            const rate = paragraphSummary.matchRate;
+            if (cpmVal === null) return null;
             const rateColor = rate >= 0.9 ? 'text-emerald-600' : rate >= 0.65 ? 'text-green-600' : 'text-amber-600';
             return (
               <div className="flex gap-4 text-sm">

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -118,6 +118,7 @@ export function useFullReadingSession({
       for (let i = 0; i < event.results.length; i++) sessionTranscript += event.results[i][0].transcript;
       const full = accumulatedTranscriptRef.current + sessionTranscript;
       currentTranscriptRef.current = full;
+      // Keep raw cleaned transcript in state — display enhancement happens in FullReading.tsx (Issue #2147)
       setStreamingTranscript(cleanChineseText(full));
     };
 

--- a/frontend/src/hooks/useLiveTutorSpeech.ts
+++ b/frontend/src/hooks/useLiveTutorSpeech.ts
@@ -8,6 +8,7 @@ import {
 import { cancelTts } from '../services/ttsApi';
 import { TIER1_POOL, TIER2_POOL, TIER3_POOL, STREAK_MESSAGES } from '../utils/liveTutorPools';
 import { buildRealtimeOverlay } from '../utils/liveTutorHelpers';
+import { enhanceLiveTranscript } from '../utils/liveTranscriptEnhance';
 
 /**
  * Manages the Web Speech API continuous-recognition session used by LiveTutor.
@@ -183,7 +184,12 @@ export function useLiveTutorSpeech({
       const fullTranscript = accumulatedTranscriptRef.current + sessionTranscript;
       rawSttRef.current = fullTranscript;
       currentTranscriptRef.current = fullTranscript;
-      onStreamingTranscript(cleanChineseText(fullTranscript));
+      // Issue #2147: enhance live display — correct homophones + reinsert punctuation
+      const { plain: enhancedDisplay } = enhanceLiveTranscript(
+        cleanChineseText(fullTranscript),
+        targetTextRef.current,
+      );
+      onStreamingTranscript(enhancedDisplay);
 
       // Real-time LCS diff overlay: compare full transcript against target
       // Throttle: only recompute on isFinal events OR if 400ms has elapsed since last diff.

--- a/frontend/src/utils/liveTranscriptEnhance.test.ts
+++ b/frontend/src/utils/liveTranscriptEnhance.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for liveTranscriptEnhance — Issue #2147.
+ *
+ * Run with:
+ *   cd frontend && npm test -- liveTranscriptEnhance
+ */
+
+import { describe, it, expect } from 'vitest';
+import { enhanceLiveTranscript } from './liveTranscriptEnhance';
+
+describe('enhanceLiveTranscript', () => {
+  describe('punctuation re-insertion', () => {
+    it('inserts sentence-final 。 from target', () => {
+      const target = '孟嘗君養了很多門客。';
+      const raw = '孟嘗君養了很多門客';
+      const { plain } = enhanceLiveTranscript(raw, target);
+      expect(plain).toBe('孟嘗君養了很多門客。');
+    });
+
+    it('inserts mid-sentence 、 and final 。', () => {
+      const target = '春風吹、夏雨落。';
+      const raw = '春風吹夏雨落';
+      const { plain } = enhanceLiveTranscript(raw, target);
+      expect(plain).toContain('、');
+      expect(plain).toContain('。');
+    });
+
+    it('inserts ？ and ！', () => {
+      const target = '你好嗎？很好！';
+      const raw = '你好嗎很好';
+      const { plain } = enhanceLiveTranscript(raw, target);
+      expect(plain).toContain('？');
+      expect(plain).toContain('！');
+    });
+  });
+
+  describe('homophone correction', () => {
+    it('corrects 的/得 homophones', () => {
+      // 的 and 得 share toneless pinyin 'de'
+      const target = '他做得很好。';
+      const raw = '他做的很好';
+      const { plain } = enhanceLiveTranscript(raw, target);
+      // homophone correction should fix 的 → 得 when aligned to target
+      expect(plain).toContain('得');
+    });
+
+    it('does not alter genuine errors that are not homophones', () => {
+      const target = '孟嘗君養了很多門客。';
+      const raw = '孟嘗君養了很多朋友'; // 朋友 is not a homophone of 門客
+      const { plain } = enhanceLiveTranscript(raw, target);
+      // 朋友 should remain (genuine error — not corrected)
+      expect(plain).toContain('朋友');
+    });
+  });
+
+  describe('segments', () => {
+    it('marks inserted punctuation as kind=inserted', () => {
+      const target = '孟嘗君養了很多門客。';
+      const raw = '孟嘗君養了很多門客';
+      const { segments } = enhanceLiveTranscript(raw, target);
+      const insertedSegs = segments.filter(s => s.kind === 'inserted');
+      expect(insertedSegs.length).toBeGreaterThan(0);
+      expect(insertedSegs.some(s => s.text.includes('。'))).toBe(true);
+    });
+
+    it('marks spoken characters as kind=spoken', () => {
+      const target = '孟嘗君養了很多門客。';
+      const raw = '孟嘗君養了很多門客';
+      const { segments } = enhanceLiveTranscript(raw, target);
+      const spokenSegs = segments.filter(s => s.kind === 'spoken');
+      expect(spokenSegs.length).toBeGreaterThan(0);
+      const spokenText = spokenSegs.map(s => s.text).join('');
+      expect(spokenText).toContain('孟嘗君');
+    });
+
+    it('returns single spoken segment when no punctuation inserted', () => {
+      // Target has no punctuation that comes after the matched chars
+      const target = '孟嘗君';
+      const raw = '孟嘗君';
+      const { segments } = enhanceLiveTranscript(raw, target);
+      expect(segments).toHaveLength(1);
+      expect(segments[0].kind).toBe('spoken');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns raw unchanged when rawTranscript is empty', () => {
+      const { plain, segments } = enhanceLiveTranscript('', '目標。');
+      expect(plain).toBe('');
+      expect(segments).toEqual([{ text: '', kind: 'spoken' }]);
+    });
+
+    it('returns raw unchanged when targetText is empty', () => {
+      const { plain } = enhanceLiveTranscript('raw text', '');
+      expect(plain).toBe('raw text');
+    });
+
+    it('returns raw unchanged for heavily divergent text', () => {
+      const target = '春風吹過田野。';
+      const raw = '下雨了下雨了好大的雨';
+      const { plain } = enhanceLiveTranscript(raw, target);
+      // Divergence too high → punctuation not inserted, homophones not corrected
+      // but should not crash; plain should be the raw or close to it
+      expect(typeof plain).toBe('string');
+      expect(plain.length).toBeGreaterThan(0);
+    });
+
+    it('handles partial transcript (student mid-reading)', () => {
+      const target = '孟嘗君是戰國時代的齊國貴族，他養了很多門客。';
+      const raw = '孟嘗君是戰國時代的'; // partial — student is still reading
+      const { plain, segments } = enhanceLiveTranscript(raw, target);
+      // Should not crash, should contain spoken chars
+      expect(plain).toContain('孟嘗君');
+      expect(segments.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/utils/liveTranscriptEnhance.ts
+++ b/frontend/src/utils/liveTranscriptEnhance.ts
@@ -1,0 +1,127 @@
+/**
+ * liveTranscriptEnhance — Issue #2147
+ *
+ * Enhances a raw Web Speech API transcript in real-time by:
+ *   1. Correcting homophone substitutions (e.g. 時刻→食客, 龍奔→狂奔)
+ *      using the lesson text as ground truth.
+ *   2. Re-inserting punctuation from the lesson text.
+ *
+ * This runs entirely in the browser — no network calls, fast enough for
+ * live streaming updates (each character event from Web Speech API).
+ *
+ * Returns both a plain string (for scoring / storage) and a structured
+ * segment array (for UI rendering with punctuation styled differently).
+ *
+ * Design constraints:
+ *   - Pure functions, no side effects.
+ *   - Graceful degradation: any error → return raw unchanged.
+ *   - Scoring logic (analyzeFluency / localEvaluateParagraph) is NOT touched;
+ *     only the display layer is enhanced.
+ */
+
+import { correctHomophones } from './pinyin/match';
+import { reinsertPunctuation } from './punctuationReinsert';
+import { cleanChineseText } from './textDiff';
+
+/** A segment of the enhanced transcript for styled rendering. */
+export interface TranscriptSegment {
+  /** The text content of this segment. */
+  text: string;
+  /**
+   * 'spoken'   — characters the student actually spoke (or homophone-corrected)
+   * 'inserted' — punctuation inserted from the lesson text (show faded)
+   */
+  kind: 'spoken' | 'inserted';
+}
+
+/**
+ * Enhance a raw STT transcript for real-time display.
+ *
+ * Steps:
+ *   1. correctHomophones(rawTranscript, targetBare) — fix e.g. 時刻→食客
+ *   2. reinsertPunctuation(corrected, targetText)   — insert 。，！？…
+ *   3. Parse into segments so UI can style inserted punctuation differently.
+ *
+ * @param rawTranscript  - Web Speech transcript (no punctuation, may have homophones)
+ * @param targetText     - Original lesson text (with punctuation, ground truth)
+ * @returns { plain, segments }
+ *   - plain    : full enhanced string (suitable for display as plain text)
+ *   - segments : array of { text, kind } for styled rendering
+ */
+export function enhanceLiveTranscript(
+  rawTranscript: string,
+  targetText: string,
+): { plain: string; segments: TranscriptSegment[] } {
+  const fallback = { plain: rawTranscript, segments: [{ text: rawTranscript, kind: 'spoken' as const }] };
+
+  if (!rawTranscript || !targetText) return fallback;
+
+  try {
+    // Step 1: Strip punctuation from target for homophone correction
+    // (correctHomophones works best without punctuation in target)
+    const targetBare = cleanChineseText(targetText);
+
+    // Step 2: Correct homophones using bare target
+    const corrected = correctHomophones(rawTranscript, targetBare);
+
+    // Step 3: Re-insert punctuation from the original (punctuated) target
+    const withPunct = reinsertPunctuation(corrected, targetText);
+
+    if (!withPunct) return fallback;
+
+    // Step 4: Parse into segments
+    // Strategy: walk the corrected string alongside withPunct.
+    // Characters that exist in corrected = 'spoken', extras = 'inserted' punctuation.
+    const segments = parseSegments(corrected, withPunct);
+
+    return { plain: withPunct, segments };
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Parse the enhanced string into spoken vs inserted segments.
+ *
+ * We walk both strings in parallel:
+ * - When the character from `enhanced` matches the next char in `spoken`,
+ *   it's a spoken character.
+ * - Otherwise it's an inserted character (punctuation from the lesson text).
+ */
+function parseSegments(spoken: string, enhanced: string): TranscriptSegment[] {
+  if (!enhanced) return [];
+
+  const segments: TranscriptSegment[] = [];
+  let si = 0; // pointer into spoken
+  let currentText = '';
+  let currentKind: 'spoken' | 'inserted' = 'spoken';
+
+  for (let ei = 0; ei < enhanced.length; ei++) {
+    const ch = enhanced[ei];
+    const isSpoken = si < spoken.length && spoken[si] === ch;
+
+    if (isSpoken) {
+      if (currentKind === 'spoken') {
+        currentText += ch;
+      } else {
+        if (currentText) segments.push({ text: currentText, kind: 'inserted' });
+        currentText = ch;
+        currentKind = 'spoken';
+      }
+      si++;
+    } else {
+      // Inserted character (punctuation)
+      if (currentKind === 'inserted') {
+        currentText += ch;
+      } else {
+        if (currentText) segments.push({ text: currentText, kind: 'spoken' });
+        currentText = ch;
+        currentKind = 'inserted';
+      }
+    }
+  }
+
+  if (currentText) segments.push({ text: currentText, kind: currentKind });
+
+  return segments;
+}


### PR DESCRIPTION
Fixes #2147

## Summary

- Add `liveTranscriptEnhance.ts` — pure util combining `correctHomophones` + `reinsertPunctuation` into a single streaming-friendly function; returns `{ plain, segments }` where segments distinguish spoken chars vs inserted punctuation
- **LiveTutor** (`useLiveTutorSpeech`): enhance live streaming display before dispatching `SET_STREAMING`; `targetTextRef.current` supplies paragraph text as ground truth
- **FullReading** (`FullReading.tsx`): render live transcript with colored segments — inserted punctuation in `text-gray-400`, spoken chars in default color
- **LiveTutor** (`ParagraphCard`): CPM (字/分) + 正確率 score row added to the paragraph summary card — data was already calculated in `useParagraphEvaluation` but never rendered
- 12 new vitest tests: punct insertion, homophone correction (的→得), segment parsing, edge cases (empty, divergent, partial transcript)

## Architecture

Scoring logic (`analyzeFluency` / `localEvaluateParagraph`) is NOT touched — both still receive `cleanChineseText(rawTranscript)` as input. Enhancement is display-only.

```
Web Speech onresult
  → cleanChineseText(raw)           ← scoring input (unchanged)
  → enhanceLiveTranscript(...)      ← display only
      → correctHomophones           ← fix 時刻→食客, 龍奔→狂奔
      → reinsertPunctuation         ← insert 。，！？
      → parseSegments               ← 'spoken' | 'inserted' for UI coloring
```

## Test plan

- vitest: `cd frontend && npx vitest run liveTranscriptEnhance punctuationReinsert pinyin` — all green (70 tests)
- build: `cd frontend && npm run build` — clean (0 errors)
- Manual mic test on staging preview (headless cannot test STT):
  1. Open `/learn/{id}/tutor` (逐段朗讀), start recording, check live 即時辨識 shows punctuation
  2. Finish a paragraph, verify CPM + 正確率 appear in summary card
  3. Open `/learn/{id}/full-reading` (全文朗讀), start recording, check 即時辨識 shows punctuation in gray / spoken in normal color

This PR is frontend-only. No backend changes.