### PR TITLE
fix(live-tutor): stop garbled Web Speech from overriding Gemini transcript

### DIFF
--- a/backend/tests/test_reading_transcription.py
+++ b/backend/tests/test_reading_transcription.py
@@ -27,6 +27,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import json
 import pytest
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -59,6 +60,22 @@ def _make_mock_gemini_call(response):
     return _fake_wait_for
 
 
+@contextmanager
+def _patch_webm_transcode_success(mock_resp):
+    """webm inputs transcode before Gemini; skip real ffmpeg in unit tests."""
+    with (
+        patch(
+            "app.services.reading_transcription_service.asyncio.to_thread",
+            new=AsyncMock(return_value=b"fake-ogg-transcoded"),
+        ),
+        patch(
+            "app.services.reading_transcription_service.asyncio.wait_for",
+            new=AsyncMock(return_value=mock_resp),
+        ),
+    ):
+        yield
+
+
 class TestTranscriptionServiceSuccess:
     """Gemini returns a valid JSON response."""
 
@@ -71,10 +88,7 @@ class TestTranscriptionServiceSuccess:
             reasoning="原文專有名詞「孟嘗君」辨識正確。",
         )
 
-        with patch(
-            "app.services.reading_transcription_service.asyncio.wait_for",
-            new=AsyncMock(return_value=mock_resp),
-        ):
+        with _patch_webm_transcode_success(mock_resp):
             result = await transcribe_reading_audio(
                 audio_bytes=b"fake_audio_bytes",
                 mime_type="audio/webm",
@@ -93,10 +107,7 @@ class TestTranscriptionServiceSuccess:
 
         mock_resp = _make_gemini_response("春風吹過田野。", "轉錄正確。")
 
-        with patch(
-            "app.services.reading_transcription_service.asyncio.wait_for",
-            new=AsyncMock(return_value=mock_resp),
-        ):
+        with _patch_webm_transcode_success(mock_resp):
             result = await transcribe_reading_audio(
                 audio_bytes=b"audio",
                 mime_type="audio/webm",
@@ -185,10 +196,7 @@ class TestTranscriptionServiceFailClosed:
         mock_resp.prompt_feedback = MagicMock()
         mock_resp.prompt_feedback.block_reason = None
 
-        with patch(
-            "app.services.reading_transcription_service.asyncio.wait_for",
-            new=AsyncMock(return_value=mock_resp),
-        ):
+        with _patch_webm_transcode_success(mock_resp):
             result = await transcribe_reading_audio(
                 audio_bytes=b"audio",
                 mime_type="audio/webm",

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -9,25 +9,10 @@ import { splitZhuyinChars } from '../../../utils/zhuyinUtils';
 import { groupIdxForProgress } from '../../../utils/ttsHighlight';
 import { useKaraoke } from '../../../context/KaraokeContext';
 import { interleavePunctuation } from '../../../utils/textDiff';
+import { getEncouragement } from '../../../utils/readingEncouragement';
 
 /** Per-sentence retry (record + eval). Off until short-sentence practice ships. */
 const SENTENCE_RETRY_UI_ENABLED = false;
-
-/* ── Encouragement messages (PR #1076 / #1096) ──────────────────────────── */
-
-const ENCOURAGE_TIERS: Array<{ min: number; color: string; msgs: string[] }> = [
-  { min: 0.95, color: 'text-emerald-600', msgs: ['完美！太流暢了！', '讀得超棒！', '太厲害了！', '好厲害，一字不差！'] },
-  { min: 0.80, color: 'text-green-600', msgs: ['讀得很好！', '棒棒！繼續加油！', '很不錯喔！', '表現很棒！'] },
-  { min: 0.65, color: 'text-green-600', msgs: ['讀得不錯！', '很好喔，再練一下更好！', '進步很多了！'] },
-  { min: 0.50, color: 'text-amber-600', msgs: ['有進步喔！再試一次會更好！', '很努力！繼續加油！', '你做得到的！'] },
-  { min: 0, color: 'text-amber-600', msgs: ['沒關係，我們再試一次！', '慢慢來，不著急！', '多練幾次就會了！'] },
-];
-
-function getEncouragement(matchRate: number): { text: string; color: string } {
-  const tier = ENCOURAGE_TIERS.find(t => matchRate >= t.min) ?? ENCOURAGE_TIERS[ENCOURAGE_TIERS.length - 1];
-  const idx = Math.floor(matchRate * 1000) % tier.msgs.length;
-  return { text: tier.msgs[idx], color: tier.color };
-}
 
 /* ── Component ──────────────────────────────────────────────────────────── */
 

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
@@ -361,7 +361,7 @@ export function useParagraphEvaluation({
           const gemini = await Promise.race([
             evaluateReading(cleaned, targetText, durationMs, token ?? undefined),
             new Promise<never>((_, reject) => {
-              localTimeout = setTimeout(() => reject(new Error('gemini_timeout')), 8000);
+              localTimeout = setTimeout(() => reject(new Error('gemini_timeout')), 28_000);
               geminiTimeoutRef.current = localTimeout;
             }),
           ]);

--- a/frontend/src/utils/fixtures/gcpStagingTranscriptGuard20260616.ts
+++ b/frontend/src/utils/fixtures/gcpStagingTranscriptGuard20260616.ts
@@ -1,0 +1,21 @@
+/**
+ * Staging incident fixture — user session, lineIndex 1, ~2026-06-16.
+ *
+ * GCP (lingoleap-backend-staging):
+ * - reading_transcribe_success transcript_len ≈ 193
+ * - reading_eval_request spoken_len ≈ 105 (after bad conservative clamp)
+ * - duration_ms 41317, audio_bytes 665995
+ *
+ * Bug: pickConservativeTranscript treated garbled short Web Speech as proof the
+ * student stopped reading, discarding correct Gemini audio transcript.
+ */
+export const GCP_STAGING_TRANSCRIPT_GUARD_20260616 = {
+  durationMs: 41_317,
+  lineIndex: 1,
+  targetText:
+    '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。孟嘗君便高高興興的和一批食客一起去秦國赴任。天有不測風雲，誰知道到了秦國，還沒有登上相位，就有人看他不順眼，開始對秦昭王咬耳根：「他是齊國人，做決策時一定先想齊國的好處，而後才考慮秦國，這樣可危險了。」秦昭王多疑狠毒，這些讒言讓他心裡的懷疑、猜忌一起發作，他不但開除了孟嘗君，還動了殺心，心想：「這人我不用，也不能給別人用。」便把他軟禁起來。',
+  geminiAudioTranscript:
+    '公元前299年，秦昭王聽說孟嘗君的賢達，便邀請他到秦國當宰相。孟嘗君便高高興興的和一批食客一起去秦國赴任。天有不測風雲，誰知道到了秦國，還沒有登上相位，就有人看他不順眼，咬耳朵對秦昭王，他是齊國人，做決策時一定先想齊國的好處，才考慮秦國，這樣就危險了。秦昭王多疑狠毒，這些讒言讓他心裡的猜忌懷疑一起發作，他不但開除了孟嘗君，還動了殺心，心想這人我不用，也不能給別人用，便把他軟禁了起來。',
+  garbledWebSpeech:
+    '公元前299年秦昭王金說孟嘗君的賢達變邀請他到秦國當宅相片高高興興的和ep10可以一起去秦國富任天有不測風雲誰知道告了秦國還沒有登上香味有人看他不順眼咬耳朵對請找往他是許多人做決策是一定心想起過的好處才考慮清楚',
+} as const;

--- a/frontend/src/utils/liveTutorRegression.test.ts
+++ b/frontend/src/utils/liveTutorRegression.test.ts
@@ -19,6 +19,7 @@ import {
 } from './liveTutorPools';
 import { diffCharacters, interleavePunctuation } from './textDiff';
 import type { DiffToken } from '../types';
+import { GCP_STAGING_TRANSCRIPT_GUARD_20260616 as GCP_LINE1 } from './fixtures/gcpStagingTranscriptGuard20260616';
 
 const POOLS = {
   tier1: TIER1_POOL,
@@ -98,7 +99,7 @@ describe('Live Tutor regression — staging 孟嘗君 line 0 (empty Web Speech +
 });
 
 describe('Live Tutor regression — staging 秦昭王 line (Web Speech anchor)', () => {
-  it('prefers partial Web Speech when Gemini returns full target', () => {
+  it('prefers partial Web Speech when Gemini returns full target and Web Speech is clean', () => {
     const web = '公元前299年';
     const { cleaned, conservativeClampApplied, matchRate } = evaluateGeminiPath(
       QIN_LINE,
@@ -122,6 +123,18 @@ describe('Live Tutor regression — staging 秦昭王 line (Web Speech anchor)',
     );
     expect(conservativeClampApplied).toBe(false);
     expect(cleaned).toBe(gemini);
+  });
+
+  it('keeps full Gemini audio when Web Speech is garbled mid-paragraph (GCP staging line 1)', () => {
+    const { cleaned, conservativeClampApplied, matchRate } = evaluateGeminiPath(
+      GCP_LINE1.geminiAudioTranscript,
+      GCP_LINE1.garbledWebSpeech,
+      GCP_LINE1.targetText,
+      GCP_LINE1.durationMs,
+    );
+    expect(conservativeClampApplied).toBe(false);
+    expect(cleaned).toBe(GCP_LINE1.geminiAudioTranscript);
+    expect(matchRate).toBeGreaterThan(0.85);
   });
 });
 

--- a/frontend/src/utils/readingEncouragement.test.ts
+++ b/frontend/src/utils/readingEncouragement.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  encouragementContainsAbsoluteClaim,
+  getEncouragement,
+} from './readingEncouragement';
+
+describe('readingEncouragement', () => {
+  it('does not claim 一字不差 or 完美 when displayed accuracy is 96%', () => {
+    expect(encouragementContainsAbsoluteClaim(0.96)).toBe(false);
+    expect(encouragementContainsAbsoluteClaim(0.963)).toBe(false);
+  });
+
+  it('allows absolute praise only at 100% rounded accuracy', () => {
+    expect(encouragementContainsAbsoluteClaim(1)).toBe(true);
+    expect(getEncouragement(1).text).toMatch(/一字不差|完美/);
+  });
+
+  it('uses encouraging but honest copy for high-but-not-perfect scores', () => {
+    const { text } = getEncouragement(0.96);
+    expect(text).toMatch(/讀得|厲害|表現/);
+    expect(text).not.toMatch(/一字不差/);
+  });
+});

--- a/frontend/src/utils/readingEncouragement.ts
+++ b/frontend/src/utils/readingEncouragement.ts
@@ -1,0 +1,38 @@
+/**
+ * Live Tutor paragraph summary headline — must match displayed accuracy, no overclaim.
+ */
+
+const ENCOURAGE_TIERS: Array<{ min: number; color: string; msgs: string[] }> = [
+  { min: 0.95, color: 'text-emerald-600', msgs: ['讀得很準！', '讀得超棒！', '太厲害了！', '表現非常好！'] },
+  { min: 0.80, color: 'text-green-600', msgs: ['讀得很好！', '棒棒！繼續加油！', '很不錯喔！', '表現很棒！'] },
+  { min: 0.65, color: 'text-green-600', msgs: ['讀得不錯！', '很好喔，再練一下更好！', '進步很多了！'] },
+  { min: 0.50, color: 'text-amber-600', msgs: ['有進步喔！再試一次會更好！', '很努力！繼續加油！', '你做得到的！'] },
+  { min: 0, color: 'text-amber-600', msgs: ['沒關係，我們再試一次！', '慢慢來，不著急！', '多練幾次就會了！'] },
+];
+
+/** Only shown when rounded accuracy is 100% — matches the stat line. */
+const PERFECT_MSGS = ['完美！太流暢了！', '好厲害，一字不差！', '全都唸對了，太厲害！'];
+
+const ABSOLUTE_CLAIM_RE = /一字不差|完美|全都唸對了/;
+
+export function getEncouragement(matchRate: number): { text: string; color: string } {
+  const percent = Math.round(matchRate * 100);
+  const pickIdx = Math.floor(matchRate * 1000);
+
+  if (percent >= 100) {
+    return {
+      text: PERFECT_MSGS[pickIdx % PERFECT_MSGS.length],
+      color: ENCOURAGE_TIERS[0].color,
+    };
+  }
+
+  const tier =
+    ENCOURAGE_TIERS.find((t) => matchRate >= t.min) ??
+    ENCOURAGE_TIERS[ENCOURAGE_TIERS.length - 1];
+  return { text: tier.msgs[pickIdx % tier.msgs.length], color: tier.color };
+}
+
+/** @internal test helper */
+export function encouragementContainsAbsoluteClaim(matchRate: number): boolean {
+  return ABSOLUTE_CLAIM_RE.test(getEncouragement(matchRate).text);
+}

--- a/frontend/src/utils/transcriptGuard.gcpRegression.test.ts
+++ b/frontend/src/utils/transcriptGuard.gcpRegression.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression: GCP-proven false negative from conservative transcript clamp.
+ * Do not delete — encodes staging incident 2026-06-16 (孟嘗君 line 1, 41s read).
+ */
+import { describe, expect, it } from 'vitest';
+import { GCP_STAGING_TRANSCRIPT_GUARD_20260616 as INCIDENT } from './fixtures/gcpStagingTranscriptGuard20260616';
+import { buildTranscriptForEvaluation } from './liveTutorTranscriptPipeline';
+import { localEvaluateParagraph } from './localEval';
+import {
+  STREAK_MESSAGES,
+  TIER1_POOL,
+  TIER2_POOL,
+  TIER3_POOL,
+} from './liveTutorPools';
+import { interleavePunctuation } from './textDiff';
+import { pickConservativeTranscript } from './transcriptGuard';
+
+const POOLS = {
+  tier1: TIER1_POOL,
+  tier2: TIER2_POOL,
+  tier3: TIER3_POOL,
+  streakMsgs: STREAK_MESSAGES,
+};
+
+describe('GCP staging 2026-06-16 — garbled Web Speech must not override Gemini audio', () => {
+  it('pickConservativeTranscript keeps geminiAudioTranscript (not garbled webSpeech)', () => {
+    const picked = pickConservativeTranscript(
+      INCIDENT.geminiAudioTranscript,
+      INCIDENT.garbledWebSpeech,
+      INCIDENT.targetText,
+      INCIDENT.durationMs,
+    );
+    expect(picked).toBe(INCIDENT.geminiAudioTranscript);
+    expect(picked).not.toBe(INCIDENT.garbledWebSpeech);
+  });
+
+  it('buildTranscriptForEvaluation does not set conservativeClampApplied', () => {
+    const { transcriptForEval, cleaned, conservativeClampApplied } =
+      buildTranscriptForEvaluation({
+        source: 'gemini',
+        rawTranscript: INCIDENT.geminiAudioTranscript,
+        rawStt: INCIDENT.garbledWebSpeech,
+        targetText: INCIDENT.targetText,
+        durationMs: INCIDENT.durationMs,
+      });
+
+    expect(conservativeClampApplied).toBe(false);
+    expect(transcriptForEval).toBe(INCIDENT.geminiAudioTranscript);
+    expect(cleaned).not.toBe(INCIDENT.garbledWebSpeech);
+  });
+
+  it('Gemini path scores high; garbled Web Speech path would falsely grey the tail', () => {
+    const { matchRate: geminiMatch, diffTokens: geminiDiff } = localEvaluateParagraph(
+      INCIDENT.geminiAudioTranscript,
+      INCIDENT.targetText,
+      INCIDENT.durationMs,
+      POOLS,
+      0,
+    );
+    const { matchRate: garbledMatch, diffTokens: garbledDiff } = localEvaluateParagraph(
+      INCIDENT.garbledWebSpeech,
+      INCIDENT.targetText,
+      INCIDENT.durationMs,
+      POOLS,
+      0,
+    );
+
+    expect(geminiMatch).toBeGreaterThan(0.85);
+    expect(garbledMatch).toBeLessThan(0.55);
+
+    const geminiDisplay = interleavePunctuation(INCIDENT.targetText, geminiDiff);
+    const garbledDisplay = interleavePunctuation(INCIDENT.targetText, garbledDiff);
+    const greyIfGarbled = garbledDisplay.filter(
+      (t) => t.type === 'missing' || t.type === 'unread',
+    ).length;
+    const greyIfGemini = geminiDisplay.filter(
+      (t) => t.type === 'missing' || t.type === 'unread',
+    ).length;
+
+    expect(greyIfGarbled).toBeGreaterThan(greyIfGemini + 20);
+  });
+
+  it('still clamps when Web Speech is a clean partial read (student only spoke opening)', () => {
+    const cleanPartial = '公元前299年，秦昭王聽說孟嘗君的賢達，';
+    const picked = pickConservativeTranscript(
+      INCIDENT.geminiAudioTranscript,
+      cleanPartial,
+      INCIDENT.targetText,
+      12_000,
+    );
+    expect(picked).toBe(cleanPartial);
+  });
+});

--- a/frontend/src/utils/transcriptGuard.test.ts
+++ b/frontend/src/utils/transcriptGuard.test.ts
@@ -24,10 +24,17 @@ describe('pickConservativeTranscript', () => {
     expect(pickConservativeTranscript(gemini, web, TARGET)).toBe(web);
   });
 
-  it('falls back when Gemini is much longer than Web Speech', () => {
+  it('falls back when Gemini is much longer than Web Speech and Web Speech is a clean anchor', () => {
     const web = '公元前';
     const gemini = '公元前299年秦昭王聽說孟嘗君';
     expect(pickConservativeTranscript(gemini, web, TARGET)).toBe(web);
+  });
+
+  it('keeps Gemini when Web Speech is long but garbled (staging 孟嘗君 line 1)', () => {
+    const gemini = TARGET;
+    const garbledWeb =
+      '公元前299年秦昭王金說孟產君孟嚐君是有錢的貴族最讓人津津樂道是在家裡養了三千長開眼的作客才考慮清楚';
+    expect(pickConservativeTranscript(gemini, garbledWeb, TARGET, 41_317)).toBe(gemini);
   });
 
   it('uses short Gemini when Web Speech is empty', () => {

--- a/frontend/src/utils/transcriptGuard.ts
+++ b/frontend/src/utils/transcriptGuard.ts
@@ -21,6 +21,31 @@ const CPM_SLACK = 1.25;
 /** Minimum normalized chars to keep after duration cap (avoid empty false negatives). */
 const MIN_TRUNCATED_NORM = 3;
 
+/**
+ * Web Speech must align with the target opening before we let it override Gemini.
+ * Garbled / lagging browser STT often ends mid-paragraph with a low prefix match —
+ * that is not evidence the student stopped reading.
+ */
+const RELIABLE_ANCHOR_PREFIX_MATCH = 0.75;
+
+function prefixMatchRate(spokenNorm: string, targetNorm: string): number {
+  if (!spokenNorm) return 0;
+  const targetPrefix = targetNorm.slice(0, spokenNorm.length);
+  const spoken = Array.from(spokenNorm);
+  const target = Array.from(targetPrefix);
+  if (target.length < spoken.length * 0.5) return 0;
+  let matches = 0;
+  for (let i = 0; i < spoken.length; i++) {
+    if (spoken[i] === target[i]) matches++;
+  }
+  return matches / spoken.length;
+}
+
+function isReliableWebspeechAnchor(fallbackNorm: string, targetNorm: string): boolean {
+  if (fallbackNorm.length < 2) return false;
+  return prefixMatchRate(fallbackNorm, targetNorm) >= RELIABLE_ANCHOR_PREFIX_MATCH;
+}
+
 export function maxPlausibleNormChars(durationMs: number | undefined): number {
   if (!durationMs || durationMs <= 0) return 0;
   const minutes = durationMs / 60000;
@@ -115,7 +140,23 @@ export function pickConservativeTranscript(
     (ratio >= EXTRA_LENGTH_RATIO || extraChars >= Math.max(5, Math.floor(targetNorm.length * 0.25)));
 
   if (suspiciousFullParagraph || suspiciousLength) {
-    return webspeechFallback;
+    // Only trust Web Speech when it cleanly tracks the lesson opening (partial read).
+    if (isReliableWebspeechAnchor(fallbackNorm, targetNorm)) {
+      return webspeechFallback;
+    }
+
+    const maxNorm = maxPlausibleNormChars(durationMs);
+    if (maxNorm > 0 && preferredNorm.length <= maxNorm) {
+      return preferred;
+    }
+
+    if (maxNorm > 0) {
+      const truncated = truncateTranscriptToNormLength(preferred, maxNorm);
+      const truncatedNorm = normalizeForComparison(cleanChineseText(truncated));
+      if (truncatedNorm.length >= MIN_TRUNCATED_NORM) return truncated;
+    }
+
+    return preferred;
   }
 
   return preferred;


### PR DESCRIPTION
## Summary
- Fix staging false-negative where garbled Web Speech overwrote a correct Gemini audio transcript (`pickConservativeTranscript` now requires a reliable opening prefix match before clamping).
- Raise client-side Gemini eval race timeout from 8s to 28s to match backend latency on long recordings.
- Move encouragement copy to `readingEncouragement.ts` so absolute praise (e.g. 「一字不差」) only appears at 100% match.
- Add GCP staging regression fixture/tests for 孟嘗君 line 1; mock webm transcode in backend transcription unit tests.

## Test plan
- [x] `npm test -- --run` on transcriptGuard / liveTutorRegression / readingEncouragement / useParagraphEvaluation (66 passed)
- [x] `pytest tests/test_reading_transcription.py specs/test_reading_transcription_spec.py` (38 passed)
- [ ] Staging: 孟嘗君 line 1 — full paragraph highlighted, `conservativeClampApplied: false`, no `gemini_timeout`
- [ ] Staging: 孟嘗君 line 0 — partial Web Speech clamp still applies when anchor is clean
- [ ] Staging: ~96% match does not show 「一字不差」


Made with [Cursor](https://cursor.com)