### PR TITLE
fix(full-reading): show 朗讀結果 instead of 逐字比對 panel (Related to #2187)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -390,8 +390,8 @@ const FullReading: React.FC<FullReadingProps> = ({
                 audioUrl={audioRecorder.audioUrl ?? null}
               />
 
-              {/* 逐字比對 diff (Issue #1960 — FullReadingFeedbackPanel) */}
-              <FullReadingFeedbackPanel diffTokens={result.diffTokens} />
+              {/* 朗讀結果 (Issue #1960 — same style as LiveTutor ParagraphCard) */}
+              <FullReadingFeedbackPanel diffTokens={result.diffTokens} targetText={fullText} />
 
               {/* 正確率 + 語速 metrics card (Issue #1505) */}
               <ReadingMetricsCard

--- a/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
@@ -1,28 +1,54 @@
 /**
- * FullReadingFeedbackPanel — Per-token diff display (Issue #1960).
+ * FullReadingFeedbackPanel — Color-coded reading result (Issue #1960).
  *
- * Extracted from FullReading.tsx result section.
- * Renders the 逐字比對 card using DiffDisplay when diffTokens are present.
- *
- * Intentionally minimal: only renders when tokens exist and length > 0.
+ * Matches LiveTutor ParagraphCard: show 朗讀結果 inline colors,
+ * not the DiffDisplay 逐字比對 legend panel.
  */
 
-import React from 'react';
-import DiffDisplay from '../../ui/DiffDisplay';
+import React, { useMemo } from 'react';
 import { DiffToken } from '../../../types';
+import { interleavePunctuation } from '../../../utils/textDiff';
 
 export interface FullReadingFeedbackPanelProps {
   /** Token array from reading evaluation. undefined or empty → renders nothing. */
   diffTokens: DiffToken[] | undefined;
+  /** Full lesson text — punctuation is interleaved for display. */
+  targetText: string;
 }
 
-const FullReadingFeedbackPanel: React.FC<FullReadingFeedbackPanelProps> = ({ diffTokens }) => {
-  if (!diffTokens || diffTokens.length === 0) return null;
+const FullReadingFeedbackPanel: React.FC<FullReadingFeedbackPanelProps> = ({
+  diffTokens,
+  targetText,
+}) => {
+  const readingResultTokens = useMemo(
+    () => (diffTokens && diffTokens.length > 0 ? interleavePunctuation(targetText, diffTokens) : null),
+    [targetText, diffTokens],
+  );
+
+  if (!readingResultTokens || readingResultTokens.length === 0) return null;
 
   return (
     <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
-      <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">逐字比對</p>
-      <DiffDisplay tokens={diffTokens} showLegend className="text-lg" />
+      <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">
+        朗讀結果
+      </p>
+      <p className="text-lg leading-relaxed">
+        {readingResultTokens.map((t, i) => (
+          <span
+            key={i}
+            className={
+              t.type === 'punctuation' ? 'text-on-surface' :
+              t.type === 'correct' ? 'text-emerald-600 font-medium' :
+              t.type === 'forgiven' ? 'text-blue-500' :
+              t.type === 'wrong' ? 'text-tertiary line-through' :
+              t.type === 'missing' || t.type === 'unread' ? 'text-on-surface-variant/30' :
+              'text-on-surface'
+            }
+          >
+            {t.char}
+          </span>
+        ))}
+      </p>
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingScoreCard.tsx
@@ -6,7 +6,7 @@
  *   - 你說的 streaming transcript (optional)
  *   - 重聽錄音 audio playback (optional)
  *
- * Note: DiffDisplay (逐字比對) is intentionally kept in FullReadingFeedbackPanel
+ * Note: 朗讀結果 color display is in FullReadingFeedbackPanel
  * to keep this component focused on the summary score + playback.
  */
 

--- a/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
+++ b/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
@@ -325,28 +325,29 @@ import FullReadingFeedbackPanel from '../FullReadingFeedbackPanel';
 import type { DiffToken as DT2 } from '../../../../types';
 
 describe('FullReadingFeedbackPanel', () => {
-  it('renders diff section when diffTokens are present', () => {
+  it('renders 朗讀結果 when diffTokens are present', () => {
     const diffTokens: DT2[] = [
       { char: '你', type: 'correct' },
       { char: '好', type: 'wrong', expected: '世' },
     ];
     render(
-      <FullReadingFeedbackPanel diffTokens={diffTokens} />
+      <FullReadingFeedbackPanel diffTokens={diffTokens} targetText="你好" />
     );
-    expect(screen.getByText('逐字比對')).toBeInTheDocument();
-  });
-
-  it('does not render diff section when diffTokens is empty', () => {
-    render(
-      <FullReadingFeedbackPanel diffTokens={[]} />
-    );
+    expect(screen.getByText('朗讀結果')).toBeInTheDocument();
     expect(screen.queryByText('逐字比對')).not.toBeInTheDocument();
   });
 
-  it('does not render diff section when diffTokens is undefined', () => {
+  it('does not render result section when diffTokens is empty', () => {
     render(
-      <FullReadingFeedbackPanel diffTokens={undefined} />
+      <FullReadingFeedbackPanel diffTokens={[]} targetText="你好" />
     );
-    expect(screen.queryByText('逐字比對')).not.toBeInTheDocument();
+    expect(screen.queryByText('朗讀結果')).not.toBeInTheDocument();
+  });
+
+  it('does not render result section when diffTokens is undefined', () => {
+    render(
+      <FullReadingFeedbackPanel diffTokens={undefined} targetText="你好" />
+    );
+    expect(screen.queryByText('朗讀結果')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Replace full-reading「逐字比對」DiffDisplay + legend with「朗讀結果」inline color coding, matching LiveTutor ParagraphCard
- Pass full lesson `targetText` so punctuation interleaves correctly in the result view

## Test plan
- [x] `npm run test -- --run src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx` (19 passed)
- [ ] Staging: `/learn/{id}/full-reading` → complete one reading → verify「朗讀結果」shows green/red/faded chars, no「逐字比對」legend


Made with [Cursor](https://cursor.com)