### PR TITLE
fix(full-reading): remove dupe timer, add cancel button, fix mic leak

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -147,6 +147,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
     fallbackReason,
     clearFallbackReason,
     startSession,
+    stopSession,
     submitReading,
     audioRecorder,
   } = useFullReadingSession({
@@ -203,6 +204,11 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
 
     return <>{zhuyinLine ?? line}</>;
   };
+
+  const handleCancel = useCallback(() => {
+    stopSession();
+    audioRecorder.clearRecording();
+  }, [stopSession, audioRecorder]);
 
   const handleRetry = useCallback(() => {
     try { localStorage.removeItem(storageKey); } catch {}
@@ -313,19 +319,6 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
             </div>
           </div>
 
-          {/* Recording live card — shows animated mic + timer while session is active */}
-          {isSessionActive && (
-            <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-4 mt-6 flex flex-col items-center gap-2">
-              <div className="flex items-center justify-center gap-3 py-1">
-                <span className="relative flex h-6 w-6 items-center justify-center flex-shrink-0">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-60" />
-                  <span className="relative material-symbols-outlined text-xl text-red-500" style={{ fontVariationSettings: "'FILL' 1" }}>mic</span>
-                </span>
-                <span className="font-mono tabular-nums text-lg font-bold text-red-600">{formatTime(recordingSecs)}</span>
-              </div>
-              <p className="text-xs text-on-surface-variant">朗讀中・隨時可以停止</p>
-            </div>
-          )}
 
           {/* I4 (Issue #2156): Gemini fallback alert banner — must be visible, never silent.
               Shown when backend returns method='fallback' so user knows the result is
@@ -410,6 +403,7 @@ const FullReading: React.FC<FullReadingProps> = ({ story, onFinish, onBack, init
         onSpeak={speakFullStory}
         onStartSession={startSession}
         onSubmit={submitReading}
+        onCancel={handleCancel}
         onStopTts={stopTtsAll}
         onPauseTts={tts.pauseTts}
         onResumeTts={tts.resumeTts}

--- a/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingControls.tsx
@@ -23,6 +23,8 @@ export interface FullReadingControlsProps {
   onStartSession: () => void;
   /** Called when user clicks 完成朗讀 (P1#1: async — awaits audio blob) */
   onSubmit: () => void | Promise<void>;
+  /** Called when user clicks 取消 during recording — stops session without submitting */
+  onCancel: () => void;
   /** Called when user clicks 停止 (TTS) */
   onStopTts: () => void;
   /** Called when user clicks 暫停 (TTS playing, not paused) */
@@ -49,6 +51,7 @@ const FullReadingControls: React.FC<FullReadingControlsProps> = ({
   onSpeak,
   onStartSession,
   onSubmit,
+  onCancel,
   onStopTts,
   onPauseTts,
   onResumeTts,
@@ -97,14 +100,35 @@ const FullReadingControls: React.FC<FullReadingControlsProps> = ({
             準備中...
           </button>
         ) : state === 'recording' ? (
-          <button
-            onClick={onSubmit}
-            className="w-full h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)]"
-            style={{ background: 'linear-gradient(135deg, #006947, #34d399)' }}
-          >
-            <span className="material-symbols-outlined text-xl">check_circle</span>
-            完成朗讀
-          </button>
+          <div className="w-full flex flex-col items-center gap-3">
+            {/* Timer row */}
+            <div className="flex items-center gap-2">
+              <span className="relative flex h-5 w-5 items-center justify-center">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-300 opacity-60" />
+                <span className="relative material-symbols-outlined text-base text-red-500" style={{fontVariationSettings:"'FILL' 1"}}>mic</span>
+              </span>
+              <span className="font-mono tabular-nums text-lg font-bold text-red-600">{formatTime(recordingSecs)}</span>
+            </div>
+            {/* Cancel + Submit buttons */}
+            <div className="w-full flex gap-3">
+              <button
+                onClick={onCancel}
+                className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+              >
+                <span className="material-symbols-outlined text-xl">close</span>
+                取消
+              </button>
+              <button
+                onClick={onSubmit}
+                className="flex-1 h-14 rounded-full font-headline font-bold text-xl transition-all flex items-center justify-center gap-2 active:scale-[0.98] text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)]"
+                style={{ background: 'linear-gradient(135deg, #006947, #34d399)' }}
+              >
+                <span className="material-symbols-outlined text-xl">check_circle</span>
+                完成
+              </button>
+            </div>
+            <p className="text-xs text-on-surface-variant">隨時可以停止，按「完成」即送出評分</p>
+          </div>
         ) : state === 'ttsPlaying' ? (
           <div className="w-full flex gap-3">
             <button

--- a/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
+++ b/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
@@ -65,13 +65,14 @@ describe('FullReadingControls', () => {
     expect(onStartSession).toHaveBeenCalledTimes(1);
   });
 
-  it('renders 完成朗讀 button when recording is active', () => {
+  it('renders 完成 and 取消 buttons when recording is active', () => {
     render(
       <FullReadingControls
         state="recording"
         onSpeak={noop}
         onStartSession={noop}
         onSubmit={noop}
+        onCancel={noop}
         onStopTts={noop}
         onPauseTts={noop}
         onResumeTts={noop}
@@ -83,7 +84,8 @@ describe('FullReadingControls', () => {
         recordingSecs={0}
       />
     );
-    expect(screen.getByText('完成朗讀')).toBeInTheDocument();
+    expect(screen.getByText('完成')).toBeInTheDocument();
+    expect(screen.getByText('取消')).toBeInTheDocument();
   });
 
   it('renders 準備中... button when preparing', () => {


### PR DESCRIPTION
## Summary

Fixes #2189 — 錄音模組三個問題：

- **移除重複計時器**：刪除 `FullReading.tsx` 裡的「Recording live card」block（~316 行的 `isSessionActive` 條件區塊），計時器只保留 `FullReadingControls` 裡的一個
- **新增「取消」按鈕**：錄音狀態下，「完成」旁邊加「取消」按鈕，兩個並排
- **修正 mic 洩漏**：取消時改用 `handleCancel = () => { stopSession(); audioRecorder.clearRecording(); }`，確保 mic stream 被正確釋放

## Test plan

- [ ] 開始錄音 → 畫面只有一個計時器（不重複）
- [ ] 錄音中點「取消」→ 錄音停止，麥克風燈熄滅
- [ ] 錄音中點「完成」→ 送出評分流程正常
- [ ] `FullReadingPanels.test.tsx` 通過（已更新 assertion 為 `完成` + `取消`）
- [ ] Build 0 TypeScript errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)