### PR TITLE
fix(annotation): 側邊面板標記詞顯示錯位修復（PUA strip）(Fixes #2165)

### DIFF
--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../utils/paragraphMarkers';
 
 // Sub-components and utilities extracted as part of #1855 refactor
-import { getSelectionInfo } from './annotationOffsets';
+import { getSelectionInfo, stripPUASelectors } from './annotationOffsets';
 import {
   annotationReducer,
   computeSummary,
@@ -361,7 +361,12 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
         return a.charStart - b.charStart;
       })
       .map((annotation) => {
-        const paragraph = story.content[annotation.paragraphIndex] ?? '';
+        // charStart/charEnd are RAW char offsets (PUA Variation Selectors stripped
+        // by getSelectionInfo). Lesson YAML embeds PUA selectors in the paragraph
+        // text, so slice the PUA-stripped paragraph — otherwise the panel word
+        // drifts left (e.g. 孟嘗君 → 投奔孟). AnnotatedParagraph already strips; this
+        // is the side-panel consumer that #2155 missed. (#2165)
+        const paragraph = stripPUASelectors(story.content[annotation.paragraphIndex] ?? '');
         return {
           annotation,
           text: paragraph.slice(annotation.charStart, annotation.charEnd),


### PR DESCRIPTION
## 問題
reading-annotation 側邊「我的記號」：選「孟嘗君」顯示成「投奔孟」（左移 2）。#2155 沒修好（只補 walk 端）。

## Root cause（確定性實證）
教材 YAML 內嵌注音 PUA selector（1076 para 3 含 1 對）。`getSelectionInfo` 回 PUA-剝除 raw offset，但 panel 直接 slice 含 PUA 的 `story.content` → 漂移。`raw.slice(138,141)`=投奔孟、`stripPUA.slice(138,141)`=孟嘗君。

## 修法（1 行）
annotationsForPanel slice 前 `stripPUASelectors`（與 AnnotatedParagraph 段內高亮一致）。

## 驗證
- tsc 零 error
- 待 preview 用 localStorage 注入標記做確定性驗（選孟嘗君→面板顯示孟嘗君）

🤖 Generated with [Claude Code](https://claude.com/claude-code)