### PR TITLE
fix(live-tutor): reading eval rules tests + CPM/fullwidth fixes

### DIFF
--- a/backend/app/services/reading_evaluation_service.py
+++ b/backend/app/services/reading_evaluation_service.py
@@ -137,6 +137,14 @@ def _calculate_tier(
     return 3
 
 
+def _cpm_from_correct_count(correct_count: int, duration_ms: int | None) -> float | None:
+    """CPM from correctly-read chars only (matches frontend fluencyAnalyzer)."""
+    if duration_ms is None or duration_ms <= 0:
+        return None
+    duration_sec = max(duration_ms / 1000, 0.5)
+    return round(correct_count / duration_sec * 60, 1)
+
+
 def _is_near_sound(a: str, b: str) -> bool:
     """Return True if two chars are near-sound (zh↔z, sh↔s, ch↔c, n↔l)."""
     pa, pb = get_pinyin(a), get_pinyin(b)
@@ -212,23 +220,25 @@ def _build_fallback_result(spoken_text: str, target_text: str) -> dict:
                 dp[i - 1][j - 1] + cost,
             )
 
-    # Backtrack
+    # Backtrack — prefer target gaps (漏字) over matching distant duplicates (frontend parity)
     alignment: list[tuple[str | None, str | None]] = []  # (target_char, spoken_char)
     i, j = t_len, s_len
     while i > 0 or j > 0:
-        if i > 0 and j > 0:
-            cost = 0 if target_chars[i - 1] == spoken_chars[j - 1] else 1
-            if dp[i][j] == dp[i - 1][j - 1] + cost:
-                alignment.append((target_chars[i - 1], spoken_chars[j - 1]))
-                i -= 1
-                j -= 1
-                continue
         if i > 0 and (j == 0 or dp[i][j] == dp[i - 1][j] + 1):
             alignment.append((target_chars[i - 1], None))
             i -= 1
-        else:
+            continue
+        if j > 0 and (i == 0 or dp[i][j] == dp[i][j - 1] + 1):
             alignment.append((None, spoken_chars[j - 1]))
             j -= 1
+            continue
+        if i > 0 and j > 0:
+            cost = 0 if target_chars[i - 1] == spoken_chars[j - 1] else 1
+            alignment.append((target_chars[i - 1], spoken_chars[j - 1]))
+            i -= 1
+            j -= 1
+            continue
+        break
     alignment.reverse()
 
     # Count totals for adjusted_match_rate calculation
@@ -318,10 +328,9 @@ async def evaluate_reading_with_ai(
     # Calculate effective pass threshold (short paragraph compensation)
     reading_pass = _apply_short_text_compensation(Thresholds.READING_PASS, t_len)
 
-    # Calculate CPM
-    cpm: float | None = None
-    if duration_ms and duration_ms > 0 and t_len > 0:
-        cpm = round(t_len / (duration_ms / 1000) * 60, 1)
+    # Alignment preview for CPM (chars actually read, not full target length)
+    alignment_preview = _build_fallback_result(spoken_text, target_text)
+    cpm = _cpm_from_correct_count(alignment_preview["stats"]["correct_count"], duration_ms)
 
     # Sanitise inputs before sending to AI
     safe_spoken = sanitize_ai_input(spoken_text)
@@ -431,7 +440,6 @@ async def evaluate_reading_with_ai(
             exc,
             extra={"event": "reading_eval_fallback", "error": str(exc)},
         )
-        result = _build_fallback_result(spoken_text, target_text)
-        if cpm is not None:
-            result["cpm"] = cpm
+        result = alignment_preview
+        result["cpm"] = cpm
         return result

--- a/backend/app/services/stt/normalization.py
+++ b/backend/app/services/stt/normalization.py
@@ -2,14 +2,17 @@
 Text normalization utilities for STT evaluation.
 
 Shared by algorithm.py and reading_evaluation_service.py.
+Parity with frontend textDiff.ts normalizeForComparison pipeline.
 """
 
 import re
 
 _BOPOMOFO_RE = re.compile(r"[\u3100-\u312F\u31A0-\u31BF\u02CA\u02C7\u02CB\u02D9]")
+# Use unicode escapes for curly quotes — raw-string ""'' breaks the character class.
 _PUNCTUATION_RE = re.compile(
-    r"[「」『』，。！？：；、．…—－\-（）()\[\]《》""'']"
-    + r"[\s,.!?;:'\"]"
+    r"[「」『』，。！？：；、．…—－\-（）()\[\]《》"
+    r"\u201c\u201d\u2018\u2019"
+    r"\s,.!?;:'\"]"
 )
 _NUMERAL_MAP = ["零", "一", "二", "三", "四", "五", "六", "七", "八", "九"]
 
@@ -50,12 +53,58 @@ def _int_to_chinese(n: int) -> str:
     return result
 
 
+def normalize_fullwidth_digits(text: str) -> str:
+    """Full-width ０-９ → half-width 0-9 before Arabic→Chinese numeral conversion."""
+    out: list[str] = []
+    for ch in text:
+        o = ord(ch)
+        if 0xFF10 <= o <= 0xFF19:
+            out.append(chr(ord("0") + o - 0xFF10))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
 def normalize_numbers(text: str) -> str:
     """Replace Arabic numerals with Chinese numeral equivalents."""
     return re.sub(r"\d+", lambda m: _int_to_chinese(int(m.group())), text)
 
 
+def normalize_punctuation_to_chinese(text: str) -> str:
+    """Half-width STT punctuation → full-width Chinese (matches frontend)."""
+    return (
+        text.replace(",", "，")
+        .replace(";", "；")
+        .replace(".", "。")
+        .replace("?", "？")
+        .replace("!", "！")
+        .replace(":", "：")
+        .replace("(", "（")
+        .replace(")", "）")
+        .replace(" ", "")
+    )
+
+
+def _strip_decorative_symbols(text: str) -> str:
+    t = re.sub(r"~+", "", text)
+    t = t.replace("…", "").replace("...", "").replace("．．．", "")
+    t = t.replace("——", "").replace("—", "").replace("－", "").replace("-", "")
+    for ch in "「」『』《》[]【】\"'\u201c\u201d\u2018\u2019":
+        t = t.replace(ch, "")
+    t = re.sub(r"（[^）]*）", "", t)
+    t = re.sub(r"\([^)]*\)", "", t)
+    return t
+
+
+def normalize_chinese_number_variants(text: str) -> str:
+    """兩 → 二 for spoken-number alignment (matches frontend)."""
+    return text.replace("兩", "二")
+
+
 def normalize_for_comparison(text: str) -> str:
     """Strip punctuation, bopomofo, whitespace; convert numerals for alignment."""
-    stripped = _PUNCTUATION_RE.sub("", normalize_numbers(text))
+    pipeline = normalize_fullwidth_digits(normalize_punctuation_to_chinese(text))
+    pipeline = _strip_decorative_symbols(pipeline)
+    pipeline = normalize_chinese_number_variants(normalize_numbers(pipeline))
+    stripped = _PUNCTUATION_RE.sub("", pipeline)
     return _BOPOMOFO_RE.sub("", stripped)

--- a/backend/tests/test_reading_eval_alignment_rules.py
+++ b/backend/tests/test_reading_eval_alignment_rules.py
@@ -1,0 +1,177 @@
+"""
+Alignment and scoring rules for reading evaluation fallback path.
+
+Mirrors frontend readingEvalRules.test.ts (R1–R6) for
+_build_fallback_result / _normalize_text — no audio/STT API required.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.services.reading_evaluation_service import (
+    _build_fallback_result,
+    _normalize_text,
+)
+from app.services.stt.pinyin import is_homophone
+from app.services.stt.algorithm import correct_homophones, compute_match_rate
+
+MENGCHANGJUN_LINE = (
+    "中國的戰國時期，有七個國家總是爭強鬥勝、互比苗頭，為了要在競爭中勝出，各國都在搶傑出的管理人才，"
+    "其中最有名的人才，就是齊國的孟嘗君。孟嘗君是有錢的貴族，最讓人津津樂道的是他在家裡養了三千名食客，"
+    "食客就是在家裡吃飯的客人，三千人開飯的場面一眼望不完，真是非常壯觀。"
+    "只要自認為有本事的人來投奔孟嘗君，他二話不說，總是張開雙手歡迎。"
+    "這些食客具備各式各樣的才能，可以隨時幫他解決各種問題。"
+)
+
+QIN_LINE = "公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。"
+
+DUPLICATE_RENCAI = "管理人才有本事的人才有才能"
+
+
+def _fallback(spoken: str, target: str) -> dict:
+    return _build_fallback_result(spoken, target)
+
+
+def _types(result: dict) -> list[str]:
+    return [t["type"] for t in result["diff_tokens"]]
+
+
+# ─── R1: punctuation excluded ───────────────────────────────────────────────
+
+
+def test_r1_normalize_removes_punctuation():
+    assert _normalize_text("媽媽說，你好。") == "媽媽說你好"
+
+
+def test_r1_fallback_full_match_ignores_punctuation():
+    target = "媽媽說，你好。"
+    spoken = "媽媽說你好"
+    result = _fallback(spoken, target)
+    assert result["adjusted_match_rate"] >= 0.99
+
+
+# ─── R2: missing chars ──────────────────────────────────────────────────────
+
+
+def test_r2_detects_single_missing_char():
+    target = "其中最有名的人才是齊國的孟嘗君"
+    spoken = "其中有名的人才是齊國的孟嘗君"
+    result = _fallback(spoken, target)
+    missing = [t for t in result["diff_tokens"] if t["type"] == "missing"]
+    assert any(t["char"] == "最" for t in missing)
+    assert result["adjusted_match_rate"] < 1.0
+
+
+def test_r2_partial_paragraph_low_match():
+    spoken = "中國的戰國時期"
+    result = _fallback(spoken, MENGCHANGJUN_LINE)
+    assert result["adjusted_match_rate"] < 0.4
+    assert result["stats"]["missing_count"] > 5
+
+
+def test_r2_empty_speech_all_missing():
+    result = _fallback("", "他們去公園玩耍")
+    assert result["match_rate"] == 0.0
+    assert result["stats"]["missing_count"] == len(_normalize_text("他們去公園玩耍"))
+
+
+# ─── R3: no ghost-green on duplicate chars ───────────────────────────────────
+
+
+def test_r3_only_first_rencai_pair_matches():
+    spoken = "管理人才"
+    result = _fallback(spoken, DUPLICATE_RENCAI)
+    correct_ren = sum(
+        1
+        for t in result["diff_tokens"]
+        if t["char"] == "人" and t["type"] in ("correct", "forgiven")
+    )
+    correct_cai = sum(
+        1
+        for t in result["diff_tokens"]
+        if t["char"] == "才" and t["type"] in ("correct", "forgiven")
+    )
+    assert correct_ren == 1
+    assert correct_cai == 1
+    assert result["stats"]["missing_count"] > 0
+
+
+def test_r3_partial_prefix_not_full_paragraph_score():
+    spoken = "中國的戰國時期，有七個國家"
+    result = _fallback(spoken, MENGCHANGJUN_LINE)
+    assert result["adjusted_match_rate"] < 0.5
+
+
+# ─── R4: number normalization ───────────────────────────────────────────────
+
+
+def test_r4_299_spoken_as_chinese_digits():
+    spoken = "公元前二百九十九年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。"
+    result = _fallback(spoken, QIN_LINE)
+    assert result["adjusted_match_rate"] >= 0.95
+
+
+def test_r4_partial_through_digit_run():
+    spoken = "公元前二百九十九年"
+    target = "公元前299年，秦昭王"
+    result = _fallback(spoken, target)
+    assert result["stats"]["missing_count"] >= 3
+    assert "missing" in _types(result)
+
+
+def test_r4_fullwidth_digits_match_chinese_spoken():
+    target = "公元前２９９年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。"
+    spoken = "公元前二百九十九年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。"
+    result = _fallback(spoken, target)
+    assert result["adjusted_match_rate"] >= 0.95
+
+
+def test_r4_liang_bai_spoken_matches_er_bai_target():
+    result = _fallback("兩百個", "二百個人")
+    assert result["stats"]["correct_count"] >= 2
+    assert any(t["char"] == "人" and t["type"] == "missing" for t in result["diff_tokens"])
+
+
+# ─── R5: homophone / near-sound forgiveness ─────────────────────────────────
+
+
+def test_r5_homophone_forgiven_in_fallback():
+    spoken = "他門去工園完刷"
+    target = "他們去公園玩耍"
+    result = _fallback(spoken, target)
+    assert result["stats"]["forgiven_count"] >= 2
+    assert result["adjusted_match_rate"] > result["match_rate"] or result["adjusted_match_rate"] >= 0.7
+
+
+def test_r5_correct_homophones_improves_match_rate():
+    spoken = "他門去公園玩耍"
+    target = "他們去公園玩耍"
+    corrected = correct_homophones(spoken, _normalize_text(target))
+    assert compute_match_rate(corrected, target) >= compute_match_rate(spoken, target)
+
+
+def test_r5_genuine_error_stays_wrong():
+    result = _fallback("大樹", "小樹")
+    assert any(t["type"] == "wrong" for t in result["diff_tokens"])
+    assert not is_homophone("大", "小")
+
+
+# ─── R6: scorable chars only ────────────────────────────────────────────────
+
+
+def test_r6_bopomofo_stripped():
+    assert _normalize_text("人ㄖㄣˊ") == "人"
+    result = _fallback("人", "人ㄖㄣˊ")
+    assert result["adjusted_match_rate"] >= 0.99
+
+
+def test_r6_parenthetical_notes_stripped():
+    target = "你好（旁白）世界"
+    spoken = "你好世界"
+    norm = _normalize_text(target)
+    assert "旁白" not in norm
+    result = _fallback(spoken, target)
+    assert result["adjusted_match_rate"] >= 0.99

--- a/backend/tests/test_reading_evaluation_service.py
+++ b/backend/tests/test_reading_evaluation_service.py
@@ -23,6 +23,14 @@ from app.services.reading_evaluation_service import (
 )
 from app.services.persona import Thresholds
 
+MENGCHANGJUN_LINE = (
+    "中國的戰國時期，有七個國家總是爭強鬥勝、互比苗頭，為了要在競爭中勝出，各國都在搶傑出的管理人才，"
+    "其中最有名的人才，就是齊國的孟嘗君。孟嘗君是有錢的貴族，最讓人津津樂道的是他在家裡養了三千名食客，"
+    "食客就是在家裡吃飯的客人，三千人開飯的場面一眼望不完，真是非常壯觀。"
+    "只要自認為有本事的人來投奔孟嘗君，他二話不說，總是張開雙手歡迎。"
+    "這些食客具備各式各樣的才能，可以隨時幫他解決各種問題。"
+)
+
 
 # ---------------------------------------------------------------------------
 # _normalize_text
@@ -262,6 +270,48 @@ async def test_ai_path_cpm_calculated_with_duration():
         )
     assert result["cpm"] is not None
     assert result["cpm"] > 0
+
+
+@pytest.mark.asyncio
+async def test_ai_path_cpm_uses_correct_count_not_full_target():
+    """Partial read: CPM denominator = chars actually read, not full target length."""
+    long_target = MENGCHANGJUN_LINE
+    spoken = "中國的戰國時期"
+    duration_ms = 60_000
+    preview = _build_fallback_result(spoken, long_target)
+    expected_cpm = round(preview["stats"]["correct_count"] / 60 * 60, 1)
+
+    with patch(
+        "app.services.reading_evaluation_service.generate_structured_response",
+        new=AsyncMock(return_value=MOCK_AI_RESPONSE),
+    ):
+        result = await evaluate_reading_with_ai(
+            spoken_text=spoken,
+            target_text=long_target,
+            duration_ms=duration_ms,
+        )
+    assert result["cpm"] == expected_cpm
+    assert result["cpm"] < len(_normalize_text(long_target)) * 0.5
+
+
+@pytest.mark.asyncio
+async def test_fallback_cpm_uses_correct_count():
+    """Fallback path CPM also uses alignment correct_count."""
+    spoken = "中國的戰國時期"
+    target = MENGCHANGJUN_LINE
+    duration_ms = 60_000
+    with patch(
+        "app.services.reading_evaluation_service.generate_structured_response",
+        new=AsyncMock(side_effect=RuntimeError("down")),
+    ):
+        result = await evaluate_reading_with_ai(
+            spoken_text=spoken,
+            target_text=target,
+            duration_ms=duration_ms,
+        )
+    assert result["evaluation_method"] == "fallback"
+    preview = _build_fallback_result(spoken, target)
+    assert result["cpm"] == round(preview["stats"]["correct_count"] / 60 * 60, 1)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_stt_refactored.py
+++ b/backend/tests/test_stt_refactored.py
@@ -78,6 +78,12 @@ def test_normalize_for_comparison_converts_numbers():
     assert "十二" in result
 
 
+def test_normalize_for_comparison_converts_fullwidth_digits():
+    result = normalize_for_comparison("公元前２９９年")
+    assert "２" not in result
+    assert "二百九十九" in result
+
+
 # ---------------------------------------------------------------------------
 # algorithm module
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -26,6 +26,10 @@ import LiveTutorControls from './LiveTutorControls';
 import type { LocalEvalResult } from '../../../utils/localEval';
 import type { RetrySentenceInfo } from './hooks/useSentenceRetry';
 import { getLineResultForParagraph } from './liveTutorTypes';
+import {
+  planParagraphEvalRestore,
+  resolveDisplayLastDiffTokens,
+} from './paragraphEvalRestore';
 
 /* ------------------------------------------------------------------ */
 /*  Small sub-components                                               */
@@ -529,19 +533,13 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
     const existingResult = getLineResultForParagraph(lineResults, currentLineIndex);
     const existingSummary = paragraphSummaries[currentLineIndex];
+    const restorePlan = planParagraphEvalRestore(existingResult, existingSummary, targets.length);
 
-    if (existingResult && existingSummary) {
-      // Revisiting a scored paragraph — restore diff + per-sentence results
-      sentenceResultsRef.current = existingSummary.sentenceResults
-        ? [...existingSummary.sentenceResults]
-        : new Array(targets.length).fill(null);
-      nextSentenceIdxRef.current = targets.length;
-      lastFinalResultIdxRef.current = targets.length - 1;
-      if (existingSummary.geminiPending) {
-        dispatch({ type: 'START_LOCAL', diffTokens: existingResult.diffTokens });
-      } else {
-        dispatch({ type: 'GEMINI_DONE', diffTokens: existingResult.diffTokens });
-      }
+    if (restorePlan.kind === 'restore') {
+      sentenceResultsRef.current = restorePlan.sentenceResults;
+      nextSentenceIdxRef.current = restorePlan.nextSentenceIdx;
+      lastFinalResultIdxRef.current = restorePlan.lastFinalResultIdx;
+      dispatch(restorePlan.dispatchAction);
     } else {
       sentenceResultsRef.current = new Array(targets.length).fill(null);
       nextSentenceIdxRef.current = 0;
@@ -621,9 +619,11 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   const paragraphSummary = paragraphSummaries[currentLineIndex] ?? null;
   const savedLineResult = getLineResultForParagraph(lineResults, currentLineIndex);
-  const displayLastDiffTokens =
-    evalState.lastDiffTokens
-    ?? (paragraphSummary ? savedLineResult?.diffTokens ?? null : null);
+  const displayLastDiffTokens = resolveDisplayLastDiffTokens(
+    evalState.lastDiffTokens,
+    paragraphSummary,
+    savedLineResult,
+  );
 
   /* ================================================================ */
   /*  JSX                                                             */

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorFeedbackDrawer.test.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorFeedbackDrawer.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LiveTutorFeedbackDrawer from './LiveTutorFeedbackDrawer';
+
+const baseProps = {
+  show: false,
+  onClose: () => {},
+  scrollRef: { current: null },
+  isSessionActive: false,
+  isPreparing: false,
+  streamingUserInput: '',
+  rightPanelDiffTokens: null,
+  targetText: '你好',
+  paragraphSummary: null,
+  currentLineIndex: 0,
+  totalLines: 1,
+  completedCount: 0,
+  retryCount: 0,
+  micError: '',
+};
+
+describe('LiveTutorFeedbackDrawer — hidden in Live Tutor layout (#8bff6795)', () => {
+  it('renders nothing when show=false', () => {
+    const { container } = render(<LiveTutorFeedbackDrawer {...baseProps} />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText('朗讀回饋')).not.toBeInTheDocument();
+  });
+
+  it('renders drawer chrome when show=true', () => {
+    const { container } = render(<LiveTutorFeedbackDrawer {...baseProps} show />);
+    expect(screen.getAllByText('朗讀回饋').length).toBeGreaterThanOrEqual(1);
+    expect(container.querySelector('button')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/reading-steps/live-tutor/TutorFeedbackPanel.test.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/TutorFeedbackPanel.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import TutorFeedbackPanel from './TutorFeedbackPanel';
+import type { DiffToken } from '../../../types';
+
+const tokensWithZhuyin: DiffToken[] = [
+  { char: '你', type: 'correct', zhuyin: 'ㄋㄧˇ' },
+  { char: '好', type: 'correct', zhuyin: 'ㄏㄠˇ' },
+];
+
+describe('TutorFeedbackPanel — bopomofo ruby via DiffDisplay (#2226)', () => {
+  it('renders ruby annotations when diff tokens carry zhuyin', () => {
+    const { container } = render(
+      <TutorFeedbackPanel
+        width={400}
+        isMobile={false}
+        scrollRef={{ current: null }}
+        isSessionActive={false}
+        isPreparing={false}
+        streamingUserInput=""
+        rightPanelDiffTokens={tokensWithZhuyin}
+        targetText="你好"
+        paragraphSummary={{
+          feedback: '',
+          matchRate: 1,
+          wrongCount: 0,
+          missingCount: 0,
+          tier: 1,
+          geminiPending: false,
+        }}
+        currentLineIndex={0}
+        totalLines={1}
+        completedCount={1}
+        retryCount={0}
+        micError=""
+      />,
+    );
+    expect(container.querySelectorAll('ruby').length).toBeGreaterThanOrEqual(2);
+    expect(container.textContent).toContain('ㄋㄧˇ');
+  });
+});

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.test.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evalReducer,
+  initialEvalState,
+  type EvalState,
+} from './useParagraphEvaluation';
+import type { DiffToken } from '../../../../types';
+
+const localDiff: DiffToken[] = [
+  { char: '中', type: 'correct' },
+  { char: '國', type: 'correct' },
+  { char: '的', type: 'missing' },
+];
+
+const geminiDiff: DiffToken[] = [
+  { char: '中', type: 'correct' },
+  { char: '國', type: 'correct' },
+  { char: '的', type: 'correct' },
+  { char: '戰', type: 'correct' },
+];
+
+describe('evalReducer — display diff must stay on local Phase-1 result', () => {
+  it('START_LOCAL stores local diff tokens', () => {
+    const next = evalReducer(initialEvalState, { type: 'START_LOCAL', diffTokens: localDiff });
+    expect(next.lastDiffTokens).toEqual(localDiff);
+    expect(next.isAwaitingGemini).toBe(true);
+    expect(next.phase).toBe('local_done');
+  });
+
+  it('GEMINI_DONE does not overwrite lastDiffTokens with Gemini diff', () => {
+    const awaiting: EvalState = {
+      ...initialEvalState,
+      phase: 'local_done',
+      isAwaitingGemini: true,
+      lastDiffTokens: localDiff,
+    };
+    const next = evalReducer(awaiting, {
+      type: 'GEMINI_DONE',
+      diffTokens: geminiDiff,
+    });
+    expect(next.lastDiffTokens).toEqual(localDiff);
+    expect(next.isAwaitingGemini).toBe(false);
+    expect(next.phase).toBe('gemini_done');
+  });
+
+  it('GEMINI_ERROR keeps local diff tokens', () => {
+    const awaiting: EvalState = {
+      ...initialEvalState,
+      lastDiffTokens: localDiff,
+      isAwaitingGemini: true,
+    };
+    const next = evalReducer(awaiting, { type: 'GEMINI_ERROR' });
+    expect(next.lastDiffTokens).toEqual(localDiff);
+    expect(next.phase).toBe('gemini_error');
+  });
+});

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef } from 'react';
 import { DiffToken, Story } from '../../../../types';
 import { normalizeForComparison, cleanChineseText } from '../../../../utils/textDiff';
-import { pickConservativeTranscript } from '../../../../utils/transcriptGuard';
+import { buildTranscriptForEvaluation } from '../../../../utils/liveTutorTranscriptPipeline';
 import { evaluateReading } from '../../../../services/learningApi';
 import { useAuth } from '../../../../contexts/AuthContext';
 import {
@@ -155,11 +155,13 @@ export function useParagraphEvaluation({
       source: 'gemini' | 'webspeech' = 'webspeech',
     ) => {
       const targetText = story.content[lineIdx] || '';
-      const transcriptForEval =
-        source === 'gemini' && rawStt.trim()
-          ? pickConservativeTranscript(rawTranscript, rawStt, targetText)
-          : rawTranscript;
-      const cleaned = cleanChineseText(transcriptForEval);
+      const { transcriptForEval, cleaned, conservativeClampApplied } = buildTranscriptForEvaluation({
+        source,
+        rawTranscript,
+        rawStt,
+        targetText,
+        durationMs,
+      });
 
       if (isEvalConsoleEnabled() && transcriptForEval !== rawTranscript) {
         console.warn(
@@ -256,7 +258,8 @@ export function useParagraphEvaluation({
           geminiAudioTranscript: source === 'gemini' ? rawTranscript : null,
           usedForEvaluation: cleaned,
           transcriptSource: source,
-          conservativeClampApplied: transcriptForEval !== rawTranscript,
+          conservativeClampApplied,
+          durationMs,
         });
       }
 

--- a/frontend/src/components/reading-steps/live-tutor/liveTutorLayout.test.ts
+++ b/frontend/src/components/reading-steps/live-tutor/liveTutorLayout.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const liveTutorSrc = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'LiveTutor.tsx'),
+  'utf-8',
+);
+
+describe('LiveTutor layout — feedback drawer not mounted (#8bff6795)', () => {
+  it('LiveTutor.tsx does not import LiveTutorFeedbackDrawer (inline ParagraphCard feedback)', () => {
+    expect(liveTutorSrc).not.toMatch(/LiveTutorFeedbackDrawer/);
+  });
+});

--- a/frontend/src/components/reading-steps/live-tutor/paragraphEvalRestore.test.ts
+++ b/frontend/src/components/reading-steps/live-tutor/paragraphEvalRestore.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import type { DiffToken } from '../../../types';
+import {
+  planParagraphEvalRestore,
+  resolveDisplayLastDiffTokens,
+} from './paragraphEvalRestore';
+import type { LineResult, ParagraphSummaryData } from './liveTutorTypes';
+
+const sampleDiff: DiffToken[] = [{ char: '你', type: 'correct' }];
+
+const lineResult: LineResult = {
+  lineIndex: 0,
+  matchRate: 0.9,
+  cpm: 80,
+  durationMs: 10_000,
+  transcript: '你好',
+  diffTokens: sampleDiff,
+};
+
+const summary: ParagraphSummaryData = {
+  feedback: 'ok',
+  matchRate: 0.9,
+  wrongCount: 0,
+  missingCount: 0,
+  tier: 2,
+  geminiPending: false,
+  sentenceResults: [null],
+};
+
+describe('planParagraphEvalRestore — revisit keeps scored paragraph (#451912f4)', () => {
+  it('clears when paragraph has no saved result', () => {
+    expect(planParagraphEvalRestore(undefined, undefined, 2)).toEqual({ kind: 'clear' });
+  });
+
+  it('clears when only line result exists without summary', () => {
+    expect(planParagraphEvalRestore(lineResult, undefined, 2)).toEqual({ kind: 'clear' });
+  });
+
+  it('restores GEMINI_DONE when scoring finished', () => {
+    const plan = planParagraphEvalRestore(lineResult, summary, 1);
+    expect(plan).toMatchObject({
+      kind: 'restore',
+      dispatchAction: { type: 'GEMINI_DONE', diffTokens: sampleDiff },
+      nextSentenceIdx: 1,
+      lastFinalResultIdx: 0,
+    });
+  });
+
+  it('restores START_LOCAL when Gemini still pending', () => {
+    const pending = { ...summary, geminiPending: true };
+    const plan = planParagraphEvalRestore(lineResult, pending, 3);
+    expect(plan).toMatchObject({
+      kind: 'restore',
+      dispatchAction: { type: 'START_LOCAL', diffTokens: sampleDiff },
+      nextSentenceIdx: 3,
+      lastFinalResultIdx: 2,
+    });
+  });
+
+  it('fills sentenceResults array when summary has none', () => {
+    const plan = planParagraphEvalRestore(lineResult, { ...summary, sentenceResults: undefined }, 2);
+    if (plan.kind !== 'restore') throw new Error('expected restore');
+    expect(plan.sentenceResults).toEqual([null, null]);
+  });
+});
+
+describe('resolveDisplayLastDiffTokens — revisit diff fallback', () => {
+  it('prefers live eval lastDiffTokens', () => {
+    const live: DiffToken[] = [{ char: '好', type: 'correct' }];
+    expect(resolveDisplayLastDiffTokens(live, summary, lineResult)).toBe(live);
+  });
+
+  it('falls back to saved line result when summary exists but eval cleared', () => {
+    expect(resolveDisplayLastDiffTokens(null, summary, lineResult)).toEqual(sampleDiff);
+  });
+
+  it('returns null when no summary and no live tokens', () => {
+    expect(resolveDisplayLastDiffTokens(null, null, lineResult)).toBeNull();
+  });
+});

--- a/frontend/src/components/reading-steps/live-tutor/paragraphEvalRestore.ts
+++ b/frontend/src/components/reading-steps/live-tutor/paragraphEvalRestore.ts
@@ -1,0 +1,46 @@
+import type { DiffToken } from '../../../types';
+import type { EvalAction } from './hooks/useParagraphEvaluation';
+import type { LineResult, ParagraphSummaryData } from './liveTutorTypes';
+
+export type ParagraphEvalRestorePlan =
+  | { kind: 'clear' }
+  | {
+      kind: 'restore';
+      dispatchAction: EvalAction;
+      sentenceResults: Array<import('../../../utils/localEval').LocalEvalResult | null>;
+      nextSentenceIdx: number;
+      lastFinalResultIdx: number;
+    };
+
+/** Decide how to restore eval + per-sentence state when revisiting a scored paragraph. */
+export function planParagraphEvalRestore(
+  existingResult: LineResult | undefined,
+  existingSummary: ParagraphSummaryData | undefined,
+  targetsLength: number,
+): ParagraphEvalRestorePlan {
+  if (existingResult && existingSummary) {
+    const sentenceResults = existingSummary.sentenceResults
+      ? [...existingSummary.sentenceResults]
+      : new Array(targetsLength).fill(null);
+    const dispatchAction: EvalAction = existingSummary.geminiPending
+      ? { type: 'START_LOCAL', diffTokens: existingResult.diffTokens }
+      : { type: 'GEMINI_DONE', diffTokens: existingResult.diffTokens };
+    return {
+      kind: 'restore',
+      dispatchAction,
+      sentenceResults,
+      nextSentenceIdx: targetsLength,
+      lastFinalResultIdx: targetsLength - 1,
+    };
+  }
+  return { kind: 'clear' };
+}
+
+/** When eval state was cleared on revisit, fall back to persisted line result diff. */
+export function resolveDisplayLastDiffTokens(
+  lastDiffTokens: DiffToken[] | null,
+  paragraphSummary: ParagraphSummaryData | null,
+  savedLineResult: LineResult | undefined,
+): DiffToken[] | null {
+  return lastDiffTokens ?? (paragraphSummary ? savedLineResult?.diffTokens ?? null : null);
+}

--- a/frontend/src/utils/liveTutorRegression.test.ts
+++ b/frontend/src/utils/liveTutorRegression.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Live Tutor regression tests — guard against known STT / diff / scoring bugs.
+ *
+ * Scenarios covered:
+ * 1. Empty Web Speech + Gemini full-paragraph hallucination → not 100% / not 900 CPM
+ * 2. Gemini source always runs conservative guard (even when rawStt is empty)
+ * 3. Web Speech anchor wins when Gemini over-fills vs partial read
+ * 4. Display interleave: partial read does not mark unread tail as correct (299 digit run)
+ * 5. evalReducer: Gemini async must not replace local diff tokens for display
+ */
+import { describe, expect, it } from 'vitest';
+import { buildTranscriptForEvaluation } from './liveTutorTranscriptPipeline';
+import { localEvaluateParagraph } from './localEval';
+import {
+  TIER1_POOL,
+  TIER2_POOL,
+  TIER3_POOL,
+  STREAK_MESSAGES,
+} from './liveTutorPools';
+import { diffCharacters, interleavePunctuation } from './textDiff';
+import type { DiffToken } from '../types';
+
+const POOLS = {
+  tier1: TIER1_POOL,
+  tier2: TIER2_POOL,
+  tier3: TIER3_POOL,
+  streakMsgs: STREAK_MESSAGES,
+};
+
+const MENGCHANGJUN_LINE =
+  '中國的戰國時期，有七個國家總是爭強鬥勝、互比苗頭，為了要在競爭中勝出，各國都在搶傑出的管理人才，其中最有名的人才，就是齊國的孟嘗君。孟嘗君是有錢的貴族，最讓人津津樂道的是他在家裡養了三千名食客，食客就是在家裡吃飯的客人，三千人開飯的場面一眼望不完，真是非常壯觀。只要自認為有本事的人來投奔孟嘗君，他二話不說，總是張開雙手歡迎。這些食客具備各式各樣的才能，可以隨時幫他解決各種問題。';
+
+const QIN_LINE =
+  '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+
+function evaluateGeminiPath(
+  rawGemini: string,
+  rawStt: string,
+  targetText: string,
+  durationMs: number,
+) {
+  const { cleaned, conservativeClampApplied } = buildTranscriptForEvaluation({
+    source: 'gemini',
+    rawTranscript: rawGemini,
+    rawStt: rawStt,
+    targetText,
+    durationMs,
+  });
+  const local = localEvaluateParagraph(cleaned, targetText, durationMs, POOLS, 0);
+  return { cleaned, conservativeClampApplied, ...local };
+}
+
+describe('Live Tutor regression — staging 孟嘗君 line 0 (empty Web Speech + Gemini full paste)', () => {
+  const durationMs = 10_000;
+
+  it('without guard, full Gemini transcript falsely scores 100%', () => {
+    const naive = localEvaluateParagraph(MENGCHANGJUN_LINE, MENGCHANGJUN_LINE, durationMs, POOLS, 0);
+    expect(naive.matchRate).toBe(1);
+    expect(naive.cpm).toBeGreaterThan(800);
+  });
+
+  it('applies conservative clamp even when webSpeech is empty', () => {
+    const { conservativeClampApplied, cleaned } = evaluateGeminiPath(
+      MENGCHANGJUN_LINE,
+      '',
+      MENGCHANGJUN_LINE,
+      durationMs,
+    );
+    expect(conservativeClampApplied).toBe(true);
+    expect(cleaned.length).toBeLessThan(MENGCHANGJUN_LINE.length);
+  });
+
+  it('does not report 100% accuracy after clamp', () => {
+    const { matchRate, cpm } = evaluateGeminiPath(
+      MENGCHANGJUN_LINE,
+      '',
+      MENGCHANGJUN_LINE,
+      durationMs,
+    );
+    expect(matchRate).toBeLessThan(0.95);
+    expect(cpm).toBeLessThan(700);
+  });
+
+  it('display diff leaves unread tail non-green after clamp', () => {
+    const { diffTokens } = evaluateGeminiPath(
+      MENGCHANGJUN_LINE,
+      '',
+      MENGCHANGJUN_LINE,
+      durationMs,
+    );
+    const display = interleavePunctuation(MENGCHANGJUN_LINE, diffTokens);
+    const unread = display.filter((t) => t.type === 'missing' || t.type === 'unread');
+    expect(unread.length).toBeGreaterThan(10);
+    expect(display.filter((t) => t.type === 'correct').length).toBeLessThan(
+      display.filter((t) => t.type !== 'punctuation').length,
+    );
+  });
+});
+
+describe('Live Tutor regression — staging 秦昭王 line (Web Speech anchor)', () => {
+  it('prefers partial Web Speech when Gemini returns full target', () => {
+    const web = '公元前299年';
+    const { cleaned, conservativeClampApplied, matchRate } = evaluateGeminiPath(
+      QIN_LINE,
+      web,
+      QIN_LINE,
+      12_000,
+    );
+    expect(conservativeClampApplied).toBe(true);
+    expect(cleaned).toBe(web);
+    expect(matchRate).toBeLessThan(0.5);
+  });
+
+  it('keeps Gemini when only slightly longer than Web Speech', () => {
+    const web = '公元前299年';
+    const gemini = '公元前299年，秦昭王';
+    const { cleaned, conservativeClampApplied } = evaluateGeminiPath(
+      gemini,
+      web,
+      QIN_LINE,
+      12_000,
+    );
+    expect(conservativeClampApplied).toBe(false);
+    expect(cleaned).toBe(gemini);
+  });
+});
+
+describe('Live Tutor regression — buildTranscriptForEvaluation contract', () => {
+  it('webspeech source bypasses guard', () => {
+    const { conservativeClampApplied, cleaned } = buildTranscriptForEvaluation({
+      source: 'webspeech',
+      rawTranscript: MENGCHANGJUN_LINE,
+      rawStt: '',
+      targetText: MENGCHANGJUN_LINE,
+      durationMs: 10_000,
+    });
+    expect(conservativeClampApplied).toBe(false);
+    expect(cleaned).toBe(MENGCHANGJUN_LINE);
+  });
+
+  it('gemini + empty stt + no duration rejects full paste (no false score input)', () => {
+    const { cleaned, conservativeClampApplied } = buildTranscriptForEvaluation({
+      source: 'gemini',
+      rawTranscript: MENGCHANGJUN_LINE,
+      rawStt: '',
+      targetText: MENGCHANGJUN_LINE,
+      durationMs: 0,
+    });
+    expect(conservativeClampApplied).toBe(true);
+    expect(cleaned).toBe('');
+  });
+});
+
+describe('Live Tutor regression — interleave Arabic digits (299)', () => {
+  it('partial read through 299 does not green the rest of the paragraph', () => {
+    const target = '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+    const spoken = '公元前二百九十九年';
+    const { tokens } = diffCharacters(spoken, target, { useHomophone: true });
+    const display = interleavePunctuation(target, tokens as DiffToken[]);
+
+    expect(display.find((t) => t.char === '秦' && t.type === 'missing')).toBeDefined();
+    expect(display.find((t) => t.char === '2' && t.type === 'correct')).toBeDefined();
+    expect(display.filter((t) => t.type === 'correct').length).toBeLessThan(15);
+  });
+});

--- a/frontend/src/utils/liveTutorTranscriptPipeline.ts
+++ b/frontend/src/utils/liveTutorTranscriptPipeline.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure transcript selection for Live Tutor paragraph evaluation.
+ * Kept separate from the hook so regression tests mirror production logic.
+ */
+import { cleanChineseText } from './textDiff';
+import { pickConservativeTranscript } from './transcriptGuard';
+
+export type TranscriptSource = 'gemini' | 'webspeech';
+
+export function buildTranscriptForEvaluation(input: {
+  source: TranscriptSource;
+  rawTranscript: string;
+  rawStt: string;
+  targetText: string;
+  durationMs: number;
+}): {
+  transcriptForEval: string;
+  cleaned: string;
+  conservativeClampApplied: boolean;
+} {
+  const { source, rawTranscript, rawStt, targetText, durationMs } = input;
+  const transcriptForEval =
+    source === 'gemini'
+      ? pickConservativeTranscript(rawTranscript, rawStt, targetText, durationMs)
+      : rawTranscript;
+  const cleaned = cleanChineseText(transcriptForEval);
+  return {
+    transcriptForEval,
+    cleaned,
+    conservativeClampApplied: source === 'gemini' && transcriptForEval !== rawTranscript,
+  };
+}

--- a/frontend/src/utils/readingEvalFixtures.ts
+++ b/frontend/src/utils/readingEvalFixtures.ts
@@ -1,0 +1,16 @@
+/** Shared lesson lines and STT fixtures for reading evaluation rule tests. */
+
+export const MENGCHANGJUN_LINE =
+  '中國的戰國時期，有七個國家總是爭強鬥勝、互比苗頭，為了要在競爭中勝出，各國都在搶傑出的管理人才，其中最有名的人才，就是齊國的孟嘗君。孟嘗君是有錢的貴族，最讓人津津樂道的是他在家裡養了三千名食客，食客就是在家裡吃飯的客人，三千人開飯的場面一眼望不完，真是非常壯觀。只要自認為有本事的人來投奔孟嘗君，他二話不說，總是張開雙手歡迎。這些食客具備各式各樣的才能，可以隨時幫他解決各種問題。';
+
+export const QIN_LINE =
+  '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+
+export const DUPLICATE_RENCAI_TARGET = '管理人才有本事的人才有才能';
+
+export const POOLS_FIXTURE = {
+  tier1: ['很棒！'],
+  tier2: ['不錯！'],
+  tier3: ['再試一次！'],
+  streakMsgs: ['', '', '連續三次！'],
+};

--- a/frontend/src/utils/readingEvalRules.test.ts
+++ b/frontend/src/utils/readingEvalRules.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Reading evaluation rule tests (Live Tutor + local eval pipeline).
+ *
+ * Maps product rules to automated checks (no microphone / STT API required).
+ * See section headers for rule IDs R1–R6 and appendix rules from prior commits.
+ */
+import { describe, expect, it } from 'vitest';
+import type { DiffToken } from '../types';
+import { analyzeFluency } from './fluencyAnalyzer';
+import { localEvaluateParagraph, getReadingPassThreshold } from './localEval';
+import { buildTranscriptForEvaluation } from './liveTutorTranscriptPipeline';
+import {
+  cleanSpokenForDiff,
+  countScorableCharacters,
+  diffCharacters,
+  interleavePunctuation,
+  normalizeForComparison,
+  normalizePunctuationToChinese,
+} from './textDiff';
+import { isHomophone, isSttEquivalent } from './pinyin';
+import {
+  DUPLICATE_RENCAI_TARGET,
+  MENGCHANGJUN_LINE,
+  POOLS_FIXTURE,
+  QIN_LINE,
+} from './readingEvalFixtures';
+
+function displayChars(target: string, spoken: string): DiffToken[] {
+  const { tokens } = diffCharacters(spoken, target, { useHomophone: true });
+  return interleavePunctuation(target, tokens);
+}
+
+function greenScorableCount(display: DiffToken[]): number {
+  return display.filter((t) => t.type === 'correct' || t.type === 'forgiven').length;
+}
+
+function evaluateGeminiPath(
+  rawGemini: string,
+  rawStt: string,
+  targetText: string,
+  durationMs: number,
+) {
+  const { cleaned, conservativeClampApplied } = buildTranscriptForEvaluation({
+    source: 'gemini',
+    rawTranscript: rawGemini,
+    rawStt,
+    targetText,
+    durationMs,
+  });
+  const local = localEvaluateParagraph(cleaned, targetText, durationMs, POOLS_FIXTURE, 0);
+  return { cleaned, conservativeClampApplied, ...local };
+}
+
+// ─── R1: 標點符號不計入比對／計分 ─────────────────────────────────────────
+
+describe('R1 — punctuation excluded from scoring', () => {
+  it('normalize strips punctuation from comparison length', () => {
+    const withPunct = '媽媽說，你好。';
+    const plain = '媽媽說你好';
+    expect(countScorableCharacters(withPunct)).toBe(countScorableCharacters(plain));
+    expect(normalizeForComparison(withPunct)).toBe(normalizeForComparison(plain));
+  });
+
+  it('matchRate ignores punctuation in target', () => {
+    const target = '媽媽說，你好。';
+    const spoken = '媽媽說你好';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+    expect(result.correctCount + result.missingCount + result.wrongCount).toBe(5);
+  });
+
+  it('interleave shows punctuation as punctuation type, not correct', () => {
+    const target = '你好，世界！';
+    const display = displayChars(target, '你好世界');
+    expect(display.map((t) => `${t.char}:${t.type}`)).toEqual([
+      '你:correct',
+      '好:correct',
+      '，:punctuation',
+      '世:correct',
+      '界:correct',
+      '！:punctuation',
+    ]);
+  });
+
+  it('STT ASCII punctuation still scores full match after normalization', () => {
+    const target = '中國的戰國時期，有七個國家';
+    const spoken = '中國的戰國時期, 有七個國家';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+  });
+});
+
+// ─── R2: 漏字、漏句可抓到 ─────────────────────────────────────────────────
+
+describe('R2 — missing chars and partial sentences detected', () => {
+  it('single skipped char in middle → missing', () => {
+    const target = '其中最有名的人才是齊國的孟嘗君';
+    const spoken = '其中有名的人才是齊國的孟嘗君';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.tokens.find((t) => t.char === '最' && t.type === 'missing')).toBeDefined();
+    expect(result.missingCount).toBe(1);
+    expect(result.matchRate).toBeLessThan(1);
+  });
+
+  it('unread sentence tail → missing on all unread scorable chars', () => {
+    const target = '中國的戰國時期，有七個國家總是爭強鬥勝';
+    const spoken = '中國的戰國時期';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.missingCount).toBeGreaterThan(5);
+    const display = interleavePunctuation(target, result.tokens);
+    expect(display.filter((t) => t.type === 'missing').length).toBeGreaterThan(0);
+  });
+
+  it('empty speech → 0% match, all scorable chars missing', () => {
+    const target = '他們去公園玩耍';
+    const result = diffCharacters('', target, { useHomophone: true });
+    expect(result.matchRate).toBe(0);
+    expect(result.missingCount).toBe(normalizeForComparison(target).length);
+  });
+
+  it('localEvaluateParagraph tier 3 when only opening read', () => {
+    const spoken = '中國的戰國時期';
+    const result = localEvaluateParagraph(spoken, MENGCHANGJUN_LINE, 12_000, POOLS_FIXTURE, 0);
+    expect(result.matchRate).toBeLessThan(0.4);
+    expect(result.tier).toBe(3);
+  });
+});
+
+// ─── R3: 不過分綠色（遠端重複字不因前面唸過就亮） ─────────────────────────
+
+describe('R3 — no ghost-green on distant duplicate characters', () => {
+  it('only first 人才 pair matches when student read prefix only', () => {
+    const spoken = '管理人才';
+    const result = diffCharacters(spoken, DUPLICATE_RENCAI_TARGET, { useHomophone: true });
+    const matchedRen = result.tokens.filter(
+      (t) => t.char === '人' && (t.type === 'correct' || t.type === 'forgiven'),
+    ).length;
+    const matchedCai = result.tokens.filter(
+      (t) => t.char === '才' && (t.type === 'correct' || t.type === 'forgiven'),
+    ).length;
+    expect(matchedRen).toBe(1);
+    expect(matchedCai).toBe(1);
+    expect(result.missingCount).toBeGreaterThan(0);
+  });
+
+  it('partial paragraph: green count ≈ spoken length, not full target', () => {
+    const spoken = '中國的戰國時期，有七個國家';
+    const display = displayChars(MENGCHANGJUN_LINE, spoken);
+    const green = greenScorableCount(display);
+    const spokenNorm = normalizeForComparison(spoken).length;
+    expect(green).toBeLessThanOrEqual(spokenNorm + 2);
+    expect(green).toBeLessThan(countScorableCharacters(MENGCHANGJUN_LINE) * 0.5);
+  });
+
+  it('Gemini full-paste guard: staging 孟嘗君 line does not 100% green', () => {
+    const { matchRate, diffTokens } = evaluateGeminiPath(
+      MENGCHANGJUN_LINE,
+      '',
+      MENGCHANGJUN_LINE,
+      10_000,
+    );
+    const display = interleavePunctuation(MENGCHANGJUN_LINE, diffTokens);
+    expect(matchRate).toBeLessThan(0.95);
+    expect(greenScorableCount(display)).toBeLessThan(countScorableCharacters(MENGCHANGJUN_LINE));
+  });
+
+  it('interleave marks unread tail when diff tokens end early', () => {
+    const target = '你好，世界！再見。';
+    const tokens: DiffToken[] = [
+      { char: '你', type: 'correct' },
+      { char: '好', type: 'correct' },
+    ];
+    const display = interleavePunctuation(target, tokens);
+    expect(display.find((t) => t.char === '世' && t.type === 'unread')).toBeDefined();
+    expect(display.find((t) => t.char === '再' && t.type === 'unread')).toBeDefined();
+  });
+});
+
+// ─── R4: 阿拉伯數字、中英文標點智慧轉換 ───────────────────────────────────
+
+describe('R4 — number and punctuation normalization', () => {
+  it('299 ↔ 二百九十九 full read', () => {
+    const target = QIN_LINE;
+    const spoken = '公元前二百九十九年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+  });
+
+  it('partial read through digit run: digits green, rest missing', () => {
+    const target = '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+    const spoken = '公元前二百九十九年';
+    const display = displayChars(target, spoken);
+    const digitTypes = display
+      .filter((t) => /^[0-9]$/.test(t.char))
+      .map((t) => `${t.char}:${t.type}`);
+    expect(digitTypes).toEqual(['2:correct', '9:correct', '9:correct']);
+    expect(display.find((t) => t.char === '秦' && t.type === 'missing')).toBeDefined();
+    expect(display.filter((t) => t.type === 'correct').length).toBeLessThan(15);
+  });
+
+  it('兩百 spoken matches 二百 in target', () => {
+    expect(diffCharacters('兩百', '二百', { useHomophone: true }).matchRate).toBe(1);
+  });
+
+  it('214 in target matches 兩百一十四 spoken', () => {
+    expect(diffCharacters('兩百一十四', '214', { useHomophone: true }).matchRate).toBe(1);
+  });
+
+  it('full-width digits ２９９ match spoken 二百九十九', () => {
+    const target = '公元前２９９年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+    const spoken = '公元前二百九十九年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+  });
+
+  it('partial read through full-width digit run interleaves digit UI correctly', () => {
+    const target = '公元前２９９年，秦昭王';
+    const spoken = '公元前二百九十九年';
+    const display = displayChars(target, spoken);
+    const digitTypes = display
+      .filter((t) => /^[０-９0-9]$/.test(t.char))
+      .map((t) => `${t.char}:${t.type}`);
+    expect(digitTypes).toEqual(['２:correct', '９:correct', '９:correct']);
+    expect(display.find((t) => t.char === '秦' && t.type === 'missing')).toBeDefined();
+  });
+
+  it('兩百 spoken vs 二百 target — interleave shows correct on 二', () => {
+    const target = '二百個人';
+    const spoken = '兩百個';
+    const display = displayChars(target, spoken);
+    expect(display.find((t) => t.char === '二' && t.type === 'correct')).toBeDefined();
+    expect(display.find((t) => t.char === '人' && t.type === 'missing')).toBeDefined();
+  });
+
+  it('normalizePunctuationToChinese converts half-width', () => {
+    expect(normalizePunctuationToChinese('你好, 世界.')).toBe('你好，世界。');
+  });
+});
+
+// ─── R5: 同音／近音／STT 選字誤差仍算對 ───────────────────────────────────
+
+describe('R5 — homophone, near-sound, and STT-equivalent forgiveness', () => {
+  it('homophone substitution counts toward matchRate as forgiven', () => {
+    const target = '他們去公園玩耍';
+    const spoken = '他門去工園完刷'; // 門≈們, 工≈公, 完≈玩, 刷≈耍 near
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.matchRate).toBeGreaterThan(0.8);
+    expect(result.tokens.some((t) => t.type === 'forgiven')).toBe(true);
+  });
+
+  it('的/得/地 STT confusion → correct (not forgiven penalty)', () => {
+    expect(isSttEquivalent('的', '得')).toBe(true);
+    expect(isSttEquivalent('的', '地')).toBe(true);
+    const result = diffCharacters('慢慢得走', '慢慢地走', { useHomophone: true });
+    const deToken = result.tokens.find((t) => t.char === '地');
+    expect(deToken?.type).toBe('correct');
+  });
+
+  it('homophone 工/公 counts as forgiven (same toneless pinyin)', () => {
+    expect(isHomophone('工', '公')).toBe(true);
+    const result = diffCharacters('工園', '公園', { useHomophone: true });
+    expect(result.tokens.find((t) => t.char === '公')?.type).toBe('forgiven');
+    expect(result.matchRate).toBe(1);
+  });
+
+  it('genuine wrong char (not homophone) stays wrong', () => {
+    const result = diffCharacters('大樹', '小樹', { useHomophone: true });
+    expect(result.wrongCount).toBeGreaterThan(0);
+    expect(isHomophone('大', '小')).toBe(false);
+  });
+
+  it('analyzeFluency uses homophone-aware accuracy', () => {
+    const target = '他們去公園玩耍';
+    const fluency = analyzeFluency({
+      spoken: '他門去工園完刷',
+      target,
+      durationMs: 8000,
+      thresholds: { accuracyPass: 0.6, cpmPass: 0 },
+    });
+    expect(fluency.accuracy).toBeGreaterThanOrEqual(0.8);
+    expect(fluency.accuracyPassed).toBe(true);
+  });
+});
+
+// ─── R6: 正確率只算要唸的字（不含標點、注音、裝飾符號） ─────────────────
+
+describe('R6 — accuracy denominator = scorable chars only', () => {
+  it('bopomofo in target does not inflate denominator', () => {
+    const target = '人ㄖㄣˊ';
+    const spoken = '人';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+    expect(countScorableCharacters(target)).toBe(1);
+  });
+
+  it('decorative symbols and parenthetical notes stripped before compare', () => {
+    const target = '你好~~~（旁白說明）世界';
+    const spoken = '你好世界';
+    const normTarget = normalizeForComparison(target);
+    expect(normTarget).toBe('你好世界');
+    expect(diffCharacters(spoken, target, { useHomophone: true }).matchRate).toBe(1);
+  });
+
+  it('matchRate uses correct+forgiven over scorable target length only', () => {
+    const target = '一二三四，五六。';
+    const spoken = '一二三四五六';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+    expect(result.correctCount).toBe(6);
+  });
+
+  it('filler chars stripped; non-filler extra tracked separately', () => {
+    const target = '你好';
+    const withFiller = diffCharacters('你好啊嗯', target, { useHomophone: true });
+    expect(withFiller.matchRate).toBe(1);
+    expect(withFiller.extraCount).toBe(0);
+
+    const withExtra = diffCharacters('你好吧', target, { useHomophone: true });
+    expect(withExtra.extraCount).toBeGreaterThan(0);
+    expect(withExtra.matchRate).toBe(1);
+  });
+});
+
+// ─── Appendix: rules from prior commits not in R1–R6 ───────────────────────
+
+describe('Appendix — filler words stripped from diff', () => {
+  it('嗯啊呃 filler chars excluded from spoken alignment', () => {
+    const target = '我們去上學';
+    const spoken = '嗯我們啊去上學呃';
+    const result = diffCharacters(spoken, target, { useHomophone: true });
+    expect(result.matchRate).toBe(1);
+  });
+});
+
+describe('Appendix — cleanSpokenForDiff removes stutter duplicates', () => {
+  it('collapses consecutive repeated hanzi', () => {
+    const target = '你的書';
+    expect(cleanSpokenForDiff('你你你的書', target)).toBe('你的書');
+  });
+});
+
+describe('Appendix — extra tokens hidden in display interleave', () => {
+  it('interleavePunctuation drops extra-type tokens from display', () => {
+    const target = '你好';
+    const tokens: DiffToken[] = [
+      { char: '你', type: 'correct' },
+      { char: '好', type: 'correct' },
+      { char: '啊', type: 'extra' },
+    ];
+    const display = interleavePunctuation(target, tokens);
+    expect(display.every((t) => t.type !== 'extra')).toBe(true);
+  });
+});
+
+describe('Appendix — short paragraph pass threshold compensation', () => {
+  it('≤5 chars lowers pass threshold by 0.2', () => {
+    expect(getReadingPassThreshold(4)).toBeCloseTo(getReadingPassThreshold(100) - 0.2, 5);
+  });
+
+  it('≤10 chars lowers pass threshold by 0.1', () => {
+    expect(getReadingPassThreshold(8)).toBeCloseTo(getReadingPassThreshold(100) - 0.1, 5);
+  });
+});
+
+describe('Appendix — Gemini transcript guard (no STT recording needed)', () => {
+  it('always runs guard for gemini source even when webSpeech empty', () => {
+    const { conservativeClampApplied } = buildTranscriptForEvaluation({
+      source: 'gemini',
+      rawTranscript: MENGCHANGJUN_LINE,
+      rawStt: '',
+      targetText: MENGCHANGJUN_LINE,
+      durationMs: 10_000,
+    });
+    expect(conservativeClampApplied).toBe(true);
+  });
+
+  it('Web Speech anchor when Gemini over-fills', () => {
+    const web = '公元前299年';
+    const { cleaned } = evaluateGeminiPath(QIN_LINE, web, QIN_LINE, 12_000);
+    expect(cleaned).toBe(web);
+  });
+});
+
+describe('Appendix — accuracy-only pass (speed display only, Issue #2131)', () => {
+  it('slow but accurate reader still passes fluency gate', () => {
+    const target = '春風吹過田野花兒開了我愛讀書學習進步';
+    const result = analyzeFluency({
+      spoken: target,
+      target,
+      durationMs: 30_000,
+      thresholds: { cpmPass: 120, accuracyPass: 0.8 },
+    });
+    expect(result.accuracyPassed).toBe(true);
+    expect(result.speedPassed).toBe(false);
+    expect(result.passed).toBe(true);
+  });
+});

--- a/frontend/src/utils/textDiff.ts
+++ b/frontend/src/utils/textDiff.ts
@@ -101,6 +101,11 @@ const intToChinese = (num: number): string => {
   return result;
 };
 
+const normalizeFullwidthDigits = (text: string) =>
+  text.replace(/[\uFF10-\uFF19]/g, (ch) =>
+    String.fromCharCode(ch.charCodeAt(0) - 0xff10 + 0x30),
+  );
+
 const normalizeNumbers = (text: string) => text.replace(/\d+/g, m => intToChinese(parseInt(m, 10)));
 
 /**
@@ -169,7 +174,11 @@ export const normalizeForComparison = (text: string) =>
   stripNonScorableChars(
     normalizeChineseNumberVariants(
       normalizeNumbers(
-        cleanChineseText(stripDecorativeSymbols(normalizePunctuationToChinese(text))),
+        cleanChineseText(
+          stripDecorativeSymbols(
+            normalizeFullwidthDigits(normalizePunctuationToChinese(text)),
+          ),
+        ),
       ),
     ),
   );
@@ -371,11 +380,12 @@ export function computeMatchRate(spoken: string, target: string): number {
 /** Punctuation stripped from diff comparison — re-inserted at display time only. */
 const DISPLAY_PUNCT_RE = TOKEN_PUNCT_RE;
 
-const DIGIT_RE = /\d/;
+const DIGIT_RE = /[\d\uFF10-\uFF19]/;
 
 function chineseNormLenForDigitRun(digitStr: string): number {
   if (!digitStr) return 0;
-  return Array.from(intToChinese(parseInt(digitStr, 10))).length;
+  const ascii = normalizeFullwidthDigits(digitStr);
+  return Array.from(intToChinese(parseInt(ascii, 10))).length;
 }
 
 function consumeNextDisplayToken(

--- a/frontend/src/utils/transcriptGuard.test.ts
+++ b/frontend/src/utils/transcriptGuard.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { pickConservativeTranscript } from './transcriptGuard';
+import {
+  maxPlausibleNormChars,
+  pickConservativeTranscript,
+  truncateTranscriptToNormLength,
+} from './transcriptGuard';
 
 const TARGET =
   '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。';
+
+const LONG_TARGET =
+  '中國的戰國時期，有七個國家總是爭強鬥勝、互比苗頭，為了要在競爭中勝出，各國都在搶傑出的管理人才，其中最有名的人才，就是齊國的孟嘗君。孟嘗君是有錢的貴族，最讓人津津樂道的是他在家裡養了三千名食客，食客就是在家裡吃飯的客人，三千人開飯的場面一眼望不完，真是非常壯觀。只要自認為有本事的人來投奔孟嘗君，他二話不說，總是張開雙手歡迎。這些食客具備各式各樣的才能，可以隨時幫他解決各種問題。';
 
 describe('pickConservativeTranscript', () => {
   it('keeps Gemini when it is only slightly longer than Web Speech', () => {
@@ -23,8 +30,35 @@ describe('pickConservativeTranscript', () => {
     expect(pickConservativeTranscript(gemini, web, TARGET)).toBe(web);
   });
 
-  it('uses Gemini when Web Speech is empty', () => {
+  it('uses short Gemini when Web Speech is empty', () => {
     const gemini = '公元前299年';
-    expect(pickConservativeTranscript(gemini, '', TARGET)).toBe(gemini);
+    expect(pickConservativeTranscript(gemini, '', TARGET, 15_000)).toBe(gemini);
+  });
+
+  it('caps full-paragraph Gemini when Web Speech is empty and recording is short', () => {
+    const gemini = LONG_TARGET;
+    const capped = pickConservativeTranscript(gemini, '', LONG_TARGET, 12_000);
+    expect(capped).not.toBe(gemini);
+    expect(capped.length).toBeGreaterThan(0);
+    expect(capped.length).toBeLessThan(gemini.length);
+    expect(capped.startsWith('中國的戰國時期')).toBe(true);
+  });
+
+  it('rejects full-paragraph Gemini when Web Speech empty and duration unknown', () => {
+    expect(pickConservativeTranscript(LONG_TARGET, '', LONG_TARGET)).toBe('');
+  });
+});
+
+describe('truncateTranscriptToNormLength', () => {
+  it('keeps a prefix within normalized length budget', () => {
+    const text = '中國的戰國時期，有七個國家';
+    const out = truncateTranscriptToNormLength(text, 8);
+    expect(out).toBe('中國的戰國時期，有');
+  });
+});
+
+describe('maxPlausibleNormChars', () => {
+  it('scales with duration', () => {
+    expect(maxPlausibleNormChars(12_000)).toBeLessThan(maxPlausibleNormChars(60_000));
   });
 });

--- a/frontend/src/utils/transcriptGuard.ts
+++ b/frontend/src/utils/transcriptGuard.ts
@@ -14,6 +14,67 @@ const EXTRA_CHARS_TOLERANCE = 2;
  */
 const EXTRA_LENGTH_RATIO = 1.5;
 
+/** Generous upper-bound CPM for elementary oral reading (norm chars / min). */
+const MAX_PLAUSIBLE_CPM = 420;
+const CPM_SLACK = 1.25;
+
+/** Minimum normalized chars to keep after duration cap (avoid empty false negatives). */
+const MIN_TRUNCATED_NORM = 3;
+
+export function maxPlausibleNormChars(durationMs: number | undefined): number {
+  if (!durationMs || durationMs <= 0) return 0;
+  const minutes = durationMs / 60000;
+  return Math.max(1, Math.ceil(minutes * MAX_PLAUSIBLE_CPM * CPM_SLACK));
+}
+
+/** Trim raw transcript so its normalized length does not exceed maxNormLen. */
+export function truncateTranscriptToNormLength(text: string, maxNormLen: number): string {
+  if (maxNormLen <= 0) return '';
+  const chars = Array.from(text);
+  let best = '';
+  for (let i = 0; i < chars.length; i++) {
+    const prefix = chars.slice(0, i + 1).join('');
+    const normLen = normalizeForComparison(cleanChineseText(prefix)).length;
+    if (normLen > maxNormLen) break;
+    best = prefix;
+  }
+  return best;
+}
+
+function capGeminiWithoutWebspeechCorroboration(
+  preferred: string,
+  webspeechFallback: string,
+  targetNorm: string,
+  preferredNorm: string,
+  durationMs: number | undefined,
+): string {
+  if (!preferredNorm) return webspeechFallback;
+
+  const maxNorm = maxPlausibleNormChars(durationMs);
+  const looksLikeFullPaste =
+    targetNorm.length >= 8 && preferredNorm.length >= targetNorm.length * 0.9;
+
+  const exceedsDuration = maxNorm > 0 && preferredNorm.length > maxNorm;
+
+  if (!looksLikeFullPaste && !exceedsDuration) {
+    return preferred;
+  }
+
+  // No Web Speech anchor: cap by recording length, or reject full paste when duration unknown.
+  if (maxNorm > 0) {
+    const truncated = truncateTranscriptToNormLength(preferred, maxNorm);
+    const truncatedNorm = normalizeForComparison(cleanChineseText(truncated));
+    if (truncatedNorm.length >= MIN_TRUNCATED_NORM) return truncated;
+    return webspeechFallback;
+  }
+
+  if (looksLikeFullPaste) {
+    return webspeechFallback;
+  }
+
+  return preferred;
+}
+
 /**
  * Pick the transcript to feed scoring / diff display.
  * `preferred` is usually Gemini; `webspeechFallback` is browser STT at stop time.
@@ -22,12 +83,21 @@ export function pickConservativeTranscript(
   preferred: string,
   webspeechFallback: string,
   targetText: string,
+  durationMs?: number,
 ): string {
   const preferredNorm = normalizeForComparison(cleanChineseText(preferred));
   const fallbackNorm = normalizeForComparison(cleanChineseText(webspeechFallback));
   const targetNorm = normalizeForComparison(targetText);
 
-  if (!fallbackNorm) return preferred;
+  if (!fallbackNorm) {
+    return capGeminiWithoutWebspeechCorroboration(
+      preferred,
+      webspeechFallback,
+      targetNorm,
+      preferredNorm,
+      durationMs,
+    );
+  }
   if (!preferredNorm) return webspeechFallback;
 
   const extraChars = preferredNorm.length - fallbackNorm.length;


### PR DESCRIPTION
## Summary
- Lock R1–R6 reading evaluation rules with frontend/backend regression tests (no real STT required)
- Fix backend CPM to count only correctly read characters (partial-read case)
- Normalize fullwidth digits (e.g. ２９９) in alignment pipeline
- Preserve paragraph eval state on revisit; align digit diff display on staging

## Test plan
- [x] `npm test` — readingEvalRules, liveTutorRegression, paragraphEvalRestore (55 passed)
- [x] `pytest` — reading_evaluation_service, alignment rules, stt normalization (69 passed)
- [ ] Staging smoke: half-paragraph read, 299 digit sentence, homophone forgiveness


Made with [Cursor](https://cursor.com)