### PR TITLE
fix(live-tutor): always allow paragraph advancement regardless of matchRate

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -358,12 +358,10 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 
             const totalRetryable = targets.filter(t => t.replace(CHINESE_PUNCTUATION_REGEX, '').length > 1).length;
 
-            // Rule 2: if > half the sentences failed → suggest redo, but still show next-segment
-            // if paragraph-level evaluation passed (matchRate >= 0.5 or already completed).
-            // Sentence retry is advisory — never block paragraph-level progress. (#1318)
+            // Rule 2: if > half the sentences failed → suggest redo, but advancement is never blocked.
+            // Retry suggestion is advisory UI only — score never gates paragraph progress. (#1318, #2185)
             if (failedSentences.length > totalRetryable / 2) {
-              const canAdvanceRule2 = paragraphSummary.matchRate >= 0.5
-                || completedParagraphs.has(idx);
+              const canAdvanceRule2 = true; // advancement is never blocked by score
               return (
                 <div className="pt-3 border-t border-on-surface/10">
                   <p className="text-sm text-on-surface-variant text-center">
@@ -457,10 +455,8 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
 
           {/* Action buttons — hidden during sentence retry */}
           {retrySentenceIdx === undefined && (() => {
-            // canAdvance is based on paragraph-level matchRate only.
-            // Sentence retry suggestions are advisory and must not block paragraph progress. (#1318)
-            const canAdvance = paragraphSummary.matchRate >= 0.5
-              || completedParagraphs.has(idx);
+            // Advancement is never blocked by score — retry suggestions are advisory UI only. (#1318, #2185)
+            const canAdvance = true; // advancement is never blocked by score
 
             return (
             <div className="flex gap-3 justify-center pt-2">


### PR DESCRIPTION
Fixes #2185

## Summary

- Removed `matchRate >= 0.5` score threshold from `canAdvanceRule2` (Rule 2 / high-failure branch) and `canAdvance` (action buttons section) in `ParagraphCard.tsx`
- Both are now unconditionally `true`
- Retry suggestions ("重練這段" / sentence-level retry hints) remain visible as advisory UI hints — they just no longer gate progress
- Updated comments to reflect the new intent and reference this issue

## Why

Students whose reading accuracy fell below 50% were silently blocked from advancing to the next paragraph. The original intent (per issue #1318 comments) was always that retry UI is advisory; the score-gate was a regression from prior logic.

## Changed File

- `frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx` — 2 const lines + 4 comment lines

## Test Plan

1. Open any lesson in the live-tutor step
2. Read a paragraph with intentionally poor accuracy (below 50% match)
3. Confirm that "下一段" (next paragraph) or "完成朗讀" (finish reading) buttons appear and work even when the retry suggestion is shown
4. Confirm retry suggestion UI ("這段有比較多地方需要加強") still displays when applicable — it just no longer blocks