### PR TITLE
fix(live-tutor): pending 錄音三按鈕 + 隱藏舊評估

### DIFF
--- a/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutor.tsx
@@ -29,6 +29,7 @@ import { getLineResultForParagraph } from './liveTutorTypes';
 import {
   planParagraphEvalRestore,
   resolveDisplayLastDiffTokens,
+  resolveDisplayParagraphSummary,
 } from './paragraphEvalRestore';
 
 /* ------------------------------------------------------------------ */
@@ -377,8 +378,21 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
     setHasDetectedAudio(false);
     hasHeardAudioRef.current = false;
     volumeAboveSinceRef.current = null;
+    dispatch({ type: 'SET_STREAMING', value: '' });
+    dispatch({ type: 'SET_REALTIME_DIFF', tokens: null });
     startSession();
-  }, [clearPendingRecording, paragraphRecorder, clearParagraphFallback, startSession]);
+  }, [clearPendingRecording, paragraphRecorder, clearParagraphFallback, startSession, dispatch]);
+
+  const confirmCancel = useCallback(() => {
+    clearPendingRecording();
+    paragraphRecorder.clearRecording();
+    clearParagraphFallback();
+    setHasDetectedAudio(false);
+    hasHeardAudioRef.current = false;
+    volumeAboveSinceRef.current = null;
+    dispatch({ type: 'SET_STREAMING', value: '' });
+    dispatch({ type: 'SET_REALTIME_DIFF', tokens: null });
+  }, [clearPendingRecording, paragraphRecorder, clearParagraphFallback, dispatch]);
 
   const confirmEvaluate = useCallback(async () => {
     const pending = pendingRecordingRef.current;
@@ -620,10 +634,17 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
 
   const paragraphSummary = paragraphSummaries[currentLineIndex] ?? null;
   const savedLineResult = getLineResultForParagraph(lineResults, currentLineIndex);
+  const hideStaleEval =
+    stt.isSessionActive || recordingPendingReview || isSubmittingSentence;
   const displayLastDiffTokens = resolveDisplayLastDiffTokens(
     evalState.lastDiffTokens,
     paragraphSummary,
     savedLineResult,
+    hideStaleEval,
+  );
+  const displayParagraphSummary = resolveDisplayParagraphSummary(
+    paragraphSummary,
+    hideStaleEval,
   );
 
   /* ================================================================ */
@@ -660,7 +681,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
               lastDiffTokens={displayLastDiffTokens}
               isAwaitingGemini={evalState.isAwaitingGemini}
               retryCount={evalState.retryCount}
-              paragraphSummary={paragraphSummary}
+              paragraphSummary={displayParagraphSummary}
               completedParagraphs={completedParagraphs}
               storyLength={story.content.length}
               lineResults={lineResults}
@@ -768,6 +789,7 @@ const LiveTutor: React.FC<LiveTutorProps> = ({
         onFinishRecording={finishRecording}
         onConfirmEvaluate={confirmEvaluate}
         onConfirmRerecord={confirmRerecord}
+        onConfirmCancel={confirmCancel}
         onSpeakCurrentParagraph={speakCurrentParagraph}
         onPauseResumeTts={isTtsPaused ? resumeTts : pauseTts}
         onStopTts={stopTts}

--- a/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/LiveTutorControls.tsx
@@ -33,6 +33,8 @@ interface LiveTutorControlsProps {
   onConfirmEvaluate: () => void;
   /** Discard pending recording and record again. */
   onConfirmRerecord: () => void;
+  /** Discard pending recording and return to idle (restore prior eval if any). */
+  onConfirmCancel: () => void;
   onSpeakCurrentParagraph: () => void;
   onPauseResumeTts: () => void;
   onStopTts: () => void;
@@ -44,7 +46,7 @@ interface LiveTutorControlsProps {
  * Renders the correct button state based on session phase.
  *
  * Recording state (isSessionActive): pulsing red mic + elapsed timer + green 完成 button.
- * After 完成: 評估 / 重錄 — only 評估 triggers API scoring.
+ * After 完成: 評估 / 重錄 / 取消 — only 評估 triggers API scoring.
  */
 const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   isSessionActive,
@@ -67,6 +69,7 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
   onFinishRecording,
   onConfirmEvaluate,
   onConfirmRerecord,
+  onConfirmCancel,
   onSpeakCurrentParagraph,
   onPauseResumeTts,
   onStopTts,
@@ -140,24 +143,32 @@ const LiveTutorControls: React.FC<LiveTutorControlsProps> = ({
             {recordingPendingReview && !isSubmittingSentence ? (
               <>
                 <p className="text-sm text-on-surface-variant text-center">
-                  錄音已暫停。滿意再送評估，不滿意可重錄。
+                  錄音已暫停。滿意請按評估；想再錄按重錄；不要這次錄音請按取消。
                 </p>
-                <div className="w-full flex gap-3">
+                <div className="w-full flex gap-2">
+                  <button
+                    type="button"
+                    onClick={onConfirmCancel}
+                    className="flex-1 h-14 rounded-full font-headline font-bold text-base bg-surface-container-lowest shadow-editorial text-on-surface-variant hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-1.5"
+                  >
+                    <span className="material-symbols-outlined text-lg">close</span>
+                    取消
+                  </button>
                   <button
                     type="button"
                     onClick={onConfirmRerecord}
-                    className="flex-1 h-14 rounded-full font-headline font-bold text-lg bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+                    className="flex-1 h-14 rounded-full font-headline font-bold text-base bg-surface-container-lowest shadow-editorial text-on-surface hover:bg-surface-container-low active:scale-[0.98] transition-all flex items-center justify-center gap-1.5"
                   >
-                    <span className="material-symbols-outlined text-xl">replay</span>
+                    <span className="material-symbols-outlined text-lg">replay</span>
                     重錄
                   </button>
                   <button
                     type="button"
                     onClick={onConfirmEvaluate}
-                    className="flex-1 h-14 rounded-full font-headline font-bold text-xl text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)] active:scale-[0.98] transition-all flex items-center justify-center gap-2"
+                    className="flex-1 h-14 rounded-full font-headline font-bold text-lg text-white shadow-[0_12px_48px_rgba(0,105,71,0.3)] active:scale-[0.98] transition-all flex items-center justify-center gap-1.5"
                     style={{ background: 'linear-gradient(135deg, #006947, #34d399)' }}
                   >
-                    <span className="material-symbols-outlined text-xl">check_circle</span>
+                    <span className="material-symbols-outlined text-lg">check_circle</span>
                     評估
                   </button>
                 </div>

--- a/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
+++ b/frontend/src/components/reading-steps/live-tutor/ParagraphCard.tsx
@@ -104,10 +104,7 @@ const ParagraphCard: React.FC<ParagraphCardProps> = ({
   const isCurrentIdx = idx === currentLineIndex;
   const { karaokeEnabled } = useKaraoke();
 
-  const savedLineResult = getLineResultForParagraph(lineResults, idx);
-  const displayDiffTokens =
-    lastDiffTokens
-    ?? (paragraphSummary ? savedLineResult?.diffTokens ?? null : null);
+  const displayDiffTokens = lastDiffTokens;
 
   const readingResultTokens = useMemo(
     () => (displayDiffTokens ? interleavePunctuation(line, displayDiffTokens) : null),

--- a/frontend/src/components/reading-steps/live-tutor/paragraphEvalRestore.test.ts
+++ b/frontend/src/components/reading-steps/live-tutor/paragraphEvalRestore.test.ts
@@ -3,6 +3,7 @@ import type { DiffToken } from '../../../types';
 import {
   planParagraphEvalRestore,
   resolveDisplayLastDiffTokens,
+  resolveDisplayParagraphSummary,
 } from './paragraphEvalRestore';
 import type { LineResult, ParagraphSummaryData } from './liveTutorTypes';
 
@@ -76,5 +77,21 @@ describe('resolveDisplayLastDiffTokens — revisit diff fallback', () => {
 
   it('returns null when no summary and no live tokens', () => {
     expect(resolveDisplayLastDiffTokens(null, null, lineResult)).toBeNull();
+  });
+
+  it('hides stale saved diff while recording or pending review', () => {
+    expect(resolveDisplayLastDiffTokens(null, summary, lineResult, true)).toBeNull();
+    const live: DiffToken[] = [{ char: '好', type: 'correct' }];
+    expect(resolveDisplayLastDiffTokens(live, summary, lineResult, true)).toBeNull();
+  });
+});
+
+describe('resolveDisplayParagraphSummary — pending take UX', () => {
+  it('returns summary when not hiding stale eval', () => {
+    expect(resolveDisplayParagraphSummary(summary, false)).toBe(summary);
+  });
+
+  it('returns null while hiding stale eval', () => {
+    expect(resolveDisplayParagraphSummary(summary, true)).toBeNull();
   });
 });

--- a/frontend/src/components/reading-steps/live-tutor/paragraphEvalRestore.ts
+++ b/frontend/src/components/reading-steps/live-tutor/paragraphEvalRestore.ts
@@ -36,11 +36,27 @@ export function planParagraphEvalRestore(
   return { kind: 'clear' };
 }
 
-/** When eval state was cleared on revisit, fall back to persisted line result diff. */
+/**
+ * When eval state was cleared on revisit, fall back to persisted line result diff.
+ * While recording or awaiting 評估/重錄/取消, hide stale results so 完成 does not
+ * flash the previous score before the student commits.
+ */
 export function resolveDisplayLastDiffTokens(
   lastDiffTokens: DiffToken[] | null,
   paragraphSummary: ParagraphSummaryData | null,
   savedLineResult: LineResult | undefined,
+  hideStaleEval = false,
 ): DiffToken[] | null {
+  if (hideStaleEval) {
+    return null;
+  }
   return lastDiffTokens ?? (paragraphSummary ? savedLineResult?.diffTokens ?? null : null);
+}
+
+/** Hide persisted summary while a new take is in progress or pending review. */
+export function resolveDisplayParagraphSummary(
+  paragraphSummary: ParagraphSummaryData | null,
+  hideStaleEval: boolean,
+): ParagraphSummaryData | null {
+  return hideStaleEval ? null : paragraphSummary;
 }


### PR DESCRIPTION
## Summary
- 按「完成」進入 pending 時，不再閃現上一輪朗讀結果與 summary
- 底部改為 **取消 / 重錄 / 評估** 三按鈕：取消回 idle 並還原舊分、重錄立刻再開麥、評估才送後端
- 錄音中與評分中也隱藏舊資料，避免誤判已評完

## Test plan
- [ ] 已有評估的段落：開始朗讀 → 完成 → 確認舊 diff/summary 不顯示，僅見三按鈕
- [ ] 按「取消」→ 舊評估恢復、回到 AI 朗讀 + 開始朗讀
- [ ] 按「重錄」→ 直接再錄，舊資料仍隱藏
- [ ] 按「評估」→ 評分完成後顯示新結果
- [ ] 首次錄音（無舊資料）：取消回 idle 無殘留狀態
- [x] `npm test -- --run paragraphEvalRestore.test.ts`（11 passed）


Made with [Cursor](https://cursor.com)