### PR TITLE
fix(frontend): split full-reading result into indented paragraphs (Related to #1960)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -391,7 +391,11 @@ const FullReading: React.FC<FullReadingProps> = ({
               />
 
               {/* 朗讀結果 (Issue #1960 — same style as LiveTutor ParagraphCard) */}
-              <FullReadingFeedbackPanel diffTokens={result.diffTokens} targetText={fullText} />
+              <FullReadingFeedbackPanel
+                diffTokens={result.diffTokens}
+                targetText={fullText}
+                paragraphs={story.content}
+              />
 
               {/* 正確率 + 語速 metrics card (Issue #1505) */}
               <ReadingMetricsCard

--- a/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
+++ b/frontend/src/components/reading-steps/full-reading/FullReadingFeedbackPanel.tsx
@@ -14,41 +14,68 @@ export interface FullReadingFeedbackPanelProps {
   diffTokens: DiffToken[] | undefined;
   /** Full lesson text — punctuation is interleaved for display. */
   targetText: string;
+  /** Lesson paragraphs — when provided and join to targetText, split 朗讀結果 by paragraph. */
+  paragraphs?: string[];
+}
+
+function diffTokenClassName(type: DiffToken['type']): string {
+  return type === 'punctuation' ? 'text-on-surface' :
+    type === 'correct' ? 'text-emerald-600 font-medium' :
+    type === 'forgiven' ? 'text-blue-500' :
+    type === 'wrong' ? 'text-tertiary line-through' :
+    type === 'missing' || type === 'unread' ? 'text-on-surface-variant/30' :
+    'text-on-surface';
+}
+
+function renderDiffTokenSpans(tokens: DiffToken[], keyPrefix: string) {
+  return tokens.map((t, i) => (
+    <span key={`${keyPrefix}-${i}`} className={diffTokenClassName(t.type)}>
+      {t.char}
+    </span>
+  ));
 }
 
 const FullReadingFeedbackPanel: React.FC<FullReadingFeedbackPanelProps> = ({
   diffTokens,
   targetText,
+  paragraphs,
 }) => {
   const readingResultTokens = useMemo(
     () => (diffTokens && diffTokens.length > 0 ? interleavePunctuation(targetText, diffTokens) : null),
     [targetText, diffTokens],
   );
 
-  if (!readingResultTokens || readingResultTokens.length === 0) return null;
+  const paragraphTokenGroups = useMemo(() => {
+    if (!readingResultTokens) return null;
+
+    const paras =
+      paragraphs?.length && paragraphs.join('') === targetText
+        ? paragraphs
+        : [targetText];
+
+    let offset = 0;
+    return paras.map((para, idx) => {
+      const len = Array.from(para).length;
+      const tokens = readingResultTokens.slice(offset, offset + len);
+      offset += len;
+      return { idx, tokens };
+    });
+  }, [readingResultTokens, paragraphs, targetText]);
+
+  if (!paragraphTokenGroups || paragraphTokenGroups.length === 0) return null;
 
   return (
     <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6">
       <p className="text-xs font-headline font-bold text-on-surface-variant uppercase tracking-wider mb-3">
         朗讀結果
       </p>
-      <p className="text-lg leading-relaxed">
-        {readingResultTokens.map((t, i) => (
-          <span
-            key={i}
-            className={
-              t.type === 'punctuation' ? 'text-on-surface' :
-              t.type === 'correct' ? 'text-emerald-600 font-medium' :
-              t.type === 'forgiven' ? 'text-blue-500' :
-              t.type === 'wrong' ? 'text-tertiary line-through' :
-              t.type === 'missing' || t.type === 'unread' ? 'text-on-surface-variant/30' :
-              'text-on-surface'
-            }
-          >
-            {t.char}
-          </span>
+      <div className="space-y-4">
+        {paragraphTokenGroups.map(({ idx, tokens }) => (
+          <p key={idx} className="text-lg leading-relaxed indent-[2em]">
+            {renderDiffTokenSpans(tokens, `p${idx}`)}
+          </p>
         ))}
-      </p>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
+++ b/frontend/src/components/reading-steps/full-reading/__tests__/FullReadingPanels.test.tsx
@@ -350,4 +350,24 @@ describe('FullReadingFeedbackPanel', () => {
     );
     expect(screen.queryByText('朗讀結果')).not.toBeInTheDocument();
   });
+
+  it('renders one indented paragraph block per lesson paragraph', () => {
+    const diffTokens: DT2[] = [
+      { char: '甲', type: 'correct' },
+      { char: '乙', type: 'correct' },
+      { char: '丙', type: 'wrong', expected: '丁' },
+      { char: '戊', type: 'correct' },
+    ];
+    const { container } = render(
+      <FullReadingFeedbackPanel
+        diffTokens={diffTokens}
+        targetText="甲乙丙戊"
+        paragraphs={['甲乙', '丙戊']}
+      />,
+    );
+    const bodyParas = container.querySelectorAll('p.indent-\\[2em\\]');
+    expect(bodyParas).toHaveLength(2);
+    expect(bodyParas[0].textContent).toBe('甲乙');
+    expect(bodyParas[1].textContent).toBe('丙戊');
+  });
 });


### PR DESCRIPTION
## Summary
- 全文朗讀「朗讀結果」依 `story.content` 分段顯示
- 每段段首 `indent-[2em]`（空兩格縮排），與課文段落結構一致

## Test plan
- [x] `FullReadingPanels.test.tsx` 20 passed（含多段落 + 縮排斷言）
- [ ] Staging `/learn/{id}/full-reading` 完成朗讀後確認分段與段首縮排


Made with [Cursor](https://cursor.com)