### PR TITLE
feat(diff-display): add bopomofo ruby annotations to diff tokens (Fixes #2226)

### DIFF
--- a/backend/app/routes/learning/learning_reading.py
+++ b/backend/app/routes/learning/learning_reading.py
@@ -4,6 +4,7 @@ Handles AI-powered reading diagnosis and improvement suggestions.
 """
 import json
 import logging
+import re
 import time
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel, Field
@@ -18,6 +19,7 @@ from ...services.ai_service import generate_reading_analysis, GeminiContentFilte
 from ...services.ai_usage_tracker import last_usage, log_ai_usage
 from ...services.input_sanitizer import sanitize_ai_input
 from ...services.reading_evaluation_service import evaluate_reading_with_ai
+from pypinyin import Style, lazy_pinyin
 from ...services.reading_transcription_service import (
     ALLOWED_AUDIO_MIMES,
     transcribe_reading_audio,
@@ -336,11 +338,32 @@ class ReadingEvaluateRequest(BaseModel):
     duration_ms: int | None = Field(None, description="朗讀時長（毫秒，選填）")
 
 
+_CHINESE_CHAR_RE = re.compile(r"[一-鿿㐀-䶿]")
+
+
+def _build_zhuyin_map(target_text: str) -> dict[int, str]:
+    """Return a position→bopomofo map for all CJK characters in target_text.
+
+    Passing the full string (rather than individual chars) lets pypinyin use
+    surrounding context to disambiguate polyphonic characters (破音字), e.g.
+    「的」(ㄉㄜ˙ vs ㄉㄧˋ), 「樂」(ㄌㄜˋ vs ㄩㄝˋ), 「長」(ㄓㄤˇ vs ㄔㄤˊ).
+    """
+    # lazy_pinyin returns one bopomofo element per character (including punctuation).
+    # Non-CJK characters produce their raw form; we only keep CJK positions.
+    bopomofo_list = lazy_pinyin(target_text, style=Style.BOPOMOFO)
+    zhuyin_map: dict[int, str] = {}
+    for idx, (char, bpmf) in enumerate(zip(target_text, bopomofo_list)):
+        if _CHINESE_CHAR_RE.match(char) and bpmf and bpmf != char:
+            zhuyin_map[idx] = bpmf
+    return zhuyin_map
+
+
 class DiffToken(BaseModel):
     char: str
     type: str  # "correct" | "forgiven" | "wrong" | "missing" | "extra"
     spoken: str | None = None
     reason: str | None = None
+    zhuyin: str | None = None
 
 
 class ReadingEvalStats(BaseModel):
@@ -428,13 +451,27 @@ async def evaluate_reading_endpoint(
             prompt_template_id="reading_evaluate",
         )
 
+    # Build a position→bopomofo map from target_text so pypinyin can use full-context
+    # polyphone disambiguation (破音字).  extra tokens have no position in target_text
+    # and are not displayed; skip zhuyin for them to avoid wasted lookups.
+    zhuyin_map = _build_zhuyin_map(payload.target_text)
+    target_pos = 0  # track position through non-extra tokens
+    diff_tokens: list[DiffToken] = []
+    for t in result["diff_tokens"]:
+        token_type = t.get("type", "")
+        if token_type == "extra":
+            diff_tokens.append(DiffToken(**t))
+        else:
+            zhuyin = zhuyin_map.get(target_pos) if target_pos < len(payload.target_text) else None
+            diff_tokens.append(DiffToken(**t, zhuyin=zhuyin))
+            target_pos += 1
     return ReadingEvaluateResponse(
         match_rate=result["match_rate"],
         adjusted_match_rate=result["adjusted_match_rate"],
         tier=result["tier"],
         feedback=result["feedback"],
         cpm=result.get("cpm"),
-        diff_tokens=[DiffToken(**t) for t in result["diff_tokens"]],
+        diff_tokens=diff_tokens,
         stats=ReadingEvalStats(**result["stats"]),
         thresholds=ReadingEvalThresholds(**result["thresholds"]),
         evaluation_method=result["evaluation_method"],

--- a/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
@@ -9,14 +9,10 @@
 
 import React from 'react';
 import DiffDisplay from '../../ui/DiffDisplay';
-
-export interface DiffToken {
-  type: string;
-  text: string;
-}
+import { DiffToken } from '../../../types';
 
 export interface FullReadingFeedbackPanelProps {
-  /** Token array from analyzeFluency. undefined or empty → renders nothing. */
+  /** Token array from reading evaluation. undefined or empty → renders nothing. */
   diffTokens: DiffToken[] | undefined;
 }
 

--- a/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
@@ -11,6 +11,7 @@
  */
 
 import React from 'react';
+import { DiffToken } from '../../../types';
 
 const FULL_READING_TIERS: Array<{ min: number; stars: number; text: string; color: string }> = [
   { min: 0.90, stars: 5, text: '太厲害了！',         color: 'text-emerald-600' },
@@ -28,7 +29,7 @@ export interface FullReadingScoreCardProps {
   result: {
     matchRate: number;
     feedback: string;
-    diffTokens?: Array<{ type: string; text: string }>;
+    diffTokens?: DiffToken[];
     cpm: number;
     durationMs: number;
     errorBreakdown: { correct: number; wrong: number; missing: number; extra: number };

--- a/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
+++ b/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
@@ -223,12 +223,13 @@ describe('FullReadingControls', () => {
 
 // ── 2. FullReadingScoreCard ───────────────────────────────────────────────────
 import FullReadingScoreCard from '../FullReadingScoreCard';
+import type { DiffToken } from '../../../../types';
 
 describe('FullReadingScoreCard', () => {
   const baseResult = {
     matchRate: 0.92,
     feedback: '很好',
-    diffTokens: [{ type: 'correct', text: '你好' }],
+    diffTokens: [{ char: '你', type: 'correct' }, { char: '好', type: 'correct' }] as DiffToken[],
     cpm: 120,
     durationMs: 5000,
     errorBreakdown: { correct: 10, wrong: 0, missing: 0, extra: 0 },
@@ -321,12 +322,13 @@ describe('FullReadingScoreCard', () => {
 
 // ── 3. FullReadingFeedbackPanel ───────────────────────────────────────────────
 import FullReadingFeedbackPanel from '../FullReadingFeedbackPanel';
+import type { DiffToken as DT2 } from '../../../../types';
 
 describe('FullReadingFeedbackPanel', () => {
   it('renders diff section when diffTokens are present', () => {
-    const diffTokens = [
-      { type: 'correct', text: '你好' },
-      { type: 'wrong', text: '世界' },
+    const diffTokens: DT2[] = [
+      { char: '你', type: 'correct' },
+      { char: '好', type: 'wrong', expected: '世' },
     ];
     render(
       <FullReadingFeedbackPanel diffTokens={diffTokens} />

--- a/frontend/src/components/ui/DiffDisplay.tsx
+++ b/frontend/src/components/ui/DiffDisplay.tsx
@@ -17,18 +17,42 @@ interface DiffDisplayProps {
  * - missing → gray background + dashed underline (shows target char that was skipped)
  * - extra   → orange background + strikethrough (shows char that shouldn't be there)
  *
+ * Zhuyin (bopomofo) annotation:
+ * - Displayed above each character via HTML <ruby>/<rt> when token.zhuyin is present.
+ * - Applies to all token types (correct, forgiven, wrong, missing, unread).
+ *
  * Accessibility:
  * - Each non-correct token carries an aria-label describing the error type
  * - The container has role="group" with a descriptive label
  * - The legend uses role="list" for structured screen reader output
  */
+
+/** Wrap a character in <ruby> with bopomofo annotation if available. */
+function CharWithZhuyin({
+  char,
+  zhuyin,
+}: {
+  char: string;
+  zhuyin?: string;
+}): React.ReactElement {
+  if (!zhuyin) return <>{char}</>;
+  return (
+    <ruby>
+      {char}
+      <rt className="text-[0.6em] tracking-tight font-normal not-italic leading-none">
+        {zhuyin}
+      </rt>
+    </ruby>
+  );
+}
+
 const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, className = '' }) => {
   if (!tokens || tokens.length === 0) return null;
 
   return (
     <div className={className}>
       <div
-        className="flex flex-wrap leading-[inherit]"
+        className="flex flex-wrap leading-loose"
         role="group"
         aria-label="朗讀差異對比結果"
       >
@@ -37,20 +61,20 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, c
             case 'correct':
             case 'forgiven':
               return (
-                <span key={idx} className="text-gray-900">
-                  {token.char}
+                <span key={idx} className="text-gray-900 inline-flex flex-col items-center">
+                  <CharWithZhuyin char={token.char} zhuyin={token.zhuyin} />
                 </span>
               );
             case 'wrong':
               return (
                 <span
                   key={idx}
-                  className="bg-error text-white rounded-sm px-0.5 mx-px cursor-help relative group"
+                  className="bg-error text-white rounded-sm px-0.5 mx-px cursor-help relative group inline-flex flex-col items-center"
                   title={`應該是「${token.expected}」`}
                   aria-label={`讀錯：讀成「${token.char}」，應該是「${token.expected ?? ''}」`}
                   role="mark"
                 >
-                  {token.char}
+                  <CharWithZhuyin char={token.char} zhuyin={token.zhuyin} />
                   {token.expected && (
                     <span
                       className="absolute -top-8 left-1/2 -translate-x-1/2 bg-gray-800 text-white text-xs px-2 py-1 rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10"
@@ -65,12 +89,12 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, c
               return (
                 <span
                   key={idx}
-                  className="bg-gray-200 text-gray-400 border-b-2 border-dashed border-gray-400 rounded-sm px-0.5 mx-px"
+                  className="bg-gray-200 text-gray-400 border-b-2 border-dashed border-gray-400 rounded-sm px-0.5 mx-px inline-flex flex-col items-center"
                   title="漏讀"
                   aria-label={`漏讀：「${token.char}」沒有讀出來`}
                   role="mark"
                 >
-                  {token.char}
+                  <CharWithZhuyin char={token.char} zhuyin={token.zhuyin} />
                 </span>
               );
             case 'extra':
@@ -79,8 +103,8 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, c
               return null;
             case 'unread':
               return (
-                <span key={idx} className="text-gray-300">
-                  {token.char}
+                <span key={idx} className="text-gray-300 inline-flex flex-col items-center">
+                  <CharWithZhuyin char={token.char} zhuyin={token.zhuyin} />
                 </span>
               );
             default:
@@ -110,10 +134,6 @@ const DiffDisplay: React.FC<DiffDisplayProps> = ({ tokens, showLegend = false, c
           <span className="flex items-center gap-1" role="listitem">
             <span className="w-3 h-3 rounded-sm bg-gray-200 border border-dashed border-gray-400 inline-block" aria-hidden="true" />
             漏讀
-          </span>
-          <span className="flex items-center gap-1" role="listitem">
-            <span className="w-3 h-3 rounded-sm bg-warning/30 inline-block" aria-hidden="true" />
-            多讀
           </span>
         </div>
       )}

--- a/frontend/src/components/ui/__tests__/DiffDisplay.test.tsx
+++ b/frontend/src/components/ui/__tests__/DiffDisplay.test.tsx
@@ -41,14 +41,13 @@ describe('DiffDisplay', () => {
     expect(span).toHaveAttribute('title', '漏讀');
   });
 
-  it('renders extra characters with line-through', () => {
+  it('does not render extra characters (hidden for future coaching hints)', () => {
     const tokens: DiffToken[] = [
       { char: '啊', type: 'extra' },
     ];
     render(<DiffDisplay tokens={tokens} />);
-    const span = screen.getByText('啊');
-    expect(span).toHaveClass('line-through');
-    expect(span).toHaveAttribute('title', '多讀');
+    // extra tokens are intentionally not rendered in the diff view
+    expect(screen.queryByText('啊')).not.toBeInTheDocument();
   });
 
   it('renders mixed token types correctly', () => {
@@ -63,7 +62,8 @@ describe('DiffDisplay', () => {
     expect(screen.getByText('你')).toHaveClass('text-gray-900');
     expect(screen.getByText('好')).toHaveClass('bg-error');
     expect(screen.getByText('嗎')).toHaveClass('bg-gray-200');
-    expect(screen.getByText('的')).toHaveClass('line-through');
+    // extra token '的' is not rendered
+    expect(screen.queryByText('的')).not.toBeInTheDocument();
   });
 
   it('renders legend when showLegend is true', () => {
@@ -72,7 +72,8 @@ describe('DiffDisplay', () => {
     expect(screen.getByText('正確')).toBeInTheDocument();
     expect(screen.getByText('讀錯')).toBeInTheDocument();
     expect(screen.getByText('漏讀')).toBeInTheDocument();
-    expect(screen.getByText('多讀')).toBeInTheDocument();
+    // extra tokens are not shown in the diff display, so 多讀 is not in the legend
+    expect(screen.queryByText('多讀')).not.toBeInTheDocument();
   });
 
   it('does not render legend by default', () => {
@@ -85,5 +86,42 @@ describe('DiffDisplay', () => {
     const tokens: DiffToken[] = [{ char: '字', type: 'correct' }];
     const { container } = render(<DiffDisplay tokens={tokens} className="my-custom" />);
     expect(container.firstChild).toHaveClass('my-custom');
+  });
+
+  it('renders bopomofo annotation above character when zhuyin is provided', () => {
+    const tokens: DiffToken[] = [
+      { char: '你', type: 'correct', zhuyin: 'ㄋㄧˇ' },
+    ];
+    const { container } = render(<DiffDisplay tokens={tokens} />);
+    const ruby = container.querySelector('ruby');
+    expect(ruby).toBeInTheDocument();
+    const rt = container.querySelector('rt');
+    expect(rt).toHaveTextContent('ㄋㄧˇ');
+  });
+
+  it('renders wrong token with zhuyin annotation', () => {
+    const tokens: DiffToken[] = [
+      { char: '你', type: 'wrong', expected: '他', zhuyin: 'ㄋㄧˇ' },
+    ];
+    const { container } = render(<DiffDisplay tokens={tokens} />);
+    const rt = container.querySelector('rt');
+    expect(rt).toHaveTextContent('ㄋㄧˇ');
+  });
+
+  it('renders missing token with zhuyin annotation', () => {
+    const tokens: DiffToken[] = [
+      { char: '世', type: 'missing', zhuyin: 'ㄕˋ' },
+    ];
+    const { container } = render(<DiffDisplay tokens={tokens} />);
+    const rt = container.querySelector('rt');
+    expect(rt).toHaveTextContent('ㄕˋ');
+  });
+
+  it('does not render ruby element when zhuyin is absent', () => {
+    const tokens: DiffToken[] = [
+      { char: '字', type: 'correct' },
+    ];
+    const { container } = render(<DiffDisplay tokens={tokens} />);
+    expect(container.querySelector('ruby')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -236,6 +236,7 @@ export interface DiffToken {
   expected?: string;
   spoken?: string;
   reason?: string;
+  zhuyin?: string;
 }
 
 export interface ReadingEvalStats {


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

Fixes #2226

## Summary

- **Backend**: `DiffToken` gains `zhuyin: str | None`. At `/reading/evaluate`, build a position-indexed bopomofo map from the full `target_text` string via `pypinyin` (Style.BOPOMOFO) — passing the full text enables context-aware polyphonic character disambiguation (破音字). `extra` tokens skip zhuyin (they are not displayed). Punctuation positions correctly return `null`.
- **Frontend**: `DiffToken` type gains `zhuyin?: string`. `DiffDisplay` wraps each character in `<ruby><rt>` when `zhuyin` is present, using `leading-loose` to accommodate annotation height. Applies to all token types (correct, forgiven, wrong, missing, unread).
- **Type cleanup**: Fix pre-existing TS inconsistency in `FullReadingFeedbackPanel` and `FullReadingScoreCard` — both were using a local `DiffToken { type, text }` instead of the canonical `DiffToken` from `types.ts`.
- **Test fixes**: Fix 2 pre-existing failing tests for `extra` token (expected `line-through` but component returns `null`). Add 4 new tests for zhuyin ruby annotation behavior.
- **Legend fix**: Remove `多讀` from legend — `extra` tokens are not rendered, so the legend entry was misleading.

## Test plan

- [ ] Open Preview URL → `/login` → click 學生小明
- [ ] Navigate to `/learn/1076/tutor`
- [ ] Press 開始朗讀, read a few sentences, wait for 逐字比對 to appear
- [ ] Confirm each character has bopomofo annotation above it (ruby/rt format)
- [ ] Confirm wrong/missing characters also show annotation
- [ ] Check console errors: zero tolerance
- [ ] Run `vitest run src/components/ui/__tests__/DiffDisplay.test.tsx` → 13 passed