### PR TITLE
fix(full-reading): TDZ crash — move liveTranscriptSegments useMemo below hook (#2147)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -124,13 +124,6 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
 
   const fullText = useMemo(() => story.content.join(''), [story.content]);
 
-  /** Issue #2147: memoised live transcript segments — recomputes only when
-   *  the raw streaming text or the full lesson text changes, not on every render. */
-  const liveTranscriptSegments = useMemo(() => {
-    if (!sessionTranscript) return null;
-    return enhanceLiveTranscript(sessionTranscript, fullText).segments;
-  }, [sessionTranscript, fullText]);
-
   /* ---- TTS queue hook (owns tts instance + paragraph queue) ---- */
   const {
     tts,
@@ -162,6 +155,15 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
       setHistoryRefreshKey(k => k + 1);
     }, [setResult, setStreamingTranscript, setHistoryRefreshKey]),
   });
+
+  /** Issue #2147: memoised live transcript segments — recomputes only when
+   *  the raw streaming text or the full lesson text changes, not on every render.
+   *  MUST be declared after useFullReadingSession so sessionTranscript exists
+   *  (was placed before it → "Cannot access before initialization" TDZ crash). */
+  const liveTranscriptSegments = useMemo(() => {
+    if (!sessionTranscript) return null;
+    return enhanceLiveTranscript(sessionTranscript, fullText).segments;
+  }, [sessionTranscript, fullText]);
 
   const zhuyinLines = useMemo(
     () => processLinesSelective(story.content, vocabWords),


### PR DESCRIPTION
## 問題
全文朗讀步驟在 staging render 時直接 crash：`Cannot access 'U' before initialization`（ErrorBoundary retryCount 3，整步壞掉）。/qa headless 測 staging 抓到。

## Root cause
#2151 的 P2#1 useMemo 優化把 `liveTranscriptSegments` useMemo 放在 `sessionTranscript` 宣告之前（`sessionTranscript` 從下方 useFullReadingSession() 解構）→ TDZ。build + vitest 抓不到。

## Fix
useMemo 移到 useFullReadingSession() 解構之後，純位移、行為不變。build 綠。merge 後 staging 重跑 browse QA 驗 render error 消失。