### PR TITLE
feat: Gemini audio transcription for FullReading + LiveTutor — webm transcode + fallback alert (Fixes #2156)

### DIFF
--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -460,6 +460,10 @@ class TranscribeReadingResponse(BaseModel):
     reasoning: str | None = None
     """Gemini's 1-2 sentence explanation (for teacher audit). None on fallback."""
 
+    reason: str | None = None
+    """Fallback reason classification: 'timeout' | 'safety' | 'decode' | 'empty' | 'error'.
+    Only present when method='fallback'. Used by frontend to show appropriate alert."""
+
 
 @router.post(
     "/reading/transcribe",
@@ -469,8 +473,10 @@ class TranscribeReadingResponse(BaseModel):
     description=(
         "Accepts a student reading audio blob and the lesson target text.\n"
         "Returns a high-quality transcript with punctuation via Gemini audio.\n"
-        "On Gemini failure/timeout the route returns {transcript: null, method: 'fallback'} "
-        "(HTTP 200) so the caller can silently fall back to Web Speech transcript.\n"
+        "webm input is transcoded to ogg via ffmpeg before calling Gemini (Issue #2156).\n"
+        "On Gemini failure/timeout the route returns {transcript: null, method: 'fallback', "
+        "reason: <timeout|safety|decode|empty|error>} (HTTP 200) so the frontend can show "
+        "a fallback alert and use the Web Speech transcript.\n"
         "Rate-limited: 10 requests per minute per user.\n"
         "Audio: ≤10 MB, ≤120 s; MIME: audio/webm, audio/mp4, audio/ogg, audio/wav."
     ),
@@ -495,8 +501,10 @@ async def transcribe_reading_endpoint(
 
     Rate-limited to 10 requests per minute per user (shared with /reading/evaluate).
     Input caps are enforced before any AI call.
-    On any Gemini failure the route returns HTTP 200 with method='fallback' so
-    the frontend can silently fall back to the Web Speech transcript.
+    webm audio is transcoded to ogg/opus via ffmpeg before calling Gemini — this is the
+    root cause fix for Issue #2156 (Chrome records webm; Gemini only accepts ogg/wav/etc).
+    On any Gemini failure the route returns HTTP 200 with method='fallback' and a reason
+    field so the frontend can display the fallback alert banner (I4).
     """
     # ── 1. Validate MIME type (cheap, before reading bytes) ──────────────────
     raw_mime = audio.content_type or "audio/webm"
@@ -576,4 +584,5 @@ async def transcribe_reading_endpoint(
         transcript=result.get("transcript"),
         method=result["method"],
         reasoning=result.get("reasoning"),
+        reason=result.get("reason"),
     )

--- a/backend/app/services/reading_transcription_service.py
+++ b/backend/app/services/reading_transcription_service.py
@@ -5,12 +5,19 @@ transcription with punctuation using Gemini audio understanding.
 
 Design principles:
 - Backend is transcription-only; scoring stays in frontend analyzeFluency().
-- Fail-closed: any exception → return {transcript: null, method: "fallback"}
-  so the caller can fall back to the Web Speech transcript.
+- Fail-closed: any exception → return {transcript: null, method: "fallback", reason: <str>}
+  so the caller can show a fallback alert and use the Web Speech transcript.
 - No new DB schema: result is returned synchronously, not persisted here.
   The caller (route) may log AI usage; this service is stateless.
 
-Supported audio MIME types (Web browser MediaRecorder output):
+Audio format handling (Issue #2156 — Phase 0 root cause fix):
+  Chrome MediaRecorder defaults to audio/webm;codecs=opus.
+  Vertex AI Gemini audio only supports: wav / mp3 / aiff / aac / ogg / flac.
+  webm is NOT supported → sends error → silent fallback.
+  Fix: transcode webm (and any other unsupported format) → ogg via ffmpeg
+  before calling Gemini. ffmpeg is already in backend/Dockerfile.
+
+Supported input MIME types (browser MediaRecorder output — route allowlist):
     audio/webm, audio/webm;codecs=opus, audio/ogg, audio/ogg;codecs=opus,
     audio/mp4, audio/mpeg, audio/wav
 
@@ -23,7 +30,11 @@ Limits enforced by route (not repeated here):
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
+import subprocess
+import tempfile
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +49,7 @@ def _check_safety_filter(response):  # noqa: ANN001
 # Maximum audio duration we'll send to Gemini (cost + latency guard).
 MAX_AUDIO_DURATION_SEC = 120
 
-# Allowed audio MIME types (browser MediaRecorder output).
+# Allowed audio MIME types (browser MediaRecorder output — used by route for 415 gate).
 ALLOWED_AUDIO_MIMES: frozenset[str] = frozenset(
     {
         "audio/webm",
@@ -53,10 +64,104 @@ ALLOWED_AUDIO_MIMES: frozenset[str] = frozenset(
     }
 )
 
-# Normalise MIME type for Gemini (strip codec suffix — Gemini accepts base MIME).
+# MIME types that Vertex AI Gemini natively accepts (no transcoding needed).
+# Ref: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding
+_GEMINI_NATIVE_AUDIO_MIMES: frozenset[str] = frozenset(
+    {
+        "audio/wav",
+        "audio/mp3",
+        "audio/mpeg",
+        "audio/aiff",
+        "audio/aac",
+        "audio/ogg",
+        "audio/flac",
+    }
+)
+
+# Fallback reason literals (used for WARN log + frontend alert).
+_REASON_TRANSCODE = "decode"   # ffmpeg transcode failed
+_REASON_TIMEOUT   = "timeout"
+_REASON_SAFETY    = "safety"
+_REASON_EMPTY     = "empty"
+_REASON_ERROR     = "error"
+
+
 def _normalise_mime(raw: str) -> str:
     """Strip codec parameter: 'audio/webm;codecs=opus' → 'audio/webm'."""
     return raw.split(";")[0].strip()
+
+
+def _needs_transcode(mime_type: str) -> bool:
+    """Return True if the MIME type is NOT natively accepted by Gemini."""
+    base = _normalise_mime(mime_type)
+    return base not in _GEMINI_NATIVE_AUDIO_MIMES
+
+
+def _transcode_to_ogg(audio_bytes: bytes, source_mime: str) -> bytes | None:
+    """Transcode audio_bytes to ogg/opus using ffmpeg.
+
+    Returns the transcoded bytes on success, or None on ffmpeg failure.
+    Uses a temp file to avoid piping large blobs (ffmpeg stdin/stdout can be
+    unreliable for webm demuxers that need seekable input).
+    """
+    # Determine input file extension from mime
+    base = _normalise_mime(source_mime)
+    ext_map = {
+        "audio/webm": ".webm",
+        "audio/mp4":  ".mp4",
+        "audio/mpeg": ".mp3",
+    }
+    in_ext = ext_map.get(base, ".audio")
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=in_ext, delete=False) as in_f:
+            in_f.write(audio_bytes)
+            in_path = in_f.name
+
+        out_path = in_path + ".ogg"
+
+        cmd = [
+            "ffmpeg",
+            "-y",                  # overwrite output
+            "-i", in_path,         # input
+            "-vn",                 # no video
+            "-acodec", "libopus",  # opus codec inside ogg
+            "-b:a", "48k",         # 48 kbps — sufficient for speech
+            "-ar", "16000",        # 16 kHz — matches STT optimal rate
+            "-ac", "1",            # mono
+            out_path,
+        ]
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            timeout=30,            # hard timeout for transcode
+        )
+
+        if result.returncode != 0:
+            logger.warning(
+                "ffmpeg transcode failed (rc=%d): %s",
+                result.returncode,
+                result.stderr[-500:].decode("utf-8", errors="replace"),
+            )
+            return None
+
+        with open(out_path, "rb") as out_f:
+            return out_f.read()
+
+    except subprocess.TimeoutExpired:
+        logger.warning("ffmpeg transcode timed out for mime=%s", source_mime)
+        return None
+    except Exception as exc:
+        logger.warning("ffmpeg transcode error: %s", exc)
+        return None
+    finally:
+        for path in [in_path, out_path]:
+            try:
+                if os.path.exists(path):
+                    os.unlink(path)
+            except OSError:
+                pass
 
 
 async def transcribe_reading_audio(
@@ -69,7 +174,7 @@ async def transcribe_reading_audio(
 
     Args:
         audio_bytes: Raw audio bytes from browser MediaRecorder.
-        mime_type:   MIME type of the audio (e.g. "audio/webm").
+        mime_type:   MIME type of the audio (e.g. "audio/webm;codecs=opus").
         target_text: The original lesson text used as a transcription hint
                      (Gemini uses it to resolve homophones and specialised names).
         duration_ms: Recorded duration in milliseconds (informational only).
@@ -77,9 +182,9 @@ async def transcribe_reading_audio(
     Returns:
         On success:
             {"transcript": "<text with punctuation>", "method": "gemini", "reasoning": "..."}
-        On any failure (Gemini error, timeout, content filter):
-            {"transcript": None, "method": "fallback"}
-            Caller must use Web Speech transcript as fallback — never auto-pass.
+        On any failure (transcode failure, Gemini error, timeout, content filter):
+            {"transcript": None, "method": "fallback", "reason": "<timeout|safety|decode|empty|error>"}
+            Caller must show fallback alert and use Web Speech transcript — never auto-pass.
     """
     from google import genai  # noqa: PLC0415 — lazy import; not available in test envs
     from google.genai import types as genai_types  # noqa: PLC0415
@@ -87,7 +192,31 @@ async def transcribe_reading_audio(
     from .ai.gemini_client import GEMINI_TIMEOUT
     from .llm_models import get_model_for_task
 
-    normalised_mime = _normalise_mime(mime_type)
+    # ── 1. Transcode if Gemini doesn't natively support the input MIME ─────────
+    gemini_audio_bytes = audio_bytes
+    gemini_mime = "audio/ogg"  # default after transcode
+
+    if _needs_transcode(mime_type):
+        transcoded = await asyncio.to_thread(_transcode_to_ogg, audio_bytes, mime_type)
+        if transcoded is None:
+            logger.warning(
+                "Reading transcription fallback — transcode failed: mime=%s duration_ms=%s",
+                mime_type,
+                duration_ms,
+                extra={
+                    "event": "reading_transcribe_fallback",
+                    "reason": _REASON_TRANSCODE,
+                    "mime_type": mime_type,
+                    "duration_ms": duration_ms,
+                },
+            )
+            return {"transcript": None, "method": "fallback", "reason": _REASON_TRANSCODE}
+        gemini_audio_bytes = transcoded
+        gemini_mime = "audio/ogg"
+    else:
+        gemini_mime = _normalise_mime(mime_type)
+
+    # ── 2. Call Gemini ──────────────────────────────────────────────────────────
     model, location = get_model_for_task("reading_transcribe")
     client = genai.Client(vertexai=True, project="lingoleap-dev", location=location)
 
@@ -106,8 +235,8 @@ async def transcribe_reading_audio(
     user_prompt = f"課文原文（供校正參考）：\n{target_text}"
 
     audio_part = genai_types.Part.from_bytes(
-        data=audio_bytes,
-        mime_type=normalised_mime,
+        data=gemini_audio_bytes,
+        mime_type=gemini_mime,
     )
     text_part = genai_types.Part(text=user_prompt)
 
@@ -157,6 +286,20 @@ async def transcribe_reading_audio(
         transcript = parsed.get("transcript", "")
         reasoning = parsed.get("reasoning", "")
 
+        # Empty transcript from Gemini → treat as fallback (I5: never auto-pass)
+        if not transcript:
+            logger.warning(
+                "Reading transcription fallback — Gemini returned empty transcript: "
+                "duration_ms=%s",
+                duration_ms,
+                extra={
+                    "event": "reading_transcribe_fallback",
+                    "reason": _REASON_EMPTY,
+                    "duration_ms": duration_ms,
+                },
+            )
+            return {"transcript": None, "method": "fallback", "reason": _REASON_EMPTY}
+
         logger.info(
             "Reading transcription success: duration_ms=%s transcript_len=%d",
             duration_ms,
@@ -168,14 +311,34 @@ async def transcribe_reading_audio(
 
     except TimeoutError:
         logger.warning(
-            "Reading transcription timeout: duration_ms=%s", duration_ms,
-            extra={"event": "reading_transcribe_timeout"},
+            "Reading transcription fallback — timeout: duration_ms=%s",
+            duration_ms,
+            extra={
+                "event": "reading_transcribe_fallback",
+                "reason": _REASON_TIMEOUT,
+                "duration_ms": duration_ms,
+            },
         )
-        return {"transcript": None, "method": "fallback"}
+        return {"transcript": None, "method": "fallback", "reason": _REASON_TIMEOUT}
 
     except Exception as exc:
-        logger.error(
-            "Reading transcription failed: %s", exc,
-            extra={"event": "reading_transcribe_error", "error": str(exc)},
+        # Classify the reason for monitoring / alerting
+        exc_str = str(exc).lower()
+        if "safety" in exc_str or "filter" in exc_str or "block" in exc_str:
+            reason = _REASON_SAFETY
+        else:
+            reason = _REASON_ERROR
+
+        logger.warning(
+            "Reading transcription fallback — %s: %s (duration_ms=%s)",
+            reason,
+            exc,
+            duration_ms,
+            extra={
+                "event": "reading_transcribe_fallback",
+                "reason": reason,
+                "error": str(exc),
+                "duration_ms": duration_ms,
+            },
         )
-        return {"transcript": None, "method": "fallback"}
+        return {"transcript": None, "method": "fallback", "reason": reason}

--- a/backend/app/services/reading_transcription_service.py
+++ b/backend/app/services/reading_transcription_service.py
@@ -113,6 +113,11 @@ def _transcode_to_ogg(audio_bytes: bytes, source_mime: str) -> bytes | None:
     }
     in_ext = ext_map.get(base, ".audio")
 
+    # Pre-initialise to None so `finally` can safely reference them even if
+    # temp-file creation fails before in_path / out_path are assigned (P1#4).
+    in_path: str | None = None
+    out_path: str | None = None
+
     try:
         with tempfile.NamedTemporaryFile(suffix=in_ext, delete=False) as in_f:
             in_f.write(audio_bytes)
@@ -156,7 +161,10 @@ def _transcode_to_ogg(audio_bytes: bytes, source_mime: str) -> bytes | None:
         logger.warning("ffmpeg transcode error: %s", exc)
         return None
     finally:
+        # in_path / out_path may still be None if temp creation raised before assignment.
         for path in [in_path, out_path]:
+            if path is None:
+                continue
             try:
                 if os.path.exists(path):
                     os.unlink(path)

--- a/backend/specs/test_reading_transcription_spec.py
+++ b/backend/specs/test_reading_transcription_spec.py
@@ -67,47 +67,83 @@ class TestC1WebmNotDirectToGemini:
         assert _needs_transcode("audio/mpeg") is False
 
     def test_transcribe_audio_with_webm_transcodes_not_direct_gemini(self):
-        """When webm is submitted, _transcode_to_ogg must be called (not skipped)."""
+        """C1 integration: calling transcribe_reading_audio with webm MUST invoke
+        _transcode_to_ogg, and the transcoded ogg bytes (not original webm) must be
+        what eventually reaches the Gemini call path.
+
+        P2#2 fix: original test only asserted _needs_transcode static helpers and
+        never actually called transcribe_reading_audio — a webm-direct-to-Gemini
+        regression would have passed silently.  This version calls the real function.
+        """
+        import sys
         from app.services import reading_transcription_service as svc
 
-        transcoded_bytes = b"fake-ogg-data"
+        webm_bytes = b"fake-webm-input"
+        transcoded_ogg_bytes = b"fake-ogg-transcoded"
 
-        with patch.object(svc, "_transcode_to_ogg", return_value=transcoded_bytes) as mock_transcode, \
-             patch("app.services.reading_transcription_service._check_safety_filter"), \
-             patch("app.services.reading_transcription_service.asyncio.to_thread") as mock_thread, \
-             patch("app.services.reading_transcription_service.asyncio.wait_for") as mock_wait:
+        # Capture the bytes that arrive at the Gemini Part.from_bytes() call.
+        gemini_received_mime: list[str] = []
 
-            # Set up mock Gemini response
-            mock_response = MagicMock()
-            mock_response.text = '{"transcript": "學生朗讀文字", "reasoning": "清晰"}'
-            mock_wait.return_value = mock_response
+        fake_part = MagicMock()
+        fake_part_cls = MagicMock()
 
-            # Patch imports inside the function
-            import sys
-            fake_genai = MagicMock()
-            fake_genai_types = MagicMock()
-            fake_genai.Client.return_value = MagicMock()
-            fake_gemini_client = MagicMock()
-            fake_gemini_client.GEMINI_TIMEOUT = 30
-            fake_llm_models = MagicMock()
-            fake_llm_models.get_model_for_task.return_value = ("gemini-2.5-flash", "us-central1")
+        def capture_from_bytes(*args, **kwargs):  # noqa: ANN001
+            # Called as Part.from_bytes(data=..., mime_type=...) — capture mime_type
+            mime = kwargs.get("mime_type") or (args[1] if len(args) > 1 else "unknown")
+            gemini_received_mime.append(mime)
+            return fake_part
 
-            with patch.dict(sys.modules, {
-                "google": MagicMock(),
-                "google.genai": fake_genai,
-                "google.genai.types": fake_genai_types,
-            }):
-                with patch("app.services.reading_transcription_service.asyncio.to_thread") as mock_to_thread:
-                    mock_to_thread.return_value = mock_response
+        fake_part_cls.from_bytes = capture_from_bytes
 
-                    # Reimport inside patch context to trigger the lazy imports
-                    # We test _needs_transcode and _transcode_to_ogg integration directly
-                    assert svc._needs_transcode("audio/webm") is True
-                    assert svc._needs_transcode("audio/ogg") is False
+        fake_genai_types = MagicMock()
+        fake_genai_types.Part = fake_part_cls
 
-            # Confirm transcode mock was used
-            # (full async integration tested via mock in C2 tests)
-            mock_transcode.return_value = transcoded_bytes
+        mock_response = MagicMock()
+        mock_response.text = '{"transcript": "學生朗讀文字", "reasoning": "清晰"}'
+
+        fake_gemini_client = MagicMock()
+        fake_gemini_client.GEMINI_TIMEOUT = 30
+        fake_llm_models = MagicMock()
+        fake_llm_models.get_model_for_task.return_value = ("gemini-2.5-flash", "us-central1")
+
+        # The service does `from google.genai import types as genai_types` which resolves
+        # via sys.modules["google.genai"].types (not sys.modules["google.genai.types"]).
+        # We must set .types on the fake genai module so capture_from_bytes is reached.
+        fake_genai_module = MagicMock()
+        fake_genai_module.types = fake_genai_types
+
+        with patch.object(svc, "_transcode_to_ogg", return_value=transcoded_ogg_bytes) as mock_transcode, \
+             patch.object(svc, "_check_safety_filter"), \
+             patch("app.services.reading_transcription_service.asyncio.wait_for",
+                   new=AsyncMock(return_value=mock_response)), \
+             patch.dict(sys.modules, {
+                 "google": MagicMock(),
+                 "google.genai": fake_genai_module,
+                 "google.genai.types": fake_genai_types,
+                 "app.services.ai.gemini_client": fake_gemini_client,
+                 "app.services.llm_models": fake_llm_models,
+             }):
+
+            result = _run(svc.transcribe_reading_audio(
+                audio_bytes=webm_bytes,
+                mime_type="audio/webm",
+                target_text="課文文字",
+                duration_ms=3000,
+            ))
+
+        # C1 assertion 1: _transcode_to_ogg was called (not skipped) with the webm bytes.
+        mock_transcode.assert_called_once_with(webm_bytes, "audio/webm")
+
+        # C1 assertion 2: The MIME type reaching Gemini Part.from_bytes must be ogg,
+        # NOT webm — confirming transcoded bytes were used.
+        assert gemini_received_mime, "Part.from_bytes was never called — Gemini path not reached"
+        assert all(
+            m.startswith("audio/ogg") for m in gemini_received_mime
+        ), f"Expected audio/ogg MIME sent to Gemini, got: {gemini_received_mime}"
+
+        # C1 assertion 3: result comes from Gemini (not fallback).
+        assert result["method"] == "gemini"
+        assert result["transcript"] == "學生朗讀文字"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/specs/test_reading_transcription_spec.py
+++ b/backend/specs/test_reading_transcription_spec.py
@@ -1,0 +1,400 @@
+"""Executable spec — reading_transcription_service contracts (Issue #2156).
+
+spec_id: reading.transcription.gemini_primary_fallback_alert
+canonical_source: backend/app/services/reading_transcription_service.py
+owns_code:
+  - backend/app/services/reading_transcription_service.py
+  - backend/app/routes/learning/learning_reading.py (TranscribeReadingResponse)
+human_spec: specs/modules/reading-transcription/INTENT.md
+related_issues: [2131, 2156]
+
+Machine-verifiable contracts (C1–C5):
+
+  C1: webm input → does NOT pass webm directly to Gemini; transcodes first.
+  C2: Gemini error/timeout/safety/transcode failure → returns fallback + reason + WARN log.
+  C3: Gemini success → returns {transcript: str, method: "gemini", reasoning: str}.
+  C4: unsupported / empty MIME → 415 (route-level) or fallback (never 500).
+  C5: rate-limit / auth / size cap present in route (structural check).
+
+Run: cd backend && python -m pytest specs/test_reading_transcription_spec.py -v
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(coro):
+    """Run an async coroutine synchronously (compatible with pytest without anyio)."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# C1: webm input is NOT passed directly to Gemini — transcode must happen first
+# ---------------------------------------------------------------------------
+
+class TestC1WebmNotDirectToGemini:
+    """C1: webm mime type triggers transcode before Gemini call."""
+
+    def test_needs_transcode_returns_true_for_webm(self):
+        from app.services.reading_transcription_service import _needs_transcode
+        assert _needs_transcode("audio/webm") is True
+
+    def test_needs_transcode_returns_true_for_webm_with_codec(self):
+        from app.services.reading_transcription_service import _needs_transcode
+        assert _needs_transcode("audio/webm;codecs=opus") is True
+        assert _needs_transcode("audio/webm; codecs=opus") is True
+
+    def test_needs_transcode_returns_true_for_mp4(self):
+        from app.services.reading_transcription_service import _needs_transcode
+        assert _needs_transcode("audio/mp4") is True
+
+    def test_needs_transcode_returns_false_for_ogg(self):
+        from app.services.reading_transcription_service import _needs_transcode
+        assert _needs_transcode("audio/ogg") is False
+
+    def test_needs_transcode_returns_false_for_wav(self):
+        from app.services.reading_transcription_service import _needs_transcode
+        assert _needs_transcode("audio/wav") is False
+
+    def test_needs_transcode_returns_false_for_mp3(self):
+        from app.services.reading_transcription_service import _needs_transcode
+        assert _needs_transcode("audio/mpeg") is False
+
+    def test_transcribe_audio_with_webm_transcodes_not_direct_gemini(self):
+        """When webm is submitted, _transcode_to_ogg must be called (not skipped)."""
+        from app.services import reading_transcription_service as svc
+
+        transcoded_bytes = b"fake-ogg-data"
+
+        with patch.object(svc, "_transcode_to_ogg", return_value=transcoded_bytes) as mock_transcode, \
+             patch("app.services.reading_transcription_service._check_safety_filter"), \
+             patch("app.services.reading_transcription_service.asyncio.to_thread") as mock_thread, \
+             patch("app.services.reading_transcription_service.asyncio.wait_for") as mock_wait:
+
+            # Set up mock Gemini response
+            mock_response = MagicMock()
+            mock_response.text = '{"transcript": "學生朗讀文字", "reasoning": "清晰"}'
+            mock_wait.return_value = mock_response
+
+            # Patch imports inside the function
+            import sys
+            fake_genai = MagicMock()
+            fake_genai_types = MagicMock()
+            fake_genai.Client.return_value = MagicMock()
+            fake_gemini_client = MagicMock()
+            fake_gemini_client.GEMINI_TIMEOUT = 30
+            fake_llm_models = MagicMock()
+            fake_llm_models.get_model_for_task.return_value = ("gemini-2.5-flash", "us-central1")
+
+            with patch.dict(sys.modules, {
+                "google": MagicMock(),
+                "google.genai": fake_genai,
+                "google.genai.types": fake_genai_types,
+            }):
+                with patch("app.services.reading_transcription_service.asyncio.to_thread") as mock_to_thread:
+                    mock_to_thread.return_value = mock_response
+
+                    # Reimport inside patch context to trigger the lazy imports
+                    # We test _needs_transcode and _transcode_to_ogg integration directly
+                    assert svc._needs_transcode("audio/webm") is True
+                    assert svc._needs_transcode("audio/ogg") is False
+
+            # Confirm transcode mock was used
+            # (full async integration tested via mock in C2 tests)
+            mock_transcode.return_value = transcoded_bytes
+
+
+# ---------------------------------------------------------------------------
+# C2: Any failure → fallback + reason + WARN log
+# ---------------------------------------------------------------------------
+
+class TestC2FallbackReasonAndWarnLog:
+    """C2: Gemini errors / timeouts / transcode failures return fallback with reason."""
+
+    def _make_result(self, method, reason=None):
+        return {"transcript": None, "method": method, "reason": reason}
+
+    def test_fallback_result_has_required_keys(self):
+        result = self._make_result("fallback", "timeout")
+        assert result["method"] == "fallback"
+        assert result["transcript"] is None
+        assert result["reason"] == "timeout"
+
+    def test_reason_literals_are_defined(self):
+        from app.services.reading_transcription_service import (
+            _REASON_TRANSCODE,
+            _REASON_TIMEOUT,
+            _REASON_SAFETY,
+            _REASON_EMPTY,
+            _REASON_ERROR,
+        )
+        # All reasons are non-empty strings
+        for reason in (_REASON_TRANSCODE, _REASON_TIMEOUT, _REASON_SAFETY, _REASON_EMPTY, _REASON_ERROR):
+            assert isinstance(reason, str) and len(reason) > 0
+
+    def test_transcode_failure_logs_warn_with_reason(self, caplog):
+        """C2 variant: transcode fail → WARN log event=reading_transcribe_fallback reason=decode."""
+        from app.services import reading_transcription_service as svc
+
+        with patch.object(svc, "_transcode_to_ogg", return_value=None), \
+             caplog.at_level(logging.WARNING, logger="app.services.reading_transcription_service"):
+
+            import sys
+            fake_genai = MagicMock()
+            fake_genai_types = MagicMock()
+            fake_gemini_client = MagicMock()
+            fake_gemini_client.GEMINI_TIMEOUT = 30
+            fake_llm_models = MagicMock()
+            fake_llm_models.get_model_for_task.return_value = ("gemini-2.5-flash", "us-central1")
+
+            with patch.dict(sys.modules, {
+                "google": MagicMock(),
+                "google.genai": fake_genai,
+                "google.genai.types": fake_genai_types,
+                "app.services.ai.gemini_client": fake_gemini_client,
+                "app.services.llm_models": fake_llm_models,
+            }):
+                result = _run(svc.transcribe_reading_audio(
+                    audio_bytes=b"fake-webm-data",
+                    mime_type="audio/webm",
+                    target_text="課文文字",
+                    duration_ms=5000,
+                ))
+
+        assert result["method"] == "fallback"
+        assert result["reason"] == "decode"
+        assert result["transcript"] is None
+        # WARN log must be emitted — check message text (extra dict not in r.message)
+        assert any(
+            "fallback" in r.message.lower() and "transcode" in r.message.lower()
+            for r in caplog.records
+        ), f"Expected fallback+transcode WARN log, got: {[r.message for r in caplog.records]}"
+
+    def test_timeout_returns_fallback_with_timeout_reason(self, caplog):
+        """C2 variant: asyncio.TimeoutError → fallback reason=timeout + WARN log."""
+        from app.services import reading_transcription_service as svc
+
+        import sys
+        fake_genai = MagicMock()
+        fake_genai_types = MagicMock()
+        fake_gemini_client = MagicMock()
+        fake_gemini_client.GEMINI_TIMEOUT = 30
+        fake_llm_models = MagicMock()
+        fake_llm_models.get_model_for_task.return_value = ("gemini-2.5-flash", "us-central1")
+
+        async def raise_timeout(*a, **kw):
+            raise TimeoutError("timed out")
+
+        with patch.object(svc, "_needs_transcode", return_value=False), \
+             patch("asyncio.wait_for", side_effect=raise_timeout), \
+             caplog.at_level(logging.WARNING, logger="app.services.reading_transcription_service"):
+
+            with patch.dict(sys.modules, {
+                "google": MagicMock(),
+                "google.genai": fake_genai,
+                "google.genai.types": fake_genai_types,
+                "app.services.ai.gemini_client": fake_gemini_client,
+                "app.services.llm_models": fake_llm_models,
+            }):
+                result = _run(svc.transcribe_reading_audio(
+                    audio_bytes=b"fake-ogg",
+                    mime_type="audio/ogg",
+                    target_text="課文",
+                    duration_ms=3000,
+                ))
+
+        assert result["method"] == "fallback"
+        assert result["reason"] == "timeout"
+        assert result["transcript"] is None
+
+    def test_empty_transcript_returns_fallback_with_empty_reason(self, caplog):
+        """C2 variant: Gemini returns empty transcript → fallback reason=empty."""
+        from app.services import reading_transcription_service as svc
+
+        import sys
+        import json
+        fake_genai = MagicMock()
+        fake_genai_types = MagicMock()
+        fake_gemini_client = MagicMock()
+        fake_gemini_client.GEMINI_TIMEOUT = 30
+        fake_llm_models = MagicMock()
+        fake_llm_models.get_model_for_task.return_value = ("gemini-2.5-flash", "us-central1")
+
+        mock_response = MagicMock()
+        mock_response.text = json.dumps({"transcript": "", "reasoning": "no speech"})
+
+        async def fake_wait_for(coro, timeout):
+            return mock_response
+
+        with patch.object(svc, "_needs_transcode", return_value=False), \
+             patch.object(svc, "_check_safety_filter"), \
+             patch("asyncio.wait_for", side_effect=fake_wait_for), \
+             caplog.at_level(logging.WARNING, logger="app.services.reading_transcription_service"):
+
+            with patch.dict(sys.modules, {
+                "google": MagicMock(),
+                "google.genai": fake_genai,
+                "google.genai.types": fake_genai_types,
+                "app.services.ai.gemini_client": fake_gemini_client,
+                "app.services.llm_models": fake_llm_models,
+            }):
+                result = _run(svc.transcribe_reading_audio(
+                    audio_bytes=b"fake-ogg",
+                    mime_type="audio/ogg",
+                    target_text="課文",
+                    duration_ms=2000,
+                ))
+
+        assert result["method"] == "fallback"
+        assert result["reason"] == "empty"
+        assert result["transcript"] is None
+
+
+# ---------------------------------------------------------------------------
+# C3: Gemini success → transcript + method="gemini" + reasoning
+# ---------------------------------------------------------------------------
+
+class TestC3GeminiSuccessResponse:
+    """C3: Successful Gemini call returns transcript with punctuation + method=gemini."""
+
+    def test_success_returns_gemini_method_and_transcript(self):
+        from app.services import reading_transcription_service as svc
+
+        import sys
+        import json
+        fake_genai = MagicMock()
+        fake_genai_types = MagicMock()
+        fake_gemini_client = MagicMock()
+        fake_gemini_client.GEMINI_TIMEOUT = 30
+        fake_llm_models = MagicMock()
+        fake_llm_models.get_model_for_task.return_value = ("gemini-2.5-flash", "us-central1")
+
+        transcript_text = "秋天到了，樹葉慢慢變黃了。"
+        mock_response = MagicMock()
+        mock_response.text = json.dumps({"transcript": transcript_text, "reasoning": "清晰朗讀"})
+
+        async def fake_wait_for(coro, timeout):
+            return mock_response
+
+        with patch.object(svc, "_needs_transcode", return_value=False), \
+             patch.object(svc, "_check_safety_filter"), \
+             patch("asyncio.wait_for", side_effect=fake_wait_for):
+
+            with patch.dict(sys.modules, {
+                "google": MagicMock(),
+                "google.genai": fake_genai,
+                "google.genai.types": fake_genai_types,
+                "app.services.ai.gemini_client": fake_gemini_client,
+                "app.services.llm_models": fake_llm_models,
+            }):
+                result = _run(svc.transcribe_reading_audio(
+                    audio_bytes=b"fake-ogg",
+                    mime_type="audio/ogg",
+                    target_text="秋天到了，樹葉慢慢變黃了。",
+                    duration_ms=4000,
+                ))
+
+        assert result["method"] == "gemini"
+        assert result["transcript"] == transcript_text
+        assert "reasoning" in result
+        assert "reason" not in result or result.get("reason") is None
+
+    def test_success_result_has_no_fallback_fields(self):
+        """C3: gemini success result does not carry fallback reason."""
+        result = {"transcript": "text", "method": "gemini", "reasoning": "ok"}
+        assert result["method"] == "gemini"
+        assert result.get("reason") is None
+
+
+# ---------------------------------------------------------------------------
+# C4: Unsupported MIME / empty audio → 415 or fallback (never 500)
+# ---------------------------------------------------------------------------
+
+class TestC4UnsupportedMimeAndEmptyAudio:
+    """C4: Route-level guards for unsupported MIME and empty audio."""
+
+    def test_allowed_audio_mimes_does_not_include_video_types(self):
+        from app.services.reading_transcription_service import ALLOWED_AUDIO_MIMES
+        video_types = {"video/mp4", "video/webm", "image/jpeg", "application/octet-stream"}
+        assert video_types.isdisjoint(
+            {m.split(";")[0].strip() for m in ALLOWED_AUDIO_MIMES}
+        ), "Video/image MIME types should not be in ALLOWED_AUDIO_MIMES"
+
+    def test_allowed_audio_mimes_includes_webm(self):
+        """webm must be allowed at the route level (transcoding happens in service)."""
+        from app.services.reading_transcription_service import ALLOWED_AUDIO_MIMES
+        base_mimes = {m.split(";")[0].strip() for m in ALLOWED_AUDIO_MIMES}
+        assert "audio/webm" in base_mimes
+
+    def test_normalise_mime_strips_codec_suffix(self):
+        from app.services.reading_transcription_service import _normalise_mime
+        assert _normalise_mime("audio/webm;codecs=opus") == "audio/webm"
+        assert _normalise_mime("audio/webm; codecs=opus") == "audio/webm"
+        assert _normalise_mime("audio/ogg") == "audio/ogg"
+
+    def test_route_response_model_has_reason_field(self):
+        """C4: TranscribeReadingResponse Pydantic model includes `reason` field."""
+        from app.routes.learning.learning_reading import TranscribeReadingResponse
+        import inspect
+        fields = TranscribeReadingResponse.model_fields
+        assert "reason" in fields, "TranscribeReadingResponse must have a `reason` field"
+        assert "method" in fields
+        assert "transcript" in fields
+
+    def test_route_response_model_reason_is_optional(self):
+        """C4: reason is optional (None for gemini success)."""
+        from app.routes.learning.learning_reading import TranscribeReadingResponse
+        resp = TranscribeReadingResponse(
+            transcript="text",
+            method="gemini",
+            reasoning="ok",
+        )
+        assert resp.reason is None
+
+
+# ---------------------------------------------------------------------------
+# C5: Rate-limit / auth / size-cap structural presence in route
+# ---------------------------------------------------------------------------
+
+class TestC5RateLimitAuthSizeCap:
+    """C5: Route has rate-limit, auth, and size-cap guards (structural check)."""
+
+    def test_transcribe_endpoint_has_rate_limit_dependency(self):
+        import inspect
+        from app.routes.learning.learning_reading import transcribe_reading_endpoint
+        source = inspect.getsource(transcribe_reading_endpoint)
+        assert "ai_limit" in source, "Route must use rate-limit dependency"
+
+    def test_transcribe_endpoint_has_auth_dependency(self):
+        import inspect
+        from app.routes.learning.learning_reading import transcribe_reading_endpoint
+        source = inspect.getsource(transcribe_reading_endpoint)
+        assert "get_current_user" in source, "Route must require authentication"
+
+    def test_transcribe_endpoint_has_size_cap(self):
+        import inspect
+        from app.routes.learning.learning_reading import transcribe_reading_endpoint
+        source = inspect.getsource(transcribe_reading_endpoint)
+        assert "_MAX_AUDIO_BYTES" in source or "MAX_AUDIO" in source, \
+            "Route must enforce audio size cap"
+
+    def test_transcribe_endpoint_has_target_text_cap(self):
+        import inspect
+        from app.routes.learning.learning_reading import transcribe_reading_endpoint
+        source = inspect.getsource(transcribe_reading_endpoint)
+        assert "_MAX_TARGET_CHARS" in source or "MAX_TARGET" in source, \
+            "Route must enforce target_text length cap"
+
+    def test_needs_transcode_function_is_importable(self):
+        from app.services.reading_transcription_service import _needs_transcode
+        assert callable(_needs_transcode)
+
+    def test_transcode_to_ogg_function_is_importable(self):
+        from app.services.reading_transcription_service import _transcode_to_ogg
+        assert callable(_transcode_to_ogg)

--- a/backend/specs/test_reading_transcription_spec.py
+++ b/backend/specs/test_reading_transcription_spec.py
@@ -81,16 +81,19 @@ class TestC1WebmNotDirectToGemini:
         webm_bytes = b"fake-webm-input"
         transcoded_ogg_bytes = b"fake-ogg-transcoded"
 
-        # Capture the bytes that arrive at the Gemini Part.from_bytes() call.
+        # Capture both `data` and `mime_type` that arrive at Gemini Part.from_bytes().
         gemini_received_mime: list[str] = []
+        gemini_received_data: list[bytes] = []
 
         fake_part = MagicMock()
         fake_part_cls = MagicMock()
 
         def capture_from_bytes(*args, **kwargs):  # noqa: ANN001
-            # Called as Part.from_bytes(data=..., mime_type=...) — capture mime_type
+            # Called as Part.from_bytes(data=..., mime_type=...) — capture both.
             mime = kwargs.get("mime_type") or (args[1] if len(args) > 1 else "unknown")
+            data = kwargs.get("data") or (args[0] if args else b"")
             gemini_received_mime.append(mime)
+            gemini_received_data.append(data)
             return fake_part
 
         fake_part_cls.from_bytes = capture_from_bytes
@@ -140,6 +143,19 @@ class TestC1WebmNotDirectToGemini:
         assert all(
             m.startswith("audio/ogg") for m in gemini_received_mime
         ), f"Expected audio/ogg MIME sent to Gemini, got: {gemini_received_mime}"
+
+        # P2#2: also assert the `data` bytes are the TRANSCODED bytes, not the original webm.
+        # This catches a regression where data=original_webm_bytes + mime_type='audio/ogg' slips through.
+        assert gemini_received_data, "Part.from_bytes data was not captured"
+        assert all(
+            d == transcoded_ogg_bytes for d in gemini_received_data
+        ), (
+            f"Expected transcoded OGG bytes ({transcoded_ogg_bytes!r}) sent to Gemini, "
+            f"got: {gemini_received_data}"
+        )
+        assert all(
+            d != webm_bytes for d in gemini_received_data
+        ), "Original webm bytes must NOT reach Gemini directly (I2 violation)"
 
         # C1 assertion 3: result comes from Gemini (not fallback).
         assert result["method"] == "gemini"

--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -18,8 +18,10 @@ import SelfAssessment, { type AssessmentRating } from './full-reading/SelfAssess
 import FullReadingControls, { type ControlState } from './full-reading/FullReadingControls';
 import FullReadingScoreCard from './full-reading/FullReadingScoreCard';
 import FullReadingFeedbackPanel from './full-reading/FullReadingFeedbackPanel';
-import { enhanceLiveTranscript } from '../../utils/liveTranscriptEnhance';
-import type { TranscriptSegment } from '../../utils/liveTranscriptEnhance';
+// Note: liveTranscriptEnhance / enhanceLiveTranscript intentionally NOT imported here.
+// I3 (Issue #2156): live preview must show raw Web Speech gray text only.
+// Instant punctuation re-insertion causes visible flicker on every STT partial result.
+// Gemini adds accurate punctuation post-submission — no need to fake it live.
 
 /* ------------------------------------------------------------------ */
 
@@ -141,6 +143,8 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     isTranscribing,
     streamingTranscript: sessionTranscript,
     micError,
+    fallbackReason,
+    clearFallbackReason,
     startSession,
     submitReading,
     audioRecorder,
@@ -156,14 +160,10 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     }, [setResult, setStreamingTranscript, setHistoryRefreshKey]),
   });
 
-  /** Issue #2147: memoised live transcript segments — recomputes only when
-   *  the raw streaming text or the full lesson text changes, not on every render.
-   *  MUST be declared after useFullReadingSession so sessionTranscript exists
-   *  (was placed before it → "Cannot access before initialization" TDZ crash). */
-  const liveTranscriptSegments = useMemo(() => {
-    if (!sessionTranscript) return null;
-    return enhanceLiveTranscript(sessionTranscript, fullText).segments;
-  }, [sessionTranscript, fullText]);
+  // I3 (Issue #2156): liveTranscriptSegments / enhanceLiveTranscript removed.
+  // Raw Web Speech gray-text preview replaces the punctuation-insertion path.
+  // Reason: enhanceLiveTranscript ran on every STT partial → visible flicker.
+  // Gemini provides accurate punctuation post-submission (no live re-insertion needed).
 
   const zhuyinLines = useMemo(
     () => processLinesSelective(story.content, vocabWords),
@@ -210,7 +210,8 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     audioRecorder.clearRecording();
     setSelfRating(undefined);
     setShowComparison(false);
-  }, [storageKey, setResult, setStreamingTranscript, audioRecorder]);
+    clearFallbackReason();
+  }, [storageKey, setResult, setStreamingTranscript, audioRecorder, clearFallbackReason]);
 
   const handleFinish = useCallback(() => {
     if (!result) return;
@@ -314,16 +315,15 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
             </div>
           </div>
 
-          {/* Live transcript card — Issue #2147: enhanced with punctuation + homophone correction */}
+          {/* Live transcript card — I3 (Issue #2156): raw Web Speech gray preview only.
+              No punctuation re-insertion here — Gemini adds it post-submission. */}
           {isSessionActive && sessionTranscript && (
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 mt-6">
-              <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">即時辨識</p>
-              <p className="text-lg text-on-surface leading-relaxed">
-                {liveTranscriptSegments && liveTranscriptSegments.map((seg: TranscriptSegment, i: number) => (
-                  <span key={i} className={seg.kind === 'inserted' ? 'text-gray-400' : undefined}>
-                    {seg.text}
-                  </span>
-                ))}
+              <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">
+                即時預覽（唸完精準校正）
+              </p>
+              <p className="text-lg text-gray-400 leading-relaxed">
+                {sessionTranscript}
               </p>
             </div>
           )}
@@ -331,6 +331,28 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
           {isSessionActive && !sessionTranscript && (
             <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 mt-6">
               <p className="text-base text-on-surface-variant leading-relaxed">請開始朗讀上方課文…</p>
+            </div>
+          )}
+
+          {/* I4 (Issue #2156): Gemini fallback alert banner — must be visible, never silent.
+              Shown when backend returns method='fallback' so user knows the result is
+              based on Web Speech only (lower quality) and can retry for a better score. */}
+          {fallbackReason && result && (
+            <div className="mt-6 flex items-start gap-3 px-5 py-4 rounded-2xl bg-amber-50 border border-amber-300 shadow-sm">
+              <span className="material-symbols-outlined text-amber-600 shrink-0 mt-0.5">warning</span>
+              <div className="flex-1">
+                <p className="text-sm font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
+                <p className="text-xs text-amber-700 mt-0.5">
+                  AI 音訊分析未能完成（{fallbackReason}），評分僅依瀏覽器語音辨識，準確度較低。建議重試以獲得精準評分。
+                </p>
+              </div>
+              <button
+                onClick={clearFallbackReason}
+                className="text-amber-600 hover:text-amber-800 transition-colors shrink-0 mt-0.5"
+                aria-label="關閉提示"
+              >
+                <span className="material-symbols-outlined text-base">close</span>
+              </button>
             </div>
           )}
 

--- a/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
@@ -20,8 +20,8 @@ export interface FullReadingControlsProps {
   onSpeak: () => void;
   /** Called when user clicks 開始朗讀 */
   onStartSession: () => void;
-  /** Called when user clicks 完成朗讀 */
-  onSubmit: () => void;
+  /** Called when user clicks 完成朗讀 (P1#1: async — awaits audio blob) */
+  onSubmit: () => void | Promise<void>;
   /** Called when user clicks 停止 (TTS) */
   onStopTts: () => void;
   /** Called when user clicks 暫停 (TTS playing, not paused) */

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -256,27 +256,6 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     // null because onstop fires asynchronously after .stop() is called.
     const audioBlob = await paragraphRecorder.stopAndGetBlob();
 
-    // Helper: resolve the transcript to use for scoring.
-    // Returns Gemini transcript on success (I1), Web Speech on fallback (I4 alert).
-    const resolveTranscript = async (): Promise<string> => {
-      if (audioBlob && token) {
-        const targetText = story.content[currentLineIndex] || '';
-        try {
-          const result = await transcribeReading(audioBlob, targetText, durationMs, token);
-          if (result.method === 'gemini' && result.transcript) {
-            clearParagraphFallback();
-            return result.transcript;
-          }
-          // I4: Gemini failed — show alert, fall back to Web Speech
-          setParagraphFallbackReason(result.reason ?? 'error');
-        } catch {
-          setParagraphFallbackReason('error');
-        }
-      }
-      // No audio blob or Gemini failed → Web Speech transcript
-      return transcript;
-    };
-
     if (sentenceRetry.retrySentenceInfoRef.current) {
       // Sentence retry path: paragraph recorder is already stopped (from prior submitSentence).
       // No fresh blob is available for this sentence fragment.
@@ -286,10 +265,34 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     } else if (audioBlob || transcript) {
       // P2#1: audioBlob takes priority — try Gemini even if Web Speech returned empty string
       // (student may have spoken but STT returned nothing; Gemini can still transcribe).
-      const finalTranscript = await resolveTranscript();
-      // Only score if we have something to score (Gemini result or non-empty Web Speech).
+      // P1#4: track whether we got a Gemini transcript to pass correct `source` to evaluateAndRespond.
+      let finalTranscript = transcript;
+      let transcriptSource: 'gemini' | 'webspeech' = 'webspeech';
+
+      if (audioBlob && token) {
+        const targetText = story.content[currentLineIndex] || '';
+        try {
+          const result = await transcribeReading(audioBlob, targetText, durationMs, token);
+          if (result.method === 'gemini' && result.transcript) {
+            clearParagraphFallback();
+            finalTranscript = result.transcript;
+            transcriptSource = 'gemini';
+          } else {
+            // I4: Gemini returned fallback.
+            setParagraphFallbackReason(result.reason ?? 'error');
+            // finalTranscript stays as Web Speech; transcriptSource stays 'webspeech'
+          }
+        } catch {
+          setParagraphFallbackReason('error');
+        }
+      } else {
+        // P1#3: no blob or no token — I4 alert.
+        setParagraphFallbackReason(audioBlob ? 'no_token' : 'no_audio');
+      }
+
+      // Only score if we have something to score.
       if (finalTranscript.trim()) {
-        await evaluateAndRespondRef.current(finalTranscript, rawStt, durationMs, currentLineIndex);
+        await evaluateAndRespondRef.current(finalTranscript, rawStt, durationMs, currentLineIndex, transcriptSource);
       }
     }
   }, [stt, sentenceRetry.retrySentenceInfoRef, currentLineIndex,
@@ -575,7 +578,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
             <div className="flex-1">
               <p className="text-sm font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
               <p className="text-xs text-amber-700 mt-0.5">
-                AI 音訊分析未能完成，評分依瀏覽器語音辨識，準確度較低。建議重試此段。
+                AI 音訊分析未能完成（{paragraphFallbackReason}），評分依瀏覽器語音辨識，準確度較低。建議重試此段。
               </p>
             </div>
             <button

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -6,6 +6,9 @@ import { cancelTts } from '../../../services/ttsApi';
 import { scopedStepStorageKey, isToolboxMode } from '../../../services/learningStorageScope';
 import { useLiveTutorSpeech } from '../../../hooks/useLiveTutorSpeech';
 import { useTtsPlayback } from '../../../hooks/useTtsPlayback';
+import { useAudioRecorder } from '../../../hooks/useAudioRecorder';
+import { transcribeReading } from '../../../services/learning/session';
+import { useAuth } from '../../../contexts/AuthContext';
 import { splitIntoSentences } from '../../../utils/localEval';
 import ToolboxCompletionActions from '../../tools/ToolboxCompletionActions';
 import ReadingMetricsCard from '../full-reading/ReadingMetricsCard';
@@ -74,7 +77,16 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 }) => {
   const { px: fontSizePx } = useFontSize();
   const { isZhuyinAny, processLinesSelective } = useZhuyin();
+  const { token } = useAuth();
   const storageKey = scopedStepStorageKey('liveTutor_progress_', story.id);
+
+  // ── Per-paragraph Gemini audio recorder (Issue #2156 — I1 / I4) ──────────
+  // Records while the student reads each paragraph; stops on paragraph submit
+  // so we can send the blob to /reading/transcribe for high-quality Gemini STT.
+  const paragraphRecorder = useAudioRecorder(120);
+  /** I4: fallback alert per paragraph — set when Gemini audio transcription fails */
+  const [paragraphFallbackReason, setParagraphFallbackReason] = useState<string | null>(null);
+  const clearParagraphFallback = useCallback(() => setParagraphFallbackReason(null), []);
 
   // ── Evaluation state machine ─────────────────────────────────────────────
   const [evalState, dispatch] = useReducer(evalReducer, initialEvalState);
@@ -184,8 +196,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   const startSession = useCallback(() => {
     setNoAudioDetected(false);
+    clearParagraphFallback();
+    // Start paragraph audio recorder alongside STT (I1 — Gemini primary source)
+    paragraphRecorder.startRecording().catch(() => {
+      // recorder failure is non-critical — Web Speech fallback still works
+    });
     stt.startSession();
-  }, [stt]);
+  }, [stt, paragraphRecorder, clearParagraphFallback]);
   const stopSession = stt.stopSession;
 
   // ── Paragraph evaluation hook ────────────────────────────────────────────
@@ -232,12 +249,42 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   const submitSentence = useCallback(async () => {
     const { transcript, rawStt, durationMs } = stt.submitSentence();
+
+    // ── Gemini audio transcription for paragraph (I1 — audio primary) ────────
+    // Stop the paragraph recorder now so we have a complete blob for this paragraph.
+    paragraphRecorder.stopRecording();
+    const audioBlob = paragraphRecorder.audioBlob;
+
+    // Helper: resolve the transcript to use for scoring.
+    // Returns Gemini transcript on success (I1), Web Speech on fallback (I4 alert).
+    const resolveTranscript = async (): Promise<string> => {
+      if (audioBlob && token) {
+        const targetText = story.content[currentLineIndex] || '';
+        try {
+          const result = await transcribeReading(audioBlob, targetText, durationMs, token);
+          if (result.method === 'gemini' && result.transcript) {
+            clearParagraphFallback();
+            return result.transcript;
+          }
+          // I4: Gemini failed — show alert, fall back to Web Speech
+          setParagraphFallbackReason(result.reason ?? 'error');
+        } catch {
+          setParagraphFallbackReason('error');
+        }
+      }
+      // No audio blob or Gemini failed → Web Speech transcript
+      return transcript;
+    };
+
     if (sentenceRetry.retrySentenceInfoRef.current) {
+      // Sentence retry path: use Web Speech (short fragment, Gemini overkill)
       await handleSentenceRetryEvalRef.current(transcript, durationMs);
     } else if (transcript) {
-      await evaluateAndRespondRef.current(transcript, rawStt, durationMs, currentLineIndex);
+      const finalTranscript = await resolveTranscript();
+      await evaluateAndRespondRef.current(finalTranscript, rawStt, durationMs, currentLineIndex);
     }
-  }, [stt, sentenceRetry.retrySentenceInfoRef, currentLineIndex]);
+  }, [stt, sentenceRetry.retrySentenceInfoRef, currentLineIndex, paragraphRecorder,
+      token, story.content, clearParagraphFallback]);
 
   // ── handleRetryParagraph ─────────────────────────────────────────────────
   const handleRetryParagraph = useCallback(
@@ -246,6 +293,9 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         stopSession();
         setCurrentLineIndex(idx);
       }
+      // Reset paragraph recorder and fallback state on retry
+      paragraphRecorder.clearRecording();
+      clearParagraphFallback();
       setParagraphSummaries((prev) => {
         const next = { ...prev };
         delete next[idx];
@@ -272,6 +322,8 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       setParagraphSummaries,
       sentenceRetry,
       dispatch,
+      paragraphRecorder,
+      clearParagraphFallback,
     ],
   );
 
@@ -321,7 +373,14 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     nextSentenceIdxRef.current = 0;
     lastFinalResultIdxRef.current = -1;
     dispatch({ type: 'CLEAR_FOR_PARAGRAPH' });
+    // Reset paragraph recorder + fallback when paragraph changes (I4: stale alerts must not persist)
+    paragraphRecorder.clearRecording();
+    clearParagraphFallback();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentLineIndex, story.content]);
+  // Note: paragraphRecorder and clearParagraphFallback intentionally excluded
+  // from deps — they are stable (refs + stable callbacks) and including them
+  // would re-run this effect unnecessarily.
 
   // ── Persist progress to localStorage ────────────────────────────────────
   useEffect(() => {
@@ -494,6 +553,30 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       {/* No-audio-detected banner */}
       {noAudioDetected && stt.isSessionActive && (
         <NoAudioBanner onRestart={() => { stopSession(); startSession(); }} />
+      )}
+
+      {/* I4 (Issue #2156): Per-paragraph Gemini fallback alert — must not be silent.
+          Shown when audio transcription fails so student knows the score is from
+          Web Speech only (lower quality) and can retry for a better result. */}
+      {paragraphFallbackReason && (
+        <div className="absolute bottom-44 left-1/2 -translate-x-1/2 z-20 w-[min(92%,520px)]">
+          <div className="flex items-start gap-3 px-4 py-3 rounded-2xl bg-amber-50 border border-amber-300 shadow-md">
+            <span className="material-symbols-outlined text-amber-600 shrink-0">warning</span>
+            <div className="flex-1">
+              <p className="text-sm font-bold text-amber-800">高品質辨識暫時失敗，這是粗略結果</p>
+              <p className="text-xs text-amber-700 mt-0.5">
+                AI 音訊分析未能完成，評分依瀏覽器語音辨識，準確度較低。建議重試此段。
+              </p>
+            </div>
+            <button
+              onClick={clearParagraphFallback}
+              className="text-amber-600 hover:text-amber-800 transition-colors shrink-0"
+              aria-label="關閉提示"
+            >
+              <span className="material-symbols-outlined text-base">close</span>
+            </button>
+          </div>
+        </div>
       )}
 
       {/* ── Fixed bottom controls ─────────────────────────────────────── */}

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -251,9 +251,10 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     const { transcript, rawStt, durationMs } = stt.submitSentence();
 
     // ── Gemini audio transcription for paragraph (I1 — audio primary) ────────
-    // Stop the paragraph recorder now so we have a complete blob for this paragraph.
-    paragraphRecorder.stopRecording();
-    const audioBlob = paragraphRecorder.audioBlob;
+    // P1#1 fix: use stopAndGetBlob() which awaits the MediaRecorder onstop event.
+    // The old pattern (stopRecording() → synchronous audioBlob read) always returned
+    // null because onstop fires asynchronously after .stop() is called.
+    const audioBlob = await paragraphRecorder.stopAndGetBlob();
 
     // Helper: resolve the transcript to use for scoring.
     // Returns Gemini transcript on success (I1), Web Speech on fallback (I4 alert).
@@ -277,14 +278,23 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     };
 
     if (sentenceRetry.retrySentenceInfoRef.current) {
-      // Sentence retry path: use Web Speech (short fragment, Gemini overkill)
+      // Sentence retry path: paragraph recorder is already stopped (from prior submitSentence).
+      // No fresh blob is available for this sentence fragment.
+      // I4 compliance: show fallback banner so it's not silent about using Web Speech.
+      setParagraphFallbackReason('no_audio');
       await handleSentenceRetryEvalRef.current(transcript, durationMs);
-    } else if (transcript) {
+    } else if (audioBlob || transcript) {
+      // P2#1: audioBlob takes priority — try Gemini even if Web Speech returned empty string
+      // (student may have spoken but STT returned nothing; Gemini can still transcribe).
       const finalTranscript = await resolveTranscript();
-      await evaluateAndRespondRef.current(finalTranscript, rawStt, durationMs, currentLineIndex);
+      // Only score if we have something to score (Gemini result or non-empty Web Speech).
+      if (finalTranscript.trim()) {
+        await evaluateAndRespondRef.current(finalTranscript, rawStt, durationMs, currentLineIndex);
+      }
     }
-  }, [stt, sentenceRetry.retrySentenceInfoRef, currentLineIndex, paragraphRecorder,
-      token, story.content, clearParagraphFallback]);
+  }, [stt, sentenceRetry.retrySentenceInfoRef, currentLineIndex,
+      paragraphRecorder.stopAndGetBlob,
+      token, story.content, clearParagraphFallback, setParagraphFallbackReason]);
 
   // ── handleRetryParagraph ─────────────────────────────────────────────────
   const handleRetryParagraph = useCallback(

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -88,6 +88,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   const [paragraphFallbackReason, setParagraphFallbackReason] = useState<string | null>(null);
   const clearParagraphFallback = useCallback(() => setParagraphFallbackReason(null), []);
 
+  // ── P1: double-submit race guard (Issue #2156 Round 4) ───────────────────
+  // submitSentence is async (awaits stopAndGetBlob + Gemini API). Without a
+  // lock, tapping "Submit" twice fires two parallel evaluations for the same
+  // paragraph, causing duplicate scoring and two concurrent mic stops.
+  const isSubmittingSentenceRef = useRef(false);
+  const [isSubmittingSentence, setIsSubmittingSentence] = useState(false);
+
   // ── Evaluation state machine ─────────────────────────────────────────────
   const [evalState, dispatch] = useReducer(evalReducer, initialEvalState);
 
@@ -248,52 +255,65 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
   handleSentenceRetryEvalRef.current = sentenceRetry.handleSentenceRetryEval;
 
   const submitSentence = useCallback(async () => {
-    const { transcript, rawStt, durationMs } = stt.submitSentence();
+    // P1 Round 4: double-submit race guard.
+    // submitSentence is async — a second tap before the first resolves would fire
+    // duplicate scoring and two concurrent mic-stop calls.  Use a ref (not state)
+    // for the guard to avoid stale-closure issues inside the callback.
+    if (isSubmittingSentenceRef.current) return;
+    isSubmittingSentenceRef.current = true;
+    setIsSubmittingSentence(true);
 
-    // ── Gemini audio transcription for paragraph (I1 — audio primary) ────────
-    // P1#1 fix: use stopAndGetBlob() which awaits the MediaRecorder onstop event.
-    // The old pattern (stopRecording() → synchronous audioBlob read) always returned
-    // null because onstop fires asynchronously after .stop() is called.
-    const audioBlob = await paragraphRecorder.stopAndGetBlob();
+    try {
+      const { transcript, rawStt, durationMs } = stt.submitSentence();
 
-    if (sentenceRetry.retrySentenceInfoRef.current) {
-      // Sentence retry path: paragraph recorder is already stopped (from prior submitSentence).
-      // No fresh blob is available for this sentence fragment.
-      // I4 compliance: show fallback banner so it's not silent about using Web Speech.
-      setParagraphFallbackReason('no_audio');
-      await handleSentenceRetryEvalRef.current(transcript, durationMs);
-    } else if (audioBlob || transcript) {
-      // P2#1: audioBlob takes priority — try Gemini even if Web Speech returned empty string
-      // (student may have spoken but STT returned nothing; Gemini can still transcribe).
-      // P1#4: track whether we got a Gemini transcript to pass correct `source` to evaluateAndRespond.
-      let finalTranscript = transcript;
-      let transcriptSource: 'gemini' | 'webspeech' = 'webspeech';
+      // ── Gemini audio transcription for paragraph (I1 — audio primary) ────────
+      // P1#1 fix: use stopAndGetBlob() which awaits the MediaRecorder onstop event.
+      // The old pattern (stopRecording() → synchronous audioBlob read) always returned
+      // null because onstop fires asynchronously after .stop() is called.
+      const audioBlob = await paragraphRecorder.stopAndGetBlob();
 
-      if (audioBlob && token) {
-        const targetText = story.content[currentLineIndex] || '';
-        try {
-          const result = await transcribeReading(audioBlob, targetText, durationMs, token);
-          if (result.method === 'gemini' && result.transcript) {
-            clearParagraphFallback();
-            finalTranscript = result.transcript;
-            transcriptSource = 'gemini';
-          } else {
-            // I4: Gemini returned fallback.
-            setParagraphFallbackReason(result.reason ?? 'error');
-            // finalTranscript stays as Web Speech; transcriptSource stays 'webspeech'
+      if (sentenceRetry.retrySentenceInfoRef.current) {
+        // Sentence retry path: paragraph recorder is already stopped (from prior submitSentence).
+        // No fresh blob is available for this sentence fragment.
+        // I4 compliance: show fallback banner so it's not silent about using Web Speech.
+        setParagraphFallbackReason('no_audio');
+        await handleSentenceRetryEvalRef.current(transcript, durationMs);
+      } else if (audioBlob || transcript) {
+        // P2#1: audioBlob takes priority — try Gemini even if Web Speech returned empty string
+        // (student may have spoken but STT returned nothing; Gemini can still transcribe).
+        // P1#4: track whether we got a Gemini transcript to pass correct `source` to evaluateAndRespond.
+        let finalTranscript = transcript;
+        let transcriptSource: 'gemini' | 'webspeech' = 'webspeech';
+
+        if (audioBlob && token) {
+          const targetText = story.content[currentLineIndex] || '';
+          try {
+            const result = await transcribeReading(audioBlob, targetText, durationMs, token);
+            if (result.method === 'gemini' && result.transcript) {
+              clearParagraphFallback();
+              finalTranscript = result.transcript;
+              transcriptSource = 'gemini';
+            } else {
+              // I4: Gemini returned fallback.
+              setParagraphFallbackReason(result.reason ?? 'error');
+              // finalTranscript stays as Web Speech; transcriptSource stays 'webspeech'
+            }
+          } catch {
+            setParagraphFallbackReason('error');
           }
-        } catch {
-          setParagraphFallbackReason('error');
+        } else {
+          // P1#3: no blob or no token — I4 alert.
+          setParagraphFallbackReason(audioBlob ? 'no_token' : 'no_audio');
         }
-      } else {
-        // P1#3: no blob or no token — I4 alert.
-        setParagraphFallbackReason(audioBlob ? 'no_token' : 'no_audio');
-      }
 
-      // Only score if we have something to score.
-      if (finalTranscript.trim()) {
-        await evaluateAndRespondRef.current(finalTranscript, rawStt, durationMs, currentLineIndex, transcriptSource);
+        // Only score if we have something to score.
+        if (finalTranscript.trim()) {
+          await evaluateAndRespondRef.current(finalTranscript, rawStt, durationMs, currentLineIndex, transcriptSource);
+        }
       }
+    } finally {
+      isSubmittingSentenceRef.current = false;
+      setIsSubmittingSentence(false);
     }
   }, [stt, sentenceRetry.retrySentenceInfoRef, currentLineIndex,
       paragraphRecorder.stopAndGetBlob,
@@ -565,7 +585,17 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
       {/* No-audio-detected banner */}
       {noAudioDetected && stt.isSessionActive && (
-        <NoAudioBanner onRestart={() => { stopSession(); startSession(); }} />
+        <NoAudioBanner onRestart={() => {
+          // P1 Round 4: stop the old paragraph recorder BEFORE starting a new session.
+          // The previous onRestart only called stopSession() (STT) + startSession(), which
+          // would call paragraphRecorder.startRecording() on top of a still-active recorder,
+          // leaking the old MediaStream and causing a permission / resource conflict.
+          // clearRecording() stops the recorder, cancels any pending stopAndGetBlob promise,
+          // and releases the mic track so startRecording() can acquire a fresh stream.
+          paragraphRecorder.clearRecording();
+          stopSession();
+          startSession();
+        }} />
       )}
 
       {/* I4 (Issue #2156): Per-paragraph Gemini fallback alert — must not be silent.
@@ -601,6 +631,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         isTtsPaused={isTtsPaused}
         isAdvancing={isAdvancing}
         isAwaitingGemini={evalState.isAwaitingGemini}
+        isSubmittingSentence={isSubmittingSentence}
         streamingUserInput={evalState.streamingUserInput}
         lastDiffTokens={evalState.lastDiffTokens}
         retryCount={evalState.retryCount}

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -10,6 +10,8 @@ interface LiveTutorControlsProps {
   isTtsPaused: boolean;
   isAdvancing: boolean;
   isAwaitingGemini: boolean;
+  /** P1 Round 4: true while submitSentence async flow is in progress (double-submit guard). */
+  isSubmittingSentence?: boolean;
   // Content state
   streamingUserInput: string;
   lastDiffTokens: DiffToken[] | null;
@@ -41,6 +43,7 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   isTtsPaused,
   isAdvancing,
   isAwaitingGemini,
+  isSubmittingSentence = false,
   streamingUserInput,
   lastDiffTokens,
   retryCount,
@@ -81,20 +84,20 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
           /* Recording active — submit */
           <button
             onClick={onSubmitSentence}
-            disabled={isAwaitingGemini || (!streamingUserInput && !lastDiffTokens)}
+            disabled={isSubmittingSentence || isAwaitingGemini || (!streamingUserInput && !lastDiffTokens)}
             className={`w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] ${
-              isAwaitingGemini || (!streamingUserInput && !lastDiffTokens)
+              isSubmittingSentence || isAwaitingGemini || (!streamingUserInput && !lastDiffTokens)
                 ? 'bg-surface-container-high text-on-surface-variant cursor-not-allowed'
                 : 'text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)]'
             }`}
             style={
-              !isAwaitingGemini && (streamingUserInput || lastDiffTokens)
+              !isSubmittingSentence && !isAwaitingGemini && (streamingUserInput || lastDiffTokens)
                 ? { background: 'linear-gradient(135deg, #006947, #34d399)' }
                 : undefined
             }
           >
             <span className="material-symbols-outlined text-xl">check</span>
-            完成
+            {isSubmittingSentence ? '評分中…' : '完成'}
           </button>
 
         ) : isPreparing ? (

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
@@ -142,6 +142,10 @@ export function useParagraphEvaluation({
       _rawStt: string,
       durationMs: number,
       lineIdx: number,
+      /** I1 (P1#4): caller must declare transcript source.
+       *  'gemini' → skip sentenceResults aggregation; evaluate whole paragraph directly.
+       *  'webspeech' → may use sentenceResults aggregation (existing behavior). */
+      source: 'gemini' | 'webspeech' = 'webspeech',
     ) => {
       const targetText = story.content[lineIdx] || '';
       const cleaned = cleanChineseText(rawTranscript);
@@ -173,40 +177,18 @@ export function useParagraphEvaluation({
       }
 
       // ── Phase 1: local eval ─────────────────────────────────────────────
-      const sentResults = sentenceResultsRef.current.filter(
-        Boolean,
-      ) as LocalEvalResult[];
-
+      // I1 (P1#4): When transcript comes from Gemini, skip sentenceResults
+      // aggregation entirely — it contains per-sentence Web Speech results which
+      // would pollute the Gemini-sourced transcript.  Evaluate the full paragraph
+      // against the Gemini transcript directly.
       let localTier: 1 | 2 | 3;
       let localDiffTokens: DiffToken[];
       let localFeedback: string;
       let localMatchRate: number;
       let localCpm: number;
 
-      const totalSentences = sentenceTargetsRef.current.length;
-      if (
-        sentResults.length > 0 &&
-        sentResults.length >= Math.ceil(totalSentences / 2)
-      ) {
-        const allDiff = sentResults.flatMap((r) => r.diffTokens);
-        const correctAndForgiven = allDiff.filter(
-          (t) => t.type === 'correct' || t.type === 'forgiven',
-        ).length;
-        const totalTarget = normalizeForComparison(targetText).length || 1;
-        localMatchRate = correctAndForgiven / totalTarget;
-        const threshold = getReadingPassThreshold(totalTarget);
-        localTier =
-          localMatchRate >= READING_EXCELLENT
-            ? 1
-            : localMatchRate >= threshold
-            ? 2
-            : 3;
-        localDiffTokens = allDiff;
-        localFeedback = sentResults[sentResults.length - 1].feedback;
-        localCpm = Math.round(
-          sentResults.reduce((s, r) => s + r.cpm, 0) / sentResults.length,
-        );
-      } else {
+      if (source === 'gemini') {
+        // Gemini path: whole-paragraph evaluation — no sentenceResults mixing.
         const localResult = localEvaluateParagraph(
           cleaned,
           targetText,
@@ -224,6 +206,54 @@ export function useParagraphEvaluation({
         localFeedback = localResult.feedback;
         localMatchRate = localResult.matchRate;
         localCpm = localResult.cpm;
+      } else {
+        // Web Speech path: may aggregate sentenceResults if enough were collected.
+        const sentResults = sentenceResultsRef.current.filter(
+          Boolean,
+        ) as LocalEvalResult[];
+
+        const totalSentences = sentenceTargetsRef.current.length;
+        if (
+          sentResults.length > 0 &&
+          sentResults.length >= Math.ceil(totalSentences / 2)
+        ) {
+          const allDiff = sentResults.flatMap((r) => r.diffTokens);
+          const correctAndForgiven = allDiff.filter(
+            (t) => t.type === 'correct' || t.type === 'forgiven',
+          ).length;
+          const totalTarget = normalizeForComparison(targetText).length || 1;
+          localMatchRate = correctAndForgiven / totalTarget;
+          const threshold = getReadingPassThreshold(totalTarget);
+          localTier =
+            localMatchRate >= READING_EXCELLENT
+              ? 1
+              : localMatchRate >= threshold
+              ? 2
+              : 3;
+          localDiffTokens = allDiff;
+          localFeedback = sentResults[sentResults.length - 1].feedback;
+          localCpm = Math.round(
+            sentResults.reduce((s, r) => s + r.cpm, 0) / sentResults.length,
+          );
+        } else {
+          const localResult = localEvaluateParagraph(
+            cleaned,
+            targetText,
+            durationMs,
+            {
+              tier1: TIER1_POOL,
+              tier2: TIER2_POOL,
+              tier3: TIER3_POOL,
+              streakMsgs: STREAK_MESSAGES,
+            },
+            evalState.streak,
+          );
+          localTier = localResult.tier;
+          localDiffTokens = localResult.diffTokens;
+          localFeedback = localResult.feedback;
+          localMatchRate = localResult.matchRate;
+          localCpm = localResult.cpm;
+        }
       }
 
       dispatch({ type: 'START_LOCAL', diffTokens: localDiffTokens });

--- a/frontend/src/hooks/useAudioRecorder.ts
+++ b/frontend/src/hooks/useAudioRecorder.ts
@@ -228,6 +228,14 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
     const recorder = mediaRecorderRef.current;
 
     // Not currently recording — return whatever blob we already have (may be null).
+    // P2 Round 4: note that `audioBlob` is React state, so it reflects the value
+    // committed during the *previous* render cycle.  In practice this is fine because:
+    //  (a) if recording never started, the value is correctly null
+    //  (b) if recording completed earlier (onstop already fired), state was set
+    //      synchronously inside the onstop handler and will already be up-to-date
+    //      by the time any subsequent render-cycle call arrives.
+    // The only scenario where stale state could bite is a double-call within the
+    // same synchronous frame — which the duplicate-call guard below prevents.
     if (!recorder || recorder.state === 'inactive') {
       return Promise.resolve(audioBlob);
     }

--- a/frontend/src/hooks/useAudioRecorder.ts
+++ b/frontend/src/hooks/useAudioRecorder.ts
@@ -215,21 +215,48 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
   }, [audioUrl, maxDurationSeconds, stopRecording, stopTimer, releaseStream]);
 
   /**
-   * P1#1: Stop recording and await the onstop event, returning the final Blob.
-   * Safe to call even if not currently recording (returns null immediately).
+   * Stop recording and await the MediaRecorder onstop event, returning the final Blob.
+   *
+   * Safety guarantees (P1#1 fixes):
+   *  1. Timeout (3 s): if onstop never fires (browser bug / already-stopped race),
+   *     resolves with the current audioBlob state (may be null) rather than hanging.
+   *  2. Duplicate-call guard: if a promise is already pending, the existing resolver
+   *     is settled with null and replaced — callers get independent responses.
+   *  3. Already-inactive recorder: resolves immediately with current blob (no wait).
    */
   const stopAndGetBlob = useCallback((): Promise<Blob | null> => {
     const recorder = mediaRecorderRef.current;
+
+    // Not currently recording — return whatever blob we already have (may be null).
     if (!recorder || recorder.state === 'inactive') {
-      // Not recording — resolve immediately with whatever we already have.
-      return Promise.resolve(null);
+      return Promise.resolve(audioBlob);
     }
+
+    // Duplicate-call guard: settle the previous promise before starting a new one.
+    if (stopResolverRef.current) {
+      stopResolverRef.current(null);
+      stopResolverRef.current = null;
+    }
+
     return new Promise<Blob | null>((resolve) => {
-      stopResolverRef.current = resolve;
-      // stopRecording() calls recorder.stop() → triggers onstop → onstop calls resolve.
+      // 3 s safety timeout — onstop should fire within milliseconds; 3 s is generous.
+      const timer = setTimeout(() => {
+        if (stopResolverRef.current === resolve) {
+          stopResolverRef.current = null;
+        }
+        // Resolve with whatever React state has at this point (may be null on first call).
+        resolve(audioBlob);
+      }, 3000);
+
+      stopResolverRef.current = (blob) => {
+        clearTimeout(timer);
+        resolve(blob);
+      };
+
+      // Calling recorder.stop() triggers ondataavailable (final chunk) then onstop.
       stopRecording();
     });
-  }, [stopRecording]);
+  }, [stopRecording, audioBlob]);
 
   const clearRecording = useCallback(() => {
     // Cancel any pending stopAndGetBlob promise so it doesn't hang.

--- a/frontend/src/hooks/useAudioRecorder.ts
+++ b/frontend/src/hooks/useAudioRecorder.ts
@@ -15,6 +15,15 @@ export interface AudioRecorderState {
 export interface AudioRecorderActions {
   startRecording: () => Promise<void>;
   stopRecording: () => void;
+  /**
+   * Stop recording and wait for the MediaRecorder onstop event to fire,
+   * then return the final Blob.  Resolves to null if not recording or on error.
+   *
+   * This is the CORRECT way to obtain the blob in async callers (P1#1 fix):
+   * `stopRecording()` triggers onstop *asynchronously*; reading `audioBlob`
+   * synchronously after the call always returns null / the previous value.
+   */
+  stopAndGetBlob: () => Promise<Blob | null>;
   clearRecording: () => void;
 }
 
@@ -50,6 +59,8 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
   const analyserRef = useRef<AnalyserNode | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const rafRef = useRef<number | null>(null);
+  /** P1#1 fix: resolver for stopAndGetBlob() — resolved by onstop handler. */
+  const stopResolverRef = useRef<((blob: Blob | null) => void) | null>(null);
 
   const stopTimer = useCallback(() => {
     if (timerRef.current) {
@@ -146,6 +157,11 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
       setAudioBlob(blob);
       setAudioUrl(url);
       setStatus('stopped');
+      // P1#1: resolve any pending stopAndGetBlob() promise with the final blob.
+      if (stopResolverRef.current) {
+        stopResolverRef.current(blob);
+        stopResolverRef.current = null;
+      }
     };
 
     recorder.onerror = () => {
@@ -153,6 +169,11 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
       releaseStream();
       setErrorMessage('錄音過程中發生錯誤，請重試。');
       setStatus('error');
+      // P1#1: also resolve on error so callers don't hang.
+      if (stopResolverRef.current) {
+        stopResolverRef.current(null);
+        stopResolverRef.current = null;
+      }
     };
 
     recorder.start(250); // collect data every 250ms
@@ -193,7 +214,29 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
     }, 500);
   }, [audioUrl, maxDurationSeconds, stopRecording, stopTimer, releaseStream]);
 
+  /**
+   * P1#1: Stop recording and await the onstop event, returning the final Blob.
+   * Safe to call even if not currently recording (returns null immediately).
+   */
+  const stopAndGetBlob = useCallback((): Promise<Blob | null> => {
+    const recorder = mediaRecorderRef.current;
+    if (!recorder || recorder.state === 'inactive') {
+      // Not recording — resolve immediately with whatever we already have.
+      return Promise.resolve(null);
+    }
+    return new Promise<Blob | null>((resolve) => {
+      stopResolverRef.current = resolve;
+      // stopRecording() calls recorder.stop() → triggers onstop → onstop calls resolve.
+      stopRecording();
+    });
+  }, [stopRecording]);
+
   const clearRecording = useCallback(() => {
+    // Cancel any pending stopAndGetBlob promise so it doesn't hang.
+    if (stopResolverRef.current) {
+      stopResolverRef.current(null);
+      stopResolverRef.current = null;
+    }
     stopRecording();
     if (audioUrl) {
       URL.revokeObjectURL(audioUrl);
@@ -230,6 +273,7 @@ export function useAudioRecorder(maxDurationSeconds = MAX_DURATION_SECONDS): Aud
     volumeLevel,
     startRecording,
     stopRecording,
+    stopAndGetBlob,
     clearRecording,
   };
 }

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -15,7 +15,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { cleanChineseText } from '../utils/textDiff';
 import { analyzeFluency } from '../utils/fluencyAnalyzer';
-import { reinsertPunctuation } from '../utils/punctuationReinsert';
 import { DiffToken } from '../types';
 import { useAudioRecorder } from './useAudioRecorder';
 import { cancelTts } from '../services/ttsApi';
@@ -47,6 +46,14 @@ interface UseFullReadingSessionReturn {
   streamingTranscript: string;
   setStreamingTranscript: (v: string) => void;
   micError: string;
+  /**
+   * Fallback alert state (I4 — must alert, never silent).
+   * Set when Gemini transcription fails so FullReading can show a banner.
+   * Values: 'timeout' | 'safety' | 'decode' | 'empty' | 'error' | null
+   */
+  fallbackReason: string | null;
+  /** Clear fallback alert (e.g. on retry). */
+  clearFallbackReason: () => void;
   startSession: () => void;
   stopSession: () => void;
   submitReading: () => void;
@@ -65,6 +72,9 @@ export function useFullReadingSession({
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [streamingTranscript, setStreamingTranscript] = useState('');
   const [micError, setMicError] = useState('');
+  /** I4: fallback alert reason — non-null when Gemini failed and UI must warn user */
+  const [fallbackReason, setFallbackReason] = useState<string | null>(null);
+  const clearFallbackReason = useCallback(() => setFallbackReason(null), []);
 
   const isSessionActiveRef       = useRef(false);
   const recognitionRef           = useRef<any>(null);
@@ -215,23 +225,28 @@ export function useFullReadingSession({
         .then((result) => {
           setIsTranscribing(false);
           if (result.method === 'gemini' && result.transcript) {
-            // Gemini success: use high-quality transcript
+            // Gemini success (I1): use high-quality Gemini transcript for scoring.
+            // Do NOT re-insert punctuation — Gemini already added it.
+            clearFallbackReason();
             _evaluate(result.transcript);
           } else {
-            // Gemini fallback: use Web Speech + punctuation re-insertion (Block 2)
-            const enhanced = reinsertPunctuation(webSpeechTranscript, fullText);
-            _evaluate(enhanced);
+            // Gemini fallback (I4): show alert with reason, score with raw Web Speech.
+            // Do NOT use reinsertPunctuation to fake precision — it violates I1.
+            setFallbackReason(result.reason ?? 'error');
+            _evaluate(webSpeechTranscript);
           }
         })
         .catch(() => {
           setIsTranscribing(false);
+          // Network failure → fallback alert
+          setFallbackReason('error');
           _evaluate(webSpeechTranscript);
         });
     } else {
       // No audio blob or no token → direct Web Speech path (no Gemini call)
       _evaluate(webSpeechTranscript);
     }
-  }, [fullText, stopSession, token, storyId, onResultReady, audioRecorder.audioBlob]);
+  }, [fullText, stopSession, token, storyId, onResultReady, audioRecorder.audioBlob, clearFallbackReason]);
 
   return {
     isSessionActive,
@@ -240,6 +255,8 @@ export function useFullReadingSession({
     streamingTranscript,
     setStreamingTranscript,
     micError,
+    fallbackReason,
+    clearFallbackReason,
     startSession,
     stopSession,
     submitReading,

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -56,7 +56,8 @@ interface UseFullReadingSessionReturn {
   clearFallbackReason: () => void;
   startSession: () => void;
   stopSession: () => void;
-  submitReading: () => void;
+  /** P1#1: async — awaits stopAndGetBlob() before Gemini transcription. */
+  submitReading: () => Promise<void>;
   audioRecorder: ReturnType<typeof useAudioRecorder>;
 }
 
@@ -166,28 +167,30 @@ export function useFullReadingSession({
     currentTranscriptRef.current = '';
     accumulatedTranscriptRef.current = '';
     setStreamingTranscript('');
-    audioRecorder.stopRecording();
-  }, [audioRecorder]);
+    // NOTE: audioRecorder.stopRecording() is intentionally NOT called here.
+    // submitReading() calls stopAndGetBlob() which triggers stop + awaits onstop,
+    // so it gets the final blob.  stopSession() is also called from handleRetry
+    // (no submit) — in that case clearRecording() handles cleanup.
+  }, []);
 
   /* ---- Submit & evaluate ---- */
-  const submitReading = useCallback(() => {
-    /* #1632 double-click guard: stopSession() flips this to false synchronously,
-     * so a second click during the same tick exits before re-saving. */
+  const submitReading = useCallback(async () => {
+    /* #1632 double-click guard: isSessionActiveRef is flipped synchronously below,
+     * so a second click during the same async tick exits before re-saving. */
     if (!isSessionActiveRef.current) return;
     const webSpeechTranscript = currentTranscriptRef.current;
     const durationMs = Date.now() - startTimeRef.current;
     stopSession();
     if (!webSpeechTranscript.trim()) { setMicError('未偵測到語音，請再試一次。'); return; }
 
-    /* --- Gemini audio transcription (Issue #2131) ---
-     * 1. Try to get a higher-quality Gemini transcription from the audio blob.
-     * 2. If Gemini fails (no blob, no token, network error, fallback), use the
-     *    Web Speech transcript with punctuation re-inserted from the lesson text.
-     * 3. Scoring (analyzeFluency) runs on whichever transcript we end up with.
+    /* --- Gemini audio transcription (Issue #2131 / #2156) ---
+     * P1#1 fix: use stopAndGetBlob() which awaits the MediaRecorder onstop event.
+     * The old pattern (stopRecording() → sync audioBlob read) returned null because
+     * MediaRecorder.onstop fires asynchronously after .stop() is called.
      *
      * NOTE: Real audio E2E requires a microphone — cannot be tested headless.
      *       The transcribeReading() wrapper is unit-tested with mocks (vitest). */
-    const audioBlob = audioRecorder.audioBlob;
+    const audioBlob = await audioRecorder.stopAndGetBlob();
 
     const _evaluate = (finalTranscript: string) => {
       const fluency = analyzeFluency({
@@ -243,10 +246,12 @@ export function useFullReadingSession({
           _evaluate(webSpeechTranscript);
         });
     } else {
-      // No audio blob or no token → direct Web Speech path (no Gemini call)
+      // P1#3 (I4): No audio blob or no token — cannot call Gemini.
+      // Must show fallback alert (never silent) so user knows score is Web Speech only.
+      setFallbackReason('no_audio');
       _evaluate(webSpeechTranscript);
     }
-  }, [fullText, stopSession, token, storyId, onResultReady, audioRecorder.audioBlob, clearFallbackReason]);
+  }, [fullText, stopSession, token, storyId, onResultReady, audioRecorder.stopAndGetBlob, clearFallbackReason]);
 
   return {
     isSessionActive,

--- a/frontend/src/hooks/useFullReadingSession.ts
+++ b/frontend/src/hooks/useFullReadingSession.ts
@@ -175,22 +175,27 @@ export function useFullReadingSession({
 
   /* ---- Submit & evaluate ---- */
   const submitReading = useCallback(async () => {
-    /* #1632 double-click guard: isSessionActiveRef is flipped synchronously below,
-     * so a second click during the same async tick exits before re-saving. */
+    /* #1632 double-click guard: isSessionActiveRef is flipped synchronously. */
     if (!isSessionActiveRef.current) return;
     const webSpeechTranscript = currentTranscriptRef.current;
     const durationMs = Date.now() - startTimeRef.current;
     stopSession();
-    if (!webSpeechTranscript.trim()) { setMicError('未偵測到語音，請再試一次。'); return; }
+
+    /* P1#2: stop recorder FIRST (before any early-return) so the mic is always
+     * released and the final audio chunk is captured.  Even if Web Speech is empty,
+     * Gemini may succeed (I1 — audio primary).
+     * stopAndGetBlob() awaits onstop asynchronously (P1#1 fix). */
+    const audioBlob = await audioRecorder.stopAndGetBlob();
+
+    /* Early return ONLY when both sources are silent — otherwise Gemini gets a chance. */
+    if (!webSpeechTranscript.trim() && !audioBlob) {
+      setMicError('未偵測到語音，請再試一次。');
+      return;
+    }
 
     /* --- Gemini audio transcription (Issue #2131 / #2156) ---
-     * P1#1 fix: use stopAndGetBlob() which awaits the MediaRecorder onstop event.
-     * The old pattern (stopRecording() → sync audioBlob read) returned null because
-     * MediaRecorder.onstop fires asynchronously after .stop() is called.
-     *
      * NOTE: Real audio E2E requires a microphone — cannot be tested headless.
      *       The transcribeReading() wrapper is unit-tested with mocks (vitest). */
-    const audioBlob = await audioRecorder.stopAndGetBlob();
 
     const _evaluate = (finalTranscript: string) => {
       const fluency = analyzeFluency({
@@ -223,32 +228,39 @@ export function useFullReadingSession({
     };
 
     if (audioBlob && token) {
+      // I1: audio blob available → try Gemini regardless of Web Speech content.
       setIsTranscribing(true);
       transcribeReading(audioBlob, fullText, durationMs, token)
         .then((result) => {
           setIsTranscribing(false);
           if (result.method === 'gemini' && result.transcript) {
-            // Gemini success (I1): use high-quality Gemini transcript for scoring.
-            // Do NOT re-insert punctuation — Gemini already added it.
+            // Gemini success (I1): Gemini transcript is the sole scoring source.
             clearFallbackReason();
             _evaluate(result.transcript);
           } else {
-            // Gemini fallback (I4): show alert with reason, score with raw Web Speech.
-            // Do NOT use reinsertPunctuation to fake precision — it violates I1.
+            // I4: Gemini fallback — must alert, score with Web Speech (non-empty) or bail.
             setFallbackReason(result.reason ?? 'error');
-            _evaluate(webSpeechTranscript);
+            if (webSpeechTranscript.trim()) {
+              _evaluate(webSpeechTranscript);
+            } else {
+              // Both sources empty — show mic error instead of scoring 0%.
+              setMicError('未偵測到語音，請再試一次。');
+            }
           }
         })
         .catch(() => {
           setIsTranscribing(false);
-          // Network failure → fallback alert
           setFallbackReason('error');
-          _evaluate(webSpeechTranscript);
+          if (webSpeechTranscript.trim()) {
+            _evaluate(webSpeechTranscript);
+          } else {
+            setMicError('未偵測到語音，請再試一次。');
+          }
         });
     } else {
-      // P1#3 (I4): No audio blob or no token — cannot call Gemini.
-      // Must show fallback alert (never silent) so user knows score is Web Speech only.
+      // I4: No audio blob or no token — cannot reach Gemini.  Alert + Web Speech fallback.
       setFallbackReason('no_audio');
+      // webSpeechTranscript is non-empty here (ensured by early-return above).
       _evaluate(webSpeechTranscript);
     }
   }, [fullText, stopSession, token, storyId, onResultReady, audioRecorder.stopAndGetBlob, clearFallbackReason]);

--- a/frontend/src/services/learning/session.ts
+++ b/frontend/src/services/learning/session.ts
@@ -13,6 +13,12 @@ export interface TranscribeReadingResult {
   method: 'gemini' | 'fallback';
   /** Gemini's internal audit notes (empty string when method=fallback). */
   reasoning?: string;
+  /**
+   * Fallback reason from backend (Issue #2156 — I4 fallback alert).
+   * Values: 'timeout' | 'safety' | 'decode' | 'empty' | 'error'
+   * Present only when method='fallback'. Used by frontend to show alert banner.
+   */
+  reason?: string;
 }
 
 /**
@@ -31,7 +37,7 @@ export async function transcribeReading(
   durationMs: number,
   token: string,
 ): Promise<TranscribeReadingResult> {
-  const FALLBACK: TranscribeReadingResult = { transcript: null, method: 'fallback', reasoning: '' };
+  const FALLBACK: TranscribeReadingResult = { transcript: null, method: 'fallback', reasoning: '', reason: 'error' };
 
   try {
     const form = new FormData();
@@ -58,6 +64,7 @@ export async function transcribeReading(
         transcript: data.transcript ?? null,
         method: data.method === 'gemini' ? 'gemini' : 'fallback',
         reasoning: data.reasoning ?? '',
+        reason: data.reason ?? undefined,
       };
     }
     return FALLBACK;

--- a/frontend/src/services/learning/session.ts
+++ b/frontend/src/services/learning/session.ts
@@ -14,11 +14,19 @@ export interface TranscribeReadingResult {
   /** Gemini's internal audit notes (empty string when method=fallback). */
   reasoning?: string;
   /**
-   * Fallback reason from backend (Issue #2156 — I4 fallback alert).
-   * Values: 'timeout' | 'safety' | 'decode' | 'empty' | 'error'
-   * Present only when method='fallback'. Used by frontend to show alert banner.
+   * Fallback reason (Issue #2156 — I4 fallback alert).
+   *
+   * Backend reasons (method='fallback'):
+   *   'timeout' | 'safety' | 'decode' | 'empty' | 'error'
+   *
+   * Frontend reasons (set by caller before network call):
+   *   'no_audio'  — no recorded blob was available
+   *   'no_token'  — auth token missing; request not attempted
+   *
+   * Present only when method='fallback'. Used by both FullReading and LiveTutor
+   * to display the I4-compliant amber fallback alert banner.
    */
-  reason?: string;
+  reason?: 'timeout' | 'safety' | 'decode' | 'empty' | 'error' | 'no_audio' | 'no_token' | string;
 }
 
 /**

--- a/specs/modules/reading-transcription/INTENT.md
+++ b/specs/modules/reading-transcription/INTENT.md
@@ -1,0 +1,144 @@
+---
+spec_id: reading.transcription.gemini_primary_fallback_alert
+module: reading-transcription
+title: 全文朗讀 + 逐段朗讀 Gemini 音訊轉錄 — webm 轉碼 + fallback alert + 殺即時補強閃爍
+stability: active
+canonical_source: backend/app/services/reading_transcription_service.py
+owns_code:
+  - backend/app/services/reading_transcription_service.py
+  - backend/app/routes/learning/learning_reading.py
+  - frontend/src/hooks/useAudioRecorder.ts
+  - frontend/src/hooks/useFullReadingSession.ts
+  - frontend/src/components/reading-steps/FullReading.tsx
+  - frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+  - frontend/src/services/learning/session.ts
+owns_data: []
+spec_tests:
+  - backend/specs/test_reading_transcription_spec.py
+related_issues:
+  - 2131
+  - 2156
+source_meetings: []
+last_reviewed: 2026-06-09
+owner: young
+---
+
+# reading-transcription — INTENT
+
+## Purpose
+
+Provide high-quality audio-to-text transcription for both FullReading (全文朗讀) and LiveTutor
+(逐段朗讀) by routing browser MediaRecorder audio through Gemini Audio Understanding instead of
+relying solely on the browser's Web Speech API.
+
+The browser Web Speech API has known accuracy issues with Taiwanese Mandarin, especially for
+homophones and text-specific vocabulary. Gemini can be guided with the reference (target) text
+to resolve ambiguities, producing transcripts that more faithfully represent what the student
+actually read.
+
+---
+
+## Invariants (I1–I5)
+
+### I1 — Gemini is the sole trusted transcription source
+
+When Gemini successfully transcribes the audio, **only** the Gemini transcript is used for
+scoring (analyzeFluency / evaluateAndRespond). The Web Speech transcript is **never** passed
+to scoring logic when a valid Gemini transcript is available.
+
+Corollary: `reinsertPunctuation(webSpeechTranscript, fullText)` MUST NOT be used as a
+substitute for Gemini transcription. It produces a fake high-quality appearance without
+actual accuracy.
+
+### I2 — webm audio must be transcoded before sending to Gemini
+
+Chrome MediaRecorder defaults to `audio/webm;codecs=opus`. Vertex AI Gemini Audio Understanding
+does NOT natively accept webm. The backend service (`reading_transcription_service.py`) must
+transcode webm (and other unsupported formats) to `audio/ogg` via ffmpeg before calling Gemini.
+
+Supported input MIME types (browser → backend): `audio/webm`, `audio/webm;codecs=opus`,
+`audio/ogg`, `audio/ogg;codecs=opus`, `audio/mp4`, `audio/mpeg`, `audio/wav`.
+
+### I3 — No live punctuation re-insertion during recording (kill flicker)
+
+The live preview shown during recording (while STT is producing partial results) MUST display
+raw Web Speech text in a visually distinct (gray) style. It MUST NOT run punctuation
+re-insertion or `enhanceLiveTranscript` on every partial result — doing so causes visible
+flicker on every STT update.
+
+The label "即時預覽（唸完精準校正）" communicates to the user that accurate punctuation is
+added after submission.
+
+### I4 — Fallback must alert, never be silent
+
+When Gemini transcription fails (any reason: transcode failure, Gemini timeout, safety filter,
+empty result, network error), the UI MUST display a visible warning banner:
+
+> "⚠️ 高品質辨識暫時失敗，這是粗略結果，建議重試"
+
+The banner must be dismissible and include the reason for teacher/debug awareness. Silently
+falling back without user notification is forbidden — it would mislead the student about their
+score quality.
+
+### I5 — Fallback must not auto-pass
+
+When Gemini fails and the system falls back to Web Speech scoring, the result MUST use the
+raw Web Speech transcript for scoring. The student must not be auto-passed or given an
+artificially high score due to the fallback. If no Web Speech transcript exists either, the
+evaluation must show 0% or prompt a retry.
+
+---
+
+## Architecture
+
+```
+Browser (MediaRecorder)
+  ├─ audio/webm blob ──────────────────────────────────►  POST /api/reading/transcribe
+  │                                                        │
+  │   [Backend: reading_transcription_service.py]         │
+  │   1. Check MIME → needs transcode?                    │
+  │   2. If yes: ffmpeg webm→ogg (temp files)             │
+  │   3. Call Gemini Audio with reference text hint       │
+  │   4. Return {transcript, method, reasoning}           │
+  │      OR {transcript: null, method: "fallback", reason}│
+  │                                                        │
+  └─ Web Speech (partial + final results) ────────────►  Live preview only (gray text, I3)
+
+Frontend scoring:
+  - method=gemini → use Gemini transcript (I1)
+  - method=fallback → show alert (I4), use Web Speech, never auto-pass (I5)
+```
+
+### Per-feature integration
+
+**FullReading (全文朗讀)**:
+- `useAudioRecorder` records the full reading (max 120s)
+- On submit: stop recorder → POST to `/api/reading/transcribe`
+- `useFullReadingSession.submitReading()` resolves which transcript to use
+- `FullReading.tsx` shows fallback banner when `fallbackReason` is set
+
+**LiveTutor (逐段朗讀)**:
+- `useAudioRecorder` records each paragraph (max 120s, reset per paragraph)
+- On paragraph submit (`submitSentence`): stop recorder → POST to `/api/reading/transcribe`
+- Gemini transcript replaces Web Speech for `evaluateAndRespond` call (I1)
+- `LiveTutor.tsx` shows per-paragraph fallback banner when `paragraphFallbackReason` is set
+
+---
+
+## Contracts (machine-verifiable, see test_reading_transcription_spec.py)
+
+| ID | Contract |
+|----|----------|
+| C1 | webm MIME triggers transcode; is NOT passed directly to Gemini |
+| C2 | Any Gemini/transcode failure → `{method: "fallback", reason: str, transcript: null}` + WARN log `event=reading_transcribe_fallback` |
+| C3 | Gemini success → `{method: "gemini", transcript: str (non-empty), reasoning: str}` |
+| C4 | Unsupported MIME → HTTP 415 (route gate); empty audio → HTTP 400; never HTTP 500 on AI error |
+| C5 | Route has auth (`get_current_user`), rate-limit (`ai_limit`), and size caps (`_MAX_AUDIO_BYTES`, `_MAX_TARGET_CHARS`) |
+
+---
+
+## Non-goals
+
+- Real-time streaming transcription (Gemini audio is one-shot after recording ends)
+- Persisting transcripts to DB (handled by existing LearningSession flow)
+- E2E automated microphone testing (requires real audio hardware; manual test on staging)

--- a/specs/registry.yaml
+++ b/specs/registry.yaml
@@ -519,6 +519,29 @@ modules:
   last_reviewed: 2026-06-01
   owner: young
   intent: specs/modules/reading-eval-safety/INTENT.md
+- spec_id: reading.transcription.gemini_primary_fallback_alert
+  module: reading-transcription
+  title: 全文朗讀 + 逐段朗讀 Gemini 音訊轉錄 — webm 轉碼 + fallback alert + 殺即時補強閃爍
+  stability: active
+  canonical_source: backend/app/services/reading_transcription_service.py
+  owns_code:
+  - backend/app/services/reading_transcription_service.py
+  - backend/app/routes/learning/learning_reading.py
+  - frontend/src/hooks/useAudioRecorder.ts
+  - frontend/src/hooks/useFullReadingSession.ts
+  - frontend/src/components/reading-steps/FullReading.tsx
+  - frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+  - frontend/src/services/learning/session.ts
+  owns_data: []
+  spec_tests:
+  - backend/specs/test_reading_transcription_spec.py
+  related_issues:
+  - 2131
+  - 2156
+  source_meetings: []
+  last_reviewed: 2026-06-09
+  owner: young
+  intent: specs/modules/reading-transcription/INTENT.md
 - spec_id: semester.one_active_invariant
   module: semester
   title: 學期唯一啟用不變式（pointer module）


### PR DESCRIPTION
Fixes #2156

## Summary

### Backend
- **`reading_transcription_service.py`**: Gemini Audio Understanding with ffmpeg webm→ogg transcode. Chrome MediaRecorder defaults to `audio/webm;codecs=opus` which Gemini does not natively accept — ffmpeg transcodes to ogg before the Gemini API call (Invariant I2).
- **`learning_reading.py`**: `POST /api/reading/transcribe` endpoint — auth + rate-limit + size caps + HTTP 415 for unsupported MIME types (Contract C4/C5).

### Frontend — FullReading (全文朗讀)
- **`useFullReadingSession.ts`**: Removed `reinsertPunctuation` fallback path (was faking precision — violates I1). Added `fallbackReason` / `clearFallbackReason` state for I4 alert.
- **`FullReading.tsx`**: Removed `enhanceLiveTranscript` live flicker path (I3). Raw Web Speech gray text preview now shows with label "即時預覽（唸完精準校正）". Added amber fallback alert banner (I4) — dismissible, shows reason.

### Frontend — LiveTutor (逐段朗讀)
- **`LiveTutor.tsx`**: Added `useAudioRecorder` per paragraph. Recording starts with `startSession`, stops on `submitSentence`. `resolveTranscript()` tries Gemini first; on any failure sets `paragraphFallbackReason` for I4 alert. `evaluateAndRespond()` receives Gemini transcript when available (I1 — Web Speech never enters scoring when Gemini succeeds).

### Specs
- **`specs/modules/reading-transcription/INTENT.md`**: New spec module documenting I1-I5 invariants and C1-C5 contracts.
- **`specs/registry.yaml`**: Updated entry (38 modules total).
- **`backend/specs/test_reading_transcription_spec.py`**: 25 new machine-verifiable contract tests.

## Invariants enforced

| Invariant | Description | Where |
|-----------|-------------|-------|
| I1 | Gemini is sole trusted transcription source | useFullReadingSession, LiveTutor submitSentence |
| I2 | webm must transcode before Gemini | reading_transcription_service.py ffmpeg |
| I3 | No live punctuation re-insertion (kills flicker) | FullReading.tsx — enhanceLiveTranscript removed |
| I4 | Fallback must alert, never silent | Both FullReading + LiveTutor amber banner |
| I5 | Fallback must not auto-pass | Raw Web Speech used for scoring on fallback |

## Test plan

1. Backend pytest (new spec + existing):
   - `python3.10 -m pytest backend/specs/test_reading_transcription_spec.py -v` → 25 passed
   - Full suite: `python3.10 -m pytest specs/ -q` → 552 passed, 4 xfailed

2. Frontend build: `cd frontend && npm run build` → built in ~11s (no TS errors)

3. Frontend vitest: `npm test` → 34 failed | 1053 passed (34 failures are **pre-existing** DiffDisplay / ClassroomDetail tests, not related to this PR)

4. Specs gate: `bash specs/run-ci.sh --quick` → Gate 1 OK (registry fresh, 38 modules)

5. E2E manual test (staging — requires microphone):
   - Full reading: start session → read → stop → verify Gemini transcript used; verify fallback banner appears when backend returns `method=fallback`
   - Live tutor: start paragraph → read → submit → verify Gemini transcript scoring; retry button clears fallback banner

## Note on ffmpeg

`backend/Dockerfile` already installs ffmpeg (line 2: `apt-get install -y --no-install-recommends ffmpeg`). No Dockerfile changes needed.