### PR TITLE
fix(live-tutor): STT/LLM console debug + digit interleave on staging

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
@@ -1,13 +1,12 @@
 import { useCallback, useRef } from 'react';
 import { DiffToken, Story } from '../../../../types';
 import { normalizeForComparison, cleanChineseText } from '../../../../utils/textDiff';
-import { READING_EXCELLENT } from '../../../../utils/personaConfig';
+import { pickConservativeTranscript } from '../../../../utils/transcriptGuard';
 import { evaluateReading } from '../../../../services/learningApi';
 import { useAuth } from '../../../../contexts/AuthContext';
 import {
   localEvaluateParagraph,
   splitIntoSentences,
-  getReadingPassThreshold,
   type LocalEvalResult,
 } from '../../../../utils/localEval';
 import {
@@ -17,6 +16,13 @@ import {
   STREAK_MESSAGES,
 } from '../../../../utils/liveTutorPools';
 import { LineResult, ParagraphSummaryData } from '../liveTutorTypes';
+
+/** Dev + staging/preview hosts — production 不印 STT/LLM debug。 */
+function isEvalConsoleEnabled(): boolean {
+  if (import.meta.env.DEV) return true;
+  if (typeof window === 'undefined') return false;
+  return /staging|preview|localhost/i.test(window.location.hostname);
+}
 
 /* ─────────────────────────────────────────────────────────────────────────
  * Evaluation state machine using useReducer
@@ -59,11 +65,12 @@ export function evalReducer(state: EvalState, action: EvalAction): EvalState {
         lastDiffTokens: action.diffTokens,
       };
     case 'GEMINI_DONE':
+      // Keep Phase-1 local diff for 朗讀結果 — Gemini diff_tokens can mark unread chars
+      // correct when STT/transcription over-filled the spoken text.
       return {
         ...state,
         phase: 'gemini_done',
         isAwaitingGemini: false,
-        lastDiffTokens: action.diffTokens,
       };
     case 'GEMINI_ERROR':
       return { ...state, phase: 'gemini_error', isAwaitingGemini: false };
@@ -139,7 +146,7 @@ export function useParagraphEvaluation({
   const evaluateAndRespond = useCallback(
     async (
       rawTranscript: string,
-      _rawStt: string,
+      rawStt: string,
       durationMs: number,
       lineIdx: number,
       /** I1 (P1#4): caller must declare transcript source.
@@ -148,7 +155,18 @@ export function useParagraphEvaluation({
       source: 'gemini' | 'webspeech' = 'webspeech',
     ) => {
       const targetText = story.content[lineIdx] || '';
-      const cleaned = cleanChineseText(rawTranscript);
+      const transcriptForEval =
+        source === 'gemini' && rawStt.trim()
+          ? pickConservativeTranscript(rawTranscript, rawStt, targetText)
+          : rawTranscript;
+      const cleaned = cleanChineseText(transcriptForEval);
+
+      if (isEvalConsoleEnabled() && transcriptForEval !== rawTranscript) {
+        console.warn(
+          '[Evaluation] Gemini transcript longer than Web Speech — using Web Speech for diff',
+          { geminiLen: cleanChineseText(rawTranscript).length, usedLen: cleaned.length },
+        );
+      }
 
       // No speech detected
       if (!cleaned) {
@@ -207,83 +225,39 @@ export function useParagraphEvaluation({
         localMatchRate = localResult.matchRate;
         localCpm = localResult.cpm;
       } else {
-        // Web Speech path: may aggregate sentenceResults if enough were collected.
-        const sentResults = sentenceResultsRef.current.filter(
-          Boolean,
-        ) as LocalEvalResult[];
-
-        const totalSentences = sentenceTargetsRef.current.length;
-        if (
-          sentResults.length > 0 &&
-          sentResults.length >= Math.ceil(totalSentences / 2)
-        ) {
-          const allDiff = sentResults.flatMap((r) => r.diffTokens);
-          const correctAndForgiven = allDiff.filter(
-            (t) =>
-              (t.type === 'correct' || t.type === 'forgiven') &&
-              normalizeForComparison(t.char).length > 0,
-          ).length;
-          const totalTarget = normalizeForComparison(targetText).length || 1;
-          localMatchRate = correctAndForgiven / totalTarget;
-          const threshold = getReadingPassThreshold(totalTarget);
-          localTier =
-            localMatchRate >= READING_EXCELLENT
-              ? 1
-              : localMatchRate >= threshold
-              ? 2
-              : 3;
-          localDiffTokens = allDiff;
-          localFeedback = sentResults[sentResults.length - 1].feedback;
-          // CPM must reflect whole-paragraph pace, not averaged per-sentence chunks
-          // (per-sentence timers can drift from actual recording length).
-          localCpm = localEvaluateParagraph(
-            cleaned,
-            targetText,
-            durationMs,
-            {
-              tier1: TIER1_POOL,
-              tier2: TIER2_POOL,
-              tier3: TIER3_POOL,
-              streakMsgs: STREAK_MESSAGES,
-            },
-            evalState.streak,
-          ).cpm;
-        } else {
-          const localResult = localEvaluateParagraph(
-            cleaned,
-            targetText,
-            durationMs,
-            {
-              tier1: TIER1_POOL,
-              tier2: TIER2_POOL,
-              tier3: TIER3_POOL,
-              streakMsgs: STREAK_MESSAGES,
-            },
-            evalState.streak,
-          );
-          localTier = localResult.tier;
-          localDiffTokens = localResult.diffTokens;
-          localFeedback = localResult.feedback;
-          localMatchRate = localResult.matchRate;
-          localCpm = localResult.cpm;
-        }
+        // Always score the full paragraph transcript — do not stitch per-sentence diff
+        // tokens (length mismatch makes interleavePunctuation mark unread chars green).
+        const localResult = localEvaluateParagraph(
+          cleaned,
+          targetText,
+          durationMs,
+          {
+            tier1: TIER1_POOL,
+            tier2: TIER2_POOL,
+            tier3: TIER3_POOL,
+            streakMsgs: STREAK_MESSAGES,
+          },
+          evalState.streak,
+        );
+        localTier = localResult.tier;
+        localDiffTokens = localResult.diffTokens;
+        localFeedback = localResult.feedback;
+        localMatchRate = localResult.matchRate;
+        localCpm = localResult.cpm;
       }
 
       dispatch({ type: 'START_LOCAL', diffTokens: localDiffTokens });
 
-      if (import.meta.env.DEV) {
-        console.group('%c[Evaluation] Hybrid', 'color: cyan; font-weight: bold');
-        console.log('Line:', lineIdx, '/', story.content.length - 1);
-        console.log('Target:', targetText, '| cleaned:', cleaned);
-        console.log(
-          'Local tier:',
-          localTier,
-          '| match:',
-          (localMatchRate * 100).toFixed(1) + '%',
-          '| cpm:',
-          localCpm,
-        );
-        console.groupEnd();
+      if (isEvalConsoleEnabled()) {
+        console.log('[LiveTutor] STT', {
+          lineIndex: lineIdx,
+          targetText,
+          webSpeech: rawStt,
+          geminiAudioTranscript: source === 'gemini' ? rawTranscript : null,
+          usedForEvaluation: cleaned,
+          transcriptSource: source,
+          conservativeClampApplied: transcriptForEval !== rawTranscript,
+        });
       }
 
       // ── Retry cap ──────────────────────────────────────────────────────
@@ -415,6 +389,27 @@ export function useParagraphEvaluation({
           }));
           dispatch({ type: 'GEMINI_DONE', diffTokens: gemini.diff_tokens });
 
+          if (isEvalConsoleEnabled()) {
+            console.log('[LiveTutor] LLM 評估', {
+              localBaseline: {
+                tier: localTier,
+                matchRate: localMatchRate,
+                cpm: localCpm,
+              },
+              evaluation_method: gemini.evaluation_method,
+              tier: gemini.tier,
+              match_rate: gemini.match_rate,
+              adjusted_match_rate: gemini.adjusted_match_rate,
+              cpm: gemini.cpm,
+              feedback: gemini.feedback,
+              wrongCount: geminiWrong,
+              missingCount: geminiMissing,
+              stats: gemini.stats,
+              thresholds: gemini.thresholds,
+              diff_tokens: gemini.diff_tokens,
+            });
+          }
+
           if (gemini.tier <= 2 && localTier > 2) {
             dispatch({ type: 'INCREMENT_STREAK' });
             dispatch({ type: 'RESET_RETRY' });
@@ -424,7 +419,8 @@ export function useParagraphEvaluation({
               cpm: Math.round(gemini.cpm ?? localCpm),
               durationMs,
               transcript: cleaned,
-              diffTokens: gemini.diff_tokens,
+              // Display stays on local diff; Gemini only upgrades tier / summary.
+              diffTokens: localDiffTokens,
             };
             setLineResults((prev) => [
               ...prev.filter((r) => r.lineIndex !== lineIdx),
@@ -443,6 +439,12 @@ export function useParagraphEvaluation({
           });
           dispatch({ type: 'GEMINI_ERROR' });
           const msg = err instanceof Error ? err.message : '';
+          if (isEvalConsoleEnabled()) {
+            console.log('[LiveTutor] LLM 評估', {
+              status: msg === 'gemini_timeout' ? 'timeout' : 'error',
+              message: msg || String(err),
+            });
+          }
           if (msg !== 'gemini_timeout') {
             console.warn('[LiveTutor] Gemini eval failed, local result stands:', err);
           }

--- a/frontend/src/utils/liveTutorHelpers.ts
+++ b/frontend/src/utils/liveTutorHelpers.ts
@@ -41,13 +41,31 @@ export function calcSpeakingProgress(interim: string, target: string): number {
 /**
  * Map a count of normalized (punctuation-stripped) matched chars back to
  * the corresponding index in the original target string.
+ * Arabic digit runs (299 → 二百九十九) count as multiple normalized chars.
  */
 export function normalizedToOrigIdx(target: string, normalizedProgress: number): number {
+  const chars = Array.from(target);
   let norm = 0;
-  for (let i = 0; i < target.length; i++) {
+
+  for (let i = 0; i < chars.length; i++) {
     if (norm >= normalizedProgress) return i;
-    if (!/[「」『』，。！？：；、\s]/.test(target[i])) norm++;
+
+    const ch = chars[i];
+    if (/[「」『』，。！？：；、\s]/.test(ch)) continue;
+
+    if (/\d/.test(ch)) {
+      if (i > 0 && /\d/.test(chars[i - 1])) continue;
+      let digitEnd = i;
+      while (digitEnd < chars.length && /\d/.test(chars[digitEnd])) digitEnd++;
+      const digitRun = chars.slice(i, digitEnd).join('');
+      norm += normalizeForComparison(digitRun).length;
+      i = digitEnd - 1;
+      continue;
+    }
+
+    norm += 1;
   }
+
   return target.length;
 }
 

--- a/frontend/src/utils/textDiff.test.ts
+++ b/frontend/src/utils/textDiff.test.ts
@@ -234,6 +234,40 @@ describe('interleavePunctuation', () => {
     expect(display.some((t) => t.char === '，')).toBe(true);
     expect(display.some((t) => t.char === '、')).toBe(true);
   });
+
+  it('maps Arabic digit runs to normalized diff tokens (公元前299年)', () => {
+    const target = '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+    const spoken = '公元前二百九十九年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+    const { tokens } = diffCharacters(spoken, target, { useHomophone: true });
+    const display = interleavePunctuation(target, tokens as DiffToken[]);
+
+    expect(display.map((t) => t.char).join('')).toBe(target);
+    expect(display.filter((t) => t.type === 'correct').length).toBeGreaterThan(20);
+    expect(display.find((t) => t.char === '2')?.type).toBe('correct');
+    expect(display.find((t) => t.char === '年')?.type).toBe('correct');
+    expect(display.find((t) => t.char === '秦')?.type).toBe('correct');
+  });
+
+  it('shows partial read through Arabic digits correctly', () => {
+    const target = '公元前299年，秦昭王';
+    const spoken = '公元前二百九十九年';
+    const { tokens } = diffCharacters(spoken, target, { useHomophone: true });
+    const display = interleavePunctuation(target, tokens as DiffToken[]);
+
+    expect(display.map((t) => `${t.char}:${t.type}`)).toEqual([
+      '公:correct',
+      '元:correct',
+      '前:correct',
+      '2:correct',
+      '9:correct',
+      '9:correct',
+      '年:correct',
+      '，:punctuation',
+      '秦:missing',
+      '昭:missing',
+      '王:missing',
+    ]);
+  });
 });
 
 describe('normalizePunctuationToChinese', () => {

--- a/frontend/src/utils/textDiff.ts
+++ b/frontend/src/utils/textDiff.ts
@@ -371,10 +371,62 @@ export function computeMatchRate(spoken: string, target: string): number {
 /** Punctuation stripped from diff comparison — re-inserted at display time only. */
 const DISPLAY_PUNCT_RE = TOKEN_PUNCT_RE;
 
+const DIGIT_RE = /\d/;
+
+function chineseNormLenForDigitRun(digitStr: string): number {
+  if (!digitStr) return 0;
+  return Array.from(intToChinese(parseInt(digitStr, 10))).length;
+}
+
+function consumeNextDisplayToken(
+  displayTokens: DiffToken[],
+  tokenIdx: number,
+): { token: DiffToken | null; nextIdx: number } {
+  let idx = tokenIdx;
+  while (idx < displayTokens.length && isTokenPunctuationChar(displayTokens[idx].char)) {
+    idx += 1;
+  }
+  if (idx >= displayTokens.length) {
+    return { token: null, nextIdx: idx };
+  }
+  return { token: displayTokens[idx], nextIdx: idx + 1 };
+}
+
+function aggregateDigitRunForDisplay(
+  displayChar: string,
+  runTokens: DiffToken[],
+): DiffToken {
+  if (runTokens.length === 0) {
+    return { char: displayChar, type: 'unread' };
+  }
+  const types = runTokens.map((t) => t.type);
+  if (types.every((t) => t === 'correct')) {
+    return { char: displayChar, type: 'correct' };
+  }
+  if (types.every((t) => t === 'correct' || t === 'forgiven')) {
+    return { char: displayChar, type: 'forgiven' };
+  }
+  if (types.some((t) => t === 'wrong')) {
+    const wrong = runTokens.find((t) => t.type === 'wrong')!;
+    return { char: displayChar, type: 'wrong', expected: wrong.expected };
+  }
+  if (types.every((t) => t === 'missing' || t === 'unread')) {
+    return { char: displayChar, type: types[0] === 'unread' ? 'unread' : 'missing' };
+  }
+  if (types.some((t) => t === 'missing' || t === 'unread')) {
+    return { char: displayChar, type: 'missing' };
+  }
+  // Mis-aligned token run — do not default to correct (would show unread text as green).
+  return { char: displayChar, type: 'missing' };
+}
+
 /**
  * Re-insert punctuation from the lesson line into diff tokens for display.
  * Always walks the full target text — punctuation is never gated on how much
  * the student has read. Scoring still uses punctuation-stripped tokens.
+ *
+ * Arabic digit runs (e.g. 299 → 二百九十九) expand to multiple normalized
+ * diff tokens; each digit in the original line inherits the aggregate status.
  */
 export function interleavePunctuation(
   targetText: string,
@@ -391,33 +443,57 @@ export function interleavePunctuation(
     );
   }
 
+  const targetChars = Array.from(targetText);
   const normChars = Array.from(normalizeForComparison(targetText));
   const result: DiffToken[] = [];
   let tokenIdx = 0;
   let normIdx = 0;
 
-  for (const ch of Array.from(targetText)) {
+  for (let i = 0; i < targetChars.length; i++) {
+    const ch = targetChars[i];
+
     if (DISPLAY_PUNCT_RE.test(ch)) {
       result.push({ char: ch, type: 'punctuation' });
       continue;
     }
-    if (normIdx < normChars.length && ch === normChars[normIdx]) {
-      // Skip punctuation chars embedded in diff tokens — display uses target punctuation only.
-      while (
-        tokenIdx < displayTokens.length &&
-        isTokenPunctuationChar(displayTokens[tokenIdx].char)
-      ) {
-        tokenIdx += 1;
+
+    if (DIGIT_RE.test(ch)) {
+      if (i > 0 && DIGIT_RE.test(targetChars[i - 1])) continue;
+
+      let digitEnd = i;
+      while (digitEnd < targetChars.length && DIGIT_RE.test(targetChars[digitEnd])) {
+        digitEnd += 1;
       }
-      if (tokenIdx < displayTokens.length) {
-        result.push(displayTokens[tokenIdx]);
+      const digitRun = targetChars.slice(i, digitEnd).join('');
+      const normRunLen = chineseNormLenForDigitRun(digitRun);
+      const runTokens: DiffToken[] = [];
+
+      for (let k = 0; k < normRunLen; k++) {
+        const { token, nextIdx } = consumeNextDisplayToken(displayTokens, tokenIdx);
+        tokenIdx = nextIdx;
+        if (token) runTokens.push(token);
+      }
+      normIdx += normRunLen;
+
+      for (let d = i; d < digitEnd; d++) {
+        result.push(aggregateDigitRunForDisplay(targetChars[d], runTokens));
+      }
+      i = digitEnd - 1;
+      continue;
+    }
+
+    if (normIdx < normChars.length && ch === normChars[normIdx]) {
+      const { token, nextIdx } = consumeNextDisplayToken(displayTokens, tokenIdx);
+      tokenIdx = nextIdx;
+      if (token) {
+        result.push({ ...token, char: ch });
       } else {
         result.push({ char: ch, type: 'unread' });
       }
-      tokenIdx += 1;
       normIdx += 1;
       continue;
     }
+
     // Decorative / stripped chars in the original line — show without diff styling.
     result.push({ char: ch, type: 'punctuation' });
   }

--- a/frontend/src/utils/transcriptGuard.test.ts
+++ b/frontend/src/utils/transcriptGuard.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { pickConservativeTranscript } from './transcriptGuard';
+
+const TARGET =
+  '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+
+describe('pickConservativeTranscript', () => {
+  it('keeps Gemini when it is only slightly longer than Web Speech', () => {
+    const web = '公元前299年';
+    const gemini = '公元前299年，秦昭王';
+    expect(pickConservativeTranscript(gemini, web, TARGET)).toBe(gemini);
+  });
+
+  it('falls back to Web Speech when Gemini looks like the full paragraph', () => {
+    const web = '公元前299年';
+    const gemini = TARGET;
+    expect(pickConservativeTranscript(gemini, web, TARGET)).toBe(web);
+  });
+
+  it('falls back when Gemini is much longer than Web Speech', () => {
+    const web = '公元前';
+    const gemini = '公元前299年秦昭王聽說孟嘗君';
+    expect(pickConservativeTranscript(gemini, web, TARGET)).toBe(web);
+  });
+
+  it('uses Gemini when Web Speech is empty', () => {
+    const gemini = '公元前299年';
+    expect(pickConservativeTranscript(gemini, '', TARGET)).toBe(gemini);
+  });
+});

--- a/frontend/src/utils/transcriptGuard.ts
+++ b/frontend/src/utils/transcriptGuard.ts
@@ -1,0 +1,52 @@
+/**
+ * Guard against Gemini audio transcription over-filling text the student did not read.
+ * When the model sees target_text as a hint it may output the full lesson line even
+ * when the audio only contains the opening phrase — which makes every char look "correct".
+ */
+import { cleanChineseText, normalizeForComparison } from './textDiff';
+
+/** Absolute slack before we distrust Gemini over Web Speech. */
+const EXTRA_CHARS_TOLERANCE = 2;
+
+/**
+ * If Gemini normalized length exceeds Web Speech by more than this fraction, prefer Web Speech.
+ * e.g. webspeech=7, gemini=28 → ratio ~4 → clamp.
+ */
+const EXTRA_LENGTH_RATIO = 1.5;
+
+/**
+ * Pick the transcript to feed scoring / diff display.
+ * `preferred` is usually Gemini; `webspeechFallback` is browser STT at stop time.
+ */
+export function pickConservativeTranscript(
+  preferred: string,
+  webspeechFallback: string,
+  targetText: string,
+): string {
+  const preferredNorm = normalizeForComparison(cleanChineseText(preferred));
+  const fallbackNorm = normalizeForComparison(cleanChineseText(webspeechFallback));
+  const targetNorm = normalizeForComparison(targetText);
+
+  if (!fallbackNorm) return preferred;
+  if (!preferredNorm) return webspeechFallback;
+
+  const extraChars = preferredNorm.length - fallbackNorm.length;
+  const ratio =
+    fallbackNorm.length > 0 ? preferredNorm.length / fallbackNorm.length : Infinity;
+
+  // Gemini ≈ full paragraph but Web Speech only caught the opening → classic over-transcribe.
+  const suspiciousFullParagraph =
+    targetNorm.length >= 8 &&
+    preferredNorm.length >= targetNorm.length * 0.9 &&
+    fallbackNorm.length <= targetNorm.length * 0.6;
+
+  const suspiciousLength =
+    extraChars > EXTRA_CHARS_TOLERANCE &&
+    (ratio >= EXTRA_LENGTH_RATIO || extraChars >= Math.max(5, Math.floor(targetNorm.length * 0.25)));
+
+  if (suspiciousFullParagraph || suspiciousLength) {
+    return webspeechFallback;
+  }
+
+  return preferred;
+}


### PR DESCRIPTION
## Summary
- Fix Arabic digit interleave (299 → 二百九十九) so 朗讀結果 UI matches local diff
- Conservative transcript guard when Gemini STT over-fills
- Console logs `[LiveTutor] STT` and `[LiveTutor] LLM 評估` on dev + staging/preview hostnames

## Test plan
- [x] `vitest` textDiff + transcriptGuard (34 tests)
- [ ] Staging: G6-L22 朗讀一段 → DevTools filter `LiveTutor`


Made with [Cursor](https://cursor.com)