### PR TITLE
fix(intro): clickable step chips for quick navigation (Fixes #2196)

### DIFF
--- a/frontend/src/components/reading-steps/Intro.tsx
+++ b/frontend/src/components/reading-steps/Intro.tsx
@@ -433,16 +433,34 @@ const Intro: React.FC<IntroProps> = ({ story, onStartReading, onBack }) => {
 
           {/* #2139: 本課學習策略 yellow box relocated above (directly below title). */}
 
-          {/* 數位學習步驟 — #2082 A4: replaced the static non-clickable ol with a
-              single-line step count. StepperNav dots already provide real navigation.
-              Do NOT restore the full ol — it was confusing & non-interactive. */}
+          {/* 數位學習步驟 — #2196: clickable step chips (quick-jump shortcut).
+              #2082 A4 removed the non-clickable ol — do NOT restore a static ol.
+              This uses chip badges so each step is directly accessible. */}
           {(() => {
             const digitalSteps = resolveActiveSteps(story.stepSequence).filter(s => s.id !== 'intro');
             if (digitalSteps.length === 0) return null;
             return (
-              <p className="text-sm text-gray-500 text-center pb-2">
-                本課共 {digitalSteps.length} 個學習步驟
-              </p>
+              <div className="space-y-2 pb-2">
+                <p className="text-xs text-gray-400 text-center">
+                  本課共 {digitalSteps.length} 個步驟，點擊可快速跳轉
+                </p>
+                <div className="flex flex-wrap gap-2 justify-center">
+                  {digitalSteps.map((step, idx) => (
+                    <button
+                      key={step.id}
+                      type="button"
+                      onClick={() => navigate(`/learn/${story.id}/${step.id}`)}
+                      className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border border-gray-200 bg-white hover:border-accent hover:text-accent hover:bg-accent/5 transition-all active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+                      aria-label={`跳轉到第 ${idx + 1} 步：${step.label}`}
+                    >
+                      <span className="w-4 h-4 rounded-full bg-gray-100 text-gray-500 text-[10px] font-bold flex items-center justify-center shrink-0">
+                        {idx + 1}
+                      </span>
+                      {step.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
             );
           })()}
 


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2196

## Summary

- `Intro.tsx`: 將「本課共 N 個學習步驟」純文字改為可點擊的步驟 chip 按鈕，每個 chip 點擊後以 `navigate('/learn/:storyId/:stepId')` 直接跳轉到對應步驟
- 使用現有 `resolveActiveSteps` + 既有 `navigate` — 無新依賴
- 不恢復靜態 `<ol>` 清單（遵守 #2082 A4 規定）
- 策略框顏色（amber）在 staging 已正確，無需修改

## Note

靖杭 QA 回報的「紫框」在 staging 已是正確的黃框（`bg-amber-100/60 border-2 border-amber-300`）— 截圖確認（staging lesson 4 和 lesson 28 均為黃框）。不需要額外修改顏色。

## 靖杭 QA Credit

感謝 @if-else-master 的七課驗收測試，本 PR 根據其 QA 回報修正。

## Test plan

1. 前往任一課程簡介頁（`/learn/:id/intro`）
2. 頁面底部可看到步驟 chip 列表（「本課共 N 個步驟，點擊可快速跳轉」）
3. 點擊任一步驟 chip → 應直接跳轉至對應步驟頁面
4. 確認無 console error