### PR TITLE
fix(live-tutor): reset 開始朗讀 label on new paragraph

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -540,6 +540,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
       nextSentenceIdxRef.current = restorePlan.nextSentenceIdx;
       lastFinalResultIdxRef.current = restorePlan.lastFinalResultIdx;
       dispatch(restorePlan.dispatchAction);
+      dispatch({ type: 'RESET_RETRY' });
     } else {
       sentenceResultsRef.current = new Array(targets.length).fill(null);
       nextSentenceIdxRef.current = 0;

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.test.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.test.ts
@@ -53,4 +53,19 @@ describe('evalReducer — display diff must stay on local Phase-1 result', () =>
     expect(next.lastDiffTokens).toEqual(localDiff);
     expect(next.phase).toBe('gemini_error');
   });
+
+  it('CLEAR_FOR_PARAGRAPH resets retryCount so next paragraph shows 開始朗讀', () => {
+    const afterRetries: EvalState = {
+      ...initialEvalState,
+      retryCount: 2,
+      lastDiffTokens: localDiff,
+      streamingUserInput: '測試',
+      phase: 'gemini_done',
+    };
+    const next = evalReducer(afterRetries, { type: 'CLEAR_FOR_PARAGRAPH' });
+    expect(next.retryCount).toBe(0);
+    expect(next.lastDiffTokens).toBeNull();
+    expect(next.streamingUserInput).toBe('');
+    expect(next.phase).toBe('idle');
+  });
 });

--- a/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
+++ b/frontend/src/components/reading-steps/live-tutor/hooks/useParagraphEvaluation.ts
@@ -92,6 +92,7 @@ export function evalReducer(state: EvalState, action: EvalAction): EvalState {
         realtimeDiffTokens: null,
         streamingUserInput: '',
         isAwaitingGemini: false,
+        retryCount: 0,
       };
     default:
       return state;


### PR DESCRIPTION
## Summary
- `CLEAR_FOR_PARAGRAPH` 現在會把 `retryCount` 歸零，切到下一段（尚無結果）時麥克風按鈕顯示「開始朗讀」，不再沿用上一段的「再試一次」
- 切回已有評分紀錄的段落時也 `RESET_RETRY`，避免跨段狀態污染

## Test plan
- [x] `useParagraphEvaluation.test.ts` — CLEAR_FOR_PARAGRAPH resets retryCount (4/4)
- [ ] Staging：某段失敗 1～2 次 → 通過進下一段 → 按鈕應為「開始朗讀」


Made with [Cursor](https://cursor.com)