### PR TITLE
feat(spotlight): 閱讀聚光燈 申論/填空 AI 即時批改 (#2192 item 5)

### DIFF
--- a/backend/app/routes/learning/__init__.py
+++ b/backend/app/routes/learning/__init__.py
@@ -35,6 +35,7 @@ from .learning_dashboard import router as dashboard_router
 # Re-export symbols that parents.py imports by name
 from .learning_dashboard import DashboardResponse, get_student_dashboard  # noqa: F401
 from .learning_vocab import router as vocab_router
+from .learning_strategy import router as strategy_router
 from .learning_exit_ticket import router as exit_ticket_router
 from .learning_reading_history import router as reading_history_router
 from .mcq_rescue import router as mcq_rescue_router
@@ -54,6 +55,7 @@ router.include_router(step_progress_router)
 router.include_router(recommendations_router)
 router.include_router(dashboard_router)
 router.include_router(vocab_router)
+router.include_router(strategy_router)
 router.include_router(exit_ticket_router)
 router.include_router(reading_history_router)
 router.include_router(mcq_rescue_router)

--- a/backend/app/routes/learning/learning_strategy.py
+++ b/backend/app/routes/learning/learning_strategy.py
@@ -16,6 +16,7 @@ LLM hardening rules applied (llm-endpoint-hardening skill):
 """
 
 import logging
+import time
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
@@ -26,6 +27,7 @@ from ...auth.rate_limiter import ai_limit_10_per_min
 from ...database import get_db
 from ...models.user import User
 from ...services.ai_service import validate_strategy_answer
+from ...services.ai_usage_tracker import last_usage, log_ai_usage
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -36,7 +38,9 @@ class ValidateStrategyRequest(BaseModel):
     student_answer: str = Field(..., min_length=1, max_length=500)
     strategy_name: str | None = Field(None, max_length=128)
     story_title: str | None = Field(None, max_length=200)
-    passage: str | None = Field(None, max_length=8000)
+    # Capped at 4000 to match the prompt truncation in validate_strategy_answer
+    # (safe_passage[:4000]) — sending more is silently ignored by the grader.
+    passage: str | None = Field(None, max_length=4000)
 
 
 class ValidateStrategyResponse(BaseModel):
@@ -61,6 +65,7 @@ async def validate_strategy(
     gentle hint when off-track. Rate limited: 10 requests per minute per user.
     Fail-closed: never blocks the student on an AI outage.
     """
+    start_time = time.monotonic()
     try:
         result = await validate_strategy_answer(
             question=payload.question,
@@ -77,6 +82,27 @@ async def validate_strategy(
             feedback="已記錄你的答案，做得好！",
             suggestion="",
         )
+
+    # Track AI usage (Issue #874) — consistent with sentence-practice/validate.
+    latency_ms = int((time.monotonic() - start_time) * 1000)
+    usage = last_usage.get()
+    log_ai_usage(
+        db,
+        endpoint="/learning/strategy-practice/validate",
+        step="strategy_validate",
+        student_id=current_user.id,
+        story_title=payload.story_title,
+        input_tokens=usage.input_tokens if usage else 0,
+        output_tokens=usage.output_tokens if usage else 0,
+        model=usage.model if usage else "gemini-2.5-flash-lite",
+        latency_ms=latency_ms,
+        success=True,
+        model_version=usage.model_version if usage else None,
+        prompt_char_count=usage.prompt_char_count if usage else None,
+        response_char_count=usage.response_char_count if usage else None,
+        content_filtered=usage.content_filtered if usage else False,
+        prompt_template_id="strategy_validate_answer",
+    )
 
     return ValidateStrategyResponse(
         is_correct=bool(result.get("is_correct", True)),

--- a/backend/app/routes/learning/learning_strategy.py
+++ b/backend/app/routes/learning/learning_strategy.py
@@ -1,0 +1,85 @@
+"""Reading-spotlight (閱讀聚光燈) strategy free-text grading endpoint (Issue #2192 item 5).
+
+Endpoint:
+  POST /api/learning/strategy-practice/validate  — AI grade a free_text guided step
+
+Professor 2026-06-04 demo feedback: 申論/填空只顯示「已記錄你的答案」，沒有即時回饋。
+要導入 AI 即時批改，寫到七八成對就給正向回饋。
+
+LLM hardening rules applied (llm-endpoint-hardening skill):
+  - Rate limit (ai_limit_10_per_min dependency) — same as sentence-practice/validate
+  - Auth: Depends(get_current_user)
+  - Input cap: question max 1000, student_answer max 500 (Pydantic Field constraints)
+  - Output cap: max_output_tokens=1024 (set in validate_strategy_answer)
+  - Fail-closed: on AI error return is_correct=true + neutral 已記錄 feedback so the
+    student is never blocked by an AI outage (the step is non-gating)
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from ...auth.dependencies import get_current_user
+from ...auth.rate_limiter import ai_limit_10_per_min
+from ...database import get_db
+from ...models.user import User
+from ...services.ai_service import validate_strategy_answer
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class ValidateStrategyRequest(BaseModel):
+    question: str = Field(..., min_length=1, max_length=1000)
+    student_answer: str = Field(..., min_length=1, max_length=500)
+    strategy_name: str | None = Field(None, max_length=128)
+    story_title: str | None = Field(None, max_length=200)
+    passage: str | None = Field(None, max_length=8000)
+
+
+class ValidateStrategyResponse(BaseModel):
+    is_correct: bool
+    feedback: str
+    suggestion: str
+
+
+@router.post(
+    "/learning/strategy-practice/validate",
+    response_model=ValidateStrategyResponse,
+    dependencies=[Depends(ai_limit_10_per_min)],
+)
+async def validate_strategy(
+    payload: ValidateStrategyRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Grade a student's free-text answer to a 閱讀聚光燈 guided step.
+
+    Lenient grading (七八成對 = 正向回饋). Returns encouraging feedback plus a
+    gentle hint when off-track. Rate limited: 10 requests per minute per user.
+    Fail-closed: never blocks the student on an AI outage.
+    """
+    try:
+        result = await validate_strategy_answer(
+            question=payload.question,
+            student_answer=payload.student_answer,
+            strategy_name=payload.strategy_name,
+            story_title=payload.story_title,
+            passage=payload.passage,
+        )
+    except Exception as e:
+        logger.error("validate_strategy error: %s", e)
+        # Fail-closed toward the student: record the answer, don't block progress.
+        return ValidateStrategyResponse(
+            is_correct=True,
+            feedback="已記錄你的答案，做得好！",
+            suggestion="",
+        )
+
+    return ValidateStrategyResponse(
+        is_correct=bool(result.get("is_correct", True)),
+        feedback=str(result.get("feedback", "已記錄你的答案，做得好！")),
+        suggestion=str(result.get("suggestion", "")),
+    )

--- a/backend/app/services/ai_generation/__init__.py
+++ b/backend/app/services/ai_generation/__init__.py
@@ -24,6 +24,10 @@ from .story_structure import (  # noqa: F401
     generate_story_structure,
     grade_story_structure,
 )
+from .strategy_practice import (  # noqa: F401
+    STRATEGY_VALIDATION_SCHEMA,
+    validate_strategy_answer,
+)
 from .teacher_comment import (  # noqa: F401
     TEACHER_COMMENT_SCHEMA,
     generate_teacher_comment,
@@ -35,6 +39,7 @@ __all__ = [
     "EXAMPLE_SENTENCES_SCHEMA",
     "SENTENCE_VALIDATION_SCHEMA",
     "STORY_STRUCTURE_SCHEMA",
+    "STRATEGY_VALIDATION_SCHEMA",
     "TEACHER_COMMENT_SCHEMA",
     # Exit Ticket
     "generate_exit_ticket",
@@ -45,6 +50,8 @@ __all__ = [
     # Story Structure
     "generate_story_structure",
     "grade_story_structure",
+    # Strategy Practice (閱讀聚光燈 free-text grading)
+    "validate_strategy_answer",
     # Teacher Comment
     "generate_teacher_comment",
 ]

--- a/backend/app/services/ai_generation/strategy_practice.py
+++ b/backend/app/services/ai_generation/strategy_practice.py
@@ -1,0 +1,115 @@
+"""
+Reading-spotlight (閱讀聚光燈) strategy free-text grading (Issue #2192 item 5).
+
+Professor 2026-06-04 demo feedback: 填空/申論作答後只顯示「已記錄你的答案」，
+沒有即時回饋。要導入 AI 即時批改，寫到七八成對就給正向回饋。
+
+Public function:
+  validate_strategy_answer — lenient, encouraging AI grading of a free_text step
+"""
+
+import logging
+
+from google.genai import types as genai_types
+
+from ..ai_base import (
+    generate_structured_response,
+    sanitize_ai_input,
+    TUTOR_PERSONA,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "STRATEGY_VALIDATION_SCHEMA",
+    "validate_strategy_answer",
+]
+
+STRATEGY_VALIDATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "is_correct": {"type": "boolean"},
+        "feedback": {"type": "string"},
+        "suggestion": {"type": "string"},
+    },
+    "required": ["is_correct", "feedback", "suggestion"],
+}
+
+
+async def validate_strategy_answer(
+    question: str,
+    student_answer: str,
+    strategy_name: str | None = None,
+    story_title: str | None = None,
+    passage: str | None = None,
+) -> dict:
+    """Grade a student's free-text answer to a reading-spotlight guided step.
+
+    Lenient by design (professor: 「寫到七八成對就給正向回饋」): if the answer
+    captures roughly 70%+ of the expected idea it counts as correct and gets pure
+    encouragement. Otherwise a gentle, non-negative hint.
+
+    Returns {"is_correct": bool, "feedback": str, "suggestion": str}
+    - is_correct: True when the answer reasonably addresses the question
+    - feedback: one encouraging sentence (never uses 錯/不對/不正確)
+    - suggestion: gentle rewrite hint when not correct (empty string if correct)
+    """
+    safe_question, _ = sanitize_ai_input(question)
+    safe_answer, _ = sanitize_ai_input(student_answer)
+    safe_strategy, _ = sanitize_ai_input(strategy_name or "")
+    safe_title, _ = sanitize_ai_input(story_title or "")
+
+    system_prompt = f"""{TUTOR_PERSONA}
+
+正在陪學生練習「閱讀聚光燈」策略{f'（{safe_strategy}）' if safe_strategy else ''}{f'，課文：《{safe_title}》' if safe_title else ''}。
+學生剛剛用自己的話回答一個開放式問題。
+
+判斷規則（寬鬆，重點在抓到大意）：
+- 學生的答案只要抓到問題核心的七八成意思、方向正確，就算對 → is_correct=true
+- 不要求一字不差或完整句子；關鍵詞或大意對了就給過
+- 完全答非所問、空白、或明顯誤解 → is_correct=false
+
+回覆規則（非常重要）：
+- feedback **只能一句話**，不要用「錯」「不對」「不行」「不正確」等否定字眼
+- is_correct=true：feedback 是一句純鼓勵（可點出他抓對了什麼）；suggestion 留空字串
+- is_correct=false：feedback 是一句溫柔提醒（先肯定再提示，例如「方向對了，再想想看…」）；suggestion 是一句引導提示，幫他往正確方向想（不要直接給答案）
+- 一律使用臺灣繁體中文（zh-TW）"""
+
+    if passage:
+        safe_passage, _ = sanitize_ai_input(passage)
+        system_prompt += f"""
+
+以下是這一課的課文，請依課文內容判斷學生答案是否正確：
+\"\"\"
+{safe_passage[:4000]}
+\"\"\""""
+
+    contents = [
+        genai_types.Content(
+            role="user",
+            parts=[
+                genai_types.Part(
+                    text=(
+                        f"問題：{safe_question}\n"
+                        f"學生的答案：「{safe_answer}」\n"
+                        "請評估這個答案是否抓到問題核心。"
+                    )
+                )
+            ],
+        )
+    ]
+
+    result = await generate_structured_response(
+        system_prompt=system_prompt,
+        contents=contents,
+        response_schema=STRATEGY_VALIDATION_SCHEMA,
+        max_tokens=1024,
+        task="strategy_validate",
+        temperature=0.3,
+    )
+
+    # Defensive: clear suggestion when correct (in case model violates prompt)
+    if result.get("is_correct"):
+        result["suggestion"] = ""
+
+    return result

--- a/backend/app/services/llm_models.py
+++ b/backend/app/services/llm_models.py
@@ -30,6 +30,9 @@ TASK_MODELS: dict[str, tuple[str, str]] = {
     "comprehension_score": ("gemini-2.5-flash-lite", "global"),
     # Tested: 3/3 complete JSON, -35% latency, correct is_correct logic
     "sentence_validate": ("gemini-2.5-flash-lite", "global"),
+    # Issue #2192 item 5: lenient free-text grading for 閱讀聚光燈 guided steps.
+    # Same category as sentence_validate (short JSON eval) — flash-lite parity.
+    "strategy_validate": ("gemini-2.5-flash-lite", "global"),
 
     # ── Generation tasks ──────────────────────────────────────────────────────
     # Tested: 3/3 complete (≥3 MCQ with correct_index), -31% latency

--- a/frontend/src/components/reading-steps/GuidedStepsExercise.tsx
+++ b/frontend/src/components/reading-steps/GuidedStepsExercise.tsx
@@ -6,7 +6,8 @@
 import React, { useEffect, useState } from 'react';
 import { StrategyExercise as StrategyExerciseType } from '../../types';
 import { useAuth } from '../../contexts/AuthContext';
-import { recordMcqAttempt } from '../../services/learningApi';
+import { recordMcqAttempt, validateStrategyAnswer } from '../../services/learningApi';
+import type { StrategyGradeResult } from '../../services/learning/sentence';
 import McqRescueDialog, { McqRescueContext } from '../reading-spotlight/McqRescueDialog';
 import StrategyHeader from './StrategyHeader';
 import {
@@ -21,6 +22,10 @@ interface Props {
   onComplete?: () => void;
   lessonId?: string;
   readingStrategy?: string | null;
+  /** Story title — passed to the AI grader for free_text steps (#2192 item 5). */
+  storyTitle?: string;
+  /** Full lesson passage — gives the AI grader context to judge free_text answers. */
+  passage?: string;
   onChange?: (exerciseState: Record<string, unknown>) => void;
   initialState?: Record<string, unknown>;
 }
@@ -30,6 +35,8 @@ const GuidedStepsExercise: React.FC<Props> = ({
   onComplete,
   lessonId,
   readingStrategy,
+  storyTitle,
+  passage,
   onChange,
   initialState,
 }) => {
@@ -44,13 +51,21 @@ const GuidedStepsExercise: React.FC<Props> = ({
   );
   const [allDone, setAllDone] = useState(() => !!(initialState?.allDone as boolean));
 
+  // AI grading results for free_text steps (#2192 item 5). Persisted so teachers
+  // can see the student's answer + AI verdict via step_progress.
+  const [textGrades, setTextGrades] = useState<(StrategyGradeResult | null)[]>(
+    () => (initialState?.textGrades as (StrategyGradeResult | null)[]) ?? steps.map(() => null),
+  );
+  // Which free_text step is currently being graded (null = none).
+  const [gradingIdx, setGradingIdx] = useState<number | null>(null);
+
   // Track which step's rescue is open (null = none).
   const [rescueStepIdx, setRescueStepIdx] = useState<number | null>(null);
   const [rescueContext, setRescueContext] = useState<McqRescueContext | null>(null);
 
   useEffect(() => {
-    onChange?.({ answers, stepFeedback, allDone, exerciseType: 'guided_steps' });
-  }, [answers, stepFeedback, allDone]); // eslint-disable-line react-hooks/exhaustive-deps
+    onChange?.({ answers, stepFeedback, allDone, textGrades, exerciseType: 'guided_steps' });
+  }, [answers, stepFeedback, allDone, textGrades]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const openRescueForStep = (stepIdx: number) => {
     const step = steps[stepIdx];
@@ -79,13 +94,55 @@ const GuidedStepsExercise: React.FC<Props> = ({
     setAnswers((prev) => prev.map((a, i) => (i === stepIdx ? optionIdx : a)));
   };
 
-  const handleStepSubmit = (stepIdx: number) => {
+  const markStepDone = (stepIdx: number) => {
+    const nextFeedback = computeNextFeedback(exercise, stepFeedback, answers, stepIdx);
+    setStepFeedback(nextFeedback);
+    if (isAllStepsDone(nextFeedback)) {
+      setAllDone(true);
+      onComplete?.();
+    }
+  };
+
+  const handleStepSubmit = async (stepIdx: number) => {
     const step = steps[stepIdx];
     const answer = answers[stepIdx];
 
     if (step.type === 'free_text') {
-      if (!answer || String(answer).trim() === '') return;
-    } else if (step.type === 'select') {
+      const text = String(answer ?? '').trim();
+      if (text === '') return;
+
+      // AI grade the answer (#2192 item 5). Lenient + encouraging; the backend
+      // fails closed so the student is never blocked on an AI outage.
+      setGradingIdx(stepIdx);
+      try {
+        if (token) {
+          const grade = await validateStrategyAnswer(token, {
+            question: step.prompt ?? '',
+            studentAnswer: text,
+            strategyName: exercise.strategy_name,
+            storyTitle,
+            passage,
+          });
+          setTextGrades((prev) => prev.map((g, i) => (i === stepIdx ? grade : g)));
+        }
+      } catch {
+        // Network/parse failure → record without feedback rather than blocking.
+        setTextGrades((prev) =>
+          prev.map((g, i) =>
+            i === stepIdx
+              ? { is_correct: true, feedback: '已記錄你的答案，做得好！', suggestion: '' }
+              : g,
+          ),
+        );
+      } finally {
+        setGradingIdx(null);
+      }
+
+      markStepDone(stepIdx);
+      return;
+    }
+
+    if (step.type === 'select') {
       if (answer === null) return;
       const isCorrect = answer === (step.answer ?? 0);
 
@@ -114,6 +171,7 @@ const GuidedStepsExercise: React.FC<Props> = ({
   const handleReset = () => {
     setAnswers(steps.map(() => null));
     setStepFeedback(steps.map(() => null));
+    setTextGrades(steps.map(() => null));
     setAllDone(false);
   };
 
@@ -142,7 +200,7 @@ const GuidedStepsExercise: React.FC<Props> = ({
                   <textarea
                     value={String(answers[stepIdx] ?? '')}
                     onChange={(e) => handleTextChange(stepIdx, e.target.value)}
-                    disabled={isDone}
+                    disabled={isDone || gradingIdx === stepIdx}
                     rows={3}
                     placeholder="請在此寫下你的答案..."
                     className={[
@@ -152,7 +210,39 @@ const GuidedStepsExercise: React.FC<Props> = ({
                         : 'bg-white border-gray-300 focus:border-violet-400 focus:ring-2 focus:ring-violet-100',
                     ].join(' ')}
                   />
-                  {isDone && (
+                  {gradingIdx === stepIdx && (
+                    <p className="mt-2 text-xs text-violet-600 font-semibold flex items-center gap-1.5">
+                      <span className="material-symbols-outlined text-sm animate-spin">progress_activity</span>
+                      AI 批改中…
+                    </p>
+                  )}
+                  {/* AI feedback (#2192 item 5) — replaces the old bare「已記錄你的答案」. */}
+                  {gradingIdx !== stepIdx && textGrades[stepIdx] && (
+                    <div
+                      className={`mt-2 rounded-lg border p-3 ${
+                        textGrades[stepIdx]!.is_correct
+                          ? 'bg-emerald-50 border-emerald-200'
+                          : 'bg-amber-50 border-amber-200'
+                      }`}
+                    >
+                      <p
+                        className={`text-xs font-semibold flex items-start gap-1.5 ${
+                          textGrades[stepIdx]!.is_correct ? 'text-emerald-700' : 'text-amber-700'
+                        }`}
+                      >
+                        <span aria-hidden="true">{textGrades[stepIdx]!.is_correct ? '✓' : '💡'}</span>
+                        <span>{textGrades[stepIdx]!.feedback}</span>
+                      </p>
+                      {textGrades[stepIdx]!.suggestion && (
+                        <p className="mt-1.5 text-xs text-amber-700/90 pl-5">
+                          {textGrades[stepIdx]!.suggestion}
+                        </p>
+                      )}
+                    </div>
+                  )}
+                  {/* Fallback when graded with no AI feedback available (e.g. restored
+                      from an older session before grading existed). */}
+                  {gradingIdx !== stepIdx && isDone && !textGrades[stepIdx] && (
                     <p className="mt-2 text-xs text-emerald-600 font-semibold">
                       &#10003; 已記錄你的答案
                     </p>
@@ -223,13 +313,14 @@ const GuidedStepsExercise: React.FC<Props> = ({
                   <button
                     onClick={() => handleStepSubmit(stepIdx)}
                     disabled={
-                      step.type === 'free_text'
+                      gradingIdx === stepIdx ||
+                      (step.type === 'free_text'
                         ? !String(answers[stepIdx] ?? '').trim()
-                        : answers[stepIdx] === null
+                        : answers[stepIdx] === null)
                     }
                     className="px-4 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 disabled:bg-gray-200 disabled:text-gray-400 text-white text-xs font-semibold transition-colors"
                   >
-                    確認
+                    {gradingIdx === stepIdx ? '批改中…' : '確認'}
                   </button>
                 </div>
               )}

--- a/frontend/src/components/reading-steps/GuidedStepsExercise.tsx
+++ b/frontend/src/components/reading-steps/GuidedStepsExercise.tsx
@@ -113,27 +113,34 @@ const GuidedStepsExercise: React.FC<Props> = ({
 
       // AI grade the answer (#2192 item 5). Lenient + encouraging; the backend
       // fails closed so the student is never blocked on an AI outage.
+      const fallbackGrade: StrategyGradeResult = {
+        is_correct: true,
+        feedback: '已記錄你的答案，做得好！',
+        suggestion: '',
+      };
+      const setGrade = (grade: StrategyGradeResult) =>
+        setTextGrades((prev) => prev.map((g, i) => (i === stepIdx ? grade : g)));
+
+      if (!token) {
+        // No auth token (e.g. test/preview without login) → record, don't block.
+        setGrade(fallbackGrade);
+        markStepDone(stepIdx);
+        return;
+      }
+
       setGradingIdx(stepIdx);
       try {
-        if (token) {
-          const grade = await validateStrategyAnswer(token, {
-            question: step.prompt ?? '',
-            studentAnswer: text,
-            strategyName: exercise.strategy_name,
-            storyTitle,
-            passage,
-          });
-          setTextGrades((prev) => prev.map((g, i) => (i === stepIdx ? grade : g)));
-        }
+        const grade = await validateStrategyAnswer(token, {
+          question: step.prompt ?? '',
+          studentAnswer: text,
+          strategyName: exercise.strategy_name,
+          storyTitle,
+          passage,
+        });
+        setGrade(grade);
       } catch {
         // Network/parse failure → record without feedback rather than blocking.
-        setTextGrades((prev) =>
-          prev.map((g, i) =>
-            i === stepIdx
-              ? { is_correct: true, feedback: '已記錄你的答案，做得好！', suggestion: '' }
-              : g,
-          ),
-        );
+        setGrade(fallbackGrade);
       } finally {
         setGradingIdx(null);
       }

--- a/frontend/src/components/reading-steps/StrategyExercise.tsx
+++ b/frontend/src/components/reading-steps/StrategyExercise.tsx
@@ -24,6 +24,10 @@ interface Props {
   lessonId?: string;
   /** Reading strategy type — selects strategy-specific rescue prompt. */
   readingStrategy?: string | null;
+  /** Story title — passed to the AI grader for free_text steps (#2192 item 5). */
+  storyTitle?: string;
+  /** Full lesson passage — gives the AI grader context for free_text answers. */
+  passage?: string;
   /** Persist answer state to parent (Issue #1505 — survive page refresh). */
   onChange?: (exerciseState: Record<string, unknown>) => void;
   initialState?: Record<string, unknown>;
@@ -34,6 +38,8 @@ const StrategyExercise: React.FC<Props> = ({
   onComplete,
   lessonId,
   readingStrategy,
+  storyTitle,
+  passage,
   onChange,
   initialState,
 }) => {
@@ -63,6 +69,8 @@ const StrategyExercise: React.FC<Props> = ({
           onComplete={handleComplete}
           lessonId={lessonId}
           readingStrategy={readingStrategy}
+          storyTitle={storyTitle}
+          passage={passage}
           onChange={onChange}
           initialState={initialState}
         />

--- a/frontend/src/components/reading-steps/__tests__/StrategyExercise.test.tsx
+++ b/frontend/src/components/reading-steps/__tests__/StrategyExercise.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import StrategyExercise from '../StrategyExercise';
 import { StrategyExercise as StrategyExerciseType } from '../../../types';
-import { recordMcqAttempt } from '../../../services/learningApi';
+import { recordMcqAttempt, validateStrategyAnswer } from '../../../services/learningApi';
 
 // Stub auth + network so tests don't need providers or real API calls.
 vi.mock('../../../contexts/AuthContext', () => ({
@@ -10,6 +10,7 @@ vi.mock('../../../contexts/AuthContext', () => ({
 }));
 vi.mock('../../../services/learningApi', () => ({
   recordMcqAttempt: vi.fn(),
+  validateStrategyAnswer: vi.fn(),
   mcqRescueStart: vi.fn(),
   mcqRescueRespond: vi.fn(),
   SessionExpiredError: class SessionExpiredError extends Error {},
@@ -51,6 +52,13 @@ const guidedTwoSelect: StrategyExerciseType = {
       answer: 1,
     },
   ],
+};
+
+const guidedFreeText: StrategyExerciseType = {
+  type: 'guided_steps',
+  strategy_name: '問題.解決.結果',
+  instruction: '用自己的話回答。',
+  steps: [{ prompt: '主角遇到什麼問題？', type: 'free_text' }],
 };
 
 const traitExercise: StrategyExerciseType = {
@@ -170,6 +178,65 @@ describe('trait_wrong_answer_records_attempt_and_opens_rescue_context', () => {
     pickOption('慷慨'); // correct
     fireEvent.click(screen.getByRole('button', { name: /送出答案/ }));
     expect(screen.queryByText(/問 AI 助教/)).toBeNull();
+  });
+});
+
+// ── free_text AI grading (#2192 item 5) ─────────────────────────────────────
+
+describe('guided_steps free_text AI grading', () => {
+  beforeEach(() => {
+    vi.mocked(validateStrategyAnswer).mockReset();
+  });
+
+  it('shows AI feedback after a free_text answer is graded', async () => {
+    vi.mocked(validateStrategyAnswer).mockResolvedValue({
+      is_correct: true,
+      feedback: '你抓到重點了！',
+      suggestion: '',
+    });
+    render(<StrategyExercise exercise={guidedFreeText} onComplete={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/寫下你的答案/), {
+      target: { value: '城門打不開' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /確認/ }));
+
+    expect(await screen.findByText('你抓到重點了！')).toBeTruthy();
+    expect(validateStrategyAnswer).toHaveBeenCalledWith(
+      'test-token',
+      expect.objectContaining({ studentAnswer: '城門打不開', question: '主角遇到什麼問題？' }),
+    );
+  });
+
+  it('shows suggestion hint when answer is off-track', async () => {
+    vi.mocked(validateStrategyAnswer).mockResolvedValue({
+      is_correct: false,
+      feedback: '方向對了，再想想看～',
+      suggestion: '試著找出主角卡關的地方',
+    });
+    render(<StrategyExercise exercise={guidedFreeText} onComplete={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/寫下你的答案/), {
+      target: { value: '不知道' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /確認/ }));
+
+    expect(await screen.findByText('方向對了，再想想看～')).toBeTruthy();
+    expect(screen.getByText('試著找出主角卡關的地方')).toBeTruthy();
+  });
+
+  it('falls back to 已記錄 and still completes when grading throws', async () => {
+    vi.mocked(validateStrategyAnswer).mockRejectedValue(new Error('network'));
+    const onComplete = vi.fn();
+    render(<StrategyExercise exercise={guidedFreeText} onComplete={onComplete} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/寫下你的答案/), {
+      target: { value: '隨便寫' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /確認/ }));
+
+    expect(await screen.findByText(/已記錄你的答案/)).toBeTruthy();
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/pages/learning/StrategyExercisePage.tsx
+++ b/frontend/src/pages/learning/StrategyExercisePage.tsx
@@ -97,6 +97,8 @@ const StrategyExercisePage: React.FC = () => {
               onComplete={handleStrategyComplete}
               lessonId={selectedStory.id}
               readingStrategy={selectedStory.readingStrategy}
+              storyTitle={selectedStory.title}
+              passage={selectedStory.content?.join('\n')}
               onChange={handleAnswerChange}
               initialState={savedStrategyData}
             />

--- a/frontend/src/services/learning/sentence.ts
+++ b/frontend/src/services/learning/sentence.ts
@@ -46,3 +46,46 @@ export async function validateSentence(
   if (!res.ok) throw new Error(`validateSentence failed: ${res.status}`);
   return res.json();
 }
+
+// ---------------------------------------------------------------------------
+// Reading-spotlight (閱讀聚光燈) free-text grading (Issue #2192 item 5)
+// ---------------------------------------------------------------------------
+
+export interface StrategyGradeResult {
+  is_correct: boolean;
+  feedback: string;
+  suggestion: string;
+}
+
+/**
+ * AI-grade a free_text guided step answer. Lenient (七八成對 → 正向回饋).
+ * The backend fails closed (returns is_correct=true) on AI outage, so this
+ * resolves with an encouraging result rather than blocking the student.
+ */
+export async function validateStrategyAnswer(
+  token: string,
+  payload: {
+    question: string;
+    studentAnswer: string;
+    strategyName?: string | null;
+    storyTitle?: string | null;
+    passage?: string | null;
+  },
+): Promise<StrategyGradeResult> {
+  const res = await fetch(`${API_BASE}/api/learning/strategy-practice/validate`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      question: payload.question,
+      student_answer: payload.studentAnswer,
+      strategy_name: payload.strategyName ?? null,
+      story_title: payload.storyTitle ?? null,
+      passage: payload.passage ?? null,
+    }),
+  });
+  if (!res.ok) throw new Error(`validateStrategyAnswer failed: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
## 背景

issue #2192 驗收教授 2026-06-04 demo 回饋。先檢查七項 checklist，結果：

| 項目 | 狀態 |
|------|------|
| 1. 聚光燈入口明顯 | ✅ 已完成（StepperNav「閱讀聚光燈」label + 光徽章）|
| 2. 進入前引導說明 | ✅ 已完成（Intro 本課學習策略區塊）|
| 3. 題號格式 | ⚠️ 程式支援，視 lesson YAML |
| 4. 左側對應課文片段 | ❌ 依賴 #2205 passage-binding schema |
| 5. 申論/填空回饋 | ❌ → **本 PR 解決** |

經討論，**item 4 與 issue #2205（build-spotlight schema 重建，涵蓋同樣那 7 課）高度重疊**，且現有 frontend 尚未接新 schema，故 item 4 留待 #2205 一併處理。本 PR 專注 **item 5**。

## 本 PR 做了什麼（item 5）

教授原話：
> 「申論/填空只顯示『已記錄你的答案』，沒有即時回饋……要導入 AI 即時批改，寫到七八成對就給正向回饋。」

為 `guided_steps` 的 `free_text` 步驟導入 AI 即時批改：

**Backend**
- `strategy_validate` task（`gemini-2.5-flash-lite`, global）加入 `TASK_MODELS`
- `ai_generation/strategy_practice.py` → `validate_strategy_answer()`：寬鬆判分（抓到七八成大意即算對）+ 一句鼓勵 feedback + 溫柔 suggestion，沿用 `sentence_validate` 的暖語氣
- `routes/learning/learning_strategy.py` → `POST /api/learning/strategy-practice/validate`
  - LLM 硬化：auth、`ai_limit_10_per_min`、input cap、**fail-closed（AI 故障時不擋學生，回「已記錄」）**

**Frontend**
- `validateStrategyAnswer()`（services/learning/sentence.ts）
- `GuidedStepsExercise.tsx`：free_text 送出 → 呼叫 AI 批改 → 顯示「AI 批改中…」/ 綠色鼓勵回饋 / 黃色引導提示，取代原本乾巴巴的「已記錄你的答案」
- AI 結果寫入 `step_progress`（教師端可由此看到學生答案＋評分）
- 串接 `storyTitle` / `passage` 給 grader 當判分依據

## 測試
- ✅ Backend：import / 路由註冊 / `get_model_for_task('strategy_validate')` OK
- ✅ Spec CI：registry fresh；contracts **555 passed / 4 xfailed**（2 個 OMO image spec 因本機缺 Pillow 無法 collect，與本變更無關）
- ✅ Frontend：`StrategyExercise.test.tsx` 14/14 通過；tsc 對改動檔案無新增錯誤

## 待後續
- item 4（左側對應課文片段）→ #2205
- 教師端 UI 顯示學生申論答案＋AI 評分（資料已落 `step_progress`，UI 呈現另案）
- staging preview 上 7 課逐課實機 QA（#2192 checklist）

Related to #2192