### PR TITLE
fix(tts): Gemini TTS 503 + immersive step dots RWD

### DIFF
--- a/backend/app/services/tts/providers/gemini.py
+++ b/backend/app/services/tts/providers/gemini.py
@@ -82,7 +82,6 @@ def _synthesize_gemini(text: str) -> bytes:
             contents=tts_contents,
             config=genai_types.GenerateContentConfig(
                 response_modalities=["AUDIO"],
-                thinking_config=genai_types.ThinkingConfig(thinking_budget=0),
                 speech_config=genai_types.SpeechConfig(
                     voice_config=genai_types.VoiceConfig(
                         prebuilt_voice_config=genai_types.PrebuiltVoiceConfig(

--- a/backend/app/services/tts_service.py
+++ b/backend/app/services/tts_service.py
@@ -1,6 +1,6 @@
 """Compatibility shim for existing TTS imports."""
 
-# Gemini TTS GenerateContentConfig now lives in tts/providers/gemini.py and still sets thinking_budget=0.
+# Gemini TTS GenerateContentConfig lives in tts/providers/gemini.py (AUDIO-only; no thinking_config).
 import sys
 
 from . import tts as _tts

--- a/backend/tests/test_regression_thinking_budget_1738.py
+++ b/backend/tests/test_regression_thinking_budget_1738.py
@@ -12,8 +12,7 @@ Why thinking_budget=0 matters:
 Files guarded by this test:
   - ai_comprehension.py  (comprehension scoring, socratic questions)
   - omo_identifier.py    (worksheet image identification)
-  - tts_service.py       (TTS generation config)
-  - ai_base.py           (base LLM call utility)
+  - ai/gemini_client.py  (shared Gemini structured-response utility; Issue #1953)
   - omo_grader.py        (OMO answer grading)
 
 Run:
@@ -35,8 +34,7 @@ _SERVICES_DIR = Path(__file__).parent.parent / "app" / "services"
 _GUARDED_FILES = [
     ("ai_comprehension.py", "comprehension scoring / socratic question generation"),
     ("omo_identifier.py", "OMO worksheet image identification"),
-    ("tts_service.py", "TTS content generation config"),
-    ("ai_base.py", "base LLM call utility used by most services"),
+    ("ai/gemini_client.py", "shared Gemini structured-response utility (was ai_base.py)"),
     ("omo_grader.py", "OMO answer grading — Issue #1717"),
 ]
 
@@ -78,23 +76,25 @@ class TestThinkingBudgetEnforcement:
             "Extended thinking on identifier calls wastes tokens with no accuracy gain."
         )
 
-    def test_tts_service_has_thinking_budget_zero(self):
-        """tts_service.py must set thinking_budget=0 in GenerateContentConfig."""
-        content = self._read_service_file("tts_service.py")
-        assert _THINKING_BUDGET_PATTERN.search(content), (
-            "tts_service.py does NOT contain thinking_budget=0. "
-            "This was fixed in Issue #1738. "
-            "TTS generation is deterministic and never benefits from thinking."
+    def test_gemini_tts_does_not_use_thinking_config(self):
+        """Gemini TTS (AUDIO modality) must not pass thinking_config — API returns 400."""
+        path = _SERVICES_DIR / "tts" / "providers" / "gemini.py"
+        assert path.exists(), f"Gemini TTS provider not found at {path}"
+        content = path.read_text(encoding="utf-8")
+        assert "thinking_config" not in content, (
+            "tts/providers/gemini.py must NOT set thinking_config on GenerateContentConfig. "
+            "gemini-3.1-flash-tts-preview rejects it with 400 INVALID_ARGUMENT, "
+            "breaking live synthesis (503) on GCS cache miss."
         )
 
-    def test_ai_base_has_thinking_budget_zero(self):
-        """ai_base.py must set thinking_budget=0 in its GenerateContentConfig."""
-        content = self._read_service_file("ai_base.py")
+    def test_gemini_client_has_thinking_budget_zero(self):
+        """ai/gemini_client.py must set thinking_budget=0 in its GenerateContentConfig."""
+        content = self._read_service_file("ai/gemini_client.py")
         assert _THINKING_BUDGET_PATTERN.search(content), (
-            "ai_base.py does NOT contain thinking_budget=0. "
-            "This was fixed in Issue #1738. "
-            "ai_base.py is the shared LLM call utility — missing this setting "
-            "would enable thinking for all tasks that use the base utility."
+            "ai/gemini_client.py does NOT contain thinking_budget=0. "
+            "This was fixed in Issue #1738 and moved here in Issue #1953. "
+            "gemini_client.py is the shared LLM call utility — missing this setting "
+            "would enable thinking for all tasks that use generate_structured_response."
         )
 
     def test_omo_grader_has_thinking_budget_zero(self):
@@ -134,6 +134,14 @@ class TestThinkingBudgetContext:
         content = self._read_service_file("omo_grader.py")
         assert _GENERATE_CONTENT_CONFIG_PATTERN.search(content), (
             "omo_grader.py does not use GenerateContentConfig."
+        )
+
+    def test_gemini_client_uses_generate_content_config(self):
+        """ai/gemini_client.py uses GenerateContentConfig."""
+        content = self._read_service_file("ai/gemini_client.py")
+        assert _GENERATE_CONTENT_CONFIG_PATTERN.search(content), (
+            "ai/gemini_client.py does not use GenerateContentConfig. "
+            "If the LLM call pattern changed, update this test."
         )
 
     def test_all_guarded_files_exist(self):

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -9,7 +9,7 @@
  * Header removed (2026-04-18): all header functionality (logo, story title,
  * notification bell, zhuyin toggle, logout) is now integrated into Sidebar.
  */
-import React, { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useWorkspace } from '../../contexts/WorkspaceContext';
@@ -100,23 +100,39 @@ const StepDots: React.FC<StepDotsProps> = ({
   completedSet,
   onStepClick,
 }) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const activeEl = container.querySelector('[aria-current="step"]');
+    if (activeEl) {
+      activeEl.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  }, [currentStepIndex, steps.length]);
+
   return (
-    <div className="flex items-center gap-2 md:gap-3 flex-wrap justify-center min-w-0">
+    <div
+      ref={scrollRef}
+      className="flex-1 min-w-0 overflow-x-auto scrollbar-hide overscroll-x-contain"
+      aria-label="學習步驟進度"
+    >
+      <div className="flex items-center gap-1.5 sm:gap-2 md:gap-3 flex-nowrap justify-center min-w-max px-0.5">
       {steps.map((step, i) => {
         const isCompleted = completedSet.has(step.id);
         const isActive = i === currentStepIndex;
 
         let dotClass = 'bg-on-surface-variant/20 text-on-surface-variant';
         if (isCompleted) dotClass = 'bg-emerald-500 text-white';
-        if (isActive) dotClass = 'bg-accent text-white scale-110';
+        if (isActive) dotClass = 'bg-accent text-white ring-2 ring-accent/30';
         const displayChar = step.displayChar ?? String(i + 1);
 
         return (
-          <span key={step.id} className="group relative flex items-center justify-center">
+          <span key={step.id} className="group relative flex items-center justify-center shrink-0">
             <button
               type="button"
               onClick={() => onStepClick(step)}
-              className={`w-8 h-8 md:w-9 md:h-9 rounded-full text-sm md:text-base font-bold flex items-center justify-center transition-all hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
+              className={`w-7 h-7 sm:w-8 sm:h-8 md:w-9 md:h-9 rounded-full text-xs sm:text-sm md:text-base font-bold flex items-center justify-center transition-all hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 ${dotClass}`}
               aria-label={`${i + 1}. ${step.label}`}
               aria-current={isActive ? 'step' : undefined}
               title={step.label}
@@ -144,6 +160,7 @@ const StepDots: React.FC<StepDotsProps> = ({
           </span>
         );
       })}
+      </div>
     </div>
   );
 };
@@ -255,16 +272,16 @@ const ImmersiveTopBar: React.FC = () => {
             Toolbox mode (#1460): hide entirely — single-shot practice has no
             cross-step navigation. Other steps remain unreachable from here. */}
         {!inToolbox && (
-          <div className="flex items-center gap-1 max-w-full min-w-0 h-8 md:h-10" role="navigation" aria-label="學習步驟導航">
+          <div className="flex items-center gap-0.5 sm:gap-1 w-full max-w-full min-w-0 h-8 md:h-10" role="navigation" aria-label="學習步驟導航">
             <button
               type="button"
               onClick={() => prevStep && handleStepClick(prevStep)}
               disabled={!prevStep || !selectedStory}
-              className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="shrink-0 w-7 h-7 sm:w-8 sm:h-8 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               aria-label={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
               title={prevStep ? `上一步：${prevStep.label}` : '已是第一步'}
             >
-              <span className="material-symbols-outlined leading-none" style={{ fontSize: '28px' }}>chevron_left</span>
+              <span className="material-symbols-outlined leading-none text-2xl sm:text-[28px]">chevron_left</span>
             </button>
 
             <StepDots
@@ -278,11 +295,11 @@ const ImmersiveTopBar: React.FC = () => {
               type="button"
               onClick={() => nextStep && handleStepClick(nextStep)}
               disabled={!nextStep || !selectedStory}
-              className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              className="shrink-0 w-7 h-7 sm:w-8 sm:h-8 flex items-center justify-center rounded-full text-on-surface-variant hover:bg-surface-container-high hover:text-on-surface disabled:opacity-30 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
               aria-label={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
               title={nextStep ? `下一步：${nextStep.label}` : '已是最後一步'}
             >
-              <span className="material-symbols-outlined leading-none" style={{ fontSize: '28px' }}>chevron_right</span>
+              <span className="material-symbols-outlined leading-none text-2xl sm:text-[28px]">chevron_right</span>
             </button>
           </div>
         )}

--- a/frontend/src/components/ui/ZhuyinToggle.tsx
+++ b/frontend/src/components/ui/ZhuyinToggle.tsx
@@ -37,7 +37,7 @@ export default function ZhuyinToggle({ mode, ready, onModeChange }: ZhuyinToggle
             aria-pressed={isActive}
             aria-label={seg.title}
             title={seg.title}
-            className={`h-9 px-3 rounded-full font-headline font-bold text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 active:scale-95 whitespace-nowrap ${
+            className={`h-8 sm:h-9 px-2 sm:px-3 rounded-full font-headline font-bold text-xs sm:text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 active:scale-95 whitespace-nowrap ${
               isActive
                 ? 'bg-accent text-white shadow-[0_2px_10px_rgba(86,74,191,0.35)]'
                 : 'text-on-surface-variant hover:bg-surface-container-highest hover:text-on-surface'


### PR DESCRIPTION
## Summary
- Remove `thinking_config` from Gemini TTS `GenerateContentConfig` — `gemini-3.1-flash-tts-preview` returns 400 when thinking is set, which surfaced as 503 on GCS cache miss during AI 朗讀
- Update regression guard #1738 to track `ai/gemini_client.py` (post-#1953 shim) and assert TTS must **not** use `thinking_config`
- Immersive top bar step dots: horizontal scroll on narrow screens instead of wrap/overlap; minor Zhuyin toggle mobile sizing

## Test plan
- [x] `pytest backend/tests/test_regression_thinking_budget_1738.py` (11 passed)
- [x] `pytest backend/tests/test_tts_service.py` (63 passed)
- [x] `npm test -- src/__tests__/ttsApi.test.ts` (5 passed)
- [ ] Staging: trigger AI 朗讀 on a lesson with cache miss — expect 200 + audio, not 503
- [ ] Staging: narrow viewport (~375px) — step dots scroll horizontally, no overlap with title/arrows


Made with [Cursor](https://cursor.com)