### PR TITLE
fix(mcq): wrong answer allows retry without revealing correct option (Fixes #2199)

### DIFF
--- a/frontend/src/components/reading-steps/MultipleChoiceExercise.tsx
+++ b/frontend/src/components/reading-steps/MultipleChoiceExercise.tsx
@@ -42,6 +42,8 @@ const MultipleChoiceExercise: React.FC<Props> = ({
   const [selected, setSelected] = useState<string | null>(null);
   const [revealed, setRevealed] = useState(false);
   const [score, setScore] = useState(0);
+  // #2199: show "再選一次" feedback after a wrong answer without revealing correct
+  const [wrongFeedback, setWrongFeedback] = useState(false);
 
   // MCQ Rescue dialog state (Issue #1387 / #1507)
   const [rescueOpen, setRescueOpen] = useState(false);
@@ -54,12 +56,7 @@ const MultipleChoiceExercise: React.FC<Props> = ({
 
   function handleSelect(label: string) {
     if (revealed) return;
-    setSelected(label);
-    setRevealed(true);
     const correct = label === q.answer;
-    if (correct) {
-      setScore((s) => s + 1);
-    }
 
     // Telemetry — every click, including wrong answers where the student
     // never opens the rescue dialog (Issue #1507 / Young 5/8 meeting).
@@ -70,6 +67,23 @@ const MultipleChoiceExercise: React.FC<Props> = ({
         choice: label,
         is_correct: correct,
       });
+    }
+
+    if (correct) {
+      // #2199: only reveal on correct answer
+      setSelected(label);
+      setRevealed(true);
+      setWrongFeedback(false);
+      setScore((s) => s + 1);
+    } else {
+      // #2199: wrong — show "再選一次" without locking or revealing the answer
+      setSelected(label);
+      setWrongFeedback(true);
+      // Clear selection after brief flash so student can pick again
+      setTimeout(() => {
+        setSelected(null);
+        setWrongFeedback(false);
+      }, 900);
     }
   }
 
@@ -100,6 +114,7 @@ const MultipleChoiceExercise: React.FC<Props> = ({
     setCurrent((c) => c + 1);
     setSelected(null);
     setRevealed(false);
+    setWrongFeedback(false);
   }
 
   return (
@@ -137,11 +152,17 @@ const MultipleChoiceExercise: React.FC<Props> = ({
             const label = OPTION_LABELS[idx];
             const isChosen = selected === label;
             const isAnswerLabel = q.answer === label;
+            // #2199: wrong-flash state — briefly highlight the wrong pick before clearing
+            const isWrongFlash = wrongFeedback && isChosen;
 
             let btnClass =
               'flex items-start gap-3 rounded-lg border p-3 text-sm text-left transition-all ';
             if (!revealed) {
-              btnClass += 'border-gray-200 hover:border-blue-400 hover:bg-blue-50 cursor-pointer';
+              if (isWrongFlash) {
+                btnClass += 'border-amber-400 bg-amber-50 text-amber-800';
+              } else {
+                btnClass += 'border-gray-200 hover:border-blue-400 hover:bg-blue-50 cursor-pointer';
+              }
             } else if (isAnswerLabel) {
               btnClass += 'border-green-500 bg-green-50 font-semibold text-green-800';
             } else if (isChosen && !isAnswerLabel) {
@@ -172,14 +193,22 @@ const MultipleChoiceExercise: React.FC<Props> = ({
           })}
         </div>
 
-        {/* Explanation */}
+        {/* #2199: Wrong-answer feedback — "再選一次" without revealing correct answer */}
+        {wrongFeedback && (
+          <div className="mt-3 rounded-lg bg-amber-50 border border-amber-200 px-4 py-2.5 text-sm text-amber-800 flex items-center gap-2 animate-pulse">
+            <span aria-hidden="true">🔄</span>
+            <span className="font-medium">再選一次！</span>
+          </div>
+        )}
+
+        {/* Explanation — shown only on correct answer reveal */}
         {revealed && q.explanation && (
           <div className="mt-3 rounded-lg bg-amber-50 border border-amber-200 px-4 py-2 text-sm text-amber-800">
             💡 {zh(q.explanation)}
           </div>
         )}
 
-        {/* 問 AI 助教 — only on wrong answers, opt-in (Issue #1507) */}
+        {/* 問 AI 助教 — only on wrong answers after reveal, opt-in (Issue #1507) */}
         {revealed && !isCorrect && !rescueOpen && (
           <button
             onClick={openRescue}


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2199

## Summary

- `MultipleChoiceExercise.tsx`: 答錯後改為顯示 amber「再選一次！」提示 900ms，不 reveal 正確答案，不鎖定選項；學生可重新作答，直到答對才 reveal 正確答案並顯示解釋
- Telemetry（`recordMcqAttempt`）仍記錄每次選擇（含錯誤嘗試）
- FillInBlank（items 2/3）已在 staging 正確（#2082 A10/A11），本 PR 不改動

## Changes

| 檔案 | 說明 |
|------|------|
| `MultipleChoiceExercise.tsx` | 答錯行為：flash + 清除選擇 → 可重選。答對：reveal green + 顯示 explanation |

## 靖杭 QA Credit

感謝 @if-else-master 的七課驗收測試，本 PR 根據其 QA 回報修正。

## Test plan

1. 前往任一課程的閱讀理解頁（`/learn/:id/comprehension`）
2. 點選一個錯誤答案 → 應出現 amber「再選一次！」提示（約 900ms）
3. 提示消失後，選項恢復可選（**不顯示正確答案**）
4. 選擇正確答案 → 應顯示綠色高亮 + 解釋（若有）
5. 確認無 console error