### PR TITLE
fix(live-tutor): remove duplicate retry button and negative feedback text (Fixes #2172)

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -365,42 +365,8 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
               return (
                 <div className="pt-3 border-t border-on-surface/10">
                   <p className="text-sm text-on-surface-variant text-center">
-                    這段有比較多地方需要加強，我們重新唸一次吧！
+                    繼續加油！再唸一次一定會更好！
                   </p>
-                  <div className="flex gap-3 justify-center pt-3">
-                    <button
-                      onClick={() => onRetryParagraph(idx)}
-                      className="btn-encourage !text-sm !py-2.5 !px-6 !min-h-0"
-                    >
-                      重練這段
-                    </button>
-                    {idx < storyLength - 1 && canAdvanceRule2 && (
-                      <button
-                        onClick={() => {
-                          if (!completedParagraphs.has(idx)) {
-                            onAdvanceParagraph(idx, lineResults);
-                          } else {
-                            onSelectParagraph(idx + 1);
-                          }
-                        }}
-                        className="px-6 py-2.5 rounded-full text-sm font-bold text-white transition-all active:scale-95 flex items-center gap-2"
-                        style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
-                      >
-                        下一段
-                        <span className="material-symbols-outlined text-lg">arrow_forward</span>
-                      </button>
-                    )}
-                    {idx >= storyLength - 1 && !completedParagraphs.has(idx) && canAdvanceRule2 && (
-                      <button
-                        onClick={() => onAdvanceParagraph(idx, lineResults)}
-                        className="px-6 py-2.5 rounded-full text-sm font-bold text-white transition-all active:scale-95 flex items-center gap-2"
-                        style={{ background: 'linear-gradient(135deg, #564ABF, #9D93FF)' }}
-                      >
-                        完成朗讀
-                        <span className="material-symbols-outlined text-lg">arrow_forward</span>
-                      </button>
-                    )}
-                  </div>
                 </div>
               );
             }
@@ -466,8 +432,8 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
               >
                 重練這段
               </button>
-              {/* Always show 下一段 when paragraph-level passed (matchRate >= 0.5) */}
-              {idx < storyLength - 1 && canAdvance && (
+              {/* Always show 下一段 — never block paragraph progress (#2172) */}
+              {idx < storyLength - 1 && (
                 <button
                   onClick={() => {
                     if (!completedParagraphs.has(idx)) {


### PR DESCRIPTION
Fixes #2172

## Root Cause

`ParagraphCard.tsx` contains two independent IIFE blocks that each rendered action buttons:

1. **Rule 2 block** — fires when `failedSentences.length > totalRetryable / 2`. It returned early with its own \"重練這段\" + conditional \"下一段\" buttons.
2. **Action buttons block** — always renders (when `retrySentenceIdx === undefined`) with another \"重練這段\" + conditional \"下一段\".

When Rule 2 fired, **both sections rendered simultaneously** → two identical \"重練這段\" buttons appeared on screen.

## Changes

### Change 1 — Rule 2 block (was ~line 333-376)
Removed all buttons from this block. The Rule 2 block now renders **encouragement text only** (`繼續加油！再唸一次一定會更好！`), replacing the negative-tone \"這段有比較多地方需要加強，我們重新唸一次吧！`. The Action buttons block is the single source of truth for all CTAs.

### Change 2 — Action buttons block: 下一段 always shown
Removed the `canAdvance &&` gate on the `idx < storyLength - 1` 下一段 button. Per product feedback \"不要去擋\" — the next-paragraph button should always be available. The `完成朗讀` button at the last paragraph still requires `canAdvance` (only fires once at the end).

## Test plan
- [ ] Trigger Rule 2 (record a paragraph with > half sentences failing) — confirm only ONE \"重練這段\" button appears
- [ ] Confirm encouragement text is positive (\"繼續加油！\")
- [ ] Confirm \"下一段\" button is always visible on non-last paragraphs regardless of matchRate
- [ ] Confirm \"完成朗讀\" still requires matchRate ≥ 0.5 on the last paragraph