### PR TITLE
feat(onboarding): 語詞應用/詞語配對加說明+示範引導 (Fixes #2163)

### DIFF
--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -9,14 +9,58 @@
  *   A12 — wrong answer never reveals the correct answer; retryable
  *   A11 — text-left, smaller dashed blank, "第 N 題 / 共 M 題" heading,
  *          ABCD badges behind FILLBLANK_SHOW_ABCD feature flag (default false)
+ * Issue #2163: OnboardingCoach — first-use amber説明框 + demo animation on real UI
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { FillInBlankItem } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { fontForZhuyin } from '../../constants/fonts';
 import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStorageScope';
 import ToolboxCompletionActions from '../tools/ToolboxCompletionActions';
 import { FILLBLANK_SHOW_ABCD } from '../../config/featureFlags';
+
+// ── localStorage key for first-use onboarding gate ────────────────────────
+const FILLBLANK_ONBOARDED_KEY = 'fillblank_onboarded';
+
+// ── Onboarding coach — amber box, same style as VocabDefinitionMatchMCQ ──
+interface OnboardingCoachProps {
+  onDismiss: () => void;
+  onDemo: () => void;
+}
+
+function OnboardingCoach({ onDismiss, onDemo }: OnboardingCoachProps) {
+  return (
+    <div className="mb-5 rounded-2xl border-2 border-amber-400/60 bg-amber-50 px-5 py-4 flex flex-col gap-3">
+      <div className="flex items-start gap-3">
+        <span className="material-symbols-outlined text-amber-500 text-2xl flex-shrink-0 mt-0.5">
+          lightbulb
+        </span>
+        <div className="flex-1">
+          <p className="font-bold text-on-surface text-base mb-1">語詞應用怎麼玩？</p>
+          <p className="text-sm text-on-surface-variant leading-relaxed">
+            讀句子，從下面選出最適合填進空格的語詞。
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 self-end">
+        <button
+          type="button"
+          onClick={onDemo}
+          className="px-4 py-2 rounded-full text-sm font-bold border-2 border-accent text-accent hover:bg-accent/10 active:scale-[0.98] transition-all"
+        >
+          示範
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="px-5 py-2 rounded-full text-sm font-bold text-white bg-accent hover:brightness-110 active:scale-[0.98] transition-all"
+        >
+          我知道了
+        </button>
+      </div>
+    </div>
+  );
+}
 
 interface Props {
   sentences: FillInBlankItem[];
@@ -87,6 +131,35 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
   const { zhuyinActive, processZhuyin } = useZhuyin();
   const savedProgress = loadProgress(storyId);
 
+  // Onboarding state — gated by localStorage
+  const [showCoach, setShowCoach] = useState<boolean>(() => {
+    try {
+      return !localStorage.getItem(FILLBLANK_ONBOARDED_KEY);
+    } catch {
+      return true;
+    }
+  });
+
+  // Demo animation state: null = not running, code = the option being highlighted
+  const [demoHighlightCode, setDemoHighlightCode] = useState<string | null>(null);
+  const demoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up demo timer on unmount
+  useEffect(() => {
+    return () => {
+      if (demoTimerRef.current) clearTimeout(demoTimerRef.current);
+    };
+  }, []);
+
+  const handleDismissCoach = () => {
+    setShowCoach(false);
+    try {
+      localStorage.setItem(FILLBLANK_ONBOARDED_KEY, '1');
+    } catch {
+      // ignore
+    }
+  };
+
   const [phase, setPhase] = useState<Phase>('exercise');
   const [retryMode, setRetryMode] = useState(savedProgress?.retryMode ?? false);
   const [retryIndices, setRetryIndices] = useState<number[]>(savedProgress?.pendingRetryIndices ?? []);
@@ -126,6 +199,31 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
   const availableEntries = bankEntries;
   const currentSentence = !done ? activeSentences[currentIdx] : null;
   const currentOriginalIdx = retryMode ? retryIndices[currentIdx] : currentIdx;
+
+  /**
+   * Demo animation: pulse the correct option for the current question.
+   * Purely visual — does NOT submit an answer or affect scoring.
+   * Two amber pulses on the correct option, then done.
+   */
+  const handleDemo = () => {
+    if (demoTimerRef.current) clearTimeout(demoTimerRef.current);
+    if (!currentSentence) {
+      handleDismissCoach();
+      return;
+    }
+    const correctCode = currentSentence.answer;
+    setDemoHighlightCode(correctCode);
+    demoTimerRef.current = setTimeout(() => {
+      setDemoHighlightCode(null);
+      demoTimerRef.current = setTimeout(() => {
+        setDemoHighlightCode(correctCode);
+        demoTimerRef.current = setTimeout(() => {
+          setDemoHighlightCode(null);
+        }, 900);
+      }, 200);
+    }, 900);
+    handleDismissCoach();
+  };
 
   // A10: selecting immediately evaluates — no separate confirm button
   function handleSelect(code: string) {
@@ -358,6 +456,9 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
           </span>
         </div>
 
+        {/* Onboarding coach — shown first time or when student clicks help */}
+        {showCoach && <OnboardingCoach onDismiss={handleDismissCoach} onDemo={handleDemo} />}
+
         {/* A11: per-question heading "第 N 題 / 共 M 題" */}
         {currentSentence && (
           <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wide">
@@ -413,6 +514,7 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
           <div className="grid grid-cols-2 gap-3">
             {availableEntries.map(([code, word]) => {
               const isUsedDecoy = usedCodes.has(code);
+              const isDemoHighlight = demoHighlightCode === code;
               // A6/A12: when wrong, show which was just selected as amber highlight (no reveal of correct)
               const isWrongSelected =
                 feedback === 'wrong' &&
@@ -423,11 +525,13 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
               return (
                 <button
                   key={code}
-                  onClick={() => !isUsedDecoy && handleSelect(code)}
-                  disabled={isUsedDecoy}
+                  onClick={() => !isUsedDecoy && !demoHighlightCode && handleSelect(code)}
+                  disabled={isUsedDecoy || !!demoHighlightCode}
                   aria-disabled={isUsedDecoy}
                   className={`rounded-2xl border-2 p-4 text-left flex items-center gap-3 transition-all min-h-[56px] ${
-                    isUsedDecoy
+                    isDemoHighlight
+                      ? 'border-amber-400 bg-amber-50 animate-pulse'
+                      : isUsedDecoy
                       ? 'border-surface-container-high bg-surface-container-high/40 opacity-40 cursor-not-allowed'
                       : isWrongSelected
                       ? 'border-amber-400 bg-amber-50 active:scale-[0.97]'
@@ -439,7 +543,7 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
                     <span className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-sm font-headline font-black ${
                       isUsedDecoy
                         ? 'bg-surface-container-high text-on-surface-variant/40'
-                        : isWrongSelected
+                        : isWrongSelected || isDemoHighlight
                         ? 'bg-amber-400 text-white'
                         : 'bg-surface-container-high text-on-surface-variant'
                     }`}>
@@ -449,7 +553,7 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
                   <span className={`font-bold text-base ${
                     isUsedDecoy
                       ? 'text-on-surface-variant/40 line-through'
-                      : isWrongSelected
+                      : isWrongSelected || isDemoHighlight
                       ? 'text-amber-700'
                       : 'text-on-surface'
                   }`}>
@@ -467,6 +571,20 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
           <p className="text-xs text-center text-on-surface-variant">
             點選其他選項繼續作答
           </p>
+        )}
+
+        {/* Show help button after onboarding is dismissed */}
+        {!showCoach && (
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={() => setShowCoach(true)}
+              className="text-xs text-on-surface-variant/60 hover:text-on-surface-variant transition-colors flex items-center gap-1"
+            >
+              <span className="material-symbols-outlined text-sm">help_outline</span>
+              怎麼玩？
+            </button>
+          </div>
         )}
 
       </div>

--- a/frontend/src/components/reading-steps/VocabDefinitionMatchDragDrop.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatchDragDrop.tsx
@@ -8,6 +8,7 @@
  * last drag-drop question always has multiple options — no forced-correct final question.
  *
  * Fix #2082 (A6/A7/A8): verbal feedback, larger definition text, device-aware instruction.
+ * Issue #2163: OnboardingCoach — first-use amber說明框 + demo animation on real UI.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { VocabItem } from '../../types';
@@ -17,6 +18,52 @@ import { AnswerRecord } from './vocabDefinitionMatchLogic';
 // Using a module-level constant so it is evaluated once and shared across renders.
 const IS_TOUCH_DEVICE =
   typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+
+// ── localStorage key for first-use onboarding gate ────────────────────────
+const VOCAB_DRAGDROP_ONBOARDED_KEY = 'vocab_dragdrop_onboarded';
+
+// ── Onboarding coach — amber box, matches VocabDefinitionMatchMCQ pattern ──
+interface OnboardingCoachProps {
+  onDismiss: () => void;
+  onDemo: () => void;
+}
+
+function OnboardingCoach({ onDismiss, onDemo }: OnboardingCoachProps) {
+  const instruction = IS_TOUCH_DEVICE
+    ? '點選語詞，再點右邊的解釋框放入'
+    : '把左邊的語詞拖到右邊正確的解釋上';
+  return (
+    <div className="mb-5 rounded-2xl border-2 border-amber-400/60 bg-amber-50 px-5 py-4 flex flex-col gap-3">
+      <div className="flex items-start gap-3">
+        <span className="material-symbols-outlined text-amber-500 text-2xl flex-shrink-0 mt-0.5">
+          lightbulb
+        </span>
+        <div className="flex-1">
+          <p className="font-bold text-on-surface text-base mb-1">詞語配對怎麼玩？</p>
+          <p className="text-sm text-on-surface-variant leading-relaxed">
+            {instruction}。配對正確後語詞會消失。
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 self-end">
+        <button
+          type="button"
+          onClick={onDemo}
+          className="px-4 py-2 rounded-full text-sm font-bold border-2 border-accent text-accent hover:bg-accent/10 active:scale-[0.98] transition-all"
+        >
+          示範
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="px-5 py-2 rounded-full text-sm font-bold text-white bg-accent hover:brightness-110 active:scale-[0.98] transition-all"
+        >
+          我知道了
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export interface DragDropProps {
   vocab: VocabItem[];
@@ -38,6 +85,29 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
   // A6: verbal feedback state — show praise on correct, "再試試看！" on wrong
   const [wrongFeedbackSlot, setWrongFeedbackSlot] = useState<number | null>(null);
   const [correctFeedbackSlot, setCorrectFeedbackSlot] = useState<number | null>(null);
+
+  // Onboarding state — gated by localStorage
+  const [showCoach, setShowCoach] = useState<boolean>(() => {
+    try {
+      return !localStorage.getItem(VOCAB_DRAGDROP_ONBOARDED_KEY);
+    } catch {
+      return true;
+    }
+  });
+
+  // Demo animation: highlight a word chip + its matching slot pair
+  // demoWordIdx = vocabIdx being highlighted in the word bank
+  // demoSlotIdx = defIdx being highlighted in the definition slots
+  const [demoWordIdx, setDemoWordIdx] = useState<number | null>(null);
+  const [demoSlotIdx, setDemoSlotIdx] = useState<number | null>(null);
+  const demoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up demo timer on unmount
+  useEffect(() => {
+    return () => {
+      if (demoTimerRef.current) clearTimeout(demoTimerRef.current);
+    };
+  }, []);
 
   // Track last answer per slot for summary (correct ones only, since wrong bounce back)
   const answersRef = useRef<AnswerRecord[]>(
@@ -66,6 +136,48 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
     confirmedRef.current = new Set();
     wrongAttemptCountRef.current = new Map();
   }, [activeDefIndices, shuffledWords]);
+
+  const handleDismissCoach = () => {
+    setShowCoach(false);
+    try {
+      localStorage.setItem(VOCAB_DRAGDROP_ONBOARDED_KEY, '1');
+    } catch {
+      // ignore
+    }
+  };
+
+  /**
+   * Demo animation: highlight the first unconfirmed word chip and its matching slot.
+   * Two amber pulses on both elements to show how drag-and-drop works.
+   * Purely visual — does NOT submit a placement or affect scoring.
+   */
+  const handleDemo = () => {
+    if (demoTimerRef.current) clearTimeout(demoTimerRef.current);
+    // Pick the first unconfirmed vocab word to demo
+    const activeShuffled = shuffledWords.filter((wi) => activeDefIndices.includes(wi));
+    const firstUnconfirmed = activeShuffled.find((wi) => !confirmed.has(wi));
+    if (firstUnconfirmed == null) {
+      handleDismissCoach();
+      return;
+    }
+    // The matching slot for this word is defIdx === firstUnconfirmed
+    const matchingSlot = firstUnconfirmed;
+    setDemoWordIdx(firstUnconfirmed);
+    setDemoSlotIdx(matchingSlot);
+    demoTimerRef.current = setTimeout(() => {
+      setDemoWordIdx(null);
+      setDemoSlotIdx(null);
+      demoTimerRef.current = setTimeout(() => {
+        setDemoWordIdx(firstUnconfirmed);
+        setDemoSlotIdx(matchingSlot);
+        demoTimerRef.current = setTimeout(() => {
+          setDemoWordIdx(null);
+          setDemoSlotIdx(null);
+        }, 900);
+      }, 200);
+    }, 900);
+    handleDismissCoach();
+  };
 
   const attemptPlace = useCallback(
     (defIdx: number, vocabIdx: number) => {
@@ -203,6 +315,7 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
 
           const isDragging = draggingVocabIdx === vocabIdx;
           const isTouchSelected = touchSelected === vocabIdx;
+          const isDemoWord = demoWordIdx === vocabIdx;
 
           // Confirmed words (fly-away animation already finished): show as locked/dimmed
           if (isConfirmedWord && !isFlying) {
@@ -226,6 +339,8 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
             'rounded-2xl border-2 px-4 py-2.5 text-center font-bold text-lg select-none transition-all duration-200 ';
           if (isFlying) {
             cls += 'border-emerald-400 bg-emerald-100 text-emerald-700 animate-fly-away pointer-events-none';
+          } else if (isDemoWord) {
+            cls += 'border-amber-400 bg-amber-50 text-amber-800 animate-pulse pointer-events-none';
           } else if (isDragging) {
             cls += 'border-accent bg-accent/10 text-accent shadow-xl scale-105 opacity-80 cursor-grabbing';
           } else if (isTouchSelected) {
@@ -280,11 +395,14 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
     const isOver = hoverTarget === defIdx && !isCorrect;
     const showWrongVerbal = wrongFeedbackSlot === defIdx;
     const showCorrectVerbal = correctFeedbackSlot === defIdx;
+    const isDemoSlot = demoSlotIdx === defIdx && !isCorrect;
 
     let cls =
       'rounded-3xl border-2 px-5 py-5 min-h-[80px] flex flex-col gap-2 transition-all duration-200 cursor-pointer ';
     if (isCorrect) {
       cls += 'bg-emerald-50 border-emerald-400 cursor-default';
+    } else if (isDemoSlot) {
+      cls += 'bg-amber-50 border-amber-400 animate-pulse';
     } else if (isWrong) {
       cls += 'bg-tertiary-container/10 border-tertiary animate-shake';
     } else if (isOver) {
@@ -353,13 +471,28 @@ export function DragDropMode({ vocab, activeDefIndices, shuffledWords, onAllDone
 
   return (
     <div className="px-4 md:px-6 max-w-5xl mx-auto">
-      {/* A8: Device-aware instruction banner */}
-      <p className="text-sm text-center text-on-surface-variant mb-4">
-        <span className="material-symbols-outlined align-middle text-base mr-1">
-          {IS_TOUCH_DEVICE ? 'touch_app' : 'drag_indicator'}
-        </span>
-        {instructionText}
-      </p>
+      {/* Onboarding coach — shown first time or when student clicks help */}
+      {showCoach && <OnboardingCoach onDismiss={handleDismissCoach} onDemo={handleDemo} />}
+
+      {/* A8: Device-aware instruction banner — only shown after coach is dismissed */}
+      {!showCoach && (
+        <div className="flex items-center justify-between mb-4">
+          <p className="text-sm text-center text-on-surface-variant">
+            <span className="material-symbols-outlined align-middle text-base mr-1">
+              {IS_TOUCH_DEVICE ? 'touch_app' : 'drag_indicator'}
+            </span>
+            {instructionText}
+          </p>
+          <button
+            type="button"
+            onClick={() => setShowCoach(true)}
+            className="text-xs text-on-surface-variant/60 hover:text-on-surface-variant transition-colors flex items-center gap-1 shrink-0"
+          >
+            <span className="material-symbols-outlined text-sm">help_outline</span>
+            怎麼玩？
+          </button>
+        </div>
+      )}
 
       {/* Progress bar */}
       <div className="flex items-center gap-3 mb-6">


### PR DESCRIPTION
Fixes #2163

## Summary

在「語詞應用」和「詞語配對」加上和 VocabDefinitionMatchMCQ (#2159) 一致的 OnboardingCoach 說明+示範引導。

### FillInBlankExercise.tsx（語詞應用/填充題）
- 新增 OnboardingCoach amber 框：「語詞應用怎麼玩？」
- 說明：「讀句子，從下面選出最適合填進空格的語詞。」
- 示範：點示範按鈕 → 正解選項播兩次 amber pulse，純視覺不提交
- localStorage key: `fillblank_onboarded`（關閉後不再自動出現）
- 關閉後右下角顯示「怎麼玩？」按鈕可重新叫出

### VocabDefinitionMatchDragDrop.tsx（詞語理解/配對拖拉題）
- 新增 OnboardingCoach amber 框：「詞語配對怎麼玩？」
- 說明：桌機「把左邊的語詞拖到右邊正確的解釋上」/ 觸控「點選語詞，再點右邊的解釋框放入」
- 示範：同時 pulse 第一個未配對的語詞 chip + 對應的解釋框，純視覺不提交
- localStorage key: `vocab_dragdrop_onboarded`
- 關閉後說明列旁邊顯示「怎麼玩？」按鈕

### MultipleChoiceExercise.tsx（閱讀理解 MCQ）
- **跳過**。該元件 A/B/C/D 標籤 + progress counter + reveal-on-select 已足夠清楚，操作方式對學生直觀，不需要額外引導框。

### 一致性
- 三個元件（MCQ #2159 + FillInBlank + DragDrop）amber 框視覺風格完全一致
- lightbulb icon、「示範」+ 「我知道了」按鈕配置相同
- 示範 = 在真實題目 UI 上播動畫，不另開 modal（Young 鐵則）
- 既有作答邏輯（計分/重選/進階）完全不動

## Test plan

PR Preview 部署後，學生小明一鍵登入：

- [ ] `/learn/1076/vocab-application`（語詞應用）
  - [ ] 第一次進入：amber OnboardingCoach 自動出現
  - [ ] 點「示範」：正解選項 amber pulse 兩次，coach 關閉，可繼續作答
  - [ ] 點「我知道了」：coach 關閉，右下角「怎麼玩？」出現
  - [ ] 重新整理：coach 不再自動出現（localStorage gate）
  - [ ] 點「怎麼玩？」：coach 重新出現
  - [ ] console 無新 error

- [ ] `/learn/1076/vocab-definition`（配對拖拉）
  - [ ] 第一次進入：amber OnboardingCoach 自動出現，說明含 device-aware 文字
  - [ ] 點「示範」：word chip + 解釋框同時 pulse 兩次，coach 關閉
  - [ ] 點「我知道了」：coach 關閉，說明列旁「怎麼玩？」出現
  - [ ] 重新整理：coach 不再自動出現
  - [ ] 既有拖拉/點選作答功能正常
  - [ ] console 無新 error

---

此 PR 由 AI (Claude) 開發，屬 #2163 技術實作。