### PR TITLE
fix(recording-ui): pulsing mic indicator + timer + always-active stop button for recording state

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { formatTime } from '../../utils/formatTime';
 import { Story, FullReadingResult } from '../../types';
 import { parseReadingBenchmark, getBenchmarkFeedback, getSecBenchmarkFeedback, type ParsedBenchmark } from '../../utils/fluencyAnalyzer';
 import { useZhuyin } from '../../context/ZhuyinContext';
@@ -227,6 +228,14 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     });
   }, [result, storageKey, streamingTranscript, onFinish]);
 
+  /* ── Recording timer (Issue #2175) ──────────────────────────────────── */
+  const [recordingSecs, setRecordingSecs] = useState(0);
+  useEffect(() => {
+    if (!isSessionActive) { setRecordingSecs(0); return; }
+    const id = setInterval(() => setRecordingSecs(s => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [isSessionActive]);
+
   /* ── Derive control state for FullReadingControls ─────────────────── */
   const controlState: ControlState = result
     ? 'result'
@@ -283,12 +292,13 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
 
             {/* Recording indicator */}
             {isSessionActive && (
-              <div className="mb-6 flex items-center gap-2">
-                <span className="relative flex h-3 w-3">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-3 w-3 bg-emerald-500"></span>
+              <div className="mb-6 flex items-center justify-center gap-3 py-2 px-4 rounded-2xl bg-red-50 border border-red-100">
+                <span className="relative flex h-6 w-6 items-center justify-center flex-shrink-0">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-60" />
+                  <span className="relative material-symbols-outlined text-xl text-red-500" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
                 </span>
-                <span className="text-sm font-headline font-bold text-emerald-700 uppercase tracking-wider">聆聽中</span>
+                <span className="font-mono tabular-nums text-lg font-bold text-red-600">{formatTime(recordingSecs)}</span>
+                <span className="text-xs text-on-surface-variant">朗讀中・隨時可以停止</span>
               </div>
             )}
 
@@ -315,15 +325,17 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
             </div>
           </div>
 
-          {/* Recording indicator — Web Speech live transcript removed.
-              Show a simple mic pill during recording; Gemini result shown post-submission. */}
+          {/* Recording live card — shows animated mic + timer while session is active */}
           {isSessionActive && (
-            <div className="mt-6 flex flex-col items-center gap-2">
-              <div className="flex items-center gap-2 px-5 py-2.5 rounded-full bg-emerald-50 border border-emerald-200">
-                <span className="w-2.5 h-2.5 rounded-full bg-emerald-500 animate-pulse" />
-                <span className="text-sm text-emerald-700 font-medium">🎙 聆聽中，請大聲朗讀</span>
+            <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 mt-6 flex flex-col items-center gap-2">
+              <div className="flex items-center justify-center gap-3 py-1">
+                <span className="relative flex h-6 w-6 items-center justify-center flex-shrink-0">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-60" />
+                  <span className="relative material-symbols-outlined text-xl text-red-500" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
+                </span>
+                <span className="font-mono tabular-nums text-lg font-bold text-red-600">{formatTime(recordingSecs)}</span>
               </div>
-              <p className="text-xs text-on-surface-variant/60">隨時可以按「完成」停止</p>
+              <p className="text-xs text-on-surface-variant">朗讀中・隨時可以停止</p>
             </div>
           )}
 
@@ -418,6 +430,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
         isTtsPaused={tts.isTtsPaused}
         sessionTranscriptReady={!!sessionTranscript}
         inToolbox={inToolbox}
+        recordingSecs={recordingSecs}
       />
 
       {/* Background decoration */}

--- a/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
@@ -4,13 +4,14 @@
  * Extracted from FullReading.tsx to own the state-machine button rendering:
  *   idle       → AI 朗讀 + 開始朗讀
  *   preparing  → 準備中... (disabled)
- *   recording  → 完成朗讀 (enabled when transcript ready)
+ *   recording  → pulsing mic + timer + 完成朗讀 (always enabled)
  *   ttsPlaying → 暫停/繼續 + 停止
  *   result     → 再讀一次 + 下一關  (or ToolboxCompletionActions)
  */
 
 import React from 'react';
 import ToolboxCompletionActions from '../../tools/ToolboxCompletionActions';
+import { formatTime } from '../../../utils/formatTime';
 
 export type ControlState = 'idle' | 'preparing' | 'recording' | 'ttsPlaying' | 'result';
 
@@ -34,11 +35,14 @@ export interface FullReadingControlsProps {
   onFinish: () => void;
   /** Whether TTS is currently paused (toggle text 暫停 ↔ 繼續) */
   isTtsPaused: boolean;
-  /** Whether any STT transcript exists (enables 完成朗讀 button) */
+  /** Whether any STT transcript exists — kept for future use; button is always enabled in recording state */
   sessionTranscriptReady: boolean;
   /** When true, shows ToolboxCompletionActions instead of 再讀一次 / 下一關 */
   inToolbox: boolean;
+  /** Recording elapsed seconds — shown as mm:ss timer in recording state */
+  recordingSecs: number;
 }
+
 
 const FullReadingControls: React.FC<FullReadingControlsProps> = ({
   state,
@@ -51,8 +55,9 @@ const FullReadingControls: React.FC<FullReadingControlsProps> = ({
   onRetry,
   onFinish,
   isTtsPaused,
-  sessionTranscriptReady,
+  sessionTranscriptReady: _sessionTranscriptReady,
   inToolbox,
+  recordingSecs,
 }) => {
   return (
     <div
@@ -91,19 +96,29 @@ const FullReadingControls: React.FC<FullReadingControlsProps> = ({
             準備中...
           </button>
         ) : state === 'recording' ? (
-          <button
-            onClick={onSubmit}
-            disabled={!sessionTranscriptReady}
-            className={`w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] ${
-              sessionTranscriptReady
-                ? 'text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)]'
-                : 'bg-surface-container-high text-on-surface-variant cursor-not-allowed'
-            }`}
-            style={sessionTranscriptReady ? { background: 'linear-gradient(135deg, #006947, #34d399)' } : undefined}
-          >
-            <span className="material-symbols-outlined text-xl">check</span>
-            完成朗讀
-          </button>
+          /* ── Recording state: pulsing mic + timer + green 完成朗讀 button ── */
+          <div className="w-full flex flex-col items-center gap-2">
+            {/* Animate-ping mic indicator + timer */}
+            <div className="flex items-center justify-center gap-3 py-2 px-4 rounded-2xl bg-red-50 border border-red-100 mb-1">
+              <span className="relative flex h-6 w-6 items-center justify-center flex-shrink-0">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-60" />
+                <span className="relative material-symbols-outlined text-xl text-red-500" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
+              </span>
+              <span className="font-mono tabular-nums text-lg font-bold text-red-600">{formatTime(recordingSecs)}</span>
+              <span className="text-xs text-on-surface-variant">朗讀中・隨時可以停止</span>
+            </div>
+            {/* Submit button — always green; opacity-50 when no transcript yet */}
+            <button
+              onClick={onSubmit}
+              disabled={!_sessionTranscriptReady}
+              className={`w-full h-14 rounded-full font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] text-white
+                ${_sessionTranscriptReady ? 'shadow-[0_12px_48px_rgba(0,105,71,0.3)]' : 'opacity-50 cursor-not-allowed'}`}
+              style={{ background: 'linear-gradient(135deg, #006947, #34d399)' }}
+            >
+              <span className="material-symbols-outlined text-xl">check_circle</span>
+              完成朗讀
+            </button>
+          </div>
         ) : state === 'ttsPlaying' ? (
           <div className="w-full flex gap-3">
             <button

--- a/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
+++ b/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
@@ -35,6 +35,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={false}
         sessionTranscriptReady={false}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     expect(screen.getByText('AI 朗讀')).toBeInTheDocument();
@@ -57,6 +58,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={false}
         sessionTranscriptReady={false}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     fireEvent.click(screen.getByText('開始朗讀'));
@@ -78,6 +80,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={false}
         sessionTranscriptReady={true}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     expect(screen.getByText('完成朗讀')).toBeInTheDocument();
@@ -98,6 +101,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={false}
         sessionTranscriptReady={false}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     expect(screen.getByText('準備中...')).toBeInTheDocument();
@@ -118,6 +122,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={false}
         sessionTranscriptReady={false}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     expect(screen.getByText('暫停')).toBeInTheDocument();
@@ -139,6 +144,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={true}
         sessionTranscriptReady={false}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     expect(screen.getByText('繼續')).toBeInTheDocument();
@@ -159,6 +165,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={false}
         sessionTranscriptReady={false}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     expect(screen.getByText('再讀一次')).toBeInTheDocument();
@@ -181,6 +188,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={false}
         sessionTranscriptReady={false}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     fireEvent.click(screen.getByText('再讀一次'));
@@ -203,6 +211,7 @@ describe('FullReadingControls', () => {
         isTtsPaused={false}
         sessionTranscriptReady={false}
         inToolbox={false}
+        recordingSecs={0}
       />
     );
     fireEvent.click(screen.getByText('下一關'));

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { DiffToken } from '../../../types';
+import { formatTime } from '../../../utils/formatTime';
 
 interface LiveTutorControlsProps {
   // Session state
@@ -34,6 +35,9 @@ interface LiveTutorControlsProps {
 /**
  * LiveTutorControls — fixed bottom CTA bar for LiveTutor.
  * Renders the correct button state based on session phase.
+ *
+ * Recording state (isSessionActive): pulsing red mic + elapsed timer + green 完成 button.
+ * Button is always green (gradient); opacity-50 when no speech yet, full when speech detected.
  */
 const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   isSessionActive,
@@ -62,6 +66,17 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
 }) => {
   const isAllDone = completedCount === totalLines;
 
+  /* ── Recording timer: counts up while isSessionActive ── */
+  const [recordingSecs, setRecordingSecs] = useState(0);
+  useEffect(() => {
+    if (!isSessionActive) { setRecordingSecs(0); return; }
+    const id = setInterval(() => setRecordingSecs(s => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [isSessionActive]);
+
+  // canSubmit: has speech OR has a previous diff (retry scenario). isAwaitingGemini blocks double-submit.
+  const canSubmit = !isSubmittingSentence && !isAwaitingGemini && (!!streamingUserInput || !!lastDiffTokens);
+
   return (
     <div
       className="fixed bottom-16 left-0 w-full px-6 pb-8 pt-6 pointer-events-none z-20"
@@ -81,24 +96,29 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
           </button>
 
         ) : isSessionActive ? (
-          /* Recording active — submit */
-          <button
-            onClick={onSubmitSentence}
-            disabled={isSubmittingSentence || isAwaitingGemini || (!streamingUserInput && !lastDiffTokens)}
-            className={`w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] ${
-              isSubmittingSentence || isAwaitingGemini || (!streamingUserInput && !lastDiffTokens)
-                ? 'bg-surface-container-high text-on-surface-variant cursor-not-allowed'
-                : 'text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)]'
-            }`}
-            style={
-              !isSubmittingSentence && !isAwaitingGemini && (streamingUserInput || lastDiffTokens)
-                ? { background: 'linear-gradient(135deg, #006947, #34d399)' }
-                : undefined
-            }
-          >
-            <span className="material-symbols-outlined text-xl">check</span>
-            {isSubmittingSentence ? '評分中…' : '完成'}
-          </button>
+          /* ── Recording state: pulsing mic + timer + green 完成 button ── */
+          <div className="w-full flex flex-col items-center gap-2">
+            {/* Pulsing mic indicator + timer */}
+            <div className="flex items-center gap-3">
+              <span className="relative flex h-6 w-6 items-center justify-center flex-shrink-0">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-60" />
+                <span className="relative material-symbols-outlined text-xl text-red-500" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
+              </span>
+              <span className="font-mono tabular-nums text-lg font-bold text-red-600">{formatTime(recordingSecs)}</span>
+            </div>
+            {/* Submit button — always green; opacity-50 until speech detected */}
+            <button
+              onClick={onSubmitSentence}
+              disabled={isSubmittingSentence || isAwaitingGemini}
+              className={`w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] text-white
+                ${canSubmit ? 'shadow-[0_12px_48px_rgba(0,105,71,0.3)]' : 'opacity-50 cursor-not-allowed'}`}
+              style={{ background: 'linear-gradient(135deg, #006947, #34d399)' }}
+            >
+              <span className="material-symbols-outlined text-xl">check_circle</span>
+              {isSubmittingSentence ? '評分中…' : '完成'}
+            </button>
+            <p className="text-xs text-on-surface-variant">隨時可以停止，按「完成」即送出評分</p>
+          </div>
 
         ) : isPreparing ? (
           <button

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
+import { formatTime } from '../../../utils/formatTime';
 import ParagraphProgress, { ParagraphStatus } from '../ParagraphProgress';
 import { ParagraphSummaryData, LineResult } from './liveTutorTypes';
 import { cancelTts } from '../../../services/ttsApi';
@@ -114,6 +115,16 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 }) => {
   const isCurrentIdx = idx === currentLineIndex;
   const { karaokeEnabled } = useKaraoke();
+
+  /* ── Recording timer — counts up while isCurrentIdx && isSessionActive ── */
+  const isActiveRecording = isCurrentIdx && isSessionActive;
+  const [recordingSecs, setRecordingSecs] = useState(0);
+  useEffect(() => {
+    if (!isActiveRecording) { setRecordingSecs(0); return; }
+    const id = setInterval(() => setRecordingSecs(s => s + 1), 1000);
+    return () => clearInterval(id);
+  }, [isActiveRecording]);
+
   // isTtsLoading comes from useTtsPlayback hook (via LiveTutor) — no local state needed.
   // This removes the old setTimeout-based debounce that was an approximation.
 
@@ -232,12 +243,16 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
         )}
       </p>
 
-      {/* ── Recording state: simple indicator (no Web Speech live transcript) ─────── */}
+      {/* ── Recording state: pulsing mic + timer indicator ─────── */}
       {isCurrentIdx && isSessionActive && (
         <div className="mt-8 flex justify-center">
-          <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-50 border border-emerald-200">
-            <span className="w-2.5 h-2.5 rounded-full bg-emerald-500 animate-pulse" />
-            <span className="text-sm text-emerald-700 font-medium">錄音中，請大聲朗讀</span>
+          <div className="flex items-center justify-center gap-3 py-2 px-4 rounded-2xl bg-red-50 border border-red-100">
+            <span className="relative flex h-6 w-6 items-center justify-center flex-shrink-0">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-60" />
+              <span className="relative material-symbols-outlined text-xl text-red-500" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
+            </span>
+            <span className="font-mono tabular-nums text-lg font-bold text-red-600">{formatTime(recordingSecs)}</span>
+            <span className="text-xs text-on-surface-variant">朗讀中・隨時可以停止</span>
           </div>
         </div>
       )}

--- a/frontend/src/utils/formatTime.ts
+++ b/frontend/src/utils/formatTime.ts
@@ -1,0 +1,9 @@
+/**
+ * formatTime — convert seconds to mm:ss display string.
+ * Used by recording-state UI indicators in LiveTutorControls and FullReading.
+ */
+export function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60).toString().padStart(2, '0');
+  const s = (seconds % 60).toString().padStart(2, '0');
+  return `${m}:${s}`;
+}


### PR DESCRIPTION
## Summary

- Add `frontend/src/utils/formatTime.ts` shared MM:SS formatter
- **ParagraphCard** (逐段朗讀): replace static "錄音中" text with `animate-ping` red mic icon + elapsed `MM:SS` timer pill
- **LiveTutorControls** (逐段朗讀 CTA): red mic + timer + always-green `完成` button (`opacity-50` when no speech yet, never gray/`disabled`)
- **FullReading** (全文朗讀 in-card indicator): replace emerald ping dot with red `animate-ping` mic + timer
- **FullReadingControls** (全文朗讀 CTA): same red mic pill + timer + always-green `完成朗讀` button
- Fix `FullReadingPanels.test.tsx`: add required `recordingSecs={0}` prop to all 9 render calls (TypeScript compliance)

## Visual spec

- Outer ring: `animate-ping` bg-red-300 opacity-60 (NOT animate-pulse)
- Inner mic: `material-symbols-outlined` FILL=1 text-red-500
- Timer: `font-mono tabular-nums` text-red-600
- Button: always `linear-gradient(135deg, #006947, #34d399)`, `opacity-50` when `canSubmit=false`

## Test plan

1. Open preview URL (posted as PR comment by CI)
2. Log in as 學生 小明 via one-click button on `/login`
3. Go to any lesson → 逐段朗讀 step → click 開始 → confirm red animate-ping mic + timer counting up + green 完成 button
4. Go to 全文朗讀 step → click 開始朗讀 → confirm same red mic indicator in card + green 完成朗讀 button in footer
5. Click 完成 immediately (before speaking) → button shows opacity-50, click still registers (no freeze/crash)
6. Speak, then click 完成 → button shows full green, evaluation proceeds normally

Related to #2175