### PR TITLE
chore(qa): add story structure L1-L5 verification gates (Related to #2258)

### DIFF
--- a/backend/tests/test_lesson_loader_split_1889.py
+++ b/backend/tests/test_lesson_loader_split_1889.py
@@ -120,6 +120,22 @@ class TestCatalogToParsedOverridesG8:
             )
 
 
+class TestCatalogParsedResolveHelpers:
+    """Public helpers for QA / tooling — mirror load_layer2_lessons resolution."""
+
+    def test_catalog_to_parsed_code_g8_offset(self):
+        from app.services.lesson_code_normalization import catalog_to_parsed_code
+
+        assert catalog_to_parsed_code("G8-L08") == "G8-L10"
+        assert catalog_to_parsed_code("G8-L10") == "G8-L13"
+
+    def test_parsed_to_catalog_codes_reverse_lookup(self):
+        from app.services.lesson_code_normalization import parsed_to_catalog_codes
+
+        assert "G8-L8" in parsed_to_catalog_codes("G8-L10")
+        assert "G8-L10" in parsed_to_catalog_codes("G8-L13")
+
+
 # ---------------------------------------------------------------------------
 # Test 2 — layer2_enrichment_merges_truthy_fields_into_layer1_by_title
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_story_structure_qa_contract.py
+++ b/backend/tests/test_story_structure_qa_contract.py
@@ -1,0 +1,80 @@
+"""Contract tests for story_structure_qa_lib (L3 interaction_profile gates)."""
+
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent / "scripts"))
+
+import yaml
+import pytest
+
+from app.routes.stories import _format_yaml_structure_table, _sanitize_structure_for_client
+from story_structure_qa_lib import (
+    PARSER_GAP_LESSONS,
+    LessonTier,
+    classify_lesson,
+    gate_l1_pass,
+    gate_l3_mode_expectation,
+    verify_interaction_profile_contract,
+)
+
+
+def test_profile_contract_mixed():
+    structure = {
+        "layout": "cards",
+        "rows": [
+            {"label": "主題", "value": "x", "interactive_type": "fill_blank"},
+            {"label": "事實", "value": "y", "interactive_type": "checkbox", "options": ["a"]},
+        ],
+    }
+    client = _sanitize_structure_for_client(structure)
+    assert verify_interaction_profile_contract(client) == []
+    assert client["interaction_profile"]["mode"] == "mixed"
+
+
+def test_profile_contract_g6_l22_yaml():
+    yml = pathlib.Path(__file__).parent.parent / "data/lessons/_parsed_2026-05-01/G6-L22.yml"
+    if not yml.exists():
+        pytest.skip("G6-L22.yml missing")
+    data = yaml.safe_load(yml.read_text(encoding="utf-8"))
+    client = _sanitize_structure_for_client(_format_yaml_structure_table(data["story_structure_table"]))
+    assert verify_interaction_profile_contract(client) == []
+    assert client["interaction_profile"]["mode"] == "fill_blank"
+    assert client["interaction_profile"]["template_kind"] == "psr"
+
+
+def test_gate_l1_label_family_warn_only():
+    ok, issues = gate_l1_pass({
+        "available": True,
+        "row_recall": 1.0,
+        "blank_recall": 1.0,
+        "nesting_preserved": True,
+        "label_family_correct": False,
+    })
+    assert ok is True
+    assert any("WARN" in i for i in issues)
+
+
+def test_parser_gap_tier():
+    tier = classify_lesson(
+        grade_code="G7-L6",
+        has_keypoints_yml=True,
+        has_structure_table=True,
+        has_ai_rows=False,
+    )
+    assert tier == LessonTier.PARSER_GAP
+
+
+def test_gate_l3_parser_gap_display_only():
+    issues = gate_l3_mode_expectation(
+        LessonTier.PARSER_GAP,
+        "G7-L6",
+        {"mode": "display_only"},
+    )
+    assert issues == []
+
+
+def test_known_parser_gap_set():
+    assert "G7-L6" in PARSER_GAP_LESSONS
+    assert "G8-L13" not in PARSER_GAP_LESSONS

--- a/backend/tests/test_yaml_first_structure.py
+++ b/backend/tests/test_yaml_first_structure.py
@@ -173,12 +173,16 @@ def test_full_g7_l28_table():
 
 def test_lesson_without_structure_table_returns_none():
     """story_structure_table absent → get_lesson_by_id returns None for that field."""
-    from app.services.lesson_loader import get_lesson_by_id
-    # Lesson 1 (L01.yml) is the original 57-lesson set, has no story_structure_table
-    lesson = get_lesson_by_id(1)
-    if lesson is None:
-        pytest.skip("Lesson 1 not loaded in this environment")
-    # Should be None or absent (falls through to AI)
+    from app.services.lesson_loader import get_all_lessons, get_lesson_by_id
+
+    candidate_id = next(
+        (l["id"] for l in get_all_lessons() if l.get("story_structure_table") is None),
+        None,
+    )
+    if candidate_id is None:
+        pytest.skip("No lesson without story_structure_table in this environment")
+    lesson = get_lesson_by_id(candidate_id)
+    assert lesson is not None
     assert lesson.get("story_structure_table") is None
 
 

--- a/docs/qa/story-structure-verification-standard.md
+++ b/docs/qa/story-structure-verification-standard.md
@@ -1,0 +1,131 @@
+# 文章重點表 QA 標準（三層契約）
+
+對齊架構：
+
+```
+DOCX / keypoints.yml → story_structure_table → rows + interactive_type + layout
+        ↓
+GET /structure + interaction_profile
+        ↓
+storyStructureProfile.ts → demo/coach/DOM
+        ↓
+StoryStructureTable + ComprehensionLayout
+```
+
+**原則**：版面與互動正確性驗 **資料層 + API 契約**；示範文案與 coach 步驟驗 **前端 profile 單測**，不全掃硬編 PSR 文案。
+
+---
+
+## 1. 每課分級（Tier）
+
+| Tier | 條件 | 課數（約） |
+|------|------|-----------|
+| `docx_keypoints` | 有 `*.keypoints.yml` + YAML `story_structure_table` | 136 |
+| `ai_fallback` | 僅 `story_structure_rows`（AI/checkbox 卡版） | 16 |
+| `no_keypoints_docx` | DOCX 無填空式重點表（圖文/純表等） | 15 |
+| `parser_gap` | 有 DOCX 表但 parser 未產 `interactive_type`（已知） | 1 |
+
+已知 `parser_gap`：`G7-L6`（底線 `__`，仍 `display_only`）
+
+`G8-L13` / `G8-L14` 若 YAML 內 `□` 在純文字、未進 `interactive_type: checkbox` → L3 會標 `display_only` 且 **WARN**（資料層待修）
+
+---
+
+## 2. 五層 Gate（每課依 Tier 套用）
+
+| Gate | 名稱 | 工具 | 適用 Tier |
+|------|------|------|-----------|
+| **L1** | DOCX ↔ keypoints.yml | `eval_lesson_schema.py` | `docx_keypoints` |
+| **L2** | keypoints.yml ↔ YAML sync | `keypoints_table_sync` fingerprint | `docx_keypoints` |
+| **L3** | API 結構契約 | `_format_yaml_structure_table` + `interaction_profile` | 全部有 structure 的課 |
+| **L4** | Staging API 一致 | `GET /structure` vs loader | 圖書館已上架課 |
+| **L5** | Staging UI + DOM | browse + profile 驅動 DOM 檢查 | 圖書館已上架課 |
+
+### L1 — DOCX（沿用 #2205）
+
+| 指標 | 門檻 | 阻擋合併 |
+|------|------|----------|
+| `row_recall` | ≥ 0.95 | 是 |
+| `blank_recall` | ≥ 0.95 | 是 |
+| `nesting_preserved` | true | 是 |
+| `label_family_correct` | true | **否**（僅 warn） |
+
+### L2 — YAML sync
+
+- `keypoints_to_table(kp)` fingerprint **==** on-disk `story_structure_table`
+- 有 table 的課 **不得** 同時保留 `story_structure_rows`（AI 覆蓋）
+
+### L3 — API / interaction_profile 契約
+
+每份 structure（sanitize 後）必須：
+
+| 檢查 | 規則 |
+|------|------|
+| `rows` | 非空 |
+| `interactive_type` | 每列 ∈ `fill_blank` \| `checkbox` \| `display` |
+| `interaction_profile.mode` | 與 rows 統計一致 |
+| `interaction_profile.fill_blank_count` | == rows 內 `fill_blank` 數（含 sub_rows） |
+| `interaction_profile.checkbox_count` | == rows 內 `checkbox` 數 |
+| `interaction_profile.layout` | `worksheet_table` 若有 title/nested pair；否則 `cards` |
+| 答案不外洩 | client `value` 無 `【 答案 】`（僅 `【　　　】`） |
+
+**mode 期望（docx_keypoints）**：
+
+| 情況 | 期望 mode |
+|------|-----------|
+| 有 `【】` 填空 | `fill_blank` 或 `mixed` |
+| 僅勾選題 | `checkbox` |
+| `parser_gap` | `display_only`（已知，不阻擋） |
+| 其他 docx 有空白卻 `display_only` | **FAIL** |
+
+### L4 — Staging API
+
+- HTTP 200，`rows.length > 0`
+- `interaction_profile` 與本地 loader 一致（layout / mode / counts）
+- `docx_keypoints`：`layout` + `worksheet_rows` 與本地一致
+
+### L5 — Staging UI（profile 驅動，**不用** `<tr>` 當唯一標準）
+
+| mode | DOM 通過條件 |
+|------|----------------|
+| `display_only` | `[data-story-structure-table]` 存在；無載入錯誤 |
+| `fill_blank` / `mixed` | 上 + `[data-story-structure-interactive]` 或填空 input |
+| `checkbox` | 上 + `[data-story-structure-interactive]` 或 `input[type=checkbox]` |
+| 全 mode | 無「無法載入」；未 redirect `/login` |
+| 圖文課 G7-L28/29/30 | `[data-comprehension-lesson-text]` 存在 |
+
+**不屬 L5**：demo 氣泡文案、`buildDemoSequence` 步驟數 → `storyStructureProfile` 單元測試
+
+---
+
+## 3. Eval / Testing 分工
+
+| 層 | 自動化 | 命令 |
+|----|--------|------|
+| L1–L2 | `scripts/story_structure_qa.py --gates L1,L2` | 151 DOCX 課 |
+| L3 | 同上 `--gates L3` + `pytest test_yaml_first_structure.py` | 165 loader |
+| L4 | 同上 `--gates L4` | staging API |
+| L5 | `scripts/story_structure_qa.py --gates L5` | staging UI |
+| Demo/coach | `frontend` 單測（待補 `storyStructureProfile.test.ts`） | 不跑 165 全掃 |
+
+**一鍵全檢**：
+
+```bash
+export QA_STUDENT_EMAIL='...'   # staging /login 學生懶人登入帳號
+export QA_STUDENT_PASSWORD='...'
+backend/.venv/bin/python scripts/story_structure_qa.py --all
+```
+
+報告：`private/curriculum-source/_online-schema/story_structure_qa_report.json`
+
+---
+
+## 4. 代表課回歸集（冒煙，非抽樣代替全檢）
+
+| 課 | 驗什麼 |
+|----|--------|
+| G6-L22 | nested PSR + `worksheet_table` + `fill_blank` |
+| G7-L28 | 科學探究 + 圖文 `data-comprehension-lesson-text` |
+| G4-L1 | theme_facts + 多列紙本表 |
+| G4-L6 | `ai_fallback` / `checkbox` |
+| G8-L13 | `parser_gap` / `display_only` |

--- a/scripts/story_structure_qa.py
+++ b/scripts/story_structure_qa.py
@@ -1,0 +1,609 @@
+#!/usr/bin/env python3
+"""Story structure QA — unified L1–L5 gates per docs/qa/story-structure-verification-standard.md.
+
+Usage:
+    backend/.venv/bin/python scripts/story_structure_qa.py --all
+    backend/.venv/bin/python scripts/story_structure_qa.py --gates L1,L2,L3
+    backend/.venv/bin/python scripts/story_structure_qa.py --smoke
+    backend/.venv/bin/python scripts/story_structure_qa.py --gates L5 --no-ui   # API only
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "backend"))
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from app.services.lesson_code_normalization import (  # noqa: E402
+    catalog_to_parsed_code,
+    normalize_manifest_code,
+    parsed_to_catalog_codes,
+)
+
+from story_structure_qa_lib import (  # noqa: E402
+    IMAGE_TEXT_LESSONS,
+    LessonTier,
+    SMOKE_LESSONS,
+    classify_lesson,
+    gate_l1_pass,
+    gate_l3_mode_expectation,
+    summarize_gate,
+    ui_pass_from_dom,
+    verify_interaction_profile_contract,
+)
+
+DEFAULT_SCHEMA_DIR = ROOT / "private/curriculum-source/_online-schema"
+DEFAULT_STAGING = "https://lingoleap-backend-staging-958347263320.asia-east1.run.app"
+DEFAULT_STAGING_FE = "https://lingoleap-frontend-staging-958347263320.asia-east1.run.app"
+REPORT_PATH = DEFAULT_SCHEMA_DIR / "story_structure_qa_report.json"
+BROWSE = Path.home() / ".claude/skills/gstack/browse/dist/browse"
+
+def load_mod(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def http_json(url: str, *, token: str | None = None, method: str = "GET", body: dict | None = None) -> dict:
+    data = None
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if body is not None:
+        data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return json.loads(resp.read().decode())
+
+
+def login_staging(base: str) -> str:
+    email = os.environ.get("QA_STUDENT_EMAIL")
+    password = os.environ.get("QA_STUDENT_PASSWORD")
+    if not email or not password:
+        raise RuntimeError(
+            "Set QA_STUDENT_EMAIL and QA_STUDENT_PASSWORD before running staging QA"
+        )
+    return http_json(
+        f"{base}/api/auth/login",
+        method="POST",
+        body={"email": email, "password": password},
+    )["access_token"]
+
+
+def table_fingerprint(table: list) -> str:
+    return json.dumps(table, ensure_ascii=False, sort_keys=True)
+
+
+def browse_cmd(*args: str, timeout: int = 120) -> str:
+    r = subprocess.run([str(BROWSE), *args], capture_output=True, text=True, timeout=timeout)
+    out = (r.stdout or "") + (r.stderr or "")
+    if r.returncode != 0 and "Navigated to" not in out and "Clicked" not in out:
+        raise RuntimeError(f"browse failed: {args}\n{out}")
+    return out
+
+
+def browse_js(expr: str) -> str:
+    out = browse_cmd("js", expr, timeout=60)
+    for line in out.splitlines():
+        line = line.strip()
+        if line and not line.startswith("[browse]"):
+            return line
+    return ""
+
+
+def ensure_browser_login(fe_base: str) -> None:
+    for _attempt in range(3):
+        browse_cmd("goto", f"{fe_base}/login")
+        time.sleep(2)
+        clicked = browse_js(
+            """(() => {
+  const btn = Array.from(document.querySelectorAll('button'))
+    .find(b => {
+      const t = b.textContent || '';
+      return t.includes('學生') && t.includes('小明');
+    });
+  if (btn) { btn.click(); return 'clicked'; }
+  return 'missing';
+})()"""
+        )
+        if clicked != "clicked":
+            time.sleep(1)
+            continue
+        for _ in range(40):
+            time.sleep(1)
+            href = browse_js("location.href")
+            if "/login" not in href:
+                time.sleep(1.5)
+                return
+    raise RuntimeError("browser login timeout")
+
+
+def _read_ui_dom_state() -> dict:
+    raw = browse_js(
+        """(() => {
+  const text = document.body.innerText || '';
+  const table = document.querySelector('[data-story-structure-table]');
+  const interactive = document.querySelector('[data-story-structure-interactive]');
+  const lessonText = document.querySelector('[data-comprehension-lesson-text]');
+  const checkboxes = table ? table.querySelectorAll('input[type=checkbox]').length : 0;
+  return JSON.stringify({
+    href: location.href,
+    err: text.includes('無法載入文章重點表') || text.includes('請重新整理'),
+    loading: text.includes('正在整理文章重點'),
+    login: location.href.includes('/login'),
+    hasTable: !!table,
+    hasInteractive: !!interactive,
+    hasCheckbox: checkboxes > 0,
+    hasLessonText: !!lessonText,
+    rowCount: table ? table.querySelectorAll('tr').length : 0,
+  });
+})()"""
+    )
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {"parse_error": True, "raw": raw}
+
+
+def check_ui_page(
+    story_id: int,
+    fe_base: str,
+    require_lesson_text: bool,
+    *,
+    relogin: Callable[[], None] | None = None,
+    max_wait_s: float = 18.0,
+) -> dict:
+    state: dict = {}
+    for attempt in range(3):
+        browse_cmd("goto", f"{fe_base}/learn/{story_id}/story-structure", timeout=90)
+        time.sleep(1.0)
+        browse_js(
+            """(() => {
+  const btn = Array.from(document.querySelectorAll('button'))
+    .find(b => (b.textContent || '').includes('我知道了'));
+  if (btn) btn.click();
+  return 'ok';
+})()"""
+        )
+        deadline = time.time() + max_wait_s
+        while time.time() < deadline:
+            state = _read_ui_dom_state()
+            if state.get("login"):
+                break
+            if state.get("err"):
+                break
+            if state.get("hasTable") and not state.get("loading"):
+                break
+            if not state.get("loading") and state.get("hasTable"):
+                break
+            time.sleep(0.75)
+
+        if state.get("login") and relogin and attempt < 2:
+            try:
+                relogin()
+            except RuntimeError:
+                time.sleep(2)
+            continue
+        state["require_lesson_text"] = require_lesson_text
+        return state
+
+    state["require_lesson_text"] = require_lesson_text
+    return state
+
+
+PARSED_DIR = ROOT / "backend/data/lessons/_parsed_2026-05-01"
+
+
+def loader_for_parsed_lesson(
+    parsed_lesson_id: str,
+    lessons_by_code: dict[str, dict],
+) -> tuple[dict | None, str | None]:
+    """DOCX batch ids are parsed YAML stems; loader indexes by catalog grade_code."""
+    parsed = normalize_manifest_code(parsed_lesson_id)
+    for catalog in parsed_to_catalog_codes(parsed):
+        loader = lessons_by_code.get(normalize_manifest_code(catalog))
+        if loader:
+            return loader, catalog
+    return lessons_by_code.get(parsed), parsed
+
+
+def expected_parsed_yaml_path(
+    *,
+    parsed_lesson_id: str | None,
+    catalog_code: str | None,
+) -> Path | None:
+    if catalog_code:
+        stem = catalog_to_parsed_code(catalog_code)
+    elif parsed_lesson_id:
+        stem = normalize_manifest_code(parsed_lesson_id)
+    else:
+        return None
+    path = PARSED_DIR / f"{stem}.yml"
+    return path if path.exists() else None
+
+
+def build_structure_from_lesson(lesson: dict, format_table, sanitize):
+    if lesson.get("story_structure_table"):
+        return sanitize(format_table(lesson["story_structure_table"]))
+    if lesson.get("story_structure_rows"):
+        return sanitize({"rows": lesson["story_structure_rows"]})
+    return None
+
+
+def run_qa(
+    *,
+    gates: set[str],
+    schema_dir: Path,
+    staging_be: str,
+    staging_fe: str,
+    token: str | None,
+    smoke_only: bool,
+    run_ui: bool,
+    story_ids: set[int] | None = None,
+) -> dict:
+    batch = load_mod("batch", ROOT / "scripts/batch_all_lessons.py")
+    eval_mod = load_mod("eval", ROOT / "scripts/eval_lesson_schema.py")
+    sync_mod = load_mod("sync", ROOT / "scripts/keypoints_table_sync.py")
+    bls = eval_mod.load_bls()
+
+    from app.routes.stories import _format_yaml_structure_table, _sanitize_structure_for_client
+    from app.services.lesson_loader import get_all_lessons
+
+    grade_paths = sync_mod.build_grade_code_paths()
+    lessons_by_id = {l["id"]: l for l in get_all_lessons()}
+    lessons_by_code: dict[str, dict] = {}
+    for l in get_all_lessons():
+        code = normalize_manifest_code(l.get("grade_code") or l.get("lesson_code") or "")
+        if code:
+            lessons_by_code[code] = l
+
+    per_lesson: list[dict] = []
+    failures: list[dict] = []
+
+    # ── L1/L2/L3 per DOCX lesson + loader lessons ─────────────────────────
+    docx_gates = gates & {"L1", "L2", "L3"}
+    if docx_gates:
+        docx_lessons = batch.discover_lessons()
+        if smoke_only:
+            docx_ids = set(SMOKE_LESSONS)
+            docx_lessons = [(lid, p) for lid, p in docx_lessons if lid in docx_ids]
+
+        for lesson_id, docx_path in docx_lessons:
+            record: dict = {"lesson_id": lesson_id, "gates": {}}
+            kp_eval = eval_mod.eval_keypoints(lesson_id, docx_path, schema_dir, bls)
+            loader, catalog_code = loader_for_parsed_lesson(lesson_id, lessons_by_code)
+            parsed_code = normalize_manifest_code(lesson_id)
+            yaml_file = expected_parsed_yaml_path(parsed_lesson_id=lesson_id, catalog_code=None)
+            has_kp_yml = (schema_dir / f"{lesson_id}.keypoints.yml").exists()
+            on_disk_table = None
+            if yaml_file:
+                with open(yaml_file, encoding="utf-8") as f:
+                    on_disk_table = (yaml.safe_load(f) or {}).get("story_structure_table")
+            has_table = bool(on_disk_table)
+            has_ai = bool(loader and loader.get("story_structure_rows") and not on_disk_table)
+            tier = classify_lesson(
+                grade_code=lesson_id,
+                has_keypoints_yml=has_kp_yml,
+                has_structure_table=has_table,
+                has_ai_rows=has_ai,
+                docx_keypoints_available=kp_eval.get("available"),
+            )
+            record["tier"] = tier.value
+            record["parsed_code"] = parsed_code
+            record["catalog_code"] = catalog_code
+            record["story_id"] = loader["id"] if loader else None
+
+            if "L1" in gates and tier == LessonTier.DOCX_KEYPOINTS:
+                ok, issues = gate_l1_pass(kp_eval)
+                record["gates"]["L1"] = summarize_gate("L1", ok, issues)
+                if not ok:
+                    failures.append({"lesson_id": lesson_id, "gate": "L1", "issues": issues})
+
+            if "L2" in gates and tier == LessonTier.DOCX_KEYPOINTS and has_kp_yml:
+                issues = []
+                with open(schema_dir / f"{lesson_id}.keypoints.yml", encoding="utf-8") as f:
+                    kp_schema = yaml.safe_load(f)
+                expected = sync_mod.keypoints_to_table(kp_schema)
+                on_disk = None
+                yaml_path = None
+                for path in grade_paths.get(normalize_manifest_code(lesson_id), []):
+                    with open(path, encoding="utf-8") as f:
+                        data = yaml.safe_load(f) or {}
+                    if data.get("story_structure_table") is not None:
+                        on_disk = data["story_structure_table"]
+                        yaml_path = str(path)
+                        if data.get("story_structure_rows"):
+                            issues.append("story_structure_rows still present")
+                        break
+                if on_disk is None:
+                    issues.append("no yaml story_structure_table")
+                elif table_fingerprint(expected) != table_fingerprint(on_disk):
+                    issues.append("fingerprint mismatch")
+                ok = len(issues) == 0
+                record["gates"]["L2"] = summarize_gate("L2", ok, issues)
+                record["yaml_path"] = yaml_path
+                if not ok:
+                    failures.append({"lesson_id": lesson_id, "gate": "L2", "issues": issues})
+
+            if "L3" in gates and loader:
+                struct = build_structure_from_lesson(loader, _format_yaml_structure_table, _sanitize_structure_for_client)
+                yaml_file = expected_parsed_yaml_path(
+                    parsed_lesson_id=lesson_id,
+                    catalog_code=catalog_code,
+                )
+                if yaml_file:
+                    record.setdefault("yaml_path", str(yaml_file))
+                if yaml_file and tier == LessonTier.DOCX_KEYPOINTS:
+                    with open(yaml_file, encoding="utf-8") as f:
+                        file_data = yaml.safe_load(f) or {}
+                    file_table = file_data.get("story_structure_table")
+                    loader_table = loader.get("story_structure_table")
+                    issues_catalog: list[str] = []
+                    if not file_table:
+                        issues_catalog.append("no on-disk story_structure_table")
+                    elif not loader_table:
+                        issues_catalog.append("loader missing story_structure_table")
+                    elif table_fingerprint(file_table) != table_fingerprint(loader_table):
+                        issues_catalog.append("loader story_structure_table != on-disk yaml")
+                    ok_catalog = len(issues_catalog) == 0
+                    record["gates"]["L3_catalog"] = summarize_gate("L3_catalog", ok_catalog, issues_catalog)
+                    if not ok_catalog:
+                        failures.append(
+                            {"lesson_id": lesson_id, "gate": "L3_catalog", "issues": issues_catalog}
+                        )
+                if struct:
+                    issues = verify_interaction_profile_contract(struct)
+                    issues.extend(
+                        gate_l3_mode_expectation(
+                            tier,
+                            lesson_id,
+                            struct.get("interaction_profile") or {},
+                            docx_blanks=kp_eval.get("docx_blanks"),
+                        )
+                    )
+                    profile = struct.get("interaction_profile") or {}
+                    record["profile"] = profile
+                    ok = len(issues) == 0
+                    record["gates"]["L3"] = summarize_gate("L3", ok, issues)
+                    if not ok:
+                        failures.append({"lesson_id": lesson_id, "gate": "L3", "issues": issues})
+                elif tier not in (LessonTier.NO_KEYPOINTS_DOCX, LessonTier.NO_STRUCTURE):
+                    record["gates"]["L3"] = summarize_gate("L3", False, ["no structure in loader"])
+                    failures.append({"lesson_id": lesson_id, "gate": "L3", "issues": ["no structure"]})
+
+            per_lesson.append(record)
+
+    # ── L3 all loader lessons (including non-docx batch) ──────────────────
+    if "L3" in gates and not smoke_only:
+        for lesson in get_all_lessons():
+            code = normalize_manifest_code(lesson.get("grade_code") or "")
+            if any(r.get("lesson_id") == code for r in per_lesson):
+                continue
+            struct = build_structure_from_lesson(lesson, _format_yaml_structure_table, _sanitize_structure_for_client)
+            if not struct:
+                continue
+            tier = classify_lesson(
+                grade_code=code,
+                has_keypoints_yml=False,
+                has_structure_table=bool(lesson.get("story_structure_table")),
+                has_ai_rows=bool(lesson.get("story_structure_rows")),
+            )
+            issues = verify_interaction_profile_contract(struct)
+            issues.extend(gate_l3_mode_expectation(tier, code, struct.get("interaction_profile") or {}))
+            if issues:
+                failures.append({"lesson_id": code, "story_id": lesson["id"], "gate": "L3", "issues": issues})
+
+    # ── L4 staging API ────────────────────────────────────────────────────
+    staging_token = token
+    if ("L4" in gates or "L5" in gates) and not staging_token:
+        staging_token = login_staging(staging_be)
+
+    stories: list[dict] = []
+    if "L4" in gates or "L5" in gates:
+        page = 1
+        while True:
+            data = http_json(f"{staging_be}/api/stories?page={page}&page_size=300", token=staging_token)
+            stories.extend(data["stories"])
+            if len(stories) >= data["total"]:
+                break
+            page += 1
+        if smoke_only:
+            smoke_ids: set[int] = set()
+            for code in SMOKE_LESSONS:
+                loader, _ = loader_for_parsed_lesson(code, lessons_by_code)
+                if loader:
+                    smoke_ids.add(loader["id"])
+                elif code in lessons_by_code:
+                    smoke_ids.add(lessons_by_code[code]["id"])
+            stories = [s for s in stories if s["id"] in smoke_ids]
+        if story_ids:
+            stories = [s for s in stories if s["id"] in story_ids]
+
+    staging_records: list[dict] = []
+    if "L4" in gates:
+        for s in stories:
+            sid = s["id"]
+            code = s.get("grade_code") or ""
+            issues: list[str] = []
+            try:
+                remote = http_json(f"{staging_be}/api/stories/{sid}/structure", token=staging_token)
+            except urllib.error.HTTPError as e:
+                issues.append(f"HTTP {e.code}")
+                failures.append({"story_id": sid, "grade_code": code, "gate": "L4", "issues": issues})
+                staging_records.append({"id": sid, "grade_code": code, "gates": {"L4": summarize_gate("L4", False, issues)}})
+                continue
+
+            issues.extend(verify_interaction_profile_contract(remote))
+            local = lessons_by_id.get(sid)
+            tier = LessonTier.NO_STRUCTURE
+            if local:
+                tier = classify_lesson(
+                    grade_code=code,
+                    has_keypoints_yml=bool(local.get("story_structure_table")),
+                    has_structure_table=bool(local.get("story_structure_table")),
+                    has_ai_rows=bool(local.get("story_structure_rows")),
+                )
+                local_struct = build_structure_from_lesson(
+                    local, _format_yaml_structure_table, _sanitize_structure_for_client
+                )
+                if local_struct:
+                    lp = local_struct.get("interaction_profile") or {}
+                    rp = remote.get("interaction_profile") or {}
+                    for key in ("mode", "layout", "fill_blank_count", "checkbox_count"):
+                        if lp.get(key) != rp.get(key):
+                            issues.append(f"profile.{key} local={lp.get(key)} remote={rp.get(key)}")
+                    if local.get("story_structure_table"):
+                        if remote.get("layout") != local_struct.get("layout"):
+                            issues.append("layout mismatch vs local")
+
+            issues.extend(
+                gate_l3_mode_expectation(tier, code, remote.get("interaction_profile") or {})
+            )
+            ok = len(issues) == 0
+            rec = {
+                "id": sid,
+                "grade_code": code,
+                "tier": tier.value,
+                "profile": remote.get("interaction_profile"),
+                "gates": {"L4": summarize_gate("L4", ok, issues)},
+            }
+            staging_records.append(rec)
+            if not ok:
+                failures.append({"story_id": sid, "grade_code": code, "gate": "L4", "issues": issues})
+
+    # ── L5 staging UI ─────────────────────────────────────────────────────
+    if "L5" in gates and run_ui:
+        if not BROWSE.exists():
+            raise RuntimeError(f"browse not found: {BROWSE}")
+        def relogin() -> None:
+            for _ in range(2):
+                try:
+                    ensure_browser_login(staging_fe)
+                    return
+                except RuntimeError:
+                    time.sleep(3)
+            print("WARN: browser relogin failed", flush=True)
+
+        relogin()
+        total = len(stories)
+        for idx, s in enumerate(stories):
+            if idx > 0 and idx % 15 == 0:
+                relogin()
+            sid = s["id"]
+            code = s.get("grade_code") or ""
+            require_lt = normalize_manifest_code(code) in IMAGE_TEXT_LESSONS
+            remote = None
+            for api_try in range(2):
+                try:
+                    remote = http_json(
+                        f"{staging_be}/api/stories/{sid}/structure", token=staging_token
+                    )
+                    break
+                except urllib.error.HTTPError as e:
+                    if api_try == 0:
+                        time.sleep(1)
+                        continue
+                    print(f"L5 skip id={sid} {code} structure HTTP {e.code}", flush=True)
+            if remote is None:
+                continue
+            profile = remote.get("interaction_profile") or {}
+            dom = check_ui_page(sid, staging_fe, require_lt, relogin=relogin)
+            ok, issues = ui_pass_from_dom(dom, profile, require_lesson_text=require_lt)
+            rec = next((r for r in staging_records if r["id"] == sid), {"id": sid, "grade_code": code, "gates": {}})
+            rec.setdefault("gates", {})["L5"] = summarize_gate("L5", ok, issues)
+            rec["profile"] = profile
+            if rec not in staging_records:
+                staging_records.append(rec)
+            if not ok:
+                failures.append({"story_id": sid, "grade_code": code, "gate": "L5", "issues": issues})
+            print(f"L5 {idx + 1}/{total} id={sid} {code} {'PASS' if ok else 'FAIL'}", flush=True)
+
+    return {
+        "gates_run": sorted(gates),
+        "smoke_only": smoke_only,
+        "per_lesson_docx": per_lesson,
+        "staging": staging_records,
+        "failures": failures,
+        "summary": {
+            "docx_lessons_checked": len(per_lesson),
+            "staging_checked": len(staging_records),
+            "failure_count": len(failures),
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Story structure QA (L1–L5)")
+    parser.add_argument("--all", action="store_true", help="Run L1,L2,L3,L4,L5")
+    parser.add_argument("--smoke", action="store_true", help="Smoke lessons only")
+    parser.add_argument("--gates", default="", help="Comma-separated L1,L2,L3,L4,L5")
+    parser.add_argument("--schema-dir", default=str(DEFAULT_SCHEMA_DIR))
+    parser.add_argument("--staging-url", default=DEFAULT_STAGING)
+    parser.add_argument("--staging-fe", default=DEFAULT_STAGING_FE)
+    parser.add_argument("--token")
+    parser.add_argument("--no-ui", action="store_true", help="Skip L5 browser even if requested")
+    parser.add_argument("--story-ids", default="", help="Comma-separated story ids (L4/L5 subset)")
+    parser.add_argument("--report", default=str(REPORT_PATH))
+    args = parser.parse_args()
+
+    if args.all:
+        gates = {"L1", "L2", "L3", "L4", "L5"}
+    elif args.gates:
+        gates = {g.strip().upper() for g in args.gates.split(",") if g.strip()}
+    elif args.smoke:
+        gates = {"L1", "L2", "L3", "L4", "L5"}
+    else:
+        gates = {"L1", "L2", "L3"}
+
+    story_ids = {int(x.strip()) for x in args.story_ids.split(",") if x.strip()} or None
+
+    report = run_qa(
+        gates=gates,
+        schema_dir=Path(args.schema_dir),
+        staging_be=args.staging_url,
+        staging_fe=args.staging_fe,
+        token=args.token,
+        smoke_only=args.smoke,
+        run_ui="L5" in gates and not args.no_ui,
+        story_ids=story_ids,
+    )
+
+    report_path = Path(args.report)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print("=" * 72)
+    print("STORY STRUCTURE QA")
+    print(f"Gates: {', '.join(report['gates_run'])}  smoke={report['smoke_only']}")
+    print(f"DOCX lessons: {report['summary']['docx_lessons_checked']}")
+    print(f"Staging:      {report['summary']['staging_checked']}")
+    print(f"Failures:     {report['summary']['failure_count']}")
+    if report["failures"]:
+        print("\nFailed:")
+        for f in report["failures"][:30]:
+            print(f"  {f}")
+        if len(report["failures"]) > 30:
+            print(f"  ... +{len(report['failures']) - 30} more")
+    print(f"\nReport: {report_path}")
+    print(f"Standard: docs/qa/story-structure-verification-standard.md")
+
+    return 1 if report["failures"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/story_structure_qa_lib.py
+++ b/scripts/story_structure_qa_lib.py
@@ -1,0 +1,202 @@
+"""Shared story-structure QA logic (see docs/qa/story-structure-verification-standard.md)."""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Any
+
+# Known parser gaps — display_only despite DOCX blanks (data layer, not demo)
+PARSER_GAP_LESSONS = frozenset({"G7-L6"})
+
+SMOKE_LESSONS = ("G6-L22", "G7-L28", "G4-L1", "G4-L6", "G8-L13")
+IMAGE_TEXT_LESSONS = frozenset({"G7-L28", "G7-L29", "G7-L30"})
+
+
+class LessonTier(str, Enum):
+    DOCX_KEYPOINTS = "docx_keypoints"
+    AI_FALLBACK = "ai_fallback"
+    NO_KEYPOINTS_DOCX = "no_keypoints_docx"
+    PARSER_GAP = "parser_gap"
+    NO_STRUCTURE = "no_structure"
+
+
+def classify_lesson(
+    *,
+    grade_code: str,
+    has_keypoints_yml: bool,
+    has_structure_table: bool,
+    has_ai_rows: bool,
+    docx_keypoints_available: bool | None = None,
+) -> LessonTier:
+    code = grade_code or ""
+    if code in PARSER_GAP_LESSONS:
+        return LessonTier.PARSER_GAP
+    if has_structure_table and has_keypoints_yml:
+        return LessonTier.DOCX_KEYPOINTS
+    if has_structure_table:
+        return LessonTier.DOCX_KEYPOINTS
+    if has_ai_rows:
+        return LessonTier.AI_FALLBACK
+    if docx_keypoints_available is False:
+        return LessonTier.NO_KEYPOINTS_DOCX
+    return LessonTier.NO_STRUCTURE
+
+
+def count_interactive_types(rows: list[dict]) -> tuple[int, int, int]:
+    """Return (fill_blank, checkbox, display) counts including sub_rows."""
+    fill_blank = checkbox = display = 0
+
+    def tally(row: dict) -> None:
+        nonlocal fill_blank, checkbox, display
+        itype = row.get("interactive_type")
+        if itype == "fill_blank":
+            fill_blank += 1
+        elif itype == "checkbox":
+            checkbox += 1
+        else:
+            display += 1
+
+    for row in rows:
+        subs = row.get("sub_rows") or []
+        if subs:
+            for sub in subs:
+                tally(sub)
+        else:
+            tally(row)
+    return fill_blank, checkbox, display
+
+
+def derive_mode(fill_blank: int, checkbox: int) -> str:
+    if fill_blank and checkbox:
+        return "mixed"
+    if fill_blank:
+        return "fill_blank"
+    if checkbox:
+        return "checkbox"
+    return "display_only"
+
+
+def verify_interaction_profile_contract(structure: dict) -> list[str]:
+    """L3: interaction_profile must match rows; answers must not leak."""
+    errors: list[str] = []
+    rows = structure.get("rows") or []
+    if not rows:
+        errors.append("rows empty")
+        return errors
+
+    profile = structure.get("interaction_profile")
+    if not profile:
+        errors.append("missing interaction_profile")
+        return errors
+
+    fb, cb, _disp = count_interactive_types(rows)
+    expected_mode = derive_mode(fb, cb)
+
+    if profile.get("mode") != expected_mode:
+        errors.append(f"profile.mode {profile.get('mode')} != {expected_mode}")
+    if profile.get("fill_blank_count") != fb:
+        errors.append(f"fill_blank_count {profile.get('fill_blank_count')} != {fb}")
+    if profile.get("checkbox_count") != cb:
+        errors.append(f"checkbox_count {profile.get('checkbox_count')} != {cb}")
+
+    layout = structure.get("layout")
+    expected_layout = profile.get("layout")
+    if layout and expected_layout and layout != expected_layout:
+        errors.append(f"layout {layout} != profile.layout {expected_layout}")
+
+    # Answer leak check
+    answer_pat = re.compile(r"【\s*[^】\s　][^】]*】")
+
+    def check_value(val: str, ctx: str) -> None:
+        if answer_pat.search(val or ""):
+            errors.append(f"answer leak in {ctx}")
+
+    for i, row in enumerate(rows):
+        check_value(str(row.get("value") or ""), f"rows[{i}].value")
+        for j, sub in enumerate(row.get("sub_rows") or []):
+            check_value(str(sub.get("value") or ""), f"rows[{i}].sub_rows[{j}].value")
+
+    return errors
+
+
+def gate_l1_pass(keypoints_eval: dict) -> tuple[bool, list[str]]:
+    if not keypoints_eval.get("available"):
+        return True, ["N/A no docx keypoints table"]
+    issues: list[str] = []
+    if keypoints_eval.get("row_recall", 0) < 0.95:
+        issues.append(f"row_recall={keypoints_eval.get('row_recall')}")
+    if keypoints_eval.get("blank_recall", 0) < 0.95:
+        issues.append(f"blank_recall={keypoints_eval.get('blank_recall')}")
+    if not keypoints_eval.get("nesting_preserved"):
+        issues.append("nesting_preserved=false")
+    if not keypoints_eval.get("label_family_correct"):
+        issues.append("WARN label_family_correct=false")
+    hard = [x for x in issues if not x.startswith("WARN")]
+    return len(hard) == 0, issues
+
+
+def gate_l3_mode_expectation(
+    tier: LessonTier,
+    grade_code: str,
+    profile: dict,
+    docx_blanks: int | None = None,
+) -> list[str]:
+    """Extra L3 rules per tier."""
+    errors: list[str] = []
+    mode = profile.get("mode")
+    if tier == LessonTier.PARSER_GAP:
+        if mode != "display_only":
+            errors.append(f"parser_gap expected display_only, got {mode}")
+        return errors
+    if tier == LessonTier.AI_FALLBACK:
+        if mode == "display_only":
+            errors.append("ai_fallback should be interactive")
+        return errors
+    if tier == LessonTier.DOCX_KEYPOINTS:
+        if grade_code in PARSER_GAP_LESSONS:
+            return errors
+        if docx_blanks and docx_blanks > 0 and mode == "display_only":
+            errors.append("docx has blanks but mode is display_only")
+    return errors
+
+
+def expected_ui_dom(profile: dict) -> dict[str, bool]:
+    """L5: which DOM checks apply for this profile."""
+    mode = profile.get("mode", "display_only")
+    return {
+        "require_table": True,
+        "require_interactive": mode in ("fill_blank", "checkbox", "mixed"),
+        "require_lesson_text": False,  # set per-lesson for image_text
+        "allow_zero_tr": profile.get("layout") == "cards",
+    }
+
+
+def ui_pass_from_dom(state: dict, profile: dict, *, require_lesson_text: bool = False) -> tuple[bool, list[str]]:
+    issues: list[str] = []
+    if state.get("login"):
+        issues.append("redirected to login")
+    if state.get("err"):
+        issues.append("load error banner")
+    if state.get("loading"):
+        issues.append("still loading")
+    if not state.get("hasTable"):
+        issues.append("missing data-story-structure-table")
+
+    exp = expected_ui_dom(profile)
+    if require_lesson_text and not state.get("hasLessonText"):
+        issues.append("missing data-comprehension-lesson-text")
+
+    if exp["require_interactive"]:
+        if not state.get("hasInteractive") and not state.get("hasCheckbox"):
+            issues.append("missing interactive element")
+
+    if not exp["allow_zero_tr"] and profile.get("layout") == "worksheet_table":
+        if state.get("rowCount", 0) == 0:
+            issues.append("worksheet_table but zero tr")
+
+    return len(issues) == 0, issues
+
+
+def summarize_gate(gate: str, passed: bool, issues: list[str]) -> dict[str, Any]:
+    return {"gate": gate, "pass": passed, "issues": issues}


### PR DESCRIPTION
## Summary
- Add unified `story_structure_qa.py` runner (L1–L5 gates) with G8 catalog/parsed resolution
- Add QA standard doc and contract tests for interaction_profile / parser_gap tiers
- Staging credentials via `QA_STUDENT_EMAIL` / `QA_STUDENT_PASSWORD` env vars

## Test plan
- [x] pytest contract tests — 31 passed
- [x] L1–L4 staging QA — 0 failures
- [ ] L5 full staging UI scan (in progress)

Made with [Cursor](https://cursor.com)