### PR TITLE
fix(reading-annotation): graphic-text side-by-side flex-row layout (Fixes #2085)

### DIFF
--- a/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
+++ b/frontend/src/components/reading-steps/GraphicTextImageStrip.tsx
@@ -189,6 +189,12 @@ const GraphicTextImageStrip: React.FC<GraphicTextImageStripProps> = ({ images, l
   const resolvedLessonCode =
     lessonCode || (images[0] ? deriveLessonCodeFromFilename(images[0].filename) : '');
 
+  const sortedImages = [...images].sort((a, b) => {
+    const aIdx = CHINESE_NUMERALS.findIndex(n => (a.figure_label ?? '').includes(n));
+    const bIdx = CHINESE_NUMERALS.findIndex(n => (b.figure_label ?? '').includes(n));
+    return (aIdx === -1 ? 999 : aIdx) - (bIdx === -1 ? 999 : bIdx);
+  });
+
   return (
     <div
       data-testid="graphic-text-image-pane"
@@ -201,7 +207,7 @@ const GraphicTextImageStrip: React.FC<GraphicTextImageStripProps> = ({ images, l
       ) : (
         /* Scrollable vertical gallery — parent controls the height boundary */
         <div className="flex-1 min-h-0 overflow-y-auto custom-scrollbar pr-1">
-          {images.map((img, idx) => {
+          {sortedImages.map((img, idx) => {
             const basename = img.filename.split('/').pop() ?? img.filename;
             const src = `${GCS_IMAGE_BASE}/${resolvedLessonCode}/${basename}`;
             return (

--- a/frontend/src/components/reading-steps/ReadingAnnotation.tsx
+++ b/frontend/src/components/reading-steps/ReadingAnnotation.tsx
@@ -657,7 +657,8 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
               Images/tables whose captions appear inside paragraphs render inline
               right after the caption row (#1692). Un-referenced assets fall back
               to the strip/table block below the article. */}
-          <article className="max-w-4xl mx-auto px-6 md:px-16 space-y-10">
+          <div className={story.layout_mode === 'graphic-text' && fallbackImages.length > 0 ? 'flex flex-col lg:flex-row items-start' : undefined}>
+            <article className={story.layout_mode === 'graphic-text' && fallbackImages.length > 0 ? 'flex-1 min-w-0 px-6 md:px-12 space-y-10' : 'max-w-4xl mx-auto px-6 md:px-16 space-y-10'}>
             {story.content.map((rawPara, paraIdx) => {
               const displayText = zhuyinParagraphs?.[paraIdx] ?? rawPara;
               const inlineImgIdx = inlineImageIdxByPara.get(paraIdx);
@@ -704,23 +705,25 @@ const ReadingAnnotation: React.FC<ReadingAnnotationProps> = ({
                 </React.Fragment>
               );
             })}
-          </article>
+            </article>
 
-          {/* Fallback image strip — only un-referenced images (no caption match).
-              Preserves G7-L29 behavior where paragraphs reference 圖 N inside body
-              sentences but never as standalone caption rows. */}
-          {story.layout_mode === 'graphic-text' && fallbackImages.length > 0 && (
-            <div
-              className="max-w-4xl mx-auto px-6 md:px-16 mt-10 h-72 md:h-80 flex"
-              data-testid="reading-annotation-graphic-text-images"
-              style={{ WebkitUserSelect: 'none', userSelect: 'none' } as React.CSSProperties}
-            >
-              <GraphicTextImageStrip
-                images={fallbackImages}
-                lessonCode={story.lesson_code}
-              />
-            </div>
-          )}
+            {/* Fallback image strip — only un-referenced images (no caption match).
+                Graphic-text: renders as sticky right column alongside article.
+                Preserves G7-L29 behavior where paragraphs reference 圖 N inside body
+                sentences but never as standalone caption rows. */}
+            {story.layout_mode === 'graphic-text' && fallbackImages.length > 0 && (
+              <aside
+                className="w-full mt-8 lg:mt-0 lg:w-80 lg:shrink-0 lg:border-l border-outline-variant/20 lg:pl-4 lg:sticky lg:top-0 lg:h-[calc(100vh-5rem)] overflow-hidden"
+                data-testid="reading-annotation-graphic-text-images"
+                style={{ WebkitUserSelect: 'none', userSelect: 'none' } as React.CSSProperties}
+              >
+                <GraphicTextImageStrip
+                  images={fallbackImages}
+                  lessonCode={story.lesson_code}
+                />
+              </aside>
+            )}
+          </div>
 
           {/* Fallback tables — only un-referenced tables. */}
           {fallbackTables.length > 0 && (


### PR DESCRIPTION
Fixes #2085

## Summary

- `ReadingAnnotation.tsx`: wrap the `<article>` and fallback image strip in a flex container. On desktop (`lg:` breakpoint) they display side-by-side (`flex-row`); on mobile they stack (`flex-col`). The image pane becomes a sticky `<aside>` (`lg:w-80`, `lg:sticky`) so it stays visible as the user scrolls the article.
- `GraphicTextImageStrip.tsx`: sort images by `figure_label` Chinese numeral before rendering, fixing G7-L29 which stores images in reversed order (圖四→圖一).

## Files changed

- `frontend/src/components/reading-steps/ReadingAnnotation.tsx` — flex wrapper + aside layout
- `frontend/src/components/reading-steps/GraphicTextImageStrip.tsx` — sort by figure_label

## Test plan

- [ ] Open a G7-L28 / G7-L29 / G7-L30 lesson on the PR preview URL and go to the 閱讀標注 (ReadingAnnotation) step
- [ ] Desktop (>=1024px): article text and image pane are side-by-side; image pane is sticky as article scrolls
- [ ] Mobile / narrow viewport: article and images stack vertically
- [ ] G7-L29: images appear in 圖一→圖四 order (previously reversed)
- [ ] Non graphic-text lessons (e.g. G6-L22): layout unchanged (no wrapper div rendered)
- [ ] TypeScript build: `npm run build` passes with 0 errors