### PR TITLE
fix(infra): honest keypoints_only family for no-spotlight lessons (Fixes #2216)

### DIFF
--- a/docs/lesson-schema-registry.yaml
+++ b/docs/lesson-schema-registry.yaml
@@ -12,20 +12,11 @@
 # Source: private/curriculum-source/_online-schema/batch_run_log.json
 # Coverage: 151 lessons
 #
-# --- Coverage Report vs Registry:口徑說明 (#2214) ---
-# family=unknown (registry) vs strategy-unknown (coverage report) are DIFFERENT:
-#   registry family=unknown   : 2 lessons (G4-L1, G9-L10) — no usable strategy signal
-#                               from DOCX pipeline AND production YAML (both sources empty).
-#   coverage strategy-unknown : lessons where spotlight_status != 'pass' or 'none'
-#                               (includes fail + error) — different dimension.
-#   family=classical          : 10 文言文 lessons — no spotlight by design (not a defect).
-#   family=unknown remaining  : 2 lessons need manual annotation (see docs/unknown-family-c-bucket.tsv)
-#
 lessons:
 - lesson_id: G4-L1
   grade: G4
   title: 贏得喝采的輸家
-  family: unknown
+  family: keypoints_only
   spotlight_status: none
   spotlight_score: null
   keypoints_status: pass
@@ -33,8 +24,7 @@ lessons:
   n_figures: 10
   n_tables: 0
   known_gaps:
-  - strategy_unknown_no_bracket_filename
-  - strategy_source_both_empty
+  - no_spotlight_section
 - lesson_id: G4-L2
   grade: G4
   title: 十秒的背後
@@ -1501,7 +1491,7 @@ lessons:
 - lesson_id: G9-L10
   grade: G9
   title: 高地訓練有助於運動表現嗎？
-  family: unknown
+  family: keypoints_only
   spotlight_status: none
   spotlight_score: null
   keypoints_status: pass
@@ -1509,8 +1499,7 @@ lessons:
   n_figures: 11
   n_tables: 0
   known_gaps:
-  - strategy_unknown_no_bracket_filename
-  - strategy_source_both_empty
+  - no_spotlight_section
 - lesson_id: G9-L11
   grade: G9
   title: 長喙天蛾見前人所未見

--- a/scripts/build_lesson_registry.py
+++ b/scripts/build_lesson_registry.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-build_lesson_registry.py — issue #2212 / #2214
+build_lesson_registry.py — issue #2212 / #2214 / #2146
 Generate docs/lesson-schema-registry.yaml from batch_run_log.json + eval results.
 
 The registry is the single source of truth for:
@@ -122,14 +122,16 @@ def _resolve_family(lesson_id: str, log_entry: dict, schema_dir: Path) -> str:
     pipeline). The spotlight.yml carries the correct strategy_type from the P1
     router expansion.
 
-    Priority (#2214 extended):
+    Priority (#2214 / #2146 extended):
       0. Classical Chinese lessons (grade == '文') → 'classical' (no spotlight by design)
       1. spotlight.yml strategy_type (P1 router result)
       2. keypoints.yml strategy_type (if spotlight missing)
       3. batch_run_log strategy_type (fallback — same router, but older run)
       4. Production YAML fallback via reading_strategy_type / reading_strategy name
          (B-bucket recovery: only when production YAML has a usable strategy source)
-      5. 'unknown'
+      5. keypoints.yml row-label structure inference (#2146)
+         (D-bucket: no spotlight section at all; infer from table shape, not lesson id)
+      6. 'unknown'
     """
     # 0. Classical Chinese: grade prefix '文' → always 'classical', no spotlight expected
     if lesson_id.startswith("文-"):
@@ -164,6 +166,20 @@ def _resolve_family(lesson_id: str, log_entry: dict, schema_dir: Path) -> str:
     family = _resolve_family_from_production_yaml(lesson_id)
     if family != "unknown":
         return family
+
+    # 5. Keypoints row-label structure inference (D-bucket — #2146)
+    #    Applied only when spotlight.yml confirms "spotlight range not found" — i.e.
+    #    this lesson has NO spotlight section in the source document (not a pipeline
+    #    failure, but a structural absence). Returns 'keypoints_only' when a
+    #    keypoints table exists; 'unknown' otherwise. No lesson ids are hardcoded.
+    sp_data = _load_yaml_safe(sp_path) if sp_path.exists() else None
+    sp_error = ((sp_data.get("spotlight") if sp_data else None) or {}).get("error", "")
+    if "spotlight range not found" in sp_error:
+        kp_path = schema_dir / f"{lesson_id}.keypoints.yml"
+        if kp_path.exists():
+            inferred = _infer_family_from_keypoints_labels(kp_path)
+            if inferred != "unknown":
+                return inferred
 
     return "unknown"
 
@@ -228,6 +244,35 @@ def _resolve_family_from_production_yaml(lesson_id: str) -> str:
     return "unknown"
 
 
+
+def _infer_family_from_keypoints_labels(kp_path: Path) -> str:
+    """
+    D-bucket inference (#2146): when a lesson has NO spotlight section at all
+    (spotlight.yml contains 'spotlight range not found'), confirm that a
+    keypoints table is present and return 'keypoints_only'.
+
+    This function does NOT return 'guided_steps' — lessons without a spotlight
+    section do not belong to the guided_steps family even if their keypoints
+    table resembles a narrative or scientific-inquiry structure.  The caller
+    (_resolve_family priority-5) uses 'keypoints_only' to signal:
+      "this lesson has assessable keypoints but no spotlight; classify honestly."
+
+    Returns 'keypoints_only' when a non-empty keypoints table is found.
+    Returns 'unknown' when the file is missing, empty, or has no rows.
+    """
+    data = _load_yaml_safe(kp_path)
+    if not data:
+        return "unknown"
+
+    kp_inner = data.get("keypoints", {})
+    rows = kp_inner.get("rows", [])
+    if not rows:
+        return "unknown"
+
+    # keypoints table present → honest label: has keypoints, no spotlight
+    return "keypoints_only"
+
+
 # ── Per-lesson entry builder ─────────────────────────────────────────────────
 
 def build_entry(lesson_id: str, log_entry: dict, ev, bls, schema_dir: Path,
@@ -247,10 +292,12 @@ def build_entry(lesson_id: str, log_entry: dict, ev, bls, schema_dir: Path,
 
     # Known gap
     known_gaps = []
-    if lesson_id in KNOWN_GAPS:
-        known_gaps.append("strategy_unknown_no_bracket_filename")
     if family == "classical":
         known_gaps.append("classical_no_spotlight_by_design")
+    elif family == "keypoints_only":
+        # D-bucket (#2146): lesson has a keypoints table but NO spotlight section in the
+        # source document. Honest label: classified by table presence, not strategy type.
+        known_gaps.append("no_spotlight_section")
     elif family == "unknown":
         # C-bucket: both DOCX pipeline and production YAML could not determine strategy
         known_gaps.append("strategy_source_both_empty")


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2216
Related to #2214, #2212

## Summary

- 把「有重點表、無聚光燈 section」的課從 `family=unknown` 改為誠實標籤 `keypoints_only`
- `_infer_family_from_keypoints_labels()` 簡化為：rows 存在 → `keypoints_only`，不做啟發式 label 比對（結構性事實即是分類依據）
- `known_gap` 改為 `no_spotlight_section`，移除誤導性的 `strategy_unknown_no_bracket_filename`
- 修正 code review 發現的 null-spotlight crash guard（兩處）
- 移除 priority-5 block 中的 dead `sp_path` re-assignment

## Registry result

| Family | Before | After |
|--------|--------|-------|
| guided_steps | 119 | 119 (restored) |
| keypoints_only | 0 | **2** (G4-L1, G9-L10) |
| unknown | 2 | **0** |
| comparison_table | 13 | 13 |
| classical | 10 | 10 |
| image_table | 7 | 7 |

## Test plan

- [x] `family=unknown = 0`
- [x] G4-L1 → `keypoints_only`, known_gap: `no_spotlight_section`
- [x] G9-L10 → `keypoints_only`, known_gap: `no_spotlight_section`
- [x] `guided_steps` 回到 119（未塞入無聚光燈的課）
- [x] `bash specs/run-ci.sh --quick` → registry freshness OK
- [x] overfit lint: `grep "G4-L1\|G9-L10" scripts/build_lesson_registry.py` 只出現在 `KNOWN_GAPS` 集合
- [x] null-crash guard 修正（兩處 `.get('spotlight') or {}` 改法）
- [x] diff 只動 `scripts/build_lesson_registry.py` + `docs/lesson-schema-registry.yaml`