### PR TITLE
fix(story-structure): hide blank answers from placeholders

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -3,6 +3,7 @@ Stories API — serves platform lessons from in-memory YAML data.
 No database dependency for platform content.
 """
 
+import copy
 import re
 import time
 from fastapi import APIRouter, Query, HTTPException, Depends, Request
@@ -65,12 +66,42 @@ def _cell_to_row_dict(label: str, value: str) -> dict:
         "interactive_type": itype,
     }
     if itype == "fill_blank":
-        hints = [m.group(1).strip() for m in _BLANK_RE.finditer(value)]
-        if hints:
-            row["hint"] = hints[0]
-        if len(hints) > 1:
-            row["blank_hints"] = hints
+        # Answers inside 【】 are stored server-side for grading only — never sent to client.
+        answers = [m.group(1).strip() for m in _BLANK_RE.finditer(value)]
+        if answers:
+            row["hint"] = answers[0]
+        if len(answers) > 1:
+            row["blank_hints"] = answers
     return row
+
+
+def _strip_blank_answers(text: str) -> str:
+    """Replace 【answer】 with empty blanks for student-facing display."""
+    return _BLANK_RE.sub("【　　　】", text)
+
+
+def _sanitize_row_for_client(row: dict) -> dict:
+    """Remove grading answers from a structure row before API response."""
+    out = {k: v for k, v in row.items() if k not in ("hint", "blank_hints")}
+    if out.get("interactive_type") == "fill_blank" and out.get("value"):
+        out["value"] = _strip_blank_answers(out["value"])
+    sub_rows = out.get("sub_rows")
+    if sub_rows:
+        out["sub_rows"] = [_sanitize_row_for_client(sr) for sr in sub_rows]
+    return out
+
+
+def _sanitize_structure_for_client(structure: dict) -> dict:
+    """Return a deep copy of structure with answers stripped for student UI."""
+    result = copy.deepcopy(structure)
+    result["rows"] = [_sanitize_row_for_client(r) for r in result.get("rows", [])]
+    for ws in result.get("worksheet_rows") or []:
+        if ws.get("kind") == "pair":
+            ws["value"] = _strip_blank_answers(ws["value"])
+        elif ws.get("kind") == "section_block":
+            for item in ws.get("items") or []:
+                item["value"] = _strip_blank_answers(item["value"])
+    return result
 
 
 def _parse_yaml_table_row(raw_row: list) -> dict | None:
@@ -446,13 +477,13 @@ async def get_story_structure(
             cache_hit=True,
             prompt_template_id="story_structure_rows_yaml",
         )
-        return result
+        return _sanitize_structure_for_client(result)
 
     # Priority 2: story_structure_table — docx-parsed list-of-lists (ground truth)
     yaml_table = story.get("story_structure_table")
     if yaml_table:
         result = _format_yaml_structure_table(yaml_table)
-        # Store in cache so grade endpoint can use it; log as zero-cost hit
+        # Store full structure (with answers) in cache for grading
         _set_cached_structure(story_id, result)
         log_ai_usage(
             db,
@@ -473,12 +504,12 @@ async def get_story_structure(
             cache_hit=True,
             prompt_template_id="story_structure_yaml",
         )
-        return result
+        return _sanitize_structure_for_client(result)
 
     # ── In-memory cache hit — return immediately without rate-limit quota ───
     cached = _get_cached_structure(story_id)
     if cached is not None:
-        return cached
+        return _sanitize_structure_for_client(cached)
 
     # ── Cache miss — enforce rate limit before calling AI ───────────────────
     rl_key = f"ai:{get_client_key(request)}"
@@ -516,7 +547,7 @@ async def get_story_structure(
         cache_hit=False,
         prompt_template_id="story_structure",
     )
-    return result
+    return _sanitize_structure_for_client(result)
 
 
 # ── ⑤ 文章重點表 批改 endpoint (#1082) ────────────────────────────────────────

--- a/backend/tests/test_yaml_first_structure.py
+++ b/backend/tests/test_yaml_first_structure.py
@@ -46,14 +46,35 @@ def test_two_cell_display_row():
 
 
 def test_two_cell_fill_blank_row():
-    """[label, value] with 【answer】 → fill_blank, hint extracted."""
+    """[label, value] with 【answer】 → fill_blank, answers stored for grading only."""
     table = [["結論", "生物不能【 自然產生 】，腐敗與【 微生物污染 】有關。"]]
     result = _format_yaml_structure_table(table)
     row = result["rows"][0]
     assert row["label"] == "結論"
     assert row["interactive_type"] == "fill_blank"
-    assert "hint" in row
-    assert row["hint"] == "自然產生"  # first blank extracted
+    assert row["hint"] == "自然產生"  # first blank extracted for server-side grading
+
+
+def test_sanitize_structure_strips_answers_from_client():
+    """GET response must not leak answers in value, hint, or blank_hints."""
+    from app.routes.stories import _sanitize_structure_for_client
+
+    table = [
+        ["小兵立大功：雞鳴狗盜的故事"],
+        ["問題", "秦昭王軟禁了孟嘗君。"],
+        ["解決", "問題1", "食客會模仿【 狗 】偷東西。"],
+    ]
+    full = _format_yaml_structure_table(table)
+    client = _sanitize_structure_for_client(full)
+
+    sub = client["rows"][2]["sub_rows"][0]
+    assert "hint" not in sub
+    assert "blank_hints" not in sub
+    assert "【 狗 】" not in sub["value"]
+    assert "【　　　】" in sub["value"]
+
+    ws_item = client["worksheet_rows"][1]["items"][0]
+    assert "【 狗 】" not in ws_item["value"]
 
 
 def test_three_cell_sub_row():

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -179,7 +179,6 @@ function sectionVerticalLabel(section: string): string {
 // ── Inline blank inputs (worksheet table cells) ─────────────────────────────
 
 interface InlineBlankInputProps {
-  hint?: string;
   value: string;
   onChange: (v: string) => void;
   submitted: boolean;
@@ -188,7 +187,6 @@ interface InlineBlankInputProps {
 }
 
 const InlineBlankInput: React.FC<InlineBlankInputProps> = ({
-  hint,
   value,
   onChange,
   submitted,
@@ -214,7 +212,7 @@ const InlineBlankInput: React.FC<InlineBlankInputProps> = ({
       type="text"
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      placeholder={hint?.trim() || '　'}
+      placeholder="　"
       className={`${width} inline-block bg-transparent border-b-2 border-gray-800 text-sm text-center focus:outline-none focus:border-amber-600 mx-0.5`}
       disabled={submitted}
     />
@@ -225,7 +223,6 @@ interface InlineWorksheetContentProps {
   text: string;
   rowIdx: number;
   subIdx?: number;
-  hints?: string[];
   answers: AnswerMap;
   setAnswer: (key: string, value: string | number[]) => void;
   submitted: boolean;
@@ -236,7 +233,6 @@ const InlineWorksheetContent: React.FC<InlineWorksheetContentProps> = ({
   text,
   rowIdx,
   subIdx,
-  hints,
   answers,
   setAnswer,
   submitted,
@@ -253,12 +249,10 @@ const InlineWorksheetContent: React.FC<InlineWorksheetContentProps> = ({
         nodes.push(<span key={`t-${last}`}>{text.slice(last, match.index)}</span>);
       }
       const key = answerKey(rowIdx, subIdx, blankIdx);
-      const hint = hints?.[blankIdx] ?? match[1]?.trim();
       nodes.push(
         <span key={`b-${blankIdx}`} className="inline-flex items-baseline">
           <span>【</span>
           <InlineBlankInput
-            hint={hint}
             value={typeof answers[key] === 'string' ? (answers[key] as string) : ''}
             onChange={(v) => setAnswer(key, v)}
             submitted={submitted}
@@ -277,7 +271,7 @@ const InlineWorksheetContent: React.FC<InlineWorksheetContentProps> = ({
       nodes.push(<span key={`t-${last}`}>{text.slice(last)}</span>);
     }
     return nodes;
-  }, [text, rowIdx, subIdx, hints, answers, setAnswer, submitted, gradeResults]);
+  }, [text, rowIdx, subIdx, answers, setAnswer, submitted, gradeResults]);
 
   return <span className="text-sm leading-relaxed whitespace-pre-line">{parts}</span>;
 };
@@ -285,7 +279,6 @@ const InlineWorksheetContent: React.FC<InlineWorksheetContentProps> = ({
 // ── FillBlankCell (card layout) ─────────────────────────────────────────────
 
 interface FillBlankCellProps {
-  hint?: string;
   value: string;
   onChange: (v: string) => void;
   submitted: boolean;
@@ -293,7 +286,6 @@ interface FillBlankCellProps {
 }
 
 const FillBlankCell: React.FC<FillBlankCellProps> = ({
-  hint,
   value,
   onChange,
   submitted,
@@ -327,7 +319,7 @@ const FillBlankCell: React.FC<FillBlankCellProps> = ({
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder={hint ?? '請填入答案'}
+        placeholder="　"
         className="w-36 bg-amber-50 border-b-2 border-amber-400 text-gray-900 text-sm placeholder-gray-400 focus:outline-none focus:border-amber-600 px-1 py-0.5 text-center"
         disabled={submitted}
       />
@@ -452,7 +444,6 @@ const WorksheetTable: React.FC<WorksheetTableProps> = ({
     value: string,
     rowIdx: number,
     subIdx?: number,
-    hints?: string[],
   ) => {
     const itype = classifyInteractive(value);
     if (itype === 'fill_blank' && countBlanks(value) > 0) {
@@ -461,7 +452,6 @@ const WorksheetTable: React.FC<WorksheetTableProps> = ({
           text={value}
           rowIdx={rowIdx}
           subIdx={subIdx}
-          hints={hints}
           answers={answers}
           setAnswer={setAnswer}
           submitted={submitted}
@@ -499,7 +489,7 @@ const WorksheetTable: React.FC<WorksheetTableProps> = ({
                   {wsRow.label}
                 </td>
                 <td colSpan={2} className={cellBorder}>
-                  {renderValueCell(wsRow.value, rowIdx, undefined, row?.blank_hints)}
+                  {renderValueCell(wsRow.value, rowIdx, undefined)}
                 </td>
               </tr>
             );
@@ -540,7 +530,6 @@ const WorksheetTable: React.FC<WorksheetTableProps> = ({
                       item.value,
                       rowIdx,
                       subIdx,
-                      subRow?.blank_hints,
                     )}
                   </td>
                 </tr>
@@ -815,7 +804,6 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
       }
       return (
         <FillBlankCell
-          hint={cell.hint}
           value={typeof answers[key] === 'string' ? (answers[key] as string) : ''}
           onChange={(v) => setAnswer(key, v)}
           submitted={submitted}


### PR DESCRIPTION
## Summary
- Strip `【】` answers from GET `/api/stories/{id}/structure` before returning to the client
- Keep full answers in server cache for grading only
- Frontend blanks no longer use hint/bracket text as input placeholders

## Test plan
- [x] `pytest tests/test_yaml_first_structure.py`
- [ ] Staging QA: G6-L22 文章重點表 blanks show empty, not answers

Made with [Cursor](https://cursor.com)