### PR TITLE
feat(story-structure): profile-driven demo + blank placeholder fixes

### DIFF
--- a/backend/app/routes/stories.py
+++ b/backend/app/routes/stories.py
@@ -91,6 +91,76 @@ def _sanitize_row_for_client(row: dict) -> dict:
     return out
 
 
+def _infer_structure_template_kind(title: str | None, labels: list[str]) -> str:
+    """Infer coach/demo template from table title + row labels."""
+    blob = " ".join([title or "", *labels])
+    if re.search(r"假說|驗證|步驟|探究", blob):
+        return "scientific"
+    if re.search(r"問題", blob) and re.search(r"解決|結果|影響|成效", blob):
+        return "psr"
+    if re.search(r"主題|事實|主角|事例|論點", blob):
+        return "theme_facts"
+    return "generic"
+
+
+def _derive_interaction_profile(structure: dict) -> dict:
+    """Summarize how students interact with this structure table.
+
+    Attached to GET /structure so the frontend demo/coach can branch without
+    re-deriving from rows. New table formats only need to populate rows with
+    interactive_type — profile fields stay stable.
+    """
+    fill_blank_count = 0
+    checkbox_count = 0
+    primary_labels: list[str] = []
+    section_labels: list[str] = []
+
+    def tally_row(row: dict) -> None:
+        nonlocal fill_blank_count, checkbox_count
+        itype = row.get("interactive_type")
+        label = str(row.get("label") or "").strip()
+        if itype == "fill_blank":
+            fill_blank_count += 1
+            if label:
+                primary_labels.append(label)
+        elif itype == "checkbox":
+            checkbox_count += 1
+            if label:
+                primary_labels.append(label)
+
+    for row in structure.get("rows") or []:
+        parent_label = str(row.get("label") or "").strip()
+        if parent_label:
+            section_labels.append(parent_label)
+        sub_rows = row.get("sub_rows") or []
+        if sub_rows:
+            for sub in sub_rows:
+                tally_row(sub)
+        else:
+            tally_row(row)
+
+    if fill_blank_count and checkbox_count:
+        mode = "mixed"
+    elif fill_blank_count:
+        mode = "fill_blank"
+    elif checkbox_count:
+        mode = "checkbox"
+    else:
+        mode = "display_only"
+
+    return {
+        "mode": mode,
+        "template_kind": _infer_structure_template_kind(
+            structure.get("title"),
+            primary_labels + section_labels,
+        ),
+        "fill_blank_count": fill_blank_count,
+        "checkbox_count": checkbox_count,
+        "primary_labels": primary_labels[:4],
+        "layout": structure.get("layout") or "cards",
+    }
+
+
 def _sanitize_structure_for_client(structure: dict) -> dict:
     """Return a deep copy of structure with answers stripped for student UI."""
     result = copy.deepcopy(structure)
@@ -101,6 +171,7 @@ def _sanitize_structure_for_client(structure: dict) -> dict:
         elif ws.get("kind") == "section_block":
             for item in ws.get("items") or []:
                 item["value"] = _strip_blank_answers(item["value"])
+    result["interaction_profile"] = _derive_interaction_profile(result)
     return result
 
 

--- a/backend/tests/test_yaml_first_structure.py
+++ b/backend/tests/test_yaml_first_structure.py
@@ -75,6 +75,40 @@ def test_sanitize_structure_strips_answers_from_client():
 
     ws_item = client["worksheet_rows"][1]["items"][0]
     assert "【 狗 】" not in ws_item["value"]
+    profile = client["interaction_profile"]
+    assert profile["mode"] == "fill_blank"
+    assert profile["template_kind"] == "psr"
+    assert profile["fill_blank_count"] >= 1
+
+
+def test_interaction_profile_mixed_rows():
+    """story_structure_rows-style mixed fill_blank + checkbox."""
+    from app.routes.stories import _derive_interaction_profile
+
+    structure = {
+        "layout": "cards",
+        "rows": [
+            {"label": "主題", "value": "x", "interactive_type": "fill_blank"},
+            {"label": "事實", "value": "y", "interactive_type": "checkbox", "options": ["a", "b"]},
+        ],
+    }
+    profile = _derive_interaction_profile(structure)
+    assert profile["mode"] == "mixed"
+    assert profile["fill_blank_count"] == 1
+    assert profile["checkbox_count"] == 1
+    assert profile["template_kind"] == "theme_facts"
+
+
+def test_interaction_profile_display_only():
+    from app.routes.stories import _derive_interaction_profile
+
+    structure = {
+        "rows": [
+            {"label": "步驟", "value": "閱讀對照", "interactive_type": "display"},
+        ],
+    }
+    profile = _derive_interaction_profile(structure)
+    assert profile["mode"] == "display_only"
 
 
 def test_three_cell_sub_row():

--- a/frontend/src/components/reading-steps/ComprehensionLayout.tsx
+++ b/frontend/src/components/reading-steps/ComprehensionLayout.tsx
@@ -435,7 +435,7 @@ const ComprehensionLayout: React.FC<ComprehensionLayoutProps> = ({
            *   gallery), so practice no longer scrolls back to find the figure.
            * ══════════════════════════════════════════════════════════════════ */
           <div className="w-full h-full overflow-y-auto custom-scrollbar pr-1">
-            <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8">
+            <div className="bg-surface-container-lowest rounded-3xl shadow-editorial p-6 md:p-8" data-comprehension-lesson-text>
               <div className="flex items-center gap-2 mb-5">
                 <span className="material-symbols-outlined text-accent text-xl">auto_stories</span>
                 <span className="font-headline font-bold text-on-surface text-sm uppercase tracking-wider">

--- a/frontend/src/components/reading-steps/StoryStructureTable.tsx
+++ b/frontend/src/components/reading-steps/StoryStructureTable.tsx
@@ -8,6 +8,15 @@
 import React, { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import {
+  STORY_STRUCTURE_INTERACTIVE_ATTR,
+  DEMO_STEP_DURATION_MS,
+  buildDemoSequence,
+  deriveStructureProfile,
+  getCoachIntroText,
+  resolveDemoTargetElement,
+  type StructureInteractionProfile,
+} from './storyStructureProfile';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -53,6 +62,7 @@ interface StructureData {
   title?: string;
   worksheet_rows?: WorksheetRow[];
   rows: StructureRow[];
+  interaction_profile?: Partial<StructureInteractionProfile>;
 }
 
 interface GradeResultItem {
@@ -79,10 +89,8 @@ const INLINE_BLANK_RE = /【([^】]*)】/g;
 const SECTION_CHUNK_SIZE = 3;
 const STORY_STRUCTURE_ONBOARDED_KEY = 'story_structure_onboarded';
 
-type StoryStructureDemoStep = 'overview' | 'read' | 'type' | 'submit' | 'success';
-
 interface StoryStructureDemoRuntime {
-  step: StoryStructureDemoStep;
+  step: import('./storyStructureProfile').DemoStepId;
 }
 
 interface DemoSpotlightRect {
@@ -165,11 +173,12 @@ function DemoSpotlightOverlay({
 }
 
 interface OnboardingCoachProps {
+  introText: string;
   onDismiss: () => void;
   onDemo: () => void;
 }
 
-function OnboardingCoach({ onDismiss, onDemo }: OnboardingCoachProps) {
+function OnboardingCoach({ introText, onDismiss, onDemo }: OnboardingCoachProps) {
   return (
     <div className="mb-4 rounded-2xl border-2 border-amber-400/60 bg-amber-50 px-5 py-4 flex flex-col gap-3">
       <div className="flex items-start gap-3">
@@ -178,10 +187,7 @@ function OnboardingCoach({ onDismiss, onDemo }: OnboardingCoachProps) {
         </span>
         <div className="flex-1">
           <p className="font-bold text-on-surface text-base mb-1">文章重點表怎麼玩？</p>
-          <p className="text-sm text-on-surface-variant leading-relaxed">
-            用表格整理課文的<strong className="text-amber-800">問題、解決、結果</strong>。
-            讀左邊課文，把關鍵詞填進【　】空格，填完按「提交答案」，AI 會幫你檢查。
-          </p>
+          <p className="text-sm text-on-surface-variant leading-relaxed">{introText}</p>
         </div>
       </div>
       <div className="flex items-center gap-2 self-end">
@@ -342,6 +348,7 @@ const InlineBlankInput: React.FC<InlineBlankInputProps> = ({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder="　"
+      {...{ [STORY_STRUCTURE_INTERACTIVE_ATTR]: 'fill_blank' }}
       className={`${width} inline-block bg-transparent border-b-2 border-gray-800 text-sm text-center focus:outline-none focus:border-amber-600 mx-0.5`}
       disabled={submitted}
     />
@@ -449,6 +456,7 @@ const FillBlankCell: React.FC<FillBlankCellProps> = ({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder="　"
+        {...{ [STORY_STRUCTURE_INTERACTIVE_ATTR]: 'fill_blank' }}
         className="w-36 bg-amber-50 border-b-2 border-amber-400 text-gray-900 text-sm placeholder-gray-400 focus:outline-none focus:border-amber-600 px-1 py-0.5 text-center"
         disabled={submitted}
       />
@@ -486,7 +494,7 @@ const CheckboxCell: React.FC<CheckboxCellProps> = ({
   };
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2" {...{ [STORY_STRUCTURE_INTERACTIVE_ATTR]: 'checkbox' }}>
       {options.map((opt, idx) => {
         const isSelected = selected.includes(idx);
         const isCorrectOption = (correctOptions ?? []).includes(idx);
@@ -728,17 +736,27 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
 
   useEffect(() => () => clearDemoTimers(), [clearDemoTimers]);
 
-  const resolveDemoTarget = useCallback((step: StoryStructureDemoStep): HTMLElement | null => {
-    if (step === 'read') {
-      return document.querySelector('[data-comprehension-lesson-text]');
-    }
-    if (step === 'type') {
-      return tableContainerRef.current?.querySelector('input[type="text"]') ?? null;
-    }
-    if (step === 'submit' || step === 'success') {
-      return submitBtnRef.current;
-    }
-    return tableContainerRef.current;
+  const interactionProfile = useMemo(
+    () => (structure ? deriveStructureProfile(structure) : null),
+    [structure],
+  );
+
+  const demoSteps = useMemo(
+    () => (interactionProfile ? buildDemoSequence(interactionProfile) : []),
+    [interactionProfile],
+  );
+
+  const activeDemoStep = useMemo(
+    () => (demo ? demoSteps.find((s) => s.id === demo.step) ?? null : null),
+    [demo, demoSteps],
+  );
+
+  const resolveDemoTarget = useCallback((step: import('./storyStructureProfile').DemoStepId): HTMLElement | null => {
+    return resolveDemoTargetElement(
+      step,
+      tableContainerRef.current,
+      submitBtnRef.current,
+    );
   }, []);
 
   useLayoutEffect(() => {
@@ -773,15 +791,20 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
   }, []);
 
   const handleDemo = useCallback(() => {
+    if (!interactionProfile || demoSteps.length === 0) return;
     clearDemoTimers();
     handleDismissCoach();
-    setDemo({ step: 'overview' });
-    scheduleDemoStep(() => setDemo({ step: 'read' }), 2800);
-    scheduleDemoStep(() => setDemo({ step: 'type' }), 5600);
-    scheduleDemoStep(() => setDemo({ step: 'submit' }), 8400);
-    scheduleDemoStep(() => setDemo({ step: 'success' }), 11200);
-    scheduleDemoStep(() => setDemo(null), 14000);
-  }, [clearDemoTimers, handleDismissCoach, scheduleDemoStep]);
+    demoSteps.forEach((stepConfig, index) => {
+      scheduleDemoStep(() => setDemo({ step: stepConfig.id }), index * DEMO_STEP_DURATION_MS);
+    });
+    scheduleDemoStep(() => setDemo(null), demoSteps.length * DEMO_STEP_DURATION_MS);
+  }, [
+    clearDemoTimers,
+    handleDismissCoach,
+    scheduleDemoStep,
+    interactionProfile,
+    demoSteps,
+  ]);
 
 
   const setAnswer = useCallback((key: string, value: string | number[]) => {
@@ -1045,17 +1068,19 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
     structure.layout === 'worksheet_table' &&
     !!(structure.worksheet_rows && structure.worksheet_rows.length > 0);
 
-  const demoBubbleText: Partial<Record<StoryStructureDemoStep, string>> = {
-    overview: '① 這張表幫你整理課文的問題、解決、結果',
-    read: '② 讀左邊課文，想想空格要填什麼關鍵詞',
-    type: '③ 點【　】空格，輸入你的答案',
-    submit: '④ 全部填完後，按「提交答案」',
-    success: '⑤ AI 會幫你檢查，答錯可以看參考提示',
-  };
+  const coachIntroText = interactionProfile
+    ? getCoachIntroText(interactionProfile)
+    : '讀課文，完成表格練習';
 
   return (
     <div className={useWorksheet ? 'max-w-3xl mx-auto' : 'max-w-2xl mx-auto'}>
-      {showCoach && <OnboardingCoach onDismiss={handleDismissCoach} onDemo={handleDemo} />}
+      {showCoach && (
+        <OnboardingCoach
+          introText={coachIntroText}
+          onDismiss={handleDismissCoach}
+          onDemo={handleDemo}
+        />
+      )}
       {!showCoach && (
         <div className="flex justify-end mb-2">
           <button
@@ -1068,18 +1093,12 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
           </button>
         </div>
       )}
-      {demo && demoTargetRect && demoBubbleText[demo.step] && (
+      {demo && demoTargetRect && activeDemoStep && (
         <DemoSpotlightOverlay
           rect={demoTargetRect}
-          label={demoBubbleText[demo.step]!}
-          placement={
-            demo.step === 'type' || demo.step === 'submit' || demo.step === 'success'
-              ? 'above'
-              : 'below'
-          }
-          bubbleAnchor={
-            demo.step === 'overview' || demo.step === 'read' ? 'top' : 'center'
-          }
+          label={activeDemoStep.bubbleText}
+          placement={activeDemoStep.placement}
+          bubbleAnchor={activeDemoStep.bubbleAnchor}
         />
       )}
     <div
@@ -1178,6 +1197,7 @@ const StoryStructureTable: React.FC<Props> = ({ storyId }) => {
             </p>
             <button
               ref={submitBtnRef}
+              data-story-structure-submit
               onClick={handleSubmit}
               disabled={!allAnswered || submitting}
               className={`px-6 py-2 rounded-xl font-bold text-sm transition-all ${

--- a/frontend/src/components/reading-steps/storyStructureProfile.ts
+++ b/frontend/src/components/reading-steps/storyStructureProfile.ts
@@ -1,0 +1,275 @@
+/**
+ * Story structure interaction profile + demo sequence builder.
+ *
+ * Contract:
+ * - Backend attaches `interaction_profile` on GET /structure (preferred).
+ * - Frontend can derive the same shape from `rows` when missing (AI fallback).
+ * - Demo/coach read profile only — new table YAML formats extend rows, not demo code.
+ */
+
+export const STORY_STRUCTURE_DOM = {
+  LESSON_TEXT: '[data-comprehension-lesson-text]',
+  TABLE: '[data-story-structure-table]',
+  FIRST_INTERACTIVE: '[data-story-structure-interactive]',
+  SUBMIT: '[data-story-structure-submit]',
+} as const;
+
+export const STORY_STRUCTURE_INTERACTIVE_ATTR = 'data-story-structure-interactive';
+
+export type StructureInteractionMode =
+  | 'fill_blank'
+  | 'checkbox'
+  | 'mixed'
+  | 'display_only';
+
+export type StructureTemplateKind =
+  | 'psr'
+  | 'theme_facts'
+  | 'scientific'
+  | 'generic';
+
+export interface StructureInteractionProfile {
+  mode: StructureInteractionMode;
+  template_kind: StructureTemplateKind;
+  fill_blank_count: number;
+  checkbox_count: number;
+  primary_labels: string[];
+  layout: 'worksheet_table' | 'cards';
+}
+
+export type DemoStepId = 'overview' | 'read' | 'interact' | 'submit' | 'feedback';
+
+export interface DemoStepConfig {
+  id: DemoStepId;
+  bubbleText: string;
+  placement: 'above' | 'below';
+  bubbleAnchor: 'top' | 'center' | 'bottom';
+}
+
+export const DEMO_STEP_DURATION_MS = 2800;
+
+interface StructureRowLike {
+  label: string;
+  value?: string;
+  interactive_type?: string;
+  sub_rows?: StructureRowLike[];
+}
+
+interface StructureDataLike {
+  title?: string;
+  layout?: 'worksheet_table' | 'cards';
+  rows: StructureRowLike[];
+  interaction_profile?: Partial<StructureInteractionProfile>;
+}
+
+const TEMPLATE_KINDS: StructureTemplateKind[] = [
+  'psr',
+  'theme_facts',
+  'scientific',
+  'generic',
+];
+
+const INTERACTION_MODES: StructureInteractionMode[] = [
+  'fill_blank',
+  'checkbox',
+  'mixed',
+  'display_only',
+];
+
+function inferTemplateKind(title: string | undefined, labels: string[]): StructureTemplateKind {
+  const blob = [title ?? '', ...labels].join(' ');
+  if (/假說|驗證|步驟|探究/.test(blob)) return 'scientific';
+  if (/問題/.test(blob) && /解決|結果|影響|成效/.test(blob)) return 'psr';
+  if (/主題|事實|主角|事例|論點/.test(blob)) return 'theme_facts';
+  return 'generic';
+}
+
+export function deriveStructureProfile(structure: StructureDataLike): StructureInteractionProfile {
+  const api = structure.interaction_profile;
+  if (
+    api?.mode &&
+    INTERACTION_MODES.includes(api.mode as StructureInteractionMode) &&
+    api.template_kind &&
+    TEMPLATE_KINDS.includes(api.template_kind as StructureTemplateKind)
+  ) {
+    return {
+      mode: api.mode as StructureInteractionMode,
+      template_kind: api.template_kind as StructureTemplateKind,
+      fill_blank_count: api.fill_blank_count ?? 0,
+      checkbox_count: api.checkbox_count ?? 0,
+      primary_labels: api.primary_labels ?? [],
+      layout:
+        api.layout === 'worksheet_table' || structure.layout === 'worksheet_table'
+          ? 'worksheet_table'
+          : 'cards',
+    };
+  }
+
+  let fillBlankCount = 0;
+  let checkboxCount = 0;
+  const primaryLabels: string[] = [];
+  const sectionLabels: string[] = [];
+
+  const tally = (row: StructureRowLike) => {
+    const label = row.label?.trim() ?? '';
+    if (row.interactive_type === 'fill_blank') {
+      fillBlankCount += 1;
+      if (label) primaryLabels.push(label);
+    } else if (row.interactive_type === 'checkbox') {
+      checkboxCount += 1;
+      if (label) primaryLabels.push(label);
+    }
+  };
+
+  structure.rows.forEach((row) => {
+    const parentLabel = row.label?.trim() ?? '';
+    if (parentLabel) sectionLabels.push(parentLabel);
+    if (row.sub_rows?.length) {
+      row.sub_rows.forEach(tally);
+    } else {
+      tally(row);
+    }
+  });
+
+  let mode: StructureInteractionMode;
+  if (fillBlankCount && checkboxCount) mode = 'mixed';
+  else if (fillBlankCount) mode = 'fill_blank';
+  else if (checkboxCount) mode = 'checkbox';
+  else mode = 'display_only';
+
+  return {
+    mode,
+    template_kind: inferTemplateKind(structure.title, [...primaryLabels, ...sectionLabels]),
+    fill_blank_count: fillBlankCount,
+    checkbox_count: checkboxCount,
+    primary_labels: primaryLabels.slice(0, 4),
+    layout: structure.layout === 'worksheet_table' ? 'worksheet_table' : 'cards',
+  };
+}
+
+function overviewText(profile: StructureInteractionProfile): string {
+  switch (profile.template_kind) {
+    case 'psr':
+      return '① 這張表幫你整理課文的問題、解決、結果';
+    case 'scientific':
+      return '① 這張表帶你走科學探究：問題、假說、驗證、結論';
+    case 'theme_facts':
+      return '① 用表格整理課文的主題與重要事實';
+    case 'generic':
+    default:
+      return profile.mode === 'display_only'
+        ? '① 對照表格，整理課文的關鍵重點'
+        : '① 這張表幫你整理課文重點';
+  }
+}
+
+function readText(profile: StructureInteractionProfile): string {
+  if (profile.mode === 'display_only') {
+    return '② 讀課文，對照表格裡的整理';
+  }
+  if (profile.mode === 'checkbox') {
+    return '② 讀課文，想想哪些選項符合文章重點';
+  }
+  return '② 讀課文，想想空格要填什麼關鍵詞';
+}
+
+function interactText(profile: StructureInteractionProfile): string {
+  if (profile.mode === 'checkbox') {
+    return '③ 勾選符合課文的重點選項';
+  }
+  if (profile.mode === 'mixed') {
+    return '③ 填空或勾選符合課文的答案';
+  }
+  return '③ 點【　】空格，輸入你的答案';
+}
+
+export function buildDemoSequence(profile: StructureInteractionProfile): DemoStepConfig[] {
+  const steps: DemoStepConfig[] = [
+    {
+      id: 'overview',
+      bubbleText: overviewText(profile),
+      placement: 'below',
+      bubbleAnchor: 'top',
+    },
+    {
+      id: 'read',
+      bubbleText: readText(profile),
+      placement: 'below',
+      bubbleAnchor: 'top',
+    },
+  ];
+
+  if (profile.mode !== 'display_only') {
+    steps.push(
+      {
+        id: 'interact',
+        bubbleText: interactText(profile),
+        placement: 'above',
+        bubbleAnchor: 'center',
+      },
+      {
+        id: 'submit',
+        bubbleText: '④ 全部完成後，按「提交答案」',
+        placement: 'above',
+        bubbleAnchor: 'center',
+      },
+      {
+        id: 'feedback',
+        bubbleText: '⑤ AI 會幫你檢查，答錯可以看參考提示',
+        placement: 'above',
+        bubbleAnchor: 'center',
+      },
+    );
+  }
+
+  return steps;
+}
+
+export function getCoachIntroText(profile: StructureInteractionProfile): string {
+  const templateLine = (() => {
+    switch (profile.template_kind) {
+      case 'psr':
+        return '問題、解決、結果';
+      case 'scientific':
+        return '問題、假說、驗證、結論';
+      case 'theme_facts':
+        return '主題與重要事實';
+      default:
+        return '課文重點';
+    }
+  })();
+
+  if (profile.mode === 'display_only') {
+    return `對照課文閱讀這張表，整理「${templateLine}」等關鍵資訊`;
+  }
+  if (profile.mode === 'checkbox') {
+    return `用表格整理課文的${templateLine}。讀課文後勾選符合的重點，填完按「提交答案」，AI 會幫你檢查`;
+  }
+  if (profile.mode === 'mixed') {
+    return `用表格整理課文的${templateLine}。讀課文後填空或勾選答案，填完按「提交答案」，AI 會幫你檢查`;
+  }
+  return `用表格整理課文的${templateLine}。讀課文，把關鍵詞填進【　】空格，填完按「提交答案」，AI 會幫你檢查`;
+}
+
+export function resolveDemoTargetElement(
+  stepId: DemoStepId,
+  tableContainer: HTMLElement | null,
+  submitButton: HTMLElement | null,
+): HTMLElement | null {
+  switch (stepId) {
+    case 'overview':
+      return tableContainer;
+    case 'read':
+      return document.querySelector(STORY_STRUCTURE_DOM.LESSON_TEXT);
+    case 'interact':
+      return (
+        tableContainer?.querySelector(STORY_STRUCTURE_DOM.FIRST_INTERACTIVE) ??
+        tableContainer
+      );
+    case 'submit':
+    case 'feedback':
+      return submitButton ?? tableContainer;
+    default:
+      return tableContainer;
+  }
+}


### PR DESCRIPTION
## Summary
- Strip `【答案】` from GET `/structure` responses; server keeps hints for grading (#2256)
- Add「怎麼玩？」coach + spotlight demo with flying tooltips (#2257, #2258)
- Add `interaction_profile` API contract + `storyStructureProfile.ts` so demo/coach adapt to fill_blank, checkbox, mixed, and display_only tables
- Fix graphic-text lessons: `data-comprehension-lesson-text` on paired reading panel

## Test plan
- [x] `npm run build`
- [x] `pytest tests/test_yaml_first_structure.py` (interaction_profile tests)
- [ ] Staging QA: G6-L22 (1076), G7-L28 (1108), G4-L6 (1006), G8-L13 (1127) — demo + coach per format

Made with [Cursor](https://cursor.com)