### PR TITLE
fix(frontend): story structure worksheet HTML table (Related to #2193)

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -26,7 +26,7 @@ from ..schemas.story import StoryListItem, StoryDetail, StoryListResponse, Story
 
 _structure_cache: dict[str, tuple[float, object]] = {}
 _CACHE_TTL = 86400  # 24 hours
-_CACHE_VERSION = "v2"  # bump when schema changes to auto-invalidate
+_CACHE_VERSION = "v3"  # bump when schema changes to auto-invalidate
 
 
 def _cache_key(story_id: str) -> str:
@@ -65,85 +65,207 @@ def _cell_to_row_dict(label: str, value: str) -> dict:
         "interactive_type": itype,
     }
     if itype == "fill_blank":
-        # Extract first blank content as the reference answer hint
-        m = _BLANK_RE.search(value)
-        if m:
-            row["hint"] = m.group(1).strip()
+        hints = [m.group(1).strip() for m in _BLANK_RE.finditer(value)]
+        if hints:
+            row["hint"] = hints[0]
+        if len(hints) > 1:
+            row["blank_hints"] = hints
     return row
 
 
+def _parse_yaml_table_row(raw_row: list) -> dict | None:
+    """Parse one YAML story_structure_table row into a normalized item."""
+    if not isinstance(raw_row, list) or not raw_row:
+        return None
+
+    n = len(raw_row)
+    if n == 1:
+        return {"kind": "title", "text": str(raw_row[0]).strip()}
+
+    if n == 2:
+        return {
+            "kind": "pair",
+            "label": str(raw_row[0]).strip(),
+            "value": str(raw_row[1]).strip(),
+        }
+
+    if n == 3:
+        return {
+            "kind": "nested_triple",
+            "section": str(raw_row[0]).strip(),
+            "sub_label": str(raw_row[1]).strip(),
+            "value": str(raw_row[2]).strip(),
+        }
+
+    label = str(raw_row[0]).strip()
+    remainder = [str(c) for c in raw_row[1:]]
+    if len(remainder) % 2 == 0:
+        return {
+            "kind": "paired_block",
+            "label": label,
+            "pairs": [
+                {"sub_label": remainder[i], "value": remainder[i + 1]}
+                for i in range(0, len(remainder), 2)
+            ],
+        }
+
+    return {
+        "kind": "pair",
+        "label": label,
+        "value": " ".join(remainder),
+    }
+
+
+def _merge_parsed_to_structure_rows(parsed: list[dict]) -> list[dict]:
+    """Convert parsed items into grading-friendly rows (group nested triples)."""
+    rows: list[dict] = []
+    i = 0
+    while i < len(parsed):
+        item = parsed[i]
+        kind = item["kind"]
+
+        if kind == "title":
+            rows.append({
+                "label": item["text"],
+                "value": "",
+                "interactive_type": "display",
+            })
+            i += 1
+            continue
+
+        if kind == "pair":
+            rows.append(_cell_to_row_dict(item["label"], item["value"]))
+            i += 1
+            continue
+
+        if kind == "nested_triple":
+            section = item["section"]
+            sub_rows: list[dict] = []
+            while (
+                i < len(parsed)
+                and parsed[i]["kind"] == "nested_triple"
+                and parsed[i]["section"] == section
+            ):
+                cur = parsed[i]
+                sub_rows.append(_cell_to_row_dict(cur["sub_label"], cur["value"]))
+                i += 1
+            rows.append({
+                "label": section,
+                "value": "",
+                "interactive_type": "display",
+                "sub_rows": sub_rows,
+            })
+            continue
+
+        if kind == "paired_block":
+            sub_rows = [
+                _cell_to_row_dict(p["sub_label"], p["value"])
+                for p in item["pairs"]
+            ]
+            rows.append({
+                "label": item["label"],
+                "value": "",
+                "interactive_type": "display",
+                "sub_rows": sub_rows,
+            })
+            i += 1
+            continue
+
+        i += 1
+
+    return rows
+
+
+def _build_worksheet_rows(parsed: list[dict]) -> tuple[str | None, list[dict]]:
+    """Build 紙本學習單 HTML table rows (title / pair / section_block)."""
+    title: str | None = None
+    worksheet_rows: list[dict] = []
+    i = 0
+
+    while i < len(parsed):
+        item = parsed[i]
+        kind = item["kind"]
+
+        if kind == "title":
+            title = item["text"]
+            i += 1
+            continue
+
+        if kind == "pair":
+            worksheet_rows.append({
+                "kind": "pair",
+                "label": item["label"],
+                "value": item["value"],
+            })
+            i += 1
+            continue
+
+        if kind == "nested_triple":
+            section = item["section"]
+            items: list[dict] = []
+            while (
+                i < len(parsed)
+                and parsed[i]["kind"] == "nested_triple"
+                and parsed[i]["section"] == section
+            ):
+                cur = parsed[i]
+                items.append({
+                    "label": cur["sub_label"],
+                    "value": cur["value"],
+                })
+                i += 1
+            worksheet_rows.append({
+                "kind": "section_block",
+                "section": section,
+                "items": items,
+            })
+            continue
+
+        if kind == "paired_block":
+            worksheet_rows.append({
+                "kind": "section_block",
+                "section": item["label"],
+                "items": [
+                    {"label": p["sub_label"], "value": p["value"]}
+                    for p in item["pairs"]
+                ],
+            })
+            i += 1
+            continue
+
+        i += 1
+
+    return title, worksheet_rows
+
+
 def _format_yaml_structure_table(table: list) -> dict:
-    """Convert story_structure_table YAML list → {'rows': [...]} API shape.
+    """Convert story_structure_table YAML list → API shape.
 
     YAML row formats:
       [title]                   → 1-cell display row (title of the whole table)
       [label, value]            → simple row (fill_blank if has 【…】, else display)
-      [label, sub_label, sub_value, ...]  → row with sub_rows (pairs after label)
-      [label, col1, col2, col3] → header row or row with 3 sub-cells (display)
+      [label, sub_label, sub_value]  → nested PSR row (merged by shared section label)
+      [label, sub1, val1, sub2, val2, ...] → paired sub_rows under one section
 
-    All interactive_type values are 'fill_blank' or 'display'.
-    Checkbox interactivity is NOT reproduced from YAML (requires AI options arrays);
-    cells with □ checkbox markers are treated as 'display'.
+    Returns rows for grading plus worksheet_rows for 紙本 table rendering when
+    the source table has a title row or nested PSR blocks.
     """
-    rows: list[dict] = []
+    parsed = [
+        item for raw in table
+        if (item := _parse_yaml_table_row(raw)) is not None
+    ]
+    rows = _merge_parsed_to_structure_rows(parsed)
+    title, worksheet_rows = _build_worksheet_rows(parsed)
 
-    for raw_row in table:
-        if not isinstance(raw_row, list) or not raw_row:
-            continue
-
-        n = len(raw_row)
-
-        if n == 1:
-            # Title row — display spanning label
-            rows.append({
-                "label": str(raw_row[0]).strip(),
-                "value": "",
-                "interactive_type": "display",
-            })
-
-        elif n == 2:
-            # [label, value]
-            rows.append(_cell_to_row_dict(str(raw_row[0]), str(raw_row[1])))
-
-        elif n == 3:
-            # [label, sub_label, sub_value] — row with one sub_row
-            row = {
-                "label": str(raw_row[0]).strip(),
-                "value": "",
-                "interactive_type": "display",
-                "sub_rows": [
-                    _cell_to_row_dict(str(raw_row[1]), str(raw_row[2])),
-                ],
-            }
-            rows.append(row)
-
-        else:
-            # n >= 4: treat as row with (n-1)/2 paired sub_rows if n is odd,
-            # or as a display row with all remaining cells joined if even
-            label = str(raw_row[0]).strip()
-            remainder = [str(c) for c in raw_row[1:]]
-
-            # Try to pair as (sub_label, sub_value) only when length is even
-            if len(remainder) % 2 == 0:
-                sub_rows = []
-                for i in range(0, len(remainder), 2):
-                    sub_rows.append(_cell_to_row_dict(remainder[i], remainder[i + 1]))
-                rows.append({
-                    "label": label,
-                    "value": "",
-                    "interactive_type": "display",
-                    "sub_rows": sub_rows,
-                })
-            else:
-                # Odd remainder — join all as a single display row
-                combined = " ".join(remainder)
-                rows.append({
-                    "label": label,
-                    "value": combined,
-                    "interactive_type": "display",
-                })
-
-    return {"rows": rows}
+    result: dict = {"rows": rows}
+    has_nested = any(p["kind"] in ("nested_triple", "paired_block") for p in parsed)
+    if title or has_nested or any(p["kind"] == "pair" for p in parsed):
+        result["layout"] = "worksheet_table"
+        if title:
+            result["title"] = title
+        if worksheet_rows:
+            result["worksheet_rows"] = worksheet_rows
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +275,7 @@ def _format_yaml_structure_table(table: list) -> dict:
 class StructureAnswerItem(BaseModel):
     row_index: int
     sub_row_index: int | None = None
+    blank_index: int | None = None
     value: str | None = None          # for fill_blank
     selected_options: list[int] | None = None  # for checkbox
 

--- a/backend/app/services/ai_generation/story_structure.py
+++ b/backend/app/services/ai_generation/story_structure.py
@@ -331,11 +331,19 @@ async def grade_story_structure(
                 correct_texts = [options[i] for i in sorted(expected) if i < len(options)]
                 result_entry["feedback"] = f"正確答案是：{'、'.join(correct_texts)}"
         else:
-            # fill_blank: fuzzy text match
+            # fill_blank: fuzzy text match (per blank when blank_hints present)
             student_value = str(answer.get("value") or "").strip()
+            blank_hints = target.get("blank_hints") or []
+            blank_idx = answer.get("blank_index")
+            if blank_hints and blank_idx is not None and 0 <= blank_idx < len(blank_hints):
+                correct_answer = blank_hints[blank_idx]
+            else:
+                correct_answer = target.get("hint") or correct_answer
             is_correct = _fuzzy_match_chinese(student_value, correct_answer, story_text)
             result_entry["correct"] = is_correct
             result_entry["correct_answer"] = correct_answer
+            if blank_idx is not None:
+                result_entry["blank_index"] = blank_idx
             if is_correct:
                 result_entry["feedback"] = "答對了！"
             else:

--- a/backend/specs/test_reading_annotation_spec.py
+++ b/backend/specs/test_reading_annotation_spec.py
@@ -142,10 +142,31 @@ def test_annotation_save_request_max_500():
 # Contract: Router is registered
 # ---------------------------------------------------------------------------
 
+def _collect_router_paths(router) -> list[str]:
+    """Collect paths from a composed APIRouter across FastAPI versions.
+
+    FastAPI 0.137+ stores included routers as _IncludedRouter without a
+    top-level .path; traverse via .original_router when present.
+    """
+    paths: list[str] = []
+    for route in router.routes:
+        path = getattr(route, "path", None)
+        if path:
+            paths.append(path)
+            continue
+        nested = getattr(route, "original_router", None)
+        if nested is not None:
+            paths.extend(_collect_router_paths(nested))
+            continue
+        if hasattr(route, "routes"):
+            paths.extend(_collect_router_paths(route))
+    return paths
+
+
 def test_annotations_router_registered():
     """Contract: annotations router is registered in the learning package."""
     from app.routes.learning import router
-    routes = [r.path for r in router.routes if hasattr(r, "path")]
+    routes = _collect_router_paths(router)
     annotation_routes = [r for r in routes if "annotations" in r]
     assert len(annotation_routes) >= 2, (
         f"Expected at least 2 annotation routes (GET + PUT), found: {annotation_routes}"

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -1,13 +1,11 @@
 /**
  * StoryStructureTable — 互動式文章重點表 (#615, #845, #1082, #2084)
  *
- * Fetches AI-generated story structure from /api/stories/{id}/structure.
- * Supports interactive fill-in-the-blank and checkbox questions with AI grading.
- * Genre-aware: 記敘文 shows 主角/主題/事例, 說明文 shows concept structure, etc.
- *
- * #2084: Visual hierarchy (color-coded left-border badges) + copyable template button.
+ * Fetches story structure from /api/stories/{id}/structure.
+ * When API returns layout=worksheet_table, renders 紙本學習單 HTML table;
+ * otherwise falls back to card layout (#2084).
  */
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -19,6 +17,7 @@ interface StructureSubRow {
   value: string;
   interactive_type: InteractiveType;
   hint?: string;
+  blank_hints?: string[];
   options?: string[];
   correct_options?: number[];
 }
@@ -28,18 +27,37 @@ interface StructureRow {
   value: string;
   interactive_type: InteractiveType;
   hint?: string;
+  blank_hints?: string[];
   options?: string[];
   correct_options?: number[];
   sub_rows?: StructureSubRow[];
 }
 
+interface WorksheetPairRow {
+  kind: 'pair';
+  label: string;
+  value: string;
+}
+
+interface WorksheetSectionBlockRow {
+  kind: 'section_block';
+  section: string;
+  items: { label: string; value: string }[];
+}
+
+type WorksheetRow = WorksheetPairRow | WorksheetSectionBlockRow;
+
 interface StructureData {
+  layout?: 'worksheet_table' | 'cards';
+  title?: string;
+  worksheet_rows?: WorksheetRow[];
   rows: StructureRow[];
 }
 
 interface GradeResultItem {
   row_index: number;
   sub_row_index?: number;
+  blank_index?: number;
   correct: boolean;
   feedback: string;
   correct_answer: string;
@@ -50,28 +68,52 @@ interface GradeResult {
   score: number;
 }
 
-// Answer state key: "rowIdx" for top-level, "rowIdx-subIdx" for sub-rows
 type AnswerMap = Record<string, string | number[]>;
 
 interface Props {
   storyId: string;
 }
 
+const INLINE_BLANK_RE = /【([^】]*)】/g;
+const SECTION_CHUNK_SIZE = 3;
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function answerKey(rowIdx: number, subIdx?: number): string {
-  return subIdx !== undefined ? `${rowIdx}-${subIdx}` : `${rowIdx}`;
+function answerKey(rowIdx: number, subIdx?: number, blankIdx?: number): string {
+  if (subIdx !== undefined && blankIdx !== undefined) {
+    return `${rowIdx}-${subIdx}-b${blankIdx}`;
+  }
+  if (subIdx !== undefined) return `${rowIdx}-${subIdx}`;
+  if (blankIdx !== undefined) return `${rowIdx}-b${blankIdx}`;
+  return `${rowIdx}`;
 }
 
-/**
- * Maps a row/sub-row label to a Tailwind border + bg colour token for the
- * left-border visual-hierarchy accent (#2084).
- *
- * Returns an object with:
- *   - borderClass  — e.g. "border-l-4 border-amber-400"
- *   - bgClass      — e.g. "bg-amber-50"
- *   - textClass    — e.g. "text-amber-800"
- */
+function countBlanks(text: string): number {
+  return [...text.matchAll(INLINE_BLANK_RE)].length;
+}
+
+function classifyInteractive(value: string): InteractiveType {
+  if (INLINE_BLANK_RE.test(value)) return 'fill_blank';
+  return 'display';
+}
+
+function resolveGradeIndex(
+  rows: StructureRow[],
+  wsRow: WorksheetRow,
+  itemIdx?: number,
+): { rowIdx: number; subIdx?: number } {
+  if (wsRow.kind === 'pair') {
+    const rowIdx = rows.findIndex(
+      (r) => r.label === wsRow.label && !(r.sub_rows && r.sub_rows.length > 0),
+    );
+    return { rowIdx };
+  }
+  const rowIdx = rows.findIndex(
+    (r) => r.label === wsRow.section && !!(r.sub_rows && r.sub_rows.length > 0),
+  );
+  return { rowIdx, subIdx: itemIdx };
+}
+
 function getLabelAccent(label: string): {
   borderClass: string;
   bgClass: string;
@@ -113,13 +155,134 @@ function findGradeItem(
   results: GradeResultItem[],
   rowIdx: number,
   subIdx?: number,
+  blankIdx?: number,
 ): GradeResultItem | undefined {
-  return results.find(
-    (r) => r.row_index === rowIdx && r.sub_row_index === subIdx,
-  );
+  return results.find((r) => {
+    if (r.row_index !== rowIdx || r.sub_row_index !== subIdx) return false;
+    if (blankIdx !== undefined) return r.blank_index === blankIdx;
+    return r.blank_index === undefined || r.blank_index === null;
+  });
 }
 
-// ── FillBlankCell ─────────────────────────────────────────────────────────────
+function chunkItems<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function sectionVerticalLabel(section: string): string {
+  return section.replace(/\s+/g, '');
+}
+
+// ── Inline blank inputs (worksheet table cells) ─────────────────────────────
+
+interface InlineBlankInputProps {
+  hint?: string;
+  value: string;
+  onChange: (v: string) => void;
+  submitted: boolean;
+  gradeItem?: GradeResultItem;
+  compact?: boolean;
+}
+
+const InlineBlankInput: React.FC<InlineBlankInputProps> = ({
+  hint,
+  value,
+  onChange,
+  submitted,
+  gradeItem,
+  compact,
+}) => {
+  const width = compact ? 'w-16' : 'w-24';
+  if (submitted && gradeItem) {
+    const isCorrect = gradeItem.correct;
+    return (
+      <span
+        className={`inline-block border-b-2 px-0.5 mx-0.5 text-sm ${
+          isCorrect ? 'border-emerald-500 text-emerald-800' : 'border-red-500 text-red-800'
+        }`}
+        title={!isCorrect ? gradeItem.feedback : undefined}
+      >
+        {value || '　'}
+      </span>
+    );
+  }
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={hint?.trim() || '　'}
+      className={`${width} inline-block bg-transparent border-b-2 border-gray-800 text-sm text-center focus:outline-none focus:border-amber-600 mx-0.5`}
+      disabled={submitted}
+    />
+  );
+};
+
+interface InlineWorksheetContentProps {
+  text: string;
+  rowIdx: number;
+  subIdx?: number;
+  hints?: string[];
+  answers: AnswerMap;
+  setAnswer: (key: string, value: string | number[]) => void;
+  submitted: boolean;
+  gradeResults: GradeResultItem[];
+}
+
+const InlineWorksheetContent: React.FC<InlineWorksheetContentProps> = ({
+  text,
+  rowIdx,
+  subIdx,
+  hints,
+  answers,
+  setAnswer,
+  submitted,
+  gradeResults,
+}) => {
+  const parts = useMemo(() => {
+    const nodes: React.ReactNode[] = [];
+    let last = 0;
+    let blankIdx = 0;
+    const re = new RegExp(INLINE_BLANK_RE.source, 'g');
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text)) !== null) {
+      if (match.index > last) {
+        nodes.push(<span key={`t-${last}`}>{text.slice(last, match.index)}</span>);
+      }
+      const key = answerKey(rowIdx, subIdx, blankIdx);
+      const hint = hints?.[blankIdx] ?? match[1]?.trim();
+      nodes.push(
+        <span key={`b-${blankIdx}`} className="inline-flex items-baseline">
+          <span>【</span>
+          <InlineBlankInput
+            hint={hint}
+            value={typeof answers[key] === 'string' ? (answers[key] as string) : ''}
+            onChange={(v) => setAnswer(key, v)}
+            submitted={submitted}
+            gradeItem={
+              submitted ? findGradeItem(gradeResults, rowIdx, subIdx, blankIdx) : undefined
+            }
+            compact
+          />
+          <span>】</span>
+        </span>,
+      );
+      blankIdx += 1;
+      last = match.index + match[0].length;
+    }
+    if (last < text.length) {
+      nodes.push(<span key={`t-${last}`}>{text.slice(last)}</span>);
+    }
+    return nodes;
+  }, [text, rowIdx, subIdx, hints, answers, setAnswer, submitted, gradeResults]);
+
+  return <span className="text-sm leading-relaxed whitespace-pre-line">{parts}</span>;
+};
+
+// ── FillBlankCell (card layout) ─────────────────────────────────────────────
 
 interface FillBlankCellProps {
   hint?: string;
@@ -259,6 +422,137 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
   );
 };
 
+// ── Worksheet HTML table ─────────────────────────────────────────────────────
+
+interface WorksheetTableProps {
+  structure: StructureData;
+  answers: AnswerMap;
+  setAnswer: (key: string, value: string | number[]) => void;
+  submitted: boolean;
+  gradeResults: GradeResultItem[];
+  renderCellContent: (
+    cell: StructureRow | StructureSubRow,
+    rowIdx: number,
+    subIdx?: number,
+  ) => React.ReactNode;
+}
+
+const WorksheetTable: React.FC<WorksheetTableProps> = ({
+  structure,
+  answers,
+  setAnswer,
+  submitted,
+  gradeResults,
+  renderCellContent,
+}) => {
+  const { title, worksheet_rows = [], rows } = structure;
+  const cellBorder = 'border border-black px-2 py-2 align-top';
+
+  const renderValueCell = (
+    value: string,
+    rowIdx: number,
+    subIdx?: number,
+    hints?: string[],
+  ) => {
+    const itype = classifyInteractive(value);
+    if (itype === 'fill_blank' && countBlanks(value) > 0) {
+      return (
+        <InlineWorksheetContent
+          text={value}
+          rowIdx={rowIdx}
+          subIdx={subIdx}
+          hints={hints}
+          answers={answers}
+          setAnswer={setAnswer}
+          submitted={submitted}
+          gradeResults={gradeResults}
+        />
+      );
+    }
+    if (rowIdx >= 0) {
+      const cell = subIdx !== undefined ? rows[rowIdx]?.sub_rows?.[subIdx] : rows[rowIdx];
+      if (cell) return renderCellContent(cell, rowIdx, subIdx);
+    }
+    return <span className="text-sm leading-relaxed whitespace-pre-line">{value}</span>;
+  };
+
+  return (
+    <table className="w-full border-collapse border border-black text-sm bg-white">
+      <tbody>
+        {title && (
+          <tr>
+            <td
+              colSpan={3}
+              className={`${cellBorder} text-center font-bold text-base py-3`}
+            >
+              {title}
+            </td>
+          </tr>
+        )}
+        {worksheet_rows.map((wsRow, wsIdx) => {
+          if (wsRow.kind === 'pair') {
+            const { rowIdx } = resolveGradeIndex(rows, wsRow);
+            const row = rows[rowIdx];
+            return (
+              <tr key={`pair-${wsIdx}`}>
+                <td className={`${cellBorder} text-center font-medium w-16 whitespace-nowrap`}>
+                  {wsRow.label}
+                </td>
+                <td colSpan={2} className={cellBorder}>
+                  {renderValueCell(wsRow.value, rowIdx, undefined, row?.blank_hints)}
+                </td>
+              </tr>
+            );
+          }
+
+          const chunks = chunkItems(wsRow.items, SECTION_CHUNK_SIZE);
+          return chunks.flatMap((chunk, chunkIdx) =>
+            chunk.map((item, itemIdx) => {
+              const globalItemIdx = chunkIdx * SECTION_CHUNK_SIZE + itemIdx;
+              const { rowIdx, subIdx } = resolveGradeIndex(rows, wsRow, globalItemIdx);
+              const subRow = rowIdx >= 0 ? rows[rowIdx]?.sub_rows?.[subIdx ?? 0] : undefined;
+              const showSection = itemIdx === 0;
+              const sectionLabel =
+                chunkIdx === 0 ? sectionVerticalLabel(wsRow.section) : '';
+
+              return (
+                <tr key={`sec-${wsIdx}-${chunkIdx}-${itemIdx}`}>
+                  {showSection && (
+                    <td
+                      rowSpan={chunk.length}
+                      className={`${cellBorder} text-center font-medium w-10 align-middle ${
+                        sectionLabel ? 'bg-white' : ''
+                      }`}
+                      style={
+                        sectionLabel
+                          ? { writingMode: 'vertical-rl', textOrientation: 'upright' }
+                          : undefined
+                      }
+                    >
+                      {sectionLabel}
+                    </td>
+                  )}
+                  <td className={`${cellBorder} text-center font-medium w-20 whitespace-nowrap`}>
+                    {item.label}
+                  </td>
+                  <td className={cellBorder}>
+                    {renderValueCell(
+                      item.value,
+                      rowIdx,
+                      subIdx,
+                      subRow?.blank_hints,
+                    )}
+                  </td>
+                </tr>
+              );
+            }),
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
 // ── Main Component ────────────────────────────────────────────────────────────
 
 const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
@@ -295,7 +589,38 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
     setAnswers((prev) => ({ ...prev, [key]: value }));
   }, []);
 
-  // Build the answer payload for POST /structure/grade
+  const pushFillBlankAnswers = useCallback(
+    (
+      payload: object[],
+      rowIdx: number,
+      subIdx: number | undefined,
+      cell: StructureRow | StructureSubRow,
+    ) => {
+      const blankCount =
+        cell.blank_hints?.length ||
+        (cell.interactive_type === 'fill_blank' ? Math.max(countBlanks(cell.value), 1) : 0);
+      if (blankCount <= 1) {
+        const key = answerKey(rowIdx, subIdx);
+        payload.push({
+          row_index: rowIdx,
+          ...(subIdx !== undefined ? { sub_row_index: subIdx } : {}),
+          value: typeof answers[key] === 'string' ? answers[key] : '',
+        });
+        return;
+      }
+      for (let b = 0; b < blankCount; b += 1) {
+        const key = answerKey(rowIdx, subIdx, b);
+        payload.push({
+          row_index: rowIdx,
+          ...(subIdx !== undefined ? { sub_row_index: subIdx } : {}),
+          blank_index: b,
+          value: typeof answers[key] === 'string' ? answers[key] : '',
+        });
+      }
+    },
+    [answers],
+  );
+
   const buildAnswerPayload = useCallback((): object[] => {
     if (!structure) return [];
     const payload: object[] = [];
@@ -304,80 +629,82 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
       if (row.sub_rows && row.sub_rows.length > 0) {
         row.sub_rows.forEach((sub, subIdx) => {
           if (sub.interactive_type === 'display') return;
-          const key = answerKey(rowIdx, subIdx);
-          const val = answers[key];
           if (sub.interactive_type === 'checkbox') {
+            const key = answerKey(rowIdx, subIdx);
             payload.push({
               row_index: rowIdx,
               sub_row_index: subIdx,
-              selected_options: Array.isArray(val) ? val : [],
+              selected_options: Array.isArray(answers[key]) ? answers[key] : [],
             });
           } else {
-            payload.push({
-              row_index: rowIdx,
-              sub_row_index: subIdx,
-              value: typeof val === 'string' ? val : '',
-            });
+            pushFillBlankAnswers(payload, rowIdx, subIdx, sub);
           }
         });
       } else {
         if (row.interactive_type === 'display') return;
-        const key = answerKey(rowIdx);
-        const val = answers[key];
         if (row.interactive_type === 'checkbox') {
+          const key = answerKey(rowIdx);
           payload.push({
             row_index: rowIdx,
-            selected_options: Array.isArray(val) ? val : [],
+            selected_options: Array.isArray(answers[key]) ? answers[key] : [],
           });
         } else {
-          payload.push({
-            row_index: rowIdx,
-            value: typeof val === 'string' ? val : '',
-          });
+          pushFillBlankAnswers(payload, rowIdx, undefined, row);
         }
       }
     });
 
     return payload;
-  }, [structure, answers]);
+  }, [structure, answers, pushFillBlankAnswers]);
 
-  // Build a plain-text template for clipboard copy (#2084 — 可複製模板)
-  // Format:  上位概念: <row.label>\n重點: ________________\n
-  // Only includes display rows (answers, not blanks).
   const handleCopyTemplate = useCallback(() => {
     if (!structure) return;
     const lines: string[] = ['【文章重點表模板】', ''];
+    if (structure.title) lines.push(structure.title, '');
 
-    structure.rows.forEach((row) => {
-      if (row.sub_rows && row.sub_rows.length > 0) {
-        lines.push(`【${row.label}】`);
-        row.sub_rows.forEach((sub) => {
-          lines.push(`  上位概念：${sub.label}`);
-          if (sub.interactive_type === 'display' && sub.value?.trim()) {
-            lines.push(`  重點：${sub.value}`);
-          } else {
-            lines.push(`  重點：________________`);
-          }
-          lines.push('');
-        });
-      } else {
-        lines.push(`上位概念：${row.label}`);
-        if (row.interactive_type === 'display' && row.value?.trim()) {
-          lines.push(`重點：${row.value}`);
+    if (structure.layout === 'worksheet_table' && structure.worksheet_rows) {
+      structure.worksheet_rows.forEach((wsRow) => {
+        if (wsRow.kind === 'pair') {
+          lines.push(`${wsRow.label}：${wsRow.value.replace(INLINE_BLANK_RE, '【　　　】')}`);
         } else {
-          lines.push(`重點：________________`);
+          lines.push(`【${wsRow.section}】`);
+          wsRow.items.forEach((item) => {
+            lines.push(
+              `  ${item.label}：${item.value.replace(INLINE_BLANK_RE, '【　　　】')}`,
+            );
+          });
         }
         lines.push('');
-      }
-    });
+      });
+    } else {
+      structure.rows.forEach((row) => {
+        if (row.sub_rows && row.sub_rows.length > 0) {
+          lines.push(`【${row.label}】`);
+          row.sub_rows.forEach((sub) => {
+            lines.push(`  上位概念：${sub.label}`);
+            lines.push(
+              sub.interactive_type === 'display' && sub.value?.trim()
+                ? `  重點：${sub.value}`
+                : '  重點：________________',
+            );
+            lines.push('');
+          });
+        } else {
+          lines.push(`上位概念：${row.label}`);
+          lines.push(
+            row.interactive_type === 'display' && row.value?.trim()
+              ? `重點：${row.value}`
+              : '重點：________________',
+          );
+          lines.push('');
+        }
+      });
+    }
 
-    const text = lines.join('\n');
-    navigator.clipboard.writeText(text).then(() => {
+    navigator.clipboard.writeText(lines.join('\n')).then(() => {
       setCopyDone(true);
       setTimeout(() => setCopyDone(false), 1500);
-    }).catch(() => {
-      // Clipboard unavailable (non-HTTPS or permission denied) — silent no-op
-    });
+    }).catch(() => {});
   }, [structure]);
 
   const handleSubmit = useCallback(async () => {
@@ -401,37 +728,64 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
     }
   }, [structure, submitting, gradeResult, token, storyId, API_BASE, buildAnswerPayload]);
 
-  // Count total interactive fields and how many are answered
-  const { totalInteractive, totalAnswered } = (() => {
+  const countInteractiveFields = useCallback(
+    (cell: StructureRow | StructureSubRow): number => {
+      if (cell.interactive_type === 'display') return 0;
+      if (cell.interactive_type === 'checkbox') return 1;
+      const blanks = cell.blank_hints?.length || countBlanks(cell.value);
+      return blanks > 0 ? blanks : 1;
+    },
+    [],
+  );
+
+  const { totalInteractive, totalAnswered } = useMemo(() => {
     if (!structure) return { totalInteractive: 0, totalAnswered: 0 };
     let total = 0;
     let answered = 0;
-    structure.rows.forEach((row, rowIdx) => {
-      const targets = row.sub_rows?.length
-        ? row.sub_rows.map((s, si) => ({ ...s, _key: answerKey(rowIdx, si) }))
-        : [{ ...row, _key: answerKey(rowIdx) }];
 
-      targets.forEach(({ interactive_type, _key }) => {
-        if (interactive_type === 'display') return;
-        total++;
-        const val = answers[_key];
-        if (interactive_type === 'checkbox') {
-          if (Array.isArray(val) && val.length > 0) answered++;
-        } else {
-          if (typeof val === 'string' && val.trim().length > 0) answered++;
-        }
-      });
+    const tallyCell = (
+      cell: StructureRow | StructureSubRow,
+      rowIdx: number,
+      subIdx?: number,
+    ) => {
+      const fieldCount = countInteractiveFields(cell);
+      if (fieldCount === 0) return;
+
+      if (cell.interactive_type === 'checkbox') {
+        total += 1;
+        const key = answerKey(rowIdx, subIdx);
+        const val = answers[key];
+        if (Array.isArray(val) && val.length > 0) answered += 1;
+        return;
+      }
+
+      const blankCount =
+        cell.blank_hints?.length ||
+        (cell.interactive_type === 'fill_blank' ? Math.max(countBlanks(cell.value), 1) : 1);
+      total += blankCount;
+      for (let b = 0; b < blankCount; b += 1) {
+        const key = answerKey(rowIdx, subIdx, blankCount > 1 ? b : undefined);
+        const val = answers[key];
+        if (typeof val === 'string' && val.trim().length > 0) answered += 1;
+      }
+    };
+
+    structure.rows.forEach((row, rowIdx) => {
+      if (row.sub_rows?.length) {
+        row.sub_rows.forEach((sub, subIdx) => tallyCell(sub, rowIdx, subIdx));
+      } else {
+        tallyCell(row, rowIdx);
+      }
     });
+
     return { totalInteractive: total, totalAnswered: answered };
-  })();
+  }, [structure, answers, countInteractiveFields]);
 
   const allAnswered = totalAnswered >= totalInteractive && totalInteractive > 0;
   const submitted = gradeResult !== null;
   const gradeResults = gradeResult?.results ?? [];
   const score = gradeResult?.score ?? 0;
 
-  // renderCellContent must be declared BEFORE any early returns to satisfy Rules of Hooks.
-  // When loading=true or structure=null, this hook still runs but is never called.
   const renderCellContent = useCallback(
     (
       cell: StructureRow | StructureSubRow,
@@ -472,8 +826,6 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
     [answers, submitted, gradeResults, setAnswer],
   );
 
-  // ── Render ─────────────────────────────────────────────────────────────────
-
   if (loading) {
     return (
       <div className="flex items-center justify-center p-8 text-gray-400 text-sm">
@@ -491,14 +843,19 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
   }
 
   const { rows } = structure;
+  const useWorksheet =
+    structure.layout === 'worksheet_table' &&
+    !!(structure.worksheet_rows && structure.worksheet_rows.length > 0);
 
   return (
-    <div className="overflow-hidden rounded-xl border-2 border-gray-300 shadow-sm max-w-2xl mx-auto">
-      {/* Header */}
+    <div
+      className={`overflow-hidden rounded-xl border-2 border-gray-300 shadow-sm mx-auto ${
+        useWorksheet ? 'max-w-3xl' : 'max-w-2xl'
+      }`}
+    >
       <div className="bg-amber-50 border-b-2 border-amber-400 px-5 py-3 flex items-center justify-between gap-2">
         <span className="text-amber-800 font-bold text-base">📋 文章重點表</span>
         <div className="flex items-center gap-2">
-          {/* Copy template button (#2084) */}
           <button
             onClick={handleCopyTemplate}
             className="flex items-center gap-1.5 px-3 py-1 rounded-lg border border-amber-300 bg-white text-amber-700 text-xs font-semibold hover:bg-amber-100 active:scale-95 transition-all select-none"
@@ -523,55 +880,62 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
         </div>
       </div>
 
-      {/* #1534: card layout — coloured row banner + per-sub_row body */}
-      {/* #2084: left-border colour accent for visual hierarchy (problem/solution/result) */}
-      <div className="divide-y-2 divide-gray-200 text-base">
-        {rows.map((row, rowIdx) => {
-          const hasSubRows = !!(row.sub_rows && row.sub_rows.length > 0);
-          const topLevelEmptyDisplay =
-            !hasSubRows && row.interactive_type === 'display' && !row.value?.trim();
-          const accent = getLabelAccent(row.label);
+      {useWorksheet ? (
+        <div className="p-3 bg-white overflow-x-auto">
+          <WorksheetTable
+            structure={structure}
+            answers={answers}
+            setAnswer={setAnswer}
+            submitted={submitted}
+            gradeResults={gradeResults}
+            renderCellContent={renderCellContent}
+          />
+        </div>
+      ) : (
+        <div className="divide-y-2 divide-gray-200 text-base">
+          {rows.map((row, rowIdx) => {
+            const hasSubRows = !!(row.sub_rows && row.sub_rows.length > 0);
+            const topLevelEmptyDisplay =
+              !hasSubRows && row.interactive_type === 'display' && !row.value?.trim();
+            const accent = getLabelAccent(row.label);
 
-          return (
-            <section key={`${rowIdx}-${row.label}`}>
-              {/* Row header — colour-accented left border (#2084) */}
-              <div
-                className={`${accent.borderClass} ${accent.bgClass} px-4 py-2.5 font-bold ${accent.textClass} leading-snug`}
-              >
-                {row.label}
-              </div>
-
-              {hasSubRows ? (
-                /* Sub-rows: indented with left border for mind-map feel (#2084) */
-                <div className="divide-y divide-gray-100 ml-6 border-l-2 border-gray-200">
-                  {(row.sub_rows ?? []).map((sub, subIdx) => {
-                    const subAccent = getLabelAccent(sub.label);
-                    return (
-                      <div key={`${subIdx}-${sub.label}`}>
-                        {/* Sub-label banner with own accent */}
-                        <div
-                          className={`${subAccent.borderClass} ${subAccent.bgClass} px-4 py-2 text-sm font-semibold ${subAccent.textClass} leading-snug`}
-                        >
-                          {sub.label}
-                        </div>
-                        <div className="px-4 py-3">
-                          {renderCellContent(sub, rowIdx, subIdx)}
-                        </div>
-                      </div>
-                    );
-                  })}
+            return (
+              <section key={`${rowIdx}-${row.label}`}>
+                <div
+                  className={`${accent.borderClass} ${accent.bgClass} px-4 py-2.5 font-bold ${accent.textClass} leading-snug`}
+                >
+                  {row.label}
                 </div>
-              ) : topLevelEmptyDisplay ? null : (
-                <div className="px-4 py-3">
-                  {renderCellContent(row, rowIdx)}
-                </div>
-              )}
-            </section>
-          );
-        })}
-      </div>
 
-      {/* Submit / Result bar */}
+                {hasSubRows ? (
+                  <div className="divide-y divide-gray-100 ml-6 border-l-2 border-gray-200">
+                    {(row.sub_rows ?? []).map((sub, subIdx) => {
+                      const subAccent = getLabelAccent(sub.label);
+                      return (
+                        <div key={`${subIdx}-${sub.label}`}>
+                          <div
+                            className={`${subAccent.borderClass} ${subAccent.bgClass} px-4 py-2 text-sm font-semibold ${subAccent.textClass} leading-snug`}
+                          >
+                            {sub.label}
+                          </div>
+                          <div className="px-4 py-3">
+                            {renderCellContent(sub, rowIdx, subIdx)}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : topLevelEmptyDisplay ? null : (
+                  <div className="px-4 py-3">
+                    {renderCellContent(row, rowIdx)}
+                  </div>
+                )}
+              </section>
+            );
+          })}
+        </div>
+      )}
+
       <div className="px-5 py-4 border-t-2 border-gray-200 bg-gray-50">
         {!submitted ? (
           <div className="flex items-center justify-between gap-4">


### PR DESCRIPTION
## Summary
- Backend `GET /api/stories/{id}/structure` now returns `layout: "worksheet_table"`, `title`, and `worksheet_rows` (pair + section_block with rowspan semantics)
- Merges consecutive `[解決, sub, value]` YAML triples into one parent row with `sub_rows` for grading
- Frontend `StoryStructureTable` renders paper-style black-bordered HTML table with vertical section labels and inline `【】` blanks (multi-blank supported via `blank_index`)
- Cache version bumped to `v3` to invalidate stale structure responses

## Test plan
- [x] `pytest backend/tests/test_yaml_first_structure.py` — 8 passed
- [x] `npm run build` — passed
- [ ] Staging: `GET /api/stories/1076/structure` returns `worksheet_rows`
- [ ] Staging: `/learn/1076/story-structure` matches printed worksheet layout (G6-L22 小兵立大功)


Made with [Cursor](https://cursor.com)