### PR TITLE
fix(frontend): use lesson benchmark feedback in full-reading self-assessment (Related to #1386)

### DIFF
--- a/frontend/src/components/reading-steps/FullReading.tsx
+++ b/frontend/src/components/reading-steps/FullReading.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { formatTime } from '../../utils/formatTime';
 import { Story, FullReadingResult } from '../../types';
-import { parseReadingBenchmark, getBenchmarkFeedback, getSecBenchmarkFeedback, type ParsedBenchmark } from '../../utils/fluencyAnalyzer';
+import { parseReadingBenchmark, getAiFluencyInsight, type ParsedBenchmark } from '../../utils/fluencyAnalyzer';
 import { useZhuyin } from '../../context/ZhuyinContext';
 import { useKaraoke } from '../../context/KaraokeContext';
 import { useFullReadingSession, type SavedResult } from '../../hooks/useFullReadingSession';
@@ -91,37 +91,13 @@ const FullReading: React.FC<FullReadingProps> = ({
     return 'unit' in parsedBenchmark[0] && (parsedBenchmark[0] as any).unit === 'sec';
   }, [parsedBenchmark]);
 
-  /** AI-computed rating for the latest result */
-  const aiRating = useMemo<AssessmentRating | undefined>(() => {
+  /** AI-computed fluency insight for self-assessment comparison */
+  const aiFluencyInsight = useMemo(() => {
     if (!result || !parsedBenchmark || parsedBenchmark.length === 0) return undefined;
-    let feedbackText: string | null = null;
-    if (useSecUnit) {
-      const durationSec = (result.durationMs || 0) / 1000;
-      feedbackText = getSecBenchmarkFeedback(durationSec, parsedBenchmark);
-    } else {
-      feedbackText = getBenchmarkFeedback(result.cpm || 0, parsedBenchmark);
-    }
-    if (!feedbackText) return undefined;
-    // Map benchmark feedback position to rating
-    // parsedBenchmark[0] = lowest tier (slow/low), last = highest tier (fast/high)
-    const idx = parsedBenchmark.findIndex(b => {
-      if (useSecUnit && 'unit' in b) {
-        const bs = b as any;
-        const durationSec = (result.durationMs || 0) / 1000;
-        return durationSec >= bs.minSec && durationSec <= bs.maxSec;
-      } else if (!useSecUnit && !('unit' in b)) {
-        const bc = b as any;
-        return result.cpm >= bc.minCpm && result.cpm <= bc.maxCpm;
-      }
-      return false;
-    });
-    if (idx === -1) return undefined;
-    const total = parsedBenchmark.length;
-    if (total === 1) return 'mid';
-    if (idx === 0) return useSecUnit ? 'high' : 'low'; // sec: fastest = high; cpm: slowest = low
-    if (idx === total - 1) return useSecUnit ? 'low' : 'high'; // sec: slowest = low; cpm: fastest = high
-    return 'mid';
-  }, [result, parsedBenchmark, useSecUnit]);
+    return getAiFluencyInsight(result.cpm || 0, result.durationMs || 0, parsedBenchmark) ?? undefined;
+  }, [result, parsedBenchmark]);
+
+  const aiRating = aiFluencyInsight?.rating;
 
   const { isZhuyinAny, processLinesSelective } = useZhuyin();
   const { karaokeEnabled } = useKaraoke();
@@ -416,6 +392,7 @@ const FullReading: React.FC<FullReadingProps> = ({
                 }}
                 selectedRating={selfRating}
                 aiRating={aiRating}
+                aiInsight={aiFluencyInsight}
                 showComparison={showComparison}
                 attemptNumber={Math.max(dedicatedHistory.length, 1)}
               />

--- a/frontend/src/components/reading-steps/__tests__/SelfAssessment.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/SelfAssessment.test.tsx
@@ -64,17 +64,50 @@ describe('SelfAssessment', () => {
     expect(screen.getByText(/你的判斷跟 AI 一樣/)).toBeTruthy();
   });
 
-  it('shows mismatch message with AI rating label when ratings differ', () => {
+  it('shows mismatch message with objective fluency data when ratings differ', () => {
     render(
       <SelfAssessment
         onSelect={vi.fn()}
-        selectedRating="low"
-        aiRating="mid"
+        selectedRating="high"
+        aiRating="low"
+        aiInsight={{
+          rating: 'low',
+          benchmarkFeedback: '還要多加練習。',
+          metricValue: 150,
+          metricUnit: 'cpm',
+          rangeLabel: '190 字/分以下',
+          gapToMidTier: 41,
+          midTierLabel: '191~220 字/分鐘',
+        }}
         showComparison={true}
       />
     );
-    expect(screen.getByText(/AI 覺得你這次讀得/)).toBeTruthy();
-    expect(screen.getByText('中')).toBeTruthy();
+    expect(screen.getByText(/這次朗讀語速 150 字\/分鐘/)).toBeTruthy();
+    expect(screen.getByText(/191~220 字\/分鐘/)).toBeTruthy();
+    expect(screen.getByText(/還要多加練習。/)).toBeTruthy();
+    expect(screen.queryByText(/AI 覺得你這次讀得/)).toBeNull();
+    expect(screen.queryByText('低')).toBeNull();
+  });
+
+  it('shows benchmark feedback on match when aiInsight is provided', () => {
+    render(
+      <SelfAssessment
+        onSelect={vi.fn()}
+        selectedRating="mid"
+        aiRating="mid"
+        aiInsight={{
+          rating: 'mid',
+          benchmarkFeedback: '嗯，還不錯喲！',
+          metricValue: 225,
+          metricUnit: 'cpm',
+          rangeLabel: '211~240 字/分鐘',
+          gapToMidTier: null,
+          midTierLabel: '211~240 字/分鐘',
+        }}
+        showComparison={true}
+      />
+    );
+    expect(screen.getByText(/嗯，還不錯喲！/)).toBeTruthy();
   });
 
   it('marks selected button as aria-pressed', () => {

--- a/frontend/src/components/reading-steps/full-reading/SelfAssessment.tsx
+++ b/frontend/src/components/reading-steps/full-reading/SelfAssessment.tsx
@@ -6,6 +6,7 @@
  * Issue #1386
  */
 import React from 'react';
+import type { AiFluencyInsight } from '../../../utils/fluencyAnalyzer';
 
 export type AssessmentRating = 'low' | 'mid' | 'high';
 
@@ -14,6 +15,8 @@ interface SelfAssessmentProps {
   selectedRating?: AssessmentRating;
   /** AI-computed rating based on CPM vs threshold */
   aiRating?: AssessmentRating;
+  /** Objective fluency data for mismatch comparison copy */
+  aiInsight?: AiFluencyInsight;
   /** Whether to show comparison (true after student has selected) */
   showComparison?: boolean;
   /** Which practice attempt this self-assessment is for (1-indexed).
@@ -46,15 +49,52 @@ const RATING_CONFIG: Record<AssessmentRating, { label: string; icon: string; bg:
   },
 };
 
-const RATING_LABELS: Record<AssessmentRating, string> = {
-  low: '低',
-  mid: '中',
-  high: '高',
+const RATING_RANK: Record<AssessmentRating, number> = {
+  low: 0,
+  mid: 1,
+  high: 2,
 };
 
-function ComparisonMessage({ selected, ai }: { selected: AssessmentRating; ai: AssessmentRating }) {
+function formatMetric(insight: AiFluencyInsight): string {
+  return insight.metricUnit === 'cpm'
+    ? `${insight.metricValue} 字/分鐘`
+    : `${insight.metricValue} 秒`;
+}
+
+function buildMismatchMessage(selected: AssessmentRating, insight: AiFluencyInsight): string {
+  const metricStr = formatMetric(insight);
+  let message = `這次朗讀語速 ${metricStr}，落在「${insight.rangeLabel}」`;
+
+  if (insight.gapToMidTier != null && insight.gapToMidTier > 0 && insight.midTierLabel) {
+    const gapUnit = insight.metricUnit === 'cpm' ? '字/分鐘' : '秒';
+    message += `，距離這篇建議區間（${insight.midTierLabel}）還差約 ${insight.gapToMidTier} ${gapUnit}`;
+  }
+
+  message += `。${insight.benchmarkFeedback}`;
+
+  if (RATING_RANK[selected] > RATING_RANK[insight.rating]) {
+    message += ' 你給自己的評價偏高，多練幾次會更熟悉自己的程度！';
+  } else if (RATING_RANK[selected] < RATING_RANK[insight.rating]) {
+    message += ' 其實表現比你想像好，繼續練自我判斷會更準！';
+  }
+
+  return message;
+}
+
+function ComparisonMessage({
+  selected,
+  ai,
+  insight,
+}: {
+  selected: AssessmentRating;
+  ai: AssessmentRating;
+  insight?: AiFluencyInsight;
+}) {
   const match = selected === ai;
   if (match) {
+    const matchBody = insight?.benchmarkFeedback
+      ? `你的判斷跟 AI 一樣 — 很有自我認識！${insight.benchmarkFeedback}`
+      : '你的判斷跟 AI 一樣 — 很有自我認識！';
     return (
       <div className="mt-4 flex items-center gap-2 p-3 rounded-2xl bg-emerald-50 border border-emerald-200">
         <span
@@ -64,11 +104,16 @@ function ComparisonMessage({ selected, ai }: { selected: AssessmentRating; ai: A
           check_circle
         </span>
         <p className="text-sm text-emerald-700 font-headline">
-          你的判斷跟 AI 一樣 — 很有自我認識！
+          {matchBody}
         </p>
       </div>
     );
   }
+
+  const body = insight
+    ? buildMismatchMessage(selected, insight)
+    : '你和 AI 的判斷不太一樣，多練幾次會更熟悉自己的程度！';
+
   return (
     <div className="mt-4 flex items-start gap-2 p-3 rounded-2xl bg-surface-container-low border border-surface-container-high">
       <span
@@ -78,11 +123,7 @@ function ComparisonMessage({ selected, ai }: { selected: AssessmentRating; ai: A
         info
       </span>
       <p className="text-sm text-on-surface-variant font-headline">
-        AI 覺得你這次讀得「
-        <span className={`font-bold ${RATING_CONFIG[ai].text}`}>
-          {RATING_LABELS[ai]}
-        </span>
-        」。每個人感受不一樣，繼續練習你會越來越準！
+        {body}
       </p>
     </div>
   );
@@ -92,6 +133,7 @@ const SelfAssessment: React.FC<SelfAssessmentProps> = ({
   onSelect,
   selectedRating,
   aiRating,
+  aiInsight,
   showComparison = false,
   attemptNumber,
 }) => {
@@ -149,7 +191,7 @@ const SelfAssessment: React.FC<SelfAssessmentProps> = ({
       </div>
 
       {showComparison && selectedRating && aiRating && (
-        <ComparisonMessage selected={selectedRating} ai={aiRating} />
+        <ComparisonMessage selected={selectedRating} ai={aiRating} insight={aiInsight} />
       )}
     </div>
   );

--- a/frontend/src/utils/fluencyAnalyzer.test.ts
+++ b/frontend/src/utils/fluencyAnalyzer.test.ts
@@ -10,6 +10,7 @@ import {
   parseReadingBenchmark,
   getBenchmarkFeedback,
   getSecBenchmarkFeedback,
+  getAiFluencyInsight,
   type BenchmarkLevel,
   type BenchmarkLevelSec,
 } from './fluencyAnalyzer';
@@ -128,6 +129,16 @@ describe('parseReadingBenchmark — CPM format (regression)', () => {
     expect(getBenchmarkFeedback(200, levels)).toBe('很好');
     expect(getBenchmarkFeedback(250, levels)).toBe('超棒！');
     expect(getBenchmarkFeedback(220, levels)).toBe('很好');
+  });
+
+  it('getAiFluencyInsight returns gap to mid tier for slow CPM', () => {
+    const levels = parseReadingBenchmark(g4Levels);
+    const insight = getAiFluencyInsight(150, 60000, levels);
+    expect(insight?.rating).toBe('low');
+    expect(insight?.metricValue).toBe(150);
+    expect(insight?.rangeLabel).toBe('190 字/分以下');
+    expect(insight?.gapToMidTier).toBe(41);
+    expect(insight?.midTierLabel).toBe('191~220 字/分鐘');
   });
 
   it('empty levels returns empty array', () => {

--- a/frontend/src/utils/fluencyAnalyzer.ts
+++ b/frontend/src/utils/fluencyAnalyzer.ts
@@ -283,3 +283,121 @@ export function getSecBenchmarkFeedback(
   }
   return null;
 }
+
+/** Three-tier fluency rating derived from lesson reading_benchmark. */
+export type FluencyTierRating = 'low' | 'mid' | 'high';
+
+export interface AiFluencyInsight {
+  rating: FluencyTierRating;
+  benchmarkFeedback: string;
+  metricValue: number;
+  metricUnit: 'cpm' | 'sec';
+  rangeLabel: string;
+  /** Distance to the lesson's recommended mid tier; null when already there or better. */
+  gapToMidTier: number | null;
+  midTierLabel: string | null;
+}
+
+function mapBenchmarkIndexToRating(
+  idx: number,
+  total: number,
+  useSec: boolean
+): FluencyTierRating {
+  if (total === 1) return 'mid';
+  if (idx === 0) return useSec ? 'high' : 'low';
+  if (idx === total - 1) return useSec ? 'low' : 'high';
+  return 'mid';
+}
+
+export function formatCpmRangeLabel(level: BenchmarkLevel): string {
+  if (level.maxCpm === Infinity) return `${level.minCpm} 字/分以上`;
+  if (level.minCpm === 0) return `${level.maxCpm + 1} 字/分以下`;
+  return `${level.minCpm}~${level.maxCpm} 字/分鐘`;
+}
+
+export function formatSecRangeLabel(level: BenchmarkLevelSec): string {
+  if (level.maxSec === Infinity) return `${level.minSec} 秒以上`;
+  if (level.minSec === 0) return `${level.maxSec} 秒以下`;
+  return `${level.minSec}~${level.maxSec} 秒`;
+}
+
+function getMidTierIndex(levels: ParsedBenchmark[]): number {
+  if (levels.length <= 1) return 0;
+  return 1;
+}
+
+/**
+ * Build objective AI fluency insight for self-assessment comparison (Issue #1386).
+ * Uses lesson reading_benchmark tiers — no pejorative low/mid/high labels in UI copy.
+ */
+export function getAiFluencyInsight(
+  cpm: number,
+  durationMs: number,
+  levels: ParsedBenchmark[]
+): AiFluencyInsight | null {
+  if (levels.length === 0) return null;
+
+  const useSec = 'unit' in levels[0];
+  const midIdx = getMidTierIndex(levels);
+
+  if (useSec) {
+    const durationSec = Math.round((durationMs / 1000) * 10) / 10;
+    let matchedIdx = -1;
+    let matched: BenchmarkLevelSec | null = null;
+    for (let i = 0; i < levels.length; i++) {
+      const level = levels[i] as BenchmarkLevelSec;
+      if (durationSec >= level.minSec && durationSec <= level.maxSec) {
+        matchedIdx = i;
+        matched = level;
+        break;
+      }
+    }
+    if (matchedIdx === -1 || !matched) return null;
+
+    const midLevel = levels[midIdx] as BenchmarkLevelSec;
+    let gapToMidTier: number | null = null;
+    if (matchedIdx > midIdx) {
+      // Slower than recommended — need to shave seconds off
+      gapToMidTier = Math.max(0, Math.round((durationSec - midLevel.maxSec) * 10) / 10);
+    }
+
+    return {
+      rating: mapBenchmarkIndexToRating(matchedIdx, levels.length, true),
+      benchmarkFeedback: matched.feedback,
+      metricValue: durationSec,
+      metricUnit: 'sec',
+      rangeLabel: formatSecRangeLabel(matched),
+      gapToMidTier,
+      midTierLabel: formatSecRangeLabel(midLevel),
+    };
+  }
+
+  const roundedCpm = Math.round(cpm);
+  let matchedIdx = -1;
+  let matched: BenchmarkLevel | null = null;
+  for (let i = 0; i < levels.length; i++) {
+    const level = levels[i] as BenchmarkLevel;
+    if (roundedCpm >= level.minCpm && roundedCpm <= level.maxCpm) {
+      matchedIdx = i;
+      matched = level;
+      break;
+    }
+  }
+  if (matchedIdx === -1 || !matched) return null;
+
+  const midLevel = levels[midIdx] as BenchmarkLevel;
+  let gapToMidTier: number | null = null;
+  if (matchedIdx < midIdx && roundedCpm < midLevel.minCpm) {
+    gapToMidTier = midLevel.minCpm - roundedCpm;
+  }
+
+  return {
+    rating: mapBenchmarkIndexToRating(matchedIdx, levels.length, false),
+    benchmarkFeedback: matched.feedback,
+    metricValue: roundedCpm,
+    metricUnit: 'cpm',
+    rangeLabel: formatCpmRangeLabel(matched),
+    gapToMidTier,
+    midTierLabel: formatCpmRangeLabel(midLevel),
+  };
+}


### PR DESCRIPTION
## Summary
- Remove pejorative「AI 覺得你讀得低/中/高」self-assessment comparison copy
- Show objective CPM range + gap to mid tier on mismatch
- Use each lesson's `reading_benchmark.feedback` encouragement text (e.g. 還要多加練習。/ 嗯，還不錯喲！/ 哇嗚，超級厲害！)

## Test plan
- [x] `npm test -- --run SelfAssessment.test.tsx fluencyAnalyzer.test.ts` (39 passed)
- [ ] Staging: `/learn/{id}/full-reading` → complete reading → self-assess → verify comparison copy uses benchmark feedback, no「低」label

Made with [Cursor](https://cursor.com)