### PR TITLE
fix(vocab-definition): allow free switch between MCQ and drag-drop

### DIFF
--- a/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatch.tsx
@@ -75,6 +75,34 @@ function NoDataFallback({ onFinish }: { onFinish: () => void }) {
   );
 }
 
+function StageCompletedPlaceholder({
+  title,
+  otherModeLabel,
+  otherDone,
+  onGoOther,
+}: {
+  title: string;
+  otherModeLabel: string;
+  otherDone: boolean;
+  onGoOther: () => void;
+}) {
+  return (
+    <div className="max-w-md mx-auto px-4 py-16 text-center space-y-4">
+      <span className="material-symbols-outlined text-5xl text-emerald-500">check_circle</span>
+      <p className="text-lg font-headline font-bold text-on-surface">{title} 已完成</p>
+      {!otherDone && (
+        <button type="button" onClick={onGoOther} className="btn-immersive">
+          前往{otherModeLabel}
+          <span className="material-symbols-outlined text-lg ml-1">arrow_forward</span>
+        </button>
+      )}
+      {otherDone && (
+        <p className="text-sm text-on-surface-variant">兩關都完成了，正在準備成績…</p>
+      )}
+    </div>
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Main Component (thin orchestrator)                                  */
 /* ------------------------------------------------------------------ */
@@ -195,15 +223,42 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
     shuffledWords.current = shuffle(indices);
   }, []);
 
+  const mcDone = mcAnswers.length > 0;
+  const dragDropDone = dragDropAnswers.length > 0;
+
+  const goToSummaryIfBothDone = useCallback(
+    (nextMcAnswers: AnswerRecord[], nextDragDropAnswers: AnswerRecord[]) => {
+      if (nextMcAnswers.length > 0 && nextDragDropAnswers.length > 0) {
+        setPhase('summary');
+      }
+    },
+    [],
+  );
+
+  const handleSelectMode = useCallback(
+    (nextMode: InteractionMode) => {
+      if (nextMode === mode) return;
+      setMode(nextMode);
+      if (nextMode === 'multiple-choice' && !mcDone) {
+        setActiveDefIndices(allIndices);
+      }
+      if (nextMode === 'drag-drop' && !dragDropDone) {
+        setActiveDefIndices(allIndices);
+        shuffledWords.current = shuffle(allIndices);
+      }
+    },
+    [mode, mcDone, dragDropDone, allIndices],
+  );
+
   const handleAllDone = useCallback((answers: AnswerRecord[]) => {
     if (mode === 'multiple-choice') {
       setMcAnswers(answers);
-      startStage('drag-drop', allIndices);
+      goToSummaryIfBothDone(answers, dragDropAnswers);
       return;
     }
     setDragDropAnswers(answers);
-    setPhase('summary');
-  }, [mode, startStage, allIndices]);
+    goToSummaryIfBothDone(mcAnswers, answers);
+  }, [mode, mcAnswers, dragDropAnswers, goToSummaryIfBothDone]);
 
   const handleRetryModeWrong = useCallback((targetMode: InteractionMode) => {
     const sourceAnswers = targetMode === 'multiple-choice' ? mcAnswers : dragDropAnswers;
@@ -253,24 +308,43 @@ const VocabDefinitionMatch: React.FC<VocabDefinitionMatchProps> = ({
           <>
             <StageStatus
               current={mode}
-              mcDone={mcAnswers.length > 0}
-              dragDropDone={dragDropAnswers.length > 0}
+              mcDone={mcDone}
+              dragDropDone={dragDropDone}
+              onSelectMode={handleSelectMode}
             />
 
             {mode === 'multiple-choice' && (
-              <MultipleChoiceMode
-                vocab={vocab}
-                activeDefIndices={activeDefIndices}
-                onAllDone={handleAllDone}
-              />
+              mcDone ? (
+                <StageCompletedPlaceholder
+                  title="選擇題"
+                  otherModeLabel="拖拉配對"
+                  otherDone={dragDropDone}
+                  onGoOther={() => handleSelectMode('drag-drop')}
+                />
+              ) : (
+                <MultipleChoiceMode
+                  vocab={vocab}
+                  activeDefIndices={activeDefIndices}
+                  onAllDone={handleAllDone}
+                />
+              )
             )}
             {mode === 'drag-drop' && (
-              <DragDropMode
-                vocab={vocab}
-                activeDefIndices={activeDefIndices}
-                shuffledWords={shuffledWords.current}
-                onAllDone={handleAllDone}
-              />
+              dragDropDone ? (
+                <StageCompletedPlaceholder
+                  title="拖拉配對"
+                  otherModeLabel="選擇題"
+                  otherDone={mcDone}
+                  onGoOther={() => handleSelectMode('multiple-choice')}
+                />
+              ) : (
+                <DragDropMode
+                  vocab={vocab}
+                  activeDefIndices={activeDefIndices}
+                  shuffledWords={shuffledWords.current}
+                  onAllDone={handleAllDone}
+                />
+              )
             )}
           </>
         )}

--- a/frontend/src/components/reading-steps/VocabDefinitionMatchStageStatus.tsx
+++ b/frontend/src/components/reading-steps/VocabDefinitionMatchStageStatus.tsx
@@ -1,75 +1,91 @@
 /**
  * StageStatus — Two-step progress indicator for VocabDefinitionMatch (#1846)
  *
- * Extracted from VocabDefinitionMatch.tsx. Stateless UI component.
+ * Extracted from VocabDefinitionMatch.tsx. Both steps are freely selectable —
+ * drag-drop is no longer locked behind multiple-choice completion.
  */
 import React from 'react';
-import { Lock } from 'lucide-react';
 import { InteractionMode } from './vocabDefinitionMatchLogic';
 
 export interface StageStatusProps {
   current: InteractionMode;
   mcDone: boolean;
   dragDropDone: boolean;
+  onSelectMode: (mode: InteractionMode) => void;
 }
 
-export function StageStatus({ current, mcDone, dragDropDone }: StageStatusProps) {
+function StepButton({
+  label,
+  stepNumber,
+  done,
+  active,
+  onClick,
+}: {
+  label: string;
+  stepNumber: number;
+  done: boolean;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-col items-center gap-1 rounded-xl px-2 py-1 transition-colors hover:bg-surface-container-low focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      aria-current={active ? 'step' : undefined}
+      aria-label={`${label}${done ? '（已完成）' : ''}`}
+    >
+      <div
+        className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold border-2 transition-colors ${
+          done
+            ? 'bg-emerald-500 border-emerald-500 text-white'
+            : active
+              ? 'bg-accent border-accent text-white'
+              : 'bg-white border-gray-300 text-gray-500'
+        }`}
+      >
+        {done ? '✓' : stepNumber}
+      </div>
+      <span
+        className={`text-xs font-semibold whitespace-nowrap ${
+          active ? 'text-accent' : done ? 'text-emerald-600' : 'text-gray-500'
+        }`}
+      >
+        {label}
+      </span>
+    </button>
+  );
+}
+
+export function StageStatus({ current, mcDone, dragDropDone, onSelectMode }: StageStatusProps) {
   const step1Active = current === 'multiple-choice';
   const step2Active = current === 'drag-drop';
-  const step2Locked = !mcDone;
+  const anyDone = mcDone || dragDropDone;
 
   return (
-    <div className="flex items-center justify-center gap-0 mb-6 max-w-sm mx-auto select-none">
-      {/* Step 1 */}
-      <div className="flex flex-col items-center gap-1">
-        <div
-          className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold border-2 transition-colors ${
-            mcDone
-              ? 'bg-emerald-500 border-emerald-500 text-white'
-              : step1Active
-                ? 'bg-accent border-accent text-white'
-                : 'bg-white border-gray-300 text-gray-400'
-          }`}
-        >
-          {mcDone ? '✓' : '1'}
-        </div>
-        <span
-          className={`text-xs font-semibold whitespace-nowrap ${
-            step1Active ? 'text-accent' : mcDone ? 'text-emerald-600' : 'text-gray-400'
-          }`}
-        >
-          選擇題
-        </span>
-      </div>
-
-      {/* Connector line */}
-      <div
-        className={`h-0.5 w-12 mb-4 transition-colors ${
-          mcDone ? 'bg-emerald-400' : 'bg-gray-200'
-        }`}
+    <div className="flex items-center justify-center gap-0 mb-6 max-w-sm mx-auto">
+      <StepButton
+        label="選擇題"
+        stepNumber={1}
+        done={mcDone}
+        active={step1Active}
+        onClick={() => onSelectMode('multiple-choice')}
       />
 
-      {/* Step 2 */}
-      <div className="flex flex-col items-center gap-1">
-        <div
-          className={`w-9 h-9 rounded-full flex items-center justify-center text-sm font-bold border-2 transition-colors ${
-            dragDropDone
-              ? 'bg-emerald-500 border-emerald-500 text-white'
-              : step2Active
-                ? 'bg-accent border-accent text-white'
-                : 'bg-gray-100 border-gray-200 text-gray-300'
-          }`}
-        >
-          {dragDropDone ? '✓' : step2Locked ? <Lock size={14} /> : '2'}
-        </div>
-        <span
-          className={`text-xs font-semibold whitespace-nowrap ${
-            step2Active ? 'text-accent' : dragDropDone ? 'text-emerald-600' : 'text-gray-300'
-          }`}
-        >
-          拖拉配對
-        </span>
-      </div>
+      <div
+        className={`h-0.5 w-12 mb-4 transition-colors ${
+          anyDone ? 'bg-emerald-400' : 'bg-gray-200'
+        }`}
+        aria-hidden
+      />
+
+      <StepButton
+        label="拖拉配對"
+        stepNumber={2}
+        done={dragDropDone}
+        active={step2Active}
+        onClick={() => onSelectMode('drag-drop')}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 詞語理解第二關「拖拉配對」不再鎖在選擇題之後
- Step tabs 可自由切換 MCQ / 拖拉配對，順序自訂
- 兩關都完成才進入成績摘要

## Test plan
- [ ] 登入學生 → 進入含詞語理解的課文
- [ ] 確認可直接點「拖拉配對」不需先做完選擇題
- [ ] 完成一關後可切到另一關
- [ ] 兩關都完成後顯示 summary

Made with [Cursor](https://cursor.com)