### PR TITLE
fix(stepper): unlock report step — every learning step freely navigable (Fixes #2228)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -91,7 +91,6 @@ interface StepDotsProps {
   steps: ReturnType<typeof useStepSequence>;
   currentStepIndex: number;
   completedSet: Set<string>;
-  allNonReportDone: boolean;
   onStepClick: (step: ReturnType<typeof useStepSequence>[number]) => void;
 }
 
@@ -99,7 +98,6 @@ const StepDots: React.FC<StepDotsProps> = ({
   steps,
   currentStepIndex,
   completedSet,
-  allNonReportDone,
   onStepClick,
 }) => {
   return (
@@ -107,8 +105,6 @@ const StepDots: React.FC<StepDotsProps> = ({
       {steps.map((step, i) => {
         const isCompleted = completedSet.has(step.id);
         const isActive = i === currentStepIndex;
-        const isReport = step.id === 'report';
-        const isLocked = isReport && !allNonReportDone;
 
         let dotClass = 'bg-on-surface-variant/20 text-on-surface-variant';
         if (isCompleted) dotClass = 'bg-emerald-500 text-white';
@@ -119,15 +115,11 @@ const StepDots: React.FC<StepDotsProps> = ({
           <span key={step.id} className="group relative flex items-center justify-center">
             <button
               type="button"
-              onClick={() => {
-                if (isLocked) return;
-                onStepClick(step);
-              }}
-              disabled={isLocked}
-              className={`w-8 h-8 md:w-9 md:h-9 rounded-full text-sm md:text-base font-bold flex items-center justify-center transition-all hover:scale-110 disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
-              aria-label={`${i + 1}. ${step.label}${isLocked ? '（完成所有階段後解鎖）' : ''}`}
+              onClick={() => onStepClick(step)}
+              className={`w-8 h-8 md:w-9 md:h-9 rounded-full text-sm md:text-base font-bold flex items-center justify-center transition-all hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
+              aria-label={`${i + 1}. ${step.label}`}
               aria-current={isActive ? 'step' : undefined}
-              title={isLocked ? `${step.label}（完成所有階段後解鎖）` : step.label}
+              title={step.label}
             >
               {isCompleted ? (
                 <svg className="w-4 h-4 md:w-5 md:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth="3">
@@ -183,7 +175,6 @@ const ImmersiveTopBar: React.FC = () => {
 
   // Determine completed steps
   const completedSet = new Set(session?.completedSteps ?? []);
-  const allNonReportDone = activeSteps.filter(s => s.id !== 'report').every(s => completedSet.has(s.id));
 
   const handleBack = () => {
     if (inToolbox) {
@@ -200,27 +191,21 @@ const ImmersiveTopBar: React.FC = () => {
 
   const handleStepClick = (step: ReturnType<typeof useStepSequence>[number]) => {
     if (!selectedStory) return;
-    // Report only accessible when all other steps done
-    if (step.id === 'report' && !allNonReportDone) return;
     navigate(`/learn/${selectedStory.id}/${step.id}`);
   };
 
-  // Issue #1094: prev/next step arrows skip the locked report step
-  const prevStep = useMemo(() => {
-    for (let i = currentStepIndex - 1; i >= 0; i--) {
-      const s = activeSteps[i];
-      if (!(s.id === 'report' && !allNonReportDone)) return s;
-    }
-    return null;
-  }, [activeSteps, currentStepIndex, allNonReportDone]);
+  const prevStep = useMemo(
+    () => (currentStepIndex > 0 ? activeSteps[currentStepIndex - 1] : null),
+    [activeSteps, currentStepIndex],
+  );
 
-  const nextStep = useMemo(() => {
-    for (let i = currentStepIndex + 1; i < activeSteps.length; i++) {
-      const s = activeSteps[i];
-      if (!(s.id === 'report' && !allNonReportDone)) return s;
-    }
-    return null;
-  }, [activeSteps, currentStepIndex, allNonReportDone]);
+  const nextStep = useMemo(
+    () =>
+      currentStepIndex >= 0 && currentStepIndex < activeSteps.length - 1
+        ? activeSteps[currentStepIndex + 1]
+        : null,
+    [activeSteps, currentStepIndex],
+  );
 
   return (
     <header
@@ -286,7 +271,6 @@ const ImmersiveTopBar: React.FC = () => {
               steps={activeSteps}
               currentStepIndex={currentStepIndex}
               completedSet={completedSet}
-              allNonReportDone={allNonReportDone}
               onStepClick={handleStepClick}
             />
 

--- a/frontend/src/components/reading-steps/StepFooterNav.tsx
+++ b/frontend/src/components/reading-steps/StepFooterNav.tsx
@@ -30,26 +30,19 @@ const StepFooterNav: React.FC = () => {
   const currentStep = currentStepIndex >= 0 ? activeSteps[currentStepIndex] : null;
 
   const completedSet = new Set(session?.completedSteps ?? []);
-  const allNonReportDone = activeSteps
-    .filter((s) => s.id !== 'report')
-    .every((s) => completedSet.has(s.id));
 
-  // Mirror the same locking logic as ImmersiveTopBar (#1094)
-  const prevStep = useMemo(() => {
-    for (let i = currentStepIndex - 1; i >= 0; i--) {
-      const s = activeSteps[i];
-      if (!(s.id === 'report' && !allNonReportDone)) return s;
-    }
-    return null;
-  }, [activeSteps, currentStepIndex, allNonReportDone]);
+  const prevStep = useMemo(
+    () => (currentStepIndex > 0 ? activeSteps[currentStepIndex - 1] : null),
+    [activeSteps, currentStepIndex],
+  );
 
-  const nextStep = useMemo(() => {
-    for (let i = currentStepIndex + 1; i < activeSteps.length; i++) {
-      const s = activeSteps[i];
-      if (!(s.id === 'report' && !allNonReportDone)) return s;
-    }
-    return null;
-  }, [activeSteps, currentStepIndex, allNonReportDone]);
+  const nextStep = useMemo(
+    () =>
+      currentStepIndex >= 0 && currentStepIndex < activeSteps.length - 1
+        ? activeSteps[currentStepIndex + 1]
+        : null,
+    [activeSteps, currentStepIndex],
+  );
 
   const handleNav = (step: (typeof activeSteps)[number] | null) => {
     if (!step || !selectedStory) return;


### PR DESCRIPTION
> 🤖 由 Claude AI 代發（非 Young 本人）

## 背景
負責人 Young 決策：學習流程**每一步都不該被進度鎖**，學生要能自由跳轉。「報告」步原本鎖到「完成所有階段」才開（教授 demo 後確認此鎖不該存在）。

## 改動
移除報告步的進度鎖，**兩個導航元件**都修（獨立 code review 抓到第二個）：
- `AppShell.tsx`（ImmersiveTopBar 上方 dots + 箭頭）：移除 `isLocked`/`isReport` + `allNonReportDone` plumbing，報告 dot 永遠可點、無「完成所有階段後解鎖」字樣，prev/next 簡化為相鄰步
- `StepFooterNav.tsx`（底部下一步列）：同樣移除 `allNonReportDone` + report-skip，與上方 nav 一致

保留 `StepperNav.tsx` 的 needsStory guard（那不是進度鎖，是「沒載入課程」防呆）。`allNonReportDone` 已全 frontend 清光。

## 驗證
- 獨立 code-reviewer：APPROVE（無殘留引用、兩 nav 邏輯一致、邊界正確、無型別錯）
- 本機 type-check：AppShell 無新增錯（既有 tsc 錯與本 PR 無關）
- 本機 full build 因磁碟吃緊改交 CI（`build = vite build`，esbuild 不卡 tsc）
- merge 後將在 staging 用「學生 小明」一鍵登入實測：報告 dot 可點、可導入報告頁、下一步箭頭能到報告步

Fixes #2228

🤖 Generated with [Claude Code](https://claude.com/claude-code)