### PR TITLE
fix(migration): correct annotation_entries down_revision to resolve multi-head

### DIFF
--- a/backend/alembic/versions/2ed91926c851_create_annotation_entries_table.py
+++ b/backend/alembic/versions/2ed91926c851_create_annotation_entries_table.py
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "2ed91926c851"
-down_revision = "pii01rep02air03"
+down_revision = "ls01fk02omo03"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Root cause

`2ed91926c851_create_annotation_entries_table.py` had `down_revision = "pii01rep02air03"`, but `ls01fk02omo03_add_learning_session_id_to_omo_uploads.py` also points to `pii01rep02air03` — creating two alembic heads:

```
705ba7c6b659 → pii01rep02air03 ─┬─ ls01fk02omo03  (pre-existing)
                                 └─ 2ed91926c851   (annotation, wrong parent)
```

Alembic `upgrade head` fails with "Multiple head revisions" → staging backend container crashes on startup.

## Fix

Change `down_revision` in `2ed91926c851` to `"ls01fk02omo03"` (the true latest head):

```
705ba7c6b659 → pii01rep02air03 → ls01fk02omo03 → 2ed91926c851  ✅
```

## Test plan
- [ ] CI passes (Backend Tests + Deploy to Staging)
- [ ] Staging backend health check: `GET /api/health` returns 200