### PR TITLE
fix(library): completed card shows clear-progress button (Fixes #2188)

### DIFF
--- a/frontend/src/components/student/StoryCard.tsx
+++ b/frontend/src/components/student/StoryCard.tsx
@@ -44,9 +44,11 @@ interface StoryCardProps {
   estimatedXP?: number;
   /** When true, shows a "level up soon" hint instead of the XP estimate. */
   closeToLevelUp?: boolean;
+  /** When provided, shows a small "clear progress" button on the card (Issue #2188). */
+  onClearProgress?: () => void;
 }
 
-const StoryCard: React.FC<StoryCardProps> = ({ story, isLoading, isCompleted, onClick, userStatus, estimatedXP, closeToLevelUp }) => {
+const StoryCard: React.FC<StoryCardProps> = ({ story, isLoading, isCompleted, onClick, userStatus, estimatedXP, closeToLevelUp, onClearProgress }) => {
   const diff = getDifficulty(story);
   const diffConfig = DIFFICULTY_CONFIG[diff];
   const statusBadge = userStatus ? STATUS_BADGE[userStatus] : null;
@@ -130,6 +132,18 @@ const StoryCard: React.FC<StoryCardProps> = ({ story, isLoading, isCompleted, on
               </span>
             )}
           </div>
+        )}
+        {/* Clear progress button — only for completed stories (Issue #2188) */}
+        {isCompleted && onClearProgress && (
+          <button
+            type="button"
+            className="mt-2 flex items-center gap-1 text-xs text-gray-400 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={(e) => { e.stopPropagation(); onClearProgress(); }}
+            title="清除練習進度"
+          >
+            <span className="material-symbols-outlined" style={{ fontSize: '14px' }}>restart_alt</span>
+            清除進度
+          </button>
         )}
       </div>
     </div>

--- a/frontend/src/pages/app/InlinePages.tsx
+++ b/frontend/src/pages/app/InlinePages.tsx
@@ -15,14 +15,12 @@ import { lazy } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { hasRole } from '../../services/authApi';
 import { clearActiveSession } from '../../services/api';
-import { checkSelfPracticeCompleted, SessionExpiredError } from '../../services/learningApi';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
 import { PARENT_PORTAL_ENABLED } from '../../config/featureFlags';
 import { scopedStepStorageKey } from '../../services/learningStorageScope';
 import StoryLibrary from '../student/StoryLibrary';
 import WriteCharacter from '../../components/stroke-order/WriteCharacter';
 import SessionResumePrompt from '../../components/SessionResumePrompt';
-import { Story } from '../../types';
 
 const ACTIVE_ASSIGNMENT_CONTEXT_KEY = 'activeAssignmentContext';
 const ASSIGNMENT_DB_SESSION_KEY_PREFIX = 'assignment-db-session-';
@@ -83,7 +81,6 @@ export const LibraryPage: React.FC = () => {
   const classroomId = searchParams.get('classroom');
   const classroomIdNum = classroomId ? parseInt(classroomId, 10) : null;
   const [showResumePrompt, setShowResumePrompt] = useState(true);
-  const [restartConfirmStory, setRestartConfirmStory] = useState<Story | null>(null);
 
   const clearAssignmentContext = (storyId: string) => {
     try {
@@ -145,51 +142,14 @@ export const LibraryPage: React.FC = () => {
     });
   };
 
-  const handleSelectStory = async (story: Story) => {
+  const handleSelectStory = (story: { id: string }) => {
     clearAssignmentContext(story.id);
     cleanupAssignmentScopedProgressKeys(story.id);
-
-    // Check completion: DB first (cross-device), localStorage as fallback.
-    let isCompletedBefore = false;
-    if (token) {
-      try {
-        isCompletedBefore = await checkSelfPracticeCompleted(story.id, token);
-      } catch (err) {
-        if (err instanceof SessionExpiredError) {
-          console.warn('[LibraryPage] checkSelfPracticeCompleted: token expired, falling back to localStorage');
-        }
-        // Fall through to localStorage check below.
-      }
-      // Sync DB truth back to localStorage so subsequent checks are instant.
-      if (isCompletedBefore) {
-        try { localStorage.setItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`, '1'); } catch { /* non-fatal */ }
-      }
-    }
-    if (!isCompletedBefore) {
-      try {
-        isCompletedBefore = localStorage.getItem(`${SELF_PRACTICE_COMPLETED_KEY_PREFIX}${story.id}`) === '1';
-      } catch {
-        isCompletedBefore = false;
-      }
-    }
-
-    if (isCompletedBefore) {
-      setRestartConfirmStory(story);
-      return;
-    }
-
     navigate(`/learn/${story.id}/intro`);
   };
 
-  const handleConfirmRestart = () => {
-    if (!restartConfirmStory) return;
-    clearSelfPracticeProgress(restartConfirmStory.id);
-    navigate(`/learn/${restartConfirmStory.id}/intro`);
-    setRestartConfirmStory(null);
-  };
-
-  const handleCancelRestart = () => {
-    setRestartConfirmStory(null);
+  const handleClearProgress = (storyId: string) => {
+    clearSelfPracticeProgress(storyId);
   };
 
   return (
@@ -197,56 +157,16 @@ export const LibraryPage: React.FC = () => {
       {showResumePrompt && (
         <SessionResumePrompt onDismiss={() => setShowResumePrompt(false)} />
       )}
-      {restartConfirmStory && (
-        <RestartPracticeConfirmModal
-          storyTitle={restartConfirmStory.title}
-          onConfirm={handleConfirmRestart}
-          onCancel={handleCancelRestart}
-        />
-      )}
       <div className="mt-4">
-        <StoryLibrary onStartReading={handleSelectStory} classroomId={classroomIdNum} />
+        <StoryLibrary
+          onStartReading={handleSelectStory}
+          classroomId={classroomIdNum}
+          onClearProgress={handleClearProgress}
+        />
       </div>
     </div>
   );
 };
-
-interface RestartPracticeConfirmModalProps {
-  storyTitle: string;
-  onConfirm: () => void;
-  onCancel: () => void;
-}
-
-const RestartPracticeConfirmModal: React.FC<RestartPracticeConfirmModalProps> = ({
-  storyTitle,
-  onConfirm,
-  onCancel,
-}) => (
-  <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="dialog" aria-modal="true" aria-label="確認重新練習">
-    <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm mx-4 p-6 space-y-4">
-      <h3 className="text-lg font-bold text-gray-900">重新練習確認</h3>
-      <p className="text-sm text-gray-600">
-        你已完成過「<strong>{storyTitle}</strong>」，要清除目前自學進度並重新開始嗎？
-      </p>
-      <div className="flex justify-end gap-3">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg"
-        >
-          取消
-        </button>
-        <button
-          type="button"
-          onClick={onConfirm}
-          className="px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent-hover rounded-lg"
-        >
-          重新練習
-        </button>
-      </div>
-    </div>
-  </div>
-);
 
 /** Write character page. */
 export const WritePage: React.FC = () => {

--- a/frontend/src/pages/student/StoryLibrary.tsx
+++ b/frontend/src/pages/student/StoryLibrary.tsx
@@ -15,6 +15,8 @@ interface StoryLibraryProps {
   completedSlugs?: string[];
   /** When set, show only texts assigned to this classroom (from 我的班級→課文庫). */
   classroomId?: number | null;
+  /** When provided, shows a clear-progress button on completed story cards (Issue #2188). */
+  onClearProgress?: (storyId: string) => void;
 }
 
 // ── Skeleton card ─────────────────────────────────────────────────────────────
@@ -36,6 +38,7 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
   limit,
   completedSlugs = [],
   classroomId = null,
+  onClearProgress,
 }) => {
   const { token, user } = useAuth();
   const [xpToNext, setXpToNext] = useState<number | null>(null);
@@ -95,7 +98,16 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
   // Issue #1249: per-story student status map
   const [libraryStatus, setLibraryStatus] = useState<Record<string, LibraryStoryStatus>>({});
 
-  const completedSet = new Set(completedSlugs);
+  // Bug fix #2188: completedSet merges external completedSlugs prop AND
+  // stories with status='completed' from the API (libraryStatus).  This
+  // means the clear-progress button is visible even when the caller does not
+  // explicitly supply completedSlugs (the common case for LibraryPage).
+  const completedSet = new Set([
+    ...completedSlugs,
+    ...Object.entries(libraryStatus)
+      .filter(([, s]) => s === 'completed')
+      .map(([id]) => id),
+  ]);
 
   // Fetch XP info for callout badges (lightweight, non-blocking)
   useEffect(() => {
@@ -350,6 +362,17 @@ const StoryLibrary: React.FC<StoryLibraryProps> = ({
                 userStatus={libraryStatus[story.id]}
                 estimatedXP={ESTIMATED_XP}
                 closeToLevelUp={isCloseToLevelUp}
+                onClearProgress={completedSet.has(story.id) && onClearProgress ? () => {
+                  // Bug fix #2188: update libraryStatus state immediately so the
+                  // card drops its "completed" appearance without needing a full
+                  // page refresh (the DB record is reset by the caller).
+                  setLibraryStatus((prev) => {
+                    const next = { ...prev };
+                    delete next[story.id];
+                    return next;
+                  });
+                  onClearProgress(story.id);
+                } : undefined}
               />
             );
           })}


### PR DESCRIPTION
Fixes #2188

## Summary

- Removed the restart confirmation modal when clicking a completed story card — clicking now navigates directly
- Added a hover-visible "清除進度" button in the bottom-left of completed story cards

## Bug Fixes (second attempt)

**Bug 1 — `completedSlugs` never passed, button never appeared:**
`StoryLibrary` receives `completedSlugs` as a prop defaulting to `[]`. `LibraryPage` was not passing this prop, so `completedSet` was always empty and `isCompleted` was always false. Fixed by having `StoryLibrary` merge `completedSlugs` with stories whose `libraryStatus === 'completed'` from the already-fetched API data — so the clear button now appears for completed stories even when `completedSlugs` is not supplied externally.

**Bug 2 — UI state not updated after clearing:**
After `onClearProgress` was called, `libraryStatus` state still held `completed` for that story so the card kept showing as completed. Fixed by having the clear handler update `libraryStatus` state immediately (removes the story entry), so the UI reflects the cleared state without a page refresh. The localStorage clear (in `InlinePages.tsx`) handles the client-side persistence side.

## Files Changed

- `frontend/src/pages/app/InlinePages.tsx` — removed `isCompletedBefore` check + `restartConfirmStory` state + modal JSX; `handleSelectStory` now navigates directly
- `frontend/src/components/student/StoryCard.tsx` — added `onClearProgress?: () => void` prop + hover-visible "清除進度" button (stopPropagation on click)
- `frontend/src/pages/student/StoryLibrary.tsx` — `completedSet` now merges prop + API status; `onClearProgress` handler also removes story from `libraryStatus` state

## Test Plan

1. Open the student library page
2. Find a story with status "已完成" (completed)
3. Hover over the card — a small "清除進度" button should appear in the bottom area
4. Click the card body — should navigate directly to the story (no modal)
5. Click "清除進度" — card should immediately lose its completed appearance
6. No confirmation modal should appear at any point