### PR TITLE
fix(frontend): remove double underline in fill-in-blank placeholder (Related to #2082)

### DIFF
--- a/frontend/src/components/reading-steps/FillInBlankExercise.tsx
+++ b/frontend/src/components/reading-steps/FillInBlankExercise.tsx
@@ -19,6 +19,10 @@ import { scopedStepStorageKey, isToolboxMode } from '../../services/learningStor
 import ToolboxCompletionActions from '../tools/ToolboxCompletionActions';
 import { FILLBLANK_SHOW_ABCD, FILLBLANK_OPTION_MODE } from '../../config/featureFlags';
 
+// A8: Detect touch (coarse pointer) vs mouse at mount time.
+const IS_TOUCH_DEVICE =
+  typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
+
 // ── localStorage key for first-use onboarding gate ────────────────────────
 const FILLBLANK_ONBOARDED_KEY = 'fillblank_onboarded';
 
@@ -360,9 +364,12 @@ const FillInBlankExercise: React.FC<Props> = ({ sentences, vocabBank, onComplete
         </span>
       )
       : (
-        // A11: smaller dashed underline blank, not big pill
-        <span className="inline-block border-b-2 border-dashed border-on-surface-variant/40 mx-1 text-on-surface-variant/40 text-center min-w-[3.5em] pb-0.5">
-          ＿＿
+        // A11: single dashed underline blank (no ＿＿ glyphs — they doubled the line)
+        <span
+          className="inline-block border-b-2 border-dashed border-on-surface-variant/40 mx-1 min-w-[3.5em] pb-0.5"
+          aria-label="填空"
+        >
+          {'\u3000'}
         </span>
       );
 


### PR DESCRIPTION
## Summary
- 語詞應用填空區 placeholder 同時有全形底線 `＿＿` + CSS `border-dashed`，視覺上變成兩條橫線
- 改為只保留虛線底線，用全形空格 `\u3000` 維持寬度

## Test plan
- [x] `npm run build` 通過
- [ ] staging `/learn/1076/vocab-application` 填空區只剩一條虛線


Made with [Cursor](https://cursor.com)