### PR TITLE
fix(reading): 朗讀正確率不再超過 100%（分母改用 token 統計）

### DIFF
--- a/backend/app/services/reading_evaluation_service.py
+++ b/backend/app/services/reading_evaluation_service.py
@@ -392,9 +392,18 @@ async def evaluate_reading_with_ai(
             elif token_type == "extra":
                 stats["extra_count"] += 1
 
-        # Use the target tokens (correct + forgiven + wrong + missing) as denominator
-        # This mirrors: adjusted = (correct + forgiven) / target_length
-        denominator = t_len if t_len > 0 else 1
+        # Denominator = target-position tokens only (correct + forgiven + wrong + missing),
+        # excluding `extra` (贅字). This keeps numerator and denominator on the SAME basis:
+        # both count target positions, so (correct + forgiven) <= denominator is guaranteed
+        # → adjusted_match_rate <= 1.0 by construction, not by a min(1.0, ...) clamp.
+        #
+        # Issue #2253: previously the denominator was t_len (原文字數) while the numerator
+        # came from Gemini token counts. When STT produced 贅字/重複字 and Gemini tagged them
+        # correct/forgiven, the numerator could exceed t_len → rate > 100% (seen 150%–300%).
+        target_tokens = (
+            correct + forgiven + stats["wrong_count"] + stats["missing_count"]
+        )
+        denominator = target_tokens if target_tokens > 0 else 1
 
         # Raw match rate (correct only)
         match_rate = correct / denominator

--- a/backend/tests/test_reading_evaluation_service.py
+++ b/backend/tests/test_reading_evaluation_service.py
@@ -413,3 +413,88 @@ async def test_short_text_lowers_pass_threshold():
         )
     effective_pass = result["thresholds"]["reading_pass"]
     assert effective_pass < Thresholds.READING_PASS
+
+
+# ---------------------------------------------------------------------------
+# evaluate_reading_with_ai — rate never exceeds 100% (Issue #2253)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ai_path_rate_never_exceeds_one():
+    """贅字/重複字導致 Gemini 回傳 token 數 > 原文字數時，正確率仍 ≤ 100%。
+
+    Issue #2253: STT 把單字唸成多次（贅字/重複字），Gemini 為每個都產生
+    correct/forgiven token，導致分子 > 原文字數分母 → adjusted_match_rate > 1.0。
+    """
+    fake = {
+        "diff_tokens": [
+            {"char": "天", "type": "correct"},
+            {"char": "天", "type": "correct"},
+            {"char": "天", "type": "correct"},
+        ],
+        "feedback": "很棒",
+    }
+    with patch(
+        "app.services.reading_evaluation_service.generate_structured_response",
+        new=AsyncMock(return_value=fake),
+    ):
+        result = await evaluate_reading_with_ai(spoken_text="天天天", target_text="天")
+    assert result["adjusted_match_rate"] <= 1.0   # 修復前 FAIL（算出 3.0）
+    assert result["match_rate"] <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_ai_path_empty_diff_tokens_no_crash():
+    """空的 diff_tokens（target_tokens == 0）不爆，回傳 0.0 而非除零錯誤。"""
+    fake = {"diff_tokens": [], "feedback": "加油"}
+    with patch(
+        "app.services.reading_evaluation_service.generate_structured_response",
+        new=AsyncMock(return_value=fake),
+    ):
+        result = await evaluate_reading_with_ai(spoken_text="天", target_text="天")
+    assert result["match_rate"] == 0.0
+    assert result["adjusted_match_rate"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_ai_path_all_extra_does_not_inflate():
+    """全 extra（贅字，不對應任何原文位置）→ target_tokens == 0 → 不爆、不灌水。"""
+    fake = {
+        "diff_tokens": [
+            {"char": "啊", "type": "extra"},
+            {"char": "嗯", "type": "extra"},
+        ],
+        "feedback": "再試一次",
+    }
+    with patch(
+        "app.services.reading_evaluation_service.generate_structured_response",
+        new=AsyncMock(return_value=fake),
+    ):
+        result = await evaluate_reading_with_ai(spoken_text="啊嗯", target_text="天空")
+    # extra 被排除在分母外，分子也沒有 correct/forgiven → 0.0，且 <= 1.0
+    assert result["match_rate"] == 0.0
+    assert result["adjusted_match_rate"] == 0.0
+    assert result["stats"]["extra_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_ai_path_wrong_and_missing_count_toward_denominator():
+    """wrong / missing 計入分母（目標位置），rate 仍 <= 1.0 且反映實際命中率。"""
+    fake = {
+        "diff_tokens": [
+            {"char": "天", "type": "correct"},
+            {"char": "空", "type": "wrong", "spoken": "海"},
+            {"char": "藍", "type": "missing"},
+        ],
+        "feedback": "繼續加油",
+    }
+    with patch(
+        "app.services.reading_evaluation_service.generate_structured_response",
+        new=AsyncMock(return_value=fake),
+    ):
+        result = await evaluate_reading_with_ai(spoken_text="天海", target_text="天空藍")
+    # 分母 = correct(1) + forgiven(0) + wrong(1) + missing(1) = 3
+    # match_rate = 1/3, adjusted = 1/3（結果經 round(_, 4)）
+    assert result["match_rate"] == pytest.approx(1 / 3, abs=1e-4)
+    assert result["adjusted_match_rate"] == pytest.approx(1 / 3, abs=1e-4)
+    assert result["adjusted_match_rate"] <= 1.0


### PR DESCRIPTION
Closes #2253
Related: #2197, #2187

## 問題
朗讀 AI 評估路徑算出的正確率會 **> 100%**（QA 實測 150%~300%）。

根因：`reading_evaluation_service.py` 的 AI/Gemini 路徑分子分母不同源 —— 分子 `correct + forgiven` 來自 Gemini 回傳的 token 數（無上限、未驗證），分母卻是原文字數 `t_len`。當 STT 出現贅字/重複字、Gemini 也為這些字產生 correct/forgiven token 時，分子 > 分母 → 破 100%。

> 本地 LCS 路徑與前端 `textDiff.ts` 因對齊算法天然保證 token 數 ≤ t_len，不受影響；問題只在後端 AI 路徑。

## 修法
分母改為實際 target-position token 統計（排除 `extra` 贅字），讓分子分母同源：
```python
target_tokens = correct + forgiven + stats["wrong_count"] + stats["missing_count"]
denominator = target_tokens if target_tokens > 0 else 1
```
`(correct + forgiven) <= denominator` 數學上恆成立 → 永遠 ≤ 100%（非靠 `min(1.0, ...)` 硬夾）。`match_rate` 與 `adjusted_match_rate` 共用此分母。

## TDD（red → green）
- 🔴 RED `test_ai_path_rate_never_exceeds_one`（`spoken="天天天"`, `target="天"`）→ 修復前 `assert 3.0 <= 1.0` 失敗
- 🟢 GREEN 改算法後通過
- 邊界測試：空 `diff_tokens`、全 `extra`、`wrong`/`missing` 計入分母

## 測試
- `tests/test_reading_evaluation_service.py` + `specs/test_reading_eval_safety_spec.py`：**全綠**（含關鍵回歸 `test_ai_path_tier_calculated_from_adjusted`：3 correct + 4 forgiven = 7/7 → 1.0）
- `bash specs/run-ci.sh`：Gate 1 registry OK、Gate 2 契約 561 passed / 4 xfailed
- 本機 smoke：前後端跑修復分支，登入學生小明 → 朗讀步驟驗證正確率 ≤ 100%

> Gate 3（legacy_tests）的失敗為本機 sqlite 測試 DB 未建表的既有問題（在乾淨 staging base 重跑同樣失敗），非本 PR 引入。

## 延伸 case（未含在本 PR，第二階段）
「管理人才」唸成「管理人的人才」，重複「人」是否被算兩次 —— 需 1-to-1 對齊（LCS）或後端驗證 `correct+forgiven+wrong+missing == t_len`。詳見 #2253。

## 變更檔案
- `backend/app/services/reading_evaluation_service.py`（核心修正）
- `backend/tests/test_reading_evaluation_service.py`（RED + 3 邊界測試）

🤖 Generated with [Claude Code](https://claude.com/claude-code)