### PR TITLE
fix(report): remove lock gate — show all 6 sections with available data (Fixes #2201)

### DIFF
--- a/frontend/src/components/reading-steps/AssessmentReport.tsx
+++ b/frontend/src/components/reading-steps/AssessmentReport.tsx
@@ -86,7 +86,6 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
   // ── Metrics (pure computation, no side effects) ──────────────────────────
   const {
     hideScores,
-    hasNoData,
     completedSections,
     overallScore,
     segmentStats,
@@ -184,11 +183,11 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
         />
       )}
 
-      {!readOnly && !hasNoData && <CelebrationOverlay score={overallScore} />}
+      {!readOnly && overallScore !== null && <CelebrationOverlay score={overallScore} />}
 
       {/* ============ 星星評級 Star Rating (Issue #222) —
           學生端隱藏（Issue #1094：改鼓勵式，不呈現星星/分數） ============ */}
-      {!hasNoData && !hideScores && (
+      {overallScore !== null && !hideScores && (
         <StarCelebration
           stars={starCount}
           readingAccuracy={bestReadingAccuracy}
@@ -196,37 +195,8 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
         />
       )}
 
-      {/* Progress indicator — shown when not all sections are complete */}
-      {hasNoData ? (
-        /* #2146: 空狀態文案 — 教授 demo 誤判「報告功能尚未完成」。
-           其實報告已就緒，只是 demo 時沒先做朗讀 → 無資料。改成明確標
-           「完成練習後自動解鎖」+ 預覽報告會包含的環節，讓它讀起來是
-           完整功能在等資料，而非未完成的 stub。 */
-        <div className="bg-amber-50 border border-amber-200 rounded-2xl p-6 text-center">
-          <p className="text-3xl mb-2">📊</p>
-          <h2 className="text-lg font-bold text-amber-900 mb-1">學習報告已就緒，完成練習後解鎖</h2>
-          <p className="text-sm text-amber-700 mb-4">
-            先完成「逐段朗讀」或「全文朗讀」，系統會自動為你生成<strong>朗朗上口六環節診斷報告</strong>。
-          </p>
-          <div className="bg-white/70 border border-amber-100 rounded-xl px-4 py-3 mb-4 text-left inline-block">
-            <p className="text-xs font-bold text-amber-800 mb-1.5">報告將包含</p>
-            <ul className="text-xs text-amber-700 space-y-1">
-              <li>📖 朗讀流暢度與正確率</li>
-              <li>🎯 課文理解診斷</li>
-              <li>🔍 易錯字詞分析</li>
-              <li>💡 個別化練習建議</li>
-            </ul>
-          </div>
-          <div>
-            <button
-              onClick={onRetry}
-              className="bg-accent hover:bg-accent-hover text-white px-6 py-2 rounded-full text-sm font-bold transition-all"
-            >
-              開始練習解鎖報告
-            </button>
-          </div>
-        </div>
-      ) : completedSections < 6 ? (
+      {/* Progress indicator — shown while sections are still being completed (#2201: no lock gate) */}
+      {completedSections < 6 && (
         <div className="bg-blue-50 border border-blue-100 rounded-2xl px-5 py-3 flex items-center gap-3">
           <div className="flex gap-1">
             {Array.from({ length: 6 }).map((_, i) => (
@@ -240,20 +210,20 @@ const AssessmentReport: React.FC<AssessmentReportProps> = ({
             已完成 <span className="font-black">{completedSections}</span> / 6 環節
           </p>
         </div>
-      ) : null}
+      )}
 
       {/* Header */}
       <div className="text-center">
-        {hasNoData ? null : (
+        {completedSections >= 6 && (
           <div className="inline-block bg-green-100 text-green-700 px-4 py-1 rounded-full text-sm font-bold mb-4">
             恭喜完成練習！
           </div>
         )}
         <h2 className="text-4xl font-bold mb-2">
-          {hasNoData ? '朗朗上口診斷報告' : '好棒！你今天又進步了。'}
+          {completedSections >= 6 ? '好棒！你今天又進步了。' : '朗朗上口診斷報告'}
         </h2>
         <p className="text-gray-500">
-          {hasNoData ? '完成練習後，這裡會顯示你的六環節完整成果。' : '讓我們看看這次學習的完整成果吧。'}
+          {completedSections >= 6 ? '讓我們看看這次學習的完整成果吧。' : '完成各練習環節，這裡會顯示你的六環節完整成果。'}
         </p>
         {story && (
           <p className="text-sm text-gray-400 mt-1">{story.title}</p>


### PR DESCRIPTION
Fixes #2201

## Summary

- Removes the amber-card lock gate that blocked the full report UI when \`hasNoData\` was true
- The report now always renders all six \`AssessmentSectionWrapper\` sections — each section's own \`disabled\` prop already handles missing data gracefully (shows greyed-out state)
- Progress bar (0/6 → 6/6) still shows while sections are being completed
- Header copy, celebration badge, \`CelebrationOverlay\`, and \`StarCelebration\` updated to gate on \`completedSections >= 6\` / \`overallScore !== null\` instead of the removed \`hasNoData\` flag

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| No steps done | Amber lock card only; no sections visible | Full 6-section skeleton; all sections disabled (greyed out); score shows \`--\` |
| Some steps done | Lock card gone + partial sections | Same partial sections (no change) |
| All steps done | Full report | Full report (no change) |

## Test plan

- [ ] Open the report tab on a fresh lesson (no prior reading) — verify: no amber lock card, all 6 sections visible but disabled, score shows \`--\`
- [ ] Complete a reading step, then open report — verify affected sections become active
- [ ] \`npm run build\` passes with no errors (verified locally)