### PR TITLE
fix(spec): annotation router contract for FastAPI 0.137

### DIFF
--- a/backend/specs/test_reading_annotation_spec.py
+++ b/backend/specs/test_reading_annotation_spec.py
@@ -142,11 +142,26 @@ def test_annotation_save_request_max_500():
 # Contract: Router is registered
 # ---------------------------------------------------------------------------
 
+def _collect_route_paths(router) -> list[str]:
+    """Collect route paths from a router, including nested include_router() trees."""
+    paths: list[str] = []
+    for route in router.routes:
+        path = getattr(route, "path", None)
+        if path:
+            paths.append(path)
+        nested = getattr(route, "original_router", None)
+        if nested is not None:
+            paths.extend(_collect_route_paths(nested))
+    return paths
+
+
 def test_annotations_router_registered():
     """Contract: annotations router is registered in the learning package."""
     from app.routes.learning import router
-    routes = [r.path for r in router.routes if hasattr(r, "path")]
-    annotation_routes = [r for r in routes if "annotations" in r]
+
+    annotation_routes = [
+        p for p in _collect_route_paths(router) if "annotations" in p
+    ]
     assert len(annotation_routes) >= 2, (
         f"Expected at least 2 annotation routes (GET + PUT), found: {annotation_routes}"
     )


### PR DESCRIPTION
## Summary
- 修 `test_annotations_router_registered`：FastAPI 0.137 把 `include_router()` 改成 `_IncludedRouter` 巢狀結構，舊測試只掃頂層 `router.routes` 會拿到 `[]`
- 新增 `_collect_route_paths()` 遞迴走 `original_router`，同時相容 0.133（扁平 APIRoute）與 0.137+（巢狀）

## Test plan
- [x] `pytest specs/test_reading_annotation_spec.py::test_annotations_router_registered`（venv 3.10 + python3.11）
- [ ] CI Spec Check 綠燈後 merge to staging


Made with [Cursor](https://cursor.com)