### PR TITLE
feat(vocab-application): 選項呈現兩案 A/B — random4 / disappear (Fixes #2167)

### DIFF
--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -11,13 +11,13 @@
  *          ABCD badges behind FILLBLANK_SHOW_ABCD feature flag (default false)
  * Issue #2163: OnboardingCoach — first-use amber説明框 + demo animation on real UI
  */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FillInBlankItem } from '../../types';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { fontForZhuyin } from '../../constants/fonts';
 import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStorageScope';
 import ToolboxCompletionActions from '../tools/ToolboxCompletionActions';
-import { FILLBLANK_SHOW_ABCD } from '../../config/featureFlags';
+import { FILLBLANK_SHOW_ABCD, FILLBLANK_OPTION_MODE } from '../../config/featureFlags';
 
 // ── localStorage key for first-use onboarding gate ────────────────────────
 const FILLBLANK_ONBOARDED_KEY = 'fillblank_onboarded';
@@ -195,10 +195,32 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
     if (done && phase === 'exercise') setPhase('summary');
   }, [done, phase]);
 
-  // Show all bank entries; used ones stay visible as decoys (greyed-out, non-selectable).
-  const availableEntries = bankEntries;
   const currentSentence = !done ? activeSentences[currentIdx] : null;
   const currentOriginalIdx = retryMode ? retryIndices[currentIdx] : currentIdx;
+
+  // #7 教授「選項呈現兩案」(featureFlag FILLBLANK_OPTION_MODE):
+  //   'all'      → 全部選項，用過 grey out (default, 現狀)
+  //   'disappear'→ 全部選項，用過直接移除 = 案 (b)
+  //   'random4'  → 每題只 4 個（正解 + 3 確定性 decoy）= 案 (a) 降難度
+  // random4 用 currentOriginalIdx 當 seed → 同題重選不會洗牌。
+  const availableEntries = useMemo(() => {
+    if (FILLBLANK_OPTION_MODE === 'disappear') {
+      return bankEntries.filter(([code]) => !usedCodes.has(code));
+    }
+    if (FILLBLANK_OPTION_MODE === 'random4' && currentSentence) {
+      const correct = currentSentence.answer;
+      const correctEntry = bankEntries.find(([c]) => c === correct);
+      const decoys = bankEntries.filter(([c]) => c !== correct);
+      if (!correctEntry || decoys.length < 3) return bankEntries;
+      const seed = (currentOriginalIdx + 1) * 7;
+      // deterministic rotation → first 3 distinct decoys
+      const rotated = decoys.map((_, i) => decoys[(i + seed) % decoys.length]);
+      const out = rotated.slice(0, 3);
+      out.splice(seed % (out.length + 1), 0, correctEntry); // stable, non-fixed slot
+      return out;
+    }
+    return bankEntries; // 'all'
+  }, [bankEntries, usedCodes, currentSentence, currentOriginalIdx]);
 
   /**
    * Demo animation: pulse the correct option for the current question.

--- a/frontend/src/config/featureFlags.ts
+++ b/frontend/src/config/featureFlags.ts
@@ -25,3 +25,19 @@ const _lsAbcd =
     : null;
 export const FILLBLANK_SHOW_ABCD: boolean =
   _lsAbcd != null ? _lsAbcd === 'true' : _rawAbcd === 'true';
+
+// FILLBLANK_OPTION_MODE: how answer options are presented (#7 教授「選項呈現兩案」).
+//   'all'      → show every bank word; used ones grey out (current default)
+//   'random4'  → show 4 options per question (correct + 3 random decoys) = 案 (a) 降難度
+//   'disappear'→ show all; used words are removed (not greyed) = 案 (b)
+// 兩案併陳供 A/B：default 'all', switch via VITE_FILLBLANK_OPTION_MODE or
+// localStorage key "flag_FILLBLANK_OPTION_MODE".
+export type FillBlankOptionMode = 'all' | 'random4' | 'disappear';
+const _rawOptMode = import.meta.env.VITE_FILLBLANK_OPTION_MODE as string | undefined;
+const _lsOptMode =
+  typeof window !== 'undefined'
+    ? window.localStorage?.getItem('flag_FILLBLANK_OPTION_MODE')
+    : null;
+const _optMode = (_lsOptMode ?? _rawOptMode) as string | null | undefined;
+export const FILLBLANK_OPTION_MODE: FillBlankOptionMode =
+  _optMode === 'random4' || _optMode === 'disappear' ? _optMode : 'all';


### PR DESCRIPTION
## 教授 #7「選項呈現兩案併陳」
- 案 (a) 隨機抽 4 含正解 = `random4`
- 案 (b) 全顯示用過消失 = `disappear`

## 做法
featureFlag `FILLBLANK_OPTION_MODE`（'all'|'random4'|'disappear'，default 'all'）。localStorage `flag_FILLBLANK_OPTION_MODE` runtime 可切（比照 FILLBLANK_SHOW_ABCD）→ 兩案併陳可 A/B。random4 用題 index seed、同題重選不洗牌。

> ABCD 兩版（#7 另一半）已存在於 FILLBLANK_SHOW_ABCD。

## 驗證
- tsc 零 error；待 preview 切 flag 驗 random4=4選項 / disappear=用過消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)