### PR TITLE
fix(annotation): demo modal close keeps coach visible + offset walk excludes ruby text (Fixes #2154)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -154,9 +154,11 @@ function OnboardingCoach({ onDismiss }: OnboardingCoachProps) {
   const [showDemo, setShowDemo] = useState(false);
   const gestureWord = IS_TOUCH ? '用手指在文字上滑過' : '用滑鼠在文字上拖曳選取';
 
+  // Bug fix (#2154): closing the demo overlay must NOT dismiss the coach box.
+  // onDismiss() writes to localStorage and hides the coach permanently — that
+  // should only happen when the user explicitly clicks "我知道了" in the coach.
   const handleDemoClose = () => {
     setShowDemo(false);
-    onDismiss();
   };
 
   return (

--- a/frontend/src/components/reading-steps/annotationOffsets.ts
+++ b/frontend/src/components/reading-steps/annotationOffsets.ts
@@ -69,9 +69,29 @@ export interface SelectionInfo {
 }
 
 /**
+ * Returns true when a node is inside a <rt> element (ruby pronunciation text).
+ * BpmfIansui renders zhuyin purely via CSS font features, so <rt> is only present
+ * when the page uses HTML ruby markup. We always skip <rt> content so that
+ * phonetic annotations never inflate char offsets.
+ */
+function isInsideRt(node: Node): boolean {
+  let cur: Node | null = node.parentNode;
+  while (cur && cur.nodeType === Node.ELEMENT_NODE) {
+    if ((cur as Element).tagName === 'RT') return true;
+    cur = cur.parentNode;
+  }
+  return false;
+}
+
+/**
  * Given a Selection that spans inside a paragraph <p data-para-idx="N">,
  * compute character offsets into the raw paragraph text.
  * Returns null if selection is empty or crosses paragraph boundaries.
+ *
+ * Bug fix (#2154): Added <rt> exclusion so ruby phonetic text nodes never
+ * contribute to the raw-character offset accumulation. Also tightened the
+ * paragraph identity check so selection offset is computed relative to
+ * the exact [data-para-idx] container that owns the selection start.
  */
 export function getSelectionInfo(): SelectionInfo | null {
   const sel = window.getSelection();
@@ -80,9 +100,22 @@ export function getSelectionInfo(): SelectionInfo | null {
   const range = sel.getRangeAt(0);
   if (range.collapsed) return null;
 
-  // Find the paragraph element from start container
-  const startEl = range.startContainer.parentElement?.closest('[data-para-idx]') as HTMLElement | null;
-  const endEl = range.endContainer.parentElement?.closest('[data-para-idx]') as HTMLElement | null;
+  // Find the [data-para-idx] paragraph element that contains each selection
+  // boundary. Walk up from the selection container node itself (not just its
+  // parentElement) so that offset computation starts from the right <p>.
+  const startNode = range.startContainer;
+  const endNode   = range.endContainer;
+
+  const startEl = (startNode.nodeType === Node.ELEMENT_NODE
+    ? (startNode as Element)
+    : startNode.parentElement
+  )?.closest('[data-para-idx]') as HTMLElement | null;
+
+  const endEl = (endNode.nodeType === Node.ELEMENT_NODE
+    ? (endNode as Element)
+    : endNode.parentElement
+  )?.closest('[data-para-idx]') as HTMLElement | null;
+
   if (!startEl || !endEl) return null;
 
   // Must be same paragraph
@@ -90,7 +123,7 @@ export function getSelectionInfo(): SelectionInfo | null {
   if (!paraIdxStr || startEl !== endEl) return null;
 
   const paragraphIndex = parseInt(paraIdxStr, 10);
-  const paraEl = startEl; // same element
+  const paraEl = startEl;
 
   // Compute char offsets relative to the original paragraph text.
   // Walk text nodes with a TreeWalker to get the actual character offset from
@@ -101,16 +134,21 @@ export function getSelectionInfo(): SelectionInfo | null {
   // Walk all text nodes inside the paragraph to find where range.startContainer
   // sits and accumulate the character offset up to range.startOffset.
   //
-  // When zhuyin is active, each text node may contain BpmfIansui PUA variant
-  // selectors (U+E01E1–U+E01E5, stored as surrogate pairs = 2 UTF-16 units
-  // each).  These inflate node.textContent.length and range.startOffset
-  // compared to the raw paragraph text.  countRawChars() strips them so the
-  // stored annotation indices always refer to raw-text positions.
+  // Rules:
+  // 1. Skip text nodes inside <rt> (HTML ruby phonetic text) — these are never
+  //    part of the raw paragraph text and must not inflate offsets.
+  // 2. When zhuyin is active, text nodes may contain BpmfIansui PUA variant
+  //    selectors (U+E01E1–U+E01E5, stored as surrogate pairs = 2 UTF-16 units
+  //    each). countRawChars() strips them so stored indices always refer to
+  //    raw-text positions.
   let charStart = 0;
   let found = false;
   const walker = document.createTreeWalker(paraEl, NodeFilter.SHOW_TEXT);
   let node: Text | null;
   while ((node = walker.nextNode() as Text | null)) {
+    // Skip phonetic ruby text — its characters are not part of the raw content.
+    if (isInsideRt(node)) continue;
+
     if (node === range.startContainer) {
       // range.startOffset is a UTF-16 offset into this text node; convert to
       // raw-character count by stripping PUA selectors up to that point.


### PR DESCRIPTION
Fixes #2154

## Summary

Two bugs in the reading-annotation step, both found via staging QA.

### Bug 1 — Demo modal close permanently dismissed the coach box

`handleDemoClose` called `onDismiss()` after `setShowDemo(false)`. `onDismiss` maps to `handleDismissCoach` which sets `showCoach = false` and writes `annotation_onboarded` to localStorage — permanently hiding the coach. Closing the demo overlay should only hide the overlay; the coach must stay visible until the user explicitly clicks "我知道了".

Fix: remove `onDismiss()` from `handleDemoClose`. The coach's own "我知道了" button is the sole dismiss path.

**File:** `frontend/src/components/reading-steps/ReadingAnnotation.tsx`

### Bug 2 — Selection offset drifts left when paragraph has pre-existing annotations

`getSelectionInfo()` in `annotationOffsets.ts` used `range.startContainer.parentElement?.closest(...)` — this misses the case where `startContainer` is an Element node rather than a Text node. Also added explicit exclusion of `<rt>` (HTML ruby phonetic text) nodes from the TreeWalker offset accumulation, so phonetic annotations never inflate raw-char offsets.

**File:** `frontend/src/components/reading-steps/annotationOffsets.ts`

## Test plan

After PR preview deploys:
1. Log in as student (小明 one-click login)
2. Navigate to `/learn/1076/reading-annotation`
3. **Bug 1**: Click "示範" → watch animated demo overlay → click "我知道了，開始標記！" → confirm the coach box (「如何標記詞語？」) is still visible
4. **Bug 2**: Mark one or two words in any paragraph → drag-select another word → confirm the right-panel "我的記號" shows the correct word (not shifted left)
5. Bug 2 with zhuyin ON: enable zhuyin, repeat step 4
6. Confirm zero new console errors

🤖 Generated with [Claude Code](https://claude.ai/code) — AI/Claude authored, not Young