### PR TITLE
fix(vocab-mcq): 答錯不漏正解 + 說明/示範動畫 (Fixes #2159)

### DIFF
--- a/frontend/src/components/reading-steps/VocabDefinitionMatchMCQ.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatchMCQ.tsx
@@ -9,10 +9,17 @@
  *
  * Fix #1912: wrong answer now shows ✗ marker + correct answer reveal + explicit next
  * button. Adopted from step 9 (Comprehension) pattern. Silent accept removed.
+ *
+ * Fix #2159: wrong answer no longer reveals correct answer. Student can retry until
+ * correct. Added onboarding coach + demo animation on real option buttons.
  */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { VocabItem } from '../../types';
 import { buildMCQOptions, AnswerRecord } from './vocabDefinitionMatchLogic';
+import { getEncouragementMessage } from '../../utils/encouragement';
+
+// ── localStorage key for first-use onboarding gate ────────────────────────
+const VOCAB_MCQ_ONBOARDED_KEY = 'vocab_mcq_onboarded';
 
 export interface MultipleChoiceProps {
   vocab: VocabItem[];
@@ -20,10 +27,52 @@ export interface MultipleChoiceProps {
   onAllDone: (answers: AnswerRecord[]) => void;
 }
 
+// AnswerState now tracks all wrong choices for the current question so
+// multiple wrong attempts can all be marked red simultaneously.
 type AnswerState =
   | { status: 'idle' }
   | { status: 'correct'; chosenIdx: number }
-  | { status: 'wrong'; chosenIdx: number };
+  | { status: 'wrong'; wrongIndices: Set<number> };
+
+// ── Onboarding coach (amber box, matches ReadingAnnotation pattern) ────────
+interface OnboardingCoachProps {
+  onDismiss: () => void;
+  onDemo: () => void;
+}
+
+function OnboardingCoach({ onDismiss, onDemo }: OnboardingCoachProps) {
+  return (
+    <div className="mb-5 rounded-2xl border-2 border-amber-400/60 bg-amber-50 px-5 py-4 flex flex-col gap-3">
+      <div className="flex items-start gap-3">
+        <span className="material-symbols-outlined text-amber-500 text-2xl flex-shrink-0 mt-0.5">
+          lightbulb
+        </span>
+        <div className="flex-1">
+          <p className="font-bold text-on-surface text-base mb-1">詞語理解怎麼玩？</p>
+          <p className="text-sm text-on-surface-variant leading-relaxed">
+            讀上方的解釋，從下面的選項中選出對應的語詞。
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 self-end">
+        <button
+          type="button"
+          onClick={onDemo}
+          className="px-4 py-2 rounded-full text-sm font-bold border-2 border-accent text-accent hover:bg-accent/10 active:scale-[0.98] transition-all"
+        >
+          示範
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="px-5 py-2 rounded-full text-sm font-bold text-white bg-accent hover:brightness-110 active:scale-[0.98] transition-all"
+        >
+          我知道了
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: MultipleChoiceProps) {
   const [queueIdx, setQueueIdx] = useState(0);
@@ -32,15 +81,39 @@ export function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: Multi
   );
   const [answerState, setAnswerState] = useState<AnswerState>({ status: 'idle' });
 
+  // Onboarding state — gated by localStorage
+  const [showCoach, setShowCoach] = useState<boolean>(() => {
+    try {
+      return !localStorage.getItem(VOCAB_MCQ_ONBOARDED_KEY);
+    } catch {
+      return true;
+    }
+  });
+
+  // Demo animation state: null = not running, number = vocabIdx being highlighted
+  const [demoHighlight, setDemoHighlight] = useState<number | null>(null);
+  const demoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Encouragement message picked once per wrong answer
+  const [encouragementMsg, setEncouragementMsg] = useState<string>('');
+
   useEffect(() => {
     setQueueIdx(0);
     setAnswerState({ status: 'idle' });
+    setEncouragementMsg('');
     answersRef.current = activeDefIndices.map((defIdx) => ({
       defIndex: defIdx,
       answeredWordIdx: null,
       correct: null,
     }));
   }, [activeDefIndices]);
+
+  // Clean up demo timer on unmount
+  useEffect(() => {
+    return () => {
+      if (demoTimerRef.current) clearTimeout(demoTimerRef.current);
+    };
+  }, []);
 
   const currentDefIdx = activeDefIndices[queueIdx];
 
@@ -50,11 +123,49 @@ export function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: Multi
     [queueIdx, currentDefIdx, vocab],
   );
 
+  const handleDismissCoach = () => {
+    setShowCoach(false);
+    try {
+      localStorage.setItem(VOCAB_MCQ_ONBOARDED_KEY, '1');
+    } catch {
+      // ignore
+    }
+  };
+
+  /**
+   * Demo animation: animate a cursor-like highlight onto the correct option.
+   * Purely visual — does NOT submit an answer or affect scoring.
+   * Steps:
+   *   0ms   → start highlight on correct option
+   *   900ms → pulse off (clear highlight)
+   *   1100ms → second pulse
+   *   2000ms → done
+   */
+  const handleDemo = () => {
+    if (demoTimerRef.current) clearTimeout(demoTimerRef.current);
+    setDemoHighlight(currentDefIdx);
+    demoTimerRef.current = setTimeout(() => {
+      setDemoHighlight(null);
+      demoTimerRef.current = setTimeout(() => {
+        setDemoHighlight(currentDefIdx);
+        demoTimerRef.current = setTimeout(() => {
+          setDemoHighlight(null);
+        }, 900);
+      }, 200);
+    }, 900);
+    // Also dismiss the coach so student can act
+    handleDismissCoach();
+  };
+
   const handleChoice = (vocabIdx: number) => {
-    if (answerState.status !== 'idle') return;
+    // Ignore clicks while correct answer is showing (auto-advance in progress)
+    if (answerState.status === 'correct') return;
+    // Ignore clicks on already-wrong options (but allow clicking other options)
+    if (answerState.status === 'wrong' && answerState.wrongIndices.has(vocabIdx)) return;
 
     const isCorrect = vocabIdx === currentDefIdx;
 
+    // Update the answers record — on retry, overwrite with the latest attempt
     answersRef.current = answersRef.current.map((a) =>
       a.defIndex === currentDefIdx
         ? { ...a, answeredWordIdx: vocabIdx, correct: isCorrect }
@@ -63,9 +174,11 @@ export function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: Multi
 
     if (isCorrect) {
       setAnswerState({ status: 'correct', chosenIdx: vocabIdx });
+      setEncouragementMsg('');
       // Auto-advance after short delay on correct answer (step 9 pattern)
       setTimeout(() => {
         setAnswerState({ status: 'idle' });
+        setEncouragementMsg('');
         const nextIdx = queueIdx + 1;
         if (nextIdx >= activeDefIndices.length) {
           onAllDone(answersRef.current);
@@ -74,39 +187,39 @@ export function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: Multi
         }
       }, 400);
     } else {
-      // Wrong answer: show ✗ + correct reveal + explicit next button (fix #1912)
-      setAnswerState({ status: 'wrong', chosenIdx: vocabIdx });
-    }
-  };
-
-  const handleNext = () => {
-    setAnswerState({ status: 'idle' });
-    const nextIdx = queueIdx + 1;
-    if (nextIdx >= activeDefIndices.length) {
-      onAllDone(answersRef.current);
-    } else {
-      setQueueIdx(nextIdx);
+      // Wrong answer: mark only the chosen option red; do NOT reveal correct answer.
+      // Student can keep clicking other options.
+      const prevWrong =
+        answerState.status === 'wrong' ? new Set(answerState.wrongIndices) : new Set<number>();
+      prevWrong.add(vocabIdx);
+      setAnswerState({ status: 'wrong', wrongIndices: prevWrong });
+      setEncouragementMsg(getEncouragementMessage());
     }
   };
 
   const item = vocab[currentDefIdx];
-  const isAnswered = answerState.status !== 'idle';
 
   const getButtonClass = (vocabIdx: number): string => {
-    const base = 'rounded-2xl border-2 p-4 flex items-center justify-center font-bold text-xl transition-all duration-200 select-none active:scale-[0.97] min-h-[56px]';
-    if (!isAnswered) {
-      return `${base} border-surface-container-high bg-surface-container-lowest text-on-surface hover:border-accent hover:bg-accent/5`;
+    const base =
+      'rounded-2xl border-2 p-4 flex items-center justify-center font-bold text-xl transition-all duration-200 select-none active:scale-[0.97] min-h-[56px]';
+
+    // Demo highlight overrides everything — amber pulsing style
+    if (demoHighlight === vocabIdx) {
+      return `${base} border-amber-400 bg-amber-50 text-amber-800 animate-pulse`;
     }
-    if (vocabIdx === currentDefIdx) {
-      // Correct answer — highlight green
+
+    // Correct answer confirmed — show green
+    if (answerState.status === 'correct' && vocabIdx === answerState.chosenIdx) {
       return `${base} border-emerald-400 bg-emerald-50 text-emerald-800`;
     }
-    if (answerState.status === 'wrong' && vocabIdx === answerState.chosenIdx) {
-      // Chosen wrong answer — highlight red
+
+    // Wrong attempt on this specific option — red. Others remain interactive.
+    if (answerState.status === 'wrong' && answerState.wrongIndices.has(vocabIdx)) {
       return `${base} border-red-400 bg-red-50 text-red-700`;
     }
-    // Other options — muted
-    return `${base} border-surface-container-high bg-surface-container-lowest text-on-surface opacity-40`;
+
+    // Default interactive style
+    return `${base} border-surface-container-high bg-surface-container-lowest text-on-surface hover:border-accent hover:bg-accent/5`;
   };
 
   return (
@@ -114,17 +227,26 @@ export function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: Multi
       {/* Progress bar */}
       <div className="flex items-center gap-3 mb-6">
         <div className="flex-1 h-2.5 bg-surface-container-high rounded-full overflow-hidden">
-          <div className="h-full bg-accent rounded-full transition-all duration-500 ease-out"
-            style={{ width: `${activeDefIndices.length > 0 ? (queueIdx / activeDefIndices.length) * 100 : 0}%` }} />
+          <div
+            className="h-full bg-accent rounded-full transition-all duration-500 ease-out"
+            style={{
+              width: `${activeDefIndices.length > 0 ? (queueIdx / activeDefIndices.length) * 100 : 0}%`,
+            }}
+          />
         </div>
         <span className="text-sm font-headline font-bold text-on-surface-variant shrink-0">
           {queueIdx + 1} / {activeDefIndices.length}
         </span>
       </div>
 
+      {/* Onboarding coach — shown first time or when student clicks help */}
+      {showCoach && <OnboardingCoach onDismiss={handleDismissCoach} onDemo={handleDemo} />}
+
       {/* Definition card */}
       <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-8 mb-6">
-        <p className="text-xl md:text-2xl text-on-surface leading-[2.5rem] md:leading-[3rem]">{item?.definition}</p>
+        <p className="text-xl md:text-2xl text-on-surface leading-[2.5rem] md:leading-[3rem]">
+          {item?.definition}
+        </p>
       </div>
 
       {/* Options — 2-column grid */}
@@ -136,46 +258,53 @@ export function MultipleChoiceMode({ vocab, activeDefIndices, onAllDone }: Multi
             key={vocabIdx}
             className={getButtonClass(vocabIdx)}
             onClick={() => handleChoice(vocabIdx)}
-            disabled={isAnswered}
+            // Only disable when correct answer is being processed (auto-advance delay)
+            // or during demo highlight — wrong answers keep buttons interactive
+            disabled={answerState.status === 'correct' || demoHighlight !== null}
           >
-            {/* Wrong-answer ✗ marker (#1912) */}
-            {answerState.status === 'wrong' && vocabIdx === answerState.chosenIdx && (
+            {/* Confirmed correct answer ✓ marker */}
+            {answerState.status === 'correct' && vocabIdx === answerState.chosenIdx && (
+              <span className="mr-1 text-emerald-600" aria-hidden="true">
+                ✓
+              </span>
+            )}
+            {/* Wrong-answer ✗ marker — only on the chosen wrong option */}
+            {answerState.status === 'wrong' && answerState.wrongIndices.has(vocabIdx) && (
               <span
                 className="mr-1 text-red-600"
-                aria-label="錯誤"
+                aria-label="答錯了"
                 data-testid="wrong-answer-indicator"
               >
                 ✗
               </span>
-            )}
-            {/* Correct answer ✓ marker */}
-            {isAnswered && vocabIdx === currentDefIdx && (
-              <span className="mr-1 text-emerald-600" aria-hidden="true">✓</span>
             )}
             {vocab[vocabIdx]?.word}
           </button>
         ))}
       </div>
 
-      {/* Wrong-answer feedback panel (#1912) */}
+      {/* Wrong-answer encouragement panel — no answer reveal (#2159) */}
       {answerState.status === 'wrong' && (
-        <div className="mt-5 rounded-2xl border border-red-200 bg-red-50 p-4 space-y-3">
-          <div className="flex items-center gap-2 text-red-700 font-bold text-sm">
-            <span aria-hidden="true">✗</span>
-            <span>答錯了，正確答案是：</span>
-            <span className="text-red-800 font-bold text-base">{vocab[currentDefIdx]?.word}</span>
+        <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50 p-4">
+          <div className="flex items-center gap-2 text-amber-700 font-bold text-sm">
+            <span aria-hidden="true" className="text-lg">
+              💪
+            </span>
+            <span>{encouragementMsg || '答錯了，再試試看！'}</span>
           </div>
-          {vocab[currentDefIdx]?.definition && (
-            <p className="text-sm text-red-600 leading-relaxed">
-              💡 {vocab[currentDefIdx].definition}
-            </p>
-          )}
+        </div>
+      )}
+
+      {/* Show help button after onboarding is dismissed */}
+      {!showCoach && (
+        <div className="mt-4 flex justify-end">
           <button
             type="button"
-            onClick={handleNext}
-            className="mt-1 px-5 py-2 rounded-full text-sm font-bold bg-accent text-white hover:bg-accent-hover transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+            onClick={() => setShowCoach(true)}
+            className="text-xs text-on-surface-variant/60 hover:text-on-surface-variant transition-colors flex items-center gap-1"
           >
-            繼續下一題
+            <span className="material-symbols-outlined text-sm">help_outline</span>
+            怎麼玩？
           </button>
         </div>
       )}


### PR DESCRIPTION
Fixes #2159

## Summary

改動只在 `frontend/src/components/reading-steps/VocabDefinitionMatchMCQ.tsx`。

### Bug 1 修復：答錯不漏正解，可重選（改動 #1912 行為）

**Before**: 點錯選項 → 正解選項立刻標綠 ✓ + 顯示「正確答案是：XXX」+ 解釋 + 「繼續下一題」按鈕，全部 disabled。學生不需思考就知道答案。

**After**:
- 只把「被點的錯選項」標紅 ✗，正解不做任何標示
- 下方顯示 amber 鼓勵語（`getEncouragementMessage()`，例如「加油！再想想看」）
- 選項保持可點，學生可繼續重選直到答對
- 移除「繼續下一題」按鈕（答錯不能跳題）
- 可多次點錯，每個點錯過的選項都保持紅色

### 新功能 2：說明 + 示範動畫（#2159 新增）

- 第一次進入時顯示 amber OnboardingCoach 說明框（匹配 `ReadingAnnotation` 的 amber 風格）
- localStorage key `vocab_mcq_onboarded` gate，關閉後不再自動出現
- 「示範」按鈕：在真正的題目選項 UI 上播放兩次 amber pulse 動畫，指示正解位置，**純視覺演示，不提交答案也不計分**
- 右下角「怎麼玩？」按鈕可重新叫出說明框

### 不動的部分
- 答對後的 ✓ + 400ms auto-advance 流程完全不動
- `buildMCQOptions` 邏輯不動
- TypeScript: zero errors on changed file (只有 worktree 無 node_modules 的環境錯誤，與改動無關)

## Test plan

PR Preview 部署後，學生小明登入 → `/learn/1076/vocab-definition`：

- [ ] 點一個錯選項 → 截圖確認：無綠 ✓ 正解、無「正確答案是」文字、有 amber 鼓勵語、選項仍可點
- [ ] 點另一個錯選項 → 兩個選項都標紅、前一個鼓勵語更新
- [ ] 點正解 → 選項標綠 ✓ → 400ms 後自動進下一題（不動）
- [ ] 說明框（amber）第一次進入自動出現；「我知道了」可關閉
- [ ] 「示範」按鈕：amber 動畫打在正解選項上，完成後學生自己作答
- [ ] 「怎麼玩？」按鈕可重新呼出說明框
- [ ] console 無新 error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)